### PR TITLE
chore(release): rename pipeline artifacts Conduit -> Toolport

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,7 +123,7 @@ jobs:
           $account  = "${{ vars.AZURE_SIGNING_ACCOUNT }}";  if (-not $account)  { $account  = "southforgesigning" }
           $certProfile = "${{ vars.AZURE_SIGNING_PROFILE }}"
           if (-not $certProfile) { Write-Error "AZURE_SIGNING_PROFILE repo variable is not set (the certificate profile name)"; exit 1 }
-          $cmd = "trusted-signing-cli -e $endpoint -a $account -c $certProfile -d Conduit %1"
+          $cmd = "trusted-signing-cli -e $endpoint -a $account -c $certProfile -d Toolport %1"
           $conf = @{ bundle = @{ windows = @{ signCommand = $cmd } } } | ConvertTo-Json -Depth 5
           Set-Content -Path "src-tauri/tauri.signing.conf.json" -Value $conf -Encoding utf8
           "config_arg=--config src-tauri/tauri.signing.conf.json" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
@@ -150,7 +150,7 @@ jobs:
       # macOS signing + packaging. Tauri built the app UNSIGNED above; this step
       # nests the gateway in its own .app, embeds the app + gateway provisioning
       # profiles, signs inside-out, notarizes + staples, builds + notarizes the
-      # dmg, and regenerates the updater artifact (`Conduit_<target>.app.tar.gz`
+      # dmg, and regenerates the updater artifact (`Toolport_<target>.app.tar.gz`
       # + .sig) over the re-signed app so auto-update keeps working. Each arch is
       # named by its target so latest.json can point at the right one.
       #
@@ -162,7 +162,7 @@ jobs:
         if: startsWith(matrix.os, 'macos')
         run: bash scripts/macos-package-ci.sh
         env:
-          APP: src-tauri/target/${{ matrix.target }}/release/bundle/macos/Conduit.app
+          APP: src-tauri/target/${{ matrix.target }}/release/bundle/macos/Toolport.app
           TARGET: ${{ matrix.target }}
           APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
           APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
