### PR TITLE
docs: refresh for v0.9.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,62 @@ All notable changes to Conduit are documented here. Format loosely follows
 
 ## [Unreleased]
 
+- **Security: confidence scoring + new injection categories.** The tool-poisoning /
+  content-defense scanner now combines signals into a weighted confidence score
+  (surfaced on security events) and adds three detection categories (role-jailbreak,
+  system-prompt exfiltration, chat-template delimiter injection). Existing signatures
+  and behavior are unchanged.
+
+## [0.9.4] - 2026-07-01
+
+### Added
+- **Registry backup and recovery.** A `registry.json.bak` sibling keeps the
+  last-known-good server list; Conduit recovers from it if `registry.json` is deleted
+  or corrupted, so a bad write or an accidental wipe no longer loses your servers.
+
+### Fixed
+- **Per-server head-of-line blocking.** The gateway releases the per-server lock during
+  a downstream backoff, so one server's 429 rate-limit no longer stalls other concurrent
+  calls to that same server.
+- **Retry-After clamp.** A downstream's `Retry-After` header is capped to the backoff
+  cap (10s), so a misconfigured or hostile server can't park a call for minutes.
+
+### Docs
+- Codex setup walkthrough in the README.
+
+## [0.9.3] - 2026-07-01
+
+### Security
+- **macOS: no more keychain prompts on update.** Secrets now live in the macOS
+  data-protection keychain under a team-scoped shared access group, and the gateway
+  ships as a nested notarized helper that shares that group. The gateway reads the
+  secrets the app saved with no password prompt, even across app updates (the repeated
+  "Conduit wants to use your confidential information" dialog is gone). Secrets still
+  never touch disk.
+
+### Added
+- **Quarantine-on-drift.** High-risk tool-definition changes (a poisoned definition, or
+  a destructive tool that changed or newly appeared) are blocked until you re-approve.
+- **Headless encrypted-file secret backend** (`CONDUIT_SECRET_KEY`) for server/self-host
+  use where no OS keychain is available.
+
+### Changed
+- Teams pricing is $12/seat (was $20). Smaller initial bundle via code-splitting.
+
+## [0.9.2] - 2026-06-30
+
+### Added
+- **Catalog: configure-on-add** (enter keys while adding a server), **self-hosted
+  servers** (n8n, Langfuse), and more entries (DataForSEO, Chrome DevTools, Railway,
+  Twilio, Postiz).
+- **Per-call confirmation for destructive tools.**
+- **Paste a config snippet** to auto-fill the Add Server dialog.
+
+### Fixed
+- Remote servers refresh an expired OAuth token on a mid-session 401 and retry, no manual
+  reconnect.
+- Teams only soft-syncs servers the member opts into (no silent RCE from team config).
+
 ## [0.9.1] - 2026-06-29
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ and refreshes too.
 
 ## Supported clients
 
-Conduit auto-detects these **19 AI clients**, installs the gateway into each with one
+Conduit auto-detects these **20 AI clients**, installs the gateway into each with one
 click, and can import a client's existing servers. It writes the config file shown
 below for you, so you never have to edit these by hand.
 
@@ -148,6 +148,7 @@ below for you, so you never have to edit these by hand.
 | VS Code | `<config>/Code/User/mcp.json` | JSON (`servers`) |
 | Windsurf | `~/.codeium/windsurf/mcp_config.json` | JSON (`mcpServers`) |
 | Codex | `~/.codex/config.toml` | TOML (`mcp_servers`) |
+| Continue | `~/.continue/config.yaml` | YAML (`mcpServers`) |
 | Antigravity | `~/.gemini/config/mcp_config.json` | JSON (`mcpServers`) |
 | Gemini CLI | `~/.gemini/settings.json` | JSON (`mcpServers`) |
 | Cline | `<config>/Code/User/globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json` | JSON (`mcpServers`) |
@@ -294,18 +295,18 @@ The frontend is typechecked with `npx tsc --noEmit`.
   releases bundle it, so installed users never hit this.
 - **Repeated macOS keychain prompts / "could not read secret from the keychain"
   in dev.** An unsigned dev build gets an unstable code-signing identity, so the
-  keychain re-prompts or denies reads. A signed release fixes this; it is a
-  dev-only artifact.
+  keychain re-prompts or denies reads. Signed release builds (v0.9.3+) don't: they
+  store secrets in the macOS data-protection keychain under a shared access group,
+  so the gateway reads them with no prompt. This is a dev-only artifact.
 - **"could not read/store secret" on Linux.** Secret storage uses the freedesktop
   Secret Service (libsecret), provided by GNOME Keyring, KWallet, or similar. A
   headless box or a session without a running keyring daemon has nowhere to store
   secrets. Run Conduit in a desktop session, or install and unlock a keyring
   (e.g. `gnome-keyring`).
-- **macOS keychain prompt the first time the gateway runs.** When a client spawns
-  the gateway and it reads a saved key, macOS asks for keychain access ("Conduit
-  wants to use ..."). Click **Always Allow** once and it won't ask again. (The app
-  and the gateway are separate signed binaries today; a future release will share
-  keychain access so this prompt goes away.)
+- **macOS keychain and the gateway (v0.9.3+).** The app and the separately-signed
+  gateway share a team-scoped keychain access group, so the gateway reads the
+  secrets the app saved with no prompt, even across app updates. (Earlier releases
+  showed a one-time "Always Allow" prompt; on current signed builds it's gone.)
 - **VS Code: the conduit server doesn't start automatically.** VS Code may require
   you to click **Start Server** on the conduit MCP entry the first time, that's VS
   Code's own MCP handling, not Conduit. After that it reconnects on its own.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -7,9 +7,10 @@ that exposes 3 meta-tools the agent searches on demand, so context stays flat:
 measured ~90% fewer tokens at the same task success. This document is the working
 spec, capturing the architecture decision and the build order.
 
-**Status (2026-06-28):** v0.7.0 published. Signed/notarized macOS (Apple Silicon +
-Intel), Windows (Azure Trusted Signing), Linux (deb/AppImage) via a tag-triggered
-pipeline + in-app auto-updater. 19 clients. Shipping: lazy discovery, OAuth/key auth
+**Status (2026-07-01):** v0.9.4 published. Signed/notarized macOS (Apple Silicon +
+Intel, data-protection keychain + nested gateway, no keychain prompts on update),
+Windows (Azure Trusted Signing), Linux (deb/AppImage) via a tag-triggered pipeline +
+in-app auto-updater. 20 clients. Shipping: lazy discovery, OAuth/key auth
 with live propagation, catalog, import/migrate, per-tool + destructive-tool
 governance, audit log, resources/prompts proxying, tool playground, semantic search,
 rug-pull + injection + agentjacking detection, result-shaping Tier 1. **v0.7.0 made


### PR DESCRIPTION
Documentation-only. Brings the public docs current with what shipped through v0.9.4:
- README macOS keychain sections now reflect v0.9.3 (data-protection keychain + shared access group; the repeated prompt on update is gone). Dev-only caveat kept.
- Client count 19 -> 20 + added the missing Continue row.
- ROADMAP status line moved from v0.7.0 to v0.9.4.
- CHANGELOG backfilled with the missing 0.9.2 / 0.9.3 / 0.9.4 releases + an Unreleased note for the detection-scoring change.

Verified facts against the code/releases (client list, seat/keychain behavior, per-version commits).