### PR TITLE
feat: catalog configure-on-add + self-hosted servers (n8n, Langfuse)

### DIFF
--- a/src-tauri/src/catalog.rs
+++ b/src-tauri/src/catalog.rs
@@ -45,6 +45,11 @@ pub struct CatalogEntry {
     /// One-line hint on what credential to create (scopes, what to paste).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub setup_hint: Option<String>,
+    /// Placeholder text for the URL field when the server is self-hosted or
+    /// needs a user-specific endpoint. When present, the catalog UI opens
+    /// ServerDialog instead of immediate-add so the user can enter their URL.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub url_hint: Option<String>,
 }
 
 /// Browse-view grouping for a curated server, keyed by name. Keeps the verified
@@ -59,8 +64,13 @@ fn category_for(name: &str) -> &'static str {
         | "Tavily" | "Perplexity" => "Search & knowledge",
         "Firecrawl" | "Apify" | "Browserbase" => "Web & automation",
         "Stripe" | "Notion" | "Composio" | "Linear" | "Atlassian" | "Asana" | "Airtable"
-        | "Todoist" | "Slack" | "Resend" | "Figma" => "Apps & productivity",
-        "Filesystem" | "Fetch" | "Git" | "Playwright" | "Sequential Thinking" | "Memory"
+        | "Todoist" | "Slack" | "Resend" | "Figma" | "n8n" | "Langfuse" => "Apps & productivity",
+        "Filesystem"
+        | "Fetch"
+        | "Git"
+        | "Playwright"
+        | "Sequential Thinking"
+        | "Memory"
         | "Time" => "Local tools",
         _ => "",
     }
@@ -149,26 +159,47 @@ pub fn curated() -> Vec<CatalogEntry> {
         category: String::new(),
         credentials_url: None,
         setup_hint: None,
+        url_hint: None,
+    };
+    // Self-hosted server: the user supplies the URL (shown as placeholder).
+    // transport is http because the server speaks MCP over HTTP, but the URL
+    // is None — the catalog UI opens ServerDialog so the user enters their
+    // instance endpoint before the server is created.
+    let self_hosted = |name: &str, desc: &str, url_hint: &str, home: &str| CatalogEntry {
+        name: name.to_string(),
+        description: desc.to_string(),
+        transport: "http".to_string(),
+        command: None,
+        args: vec![],
+        url: None,
+        env_keys: vec![],
+        source: "curated".to_string(),
+        homepage: Some(home.to_string()),
+        publisher: None,
+        category: String::new(),
+        credentials_url: None,
+        setup_hint: None,
+        url_hint: Some(url_hint.to_string()),
     };
     // Local (stdio) servers: `command` + args, with any required secret env keys.
-    let cmd =
-        |name: &str, desc: &str, command: &str, args: &[&str], env: &[&str], home: &str| {
-            CatalogEntry {
-                name: name.to_string(),
-                description: desc.to_string(),
-                transport: "stdio".to_string(),
-                command: Some(command.to_string()),
-                args: args.iter().map(|s| s.to_string()).collect(),
-                url: None,
-                env_keys: env.iter().map(|s| s.to_string()).collect(),
-                source: "curated".to_string(),
-                homepage: Some(home.to_string()),
-                publisher: None,
-                category: String::new(),
-                credentials_url: None,
-                setup_hint: None,
-            }
-        };
+    let cmd = |name: &str, desc: &str, command: &str, args: &[&str], env: &[&str], home: &str| {
+        CatalogEntry {
+            name: name.to_string(),
+            description: desc.to_string(),
+            transport: "stdio".to_string(),
+            command: Some(command.to_string()),
+            args: args.iter().map(|s| s.to_string()).collect(),
+            url: None,
+            env_keys: env.iter().map(|s| s.to_string()).collect(),
+            source: "curated".to_string(),
+            homepage: Some(home.to_string()),
+            publisher: None,
+            category: String::new(),
+            credentials_url: None,
+            setup_hint: None,
+            url_hint: None,
+        }
+    };
 
     let mut list = vec![
         // --- Payments & commerce ---
@@ -214,6 +245,9 @@ pub fn curated() -> Vec<CatalogEntry> {
         cmd("Figma", "Turn Figma designs into code (Framelink).", "npx", &["-y", "figma-developer-mcp", "--stdio"], &["FIGMA_API_KEY"], "https://github.com/GLips/Figma-Context-MCP"),
         // --- Email ---
         cmd("Resend", "Send transactional email through Resend.", "npx", &["-y", "resend-mcp"], &["RESEND_API_KEY"], "https://resend.com/docs"),
+        // --- Self-hosted (user supplies URL) ---
+        self_hosted("n8n", "Trigger, manage, and edit n8n workflows via MCP.", "https://your-instance.com/mcp-server/http", "https://n8n.io"),
+        self_hosted("Langfuse", "Prompt management and observability for LLM apps.", "https://your-langfuse.com/mcp", "https://langfuse.com"),
         // --- Local utilities (no account needed) ---
         cmd("Filesystem", "Read and write files in directories you allow.", "npx", &["-y", "@modelcontextprotocol/server-filesystem"], &[], "https://github.com/modelcontextprotocol/servers"),
         cmd("Fetch", "Fetch a URL and return its content as markdown.", "uvx", &["mcp-server-fetch"], &[], "https://github.com/modelcontextprotocol/servers"),
@@ -346,6 +380,7 @@ fn map_server(server: &Value) -> Option<CatalogEntry> {
                 category: String::new(),
                 credentials_url: None,
                 setup_hint: None,
+                url_hint: None,
             });
         }
     }
