### PR TITLE
feat: human-in-the-loop tool-approval queue (P1)

### DIFF
--- a/docs/design/hitl-approval-queue.md
+++ b/docs/design/hitl-approval-queue.md
@@ -1,6 +1,6 @@
 # Design: Human-in-the-Loop (HITL) Tool-Approval Queue
 
-Status: DRAFT for review (2026-07-02, rev 2 — best-in-class architecture). Not yet implemented.
+Status: P1 IMPLEMENTED in PR #82 (2026-07-02, rev 2 architecture). Remaining before merge: a runtime end-to-end check (needs the app running). Deferred to P2: named-pipe/uds transport hardening, an async "held, will resume" fallback, and tool+args-hash dedupe.
 
 ## Goal
 
@@ -52,13 +52,13 @@ Flow for a gated call:
    **pushes** `{ approved | denied, approver_ts }` back over the same connection.
 4. Gateway wakes: approved -> `route_call` + real result; denied/timeout -> clear error.
 
-**Why this is the best-in-class choice — it wins on every axis the two alternatives lose:**
+**Why this is the best-in-class choice, it wins on every axis the two alternatives lose:**
 
 - **Coverage:** every gateway process dials *out* to the one app broker, so stdio clients
   are covered, not just the app's own `--http` gateway.
 - **No args on disk:** arguments travel over the socket and stay in memory. The disk only
   ever holds the endpoint descriptor (no payloads). This is the decisive privacy win.
-- **Latency:** event-driven push, not poll intervals — approval feels instant.
+- **Latency:** event-driven push, not poll intervals, approval feels instant.
 - **Fail-closed by construction:** app not running -> the connect fails immediately -> deny
   with "open Toolport to approve". Timeout -> deny. Dropped connection -> deny.
 - **Integrity:** the decision arrives over an authenticated socket from the trusted UI, not
@@ -83,7 +83,7 @@ Flow for a gated call:
    the agent race ahead of a pending sensitive action); other clients are separate processes
    and unaffected.
 2. **Scope: layered, security-first default.** v1 gates (a) `destructiveHint` tools AND
