### PR TITLE
feat(audit): attribute each tool call to its client

### DIFF
--- a/src-tauri/src/audit.rs
+++ b/src-tauri/src/audit.rs
@@ -42,6 +42,7 @@ pub fn record_timed(
     ok: bool,
     duration_ms: Option<u64>,
     error: Option<&str>,
+    client: Option<&str>,
 ) {
     let mut entry = json!({
         "ts": epoch_millis() as u64,
@@ -51,6 +52,11 @@ pub fn record_timed(
     });
     if let Some(ms) = duration_ms {
         entry["durationMs"] = json!(ms);
+    }
+    // Which client made the call (a registered HTTP client's label), so the audit
+    // log answers "who invoked this?". Absent for the local stdio client / open tokens.
+    if let Some(c) = client.filter(|c| !c.is_empty()) {
+        entry["client"] = json!(c);
     }
     if !ok {
         if let Some(err) = error {
@@ -67,14 +73,18 @@ pub fn record_timed(
 /// confirm-destructive feature working, not a failure, so `ok: true` keeps it out of
 /// the error rate; the `held` flag lets the UI mark it as held rather than as a
 /// (misleading) successful destructive call.
-pub fn record_held(server: &str, tool: &str) {
-    write_line(&json!({
+pub fn record_held(server: &str, tool: &str, client: Option<&str>) {
+    let mut entry = json!({
         "ts": epoch_millis() as u64,
         "server": server,
         "tool": tool,
         "ok": true,
         "held": true,
-    }));
+    });
+    if let Some(c) = client.filter(|c| !c.is_empty()) {
+        entry["client"] = json!(c);
+    }
+    write_line(&entry);
 }
 
 /// Append one entry as a single JSON line. A single `write_all` (not `writeln!`, which

--- a/src-tauri/src/bin/conduit-gateway.rs
+++ b/src-tauri/src/bin/conduit-gateway.rs
@@ -1172,6 +1172,19 @@ fn resolve_http_scope(
     None
 }
 
+/// The audit label for a registered HTTP client's bearer: its `label`, or its `id`
+/// when the label is blank. `None` when the token isn't a registered client (legacy
+/// single-token, open loopback, or the local stdio app), so those calls stay
+/// unattributed in the audit log rather than mislabeled. Pure, so it's unit-testable.
+fn http_client_label(reg: &Registry, provided: Option<&str>) -> Option<String> {
+    let client = reg.http_client_for_token(provided?)?;
+    Some(if client.label.trim().is_empty() {
+        client.id.clone()
+    } else {
+        client.label.clone()
+    })
+}
+
 #[allow(clippy::too_many_arguments)]
 fn handle_request(
     req: &Value,
@@ -1591,7 +1604,7 @@ fn handle_request(
                     );
                     // Held for confirmation, not a failure: record as held (ok), so the
                     // confirm-destructive feature doesn't inflate the error rate.
-                    audit::record_held(srv, tool);
+                    audit::record_held(srv, tool, router.current_client());
                     return Some(success(
                         id,
                         json!({
@@ -1617,7 +1630,7 @@ fn handle_request(
                     } else {
                         Some(content_text(&result))
                     };
-                    audit::record_timed(srv, tool, ok, Some(ms), err.as_deref());
+                    audit::record_timed(srv, tool, ok, Some(ms), err.as_deref(), router.current_client());
                     // Content defense: scan this untrusted tool output for injection
                     // and label any flagged text as data before it reaches the agent.
                     if reg.content_defense {
@@ -1650,7 +1663,7 @@ fn handle_request(
                 }
                 Err(e) => {
                     let ms = started.elapsed().as_millis() as u64;
-                    audit::record_timed(srv, tool, false, Some(ms), Some(&e));
+                    audit::record_timed(srv, tool, false, Some(ms), Some(&e), router.current_client());
                     let recovery = recovery_hint(cached, srv);
                     Some(success(
                         id,
@@ -2115,6 +2128,7 @@ fn process_request(
     guard: &mut SearchGuard,
     confirm: &mut ConfirmGuard,
     allowed: Option<&std::collections::HashSet<String>>,
+    client: Option<&str>,
 ) -> Option<Value> {
     let method = req.get("method").and_then(|m| m.as_str()).unwrap_or("");
 
@@ -2195,6 +2209,9 @@ fn process_request(
         .router
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner);
+    // Attribute this request to its client (set under the router lock, so concurrent
+    // HTTP requests can't cross-contaminate) for the audit log.
+    r.set_current_client(client);
     handle_request(
         req,
         &reg,
@@ -2434,6 +2451,7 @@ fn handle_http(
     path: &str,
     body: &str,
     allowed: Option<&std::collections::HashSet<String>>,
+    client: Option<&str>,
 ) -> (u16, &'static str, String) {
     match (method, path) {
         // CORS preflight: browsers (Open WebUI fetches tool specs client-side)
@@ -2477,7 +2495,7 @@ fn handle_http(
                 "method": "tools/call",
                 "params": { "name": name, "arguments": args }
             });
-            match process_request(state, &req, guard, confirm, allowed) {
+            match process_request(state, &req, guard, confirm, allowed, client) {
                 Some(resp) => {
                     if let Some(err) = resp.get("error") {
                         let msg = err.get("message").and_then(|m| m.as_str()).unwrap_or("error");
@@ -2646,6 +2664,7 @@ fn serve_http_loop(server: tiny_http::Server, state: GatewayState, token: Option
             .find(|h| h.field.equiv("Authorization"))
             .map(|h| h.value.as_str().to_string());
         let provided_tok = provided.as_deref().and_then(parse_bearer);
+        let mut client_label: Option<String> = None;
         let scope: Option<Option<std::collections::HashSet<String>>> = if method == "OPTIONS" {
             Some(None)
         } else {
@@ -2653,6 +2672,9 @@ fn serve_http_loop(server: tiny_http::Server, state: GatewayState, token: Option
                 .registry
                 .lock()
                 .unwrap_or_else(std::sync::PoisonError::into_inner);
+            // Resolve the client's audit label from the same token, so every call it
+            // makes can be attributed to it in the audit log.
+            client_label = http_client_label(&reg, provided_tok);
             resolve_http_scope(&reg, token.as_deref(), provided_tok)
         };
 
@@ -2687,6 +2709,7 @@ fn serve_http_loop(server: tiny_http::Server, state: GatewayState, token: Option
                             &path,
                             &body,
                             allowed.as_ref(),
+                            client_label.as_deref(),
                         )
                     }))
                     .unwrap_or((
@@ -2946,7 +2969,8 @@ fn main() {
             "request: {}",
             req.get("method").and_then(|m| m.as_str()).unwrap_or("")
         ));
-        let response = process_request(&state, &req, &mut search_guard, &mut confirm_guard, None);
+        let response =
+            process_request(&state, &req, &mut search_guard, &mut confirm_guard, None, None);
         if let Some(resp) = response {
             let mut out = state
                 .stdout
@@ -3164,6 +3188,33 @@ mod tests {
     }
 
     #[test]
+    fn http_client_label_attributes_registered_clients() {
+        let mut reg = Registry::default();
+        // Unknown / absent bearer -> unattributed (stays out of the audit log).
+        assert_eq!(http_client_label(&reg, None), None);
+        assert_eq!(http_client_label(&reg, Some("nope")), None);
+        // A registered client resolves to its human-readable label.
+        reg.http_clients.push(registry::HttpClient {
+            id: "c1".into(),
+            label: "Cursor".into(),
+            token_sha256: registry::sha256_hex("tok1"),
+            profile: String::new(),
+        });
+        assert_eq!(
+            http_client_label(&reg, Some("tok1")).as_deref(),
+            Some("Cursor")
+        );
+        // A blank label falls back to the id, so attribution is never an empty string.
+        reg.http_clients.push(registry::HttpClient {
+            id: "c2".into(),
+            label: "   ".into(),
+            token_sha256: registry::sha256_hex("tok2"),
+            profile: String::new(),
+        });
+        assert_eq!(http_client_label(&reg, Some("tok2")).as_deref(), Some("c2"));
+    }
+
+    #[test]
     fn status_summary_scopes_to_allowed_servers() {
         use std::collections::HashSet;
         let mut reg = Registry::default();
@@ -3313,6 +3364,7 @@ mod tests {
             "OPTIONS",
             "/conduit_search_tools",
             "",
+            None,
             None,
         );
         assert_eq!(status, 204);

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -701,7 +701,9 @@ async fn call_tool(
         // A transport error carries its own message; capture it so Activity can
         // show why a playground call failed, not just that it did.
         let err = result.as_ref().err().map(|e| e.to_string());
-        audit::record_timed(&server.id, &tool, ok, Some(ms), err.as_deref());
+        // The in-app tool playground: a local action by the desktop user, so it's
+        // unattributed (client identity is only meaningful for registered HTTP clients).
+        audit::record_timed(&server.id, &tool, ok, Some(ms), err.as_deref(), None);
         result
     })
     .await

--- a/src-tauri/src/router.rs
+++ b/src-tauri/src/router.rs
@@ -195,11 +195,27 @@ pub struct Router {
     prompts: Vec<Value>,
     /// Exposed prompt name -> (server id, original prompt name).
     prompt_routes: HashMap<String, (String, String)>,
+    /// The client whose request is currently being dispatched (a registered HTTP
+    /// client's label), set per-request by the dispatcher while it holds the router
+    /// lock, so the audit log can attribute each call to who made it. `None` for the
+    /// local stdio client and legacy/open tokens (unattributed).
+    current_client: Option<String>,
 }
 
 impl Router {
     pub fn new() -> Self {
         Router::default()
+    }
+
+    /// Set (or clear) the client attributed to the request about to be dispatched.
+    /// Called under the router lock, so it can't race across concurrent requests.
+    pub fn set_current_client(&mut self, client: Option<&str>) {
+        self.current_client = client.map(str::to_string);
+    }
+
+    /// The client attributed to the in-flight request, for audit attribution.
+    pub fn current_client(&self) -> Option<&str> {
+        self.current_client.as_deref()
     }
 
     /// A router that enforces `policy` as servers are added.

--- a/src/components/ActivityView.tsx
+++ b/src/components/ActivityView.tsx
@@ -452,6 +452,14 @@ function CallRow({ e }: { e: AuditEntry }) {
         <span className="min-w-0 truncate font-mono text-xs text-muted-foreground">
           {e.tool}
         </span>
+        {e.client && (
+          <span
+            className="shrink-0 rounded bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground"
+            title="Client that made this call"
+          >
+            {e.client}
+          </span>
+        )}
         <span className="ml-auto shrink-0 text-xs tabular-nums text-muted-foreground">
           {fmtMs(e.durationMs ?? null)}
         </span>

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -67,6 +67,9 @@ export interface AuditEntry {
   error?: string;
   /** A destructive call held for confirmation (not a success and not an error). */
   held?: boolean;
+  /** The registered HTTP client that made the call, when known. Absent for the
+   * local desktop client and legacy/open tokens. */
+  client?: string;
 }
 
 export interface ProbeResult {


### PR DESCRIPTION
## Why (Tier 1, closes the Lunar MCPX concession)
The gateway audit log recorded `server`/`tool`/`ok`/`duration` but not **which client** made the call. In HTTP-bridge mode one gateway serves every registered client, so the log couldn't answer "who invoked this?", the per-client visibility gap we honestly concede to Lunar MCPX, and the prerequisite for the per-client observability quadrant.

## What
- `http_client_label(reg, bearer)` resolves a registered HTTP client's label (or id fallback) from its token; unit-tested. Unknown/legacy/open tokens and the local stdio client stay **unattributed** (never mislabeled).
- The label is stashed on the `Router` under the per-request lock in `process_request`, so concurrent HTTP requests can't cross-contaminate, then read by the existing `record_timed`/`record_held` calls and stamped into the audit line as `client`.
- `get_audit_log` already returns raw lines, so the field reaches the UI with no reader change; Activity shows it as a subtle per-row label.

## Scope notes
- Threading avoided churn on `handle_request`'s ~22 call sites by using the Router field (the router is already in scope at the audit calls).
- The in-app tool playground and stdio pass `None` (local, unattributed).

## Test
New `http_client_label` unit test; full gateway + lib suite green (259); `tsc --noEmit` clean.