### PR TITLE
fix(clients): key Hermes mcp_servers entries by name, not id

### DIFF
--- a/src-tauri/src/clients.rs
+++ b/src-tauri/src/clients.rs
@@ -1317,7 +1317,7 @@ fn write_hermes_yaml_servers(path: &Path, servers: &[ServerEntry]) -> Result<(),
     let mcp_servers = hermes_mcp_servers_mut(&mut root);
     mcp_servers.clear();
     for entry in servers {
-        let name_val = serde_yaml::Value::String(entry.id.clone());
+        let name_val = serde_yaml::Value::String(entry.name.clone());
         mcp_servers.insert(name_val, entry_to_hermes_yaml(entry));
     }
     let out = serde_yaml::to_string(&root).map_err(|e| e.to_string())?;


### PR DESCRIPTION
## What and why

PR #20 keyed Hermes `mcp_servers` entries by `id` (e.g. `abc-123-def`) while the Goose YAML writer — the closest analog — keys by `name` (e.g. `my-server`). Both formats use the human-readable name as the map key; Hermes `config.yaml` follows the same convention.

This was flagged as a non-blocker in the PR #20 review. One-line fix.

**On the rustfmt churn:** checked — the file passes `rustfmt --check` as-is. Those reformatted lines in PR #20 are the correct formatting; the code was just not previously formatted. Reverting them would make the file non-compliant.

## Checklist

- [x] Code follows existing style (verified with `cargo fmt --check`)
- [x] All tests pass (`cargo test --lib --bins`: 97 lib + 24 gateway)
- [x] Single logical change (1 file, 1 line)
- [x] No breaking changes for existing Hermes config.yaml files (only affects new writes)