-   (b) any tool from an **untrusted-provenance** server (`source` = shared/registry — the
+   (b) any tool from an **untrusted-provenance** server (`source` = shared/registry, the
    same trust signal the SSRF guard uses), with per-server / per-tool **overrides** designed
    in from day one (allowlist to skip, forcelist to always gate) and a configurable
    escalation to "all non-`readOnlyHint` tools." Reusing the provenance signal ties HITL to
@@ -92,7 +92,7 @@ Flow for a gated call:
 3. **Timeout: fail-closed, generous, notified.** Default ~120s, configurable; no decision ->
    **deny**. Because a missed approval denies the call, pending items MUST raise a prominent
    OS notification so you don't miss the window.
-4. **Args stay in memory** (resolved by the broker) — no disk trade-off to make.
+4. **Args stay in memory** (resolved by the broker), no disk trade-off to make.
 
 ## Security analysis
 
@@ -127,7 +127,7 @@ Flow for a gated call:
 
 Verify the gateway's stdio **serve loop** can park one `tools/call` on the broker read
 without stalling the process in a way that breaks liveness (it already blocks on `ureq` for
-downstream calls, so a bounded blocking read fits the same model — but confirm request
+downstream calls, so a bounded blocking read fits the same model, but confirm request
 dispatch and the ~1s registry watcher still tick while parked). If the loop is strictly
 sequential, blocking is still fine (see decision 1); this check just confirms no deadlock
 with the registry watcher / notifications.

--- a/docs/design/hitl-approval-queue.md
+++ b/docs/design/hitl-approval-queue.md
@@ -1,0 +1,140 @@
+# Design: Human-in-the-Loop (HITL) Tool-Approval Queue
+
+Status: DRAFT for review (2026-07-02, rev 2 — best-in-class architecture). Not yet implemented.
+
+## Goal
+
+Let a human approve or deny sensitive tool calls *out-of-band* before they execute,
+holding the call until a decision (or a fail-closed timeout). Distinct from the existing
+**agent-facing** `toolport_confirm`, where the *model* re-confirms its own destructive
+call. HITL puts a *person* in the loop through the Toolport app. This is a genuine
+security differentiator (the "approval queue" gap vs. Lunar MCPX / IBM ContextForge), so
+it is worth building to a high bar rather than the minimal one.
+
+## Architecture constraints (verified against the code)
+
+1. **Many gateway processes, not one.** Each stdio client (Claude Desktop, Cursor, Claude
+   Code) spawns its own `conduit-gateway` over stdio; the app also supervises one in
+   `--http` mode (`lib.rs:1470-1541`). `ConfirmGuard` is in-memory **per process**
+   (`conduit-gateway.rs:914-974`).
+2. **No inbound control channel to a gateway** today; app->gateway is one-way via files
+   under `~/.conduit/`, polled by mtime every ~1000ms (`conduit-gateway.rs:2073-2142`).
+3. Observability today = shared JSONL the app polls (`inspect.jsonl` ring-50,
+   `audit.jsonl`).
+4. Existing destructive interception in `process_request` (`conduit-gateway.rs:1599-1642`):
+   token stored in `ConfirmGuard`, returned to the model as an `isError` preview, replayed
+   via `toolport_confirm` (`:1362-1389`), 60s TTL, `is_destructive` = `annotations.destructiveHint`.
+5. Frontend (`src/components/`): `ActivityView.tsx` + `SettingsView.tsx`; the quarantine
+   list/release UI is a good precedent for an approve/deny queue.
+
+## The core problem
+
+A HITL gate must (a) cover **all** gateway processes (the stdio ones are the main case),
+(b) **block** the agent's call until a human decides, (c) never leak arguments to disk,
+and (d) be **fail-closed**. Two obvious designs each fail one of these, which is what
+drives the recommended one.
+
+## DECISION: app-hosted approval broker; gateways dial out and long-poll
+
+The Toolport **app** runs a tiny local **approval broker** (an OS-permissioned IPC
+endpoint: a Windows **named pipe** / Unix **domain socket**, via the `interprocess` crate;
+localhost-TCP+token is the fallback if the cross-platform IPC is painful). On start the app
+writes `~/.conduit/approval-endpoint.json = { endpoint, token }` (token = 128-bit secret;
+readable only by processes that can already read `~/.conduit/`, the same trust boundary as
+secrets).
+
+Flow for a gated call:
+1. Gateway (`process_request`) reads the endpoint+token, **connects to the app**, and sends
+   `{ client, server, tool, args, provenance, ts }` authenticated by the token.
+2. The app shows it in a **Pending Approvals** queue (ActivityView) plus a prominent OS
+   notification, and **holds the connection open**.
+3. Gateway **blocks reading** that connection (with a timeout). On the human's click the app
+   **pushes** `{ approved | denied, approver_ts }` back over the same connection.
+4. Gateway wakes: approved -> `route_call` + real result; denied/timeout -> clear error.
+
+**Why this is the best-in-class choice — it wins on every axis the two alternatives lose:**
+
+- **Coverage:** every gateway process dials *out* to the one app broker, so stdio clients
+  are covered, not just the app's own `--http` gateway.
+- **No args on disk:** arguments travel over the socket and stay in memory. The disk only
+  ever holds the endpoint descriptor (no payloads). This is the decisive privacy win.
+- **Latency:** event-driven push, not poll intervals — approval feels instant.
+- **Fail-closed by construction:** app not running -> the connect fails immediately -> deny
+  with "open Toolport to approve". Timeout -> deny. Dropped connection -> deny.
+- **Integrity:** the decision arrives over an authenticated socket from the trusted UI, not
+  a file any local process could race to write.
+
+### Alternatives considered (and why not)
+
+- **A. Shared-file handshake** (gateway writes `pending/<token>.json`, app writes
+  `decided/<token>.json`): works cross-process and reuses the poll pattern, BUT forces tool
+  **arguments onto disk** and adds ~1-2s round-trip polling latency. Rejected on the
+  disk-privacy and latency axes. (Kept as the low-effort fallback if the IPC broker proves
+  too costly.)
+- **B. HTTP endpoint on the app's `--http` gateway:** only reaches that one process; misses
+  every stdio client. Rejected on coverage.
+
+## The four decisions, resolved
+
+1. **Blocking, not async.** Hold the agent's call until a decision; the agent just sees a
+   slower tool and gets the real result or a denial. Async (return-pending-then-replay)
+   leaks approval mechanics into the agent and creates a "looks failed" window. A parked
+   call blocking that client's *other* calls is acceptable and arguably desirable (don't let
+   the agent race ahead of a pending sensitive action); other clients are separate processes
+   and unaffected.
+2. **Scope: layered, security-first default.** v1 gates (a) `destructiveHint` tools AND
+   (b) any tool from an **untrusted-provenance** server (`source` = shared/registry — the
+   same trust signal the SSRF guard uses), with per-server / per-tool **overrides** designed
+   in from day one (allowlist to skip, forcelist to always gate) and a configurable
+   escalation to "all non-`readOnlyHint` tools." Reusing the provenance signal ties HITL to
+   the existing trust model instead of relying solely on servers that bother to set
+   `destructiveHint`.
+3. **Timeout: fail-closed, generous, notified.** Default ~120s, configurable; no decision ->
+   **deny**. Because a missed approval denies the call, pending items MUST raise a prominent
+   OS notification so you don't miss the window.
+4. **Args stay in memory** (resolved by the broker) — no disk trade-off to make.
+
+## Security analysis
+
+- **Trust boundary** = the local user (same as `registry.json`/secrets). The endpoint token
+  is defense-in-depth so a random local process can't register fake approvals or read
+  pending args; OS-permissioned IPC (named pipe / uds) removes any network surface.
+- **Tamper/replay:** single-use TTL'd tokens; decision only accepted over the authenticated
+  broker connection.
+- **DoS:** the broker caps the pending queue and rate-limits per client; excess -> deny.
+- **Fail-closed everywhere:** app down, timeout, or dropped connection all deny. If HITL is
+  ON, we never silently fall back to the weaker agent-confirm (that would defeat the gate);
+  the error tells the human to open Toolport.
+- **Audit:** app records approve/deny/timeout to `audit.jsonl` with capped/omitted args
+  (never the full payload on disk), extending `record_held`.
+
+## UX
+
+- **ActivityView:** a Pending Approvals section (reuse quarantine's list/release pattern):
+  client, server, tool, args, a provenance/trust badge, why-it-was-gated, a countdown, and
+  Approve/Deny. Offer **approve-for-session** / **always-allow-this-tool** to curb fatigue.
+- **Global:** an OS notification + badge when something is pending (time-sensitive).
+- **SettingsView:** toggle `human_approval`, timeout, scope, and per-server/tool overrides.
+
+## Phased plan
+
+- **P1 (MVP):** app broker (IPC) + gateway client + blocking park + destructive/untrusted
+  scope + ActivityView queue + fail-closed timeout + audit outcomes.
+- **P2:** OS notification + approve-for-session/always-allow + Settings scope UI.
+- **P3:** per-server/tool policy editor, multi-approver, "all non-readonly" escalation.
+
+## Feasibility check to do first (before P1 code)
+
+Verify the gateway's stdio **serve loop** can park one `tools/call` on the broker read
+without stalling the process in a way that breaks liveness (it already blocks on `ureq` for
+downstream calls, so a bounded blocking read fits the same model — but confirm request
+dispatch and the ~1s registry watcher still tick while parked). If the loop is strictly
+sequential, blocking is still fine (see decision 1); this check just confirms no deadlock
+with the registry watcher / notifications.
+
+## Longer-term note
+
+The multi-process reality (one gateway per client) is the root complication. A future
+**single shared gateway daemon** that all clients attach to would collapse HITL (one
+broker, one `ConfirmGuard`) and simplify audit/attribution too. Out of scope here, but the
+broker design is a stepping stone toward it.

--- a/src-tauri/src/approval.rs
+++ b/src-tauri/src/approval.rs
@@ -1,0 +1,176 @@
+//! Human-in-the-loop (HITL) tool-approval: the contract both sides share.
+//!
+//! When HITL is on, the gateway holds a *gated* tool call and asks the Toolport app for a
+//! human decision before it runs. The app hosts a small approval broker; every gateway
+//! process (there is one per stdio client, plus the app's `--http` bridge) dials OUT to it,
+//! sends the pending call, and blocks reading for the decision. Arguments travel over the
+//! connection and never touch disk. Everything is fail-closed: no endpoint, no answer, a
+//! timeout, or any transport error all mean DENY.
+//!
+//! This module is the piece both the gateway-side client and the app-side broker share:
+//! the wire types, the gating policy, and the on-disk endpoint descriptor. Keeping it in
+//! the lib means there is exactly one definition of the protocol.
+
+use serde::{Deserialize, Serialize};
+
+/// The broker descriptor's filename inside the Conduit data dir. The app writes it on
+/// startup; every gateway process reads it. It holds ONLY the endpoint address and an auth
+/// token, never any call payload.
+pub const ENDPOINT_FILE: &str = "approval-endpoint.json";
+
+/// Fail-closed timeout for a pending approval: if no human decides within this window, the
+/// call is denied. (Configurable later; a sensible default for v1.)
+pub const DEFAULT_TIMEOUT_SECS: u64 = 120;
+
+/// The broker endpoint descriptor the app publishes and gateways read.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EndpointDescriptor {
+    /// The address a gateway connects to (e.g. `127.0.0.1:PORT`, or a named-pipe / uds path
+    /// once the transport is hardened). Opaque to policy.
+    pub endpoint: String,
+    /// A 128-bit random token the gateway must present. Defense-in-depth over the local-user
+    /// filesystem trust boundary: only a process that can read the Conduit data dir (same as
+    /// secrets) can obtain it.
+    pub token: String,
+}
+
+/// Why a call was gated, surfaced in the approval UI.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ApprovalReason {
+    /// The tool is annotated `destructiveHint: true`.
+    Destructive,
+    /// The tool's server has untrusted provenance (a shared or public-registry import).
+    UntrustedSource,
+    /// Both of the above.
+    DestructiveAndUntrusted,
+}
+
+/// A request from a gateway to the broker: "a human should approve this call." The arguments
+/// are included so the person can review them; they stay in memory on both ends.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ApprovalRequest {
+    /// Auth token from the endpoint descriptor.
+    pub token: String,
+    /// Opaque per-call id; also the correlation key for the decision.
+    pub id: String,
+    /// Which client/agent triggered it (for display + attribution), when known.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub client: Option<String>,
+    /// The downstream server the tool belongs to.
+    pub server: String,
+    /// The tool name.
+    pub tool: String,
+    /// Why it was gated, for the UI.
+    pub reason: ApprovalReason,
+    /// The exact arguments the human is approving.
+    pub arguments: serde_json::Value,
+}
+
+/// The broker's answer to an [`ApprovalRequest`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ApprovalDecision {
+    /// A human approved; the call runs.
+    Approved,
+    /// A human denied; the call is refused.
+    Denied,
+    /// No human decided in time (fail-closed); the caller treats this as a deny.
+    Timeout,
+}
+
+impl ApprovalDecision {
+    /// The security-critical predicate: ONLY an explicit human approval lets the call
+    /// proceed. Denied, Timeout, and (at the call site) any transport error all block.
+    pub fn is_approved(self) -> bool {
+        matches!(self, ApprovalDecision::Approved)
+    }
+}
+
+/// HITL gating policy: given whether a tool is destructive and whether its server has
+/// untrusted provenance, decide if the call needs a human. `enabled` is the registry's
+/// `human_approval` master switch. Returns the reason when gated, `None` when the call may
+/// run without approval.
+///
+/// v1 gates destructive tools AND anything from an untrusted-provenance server (the same
+/// shared/registry signal the SSRF connect-guard uses), so it does not rely solely on
+/// servers that bother to set `destructiveHint`.
+pub fn gate_reason(
+    enabled: bool,
+    is_destructive: bool,
+    untrusted_source: bool,
+) -> Option<ApprovalReason> {
+    if !enabled {
+        return None;
+    }
+    match (is_destructive, untrusted_source) {
+        (true, true) => Some(ApprovalReason::DestructiveAndUntrusted),
+        (true, false) => Some(ApprovalReason::Destructive),
+        (false, true) => Some(ApprovalReason::UntrustedSource),
+        (false, false) => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn gate_is_off_when_disabled() {
+        assert_eq!(gate_reason(false, true, true), None);
+        assert_eq!(gate_reason(false, true, false), None);
+    }
+
+    #[test]
+    fn gate_covers_destructive_and_untrusted() {
+        assert_eq!(gate_reason(true, true, false), Some(ApprovalReason::Destructive));
+        assert_eq!(gate_reason(true, false, true), Some(ApprovalReason::UntrustedSource));
+        assert_eq!(
+            gate_reason(true, true, true),
+            Some(ApprovalReason::DestructiveAndUntrusted)
+        );
+        // A read-only tool from a trusted server is never gated, even with HITL on.
+        assert_eq!(gate_reason(true, false, false), None);
+    }
+
+    #[test]
+    fn only_explicit_approval_proceeds() {
+        assert!(ApprovalDecision::Approved.is_approved());
+        assert!(!ApprovalDecision::Denied.is_approved());
+        assert!(!ApprovalDecision::Timeout.is_approved());
+    }
+
+    #[test]
+    fn wire_types_round_trip() {
+        let req = ApprovalRequest {
+            token: "tok".into(),
+            id: "abc".into(),
+            client: Some("cursor".into()),
+            server: "db".into(),
+            tool: "drop_table".into(),
+            reason: ApprovalReason::Destructive,
+            arguments: serde_json::json!({ "table": "users" }),
+        };
+        let round: ApprovalRequest =
+            serde_json::from_str(&serde_json::to_string(&req).unwrap()).unwrap();
+        assert_eq!(round.tool, "drop_table");
+        assert_eq!(round.reason, ApprovalReason::Destructive);
+        assert_eq!(round.arguments["table"], "users");
+
+        let dec: ApprovalDecision =
+            serde_json::from_str(&serde_json::to_string(&ApprovalDecision::Approved).unwrap())
+                .unwrap();
+        assert!(dec.is_approved());
+    }
+
+    #[test]
+    fn endpoint_descriptor_round_trips() {
+        let d = EndpointDescriptor { endpoint: "127.0.0.1:8790".into(), token: "s3cret".into() };
+        let round: EndpointDescriptor =
+            serde_json::from_str(&serde_json::to_string(&d).unwrap()).unwrap();
+        assert_eq!(round.endpoint, "127.0.0.1:8790");
+        assert_eq!(round.token, "s3cret");
+    }
+}

--- a/src-tauri/src/approval_broker.rs
+++ b/src-tauri/src/approval_broker.rs
@@ -1,0 +1,296 @@
+//! App-side HITL approval broker.
+//!
+//! The Toolport app hosts this broker; every `conduit-gateway` process (one per stdio
+//! client, plus the app's `--http` bridge) dials OUT to it when it holds a gated tool
+//! call, and blocks reading for the decision. This is the counterpart to the gateway's
+//! `request_human_decision` (see `bin/conduit-gateway.rs`).
+//!
+//! Protocol: the gateway connects over loopback TCP, sends one JSON line
+//! ([`ApprovalRequest`]) carrying the shared token, and reads one JSON line back
+//! ([`ApprovalDecision`]). Arguments travel over the socket and are never written to
+//! disk. The only thing on disk is the endpoint descriptor (address + token). The
+//! human decides in the app UI; a fail-closed timeout denies. Transport is loopback
+//! TCP + token for now; hardening to a named-pipe / uds is a follow-up.
+
+use std::collections::HashMap;
+use std::io::{BufRead, BufReader, Write};
+use std::net::{TcpListener, TcpStream};
+use std::sync::mpsc::{channel, Sender};
+use std::sync::{Arc, Mutex, PoisonError};
+use std::time::Duration;
+
+use serde::Serialize;
+use tauri::{AppHandle, Emitter};
+
+use crate::approval::{
+    ApprovalDecision, ApprovalReason, ApprovalRequest, EndpointDescriptor, DEFAULT_TIMEOUT_SECS,
+    ENDPOINT_FILE,
+};
+
+/// A pending approval as the UI sees it. The auth token is deliberately NOT included.
+#[derive(Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PendingView {
+    pub id: String,
+    pub client: Option<String>,
+    pub server: String,
+    pub tool: String,
+    pub reason: ApprovalReason,
+    pub arguments: serde_json::Value,
+}
+
+/// A gateway connection parked waiting for a human decision.
+struct Waiter {
+    view: PendingView,
+    decide: Sender<ApprovalDecision>,
+}
+
+struct Inner {
+    /// The token a gateway must present (matches the published descriptor).
+    token: String,
+    /// id -> parked connection. Bounded by `MAX_PENDING`.
+    pending: Mutex<HashMap<String, Waiter>>,
+}
+
+/// Cap on simultaneously-pending approvals, so a misbehaving client can't grow the
+/// queue without bound. Beyond this, new requests are denied immediately.
+const MAX_PENDING: usize = 64;
+
+/// Handle to the broker, managed as Tauri state so the approve/deny commands can reach it.
+#[derive(Clone)]
+pub struct ApprovalBroker {
+    inner: Arc<Inner>,
+}
+
+impl ApprovalBroker {
+    /// Snapshot the pending queue for the UI.
+    pub fn list(&self) -> Vec<PendingView> {
+        self.inner
+            .pending
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .values()
+            .map(|w| w.view.clone())
+            .collect()
+    }
+
+    /// Deliver a human decision for `id`. `Err` if the id is unknown (already resolved
+    /// or timed out). Sending is best-effort: a parked connection that already timed out
+    /// has dropped its receiver, which is harmless.
+    pub fn decide(&self, id: &str, approved: bool) -> Result<(), String> {
+        let waiter = self
+            .inner
+            .pending
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .remove(id);
+        match waiter {
+            Some(w) => {
+                let d = if approved {
+                    ApprovalDecision::Approved
+                } else {
+                    ApprovalDecision::Denied
+                };
+                let _ = w.decide.send(d);
+                Ok(())
+            }
+            None => Err("no pending approval with that id (it may have expired)".into()),
+        }
+    }
+}
+
+/// Start the broker: generate a token, bind a loopback port, publish the endpoint
+/// descriptor into the data dir, and spawn the accept loop. ALWAYS returns a broker so
+/// the Tauri commands have state to bind to; if binding/publishing fails, the broker is
+/// inert (no listener) and HITL simply never receives approvals - gateways then fail
+/// closed on their own (a connect to nothing denies). Never panics.
+pub fn start(app: AppHandle) -> ApprovalBroker {
+    let mut tok = [0u8; 24];
+    let token: String = match getrandom::getrandom(&mut tok) {
+        Ok(()) => tok.iter().map(|b| format!("{b:02x}")).collect(),
+        Err(_) => String::new(),
+    };
+    let broker = ApprovalBroker {
+        inner: Arc::new(Inner {
+            token: token.clone(),
+            pending: Mutex::new(HashMap::new()),
+        }),
+    };
+
+    match TcpListener::bind(("127.0.0.1", 0)) {
+        Ok(listener) => {
+            if let Some(port) = listener.local_addr().ok().map(|a| a.port()) {
+                if let Some(dir) = crate::registry::conduit_dir() {
+                    let desc = EndpointDescriptor {
+                        endpoint: format!("127.0.0.1:{port}"),
+                        token,
+                    };
+                    // A stale descriptor (app crashed) points at a dead port, so a gateway
+                    // connect fails and denies - fail-closed either way.
+                    let _ = std::fs::write(
+                        dir.join(ENDPOINT_FILE),
+                        serde_json::to_string(&desc).unwrap_or_default(),
+                    );
+                }
+                let accept_broker = broker.clone();
+                std::thread::spawn(move || {
+                    for conn in listener.incoming().flatten() {
+                        let b = accept_broker.clone();
+                        let a = app.clone();
+                        std::thread::spawn(move || handle_conn(conn, b, a));
+                    }
+                });
+            }
+        }
+        Err(_) => { /* inert broker; HITL never fires, gateways fail-closed */ }
+    }
+    broker
+}
+
+/// Serve one gateway connection: read the request, authenticate it, park it for a human
+/// decision (or a fail-closed timeout), and write the decision back.
+fn handle_conn(stream: TcpStream, broker: ApprovalBroker, app: AppHandle) {
+    // Read the request promptly; a slow/stalled sender must not tie up a thread.
+    let _ = stream.set_read_timeout(Some(Duration::from_secs(10)));
+    let reader_stream = match stream.try_clone() {
+        Ok(s) => s,
+        Err(_) => return,
+    };
+    let mut line = String::new();
+    if BufReader::new(reader_stream).read_line(&mut line).is_err() {
+        return;
+    }
+    let req: ApprovalRequest = match serde_json::from_str(line.trim()) {
+        Ok(r) => r,
+        Err(_) => return,
+    };
+
+    let mut out = stream;
+    let deny = |out: &mut TcpStream| {
+        let _ = out.set_write_timeout(Some(Duration::from_secs(10)));
+        let _ = writeln!(
+            out,
+            "{}",
+            serde_json::to_string(&ApprovalDecision::Denied).unwrap_or_default()
+        );
+    };
+
+    // Authenticate: only a process holding our token may register an approval.
+    if req.token.is_empty() || req.token != broker.inner.token {
+        deny(&mut out);
+        return;
+    }
+
+    let view = PendingView {
+        id: req.id.clone(),
+        client: req.client.clone(),
+        server: req.server.clone(),
+        tool: req.tool.clone(),
+        reason: req.reason,
+        arguments: req.arguments.clone(),
+    };
+    let (tx, rx) = channel::<ApprovalDecision>();
+    {
+        let mut pending = broker
+            .inner
+            .pending
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner);
+        if pending.len() >= MAX_PENDING {
+            drop(pending);
+            deny(&mut out);
+            return;
+        }
+        pending.insert(
+            req.id.clone(),
+            Waiter {
+                view: view.clone(),
+                decide: tx,
+            },
+        );
+    }
+
+    // Surface it to the UI (best-effort; the poll-based list() is the source of truth).
+    let _ = app.emit("approval-pending", &view);
+
+    // Block for the human decision or the fail-closed timeout.
+    let decision = rx
+        .recv_timeout(Duration::from_secs(DEFAULT_TIMEOUT_SECS))
+        .unwrap_or(ApprovalDecision::Timeout);
+    // Ensure it's gone (timeout path leaves it; decide() already removed it).
+    broker
+        .inner
+        .pending
+        .lock()
+        .unwrap_or_else(PoisonError::into_inner)
+        .remove(&req.id);
+    let _ = app.emit("approval-resolved", &req.id);
+
+    let _ = out.set_write_timeout(Some(Duration::from_secs(10)));
+    let _ = writeln!(
+        out,
+        "{}",
+        serde_json::to_string(&decision).unwrap_or_else(|_| "\"timeout\"".into())
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn broker() -> ApprovalBroker {
+        ApprovalBroker {
+            inner: Arc::new(Inner {
+                token: "tok".into(),
+                pending: Mutex::new(HashMap::new()),
+            }),
+        }
+    }
+
+    fn park(b: &ApprovalBroker, id: &str) -> std::sync::mpsc::Receiver<ApprovalDecision> {
+        let (tx, rx) = channel();
+        let view = PendingView {
+            id: id.into(),
+            client: None,
+            server: "s".into(),
+            tool: "drop".into(),
+            reason: ApprovalReason::Destructive,
+            arguments: serde_json::json!({}),
+        };
+        b.inner
+            .pending
+            .lock()
+            .unwrap()
+            .insert(id.into(), Waiter { view, decide: tx });
+        rx
+    }
+
+    #[test]
+    fn approve_delivers_then_removes() {
+        let b = broker();
+        let rx = park(&b, "x");
+        assert_eq!(b.list().len(), 1);
+        b.decide("x", true).unwrap();
+        assert_eq!(
+            rx.recv_timeout(Duration::from_secs(1)).unwrap(),
+            ApprovalDecision::Approved
+        );
+        assert!(b.list().is_empty(), "resolved entry should be gone");
+    }
+
+    #[test]
+    fn deny_delivers_denied() {
+        let b = broker();
+        let rx = park(&b, "y");
+        b.decide("y", false).unwrap();
+        assert_eq!(
+            rx.recv_timeout(Duration::from_secs(1)).unwrap(),
+            ApprovalDecision::Denied
+        );
+    }
+
+    #[test]
+    fn unknown_id_errs() {
+        assert!(broker().decide("nope", true).is_err());
+    }
+}

