### PR TITLE
fix(ui): add Copy action to error toasts for bug reports

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,6 +18,7 @@ import {
   TriangleAlert,
 } from "lucide-react";
 import { toast } from "sonner";
+import { toastError } from "@/lib/toast";
 import {
   detectClients,
   getRegistry,
@@ -151,7 +152,7 @@ function App() {
         // After the first successful load, a refresh failure shouldn't blow away a
         // working list. Surface it as a toast and keep what's on screen.
         if (loadedOnce.current) {
-          toast.error(`Couldn't refresh: ${e}`);
+          toastError(`Couldn't refresh: ${e}`);
         } else {
           setError(String(e));
         }
@@ -290,7 +291,7 @@ function App() {
       // moves it to the disabled group, no probe needed.)
       if (enabled) void reprobe();
     } catch (e) {
-      toast.error(`Couldn't toggle: ${e}`);
+      toastError(`Couldn't toggle: ${e}`);
     } finally {
       setBusyId(null);
     }
@@ -302,7 +303,7 @@ function App() {
       setRegistry(await removeServer(serverId));
       toast.success(`Removed "${name}"`);
     } catch (e) {
-      toast.error(`Couldn't remove: ${e}`);
+      toastError(`Couldn't remove: ${e}`);
     } finally {
       setBusyId(null);
     }
@@ -317,7 +318,7 @@ function App() {
       if (enable) void reprobe();
       toast.success(enable ? "Enabled all servers" : "Disabled all servers");
     } catch (e) {
-      toast.error(`Couldn't update servers: ${e}`);
+      toastError(`Couldn't update servers: ${e}`);
     } finally {
       setTogglingAll(false);
     }
@@ -335,7 +336,7 @@ function App() {
           : "Nothing new to import",
       );
     } catch (e) {
-      toast.error(`Import failed: ${e}`);
+      toastError(`Import failed: ${e}`);
     }
   }
 

--- a/src/components/ActivityView.tsx
+++ b/src/components/ActivityView.tsx
@@ -10,6 +10,7 @@ import {
   XCircle,
 } from "lucide-react";
 import { toast } from "sonner";
+import { toastError } from "@/lib/toast";
 import {
   getAuditLog,
   getAuditStats,
@@ -238,7 +239,7 @@ function SavingsBanner({ savings }: { savings: SavingsSummary }) {
       await navigator.clipboard.writeText(text);
       toast.success("Savings copied, paste them anywhere");
     } catch {
-      toast.error("Couldn't copy to clipboard");
+      toastError("Couldn't copy to clipboard");
     }
   };
 

