### PR TITLE
fix(macos): zero-prompt keychain via data-protection keychain + nested signed gateway

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Shell scripts must stay LF, or they fail to run on the macOS/Linux CI runners
+# (a CRLF in the shebang line gives "bad interpreter"). This pins them regardless
+# of a contributor's core.autocrlf setting.
+*.sh text eol=lf

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,10 +33,10 @@ jobs:
           - os: windows-latest
             bundles: nsis
           - os: macos-latest # Apple Silicon (native)
-            bundles: app,dmg
+            bundles: app
             target: aarch64-apple-darwin
           - os: macos-latest # Intel (cross-compiled on the arm64 runner)
-            bundles: app,dmg
+            bundles: app
             target: x86_64-apple-darwin
           - os: ubuntu-22.04
             bundles: deb,appimage
@@ -137,31 +137,43 @@ jobs:
           CONDUIT_SIDECAR_TARGET: ${{ matrix.target }}
           # Tauri updater signing. Required to produce signed `.sig` files for the
           # updater artifacts (createUpdaterArtifacts is set in the bundle config).
+          # macOS regenerates these in the signing step below; the others use them
+          # as-is.
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
-          # macOS code signing + notarization. Empty/ignored on Windows and Linux;
-          # Tauri only acts on these when building the macOS bundle. Set these as
-          # repository secrets to produce a signed, notarized .dmg (see
-          # docs/SIGNING.md). Without them the macOS build is unsigned.
+          # macOS is intentionally built UNSIGNED here. The keychain-access-group
+          # fix needs the gateway nested in its own .app + embedded provisioning
+          # profiles + inside-out signing, none of which Tauri's built-in macOS
+          # signing can do. The "Sign + notarize + package (macOS)" step below owns
+          # ALL macOS signing, notarization, dmg, and updater-artifact generation.
+
+      # macOS signing + packaging. Tauri built the app UNSIGNED above; this step
+      # nests the gateway in its own .app, embeds the app + gateway provisioning
+      # profiles, signs inside-out, notarizes + staples, builds + notarizes the
+      # dmg, and regenerates the updater artifact (`Conduit_<target>.app.tar.gz`
+      # + .sig) over the re-signed app so auto-update keeps working. Each arch is
+      # named by its target so latest.json can point at the right one.
+      #
+      # Requires, in addition to the existing APPLE_*/TAURI_SIGNING_* secrets, two
+      # new ones holding the base64 of the Developer ID provisioning profiles:
+      # APPLE_PROVISIONING_PROFILE_APP and APPLE_PROVISIONING_PROFILE_GATEWAY. The
+      # script fails fast with a clear message if any required secret is missing.
+      - name: Sign + notarize + package (macOS)
+        if: startsWith(matrix.os, 'macos')
+        run: bash scripts/macos-package-ci.sh
+        env:
+          APP: src-tauri/target/${{ matrix.target }}/release/bundle/macos/Conduit.app
+          TARGET: ${{ matrix.target }}
           APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
           APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
           APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          APPLE_PROVISIONING_PROFILE_APP: ${{ secrets.APPLE_PROVISIONING_PROFILE_APP }}
+          APPLE_PROVISIONING_PROFILE_GATEWAY: ${{ secrets.APPLE_PROVISIONING_PROFILE_GATEWAY }}
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-
-      # Both macOS targets emit an identically named `Conduit.app.tar.gz` updater
-      # artifact, which would overwrite each other on one release. Tag each with
-      # its target so latest.json can point at the right arch.
-      - name: Stage macOS updater artifact (unique per arch)
-        if: startsWith(matrix.os, 'macos')
-        run: |
-          dir="src-tauri/target/${{ matrix.target }}/release/bundle/macos"
-          base="$dir/Conduit.app.tar.gz"
-          if [ -f "$base" ]; then
-            cp "$base" "$dir/Conduit_${{ matrix.target }}.app.tar.gz"
-            cp "$base.sig" "$dir/Conduit_${{ matrix.target }}.app.tar.gz.sig"
-          fi
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
 
       - name: Draft release with the installers
         uses: softprops/action-gh-release@v3

--- a/docs/macos-keychain-test-runbook.md
+++ b/docs/macos-keychain-test-runbook.md
@@ -1,0 +1,168 @@
+# macOS keychain-access-group test runbook (Phase 2)
+
+This is the exact VM sequence to PROVE the keychain-access-group wrapper works on a
+signed build: the app and the gateway share a team-scoped keychain access group
+(`V4YZPC7T6G.com.tsout.conduit.shared`), so the gateway reads secrets the app wrote
+into the data-protection keychain with NO password prompt, across app updates,
+while a non-team copy is denied.
+
+Run everything on the Mac (VM) with the signing identity and both provisioning
+profiles installed. None of the steps below can be exercised on Windows or Linux:
+`codesign`, the data-protection keychain, and the access-group entitlement are
+macOS-only.
+
+## Prerequisites (on the Mac VM)
+
+- The Developer ID Application identity is in the login keychain:
+  ```
+  security find-identity -v -p codesigning | grep 'Brandon SOuth (V4YZPC7T6G)'
+  ```
+- Both provisioning profiles are present (downloaded earlier):
+  - `~/Downloads/Conduit_Developer_ID.provisionprofile` (app)
+  - `~/Downloads/Conduit_Gateway_Developer_ID.provisionprofile` (gateway)
+- Rust toolchain + Node + the Tauri CLI are installed (you build from source).
+
+## (a) Build the bundle
+
+From the repo root:
+
+```
+npx tauri build --config src-tauri/tauri.bundle.conf.json
+```
+
+This produces `src-tauri/target/release/bundle/macos/Conduit.app` with the bare
+gateway at `Conduit.app/Contents/MacOS/conduit-gateway`.
+
+## (b) Sign + package (wrap the gateway as a nested .app)
+
+```
+./scripts/macos-sign-local.sh
+```
+
+Defaults: APP = `src-tauri/target/release/bundle/macos/Conduit.app`, IDENTITY =
+`Developer ID Application: Brandon SOuth (V4YZPC7T6G)`, profiles from `~/Downloads`.
+Override positionally or via env if needed:
+
+```
+APP=/path/to/Conduit.app ./scripts/macos-sign-local.sh
+```
+
+The script:
+- moves the gateway into `Conduit.app/Contents/Helpers/ConduitGateway.app`,
+- embeds the gateway provisioning profile there,
+- leaves a symlink at the old bare path for backward compat,
+- signs inside-out and prints the `keychain-access-groups` entitlement plus each
+  embedded profile's `ExpirationDate` (confirm it reads ~2044).
+
+It is idempotent: re-running rebuilds the helper bundle and re-signs.
+
+Confirm the layout:
+
+```
+ls -l "src-tauri/target/release/bundle/macos/Conduit.app/Contents/MacOS/conduit-gateway"
+# -> a symlink: conduit-gateway -> ../Helpers/ConduitGateway.app/Contents/MacOS/conduit-gateway
+
+file "src-tauri/target/release/bundle/macos/Conduit.app/Contents/Helpers/ConduitGateway.app/Contents/MacOS/conduit-gateway"
+# -> Mach-O ... (the real binary)
+```
+
+## (c) Launch the app and write a secret to the keychain
+
+Launch the signed app (Gatekeeper should accept it since it is Developer ID +
+hardened runtime):
+
+```
+open "src-tauri/target/release/bundle/macos/Conduit.app"
+```
+
+In the app, add an MCP server that has a secret (an API key). Saving it writes the
+secret into the data-protection keychain under the shared access group. Note the
+exact secret value you entered so you can compare later, and note the keychain
+service/account the app uses for that secret (visible in `Keychain Access` or via
+`security` if you know the service name).
+
+## (d) Prove the gateway reads the secret with NO prompt
+
+The gateway reads that secret when spawned as a client would spawn it. Run the
+nested gateway binary directly. Because the binary is signed with the gateway
+entitlements + embedded profile that authorize the same access group, the read
+must succeed silently (no keychain password dialog).
+
+```
+GW="src-tauri/target/release/bundle/macos/Conduit.app/Contents/Helpers/ConduitGateway.app/Contents/MacOS/conduit-gateway"
+
+# Spawn it the way a client does (stdio MCP). Either point a real client at it,
+# or drive a quick MCP handshake. The point is that the gateway resolves the
+# server's secret from the keychain to connect to that server.
+"$GW" --help    # sanity: it runs
+```
+
+To exercise the actual secret read, start the gateway so it proxies the server you
+configured in step (c) (it resolves that server's API key from the shared keychain
+group), then issue a tool call that requires the key. Watch for:
+
+- NO keychain "conduit-gateway wants to use your confidential information" prompt.
+- The proxied call succeeds (the gateway found and used the secret).
+
+You can also confirm the value round-trips with `security` IF you know the service
+name (replace `SERVICE` and `ACCOUNT`):
+
+```
+security find-generic-password -s 'SERVICE' -a 'ACCOUNT' -w
+# prints the secret value you entered in step (c), no prompt
+```
+
+Repeat the same `security` read after also spawning the gateway to confirm both the
+app-written and gateway-read paths agree.
+
+Expected result: the value reads back and there is NO password prompt. This is the
+core proof that the shared access group works on a signed build.
+
+## (e) Update test: re-sign, still no prompt
+
+Simulate an app update (new signature, same team). Re-run the sign script, which
+produces a fresh signature over the same identity/team:
+
+```
+./scripts/macos-sign-local.sh
+```
+
+Relaunch the app and re-spawn the gateway, then repeat step (d). The keychain item
+is bound to the access group (team-scoped), not to a specific code signature, so:
+
+- The gateway STILL reads the secret with NO prompt.
+
+If a prompt appears here, the access group is not being honored across the new
+signature (regression).
+
+## (f) Denial test: a non-team / ad-hoc-signed copy is rejected
+
+Prove that a binary WITHOUT the team's access-group entitlement cannot read the
+secret. Copy the gateway out and re-sign it ad-hoc (no entitlements, no team):
+
+```
+cp "$GW" /tmp/conduit-gateway-adhoc
+codesign --force -s - /tmp/conduit-gateway-adhoc   # ad-hoc, strips entitlements
+codesign -d --entitlements - /tmp/conduit-gateway-adhoc 2>&1 | grep -i keychain || echo "no keychain-access-groups (expected)"
+
+# Now try to read the same secret with the ad-hoc binary's identity.
+/tmp/conduit-gateway-adhoc ...   # attempt the same secret-backed proxied call
+```
+
+Expected result: the read is DENIED. You should see either:
+
+- `errSecMissingEntitlement` / OSStatus `-34018`, or
+- a keychain password prompt (the system refuses silent access without the group).
+
+A clean way to see the raw status is with the same `security` call run under the
+ad-hoc binary's context, or by observing the gateway log the keychain error. The
+key point: the ad-hoc copy must NOT silently read the secret, while the
+properly-signed nested gateway (steps d and e) must.
+
+## What this proves
+
+- The app and the nested, profile-bearing gateway share one team-scoped keychain
+  access group, so the gateway reads app-written secrets with no prompt.
+- That holds across a re-sign (app update).
+- A binary lacking the entitlement is denied, so the access group is doing real
+  work (not just "any local process can read it").

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "conduit",
   "private": true,
