### PR TITLE
v0.9.4: clamp Retry-After + registry.json backup/recovery

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "conduit",
   "private": true,
-  "version": "0.9.3",
+  "version": "0.9.4",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -587,7 +587,7 @@ dependencies = [
 
 [[package]]
 name = "conduit"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "base64 0.22.1",
  "chacha20poly1305",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conduit"
-version = "0.9.3"
+version = "0.9.4"
 description = "Local MCP gateway: manage all your MCP servers in one place, set up once and shared by every AI client, with ~90% fewer tokens per request"
 authors = ["South Forge AI"]
 edition = "2021"

--- a/src-tauri/src/registry.rs
+++ b/src-tauri/src/registry.rs
@@ -616,20 +616,57 @@ pub fn gateway_log_path() -> Option<PathBuf> {
     Some(conduit_dir()?.join("gateway.log"))
 }
 
+/// Sibling `<registry>.bak` path holding the last-known-good registry.
+fn backup_path(path: &Path) -> PathBuf {
+    let mut name = path.as_os_str().to_owned();
+    name.push(".bak");
+    PathBuf::from(name)
+}
+
+/// Recover the registry from the `.bak` sibling that `save_to` maintains. Returns
+/// the parsed backup (and best-effort rewrites the primary from it so a later read
+/// self-heals), or None when there's no usable backup.
+fn restore_from_backup(path: &Path) -> Option<Registry> {
+    let content = std::fs::read_to_string(backup_path(path)).ok()?;
+    if content.trim().is_empty() {
+        return None;
+    }
+    let registry: Registry = serde_json::from_str(&content).ok()?;
+    // Best-effort: restore the primary so we don't keep reading the .bak. Recovery
+    // still succeeds if this write fails.
+    let _ = atomic_write(path, &content);
+    Some(registry)
+}
+
 pub fn load_from(path: &Path) -> Result<Registry, String> {
     if !path.exists() {
-        return Ok(Registry::default());
+        // registry.json is gone; recover the last-known-good from the .bak sibling
+        // if one survived (e.g. the primary was deleted but the backup intact).
+        return Ok(restore_from_backup(path).unwrap_or_default());
     }
     let content = std::fs::read_to_string(path).map_err(|e| e.to_string())?;
     if content.trim().is_empty() {
-        return Ok(Registry::default());
+        return Ok(restore_from_backup(path).unwrap_or_default());
     }
-    serde_json::from_str(&content).map_err(|e| format!("Corrupt registry: {e}"))
+    match serde_json::from_str(&content) {
+        Ok(reg) => Ok(reg),
+        // Corrupt registry.json: recover from the backup before surfacing the
+        // error, so a bad file doesn't wipe the user's server list.
+        Err(e) => restore_from_backup(path).ok_or_else(|| format!("Corrupt registry: {e}")),
+    }
 }
 
 pub fn save_to(path: &Path, registry: &Registry) -> Result<(), String> {
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
+    }
+    // Snapshot the current on-disk registry to a `.bak` sibling before overwriting,
+    // but only if it still parses, so a bad write or an accidental deletion of
+    // registry.json has a last-known-good to recover from (see load_from).
+    if let Ok(existing) = std::fs::read_to_string(path) {
+        if !existing.trim().is_empty() && serde_json::from_str::<Registry>(&existing).is_ok() {
+            let _ = atomic_write(&backup_path(path), &existing);
+        }
     }
     let json = serde_json::to_string_pretty(registry).map_err(|e| e.to_string())?;
     // The registry is the single source of truth for every server, so a crash,
@@ -934,5 +971,48 @@ mod tests {
             .any(|e| e.file_name().to_string_lossy().starts_with(&prefix));
         assert!(!leftover, "temp file left behind after a successful write");
         std::fs::remove_file(&path).ok();
+    }
+
+    #[test]
+    fn save_keeps_backup_and_load_recovers_from_it() {
+        let dir = std::env::temp_dir();
+        let path = dir.join(format!("conduit-reg-bak-{}.json", std::process::id()));
+        let bak = backup_path(&path);
+        std::fs::remove_file(&path).ok();
+        std::fs::remove_file(&bak).ok();
+
+        // First save: one server. No prior file, so nothing to snapshot yet.
+        let mut reg = Registry::default();
+        reg.add_server(sample_server("alpha"));
+        save_to(&path, &reg).unwrap();
+        assert!(!bak.exists(), "no backup on the first save");
+
+        // Second save snapshots the one-server registry into .bak before overwriting
+        // it with an empty one.
+        save_to(&path, &Registry::default()).unwrap();
+        assert_eq!(
+            load_from(&bak).unwrap().servers.len(),
+            1,
+            ".bak holds the pre-overwrite registry"
+        );
+
+        // A corrupt primary recovers its server list from the backup.
+        std::fs::write(&path, "{ not valid json").unwrap();
+        assert_eq!(
+            load_from(&path).unwrap().servers.len(),
+            1,
+            "recovered from .bak when the primary is corrupt"
+        );
+
+        // A missing primary also recovers from the backup.
+        std::fs::remove_file(&path).ok();
+        assert_eq!(
+            load_from(&path).unwrap().servers.len(),
+            1,
+            "recovered from .bak when the primary is missing"
+        );
+
+        std::fs::remove_file(&path).ok();
+        std::fs::remove_file(&bak).ok();
     }
 }

