### PR TITLE
First-run onboarding + in-app auto-updater

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,12 @@ name: Release
 # macOS, and Linux, then attaches them to a DRAFT GitHub release. Review the
 # draft and publish it. Bump the version in src-tauri/tauri.conf.json (and
 # Cargo.toml / package.json) to match the tag before tagging.
+#
+# It also emits signed auto-updater artifacts and a `latest.json` manifest, so
+# installed copies (v0.3.3+) can update themselves. The Tauri updater signing
+# key lives in two repo secrets: TAURI_SIGNING_PRIVATE_KEY and
+# TAURI_SIGNING_PRIVATE_KEY_PASSWORD. The matching public key is in
+# tauri.conf.json under plugins.updater.pubkey.
 on:
   push:
     tags:
@@ -64,6 +70,10 @@ jobs:
           # When set, prepare-sidecar builds the gateway for this target; empty on
           # Windows/Linux, which build for the host.
           CONDUIT_SIDECAR_TARGET: ${{ matrix.target }}
+          # Tauri updater signing. Required to produce signed `.sig` files for the
+          # updater artifacts (createUpdaterArtifacts is set in the bundle config).
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
           # macOS code signing + notarization. Empty/ignored on Windows and Linux;
           # Tauri only acts on these when building the macOS bundle. Set these as
           # repository secrets to produce a signed, notarized .dmg (see
@@ -75,6 +85,19 @@ jobs:
           APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
 
+      # Both macOS targets emit an identically named `Conduit.app.tar.gz` updater
+      # artifact, which would overwrite each other on one release. Tag each with
+      # its target so latest.json can point at the right arch.
+      - name: Stage macOS updater artifact (unique per arch)
+        if: startsWith(matrix.os, 'macos')
+        run: |
+          dir="src-tauri/target/${{ matrix.target }}/release/bundle/macos"
+          base="$dir/Conduit.app.tar.gz"
+          if [ -f "$base" ]; then
+            cp "$base" "$dir/Conduit_${{ matrix.target }}.app.tar.gz"
+            cp "$base.sig" "$dir/Conduit_${{ matrix.target }}.app.tar.gz.sig"
+          fi
+
       - name: Draft release with the installers
         uses: softprops/action-gh-release@v2
         with:
