### PR TITLE
feat: improve duplicate server UX for multi-account setups

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -283,6 +283,7 @@ function App() {
     <RegistryServerCard
       key={server.id}
       server={server}
+      registry={registry}
       enabled={registry ? isEnabled(registry, server.id) : false}
       busy={busyId === server.id}
       health={health[server.id]}

--- a/src/components/RegistryServerCard.tsx
+++ b/src/components/RegistryServerCard.tsx
@@ -12,6 +12,7 @@ import { ServerDialog } from "@/components/ServerDialog";
 
 interface Props {
   server: ServerEntry;
+  registry: Registry | null;
   enabled: boolean;
   busy?: boolean;
   health?: ProbeResult;
@@ -44,7 +45,9 @@ const DOT: Record<Status, string> = {
   error: "bg-destructive",
 };
 
+
 export function RegistryServerCard({
+  registry,
   server,
   enabled,
   busy,
@@ -72,6 +75,20 @@ export function RegistryServerCard({
           : status === "checking"
             ? "Checking…"
             : "Disabled";
+
+  const existingNames = new Set(
+    registry?.servers.map((s) => s.name.toLowerCase()) ?? [],
+  );
+
+  const baseName = server.name.replace(/\s\(\d+\)$/, "");
+
+  let duplicateName = `${baseName} (2)`;
+  let index = 2;
+
+  while (existingNames.has(duplicateName.toLowerCase())) {
+    index++;
+    duplicateName = `${baseName} (${index})`;
+  }          
 
   return (
     <Card
@@ -147,10 +164,11 @@ export function RegistryServerCard({
             />
             <ServerDialog
               onSaved={onRegistryChange}
-              initial={{ ...server, name: `${server.name} 2` }}
+              initial={{ ...server, name: duplicateName }}
               trigger={
                 <button
                   aria-label={`Duplicate ${server.name}`}
+                  title="Add another account"
                   className="rounded p-1 text-muted-foreground/60 opacity-0 transition group-hover:opacity-100 focus-visible:opacity-100 hover:bg-accent hover:text-foreground"
                 >
                   <Copy className="size-3.5" />


### PR DESCRIPTION
<!-- Thanks for contributing to Conduit. Keep PRs focused and small where you can. -->

## What and why

This PR improves the multi-account duplicate server workflow for registry servers.

- Added a tooltip (`Add another account`) to the duplicate action to make the feature more discoverable.
- Updated the suggested duplicate naming from `{name} 2` to `{name} (2)`.
- Added collision handling so repeated duplicates are automatically named `{name} (3)`, `{name} (4)`, etc., avoiding duplicate names.

Closes #6.

## Testing

- [x] `cargo test --manifest-path src-tauri/Cargo.toml` passes
- [x] `npx tsc --noEmit && npm run build` passes
- [x] Ran the app (`npm run tauri dev`) and checked the change by hand

## Notes

## Notes

- Verified the changes by duplicating the Firecrawl MCP server multiple times.
- Confirmed the duplicate action displays the **"Add another account"** tooltip.
- Confirmed duplicate names are suggested as `Firecrawl (2)`, `Firecrawl (3)`, etc., without name collisions.
- Confirmed duplicated servers require fresh authentication (secret values are not copied).
- No secrets, API keys, or personal paths are included in this diff.