@@ -379,7 +414,15 @@ fn map_server(server: &Value) -> Option<CatalogEntry> {
         }
         let (command, args) = match registry_type {
             "pypi" => ("uvx".to_string(), vec![spec]),
-            "oci" | "docker" => ("docker".to_string(), vec!["run".to_string(), "-i".to_string(), "--rm".to_string(), spec]),
+            "oci" | "docker" => (
+                "docker".to_string(),
+                vec![
+                    "run".to_string(),
+                    "-i".to_string(),
+                    "--rm".to_string(),
+                    spec,
+                ],
+            ),
             _ => ("npx".to_string(), vec!["-y".to_string(), spec]),
         };
         let env_keys = pkg
@@ -406,6 +449,7 @@ fn map_server(server: &Value) -> Option<CatalogEntry> {
             category: String::new(),
             credentials_url: None,
             setup_hint: None,
+            url_hint: None,
         });
     }
 
@@ -467,8 +511,13 @@ mod tests {
         assert!(c.len() >= 20);
         for e in &c {
             assert!(!e.name.is_empty());
-            // Each entry is either a remote (url) or a command, never neither.
-            assert!(e.url.is_some() || e.command.is_some(), "{} has no target", e.name);
+            // Each entry has a target: a URL, a command, or a url_hint
+            // (self-hosted servers where the user supplies the URL at add time).
+            assert!(
+                e.url.is_some() || e.command.is_some() || e.url_hint.is_some(),
+                "{} has no target",
+                e.name
+            );
             // Every curated entry must land in a browse-view category.
             assert!(!e.category.is_empty(), "{} has no category", e.name);
         }
@@ -482,7 +531,9 @@ mod tests {
         assert_eq!(vercel.len(), 1);
         assert_eq!(vercel[0].name, "Vercel");
         // Description matches too (Postgres -> Neon/Supabase).
-        assert!(filter_catalog(curated(), "postgres").iter().any(|e| e.name == "Neon"));
+        assert!(filter_catalog(curated(), "postgres")
+            .iter()
+            .any(|e| e.name == "Neon"));
         // Empty query returns the full set.
         assert_eq!(filter_catalog(curated(), "").len(), curated().len());
     }
@@ -552,14 +603,23 @@ mod tests {
         // Leading-dash identifier (flag injection into npx) is dropped.
         let flag = json!({ "name": "io.x/y", "title": "Y",
             "packages": [{ "registryType": "npm", "identifier": "--unsafe-flag" }] });
-        assert!(map_server(&flag).is_none(), "flag-injection identifier must be dropped");
+        assert!(
+            map_server(&flag).is_none(),
+            "flag-injection identifier must be dropped"
+        );
         // Shell metacharacters in the version are dropped.
         let meta = json!({ "name": "io.x/z", "title": "Z",
             "packages": [{ "registryType": "npm", "identifier": "pkg", "version": "1; rm -rf /" }] });
-        assert!(map_server(&meta).is_none(), "shell metachars must be dropped");
+        assert!(
+            map_server(&meta).is_none(),
+            "shell metachars must be dropped"
+        );
         // A non-http(s) remote URL is dropped.
         let scheme = json!({ "name": "io.x/w", "title": "W",
             "remotes": [{ "type": "streamable-http", "url": "file:///etc/passwd" }] });
-        assert!(map_server(&scheme).is_none(), "non-http remote must be dropped");
+        assert!(
+            map_server(&scheme).is_none(),
+            "non-http remote must be dropped"
+        );
     }
 }

--- a/src/components/CatalogView.tsx
+++ b/src/components/CatalogView.tsx
@@ -8,6 +8,7 @@ import type { CatalogEntry, Registry, ServerEntry, Stack } from "@/lib/types";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { TransportPill } from "@/components/TransportPill";
+import { ServerDialog } from "@/components/ServerDialog";
 
 /** Section order for the browse view; categories not listed fall to the end. */
 const CATEGORY_ORDER = [
@@ -34,6 +35,7 @@ export function CatalogView({ registry, onAdded }: Props) {
   const [popularError, setPopularError] = useState(false);
   const [stacks, setStacks] = useState<Stack[]>([]);
   const [stackBusy, setStackBusy] = useState<string | null>(null);
+  const [configEntry, setConfigEntry] = useState<CatalogEntry | null>(null);
 
   const have = new Set((registry?.servers ?? []).map((s) => s.name.toLowerCase()));
 
@@ -85,7 +87,25 @@ export function CatalogView({ registry, onAdded }: Props) {
     };
   }, [query]);
 
