### PR TITLE
fix(a11y): add aria-labels to status/transport pills and disabled cards

### DIFF
--- a/src/components/ClientDetail.tsx
+++ b/src/components/ClientDetail.tsx
@@ -421,7 +421,10 @@ function ServerMiniCard({
   onImport: () => void;
 }) {
   return (
-    <Card className={`gap-0 ${imported ? "opacity-70" : ""}`}>
+    <Card
+      aria-disabled={imported}
+      className={`gap-0 ${imported ? "opacity-70" : ""}`}
+    >
       <CardContent className="flex flex-col gap-2 p-3">
         <div className="flex items-center justify-between gap-2">
           <div className="flex min-w-0 items-center gap-1.5">

--- a/src/components/RegistryServerRow.tsx
+++ b/src/components/RegistryServerRow.tsx
@@ -51,6 +51,21 @@ const DOT: Record<Status, string> = {
   error: "bg-destructive",
 };
 
+function statusAriaLabel(status: Status, label: string): string {
+  switch (status) {
+    case "disabled":
+      return "Server disabled";
+    case "checking":
+      return "Checking connection";
+    case "connected":
+      return `Connected, ${label}`;
+    case "needs-auth":
+      return "Authentication required";
+    case "error":
+      return "Connection error";
+  }
+}
+
 const ACTION =
   "inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring";
 
@@ -119,7 +134,8 @@ export function RegistryServerRow({
 
         <span
           className={`size-2 shrink-0 rounded-full ${DOT[status]}`}
-          aria-hidden="true"
+          aria-label={statusAriaLabel(status, label)}
+          role="status"
         />
 
         <span className="min-w-0 truncate text-sm font-medium">
@@ -276,7 +292,10 @@ function StatusLabel({
   error: string | null;
 }) {
   const text = (
-    <span className="text-xs whitespace-nowrap text-muted-foreground">
+    <span
+      aria-hidden="true"
+      className="text-xs whitespace-nowrap text-muted-foreground"
+    >
       {label}
     </span>
   );

--- a/src/components/TransportPill.tsx
+++ b/src/components/TransportPill.tsx
@@ -32,10 +32,11 @@ export function TransportPill({ transport }: { transport: Transport }) {
   const Icon = m.icon;
   return (
     <span
+      aria-label={`Transport: ${m.label}`}
       className={`inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-xs font-medium ${m.className}`}
     >
-      <Icon className="size-3" />
-      {m.label}
+      <Icon className="size-3" aria-hidden="true" />
+      <span aria-hidden="true">{m.label}</span>
     </span>
   );
 }


### PR DESCRIPTION
## Summary

Improve screen reader announcements for MCP server transport type, connection health status, and visually dimmed imported client cards.

## Motivation

Status dots and transport pills convey meaning visually but were not fully announced to assistive technologies. Disabled/imported server cards use reduced opacity without an accessible disabled state.

Fixes #30

## Changes

- **`TransportPill`**: add `aria-label` (e.g. "Transport: stdio") and hide redundant inner icon/text from screen readers
- **`RegistryServerRow`**: status dot gets `role="status"` with a descriptive `aria-label` per connection state; visible `StatusLabel` text is `aria-hidden` to avoid duplicate announcements
- **`ClientDetail` `ServerMiniCard`**: `aria-disabled` on imported cards styled with `opacity-70`

Note: the issue references `RegistryServerCard.tsx` / `StatusPill`, which were refactored into `RegistryServerRow` with an inline status dot — the fix targets the current structure.

## Tests

- `npx tsc --noEmit` — pass
- `npm run build` — pass
- `cargo test --manifest-path src-tauri/Cargo.toml` — skipped (environment Cargo 1.83 lacks `edition2024` support for a transitive dependency; change is frontend-only)

## Notes

- Did not add `aria-disabled` on disabled registry rows: the row stays fully interactive (toggle, expand, edit) and health is already announced via the status dot label ("Server disabled").