### PR TITLE
Add Firecrawl MCP server to curated catalog

### DIFF
--- a/src-tauri/src/catalog.rs
+++ b/src-tauri/src/catalog.rs
@@ -95,6 +95,7 @@ pub fn curated() -> Vec<CatalogEntry> {
         http("DeepWiki", "Ask questions about any public GitHub repo. No auth.", "https://mcp.deepwiki.com/mcp", "https://deepwiki.com"),
         http("Hugging Face", "Models, datasets, and Spaces on Hugging Face.", "https://huggingface.co/mcp", "https://huggingface.co/settings/mcp"),
         cmd("Brave Search", "Web search via the Brave Search API.", "npx", &["-y", "@modelcontextprotocol/server-brave-search"], &["BRAVE_API_KEY"], "https://github.com/modelcontextprotocol/servers"),
+        cmd("Firecrawl", "Web scraping and data extraction from websites.", "npx", &["-y", "firecrawl-mcp"], &["FIRECRAWL_API_KEY"], "https://github.com/firecrawl/firecrawl-mcp-server"),
         // --- Email & comms already above; Design ---
         cmd("Figma", "Turn Figma designs into code (Framelink).", "npx", &["-y", "figma-developer-mcp", "--stdio"], &["FIGMA_API_KEY"], "https://github.com/GLips/Figma-Context-MCP"),
         // --- Email ---


### PR DESCRIPTION
## What and why

- Adds Firecrawl to the curated MCP server catalog in `src-tauri/src/catalog.rs`.
- Firecrawl is a popular MCP server for web scraping, crawling, and structured data extraction. Adding it to the curated catalog improves discoverability and the first-run experience for users looking for web data and search-related MCP servers.

Closes #3 

## Testing

- [x] `cargo test --manifest-path src-tauri/Cargo.toml` passes
- [x] `npx tsc --noEmit && npm run build` passes
- [x] Ran the app (`npm run tauri dev`) and checked the change by hand


## Notes

- Verified the Firecrawl MCP server locally in Conduit before adding the catalog entry.
- Confirmed the server connects successfully and exposes tools.
- Tested the `firecrawl_scrape` tool against public URLs and received valid responses.
- Added only the required environment variable name (`FIRECRAWL_API_KEY`), with no secret values included.
- No secrets, API keys, or personal paths are included in this diff.