### PR TITLE
feat(hitl): notify on held calls + approval-UI polish + branding cleanup

### DIFF
--- a/src-tauri/.cargo/audit.toml
+++ b/src-tauri/.cargo/audit.toml
@@ -11,4 +11,14 @@ ignore = [
     # Tracked in README "Known issues". Remove when Tauri's Linux stack adopts a
     # glib-0.20 base.
     "RUSTSEC-2024-0429",
+    # quick-xml DoS advisories (quadratic parse / unbounded namespace allocation on
+    # malicious XML input). quick-xml 0.39.4 is pulled in transitively by `plist`
+    # (via tauri-utils/tauri) and is used ONLY to parse the app's own bundle
+    # Info.plist at build/bundle time - trusted, first-party input, never
+    # attacker-controlled network data - so the denial-of-service vectors are not
+    # reachable in our usage. The fix needs quick-xml >=0.41, which the pinned
+    # `plist`/tauri-utils stack does not allow without moving the whole Tauri stack.
+    # Remove when that stack adopts quick-xml 0.41+.
+    "RUSTSEC-2026-0194",
+    "RUSTSEC-2026-0195",
 ]

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -607,6 +607,7 @@ dependencies = [
  "tauri-build",
  "tauri-plugin-deep-link",
  "tauri-plugin-dialog",
+ "tauri-plugin-notification",
  "tauri-plugin-opener",
  "tauri-plugin-process",
  "tauri-plugin-single-instance",
@@ -743,7 +744,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
- "rand_core",
+ "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -2276,6 +2277,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
 
 [[package]]
+name = "mac-notification-sys"
+version = "0.6.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd604973958ddcc11b561193c0fb96ba146506ef2f231ef2e7c35fd2cbc9beca"
+dependencies = [
+ "cc",
+ "log",
+ "objc2",
+ "objc2-foundation",
+ "time",
+ "uuid",
+]
+
+[[package]]
 name = "markup5ever"
 version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2396,6 +2411,20 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "memoffset",
+]
+
+[[package]]
+name = "notify-rust"
+version = "4.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5b4c1b4f2aa9f25f63a7a49d3dd0ed567b3670da15330a66b29434be899b891"
+dependencies = [
+ "futures-lite",
+ "log",
+ "mac-notification-sys",
+ "serde",
+ "tauri-winrt-notification",
+ "zbus 5.16.0",
 ]
 
 [[package]]
@@ -3155,8 +3184,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -3166,7 +3205,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -3176,6 +3225,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -3553,7 +3611,7 @@ dependencies = [
  "hkdf",
  "num",
  "once_cell",
- "rand",
+ "rand 0.8.6",
  "serde",
  "sha2",
  "zbus 4.4.0",
@@ -4305,6 +4363,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-notification"
+version = "2.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01fc2c5ff41105bd1f7242d8201fdf3efd70749b82fa013a17f2126357d194cc"
+dependencies = [
+ "log",
+ "notify-rust",
+ "rand 0.9.4",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
+ "time",
+ "url",
+]
+
+[[package]]
 name = "tauri-plugin-opener"
 version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4483,6 +4560,17 @@ dependencies = [
  "dunce",
  "embed-resource",
  "toml 1.1.2+spec-1.1.0",
+]
+
+[[package]]
+name = "tauri-winrt-notification"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed071c670382e85fc2f48ae706492d8c338f4f89bf72520d32f8abfe880aade"
+dependencies = [
+ "thiserror 2.0.18",
+ "windows",
+ "windows-version",
 ]
 
 [[package]]
@@ -6008,7 +6096,7 @@ dependencies = [
  "hex",
  "nix",
  "ordered-stream",
- "rand",
+ "rand 0.8.6",
  "serde",
  "serde_repr",
  "sha1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -24,6 +24,7 @@ tauri-plugin-opener = "2"
 tauri-plugin-updater = "2"
 tauri-plugin-process = "2"
 tauri-plugin-dialog = "2"
+tauri-plugin-notification = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 json5 = "0.4"

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -10,6 +10,7 @@
     "process:allow-restart",
     "dialog:allow-save",
     "dialog:allow-open",
-    "deep-link:default"
+    "deep-link:default",
+    "notification:default"
   ]
 }

