### PR TITLE
fix(remote): inject custom secret env vars for HTTP servers

### DIFF
--- a/src-tauri/src/bin/conduit-gateway.rs
+++ b/src-tauri/src/bin/conduit-gateway.rs
@@ -1092,8 +1092,8 @@ fn connect_one(server: &ServerEntry, dirty: &Arc<AtomicBool>) -> Option<Downstre
             Ok(t) => DownstreamServer::connect(server.id.clone(), Box::new(t)),
             Err(e) => Err(e),
         }
-    } else if let Some(url) = &server.url {
-        remote::connect_remote(&server.id, url)
+    } else if server.url.is_some() {
+        remote::connect_remote(server)
     } else {
         Err("no command or url".to_string())
     };

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -75,8 +75,8 @@ fn connect_server(server: &ServerEntry) -> Result<DownstreamServer, String> {
         }
         let t = StdioTransport::spawn(command, &server.args, &env)?;
         DownstreamServer::connect(server.id.clone(), Box::new(t))
-    } else if let Some(url) = &server.url {
-        remote::connect_remote(&server.id, url)
+    } else if server.url.is_some() {
+        remote::connect_remote(server)
     } else {
         Err("no command or url".to_string())
     }

--- a/src-tauri/src/remote.rs
+++ b/src-tauri/src/remote.rs
@@ -8,6 +8,7 @@
 use serde::{Deserialize, Serialize};
 
 use crate::downstream::{DownstreamServer, HttpTransport};
+use crate::registry::ServerEntry;
 use crate::{oauth, secrets};
 
 const STATE_KEY: &str = "__oauth_state__";
@@ -107,10 +108,34 @@ fn authed_transport(url: &str, token: Option<String>) -> Result<HttpTransport, S
     Ok(HttpTransport::with_auth(url, token))
 }
 
+/// The first custom secret env var that has a value vaulted in the keychain.
+/// For HTTP servers that don't use OAuth (e.g. Magica with a `BEARER` API key),
+/// this is the token we send as `Authorization: Bearer ***`.
+fn first_vaulted_secret(server: &ServerEntry) -> Option<String> {
+    for e in &server.env {
+        if e.secret && e.value.is_none() {
+            if let Some(v) = secrets::get_secret(&server.id, &e.key) {
+                return Some(v);
+            }
+        }
+    }
+    None
+}
+
 /// Connect to a remote server, injecting any vaulted token. On an auth error,
 /// refresh the token once and retry.
-pub fn connect_remote(server_id: &str, url: &str) -> Result<DownstreamServer, String> {
-    let auth = secrets::get_secret(server_id, secrets::HTTP_AUTH_KEY);
+///
+/// Token lookup order for HTTP servers:
+/// 1. `__http_auth__` — the key used by the OAuth flow and the "paste token" UI.
+/// 2. The first vaulted custom secret env var (e.g. `BEARER`) — for servers like
+///    Magica that declare a manual API-key env var in the registry but don't use
+///    OAuth. Without this fallback, "Manage secrets" tokens were silently ignored
+///    for HTTP servers.
+pub fn connect_remote(server: &ServerEntry) -> Result<DownstreamServer, String> {
+    let url = server.url.as_deref().unwrap_or("");
+    let server_id = &server.id;
+    let auth = secrets::get_secret(server_id, secrets::HTTP_AUTH_KEY)
+        .or_else(|| first_vaulted_secret(server));
     let transport = authed_transport(url, auth)?;
     match DownstreamServer::connect(server_id.to_string(), Box::new(transport)) {
         Ok(ds) => Ok(ds),


### PR DESCRIPTION
## What and why

HTTP servers that use static API keys (e.g. Magica with a `BEARER` env var) had their tokens silently ignored by the gateway. The token was stored in the keychain via "Manage secrets" but never sent to the server.

**Root cause:** `connect_remote()` only checked the reserved `__http_auth__` key — the key used by the OAuth flow and the paste-token UI. Custom secret env vars declared in the server's registry config (e.g. `{ "key": "BEARER", "secret": true }`) were only injected for **stdio** servers (as environment variables). For **HTTP** servers, the gateway never looked them up, so no `Authorization` header was sent.

**Fix:** `connect_remote()` now accepts `&ServerEntry` instead of `(&server_id, &url)`, so it can check the server's declared env vars. Token lookup order:

1. `__http_auth__` — the OAuth flow / paste-token key (highest priority)
2. First vaulted custom secret env var (e.g. `BEARER`) — for servers that use static API keys
3. OAuth refresh on 401 — if a refresh token is available

## Testing

- [x] `cargo test --manifest-path src-tauri/Cargo.toml` passes (92 lib + 24 gateway tests, 0 failures)
- [x] `npx tsc --noEmit && npm run build` passes
- [x] `cargo clippy` — zero warnings on changed code
- [x] Manual: verified Magica MCP server (32 tools) connects successfully with a `BEARER` API key stored via "Manage secrets"

## Notes

- The signature change from `(&str, &str)` to `(&ServerEntry)` is minimal — `connect_remote` already needed the server ID and URL, and now also reads the env list.
- Both call sites (`lib.rs::connect_server` and `conduit-gateway.rs::connect_one`) are updated with matching `server.url.is_some()` guards.