-  "version": "0.9.2",
+  "version": "0.9.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/scripts/macos-package-ci.sh
+++ b/scripts/macos-package-ci.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+#
+# macos-package-ci.sh
+#
+# CI macOS sign + notarize + package for the keychain-access-group nested-gateway
+# build. Runs on a GitHub macOS runner AFTER `tauri build` has produced an
+# (unsigned) Conduit.app. It does everything Tauri's built-in macOS signing
+# cannot: nest the gateway in its own .app, embed provisioning profiles, sign
+# inside-out, notarize, and regenerate the .dmg + updater artifact over the
+# re-signed app.
+#
+# Why we re-do packaging instead of letting Tauri sign: Tauri signs the app, then
+# builds the .dmg and the updater `.app.tar.gz` (+ Ed25519 `.sig`) from that signed
+# app. Our nested-gateway + profile signing changes the app bundle, which would
+# invalidate Tauri's signature, dmg, and updater sig. So we build the app UNSIGNED
+# with Tauri and own the whole sign/notarize/package tail here.
+#
+# Required env:
+#   APP                         path to the built Conduit.app
+#   TARGET                      rust target triple (e.g. x86_64-apple-darwin); used for artifact names
+#   APPLE_CERTIFICATE           base64 of the "Developer ID Application" .p12
+#   APPLE_CERTIFICATE_PASSWORD  password for that .p12
+#   APPLE_SIGNING_IDENTITY      e.g. "Developer ID Application: Brandon SOuth (V4YZPC7T6G)"
+#   APPLE_PROVISIONING_PROFILE_APP      base64 of the app .provisionprofile
+#   APPLE_PROVISIONING_PROFILE_GATEWAY  base64 of the gateway .provisionprofile
+#   APPLE_ID, APPLE_PASSWORD, APPLE_TEAM_ID            notarization credentials
+#   TAURI_SIGNING_PRIVATE_KEY, TAURI_SIGNING_PRIVATE_KEY_PASSWORD   updater key (for .sig regen)
+#   RUNNER_TEMP                 provided by GitHub Actions (a writable temp dir)
+#
+# This MUST run on macOS. It is intended for CI; for local testing use
+# scripts/macos-sign-local.sh directly (it skips the cert import + notarize).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+log()  { printf '\033[1m%s\033[0m\n' "== $* =="; }
+die()  { printf '\033[31mERROR: %s\033[0m\n' "$*" >&2; exit 1; }
+
+[[ "$(uname -s)" == "Darwin" ]] || die "macos-package-ci.sh must run on macOS"
+
+: "${APP:?APP (path to Conduit.app) is required}"
+: "${TARGET:?TARGET (rust target triple) is required}"
+: "${APPLE_CERTIFICATE:?APPLE_CERTIFICATE is required}"
+: "${APPLE_CERTIFICATE_PASSWORD:?APPLE_CERTIFICATE_PASSWORD is required}"
+: "${APPLE_SIGNING_IDENTITY:?APPLE_SIGNING_IDENTITY is required}"
+: "${APPLE_PROVISIONING_PROFILE_APP:?APPLE_PROVISIONING_PROFILE_APP is required}"
+: "${APPLE_PROVISIONING_PROFILE_GATEWAY:?APPLE_PROVISIONING_PROFILE_GATEWAY is required}"
+: "${APPLE_ID:?APPLE_ID is required}"
+: "${APPLE_PASSWORD:?APPLE_PASSWORD is required}"
+: "${APPLE_TEAM_ID:?APPLE_TEAM_ID is required}"
+: "${RUNNER_TEMP:=$(mktemp -d)}"
+
+[[ -d "$APP" ]] || die "App bundle not found: $APP (did 'tauri build' run for $TARGET?)"
+
+WORK="$RUNNER_TEMP/conduit-sign"
+mkdir -p "$WORK"
+APP_PROFILE="$WORK/app.provisionprofile"
+GW_PROFILE="$WORK/gateway.provisionprofile"
+CERT_P12="$WORK/cert.p12"
+KEYCHAIN="$WORK/conduit-signing.keychain-db"
+KEYCHAIN_PASSWORD="ci-$(date +%s)-$$"
+
+# Restore the user's keychain search list and remove our temp keychain on exit,
+# so a failure can't leave the runner's signing state polluted (matters less on an
+# ephemeral runner, but keeps local re-runs clean too).
+cleanup() {
+  security delete-keychain "$KEYCHAIN" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+# ---------------------------------------------------------------------------
+# 1. Import the Developer ID cert into a temporary keychain.
+# ---------------------------------------------------------------------------
+log "Importing signing certificate into a temporary keychain"
+echo "$APPLE_CERTIFICATE" | base64 --decode > "$CERT_P12"
+security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+# Keep it unlocked for the whole job (6h) so notarytool/codesign never re-prompt.
+security set-keychain-settings -lut 21600 "$KEYCHAIN"
+security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+security import "$CERT_P12" -k "$KEYCHAIN" -P "$APPLE_CERTIFICATE_PASSWORD" \
+  -T /usr/bin/codesign -T /usr/bin/security
+# Allow codesign to use the key without an interactive prompt.
+security set-key-partition-list -S apple-tool:,apple:,codesign: \
+  -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN" >/dev/null
+# Put our keychain first on the search list so the identity resolves.
+EXISTING_KEYCHAINS="$(security list-keychains -d user | sed 's/[":]//g' | xargs)"
+# shellcheck disable=SC2086
+security list-keychains -d user -s "$KEYCHAIN" $EXISTING_KEYCHAINS
+
+security find-identity -v -p codesigning "$KEYCHAIN" | sed 's/^/  /'
+security find-identity -v -p codesigning "$KEYCHAIN" | grep -qF "$APPLE_SIGNING_IDENTITY" \
+  || die "Signing identity not found after import: $APPLE_SIGNING_IDENTITY"
+
+# ---------------------------------------------------------------------------
+# 2. Decode the provisioning profiles.
+# ---------------------------------------------------------------------------
+log "Decoding provisioning profiles"
+echo "$APPLE_PROVISIONING_PROFILE_APP" | base64 --decode > "$APP_PROFILE"
+echo "$APPLE_PROVISIONING_PROFILE_GATEWAY" | base64 --decode > "$GW_PROFILE"
+# Sanity: they must be CMS-decodable plists, or the embed is garbage.
+security cms -D -i "$APP_PROFILE" >/dev/null 2>&1 || die "APPLE_PROVISIONING_PROFILE_APP is not a valid provisioning profile"
+security cms -D -i "$GW_PROFILE"  >/dev/null 2>&1 || die "APPLE_PROVISIONING_PROFILE_GATEWAY is not a valid provisioning profile"
+
+# ---------------------------------------------------------------------------
+# 3. Nest the gateway + embed profiles + inside-out sign (the proven local flow).
+# ---------------------------------------------------------------------------
+log "Signing (nest gateway + embed profiles + inside-out codesign)"
+APP="$APP" IDENTITY="$APPLE_SIGNING_IDENTITY" APP_PROFILE="$APP_PROFILE" GW_PROFILE="$GW_PROFILE" \
+  bash "$SCRIPT_DIR/macos-sign-local.sh" "$APP" "$APPLE_SIGNING_IDENTITY" "$APP_PROFILE" "$GW_PROFILE"
+
+# ---------------------------------------------------------------------------
+# 4. Notarize + staple the app.
+#    Gatekeeper requires the .app be notarized and stapled. notarytool wants a
+#    zip; ditto --keepParent preserves the .app structure.
+# ---------------------------------------------------------------------------
+log "Notarizing the app"
+APP_ZIP="$WORK/Conduit-notarize.zip"
+ditto -c -k --keepParent "$APP" "$APP_ZIP"
+xcrun notarytool submit "$APP_ZIP" \
+  --apple-id "$APPLE_ID" --password "$APPLE_PASSWORD" --team-id "$APPLE_TEAM_ID" \
+  --wait
+xcrun stapler staple "$APP"
+xcrun stapler validate "$APP" || die "stapler validate failed on the app"
+
+# ---------------------------------------------------------------------------
+# 5. Build, sign, notarize, staple the .dmg (from the stapled app).
+#    Plain UDZO image via hdiutil (no extra deps). Styling can be layered on
+#    later; correctness/notarization is what matters for the release.
+# ---------------------------------------------------------------------------
+log "Building + notarizing the dmg"
+DMG_DIR="$REPO_ROOT/src-tauri/target/$TARGET/release/bundle/dmg"
+mkdir -p "$DMG_DIR"
+DMG="$DMG_DIR/Conduit_${TARGET}.dmg"
+rm -f "$DMG"
+hdiutil create -volname "Conduit" -srcfolder "$APP" -ov -format UDZO "$DMG"
+codesign --force --timestamp -s "$APPLE_SIGNING_IDENTITY" "$DMG"
+xcrun notarytool submit "$DMG" \
+  --apple-id "$APPLE_ID" --password "$APPLE_PASSWORD" --team-id "$APPLE_TEAM_ID" \
+  --wait
+xcrun stapler staple "$DMG"
+
+# ---------------------------------------------------------------------------
+# 6. Regenerate the updater artifact over the re-signed app.
+#    Tauri's `<app>.app.tar.gz` + `.sig` were computed over the UNSIGNED app, so
+#    re-tar the signed/stapled app and re-sign with the Ed25519 updater key, or
+#    auto-update would reject the bytes.
+# ---------------------------------------------------------------------------
+log "Regenerating the updater artifact"
+MACOS_DIR="$REPO_ROOT/src-tauri/target/$TARGET/release/bundle/macos"
+TARBALL="$MACOS_DIR/Conduit_${TARGET}.app.tar.gz"
+rm -f "$MACOS_DIR/Conduit.app.tar.gz" "$MACOS_DIR/Conduit.app.tar.gz.sig" "$TARBALL" "$TARBALL.sig"
+( cd "$MACOS_DIR" && tar -czf "$TARBALL" "$(basename "$APP")" )
+# `tauri signer sign` reads the key + password from the same env vars `tauri build`
+# uses; pass them explicitly so it never prompts.
+TAURI_SIGNING_PRIVATE_KEY="$TAURI_SIGNING_PRIVATE_KEY" \
+TAURI_SIGNING_PRIVATE_KEY_PASSWORD="${TAURI_SIGNING_PRIVATE_KEY_PASSWORD:-}" \
+  npx tauri signer sign "$TARBALL"
+[[ -f "$TARBALL.sig" ]] || die "updater .sig was not produced for $TARBALL"
+
+log "DONE"
+echo "  app     : $APP (signed, notarized, stapled)"
+echo "  dmg     : $DMG"
+echo "  updater : $TARBALL (+ .sig)"