+  /** Returns true if the entry needs the ServerDialog (has credentials, a
+   * user-supplied URL, or args the user should review). False = safe to
+   * immediate-add with no configuration. */
+  function needsConfig(entry: CatalogEntry): boolean {
+    return (
+      entry.urlHint != null ||
+      entry.envKeys.length > 0 ||
+      entry.args.length > 0
+    );
+  }
+
   async function add(entry: CatalogEntry) {
+    // Self-hosted servers or entries with credentials/args: open the dialog
+    // so the user can enter their URL, paste API keys, or adjust args before
+    // the server is created.
+    if (needsConfig(entry)) {
+      setConfigEntry(entry);
+      return;
+    }
     setBusy(entry.name);
     try {
       const server: ServerEntry = {
@@ -265,6 +285,32 @@ export function CatalogView({ registry, onAdded }: Props) {
         <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
           {shown.map(card)}
         </div>
+      )}
+      {configEntry && (
+        <ServerDialog
+          onSaved={(reg) => {
+            onAdded(reg);
+            setConfigEntry(null);
+          }}
+          onClose={() => setConfigEntry(null)}
+          initial={{
+            id: "",
+            name: configEntry.name,
+            transport: configEntry.transport,
+            command: configEntry.command,
+            args: configEntry.args,
+            env: configEntry.envKeys.map((key) => ({
+              key,
+              value: null,
+              secret: true,
+            })),
+            url: configEntry.url,
+            source: `catalog:${configEntry.source}`,
+          }}
+          existingNames={(registry?.servers ?? []).map((s) => s.name)}
+          autoOpen
+          trigger={<span className="hidden" />}
+        />
       )}
     </div>
   );

--- a/src/components/ServerDialog.tsx
+++ b/src/components/ServerDialog.tsx
@@ -32,10 +32,14 @@ interface Props {
   initial?: ServerEntry;
   /** Names of servers that already exist, to warn on a duplicate name. */
   existingNames?: string[];
+  /** Open the dialog automatically on mount (used by catalog configure-add). */
+  autoOpen?: boolean;
+  /** Called when the dialog closes without saving (dismiss/cancel). */
+  onClose?: () => void;
 }
 
-export function ServerDialog({ trigger, onSaved, editId, initial, existingNames }: Props) {
-  const [open, setOpen] = useState(false);
+export function ServerDialog({ trigger, onSaved, editId, initial, existingNames, autoOpen, onClose }: Props) {
+  const [open, setOpen] = useState(autoOpen ?? false);
   const [form, setForm] = useState({
     name: initial?.name ?? "",
     transport: (initial?.transport ?? "stdio") as Transport,
@@ -70,6 +74,10 @@ export function ServerDialog({ trigger, onSaved, editId, initial, existingNames 
   // button), so reset the form each time it opens - otherwise it keeps the last
   // entry's values instead of starting blank (or re-deriving from `initial`).
   function onOpenChange(next: boolean) {
+    if (!next && onClose) {
+      onClose();
+      return;
+    }
     if (next) {
       setForm({
         name: initial?.name ?? "",

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -200,6 +200,8 @@ export interface CatalogEntry {
   credentialsUrl?: string;
   /** One-line hint on what credential to create (scopes, what to paste). */
   setupHint?: string;
+  /** Placeholder for URL field when self-hosted (opens dialog on add). */
+  urlHint?: string;
 }
 
 /** A curated "stack": a role-based bundle of catalog servers for guided setup. */


### PR DESCRIPTION
## What

Two changes that make the catalog work for servers that need configuration:

### 1. Configure-on-add

Catalog entries that need configuration now open **ServerDialog** on Add instead of creating silently. The user sees the pre-filled name, transport, env keys, and args before the server is created — so they can enter credentials, adjust args, or change the URL.

**Routing logic:**
- HTTP with fixed cloud URL (Vercel, Sentry, Stripe...) → **immediate add** (unchanged)
- stdio with no args and no env (Sequential Thinking, Memory...) → **immediate add** (unchanged)
- Everything else (has env keys, has args, or is self-hosted) → **opens ServerDialog**

This fixes the dead-end where adding Twilio created a server with empty env keys and no guidance on where to put credentials.

### 2. Self-hosted servers

New `self_hosted()` catalog helper + `url_hint` field for servers where the user supplies the URL. These entries have placeholder text (e.g. `https://your-instance.com/mcp-server/http`) instead of a fixed URL, and always open the dialog on Add.

**New catalog entries:**
- **n8n** — Trigger, manage, and edit n8n workflows via MCP
- **Langfuse** — Prompt management and observability for LLM apps

## Files
- `catalog.rs` — `url_hint` field on `CatalogEntry`, `self_hosted()` helper, n8n + Langfuse entries
- `CatalogView.tsx` — `needsConfig()` routing + ServerDialog rendering with `autoOpen`
- `ServerDialog.tsx` — `autoOpen` and `onClose` props for catalog-driven flow
- `types.ts` — `urlHint?: string` on `CatalogEntry`

## Testing
- All catalog tests pass (7/7)
- TypeScript clean
- `curated_is_nonempty_and_well_formed` test updated to accept `url_hint` as a valid target