### PR TITLE
feat: opt-in live request/response inspection

### DIFF
--- a/src-tauri/src/bin/conduit-gateway.rs
+++ b/src-tauri/src/bin/conduit-gateway.rs
@@ -29,6 +29,7 @@ use serde_json::{json, Value};
 use conduit_lib::audit;
 use conduit_lib::clients;
 use conduit_lib::downstream::{DownstreamServer, StdioTransport, PROTOCOL_VERSION};
+use conduit_lib::inspect;
 use conduit_lib::integrity;
 use conduit_lib::registry::{self, Registry, ServerEntry};
 use conduit_lib::remote;
@@ -1615,6 +1616,15 @@ fn handle_request(
                 }
             }
 
+            // Live inspection (opt-in, off by default): capture the raw request
+            // args now, only when enabled, so the response can be paired with them
+            // below. When off, nothing is cloned and nothing is ever captured.
+            let inspect_args = if reg.live_inspect {
+                Some(arguments.clone())
+            } else {
+                None
+            };
+
             let started = Instant::now();
             match router.route_call(name, arguments) {
                 Ok(mut result) => {
@@ -1631,6 +1641,14 @@ fn handle_request(
                         Some(content_text(&result))
                     };
                     audit::record_timed(srv, tool, ok, Some(ms), err.as_deref(), router.current_client());
+                    // Live inspection: capture the RAW result here, before content
+                    // defense and shaping rewrite it, so the inspector shows exactly
+                    // what the server returned. Only runs when live_inspect is on
+                    // (inspect_args is Some only then). Attributed to the same client
+                    // as the audit line.
+                    if let Some(req) = &inspect_args {
+                        inspect::record(router.current_client(), srv, tool, req, &result, ok, ms);
+                    }
                     // Content defense: scan this untrusted tool output for injection
                     // and label any flagged text as data before it reaches the agent.
                     if reg.content_defense {
@@ -1664,6 +1682,11 @@ fn handle_request(
                 Err(e) => {
                     let ms = started.elapsed().as_millis() as u64;
                     audit::record_timed(srv, tool, false, Some(ms), Some(&e), router.current_client());
+                    // Live inspection: capture the failed call too, with the error
+                    // as the response body. Only when live_inspect is on.
+                    if let Some(req) = &inspect_args {
+                        inspect::record(router.current_client(), srv, tool, req, &json!({ "error": e }), false, ms);
+                    }
                     let recovery = recovery_hint(cached, srv);
                     Some(success(
                         id,

--- a/src-tauri/src/inspect.rs
+++ b/src-tauri/src/inspect.rs
@@ -1,0 +1,252 @@
+//! Live request/response inspection: an opt-in, off-by-default local "network tab"
+//! for MCP tool calls.
+//!
+//! This is the ONE place Conduit captures a tool call's arguments and result. It
+//! is deliberately kept apart from the governance audit log (`audit.jsonl`), which
+//! stays free of args/results forever. Capture only happens while the user has
+//! `live_inspect` on; when it's off, nothing here is ever called and no file is
+//! written.
+//!
+//! The capture is EPHEMERAL and BOUNDED:
+//! - a separate file `inspect.jsonl`, ring-trimmed to the last 50 entries on every
+//!   write, so it can never grow;
+//! - each captured `request` and `response` is size-capped to ~4 KB of serialized
+//!   JSON; anything larger is dropped and replaced with a short marker string, so a
+//!   large body is never stored in full.
+//!
+//! Local only: like the audit log, this never leaves the machine.
+
+use std::io::Write;
+use std::path::PathBuf;
+
+use serde_json::{json, Value};
+
+/// How many of the most recent captured calls to keep. A small window: this is a
+/// live inspector, not a log, so it stays tiny and ephemeral.
+const KEEP_LINES: usize = 50;
+
+/// Cap on a single captured `request` or `response`, in bytes of serialized JSON.
+/// A body larger than this is dropped and replaced with a truncation marker, so the
+/// full body is never written to disk.
+const MAX_BODY_BYTES: usize = 4 * 1024;
+
+pub fn inspect_path() -> Option<PathBuf> {
+    // Same anchor as the registry/audit log, so the app and a client-spawned gateway
+    // (which may run under MSIX virtualization) read and write the *same* file.
+    Some(crate::registry::conduit_dir()?.join("inspect.jsonl"))
+}
+
+fn epoch_millis() -> u128 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis())
+        .unwrap_or(0)
+}
+
+/// Return `value` unchanged if its serialized JSON fits in `max_bytes`, otherwise a
+/// short marker string like `"<truncated 12345 bytes>"`. The full oversized body is
+/// never returned, so it never reaches disk.
+fn cap_json(value: &Value, max_bytes: usize) -> Value {
+    let serialized = value.to_string();
+    if serialized.len() <= max_bytes {
+        value.clone()
+    } else {
+        json!(format!("<truncated {} bytes>", serialized.len()))
+    }
+}
+
+/// Capture one tool call's request + response into the ephemeral inspect ring.
+/// Only ever called while `live_inspect` is on. `request` and `response` are each
+/// size-capped before being written; oversized bodies become a truncation marker.
+pub fn record(
+    client: Option<&str>,
+    server: &str,
+    tool: &str,
+    request: &Value,
+    response: &Value,
+    ok: bool,
+    duration_ms: u64,
+) {
+    let mut entry = json!({
+        "ts": epoch_millis() as u64,
+        "server": server,
+        "tool": tool,
+        "request": cap_json(request, MAX_BODY_BYTES),
+        "response": cap_json(response, MAX_BODY_BYTES),
+        "ok": ok,
+        "durationMs": duration_ms,
+    });
+    if let Some(c) = client {
+        if !c.is_empty() {
+            entry["client"] = json!(c);
+        }
+    }
+    write_line(&entry);
+}
+
+/// Append one entry as a single JSON line, then ring-trim to the last `KEEP_LINES`.
+/// A single `write_all` (not `writeln!`, which can issue several write syscalls)
+/// keeps the many client-spawned gateways that share this file from interleaving
+/// each other's bytes into corrupt JSON.
+fn write_line(entry: &Value) {
+    let Some(path) = inspect_path() else {
+        return;
+    };
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    if let Ok(mut file) = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&path)
+    {
+        let _ = file.write_all(format!("{entry}\n").as_bytes());
+    }
+    ring_trim(&path);
+}
+
+/// Keep only the most recent `KEEP_LINES` lines. Unlike the audit log (which trims
+/// only past a size threshold), this ring trims on every write so the inspector
+/// stays bounded to a tiny window. Best-effort: a failure never affects the call.
+fn ring_trim(path: &std::path::Path) {
+    let Ok(content) = std::fs::read_to_string(path) else {
+        return;
+    };
+    let lines: Vec<&str> = content.lines().filter(|l| !l.trim().is_empty()).collect();
+    if lines.len() <= KEEP_LINES {
+        return;
+    }
+    let start = lines.len() - KEEP_LINES;
+    let mut trimmed = lines[start..].join("\n");
+    trimmed.push('\n');
+    let _ = crate::registry::atomic_write(path, &trimmed);
+}
+
+/// The most recent `limit` captured calls, newest first.
+pub fn read_recent(limit: usize) -> Vec<Value> {
+    let path = match inspect_path() {
+        Some(p) => p,
+        None => return Vec::new(),
+    };
+    let content = match std::fs::read_to_string(&path) {
+        Ok(c) => c,
+        Err(_) => return Vec::new(),
+    };
+    let mut entries: Vec<Value> = content
+        .lines()
+        .rev()
+        .take(limit)
+        .filter_map(|line| serde_json::from_str(line).ok())
+        .collect();
+    entries.truncate(limit);
+    entries
+}
+
+/// Clear the inspect ring (delete the file). Called when the user turns live
+/// inspection off, so no captured args/results linger.
+pub fn clear() {
+    if let Some(path) = inspect_path() {
+        let _ = std::fs::remove_file(&path);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    // The inspect file path is process-global (one file per machine), so these
+    // tests can't run concurrently against it. Serialize them, and reset the file
+    // at the start of each so they don't see each other's writes.
+    static TEST_LOCK: Mutex<()> = Mutex::new(());
+
+    fn reset() {
+        clear();
+    }
+
+    #[test]
+    fn record_then_read_recent_returns_it() {
+        let _g = TEST_LOCK.lock().unwrap();
+        reset();
+        record(
+            Some("cursor"),
+            "github",
+            "search",
+            &json!({ "q": "conduit" }),
+            &json!({ "content": [{ "type": "text", "text": "hit" }] }),
+            true,
+            42,
+        );
+        let recent = read_recent(10);
+        assert_eq!(recent.len(), 1);
+        let e = &recent[0];
+        assert_eq!(e["server"], "github");
+        assert_eq!(e["tool"], "search");
+        assert_eq!(e["client"], "cursor");
+        assert_eq!(e["ok"], true);
+        assert_eq!(e["durationMs"], 42);
+        assert_eq!(e["request"]["q"], "conduit");
+        assert_eq!(e["response"]["content"][0]["text"], "hit");
+        reset();
+    }
+
+    #[test]
+    fn ring_caps_at_fifty() {
+        let _g = TEST_LOCK.lock().unwrap();
+        reset();
+        for i in 0..60 {
+            record(
+                None,
+                "srv",
+                "tool",
+                &json!({ "i": i }),
+                &json!({ "ok": true }),
+                true,
+                1,
+            );
+        }
+        let recent = read_recent(1000);
+        // Ring-trimmed to the last 50, so only 50 remain...
+        assert_eq!(recent.len(), 50);
+        // ...and they are the most recent (i = 59 newest, i = 10 oldest kept).
+        assert_eq!(recent[0]["request"]["i"], 59);
+        assert_eq!(recent[49]["request"]["i"], 10);
+        reset();
+    }
+
+    #[test]
+    fn oversized_request_is_truncated_not_stored() {
+        let _g = TEST_LOCK.lock().unwrap();
+        reset();
+        // A request whose serialized JSON is well over the 4 KB cap.
+        let big = "x".repeat(8 * 1024);
+        record(
+            None,
+            "srv",
+            "tool",
+            &json!({ "blob": big }),
+            &json!({ "ok": true }),
+            true,
+            1,
+        );
+        let recent = read_recent(10);
+        assert_eq!(recent.len(), 1);
+        let req = &recent[0]["request"];
+        // The full body is NOT stored: request collapses to the marker string.
+        assert!(req.is_string(), "oversized request should be a marker string");
+        let marker = req.as_str().unwrap();
+        assert!(marker.starts_with("<truncated "), "got: {marker}");
+        assert!(marker.contains("bytes>"));
+        // And the giant blob is nowhere in the stored line.
+        assert!(!recent[0].to_string().contains(&big));
+        // The (small) response is stored intact.
+        assert_eq!(recent[0]["response"]["ok"], true);
+        reset();
+    }
+
+    #[test]
+    fn cap_json_keeps_small_bodies() {
+        let v = json!({ "a": 1 });
+        assert_eq!(cap_json(&v, MAX_BODY_BYTES), v);
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -6,6 +6,7 @@ pub mod audit;
 pub mod catalog;
 pub mod clients;
 pub mod downstream;
+pub mod inspect;
 pub mod integrity;
 pub mod oauth;
 pub mod registry;
@@ -821,6 +822,34 @@ fn set_confirm_destructive(state: State<RegistryState>, confirm: bool) -> Result
     Ok(reg.clone())
 }
 
+/// Toggle live request/response inspection. When enabled, the gateway captures each
+/// tool call's args + result into a small, separate, ephemeral local ring
+/// (`inspect.jsonl`, last 50 calls, each body size-capped) that the Activity view can
+/// show. Off by default; the governance audit log is never touched by this. Turning
+/// it off in the UI should also clear the ring (see `clear_inspect_log`).
+#[tauri::command]
+fn set_live_inspect(state: State<RegistryState>, enabled: bool) -> Result<Registry, String> {
+    let mut reg = state.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+    reg.set_live_inspect(enabled);
+    registry::save(&reg)?;
+    Ok(reg.clone())
+}
+
+/// The most recent live-inspection captures (newest first): each tool call's args and
+/// result, only present while live inspection has been on. Empty when off/unused.
+#[tauri::command]
+fn get_inspect_log(limit: usize) -> Vec<serde_json::Value> {
+    inspect::read_recent(limit)
+}
+
+/// Clear the live-inspection ring (delete `inspect.jsonl`), so no captured args/results
+/// linger. Called when the user turns live inspection off.
+#[tauri::command]
+fn clear_inspect_log() -> Result<(), String> {
+    inspect::clear();
+    Ok(())
+}
+
 /// Toggle quarantine-on-drift. When enabled, the gateway hides and blocks a high-risk
 /// tool (poisoned definition, or a destructive tool whose definition changed/appeared)
 /// that drifts from its pinned baseline, until the user re-approves it.
@@ -1633,6 +1662,9 @@ pub fn run() {
             set_tool_enabled,
             set_deny_destructive,
             set_confirm_destructive,
+            set_live_inspect,
+            get_inspect_log,
+            clear_inspect_log,
             set_quarantine_on_drift,
             list_quarantined,
             release_quarantine,

--- a/src-tauri/src/registry.rs
+++ b/src-tauri/src/registry.rs
@@ -171,6 +171,14 @@ pub struct Registry {
     /// Detection + labeling, never blocks. On by default.
     #[serde(default = "default_true")]
     pub content_defense: bool,
+    /// Live request/response inspection: when true, the gateway captures each tool
+    /// call's arguments and result into a small, separate, ephemeral local ring
+    /// (`inspect.jsonl`, last 50 calls, each body size-capped) so the Activity view
+    /// can show them. OFF by default and never touches the governance audit log,
+    /// which stays free of args/results. This is the ONE place args/results are
+    /// captured, and only on the user's machine.
+    #[serde(default)]
+    pub live_inspect: bool,
     /// Optional semantic re-ranking for tool search (blends embedding similarity
     /// into the lexical ranking). Off by default; when off or unconfigured, search
     /// is pure lexical exactly as before.
@@ -268,6 +276,7 @@ impl Default for Registry {
             allow_agent_control: false,
             integrity_check: true,
             content_defense: true,
+            live_inspect: false,
             semantic_search: SemanticSettings::default(),
             team: None,
             result_budgets: HashMap::new(),
@@ -450,6 +459,13 @@ impl Registry {
     /// Set lazy discovery mode (gateway exposes meta-tools vs the full catalog).
     pub fn set_lazy_discovery(&mut self, lazy: bool) {
         self.lazy_discovery = lazy;
+    }
+
+    /// Turn live request/response inspection on or off. When on, the gateway
+    /// captures each tool call's args + result into the ephemeral `inspect.jsonl`
+    /// ring; when off, nothing is captured and no inspect file is written.
+    pub fn set_live_inspect(&mut self, on: bool) {
+        self.live_inspect = on;
     }
 
     pub fn add_profile(&mut self, name: &str) -> String {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -512,7 +512,7 @@ function App() {
                 }
               >
               {view === "activity" ? (
-                <ActivityView refreshKey={activityKey} />
+                <ActivityView refreshKey={activityKey} registry={registry} />
               ) : view === "catalog" ? (
                 <CatalogView registry={registry} onAdded={setRegistry} />
               ) : view === "playground" ? (

--- a/src/components/ActivityView.tsx
+++ b/src/components/ActivityView.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import {
+  Activity,
   AlertTriangle,
   CheckCircle2,
   ChevronRight,
@@ -16,6 +17,7 @@ import { toastError } from "@/lib/toast";
 import {
   getAuditLog,
   getAuditStats,
+  getInspectLog,
   getSavingsSummary,
   getSecurityEvents,
   type SecurityEvent,
@@ -23,6 +25,8 @@ import {
 import type {
   AuditEntry,
   AuditStats,
+  InspectEntry,
+  Registry,
   SavingsSummary,
   ServerStat,
 } from "@/lib/types";
@@ -531,7 +535,142 @@ function StatsPanel({ stats }: { stats: AuditStats }) {
   );
 }
 
-export function ActivityView({ refreshKey }: { refreshKey: number }) {
+/** Pretty-print a captured body. A truncation marker (a plain string like
+ * "<truncated N bytes>") is shown as-is; everything else is JSON-formatted. */
+function fmtBody(v: unknown): string {
+  if (typeof v === "string") return v;
+  try {
+    return JSON.stringify(v, null, 2);
+  } catch {
+    return String(v);
+  }
+}
+
+/** One captured call. Expands to show the pretty-printed request + response JSON. */
+function InspectRow({ e }: { e: InspectEntry }) {
+  const [open, setOpen] = useState(false);
+  return (
+    <div className="rounded-md border border-border/50 text-sm">
+      <div
+        className="flex cursor-pointer items-center gap-3 px-3 py-2 hover:bg-muted/30"
+        onClick={() => setOpen((o) => !o)}
+        role="button"
+        aria-expanded={open}
+        tabIndex={0}
+      >
+        <ChevronRight
+          className={`size-3.5 shrink-0 text-muted-foreground transition-transform ${
+            open ? "rotate-90" : ""
+          }`}
+        />
+        {e.ok ? (
+          <CheckCircle2 className="size-4 shrink-0 text-success" />
+        ) : (
+          <XCircle className="size-4 shrink-0 text-destructive" />
+        )}
+        <span className="min-w-0 truncate font-medium">{e.server}</span>
+        <span className="min-w-0 truncate font-mono text-xs text-muted-foreground">
+          {e.tool}
+        </span>
+        {e.client && (
+          <span className="shrink-0 rounded bg-muted px-1.5 py-0.5 text-[11px] text-muted-foreground">
+            {e.client}
+          </span>
+        )}
+        <span className="ml-auto shrink-0 text-xs tabular-nums text-muted-foreground">
+          {fmtMs(e.durationMs ?? null)}
+        </span>
+        <span className="shrink-0 text-xs text-muted-foreground">
+          {new Date(e.ts).toLocaleTimeString()}
+        </span>
+      </div>
+      {open && (
+        <div className="border-t border-border/50 bg-muted/20 px-3 py-2 pl-9">
+          <div className="mb-1 text-[11px] font-medium tracking-wide text-muted-foreground uppercase">
+            Request
+          </div>
+          <pre className="mb-3 overflow-x-auto rounded bg-background/60 p-2 font-mono text-xs whitespace-pre-wrap break-words">
+            {fmtBody(e.request)}
+          </pre>
+          <div className="mb-1 text-[11px] font-medium tracking-wide text-muted-foreground uppercase">
+            Response
+          </div>
+          <pre className="overflow-x-auto rounded bg-background/60 p-2 font-mono text-xs whitespace-pre-wrap break-words">
+            {fmtBody(e.response)}
+          </pre>
+        </div>
+      )}
+    </div>
+  );
+}
+
+/** Collapsible live inspector: a local "network tab" for MCP. Only rendered while
+ * live inspection is on. Lists recent captured calls, each expandable to its raw
+ * request + response JSON. Ephemeral, local, opt-in. */
+function LiveInspector({ refreshKey }: { refreshKey: number }) {
+  const [entries, setEntries] = useState<InspectEntry[]>([]);
+  const [open, setOpen] = useState(true);
+
+  useEffect(() => {
+    let alive = true;
+    getInspectLog(50)
+      .then((e) => alive && setEntries(e))
+      .catch(() => alive && setEntries([]));
+    return () => {
+      alive = false;
+    };
+  }, [refreshKey]);
+
+  return (
+    <div className="mb-6 rounded-lg border border-info/30 bg-info/[0.04] p-4">
+      <button
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+        className="flex w-full items-center gap-2 text-left"
+      >
+        <Activity className="size-4 shrink-0 text-info" />
+        <h3 className="text-sm font-medium">Live inspector</h3>
+        <span className="rounded-full bg-info/15 px-1.5 py-0.5 text-xs font-medium text-info">
+          {entries.length}
+        </span>
+        <ChevronRight
+          className={`ml-auto size-4 text-muted-foreground transition-transform ${
+            open ? "rotate-90" : ""
+          }`}
+        />
+      </button>
+      {open && (
+        <>
+          <p className="mt-2 mb-3 max-w-2xl text-xs text-muted-foreground">
+            Ephemeral, local, opt-in. While live inspection is on, Conduit keeps the
+            last 50 tool calls' arguments and results here so you can inspect them.
+            This buffer is separate from the audit log, never leaves your machine, and
+            clears when you turn inspection off or restart the gateway.
+          </p>
+          {entries.length === 0 ? (
+            <p className="py-6 text-center text-sm text-muted-foreground">
+              No calls captured yet. Run a tool through Conduit and it'll show here.
+            </p>
+          ) : (
+            <div className="flex flex-col gap-1">
+              {entries.map((e, i) => (
+                <InspectRow key={`${e.ts}-${e.server}-${e.tool}-${i}`} e={e} />
+              ))}
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}
+
+export function ActivityView({
+  refreshKey,
+  registry,
+}: {
+  refreshKey: number;
+  registry: Registry | null;
+}) {
   const [entries, setEntries] = useState<AuditEntry[] | null>(null);
   const [stats, setStats] = useState<AuditStats | null>(null);
   const [savings, setSavings] = useState<SavingsSummary | null>(null);
@@ -594,6 +733,7 @@ export function ActivityView({ refreshKey }: { refreshKey: number }) {
       ) : (
         <SecurityResting />
       )}
+      {registry?.liveInspect ? <LiveInspector refreshKey={refreshKey} /> : null}
       {savings && savings.tokensSaved > 0 ? (
         <SavingsBanner savings={savings} />
       ) : null}

--- a/src/components/SettingsView.tsx
+++ b/src/components/SettingsView.tsx
@@ -1,8 +1,9 @@
 import { useEffect, useState } from "react";
-import { Bot, Check, Copy, Globe, Layers, ShieldAlert, ShieldCheck, ShieldX, Trash2, X } from "lucide-react";
+import { Activity, Bot, Check, Copy, Globe, Layers, ShieldAlert, ShieldCheck, ShieldX, Trash2, X } from "lucide-react";
 import { toastError } from "@/lib/toast";
 import {
   addHttpClient,
+  clearInspectLog,
   httpBridgeStatus,
   listQuarantined,
   releaseQuarantine,
@@ -11,6 +12,7 @@ import {
   setConfirmDestructive,
   setDenyDestructive,
   setLazyDiscovery,
+  setLiveInspect,
   setQuarantineOnDrift,
   startHttpBridge,
   stopHttpBridge,
@@ -40,6 +42,7 @@ export function SettingsView({ registry, onRegistryChange }: Props) {
   const confirmDestructive = registry?.confirmDestructive ?? false;
   const allowAgentControl = registry?.allowAgentControl ?? false;
   const quarantineOnDrift = registry?.quarantineOnDrift ?? false;
+  const liveInspect = registry?.liveInspect ?? false;
   const [busy, setBusy] = useState(false);
   const [quarantined, setQuarantined] = useState<QuarantinedTool[]>([]);
   const [bridge, setBridge] = useState<HttpBridgeStatus | null>(null);
@@ -132,6 +135,21 @@ export function SettingsView({ registry, onRegistryChange }: Props) {
       }
     };
 
+  // Live inspection needs a step the plain `apply` helper doesn't: when turned OFF,
+  // clear the ephemeral capture ring so nothing lingers on disk.
+  const applyLiveInspect = async (on: boolean) => {
+    setBusy(true);
+    try {
+      const reg = await setLiveInspect(on);
+      if (!on) await clearInspectLog();
+      onRegistryChange(reg);
+    } catch (e) {
+      toastError(`Couldn't update the setting: ${e}`);
+    } finally {
+      setBusy(false);
+    }
+  };
+
   const toggle = (
     Icon: typeof Layers,
     on: boolean,
@@ -200,6 +218,14 @@ export function SettingsView({ registry, onRegistryChange }: Props) {
           "Allow agent control",
           "Let an agent turn servers on/off (the block above stays yours)",
           apply(setAllowAgentControl),
+        )}
+        {toggle(
+          Activity,
+          liveInspect,
+          "text-info",
+          "Live request/response inspection",
+          "Off by default. While on, Conduit captures each tool call's arguments and results to a small local, ephemeral buffer (the last 50 calls) so you can inspect them in Activity. This is separate from the audit log, never leaves your machine, and is cleared when you turn it off or restart the gateway.",
+          applyLiveInspect,
         )}
         {quarantined.length > 0 && (
           <div className="flex flex-col gap-2 rounded-md border border-destructive/30 bg-destructive/5 px-3 py-2.5">

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -6,6 +6,7 @@ import type {
   CatalogEntry,
   DetectedClient,
   ImportItem,
+  InspectEntry,
   McpPrompt,
   McpResource,
   McpTool,
@@ -161,6 +162,23 @@ export function setDenyDestructive(deny: boolean): Promise<Registry> {
 /** Toggle per-call confirmation for destructive tools (intercept + preview + token). */
 export function setConfirmDestructive(confirm: boolean): Promise<Registry> {
   return invoke<Registry>("set_confirm_destructive", { confirm });
+}
+
+/** Toggle live request/response inspection (opt-in, off by default). When on, the
+ * gateway captures each tool call's args + result into a small ephemeral local ring. */
+export function setLiveInspect(enabled: boolean): Promise<Registry> {
+  return invoke<Registry>("set_live_inspect", { enabled });
+}
+
+/** Recent live-inspection captures (newest first): each call's args + result. Empty
+ * unless live inspection has been on. */
+export function getInspectLog(limit = 50): Promise<InspectEntry[]> {
+  return invoke<InspectEntry[]>("get_inspect_log", { limit });
+}
+
+/** Clear the live-inspection ring so no captured args/results linger. */
+export function clearInspectLog(): Promise<void> {
+  return invoke<void>("clear_inspect_log");
 }
 
 /** Toggle quarantine-on-drift: block a high-risk tool that drifted until re-approved. */

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -72,6 +72,20 @@ export interface AuditEntry {
   client?: string;
 }
 
+/** One live-inspection capture: a tool call's request args and response, plus timing.
+ * Only present while live inspection is on. `request`/`response` are the raw captured
+ * bodies (or a "<truncated N bytes>" marker string when the body exceeded the size cap). */
+export interface InspectEntry {
+  ts: number;
+  client?: string;
+  server: string;
+  tool: string;
+  request: unknown;
+  response: unknown;
+  ok: boolean;
+  durationMs?: number;
+}
+
 export interface ProbeResult {
   serverId: string;
   ok: boolean;
@@ -294,6 +308,10 @@ export interface Registry {
   denyDestructive?: boolean;
   /** Per-call confirmation: intercept destructive tools with a preview + token. */
   confirmDestructive?: boolean;
+  /** Live request/response inspection: capture each tool call's args + result into a
+   * small, separate, ephemeral local ring (last 50 calls) for the Activity inspector.
+   * Off by default; never touches the audit log. */
+  liveInspect?: boolean;
   /** Quarantine-on-drift: block a high-risk tool that changed until re-approved. */
   quarantineOnDrift?: boolean;
   /** Global switch: expose 3 meta-tools instead of the full catalog. */


### PR DESCRIPTION
## Tier 1 (the MCP Peek kill-shot)
An **opt-in, off-by-default** local inspector for MCP tool calls, request args + response, viewable in Activity. Conduit is already the gateway, so this is native rather than a separate proxy.

## Privacy design (this is the sensitive part)
This is the ONE place args/results are captured; the governance audit log (`audit.jsonl`) stays free of them forever. New `inspect.rs`:
- **Off by default** (`liveInspect` registry bool, default false). When off: no clone, no `record`, no file, verified the only two capture sites are both behind the `if let Some(req) = &inspect_args` gate, and `inspect_args` is `Some` only when `live_inspect` is true.
- **Ephemeral + bounded:** a separate `inspect.jsonl`, ring-trimmed to the **last 50** on every write.
- **Body-capped:** each request/response capped to ~4 KB serialized; larger bodies are dropped and replaced with a `<truncated N bytes>` marker, the full body is never written to disk.
- **Cleared on toggle-off** (`clearInspectLog()`), and local-only.
- Honest Settings copy spelling all of this out.

Attributed to the same client as the audit line via `router.current_client()` (from #76).

## Files
`inspect.rs` (new) + registry `live_inspect` + 3 Tauri commands; gateway captures the raw result before content-defense/shaping; Settings toggle; a collapsible Live inspector in Activity (only rendered when enabled).

## Test
4 new inspect unit tests (record→read, ring caps at 50, oversized→marker, small kept); full suite green (213 lib + 50 bin); tsc clean. Rebased onto current main (adopts the #76 audit signature + client attribution).