--- a/scripts/macos-sign-local.sh
+++ b/scripts/macos-sign-local.sh
@@ -1,0 +1,318 @@
+#!/usr/bin/env bash
+#
+# macos-sign-local.sh
+#
+# LOCAL macOS sign + package flow for the keychain-access-group wrapper (Phase 2).
+#
+# What it does:
+#   1. Finds the bare conduit-gateway binary inside a built Conduit.app.
+#   2. Rebuilds it as a nested helper bundle:
+#        Conduit.app/Contents/Helpers/ConduitGateway.app
+#      so the gateway can carry its OWN embedded provisioning profile (a bare
+#      Mach-O cannot embed a .provisionprofile; only a bundle can).
+#   3. Leaves a symlink at the OLD bare path
+#        Conduit.app/Contents/MacOS/conduit-gateway
+#      pointing at the nested binary, so existing client configs that spawn the
+#      old path keep working.
+#   4. Codesigns inside-out (no --deep): gateway bundle first, then the outer app,
+#      each with the hardened runtime + its own entitlements + embedded profile.
+#   5. Verifies + prints the keychain-access-groups entitlement and the embedded
+#      profile ExpirationDate on both bundles.
+#
+# This script is intended to run on a Mac (VM) AFTER:
+#   npx tauri build --config src-tauri/tauri.bundle.conf.json
+#
+# It is idempotent and safe to re-run (e.g. the "update" test). It re-creates the
+# helper bundle from whichever real binary it can find, then re-signs.
+#
+# It does NOT touch the Tauri config or .github/workflows/release.yml. The CI
+# integration is a later phase.
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Parameters (override via env or positional args).
+#   $1 = APP path, $2 = IDENTITY, $3 = APP_PROFILE, $4 = GW_PROFILE
+# ---------------------------------------------------------------------------
+APP="${1:-${APP:-src-tauri/target/release/bundle/macos/Conduit.app}}"
+IDENTITY="${2:-${IDENTITY:-Developer ID Application: Brandon SOuth (V4YZPC7T6G)}}"
+APP_PROFILE="${3:-${APP_PROFILE:-$HOME/Downloads/Conduit_Developer_ID.provisionprofile}}"
+GW_PROFILE="${4:-${GW_PROFILE:-$HOME/Downloads/Conduit_Gateway_Developer_ID.provisionprofile}}"
+
+# Entitlements live in the repo, relative to this script's location, so the
+# script works regardless of the caller's CWD.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+APP_ENTITLEMENTS="$REPO_ROOT/src-tauri/Entitlements.plist"
+GW_ENTITLEMENTS="$REPO_ROOT/src-tauri/Gateway.entitlements"
+
+# Identifiers (must match the entitlements + profiles).
+GW_BUNDLE_ID="com.tsout.conduit.gateway"
+GW_EXECUTABLE="conduit-gateway"
+HELPER_APP_NAME="ConduitGateway.app"
+
+# A version string for the helper Info.plist. Pull it from the app's own
+# Info.plist if available, else fall back.
+HELPER_VERSION="${HELPER_VERSION:-}"
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+red()   { printf '\033[31m%s\033[0m\n' "$*"; }
+green() { printf '\033[32m%s\033[0m\n' "$*"; }
+bold()  { printf '\033[1m%s\033[0m\n' "$*"; }
+
+die() {
+  red "ERROR: $*" >&2
+  exit 1
+}
+
+require_macos() {
+  if [[ "$(uname -s)" != "Darwin" ]]; then
+    die "This script must run on macOS (uname -s = $(uname -s)). codesign and the keychain group cannot be exercised on any other host."
+  fi
+}
+
+require_tool() {
+  command -v "$1" >/dev/null 2>&1 || die "Required tool not found on PATH: $1"
+}
+
+# ---------------------------------------------------------------------------
+# Preflight
+# ---------------------------------------------------------------------------
+require_macos
+require_tool codesign
+require_tool find
+require_tool file
+require_tool security
+require_tool plutil
+[[ -x /usr/libexec/PlistBuddy ]] || die "PlistBuddy not found at /usr/libexec/PlistBuddy (expected on every macOS)"
+
+bold "== Conduit macOS local sign + package =="
+echo "APP          = $APP"
+echo "IDENTITY     = $IDENTITY"
+echo "APP_PROFILE  = $APP_PROFILE"
+echo "GW_PROFILE   = $GW_PROFILE"
+echo "APP entitlements = $APP_ENTITLEMENTS"
+echo "GW  entitlements = $GW_ENTITLEMENTS"
+echo
+
+[[ -d "$APP" ]]                  || die "App bundle not found: $APP  (run 'npx tauri build --config src-tauri/tauri.bundle.conf.json' first)"
+[[ -f "$APP_ENTITLEMENTS" ]]     || die "App entitlements not found: $APP_ENTITLEMENTS"
+[[ -f "$GW_ENTITLEMENTS" ]]      || die "Gateway entitlements not found: $GW_ENTITLEMENTS"
+[[ -f "$APP_PROFILE" ]]          || die "App provisioning profile not found: $APP_PROFILE"
+[[ -f "$GW_PROFILE" ]]           || die "Gateway provisioning profile not found: $GW_PROFILE"
+
+# Confirm the signing identity is actually present in the keychain.
+if ! security find-identity -v -p codesigning 2>/dev/null | grep -qF "$IDENTITY"; then
+  die "Signing identity not found in keychain: $IDENTITY
+     (run 'security find-identity -v -p codesigning' to see what is installed)"
+fi
+
+HELPERS_DIR="$APP/Contents/Helpers"
+HELPER_APP="$HELPERS_DIR/$HELPER_APP_NAME"
+HELPER_BIN="$HELPER_APP/Contents/MacOS/$GW_EXECUTABLE"
+SYMLINK_PATH="$APP/Contents/MacOS/$GW_EXECUTABLE"
+
+# ---------------------------------------------------------------------------
+# 1. Locate the gateway binary inside the app.
+#    It is EITHER the bare Mach-O at Contents/MacOS/conduit-gateway (fresh build),
+#    OR already inside the nested helper bundle (re-run). We must not pick up the
+#    backward-compat symlink as the "real" binary.
+# ---------------------------------------------------------------------------
+bold "[1/5] Locating the gateway binary inside the app"
+
+# Find every candidate named conduit-gateway, skipping symlinks (-type f).
+mapfile -t CANDIDATES < <(find "$APP/Contents" -name "$GW_EXECUTABLE" -type f 2>/dev/null || true)
+
+REAL_BIN=""
+# Prefer a binary already inside the helper bundle (idempotent re-run).
+for c in "${CANDIDATES[@]:-}"; do
+  if [[ "$c" == "$HELPER_BIN" ]]; then
+    REAL_BIN="$c"
+    break
+  fi
+done
+# Otherwise take the bare one at Contents/MacOS.
+if [[ -z "$REAL_BIN" ]]; then
+  for c in "${CANDIDATES[@]:-}"; do
+    if [[ "$c" == "$SYMLINK_PATH" ]]; then
+      REAL_BIN="$c"
+      break
+    fi
+  done
+fi
+# Last resort: the first real file we found.
+if [[ -z "$REAL_BIN" && "${#CANDIDATES[@]}" -gt 0 ]]; then
+  REAL_BIN="${CANDIDATES[0]}"
+fi
+
+[[ -n "$REAL_BIN" ]] || die "Could not find a '$GW_EXECUTABLE' binary anywhere under $APP/Contents.
+     The gateway is shipped as a Tauri externalBin; expected it at $SYMLINK_PATH.
+     Did 'npx tauri build --config src-tauri/tauri.bundle.conf.json' run?"
+
+# Sanity: it should be a Mach-O, not the empty placeholder.
+[[ -s "$REAL_BIN" ]] || die "Gateway binary is empty: $REAL_BIN"
+if ! file "$REAL_BIN" | grep -qiE 'mach-o'; then
+  die "Found '$GW_EXECUTABLE' but it is not a Mach-O binary: $REAL_BIN"
+fi
+green "  found: $REAL_BIN"
+
+# Determine helper version from the app's Info.plist if not already set.
+if [[ -z "$HELPER_VERSION" ]]; then
+  HELPER_VERSION="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "$APP/Contents/Info.plist" 2>/dev/null || echo '0.0.0')"
+fi
+echo "  helper version = $HELPER_VERSION"
+
+# ---------------------------------------------------------------------------
+# 2. Build the nested helper bundle.
+# ---------------------------------------------------------------------------
+bold "[2/5] Building nested helper bundle: $HELPER_APP"
+
+# Stash the real binary aside so we can rebuild the bundle from a clean slate.
+TMP_BIN="$(mktemp "${TMPDIR:-/tmp}/conduit-gateway.XXXXXX")"
+cp -f "$REAL_BIN" "$TMP_BIN"
+chmod +x "$TMP_BIN"
+
+# Remove any prior helper bundle and the bare/symlink path, then recreate. This
+# is what makes the script idempotent: every run rebuilds from $TMP_BIN.
+rm -rf "$HELPER_APP"
+rm -f "$SYMLINK_PATH"      # also removes a stale symlink or a leftover bare binary
+mkdir -p "$HELPER_APP/Contents/MacOS"
+
+# (a) the binary, moved into the helper bundle.
+mv -f "$TMP_BIN" "$HELPER_BIN"
+chmod +x "$HELPER_BIN"
+
+# (b) Info.plist
+cat > "$HELPER_APP/Contents/Info.plist" <<PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleIdentifier</key>
+	<string>$GW_BUNDLE_ID</string>
+	<key>CFBundleExecutable</key>
+	<string>$GW_EXECUTABLE</string>
+	<key>CFBundleName</key>
+	<string>ConduitGateway</string>
+	<key>CFBundleDisplayName</key>
+	<string>Conduit Gateway</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$HELPER_VERSION</string>
+	<key>CFBundleVersion</key>
+	<string>$HELPER_VERSION</string>
+	<key>LSBackgroundOnly</key>
+	<true/>
+</dict>
+</plist>
+PLIST
+
+# Validate the plist we just wrote.
+plutil -lint "$HELPER_APP/Contents/Info.plist" >/dev/null || die "Generated helper Info.plist failed plutil -lint"
+
+# (c) embedded.provisionprofile (the GATEWAY profile)
+cp -f "$GW_PROFILE" "$HELPER_APP/Contents/embedded.provisionprofile"
+green "  helper bundle assembled"
+
+# ---------------------------------------------------------------------------
+# 3. Backward-compat symlink at the OLD bare gateway path.
+#    Contents/MacOS/conduit-gateway -> ../Helpers/ConduitGateway.app/Contents/MacOS/conduit-gateway
+# ---------------------------------------------------------------------------
+bold "[3/5] Linking old bare path -> nested binary (backward compat)"
+ln -s "../Helpers/$HELPER_APP_NAME/Contents/MacOS/$GW_EXECUTABLE" "$SYMLINK_PATH"
+[[ -L "$SYMLINK_PATH" ]] || die "Failed to create backward-compat symlink at $SYMLINK_PATH"
+# Resolve it to confirm it points at the real binary.
+if ! readlink "$SYMLINK_PATH" >/dev/null 2>&1; then
+  die "Symlink at $SYMLINK_PATH does not resolve"
+fi
+green "  symlink: $SYMLINK_PATH -> $(readlink "$SYMLINK_PATH")"
+
+# ---------------------------------------------------------------------------
+# 4. Codesign INSIDE-OUT (no --deep): gateway bundle first, then the outer app.
+# ---------------------------------------------------------------------------
+bold "[4/5] Codesigning inside-out"
+
+echo "  signing gateway bundle ..."
+codesign --force --options runtime --timestamp \
+  --entitlements "$GW_ENTITLEMENTS" \
+  -s "$IDENTITY" \
+  "$HELPER_APP" \
+  || die "codesign failed on the gateway helper bundle"
+
+# Embed the APP profile into the outer app before signing it.
+cp -f "$APP_PROFILE" "$APP/Contents/embedded.provisionprofile"
+
+echo "  signing outer app ..."
+codesign --force --options runtime --timestamp \
+  --entitlements "$APP_ENTITLEMENTS" \
+  -s "$IDENTITY" \
+  "$APP" \
+  || die "codesign failed on the outer app bundle"
+green "  signed"
+
+# ---------------------------------------------------------------------------
+# 5. Verify + print.
+# ---------------------------------------------------------------------------
+bold "[5/5] Verifying"
+
+print_entitlement_group() {
+  local bundle="$1"
+  local label="$2"
+  echo "--- $label: keychain-access-groups ---"
+  # codesign -d --entitlements - dumps the entitlements; grep the group line(s).
+  if codesign -d --entitlements - "$bundle" 2>/dev/null | grep -A1 -i 'keychain-access-groups' ; then
+    :
+  else
+    red "  WARNING: could not read keychain-access-groups from $bundle"
+  fi
+  echo
+}
+
+print_profile_expiry() {
+  local profile="$1"
+  local label="$2"
+  [[ -f "$profile" ]] || { red "  MISSING embedded.provisionprofile for $label: $profile"; return 1; }
+  # The profile is CMS-wrapped; decode it to plist then read ExpirationDate.
+  local exp
+  exp="$(security cms -D -i "$profile" 2>/dev/null | /usr/libexec/PlistBuddy -c 'Print :ExpirationDate' /dev/stdin 2>/dev/null || true)"
+  if [[ -z "$exp" ]]; then
+    red "  WARNING: could not read ExpirationDate from $profile"
+  else
+    echo "  $label embedded profile ExpirationDate: $exp"
+  fi
+}
+
+echo
+bold "codesign -dvvv (gateway):"
+codesign -dvvv "$HELPER_APP" 2>&1 | sed 's/^/  /'
+echo
+bold "codesign -dvvv (app):"
+codesign -dvvv "$APP" 2>&1 | sed 's/^/  /'
+echo
+
+print_entitlement_group "$HELPER_APP" "GATEWAY"
+print_entitlement_group "$APP" "APP"
+
+bold "Embedded provisioning profiles:"
+[[ -f "$HELPER_APP/Contents/embedded.provisionprofile" ]] \
+  || die "Gateway embedded.provisionprofile missing after signing"
+[[ -f "$APP/Contents/embedded.provisionprofile" ]] \
+  || die "App embedded.provisionprofile missing after signing"
+print_profile_expiry "$HELPER_APP/Contents/embedded.provisionprofile" "GATEWAY"
+print_profile_expiry "$APP/Contents/embedded.provisionprofile" "APP"
+echo
+
+bold "codesign --verify --strict --deep:"
+codesign --verify --strict --deep --verbose=2 "$APP" 2>&1 | sed 's/^/  /' \
+  || die "codesign --verify --strict --deep FAILED on $APP"
+
+echo
+green "OK: signed + verified."
+echo "  App     : $APP"
+echo "  Gateway : $HELPER_BIN"
+echo "  Compat  : $SYMLINK_PATH -> $(readlink "$SYMLINK_PATH")"

