### PR TITLE
Add BoltAI MCP client support

### DIFF
--- a/src-tauri/src/clients.rs
+++ b/src-tauri/src/clients.rs
@@ -166,6 +166,10 @@ fn cursor_path() -> Option<PathBuf> {
     Some(home()?.join(".cursor").join("mcp.json"))
 }
 
+fn boltai_path() -> Option<PathBuf> {
+    Some(home()?.join(".boltai").join("mcp.json"))
+}
+
 fn vscode_path() -> Option<PathBuf> {
     Some(config()?.join("Code").join("User").join("mcp.json"))
 }
@@ -511,6 +515,14 @@ fn defs() -> Vec<ClientDef> {
             format: Format::JsonMcpServers,
             uses_connectors: false,
             path: jan_path,
+            plugin_scan: None,
+        },
+        ClientDef {
+            id: "boltai",
+            name: "BoltAI",
+            format: Format::JsonMcpServers,
+            uses_connectors: false,
+            path: boltai_path,
             plugin_scan: None,
         },
         ClientDef {


### PR DESCRIPTION
## What and why

Adds support for BoltAI MCP configuration detection and management.

Changes made:
- Added a BoltAI config path resolver pointing to `~/.boltai/mcp.json`
- Added a BoltAI client definition using `Format::JsonMcpServers`

This allows Conduit to detect and manage BoltAI MCP server configurations using the existing JSON MCP infrastructure.

Closes #4

## Testing

Verified by running:

- [x] `cargo test --manifest-path src-tauri/Cargo.toml` passes
- [ ] `npx tsc --noEmit && npm run build` passes
- [ ] Ran the app (`npm run tauri dev`) and checked the change by hand

## Notes

- Reused the existing `JsonMcpServers` format and shared JSON writers.
- No changes were required to the write/edit logic.
- All existing tests passed.
- No secrets, keys, or personal paths are included in the diff.