### PR TITLE
feat(integrity): tier tool-security notices by severity to cut alert fatigue

### DIFF
--- a/src-tauri/src/integrity.rs
+++ b/src-tauri/src/integrity.rs
@@ -80,13 +80,18 @@ fn pin_of(tool: &Value) -> Pin {
     }
 }
 
-/// A safety annotation went from `true -> false` between the pinned baseline and the
-/// current definition: the tool is now claiming FEWER constraints (was read-only, now
-/// writes; or was flagged destructive, now isn't). That's a silent privilege
-/// escalation and a rug-pull tell, so it drives a loud, high-severity notice.
+/// A safety annotation went from `true` to no-longer-`true` (either flipped to `false`
+/// OR dropped entirely) between the pinned baseline and the current definition: the tool
+/// is now claiming FEWER constraints (was read-only, now writes; or was flagged
+/// destructive, now isn't). That's a silent privilege escalation and a rug-pull tell, so
+/// it drives a loud, high-severity notice.
 fn annotation_downgrade(old: &Pin, tool: &Value) -> bool {
-    (old.ro == Some(true) && read_hint(tool, "readOnlyHint") == Some(false))
-        || (old.dh == Some(true) && read_hint(tool, "destructiveHint") == Some(false))
+    // `!= Some(true)` (not `== Some(false)`) so DROPPING the hint counts too: a tool that
+    // was `readOnlyHint: true` and now omits it no longer asserts the constraint, the same
+    // privilege shed as flipping it to `false` - and omission is the obvious evasion if we
+    // only matched an explicit `false`.
+    (old.ro == Some(true) && read_hint(tool, "readOnlyHint") != Some(true))
+        || (old.dh == Some(true) && read_hint(tool, "destructiveHint") != Some(true))
 }
 
 /// Severity of a drift, splitting loud/actionable signal from benign churn:
@@ -823,13 +828,19 @@ pub fn security_path() -> Option<PathBuf> {
 /// source. Matches the frontend's collapse window so the two agree.
 const DEDUP_WINDOW_MS: u64 = 10 * 60 * 1000;
 
-/// Whether an event with the same `(type, server, tool, change)` was already recorded
-/// within `DEDUP_WINDOW_MS`. Best-effort cross-gateway suppression: every connected
-/// client spawns its own gateway, and they all run `check` against the SHARED baseline,
-/// so one benign server-side revision can be flagged ~6 times at once. Left unchecked
-/// that floods `security.jsonl` and buries the rare real signal (the whole point of this
-/// surface). Racy by nature (no lock across processes), but it collapses the common
-/// concurrent burst; the frontend dedupes again for anything that slips through.
+/// Whether an event with the same `(type, server, tool, change, severity)` was already
+/// recorded within `DEDUP_WINDOW_MS`. Best-effort cross-gateway suppression: every
+/// connected client spawns its own gateway, and they all run `check` against the SHARED
+/// baseline, so one benign server-side revision can be flagged ~6 times at once. Left
+/// unchecked that floods `security.jsonl` and buries the rare real signal (the whole
+/// point of this surface). Racy by nature (no lock across processes), but it collapses
+/// the common concurrent burst; the frontend dedupes again for anything that slips
+/// through.
+///
+/// `severity` is part of the identity ON PURPOSE: a benign `info` revision must NEVER
+/// suppress a later `high` one on the same tool (a tool that first churns benignly, then
+/// sheds a safety annotation or turns destructive). Collapsing across severities would
+/// swallow exactly the loud signal this surface exists to raise.
 fn recently_recorded(event: &Value, path: &Path) -> bool {
     let ty = match event.get("type").and_then(Value::as_str) {
         Some(t) => t,
@@ -842,6 +853,7 @@ fn recently_recorded(event: &Value, path: &Path) -> bool {
     let server = event.get("server").and_then(Value::as_str);
     let tool = event.get("tool").and_then(Value::as_str);
     let change = event.get("change").and_then(Value::as_str);
+    let severity = event.get("severity").and_then(Value::as_str);
     let content = match std::fs::read_to_string(path) {
         Ok(c) => c,
         Err(_) => return false,
@@ -858,6 +870,7 @@ fn recently_recorded(event: &Value, path: &Path) -> bool {
             && prev.get("server").and_then(Value::as_str) == server
             && prev.get("tool").and_then(Value::as_str) == tool
             && prev.get("change").and_then(Value::as_str) == change
+            && prev.get("severity").and_then(Value::as_str) == severity
         {
             let prev_ts = prev.get("ts").and_then(Value::as_u64).unwrap_or(0);
             return now_ts.saturating_sub(prev_ts) <= DEDUP_WINDOW_MS;
@@ -1232,6 +1245,16 @@ mod tests {
         let pins: Pins = [("db__query".to_string(), pin(&dh_true))].into_iter().collect();
         let d = diff(&pins, &[dh_false]);
         assert_eq!(d[0]["severity"], SEV_HIGH, "destructiveHint downgrade must be high");
+
+        // Dropping the hint ENTIRELY (true -> absent) is also a downgrade: the tool no
+        // longer asserts the constraint. Must be high, so the check can't be evaded by
+        // omitting the annotation instead of flipping it to false.
+        let ro_absent = json!({ "name": "db__query", "description": "Query.",
+            "inputSchema": {"type":"object"} });
+        let pins: Pins = [("db__query".to_string(), pin(&ro_true))].into_iter().collect();
+        let d = diff(&pins, std::slice::from_ref(&ro_absent));
+        assert_eq!(d.len(), 1);
+        assert_eq!(d[0]["severity"], SEV_HIGH, "dropping readOnlyHint (true->absent) must be high");
     }
 
     #[test]
@@ -1283,6 +1306,17 @@ mod tests {
         // A different tool (or change kind) is never a duplicate.
         assert!(!recently_recorded(&event("rc", "rc__y", "changed", SEV_INFO), &path));
         assert!(!recently_recorded(&event("rc", "rc__x", "added", SEV_INFO), &path));
+
+        // Severity is part of the identity: a HIGH change on the same tool moments after
+        // the benign INFO one must NOT be suppressed (else a real escalation - the tool
+        // shedding a safety annotation right after a benign revision - gets swallowed by
+        // the earlier info line, defeating the whole surface).
+        let mut escalation = event("rc", "rc__x", "changed", SEV_HIGH);
+        escalation["ts"] = json!(base_ts + 5);
+        assert!(
+            !recently_recorded(&escalation, &path),
+            "a high event must not be deduped against a preceding info event"
+        );
 
         let _ = std::fs::remove_file(&path);
     }

--- a/src-tauri/src/integrity.rs
+++ b/src-tauri/src/integrity.rs
@@ -17,11 +17,93 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::io::Write;
 use std::path::{Path, PathBuf};
 
+use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use sha2::{Digest, Sha256};
 
-/// Pins map: namespaced tool name (`server__tool`) -> fingerprint.
-type Pins = BTreeMap<String, String>;
+/// Pins map: namespaced tool name (`server__tool`) -> pinned baseline.
+type Pins = BTreeMap<String, Pin>;
+
+/// A pinned tool baseline. The fingerprint alone can't be reversed to tell WHAT
+/// changed, so we also remember the two safety-relevant annotation bits
+/// (`readOnlyHint` / `destructiveHint`). That lets a later flip from `true -> false`
+/// (a tool quietly shedding a safety constraint) be recognized as a privilege
+/// escalation and flagged loudly, instead of vanishing into benign schema churn.
+#[derive(Clone, PartialEq, Serialize, Deserialize)]
+struct Pin {
+    /// Version-prefixed fingerprint of the whole definition (see `fingerprint`).
+    fp: String,
+    /// `readOnlyHint` at pin time, if the tool advertised one.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    ro: Option<bool>,
+    /// `destructiveHint` at pin time, if the tool advertised one.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    dh: Option<bool>,
+}
+
+/// On-disk pin value: either the legacy bare fingerprint string (pins written before
+/// annotation state was tracked) or the current struct. Deserialized through this so
+/// old baselines load without a spurious flood of "changed"; everything is re-saved in
+/// the struct form on the next check.
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum PinRepr {
+    Full(Pin),
+    Legacy(String),
+}
+
+impl From<PinRepr> for Pin {
+    fn from(r: PinRepr) -> Self {
+        match r {
+            PinRepr::Full(p) => p,
+            PinRepr::Legacy(fp) => Pin { fp, ro: None, dh: None },
+        }
+    }
+}
+
+/// The safety-relevant MCP annotation hint `key` for `tool`, reading the spec's nested
+/// `annotations.<key>` and the top-level fallback some servers emit (mirrors
+/// `router::is_destructive`).
+fn read_hint(tool: &Value, key: &str) -> Option<bool> {
+    tool.get("annotations")
+        .and_then(|a| a.get(key))
+        .and_then(Value::as_bool)
+        .or_else(|| tool.get(key).and_then(Value::as_bool))
+}
+
+/// Build the pin baseline for `tool` (fingerprint + the two safety annotation bits).
+fn pin_of(tool: &Value) -> Pin {
+    Pin {
+        fp: fingerprint(tool),
+        ro: read_hint(tool, "readOnlyHint"),
+        dh: read_hint(tool, "destructiveHint"),
+    }
+}
+
+/// A safety annotation went from `true -> false` between the pinned baseline and the
+/// current definition: the tool is now claiming FEWER constraints (was read-only, now
+/// writes; or was flagged destructive, now isn't). That's a silent privilege
+/// escalation and a rug-pull tell, so it drives a loud, high-severity notice.
+fn annotation_downgrade(old: &Pin, tool: &Value) -> bool {
+    (old.ro == Some(true) && read_hint(tool, "readOnlyHint") == Some(false))
+        || (old.dh == Some(true) && read_hint(tool, "destructiveHint") == Some(false))
+}
+
+/// Severity of a drift, splitting loud/actionable signal from benign churn:
+/// - `high`: the tool is destructive, or a safety annotation was downgraded. These
+///   interrupt the user (badge + notice) and drive quarantine-on-drift.
+/// - `info`: everything else (a non-destructive tool's description/schema was revised
+///   with its safety hints intact). Recorded to a quiet, viewable history, no badge.
+const SEV_HIGH: &str = "high";
+const SEV_INFO: &str = "info";
+
+fn drift_severity(tool: &Value, annotation_downgrade: bool) -> &'static str {
+    if crate::router::is_destructive(tool) || annotation_downgrade {
+        SEV_HIGH
+    } else {
+        SEV_INFO
+    }
+}
 
 const MAX_SECURITY_BYTES: u64 = 1024 * 1024;
 const KEEP_LINES: usize = 2000;
@@ -128,9 +210,9 @@ fn load_pins(profile: Option<&str>) -> PinsLoad {
     }
     match std::fs::read_to_string(&path)
         .ok()
-        .and_then(|s| serde_json::from_str::<Pins>(&s).ok())
+        .and_then(|s| serde_json::from_str::<BTreeMap<String, PinRepr>>(&s).ok())
     {
-        Some(pins) => PinsLoad::Loaded(pins),
+        Some(pins) => PinsLoad::Loaded(pins.into_iter().map(|(k, v)| (k, v.into())).collect()),
         None => PinsLoad::Corrupt,
     }
 }
@@ -171,8 +253,8 @@ pub fn check(profile: Option<&str>, current: &[Value]) -> Vec<Value> {
             Some(n) if n.contains("__") => n,
             _ => continue,
         };
-        let fp = fingerprint(t);
-        now.insert(name.to_string(), fp.clone());
+        let pin = pin_of(t);
+        now.insert(name.to_string(), pin.clone());
         let server = server_of(name);
         let est = established.contains(server);
 
@@ -185,12 +267,13 @@ pub fn check(profile: Option<&str>, current: &[Value]) -> Vec<Value> {
                 // A different fingerprint is only a real change if it came from the same
                 // algorithm version; a version mismatch is our format upgrade, not the
                 // tool's, so re-baseline quietly (no event, no re-scan).
-                Some(old) if *old != fp && fp_version(old) == fp_version(&fp) => {
-                    events.push(event(server, name, "changed"));
+                Some(old) if old.fp != pin.fp && fp_version(&old.fp) == fp_version(&pin.fp) => {
+                    let sev = drift_severity(t, annotation_downgrade(old, t));
+                    events.push(event(server, name, "changed", sev));
                     scan = true;
                 }
                 None => {
-                    events.push(event(server, name, "added"));
+                    events.push(event(server, name, "added", drift_severity(t, false)));
                     scan = true;
                 }
                 _ => {}
@@ -318,11 +401,20 @@ pub fn apply_quarantine(profile: Option<&str>, current: &[Value], events: &[Valu
         ) else {
             continue;
         };
+        // Only high-severity drift is blocked. `check` already tagged severity, so a
+        // non-destructive "changed" that reached `high` can only be an annotation
+        // downgrade (a tool shedding readOnlyHint/destructiveHint) - the exact
+        // privilege-escalation case we want quarantined even though the tool isn't
+        // itself marked destructive. A poison flag is always high.
+        if e.get("severity").and_then(Value::as_str) != Some(SEV_HIGH) {
+            continue;
+        }
         let reason = match change {
             "poison" => "a poisoned definition was detected",
             "changed" if is_destructive_named(current, tool) => {
                 "a destructive tool's definition changed"
             }
+            "changed" => "a tool dropped a readOnly/destructive safety annotation",
             "added" if is_destructive_named(current, tool) => "a new destructive tool appeared",
             _ => continue,
         };
@@ -673,6 +765,7 @@ fn result_injection_event(server: &str, tool: &str, signatures: &[String], score
         "change": "result",
         "signatures": signatures,
         "score": round2(score),
+        "severity": SEV_HIGH,
     })
 }
 
@@ -694,6 +787,7 @@ fn poison_event(server: &str, tool: &str, signatures: &[String], score: f32) -> 
         "change": "poison",
         "signatures": signatures,
         "score": round2(score),
+        "severity": SEV_HIGH,
     })
 }
 
@@ -704,16 +798,20 @@ fn pins_tamper_event() -> Value {
         "ts": epoch_millis(),
         "type": "pins_load_failed",
         "change": "tamper",
+        "severity": SEV_HIGH,
     })
 }
 
-fn event(server: &str, tool: &str, change: &str) -> Value {
+/// A tool-definition drift event tagged with its `severity` (`high` = loud/actionable,
+/// `info` = benign churn for the quiet history). See `drift_severity`.
+fn event(server: &str, tool: &str, change: &str, severity: &str) -> Value {
     json!({
         "ts": epoch_millis(),
         "type": "tool_drift",
         "server": server,
         "tool": tool,
         "change": change,
+        "severity": severity,
     })
 }
 
@@ -721,10 +819,62 @@ pub fn security_path() -> Option<PathBuf> {
     Some(crate::registry::conduit_dir()?.join("security.jsonl"))
 }
 
+/// Window in which an identical event is treated as a duplicate and suppressed at the
+/// source. Matches the frontend's collapse window so the two agree.
+const DEDUP_WINDOW_MS: u64 = 10 * 60 * 1000;
+
+/// Whether an event with the same `(type, server, tool, change)` was already recorded
+/// within `DEDUP_WINDOW_MS`. Best-effort cross-gateway suppression: every connected
+/// client spawns its own gateway, and they all run `check` against the SHARED baseline,
+/// so one benign server-side revision can be flagged ~6 times at once. Left unchecked
+/// that floods `security.jsonl` and buries the rare real signal (the whole point of this
+/// surface). Racy by nature (no lock across processes), but it collapses the common
+/// concurrent burst; the frontend dedupes again for anything that slips through.
+fn recently_recorded(event: &Value, path: &Path) -> bool {
+    let ty = match event.get("type").and_then(Value::as_str) {
+        Some(t) => t,
+        None => return false,
+    };
+    let now_ts = event
+        .get("ts")
+        .and_then(Value::as_u64)
+        .unwrap_or_else(epoch_millis);
+    let server = event.get("server").and_then(Value::as_str);
+    let tool = event.get("tool").and_then(Value::as_str);
+    let change = event.get("change").and_then(Value::as_str);
+    let content = match std::fs::read_to_string(path) {
+        Ok(c) => c,
+        Err(_) => return false,
+    };
+    // Newest-first; the first line matching the identity decides (older matches are
+    // strictly further outside the window, so there's no need to scan past it). Bounded
+    // to the retained-line budget so this stays cheap on a large log.
+    for line in content.lines().rev().take(KEEP_LINES) {
+        let prev: Value = match serde_json::from_str(line) {
+            Ok(v) => v,
+            Err(_) => continue,
+        };
+        if prev.get("type").and_then(Value::as_str) == Some(ty)
+            && prev.get("server").and_then(Value::as_str) == server
+            && prev.get("tool").and_then(Value::as_str) == tool
+            && prev.get("change").and_then(Value::as_str) == change
+        {
+            let prev_ts = prev.get("ts").and_then(Value::as_u64).unwrap_or(0);
+            return now_ts.saturating_sub(prev_ts) <= DEDUP_WINDOW_MS;
+        }
+    }
+    false
+}
+
 fn record_event(event: &Value) {
     if let Some(path) = security_path() {
         if let Some(parent) = path.parent() {
             let _ = std::fs::create_dir_all(parent);
+        }
+        // Collapse the concurrent multi-gateway burst before it hits disk (see
+        // `recently_recorded`), so the shared log carries one line per real change.
+        if recently_recorded(event, &path) {
+            return;
         }
         if let Ok(mut file) = std::fs::OpenOptions::new().create(true).append(true).open(&path) {
             // Single write_all (not writeln!, which issues several syscalls) so the many
@@ -794,10 +944,11 @@ mod tests {
             tool("srv__read", "Read a record."),
         ];
         // A benign change to a non-destructive tool must NOT quarantine; a destructive
-        // tool's change and any poison flag must.
+        // tool's change and any poison flag must. Severity is what `check` would tag:
+        // read's plain change is `info`, wipe's (destructive) is `high`.
         let events = vec![
-            event("srv", "srv__read", "changed"),
-            event("srv", "srv__wipe", "changed"),
+            event("srv", "srv__read", "changed", SEV_INFO),
+            event("srv", "srv__wipe", "changed", SEV_HIGH),
             poison_event("srv", "srv__read", &["instruction-override".to_string()], 0.9),
         ];
         assert!(apply_quarantine(profile, &current, &events));
@@ -858,7 +1009,7 @@ mod tests {
         // Pins written by an older version are bare hex (no "vN:" prefix). After a
         // fingerprint-format upgrade the same tool hashes differently, but that's our
         // change, not the tool's, so it must re-baseline without a spurious "changed".
-        let pins: Pins = [("stripe__charge".to_string(), "deadbeef".to_string())]
+        let pins: Pins = [("stripe__charge".to_string(), legacy_pin("deadbeef"))]
             .into_iter()
             .collect();
         let current = vec![tool("stripe__charge", "Create a charge.")];
@@ -869,8 +1020,8 @@ mod tests {
     fn detect_changed_and_added_on_established_server() {
         // diff() is the pure core; test it directly so we don't touch disk.
         let pins: Pins = [
-            ("stripe__charge".to_string(), fingerprint(&tool("stripe__charge", "Create a charge."))),
-            ("stripe__refund".to_string(), fingerprint(&tool("stripe__refund", "Refund."))),
+            ("stripe__charge".to_string(), pin(&tool("stripe__charge", "Create a charge."))),
+            ("stripe__refund".to_string(), pin(&tool("stripe__refund", "Refund."))),
         ]
         .into_iter()
         .collect();
@@ -1020,33 +1171,157 @@ mod tests {
 
     #[test]
     fn newly_seen_server_is_baselined_not_flagged() {
-        let pins: Pins = [("stripe__charge".to_string(), "h".to_string())].into_iter().collect();
+        let pins: Pins = [("stripe__charge".to_string(), legacy_pin("h"))].into_iter().collect();
         // A brand-new server's tools should not flag as drift.
         let current = vec![tool("github__search", "Search repos.")];
         assert!(diff(&pins, &current).is_empty());
     }
 
-    // Pure diff extracted for testing without disk I/O.
+    #[test]
+    fn drift_severity_tiers_loud_vs_benign() {
+        // The alert-fatigue case: a non-destructive tool's description is revised
+        // server-side (RevenueCat's beta churn), safety hints intact -> `info`, quiet
+        // history, no badge.
+        let pins: Pins = [(
+            "rc__edit_paywall_ai".to_string(),
+            pin(&tool("rc__edit_paywall_ai", "Edit a paywall.")),
+        )]
+        .into_iter()
+        .collect();
+        let current = vec![tool("rc__edit_paywall_ai", "Edit a paywall (beta v2).")];
+        let d = diff(&pins, &current);
+        assert_eq!(d.len(), 1);
+        assert_eq!(d[0]["change"], "changed");
+        assert_eq!(d[0]["severity"], SEV_INFO, "benign non-destructive churn is info");
+
+        // A destructive tool's definition changing is loud.
+        let pins: Pins = [(
+            "srv__wipe".to_string(),
+            pin(&destructive_tool("srv__wipe", "Wipe.")),
+        )]
+        .into_iter()
+        .collect();
+        let d = diff(&pins, &[destructive_tool("srv__wipe", "Wipe everything now.")]);
+        assert_eq!(d[0]["severity"], SEV_HIGH, "a destructive tool's change is high");
+    }
+
+    #[test]
+    fn annotation_downgrade_is_high_severity() {
+        let ro_true = json!({ "name": "db__query", "description": "Query.",
+            "inputSchema": {"type":"object"}, "annotations": { "readOnlyHint": true } });
+        let ro_false = json!({ "name": "db__query", "description": "Query.",
+            "inputSchema": {"type":"object"}, "annotations": { "readOnlyHint": false } });
+
+        // readOnlyHint true -> false is a silent privilege escalation: high, even though
+        // the tool is not marked destructive.
+        let pins: Pins = [("db__query".to_string(), pin(&ro_true))].into_iter().collect();
+        let d = diff(&pins, std::slice::from_ref(&ro_false));
+        assert_eq!(d.len(), 1);
+        assert_eq!(d[0]["severity"], SEV_HIGH, "readOnlyHint downgrade must be high");
+
+        // The reverse (false -> true, tightening) is just benign churn -> info.
+        let pins: Pins = [("db__query".to_string(), pin(&ro_false))].into_iter().collect();
+        let d = diff(&pins, std::slice::from_ref(&ro_true));
+        assert_eq!(d[0]["severity"], SEV_INFO, "tightening readOnlyHint is not a downgrade");
+
+        // destructiveHint true -> false is likewise a downgrade -> high.
+        let dh_true = json!({ "name": "db__query", "description": "Query.",
+            "inputSchema": {"type":"object"}, "annotations": { "destructiveHint": true } });
+        let dh_false = json!({ "name": "db__query", "description": "Query.",
+            "inputSchema": {"type":"object"}, "annotations": { "destructiveHint": false } });
+        let pins: Pins = [("db__query".to_string(), pin(&dh_true))].into_iter().collect();
+        let d = diff(&pins, &[dh_false]);
+        assert_eq!(d[0]["severity"], SEV_HIGH, "destructiveHint downgrade must be high");
+    }
+
+    #[test]
+    fn annotation_downgrade_quarantines_non_destructive_tool() {
+        let profile = Some("integrity-downgrade-unit");
+        if let Some(p) = quarantine_path(profile) {
+            let _ = std::fs::remove_file(p);
+        }
+        // A non-destructive tool that shed readOnlyHint. apply_quarantine keys off the
+        // event severity, so this high-severity `changed` is blocked even though the tool
+        // is not marked destructive.
+        let current = vec![json!({ "name": "db__query", "description": "Query.",
+            "inputSchema": {"type":"object"}, "annotations": { "readOnlyHint": false } })];
+        let events = vec![event("db", "db__query", "changed", SEV_HIGH)];
+        assert!(apply_quarantine(profile, &current, &events));
+        assert!(quarantined(profile).contains("db__query"));
+
+        // A benign (info) change to the same tool would NOT quarantine.
+        assert!(release(profile, "db__query"));
+        let benign = vec![event("db", "db__query", "changed", SEV_INFO)];
+        assert!(!apply_quarantine(profile, &current, &benign));
+
+        if let Some(p) = quarantine_path(profile) {
+            let _ = std::fs::remove_file(p);
+        }
+    }
+
+    #[test]
+    fn recently_recorded_collapses_burst_within_window() {
+        let path = std::env::temp_dir()
+            .join(format!("toolport-dedup-test-{}.jsonl", std::process::id()));
+        let _ = std::fs::remove_file(&path);
+
+        // One gateway has already written a drift event.
+        let e1 = event("rc", "rc__x", "changed", SEV_INFO);
+        std::fs::write(&path, format!("{e1}\n")).unwrap();
+        let base_ts = e1["ts"].as_u64().unwrap();
+
+        // A second gateway's identical event a few ms later is a duplicate.
+        let mut soon = event("rc", "rc__x", "changed", SEV_INFO);
+        soon["ts"] = json!(base_ts + 5);
+        assert!(recently_recorded(&soon, &path), "concurrent duplicate must be suppressed");
+
+        // The same drift long after the window is a fresh, real re-flag.
+        let mut later = event("rc", "rc__x", "changed", SEV_INFO);
+        later["ts"] = json!(base_ts + DEDUP_WINDOW_MS + 1);
+        assert!(!recently_recorded(&later, &path), "a re-flag past the window is not a dup");
+
+        // A different tool (or change kind) is never a duplicate.
+        assert!(!recently_recorded(&event("rc", "rc__y", "changed", SEV_INFO), &path));
+        assert!(!recently_recorded(&event("rc", "rc__x", "added", SEV_INFO), &path));
+
+        let _ = std::fs::remove_file(&path);
+    }
+
+    /// Build a Pin from a tool, for tests that construct a baseline.
+    fn pin(tool: &Value) -> Pin {
+        pin_of(tool)
+    }
+
+    /// A legacy bare-fingerprint pin (as written before annotation state was tracked).
+    fn legacy_pin(fp: &str) -> Pin {
+        Pin { fp: fp.to_string(), ro: None, dh: None }
+    }
+
+    // Pure diff extracted for testing without disk I/O. Mirrors `check`'s drift
+    // classification (including severity) so tests exercise the real logic.
     fn diff(pins: &Pins, current: &[Value]) -> Vec<Value> {
         let mut now: Pins = BTreeMap::new();
         for t in current {
             if let Some(name) = t.get("name").and_then(Value::as_str) {
                 if name.contains("__") {
-                    now.insert(name.to_string(), fingerprint(t));
+                    now.insert(name.to_string(), pin_of(t));
                 }
             }
         }
         let established: BTreeSet<&str> = pins.keys().map(|k| server_of(k)).collect();
         let mut drifts = Vec::new();
-        for (name, fp) in &now {
-            if !established.contains(server_of(name)) {
-                continue;
-            }
+        for t in current {
+            let name = match t.get("name").and_then(Value::as_str) {
+                Some(n) if n.contains("__") && established.contains(server_of(n)) => n,
+                _ => continue,
+            };
+            let new = &now[name];
             match pins.get(name) {
-                Some(old) if old != fp && fp_version(old) == fp_version(fp) => {
-                    drifts.push(event(server_of(name), name, "changed"))
+                Some(old) if old.fp != new.fp && fp_version(&old.fp) == fp_version(&new.fp) => {
+                    let sev = drift_severity(t, annotation_downgrade(old, t));
+                    drifts.push(event(server_of(name), name, "changed", sev))
                 }
-                None => drifts.push(event(server_of(name), name, "added")),
+                None => drifts.push(event(server_of(name), name, "added", drift_severity(t, false))),
                 _ => {}
             }
         }

--- a/src/components/ActivityView.tsx
+++ b/src/components/ActivityView.tsx
@@ -155,8 +155,10 @@ function renderKey(e: SecurityEvent): string {
 
 /** Each connected client runs its own gateway process, so a single server tool change
  * is flagged once PER client against the shared baseline, producing identical notices.
- * Collapse those: keep only the newest of any (type, server, tool, change) seen within a
- * short window, so genuinely-separate changes over time are preserved. */
+ * Collapse those: keep only the newest of any (type, server, tool, change, severity) seen
+ * within a short window, so genuinely-separate changes over time are preserved. Severity
+ * is part of the identity so a benign `info` revision can never collapse (and hide) a
+ * later `high` one on the same tool - that loud signal must survive the dedupe. */
 function dedupeSecurity(events: SecurityEvent[]): SecurityEvent[] {
   const WINDOW_MS = 10 * 60 * 1000;
   const newestFirst = [...events].sort((a, b) => b.ts - a.ts);
@@ -168,6 +170,7 @@ function dedupeSecurity(events: SecurityEvent[]): SecurityEvent[] {
         k.server === e.server &&
         k.tool === e.tool &&
         k.change === e.change &&
+        eventSeverity(k) === eventSeverity(e) &&
         Math.abs(k.ts - e.ts) <= WINDOW_MS,
     );
     if (!dupe) kept.push(e);

--- a/src/components/ActivityView.tsx
+++ b/src/components/ActivityView.tsx
@@ -4,6 +4,7 @@ import {
   AlertTriangle,
   CheckCircle2,
   ChevronRight,
+  History,
   ScrollText,
   Share2,
   ShieldAlert,
@@ -119,11 +120,37 @@ function eventBadge(e: SecurityEvent): { label: string; cls: string } {
 
 const SECURITY_DISMISSED_KEY = "conduit.security.dismissed";
 
-/** Stable per-event key so a dismissal sticks across refreshes. Includes server +
- * change so tool-less events (e.g. pins_load_failed, where tool is undefined) don't
- * collapse to the same key and dismiss each other. */
+/** High-signal, interrupting events vs benign, quiet-history churn. The backend now
+ * tags a `severity`; for events written before that (no field) we classify by type:
+ * poison / injected-result / lost-baseline are high, a plain tool_drift is benign. */
+function eventSeverity(e: SecurityEvent): "high" | "info" {
+  if (e.severity === "high" || e.severity === "info") return e.severity;
+  if (
+    e.type === "tool_poison_flag" ||
+    e.type === "result_injection" ||
+    e.type === "pins_load_failed"
+  ) {
+    return "high";
+  }
+  return "info";
+}
+
+/** Durable per-event key for dismissal: identity (type, server, tool, change, severity),
+ * NOT the timestamp. A benign drift that re-flags later (e.g. RevenueCat revising a beta
+ * tool again) collapses to the same key, so dismissing it once keeps it dismissed instead
+ * of returning as a brand-new, undismissable notice. Server + change are kept so tool-less
+ * events (e.g. pins_load_failed) don't collide and dismiss each other. Severity is kept so
+ * dismissing a tool's benign change never masks a later HIGH-severity change on that same
+ * tool (e.g. it turns destructive) - that must still interrupt. */
 function securityKey(e: SecurityEvent): string {
-  return `${e.type}:${e.server ?? ""}:${e.tool ?? ""}:${e.ts}:${e.change}`;
+  return `${e.type}:${e.server ?? ""}:${e.tool ?? ""}:${e.change}:${eventSeverity(e)}`;
+}
+
+/** Unique React list key. `securityKey` is deliberately timestamp-free (so dismissal is
+ * durable), but two un-collapsed instances of the same drift can be on screen at once,
+ * so the render key still needs the timestamp to stay unique. */
+function renderKey(e: SecurityEvent): string {
+  return `${securityKey(e)}:${e.ts}`;
 }
 
 /** Each connected client runs its own gateway process, so a single server tool change
@@ -219,7 +246,7 @@ function SecurityNotices({
             {events.slice(0, 10).map((e) => {
               const badge = eventBadge(e);
               return (
-                <li key={securityKey(e)} className="flex items-center gap-2">
+                <li key={renderKey(e)} className="flex items-center gap-2">
                   <span
                     className={`rounded px-1.5 py-0.5 font-medium ${badge.cls}`}
                   >
@@ -249,6 +276,76 @@ function SecurityNotices({
                 </li>
               );
             })}
+          </ul>
+        </>
+      )}
+    </div>
+  );
+}
+
+/** A quiet, non-interrupting history of benign tool-definition churn: a
+ * non-destructive tool's description or schema was revised with its safety hints
+ * intact (vendors routinely revise beta tools server-side). Collapsed by default,
+ * muted styling, no badge or warning color, it's viewable for the record, not an
+ * alert. The loud, actionable signal (poison, destructive change, safety-annotation
+ * downgrade) stays in SecurityNotices. Dismissal is durable per drift identity, so
+ * clearing a recurring benign change keeps it quiet when the vendor churns it again. */
+function QuietDriftHistory({
+  events,
+  onDismiss,
+}: {
+  events: SecurityEvent[];
+  onDismiss: (e: SecurityEvent) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  return (
+    <div className="mb-4 rounded-lg border border-border/60 bg-muted/20 p-3">
+      <button
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+        className="flex w-full items-center gap-2 text-left text-xs text-muted-foreground"
+      >
+        <History className="size-3.5 shrink-0" />
+        <span className="font-medium text-foreground/80">Recent tool changes</span>
+        <span className="rounded-full bg-muted px-1.5 py-0.5 font-medium">
+          {events.length}
+        </span>
+        <ChevronRight
+          className={`ml-auto size-3.5 transition-transform ${open ? "rotate-90" : ""}`}
+        />
+      </button>
+      {open && (
+        <>
+          <p className="mt-2 mb-2 max-w-2xl text-xs text-muted-foreground">
+            Benign, non-destructive definition changes on tools you've already approved
+            (vendors revise beta tools server-side). Kept for the record, not flagged as a
+            risk. Dismiss any you've reviewed, they'll stay quiet if the same change
+            recurs.
+          </p>
+          <ul className="space-y-1 text-xs">
+            {events.slice(0, 20).map((e) => (
+              <li key={renderKey(e)} className="flex items-center gap-2">
+                <span className="rounded bg-muted px-1.5 py-0.5 text-muted-foreground">
+                  {e.change === "added" ? "new tool" : "changed"}
+                </span>
+                <code className="font-mono text-muted-foreground">{e.tool}</code>
+                <span className="ml-auto text-muted-foreground/70">
+                  {new Date(e.ts).toLocaleString(undefined, {
+                    month: "short",
+                    day: "numeric",
+                    hour: "2-digit",
+                    minute: "2-digit",
+                  })}
+                </span>
+                <button
+                  onClick={() => onDismiss(e)}
+                  aria-label="Dismiss this change"
+                  className="rounded p-0.5 text-muted-foreground/50 transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-border"
+                >
+                  <X className="size-3.5" />
+                </button>
+              </li>
+            ))}
           </ul>
         </>
       )}
@@ -713,6 +810,10 @@ export function ActivityView({
   }, [refreshKey]);
 
   const liveSecurity = dedupeSecurity(security).filter((e) => !dismissed.has(securityKey(e)));
+  // Split loud/actionable signal from benign churn so vendor revisions don't bury a real
+  // poison or privilege-escalation flag (the failure this whole surface exists to avoid).
+  const highSecurity = liveSecurity.filter((e) => eventSeverity(e) === "high");
+  const infoSecurity = liveSecurity.filter((e) => eventSeverity(e) === "info");
   const dismissSecurity = (e: SecurityEvent) => {
     setDismissed((prev) => {
       const next = new Set(prev);
@@ -728,11 +829,14 @@ export function ActivityView({
 
   const banner = (
     <>
-      {liveSecurity.length > 0 ? (
-        <SecurityNotices events={liveSecurity} onDismiss={dismissSecurity} />
+      {highSecurity.length > 0 ? (
+        <SecurityNotices events={highSecurity} onDismiss={dismissSecurity} />
       ) : (
         <SecurityResting />
       )}
+      {infoSecurity.length > 0 ? (
+        <QuietDriftHistory events={infoSecurity} onDismiss={dismissSecurity} />
+      ) : null}
       {registry?.liveInspect ? <LiveInspector refreshKey={refreshKey} /> : null}
       {savings && savings.tokensSaved > 0 ? (
         <SavingsBanner savings={savings} />

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -59,6 +59,10 @@ export interface SecurityEvent {
   change: string;
   /** For tool_poison_flag: which heuristic signatures matched. */
   signatures?: string[];
+  /** "high" = loud/actionable (poison, destructive-tool change, safety-annotation
+   * downgrade); "info" = benign non-destructive schema churn for the quiet history.
+   * Absent on events written before severity tiering; classified by type on read. */
+  severity?: "high" | "info";
 }
 
 /** Recent tool-definition integrity events (newest first). */


### PR DESCRIPTION
## Problem

The drift detector fingerprints each tool's full definition and records a `tool_drift` event on any change. Benign vendor churn (RevenueCat's beta tools revise definitions server-side) re-flags "changed" repeatedly, and each of ~6 connected clients spawns its own gateway that flags the same change independently against the shared baseline. Verified impact: in a 197-event `security.jsonl`, the one real high-severity signal (a `neon__prepare_database_migration` poison flag) sat below 60 benign drift events. Noise was burying signal, the worst outcome for a security surface.

This calibrates **what interrupts the user**. Poison / rug-pull detection is unchanged.

## Backend (`src-tauri/src/integrity.rs`)

- **Severity on every event.** `high` (loud + drives quarantine): poison hits, injected results, lost baseline, a **destructive** tool's definition changing/appearing, and a **safety-annotation downgrade** (`readOnlyHint` / `destructiveHint` flipping `true -> false`). `info` (quiet, viewable history): a non-destructive tool revised with its safety hints intact.
- **Pin store now carries annotation state** (`name -> Pin { fp, ro, dh }`) so a `true -> false` flip is detectable (a hash can't be reversed). Backward-compatible `PinRepr` deserializer: existing `tool-pins.json` load without a spurious flood and migrate silently on the next check.
- **`apply_quarantine` gates on `severity == high`**, which also blocks the new annotation-downgrade case (a non-destructive tool shedding `readOnlyHint`).
- **Source-level dedup**: `record_event` suppresses an identical `(type, server, tool, change)` within a 10-min window, collapsing the concurrent multi-gateway burst to one line so the log itself stops burying real signal.

## Frontend (`ActivityView.tsx`, `api.ts`)

- Split notices: `high` -> the loud **SecurityNotices**; `info` -> a new collapsed, muted **QuietDriftHistory** (no badge/warning). Legacy events without `severity` are classified by type on read.
- **Durable dismissal**: `securityKey` drops the timestamp (now `type/server/tool/change/severity`), so a benign drift that re-flags stays dismissed instead of returning as a new undismissable notice, and dismissing once effectively mutes a recurring per-tool benign change. Severity stays in the key so a benign dismissal never masks a later high-severity change on the same tool.

## Tests / checks

- 4 new integrity tests (severity tiering, annotation downgrade -> high + quarantine, source-dedup window).
- Rust: 18 integrity tests + full workspace (226 lib + 53 gateway) pass; `cargo clippy` clean on `integrity.rs`.
- Frontend: `tsc --noEmit` clean.

## Note

Downgrade edge (upgrade then run an older build) fails safe: a struct-format `tool-pins.json` read by the old `BTreeMap<String,String>` loader parses as corrupt, which emits a loud `pins_load_failed` and re-baselines rather than silently resetting detection.