--- a/scripts/macos-sign-local.sh
+++ b/scripts/macos-sign-local.sh
@@ -281,9 +281,15 @@ print_profile_expiry() {
   local profile="$1"
   local label="$2"
   [[ -f "$profile" ]] || { red "  MISSING embedded.provisionprofile for $label: $profile"; return 1; }
-  # The profile is CMS-wrapped; decode it to plist then read ExpirationDate.
-  local exp
-  exp="$(security cms -D -i "$profile" 2>/dev/null | /usr/libexec/PlistBuddy -c 'Print :ExpirationDate' /dev/stdin 2>/dev/null || true)"
+  # The profile is CMS-wrapped; decode it to a temp plist (PlistBuddy can't read
+  # /dev/stdin) then read ExpirationDate.
+  local exp tmp
+  tmp="$(mktemp "${TMPDIR:-/tmp}/conduit-profile.XXXXXX")"
+  exp=""
+  if security cms -D -i "$profile" -o "$tmp" 2>/dev/null; then
+    exp="$(/usr/libexec/PlistBuddy -c 'Print :ExpirationDate' "$tmp" 2>/dev/null || true)"
+  fi
+  rm -f "$tmp"
   if [[ -z "$exp" ]]; then
     red "  WARNING: could not read ExpirationDate from $profile"
   else

--- a/scripts/macos-sign-local.sh
+++ b/scripts/macos-sign-local.sh
@@ -123,7 +123,11 @@ SYMLINK_PATH="$APP/Contents/MacOS/$GW_EXECUTABLE"
 bold "[1/5] Locating the gateway binary inside the app"
 
 # Find every candidate named conduit-gateway, skipping symlinks (-type f).
-mapfile -t CANDIDATES < <(find "$APP/Contents" -name "$GW_EXECUTABLE" -type f 2>/dev/null || true)
+# (Portable read loop instead of `mapfile`, which is bash 4+ only; macOS ships bash 3.2.)
+CANDIDATES=()
+while IFS= read -r _candidate; do
+  [[ -n "$_candidate" ]] && CANDIDATES+=("$_candidate")
+done < <(find "$APP/Contents" -name "$GW_EXECUTABLE" -type f 2>/dev/null || true)
 
 REAL_BIN=""
 # Prefer a binary already inside the helper bundle (idempotent re-run).

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -587,7 +587,7 @@ dependencies = [
 
 [[package]]
 name = "conduit"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "base64 0.22.1",
  "chacha20poly1305",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conduit"
-version = "0.9.2"
+version = "0.9.3"
 description = "Local MCP gateway: manage all your MCP servers in one place, set up once and shared by every AI client, with ~90% fewer tokens per request"
 authors = ["South Forge AI"]
 edition = "2021"

--- a/src-tauri/Entitlements.plist
+++ b/src-tauri/Entitlements.plist
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<!-- Tauri / WKWebView needs JIT + unsigned executable memory on macOS under
+	     the hardened runtime. -->
+	<key>com.apple.security.cs.allow-jit</key>
+	<true/>
+	<key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+	<true/>
+
+	<!-- Application Identifier for the Conduit app. Must match the embedded
+	     provisioning profile and the keychain access group prefix (Team ID
+	     V4YZPC7T6G). -->
+	<key>com.apple.application-identifier</key>
+	<string>V4YZPC7T6G.com.tsout.conduit</string>
+
+	<!-- Team-scoped shared keychain access group. The gateway declares the SAME
+	     group (Gateway.entitlements) so both binaries read each other's
+	     data-protection-keychain items with no prompt. -->
+	<key>keychain-access-groups</key>
+	<array>
+		<string>V4YZPC7T6G.com.tsout.conduit.shared</string>
+	</array>
+</dict>
+</plist>

--- a/src-tauri/Gateway.entitlements
+++ b/src-tauri/Gateway.entitlements
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<!-- Application Identifier for the standalone conduit-gateway binary. Must
+	     match its embedded provisioning profile and the keychain access group
+	     prefix (Team ID V4YZPC7T6G). -->
+	<key>com.apple.application-identifier</key>
+	<string>V4YZPC7T6G.com.tsout.conduit.gateway</string>
+
+	<!-- Same team-scoped shared keychain access group as the app
+	     (Entitlements.plist), so the gateway reads secrets the app wrote into the
+	     data-protection keychain with no prompt. -->
+	<key>keychain-access-groups</key>
+	<array>
+		<string>V4YZPC7T6G.com.tsout.conduit.shared</string>
+	</array>
+</dict>
+</plist>

--- a/src-tauri/src/clients.rs
+++ b/src-tauri/src/clients.rs
@@ -2204,6 +2204,31 @@ pub(crate) fn resolve_gateway_path() -> Option<PathBuf> {
     // and the Linux .deb (/usr/bin).
     let plain = dir.join(format!("conduit-gateway{ext}"));
 
+    // macOS signed bundle: the keychain-access-group wrapper (scripts/macos-sign-local.sh)
+    // re-homes the gateway into a nested helper bundle so it can carry its own
+    // embedded provisioning profile:
+    //     Conduit.app/Contents/Helpers/ConduitGateway.app/Contents/MacOS/conduit-gateway
+    // The app binary runs from Conduit.app/Contents/MacOS, so `dir` is that
+    // directory. Prefer the nested binary when it exists. The old bare path
+    // (Contents/MacOS/conduit-gateway) is kept as a SYMLINK to this same binary by
+    // the signing script for backward compatibility with already-written client
+    // configs, so spawning either path reaches the same signed, profile-bearing
+    // gateway. (Existing-install client-config rewrite to the nested path is a
+    // later concern; not handled here.)
+    #[cfg(target_os = "macos")]
+    {
+        let nested = dir
+            .join("..")
+            .join("Helpers")
+            .join("ConduitGateway.app")
+            .join("Contents")
+            .join("MacOS")
+            .join("conduit-gateway");
+        if nested.exists() {
+            return Some(nested);
+        }
+    }
+
     // AppImage is the exception: it runs from an ephemeral mount (e.g.
     // /tmp/.mount_XXXX) that disappears when the app exits, so a gateway path inside
     // it would be dead by the time a client tries to spawn it. Copy the gateway to a

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1534,14 +1534,16 @@ fn http_bridge_status(state: State<HttpBridgeState>) -> Result<HttpBridgeStatus,
 pub fn run() {
     let registry = registry::load().unwrap_or_default();
 
-    // Migrate legacy (ACL-bearing) keychain entries in the background. On macOS,
-    // older versions of Conduit created keychain items via the `keyring` crate,
-    // which attaches per-app ACLs that trigger repeated password prompts. This
-    // reads each entry's value, deletes it, and re-creates it via the ACL-free
-    // SecItemAdd path — no secret values are lost. Guarded by a marker file so it
-    // runs exactly once. Only the app runs this (the gateway can't read legacy
-    // entries without triggering prompts). Best-effort: failures are logged but
-    // never block startup.
+    // Migrate legacy keychain secrets into the data-protection keychain (the
+    // team-scoped shared access group) in the background. On macOS, older versions
+    // of Conduit stored secrets as per-app-ACL keychain items that trigger a
+    // password prompt every time a freshly-signed app/gateway reads them. This
+    // moves each value into the data-protection keychain, which the separately
+    // signed gateway reads with NO prompt across updates — read each value, write +
+    // verify the data-protection copy, then delete the legacy item (no secret is
+    // lost; an item that can't move is left in place). Guarded by a marker file so
+    // it runs once. Only the app runs this (the gateway is read-only). Best-effort:
+    // failures are logged but never block startup.
     {
         let reg = registry.clone();
         std::thread::spawn(move || {
@@ -1565,10 +1567,10 @@ pub fn run() {
                 teams::TEAM_TOKEN_SERVER.to_string(),
                 teams::TEAM_TOKEN_KEY.to_string(),
             ));
-            let report = secrets::migrate_legacy_entries(&keys);
+            let report = secrets::migrate_secrets_to_dpk(&keys);
             if report.migrated > 0 || report.failed > 0 {
                 eprintln!(
-                    "conduit: keychain migration complete ({} entries rewritten, {} failed, {} not found)",
+                    "conduit: keychain migration complete ({} entries moved to data-protection keychain, {} failed, {} not found)",
                     report.migrated, report.failed, report.not_found
                 );
             }

--- a/src-tauri/src/secrets.rs
+++ b/src-tauri/src/secrets.rs
@@ -15,36 +15,55 @@ fn account(server_id: &str, key: &str) -> String {
 
 // ── macOS ──────────────────────────────────────────────────────────────────
 //
-// On macOS we bypass the `keyring` crate and call `security_framework` directly.
+// On macOS we bypass the `keyring` crate and call `security_framework` /
+// `SecItem*` directly.
 //
-// `keyring`'s apple-native backend routes writes through the *legacy* file-based
-// keychain API (`SecKeychainAddGenericPassword` / `SecKeychainItemModify`),
-// which creates items with a **per application Access Control List (ACL)**.
-// Every binary that touches the item — the Tauri UI app *and* the standalone
-// gateway binary — needs its own "Always Allow" grant, and a fresh prompt can
-// fire on first access from each context.
+// **Per-server secret storage uses the DATA-PROTECTION keychain** with a
+// team-scoped access group (`V4YZPC7T6G.com.tsout.conduit.shared`). Items are
+// created via raw `SecItemAdd` with `kSecUseDataProtectionKeychain=true`,
+// `kSecAttrAccessGroup=<shared group>`, and
+// `kSecAttrAccessible=kSecAttrAccessibleAfterFirstUnlock`. Both the Tauri UI app
+// (`com.tsout.conduit`) and the standalone gateway binary
+// (`com.tsout.conduit.gateway`) embed the SAME access group in their
+// entitlements (`Entitlements.plist` / `Gateway.entitlements`), so BOTH read the
+// item with no prompt and no per-application ACL. This replaces the older
+// legacy-keychain `SecAccess`/trusted-application ACL approach.
 //
-// Instead we use the modern `SecItem*` API (`security_framework::passwords`),
-// which stores items without per-application ACLs. Any process running as the
-// user can read them after a single unlock.
+// IMPORTANT: the data-protection keychain requires a code-signed binary with a
+// valid Application Identifier (from an embedded provisioning profile / the
+// `application-identifier` entitlement). On an UNSIGNED binary every DP-keychain
+// call returns `errSecMissingEntitlement` (-34018). The DP-keychain round-trip
+// tests are therefore `#[ignore]`d and only pass on a signed build (see Phase 7
+// of the keychain-access-group rollout). Plain `cargo test` on an unsigned/dev
+// build cannot exercise this path.
 //
-// Entries created by a previous version of Conduit (via the `keyring` crate)
-// still live in the file-based keychain and carry per-app ACLs. On macOS,
-// `migrate_legacy_entries()` runs once at app startup (guarded by a marker file)
-// to read each entry's value, delete it, and re-create it via the ACL-free
-// `SecItemAdd` path. This is transparent: no secret values are lost, and after
-// the migration both the app and gateway read silently.
+// `migrate_legacy_to_dpk()` runs once at app startup (guarded by a NEW marker
+// file, `.keychain-dpk-migrated`) to move per-server secrets out of the legacy
+// file-based keychain and into the data-protection store: read the old value,
+// write it to the new store, verify the round-trip, and ONLY THEN delete the old
+// legacy item. Any failure leaves the old item in place, so no secret is lost.
+//
+// The `keyring`-crate / `SecKeychainItem` legacy helpers below
+// (`get_generic_password`, `delete_entry_by_account`, the master-key `mod file`
+// path) are retained: the master key for the encrypted-file backend still lives
+// in the legacy keychain, and migration reads the old legacy items through them.
 #[cfg(target_os = "macos")]
 mod platform {
     use core_foundation::base::TCFType;
     use security_framework::item::{ItemClass, ItemSearchOptions, Limit, Reference, SearchResult};
     use security_framework::os::macos::keychain_item::SecKeychainItem;
-    use security_framework::passwords::{
-        delete_generic_password, get_generic_password, set_generic_password,
-    };
+    use security_framework::passwords::get_generic_password;
     use security_framework_sys::base::errSecItemNotFound;
 
     use super::{account, SERVICE};
+
+    /// Team-scoped keychain access group shared by the Conduit app and the
+    /// gateway. Both binaries declare this group in their entitlements
+    /// (`keychain-access-groups`), which is what lets each read the other's
+    /// data-protection-keychain items with no prompt. The `V4YZPC7T6G` prefix is
+    /// the Apple Developer Team ID; it MUST match the entitlement files
+    /// (`Entitlements.plist` / `Gateway.entitlements`) exactly.
+    pub const SHARED_ACCESS_GROUP: &str = "V4YZPC7T6G.com.tsout.conduit.shared";
 
     /// Reserved keychain account for the single 32-byte master key that encrypts
     /// the file backend (`secrets.enc`). Distinct from every server-secret account
@@ -104,37 +123,44 @@ mod platform {
         Ok(key)
     }
 
+    /// Store a per-server secret in the **data-protection keychain** under the
+    /// shared access group, via raw `SecItemAdd`.
+    ///
+    /// Builds a dictionary with `kSecClass=kSecClassGenericPassword`,
+    /// `kSecAttrService`, `kSecAttrAccount`, `kSecValueData`,
+    /// `kSecUseDataProtectionKeychain=true`, `kSecAttrAccessGroup=<shared group>`,
+    /// and `kSecAttrAccessible=kSecAttrAccessibleAfterFirstUnlock`. A
+    /// `SecItemDelete` with the SAME query keys (incl. the access group + the
+    /// data-protection flag) runs first for idempotency, then `SecItemAdd` creates
+    /// a fresh item.
+    ///
+    /// The high-level `security_framework::passwords` API targets the *legacy*
+    /// keychain and cannot set the access group or the data-protection flag, so
+    /// this MUST be raw FFI.
+    ///
+    /// Returns `Err` on an unsigned/dev build: the data-protection keychain
+    /// rejects every call with `errSecMissingEntitlement` (-34018) when the binary
+    /// has no Application Identifier (no embedded provisioning profile).
     pub fn set_secret(server_id: &str, key: &str, value: &str) -> Result<(), String> {
-        let acct = account(server_id, key);
-        // Preferred path: create the item WITH a shared-access ACL (this app + the
-        // gateway) in one atomic SecItemAdd. Setting the ACL at creation needs no
-        // prompt; setting it AFTER creation (SecKeychainItemSetAccess) prompts for
-        // the keychain password. With the ACL in place the separately-signed gateway
-        // reads the secret with no prompt either.
-        match add_with_shared_access(&acct, value) {
-            Ok(()) => Ok(()),
-            Err(e) => {
-                // Never let secret storage fail: fall back to the plain ACL-free
-                // write (the gateway then falls back to a one-time "Always Allow").
-                eprintln!("conduit: shared-access write failed ({e}); using plain write");
-                let _ = delete_generic_password(SERVICE, &acct);
-                set_generic_password(SERVICE, &acct, value.as_bytes()).map_err(|e| e.to_string())
-            }
-        }
+        dpk::set(&account(server_id, key), value)
     }
 
-    /// Create a generic-password item that BOTH the Conduit app and the
-    /// `conduit-gateway` binary can read with no keychain prompt: build a legacy
-    /// `SecAccess` whose trusted-applications list names both binaries and pass it
-    /// as `kSecAttrAccess` on `SecItemAdd`. Setting the ACL atomically at creation
-    /// avoids the keychain-password prompt that a post-hoc `SecKeychainItemSetAccess`
-    /// would raise.
+    /// Create a generic-password item in the **legacy** keychain that BOTH the
+    /// Conduit app and the `conduit-gateway` binary can read with no keychain
+    /// prompt: build a legacy `SecAccess` whose trusted-applications list names
+    /// both binaries and pass it as `kSecAttrAccess` on `SecItemAdd`. Setting the
+    /// ACL atomically at creation avoids the keychain-password prompt that a
+    /// post-hoc `SecKeychainItemSetAccess` would raise.
     ///
-    /// Why this and not `keychain-access-groups`: that's a *restricted* entitlement
-    /// requiring an embedded provisioning profile, which a bare CLI binary (the
-    /// gateway, spawned standalone by clients) cannot carry, so AMFI SIGKILLs it at
-    /// launch (-34018 / amfid -413). The legacy trusted-application ACL works for
-    /// Developer ID distribution with no profile. APIs are deprecated-but-functional.
+    /// **Scope after the data-protection rewrite:** per-server secrets now use the
+    /// data-protection keychain + the team-scoped access group (`dpk::set`). This
+    /// legacy trusted-application path is retained ONLY for the encrypted-file
+    /// backend's master key (`ensure_master_key`), which the gateway must read as
+    /// a *bare CLI binary* that cannot carry the provisioning profile required for
+    /// an access-group entitlement (a profile-less binary with a restricted
+    /// `keychain-access-groups` entitlement is SIGKILLed by AMFI at launch,
+    /// -34018 / amfid -413). The legacy ACL works for Developer ID distribution
+    /// with no profile; the APIs are deprecated-but-functional.
     fn add_with_shared_access(account_str: &str, value: &str) -> Result<(), String> {
         use core_foundation::array::CFArray;
         use core_foundation::base::{CFType, CFTypeRef, TCFType};
@@ -251,42 +277,201 @@ mod platform {
         Ok(())
     }
 
+    /// Test-only: seed an item in the **legacy** keychain (the one the
+    /// legacy -> data-protection migration reads FROM) so a signed-build test can
+    /// exercise `migrate_legacy_to_dpk`. Writes via `add_with_shared_access`,
+    /// which targets the legacy keychain under the same SERVICE/account the
+    /// migration scans with `get_generic_password`.
+    #[cfg(test)]
+    pub fn seed_legacy_for_test(server_id: &str, key: &str, value: &str) -> Result<(), String> {
+        add_with_shared_access(&account(server_id, key), value)
+    }
+
     pub fn get_secret_result(server_id: &str, key: &str) -> Result<Option<String>, String> {
-        match get_generic_password(SERVICE, &account(server_id, key)) {
-            Ok(bytes) => String::from_utf8(bytes).map(Some).map_err(|e| e.to_string()),
-            Err(e) if e.code() == -25300 /* errSecItemNotFound */ => Ok(None),
-            Err(e) => Err(e.to_string()),
-        }
+        dpk::get(&account(server_id, key))
     }
 
     pub fn delete_secret(server_id: &str, key: &str) -> Result<(), String> {
-        match delete_generic_password(SERVICE, &account(server_id, key)) {
-            Ok(()) => Ok(()),
-            Err(e) if e.code() == -25300 /* errSecItemNotFound */ => Ok(()),
-            Err(e) => Err(e.to_string()),
+        dpk::delete(&account(server_id, key))
+    }
+
+    /// Raw `SecItem*` FFI bound to the **data-protection keychain** with the
+    /// shared access group. All three operations carry
+    /// `kSecUseDataProtectionKeychain=true` and `kSecAttrAccessGroup=<shared
+    /// group>` so the app and gateway see the same items.
+    ///
+    /// `kSecAttrAccessible` / `kSecAttrAccessibleAfterFirstUnlock` /
+    /// `kSecMatchLimitOne` are NOT re-exported by `security_framework_sys` (and
+    /// `kSecUseDataProtectionKeychain` is feature-gated behind `OSX_10_15` there),
+    /// so this block declares every `kSec*` constant it needs itself via
+    /// `#[link(name = "Security")]`. `kCFBooleanTrue` for the data-protection flag
+    /// comes from `core_foundation::boolean::CFBoolean::true_value()`.
+    mod dpk {
+        use core_foundation::base::{CFType, CFTypeRef, TCFType};
+        use core_foundation::boolean::CFBoolean;
+        use core_foundation::data::CFData;
+        use core_foundation::dictionary::CFDictionary;
+        use core_foundation::string::CFString;
+        use std::os::raw::c_void;
+
+        use super::{SERVICE, SHARED_ACCESS_GROUP};
+
+        const ERR_SEC_ITEM_NOT_FOUND: i32 = -25300;
+
+        #[link(name = "Security", kind = "framework")]
+        extern "C" {
+            fn SecItemAdd(attributes: *const c_void, result: *mut *const c_void) -> i32;
+            fn SecItemCopyMatching(query: *const c_void, result: *mut *const c_void) -> i32;
+            fn SecItemDelete(query: *const c_void) -> i32;
+
+            static kSecClass: CFTypeRef;
+            static kSecClassGenericPassword: CFTypeRef;
+            static kSecAttrService: CFTypeRef;
+            static kSecAttrAccount: CFTypeRef;
+            static kSecValueData: CFTypeRef;
+            static kSecAttrAccessGroup: CFTypeRef;
+            static kSecAttrAccessible: CFTypeRef;
+            static kSecAttrAccessibleAfterFirstUnlock: CFTypeRef;
+            static kSecUseDataProtectionKeychain: CFTypeRef;
+            static kSecReturnData: CFTypeRef;
+            static kSecMatchLimit: CFTypeRef;
+            static kSecMatchLimitOne: CFTypeRef;
+        }
+
+        /// The kSec* constants are CFString/CFType singletons; wrap them under the
+        /// get rule (no ownership transfer) into safe `CFType`s.
+        fn k(raw: CFTypeRef) -> CFType {
+            unsafe { CFType::wrap_under_get_rule(raw) }
+        }
+
+        /// The shared base query keys present in EVERY operation: class,
+        /// service, account, the access group, and the data-protection flag.
+        fn base_query(account_str: &str) -> Vec<(CFType, CFType)> {
+            unsafe {
+                vec![
+                    (k(kSecClass), k(kSecClassGenericPassword)),
+                    (k(kSecAttrService), CFString::new(SERVICE).as_CFType()),
+                    (k(kSecAttrAccount), CFString::new(account_str).as_CFType()),
+                    (
+                        k(kSecAttrAccessGroup),
+                        CFString::new(SHARED_ACCESS_GROUP).as_CFType(),
+                    ),
+                    (
+                        k(kSecUseDataProtectionKeychain),
+                        CFBoolean::true_value().as_CFType(),
+                    ),
+                ]
+            }
+        }
+
+        /// `SecItemDelete` for idempotency, then `SecItemAdd`. Returns Err on any
+        /// non-success add status (notably -34018 `errSecMissingEntitlement` on an
+        /// unsigned build).
+        pub fn set(account_str: &str, value: &str) -> Result<(), String> {
+            // 1. Delete any existing item (same keys incl. access group + DP flag).
+            let del = CFDictionary::from_CFType_pairs(&base_query(account_str));
+            unsafe {
+                SecItemDelete(del.as_concrete_TypeRef() as *const c_void);
+            }
+
+            // 2. Add the fresh item with the value + accessibility class.
+            let mut pairs = base_query(account_str);
+            pairs.push((
+                k(unsafe { kSecValueData }),
+                CFData::from_buffer(value.as_bytes()).as_CFType(),
+            ));
+            pairs.push((
+                k(unsafe { kSecAttrAccessible }),
+                k(unsafe { kSecAttrAccessibleAfterFirstUnlock }),
+            ));
+            let add = CFDictionary::from_CFType_pairs(&pairs);
+            let st =
+                unsafe { SecItemAdd(add.as_concrete_TypeRef() as *const c_void, std::ptr::null_mut()) };
+            if st != 0 {
+                return Err(format!("SecItemAdd (data-protection keychain) failed: {st}"));
+            }
+            Ok(())
+        }
+
+        /// `SecItemCopyMatching` with `kSecReturnData=true` and
+        /// `kSecMatchLimit=kSecMatchLimitOne`. `errSecItemNotFound` (-25300) maps
+        /// to `Ok(None)`; the returned CFData is decoded to a `String`.
+        pub fn get(account_str: &str) -> Result<Option<String>, String> {
+            let mut pairs = base_query(account_str);
+            pairs.push((k(unsafe { kSecReturnData }), CFBoolean::true_value().as_CFType()));
+            pairs.push((k(unsafe { kSecMatchLimit }), k(unsafe { kSecMatchLimitOne })));
+            let query = CFDictionary::from_CFType_pairs(&pairs);
+
+            let mut result: *const c_void = std::ptr::null_mut();
+            let st = unsafe {
+                SecItemCopyMatching(query.as_concrete_TypeRef() as *const c_void, &mut result)
+            };
+            if st == ERR_SEC_ITEM_NOT_FOUND {
+                return Ok(None);
+            }
+            if st != 0 {
+                return Err(format!(
+                    "SecItemCopyMatching (data-protection keychain) failed: {st}"
+                ));
+            }
+            if result.is_null() {
+                return Ok(None);
+            }
+            // SecItemCopyMatching returns a CFDataRef (we requested return-data);
+            // it's a +1 (create-rule) reference we own. `as _` resolves to
+            // `CFData::Ref` (the concrete `CFDataRef`) from the function arg type.
+            let data = unsafe { CFData::wrap_under_create_rule(result as _) };
+            String::from_utf8(data.bytes().to_vec())
+                .map(Some)
+                .map_err(|e| e.to_string())
+        }
+
+        /// `SecItemDelete` against the data-protection keychain.
+        /// `errSecItemNotFound` maps to `Ok(())`.
+        pub fn delete(account_str: &str) -> Result<(), String> {
+            let query = CFDictionary::from_CFType_pairs(&base_query(account_str));
+            let st = unsafe { SecItemDelete(query.as_concrete_TypeRef() as *const c_void) };
+            if st == 0 || st == ERR_SEC_ITEM_NOT_FOUND {
+                Ok(())
+            } else {
+                Err(format!("SecItemDelete (data-protection keychain) failed: {st}"))
+            }
         }
     }
 
-    /// Migrate all `conduit-mcp` keychain entries from the legacy file-based
-    /// keychain (ACL-bearing) to the ACL-free `SecItem` path.
+    /// Migrate per-server secrets OUT of the **legacy file-based keychain** and
+    /// INTO the **data-protection keychain** (shared access group).
     ///
-    /// **Algorithm (per-key read-delete-rewrite):**
+    /// **Per-key flow (write -> verify -> only-then-delete, no data loss):**
     ///
     /// For each `(server_id, key)` pair:
-    /// 1. **Read** the current value via `get_generic_password`. Safe from the
-    ///    app process, which has ACL grants from the old version.
-    /// 2. **Delete** that specific entry by account-filtered ref search +
-    ///    FFI `SecKeychainItemDelete` (the only API that reliably removes legacy
-    ///    file-based items). Scoped to one account so an interruption costs one
-    ///    key, not all of them.
-    /// 3. **Re-create** the value via `set_generic_password` (`SecItemAdd`),
-    ///    which stores items without per-application ACLs. Since the old entry
-    ///    was just deleted, `SecItemAdd` creates a fresh item rather than hitting
-    ///    `SecItemUpdate` (which would preserve the old ACL).
+    /// 1. **Read** the OLD value from the legacy keychain via the existing
+    ///    `get_generic_password`. Safe from the app process, which has ACL grants
+    ///    from the old version.
+    /// 2. **Write** it to the NEW data-protection store (`set_secret` ->
+    ///    `dpk::set`).
+    /// 3. **Verify** by reading it back from the new store (`dpk::get`); the
+    ///    round-tripped value must equal the original.
+    /// 4. **Only then delete** the old legacy item via the existing
+    ///    `delete_entry_by_account` (account-filtered ref search +
+    ///    `SecKeychainItemDelete`, the only API that reliably removes legacy
+    ///    file-based items).
     ///
-    /// Keys that don't exist in the keychain (e.g. `__oauth_state__` for a
-    /// non-OAuth server) are counted as `not_found`, not a failure.
-    pub fn migrate_legacy_entries(
+    /// On ANY failure for a key (read/write/verify error, or a verify mismatch),
+    /// the old legacy item is LEFT IN PLACE — no secret is lost — and the key is
+    /// counted as `failed`. Keys that don't exist in the legacy keychain (e.g.
+    /// `__oauth_state__` on a non-OAuth server) are counted as `not_found`, not a
+    /// failure.
+    ///
+    /// **Signed-build-only:** step 2/3 hit the data-protection keychain, which
+    /// returns `errSecMissingEntitlement` (-34018) on an unsigned binary, so this
+    /// can only succeed on a signed build with the embedded provisioning profile.
+    ///
+    /// Not yet wired into app startup — Phase 1 ships the function + the
+    /// `DPK_MIGRATION_MARKER`; a later phase flips the dispatcher precedence and
+    /// calls it once behind the marker. `#[allow(dead_code)]` until then.
+    #[allow(dead_code)]
+    pub fn migrate_legacy_to_dpk(
         keys: &[(String, String)],
     ) -> Result<super::MigrationReport, String> {
         let mut migrated = 0;
@@ -298,14 +483,19 @@ mod platform {
             match get_generic_password(SERVICE, &acct) {
                 Ok(bytes) => match String::from_utf8(bytes) {
                     Ok(value) => {
-                        // Delete just this entry, then rewrite via set_secret, which
-                        // recreates it WITH the shared-access ACL (app + gateway) so
-                        // the gateway reads it with no prompt. Per-account scoping
-                        // means an interruption costs one key, not the keychain.
-                        let _ = delete_entry_by_account(&acct);
-                        match set_secret(server_id, key, &value) {
-                            Ok(()) => migrated += 1,
-                            Err(_) => failed += 1,
+                        // write (new store) -> verify (new store) -> only then
+                        // delete the OLD legacy item. Leave the legacy item in
+                        // place on any failure so no secret is lost.
+                        let moved = set_secret(server_id, key, &value).is_ok()
+                            && matches!(
+                                dpk::get(&acct),
+                                Ok(Some(ref v)) if *v == value
+                            );
+                        if moved {
+                            let _ = delete_entry_by_account(&acct);
+                            migrated += 1;
+                        } else {
+                            failed += 1;
                         }
                     }
                     Err(_) => failed += 1, // non-UTF-8 value — can't round-trip
@@ -637,6 +827,14 @@ const MIGRATION_MARKER: &str = ".keychain-acl-migrated";
 #[cfg(target_os = "macos")]
 const FILE_MIGRATION_MARKER: &str = ".secrets-file-migrated";
 
+/// Marker file name for the legacy-keychain -> data-protection-keychain
+/// migration (the team-scoped shared access group). A NEW name (the older
+/// markers are left untouched) so this runs exactly once on upgrade to the
+/// data-protection-keychain build. App-only; written only on a clean pass.
+#[cfg(target_os = "macos")]
+#[allow(dead_code)]
+const DPK_MIGRATION_MARKER: &str = ".keychain-dpk-migrated";
+
 /// Result of the one-time keychain migration.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub struct MigrationReport {
@@ -739,9 +937,18 @@ mod tests {
     static ENV_LOCK: Mutex<()> = Mutex::new(());
 
     // Round-trips through the real OS keychain. Headless Linux CI has no Secret
-    // Service (D-Bus), so skip it there; it still runs on macOS and Windows.
+    // Service (D-Bus), so skip it there; it still runs on Windows.
+    //
+    // On macOS this now targets the DATA-PROTECTION keychain (shared access
+    // group), which returns errSecMissingEntitlement (-34018) on an unsigned
+    // binary, so it's `#[ignore]`d there: run only on a signed build with the
+    // embedded provisioning profile (see Phase 7).
     #[test]
     #[cfg_attr(target_os = "linux", ignore = "no Secret Service in headless CI")]
+    #[cfg_attr(
+        target_os = "macos",
+        ignore = "data-protection keychain needs a signed build w/ provisioning profile (Phase 7)"
+    )]
     fn set_get_delete_round_trip() {
         let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let sid = "conduit-test-server";
@@ -809,8 +1016,14 @@ mod tests {
 
     /// macOS: the keychain -> file migration moves a value into the file backend
     /// and the value reads back from the file backend afterward.
+    ///
+    /// Seeds the source item via `platform::set_secret`, which now writes to the
+    /// DATA-PROTECTION keychain (errSecMissingEntitlement -34018 on an unsigned
+    /// binary), so this is signed-build-only: run only on a signed build with the
+    /// embedded provisioning profile (see Phase 7).
     #[cfg(target_os = "macos")]
     #[test]
+    #[ignore = "data-protection keychain needs a signed build w/ provisioning profile (Phase 7)"]
     fn migrate_keychain_to_file_moves_value() {
         let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let prev = std::env::var("CONDUIT_SECRET_KEY").ok();
@@ -862,61 +1075,99 @@ mod tests {
         assert!(file::open(&wrong, &sealed).is_err());
     }
 
-    /// The migration preserves secret values: it reads, deletes, and re-creates
-    /// each entry via the ACL-free `SecItemAdd` path. After migration, the value
-    /// is still readable.
+    /// The data-protection keychain round-trips a per-server secret: write via
+    /// `platform::set_secret` (`dpk::set`), read it back via
+    /// `platform::get_secret_result` (`dpk::get`), then delete it
+    /// (`dpk::delete`). After delete, the read returns `None`.
     ///
-    /// This test exercises the **full platform migration function**
-    /// (`platform::migrate_legacy_entries`), including the per-key
-    /// delete-and-rewrite cycle. It creates a test entry, runs the migration
-    /// for that key, and verifies the value survives.
+    /// Signed-build-only: every call carries `kSecUseDataProtectionKeychain`, so
+    /// an unsigned binary gets errSecMissingEntitlement (-34018). Run only on a
+    /// signed build with the embedded provisioning profile (see Phase 7).
     #[cfg(target_os = "macos")]
     #[test]
-    fn migrate_preserves_values() {
+    #[ignore = "data-protection keychain needs a signed build w/ provisioning profile (Phase 7)"]
+    fn dpk_set_get_delete_round_trip() {
+        let sid = "conduit-dpk-test";
+        let key = "DPK_ROUND_TRIP_KEY";
+        let original = "s3cr3t-value-in-data-protection-keychain";
+
+        platform::set_secret(sid, key, original).unwrap();
+        assert_eq!(
+            platform::get_secret_result(sid, key).unwrap().as_deref(),
+            Some(original),
+            "value must round-trip through the data-protection keychain"
+        );
+
+        platform::delete_secret(sid, key).unwrap();
+        assert_eq!(
+            platform::get_secret_result(sid, key).unwrap(),
+            None,
+            "value must be gone after delete"
+        );
+    }
+
+    /// The legacy -> data-protection migration preserves secret values: it reads
+    /// the old legacy item, writes + verifies the new DP item, then deletes the
+    /// legacy one. After migration the value reads back from the DP store.
+    ///
+    /// This exercises `platform::migrate_legacy_to_dpk`, whose write/verify steps
+    /// hit the data-protection keychain (errSecMissingEntitlement -34018 on an
+    /// unsigned binary). Signed-build-only: run only on a signed build with the
+    /// embedded provisioning profile (see Phase 7). Seeding a *legacy* keychain
+    /// item to migrate FROM also requires the keychain to be writable in that
+    /// context, which this harness sets up on the signed build.
+    #[cfg(target_os = "macos")]
+    #[test]
+    #[ignore = "data-protection keychain needs a signed build w/ provisioning profile (Phase 7)"]
+    fn migrate_legacy_to_dpk_preserves_values() {
         let sid = "conduit-migrate-test";
         let key = "MIGRATE_PRESERVE_KEY";
         let original = "s3cr3t-value-to-preserve";
 
-        // Pre-create the entry in the KEYCHAIN directly (this test exercises the
-        // ACL-free keychain migration, not the file-backend dispatcher — so seed
-        // and read via `platform::` to stay backend-agnostic even when a master
-        // key has made the file backend the default).
-        platform::set_secret(sid, key, original).unwrap();
+        // Seed the OLD legacy keychain item (the migration reads it via
+        // `get_generic_password`). `add_with_shared_access` writes to the legacy
+        // keychain under the same SERVICE/account the migration scans.
+        platform::seed_legacy_for_test(sid, key, original).unwrap();
 
-        // Run the full platform migration for this one key.
         let keys = vec![(sid.to_string(), key.to_string())];
-        let report = platform::migrate_legacy_entries(&keys).expect("migration should succeed");
+        let report = platform::migrate_legacy_to_dpk(&keys).expect("migration should succeed");
 
         assert_eq!(report.migrated, 1, "one entry should have been migrated");
         assert_eq!(report.failed, 0, "no entries should have failed");
         assert_eq!(report.not_found, 0, "no entries should have been not-found");
 
-        // The value must survive the read-delete-rewrite cycle intact.
+        // The value must now read back from the DATA-PROTECTION store.
         assert_eq!(
             platform::get_secret_result(sid, key).unwrap().as_deref(),
             Some(original),
-            "secret value must survive migration"
+            "secret value must survive migration into the data-protection store"
         );
 
-        // Clean up.
+        // Clean up the DP item.
         platform::delete_secret(sid, key).unwrap();
     }
 
     /// The migration correctly reports `not_found` for keys that don't exist in
-    /// the keychain (e.g. `__oauth_state__` on a non-OAuth server). This should
-    /// not be counted as a failure.
+    /// the legacy keychain (e.g. `__oauth_state__` on a non-OAuth server). This
+    /// should not be counted as a failure.
+    ///
+    /// The not-found path only reads the legacy keychain (`get_generic_password`)
+    /// and never reaches the data-protection write, so this part is exercisable
+    /// unsigned. Kept `#[ignore]` for consistency with the DP-migration suite
+    /// (signed-build-only).
     #[cfg(target_os = "macos")]
     #[test]
-    fn migrate_reports_not_found_for_missing_keys() {
+    #[ignore = "part of the data-protection migration suite; run on a signed build (Phase 7)"]
+    fn migrate_legacy_to_dpk_reports_not_found_for_missing_keys() {
         let sid = "conduit-missing-test";
         let key = "THIS_KEY_DOES_NOT_EXIST";
 
-        // Ensure the keychain entry doesn't exist (delete via `platform::` so we
-        // target the keychain the migration reads, not the file backend).
+        // Ensure neither store has the entry.
         let _ = platform::delete_secret(sid, key);
 
         let keys = vec![(sid.to_string(), key.to_string())];
-        let report = platform::migrate_legacy_entries(&keys).expect("migration should succeed");
+        let report =
+            platform::migrate_legacy_to_dpk(&keys).expect("migration should succeed");
 
         assert_eq!(report.migrated, 0, "nothing to migrate");
         assert_eq!(report.failed, 0, "missing keys are not failures");

--- a/src-tauri/src/secrets.rs
+++ b/src-tauri/src/secrets.rs
@@ -166,9 +166,6 @@ mod platform {
         }
 
         // 1. Build a SecAccess trusting the two binaries (this app + the gateway).
-        let app_path = std::env::current_exe().map_err(|e| e.to_string())?;
-        let gw_path = crate::clients::resolve_gateway_path()
-            .ok_or_else(|| "could not resolve gateway path".to_string())?;
         let trusted_app = |p: &std::path::Path| -> Result<CFType, String> {
             let c = CString::new(p.to_string_lossy().into_owned()).map_err(|e| e.to_string())?;
             let mut app: *mut c_void = std::ptr::null_mut();
@@ -181,7 +178,23 @@ mod platform {
             }
             Ok(unsafe { CFType::wrap_under_create_rule(app as CFTypeRef) })
         };
-        let trusted = CFArray::from_CFTypes(&[trusted_app(&app_path)?, trusted_app(&gw_path)?]);
+        // The app (this process) must be trustable; if it isn't there's nothing
+        // usable to write. The gateway is best-effort: add it when its path resolves
+        // and a trusted-application can be built for it, otherwise proceed app-only
+        // (the item stays ACL-protected, NOT world-readable; the gateway just falls
+        // back to a one-time "Always Allow" until the next rewrite names it). This
+        // also keeps unit tests working, where the gateway binary isn't on disk.
+        let app_path = std::env::current_exe().map_err(|e| e.to_string())?;
+        let mut trusted_apps: Vec<CFType> = Vec::with_capacity(2);
+        trusted_apps.push(trusted_app(&app_path)?);
+        match crate::clients::resolve_gateway_path() {
+            Some(gw_path) => match trusted_app(&gw_path) {
+                Ok(t) => trusted_apps.push(t),
+                Err(e) => eprintln!("conduit: gateway not added to keychain ACL ({e}); app-only"),
+            },
+            None => eprintln!("conduit: gateway path unresolved; keychain ACL is app-only"),
+        }
+        let trusted = CFArray::from_CFTypes(&trusted_apps);
         let label = CFString::new("conduit-mcp");
         let mut access: *mut c_void = std::ptr::null_mut();
         let st = unsafe {
@@ -730,7 +743,7 @@ mod tests {
     #[test]
     #[cfg_attr(target_os = "linux", ignore = "no Secret Service in headless CI")]
     fn set_get_delete_round_trip() {
-        let _guard = ENV_LOCK.lock().unwrap();
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let sid = "conduit-test-server";
         let key = "CONDUIT_TEST_KEY";
         set_secret(sid, key, "s3cr3t").unwrap();
@@ -746,7 +759,7 @@ mod tests {
     /// self-contained — it sets and then unsets the var, restoring prior state.
     #[test]
     fn file_active_when_env_key_set() {
-        let _guard = ENV_LOCK.lock().unwrap();
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let prev = std::env::var("CONDUIT_SECRET_KEY").ok();
         std::env::set_var("CONDUIT_SECRET_KEY", "unit-test-passphrase");
         assert!(
@@ -780,7 +793,7 @@ mod tests {
     #[cfg(target_os = "macos")]
     #[test]
     fn file_active_once_master_key_exists() {
-        let _guard = ENV_LOCK.lock().unwrap();
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         // Make sure the env var is not what's activating it.
         let prev = std::env::var("CONDUIT_SECRET_KEY").ok();
         std::env::remove_var("CONDUIT_SECRET_KEY");
@@ -799,7 +812,7 @@ mod tests {
     #[cfg(target_os = "macos")]
     #[test]
     fn migrate_keychain_to_file_moves_value() {
-        let _guard = ENV_LOCK.lock().unwrap();
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let prev = std::env::var("CONDUIT_SECRET_KEY").ok();
         std::env::remove_var("CONDUIT_SECRET_KEY");
 

--- a/src-tauri/src/secrets.rs
+++ b/src-tauri/src/secrets.rs
@@ -46,6 +46,64 @@ mod platform {
 
     use super::{account, SERVICE};
 
+    /// Reserved keychain account for the single 32-byte master key that encrypts
+    /// the file backend (`secrets.enc`). Distinct from every server-secret account
+    /// (which is `server_id::key`), so it never collides with a real secret. This
+    /// is the ONLY keychain item Conduit creates once the file backend is the
+    /// default on macOS — per-server secrets then live only in `secrets.enc`.
+    pub const MASTER_KEY_ACCOUNT: &str = "__conduit_master_key__";
+
+    /// Read the 32-byte master key from the keychain, if present.
+    ///
+    /// Returns `Ok(None)` when no master-key item exists yet (`errSecItemNotFound`,
+    /// -25300) — the signal that the file backend is not yet the default. Returns
+    /// `Err` on a stored value that isn't exactly 32 bytes after base64-decode
+    /// (corrupt item) or any other keychain failure. This is **read-only**: both
+    /// the app and the gateway call it. Only the app ever creates the key (via
+    /// `ensure_master_key`).
+    pub fn read_master_key() -> Result<Option<[u8; 32]>, String> {
+        use base64::Engine;
+        match get_generic_password(SERVICE, MASTER_KEY_ACCOUNT) {
+            Ok(bytes) => {
+                let encoded = String::from_utf8(bytes).map_err(|e| e.to_string())?;
+                let raw = base64::engine::general_purpose::STANDARD
+                    .decode(encoded.trim())
+                    .map_err(|e| e.to_string())?;
+                if raw.len() != 32 {
+                    return Err(format!(
+                        "master key in keychain is {} bytes, expected 32",
+                        raw.len()
+                    ));
+                }
+                let mut key = [0u8; 32];
+                key.copy_from_slice(&raw);
+                Ok(Some(key))
+            }
+            Err(e) if e.code() == -25300 /* errSecItemNotFound */ => Ok(None),
+            Err(e) => Err(e.to_string()),
+        }
+    }
+
+    /// Return the master key, creating it if it doesn't exist yet.
+    ///
+    /// If a key is already stored, returns it. Otherwise generates 32 random bytes
+    /// and stores them base64-encoded via the EXISTING `add_with_shared_access`
+    /// path, so the shared-access ACL lets BOTH the app and the separately-signed
+    /// gateway read the master key with no prompt. **Only the app's startup calls
+    /// this** — the gateway is read-only and must never create the key (it calls
+    /// `read_master_key` instead).
+    pub fn ensure_master_key() -> Result<[u8; 32], String> {
+        use base64::Engine;
+        if let Some(key) = read_master_key()? {
+            return Ok(key);
+        }
+        let mut key = [0u8; 32];
+        getrandom::getrandom(&mut key).map_err(|e| e.to_string())?;
+        let encoded = base64::engine::general_purpose::STANDARD.encode(key);
+        add_with_shared_access(MASTER_KEY_ACCOUNT, &encoded)?;
+        Ok(key)
+    }
+
     pub fn set_secret(server_id: &str, key: &str, value: &str) -> Result<(), String> {
         let acct = account(server_id, key);
         // Preferred path: create the item WITH a shared-access ACL (this app + the
@@ -251,6 +309,64 @@ mod platform {
         })
     }
 
+    /// Migrate per-server secrets OUT of individual keychain items and INTO the
+    /// encrypted file backend (`secrets.enc`), so they stop living as separate
+    /// ACL'd keychain items that prompt on every app update.
+    ///
+    /// Per-key flow (no secret loss, with rollback):
+    /// 1. **Read** the value from the OLD keychain item (`get_generic_password`).
+    /// 2. **Write** it into the file backend (`super::file::set_secret`).
+    /// 3. **Verify** by reading it back from the file backend; the round-tripped
+    ///    value must equal the original.
+    /// 4. **Only then delete** the old keychain item (`delete_entry_by_account`).
+    ///
+    /// On ANY failure for a key (read/write/verify error, or a verify mismatch),
+    /// the old keychain item is LEFT IN PLACE — no data loss — and the key is
+    /// counted as `failed`. `errSecItemNotFound` is counted as `not_found`
+    /// (expected for reserved keys on servers that don't use them).
+    ///
+    /// Requires the master key to already exist (so `super::file::active()` is
+    /// true); the caller ensures that before invoking this.
+    pub fn migrate_keychain_to_file(
+        keys: &[(String, String)],
+    ) -> Result<super::MigrationReport, String> {
+        let mut migrated = 0;
+        let mut failed = 0;
+        let mut not_found = 0;
+
+        for (server_id, key) in keys {
+            let acct = account(server_id, key);
+            match get_generic_password(SERVICE, &acct) {
+                Ok(bytes) => match String::from_utf8(bytes) {
+                    Ok(value) => {
+                        // write -> verify -> delete. Leave the keychain item in
+                        // place on any failure so no secret is lost.
+                        let moved = super::file::set_secret(server_id, key, &value).is_ok()
+                            && matches!(
+                                super::file::get_secret_result(server_id, key),
+                                Ok(Some(ref v)) if *v == value
+                            );
+                        if moved {
+                            let _ = delete_entry_by_account(&acct);
+                            migrated += 1;
+                        } else {
+                            failed += 1;
+                        }
+                    }
+                    Err(_) => failed += 1, // non-UTF-8 value — can't round-trip
+                },
+                Err(e) if e.code() == -25300 => not_found += 1, // expected for reserved keys
+                Err(_) => failed += 1,                          // locked keychain, denied access
+            }
+        }
+
+        Ok(super::MigrationReport {
+            migrated,
+            failed,
+            not_found,
+        })
+    }
+
     /// Delete all generic-password entries matching a specific account string.
     /// Uses an account-filtered ref search + FFI `SecKeychainItemDelete` — the
     /// only API that can reliably remove legacy file-based items (`SecItemDelete`
@@ -346,16 +462,38 @@ mod file {
     /// account -> secret value.
     type Store = BTreeMap<String, String>;
 
-    /// The 32-byte key derived from `CONDUIT_SECRET_KEY`, or None when it's unset/empty
-    /// (the signal to use the OS keychain instead).
+    /// The 32-byte key that encrypts `secrets.enc`, or None when the file backend
+    /// is inactive (the signal to use the OS keychain directly).
+    ///
+    /// Precedence:
+    /// 1. `CONDUIT_SECRET_KEY` set + non-empty -> SHA-256 of it (headless path,
+    ///    unchanged; must match for both the app and the gateway).
+    /// 2. macOS only -> the keychain master key, **read-only** (never generated
+    ///    here). The app's startup creates it via `platform::ensure_master_key`;
+    ///    once it exists this returns it, so `active()` becomes true and the file
+    ///    backend is the default on macOS desktop. The gateway also reads it here,
+    ///    so it needs no call changes.
+    /// 3. Otherwise None (Windows/Linux keep the OS keyring unless
+    ///    `CONDUIT_SECRET_KEY` is set).
     fn key_material() -> Option<[u8; 32]> {
-        let secret = std::env::var("CONDUIT_SECRET_KEY").ok()?;
-        if secret.is_empty() {
-            return None;
+        if let Ok(secret) = std::env::var("CONDUIT_SECRET_KEY") {
+            if !secret.is_empty() {
+                let mut key = [0u8; 32];
+                key.copy_from_slice(&Sha256::digest(secret.as_bytes()));
+                return Some(key);
+            }
         }
-        let mut key = [0u8; 32];
-        key.copy_from_slice(&Sha256::digest(secret.as_bytes()));
-        Some(key)
+        #[cfg(target_os = "macos")]
+        {
+            // Read-only: do NOT generate the key here. If reading fails (locked
+            // keychain), fall through to None so the keychain path is used rather
+            // than encrypting with a phantom key.
+            return super::platform::read_master_key().ok().flatten();
+        }
+        #[cfg(not(target_os = "macos"))]
+        {
+            None
+        }
     }
 
     pub fn active() -> bool {
@@ -473,10 +611,18 @@ pub fn delete_secret(server_id: &str, key: &str) -> Result<(), String> {
 // once on upgrade so EXISTING secrets are rewritten WITH the shared-access ACL,
 // not just legacy keyring-API entries.
 
-/// Marker file name in the Conduit data directory. Only the macOS migration reads
-/// it, so it's cfg-gated to avoid a dead-code warning on Windows/Linux builds.
+/// Marker file name for the legacy ACL migration (keychain -> ACL-free keychain).
+/// Left untouched for backward compatibility, but the current macOS path migrates
+/// secrets into the file backend instead (see `FILE_MIGRATION_MARKER`).
 #[cfg(target_os = "macos")]
+#[allow(dead_code)]
 const MIGRATION_MARKER: &str = ".keychain-acl-migrated";
+
+/// Marker file name for the keychain -> encrypted-file migration. A NEW name so
+/// the migration runs exactly once on upgrade to the file-backend-by-default
+/// build, even on installs that already ran the older ACL migration.
+#[cfg(target_os = "macos")]
+const FILE_MIGRATION_MARKER: &str = ".secrets-file-migrated";
 
 /// Result of the one-time keychain migration.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
@@ -492,35 +638,54 @@ pub struct MigrationReport {
     pub not_found: usize,
 }
 
-/// Run the one-time legacy keychain migration. For each secret key the registry
-/// knows about, reads the current value, deletes the entry, and re-creates it
-/// via the ACL-free `SecItemAdd` path. Guarded by a marker file so it runs
-/// exactly once. Only call from the UI app (not the gateway).
+/// Run the one-time macOS secret migration to the encrypted file backend.
+///
+/// On macOS this:
+/// 1. **Ensures the master key** (`platform::ensure_master_key`) FIRST, so the
+///    file backend becomes active (`file::active()` is true). If ensuring the
+///    key fails (e.g. the keychain is locked), it logs and returns the default
+///    report WITHOUT writing the marker, so the whole thing retries next launch.
+/// 2. If the file-migration marker is absent, **moves each secret** from its old
+///    per-server keychain item into `secrets.enc` via
+///    `platform::migrate_keychain_to_file` (read -> write-file -> verify -> only
+///    then delete the keychain item; on any failure the keychain item is left in
+///    place so nothing is lost). The marker is written ONLY when that pass
+///    returns `Ok`.
+///
+/// Only call from the UI app (not the gateway): the gateway is read-only and
+/// must never create the master key or rewrite entries.
 ///
 /// `secret_keys` is a list of `(server_id, key)` pairs for every secret env var
-/// in the registry (and `HTTP_AUTH_KEY` for remote servers).
-///
-/// The marker file is **only** written when the platform migration returns `Ok`.
-/// If it returns `Err` (e.g. the keychain was locked so the search failed), the
-/// marker is not written and the migration retries on the next launch.
+/// in the registry (and reserved keys like `HTTP_AUTH_KEY` for remote servers).
 pub fn migrate_legacy_entries(secret_keys: &[(String, String)]) -> MigrationReport {
     #[cfg(target_os = "macos")]
     {
-        if migration_marker_exists() {
+        // 1. Ensure the master key exists before anything else. This is what
+        //    flips the file backend on for this install. If it fails (locked
+        //    keychain), don't write the marker — retry on the next launch.
+        if let Err(e) = platform::ensure_master_key() {
+            eprintln!(
+                "conduit: could not ensure secrets master key, will retry next launch ({e})"
+            );
             return MigrationReport::default();
         }
 
-        let report = match platform::migrate_legacy_entries(secret_keys) {
+        // 2. One-time migration of per-server secrets into the file backend.
+        if file_migration_marker_exists() {
+            return MigrationReport::default();
+        }
+
+        let report = match platform::migrate_keychain_to_file(secret_keys) {
             Ok(report) => report,
             Err(e) => {
                 // Don't write the marker — the migration didn't run, so it
                 // should retry on the next launch.
-                eprintln!("conduit: keychain migration skipped, will retry next launch ({e})");
+                eprintln!("conduit: secret migration skipped, will retry next launch ({e})");
                 return MigrationReport::default();
             }
         };
 
-        let _ = create_migration_marker();
+        let _ = create_file_migration_marker();
         report
     }
     #[cfg(not(target_os = "macos"))]
@@ -530,40 +695,145 @@ pub fn migrate_legacy_entries(secret_keys: &[(String, String)]) -> MigrationRepo
     }
 }
 
-/// Check whether the migration marker file exists in the Conduit data directory.
+/// Whether the keychain -> file migration marker exists in the Conduit data dir.
 #[cfg(target_os = "macos")]
-fn migration_marker_exists() -> bool {
+fn file_migration_marker_exists() -> bool {
     crate::registry::conduit_dir()
-        .map(|d| d.join(MIGRATION_MARKER))
+        .map(|d| d.join(FILE_MIGRATION_MARKER))
         .map(|p| p.exists())
         .unwrap_or(false)
 }
 
-/// Create the migration marker file. Returns `true` on success.
+/// Create the keychain -> file migration marker file. Returns `true` on success.
 #[cfg(target_os = "macos")]
-fn create_migration_marker() -> bool {
+fn create_file_migration_marker() -> bool {
     let Some(dir) = crate::registry::conduit_dir() else {
         return false;
     };
     let _ = std::fs::create_dir_all(&dir);
-    std::fs::write(dir.join(MIGRATION_MARKER), b"1").is_ok()
+    std::fs::write(dir.join(FILE_MIGRATION_MARKER), b"1").is_ok()
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Mutex;
+
+    /// Serializes tests that read or mutate the process-global `CONDUIT_SECRET_KEY`
+    /// env var (and thus `file::active()`). Without this, a test that sets the var
+    /// races with a sibling that assumes the keychain path, causing spurious
+    /// failures under the default multi-threaded test runner.
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
 
     // Round-trips through the real OS keychain. Headless Linux CI has no Secret
     // Service (D-Bus), so skip it there; it still runs on macOS and Windows.
     #[test]
     #[cfg_attr(target_os = "linux", ignore = "no Secret Service in headless CI")]
     fn set_get_delete_round_trip() {
+        let _guard = ENV_LOCK.lock().unwrap();
         let sid = "conduit-test-server";
         let key = "CONDUIT_TEST_KEY";
         set_secret(sid, key, "s3cr3t").unwrap();
         assert_eq!(get_secret(sid, key).as_deref(), Some("s3cr3t"));
         delete_secret(sid, key).unwrap();
         assert_eq!(get_secret(sid, key), None);
+    }
+
+    /// Cross-platform: setting `CONDUIT_SECRET_KEY` activates the file backend.
+    /// Runs on every OS (the env-var precedence is platform-independent).
+    ///
+    /// NOTE: mutates a process-global env var, so it's `#[serial]`-free but kept
+    /// self-contained — it sets and then unsets the var, restoring prior state.
+    #[test]
+    fn file_active_when_env_key_set() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let prev = std::env::var("CONDUIT_SECRET_KEY").ok();
+        std::env::set_var("CONDUIT_SECRET_KEY", "unit-test-passphrase");
+        assert!(
+            file::active(),
+            "file backend must be active when CONDUIT_SECRET_KEY is set"
+        );
+        // Restore prior state so other tests aren't affected.
+        match prev {
+            Some(v) => std::env::set_var("CONDUIT_SECRET_KEY", v),
+            None => std::env::remove_var("CONDUIT_SECRET_KEY"),
+        }
+    }
+
+    /// macOS: ensuring the master key returns 32 bytes and is idempotent — a
+    /// second `ensure` returns the SAME key, and a plain `read` returns it too.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn master_key_ensure_then_read_is_idempotent() {
+        let first = platform::ensure_master_key().expect("ensure should succeed");
+        assert_eq!(first.len(), 32);
+        let second = platform::ensure_master_key().expect("ensure should be idempotent");
+        assert_eq!(first, second, "ensure must return the same key each time");
+        let read = platform::read_master_key()
+            .expect("read should succeed")
+            .expect("master key should exist after ensure");
+        assert_eq!(first, read, "read must return the ensured key");
+    }
+
+    /// macOS: once the master key exists, the file backend is selected
+    /// (`active()` is true) even without `CONDUIT_SECRET_KEY`.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn file_active_once_master_key_exists() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        // Make sure the env var is not what's activating it.
+        let prev = std::env::var("CONDUIT_SECRET_KEY").ok();
+        std::env::remove_var("CONDUIT_SECRET_KEY");
+        platform::ensure_master_key().expect("ensure should succeed");
+        assert!(
+            file::active(),
+            "file backend must be active once the master key exists"
+        );
+        if let Some(v) = prev {
+            std::env::set_var("CONDUIT_SECRET_KEY", v);
+        }
+    }
+
+    /// macOS: the keychain -> file migration moves a value into the file backend
+    /// and the value reads back from the file backend afterward.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn migrate_keychain_to_file_moves_value() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let prev = std::env::var("CONDUIT_SECRET_KEY").ok();
+        std::env::remove_var("CONDUIT_SECRET_KEY");
+
+        // Master key must exist so the file backend is active.
+        platform::ensure_master_key().expect("ensure should succeed");
+
+        let sid = "conduit-file-migrate-test";
+        let key = "FILE_MIGRATE_KEY";
+        let original = "value-moved-into-file-backend";
+
+        // Seed an OLD per-server keychain item directly.
+        platform::set_secret(sid, key, original).unwrap();
+
+        // Run the keychain -> file migration for this key.
+        let keys = vec![(sid.to_string(), key.to_string())];
+        let report =
+            platform::migrate_keychain_to_file(&keys).expect("file migration should succeed");
+        assert_eq!(report.migrated, 1, "one entry should have been migrated");
+        assert_eq!(report.failed, 0, "no entries should have failed");
+
+        // The value now reads back from the FILE backend.
+        assert_eq!(
+            file::get_secret_result(sid, key).unwrap().as_deref(),
+            Some(original),
+            "migrated value must be readable from the file backend"
+        );
+        // And the top-level dispatcher (which routes through file::active()) too.
+        assert_eq!(get_secret(sid, key).as_deref(), Some(original));
+
+        // Clean up the file-backend entry.
+        let _ = file::delete_secret(sid, key);
+        if let Some(v) = prev {
+            std::env::set_var("CONDUIT_SECRET_KEY", v);
+        }
     }
 
     #[test]
@@ -594,8 +864,11 @@ mod tests {
         let key = "MIGRATE_PRESERVE_KEY";
         let original = "s3cr3t-value-to-preserve";
 
-        // Pre-create the entry so the migration has something to migrate.
-        set_secret(sid, key, original).unwrap();
+        // Pre-create the entry in the KEYCHAIN directly (this test exercises the
+        // ACL-free keychain migration, not the file-backend dispatcher — so seed
+        // and read via `platform::` to stay backend-agnostic even when a master
+        // key has made the file backend the default).
+        platform::set_secret(sid, key, original).unwrap();
 
         // Run the full platform migration for this one key.
         let keys = vec![(sid.to_string(), key.to_string())];
@@ -607,13 +880,13 @@ mod tests {
 
         // The value must survive the read-delete-rewrite cycle intact.
         assert_eq!(
-            get_secret(sid, key).as_deref(),
+            platform::get_secret_result(sid, key).unwrap().as_deref(),
             Some(original),
             "secret value must survive migration"
         );
 
         // Clean up.
-        delete_secret(sid, key).unwrap();
+        platform::delete_secret(sid, key).unwrap();
     }
 
     /// The migration correctly reports `not_found` for keys that don't exist in
@@ -625,8 +898,9 @@ mod tests {
         let sid = "conduit-missing-test";
         let key = "THIS_KEY_DOES_NOT_EXIST";
 
-        // Ensure the entry doesn't exist.
-        let _ = delete_secret(sid, key);
+        // Ensure the keychain entry doesn't exist (delete via `platform::` so we
+        // target the keychain the migration reads, not the file backend).
+        let _ = platform::delete_secret(sid, key);
 
         let keys = vec![(sid.to_string(), key.to_string())];
         let report = platform::migrate_legacy_entries(&keys).expect("migration should succeed");

--- a/src-tauri/src/secrets.rs
+++ b/src-tauri/src/secrets.rs
@@ -467,10 +467,9 @@ mod platform {
     /// returns `errSecMissingEntitlement` (-34018) on an unsigned binary, so this
     /// can only succeed on a signed build with the embedded provisioning profile.
     ///
-    /// Not yet wired into app startup — Phase 1 ships the function + the
-    /// `DPK_MIGRATION_MARKER`; a later phase flips the dispatcher precedence and
-    /// calls it once behind the marker. `#[allow(dead_code)]` until then.
-    #[allow(dead_code)]
+    /// Wired into app startup via `migrate_secrets_to_dpk`, which guards it behind
+    /// `DPK_MIGRATION_MARKER` so it runs once per install. The app process is the
+    /// only caller (the gateway is read-only).
     pub fn migrate_legacy_to_dpk(
         keys: &[(String, String)],
     ) -> Result<super::MigrationReport, String> {
@@ -668,35 +667,25 @@ mod file {
     /// The 32-byte key that encrypts `secrets.enc`, or None when the file backend
     /// is inactive (the signal to use the OS keychain directly).
     ///
-    /// Precedence:
-    /// 1. `CONDUIT_SECRET_KEY` set + non-empty -> SHA-256 of it (headless path,
-    ///    unchanged; must match for both the app and the gateway).
-    /// 2. macOS only -> the keychain master key, **read-only** (never generated
-    ///    here). The app's startup creates it via `platform::ensure_master_key`;
-    ///    once it exists this returns it, so `active()` becomes true and the file
-    ///    backend is the default on macOS desktop. The gateway also reads it here,
-    ///    so it needs no call changes.
-    /// 3. Otherwise None (Windows/Linux keep the OS keyring unless
-    ///    `CONDUIT_SECRET_KEY` is set).
+    /// The file backend is **headless-only**: it activates IFF `CONDUIT_SECRET_KEY`
+    /// is set + non-empty (the key is SHA-256 of it; the app and gateway must agree
+    /// on the env var). On every desktop OS this returns None, so secrets live in
+    /// the OS keychain — on macOS that is the *data-protection* keychain under the
+    /// team-scoped shared access group (`platform`), which keeps keys off disk and
+    /// lets the separately-signed gateway read them with no prompt.
+    ///
+    /// We deliberately do NOT derive the key from a keychain master item on
+    /// desktop. Doing so would activate `secrets.enc` on disk and shadow the
+    /// data-protection keychain — the "keys never on disk" property we sell — and
+    /// reading that master item across an app update is itself a prompt source.
     fn key_material() -> Option<[u8; 32]> {
-        if let Ok(secret) = std::env::var("CONDUIT_SECRET_KEY") {
-            if !secret.is_empty() {
-                let mut key = [0u8; 32];
-                key.copy_from_slice(&Sha256::digest(secret.as_bytes()));
-                return Some(key);
-            }
+        let secret = std::env::var("CONDUIT_SECRET_KEY").ok()?;
+        if secret.is_empty() {
+            return None;
         }
-        #[cfg(target_os = "macos")]
-        {
-            // Read-only: do NOT generate the key here. If reading fails (locked
-            // keychain), fall through to None so the keychain path is used rather
-            // than encrypting with a phantom key.
-            return super::platform::read_master_key().ok().flatten();
-        }
-        #[cfg(not(target_os = "macos"))]
-        {
-            None
-        }
+        let mut key = [0u8; 32];
+        key.copy_from_slice(&Sha256::digest(secret.as_bytes()));
+        Some(key)
     }
 
     pub fn active() -> bool {
@@ -832,7 +821,6 @@ const FILE_MIGRATION_MARKER: &str = ".secrets-file-migrated";
 /// markers are left untouched) so this runs exactly once on upgrade to the
 /// data-protection-keychain build. App-only; written only on a clean pass.
 #[cfg(target_os = "macos")]
-#[allow(dead_code)]
 const DPK_MIGRATION_MARKER: &str = ".keychain-dpk-migrated";
 
 /// Result of the one-time keychain migration.
@@ -925,6 +913,69 @@ fn create_file_migration_marker() -> bool {
     std::fs::write(dir.join(FILE_MIGRATION_MARKER), b"1").is_ok()
 }
 
+/// Run the one-time macOS migration of per-server secrets from the legacy
+/// file-based keychain INTO the data-protection keychain (the team-scoped shared
+/// access group), guarded by `DPK_MIGRATION_MARKER` so it runs once per install.
+///
+/// This is the migration that replaces the old ACL / encrypted-file paths: after
+/// it runs, every secret lives in the data-protection keychain, which the
+/// separately-signed gateway reads with NO prompt across app updates.
+///
+/// Only the UI app calls this (the gateway is read-only and must never rewrite
+/// entries). Best-effort and lossless: `migrate_legacy_to_dpk` reads each legacy
+/// item, writes + verifies the data-protection copy, then deletes the legacy item;
+/// an item it can't move is left in the legacy keychain. The marker is written
+/// only on a fully clean pass (`failed == 0`), so a transient denial or locked
+/// keychain is retried on the next launch rather than stranding a secret.
+pub fn migrate_secrets_to_dpk(secret_keys: &[(String, String)]) -> MigrationReport {
+    #[cfg(target_os = "macos")]
+    {
+        if dpk_migration_marker_exists() {
+            return MigrationReport::default();
+        }
+        let report = match platform::migrate_legacy_to_dpk(secret_keys) {
+            Ok(report) => report,
+            Err(e) => {
+                eprintln!(
+                    "conduit: data-protection keychain migration skipped, will retry next launch ({e})"
+                );
+                return MigrationReport::default();
+            }
+        };
+        // Only mark complete once nothing failed, so a denied prompt or locked
+        // keychain gets another chance next launch instead of being marked done.
+        if report.failed == 0 {
+            let _ = create_dpk_migration_marker();
+        }
+        report
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = secret_keys;
+        MigrationReport::default()
+    }
+}
+
+/// Whether the legacy -> data-protection keychain migration marker exists.
+#[cfg(target_os = "macos")]
+fn dpk_migration_marker_exists() -> bool {
+    crate::registry::conduit_dir()
+        .map(|d| d.join(DPK_MIGRATION_MARKER))
+        .map(|p| p.exists())
+        .unwrap_or(false)
+}
+
+/// Create the legacy -> data-protection keychain migration marker. Returns `true`
+/// on success.
+#[cfg(target_os = "macos")]
+fn create_dpk_migration_marker() -> bool {
+    let Some(dir) = crate::registry::conduit_dir() else {
+        return false;
+    };
+    let _ = std::fs::create_dir_all(&dir);
+    std::fs::write(dir.join(DPK_MIGRATION_MARKER), b"1").is_ok()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -995,68 +1046,22 @@ mod tests {
         assert_eq!(first, read, "read must return the ensured key");
     }
 
-    /// macOS: once the master key exists, the file backend is selected
-    /// (`active()` is true) even without `CONDUIT_SECRET_KEY`.
+    /// macOS: the file backend is headless-only. Without `CONDUIT_SECRET_KEY`,
+    /// `active()` stays false even after a keychain master key exists, so desktop
+    /// secrets route to the data-protection keychain, never to `secrets.enc`.
     #[cfg(target_os = "macos")]
     #[test]
-    fn file_active_once_master_key_exists() {
+    fn master_key_does_not_activate_file_backend() {
         let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
-        // Make sure the env var is not what's activating it.
         let prev = std::env::var("CONDUIT_SECRET_KEY").ok();
         std::env::remove_var("CONDUIT_SECRET_KEY");
-        platform::ensure_master_key().expect("ensure should succeed");
+        // Creating a master key must NOT flip the file backend on (best-effort:
+        // the create may no-op on an unsigned build, which is fine for this test).
+        let _ = platform::ensure_master_key();
         assert!(
-            file::active(),
-            "file backend must be active once the master key exists"
+            !file::active(),
+            "file backend must stay inactive on desktop without CONDUIT_SECRET_KEY"
         );
-        if let Some(v) = prev {
-            std::env::set_var("CONDUIT_SECRET_KEY", v);
-        }
-    }
-
-    /// macOS: the keychain -> file migration moves a value into the file backend
-    /// and the value reads back from the file backend afterward.
-    ///
-    /// Seeds the source item via `platform::set_secret`, which now writes to the
-    /// DATA-PROTECTION keychain (errSecMissingEntitlement -34018 on an unsigned
-    /// binary), so this is signed-build-only: run only on a signed build with the
-    /// embedded provisioning profile (see Phase 7).
-    #[cfg(target_os = "macos")]
-    #[test]
-    #[ignore = "data-protection keychain needs a signed build w/ provisioning profile (Phase 7)"]
-    fn migrate_keychain_to_file_moves_value() {
-        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
-        let prev = std::env::var("CONDUIT_SECRET_KEY").ok();
-        std::env::remove_var("CONDUIT_SECRET_KEY");
-
-        // Master key must exist so the file backend is active.
-        platform::ensure_master_key().expect("ensure should succeed");
-
-        let sid = "conduit-file-migrate-test";
-        let key = "FILE_MIGRATE_KEY";
-        let original = "value-moved-into-file-backend";
-
-        // Seed an OLD per-server keychain item directly.
-        platform::set_secret(sid, key, original).unwrap();
-
-        // Run the keychain -> file migration for this key.
-        let keys = vec![(sid.to_string(), key.to_string())];
-        let report =
-            platform::migrate_keychain_to_file(&keys).expect("file migration should succeed");
-        assert_eq!(report.migrated, 1, "one entry should have been migrated");
-        assert_eq!(report.failed, 0, "no entries should have failed");
-
-        // The value now reads back from the FILE backend.
-        assert_eq!(
-            file::get_secret_result(sid, key).unwrap().as_deref(),
-            Some(original),
-            "migrated value must be readable from the file backend"
-        );
-        // And the top-level dispatcher (which routes through file::active()) too.
-        assert_eq!(get_secret(sid, key).as_deref(), Some(original));
-
-        // Clean up the file-backend entry.
-        let _ = file::delete_secret(sid, key);
         if let Some(v) = prev {
             std::env::set_var("CONDUIT_SECRET_KEY", v);
         }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Conduit",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "identifier": "com.tsout.conduit",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## What

Eliminates the recurring macOS keychain password prompts (one on every app update) without the "keys on disk" tradeoff. Secrets live in the macOS **data-protection keychain** under a team-scoped shared **access group**, and the gateway is wrapped in a nested helper `.app` (`Conduit.app/Contents/Helpers/ConduitGateway.app`) so it can carry its own embedded provisioning profile. Access-group membership is signature-independent within the team, so there is no per-app ACL and no prompt, including across updates.

## Why this approach

A bare CLI gateway can't carry a provisioning profile, and `keychain-access-groups` is a restricted entitlement that requires one. Wrapping the gateway in its own `.app` lets it carry the profile. This supersedes the trusted-app-ACL approach in #65, which re-prompted whenever the app was re-signed (i.e. every update).

## Changes

- `secrets.rs`: data-protection keychain via raw Security.framework FFI (`dpk` module) + the shared access group; `migrate_secrets_to_dpk` moves legacy keychain secrets in once (marker-guarded).
- Fixed the encrypted-file backend silently shadowing the keychain on desktop: the file backend is now headless-only (`CONDUIT_SECRET_KEY`), so desktop secrets always go to the keychain and never touch disk.
- New `Entitlements.plist` + `Gateway.entitlements`; `clients.rs` `resolve_gateway_path` returns the nested signed gateway path.
- `scripts/macos-sign-local.sh` (local) + `scripts/macos-package-ci.sh` + `release.yml`: nest the gateway, embed both profiles, sign inside-out, notarize, and regenerate the dmg + updater artifact over the re-signed app.

## Verification

Verified end-to-end on an **Intel Mac**: the signed app writes a secret to the data-protection keychain (no `secrets.enc` on disk), with no prompt on save, edit, or relaunch across a re-sign, and a **separately-signed gateway spawned by VS Code read the secret cross-process** (Resend connected and listed domains) with zero prompts. Apple Silicon uses the identical OS mechanism.

Supersedes #65.