--- a/src-tauri/src/bin/conduit-gateway.rs
+++ b/src-tauri/src/bin/conduit-gateway.rs
@@ -34,6 +34,7 @@ use conduit_lib::integrity;
 use conduit_lib::registry::{self, Registry, ServerEntry};
 use conduit_lib::remote;
 use conduit_lib::router::{is_destructive, sanitize_segment, Router, ToolPolicy};
+use conduit_lib::approval;
 use conduit_lib::savings;
 use conduit_lib::secrets;
 use conduit_lib::semantic;
@@ -1205,6 +1206,56 @@ fn http_client_label(reg: &Registry, provided: Option<&str>) -> Option<String> {
 }
 
 #[allow(clippy::too_many_arguments)]
+/// A fresh 128-bit correlation id for an approval request (same CSPRNG-or-die policy
+/// as the confirm token: a randomness failure on a security gate is fatal, not papered).
+fn new_correlation_id() -> String {
+    let mut buf = [0u8; 16];
+    getrandom::getrandom(&mut buf).expect("CSPRNG unavailable");
+    buf.iter().map(|b| format!("{b:02x}")).collect()
+}
+
+/// Read the approval-broker endpoint the Toolport app publishes into the data dir.
+/// `None` when it is absent/unreadable (the app is not running) - a fail-closed signal.
+fn read_endpoint_descriptor() -> Option<approval::EndpointDescriptor> {
+    let dir = conduit_lib::registry::conduit_dir()?;
+    let raw = std::fs::read_to_string(dir.join(approval::ENDPOINT_FILE)).ok()?;
+    serde_json::from_str(&raw).ok()
+}
+
+/// Ask the app broker for a human decision on `req`. FAIL-CLOSED: a missing endpoint, a
+/// failed connect, any I/O error, or a read timeout all return `Timeout` (a deny). The
+/// arguments travel over the socket and never touch disk. Transport is loopback TCP +
+/// token for now; hardening to an OS-permissioned named-pipe / uds is a follow-up.
+fn decide_via_broker(
+    desc: Option<approval::EndpointDescriptor>,
+    req: &mut approval::ApprovalRequest,
+) -> approval::ApprovalDecision {
+    use std::io::{BufRead, BufReader, Write};
+    use std::net::TcpStream;
+    let deny = approval::ApprovalDecision::Timeout;
+    let Some(desc) = desc else { return deny };
+    req.token = desc.token.clone();
+    let Ok(mut stream) = TcpStream::connect(&desc.endpoint) else { return deny };
+    let _ = stream.set_write_timeout(Some(Duration::from_secs(10)));
+    let _ = stream.set_read_timeout(Some(Duration::from_secs(approval::DEFAULT_TIMEOUT_SECS)));
+    let Ok(line) = serde_json::to_string(req) else { return deny };
+    if stream.write_all(line.as_bytes()).is_err() || stream.write_all(b"\n").is_err() {
+        return deny;
+    }
+    let _ = stream.flush();
+    let mut resp = String::new();
+    if BufReader::new(stream).read_line(&mut resp).is_err() || resp.trim().is_empty() {
+        return deny;
+    }
+    serde_json::from_str::<approval::ApprovalDecision>(resp.trim()).unwrap_or(deny)
+}
+
+/// Hold a gated tool call until a human decides via the Toolport app (or it fails closed).
+fn request_human_decision(mut req: approval::ApprovalRequest) -> approval::ApprovalDecision {
+    let desc = read_endpoint_descriptor();
+    decide_via_broker(desc, &mut req)
+}
+
 fn handle_request(
     req: &Value,
     reg: &Registry,
@@ -1594,6 +1645,62 @@ fn handle_request(
                     id,
                     json!({ "content": [{ "type": "text", "text": msg }], "isError": true }),
                 ));
