### PR TITLE
fix(catalog): surface url_hint in ServerDialog for self-hosted servers

### DIFF
--- a/src/components/CatalogView.tsx
+++ b/src/components/CatalogView.tsx
@@ -309,6 +309,7 @@ export function CatalogView({ registry, onAdded }: Props) {
           }}
           existingNames={(registry?.servers ?? []).map((s) => s.name)}
           autoOpen
+          urlHint={configEntry.urlHint ?? undefined}
           trigger={<span className="hidden" />}
         />
       )}

--- a/src/components/ServerDialog.tsx
+++ b/src/components/ServerDialog.tsx
@@ -36,9 +36,13 @@ interface Props {
   autoOpen?: boolean;
   /** Called when the dialog closes without saving (dismiss/cancel). */
   onClose?: () => void;
+  /** Placeholder + helper text for the URL field when the server is self-hosted
+   * (e.g. n8n, Langfuse). Shown as input placeholder and as an explanatory note
+   * below the field. */
+  urlHint?: string;
 }
 
-export function ServerDialog({ trigger, onSaved, editId, initial, existingNames, autoOpen, onClose }: Props) {
+export function ServerDialog({ trigger, onSaved, editId, initial, existingNames, autoOpen, onClose, urlHint }: Props) {
   const [open, setOpen] = useState(autoOpen ?? false);
   const [form, setForm] = useState({
     name: initial?.name ?? "",
@@ -346,10 +350,16 @@ export function ServerDialog({ trigger, onSaved, editId, initial, existingNames,
               <Label htmlFor="srv-url">URL</Label>
               <Input
                 id="srv-url"
-                placeholder="https://mcp.example.com/mcp"
+                placeholder={urlHint ?? "https://mcp.example.com/mcp"}
                 value={form.url}
                 onChange={(e) => set("url", e.target.value)}
               />
+              {urlHint && (
+                <p className="text-xs text-muted-foreground">
+                  Enter the URL of your self-hosted instance. For example:{" "}
+                  <code className="font-mono">{urlHint}</code>
+                </p>
+              )}
             </div>
           )}
 


### PR DESCRIPTION
## Problem

When adding a self-hosted server (n8n, Langfuse) from the catalog, the `ServerDialog` opens with a **blank URL field and no guidance** — just the generic placeholder `https://mcp.example.com/mcp`. The catalog entries already define helpful `url_hint` values (e.g. `https://your-instance.com/mcp-server/http`), but that data never reaches the dialog.

## Fix

Thread `urlHint` from `CatalogView` → `ServerDialog`:

- **URL input placeholder** uses `urlHint` when present (falls back to the existing generic placeholder)
- **Helper note** renders below the field with an example URL in a `<code>` block

**Before:** URL field shows `https://mcp.example.com/mcp` — no context.

**After:** URL field shows `https://your-instance.com/mcp-server/http` with helper text: *"Enter the URL of your self-hosted instance. For example: `https://your-instance.com/mcp-server/http`"*

## Changes

| File | Change |
|---|---|
| `ServerDialog.tsx` | New `urlHint?: string` prop; placeholder + helper note |
| `CatalogView.tsx` | Pass `configEntry.urlHint` through to `ServerDialog` |

2 files, +13/-1 lines. No type changes needed — `CatalogEntry.urlHint` already existed in both Rust and TS.

## Verification

- ✅ `tsc --noEmit` — clean
- ✅ `npm run build` — clean
- ✅ 13/13 catalog tests pass (no Rust changes)
- ✅ Backward compatible — `urlHint` is optional with `??` fallback