@@ -82,7 +105,54 @@ jobs:
           generate_release_notes: true
           files: |
             src-tauri/target/release/bundle/nsis/*-setup.exe
+            src-tauri/target/release/bundle/nsis/*-setup.exe.sig
             src-tauri/target/aarch64-apple-darwin/release/bundle/dmg/*.dmg
             src-tauri/target/x86_64-apple-darwin/release/bundle/dmg/*.dmg
+            src-tauri/target/*/release/bundle/macos/Conduit_*-apple-darwin.app.tar.gz
+            src-tauri/target/*/release/bundle/macos/Conduit_*-apple-darwin.app.tar.gz.sig
             src-tauri/target/release/bundle/deb/*.deb
             src-tauri/target/release/bundle/appimage/*.AppImage
+            src-tauri/target/release/bundle/appimage/*.AppImage.sig
+
+  # Assemble the updater manifest from every platform's signature, after all
+  # installers are uploaded to the draft. If this job fails the draft still has
+  # working installers - only auto-update is affected.
+  updater-manifest:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Compose and upload latest.json
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.ref_name }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          base="https://github.com/$REPO/releases/download/$TAG"
+          gh release download "$TAG" --repo "$REPO" --pattern '*.sig' --dir sigs
+          assets=$(gh release view "$TAG" --repo "$REPO" --json assets --jq '.assets[].name')
+          pick() { echo "$assets" | grep -E "$1" | head -1 || true; }
+          win=$(pick '\-setup\.exe$')
+          mac_arm=$(pick 'aarch64-apple-darwin\.app\.tar\.gz$')
+          mac_x64=$(pick 'x86_64-apple-darwin\.app\.tar\.gz$')
+          lin=$(pick '\.AppImage$')
+          sig() { cat "sigs/$1.sig"; }
+          jq -n \
+            --arg version "$TAG" \
+            --arg pub_date "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            --arg win_url "$base/$win"       --arg win_sig "$(sig "$win")" \
+            --arg marm_url "$base/$mac_arm"  --arg marm_sig "$(sig "$mac_arm")" \
+            --arg mx64_url "$base/$mac_x64"  --arg mx64_sig "$(sig "$mac_x64")" \
+            --arg lin_url "$base/$lin"       --arg lin_sig "$(sig "$lin")" \
+            '{
+               version: $version,
+               pub_date: $pub_date,
+               platforms: {
+                 "windows-x86_64": { signature: $win_sig,  url: $win_url },
+                 "darwin-aarch64": { signature: $marm_sig, url: $marm_url },
+                 "darwin-x86_64":  { signature: $mx64_sig, url: $mx64_url },
+                 "linux-x86_64":   { signature: $lin_sig,  url: $lin_url }
+               }
+             }' > latest.json
+          echo "--- latest.json ---"; cat latest.json
+          gh release upload "$TAG" latest.json --repo "$REPO" --clobber

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -5,9 +5,10 @@ Conduit is a cross-platform manager for MCP servers across AI coding tools
 working spec. It captures the architecture decision and the build order.
 
 **Status (2026-06-20):** shipping. Signed/notarized macOS (Apple Silicon + Intel),
-Windows, and Linux (deb/AppImage) builds via a tag-triggered release pipeline. v0.3.x
-released. Next: macOS keychain access-group entitlement, auto-updater, and the
-launch (Product Hunt, MCP registry).
+Windows, and Linux (deb/AppImage) builds via a tag-triggered release pipeline. v0.3.2
+released. First-run onboarding and an in-app auto-updater are built (pending the v0.3.3
+release). Next: cut v0.3.3, the macOS keychain access-group entitlement, and the launch
+(Product Hunt scheduled, MCP registries listed).
 
 ## The core decision: Conduit is a gateway, not a file editor
 
@@ -126,13 +127,16 @@ Tier 2 - feature completeness (in progress)
 
 Tier 3 - launch prep
 - [x] Bundle the gateway sidecar; signed/notarized macOS installers (Win/Linux
-      unsigned with documented bypass); cargo-audit in CI. Auto-updater still TODO.
+      unsigned with documented bypass); cargo-audit in CI.
 - [x] Verify macOS / Linux (signed mac dmgs arm64 + Intel, Linux deb/AppImage;
       tested across Windows/macOS/Ubuntu VMs)
-- [x] Marketing site (conduit.southforgeai.com) with demo video. First-run
-      onboarding still minimal.
+- [x] Marketing site (conduit.southforgeai.com) with demo video.
+- [x] In-app auto-updater (Tauri v2 updater plugin + signed `latest.json` from the
+      release pipeline). Live from v0.3.3 onward.
+- [x] First-run onboarding wizard (detect clients, add servers, connect a client).
 - [ ] macOS keychain access-group entitlement (app + gateway share secrets with
-      no "Always Allow" prompt); auto-updater; Product Hunt + MCP registry launch
+      no "Always Allow" prompt)
+- [ ] Launch: Product Hunt (scheduled), MCP registries (Glama/mcp.so/awesome-mcp listed)
 
 Tier 4 - teams / enterprise (paid)
 - [ ] Hosted/remote gateway, shared/synced config, RBAC/SSO

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@fontsource-variable/geist": "^5.2.9",
         "@tailwindcss/vite": "^4.3.1",
         "@tauri-apps/api": "^2",
+        "@tauri-apps/plugin-dialog": "^2.7.1",
         "@tauri-apps/plugin-opener": "^2",
         "@tauri-apps/plugin-process": "^2.3.1",
         "@tauri-apps/plugin-updater": "^2.10.1",
@@ -3621,6 +3622,15 @@
       ],
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/@tauri-apps/plugin-dialog": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-dialog/-/plugin-dialog-2.7.1.tgz",
+      "integrity": "sha512-OK1UBXYt+ojcmxMktzzuyonYIFta8CmAASpX+CA+DTGK24KlHjhYI6x2iOJ/TjZF4N7/ACK1oFmEOjIY9IhzOQ==",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@tauri-apps/api": "^2.11.0"
       }
     },
     "node_modules/@tauri-apps/plugin-opener": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,19 @@
 {
   "name": "conduit",
-  "version": "0.1.0",
+  "version": "0.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "conduit",
-      "version": "0.1.0",
+      "version": "0.3.2",
       "dependencies": {
         "@fontsource-variable/geist": "^5.2.9",
         "@tailwindcss/vite": "^4.3.1",
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-opener": "^2",
+        "@tauri-apps/plugin-process": "^2.3.1",
+        "@tauri-apps/plugin-updater": "^2.10.1",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "lucide-react": "^1.21.0",
@@ -3628,6 +3630,24 @@
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@tauri-apps/api": "^2.11.0"
+      }
+    },
+    "node_modules/@tauri-apps/plugin-process": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-process/-/plugin-process-2.3.1.tgz",
+      "integrity": "sha512-nCa4fGVaDL/B9ai03VyPOjfAHRHSBz5v6F/ObsB73r/dA3MHHhZtldaDMIc0V/pnUw9ehzr2iEG+XkSEyC0JJA==",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@tauri-apps/api": "^2.8.0"
+      }
+    },
+    "node_modules/@tauri-apps/plugin-updater": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-updater/-/plugin-updater-2.10.1.tgz",
+      "integrity": "sha512-NFYMg+tWOZPJdzE/PpFj2qfqwAWwNS3kXrb1tm1gnBJ9mYzZ4WDRrwy8udzWoAnfGCHLuePNLY1WVCNHnh3eRA==",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@tauri-apps/api": "^2.10.1"
       }
     },
     "node_modules/@ts-morph/common": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@fontsource-variable/geist": "^5.2.9",
     "@tailwindcss/vite": "^4.3.1",
     "@tauri-apps/api": "^2",
+    "@tauri-apps/plugin-dialog": "^2.7.1",
     "@tauri-apps/plugin-opener": "^2",
     "@tauri-apps/plugin-process": "^2.3.1",
     "@tauri-apps/plugin-updater": "^2.10.1",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
     "@tailwindcss/vite": "^4.3.1",
     "@tauri-apps/api": "^2",
     "@tauri-apps/plugin-opener": "^2",
+    "@tauri-apps/plugin-process": "^2.3.1",
+    "@tauri-apps/plugin-updater": "^2.10.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^1.21.0",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -551,6 +551,7 @@ dependencies = [
  "sha2",
  "tauri",
  "tauri-build",
+ "tauri-plugin-dialog",
  "tauri-plugin-opener",
  "tauri-plugin-process",
  "tauri-plugin-updater",
@@ -3117,6 +3118,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfd"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a15ad77d9e70a92437d8f74c35d99b4e4691128df018833e99f90bcd36152672"
+dependencies = [
+ "block2",
+ "dispatch2",
+ "glib-sys",
+ "gobject-sys",
+ "gtk-sys",
+ "js-sys",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "raw-window-handle",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3999,6 +4024,48 @@ dependencies = [
  "serde_json",
  "tauri-utils",
  "walkdir",
+]
+
+[[package]]
+name = "tauri-plugin-dialog"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65981abb771e74e571a38196c3baa11c459379164791eba0e67abc1a5fac9884"
+dependencies = [
+ "log",
+ "raw-window-handle",
+ "rfd",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "tauri-plugin-fs",
+ "thiserror 2.0.18",
+ "url",
+]
+
+[[package]]
+name = "tauri-plugin-fs"
+version = "2.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7ecc274121aca0c036a2b42d1cbe83d368d348f54e0bb8a735c2b1548e8f371"
+dependencies = [
+ "anyhow",
+ "dunce",
+ "glob",
+ "log",
+ "objc2-foundation",
+ "percent-encoding",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "tauri",
+ "tauri-plugin",
+ "tauri-utils",
+ "thiserror 2.0.18",
+ "toml 1.1.2+spec-1.1.0",
+ "url",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -59,6 +59,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -543,6 +552,8 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-plugin-opener",
+ "tauri-plugin-process",
+ "tauri-plugin-updater",
  "toml 0.8.2",
  "ureq",
  "urlencoding",
@@ -760,6 +771,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1066,6 +1088,16 @@ checksum = "38e2275cc4e4fc009b0669731a1e5ab7ebf11f469eaede2bab9309a5b4d6057f"
 dependencies = [
  "memoffset",
  "rustc_version",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
 ]
 
 [[package]]
@@ -1631,6 +1663,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-util"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1909,6 +1956,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys 0.4.1",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "jni-sys"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2112,6 +2189,12 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "minisign-verify"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f9645cb765ea72b8111f36c522475d2daa0d22c957a9826437e97534bc4e9e"
 
 [[package]]
 name = "miniz_oxide"
@@ -2422,6 +2505,7 @@ checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.13.0",
  "block2",
+ "libc",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -2435,6 +2519,18 @@ dependencies = [
  "bitflags 2.13.0",
  "objc2",
  "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-osa-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f112d1746737b0da274ef79a23aac283376f335f4095a083a267a082f21db0c0"
+dependencies = [
+ "bitflags 2.13.0",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
 ]
 
 [[package]]
@@ -2513,6 +2609,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2526,6 +2628,20 @@ checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
 dependencies = [
  "futures-core",
  "pin-project-lite",
+]
+
+[[package]]
+name = "osakit"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "732c71caeaa72c065bb69d7ea08717bd3f4863a4f451402fc9513e29dbd5261b"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+ "objc2-osa-kit",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2975,15 +3091,20 @@ dependencies = [
  "http-body",
  "http-body-util",
  "hyper",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
  "percent-encoding",
  "pin-project-lite",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
  "sync_wrapper",
  "tokio",
+ "tokio-rustls",
  "tokio-util",
  "tower",
  "tower-http",
@@ -3053,6 +3174,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework 3.7.0",
+]
+
+[[package]]
 name = "rustls-pki-types"
 version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3060,6 +3193,33 @@ checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
  "zeroize",
 ]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni 0.22.4",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework 3.7.0",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
@@ -3085,6 +3245,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3431,6 +3600,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "siphasher"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3637,7 +3822,7 @@ dependencies = [
  "gdkwayland-sys",
  "gdkx11-sys",
  "gtk",
- "jni",
+ "jni 0.21.1",
  "libc",
  "log",
  "ndk",
@@ -3671,6 +3856,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tar"
+version = "0.4.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "target-lexicon"
 version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3693,7 +3889,7 @@ dependencies = [
  "gtk",
  "heck 0.5.0",
  "http",
- "jni",
+ "jni 0.21.1",
  "libc",
  "log",
  "mime",
@@ -3828,6 +4024,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-process"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d55511a7bf6cd70c8767b02c97bf8134fa434daf3926cfc1be0a0f94132d165a"
+dependencies = [
+ "tauri",
+ "tauri-plugin",
+]
+
+[[package]]
+name = "tauri-plugin-updater"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "806d9dac662c2e4594ff03c647a552f2c9bd544e7d0f683ec58f872f952ce4af"
+dependencies = [
+ "base64 0.22.1",
+ "dirs 6.0.0",
+ "flate2",
+ "futures-util",
+ "http",
+ "infer",
+ "log",
+ "minisign-verify",
+ "osakit",
+ "percent-encoding",
+ "reqwest",
+ "rustls",
+ "semver",
+ "serde",
+ "serde_json",
+ "tar",
+ "tauri",
+ "tauri-plugin",
+ "tempfile",
+ "thiserror 2.0.18",
+ "time",
+ "tokio",
+ "url",
+ "windows-sys 0.60.2",
+ "zip",
+]
+
+[[package]]
 name = "tauri-runtime"
 version = "2.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3837,7 +4076,7 @@ dependencies = [
  "dpi",
  "gtk",
  "http",
- "jni",
+ "jni 0.21.1",
  "objc2",
  "objc2-ui-kit",
  "objc2-web-kit",
@@ -3860,7 +4099,7 @@ checksum = "fe41e015bf8fc4d6477ff4926a0ef769dc64ff34c7b0038b6f7cacae892acb5c"
 dependencies = [
  "gtk",
  "http",
- "jni",
+ "jni 0.21.1",
  "log",
  "objc2",
  "objc2-app-kit",
@@ -4057,6 +4296,16 @@ dependencies = [
  "pin-project-lite",
  "socket2",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
 ]
 
 [[package]]
@@ -4649,6 +4898,15 @@ dependencies = [
  "pkg-config",
  "soup3-sys",
  "system-deps",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -5269,7 +5527,7 @@ dependencies = [
  "gtk",
  "http",
  "javascriptcore-rs",
- "jni",
+ "jni 0.21.1",
  "libc",
  "ndk",
  "objc2",
@@ -5314,6 +5572,16 @@ dependencies = [
  "libc",
  "once_cell",
  "pkg-config",
+]
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
 ]
 
 [[package]]
@@ -5558,6 +5826,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.118",
+]
+
+[[package]]
+name = "zip"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa8cd6af31c3b31c6631b8f483848b91589021b28fffe50adada48d4f4d2ed1"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "indexmap 2.14.0",
+ "memchr",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -21,6 +21,8 @@ tauri-build = { version = "2", features = [] }
 [dependencies]
 tauri = { version = "2", features = [] }
 tauri-plugin-opener = "2"
+tauri-plugin-updater = "2"
+tauri-plugin-process = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "0.8"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -23,6 +23,7 @@ tauri = { version = "2", features = [] }
 tauri-plugin-opener = "2"
 tauri-plugin-updater = "2"
 tauri-plugin-process = "2"
+tauri-plugin-dialog = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "0.8"

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -5,6 +5,8 @@
   "windows": ["main"],
   "permissions": [
     "core:default",
-    "opener:default"
+    "opener:default",
+    "updater:default",
+    "process:allow-restart"
   ]
 }

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -7,6 +7,8 @@
     "core:default",
     "opener:default",
     "updater:default",
-    "process:allow-restart"
+    "process:allow-restart",
+    "dialog:allow-save",
+    "dialog:allow-open"
   ]
 }

--- a/src-tauri/src/audit.rs
+++ b/src-tauri/src/audit.rs
@@ -140,11 +140,20 @@ fn aggregate(entries: &[Value]) -> Value {
     use std::collections::HashMap;
 
     #[derive(Default)]
+    struct ToolAgg {
+        calls: u64,
+        errors: u64,
+        durs: Vec<u64>,
+        last_ts: u64,
+    }
+
+    #[derive(Default)]
     struct Agg {
         calls: u64,
         errors: u64,
         durs: Vec<u64>,
         last_ts: u64,
+        tools: HashMap<String, ToolAgg>,
     }
 
     let mut by_server: HashMap<String, Agg> = HashMap::new();
@@ -153,6 +162,7 @@ fn aggregate(entries: &[Value]) -> Value {
 
     for e in entries {
         let server = e.get("server").and_then(|v| v.as_str()).unwrap_or("?");
+        let tool = e.get("tool").and_then(|v| v.as_str()).unwrap_or("?");
         let ok = e.get("ok").and_then(|v| v.as_bool()).unwrap_or(true);
         let ts = e.get("ts").and_then(|v| v.as_u64()).unwrap_or(0);
         let dur = e.get("durationMs").and_then(|v| v.as_u64());
@@ -170,12 +180,44 @@ fn aggregate(entries: &[Value]) -> Value {
             a.durs.push(d);
         }
         a.last_ts = a.last_ts.max(ts);
+
+        let t = a.tools.entry(tool.to_string()).or_default();
+        t.calls += 1;
+        if !ok {
+            t.errors += 1;
+        }
+        if let Some(d) = dur {
+            t.durs.push(d);
+        }
+        t.last_ts = t.last_ts.max(ts);
     }
 
     let mut servers: Vec<Value> = by_server
         .into_iter()
         .map(|(server, mut a)| {
             let (avg, p95) = latency(&mut a.durs);
+            // Per-tool breakdown, busiest tool first.
+            let mut tools: Vec<Value> = a
+                .tools
+                .into_iter()
+                .map(|(tool, mut t)| {
+                    let (tavg, tp95) = latency(&mut t.durs);
+                    json!({
+                        "tool": tool,
+                        "calls": t.calls,
+                        "errors": t.errors,
+                        "errorRate": if t.calls > 0 { t.errors as f64 / t.calls as f64 } else { 0.0 },
+                        "avgMs": tavg,
+                        "p95Ms": tp95,
+                        "lastTs": t.last_ts,
+                    })
+                })
+                .collect();
+            tools.sort_by(|x, y| {
+                y.get("calls")
+                    .and_then(|v| v.as_u64())
+                    .cmp(&x.get("calls").and_then(|v| v.as_u64()))
+            });
             json!({
                 "server": server,
                 "calls": a.calls,
@@ -184,6 +226,7 @@ fn aggregate(entries: &[Value]) -> Value {
                 "avgMs": avg,
                 "p95Ms": p95,
                 "lastTs": a.last_ts,
+                "tools": tools,
             })
         })
         .collect();
@@ -238,6 +281,24 @@ mod tests {
         assert_eq!(servers[0]["avgMs"], 20); // only the two durations: (10+30)/2
         assert_eq!(servers[1]["server"], "stripe");
         assert_eq!(servers[1]["calls"], 1);
+    }
+
+    #[test]
+    fn aggregate_breaks_down_by_tool() {
+        let entries = vec![
+            json!({"server":"github","tool":"search","ok":true,"ts":10,"durationMs":10}),
+            json!({"server":"github","tool":"search","ok":false,"ts":20,"durationMs":30}),
+            json!({"server":"github","tool":"create_issue","ok":true,"ts":15,"durationMs":50}),
+        ];
+        let s = aggregate(&entries);
+        let tools = s["servers"][0]["tools"].as_array().unwrap();
+        // Busiest tool first: search (2 calls) before create_issue (1).
+        assert_eq!(tools[0]["tool"], "search");
+        assert_eq!(tools[0]["calls"], 2);
+        assert_eq!(tools[0]["errors"], 1);
+        assert_eq!(tools[0]["avgMs"], 20); // (10+30)/2
+        assert_eq!(tools[1]["tool"], "create_issue");
+        assert_eq!(tools[1]["calls"], 1);
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -622,29 +622,6 @@ fn secret_status(server_id: String, keys: Vec<String>) -> Vec<(String, bool)> {
         .collect()
 }
 
-/// The latest published release tag on GitHub (e.g. "v0.3.1"), for an
-/// update-available hint. Network/parse failures are returned as Err and the UI
-/// simply shows no update info.
-#[tauri::command]
-async fn latest_release() -> Result<String, String> {
-    tauri::async_runtime::spawn_blocking(|| {
-        let body: serde_json::Value =
-            ureq::get("https://api.github.com/repos/tsouth89/conduit/releases/latest")
-                .set("User-Agent", "conduit-app")
-                .timeout(std::time::Duration::from_secs(10))
-                .call()
-                .map_err(|e| e.to_string())?
-                .into_json()
-                .map_err(|e| e.to_string())?;
-        body.get("tag_name")
-            .and_then(|t| t.as_str())
-            .map(str::to_string)
-            .ok_or_else(|| "no tag_name in response".to_string())
-    })
-    .await
-    .map_err(|e| e.to_string())?
-}
-
 /// Open Conduit's data directory (registry, logs, audit) in the OS file manager,
 /// so users can back it up or inspect it.
 #[tauri::command]
@@ -818,7 +795,6 @@ pub fn run() {
             search_catalog,
             promote_to_catalog,
             unpromote_from_catalog,
-            latest_release,
             open_data_dir,
             set_all_enabled,
             export_config,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -732,6 +732,8 @@ pub fn run() {
 
     tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
+        .plugin(tauri_plugin_updater::Builder::new().build())
+        .plugin(tauri_plugin_process::init())
         .manage(Mutex::new(registry))
         .invoke_handler(tauri::generate_handler![
             detect_clients,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -666,11 +666,34 @@ fn open_data_dir() -> Result<(), String> {
 
 /// Serialize the user's servers into a shareable setup (server definitions only,
 /// never secret values). A teammate imports this and adds their own keys, so a
-/// curated server set can be shared without leaking any credentials.
+/// curated server set can be shared without leaking any credentials. An optional
+/// name/description lets the sharer label the set.
 #[tauri::command]
-fn export_config(state: State<RegistryState>) -> Result<String, String> {
+fn export_config(
+    state: State<RegistryState>,
+    name: Option<String>,
+    description: Option<String>,
+) -> Result<String, String> {
     let reg = state.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
-    serde_json::to_string_pretty(&build_export(&reg)).map_err(|e| e.to_string())
+    serde_json::to_string_pretty(&build_export(&reg, name.as_deref(), description.as_deref()))
+        .map_err(|e| e.to_string())
+}
+
+/// Write a shareable setup to a file on disk (the path comes from a save dialog).
+/// Same content as export_config; just easier to hand to a teammate than a paste.
+#[tauri::command]
+fn export_config_to_path(
+    state: State<RegistryState>,
+    path: String,
+    name: Option<String>,
+    description: Option<String>,
+) -> Result<(), String> {
+    let json = {
+        let reg = state.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+        serde_json::to_string_pretty(&build_export(&reg, name.as_deref(), description.as_deref()))
+            .map_err(|e| e.to_string())?
+    };
+    std::fs::write(&path, json).map_err(|e| format!("Couldn't write the file: {e}"))
 }
 
 /// Import a shared setup. Adds servers not already present (by name); secret
@@ -683,10 +706,27 @@ fn import_config(state: State<RegistryState>, json: String) -> Result<Registry, 
     Ok(reg.clone())
 }
 
+/// Import a shared setup from a file on disk (the path comes from an open dialog).
+#[tauri::command]
+fn import_config_from_path(
+    state: State<RegistryState>,
+    path: String,
+) -> Result<Registry, String> {
+    let json = std::fs::read_to_string(&path).map_err(|e| format!("Couldn't read the file: {e}"))?;
+    let mut reg = state.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+    apply_import(&mut reg, &json)?;
+    registry::save(&reg)?;
+    Ok(reg.clone())
+}
+
 /// Build a shareable setup document: server definitions only, with the gateway
 /// entry excluded and every secret value stripped. Pure, so the never-leak-a-key
 /// invariant is testable without Tauri state.
-fn build_export(reg: &Registry) -> serde_json::Value {
+fn build_export(
+    reg: &Registry,
+    name: Option<&str>,
+    description: Option<&str>,
+) -> serde_json::Value {
     let servers: Vec<ServerEntry> = reg
         .servers
         .iter()
@@ -700,7 +740,14 @@ fn build_export(reg: &Registry) -> serde_json::Value {
             s
         })
         .collect();
-    serde_json::json!({ "kind": "conduit-setup", "version": 1, "servers": servers })
+    let mut doc = serde_json::json!({ "kind": "conduit-setup", "version": 1, "servers": servers });
+    if let Some(n) = name.map(str::trim).filter(|s| !s.is_empty()) {
+        doc["name"] = serde_json::json!(n);
+    }
+    if let Some(d) = description.map(str::trim).filter(|s| !s.is_empty()) {
+        doc["description"] = serde_json::json!(d);
+    }
+    doc
 }
 
 /// Merge a shared setup into the registry: add servers not already present (by
@@ -734,6 +781,7 @@ pub fn run() {
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(tauri_plugin_process::init())
+        .plugin(tauri_plugin_dialog::init())
         .manage(Mutex::new(registry))
         .invoke_handler(tauri::generate_handler![
             detect_clients,
@@ -774,7 +822,9 @@ pub fn run() {
             open_data_dir,
             set_all_enabled,
             export_config,
+            export_config_to_path,
             import_config,
+            import_config_from_path,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
@@ -819,7 +869,7 @@ mod tests {
             disabled_tools: vec![],
         });
 
-        let doc = build_export(&reg);
+        let doc = build_export(&reg, Some("Team setup"), Some("Our shared servers"));
         let serialized = serde_json::to_string(&doc).unwrap();
         // The secret value must never appear in a shared setup.
         assert!(!serialized.contains("sk-live-xyz"));
@@ -827,6 +877,9 @@ mod tests {
         // Gateway entry excluded.
         assert_eq!(servers.len(), 1);
         assert_eq!(servers[0]["env"][0]["value"], serde_json::Value::Null);
+        // Optional label is carried through.
+        assert_eq!(doc["name"], "Team setup");
+        assert_eq!(doc["description"], "Our shared servers");
     }
 
     #[test]

--- a/src-tauri/tauri.bundle.conf.json
+++ b/src-tauri/tauri.bundle.conf.json
@@ -4,6 +4,7 @@
     "beforeBuildCommand": "npm run build:bundle"
   },
   "bundle": {
+    "createUpdaterArtifacts": true,
     "externalBin": [
       "binaries/conduit-gateway"
     ]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -33,5 +33,13 @@
       "icons/icon.icns",
       "icons/icon.ico"
     ]
+  },
+  "plugins": {
+    "updater": {
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDk2OEVFNkEzQ0Q1MzYxNDkKUldSSllWUE5vK2FPbGhXMmttM1J6c3FYVUlrdHhCbHd0M2o5ek4rZXl6M01SdmZwRnU1cGRnL24K",
+      "endpoints": [
+        "https://github.com/tsouth89/conduit/releases/latest/download/latest.json"
+      ]
+    }
   }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -291,6 +291,7 @@ function App() {
           onSelectClient={selectClient}
           view={view}
           onSelectView={selectView}
+          onReplayOnboarding={() => setShowOnboarding(true)}
         />
 
         <main className="flex min-w-0 flex-1 flex-col">

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -29,6 +29,7 @@ import {
   type ServerEntry,
 } from "@/lib/types";
 import { AppSidebar } from "@/components/AppSidebar";
+import { Onboarding } from "@/components/Onboarding";
 import { RegistryServerCard } from "@/components/RegistryServerCard";
 import { ClientDetail } from "@/components/ClientDetail";
 import { ActivityView } from "@/components/ActivityView";
@@ -54,6 +55,10 @@ function App() {
   const [health, setHealth] = useState<Record<string, ProbeResult>>({});
   const [probing, setProbing] = useState(false);
   const [query, setQuery] = useState("");
+  const [onboarded, setOnboarded] = useState(
+    () => localStorage.getItem("conduit.onboarded") === "1",
+  );
+  const [showOnboarding, setShowOnboarding] = useState(false);
 
   const lastProbeRef = useRef(0);
   const probingRef = useRef(false);
@@ -169,6 +174,23 @@ function App() {
   const selectedClient = selectedClientId
     ? clients.find((c) => c.id === selectedClientId)
     : undefined;
+
+  // Show the first-run wizard once, only on a genuinely fresh setup: no servers
+  // and no client connected yet. Latched in its own state so a mid-flow connect
+  // (which flips gatewayInstalled) doesn't unmount the dialog. Existing users,
+  // and anyone who has dismissed it, never see it.
+  useEffect(() => {
+    if (onboarded || showOnboarding || loading || !registry) return;
+    const fresh =
+      servers.length === 0 && !clients.some((c) => c.gatewayInstalled);
+    if (fresh) setShowOnboarding(true);
+  }, [onboarded, showOnboarding, loading, registry, servers.length, clients]);
+
+  function finishOnboarding() {
+    localStorage.setItem("conduit.onboarded", "1");
+    setOnboarded(true);
+    setShowOnboarding(false);
+  }
 
   async function handleToggle(serverId: string, enabled: boolean) {
     if (!profileId) return;
@@ -424,6 +446,19 @@ function App() {
           </ScrollArea>
         </main>
       </div>
+      {showOnboarding && registry && (
+        <Onboarding
+          clients={clients}
+          registry={registry}
+          onRegistryChange={setRegistry}
+          onClientsRefresh={load}
+          onBrowseCatalog={() => {
+            finishOnboarding();
+            selectView("catalog");
+          }}
+          onFinish={finishOnboarding}
+        />
+      )}
       <Toaster position="bottom-right" />
     </TooltipProvider>
   );

--- a/src/components/ActivityView.tsx
+++ b/src/components/ActivityView.tsx
@@ -1,12 +1,82 @@
-import { useEffect, useState } from "react";
-import { CheckCircle2, ScrollText, XCircle } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+import { CheckCircle2, ChevronRight, ScrollText, XCircle } from "lucide-react";
 import { getAuditLog, getAuditStats } from "@/lib/api";
-import type { AuditEntry, AuditStats } from "@/lib/types";
+import type { AuditEntry, AuditStats, ServerStat } from "@/lib/types";
 
 /** Compact latency string: "180 ms" or "1.2 s", or a dash when unmeasured. */
 function fmtMs(ms: number | null): string {
   if (ms == null) return "—";
   return ms >= 1000 ? `${(ms / 1000).toFixed(1)} s` : `${ms} ms`;
+}
+
+function errCell(errors: number, errorRate: number) {
+  return errors > 0 ? `${(errorRate * 100).toFixed(0)}%` : "0";
+}
+
+/** One server row that expands to reveal its per-tool breakdown. */
+function ServerRow({ s }: { s: ServerStat }) {
+  const [open, setOpen] = useState(false);
+  const tools = s.tools ?? [];
+  const expandable = tools.length > 0;
+  return (
+    <>
+      <tr
+        className={`border-b last:border-0 ${expandable ? "cursor-pointer hover:bg-muted/30" : ""}`}
+        onClick={() => expandable && setOpen((o) => !o)}
+      >
+        <td className="px-3 py-2 font-medium">
+          <span className="flex items-center gap-1.5">
+            {expandable ? (
+              <ChevronRight
+                className={`size-3.5 text-muted-foreground transition-transform ${open ? "rotate-90" : ""}`}
+              />
+            ) : (
+              <span className="inline-block size-3.5" />
+            )}
+            {s.server}
+          </span>
+        </td>
+        <td className="px-3 py-2 text-right tabular-nums">{s.calls}</td>
+        <td
+          className={`px-3 py-2 text-right tabular-nums ${
+            s.errors > 0 ? "text-destructive" : "text-muted-foreground"
+          }`}
+        >
+          {errCell(s.errors, s.errorRate)}
+        </td>
+        <td className="px-3 py-2 text-right tabular-nums text-muted-foreground">
+          {fmtMs(s.avgMs)}
+        </td>
+        <td className="px-3 py-2 text-right tabular-nums text-muted-foreground">
+          {fmtMs(s.p95Ms)}
+        </td>
+      </tr>
+      {open &&
+        tools.map((t) => (
+          <tr key={t.tool} className="border-b border-border/40 bg-muted/20 last:border-0">
+            <td className="py-1.5 pr-3 pl-9 font-mono text-xs text-muted-foreground">
+              {t.tool}
+            </td>
+            <td className="px-3 py-1.5 text-right text-xs tabular-nums text-muted-foreground">
+              {t.calls}
+            </td>
+            <td
+              className={`px-3 py-1.5 text-right text-xs tabular-nums ${
+                t.errors > 0 ? "text-destructive" : "text-muted-foreground"
+              }`}
+            >
+              {errCell(t.errors, t.errorRate)}
+            </td>
+            <td className="px-3 py-1.5 text-right text-xs tabular-nums text-muted-foreground">
+              {fmtMs(t.avgMs)}
+            </td>
+            <td className="px-3 py-1.5 text-right text-xs tabular-nums text-muted-foreground">
+              {fmtMs(t.p95Ms)}
+            </td>
+          </tr>
+        ))}
+    </>
+  );
 }
 
 function StatsPanel({ stats }: { stats: AuditStats }) {
@@ -43,27 +113,14 @@ function StatsPanel({ stats }: { stats: AuditStats }) {
           </thead>
           <tbody>
             {stats.servers.map((s) => (
-              <tr key={s.server} className="border-b last:border-0">
-                <td className="px-3 py-2 font-medium">{s.server}</td>
-                <td className="px-3 py-2 text-right tabular-nums">{s.calls}</td>
-                <td
-                  className={`px-3 py-2 text-right tabular-nums ${
-                    s.errors > 0 ? "text-destructive" : "text-muted-foreground"
-                  }`}
-                >
-                  {s.errors > 0 ? `${(s.errorRate * 100).toFixed(0)}%` : "0"}
-                </td>
-                <td className="px-3 py-2 text-right tabular-nums text-muted-foreground">
-                  {fmtMs(s.avgMs)}
-                </td>
-                <td className="px-3 py-2 text-right tabular-nums text-muted-foreground">
-                  {fmtMs(s.p95Ms)}
-                </td>
-              </tr>
+              <ServerRow key={s.server} s={s} />
             ))}
           </tbody>
         </table>
       </div>
+      <p className="text-xs text-muted-foreground/70">
+        Click a server to see its per-tool breakdown.
+      </p>
     </div>
   );
 }
