### PR TITLE
fix: release per-server Mutex during backoff sleep (head-of-line blocking)

### DIFF
--- a/src-tauri/src/downstream.rs
+++ b/src-tauri/src/downstream.rs
@@ -40,10 +40,42 @@ const MAX_RESPONSE_BYTES: u64 = 16 * 1024 * 1024;
 /// do NOT retry 5xx or post-send I/O errors, because an MCP `tools/call` is not
 /// guaranteed idempotent and may already have executed server-side, so a blind
 /// retry could double-execute it (send the email twice, charge the card twice).
-const HTTP_MAX_RETRIES: u32 = 2;
+pub(crate) const HTTP_MAX_RETRIES: u32 = 2;
 /// Base backoff between retries; doubles each attempt, capped at HTTP_RETRY_CAP.
-const HTTP_RETRY_BASE: Duration = Duration::from_millis(250);
-const HTTP_RETRY_CAP: Duration = Duration::from_secs(10);
+pub(crate) const HTTP_RETRY_BASE: Duration = Duration::from_millis(250);
+pub(crate) const HTTP_RETRY_CAP: Duration = Duration::from_secs(10);
+
+
+/// Error from a single transport request attempt. The caller (Router) owns the
+/// retry loop so it can release the per-server Mutex during the backoff sleep,
+/// instead of blocking every other agent queued on the same server.
+#[derive(Debug, Clone)]
+pub enum TransportError {
+    /// Non-retryable: the request was processed (or is structurally invalid).
+    Fatal(String),
+    /// Retryable: a 429 rate-limit or a connection that never reached the server.
+    /// `retry_after` carries the server-advertised delay (Retry-After) if present;
+    /// the caller falls back to its own exponential backoff when `None`.
+    Retry {
+        retry_after: Option<Duration>,
+        message: String,
+    },
+}
+
+impl std::fmt::Display for TransportError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            TransportError::Fatal(msg) => write!(f, "{msg}"),
+            TransportError::Retry { message, .. } => write!(f, "{message}"),
+        }
+    }
+}
+
+impl From<String> for TransportError {
+    fn from(s: String) -> Self {
+        TransportError::Fatal(s)
+    }
+}
 
 /// Read up to `max` bytes of a ureq response body, lossily as text, never more than
 /// the cap even if the server keeps streaming.
@@ -55,7 +87,7 @@ fn read_capped(resp: ureq::Response, max: u64) -> String {
 }
 
 /// Exponential backoff for retry `attempt` (0-based): base * 2^attempt, capped.
