### PR TITLE
rename: Conduit -> Toolport (visible strings, internals kept on conduit)

### DIFF
--- a/src-tauri/src/bin/conduit-gateway.rs
+++ b/src-tauri/src/bin/conduit-gateway.rs
@@ -1,4 +1,4 @@
-//! Conduit gateway.
+//! Toolport gateway.
 //!
 //! A local MCP server, spoken over stdio (newline-delimited JSON-RPC 2.0). Each
 //! AI client points at this one binary; the gateway routes to all the real
@@ -50,7 +50,7 @@ fn error(id: Value, code: i64, message: &str) -> Value {
 fn status_tool_def() -> Value {
     json!({
         "name": "conduit_status",
-        "description": "Report Conduit's status: the MCP servers enabled in the active profile, each server's tool count, and how many tokens (and dollars) lazy discovery has saved you so far.",
+        "description": "Report Toolport's status: the MCP servers enabled in the active profile, each server's tool count, and how many tokens (and dollars) lazy discovery has saved you so far.",
         "inputSchema": { "type": "object", "properties": {}, "additionalProperties": false }
     })
 }
@@ -61,7 +61,7 @@ fn status_tool_def() -> Value {
 /// the real tool on demand and dispatches through `conduit_call_tool`.
 ///
 /// The description leads with a directive plus GENERIC capability examples (email,
-/// payments, deployments, ...) so the model treats Conduit as the front door for any
+/// payments, deployments, ...) so the model treats Toolport as the front door for any
 /// external action rather than grabbing a loosely-matched competitor tool or giving
 /// up. We intentionally do NOT list the user's specific connected servers here: that
 /// would scale the description with server count, go stale, and leak the user's stack
@@ -133,7 +133,7 @@ fn confirm_tool_def() -> Value {
     json!({
         "name": "conduit_confirm",
         "description": "Confirm and execute a destructive tool call that was intercepted for review. \
-            When Conduit blocks a destructive call, it returns a preview with a `token`. \
+            When Toolport blocks a destructive call, it returns a preview with a `token`. \
             Call this with that token to proceed. The original arguments are replayed exactly \
             — you cannot change them. The token expires after 60 seconds.",
         "inputSchema": {
@@ -150,9 +150,9 @@ fn confirm_tool_def() -> Value {
 fn fetch_result_tool_def() -> Value {
     json!({
         "name": "conduit_fetch_result",
-        "description": "Read more of a large tool result that Conduit truncated. When a \
-            result is too big for context, Conduit returns the head plus a cursor in a \
-            `[Conduit shaped this result]` marker; call this with that `cursor` and the \
+        "description": "Read more of a large tool result that Toolport truncated. When a \
+            result is too big for context, Toolport returns the head plus a cursor in a \
+            `[Toolport shaped this result]` marker; call this with that `cursor` and the \
             `offset` shown in the marker to page through the rest. Nothing was lost.",
         "inputSchema": {
             "type": "object",
@@ -169,9 +169,9 @@ fn fetch_result_tool_def() -> Value {
 fn enable_server_tool_def() -> Value {
     json!({
         "name": "conduit_enable_server",
-        "description": "Turn ON an MCP server in Conduit so its tools become available to you. \
+        "description": "Turn ON an MCP server in Toolport so its tools become available to you. \
             Pass the server's id or name (run conduit_status to see the list). Takes effect within \
-            about a second. Only works when the user has allowed agent control in Conduit; the \
+            about a second. Only works when the user has allowed agent control in Toolport; the \
             global block on destructive tools stays under the user's control and cannot be changed here.",
         "inputSchema": {
             "type": "object",
@@ -187,9 +187,9 @@ fn enable_server_tool_def() -> Value {
 fn disable_server_tool_def() -> Value {
     json!({
         "name": "conduit_disable_server",
-        "description": "Turn OFF an MCP server in Conduit so its tools are no longer loaded. Pass the \
+        "description": "Turn OFF an MCP server in Toolport so its tools are no longer loaded. Pass the \
             server's id or name (run conduit_status to see the list). Takes effect within about a \
-            second. Only works when the user has allowed agent control in Conduit.",
+            second. Only works when the user has allowed agent control in Toolport.",
         "inputSchema": {
             "type": "object",
             "properties": {
@@ -215,15 +215,15 @@ fn set_server_enabled_via_agent(
 ) -> Result<String, String> {
     if !reg.allow_agent_control {
         return Err(
-            "Conduit: agent control is off. The user must turn on \"Allow agent control\" \
-            in Conduit before an agent can enable or disable servers."
+            "Toolport: agent control is off. The user must turn on \"Allow agent control\" \
+            in Toolport before an agent can enable or disable servers."
                 .to_string(),
         );
     }
     let target = target.trim();
     if target.is_empty() {
         return Err(
-            "Conduit: pass the `server` id or name to change (run conduit_status for the list)."
+            "Toolport: pass the `server` id or name to change (run conduit_status for the list)."
                 .to_string(),
         );
     }
@@ -234,7 +234,7 @@ fn set_server_enabled_via_agent(
         .ok_or_else(|| {
             let known: Vec<&str> = reg.servers.iter().map(|s| s.name.as_str()).collect();
             format!(
-                "Conduit: no server matches \"{target}\". Known servers: {}.",
+                "Toolport: no server matches \"{target}\". Known servers: {}.",
                 known.join(", ")
             )
         })?;
@@ -243,14 +243,14 @@ fn set_server_enabled_via_agent(
     let profile_id = profile
         .map(str::to_string)
         .or_else(|| reg.active_profile_id.clone())
-        .ok_or_else(|| "Conduit: no active profile to change.".to_string())?;
+        .ok_or_else(|| "Toolport: no active profile to change.".to_string())?;
 
     // Load fresh so a concurrent edit in the app isn't clobbered, and re-check the
     // opt-in on that fresh copy (the user may have just turned it off).
     let mut fresh = registry::load_from(path)
-        .map_err(|e| format!("Conduit: could not read the registry ({e})."))?;
+        .map_err(|e| format!("Toolport: could not read the registry ({e})."))?;
     if !fresh.allow_agent_control {
-        return Err("Conduit: agent control is off.".to_string());
+        return Err("Toolport: agent control is off.".to_string());
     }
     if fresh.is_enabled(&profile_id, &server_id) == enable {
         return Ok(format!(
@@ -260,7 +260,7 @@ fn set_server_enabled_via_agent(
     }
     fresh.set_server_enabled(&profile_id, &server_id, enable)?;
     registry::save_to(path, &fresh)
-        .map_err(|e| format!("Conduit: could not save the registry ({e})."))?;
+        .map_err(|e| format!("Toolport: could not save the registry ({e})."))?;
     glog(&format!(
         "agent control: {} server '{server_id}' in profile '{profile_id}'",
         if enable { "ENABLED" } else { "DISABLED" }
@@ -771,7 +771,7 @@ fn enabled_summary(
     // bridge's union - never another tenant's name, command, URL, or tool count).
     // Stdio and the legacy full-access bridge token see the active profile, as
     // before. Both the server list and the tool counts are gated by this set, so
-    // they always agree. Exclude Conduit's own gateway entry (infrastructure).
+    // they always agree. Exclude Toolport's own gateway entry (infrastructure).
     let visible: std::collections::HashSet<String> = match allowed {
         Some(a) => a.clone(),
         None => reg
@@ -845,7 +845,7 @@ fn fmt_tokens(n: u64) -> String {
 }
 
 /// One line summarizing what lazy discovery has saved, for conduit_status, so an
-/// agent can answer "what is Conduit saving me?". Empty until something is saved
+/// agent can answer "what is Toolport saving me?". Empty until something is saved
 /// (a fresh install, or non-lazy mode where nothing is recorded).
 fn savings_line() -> String {
     let s = savings::summary();
@@ -1343,7 +1343,7 @@ fn handle_request(
                     return Some(success(
                         id,
                         json!({
-                            "content": [{ "type": "text", "text": "Conduit: pass the `token` from the intercepted call's preview." }],
+                            "content": [{ "type": "text", "text": "Toolport: pass the `token` from the intercepted call's preview." }],
                             "isError": true
                         }),
                     ));
@@ -1358,7 +1358,7 @@ fn handle_request(
                         return Some(success(
                             id,
                             json!({
-                                "content": [{ "type": "text", "text": "Conduit: token expired or invalid. Call the tool again to get a new preview." }],
+                                "content": [{ "type": "text", "text": "Toolport: token expired or invalid. Call the tool again to get a new preview." }],
                                 "isError": true
                             }),
                         ));
@@ -1506,7 +1506,7 @@ fn handle_request(
                     .unwrap_or("");
                 let result = match registry::resolved_path() {
                     Some(p) => set_server_enabled_via_agent(reg, profile, &p, target, enable),
-                    None => Err("Conduit: could not locate the registry file.".to_string()),
+                    None => Err("Toolport: could not locate the registry file.".to_string()),
                 };
                 let (text, is_error) = match result {
                     Ok(msg) => (msg, false),
@@ -1538,7 +1538,7 @@ fn handle_request(
                     return Some(success(
                         id,
                         json!({
-                            "content": [{ "type": "text", "text": format!("Conduit: '{srv}' is not available to this client.") }],
+                            "content": [{ "type": "text", "text": format!("Toolport: '{srv}' is not available to this client.") }],
                             "isError": true
                         }),
                     ));
@@ -1561,7 +1561,7 @@ fn handle_request(
                     )
                 };
                 let msg = format!(
-                    "Conduit: \"{value}\" for \"{param}\" looks like a placeholder, not a real \
+                    "Toolport: \"{value}\" for \"{param}\" looks like a placeholder, not a real \
                      value, and was not sent. Don't invent identifiers. To get a real \"{param}\", \
                      {source}, then call {name} again with the value it returns."
                 );
@@ -1691,7 +1691,7 @@ fn handle_request(
                     Some(success(
                         id,
                         json!({
-                            "content": [{ "type": "text", "text": format!("Conduit: {e}.{recovery}") }],
+                            "content": [{ "type": "text", "text": format!("Toolport: {e}.{recovery}") }],
                             "isError": true
                         }),
                     ))
@@ -1711,7 +1711,7 @@ fn handle_request(
                 .unwrap_or("");
             match router.read_resource(uri) {
                 Ok(result) => Some(success(id, result)),
-                Err(e) => Some(error(id, -32602, &format!("Conduit: {e}"))),
+                Err(e) => Some(error(id, -32602, &format!("Toolport: {e}"))),
             }
         }
         "prompts/list" => {
@@ -1731,7 +1731,7 @@ fn handle_request(
                 .unwrap_or_else(|| json!({}));
             match router.get_prompt(name, arguments) {
                 Ok(result) => Some(success(id, result)),
-                Err(e) => Some(error(id, -32602, &format!("Conduit: {e}"))),
+                Err(e) => Some(error(id, -32602, &format!("Toolport: {e}"))),
             }
         }
         "ping" => Some(success(id, json!({}))),
@@ -2394,8 +2394,8 @@ fn openapi_spec(
     json!({
         "openapi": "3.1.0",
         "info": {
-            "title": "Conduit gateway",
-            "description": "Conduit MCP gateway as OpenAPI for HTTP tool clients (Open WebUI and any OpenAPI consumer). Search with conduit_search_tools, then call by name with conduit_call_tool.",
+            "title": "Toolport gateway",
+            "description": "Toolport MCP gateway as OpenAPI for HTTP tool clients (Open WebUI and any OpenAPI consumer). Search with conduit_search_tools, then call by name with conduit_call_tool.",
             "version": env!("CARGO_PKG_VERSION")
         },
         // Relative base URL: resolves against the origin the spec was fetched
@@ -2409,7 +2409,7 @@ fn openapi_spec(
                 "bearerAuth": {
                     "type": "http",
                     "scheme": "bearer",
-                    "description": "The bearer token shown in Conduit's Settings -> Integrations toggle. Paste it as the API key in your client. Required whenever the gateway was started with a token (the desktop app always sets one)."
+                    "description": "The bearer token shown in Toolport's Settings -> Integrations toggle. Paste it as the API key in your client. Required whenever the gateway was started with a token (the desktop app always sets one)."
                 }
             },
             "schemas": {
@@ -2486,7 +2486,7 @@ fn handle_http(
         ("GET", "/") | ("GET", "/docs") => (
             200,
             "text/plain; charset=utf-8",
-            "Conduit gateway (HTTP/OpenAPI mode). OpenAPI at /openapi.json. POST a tool name with a JSON body, e.g. POST /conduit_search_tools {\"query\":\"...\"}."
+            "Toolport gateway (HTTP/OpenAPI mode). OpenAPI at /openapi.json. POST a tool name with a JSON body, e.g. POST /conduit_search_tools {\"query\":\"...\"}."
                 .to_string(),
         ),
         ("POST", p) => {

--- a/src-tauri/src/catalog.rs
+++ b/src-tauri/src/catalog.rs
@@ -77,7 +77,7 @@ fn category_for(name: &str) -> &'static str {
 /// no auth) so only the hint shows. `None` = unknown / no guidance.
 fn credentials_for(name: &str) -> Option<(&'static str, &'static str)> {
     Some(match name {
-        // Token-based: the agent gets an API key Conduit vaults.
+        // Token-based: the agent gets an API key Toolport vaults.
         "Linode" => (
             "https://cloud.linode.com/profile/tokens",
             "Create a Personal Access Token with read/write on the resources you need (Linodes, Volumes, Databases).",

--- a/src-tauri/src/clients.rs
+++ b/src-tauri/src/clients.rs
@@ -51,7 +51,7 @@ pub struct DetectedClient {
     /// Servers that live outside the main config file but are still readable
     /// (e.g. Cursor plugin servers). Read-only inventory - managed by the client.
     pub plugin_servers: Vec<McpServer>,
-    /// Whether the Conduit gateway is currently installed in this client's config.
+    /// Whether the Toolport gateway is currently installed in this client's config.
     pub gateway_installed: bool,
     /// Set when the config exists but could not be read or parsed.
     pub error: Option<String>,
@@ -97,10 +97,10 @@ struct ClientDef {
     plugin_scan: Option<fn() -> Vec<McpServer>>,
 }
 
-/// The name Conduit uses for its own entry when installed into a client config.
+/// The name Toolport uses for its own entry when installed into a client config.
 pub const GATEWAY_ENTRY_NAME: &str = "conduit";
 
-/// Whether a registry entry refers to Conduit's own gateway. The gateway must
+/// Whether a registry entry refers to Toolport's own gateway. The gateway must
 /// never proxy itself (that recurses), and import must never pull it in.
 pub fn is_gateway_server(server: &ServerEntry) -> bool {
     server.id == GATEWAY_ENTRY_NAME
@@ -152,7 +152,7 @@ impl Platform {
 ///
 /// On Windows it's anchored to the user profile (`~/AppData/Roaming`) rather than
 /// `dirs::config_dir()`. MSIX-packaged apps (Claude Desktop) virtualize the
-/// Roaming known-folder into their package's LocalCache, and if the Conduit
+/// Roaming known-folder into their package's LocalCache, and if the Toolport
 /// process is ever launched inside such a context, `config_dir()` would resolve
 /// to that sandbox - so reads of Claude Desktop's `claude_desktop_config.json`
 /// would miss the real file and report "not configured". The user-profile path
@@ -1187,7 +1187,7 @@ fn parse_yaml_value(content: &str) -> Result<serde_yaml::Value, String> {
 /// Read an existing JSON config we're about to modify. Tolerant of JSONC. When
 /// `lenient` (e.g. Zed's settings.json, which holds the user's whole editor config),
 /// an unparseable file is an ERROR, never silently replaced with an empty object,
-/// so Conduit can't wipe it. For the well-behaved JSON configs, an unparseable file
+/// so Toolport can't wipe it. For the well-behaved JSON configs, an unparseable file
 /// falls back to empty (start fresh), preserving prior behavior.
 fn read_existing_json(content: &str, lenient: bool) -> Result<serde_json::Value, String> {
     match parse_json_value(content) {
@@ -1452,7 +1452,7 @@ pub fn detect_clients() -> Vec<DetectedClient> {
 // Write path
 //
 // Writing a server set back into a client's own format. Every write is preceded
-// by a timestamped backup of the existing file (stored centrally under Conduit's
+// by a timestamped backup of the existing file (stored centrally under Toolport's
 // config dir, not next to the client's config), so any change is reversible.
 // Only env values that are present (non-secret) are written inline; secret
 // values are vaulted separately and injected by the gateway at runtime.
@@ -2188,9 +2188,9 @@ pub fn write_servers(client_id: &str, servers: &[ServerEntry]) -> Result<WriteOu
 // ---------------------------------------------------------------------------
 // Gateway install
 //
-// "Installing Conduit into a client" means adding a single entry to that
+// "Installing Toolport into a client" means adding a single entry to that
 // client's config that runs the conduit-gateway binary. The client then talks
-// only to Conduit, which routes to everything behind it. This is a surgical
+// only to Toolport, which routes to everything behind it. This is a surgical
 // edit: existing servers (and their secret env values) are left untouched.
 // ---------------------------------------------------------------------------
 
@@ -2208,7 +2208,7 @@ pub(crate) fn resolve_gateway_path() -> Option<PathBuf> {
     // re-homes the gateway into a nested helper bundle so it can carry its own
     // embedded provisioning profile:
     //     Conduit.app/Contents/Helpers/ConduitGateway.app/Contents/MacOS/conduit-gateway
-    // The app binary runs from Conduit.app/Contents/MacOS, so `dir` is that
+    // The app binary runs from Toolport.app/Contents/MacOS, so `dir` is that
     // directory. Prefer the nested binary when it exists. The old bare path
     // (Contents/MacOS/conduit-gateway) is kept as a SYMLINK to this same binary by
     // the signing script for backward compatibility with already-written client
@@ -2414,19 +2414,19 @@ fn install_or_remove(
     })
 }
 
-/// Add Conduit's gateway entry to a client's config (preserves existing servers).
+/// Add Toolport's gateway entry to a client's config (preserves existing servers).
 /// `profile` scopes the client to one profile via `CONDUIT_PROFILE` (None = all).
 pub fn install_gateway(client_id: &str, profile: Option<&str>) -> Result<WriteOutcome, String> {
     install_or_remove(client_id, true, profile)
 }
 
-/// Remove Conduit's gateway entry from a client's config.
+/// Remove Toolport's gateway entry from a client's config.
 pub fn uninstall_gateway(client_id: &str) -> Result<WriteOutcome, String> {
     install_or_remove(client_id, false, None)
 }
 
-/// Replace a client's entire server list with just the Conduit gateway. Used by
-/// "migrate": after the client's servers are imported into Conduit, this leaves
+/// Replace a client's entire server list with just the Toolport gateway. Used by
+/// "migrate": after the client's servers are imported into Toolport, this leaves
 /// the client talking only to the gateway. Backs up first; unrelated config keys
 /// are preserved. Caller is responsible for importing first so nothing is lost.
 pub fn migrate_to_gateway(client_id: &str, profile: Option<&str>) -> Result<WriteOutcome, String> {

--- a/src-tauri/src/downstream.rs
+++ b/src-tauri/src/downstream.rs
@@ -256,7 +256,7 @@ fn forward_line(
     tx.send(line).is_ok()
 }
 
-/// Spawn-time supply-chain guard. Conduit runs stdio servers as full-privilege
+/// Spawn-time supply-chain guard. Toolport runs stdio servers as full-privilege
 /// host processes, so this is NOT a sandbox; it refuses the specific *smuggling*
 /// techniques where a benign-looking launcher (`node`, `docker`, `sh`) is turned
 /// into arbitrary code execution or a privileged container by its arguments. The
@@ -290,7 +290,7 @@ pub fn screen_spawn_command(command: &str, args: &[String]) -> Result<(), String
     match dangerous {
         Some(flag) => Err(format!(
             "refusing to launch '{command}': the argument '{flag}' can execute \
-             arbitrary code or escape isolation. Conduit blocks inline-eval and \
+             arbitrary code or escape isolation. Toolport blocks inline-eval and \
              privileged-container flags on spawned servers as a supply-chain guard. \
              If this server is yours and you trust it, launch it from a script file \
              or a wrapper binary instead of an inline command."
@@ -328,7 +328,7 @@ fn first_flag<'a>(args: &'a [String], flags: &[&str]) -> Option<&'a str> {
 /// Docker/Podman args that ESCALATE beyond what a normal host process already has:
 /// privileged mode, added capabilities, device passthrough, and host-namespace
 /// sharing. Plain host mounts (`-v` / `--volume` / `--mount`) are intentionally NOT
-/// blocked: Conduit already runs npx/uvx/binary servers with full host-filesystem
+/// blocked: Toolport already runs npx/uvx/binary servers with full host-filesystem
 /// access, so a docker volume mount is no more dangerous than the servers we run
 /// unrestricted, and blocking it would false-positive on legitimate dockerized MCP
 /// servers. Namespace flags (`--pid`, `--net`, ...) trip only when their value is

--- a/src-tauri/src/inspect.rs
+++ b/src-tauri/src/inspect.rs
@@ -1,7 +1,7 @@
 //! Live request/response inspection: an opt-in, off-by-default local "network tab"
 //! for MCP tool calls.
 //!
-//! This is the ONE place Conduit captures a tool call's arguments and result. It
+//! This is the ONE place Toolport captures a tool call's arguments and result. It
 //! is deliberately kept apart from the governance audit log (`audit.jsonl`), which
 //! stays free of args/results forever. Capture only happens while the user has
 //! `live_inspect` on; when it's off, nothing here is ever called and no file is

--- a/src-tauri/src/integrity.rs
+++ b/src-tauri/src/integrity.rs
@@ -2,7 +2,7 @@
 //!
 //! The threat: an MCP tool can mutate its own definition after you approve it
 //! (a "rug pull"), or a server you trust can quietly grow a new tool, with
-//! malicious instructions hidden in a description or schema. Conduit sits on the
+//! malicious instructions hidden in a description or schema. Toolport sits on the
 //! path and already re-queries servers when they change, so it is the natural
 //! place to notice.
 //!
@@ -166,7 +166,7 @@ pub fn check(profile: Option<&str>, current: &[Value]) -> Vec<Value> {
     let mut now: Pins = BTreeMap::new();
 
     for t in current {
-        // Skip Conduit's own meta-tools (no `server__` prefix).
+        // Skip Toolport's own meta-tools (no `server__` prefix).
         let name = match t.get("name").and_then(Value::as_str) {
             Some(n) if n.contains("__") => n,
             _ => continue,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -316,7 +316,7 @@ fn write_to_client(
     clients::write_servers(&client_id, &servers)
 }
 
-/// Install the Conduit gateway into a client (one click "connect to Conduit").
+/// Install the Toolport gateway into a client (one click "connect to Toolport").
 /// `profile` scopes that client to one profile (None = all enabled servers).
 #[tauri::command]
 fn install_gateway(
@@ -333,7 +333,7 @@ fn install_gateway(
     Ok(outcome)
 }
 
-/// Remove the Conduit gateway from a client.
+/// Remove the Toolport gateway from a client.
 #[tauri::command]
 fn uninstall_gateway(
     state: State<RegistryState>,
@@ -400,16 +400,16 @@ fn remove_http_client(state: State<RegistryState>, id: String) -> Result<Registr
 #[serde(rename_all = "camelCase")]
 struct MigrateResult {
     registry: Registry,
-    /// How many of the client's servers were newly imported into Conduit.
+    /// How many of the client's servers were newly imported into Toolport.
     imported: usize,
     /// Names of the servers moved out of the client's config.
     moved: Vec<String>,
 }
 
-/// Migrate a client to Conduit: import its directly-configured servers into the
-/// registry, then rewrite the client's config to contain only the Conduit
+/// Migrate a client to Toolport: import its directly-configured servers into the
+/// registry, then rewrite the client's config to contain only the Toolport
 /// gateway (optionally scoped to `profile`). The client is left managing nothing
-/// directly - everything routes through Conduit. Backs the config up first.
+/// directly - everything routes through Toolport. Backs the config up first.
 ///
 /// Plugin servers (read-only, outside the config file) are left untouched.
 #[tauri::command]
@@ -541,7 +541,7 @@ fn savings_summary() -> serde_json::Value {
 /// How many trailing gateway-log lines the diagnostics bundle includes.
 const DIAG_LOG_LINES: usize = 200;
 
-/// A shareable diagnostics blob for bug reports: Conduit version + OS, a
+/// A shareable diagnostics blob for bug reports: Toolport version + OS, a
 /// secrets-stripped registry summary, and the tail of the always-on gateway log.
 /// Safe to paste into a public issue, secret values live in the OS keychain and
 /// are never included; env vars are listed by key name only.
@@ -549,7 +549,7 @@ const DIAG_LOG_LINES: usize = 200;
 fn gather_diagnostics() -> String {
     use std::fmt::Write as _;
     let mut out = String::new();
-    let _ = writeln!(out, "Conduit diagnostics");
+    let _ = writeln!(out, "Toolport diagnostics");
     let _ = writeln!(out, "version: {}", env!("CARGO_PKG_VERSION"));
     let _ = writeln!(out, "os: {} {}", std::env::consts::OS, std::env::consts::ARCH);
 
@@ -922,7 +922,7 @@ fn reload_into_state(state: &RegistryState) -> Result<Registry, String> {
     Ok(fresh)
 }
 
-/// Join a Conduit Teams server with an invite code. Vaults the member token in the OS
+/// Join a Toolport Teams server with an invite code. Vaults the member token in the OS
 /// keychain, pulls the team's server set, and merges it into the local registry
 /// non-destructively (team servers are tagged and enabled in the active profile).
 #[tauri::command]
@@ -1086,7 +1086,7 @@ fn secret_status(server_id: String, keys: Vec<String>) -> Vec<(String, bool)> {
         .collect()
 }
 
-/// Open Conduit's data directory (registry, logs, audit) in the OS file manager,
+/// Open Toolport's data directory (registry, logs, audit) in the OS file manager,
 /// so users can back it up or inspect it.
 #[tauri::command]
 fn open_data_dir() -> Result<(), String> {
@@ -1265,7 +1265,7 @@ fn read_setup_file(path: String) -> Result<String, String> {
     const MAX_SETUP_BYTES: u64 = 4 * 1024 * 1024;
     if let Ok(meta) = std::fs::metadata(&path) {
         if meta.len() > MAX_SETUP_BYTES {
-            return Err("That file is too large to be a Conduit setup.".to_string());
+            return Err("That file is too large to be a Toolport setup.".to_string());
         }
     }
     std::fs::read_to_string(&path).map_err(|e| format!("Couldn't read the file: {e}"))
@@ -1294,7 +1294,7 @@ fn preview_import(state: State<RegistryState>, json: String) -> Result<Vec<Impor
         servers: Vec<ServerEntry>,
     }
     let doc: Doc = serde_json::from_str(&json)
-        .map_err(|e| format!("That doesn't look like a Conduit setup: {e}"))?;
+        .map_err(|e| format!("That doesn't look like a Toolport setup: {e}"))?;
     let reg = state.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
     Ok(doc
         .servers
@@ -1400,7 +1400,7 @@ fn apply_import(reg: &mut Registry, json: &str) -> Result<(), String> {
         servers: Vec<ServerEntry>,
     }
     let doc: Doc = serde_json::from_str(json)
-        .map_err(|e| format!("That doesn't look like a Conduit setup: {e}"))?;
+        .map_err(|e| format!("That doesn't look like a Toolport setup: {e}"))?;
     for mut s in doc.servers {
         if reg.servers.iter().any(|e| e.name.eq_ignore_ascii_case(&s.name)) {
             continue;
@@ -1567,7 +1567,7 @@ pub fn run() {
 
     // Migrate legacy keychain secrets into the data-protection keychain (the
     // team-scoped shared access group) in the background. On macOS, older versions
-    // of Conduit stored secrets as per-app-ACL keychain items that trigger a
+    // of Toolport stored secrets as per-app-ACL keychain items that trigger a
     // password prompt every time a freshly-signed app/gateway reads them. This
     // moves each value into the data-protection keychain, which the separately
     // signed gateway reads with NO prompt across updates — read each value, write +

--- a/src-tauri/src/oauth.rs
+++ b/src-tauri/src/oauth.rs
@@ -353,7 +353,7 @@ struct DcrResponse {
 
 fn register_client(registration_endpoint: &str, redirect_uri: &str) -> Result<String, String> {
     let body = serde_json::json!({
-        "client_name": "Conduit",
+        "client_name": "Toolport",
         "redirect_uris": [redirect_uri],
         "grant_types": ["authorization_code", "refresh_token"],
         "response_types": ["code"],
@@ -546,7 +546,7 @@ fn wait_for_code(listener: &TcpListener, expected_state: &str) -> Result<String,
                         .get("error_description")
                         .map(|d| format!(": {d}"))
                         .unwrap_or_default();
-                    write_callback_page(&mut stream, "Authorization failed. You can close this window and return to Conduit.");
+                    write_callback_page(&mut stream, "Authorization failed. You can close this window and return to Toolport.");
                     return Err(format!("authorization server returned an error ({error}){desc}"));
                 }
 
@@ -555,7 +555,7 @@ fn wait_for_code(listener: &TcpListener, expected_state: &str) -> Result<String,
                     write_callback_page(&mut stream, "Authorization could not be verified. You can close this window.");
                     return Err("state mismatch (possible CSRF); try connecting again".to_string());
                 }
-                write_callback_page(&mut stream, "Authorization complete. You can close this window and return to Conduit.");
+                write_callback_page(&mut stream, "Authorization complete. You can close this window and return to Toolport.");
                 return Ok(code.cloned().unwrap_or_default());
             }
             Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {

--- a/src-tauri/src/remote.rs
+++ b/src-tauri/src/remote.rs
@@ -122,7 +122,7 @@ fn authed_transport(
     Ok(HttpTransport::with_auth_refresh(url, token, refresh))
 }
 
-/// Provenance Conduit doesn't trust to point at the user's private network. Shared
+/// Provenance Toolport doesn't trust to point at the user's private network. Shared
 /// imports (`"shared"`) and public-registry entries (`"registry"`) are
 /// attacker-influenceable; user-added, client-imported, curated-catalog, and team
 /// servers are not, so their local URLs (e.g. a localhost MCP server) still connect.
@@ -155,13 +155,13 @@ fn guard_connect_target(server: &ServerEntry) -> Result<(), String> {
     let host = oauth::host_of_url(server.url.as_deref().unwrap_or("")).unwrap_or_default();
     if host_is_link_local(&host) {
         return Err(format!(
-            "Conduit refused to connect to {host}: link-local / cloud-metadata addresses \
+            "Toolport refused to connect to {host}: link-local / cloud-metadata addresses \
              (169.254.x) are never a valid MCP server and are a common SSRF target."
         ));
     }
     if is_untrusted_source(server.source.as_deref()) && oauth::host_is_private(&host) {
         return Err(format!(
-            "Conduit refused to connect \"{}\" to the private address {host}: it came from \
+            "Toolport refused to connect \"{}\" to the private address {host}: it came from \
              an untrusted source ({}). If you trust it, add the server yourself.",
             server.name,
             server.source.as_deref().unwrap_or("unknown")

--- a/src-tauri/src/secrets.rs
+++ b/src-tauri/src/secrets.rs
@@ -1,5 +1,5 @@
 //! Secret storage in the OS keychain (Windows Credential Manager / macOS
-//! Keychain / libsecret). Secret env values never live in Conduit's registry
+//! Keychain / libsecret). Secret env values never live in Toolport's registry
 //! file or any client config - only here. The gateway pulls them at spawn time
 //! and injects them into the child server's environment.
 
@@ -57,7 +57,7 @@ mod platform {
 
     use super::{account, SERVICE};
 
-    /// Team-scoped keychain access group shared by the Conduit app and the
+    /// Team-scoped keychain access group shared by the Toolport app and the
     /// gateway. Both binaries declare this group in their entitlements
     /// (`keychain-access-groups`), which is what lets each read the other's
     /// data-protection-keychain items with no prompt. The `V4YZPC7T6G` prefix is
@@ -68,7 +68,7 @@ mod platform {
     /// Reserved keychain account for the single 32-byte master key that encrypts
     /// the file backend (`secrets.enc`). Distinct from every server-secret account
     /// (which is `server_id::key`), so it never collides with a real secret. This
-    /// is the ONLY keychain item Conduit creates once the file backend is the
+    /// is the ONLY keychain item Toolport creates once the file backend is the
     /// default on macOS — per-server secrets then live only in `secrets.enc`.
     pub const MASTER_KEY_ACCOUNT: &str = "__conduit_master_key__";
 
@@ -146,7 +146,7 @@ mod platform {
     }
 
     /// Create a generic-password item in the **legacy** keychain that BOTH the
-    /// Conduit app and the `conduit-gateway` binary can read with no keychain
+    /// Toolport app and the `conduit-gateway` binary can read with no keychain
     /// prompt: build a legacy `SecAccess` whose trusted-applications list names
     /// both binaries and pass it as `kSecAttrAccess` on `SecItemAdd`. Setting the
     /// ACL atomically at creation avoids the keychain-password prompt that a
@@ -792,7 +792,7 @@ pub fn delete_secret(server_id: &str, key: &str) -> Result<(), String> {
 
 // ── Legacy keychain migration (macOS) ──────────────────────────────────────
 //
-// Older versions of Conduit used the `keyring` crate, which created keychain
+// Older versions of Toolport used the `keyring` crate, which created keychain
 // items with per-application ACLs. This migration reads each entry's value,
 // deletes it, and re-creates it via the ACL-free `SecItemAdd` path.
 //
@@ -894,7 +894,7 @@ pub fn migrate_legacy_entries(secret_keys: &[(String, String)]) -> MigrationRepo
     }
 }
 
-/// Whether the keychain -> file migration marker exists in the Conduit data dir.
+/// Whether the keychain -> file migration marker exists in the Toolport data dir.
 #[cfg(target_os = "macos")]
 fn file_migration_marker_exists() -> bool {
     crate::registry::conduit_dir()

--- a/src-tauri/src/shaping.rs
+++ b/src-tauri/src/shaping.rs
@@ -1,7 +1,7 @@
 //! Result-shaping: keep oversized tool results from blowing the model's context
 //! WITHOUT losing data. When a downstream tool returns a result larger than the
 //! byte budget, the full body is cached in-process and the model gets a truncated
-//! head plus a Conduit-stamped marker carrying a cursor. `conduit_fetch_result`
+//! head plus a Toolport-stamped marker carrying a cursor. `conduit_fetch_result`
 //! pages through the cached full result. Lossless: nothing is dropped, only
 //! deferred, and the full data stays retrievable.
 //!
@@ -180,7 +180,7 @@ pub fn shape_result(result: &mut Value, budget: usize) -> bool {
     }
 
     let marker = format!(
-        "\n\n[Conduit shaped this result: it was ~{} KB, larger than the {} KB context \
+        "\n\n[Toolport shaped this result: it was ~{} KB, larger than the {} KB context \
          budget. Showing the first {} of {} characters. The full result is cached, call \
          conduit_fetch_result with {{\"cursor\":\"{}\",\"offset\":{}}} to read the rest. \
          Nothing was lost.]",
@@ -203,7 +203,7 @@ pub fn fetch_result(cursor: &str, offset: usize, len: usize) -> Value {
     let Some(c) = map.get(cursor) else {
         return text_result(
             format!(
-                "[Conduit: cursor \"{cursor}\" is unknown or expired. Re-run the original \
+                "[Toolport: cursor \"{cursor}\" is unknown or expired. Re-run the original \
                  tool call to get a fresh result.]"
             ),
             true,
@@ -214,7 +214,7 @@ pub fn fetch_result(cursor: &str, offset: usize, len: usize) -> Value {
     if offset >= total {
         return text_result(
             format!(
-                "[Conduit: offset {offset} is at or past the end of the result ({total} \
+                "[Toolport: offset {offset} is at or past the end of the result ({total} \
                  characters). Nothing more to read.]"
             ),
             false,
@@ -226,11 +226,11 @@ pub fn fetch_result(cursor: &str, offset: usize, len: usize) -> Value {
     let remaining = total - end;
     let footer = if remaining > 0 {
         format!(
-            "\n\n[Conduit: characters {offset}..{end} of {total}. {remaining} remain, call \
+            "\n\n[Toolport: characters {offset}..{end} of {total}. {remaining} remain, call \
              conduit_fetch_result with offset={end} for the next slice.]"
         )
     } else {
-        format!("\n\n[Conduit: end of result ({total} characters).]")
+        format!("\n\n[Toolport: end of result ({total} characters).]")
     };
     text_result(format!("{slice}{footer}"), false)
 }
@@ -299,7 +299,7 @@ mod tests {
         });
         assert!(shape_result(&mut r, 2048));
         let text = r["content"][0]["text"].as_str().unwrap();
-        let head = text.split("\n\n[Conduit shaped").next().unwrap();
+        let head = text.split("\n\n[Toolport shaped").next().unwrap();
         assert!(
             head.len() <= 2048,
             "head was {} bytes, over the 2048 budget",

--- a/src-tauri/src/teams.rs
+++ b/src-tauri/src/teams.rs
@@ -1,4 +1,4 @@
-//! Conduit Teams client: join a team, pull/push the shared MCP server set, and merge
+//! Toolport Teams client: join a team, pull/push the shared MCP server set, and merge
 //! it into the local registry non-destructively.
 //!
 //! The Teams server (the paid, source-available `conduit-teams` layer) holds only the

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
-  "productName": "Conduit",
+  "productName": "Toolport",
   "version": "0.9.4",
   "identifier": "com.tsout.conduit",
   "build": {
@@ -12,7 +12,7 @@
   "app": {
     "windows": [
       {
-        "title": "Conduit",
+        "title": "Toolport",
         "width": 1240,
         "height": 820,
         "minWidth": 940,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -100,7 +100,7 @@ function App() {
   const [showOnboarding, setShowOnboarding] = useState(false);
   // Step the wizard opens at (0 = Welcome). Set to the Connect step when resuming
   // after a catalog detour, so a browsing user still lands on the step that wires
-  // Conduit into their tools.
+  // Toolport into their tools.
   const [onboardingStep, setOnboardingStep] = useState(0);
   const [resumeAtConnect, setResumeAtConnect] = useState(false);
 
@@ -214,7 +214,7 @@ function App() {
   const profileId = registry
     ? (registry.activeProfileId ?? registry.profiles[0]?.id)
     : undefined;
-  // The gateway entry is Conduit itself, not a server it proxies - never list it.
+  // The gateway entry is Toolport itself, not a server it proxies - never list it.
   const servers = (registry?.servers ?? []).filter((s) => !isGatewayServer(s));
   const enabledCount = registry
     ? servers.filter((s) => isEnabled(registry, s.id)).length
@@ -412,7 +412,7 @@ function App() {
               </h1>
               <p className="truncate text-sm text-muted-foreground">
                 {view === "activity"
-                  ? "Tool calls routed through Conduit"
+                  ? "Tool calls routed through Toolport"
                   : view === "catalog"
                     ? "Add MCP servers from the registry"
                     : view === "playground"
@@ -674,7 +674,7 @@ function EmptyState({
     <div className="flex flex-col items-center justify-center gap-4 py-24 text-center">
       <ServerOff className="size-10 text-muted-foreground/50" />
       <div>
-        <p className="font-medium">No servers in Conduit yet</p>
+        <p className="font-medium">No servers in Toolport yet</p>
         <p className="text-sm text-muted-foreground">
           {importable > 0
             ? `Found ${importable} server${importable === 1 ? "" : "s"} in your installed clients. Import them to get started.`
@@ -711,7 +711,7 @@ function ErrorState({ message }: { message: string }) {
             </>
           ) : (
             <>
-              Conduit's backend didn't start. Try quitting and reopening the
+              Toolport's backend didn't start. Try quitting and reopening the
               app.
             </>
           )}

--- a/src/components/ActivityView.tsx
+++ b/src/components/ActivityView.tsx
@@ -166,7 +166,7 @@ function SecurityResting() {
       <ShieldCheck className="size-4 shrink-0 text-owned" />
       <span>
         <span className="font-medium text-foreground">Protection active.</span>{" "}
-        Conduit watches every tool for tampering (rug pulls), poisoned definitions,
+        Toolport watches every tool for tampering (rug pulls), poisoned definitions,
         and injected output (agentjacking). No issues right now.
       </span>
     </div>
@@ -176,7 +176,7 @@ function SecurityResting() {
 /** Surfaces tool security events: a tool you approved changed (rug-pull signal),
  * a known server added one, a tool definition contains injection-like content
  * (poisoning), or a tool returned data that looks like injected instructions
- * (agentjacking, which Conduit labels as data before the agent sees it).
+ * (agentjacking, which Toolport labels as data before the agent sees it).
  * Collapsible, and each notice can be dismissed once you've reviewed it. */
 function SecurityNotices({
   events,
@@ -212,7 +212,7 @@ function SecurityNotices({
             A tool changed after you approved it, a tool's definition contains
             instruction-like content, or a tool returned data that looks like
             injected instructions. Usually benign, but it's how rug pulls, tool
-            poisoning, and agentjacking work, so Conduit flags it (and labels
+            poisoning, and agentjacking work, so Toolport flags it (and labels
             suspicious tool output as data). Dismiss the ones you've reviewed.
           </p>
           <ul className="space-y-1.5 text-xs">
@@ -279,7 +279,7 @@ function SavingsBanner({ savings }: { savings: SavingsSummary }) {
 
   const share = async () => {
     const text =
-      `Conduit keeps ~${fmtTokens(savings.tokensSaved)} tokens of MCP tool definitions out of my agent's ` +
+      `Toolport keeps ~${fmtTokens(savings.tokensSaved)} tokens of MCP tool definitions out of my agent's ` +
       `context so far. One local gateway for all my MCP servers: conduitmcp.app`;
     try {
       await navigator.clipboard.writeText(text);
@@ -642,14 +642,14 @@ function LiveInspector({ refreshKey }: { refreshKey: number }) {
       {open && (
         <>
           <p className="mt-2 mb-3 max-w-2xl text-xs text-muted-foreground">
-            Ephemeral, local, opt-in. While live inspection is on, Conduit keeps the
+            Ephemeral, local, opt-in. While live inspection is on, Toolport keeps the
             last 50 tool calls' arguments and results here so you can inspect them.
             This buffer is separate from the audit log, never leaves your machine, and
             clears when you turn inspection off or restart the gateway.
           </p>
           {entries.length === 0 ? (
             <p className="py-6 text-center text-sm text-muted-foreground">
-              No calls captured yet. Run a tool through Conduit and it'll show here.
+              No calls captured yet. Run a tool through Toolport and it'll show here.
             </p>
           ) : (
             <div className="flex flex-col gap-1">
@@ -770,7 +770,7 @@ export function ActivityView({
           <div>
             <p className="font-medium">Couldn't load activity</p>
             <p className="max-w-md text-sm text-muted-foreground">
-              Conduit couldn't reach the gateway or read the audit log. This is
+              Toolport couldn't reach the gateway or read the audit log. This is
               not an empty log, if the gateway isn't running, start it and
               refresh.
             </p>
@@ -789,7 +789,7 @@ export function ActivityView({
           <div>
             <p className="font-medium">No tool calls yet</p>
             <p className="max-w-md text-sm text-muted-foreground">
-              Once a client runs a tool through Conduit, every call is recorded
+              Once a client runs a tool through Toolport, every call is recorded
               here, with per-server latency and error rates.
             </p>
           </div>

--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -112,7 +112,7 @@ function VersionFooter({
     if (!update) return;
     setInstalling(true);
     toast.info(`Updating to v${update.version}…`, {
-      description: "Conduit will restart when it's done.",
+      description: "Toolport will restart when it's done.",
     });
     try {
       await installUpdate(update);
@@ -154,7 +154,7 @@ function VersionFooter({
           title="Check for updates"
           className={`rounded text-muted-foreground transition hover:text-foreground disabled:opacity-70 ${FOCUS_RING}`}
         >
-          {checking ? "Checking…" : `Conduit v${version}`}
+          {checking ? "Checking…" : `Toolport v${version}`}
         </button>
       )}
 
@@ -309,7 +309,7 @@ interface RowProps {
   onSelect: () => void;
 }
 
-/** A client row is about two things only: is Conduit connected here, and is
+/** A client row is about two things only: is Toolport connected here, and is
  * there anything left to import. Raw server counts are deliberately gone -
  * client inventory isn't something you manage from the sidebar. */
 function ClientRow({ client, importCount, selected, onSelect }: RowProps) {
@@ -362,8 +362,8 @@ function ClientRow({ client, importCount, selected, onSelect }: RowProps) {
         </p>
         <p className="mt-1 text-xs text-muted-foreground">
           {connected
-            ? "Conduit is the gateway here. Other entries are just import sources."
-            : "Connect Conduit here, and import any servers you want it to manage."}
+            ? "Toolport is the gateway here. Other entries are just import sources."
+            : "Connect Toolport here, and import any servers you want it to manage."}
         </p>
         {client.usesConnectors && (
           <p className="mt-1 text-xs text-info">
@@ -464,7 +464,7 @@ export function AppSidebar({
           </g>
         </svg>
         <div className="leading-tight">
-          <div className="font-semibold tracking-tight">Conduit</div>
+          <div className="font-semibold tracking-tight">Toolport</div>
           <div className="text-xs text-muted-foreground">
             MCP control center
           </div>

--- a/src/components/CatalogView.tsx
+++ b/src/components/CatalogView.tsx
@@ -129,7 +129,7 @@ export function CatalogView({ registry, onAdded }: Props) {
     }
   }
 
-  /** Add every server in a stack that isn't already in Conduit, then point the
+  /** Add every server in a stack that isn't already in Toolport, then point the
    * user at the credential steps for the ones that need them. */
   async function setupStack(stack: Stack) {
     setStackBusy(stack.id);
@@ -156,7 +156,7 @@ export function CatalogView({ registry, onAdded }: Props) {
         if (entry.credentialsUrl || entry.envKeys.length > 0) needCreds++;
       }
       if (added === 0) {
-        toast.success(`${stack.name}: every server is already in Conduit`);
+        toast.success(`${stack.name}: every server is already in Toolport`);
       } else {
         toast.success(`Added ${added} server${added === 1 ? "" : "s"} from ${stack.name}`, {
           description:
@@ -447,7 +447,7 @@ function StackCard({
 function Provenance({ entry }: { entry: CatalogEntry }) {
   const tier =
     entry.source === "curated"
-      ? { label: "Conduit verified", cls: "text-success" }
+      ? { label: "Toolport verified", cls: "text-success" }
       : entry.source === "registry"
         ? { label: "MCP Registry", cls: "text-info" }
         : { label: "Your pick", cls: "text-owned" };
@@ -509,7 +509,7 @@ function CatalogCard({
         {added ? (
           <span className="inline-flex items-center gap-1 text-xs text-success">
             <Check className="size-3" />
-            in Conduit
+            in Toolport
           </span>
         ) : (
           <Button

--- a/src/components/ClientDetail.tsx
+++ b/src/components/ClientDetail.tsx
@@ -52,7 +52,7 @@ export function ClientDetail({
   // config into a client that isn't installed just creates a file nothing reads.
   const present = client.appPresent;
   const profiles = registry?.profiles ?? [];
-  // The scope Conduit last connected this client with ("" = follow the active
+  // The scope Toolport last connected this client with ("" = follow the active
   // profile). Keep the picker in sync with it as the selected client changes.
   const currentScope = registry?.clientScopes?.[client.id] ?? "";
   useEffect(() => {
@@ -89,7 +89,7 @@ export function ClientDetail({
     }
   }
   // Servers configured directly in the client (not the gateway) that migrate
-  // would move into Conduit and strip from the client's config.
+  // would move into Toolport and strip from the client's config.
   const movable = client.servers.filter(
     (s) => s.name.toLowerCase() !== "conduit",
   );
@@ -100,9 +100,9 @@ export function ClientDetail({
       const result = await migrateClient(client.id, profile || undefined);
       onRegistryChange(result.registry);
       toast.success(
-        `Moved ${result.moved.length} server${result.moved.length === 1 ? "" : "s"} into Conduit`,
+        `Moved ${result.moved.length} server${result.moved.length === 1 ? "" : "s"} into Toolport`,
         {
-          description: `${client.name} now uses only the Conduit gateway. Config backed up.`,
+          description: `${client.name} now uses only the Toolport gateway. Config backed up.`,
         },
       );
       setMigrateOpen(false);
@@ -119,7 +119,7 @@ export function ClientDetail({
   );
   const pluginNames = new Set(client.pluginServers.map((s) => s.name.toLowerCase()));
 
-  // Every client-side server worth showing, deduped by name, minus Conduit's
+  // Every client-side server worth showing, deduped by name, minus Toolport's
   // own gateway entry. These exist here only as import candidates.
   const byName = new Map<string, McpServer>();
   for (const s of [...client.servers, ...client.pluginServers]) {
@@ -150,7 +150,7 @@ export function ClientDetail({
     setBusy(true);
     try {
       await importOne(server);
-      toast.success(`Imported ${server.name} into Conduit`, {
+      toast.success(`Imported ${server.name} into Toolport`, {
         description: "Enable it to serve it to every client through the gateway.",
       });
     } catch (e) {
@@ -174,7 +174,7 @@ export function ClientDetail({
     }
     setBusy(false);
     if (failed.length === 0) {
-      toast.success(`Imported ${ok} server${ok === 1 ? "" : "s"} into Conduit`);
+      toast.success(`Imported ${ok} server${ok === 1 ? "" : "s"} into Toolport`);
     } else if (ok > 0) {
       toast.warning(`Imported ${ok}, couldn't import ${failed.join(", ")}`);
     } else {
@@ -187,10 +187,10 @@ export function ClientDetail({
     try {
       if (installed) {
         await uninstallGateway(client.id);
-        toast.success(`Disconnected Conduit from ${client.name}`);
+        toast.success(`Disconnected Toolport from ${client.name}`);
       } else {
         const outcome = await installGateway(client.id, profile || undefined);
-        toast.success(`Connected Conduit to ${client.name}`, {
+        toast.success(`Connected Toolport to ${client.name}`, {
           description: profile
             ? `Scoped to the "${profile}" profile.`
             : outcome.backup
@@ -214,7 +214,7 @@ export function ClientDetail({
           {installed ? (
             <span className="mb-1 inline-flex items-center gap-1 rounded-full border border-success/30 bg-success/10 px-2 py-0.5 text-xs font-medium text-success">
               <Link2 className="size-3" />
-              connected to Conduit
+              connected to Toolport
             </span>
           ) : (
             <span className="mb-1 inline-flex items-center gap-1 rounded-full border border-border bg-muted/40 px-2 py-0.5 text-xs font-medium text-muted-foreground">
@@ -275,7 +275,7 @@ export function ClientDetail({
                   Disconnect
                 </Button>
               }
-              title={`Disconnect Conduit from ${client.name}?`}
+              title={`Disconnect Toolport from ${client.name}?`}
               description="This rewrites the client's MCP config to remove the gateway. You can reconnect anytime."
               confirmLabel="Disconnect"
               destructive
@@ -289,15 +289,15 @@ export function ClientDetail({
               disabled={busy || !present}
             >
               <PlugZap className="size-4" />
-              Connect to Conduit
+              Connect to Toolport
             </Button>
           )}
         </div>
       </div>
 
       <p className="text-sm text-muted-foreground">
-        Connect points {client.name} at Conduit so it uses your managed servers.
-        Import copies this client's own servers into Conduit so it can manage them.
+        Connect points {client.name} at Toolport so it uses your managed servers.
+        Import copies this client's own servers into Toolport so it can manage them.
       </p>
 
       {client.usesConnectors && (
@@ -308,8 +308,8 @@ export function ClientDetail({
               <p className="font-medium">{client.name} manages servers as connectors</p>
               <p className="mt-1 text-muted-foreground">
                 Those live in {client.name}'s Customize → Connectors and sync to your
-                account, outside the local config files Conduit reads. Connecting Conduit
-                adds a local gateway entry so your Conduit-managed servers appear in{" "}
+                account, outside the local config files Toolport reads. Connecting Toolport
+                adds a local gateway entry so your Toolport-managed servers appear in{" "}
                 {client.name} too.
               </p>
             </div>
@@ -317,11 +317,11 @@ export function ClientDetail({
         </Card>
       )}
 
-      {/* Import: client servers are sources to pull into Conduit, nothing more. */}
+      {/* Import: client servers are sources to pull into Toolport, nothing more. */}
       <div>
         <div className="mb-1 flex items-center justify-between gap-2">
           <span className="text-xs font-medium tracking-wide text-muted-foreground uppercase">
-            Import into Conduit
+            Import into Toolport
           </span>
           <div className="flex items-center gap-1.5">
             {toImport.length > 0 && (
@@ -352,7 +352,7 @@ export function ClientDetail({
         </div>
         <p className="mb-3 text-xs text-muted-foreground">
           The servers {client.name} already has, from its config and any plugins
-          (tagged below). Import what you want Conduit to manage; it becomes the
+          (tagged below). Import what you want Toolport to manage; it becomes the
           source of truth and serves them back through the gateway. "Move config in"
           also clears the config-file ones out of {client.name}, plugin servers stay
           (only {client.name} can remove those).
@@ -382,7 +382,7 @@ export function ClientDetail({
         {toImport.length === 0 && allServers.length > 0 && (
           <p className="mt-3 inline-flex items-center gap-1.5 text-xs text-success">
             <Check className="size-3.5" />
-            Everything here is already in Conduit. Manage it under{" "}
+            Everything here is already in Toolport. Manage it under{" "}
             <span className="inline-flex items-center gap-0.5 font-medium">
               All servers <ArrowRight className="size-3" />
             </span>
@@ -393,7 +393,7 @@ export function ClientDetail({
       <Dialog open={migrateOpen} onOpenChange={setMigrateOpen}>
         <DialogContent className="sm:max-w-md">
           <DialogHeader>
-            <DialogTitle>Move {client.name} onto Conduit</DialogTitle>
+            <DialogTitle>Move {client.name} onto Toolport</DialogTitle>
           </DialogHeader>
           <div className="flex flex-col gap-3 py-1 text-sm">
             <p className="text-muted-foreground">
@@ -401,8 +401,8 @@ export function ClientDetail({
               <span className="font-medium text-foreground">
                 {movable.length} server{movable.length === 1 ? "" : "s"}
               </span>{" "}
-              from {client.name} into Conduit, then rewrites {client.name}'s config so it
-              uses <span className="font-medium text-foreground">only the Conduit gateway</span>.
+              from {client.name} into Toolport, then rewrites {client.name}'s config so it
+              uses <span className="font-medium text-foreground">only the Toolport gateway</span>.
               The original config is backed up first.
             </p>
             <p className="rounded-md bg-warning/10 p-2 text-xs text-warning">
@@ -450,7 +450,7 @@ export function ClientDetail({
             </Button>
             <Button onClick={migrate} disabled={busy}>
               <Shuffle className="size-4" />
-              Move {movable.length} into Conduit
+              Move {movable.length} into Toolport
             </Button>
           </DialogFooter>
         </DialogContent>
@@ -498,7 +498,7 @@ function ServerMiniCard({
           {imported ? (
             <span className="inline-flex items-center gap-1 text-xs text-success">
               <Check className="size-3" />
-              in Conduit
+              in Toolport
             </span>
           ) : (
             <Button

--- a/src/components/Onboarding.tsx
+++ b/src/components/Onboarding.tsx
@@ -160,10 +160,10 @@ function Welcome({
   const found =
     names.length === 0
       ? "We didn't detect any MCP clients yet. You can still add servers now, then connect a client once it's installed."
-      : `We found ${listJoin(names)} on your machine. Conduit will sit between your tools and your servers, so you set each one up once.`;
+      : `We found ${listJoin(names)} on your machine. Toolport will sit between your tools and your servers, so you set each one up once.`;
   return (
     <>
-      <StepHeader icon={<Waypoints className="size-5" />} title="Welcome to Conduit">
+      <StepHeader icon={<Waypoints className="size-5" />} title="Welcome to Toolport">
         One local gateway for all your MCP servers, shared by every AI tool, so your
         agent loads 3 tools instead of hundreds (up to 91% fewer tokens) and every
         server is watched for tampering and prompt injection.
@@ -223,7 +223,7 @@ function AddServers({
     }
   }
 
-  /** Add every server in the chosen stack that isn't already in Conduit. */
+  /** Add every server in the chosen stack that isn't already in Toolport. */
   async function applyStack(s: Stack) {
     setApplying(true);
     const existing = new Set(registry.servers.map((x) => x.name.toLowerCase()));
@@ -242,7 +242,7 @@ function AddServers({
       toast.success(
         added > 0
           ? `Added ${added} server${added === 1 ? "" : "s"} from ${s.name}`
-          : `${s.name}: every server is already in Conduit`,
+          : `${s.name}: every server is already in Toolport`,
         {
           description:
             needCreds > 0
@@ -260,7 +260,7 @@ function AddServers({
   return (
     <>
       <StepHeader icon={<Download className="size-5" />} title="Add your first servers">
-        Pick what you work on and Conduit sets up a matching stack. You can also
+        Pick what you work on and Toolport sets up a matching stack. You can also
         import from your other tools or browse the full catalog.
       </StepHeader>
 
@@ -340,7 +340,7 @@ function AddServers({
         {imported !== null && (
           <div className="flex items-center gap-2 rounded-md bg-success/10 px-3 py-2 text-sm text-success">
             <Check className="size-4" />
-            Imported. Conduit now manages {imported} server
+            Imported. Toolport now manages {imported} server
             {imported === 1 ? "" : "s"}.
           </div>
         )}
@@ -377,7 +377,7 @@ function ConnectClients({
       await installGateway(client.id);
       setDone((prev) => new Set(prev).add(client.id));
       onConnected();
-      toast.success(`Connected Conduit to ${client.name}`);
+      toast.success(`Connected Toolport to ${client.name}`);
     } catch (e) {
       toastError(`Couldn't connect: ${e}`);
     } finally {
@@ -388,7 +388,7 @@ function ConnectClients({
   return (
     <>
       <StepHeader icon={<Link2 className="size-5" />} title="Connect a client">
-        Point a tool at Conduit. It connects once, then sees every server you
+        Point a tool at Toolport. It connects once, then sees every server you
         enable here, no per-tool setup.
       </StepHeader>
 
@@ -493,11 +493,11 @@ function Done({
       >
         {ready ? (
           <>
-            Conduit now manages {serverCount} server
+            Toolport now manages {serverCount} server
             {serverCount === 1 ? "" : "s"} across {connectedCount} connected tool
             {connectedCount === 1 ? "" : "s"}. Toggle one on or off and your clients
             update live, no restart. Each client loads 3 search tools instead of
-            every tool, up to 91% fewer tokens at the same task success. And Conduit watches
+            every tool, up to 91% fewer tokens at the same task success. And Toolport watches
             every server for tampering and prompt injection, see Activity.
           </>
         ) : (
@@ -523,7 +523,7 @@ function Done({
       )}
 
       <Button onClick={onFinish} className="self-start">
-        {ready ? "Start using Conduit" : "Got it"}
+        {ready ? "Start using Toolport" : "Got it"}
         <ArrowRight className="size-4" />
       </Button>
     </>

--- a/src/components/PlaygroundView.tsx
+++ b/src/components/PlaygroundView.tsx
@@ -572,7 +572,7 @@ export function PlaygroundView({ registry, onRegistryChange }: PlaygroundProps) 
         <div>
           <p className="font-medium">No servers to test</p>
           <p className="max-w-md text-sm text-muted-foreground">
-            Add a server to Conduit, then come back here to invoke its tools and
+            Add a server to Toolport, then come back here to invoke its tools and
             see the raw results, without wiring up a client first.
           </p>
         </div>

--- a/src/components/RegistryServerRow.tsx
+++ b/src/components/RegistryServerRow.tsx
@@ -254,7 +254,7 @@ export function RegistryServerRow({
                 </button>
               }
               title={`Remove ${server.name}?`}
-              description="This deletes the server from Conduit. Any saved secrets stay in your keychain."
+              description="This deletes the server from Toolport. Any saved secrets stay in your keychain."
               confirmLabel="Remove"
               destructive
               onConfirm={onRemove}

--- a/src/components/SecretsDialog.tsx
+++ b/src/components/SecretsDialog.tsx
@@ -31,7 +31,7 @@ import { Label } from "@/components/ui/label";
 function secretErrorMessage(e: unknown): string {
   const msg = `${e}`;
   if (/secret service|freedesktop\.secret|keyring|dbus|d-bus/i.test(msg)) {
-    return "No system keyring found. Conduit keeps secrets in your OS keyring; on Linux that needs a running Secret Service (e.g. gnome-keyring or KWallet). Start and unlock one, then retry.";
+    return "No system keyring found. Toolport keeps secrets in your OS keyring; on Linux that needs a running Secret Service (e.g. gnome-keyring or KWallet). Start and unlock one, then retry.";
   }
   return msg;
 }

--- a/src/components/SettingsView.tsx
+++ b/src/components/SettingsView.tsx
@@ -224,7 +224,7 @@ export function SettingsView({ registry, onRegistryChange }: Props) {
           liveInspect,
           "text-info",
           "Live request/response inspection",
-          "Off by default. While on, Conduit captures each tool call's arguments and results to a small local, ephemeral buffer (the last 50 calls) so you can inspect them in Activity. This is separate from the audit log, never leaves your machine, and is cleared when you turn it off or restart the gateway.",
+          "Off by default. While on, Toolport captures each tool call's arguments and results to a small local, ephemeral buffer (the last 50 calls) so you can inspect them in Activity. This is separate from the audit log, never leaves your machine, and is cleared when you turn it off or restart the gateway.",
           applyLiveInspect,
         )}
         {quarantined.length > 0 && (

--- a/src/components/ShareDialog.tsx
+++ b/src/components/ShareDialog.tsx
@@ -137,9 +137,9 @@ export function ShareDialog({ trigger, onImported }: Props) {
   async function saveToFile() {
     try {
       const path = await save({
-        title: "Save Conduit setup",
+        title: "Save Toolport setup",
         defaultPath: `${slug(name) || "conduit-setup"}.json`,
-        filters: [{ name: "Conduit setup", extensions: ["json"] }],
+        filters: [{ name: "Toolport setup", extensions: ["json"] }],
       });
       if (!path) return;
       await exportConfigToPath(path, name, description, shareFilter);
@@ -166,10 +166,10 @@ export function ShareDialog({ trigger, onImported }: Props) {
   async function loadFromFile() {
     try {
       const path = await openFile({
-        title: "Open a Conduit setup",
+        title: "Open a Toolport setup",
         multiple: false,
         directory: false,
-        filters: [{ name: "Conduit setup", extensions: ["json"] }],
+        filters: [{ name: "Toolport setup", extensions: ["json"] }],
       });
       if (!path || typeof path !== "string") return;
       const json = await readSetupFile(path);
@@ -195,7 +195,7 @@ export function ShareDialog({ trigger, onImported }: Props) {
   }
 
   // Open the import review when a conduit://import?s=<id> deep link arrives (the
-  // share page's "Open in Conduit" button), including one captured before mount.
+  // share page's "Open in Toolport" button), including one captured before mount.
   useEffect(() => {
     let cancelled = false;
     let unlisten: (() => void) | undefined;

--- a/src/components/TeamsView.tsx
+++ b/src/components/TeamsView.tsx
@@ -11,7 +11,7 @@ import { isEnabled, activeProfile } from "@/lib/types";
 import type { Registry } from "@/lib/types";
 
 /**
- * Conduit Teams: join a team and have its shared MCP server set appear locally. The
+ * Toolport Teams: join a team and have its shared MCP server set appear locally. The
  * team server holds only the server set + non-secret config, never a key, so after
  * connecting you still vault each server's secrets locally (Servers tab). That keeps
  * "no keys in the cloud" true even on a team.
@@ -114,7 +114,7 @@ export function TeamsView({
     <div className="mx-auto max-w-2xl">
       <div className="mb-5 flex items-center gap-2">
         <Users className="size-5 text-muted-foreground" />
-        <h2 className="text-base font-semibold">Conduit Teams</h2>
+        <h2 className="text-base font-semibold">Toolport Teams</h2>
       </div>
 
       {error && (
@@ -137,7 +137,7 @@ export function TeamsView({
         <div className="rounded-xl border bg-card p-5">
           <h3 className="text-sm font-medium">Connect to a team</h3>
           <p className="mt-1 mb-4 max-w-prose text-sm text-muted-foreground">
-            Paste your team's Conduit Teams server URL and an invite code from your admin.
+            Paste your team's Toolport Teams server URL and an invite code from your admin.
             The team's MCP servers will appear in your active profile. Your keys never leave
             your machine, you'll add each server's secrets locally afterward.
           </p>
@@ -203,7 +203,7 @@ export function TeamsView({
                     </Button>
                   }
                   title="Leave this team?"
-                  description="This removes the team's shared servers from Conduit. Your own servers are untouched."
+                  description="This removes the team's shared servers from Toolport. Your own servers are untouched."
                   confirmLabel="Leave"
                   destructive
                   onConfirm={onDisconnect}
@@ -285,7 +285,7 @@ export function TeamsView({
                               description={
                                 isLocal
                                   ? `This runs a local command on your machine: ${detail}. Only enable it if you trust your team and recognize this command.`
-                                  : `This connects Conduit to ${detail}, a private/LAN address. Only enable it if you trust your team.`
+                                  : `This connects Toolport to ${detail}, a private/LAN address. Only enable it if you trust your team.`
                               }
                               confirmLabel="Enable"
                               onConfirm={() => onEnable(s.id)}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -237,7 +237,7 @@ export function httpBridgeStatus(): Promise<HttpBridgeStatus> {
   return invoke<HttpBridgeStatus>("http_bridge_status");
 }
 
-/** Join a Conduit Teams server with an invite code; merges the team's servers in. */
+/** Join a Toolport Teams server with an invite code; merges the team's servers in. */
 export function teamConnect(
   serverUrl: string,
   inviteCode: string,
@@ -270,7 +270,7 @@ export function detectClients(): Promise<DetectedClient[]> {
   return invoke<DetectedClient[]>("detect_clients");
 }
 
-/** Install the Conduit gateway into a client's config, optionally scoped to a
+/** Install the Toolport gateway into a client's config, optionally scoped to a
  * profile (by name). Omit profile to expose all enabled servers. */
 export function installGateway(
   clientId: string,
@@ -282,13 +282,13 @@ export function installGateway(
   });
 }
 
-/** Remove the Conduit gateway from a client's config. */
+/** Remove the Toolport gateway from a client's config. */
 export function uninstallGateway(clientId: string): Promise<WriteOutcome> {
   return invoke<WriteOutcome>("uninstall_gateway", { clientId });
 }
 
-/** Import a client's servers into Conduit, then leave the client with only the
- * Conduit gateway (optionally scoped to a profile). Backs up the config first. */
+/** Import a client's servers into Toolport, then leave the client with only the
+ * Toolport gateway (optionally scoped to a profile). Backs up the config first. */
 export function migrateClient(
   clientId: string,
   profile?: string,
@@ -344,7 +344,7 @@ export function probeAuth(url: string): Promise<AuthInfo> {
   return invoke<AuthInfo>("probe_auth", { url });
 }
 
-/** Open Conduit's data directory (registry, logs, audit) in the OS file manager. */
+/** Open Toolport's data directory (registry, logs, audit) in the OS file manager. */
 export function openDataDir(): Promise<void> {
   return invoke<void>("open_data_dir");
 }
@@ -416,7 +416,7 @@ export function setAllEnabled(
   return invoke<Registry>("set_all_enabled", { profileId, enabled });
 }
 
-/** Load Conduit's registry (servers + profiles). */
+/** Load Toolport's registry (servers + profiles). */
 export function getRegistry(): Promise<Registry> {
   return invoke<Registry>("get_registry");
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -272,7 +272,7 @@ export function aggregateServers(clients: DetectedClient[]): AggregatedServer[] 
   );
 }
 
-// --- Conduit registry (source of truth) ---
+// --- Toolport registry (source of truth) ---
 
 export interface EnvVar {
   key: string;
@@ -318,7 +318,7 @@ export interface Registry {
   lazyDiscovery?: boolean;
   /** Opt-in: let an agent enable/disable servers via the gateway's control tools. */
   allowAgentControl?: boolean;
-  /** Connection to a Conduit Teams server, if joined. Token lives in the keychain. */
+  /** Connection to a Toolport Teams server, if joined. Token lives in the keychain. */
   team?: TeamConnection | null;
   /** Per-server result-shaping budgets in bytes, keyed by server id. Absent =
    * global default; 0 = never shape (full fidelity); n = cap that server at n bytes. */
@@ -342,7 +342,7 @@ export interface HttpClient {
   profile: string;
 }
 
-/** A joined Conduit Teams server (the shared config-sync layer). */
+/** A joined Toolport Teams server (the shared config-sync layer). */
 export interface TeamConnection {
   serverUrl: string;
   teamId: string;
@@ -364,7 +364,7 @@ export function isEnabled(registry: Registry, serverId: string): boolean {
   return activeProfile(registry)?.enabledServerIds.includes(serverId) ?? false;
 }
 
-/** Whether a registry entry is Conduit's own gateway. It's infrastructure, not a
+/** Whether a registry entry is Toolport's own gateway. It's infrastructure, not a
  * proxied server, so it shouldn't appear as a manageable server in the UI.
  * Mirrors `is_gateway_server` in the Rust backend. */
 export function isGatewayServer(server: ServerEntry): boolean {
@@ -376,9 +376,9 @@ export function isGatewayServer(server: ServerEntry): boolean {
   );
 }
 
-/** Servers a client has (config + plugins) that Conduit doesn't manage yet.
+/** Servers a client has (config + plugins) that Toolport doesn't manage yet.
  * These are the only client-side entries worth surfacing - they're import
- * candidates. Conduit's own gateway entry is never importable. */
+ * candidates. Toolport's own gateway entry is never importable. */
 export function importableServers(
   client: DetectedClient,
   registry: Registry | null,


### PR DESCRIPTION
Phase 1a of the rebrand. Renames every **user- and model-facing** 'Conduit' to 'Toolport' (productName, window title, UI copy, onboarding, dialogs, toasts, OAuth callback + client_name, gateway/meta-tool descriptions, SSRF-guard messages). Every changed line is inside a string literal, comment, or JSX, verified by grep and by the fact that it compiles (an identifier rename wouldn't build).

## Kept on `conduit` (zero-breakage upgrade)
Per the confirmed principle — rename only what's visible, keep all internal identifiers — these are **unchanged**: bundle id `com.tsout.conduit`, data-dir literal `join("Conduit")`, keychain `conduit-mcp` + access group, the `conduit-gateway` binary, Cargo crates `conduit`/`conduit_lib`, the 17 `CONDUIT_*` env vars, the `conduit_*` meta-tool **names** + HTTP paths (separate aliased phase), localStorage keys, deep-link scheme, and the `ConduitGateway.app` bundle path. An existing install upgrades in place: displays 'Toolport', reads the identical data/keychain/configs — no migration, no keychain re-prompt.

## Deferred (later phases)
Meta-tool name rename (needs compat aliases), README/docs/site, icons, macOS bundle/signing.

## Test
`cargo build` + `tsc --noEmit` clean; keep-list verified intact.