@@ -71,6 +128,8 @@ function StatsPanel({ stats }: { stats: AuditStats }) {
 export function ActivityView({ refreshKey }: { refreshKey: number }) {
   const [entries, setEntries] = useState<AuditEntry[] | null>(null);
   const [stats, setStats] = useState<AuditStats | null>(null);
+  const [serverFilter, setServerFilter] = useState<string>("");
+  const [errorsOnly, setErrorsOnly] = useState(false);
 
   useEffect(() => {
     let alive = true;
@@ -84,6 +143,16 @@ export function ActivityView({ refreshKey }: { refreshKey: number }) {
       alive = false;
     };
   }, [refreshKey]);
+
+  const servers = useMemo(
+    () => [...new Set((entries ?? []).map((e) => e.server))].sort(),
+    [entries],
+  );
+
+  const visible = (entries ?? []).filter(
+    (e) =>
+      (!serverFilter || e.server === serverFilter) && (!errorsOnly || !e.ok),
+  );
 
   if (entries === null) {
     return (
@@ -111,24 +180,59 @@ export function ActivityView({ refreshKey }: { refreshKey: number }) {
   return (
     <div>
       {stats && <StatsPanel stats={stats} />}
-      <div className="flex flex-col gap-1">
-      {(entries ?? []).map((e, i) => (
-        <div
-          key={i}
-          className="flex items-center gap-3 rounded-md border border-border/50 px-3 py-2 text-sm"
+
+      <div className="mb-2 flex items-center gap-2">
+        <select
+          value={serverFilter}
+          onChange={(e) => setServerFilter(e.target.value)}
+          className="h-8 rounded-md border bg-background px-2 text-sm"
         >
-          {e.ok ? (
-            <CheckCircle2 className="size-4 shrink-0 text-emerald-400" />
-          ) : (
-            <XCircle className="size-4 shrink-0 text-destructive" />
-          )}
-          <span className="font-medium">{e.server}</span>
-          <span className="font-mono text-xs text-muted-foreground">{e.tool}</span>
-          <span className="ml-auto shrink-0 text-xs text-muted-foreground">
-            {new Date(e.ts).toLocaleString()}
-          </span>
-        </div>
-      ))}
+          <option value="">All servers</option>
+          {servers.map((s) => (
+            <option key={s} value={s}>
+              {s}
+            </option>
+          ))}
+        </select>
+        <button
+          onClick={() => setErrorsOnly((v) => !v)}
+          className={`h-8 rounded-md border px-2.5 text-sm transition-colors ${
+            errorsOnly
+              ? "border-destructive/50 bg-destructive/10 text-destructive"
+              : "text-muted-foreground hover:bg-accent"
+          }`}
+        >
+          Errors only
+        </button>
+        <span className="ml-auto text-xs text-muted-foreground">
+          {visible.length} of {entries.length}
+        </span>
+      </div>
+
+      <div className="flex flex-col gap-1">
+        {visible.length === 0 ? (
+          <p className="py-12 text-center text-sm text-muted-foreground">
+            No calls match this filter.
+          </p>
+        ) : (
+          visible.map((e, i) => (
+            <div
+              key={i}
+              className="flex items-center gap-3 rounded-md border border-border/50 px-3 py-2 text-sm"
+            >
+              {e.ok ? (
+                <CheckCircle2 className="size-4 shrink-0 text-emerald-400" />
+              ) : (
+                <XCircle className="size-4 shrink-0 text-destructive" />
+              )}
+              <span className="font-medium">{e.server}</span>
+              <span className="font-mono text-xs text-muted-foreground">{e.tool}</span>
+              <span className="ml-auto shrink-0 text-xs text-muted-foreground">
+                {new Date(e.ts).toLocaleString()}
+              </span>
+            </div>
+          ))
+        )}
       </div>
     </div>
   );

--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import {
   ArrowUpCircle,
+  Compass,
   FlaskConical,
   FolderOpen,
   Layers,
@@ -30,7 +31,13 @@ import { ShareDialog } from "@/components/ShareDialog";
  * release is published. The check is best-effort: any failure (dev build,
  * offline, no manifest yet) just shows the current version. Clicking downloads,
  * installs, and relaunches into the new version. */
-function VersionFooter({ onImport }: { onImport: (r: Registry) => void }) {
+function VersionFooter({
+  onImport,
+  onReplay,
+}: {
+  onImport: (r: Registry) => void;
+  onReplay: () => void;
+}) {
   const [version, setVersion] = useState("");
   const [update, setUpdate] = useState<Update | null>(null);
   const [installing, setInstalling] = useState(false);
@@ -103,6 +110,14 @@ function VersionFooter({ onImport }: { onImport: (r: Registry) => void }) {
             </button>
           }
         />
+        <button
+          onClick={onReplay}
+          title="Run setup again"
+          aria-label="Run setup again"
+          className="text-muted-foreground transition hover:text-foreground"
+        >
+          <Compass className="size-3.5" />
+        </button>
         <button
           onClick={() => openDataDir().catch(() => {})}
           title="Open data folder (config, logs)"
@@ -227,6 +242,7 @@ interface Props {
   onSelectClient: (id: string | null) => void;
   view: "servers" | "activity" | "catalog" | "playground";
   onSelectView: (view: "servers" | "activity" | "catalog" | "playground") => void;
+  onReplayOnboarding: () => void;
 }
 
 export function AppSidebar({
@@ -237,6 +253,7 @@ export function AppSidebar({
   onSelectClient,
   view,
   onSelectView,
+  onReplayOnboarding,
 }: Props) {
   return (
     <aside className="flex w-72 shrink-0 flex-col border-r bg-sidebar">
@@ -327,7 +344,7 @@ export function AppSidebar({
         </nav>
       </div>
 
-      <VersionFooter onImport={onRegistryChange} />
+      <VersionFooter onImport={onRegistryChange} onReplay={onReplayOnboarding} />
     </aside>
   );
 }

--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -23,6 +23,13 @@ import {
 } from "@/lib/types";
 import { openDataDir } from "@/lib/api";
 import { checkForUpdate, installUpdate } from "@/lib/updater";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { ProfileBar } from "@/components/ProfileBar";
 import { ShareDialog } from "@/components/ShareDialog";
@@ -41,6 +48,8 @@ function VersionFooter({
   const [version, setVersion] = useState("");
   const [update, setUpdate] = useState<Update | null>(null);
   const [installing, setInstalling] = useState(false);
+  const [checking, setChecking] = useState(false);
+  const [showNotes, setShowNotes] = useState(false);
 
   useEffect(() => {
     let alive = true;
@@ -54,6 +63,22 @@ function VersionFooter({
       alive = false;
     };
   }, []);
+
+  async function manualCheck() {
+    if (checking || installing) return;
+    setChecking(true);
+    try {
+      const u = await checkForUpdate();
+      if (u?.available) {
+        setUpdate(u);
+        setShowNotes(true);
+      } else {
+        toast.success("You're on the latest version");
+      }
+    } finally {
+      setChecking(false);
+    }
+  }
 
   async function applyUpdate() {
     if (!update) return;
@@ -81,7 +106,7 @@ function VersionFooter({
     <div className="mt-auto flex items-center justify-between gap-2 border-t px-4 py-3 text-xs">
       {update ? (
         <button
-          onClick={applyUpdate}
+          onClick={() => setShowNotes(true)}
           disabled={installing}
           className="flex min-w-0 items-center gap-1.5 text-emerald-400 transition hover:underline disabled:opacity-70"
         >
@@ -95,8 +120,23 @@ function VersionFooter({
           </span>
         </button>
       ) : (
-        <span className="text-muted-foreground">Conduit v{version}</span>
+        <button
+          onClick={manualCheck}
+          disabled={checking}
+          title="Check for updates"
+          className="text-muted-foreground transition hover:text-foreground disabled:opacity-70"
+        >
+          {checking ? "Checking…" : `Conduit v${version}`}
+        </button>
       )}
+
+      <UpdateNotes
+        open={showNotes}
+        onOpenChange={setShowNotes}
+        update={update}
+        installing={installing}
+        onInstall={applyUpdate}
+      />
       <div className="flex shrink-0 items-center gap-2">
         <ShareDialog
           onImported={onImport}
@@ -128,6 +168,64 @@ function VersionFooter({
         </button>
       </div>
     </div>
+  );
+}
+
+/** Release-notes dialog shown before installing an update, so the user sees
+ * what's changing and confirms the restart. */
+function UpdateNotes({
+  open,
+  onOpenChange,
+  update,
+  installing,
+  onInstall,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  update: Update | null;
+  installing: boolean;
+  onInstall: () => void;
+}) {
+  if (!update) return null;
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Update available: v{update.version}</DialogTitle>
+        </DialogHeader>
+        <div className="flex flex-col gap-3">
+          {update.body ? (
+            <div className="max-h-60 overflow-y-auto rounded-md border bg-muted/30 p-3 text-sm whitespace-pre-wrap text-muted-foreground">
+              {update.body}
+            </div>
+          ) : (
+            <p className="text-sm text-muted-foreground">
+              A new version is ready to install.
+            </p>
+          )}
+          <div className="flex justify-end gap-2">
+            <Button
+              variant="ghost"
+              onClick={() => onOpenChange(false)}
+              disabled={installing}
+            >
+              Later
+            </Button>
+            <Button onClick={onInstall} disabled={installing}>
+              {installing ? (
+                <>
+                  <Loader2 className="size-4 animate-spin" /> Installing…
+                </>
+              ) : (
+                <>
+                  <ArrowUpCircle className="size-4" /> Install and restart
+                </>
+              )}
+            </Button>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
   );
 }
 

--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -5,6 +5,7 @@ import {
   FolderOpen,
   Layers,
   Link2,
+  Loader2,
   Puzzle,
   ScrollText,
   Share2,
@@ -12,62 +13,79 @@ import {
 } from "lucide-react";
 import { getVersion } from "@tauri-apps/api/app";
 import { openUrl } from "@tauri-apps/plugin-opener";
+import { toast } from "sonner";
+import type { Update } from "@tauri-apps/plugin-updater";
 import {
   importableServers,
   type DetectedClient,
   type Registry,
 } from "@/lib/types";
-import { latestRelease, openDataDir } from "@/lib/api";
+import { openDataDir } from "@/lib/api";
+import { checkForUpdate, installUpdate } from "@/lib/updater";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { ProfileBar } from "@/components/ProfileBar";
 import { ShareDialog } from "@/components/ShareDialog";
 
-/** True if `latest` is a higher semver than `current` (tolerates a leading "v"). */
-function isNewer(latest: string, current: string): boolean {
-  const parse = (v: string) =>
-    v.replace(/^v/, "").split(".").map((n) => parseInt(n, 10) || 0);
-  const a = parse(latest);
-  const b = parse(current);
-  for (let i = 0; i < 3; i++) {
-    if ((a[i] ?? 0) !== (b[i] ?? 0)) return (a[i] ?? 0) > (b[i] ?? 0);
-  }
-  return false;
-}
-
-/** Footer showing the running version, and an update link when a newer release
- * exists. The update check is best-effort: any failure just shows the version. */
+/** Footer showing the running version, and an in-app update button when a newer
+ * release is published. The check is best-effort: any failure (dev build,
+ * offline, no manifest yet) just shows the current version. Clicking downloads,
+ * installs, and relaunches into the new version. */
 function VersionFooter({ onImport }: { onImport: (r: Registry) => void }) {
   const [version, setVersion] = useState("");
-  const [update, setUpdate] = useState<string | null>(null);
+  const [update, setUpdate] = useState<Update | null>(null);
+  const [installing, setInstalling] = useState(false);
 
   useEffect(() => {
     let alive = true;
     getVersion().then((v) => {
-      if (!alive) return;
-      setVersion(v);
-      latestRelease()
-        .then((tag) => {
-          if (alive && isNewer(tag, v)) setUpdate(tag);
-        })
-        .catch(() => {});
+      if (alive) setVersion(v);
+    });
+    checkForUpdate().then((u) => {
+      if (alive && u?.available) setUpdate(u);
     });
     return () => {
       alive = false;
     };
   }, []);
 
+  async function applyUpdate() {
+    if (!update) return;
+    setInstalling(true);
+    toast.info(`Updating to v${update.version}…`, {
+      description: "Conduit will restart when it's done.",
+    });
+    try {
+      await installUpdate(update);
+    } catch (e) {
+      setInstalling(false);
+      toast.error(`Update failed: ${e}`, {
+        description: "You can download it manually from the releases page.",
+        action: {
+          label: "Open",
+          onClick: () =>
+            openUrl("https://github.com/tsouth89/conduit/releases/latest"),
+        },
+      });
+    }
+  }
+
   if (!version) return null;
   return (
     <div className="mt-auto flex items-center justify-between gap-2 border-t px-4 py-3 text-xs">
       {update ? (
         <button
-          onClick={() =>
-            openUrl("https://github.com/tsouth89/conduit/releases/latest")
-          }
-          className="flex min-w-0 items-center gap-1.5 text-emerald-400 transition hover:underline"
+          onClick={applyUpdate}
+          disabled={installing}
+          className="flex min-w-0 items-center gap-1.5 text-emerald-400 transition hover:underline disabled:opacity-70"
         >
-          <ArrowUpCircle className="size-3.5 shrink-0" />
-          <span className="truncate">Update available ({update})</span>
+          {installing ? (
+            <Loader2 className="size-3.5 shrink-0 animate-spin" />
+          ) : (
+            <ArrowUpCircle className="size-3.5 shrink-0" />
+          )}
+          <span className="truncate">
+            {installing ? "Updating…" : `Update to v${update.version}`}
+          </span>
         </button>
       ) : (
         <span className="text-muted-foreground">Conduit v{version}</span>

--- a/src/components/Onboarding.tsx
+++ b/src/components/Onboarding.tsx
@@ -1,17 +1,24 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import {
   ArrowRight,
   Check,
   Download,
   Link2,
   Loader2,
+  Plus,
   Store,
   Waypoints,
 } from "lucide-react";
 import { toast } from "sonner";
-import { importServers, installGateway } from "@/lib/api";
+import {
+  addCatalogServer,
+  importServers,
+  installGateway,
+  popularCatalog,
+} from "@/lib/api";
 import {
   importableServers,
+  type CatalogEntry,
   type DetectedClient,
   type Registry,
 } from "@/lib/types";
@@ -161,6 +168,27 @@ function AddServers({
 }) {
   const [busy, setBusy] = useState(false);
   const [imported, setImported] = useState<number | null>(null);
+  const [starters, setStarters] = useState<CatalogEntry[]>([]);
+  const [adding, setAdding] = useState<string | null>(null);
+  const [added, setAdded] = useState<Set<string>>(new Set());
+
+  // A few popular servers for a one-click start, zero-config (no keys) first so
+  // the user gets something that works immediately.
+  useEffect(() => {
+    let alive = true;
+    popularCatalog()
+      .then((all) => {
+        if (!alive) return;
+        const sorted = [...all].sort(
+          (a, b) => a.envKeys.length - b.envKeys.length,
+        );
+        setStarters(sorted.slice(0, 4));
+      })
+      .catch(() => {});
+    return () => {
+      alive = false;
+    };
+  }, []);
 
   async function doImport() {
     setBusy(true);
@@ -173,6 +201,19 @@ function AddServers({
       toast.error(`Import failed: ${e}`);
     } finally {
       setBusy(false);
+    }
+  }
+
+  async function addStarter(entry: CatalogEntry) {
+    setAdding(entry.name);
+    try {
+      onImport(await addCatalogServer(entry));
+      setAdded((prev) => new Set(prev).add(entry.name));
+      toast.success(`Added ${entry.name}`);
+    } catch (e) {
+      toast.error(`Couldn't add ${entry.name}: ${e}`);
+    } finally {
+      setAdding(null);
     }
   }
 
@@ -201,6 +242,42 @@ function AddServers({
             {imported === 1 ? "" : "s"}.
           </div>
         )}
+
+        {starters.length > 0 && (
+          <div className="flex flex-col gap-1.5">
+            <span className="text-xs text-muted-foreground">
+              Or add a popular one:
+            </span>
+            <div className="flex flex-wrap gap-1.5">
+              {starters.map((s) => {
+                const isAdded = added.has(s.name);
+                return (
+                  <button
+                    key={s.name}
+                    onClick={() => !isAdded && addStarter(s)}
+                    disabled={adding === s.name || isAdded}
+                    title={s.description}
+                    className={`flex items-center gap-1 rounded-full border px-2.5 py-1 text-xs transition-colors ${
+                      isAdded
+                        ? "border-emerald-400/40 text-emerald-400"
+                        : "hover:bg-accent disabled:opacity-60"
+                    }`}
+                  >
+                    {adding === s.name ? (
+                      <Loader2 className="size-3 animate-spin" />
+                    ) : isAdded ? (
+                      <Check className="size-3" />
+                    ) : (
+                      <Plus className="size-3" />
+                    )}
+                    {s.name}
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+        )}
+
         <Button variant="outline" onClick={onBrowseCatalog}>
           <Store className="size-4" />
           Browse the catalog
@@ -208,7 +285,7 @@ function AddServers({
       </div>
 
       <Button variant="ghost" onClick={onNext} className="self-start">
-        {imported !== null ? "Next" : "I'll add servers later"}
+        {imported !== null || added.size > 0 ? "Next" : "I'll add servers later"}
         <ArrowRight className="size-4" />
       </Button>
     </>

--- a/src/components/Onboarding.tsx
+++ b/src/components/Onboarding.tsx
@@ -1,0 +1,321 @@
+import { useState } from "react";
+import {
+  ArrowRight,
+  Check,
+  Download,
+  Link2,
+  Loader2,
+  Store,
+  Waypoints,
+} from "lucide-react";
+import { toast } from "sonner";
+import { importServers, installGateway } from "@/lib/api";
+import {
+  importableServers,
+  type DetectedClient,
+  type Registry,
+} from "@/lib/types";
+import { Button } from "@/components/ui/button";
+import { Dialog, DialogContent } from "@/components/ui/dialog";
+
+interface Props {
+  clients: DetectedClient[];
+  registry: Registry;
+  onRegistryChange: (registry: Registry) => void;
+  /** Re-detect clients after a connect, so their status reflects reality. */
+  onClientsRefresh: () => void;
+  /** Leave the wizard and open the catalog. */
+  onBrowseCatalog: () => void;
+  /** Mark onboarding complete (skipped or finished) and close. */
+  onFinish: () => void;
+}
+
+/** First-run wizard. Shown only on a genuinely fresh setup (no servers, no
+ * client connected) and skippable at every step. It drives the existing
+ * import / connect / catalog flows so a new user reaches "my tools share these
+ * servers" without hunting through the UI. */
+export function Onboarding({
+  clients,
+  registry,
+  onRegistryChange,
+  onClientsRefresh,
+  onBrowseCatalog,
+  onFinish,
+}: Props) {
+  const [step, setStep] = useState(0);
+
+  const present = clients.filter((c) => c.appPresent);
+  const importable = new Set(
+    clients.flatMap((c) =>
+      importableServers(c, registry).map((s) => s.name.toLowerCase()),
+    ),
+  ).size;
+
+  const steps = [
+    <Welcome key="welcome" present={present} onNext={() => setStep(1)} />,
+    <AddServers
+      key="add"
+      importable={importable}
+      onImport={onRegistryChange}
+      onBrowseCatalog={onBrowseCatalog}
+      onNext={() => setStep(2)}
+    />,
+    <ConnectClients
+      key="connect"
+      present={present}
+      onConnected={onClientsRefresh}
+      onNext={() => setStep(3)}
+    />,
+    <Done key="done" onFinish={onFinish} />,
+  ];
+
+  return (
+    <Dialog open onOpenChange={(o) => !o && onFinish()}>
+      <DialogContent className="gap-0 sm:max-w-md" showCloseButton={false}>
+        <div className="flex flex-col gap-5 py-1">
+          {steps[step]}
+
+          <div className="flex items-center justify-between border-t pt-4">
+            <div className="flex items-center gap-1.5">
+              {steps.map((_, i) => (
+                <span
+                  key={i}
+                  className={`size-1.5 rounded-full transition-colors ${
+                    i === step ? "bg-emerald-400" : "bg-muted-foreground/30"
+                  }`}
+                />
+              ))}
+            </div>
+            {step < steps.length - 1 && (
+              <button
+                onClick={onFinish}
+                className="text-xs text-muted-foreground transition hover:text-foreground"
+              >
+                Skip setup
+              </button>
+            )}
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function StepHeader({
+  icon,
+  title,
+  children,
+}: {
+  icon: React.ReactNode;
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex size-10 items-center justify-center rounded-xl bg-emerald-400/10 text-emerald-400">
+        {icon}
+      </div>
+      <h2 className="text-lg font-semibold tracking-tight">{title}</h2>
+      <p className="text-sm text-muted-foreground">{children}</p>
+    </div>
+  );
+}
+
+function Welcome({
+  present,
+  onNext,
+}: {
+  present: DetectedClient[];
+  onNext: () => void;
+}) {
+  const names = present.map((c) => c.name);
+  const found =
+    names.length === 0
+      ? "We didn't detect any MCP clients yet. You can still add servers now, then connect a client once it's installed."
+      : `We found ${listJoin(names)} on your machine. Conduit will sit between your tools and your servers, so you set each one up once.`;
+  return (
+    <>
+      <StepHeader icon={<Waypoints className="size-5" />} title="Welcome to Conduit">
+        One local gateway for all your MCP servers, shared by every AI tool.
+        {" "}
+        {found}
+      </StepHeader>
+      <Button onClick={onNext} className="self-start">
+        Get started
+        <ArrowRight className="size-4" />
+      </Button>
+    </>
+  );
+}
+
+function AddServers({
+  importable,
+  onImport,
+  onBrowseCatalog,
+  onNext,
+}: {
+  importable: number;
+  onImport: (r: Registry) => void;
+  onBrowseCatalog: () => void;
+  onNext: () => void;
+}) {
+  const [busy, setBusy] = useState(false);
+  const [imported, setImported] = useState<number | null>(null);
+
+  async function doImport() {
+    setBusy(true);
+    try {
+      const next = await importServers();
+      onImport(next);
+      setImported(next.servers.length);
+      toast.success("Imported servers from your clients");
+    } catch (e) {
+      toast.error(`Import failed: ${e}`);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <>
+      <StepHeader icon={<Download className="size-5" />} title="Add your first servers">
+        Pull in the servers you've already set up in other tools, or browse the
+        catalog to add new ones.
+      </StepHeader>
+
+      <div className="flex flex-col gap-2">
+        {importable > 0 && imported === null && (
+          <Button onClick={doImport} disabled={busy}>
+            {busy ? (
+              <Loader2 className="size-4 animate-spin" />
+            ) : (
+              <Download className="size-4" />
+            )}
+            Import {importable} from your clients
+          </Button>
+        )}
+        {imported !== null && (
+          <div className="flex items-center gap-2 rounded-md bg-emerald-400/10 px-3 py-2 text-sm text-emerald-400">
+            <Check className="size-4" />
+            Imported. Conduit now manages {imported} server
+            {imported === 1 ? "" : "s"}.
+          </div>
+        )}
+        <Button variant="outline" onClick={onBrowseCatalog}>
+          <Store className="size-4" />
+          Browse the catalog
+        </Button>
+      </div>
+
+      <Button variant="ghost" onClick={onNext} className="self-start">
+        {imported !== null ? "Next" : "I'll add servers later"}
+        <ArrowRight className="size-4" />
+      </Button>
+    </>
+  );
+}
+
+function ConnectClients({
+  present,
+  onConnected,
+  onNext,
+}: {
+  present: DetectedClient[];
+  onConnected: () => void;
+  onNext: () => void;
+}) {
+  const [busyId, setBusyId] = useState<string | null>(null);
+  const [done, setDone] = useState<Set<string>>(new Set());
+
+  async function connect(client: DetectedClient) {
+    setBusyId(client.id);
+    try {
+      await installGateway(client.id);
+      setDone((prev) => new Set(prev).add(client.id));
+      onConnected();
+      toast.success(`Connected Conduit to ${client.name}`);
+    } catch (e) {
+      toast.error(`Couldn't connect: ${e}`);
+    } finally {
+      setBusyId(null);
+    }
+  }
+
+  return (
+    <>
+      <StepHeader icon={<Link2 className="size-5" />} title="Connect a client">
+        Point a tool at Conduit. It connects once, then sees every server you
+        enable here, no per-tool setup.
+      </StepHeader>
+
+      {present.length === 0 ? (
+        <p className="rounded-md bg-muted/50 px-3 py-2 text-sm text-muted-foreground">
+          No clients detected yet. Install Claude Desktop, Cursor, VS Code, or
+          another supported tool, then connect it from the sidebar.
+        </p>
+      ) : (
+        <div className="flex flex-col gap-2">
+          {present.map((client) => {
+            const connected = done.has(client.id) || client.gatewayInstalled;
+            return (
+              <div
+                key={client.id}
+                className="flex items-center justify-between gap-2 rounded-md border px-3 py-2"
+              >
+                <span className="truncate text-sm">{client.name}</span>
+                {connected ? (
+                  <span className="flex shrink-0 items-center gap-1.5 text-xs text-emerald-400">
+                    <Check className="size-3.5" />
+                    Connected
+                  </span>
+                ) : (
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    className="h-7 shrink-0 px-2 text-xs"
+                    onClick={() => connect(client)}
+                    disabled={busyId === client.id}
+                  >
+                    {busyId === client.id ? (
+                      <Loader2 className="size-3.5 animate-spin" />
+                    ) : (
+                      <Link2 className="size-3.5" />
+                    )}
+                    Connect
+                  </Button>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      <Button onClick={onNext} className="self-start">
+        {done.size > 0 ? "Next" : "Skip for now"}
+        <ArrowRight className="size-4" />
+      </Button>
+    </>
+  );
+}
+
+function Done({ onFinish }: { onFinish: () => void }) {
+  return (
+    <>
+      <StepHeader icon={<Check className="size-5" />} title="You're set up">
+        Manage your servers here and they stay in sync across every connected
+        tool. Toggle one on or off and your clients update live, no restart.
+      </StepHeader>
+      <Button onClick={onFinish} className="self-start">
+        Start using Conduit
+        <ArrowRight className="size-4" />
+      </Button>
+    </>
+  );
+}
+
+/** "Claude", "Claude and Cursor", "Claude, Cursor, and VS Code". */
+function listJoin(items: string[]): string {
+  if (items.length <= 1) return items[0] ?? "";
+  if (items.length === 2) return `${items[0]} and ${items[1]}`;
+  return `${items.slice(0, -1).join(", ")}, and ${items[items.length - 1]}`;
+}

--- a/src/components/ShareDialog.tsx
+++ b/src/components/ShareDialog.tsx
@@ -1,7 +1,13 @@
-import { useState, type ReactNode } from "react";
-import { Check, Copy, Upload } from "lucide-react";
+import { useEffect, useState, type ReactNode } from "react";
+import { Check, Copy, FileDown, FileUp, Upload } from "lucide-react";
 import { toast } from "sonner";
-import { exportConfig, importConfig } from "@/lib/api";
+import { open, save } from "@tauri-apps/plugin-dialog";
+import {
+  exportConfig,
+  exportConfigToPath,
+  importConfig,
+  importConfigFromPath,
+} from "@/lib/api";
 import type { Registry } from "@/lib/types";
 import { Button } from "@/components/ui/button";
 import {
@@ -11,6 +17,7 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 
 interface Props {
@@ -20,22 +27,31 @@ interface Props {
 
 /** Share a curated server set with a teammate (and import theirs). Secret values
  * are never included - each person vaults their own keys after importing. This is
- * the no-backend version of "push a setup to your team". */
+ * the no-backend version of "push a setup to your team". Export via clipboard or
+ * a file; label it with a name + description so the recipient knows what it is. */
 export function ShareDialog({ trigger, onImported }: Props) {
-  const [open, setOpen] = useState(false);
+  const [open_, setOpen] = useState(false);
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
   const [exported, setExported] = useState("");
   const [paste, setPaste] = useState("");
   const [copied, setCopied] = useState(false);
   const [busy, setBusy] = useState(false);
+
+  // Re-serialize whenever the dialog opens or the label changes, so the textarea
+  // and any file/clipboard export carry the current name + description.
+  useEffect(() => {
+    if (!open_) return;
+    exportConfig(name, description)
+      .then(setExported)
+      .catch(() => setExported(""));
+  }, [open_, name, description]);
 
   function onOpenChange(next: boolean) {
     setOpen(next);
     if (next) {
       setPaste("");
       setCopied(false);
-      exportConfig()
-        .then(setExported)
-        .catch(() => setExported(""));
     }
   }
 
@@ -46,6 +62,44 @@ export function ShareDialog({ trigger, onImported }: Props) {
       setTimeout(() => setCopied(false), 1500);
     } catch {
       toast.error("Couldn't copy automatically - select the text and copy it.");
+    }
+  }
+
+  async function saveToFile() {
+    try {
+      const path = await save({
+        title: "Save Conduit setup",
+        defaultPath: `${slug(name) || "conduit-setup"}.json`,
+        filters: [{ name: "Conduit setup", extensions: ["json"] }],
+      });
+      if (!path) return;
+      await exportConfigToPath(path, name, description);
+      toast.success("Saved setup to file");
+    } catch (e) {
+      toast.error(`Couldn't save: ${e}`);
+    }
+  }
+
+  async function loadFromFile() {
+    try {
+      const path = await open({
+        title: "Open a Conduit setup",
+        multiple: false,
+        directory: false,
+        filters: [{ name: "Conduit setup", extensions: ["json"] }],
+      });
+      if (!path || typeof path !== "string") return;
+      setBusy(true);
+      const reg = await importConfigFromPath(path);
+      onImported(reg);
+      toast.success("Imported shared setup", {
+        description: "Add any API keys each server needs, then enable them.",
+      });
+      setOpen(false);
+    } catch (e) {
+      toast.error(`Couldn't import: ${e}`);
+    } finally {
+      setBusy(false);
     }
   }
 
@@ -70,7 +124,7 @@ export function ShareDialog({ trigger, onImported }: Props) {
     "w-full rounded-md border bg-background p-2.5 font-mono text-xs resize-none focus:outline-none focus:ring-1 focus:ring-ring";
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
+    <Dialog open={open_} onOpenChange={onOpenChange}>
       <DialogTrigger asChild>{trigger}</DialogTrigger>
       <DialogContent className="sm:max-w-lg">
         <DialogHeader>
@@ -79,12 +133,31 @@ export function ShareDialog({ trigger, onImported }: Props) {
 
         <div className="flex flex-col gap-5 py-1">
           <div className="flex flex-col gap-2">
-            <div className="flex items-center justify-between gap-2">
-              <Label className="text-sm">Your setup</Label>
+            <Label className="text-sm">Your setup</Label>
+            <p className="text-xs text-muted-foreground">
+              Send this to a teammate to share your server set. Secrets are never
+              included - each person adds their own keys after importing.
+            </p>
+            <div className="grid grid-cols-2 gap-2">
+              <Input
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                placeholder="Name (optional)"
+                className="h-8 text-sm"
+              />
+              <Input
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+                placeholder="Description (optional)"
+                className="h-8 text-sm"
+              />
+            </div>
+            <textarea readOnly value={exported} rows={5} className={area} />
+            <div className="flex flex-wrap gap-2">
               <Button
                 size="sm"
                 variant="outline"
-                className="h-7 px-2 text-xs"
+                className="h-8"
                 onClick={copy}
                 disabled={!exported}
               >
@@ -98,12 +171,16 @@ export function ShareDialog({ trigger, onImported }: Props) {
                   </>
                 )}
               </Button>
+              <Button
+                size="sm"
+                variant="outline"
+                className="h-8"
+                onClick={saveToFile}
+                disabled={!exported}
+              >
+                <FileDown className="size-3.5" /> Save to file
+              </Button>
             </div>
-            <p className="text-xs text-muted-foreground">
-              Send this to a teammate to share your server set. Secrets are never
-              included - each person adds their own keys after importing.
-            </p>
-            <textarea readOnly value={exported} rows={6} className={area} />
           </div>
 
           <div className="flex flex-col gap-2 border-t pt-4">
@@ -112,20 +189,31 @@ export function ShareDialog({ trigger, onImported }: Props) {
               placeholder="Paste a shared setup here"
               value={paste}
               onChange={(e) => setPaste(e.target.value)}
-              rows={6}
+              rows={5}
               className={area}
             />
-            <Button
-              className="self-start"
-              onClick={doImport}
-              disabled={busy || !paste.trim()}
-            >
-              <Upload className="size-4" />
-              Import
-            </Button>
+            <div className="flex flex-wrap gap-2">
+              <Button onClick={doImport} disabled={busy || !paste.trim()}>
+                <Upload className="size-4" />
+                Import
+              </Button>
+              <Button variant="outline" onClick={loadFromFile} disabled={busy}>
+                <FileUp className="size-4" />
+                Load from file
+              </Button>
+            </div>
           </div>
         </div>
       </DialogContent>
     </Dialog>
   );
+}
+
+/** A filesystem-safe slug for the default filename. */
+function slug(s: string): string {
+  return s
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
 }

--- a/src/components/ShareDialog.tsx
+++ b/src/components/ShareDialog.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState, type ReactNode } from "react";
 import { Check, Copy, FileDown, FileUp, Upload } from "lucide-react";
 import { toast } from "sonner";
-import { open, save } from "@tauri-apps/plugin-dialog";
+import { open as openFile, save } from "@tauri-apps/plugin-dialog";
 import {
   exportConfig,
   exportConfigToPath,
@@ -30,7 +30,7 @@ interface Props {
  * the no-backend version of "push a setup to your team". Export via clipboard or
  * a file; label it with a name + description so the recipient knows what it is. */
 export function ShareDialog({ trigger, onImported }: Props) {
-  const [open_, setOpen] = useState(false);
+  const [open, setOpen] = useState(false);
   const [name, setName] = useState("");
   const [description, setDescription] = useState("");
   const [exported, setExported] = useState("");
@@ -41,11 +41,11 @@ export function ShareDialog({ trigger, onImported }: Props) {
   // Re-serialize whenever the dialog opens or the label changes, so the textarea
   // and any file/clipboard export carry the current name + description.
   useEffect(() => {
-    if (!open_) return;
+    if (!open) return;
     exportConfig(name, description)
       .then(setExported)
       .catch(() => setExported(""));
-  }, [open_, name, description]);
+  }, [open, name, description]);
 
   function onOpenChange(next: boolean) {
     setOpen(next);
@@ -82,7 +82,7 @@ export function ShareDialog({ trigger, onImported }: Props) {
 
   async function loadFromFile() {
     try {
-      const path = await open({
+      const path = await openFile({
         title: "Open a Conduit setup",
         multiple: false,
         directory: false,
@@ -124,7 +124,7 @@ export function ShareDialog({ trigger, onImported }: Props) {
     "w-full rounded-md border bg-background p-2.5 font-mono text-xs resize-none focus:outline-none focus:ring-1 focus:ring-ring";
 
   return (
-    <Dialog open={open_} onOpenChange={onOpenChange}>
+    <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogTrigger asChild>{trigger}</DialogTrigger>
       <DialogContent className="sm:max-w-lg">
         <DialogHeader>

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -161,11 +161,6 @@ export function probeAuth(url: string): Promise<AuthInfo> {
   return invoke<AuthInfo>("probe_auth", { url });
 }
 
-/** Latest published release tag on GitHub (e.g. "v0.3.1"), for an update hint. */
-export function latestRelease(): Promise<string> {
-  return invoke<string>("latest_release");
-}
-
 /** Open Conduit's data directory (registry, logs, audit) in the OS file manager. */
 export function openDataDir(): Promise<void> {
   return invoke<void>("open_data_dir");

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -171,14 +171,39 @@ export function openDataDir(): Promise<void> {
   return invoke<void>("open_data_dir");
 }
 
-/** Serialize the user's servers into a shareable setup (no secret values). */
-export function exportConfig(): Promise<string> {
-  return invoke<string>("export_config");
+/** Serialize the user's servers into a shareable setup (no secret values),
+ * optionally labelled with a name + description. */
+export function exportConfig(
+  name?: string,
+  description?: string,
+): Promise<string> {
+  return invoke<string>("export_config", {
+    name: name ?? null,
+    description: description ?? null,
+  });
+}
+
+/** Write the shareable setup to a file on disk (path from a save dialog). */
+export function exportConfigToPath(
+  path: string,
+  name?: string,
+  description?: string,
+): Promise<void> {
+  return invoke<void>("export_config_to_path", {
+    path,
+    name: name ?? null,
+    description: description ?? null,
+  });
 }
 
 /** Import a shared setup, adding servers not already present. */
 export function importConfig(json: string): Promise<Registry> {
   return invoke<Registry>("import_config", { json });
+}
+
+/** Import a shared setup from a file on disk (path from an open dialog). */
+export function importConfigFromPath(path: string): Promise<Registry> {
+  return invoke<Registry>("import_config_from_path", { path });
 }
 
 /** Enable or disable every server in a profile at once. */
@@ -201,6 +226,21 @@ export function importServers(): Promise<Registry> {
 
 export function addServer(entry: ServerEntry): Promise<Registry> {
   return invoke<Registry>("add_server", { entry });
+}
+
+/** Add a catalog entry as a registry server (the user vaults any keys after). */
+export function addCatalogServer(entry: CatalogEntry): Promise<Registry> {
+  const server: ServerEntry = {
+    id: "",
+    name: entry.name,
+    transport: entry.transport,
+    command: entry.command,
+    args: entry.args,
+    env: entry.envKeys.map((key) => ({ key, value: null, secret: true })),
+    url: entry.url,
+    source: `catalog:${entry.source}`,
+  };
+  return addServer(server);
 }
 
 export function updateServer(entry: ServerEntry): Promise<Registry> {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -80,6 +80,17 @@ export interface ToolCallResult {
   [k: string]: unknown;
 }
 
+/** Per-tool aggregate within a server (calls, error rate, latency). */
+export interface ToolStat {
+  tool: string;
+  calls: number;
+  errors: number;
+  errorRate: number;
+  avgMs: number | null;
+  p95Ms: number | null;
+  lastTs: number;
+}
+
 /** Per-server aggregate from the audit log (calls, error rate, latency). */
 export interface ServerStat {
   server: string;
@@ -89,6 +100,8 @@ export interface ServerStat {
   avgMs: number | null;
   p95Ms: number | null;
   lastTs: number;
+  /** Per-tool breakdown, busiest first. */
+  tools: ToolStat[];
 }
 
 export interface AuditStats {

--- a/src/lib/updater.ts
+++ b/src/lib/updater.ts
@@ -1,0 +1,19 @@
+import { check, type Update } from "@tauri-apps/plugin-updater";
+import { relaunch } from "@tauri-apps/plugin-process";
+
+/** Best-effort check for a newer release via the Tauri updater. Returns null on
+ * any failure (dev build, offline, or no manifest published yet) so callers can
+ * just fall back to showing the current version. */
+export async function checkForUpdate(): Promise<Update | null> {
+  try {
+    return await check();
+  } catch {
+    return null;
+  }
+}
+
+/** Download + install the update, then relaunch into the new version. */
+export async function installUpdate(update: Update): Promise<void> {
+  await update.downloadAndInstall();
+  await relaunch();
+}


### PR DESCRIPTION
Two launch-week features, ahead of tagging v0.3.3.

## 1. First-run onboarding (frontend only)
A skippable, stepped wizard shown **only on a genuinely fresh setup** (no servers, no client connected):
1. Welcome + detected clients
2. Add first servers (import from clients, or browse catalog)
3. Connect a client (one click `installGateway`)
4. "You're set up"

Reuses existing import/install/catalog commands, so **no new backend surface**. Latched in its own state and gated on a `localStorage` flag, so existing users (and anyone who skips) never see it.

## 2. In-app auto-updater (Tauri v2 updater + process plugins)
- Sidebar footer checks for a newer release on launch; when one exists it downloads/installs/relaunches in place. Best-effort: dev/offline/no-manifest just shows the version. Replaces the old "open releases page" link.
- Release pipeline now emits signed updater artifacts and a new `updater-manifest` job assembles `latest.json` across Windows/macOS(arm+intel)/Linux. The two mac targets' identically named `app.tar.gz` are tagged per-arch to avoid collision.
- Signing key is in repo secrets `TAURI_SIGNING_PRIVATE_KEY` / `TAURI_SIGNING_PRIVATE_KEY_PASSWORD`; public key is in `tauri.conf.json`.

**Caveat:** v0.3.2 installs have no pubkey baked in, so they update to v0.3.3 manually once (the manual link still works); auto-update is live from v0.3.3 onward.

## Verification done
- `tsc --noEmit`, `npm run build`, and `cargo check` all green (cargo-check also validates the new capability permissions).
- Auto-update end-to-end can only be proven by cutting a release; for v0.3.3 we verify `latest.json` is well-formed and the app parses it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)