@@ -185,8 +185,8 @@ jobs:
             src-tauri/target/release/bundle/nsis/*-setup.exe.sig
             src-tauri/target/aarch64-apple-darwin/release/bundle/dmg/*.dmg
             src-tauri/target/x86_64-apple-darwin/release/bundle/dmg/*.dmg
-            src-tauri/target/*/release/bundle/macos/Conduit_*-apple-darwin.app.tar.gz
-            src-tauri/target/*/release/bundle/macos/Conduit_*-apple-darwin.app.tar.gz.sig
+            src-tauri/target/*/release/bundle/macos/Toolport_*-apple-darwin.app.tar.gz
+            src-tauri/target/*/release/bundle/macos/Toolport_*-apple-darwin.app.tar.gz.sig
             src-tauri/target/release/bundle/deb/*.deb
             src-tauri/target/release/bundle/appimage/*.AppImage
             src-tauri/target/release/bundle/appimage/*.AppImage.sig

--- a/scripts/macos-package-ci.sh
+++ b/scripts/macos-package-ci.sh
@@ -4,7 +4,7 @@
 #
 # CI macOS sign + notarize + package for the keychain-access-group nested-gateway
 # build. Runs on a GitHub macOS runner AFTER `tauri build` has produced an
-# (unsigned) Conduit.app. It does everything Tauri's built-in macOS signing
+# (unsigned) Toolport.app. It does everything Tauri's built-in macOS signing
 # cannot: nest the gateway in its own .app, embed provisioning profiles, sign
 # inside-out, notarize, and regenerate the .dmg + updater artifact over the
 # re-signed app.
@@ -16,7 +16,7 @@
 # with Tauri and own the whole sign/notarize/package tail here.
 #
 # Required env:
-#   APP                         path to the built Conduit.app
+#   APP                         path to the built Toolport.app
 #   TARGET                      rust target triple (e.g. x86_64-apple-darwin); used for artifact names
 #   APPLE_CERTIFICATE           base64 of the "Developer ID Application" .p12
 #   APPLE_CERTIFICATE_PASSWORD  password for that .p12
@@ -40,7 +40,7 @@ die()  { printf '\033[31mERROR: %s\033[0m\n' "$*" >&2; exit 1; }
 
 [[ "$(uname -s)" == "Darwin" ]] || die "macos-package-ci.sh must run on macOS"
 
-: "${APP:?APP (path to Conduit.app) is required}"
+: "${APP:?APP (path to Toolport.app) is required}"
 : "${TARGET:?TARGET (rust target triple) is required}"
 : "${APPLE_CERTIFICATE:?APPLE_CERTIFICATE is required}"
 : "${APPLE_CERTIFICATE_PASSWORD:?APPLE_CERTIFICATE_PASSWORD is required}"
@@ -116,7 +116,7 @@ APP="$APP" IDENTITY="$APPLE_SIGNING_IDENTITY" APP_PROFILE="$APP_PROFILE" GW_PROF
 #    zip; ditto --keepParent preserves the .app structure.
 # ---------------------------------------------------------------------------
 log "Notarizing the app"
-APP_ZIP="$WORK/Conduit-notarize.zip"
+APP_ZIP="$WORK/Toolport-notarize.zip"
 ditto -c -k --keepParent "$APP" "$APP_ZIP"
 xcrun notarytool submit "$APP_ZIP" \
   --apple-id "$APPLE_ID" --password "$APPLE_PASSWORD" --team-id "$APPLE_TEAM_ID" \
@@ -132,9 +132,9 @@ xcrun stapler validate "$APP" || die "stapler validate failed on the app"
 log "Building + notarizing the dmg"
 DMG_DIR="$REPO_ROOT/src-tauri/target/$TARGET/release/bundle/dmg"
 mkdir -p "$DMG_DIR"
-DMG="$DMG_DIR/Conduit_${TARGET}.dmg"
+DMG="$DMG_DIR/Toolport_${TARGET}.dmg"
 rm -f "$DMG"
-hdiutil create -volname "Conduit" -srcfolder "$APP" -ov -format UDZO "$DMG"
+hdiutil create -volname "Toolport" -srcfolder "$APP" -ov -format UDZO "$DMG"
 codesign --force --timestamp -s "$APPLE_SIGNING_IDENTITY" "$DMG"
 xcrun notarytool submit "$DMG" \
   --apple-id "$APPLE_ID" --password "$APPLE_PASSWORD" --team-id "$APPLE_TEAM_ID" \
@@ -149,8 +149,8 @@ xcrun stapler staple "$DMG"
 # ---------------------------------------------------------------------------
 log "Regenerating the updater artifact"
 MACOS_DIR="$REPO_ROOT/src-tauri/target/$TARGET/release/bundle/macos"
-TARBALL="$MACOS_DIR/Conduit_${TARGET}.app.tar.gz"
-rm -f "$MACOS_DIR/Conduit.app.tar.gz" "$MACOS_DIR/Conduit.app.tar.gz.sig" "$TARBALL" "$TARBALL.sig"
+TARBALL="$MACOS_DIR/Toolport_${TARGET}.app.tar.gz"
+rm -f "$MACOS_DIR/Toolport.app.tar.gz" "$MACOS_DIR/Toolport.app.tar.gz.sig" "$TARBALL" "$TARBALL.sig"
 ( cd "$MACOS_DIR" && tar -czf "$TARBALL" "$(basename "$APP")" )
 # `tauri signer sign` reads the key + password from the same env vars `tauri build`
 # uses; pass them explicitly so it never prompts.


### PR DESCRIPTION
productName is now Toolport, so Tauri emits `Toolport.app` / `Toolport_<target>.app.tar.gz`. This updates the release workflow (macOS APP path, updater-artifact upload globs, Windows signing `-d` name) and `macos-package-ci.sh` (dmg filename, dmg volume label, updater tarball name + cleanup) so a tagged release builds + uploads correctly-named Toolport artifacts and `latest.json` resolves them.

Kept: `github.repository` (dynamic), the lowercase `conduit-swap` CI swap file, and the `ConduitGateway.app` gateway bundle (plumbing, not referenced here). No release is triggered by this (only tags do); the macOS path gets final validation in the 3-OS upgrade test before announcing.