-fn backoff_delay(attempt: u32) -> Duration {
+pub(crate) fn backoff_delay(attempt: u32) -> Duration {
     let mult = 1u32 << attempt.min(6);
     HTTP_RETRY_BASE.saturating_mul(mult).min(HTTP_RETRY_CAP)
 }
@@ -175,8 +207,8 @@ pub fn resolve_command(command: &str) -> String {
 
 /// A bidirectional JSON-RPC channel to one downstream server.
 pub trait Transport: Send {
-    fn request(&mut self, method: &str, params: Value) -> Result<Value, String>;
-    fn notify(&mut self, method: &str, params: Value) -> Result<(), String>;
+    fn request(&mut self, method: &str, params: Value) -> Result<Value, TransportError>;
+    fn notify(&mut self, method: &str, params: Value) -> Result<(), TransportError>;
     /// Bound how long a single `request` waits for its response. Used to fail the
     /// connect handshake fast. Default no-op: transports with their own fixed
     /// request timeout (e.g. HTTP) ignore it.
@@ -381,12 +413,12 @@ impl StdioTransport {
 }
 
 impl Transport for StdioTransport {
-    fn request(&mut self, method: &str, params: Value) -> Result<Value, String> {
+    fn request(&mut self, method: &str, params: Value) -> Result<Value, TransportError> {
         let id = self.next_id;
         self.next_id += 1;
         let msg = json!({ "jsonrpc": "2.0", "id": id, "method": method, "params": params });
-        writeln!(self.stdin, "{msg}").map_err(|e| e.to_string())?;
-        self.stdin.flush().map_err(|e| e.to_string())?;
+        writeln!(self.stdin, "{msg}").map_err(|e| TransportError::Fatal(e.to_string()))?;
+        self.stdin.flush().map_err(|e| TransportError::Fatal(e.to_string()))?;
 
         // Read until the response with our id arrives, skipping notifications.
         // The deadline bounds the whole wait so an unresponsive server fails fast
@@ -399,10 +431,10 @@ impl Transport for StdioTransport {
             let line = match self.rx.recv_timeout(remaining) {
                 Ok(l) => l,
                 Err(RecvTimeoutError::Timeout) => {
-                    return Err(format!("timed out waiting for '{method}' response"))
+                    return Err(TransportError::Fatal(format!("timed out waiting for '{method}' response")))
                 }
                 Err(RecvTimeoutError::Disconnected) => {
-                    return Err(self.closed_error())
+                    return Err(TransportError::Fatal(self.closed_error()))
                 }
             };
             let trimmed = line.trim();
@@ -415,17 +447,17 @@ impl Transport for StdioTransport {
             };
             if value.get("id").and_then(|i| i.as_i64()) == Some(id) {
                 if let Some(err) = value.get("error") {
-                    return Err(err.to_string());
+                    return Err(TransportError::Fatal(err.to_string()));
                 }
                 return Ok(value.get("result").cloned().unwrap_or(Value::Null));
             }
         }
     }
 
-    fn notify(&mut self, method: &str, params: Value) -> Result<(), String> {
+    fn notify(&mut self, method: &str, params: Value) -> Result<(), TransportError> {
         let msg = json!({ "jsonrpc": "2.0", "method": method, "params": params });
-        writeln!(self.stdin, "{msg}").map_err(|e| e.to_string())?;
-        self.stdin.flush().map_err(|e| e.to_string())
+        writeln!(self.stdin, "{msg}").map_err(|e| TransportError::Fatal(e.to_string()))?;
+        self.stdin.flush().map_err(|e| TransportError::Fatal(e.to_string()))
     }
 
     fn set_read_timeout(&mut self, timeout: Duration) {
@@ -517,13 +549,13 @@ impl HttpTransport {
         }
     }
 
-    fn post(&mut self, body: &Value, expect_response: bool) -> Result<Option<Value>, String> {
+    fn post(&mut self, body: &Value, expect_response: bool) -> Result<Option<Value>, TransportError> {
         let payload = body.to_string();
-        let mut attempt = 0u32;
+
+        // Token refresh is handled internally (it doesn't sleep, so no lock
+        // contention). Only 429 and transport-retry signals bubble up as
+        // TransportError::Retry so the Router can sleep *outside* the lock.
         let mut refreshed = false;
-        // Retry only the genuinely-safe transient failures (429 and
-        // connection-never-reached). Each attempt rebuilds the request (ureq
-        // consumes it on send).
         let resp = loop {
             let mut req = self
                 .agent
@@ -540,17 +572,15 @@ impl HttpTransport {
 
             match req.send_string(&payload) {
                 Ok(r) => break r,
-                // Rate limited: the server rejected the request before processing
-                // it, so retrying after the advertised delay is safe for any method.
-                Err(ureq::Error::Status(429, r)) if attempt < HTTP_MAX_RETRIES => {
-                    let wait = r
-                        .header("retry-after")
-                        .and_then(retry_after_delay)
-                        .unwrap_or_else(|| backoff_delay(attempt));
-                    // Drain the body so the connection can be reused.
+                // Rate limited: return a Retry signal so the Router sleeps
+                // *outside* the per-server Mutex.
+                Err(ureq::Error::Status(429, r)) => {
+                    let retry_after = r.header("retry-after").and_then(retry_after_delay);
                     let _ = read_capped(r, 8 * 1024);
-                    std::thread::sleep(wait);
-                    attempt += 1;
+                    return Err(TransportError::Retry {
+                        retry_after,
+                        message: "HTTP 429: rate limited".to_string(),
+                    });
                 }
                 // The access token likely expired: refresh it once and retry with
                 // the new token, so a long-running session self-heals instead of
@@ -558,14 +588,17 @@ impl HttpTransport {
                 Err(ureq::Error::Status(code, r))
                     if (code == 401 || code == 403) && !refreshed && self.refresh.is_some() =>
                 {
-                    let _ = read_capped(r, 8 * 1024); // drain so the connection can be reused
+                    let _ = read_capped(r, 8 * 1024);
                     refreshed = true;
                     match self.refresh.as_ref().and_then(|f| f()) {
-                        Some(tok) => self.auth = Some(tok),
+                        Some(tok) => {
+                            self.auth = Some(tok);
+                            continue;
+                        }
                         None => {
-                            return Err(format!(
+                            return Err(TransportError::Fatal(format!(
                                 "HTTP {code} (needs authentication): token refresh failed"
-                            ))
+                            )))
                         }
                     }
                 }
@@ -576,17 +609,17 @@ impl HttpTransport {
                     } else {
                         ""
                     };
-                    return Err(format!("HTTP {code}{hint}: {detail}"));
+                    return Err(TransportError::Fatal(format!("HTTP {code}{hint}: {detail}")));
                 }
-                // The connection never reached the server, so the request did not
-                // execute: safe to retry even a non-idempotent tools/call.
-                Err(ureq::Error::Transport(t))
-                    if attempt < HTTP_MAX_RETRIES && is_retryable_transport(&t) =>
-                {
-                    std::thread::sleep(backoff_delay(attempt));
-                    attempt += 1;
+                // Transport error (DNS / connection failure): retryable, but
+                // the Router owns the backoff sleep so the Mutex is released.
+                Err(ureq::Error::Transport(t)) if is_retryable_transport(&t) => {
+                    return Err(TransportError::Retry {
+                        retry_after: None,
+                        message: format!("transport error (retryable): {t}"),
+                    });
                 }
-                Err(e) => return Err(e.to_string()),
+                Err(e) => return Err(TransportError::Fatal(e.to_string())),
             }
         };
 
@@ -619,28 +652,28 @@ impl HttpTransport {
                     }
                 }
             }
-            Err("no matching message in SSE stream".to_string())
+            Err(TransportError::Fatal("no matching message in SSE stream".to_string()))
         } else {
             serde_json::from_str(&text)
                 .map(Some)
-                .map_err(|e| format!("bad JSON response: {e}"))
+                .map_err(|e| TransportError::Fatal(format!("bad JSON response: {e}")))
         }
     }
 }
 
 impl Transport for HttpTransport {
-    fn request(&mut self, method: &str, params: Value) -> Result<Value, String> {
+    fn request(&mut self, method: &str, params: Value) -> Result<Value, TransportError> {
         let id = self.next_id;
         self.next_id += 1;
         let body = json!({ "jsonrpc": "2.0", "id": id, "method": method, "params": params });
-        let resp = self.post(&body, true)?.ok_or("empty response")?;
+        let resp = self.post(&body, true)?.ok_or_else(|| TransportError::Fatal("empty response".to_string()))?;
         if let Some(err) = resp.get("error") {
-            return Err(err.to_string());
+            return Err(TransportError::Fatal(err.to_string()));
         }
         Ok(resp.get("result").cloned().unwrap_or(Value::Null))
     }
 
-    fn notify(&mut self, method: &str, params: Value) -> Result<(), String> {
+    fn notify(&mut self, method: &str, params: Value) -> Result<(), TransportError> {
         let body = json!({ "jsonrpc": "2.0", "method": method, "params": params });
         self.post(&body, false)?;
         Ok(())
@@ -678,13 +711,13 @@ impl DownstreamServer {
                 "capabilities": {},
                 "clientInfo": { "name": "conduit-gateway", "version": env!("CARGO_PKG_VERSION") }
             }),
-        )?;
+        ).map_err(|e| e.to_string())?;
         let caps = init.get("capabilities");
         let caps_resources = caps.and_then(|c| c.get("resources")).is_some();
         let caps_prompts = caps.and_then(|c| c.get("prompts")).is_some();
-        transport.notify("notifications/initialized", json!({}))?;
+        transport.notify("notifications/initialized", json!({})).map_err(|e| e.to_string())?;
 
-        let result = transport.request("tools/list", json!({}))?;
+        let result = transport.request("tools/list", json!({})).map_err(|e| e.to_string())?;
         let tools = extract_array(&result, "tools");
 
         // Restore the longer timeout: actual tool calls can legitimately be slow.
@@ -731,19 +764,19 @@ impl DownstreamServer {
         }
     }
 
-    pub fn call(&mut self, tool: &str, arguments: Value) -> Result<Value, String> {
+    pub fn call(&mut self, tool: &str, arguments: Value) -> Result<Value, TransportError> {
         self.transport
             .request("tools/call", json!({ "name": tool, "arguments": arguments }))
     }
 
     /// Read one resource by its (original, downstream) uri.
-    pub fn read_resource(&mut self, uri: &str) -> Result<Value, String> {
+    pub fn read_resource(&mut self, uri: &str) -> Result<Value, TransportError> {
         self.transport
             .request("resources/read", json!({ "uri": uri }))
     }
 
     /// Get one prompt by its (original, downstream) name.
-    pub fn get_prompt(&mut self, name: &str, arguments: Value) -> Result<Value, String> {
+    pub fn get_prompt(&mut self, name: &str, arguments: Value) -> Result<Value, TransportError> {
         self.transport
             .request("prompts/get", json!({ "name": name, "arguments": arguments }))
     }
@@ -928,5 +961,78 @@ mod tests {
         assert!(res.is_some(), "got the 200 result after refreshing");
         assert_eq!(hits.load(Ordering::SeqCst), 2, "exactly one 401 then one retry");
         assert_eq!(*retry_auth.lock().unwrap(), "Bearer fresh", "retry used the new token");
+    }
+
+    #[test]
+    fn post_returns_retry_on_429_with_retry_after() {
+        use super::{HttpTransport, TransportError};
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use std::time::Duration;
+
+        // Mock MCP server: 429 with Retry-After: 2 on the first request,
+        // 200 JSON-RPC on the second.
+        let server = tiny_http::Server::http("127.0.0.1:0").unwrap();
+        let port = server.server_addr().to_ip().unwrap().port();
+        let hits = Arc::new(AtomicUsize::new(0));
+        let hc = Arc::clone(&hits);
+        let handle = std::thread::spawn(move || {
+            for _ in 0..2 {
+                let req = match server.recv() {
+                    Ok(r) => r,
+                    Err(_) => return,
+                };
+                if hc.fetch_add(1, Ordering::SeqCst) == 0 {
+                    let ra = tiny_http::Header::from_bytes(&b"Retry-After"[..], &b"2"[..]).unwrap();
+                    let _ = req.respond(
+                        tiny_http::Response::from_string("rate limited")
+                            .with_status_code(429)
+                            .with_header(ra),
+                    );
+                } else {
+                    let ct = tiny_http::Header::from_bytes(&b"Content-Type"[..], &b"application/json"[..]).unwrap();
+                    let body = r#"{"jsonrpc":"2.0","id":1,"result":{"ok":true}}"#;
+                    let _ = req.respond(tiny_http::Response::from_string(body).with_header(ct));
+                }
+            }
+        });
+
+        let url = format!("http://127.0.0.1:{port}/");
+        let mut t = HttpTransport::new(&url);
+
+        // First call: should get a Retry signal, NOT an Ok or Fatal.
+        let result = t.post(&serde_json::json!({ "jsonrpc": "2.0", "id": 1, "method": "ping" }), true);
+        match &result {
+            Err(TransportError::Retry { retry_after, .. }) => {
+                assert_eq!(*retry_after, Some(Duration::from_secs(2)));
+            }
+            other => panic!("expected TransportError::Retry, got {other:?}"),
+        }
+
+        // Second call: the server now responds 200.
+        let result2 = t.post(&serde_json::json!({ "jsonrpc": "2.0", "id": 2, "method": "ping" }), true);
+        assert!(result2.is_ok(), "second call should succeed: {result2:?}");
+        assert_eq!(hits.load(Ordering::SeqCst), 2);
+
+        handle.join().unwrap();
+    }
+
+    #[test]
+    fn post_returns_retry_on_transport_error() {
+        use super::{HttpTransport, TransportError};
+
+        // A dead port: connection refused, which is a retryable transport error.
+        let mut t = HttpTransport::new("http://127.0.0.1:1/");
+        let result = t.post(&serde_json::json!({ "jsonrpc": "2.0", "id": 1, "method": "ping" }), true);
+        match &result {
+            Err(TransportError::Retry { retry_after, .. }) => {
+                assert!(retry_after.is_none());
+            }
+            Err(TransportError::Fatal(msg)) => {
+                // On some systems port 1 may produce a different error class.
+                eprintln!("got Fatal instead of Retry (OS-dependent): {msg}");
+            }
+            other => panic!("expected Retry or Fatal, got {other:?}"),
+        }
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -690,7 +690,7 @@ async fn call_tool(
     tauri::async_runtime::spawn_blocking(move || {
         let mut ds = connect_server(&server)?;
         let started = std::time::Instant::now();
-        let result = ds.call(&tool, arguments);
+        let result = ds.call(&tool, arguments).map_err(|e| e.to_string());
         let ms = started.elapsed().as_millis() as u64;
         // Mirror the gateway's success accounting: a result with isError=true is
         // a failed call even though the transport round-tripped fine.
@@ -700,7 +700,7 @@ async fn call_tool(
             .unwrap_or(false);
         // A transport error carries its own message; capture it so Activity can
         // show why a playground call failed, not just that it did.
-        let err = result.as_ref().err().cloned();
+        let err = result.as_ref().err().map(|e| e.to_string());
         audit::record_timed(&server.id, &tool, ok, Some(ms), err.as_deref());
         result
     })
@@ -757,7 +757,7 @@ async fn read_resource(
     let server = server_by_id(state.inner(), &server_id)?;
     tauri::async_runtime::spawn_blocking(move || {
         let mut ds = connect_server(&server)?;
-        ds.read_resource(&uri)
+        ds.read_resource(&uri).map_err(|e| e.to_string())
     })
     .await
     .map_err(|e| e.to_string())?
@@ -775,7 +775,7 @@ async fn get_prompt(
     let server = server_by_id(state.inner(), &server_id)?;
     tauri::async_runtime::spawn_blocking(move || {
         let mut ds = connect_server(&server)?;
-        ds.get_prompt(&name, arguments)
+        ds.get_prompt(&name, arguments).map_err(|e| e.to_string())
     })
     .await
     .map_err(|e| e.to_string())?

--- a/src-tauri/src/router.rs
+++ b/src-tauri/src/router.rs
@@ -17,7 +17,7 @@ use std::sync::{Arc, Mutex};
 
 use serde_json::{json, Value};
 
-use crate::downstream::DownstreamServer;
+use crate::downstream::{backoff_delay, DownstreamServer, TransportError, HTTP_MAX_RETRIES};
 
 /// Rewrite a name segment to the function-name charset clients accept
 /// (`[A-Za-z0-9_]`); every other character becomes `_`.
@@ -354,6 +354,32 @@ impl Router {
             .ok_or_else(|| format!("no connected server '{server_id}'"))
     }
 
+    /// Retry wrapper that releases the per-server Mutex during the backoff sleep
+    /// so concurrent calls to the same server aren't blocked while one call waits
+    /// for a rate-limit or connection-retry delay.
+    fn call_with_retry<T, F>(&self, slot: &Arc<ServerSlot>, mut f: F) -> Result<T, String>
+    where
+        F: FnMut(&mut DownstreamServer) -> Result<T, TransportError>,
+    {
+        let mut attempt = 0u32;
+        loop {
+            let result = {
+                let mut server = slot.inner.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+                f(&mut server)
+            };
+            match result {
+                Ok(v) => return Ok(v),
+                Err(TransportError::Retry { retry_after, message }) if attempt < HTTP_MAX_RETRIES => {
+                    let wait = retry_after.unwrap_or_else(|| backoff_delay(attempt));
+                    eprintln!("conduit: retrying downstream call after {wait:?}: {message}");
+                    std::thread::sleep(wait);
+                    attempt += 1;
+                }
+                Err(e) => return Err(e.to_string()),
+            }
+        }
+    }
+
     /// Forward an exposed tool call to its owning downstream server, using that
     /// server's original tool name. Takes `&self`: it locks only the target
     /// server, so concurrent calls to different servers run in parallel while
@@ -368,11 +394,7 @@ impl Router {
             .cloned()
             .ok_or_else(|| format!("no route for tool '{exposed_name}'"))?;
         let slot = self.slot_for(&server_id)?;
-        let mut server = slot
-            .inner
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
-        server.call(&tool, arguments)
+        self.call_with_retry(&slot, |server| server.call(&tool, arguments.clone()))
     }
 
     /// Every downstream resource, uris unchanged.
@@ -394,11 +416,7 @@ impl Router {
             .cloned()
             .ok_or_else(|| format!("no server owns resource '{uri}'"))?;
         let slot = self.slot_for(&server_id)?;
-        let mut server = slot
-            .inner
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
-        server.read_resource(uri)
+        self.call_with_retry(&slot, |server| server.read_resource(uri))
     }
 
     /// Get a prompt by its exposed name, forwarding the server's real name.
@@ -410,17 +428,16 @@ impl Router {
             .cloned()
             .ok_or_else(|| format!("no route for prompt '{exposed_name}'"))?;
         let slot = self.slot_for(&server_id)?;
-        let mut server = slot
-            .inner
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
-        server.get_prompt(&name, arguments)
+        self.call_with_retry(&slot, |server| server.get_prompt(&name, arguments.clone()))
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::atomic::{AtomicU32, Ordering};
+    use std::sync::Arc;
+    use std::time::Duration;
 
     #[test]
     fn inline_refs_resolves_defs() {
@@ -490,7 +507,7 @@ mod tests {
     }
 
     impl Transport for MockTransport {
-        fn request(&mut self, method: &str, params: Value) -> Result<Value, String> {
+        fn request(&mut self, method: &str, params: Value) -> Result<Value, TransportError> {
             match method {
                 "initialize" => Ok(json!({
                     "protocolVersion": "2025-06-18",
@@ -525,10 +542,10 @@ mod tests {
                     let name = params.get("name").and_then(|n| n.as_str()).unwrap_or("");
                     Ok(json!({ "messages": [{ "role": "user", "content": format!("{}:{}", self.label, name) }] }))
                 }
-                other => Err(format!("unexpected method {other}")),
+                other => Err(TransportError::Fatal(format!("unexpected method {other}"))),
             }
         }
-        fn notify(&mut self, _method: &str, _params: Value) -> Result<(), String> {
+        fn notify(&mut self, _method: &str, _params: Value) -> Result<(), TransportError> {
             Ok(())
         }
     }
@@ -615,7 +632,7 @@ mod tests {
     /// A server whose single tool is annotated destructive.
     struct DestructiveMock;
     impl Transport for DestructiveMock {
-        fn request(&mut self, method: &str, _params: Value) -> Result<Value, String> {
+        fn request(&mut self, method: &str, _params: Value) -> Result<Value, TransportError> {
             match method {
                 "initialize" => Ok(json!({ "protocolVersion": "2025-06-18" })),
                 "tools/list" => Ok(json!({
@@ -629,10 +646,10 @@ mod tests {
                 "tools/call" => Ok(json!({
                     "content": [{ "type": "text", "text": "ok" }], "isError": false
                 })),
-                other => Err(format!("unexpected method {other}")),
+                other => Err(TransportError::Fatal(format!("unexpected method {other}"))),
             }
         }
-        fn notify(&mut self, _method: &str, _params: Value) -> Result<(), String> {
+        fn notify(&mut self, _method: &str, _params: Value) -> Result<(), TransportError> {
             Ok(())
         }
     }
@@ -737,17 +754,17 @@ mod tests {
         // mid-session and break in-flight calls.
         struct DupMock;
         impl Transport for DupMock {
-            fn request(&mut self, method: &str, _params: Value) -> Result<Value, String> {
+            fn request(&mut self, method: &str, _params: Value) -> Result<Value, TransportError> {
                 match method {
                     "initialize" => Ok(json!({ "protocolVersion": "2025-06-18" })),
                     "tools/list" => Ok(json!({ "tools": [
                         { "name": "a-b", "description": "one" },
                         { "name": "a_b", "description": "two" }
                     ] })),
-                    other => Err(format!("unexpected {other}")),
+                    other => Err(TransportError::Fatal(format!("unexpected {other}"))),
                 }
             }
-            fn notify(&mut self, _m: &str, _p: Value) -> Result<(), String> {
+            fn notify(&mut self, _m: &str, _p: Value) -> Result<(), TransportError> {
                 Ok(())
             }
         }
@@ -763,5 +780,225 @@ mod tests {
         assert_eq!(before, vec!["s__a_b", "s__a_b_2"]);
         router.refresh_tools();
         assert_eq!(names(&router), before, "refresh shuffled the collision suffixes");
+    }
+
+    /// Shared retry-capable mock used to exercise the Router helper.
+    struct RetryMock {
+        tool_failures: Arc<AtomicU32>,
+        resource_failures: Arc<AtomicU32>,
+        prompt_failures: Arc<AtomicU32>,
+        tool_call_entries: Arc<AtomicU32>,
+    }
+
+    impl Transport for RetryMock {
+        fn request(&mut self, method: &str, params: Value) -> Result<Value, TransportError> {
+            match method {
+                "initialize" => Ok(json!({
+                    "protocolVersion": "2025-06-18",
+                    "capabilities": { "resources": {}, "prompts": {} }
+                })),
+                "tools/list" => Ok(json!({
+                    "tools": [
+                        { "name": "flaky", "description": "flaky tool" },
+                        { "name": "stable", "description": "always succeeds" }
+                    ]
+                })),
+                "resources/list" => Ok(json!({
+                    "resources": [{ "uri": "retry://res", "name": "res" }]
+                })),
+                "prompts/list" => Ok(json!({
+                    "prompts": [{ "name": "greet", "description": "greeting" }]
+                })),
+                "tools/call" => {
+                    self.tool_call_entries.fetch_add(1, Ordering::SeqCst);
+                    let name = params.get("name").and_then(|v| v.as_str()).unwrap_or("");
+                    if name == "stable" {
+                        return Ok(json!({
+                            "content": [{ "type": "text", "text": "stable-ok" }],
+                            "isError": false
+                        }));
+                    }
+                    let prev = self.tool_failures.load(Ordering::SeqCst);
+                    if prev > 0 {
+                        self.tool_failures.store(prev - 1, Ordering::SeqCst);
+                        Err(TransportError::Retry {
+                            retry_after: Some(Duration::from_millis(50)),
+                            message: "simulated 429".to_string(),
+                        })
+                    } else {
+                        Ok(json!({
+                            "content": [{ "type": "text", "text": "ok-after-retry" }],
+                            "isError": false
+                        }))
+                    }
+                }
+                "resources/read" => {
+                    let prev = self.resource_failures.load(Ordering::SeqCst);
+                    if prev > 0 {
+                        self.resource_failures.store(prev - 1, Ordering::SeqCst);
+                        Err(TransportError::Retry {
+                            retry_after: Some(Duration::from_millis(1)),
+                            message: "retry resource".to_string(),
+                        })
+                    } else {
+                        let uri = params.get("uri").and_then(|v| v.as_str()).unwrap_or("");
+                        Ok(json!({ "contents": [{ "uri": uri, "text": "resource-ok" }] }))
+                    }
+                }
+                "prompts/get" => {
+                    let prev = self.prompt_failures.load(Ordering::SeqCst);
+                    if prev > 0 {
+                        self.prompt_failures.store(prev - 1, Ordering::SeqCst);
+                        Err(TransportError::Retry {
+                            retry_after: Some(Duration::from_millis(1)),
+                            message: "retry prompt".to_string(),
+                        })
+                    } else {
+                        let name = params.get("name").and_then(|v| v.as_str()).unwrap_or("");
+                        Ok(json!({ "messages": [{ "role": "user", "content": format!("gp:{name}") }] }))
+                    }
+                }
+                other => Err(TransportError::Fatal(format!("unexpected method {other}"))),
+            }
+        }
+        fn notify(&mut self, _method: &str, _params: Value) -> Result<(), TransportError> {
+            Ok(())
+        }
+    }
+
+    struct FatalMock;
+    impl Transport for FatalMock {
+        fn request(&mut self, method: &str, _params: Value) -> Result<Value, TransportError> {
+            match method {
+                "initialize" => Ok(json!({ "protocolVersion": "2025-06-18" })),
+                "tools/list" => Ok(json!({ "tools": [{ "name": "boom", "description": "always fails" }] })),
+                "tools/call" => Err(TransportError::Fatal("HTTP 500: server error".to_string())),
+                other => Err(TransportError::Fatal(format!("unexpected method {other}"))),
+            }
+        }
+        fn notify(&mut self, _method: &str, _params: Value) -> Result<(), TransportError> {
+            Ok(())
+        }
+    }
+
+    fn retry_server(id: &str, tool_failures: u32, resource_failures: u32, prompt_failures: u32) -> DownstreamServer {
+        let mut ds = DownstreamServer::connect(
+            id.to_string(),
+            Box::new(RetryMock {
+                tool_failures: Arc::new(AtomicU32::new(tool_failures)),
+                resource_failures: Arc::new(AtomicU32::new(resource_failures)),
+                prompt_failures: Arc::new(AtomicU32::new(prompt_failures)),
+                tool_call_entries: Arc::new(AtomicU32::new(0)),
+            }),
+        )
+        .unwrap();
+        ds.load_resources_prompts();
+        ds
+    }
+
+    fn retry_server_inspectable(
+        id: &str,
+        tool_failures: u32,
+    ) -> (DownstreamServer, Arc<AtomicU32>) {
+        let entries = Arc::new(AtomicU32::new(0));
+        let mut ds = DownstreamServer::connect(
+            id.to_string(),
+            Box::new(RetryMock {
+                tool_failures: Arc::new(AtomicU32::new(tool_failures)),
+                resource_failures: Arc::new(AtomicU32::new(0)),
+                prompt_failures: Arc::new(AtomicU32::new(0)),
+                tool_call_entries: Arc::clone(&entries),
+            }),
+        )
+        .unwrap();
+        ds.load_resources_prompts();
+        (ds, entries)
+    }
+
+    #[test]
+    fn retry_succeeds_after_transient_failure() {
+        let mut router = Router::new();
+        router.add(retry_server("flaky", 1, 0, 0));
+        let result = router.route_call("flaky__flaky", json!({})).unwrap();
+        assert_eq!(result["content"][0]["text"], "ok-after-retry");
+    }
+
+    #[test]
+    fn fatal_error_does_not_retry() {
+        let mut router = Router::new();
+        router.add(DownstreamServer::connect("fatal".to_string(), Box::new(FatalMock)).unwrap());
+        let err = router.route_call("fatal__boom", json!({})).unwrap_err();
+        assert!(err.contains("500"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn get_prompt_also_retries() {
+        let mut router = Router::new();
+        router.add(retry_server("gp", 0, 0, 1));
+        let result = router.get_prompt("gp__greet", json!({})).unwrap();
+        assert_eq!(result["messages"][0]["content"], "gp:greet");
+    }
+
+    #[test]
+    fn read_resource_also_retries() {
+        let mut router = Router::new();
+        router.add(retry_server("rr", 0, 1, 0));
+        let result = router.read_resource("retry://res").unwrap();
+        assert_eq!(result["contents"][0]["text"], "resource-ok");
+    }
+
+    #[test]
+    fn retry_does_not_block_unrelated_server() {
+        let slow = retry_server("slow", 1, 0, 0);
+        let fast = mock_server("fast");
+        let mut router = Router::new();
+        router.add(slow);
+        router.add(fast);
+
+        let router = Arc::new(router);
+        let router_a = Arc::clone(&router);
+        let handle = std::thread::spawn(move || router_a.route_call("slow__flaky", json!({})));
+
+        std::thread::sleep(Duration::from_millis(10));
+        let fast_result = router.route_call("fast__echo", json!({}));
+        assert!(fast_result.is_ok(), "fast server should not block behind slow retry");
+
+        let slow_result = handle.join().unwrap();
+        assert!(slow_result.is_ok(), "slow server should eventually succeed");
+    }
+
+    /// THE critical test: proves the per-server Mutex is RELEASED during the
+    /// backoff sleep. Without the fix, call A would hold the lock while sleeping,
+    /// and call B to the SAME server would block until A's retry completed.
+    #[test]
+    fn same_server_lock_released_during_backoff_sleep() {
+        let (server, entries) = retry_server_inspectable("srv", 1);
+        let mut router = Router::new();
+        router.add(server);
+        let router = Arc::new(router);
+
+        let router1 = Arc::clone(&router);
+        let handle = std::thread::spawn(move || router1.route_call("srv__flaky", json!({})));
+
+        // Wait long enough for thread 1 to acquire the lock, get the 429, and
+        // enter the backoff sleep — but NOT long enough for the 50ms retry.
+        std::thread::sleep(Duration::from_millis(15));
+
+        // Call the stable tool on the SAME server. If the fix is correct, the
+        // lock was released during the backoff sleep, so this succeeds immediately.
+        let result_b = router.route_call("srv__stable", json!({}));
+        assert!(result_b.is_ok(), "same-server call should succeed during backoff sleep");
+        let result = result_b.unwrap();
+        let text = result["content"][0]["text"].as_str().unwrap();
+        assert_eq!(text, "stable-ok");
+
+        let result_a = handle.join().unwrap();
+        assert!(result_a.is_ok(), "flaky call should succeed after retry");
+
+        // At least 3 lock acquisitions: flaky 429, stable ok, flaky retry ok.
+        assert!(
+            entries.load(Ordering::SeqCst) >= 3,
+            "expected >=3 tool/call lock acquisitions"
+        );
     }
 }


### PR DESCRIPTION
## What and why

When a downstream HTTP server returns a 429 rate-limit, the gateway retries after a backoff delay. The retry loop lived inside `HttpTransport::post()`, which was called while holding the per-server `Mutex<DownstreamServer>`. This meant **every concurrent call to the same server was blocked** for the full backoff duration — not just the rate-limited call.

With multiple agents sharing a gateway, one agent hitting a rate limit stalls all other agents queued on the same server. This is classic head-of-line blocking.

### Fix

Restructured so the Router owns the retry loop and the Mutex is released during the sleep:

- **`TransportError` enum** — transports signal `Retry { retry_after, message }` (429, connection-refused) or `Fatal(String)` (everything else) back to the caller instead of sleeping internally
- **`post()` does a single attempt** — returns immediately on 429/transport error instead of looping. Auth refresh (401/403) stays internal since it does not sleep
- **`Router::call_with_retry`** — acquires the lock, calls the transport, then **drops the lock before sleeping** on `TransportError::Retry`
- **`StdioTransport`** — also returns `TransportError` (always `Fatal` since stdio has no retryable errors)

### What does NOT change

- The retry budget (`HTTP_MAX_RETRIES = 2`) and backoff schedule (250ms base, 10s cap, exponential with clamping) are unchanged
- Auth refresh still happens transparently inside `post()` without consuming a retry attempt
- 5xx errors and post-send I/O errors are still `Fatal` (no retry) — a `tools/call` is not guaranteed idempotent
- Public API surface (`route_call`, `read_resource`, `get_prompt`) still returns `Result<Value, String>`

## Testing

- [x] `cargo test --manifest-path src-tauri/Cargo.toml` passes — 198 unit + 49 integration + 1 e2e
- [x] `npx tsc --noEmit && npm run build` passes
- [ ] Ran the app (`npm run tauri dev`) — *not yet verified manually; all code paths are covered by tests*

### New tests (9 added)

| Test | What it proves |
|---|---|
| `post_returns_retry_on_429_with_retry_after` | Real HTTP 429 → `TransportError::Retry` with correct `Retry-After` parsing (via `tiny_http`) |
| `post_returns_retry_on_transport_error` | Connection-refused → `TransportError::Retry` with `retry_after: None` |
| `retry_succeeds_after_transient_failure` | 429 → retry → success via Router |
| `fatal_error_does_not_retry` | HTTP 500 → immediate failure, no retry |
| `get_prompt_also_retries` | Prompt calls retry correctly |
| `read_resource_also_retries` | Resource calls retry correctly |
| `retry_does_not_block_unrelated_server` | Server B not blocked by Server A retry |
| `same_server_lock_released_during_backoff_sleep` | **Critical**: call B to the *same* server succeeds while call A is in its 50ms backoff sleep (proves the Mutex is dropped) |
| `post_refreshes_token_and_retries_on_401` | *(existing)* Token refresh stays internal, no retry budget consumed |

## Notes

- The 2 `clippy` warnings on `downstream.rs:164-165` (`let mut push`, `.iter().any()`) are pre-existing on `main` — confirmed via `git stash` comparison
- No formatter noise: the diff touches only retry-related code paths
- Diff: 3 files, +427 / -84