### PR TITLE
catalog: add Composio (1,000+ apps via MCP)

### DIFF
--- a/src-tauri/src/catalog.rs
+++ b/src-tauri/src/catalog.rs
@@ -85,6 +85,7 @@ pub fn curated() -> Vec<CatalogEntry> {
         cmd("PostgreSQL", "Query a Postgres database (add your connection string to args).", "npx", &["-y", "@modelcontextprotocol/server-postgres"], &[], "https://github.com/modelcontextprotocol/servers"),
         // --- Project management & docs ---
         http("Notion", "Search and edit Notion pages and databases.", "https://mcp.notion.com/mcp", "https://developers.notion.com"),
+        http("Composio", "Connect AI agents to 1,000+ apps (Gmail, Slack, GitHub, Notion, Linear, and more).", "https://connect.composio.dev/mcp", "https://composio.dev"),
         http("Linear", "Issues, projects, and cycles in Linear.", "https://mcp.linear.app/mcp", "https://linear.app/docs"),
         http("Atlassian", "Jira issues and Confluence pages.", "https://mcp.atlassian.com/v1/mcp", "https://support.atlassian.com/atlassian-rovo-mcp-server/"),
         http("Asana", "Tasks, projects, and portfolios in Asana.", "https://mcp.asana.com/mcp", "https://developers.asana.com/docs/mcp-server"),


### PR DESCRIPTION
## What and why

Adds [Composio](https://composio.dev) to the curated catalog. Composio connects AI agents to 1,000+ apps (Gmail, Slack, GitHub, Notion, Linear, Jira, HubSpot, Figma, and more) through a single hosted MCP endpoint with OAuth authentication.

This is a popular integration platform (50,000+ users) that many Conduit users will want one-click access to.

## Testing

- [x] `cargo test --manifest-path src-tauri/Cargo.toml` passes (catalog tests: 5 passed, 0 failed)
- [x] `npx tsc --noEmit && npm run build` passes
- [x] Verified the endpoint (`https://connect.composio.dev/mcp`) is the correct hosted MCP URL

## Notes

One-line addition following the existing `http()` helper pattern for hosted MCP servers. Placed in the "Project management & docs" section alongside Notion and Linear.