--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -19,6 +19,7 @@ import {
 import { getVersion } from "@tauri-apps/api/app";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { toast } from "sonner";
+import { toastError } from "@/lib/toast";
 import type { Update } from "@tauri-apps/plugin-updater";
 import {
   importableServers,
@@ -91,7 +92,7 @@ function VersionFooter({
       } else if (r.kind === "current") {
         toast.success("You're on the latest version");
       } else {
-        toast.error("Couldn't check for updates", {
+        toastError("Couldn't check for updates", {
           description: "You may be offline. Try again in a moment.",
         });
       }
@@ -110,7 +111,7 @@ function VersionFooter({
       await installUpdate(update);
     } catch (e) {
       setInstalling(false);
-      toast.error(`Update failed: ${e}`, {
+      toastError(`Update failed: ${e}`, {
         description: "You can download it manually from the releases page.",
         action: {
           label: "Open",
@@ -194,7 +195,7 @@ function VersionFooter({
                 "Diagnostics copied, paste them into your bug report",
               );
             } catch {
-              toast.error("Could not copy diagnostics");
+              toastError("Could not copy diagnostics");
             }
           }}
           title="Copy diagnostics for a bug report"

--- a/src/components/CatalogView.tsx
+++ b/src/components/CatalogView.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { Check, ExternalLink, Loader2, Plus, Search, ShieldCheck, X } from "lucide-react";
 import { toast } from "sonner";
+import { toastError } from "@/lib/toast";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import {
   addServer,
@@ -60,7 +61,7 @@ export function CatalogView({ registry, onAdded }: Props) {
       reloadPopular();
       toast.success(`Removed ${entry.name} from your catalog`);
     } catch (e) {
-      toast.error(`Couldn't remove ${entry.name}: ${e}`);
+      toastError(`Couldn't remove ${entry.name}: ${e}`);
     }
   }
 
@@ -111,7 +112,7 @@ export function CatalogView({ registry, onAdded }: Props) {
         description: "Enable it, then authenticate if it needs credentials.",
       });
     } catch (e) {
-      toast.error(`Couldn't add ${entry.name}: ${e}`);
+      toastError(`Couldn't add ${entry.name}: ${e}`);
     } finally {
       setBusy(null);
     }

--- a/src/components/ClientDetail.tsx
+++ b/src/components/ClientDetail.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { ArrowRight, Check, Download, Link2, Plug, PlugZap, Puzzle, Shuffle } from "lucide-react";
 import { toast } from "sonner";
+import { toastError } from "@/lib/toast";
 import { addServer, installGateway, migrateClient, uninstallGateway } from "@/lib/api";
 import {
   importableServers,
@@ -71,7 +72,7 @@ export function ClientDetail({
       setMigrateOpen(false);
       onChanged();
     } catch (e) {
-      toast.error(`${e}`);
+      toastError(`${e}`);
     } finally {
       setBusy(false);
     }
@@ -117,7 +118,7 @@ export function ClientDetail({
         description: "Enable it to serve it to every client through the gateway.",
       });
     } catch (e) {
-      toast.error(`${e}`);
+      toastError(`${e}`);
     } finally {
       setBusy(false);
     }
@@ -141,7 +142,7 @@ export function ClientDetail({
     } else if (ok > 0) {
       toast.warning(`Imported ${ok}, couldn't import ${failed.join(", ")}`);
     } else {
-      toast.error(`Couldn't import ${failed.join(", ")}`);
+      toastError(`Couldn't import ${failed.join(", ")}`);
     }
   }
 
@@ -163,7 +164,7 @@ export function ClientDetail({
       }
       onChanged();
     } catch (e) {
-      toast.error(`${e}`);
+      toastError(`${e}`);
     } finally {
       setBusy(false);
     }

--- a/src/components/Onboarding.tsx
+++ b/src/components/Onboarding.tsx
@@ -10,6 +10,7 @@ import {
   Waypoints,
 } from "lucide-react";
 import { toast } from "sonner";
+import { toastError } from "@/lib/toast";
 import {
   addCatalogServer,
   importServers,
@@ -219,7 +220,7 @@ function AddServers({
       setImported(next.servers.filter((s) => !isGatewayServer(s)).length);
       toast.success("Imported servers from your clients");
     } catch (e) {
-      toast.error(`Import failed: ${e}`);
+      toastError(`Import failed: ${e}`);
     } finally {
       setBusy(false);
     }
@@ -232,7 +233,7 @@ function AddServers({
       setAdded((prev) => new Set(prev).add(entry.name));
       toast.success(`Added ${entry.name}`);
     } catch (e) {
-      toast.error(`Couldn't add ${entry.name}: ${e}`);
+      toastError(`Couldn't add ${entry.name}: ${e}`);
     } finally {
       setAdding(null);
     }
@@ -340,7 +341,7 @@ function ConnectClients({
       onConnected();
       toast.success(`Connected Conduit to ${client.name}`);
     } catch (e) {
-      toast.error(`Couldn't connect: ${e}`);
+      toastError(`Couldn't connect: ${e}`);
     } finally {
       setBusyId(null);
     }

--- a/src/components/PlaygroundView.tsx
+++ b/src/components/PlaygroundView.tsx
@@ -7,7 +7,7 @@ import {
   ShieldAlert,
   XCircle,
 } from "lucide-react";
-import { toast } from "sonner";
+import { toastError } from "@/lib/toast";
 import {
   callTool,
   listServerTools,
@@ -228,7 +228,7 @@ export function PlaygroundView({ registry, onRegistryChange }: PlaygroundProps) 
     try {
       onRegistryChange(await setToolEnabled(serverId, toolName, enabled));
     } catch (e) {
-      toast.error(`Couldn't update the tool: ${e}`);
+      toastError(`Couldn't update the tool: ${e}`);
     } finally {
       setPolicyBusy(false);
     }

--- a/src/components/ProfileBar.tsx
+++ b/src/components/ProfileBar.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { Plus, Trash2 } from "lucide-react";
 import { toast } from "sonner";
+import { toastError } from "@/lib/toast";
 import {
   createProfile,
   deleteProfile,
@@ -40,7 +41,7 @@ export function ProfileBar({ registry, onChange }: Props) {
     try {
       onChange(await setActiveProfile(id));
     } catch (e) {
-      toast.error(`Couldn't switch profile: ${e}`);
+      toastError(`Couldn't switch profile: ${e}`);
     }
   }
 
@@ -53,7 +54,7 @@ export function ProfileBar({ registry, onChange }: Props) {
       setName("");
       setOpen(false);
     } catch (e) {
-      toast.error(`Couldn't create profile: ${e}`);
+      toastError(`Couldn't create profile: ${e}`);
     }
   }
 
@@ -62,7 +63,7 @@ export function ProfileBar({ registry, onChange }: Props) {
     try {
       onChange(await deleteProfile(activeId));
     } catch (e) {
-      toast.error(`Couldn't delete profile: ${e}`);
+      toastError(`Couldn't delete profile: ${e}`);
     }
   }
 

--- a/src/components/RegistryServerRow.tsx
+++ b/src/components/RegistryServerRow.tsx
@@ -9,6 +9,7 @@ import {
   Trash2,
 } from "lucide-react";
 import { toast } from "sonner";
+import { toastError } from "@/lib/toast";
 import { promoteToCatalog } from "@/lib/api";
 import type { ProbeResult, Registry, ServerEntry } from "@/lib/types";
 import { Switch } from "@/components/ui/switch";
@@ -200,7 +201,7 @@ export function RegistryServerRow({
                   .then(() =>
                     toast.success(`Added ${server.name} to your catalog`),
                   )
-                  .catch((e) => toast.error(`${e}`))
+                  .catch((e) => toastError(`${e}`))
               }
             >
               <Star className="size-3.5" />

--- a/src/components/SecretsDialog.tsx
+++ b/src/components/SecretsDialog.tsx
@@ -1,6 +1,7 @@
 import { useRef, useState, type ReactNode } from "react";
 import { Check, ExternalLink, KeyRound, Loader2, Plus, Trash2 } from "lucide-react";
 import { toast } from "sonner";
+import { toastError } from "@/lib/toast";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import {
   authenticateOauth,
@@ -145,7 +146,7 @@ export function SecretsDialog({ server, onSaved, trigger, onChanged }: Props) {
       toast.success("Saved auth token");
       onChanged?.();
     } catch (e) {
-      toast.error(secretErrorMessage(e));
+      toastError(secretErrorMessage(e));
     } finally {
       setBusyKey(null);
     }
@@ -159,7 +160,7 @@ export function SecretsDialog({ server, onSaved, trigger, onChanged }: Props) {
       toast.success("Cleared auth token");
       onChanged?.();
     } catch (e) {
-      toast.error(secretErrorMessage(e));
+      toastError(secretErrorMessage(e));
     } finally {
       setBusyKey(null);
     }
@@ -180,7 +181,7 @@ export function SecretsDialog({ server, onSaved, trigger, onChanged }: Props) {
     } catch (e) {
       const msg = `${e}`;
       const blankHint = /state mismatch|timed out|closed/i.test(msg);
-      toast.error(`OAuth failed: ${msg}`, {
+      toastError(`OAuth failed: ${msg}`, {
         description: blankHint
           ? "If the sign-in page was blank, your default browser (e.g. Safari) may block the local redirect. Set Chrome or Brave as default and try once more, or paste an access token above instead."
           : undefined,
@@ -200,7 +201,7 @@ export function SecretsDialog({ server, onSaved, trigger, onChanged }: Props) {
       toast.success(`Saved ${key}`);
       onChanged?.();
     } catch (e) {
-      toast.error(secretErrorMessage(e));
+      toastError(secretErrorMessage(e));
     } finally {
       setBusyKey(null);
     }
@@ -213,7 +214,7 @@ export function SecretsDialog({ server, onSaved, trigger, onChanged }: Props) {
       toast.success(`Removed ${key}`);
       onChanged?.();
     } catch (e) {
-      toast.error(secretErrorMessage(e));
+      toastError(secretErrorMessage(e));
     } finally {
       setBusyKey(null);
     }
@@ -232,7 +233,7 @@ export function SecretsDialog({ server, onSaved, trigger, onChanged }: Props) {
       setNewKey("");
       setNewValue("");
     } catch (e) {
-      toast.error(secretErrorMessage(e));
+      toastError(secretErrorMessage(e));
     } finally {
       setBusyKey(null);
     }

--- a/src/components/ServerDialog.tsx
+++ b/src/components/ServerDialog.tsx
@@ -1,6 +1,7 @@
 import { useState, type ReactNode } from "react";
 import { Loader2, Plus, X } from "lucide-react";
 import { toast } from "sonner";
+import { toastError } from "@/lib/toast";
 import { addServer, setSecret, updateServer } from "@/lib/api";
 import type { Registry, ServerEntry, Transport } from "@/lib/types";
 import { Button } from "@/components/ui/button";
@@ -113,7 +114,7 @@ export function ServerDialog({ trigger, onSaved, editId, initial }: Props) {
       toast.success(editing ? `Saved ${entry.name}` : `Added ${entry.name}`);
       setOpen(false);
     } catch (e) {
-      toast.error(`Couldn't save ${entry.name}: ${e}`);
+      toastError(`Couldn't save ${entry.name}: ${e}`);
     } finally {
       setBusy(false);
     }

--- a/src/components/SettingsView.tsx
+++ b/src/components/SettingsView.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { Bot, Layers, ShieldAlert } from "lucide-react";
-import { toast } from "sonner";
+import { toastError } from "@/lib/toast";
 import {
   setAllowAgentControl,
   setDenyDestructive,
@@ -28,7 +28,7 @@ export function SettingsView({ registry, onRegistryChange }: Props) {
       try {
         onRegistryChange(await fn(v));
       } catch (e) {
-        toast.error(`Couldn't update the setting: ${e}`);
+        toastError(`Couldn't update the setting: ${e}`);
       } finally {
         setBusy(false);
       }

--- a/src/components/ShareDialog.tsx
+++ b/src/components/ShareDialog.tsx
@@ -10,6 +10,7 @@ import {
   Upload,
 } from "lucide-react";
 import { toast } from "sonner";
+import { toastError } from "@/lib/toast";
 import { open as openFile, save } from "@tauri-apps/plugin-dialog";
 import {
   exportConfig,
@@ -81,7 +82,7 @@ export function ShareDialog({ trigger, onImported }: Props) {
       setCopied(true);
       setTimeout(() => setCopied(false), 1500);
     } catch {
-      toast.error("Couldn't copy automatically. Select the text and copy it.");
+      toastError("Couldn't copy automatically. Select the text and copy it.");
     }
   }
 
@@ -96,7 +97,7 @@ export function ShareDialog({ trigger, onImported }: Props) {
       await exportConfigToPath(path, name, description);
       toast.success("Saved setup to file");
     } catch (e) {
-      toast.error(`Couldn't save: ${e}`);
+      toastError(`Couldn't save: ${e}`);
     }
   }
 
@@ -108,7 +109,7 @@ export function ShareDialog({ trigger, onImported }: Props) {
       setPendingJson(json);
       setPreview(items);
     } catch (e) {
-      toast.error(`Couldn't read that setup: ${e}`);
+      toastError(`Couldn't read that setup: ${e}`);
     } finally {
       setBusyAction(null);
     }
@@ -126,7 +127,7 @@ export function ShareDialog({ trigger, onImported }: Props) {
       const json = await readSetupFile(path);
       await startPreview(json, "preview-file");
     } catch (e) {
-      toast.error(`Couldn't open that file: ${e}`);
+      toastError(`Couldn't open that file: ${e}`);
     }
   }
 
@@ -139,7 +140,7 @@ export function ShareDialog({ trigger, onImported }: Props) {
       });
       setOpen(false);
     } catch (e) {
-      toast.error(`Couldn't import: ${e}`);
+      toastError(`Couldn't import: ${e}`);
     } finally {
       setBusyAction(null);
     }

--- a/src/lib/toast.ts
+++ b/src/lib/toast.ts
@@ -1,0 +1,33 @@
+import { toast, type ExternalToast } from "sonner";
+
+function errorClipboardText(
+  message: string,
+  description?: ExternalToast["description"],
+): string {
+  if (typeof description === "string" && description.length > 0) {
+    return `${message}\n${description}`;
+  }
+  return message;
+}
+
+function copyToastAction(text: string) {
+  return {
+    label: "Copy",
+    onClick: () => void navigator.clipboard.writeText(text),
+  };
+}
+
+/** Error toast with a Copy action for pasting into bug reports. */
+export function toastError(message: string, options?: ExternalToast) {
+  const text = errorClipboardText(message, options?.description);
+  if (options?.action) {
+    return toast.error(message, {
+      ...options,
+      cancel: options.cancel ?? copyToastAction(text),
+    });
+  }
+  return toast.error(message, {
+    ...options,
+    action: copyToastAction(text),
+  });
+}


### PR DESCRIPTION
## Summary

Add a **Copy** button to every error toast so users can paste the full message into bug reports.

## Motivation

Error toasts show readable messages but were awkward to capture for issue reports (see #32).

## Changes

- Add `toastError()` in `src/lib/toast.ts` — wraps sonner's `toast.error` with a Copy action via `navigator.clipboard.writeText`.
- When a toast already has a primary `action` (e.g. **Open** on update failure), Copy is added as the secondary `cancel` button.
- Clipboard text includes both `message` and string `description` when present.
- Migrate all frontend `toast.error` call sites to `toastError`.

## Tests

- `npx tsc --noEmit` — pass
- `npm run build` — pass
- `cargo test --manifest-path src-tauri/Cargo.toml` — not run (local Cargo 1.83 lacks edition2024 support for a transitive dep; unrelated to this UI-only change)
- Composer-2.5 code review — **APPROVE**

## Notes

No behavior change beyond the new Copy affordance. Success/info toasts are unchanged.

Fixes #32