### PR TITLE
fix(macOS): eliminate repeated keychain password prompts via SecItem API

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -547,6 +547,7 @@ dependencies = [
  "getrandom 0.2.17",
  "json5",
  "keyring",
+ "security-framework 3.7.0",
  "serde",
  "serde_json",
  "serde_yaml",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -42,6 +42,7 @@ keyring = { version = "3", features = ["windows-native"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 keyring = { version = "3", features = ["apple-native"] }
+security-framework = "3"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 keyring = { version = "3", features = ["sync-secret-service", "crypto-rust"] }

--- a/src-tauri/src/secrets.rs
+++ b/src-tauri/src/secrets.rs
@@ -3,8 +3,6 @@
 //! file or any client config - only here. The gateway pulls them at spawn time
 //! and injects them into the child server's environment.
 
-use keyring::Entry;
-
 const SERVICE: &str = "conduit-mcp";
 
 /// Reserved secret key for an http server's bearer token (Tier A auth, and where
@@ -15,11 +13,90 @@ fn account(server_id: &str, key: &str) -> String {
     format!("{server_id}::{key}")
 }
 
+// ── macOS ──────────────────────────────────────────────────────────────────
+//
+// On macOS we bypass the `keyring` crate and call `security_framework` directly.
+//
+// `keyring`'s apple-native backend routes writes through the *legacy* file-based
+// keychain API (`SecKeychainAddGenericPassword` / `SecKeychainItemModify`),
+// which creates items with a **per application Access Control List (ACL)**.
+// Every binary that touches the item — the Tauri UI app *and* the standalone
+// gateway binary — needs its own "Always Allow" grant, and a fresh prompt can
+// fire on first access from each context.
+//
+// Instead we use the modern `SecItem*` API (`security_framework::passwords`),
+// which stores items in the data-protection keychain without per-application
+// ACLs. Any process running as the user can read them after a single unlock.
+//
+// Note: entries created by a previous version of Conduit (via the `keyring`
+// crate) still live in the legacy keychain and carry ACLs. After upgrading,
+// users should delete them from Keychain Access and re-authenticate their
+// servers to create ACL-free entries through this path.
+#[cfg(target_os = "macos")]
+mod platform {
+    use security_framework::passwords::{
+        delete_generic_password, get_generic_password, set_generic_password,
+    };
+
+    use super::{account, SERVICE};
+
+    pub fn set_secret(server_id: &str, key: &str, value: &str) -> Result<(), String> {
+        set_generic_password(SERVICE, &account(server_id, key), value.as_bytes())
+            .map_err(|e| e.to_string())
+    }
+
+    pub fn get_secret_result(server_id: &str, key: &str) -> Result<Option<String>, String> {
+        match get_generic_password(SERVICE, &account(server_id, key)) {
+            Ok(bytes) => String::from_utf8(bytes).map(Some).map_err(|e| e.to_string()),
+            Err(e) if e.code() == -25300 /* errSecItemNotFound */ => Ok(None),
+            Err(e) => Err(e.to_string()),
+        }
+    }
+
+    pub fn delete_secret(server_id: &str, key: &str) -> Result<(), String> {
+        match delete_generic_password(SERVICE, &account(server_id, key)) {
+            Ok(()) => Ok(()),
+            Err(e) if e.code() == -25300 /* errSecItemNotFound */ => Ok(()),
+            Err(e) => Err(e.to_string()),
+        }
+    }
+}
+
+// ── Windows / Linux ────────────────────────────────────────────────────────
+#[cfg(not(target_os = "macos"))]
+mod platform {
+    use keyring::Entry;
+
+    use super::{account, SERVICE};
+
+    pub fn set_secret(server_id: &str, key: &str, value: &str) -> Result<(), String> {
+        Entry::new(SERVICE, &account(server_id, key))
+            .map_err(|e| e.to_string())?
+            .set_password(value)
+            .map_err(|e| e.to_string())
+    }
+
+    pub fn get_secret_result(server_id: &str, key: &str) -> Result<Option<String>, String> {
+        let entry = Entry::new(SERVICE, &account(server_id, key)).map_err(|e| e.to_string())?;
+        match entry.get_password() {
+            Ok(v) => Ok(Some(v)),
+            Err(keyring::Error::NoEntry) => Ok(None),
+            Err(e) => Err(e.to_string()),
+        }
+    }
+
+    pub fn delete_secret(server_id: &str, key: &str) -> Result<(), String> {
+        let entry = Entry::new(SERVICE, &account(server_id, key)).map_err(|e| e.to_string())?;
+        match entry.delete_credential() {
+            Ok(()) => Ok(()),
+            Err(keyring::Error::NoEntry) => Ok(()),
+            Err(e) => Err(e.to_string()),
+        }
+    }
+}
+
 pub fn set_secret(server_id: &str, key: &str, value: &str) -> Result<(), String> {
-    Entry::new(SERVICE, &account(server_id, key))
-        .map_err(|e| e.to_string())?
-        .set_password(value)
-        .map_err(|e| e.to_string())
+    platform::set_secret(server_id, key, value)
 }
 
 pub fn get_secret(server_id: &str, key: &str) -> Option<String> {
@@ -31,21 +108,11 @@ pub fn get_secret(server_id: &str, key: &str) -> Option<String> {
 /// access to this app). Callers that need to explain *why* a secret is missing
 /// use this so a read failure isn't silently treated as "never saved".
 pub fn get_secret_result(server_id: &str, key: &str) -> Result<Option<String>, String> {
-    let entry = Entry::new(SERVICE, &account(server_id, key)).map_err(|e| e.to_string())?;
-    match entry.get_password() {
-        Ok(v) => Ok(Some(v)),
-        Err(keyring::Error::NoEntry) => Ok(None),
-        Err(e) => Err(e.to_string()),
-    }
+    platform::get_secret_result(server_id, key)
 }
 
 pub fn delete_secret(server_id: &str, key: &str) -> Result<(), String> {
-    let entry = Entry::new(SERVICE, &account(server_id, key)).map_err(|e| e.to_string())?;
-    match entry.delete_credential() {
-        Ok(()) => Ok(()),
-        Err(keyring::Error::NoEntry) => Ok(()),
-        Err(e) => Err(e.to_string()),
-    }
+    platform::delete_secret(server_id, key)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## What and why

On macOS, Conduit triggers the system keychain password dialog repeatedly — on every launch and on every OAuth token refresh.

**Root cause:** The `keyring` crate macOS backend (v3.6.3) routes all writes through the **legacy file-based keychain API** (`SecKeychainAddGenericPassword`). This creates items with **per-application Access Control Lists (ACLs)**:

- The Tauri UI app and the standalone `conduit-gateway` binary are separate processes — each gets its own prompt on first access to every keychain entry.
- Token refresh flows that delete and recreate entries wipe the ACL entirely, restarting the prompt cycle.

**Fix:** Bypass the `keyring` crate on macOS and call `security_framework::passwords` directly. These use the modern `SecItem*` API (`SecItemAdd` / `SecItemUpdate` / `SecItemDelete`), which stores items without per-application ACLs.

The `keyring` crate is still used on Windows and Linux (via `cfg`-gated platform modules). The public API is unchanged.

## Testing

- [x] `cargo test --manifest-path src-tauri/Cargo.toml` passes (92 lib + 24 gateway, 0 failures)
- [x] `npx tsc --noEmit && npm run build` passes (1921 modules)
- [x] `cargo clippy` — zero warnings on changed code
- [x] Manual: verified all 7 MCP servers connect with zero keychain prompts after keychain entries are recreated through the new SecItem path

## Notes

- `security-framework` v3.7.0 was already in the dependency tree (transitively via `keyring`), so no new compiled code is added.
- The platform abstraction uses `cfg(target_os = "macos")` / `cfg(not(...))` modules with identical public function signatures.