+            }
+
+            // Human-in-the-loop approval: hold a gated call (destructive, or from an
+            // untrusted-provenance server) until a person approves it in the Toolport app.
+            // Takes precedence over the agent-facing confirm below, and is fail-closed
+            // (no broker / no answer / timeout all deny). Skipped once `confirmed`.
+            if reg.human_approval && !confirmed {
+                let agg;
+                let catalog: &[Value] = if cached.is_empty() {
+                    agg = router.aggregated_tools();
+                    &agg
+                } else {
+                    cached
+                };
+                let is_dest = catalog.iter().any(|t| {
+                    t.get("name").and_then(|n| n.as_str()) == Some(name) && is_destructive(t)
+                });
+                // Untrusted provenance = the same shared/registry signal the SSRF guard
+                // uses. Match the server the way its tools are prefixed (sanitized id).
+                let untrusted = reg
+                    .servers
+                    .iter()
+                    .find(|s| sanitize_segment(&s.id) == srv)
+                    .map(|s| matches!(s.source.as_deref(), Some("shared") | Some("registry")))
+                    .unwrap_or(false);
+                if let Some(reason) = approval::gate_reason(true, is_dest, untrusted) {
+                    let decision = request_human_decision(approval::ApprovalRequest {
+                        token: String::new(),
+                        id: new_correlation_id(),
+                        client: router.current_client().map(str::to_string),
+                        server: srv.to_string(),
+                        tool: tool.to_string(),
+                        reason,
+                        arguments: arguments.clone(),
+                    });
+                    if !decision.is_approved() {
+                        let why = if decision == approval::ApprovalDecision::Denied {
+                            "was denied by a human reviewer"
+                        } else {
+                            "was not approved in time (the Toolport app may be closed)"
+                        };
+                        audit::record_held(srv, tool, router.current_client());
+                        return Some(success(
+                            id,
+                            json!({
+                                "content": [{ "type": "text", "text": format!(
+                                    "Toolport: the call to {name} {why}, so it did not run. \
+                                     Ask the user to approve it in the Toolport app, then retry."
+                                ) }],
+                                "isError": true
+                            }),
+                        ));
+                    }
+                    // A human approved: skip the agent-confirm step and route the call.
+                    confirmed = true;
+                }
             }
 
             // Per-call confirmation for destructive tools: intercept the first