--- a/src-tauri/src/router.rs
+++ b/src-tauri/src/router.rs
@@ -17,7 +17,20 @@ use std::sync::{Arc, Mutex};
 
 use serde_json::{json, Value};
 
-use crate::downstream::{backoff_delay, DownstreamServer, TransportError, HTTP_MAX_RETRIES};
+use crate::downstream::{
+    backoff_delay, DownstreamServer, TransportError, HTTP_MAX_RETRIES, HTTP_RETRY_CAP,
+};
+
+/// The delay before a retry attempt. Prefers a server-advertised `Retry-After`,
+/// else our exponential backoff, but never longer than `HTTP_RETRY_CAP` so a
+/// downstream advertising `Retry-After: 3600` can't pin the calling agent's
+/// thread. Retries are bounded, so if the server is still limiting past the cap
+/// the loop exhausts and surfaces the error to the caller.
+fn retry_wait(retry_after: Option<std::time::Duration>, attempt: u32) -> std::time::Duration {
+    retry_after
+        .unwrap_or_else(|| backoff_delay(attempt))
+        .min(HTTP_RETRY_CAP)
+}
 
 /// Rewrite a name segment to the function-name charset clients accept
 /// (`[A-Za-z0-9_]`); every other character becomes `_`.
@@ -370,7 +383,7 @@ impl Router {
             match result {
                 Ok(v) => return Ok(v),
                 Err(TransportError::Retry { retry_after, message }) if attempt < HTTP_MAX_RETRIES => {
-                    let wait = retry_after.unwrap_or_else(|| backoff_delay(attempt));
+                    let wait = retry_wait(retry_after, attempt);
                     eprintln!("conduit: retrying downstream call after {wait:?}: {message}");
                     std::thread::sleep(wait);
                     attempt += 1;
@@ -438,6 +451,21 @@ mod tests {
     use std::sync::atomic::{AtomicU32, Ordering};
     use std::sync::Arc;
     use std::time::Duration;
+
+    #[test]
+    fn retry_wait_clamps_large_retry_after() {
+        // A downstream advertising a huge Retry-After is clamped to our cap so it
+        // can't pin the calling thread.
+        assert_eq!(retry_wait(Some(Duration::from_secs(3600)), 0), HTTP_RETRY_CAP);
+        // A reasonable Retry-After under the cap is honored as-is.
+        assert_eq!(
+            retry_wait(Some(Duration::from_secs(2)), 0),
+            Duration::from_secs(2)
+        );
+        // With no Retry-After, it falls back to the exponential backoff schedule.
+        assert_eq!(retry_wait(None, 0), backoff_delay(0));
+        assert_eq!(retry_wait(None, 1), backoff_delay(1));
+    }
 
     #[test]
     fn inline_refs_resolves_defs() {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Conduit",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "identifier": "com.tsout.conduit",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
Housekeeping release with two reliability fixes, on top of #66's head-of-line-blocking fix (already merged to main).

## Changes
- **fix(gateway): clamp Retry-After** to `HTTP_RETRY_CAP` (10s) via a testable `retry_wait()` helper. A downstream advertising a large `Retry-After` (e.g. 3600s) could otherwise pin the calling agent's thread for the whole delay. Retries stay bounded, so a still-limiting server surfaces the error instead of hanging. (Follow-up from the #66 review.)
- **feat(registry): `registry.json.bak` + recovery.** `save_to` snapshots the last-known-good registry before overwriting; `load_from` recovers from the `.bak` when `registry.json` is missing, empty, or corrupt. Guards against losing the whole server list to a bad write or an accidental deletion.
- chore: bump to 0.9.4.

Both fixes have unit tests. `cargo check --all-targets` is clean locally.