--- a/src-tauri/src/approval_broker.rs
+++ b/src-tauri/src/approval_broker.rs
@@ -20,7 +20,8 @@ use std::sync::{Arc, Mutex, PoisonError};
 use std::time::Duration;
 
 use serde::Serialize;
-use tauri::{AppHandle, Emitter};
+use tauri::{AppHandle, Emitter, Manager};
+use tauri_plugin_notification::NotificationExt;
 
 use crate::approval::{
     ApprovalDecision, ApprovalReason, ApprovalRequest, EndpointDescriptor, DEFAULT_TIMEOUT_SECS,
@@ -212,6 +213,10 @@ fn handle_conn(stream: TcpStream, broker: ApprovalBroker, app: AppHandle) {
 
     // Surface it to the UI (best-effort; the poll-based list() is the source of truth).
     let _ = app.emit("approval-pending", &view);
+    // The call BLOCKS and auto-denies on timeout, so a person who isn't looking at the
+    // (often backgrounded) app would silently miss it. Raise an OS notification and flash
+    // the taskbar so the pending decision is noticed while there's still time to make it.
+    notify_pending(&app, &view);
 
     // Block for the human decision or the fail-closed timeout.
     let decision = rx
@@ -232,6 +237,23 @@ fn handle_conn(stream: TcpStream, broker: ApprovalBroker, app: AppHandle) {
         "{}",
         serde_json::to_string(&decision).unwrap_or_else(|_| "\"timeout\"".into())
     );
+}
+
+/// Notify the human that a call is held: an OS notification plus a taskbar-attention
+/// flash on the main window. Best-effort and non-blocking - if either fails (permission
+/// off, no window) the in-app overlay is still the source of truth. We flash rather than
+/// force-focus so we don't yank the user out of what they're doing.
+fn notify_pending(app: &AppHandle, view: &PendingView) {
+    let who = view.client.as_deref().map(|c| format!("{c} wants to run ")).unwrap_or_default();
+    let _ = app
+        .notification()
+        .builder()
+        .title("Toolport: approval required")
+        .body(format!("{who}{}/{} - approve or deny it in Toolport.", view.server, view.tool))
+        .show();
+    if let Some(win) = app.get_webview_window("main") {
+        let _ = win.request_user_attention(Some(tauri::UserAttentionType::Critical));
+    }
 }
 
 #[cfg(test)]

--- a/src-tauri/src/bin/conduit-gateway.rs
+++ b/src-tauri/src/bin/conduit-gateway.rs
@@ -13,8 +13,8 @@
 //! - Watches the registry file and emits `notifications/tools/list_changed` on
 //!   change, so enabling/disabling a server applies live without a client restart
 //!   (on clients that honor it).
-//! - Lazy discovery: in lazy mode it advertises only 3 meta-tools (`toolport_status`,
-//!   `toolport_search_tools`, `toolport_call_tool`) instead of the full catalog; the
+//! - Lazy discovery: in lazy mode it advertises only a handful of meta-tools (`toolport_status`,
+//!   `toolport_search_tools`, `toolport_call_tool`, `toolport_fetch_result`) instead of the full catalog; the
 //!   model searches and calls on demand, keeping context flat.
 //! - Records every tool call to a local audit log.
 
@@ -882,9 +882,9 @@ fn savings_line() -> String {
         fmt_tokens(saved),
         dollars
     );
-    if peak > 3 {
+    if peak > 4 {
         line.push_str(&format!(
-            "; the biggest catalog collapsed {peak} tools to 3"
+            "; the biggest catalog collapsed {peak} tools down to a handful of meta-tools"
         ));
     }
     line.push_str(".\n");
@@ -1318,7 +1318,7 @@ fn handle_request(
                 }
                 // Record what lazy discovery kept out of the client's context: the
                 // full catalog we'd otherwise serve (status + every downstream tool)
-                // minus these 3 meta-tools. Estimating over the cached slice avoids
+                // minus these meta-tools. Estimating over the cached slice avoids
                 // cloning the whole catalog on a serve.
                 let agg;
                 let catalog: &[Value] = if cached.is_empty() {

--- a/src-tauri/src/bin/conduit-gateway.rs
+++ b/src-tauri/src/bin/conduit-gateway.rs
@@ -13,7 +13,7 @@
 //! - Watches the registry file and emits `notifications/tools/list_changed` on
 //!   change, so enabling/disabling a server applies live without a client restart
 //!   (on clients that honor it).
-//! - Lazy discovery: in lazy mode it advertises only a handful of meta-tools (`toolport_status`,
+//! - Lazy discovery: in lazy mode it advertises only 4 meta-tools (`toolport_status`,
 //!   `toolport_search_tools`, `toolport_call_tool`, `toolport_fetch_result`) instead of the full catalog; the
 //!   model searches and calls on demand, keeping context flat.
 //! - Records every tool call to a local audit log.
@@ -1318,7 +1318,7 @@ fn handle_request(
                 }
                 // Record what lazy discovery kept out of the client's context: the
                 // full catalog we'd otherwise serve (status + every downstream tool)
-                // minus these meta-tools. Estimating over the cached slice avoids
+                // minus these 4 meta-tools. Estimating over the cached slice avoids
                 // cloning the whole catalog on a serve.
                 let agg;
                 let catalog: &[Value] = if cached.is_empty() {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1655,6 +1655,7 @@ pub fn run() {
         .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(tauri_plugin_process::init())
         .plugin(tauri_plugin_dialog::init())
+        .plugin(tauri_plugin_notification::init())
         .manage(Mutex::new(registry))
         .manage(Mutex::new(HttpBridge::default()))
         .manage(PendingShare::default())

--- a/src-tauri/src/registry.rs
+++ b/src-tauri/src/registry.rs
@@ -153,7 +153,7 @@ pub struct Registry {
     /// Opt-in, since blocking a tool is more disruptive than just flagging the drift.
     #[serde(default)]
     pub quarantine_on_drift: bool,
-    /// Lazy discovery: the gateway exposes 3 meta-tools (status/search/call)
+    /// Lazy discovery: the gateway exposes a few meta-tools (status/search/call/fetch)
     /// instead of every downstream tool, so clients with tool-count limits don't
     /// drop tools. The gateway reads this from the registry file it already
     /// loads, so it applies to EVERY client regardless of whether the client

--- a/src-tauri/src/registry.rs
+++ b/src-tauri/src/registry.rs
@@ -153,7 +153,7 @@ pub struct Registry {
     /// Opt-in, since blocking a tool is more disruptive than just flagging the drift.
     #[serde(default)]
     pub quarantine_on_drift: bool,
-    /// Lazy discovery: the gateway exposes a few meta-tools (status/search/call/fetch)
+    /// Lazy discovery: the gateway exposes 4 meta-tools (status/search/call/fetch)
     /// instead of every downstream tool, so clients with tool-count limits don't
     /// drop tools. The gateway reads this from the registry file it already
     /// loads, so it applies to EVERY client regardless of whether the client

--- a/src-tauri/src/savings.rs
+++ b/src-tauri/src/savings.rs
@@ -1,6 +1,6 @@
 //! Lazy-discovery savings counter.
 //!
-//! Every time the gateway serves a lazy `tools/list` it advertises 3 meta-tools
+//! Every time the gateway serves a lazy `tools/list` it advertises a few meta-tools
 //! instead of the full catalog. The difference, the tool-definition tokens kept
 //! out of the client's context, is appended here as one JSON line. The app sums
 //! the log into the in-app "tokens saved" counter.

--- a/src-tauri/src/savings.rs
+++ b/src-tauri/src/savings.rs
@@ -1,6 +1,6 @@
 //! Lazy-discovery savings counter.
 //!
-//! Every time the gateway serves a lazy `tools/list` it advertises a few meta-tools
+//! Every time the gateway serves a lazy `tools/list` it advertises 4 meta-tools
 //! instead of the full catalog. The difference, the tool-definition tokens kept
 //! out of the client's context, is appended here as one JSON line. The app sums
 //! the log into the in-app "tokens saved" counter.

--- a/src/components/ActivityView.tsx
+++ b/src/components/ActivityView.tsx
@@ -271,8 +271,8 @@ function SavingsBanner({ savings }: { savings: SavingsSummary }) {
       : null;
   const details = [
     `across ${savings.listLoads.toLocaleString()} tool-list load${savings.listLoads === 1 ? "" : "s"}`,
-    savings.peakCatalog > 3
-      ? `biggest catalog collapsed ${savings.peakCatalog} tools to 3`
+    savings.peakCatalog > 4
+      ? `biggest catalog collapsed ${savings.peakCatalog} tools to a handful`
       : null,
     since ? `since ${since}` : null,
   ].filter(Boolean);

--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -123,7 +123,7 @@ function VersionFooter({
         action: {
           label: "Open",
           onClick: () =>
-            openUrl("https://github.com/tsouth89/conduit/releases/latest"),
+            openUrl("https://github.com/tsouth89/toolport/releases/latest"),
         },
       });
     }

--- a/src/components/PendingApprovals.tsx
+++ b/src/components/PendingApprovals.tsx
@@ -1,25 +1,51 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { listen } from "@tauri-apps/api/event";
-import { Check, ShieldAlert, X } from "lucide-react";
+import { Check, Globe, Loader2, Monitor, ShieldAlert, Trash2, X } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import { decideApproval, listPendingApprovals } from "@/lib/api";
 import type { PendingApproval } from "@/lib/types";
 import { toastError } from "@/lib/toast";
 
-const REASON_LABEL: Record<PendingApproval["reason"], string> = {
-  destructive: "destructive",
-  untrusted_source: "untrusted source",
-  destructive_and_untrusted: "destructive · untrusted source",
+/** Fail-closed window (must match approval::DEFAULT_TIMEOUT_SECS on the gateway). A
+ * pending call that isn't decided within this is auto-denied, so we show a countdown. */
+const TIMEOUT_MS = 120_000;
+
+type Reason = PendingApproval["reason"];
+
+/** How each gate reason presents: label, badge tone, and an icon. */
+const REASON: Record<Reason, { label: string; className: string; Icon: typeof Trash2 }> = {
+  destructive: {
+    label: "Destructive",
+    className: "bg-destructive/10 text-destructive",
+    Icon: Trash2,
+  },
+  untrusted_source: {
+    label: "Untrusted source",
+    className: "bg-warning/15 text-warning",
+    Icon: Globe,
+  },
+  destructive_and_untrusted: {
+    label: "Destructive · untrusted",
+    className: "bg-destructive/10 text-destructive",
+    Icon: Trash2,
+  },
 };
 
 /**
  * The human-in-the-loop approval queue: tool calls the gateway is holding until you
- * approve or deny them. Blocking, so it is mounted globally (visible from any view) and
- * renders nothing when the queue is empty. It polls as a safety net and refreshes
- * immediately on the gateway's `approval-pending` / `approval-resolved` events.
+ * approve or deny them. The call BLOCKS on your decision, so this is mounted globally
+ * (actionable from any view) and renders nothing when the queue is empty. It polls as a
+ * safety net and refreshes immediately on the gateway's `approval-pending` /
+ * `approval-resolved` events.
  */
 export function PendingApprovals() {
   const [pending, setPending] = useState<PendingApproval[]>([]);
   const [busy, setBusy] = useState<string | null>(null);
+  // When we first saw each id, so the countdown starts from first sighting (the broker
+  // deadline is authoritative; this is a close, honest approximation for the UI).
+  const seenAt = useRef<Map<string, number>>(new Map());
+  const [now, setNow] = useState(() => Date.now());
 
   const refresh = useCallback(async () => {
     try {
@@ -42,6 +68,21 @@ export function PendingApprovals() {
     };
   }, [refresh]);
 
+  // Tick once a second while anything is pending, to drive the countdown.
+  useEffect(() => {
+    if (pending.length === 0) return;
+    const t = setInterval(() => setNow(Date.now()), 1000);
+    return () => clearInterval(t);
+  }, [pending.length]);
+
+  // Record first-sighting for new ids; drop entries that are gone.
+  useEffect(() => {
+    const ids = new Set(pending.map((p) => p.id));
+    const t = Date.now();
+    for (const p of pending) if (!seenAt.current.has(p.id)) seenAt.current.set(p.id, t);
+    for (const id of seenAt.current.keys()) if (!ids.has(id)) seenAt.current.delete(id);
+  }, [pending]);
+
   const decide = async (id: string, approved: boolean) => {
     setBusy(id);
     try {
@@ -58,49 +99,111 @@ export function PendingApprovals() {
   if (pending.length === 0) return null;
 
   return (
-    <div className="fixed inset-x-0 top-0 z-50 flex justify-center px-4 pt-3">
-      <div className="w-full max-w-2xl rounded-lg border border-warning/50 bg-background/95 p-4 shadow-lg backdrop-blur">
-        <div className="mb-3 flex items-center gap-2 text-sm font-semibold text-warning">
-          <ShieldAlert className="h-4 w-4" />
-          {pending.length} tool call{pending.length > 1 ? "s" : ""} awaiting your approval
-        </div>
-        <ul className="space-y-2">
-          {pending.map((a) => (
-            <li key={a.id} className="rounded-md border border-border bg-card p-3">
-              <div className="flex items-start justify-between gap-3">
-                <div className="min-w-0">
-                  <div className="truncate font-mono text-sm">
-                    {a.server}
-                    <span className="text-muted-foreground"> · </span>
-                    {a.tool}
+    <div className="pointer-events-none fixed inset-x-0 top-0 z-50 flex justify-center px-4 pt-4">
+      {/* Soft scrim to draw the eye without blocking the rest of the app. */}
+      <div className="pointer-events-none absolute inset-x-0 top-0 h-40 bg-gradient-to-b from-background/70 to-transparent" />
+      <div
+        role="alertdialog"
+        aria-modal="false"
+        aria-label="Tool calls awaiting your approval"
+        className="animate-in fade-in slide-in-from-top-2 pointer-events-auto relative w-full max-w-lg overflow-hidden rounded-xl border border-warning/40 bg-popover/95 shadow-2xl ring-1 ring-warning/10 backdrop-blur"
+      >
+        <header className="flex items-center gap-3 border-b border-border/60 px-4 py-3">
+          <span className="flex size-8 shrink-0 items-center justify-center rounded-full bg-warning/15 text-warning">
+            <ShieldAlert className="size-4" />
+          </span>
+          <div className="min-w-0">
+            <div className="text-sm font-semibold leading-tight">Approval required</div>
+            <div className="text-xs text-muted-foreground">
+              {pending.length} tool call{pending.length > 1 ? "s" : ""} held — no decision auto-denies
+            </div>
+          </div>
+        </header>
+
+        <ul className="max-h-[70vh] divide-y divide-border/60 overflow-auto">
+          {pending.map((a) => {
+            const reason = REASON[a.reason];
+            const started = seenAt.current.get(a.id) ?? now;
+            const remaining = Math.max(0, Math.ceil((TIMEOUT_MS - (now - started)) / 1000));
+            const pct = Math.max(0, Math.min(100, (remaining / (TIMEOUT_MS / 1000)) * 100));
+            const urgent = remaining <= 20;
+            const isBusy = busy === a.id;
+            return (
+              <li key={a.id} className="px-4 py-3.5">
+                <div className="mb-2 flex items-start justify-between gap-3">
+                  <div className="min-w-0">
+                    <div className="flex items-center gap-1.5 font-mono text-sm">
+                      <span className="truncate text-muted-foreground">{a.server}</span>
+                      <span className="text-muted-foreground/50">/</span>
+                      <span className="truncate font-medium text-foreground">{a.tool}</span>
+                    </div>
+                    {a.client && (
+                      <div className="mt-1 flex items-center gap-1.5 text-xs text-muted-foreground">
+                        <Monitor className="size-3" />
+                        Requested by {a.client}
+                      </div>
+                    )}
                   </div>
-                  <div className="mt-0.5 text-xs text-muted-foreground">
-                    {a.client ? `${a.client} · ` : ""}
-                    {REASON_LABEL[a.reason]}
+                  <Badge className={reason.className}>
+                    <reason.Icon className="size-3" />
+                    {reason.label}
+                  </Badge>
+                </div>
+
+                <div className="mb-3">
+                  <div className="mb-1 text-[0.7rem] font-medium uppercase tracking-wide text-muted-foreground">
+                    Arguments
                   </div>
-                  <pre className="mt-2 max-h-32 overflow-auto rounded bg-muted p-2 text-xs">
+                  <pre className="max-h-36 overflow-auto rounded-md border border-border/60 bg-muted/40 p-2.5 font-mono text-xs leading-relaxed">
                     {JSON.stringify(a.arguments, null, 2)}
                   </pre>
                 </div>
-                <div className="flex shrink-0 gap-2">
-                  <button
-                    disabled={busy === a.id}
-                    onClick={() => void decide(a.id, true)}
-                    className="inline-flex items-center gap-1 rounded-md bg-info px-3 py-1.5 text-xs font-medium text-white disabled:opacity-50"
+
+                <div className="flex items-center justify-between gap-3">
+                  <div
+                    className={
+                      "flex items-center gap-1.5 text-xs tabular-nums " +
+                      (urgent ? "text-destructive" : "text-muted-foreground")
+                    }
                   >
-                    <Check className="h-3.5 w-3.5" /> Approve
-                  </button>
-                  <button
-                    disabled={busy === a.id}
-                    onClick={() => void decide(a.id, false)}
-                    className="inline-flex items-center gap-1 rounded-md border border-border px-3 py-1.5 text-xs font-medium disabled:opacity-50"
-                  >
-                    <X className="h-3.5 w-3.5" /> Deny
-                  </button>
+                    <span
+                      aria-hidden
+                      className="inline-block h-1 w-16 overflow-hidden rounded-full bg-border"
+                    >
+                      <span
+                        className={
+                          "block h-full rounded-full transition-[width] duration-1000 ease-linear " +
+                          (urgent ? "bg-destructive" : "bg-warning")
+                        }
+                        style={{ width: `${pct}%` }}
+                      />
+                    </span>
+                    {remaining}s left
+                  </div>
+                  <div className="flex shrink-0 gap-2">
+                    <Button
+                      size="sm"
+                      variant="destructive"
+                      disabled={isBusy}
+                      onClick={() => void decide(a.id, false)}
+                    >
+                      {isBusy ? <Loader2 className="animate-spin" /> : <X />}
+                      Deny
+                    </Button>
+                    <Button
+                      size="sm"
+                      disabled={isBusy}
+                      onClick={() => void decide(a.id, true)}
+                      className="bg-[color-mix(in_oklch,var(--success),black_16%)] text-white shadow-sm hover:bg-[color-mix(in_oklch,var(--success),black_26%)]"
+                    >
+                      {isBusy ? <Loader2 className="animate-spin" /> : <Check />}
+                      Approve
+                    </Button>
+                  </div>
                 </div>
-              </div>
-            </li>
-          ))}
+              </li>
+            );
+          })}
         </ul>
       </div>
     </div>

--- a/src/components/SettingsView.tsx
+++ b/src/components/SettingsView.tsx
@@ -181,7 +181,7 @@ export function SettingsView({ registry, onRegistryChange }: Props) {
           lazyDiscovery,
           "text-info",
           "Lazy discovery",
-          "Expose 3 meta-tools, not the full catalog (all clients)",
+          "Expose a few meta-tools, not the full catalog (all clients)",
           apply(setLazyDiscovery),
         )}
       </section>

--- a/src/components/SettingsView.tsx
+++ b/src/components/SettingsView.tsx
@@ -181,7 +181,7 @@ export function SettingsView({ registry, onRegistryChange }: Props) {
           lazyDiscovery,
           "text-info",
           "Lazy discovery",
-          "Expose a few meta-tools, not the full catalog (all clients)",
+          "Expose 4 meta-tools, not the full catalog (all clients)",
           apply(setLazyDiscovery),
         )}
       </section>

--- a/src/components/ShareDialog.tsx
+++ b/src/components/ShareDialog.tsx
@@ -138,7 +138,7 @@ export function ShareDialog({ trigger, onImported }: Props) {
     try {
       const path = await save({
         title: "Save Toolport setup",
-        defaultPath: `${slug(name) || "conduit-setup"}.json`,
+        defaultPath: `${slug(name) || "toolport-setup"}.json`,
         filters: [{ name: "Toolport setup", extensions: ["json"] }],
       });
       if (!path) return;

--- a/src/components/TeamsView.tsx
+++ b/src/components/TeamsView.tsx
@@ -10,6 +10,10 @@ import { teamConnect, teamSync, teamDisconnect, teamPush, setServerEnabled } fro
 import { isEnabled, activeProfile } from "@/lib/types";
 import type { Registry } from "@/lib/types";
 
+/** The hosted Toolport Teams instance, prefilled as the default. Self-hosters replace
+ * it with their own server URL. */
+const HOSTED_TEAMS_URL = "https://teams.toolport.app";
+
 /**
  * Toolport Teams: join a team and have its shared MCP server set appear locally. The
  * team server holds only the server set + non-secret config, never a key, so after
@@ -27,7 +31,7 @@ export function TeamsView({
   const isAdmin = team?.role === "admin";
   const teamServers = (registry?.servers ?? []).filter((s) => s.source?.startsWith("team:"));
 
-  const [serverUrl, setServerUrl] = useState("");
+  const [serverUrl, setServerUrl] = useState(HOSTED_TEAMS_URL);
   const [inviteCode, setInviteCode] = useState("");
   const [memberName, setMemberName] = useState("");
   const [busy, setBusy] = useState<string | null>(null);
@@ -145,10 +149,14 @@ export function TeamsView({
             <label className="grid gap-1 text-sm">
               <span className="text-muted-foreground">Team server URL</span>
               <Input
-                placeholder="https://conduit.yourcompany.com"
+                placeholder="https://toolport.yourcompany.com"
                 value={serverUrl}
                 onChange={(e) => setServerUrl(e.target.value)}
               />
+              <span className="text-xs text-muted-foreground">
+                Defaults to hosted Toolport Teams. Self-hosting? Replace it with your own
+                server URL.
+              </span>
             </label>
             <label className="grid gap-1 text-sm">
               <span className="text-muted-foreground">Invite code</span>

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -326,7 +326,7 @@ export interface Registry {
   liveInspect?: boolean;
   /** Quarantine-on-drift: block a high-risk tool that changed until re-approved. */
   quarantineOnDrift?: boolean;
-  /** Global switch: expose 3 meta-tools instead of the full catalog. */
+  /** Global switch: expose a few meta-tools instead of the full catalog. */
   lazyDiscovery?: boolean;
   /** Opt-in: let an agent enable/disable servers via the gateway's control tools. */
   allowAgentControl?: boolean;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -326,7 +326,7 @@ export interface Registry {
   liveInspect?: boolean;
   /** Quarantine-on-drift: block a high-risk tool that changed until re-approved. */
   quarantineOnDrift?: boolean;
-  /** Global switch: expose a few meta-tools instead of the full catalog. */
+  /** Global switch: expose 4 meta-tools instead of the full catalog. */
   lazyDiscovery?: boolean;
   /** Opt-in: let an agent enable/disable servers via the gateway's control tools. */
   allowAgentControl?: boolean;


### PR DESCRIPTION
Follow-up to the HITL approval queue (#82), which is now verified working end-to-end (Deny blocks, Approve routes). This addresses the one real functional gap plus UI polish and a few leftover `conduit` remnants.

## HITL
- **OS notification + taskbar flash when a call is held.** Previously a pending approval surfaced *only* via the in-app overlay — so with the app minimized (its normal state) a held call sat invisible and auto-denied at the 120s fail-closed timeout, with the user never knowing they were asked. Now the broker fires an OS notification and flashes the taskbar (`request_user_attention`, so it doesn't steal focus) when it emits `approval-pending`. Adds `tauri-plugin-notification`; best-effort, the overlay stays the source of truth.
- **Approval overlay polish.** Rebuilt with the app's `Button`/`Badge` primitives and theme tokens: green **Approve** / red **Deny** (was violet `bg-info` — wrong semantics), reason badge with icon, client attribution, labeled scrollable arguments block, fail-closed countdown bar, busy spinners, and `role="alertdialog"` for screen readers.

## Branding (leftover `conduit` → Toolport, user-facing only)
- **Teams connect form** now prefills the hosted default `https://teams.toolport.app` with a self-host hint, replacing the `conduit.yourcompany.com` placeholder.
- **Sidebar** update-failed "open releases" link → `github.com/tsouth89/toolport/releases/latest`.
- **Share/export** default filename → `toolport-setup.json`.

Internal identifiers (localStorage keys, the gateway's own `conduit` server id) are intentionally left unchanged, per the rename principle.

## Verification
- Full Rust workspace compiles (notification plugin resolved); app relaunches clean via `tauri dev`.
- `tsc --noEmit` clean.
- HITL E2E was manually verified in the dev build (deny + approve paths). The OS notification fires on the next held call.

Default-OFF still holds — HITL only activates when "Require human approval" is enabled.