@@ -3035,6 +3142,32 @@ fn main() {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The security-critical guarantee: the human-approval broker denies (never
+    /// approves) when it cannot reach a live approver - no endpoint published (app
+    /// closed) or a connection that refuses. Fail-closed is the whole point.
+    #[test]
+    fn approval_broker_fails_closed() {
+        let mk = || approval::ApprovalRequest {
+            token: String::new(),
+            id: "id".into(),
+            client: None,
+            server: "db".into(),
+            tool: "drop".into(),
+            reason: approval::ApprovalReason::Destructive,
+            arguments: serde_json::json!({}),
+        };
+        // No endpoint descriptor (Toolport app not running) -> deny.
+        let mut r = mk();
+        assert!(!decide_via_broker(None, &mut r).is_approved());
+        // A published endpoint that refuses the connection -> deny.
+        let mut r = mk();
+        let bad = Some(approval::EndpointDescriptor {
+            endpoint: "127.0.0.1:1".into(),
+            token: "t".into(),
+        });
+        assert!(!decide_via_broker(bad, &mut r).is_approved());
+    }
 
     fn router() -> Router {
         Router::new()

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3,6 +3,7 @@ use std::sync::Mutex;
 use tauri::{Emitter, Manager, State};
 
 pub mod approval;
+mod approval_broker;
 pub mod audit;
 pub mod catalog;
 pub mod clients;
@@ -821,6 +822,37 @@ fn set_confirm_destructive(state: State<RegistryState>, confirm: bool) -> Result
     reg.set_confirm_destructive(confirm);
     registry::save(&reg)?;
     Ok(reg.clone())
+}
+
+/// Toggle human-in-the-loop approval. When on, a gated tool call (destructive, or from an
+/// untrusted-provenance server) is HELD until a person approves or denies it in the app,
+/// via the approval broker. Distinct from confirm-destructive (which the agent re-confirms).
+#[tauri::command]
+fn set_human_approval(state: State<RegistryState>, on: bool) -> Result<Registry, String> {
+    let mut reg = state.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+    reg.set_human_approval(on);
+    registry::save(&reg)?;
+    Ok(reg.clone())
+}
+
+/// The tool calls currently held awaiting a human decision (for the Pending Approvals UI).
+/// Polled by the frontend; the `approval-pending` / `approval-resolved` events prompt a refresh.
+#[tauri::command]
+fn list_pending_approvals(
+    broker: State<approval_broker::ApprovalBroker>,
+) -> Vec<approval_broker::PendingView> {
+    broker.list()
+}
+
+/// Approve or deny a held tool call by id. The parked gateway call then runs (approve) or is
+/// refused (deny). `Err` if the id is unknown (already resolved or timed out).
+#[tauri::command]
+fn decide_approval(
+    broker: State<approval_broker::ApprovalBroker>,
+    id: String,
+    approved: bool,
+) -> Result<(), String> {
+    broker.decide(&id, approved)
 }
 
 /// Toggle live request/response inspection. When enabled, the gateway captures each
@@ -1663,6 +1695,9 @@ pub fn run() {
             set_tool_enabled,
             set_deny_destructive,
             set_confirm_destructive,
+            set_human_approval,
+            list_pending_approvals,
+            decide_approval,
             set_live_inspect,
             get_inspect_log,
             clear_inspect_log,
@@ -1702,6 +1737,12 @@ pub fn run() {
             // the gateway) back into the app and the UI, in a background thread.
             let handle = app.handle().clone();
             std::thread::spawn(move || watch_registry_for_app(handle));
+
+            // Start the human-approval broker: it publishes a loopback endpoint that every
+            // gateway process dials into, and holds gated tool calls until the user approves
+            // or denies them here. Always managed so the approve/deny commands have state.
+            let broker = approval_broker::start(app.handle().clone());
+            app.manage(broker);
 
             // conduit://import?s=<id> deep links open the shared-stack import.
             // The installer registers the scheme; we also register at runtime so

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2,6 +2,7 @@ use std::sync::Mutex;
 
 use tauri::{Emitter, Manager, State};
 
+pub mod approval;
 pub mod audit;
 pub mod catalog;
 pub mod clients;

--- a/src-tauri/src/registry.rs
+++ b/src-tauri/src/registry.rs
@@ -139,6 +139,14 @@ pub struct Registry {
     /// of every call first.
     #[serde(default)]
     pub confirm_destructive: bool,
+    /// Human-in-the-loop approval: when true, a *gated* tool call (destructive-hinted, or
+    /// from an untrusted-provenance server) is held and surfaced to the Toolport app for a
+    /// person to approve or deny before it runs. Unlike `confirm_destructive` (which the
+    /// AGENT re-confirms with a token), this puts a HUMAN in the loop: the call blocks until
+    /// a decision or a fail-closed timeout. Off by default. Takes precedence over
+    /// `confirm_destructive` for the tools it gates (a human decision supersedes the agent's).
+    #[serde(default)]
+    pub human_approval: bool,
     /// Quarantine-on-drift: when true, a high-risk tool (poisoned definition, or a
     /// destructive tool whose definition changed/appeared) that drifts from its pinned
     /// baseline is hidden and blocked from every client until the user re-approves it.
@@ -271,6 +279,7 @@ impl Default for Registry {
             active_profile_id: Some(DEFAULT_PROFILE_ID.to_string()),
             deny_destructive: false,
             confirm_destructive: false,
+            human_approval: false,
             quarantine_on_drift: false,
             lazy_discovery: true,
             allow_agent_control: false,
@@ -454,6 +463,13 @@ impl Registry {
         if confirm {
             self.deny_destructive = false;
         }
+    }
+
+    /// Turn human-in-the-loop approval on or off. Independent of deny/confirm: `deny`
+    /// hides tools, `confirm` has the agent re-confirm, `human_approval` holds the call
+    /// for a person. When it gates a tool it takes precedence over `confirm_destructive`.
+    pub fn set_human_approval(&mut self, on: bool) {
+        self.human_approval = on;
     }
 
     /// Set lazy discovery mode (gateway exposes meta-tools vs the full catalog).

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -47,6 +47,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { AppSidebar } from "@/components/AppSidebar";
+import { PendingApprovals } from "@/components/PendingApprovals";
 import { RegistryServerRow } from "@/components/RegistryServerRow";
 import { ServerDialog } from "@/components/ServerDialog";
 
@@ -599,6 +600,7 @@ function App() {
         />
         </Suspense>
       )}
+      <PendingApprovals />
       <Toaster position="bottom-right" />
     </TooltipProvider>
   );

--- a/src/components/PendingApprovals.tsx
+++ b/src/components/PendingApprovals.tsx
@@ -1,0 +1,108 @@
+import { useCallback, useEffect, useState } from "react";
+import { listen } from "@tauri-apps/api/event";
+import { Check, ShieldAlert, X } from "lucide-react";
+import { decideApproval, listPendingApprovals } from "@/lib/api";
+import type { PendingApproval } from "@/lib/types";
+import { toastError } from "@/lib/toast";
+
+const REASON_LABEL: Record<PendingApproval["reason"], string> = {
+  destructive: "destructive",
+  untrusted_source: "untrusted source",
+  destructive_and_untrusted: "destructive · untrusted source",
+};
+
+/**
+ * The human-in-the-loop approval queue: tool calls the gateway is holding until you
+ * approve or deny them. Blocking, so it is mounted globally (visible from any view) and
+ * renders nothing when the queue is empty. It polls as a safety net and refreshes
+ * immediately on the gateway's `approval-pending` / `approval-resolved` events.
+ */
+export function PendingApprovals() {
+  const [pending, setPending] = useState<PendingApproval[]>([]);
+  const [busy, setBusy] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    try {
+      setPending(await listPendingApprovals());
+    } catch {
+      // Broker not up yet / transient — keep the current list rather than flashing empty.
+    }
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+    const poll = setInterval(() => void refresh(), 2000);
+    const unlisten = Promise.all([
+      listen("approval-pending", () => void refresh()),
+      listen("approval-resolved", () => void refresh()),
+    ]);
+    return () => {
+      clearInterval(poll);
+      void unlisten.then((fns) => fns.forEach((f) => f()));
+    };
+  }, [refresh]);
+
+  const decide = async (id: string, approved: boolean) => {
+    setBusy(id);
+    try {
+      await decideApproval(id, approved);
+      setPending((p) => p.filter((x) => x.id !== id));
+    } catch (e) {
+      toastError(`Couldn't record your decision: ${e}`);
+      void refresh();
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  if (pending.length === 0) return null;
+
+  return (
+    <div className="fixed inset-x-0 top-0 z-50 flex justify-center px-4 pt-3">
+      <div className="w-full max-w-2xl rounded-lg border border-warning/50 bg-background/95 p-4 shadow-lg backdrop-blur">
+        <div className="mb-3 flex items-center gap-2 text-sm font-semibold text-warning">
+          <ShieldAlert className="h-4 w-4" />
+          {pending.length} tool call{pending.length > 1 ? "s" : ""} awaiting your approval
+        </div>
+        <ul className="space-y-2">
+          {pending.map((a) => (
+            <li key={a.id} className="rounded-md border border-border bg-card p-3">
+              <div className="flex items-start justify-between gap-3">
+                <div className="min-w-0">
+                  <div className="truncate font-mono text-sm">
+                    {a.server}
+                    <span className="text-muted-foreground"> · </span>
+                    {a.tool}
+                  </div>
+                  <div className="mt-0.5 text-xs text-muted-foreground">
+                    {a.client ? `${a.client} · ` : ""}
+                    {REASON_LABEL[a.reason]}
+                  </div>
+                  <pre className="mt-2 max-h-32 overflow-auto rounded bg-muted p-2 text-xs">
+                    {JSON.stringify(a.arguments, null, 2)}
+                  </pre>
+                </div>
+                <div className="flex shrink-0 gap-2">
+                  <button
+                    disabled={busy === a.id}
+                    onClick={() => void decide(a.id, true)}
+                    className="inline-flex items-center gap-1 rounded-md bg-info px-3 py-1.5 text-xs font-medium text-white disabled:opacity-50"
+                  >
+                    <Check className="h-3.5 w-3.5" /> Approve
+                  </button>
+                  <button
+                    disabled={busy === a.id}
+                    onClick={() => void decide(a.id, false)}
+                    className="inline-flex items-center gap-1 rounded-md border border-border px-3 py-1.5 text-xs font-medium disabled:opacity-50"
+                  >
+                    <X className="h-3.5 w-3.5" /> Deny
+                  </button>
+                </div>
+              </div>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/src/components/SettingsView.tsx
+++ b/src/components/SettingsView.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { Activity, Bot, Check, Copy, Globe, Layers, ShieldAlert, ShieldCheck, ShieldX, Trash2, X } from "lucide-react";
+import { Activity, Bot, Check, Copy, Globe, Layers, ShieldAlert, ShieldCheck, ShieldX, Trash2, UserCheck, X } from "lucide-react";
 import { toastError } from "@/lib/toast";
 import {
   addHttpClient,
@@ -11,6 +11,7 @@ import {
   setAllowAgentControl,
   setConfirmDestructive,
   setDenyDestructive,
+  setHumanApproval,
   setLazyDiscovery,
   setLiveInspect,
   setQuarantineOnDrift,
@@ -40,6 +41,7 @@ export function SettingsView({ registry, onRegistryChange }: Props) {
   const lazyDiscovery = registry?.lazyDiscovery ?? true;
   const denyDestructive = registry?.denyDestructive ?? false;
   const confirmDestructive = registry?.confirmDestructive ?? false;
+  const humanApproval = registry?.humanApproval ?? false;
   const allowAgentControl = registry?.allowAgentControl ?? false;
   const quarantineOnDrift = registry?.quarantineOnDrift ?? false;
   const liveInspect = registry?.liveInspect ?? false;
@@ -202,6 +204,14 @@ export function SettingsView({ registry, onRegistryChange }: Props) {
           "Confirm destructive tools",
           "Hold each destructive call for the agent to confirm before it runs",
           apply(setConfirmDestructive),
+        )}
+        {toggle(
+          UserCheck,
+          humanApproval,
+          "text-info",
+          "Require human approval",
+          "Hold destructive or untrusted-server calls until you approve them in the app",
+          apply(setHumanApproval),
         )}
         {toggle(
           ShieldX,

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -12,6 +12,7 @@ import type {
   McpTool,
   MigrateResult,
   ParsedSnippetServer,
+  PendingApproval,
   ProbeResult,
   Registry,
   SavingsSummary,
@@ -162,6 +163,22 @@ export function setDenyDestructive(deny: boolean): Promise<Registry> {
 /** Toggle per-call confirmation for destructive tools (intercept + preview + token). */
 export function setConfirmDestructive(confirm: boolean): Promise<Registry> {
   return invoke<Registry>("set_confirm_destructive", { confirm });
+}
+
+/** Toggle human-in-the-loop approval: hold a gated tool call (destructive, or from an
+ * untrusted-provenance server) until a person approves or denies it in the app. */
+export function setHumanApproval(on: boolean): Promise<Registry> {
+  return invoke<Registry>("set_human_approval", { on });
+}
+
+/** Tool calls currently held awaiting a human decision (the approval queue). */
+export function listPendingApprovals(): Promise<PendingApproval[]> {
+  return invoke<PendingApproval[]>("list_pending_approvals");
+}
+
+/** Approve or deny a held tool call by id; the parked gateway call then runs or is refused. */
+export function decideApproval(id: string, approved: boolean): Promise<void> {
+  return invoke<void>("decide_approval", { id, approved });
 }
 
 /** Toggle live request/response inspection (opt-in, off by default). When on, the

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -299,6 +299,16 @@ export interface Profile {
   enabledServerIds: string[];
 }
 
+/** A tool call held awaiting a human decision (the HITL approval queue). */
+export interface PendingApproval {
+  id: string;
+  client: string | null;
+  server: string;
+  tool: string;
+  reason: "destructive" | "untrusted_source" | "destructive_and_untrusted";
+  arguments: unknown;
+}
+
 export interface Registry {
   version: number;
   servers: ServerEntry[];
@@ -308,6 +318,8 @@ export interface Registry {
   denyDestructive?: boolean;
   /** Per-call confirmation: intercept destructive tools with a preview + token. */
   confirmDestructive?: boolean;
+  /** Human-in-the-loop: hold a gated tool call until a person approves it in the app. */
+  humanApproval?: boolean;
   /** Live request/response inspection: capture each tool call's args + result into a
    * small, separate, ephemeral local ring (last 50 calls) for the Activity inspector.
    * Off by default; never touches the audit log. */


### PR DESCRIPTION
Adds a **human-in-the-loop approval gate**: when enabled, a sensitive tool call is held until a person approves or denies it in the Toolport app. Distinct from the existing agent-facing `toolport_confirm` (where the model re-confirms its own call with a token), this puts a real person in the loop.

Off by default (`humanApproval` flag), so it is inert until a user turns it on.

## Architecture
Design doc: `docs/design/hitl-approval-queue.md`.

There is not one gateway but many (one `conduit-gateway` per stdio client, plus the app's `--http` bridge), each with its own in-memory state, sharing only `~/.conduit/`. So the app hosts an **approval broker**; every gateway process dials OUT to it and blocks reading for the decision. This was chosen over a file-handshake (which would put tool arguments on disk) and a per-gateway HTTP endpoint (which would miss the stdio clients).

- Arguments travel over the socket and never touch disk (only the endpoint descriptor does).
- **Fail-closed by construction:** no broker, a timeout, a dropped connection, or a bad token all deny.
- Gates destructive-hinted tools AND anything from an untrusted-provenance server (the same shared/registry signal the SSRF guard uses).

## What's here (4 slices)
- **Gateway gate + broker client** (`approval.rs` shared contract, `conduit-gateway.rs` interception): holds a gated call, dials the broker, denies on any non-approval. Precedence over `confirm_destructive`.
- **App broker** (`approval_broker.rs`): binds a loopback port, publishes `approval-endpoint.json`, token-authenticates, parks each connection until a human decides or a 120s fail-closed timeout, caps the pending queue.
- **Commands + events**: `set_human_approval` / `list_pending_approvals` / `decide_approval`; emits `approval-pending` / `approval-resolved`.
- **Frontend**: a Settings toggle and a global approve/deny overlay (mounted app-wide because the call blocks and must be actionable from any view).

## Testing
Full Rust workspace compiles (lib + both bins). 222 lib tests + the gateway fail-closed test green. `tsc --noEmit` clean.

## Not yet done (before merge)
- **Runtime end-to-end**: run the app, enable the toggle, have a client call a destructive tool, confirm the overlay appears and Approve/Deny routes correctly.

## Follow-ups (P2, tracked in the design doc)
- The 120s block can exceed a client's own tool-call timeout; add a "held, will resume" async fallback and dedupe by tool+args hash to avoid a slow-approve-then-retry double-run.
- Harden the transport from loopback TCP + token to an OS-permissioned named-pipe / uds.