### PR TITLE
fix(ui): show loading indicators on dialog async actions

### DIFF
--- a/src/components/SecretsDialog.tsx
+++ b/src/components/SecretsDialog.tsx
@@ -1,5 +1,5 @@
 import { useRef, useState, type ReactNode } from "react";
-import { Check, ExternalLink, KeyRound, Plus, Trash2 } from "lucide-react";
+import { Check, ExternalLink, KeyRound, Loader2, Plus, Trash2 } from "lucide-react";
 import { toast } from "sonner";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import {
@@ -85,7 +85,7 @@ export function SecretsDialog({ server, onSaved, trigger, onChanged }: Props) {
   const [inputs, setInputs] = useState<Record<string, string>>({});
   const [newKey, setNewKey] = useState("");
   const [newValue, setNewValue] = useState("");
-  const [busy, setBusy] = useState(false);
+  const [busyKey, setBusyKey] = useState<string | null>(null);
   const [authSet, setAuthSet] = useState(false);
   const [authInput, setAuthInput] = useState("");
   const [oauthBusy, setOauthBusy] = useState(false);
@@ -137,7 +137,7 @@ export function SecretsDialog({ server, onSaved, trigger, onChanged }: Props) {
 
   async function saveAuth() {
     if (!authInput) return;
-    setBusy(true);
+    setBusyKey("auth");
     try {
       await setAuthToken(server.id, authInput);
       setAuthSet(true);
@@ -147,12 +147,12 @@ export function SecretsDialog({ server, onSaved, trigger, onChanged }: Props) {
     } catch (e) {
       toast.error(secretErrorMessage(e));
     } finally {
-      setBusy(false);
+      setBusyKey(null);
     }
   }
 
   async function clearAuth() {
-    setBusy(true);
+    setBusyKey("auth-clear");
     try {
       await clearAuthToken(server.id);
       setAuthSet(false);
@@ -161,7 +161,7 @@ export function SecretsDialog({ server, onSaved, trigger, onChanged }: Props) {
     } catch (e) {
       toast.error(secretErrorMessage(e));
     } finally {
-      setBusy(false);
+      setBusyKey(null);
     }
   }
 
@@ -192,7 +192,7 @@ export function SecretsDialog({ server, onSaved, trigger, onChanged }: Props) {
 
   async function save(key: string, value: string) {
     if (!value) return;
-    setBusy(true);
+    setBusyKey(key);
     try {
       onSaved(await setSecret(server.id, key, value));
       setVaulted((v) => ({ ...v, [key]: true }));
@@ -202,12 +202,12 @@ export function SecretsDialog({ server, onSaved, trigger, onChanged }: Props) {
     } catch (e) {
       toast.error(secretErrorMessage(e));
     } finally {
-      setBusy(false);
+      setBusyKey(null);
     }
   }
 
   async function remove(key: string) {
-    setBusy(true);
+    setBusyKey(`remove:${key}`);
     try {
       onSaved(await deleteSecret(server.id, key));
       toast.success(`Removed ${key}`);
@@ -215,16 +215,27 @@ export function SecretsDialog({ server, onSaved, trigger, onChanged }: Props) {
     } catch (e) {
       toast.error(secretErrorMessage(e));
     } finally {
-      setBusy(false);
+      setBusyKey(null);
     }
   }
 
   async function addNew() {
     const k = newKey.trim();
     if (!k || !newValue) return;
-    await save(k, newValue);
-    setNewKey("");
-    setNewValue("");
+    setBusyKey("add");
+    try {
+      onSaved(await setSecret(server.id, k, newValue));
+      setVaulted((v) => ({ ...v, [k]: true }));
+      setInputs((i) => ({ ...i, [k]: "" }));
+      toast.success(`Saved ${k}`);
+      onChanged?.();
+      setNewKey("");
+      setNewValue("");
+    } catch (e) {
+      toast.error(secretErrorMessage(e));
+    } finally {
+      setBusyKey(null);
+    }
   }
 
   return (
@@ -303,10 +314,17 @@ export function SecretsDialog({ server, onSaved, trigger, onChanged }: Props) {
                       <Button
                         size="sm"
                         variant="outline"
-                        disabled={busy || !authInput}
+                        disabled={busyKey !== null || !authInput}
                         onClick={saveAuth}
                       >
-                        Save
+                        {busyKey === "auth" ? (
+                          <>
+                            <Loader2 className="size-4 animate-spin" />
+                            Saving…
+                          </>
+                        ) : (
+                          "Save"
+                        )}
                       </Button>
                       {authSet && (
                         <Button
@@ -314,10 +332,14 @@ export function SecretsDialog({ server, onSaved, trigger, onChanged }: Props) {
                           variant="ghost"
                           className="size-8 shrink-0 text-muted-foreground hover:text-destructive"
                           aria-label="Clear auth token"
-                          disabled={busy}
+                          disabled={busyKey !== null}
                           onClick={clearAuth}
                         >
-                          <Trash2 className="size-4" />
+                          {busyKey === "auth-clear" ? (
+                            <Loader2 className="size-4 animate-spin" />
+                          ) : (
+                            <Trash2 className="size-4" />
+                          )}
                         </Button>
                       )}
                     </div>
@@ -333,9 +355,14 @@ export function SecretsDialog({ server, onSaved, trigger, onChanged }: Props) {
                         disabled={oauthBusy}
                         onClick={doOauth}
                       >
-                        {oauthBusy
-                          ? "Waiting for browser sign-in…"
-                          : "Sign in with OAuth"}
+                        {oauthBusy ? (
+                          <>
+                            <Loader2 className="size-4 animate-spin" />
+                            Waiting for browser sign-in…
+                          </>
+                        ) : (
+                          "Sign in with OAuth"
+                        )}
                       </Button>
                       {!oauthBusy && /mac/i.test(navigator.userAgent) && (
                         <p className="text-[11px] text-muted-foreground">
@@ -419,10 +446,17 @@ export function SecretsDialog({ server, onSaved, trigger, onChanged }: Props) {
                     />
                     <Button
                       size="sm"
-                      disabled={busy || !(inputs[key] ?? "")}
+                      disabled={busyKey !== null || !(inputs[key] ?? "")}
                       onClick={() => save(key, inputs[key] ?? "")}
                     >
-                      Save
+                      {busyKey === key ? (
+                        <>
+                          <Loader2 className="size-4 animate-spin" />
+                          Saving…
+                        </>
+                      ) : (
+                        "Save"
+                      )}
                     </Button>
                     {vaulted[key] && (
                       <Button
@@ -430,10 +464,14 @@ export function SecretsDialog({ server, onSaved, trigger, onChanged }: Props) {
                         variant="ghost"
                         className="size-8 shrink-0 text-muted-foreground hover:text-destructive"
                         aria-label={`Remove ${key}`}
-                        disabled={busy}
+                        disabled={busyKey !== null}
                         onClick={() => remove(key)}
                       >
-                        <Trash2 className="size-4" />
+                        {busyKey === `remove:${key}` ? (
+                          <Loader2 className="size-4 animate-spin" />
+                        ) : (
+                          <Trash2 className="size-4" />
+                        )}
                       </Button>
                     )}
                   </div>
@@ -475,10 +513,14 @@ export function SecretsDialog({ server, onSaved, trigger, onChanged }: Props) {
                 size="icon"
                 className="size-8 shrink-0"
                 aria-label="Add secret"
-                disabled={busy || !newKey.trim() || !newValue}
+                disabled={busyKey !== null || !newKey.trim() || !newValue}
                 onClick={addNew}
               >
-                <Plus className="size-4" />
+                {busyKey === "add" ? (
+                  <Loader2 className="size-4 animate-spin" />
+                ) : (
+                  <Plus className="size-4" />
+                )}
               </Button>
             </div>
           </details>

--- a/src/components/ServerDialog.tsx
+++ b/src/components/ServerDialog.tsx
@@ -1,5 +1,5 @@
 import { useState, type ReactNode } from "react";
-import { Plus, X } from "lucide-react";
+import { Loader2, Plus, X } from "lucide-react";
 import { toast } from "sonner";
 import { addServer, setSecret, updateServer } from "@/lib/api";
 import type { Registry, ServerEntry, Transport } from "@/lib/types";
@@ -45,6 +45,7 @@ export function ServerDialog({ trigger, onSaved, editId, initial }: Props) {
   const [envRows, setEnvRows] = useState<{ key: string; value: string }[]>(
     initial?.env.map((e) => ({ key: e.key, value: "" })) ?? [],
   );
+  const [busy, setBusy] = useState(false);
   const isStdio = form.transport === "stdio";
   const editing = editId !== undefined;
 
@@ -94,6 +95,7 @@ export function ServerDialog({ trigger, onSaved, editId, initial }: Props) {
       url: isStdio ? null : form.url.trim() || null,
       source: initial?.source ?? "manual",
     };
+    setBusy(true);
     try {
       let result = editing ? await updateServer(entry) : await addServer(entry);
       // Vault any values the user entered now. setSecret keys by server id. For a
@@ -112,6 +114,8 @@ export function ServerDialog({ trigger, onSaved, editId, initial }: Props) {
       setOpen(false);
     } catch (e) {
       toast.error(`Couldn't save ${entry.name}: ${e}`);
+    } finally {
+      setBusy(false);
     }
   }
 
@@ -228,11 +232,20 @@ export function ServerDialog({ trigger, onSaved, editId, initial }: Props) {
           </div>
         </div>
         <DialogFooter>
-          <Button variant="outline" onClick={() => setOpen(false)}>
+          <Button variant="outline" onClick={() => setOpen(false)} disabled={busy}>
             Cancel
           </Button>
-          <Button onClick={handleSave} disabled={!form.name.trim()}>
-            {editing ? "Save" : "Add"}
+          <Button onClick={handleSave} disabled={busy || !form.name.trim()}>
+            {busy ? (
+              <>
+                <Loader2 className="size-4 animate-spin" />
+                {editing ? "Saving…" : "Adding…"}
+              </>
+            ) : editing ? (
+              "Save"
+            ) : (
+              "Add"
+            )}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/src/components/ShareDialog.tsx
+++ b/src/components/ShareDialog.tsx
@@ -5,6 +5,7 @@ import {
   Copy,
   FileDown,
   FileUp,
+  Loader2,
   ShieldAlert,
   Upload,
 } from "lucide-react";
@@ -50,7 +51,9 @@ export function ShareDialog({ trigger, onImported }: Props) {
   const [exported, setExported] = useState("");
   const [paste, setPaste] = useState("");
   const [copied, setCopied] = useState(false);
-  const [busy, setBusy] = useState(false);
+  const [busyAction, setBusyAction] = useState<
+    "preview-paste" | "preview-file" | "import" | null
+  >(null);
   // When set, the dialog shows the review-and-confirm view for `pendingJson`.
   const [preview, setPreview] = useState<ImportItem[] | null>(null);
   const [pendingJson, setPendingJson] = useState("");
@@ -98,8 +101,8 @@ export function ShareDialog({ trigger, onImported }: Props) {
   }
 
   // Parse + preview a candidate setup (paste or file) before importing anything.
-  async function startPreview(json: string) {
-    setBusy(true);
+  async function startPreview(json: string, source: "preview-paste" | "preview-file") {
+    setBusyAction(source);
     try {
       const items = await previewImport(json);
       setPendingJson(json);
@@ -107,7 +110,7 @@ export function ShareDialog({ trigger, onImported }: Props) {
     } catch (e) {
       toast.error(`Couldn't read that setup: ${e}`);
     } finally {
-      setBusy(false);
+      setBusyAction(null);
     }
   }
 
@@ -121,14 +124,14 @@ export function ShareDialog({ trigger, onImported }: Props) {
       });
       if (!path || typeof path !== "string") return;
       const json = await readSetupFile(path);
-      await startPreview(json);
+      await startPreview(json, "preview-file");
     } catch (e) {
       toast.error(`Couldn't open that file: ${e}`);
     }
   }
 
   async function confirmImport() {
-    setBusy(true);
+    setBusyAction("import");
     try {
       onImported(await importConfig(pendingJson));
       toast.success("Imported shared setup", {
@@ -138,7 +141,7 @@ export function ShareDialog({ trigger, onImported }: Props) {
     } catch (e) {
       toast.error(`Couldn't import: ${e}`);
     } finally {
-      setBusy(false);
+      setBusyAction(null);
     }
   }
 
@@ -165,15 +168,24 @@ export function ShareDialog({ trigger, onImported }: Props) {
               ))}
             </div>
             <div className="flex items-center justify-between gap-2 border-t pt-3">
-              <Button variant="ghost" onClick={() => setPreview(null)} disabled={busy}>
+              <Button variant="ghost" onClick={() => setPreview(null)} disabled={busyAction !== null}>
                 <ArrowLeft className="size-4" />
                 Back
               </Button>
-              <Button onClick={confirmImport} disabled={busy || newCount === 0}>
-                <Check className="size-4" />
-                {newCount === 0
-                  ? "Nothing new to import"
-                  : `Import ${newCount} server${newCount === 1 ? "" : "s"}`}
+              <Button onClick={confirmImport} disabled={busyAction !== null || newCount === 0}>
+                {busyAction === "import" ? (
+                  <>
+                    <Loader2 className="size-4 animate-spin" />
+                    Importing…
+                  </>
+                ) : (
+                  <>
+                    <Check className="size-4" />
+                    {newCount === 0
+                      ? "Nothing new to import"
+                      : `Import ${newCount} server${newCount === 1 ? "" : "s"}`}
+                  </>
+                )}
               </Button>
             </div>
           </div>
@@ -248,15 +260,33 @@ export function ShareDialog({ trigger, onImported }: Props) {
               />
               <div className="flex flex-wrap gap-2">
                 <Button
-                  onClick={() => startPreview(paste)}
-                  disabled={busy || !paste.trim()}
+                  onClick={() => startPreview(paste, "preview-paste")}
+                  disabled={busyAction !== null || !paste.trim()}
                 >
-                  <Upload className="size-4" />
-                  Review and import
+                  {busyAction === "preview-paste" ? (
+                    <>
+                      <Loader2 className="size-4 animate-spin" />
+                      Reviewing…
+                    </>
+                  ) : (
+                    <>
+                      <Upload className="size-4" />
+                      Review and import
+                    </>
+                  )}
                 </Button>
-                <Button variant="outline" onClick={loadFromFile} disabled={busy}>
-                  <FileUp className="size-4" />
-                  Load from file
+                <Button variant="outline" onClick={loadFromFile} disabled={busyAction !== null}>
+                  {busyAction === "preview-file" ? (
+                    <>
+                      <Loader2 className="size-4 animate-spin" />
+                      Loading…
+                    </>
+                  ) : (
+                    <>
+                      <FileUp className="size-4" />
+                      Load from file
+                    </>
+                  )}
                 </Button>
               </div>
             </div>


### PR DESCRIPTION
## Summary

Add visible loading indicators to async dialog actions in `ServerDialog`, `SecretsDialog`, and `ShareDialog` so clicks feel responsive while saves, imports, and keychain writes are in flight.

## Motivation

Fixes #31. Dialog buttons already disabled during async work, but without a spinner the UI felt frozen. The onboarding wizard already uses `Loader2` spinners; this mirrors that pattern.

## Changes

- **ServerDialog**: `busy` state on save/add; primary button shows spinner + "Saving…" / "Adding…"; Cancel disabled while busy.
- **SecretsDialog**: per-action `busyKey` so only the clicked Save/OAuth/Add/Remove control spins; other actions stay disabled.
- **ShareDialog**: per-action `busyAction` for paste preview, file load, and import confirm.

## Tests

- `npm run build` (tsc + vite build) — pass

## Notes

- Issue #33 (confirm before profile delete) is already implemented on `main` via `ConfirmDialog`.
- No behavior changes beyond loading affordances.