### PR TITLE
ci: bump GitHub Actions off the deprecated Node 20 runtime

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -28,7 +28,7 @@ jobs:
   audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
       - name: Install cargo-audit
         run: cargo install cargo-audit --locked

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,9 +36,9 @@ jobs:
             bundles: deb,appimage
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 20
 
@@ -110,7 +110,7 @@ jobs:
           fi
 
       - name: Draft release with the installers
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           draft: true
           generate_release_notes: true


### PR DESCRIPTION
## What

GitHub is deprecating the Node 20 Actions runtime (currently force-running these actions on Node 24 with a warning, breaking later). Bump every Node-based action in our workflows to its latest stable major, all of which now run on Node 24:

| Action | Was | Now | Files |
|---|---|---|---|
| `actions/checkout` | v4 | **v7** | `release.yml`, `audit.yml` |
| `actions/setup-node` | v4 | **v6** | `release.yml` |
| `softprops/action-gh-release` | v2 | **v3** | `release.yml` |

`dtolnay/rust-toolchain` and `Swatinem/rust-cache@v2` are not Node-20 actions and were left as-is. The `updater-manifest` job uses no Node-20 actions.

## Compatibility

Latest majors were taken from the GitHub API (not the example versions in the request). Input names are unchanged across these majors:
- `setup-node@v6` still takes `node-version` (kept at `20` — that controls the project's Node, not the runner runtime).
- `action-gh-release@v3` still takes `draft`, `generate_release_notes`, `files`.

These are pure Node 20 -> 24 runtime bumps. Both workflows still parse as valid YAML. The `audit.yml` change gets a live smoke test of `checkout@v7` on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)