### PR TITLE
feat(tray): run in the tray/menu bar so HITL works in the background

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,17 @@
 {
   "name": "conduit",
-  "version": "0.3.2",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "conduit",
-      "version": "0.3.2",
+      "version": "1.0.1",
       "dependencies": {
         "@fontsource-variable/geist": "^5.2.9",
         "@tailwindcss/vite": "^4.3.1",
         "@tauri-apps/api": "^2",
+        "@tauri-apps/plugin-autostart": "^2.5.1",
         "@tauri-apps/plugin-dialog": "^2.7.1",
         "@tauri-apps/plugin-opener": "^2",
         "@tauri-apps/plugin-process": "^2.3.1",
@@ -3622,6 +3623,15 @@
       ],
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/@tauri-apps/plugin-autostart": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-autostart/-/plugin-autostart-2.5.1.tgz",
+      "integrity": "sha512-zS/xx7yzveCcotkA+8TqkI2lysmG2wvQXv2HGAVExITmnFfHAdj1arGsbbfs3o6EktRHf6l34pJxc3YGG2mg7w==",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@tauri-apps/api": "^2.8.0"
       }
     },
     "node_modules/@tauri-apps/plugin-dialog": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@fontsource-variable/geist": "^5.2.9",
     "@tailwindcss/vite": "^4.3.1",
     "@tauri-apps/api": "^2",
+    "@tauri-apps/plugin-autostart": "^2.5.1",
     "@tauri-apps/plugin-dialog": "^2.7.1",
     "@tauri-apps/plugin-opener": "^2",
     "@tauri-apps/plugin-process": "^2.3.1",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -244,6 +244,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "auto-launch"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f012b8cc0c850f34117ec8252a44418f2e34a2cf501de89e29b241ae5f79471"
+dependencies = [
+ "dirs 4.0.0",
+ "thiserror 1.0.69",
+ "winreg 0.10.1",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -605,6 +616,7 @@ dependencies = [
  "sha2",
  "tauri",
  "tauri-build",
+ "tauri-plugin-autostart",
  "tauri-plugin-deep-link",
  "tauri-plugin-dialog",
  "tauri-plugin-notification",
@@ -904,6 +916,15 @@ dependencies = [
 
 [[package]]
 name = "dirs"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
+dependencies = [
+ "dirs-sys 0.3.7",
+]
+
+[[package]]
+name = "dirs"
 version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
@@ -918,6 +939,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
 dependencies = [
  "dirs-sys 0.5.0",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
+dependencies = [
+ "libc",
+ "redox_users 0.4.6",
+ "winapi",
 ]
 
 [[package]]
@@ -1076,7 +1108,7 @@ dependencies = [
  "rustc_version",
  "toml 1.1.2+spec-1.1.0",
  "vswhom",
- "winreg",
+ "winreg 0.55.0",
 ]
 
 [[package]]
@@ -4300,6 +4332,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-autostart"
+version = "2.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "459383cebc193cdd03d1ba4acc40f2c408a7abce419d64bdcd2d745bc2886f70"
+dependencies = [
+ "auto-launch",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "tauri-plugin-deep-link"
 version = "2.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5946,6 +5992,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "winreg"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -19,12 +19,13 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 tauri-build = { version = "2", features = [] }
 
 [dependencies]
-tauri = { version = "2", features = [] }
+tauri = { version = "2", features = ["tray-icon"] }
 tauri-plugin-opener = "2"
 tauri-plugin-updater = "2"
 tauri-plugin-process = "2"
 tauri-plugin-dialog = "2"
 tauri-plugin-notification = "2"
+tauri-plugin-autostart = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 json5 = "0.4"

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -11,6 +11,7 @@
     "dialog:allow-save",
     "dialog:allow-open",
     "deep-link:default",
-    "notification:default"
+    "notification:default",
+    "autostart:default"
   ]
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,6 +1,9 @@
 use std::sync::Mutex;
 
-use tauri::{Emitter, Manager, State};
+use tauri::menu::{Menu, MenuItem, PredefinedMenuItem};
+use tauri::tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent};
+use tauri::{AppHandle, Emitter, Listener, Manager, State};
+use tauri_plugin_notification::NotificationExt;
 
 pub mod approval;
 mod approval_broker;
@@ -1594,6 +1597,96 @@ fn http_bridge_status(state: State<HttpBridgeState>) -> Result<HttpBridgeStatus,
     Ok(HttpBridgeStatus::new(bridge.port, bridge.token.clone()))
 }
 
+/// Bring the main window back to the foreground (from the tray, a re-launch, or an
+/// approval). Un-hides, un-minimizes, and focuses so it works from every hidden state.
+fn show_main_window(app: &AppHandle) {
+    if let Some(w) = app.get_webview_window("main") {
+        let _ = w.show();
+        let _ = w.unminimize();
+        let _ = w.set_focus();
+    }
+}
+
+/// Reflect the pending-approval count on the tray tooltip, so a glance at the tray
+/// tells you something is waiting even with the window hidden (complements the OS
+/// notification the broker already fires). Best-effort.
+fn update_tray_tooltip(app: &AppHandle) {
+    let pending = app
+        .try_state::<approval_broker::ApprovalBroker>()
+        .map(|b| b.list().len())
+        .unwrap_or(0);
+    if let Some(tray) = app.tray_by_id("main") {
+        let tip = if pending > 0 {
+            format!(
+                "Toolport - {pending} tool call{} awaiting approval",
+                if pending == 1 { "" } else { "s" }
+            )
+        } else {
+            "Toolport".to_string()
+        };
+        let _ = tray.set_tooltip(Some(tip));
+    }
+}
+
+/// The first time the window is closed to the tray, tell the user it's still running
+/// (so a background HITL gate isn't a surprise) and how to fully quit. Once ever: a
+/// marker file in the data dir gates it.
+fn maybe_show_tray_hint(app: &AppHandle) {
+    let Some(dir) = registry::conduit_dir() else {
+        return;
+    };
+    let marker = dir.join(".tray-hint-shown");
+    if marker.exists() {
+        return;
+    }
+    let _ = std::fs::write(&marker, b"1");
+    let _ = app
+        .notification()
+        .builder()
+        .title("Toolport is still running")
+        .body(
+            "It stays in your tray so it can hold tool calls for your approval. \
+             Quit it any time from the tray icon.",
+        )
+        .show();
+}
+
+/// Build the system-tray (Windows) / menu-bar (macOS) icon: left-click opens the app,
+/// right-click shows an Open/Quit menu. Quit fully exits (the run-loop's Exit handler
+/// tears down the HTTP bridge); closing the window only hides it (see the window-event
+/// handler), so the gateway/broker keep running and HITL stays live.
+fn build_tray(app: &AppHandle) -> tauri::Result<()> {
+    let open = MenuItem::with_id(app, "tray_open", "Open Toolport", true, None::<&str>)?;
+    let sep = PredefinedMenuItem::separator(app)?;
+    let quit = MenuItem::with_id(app, "tray_quit", "Quit Toolport", true, None::<&str>)?;
+    let menu = Menu::with_items(app, &[&open, &sep, &quit])?;
+
+    let mut builder = TrayIconBuilder::with_id("main")
+        .tooltip("Toolport")
+        .menu(&menu)
+        .show_menu_on_left_click(false)
+        .on_menu_event(|app, event| match event.id.as_ref() {
+            "tray_open" => show_main_window(app),
+            "tray_quit" => app.exit(0),
+            _ => {}
+        })
+        .on_tray_icon_event(|tray, event| {
+            if let TrayIconEvent::Click {
+                button: MouseButton::Left,
+                button_state: MouseButtonState::Up,
+                ..
+            } = event
+            {
+                show_main_window(tray.app_handle());
+            }
+        });
+    if let Some(icon) = app.default_window_icon().cloned() {
+        builder = builder.icon(icon);
+    }
+    builder.build(app)?;
+    Ok(())
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     let registry = registry::load().unwrap_or_default();
@@ -1646,9 +1739,9 @@ pub fn run() {
         // a second launch carrying a conduit:// URL is forwarded to the deep-link
         // plugin's on_open_url (set up below); here we just focus the window.
         .plugin(tauri_plugin_single_instance::init(|app, _argv, _cwd| {
-            if let Some(w) = app.get_webview_window("main") {
-                let _ = w.set_focus();
-            }
+            // A second launch (or clicking the app while it's hidden in the tray) should
+            // bring the window back, not just focus a hidden window.
+            show_main_window(app);
         }))
         .plugin(tauri_plugin_deep_link::init())
         .plugin(tauri_plugin_opener::init())
@@ -1656,6 +1749,12 @@ pub fn run() {
         .plugin(tauri_plugin_process::init())
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_notification::init())
+        // Launch at login (opt-in via Settings). `--hidden` is passed on auto-launch so
+        // the app starts to the tray without flashing a window (see setup()).
+        .plugin(tauri_plugin_autostart::init(
+            tauri_plugin_autostart::MacosLauncher::LaunchAgent,
+            Some(vec!["--hidden"]),
+        ))
         .manage(Mutex::new(registry))
         .manage(Mutex::new(HttpBridge::default()))
         .manage(PendingShare::default())
@@ -1733,7 +1832,37 @@ pub fn run() {
             stop_http_bridge,
             http_bridge_status,
         ])
+        // Close-to-tray: the window's X hides it instead of quitting, so the gateway and
+        // approval broker keep running (HITL only works while the app is alive). Quit is
+        // explicit, from the tray menu. A one-time notification explains it the first time.
+        .on_window_event(|window, event| {
+            if let tauri::WindowEvent::CloseRequested { api, .. } = event {
+                if window.label() == "main" {
+                    api.prevent_close();
+                    let _ = window.hide();
+                    maybe_show_tray_hint(window.app_handle());
+                }
+            }
+        })
         .setup(|app| {
+            let handle = app.handle();
+
+            // Build the tray icon, then show the window - unless launched with `--hidden`
+            // (auto-start at login), in which case we start straight to the tray. The
+            // window is created hidden (visible:false) so a normal launch never flashes.
+            build_tray(handle)?;
+            let start_hidden = std::env::args().any(|a| a == "--hidden");
+            if !start_hidden {
+                show_main_window(handle);
+            }
+
+            // Keep the tray tooltip's pending-approval count fresh as calls are held and
+            // resolved (the broker emits these; the window may be hidden in the tray).
+            let h = handle.clone();
+            app.listen("approval-pending", move |_| update_tray_tooltip(&h));
+            let h = handle.clone();
+            app.listen("approval-resolved", move |_| update_tray_tooltip(&h));
+
             // Mirror external registry changes (an agent toggling a server through
             // the gateway) back into the app and the UI, in a background thread.
             let handle = app.handle().clone();

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -16,7 +16,8 @@
         "width": 1240,
         "height": 820,
         "minWidth": 940,
-        "minHeight": 600
+        "minHeight": 600,
+        "visible": false
       }
     ],
     "security": {

--- a/src/components/SettingsView.tsx
+++ b/src/components/SettingsView.tsx
@@ -1,5 +1,10 @@
 import { useEffect, useState } from "react";
-import { Activity, Bot, Check, Copy, Globe, Layers, ShieldAlert, ShieldCheck, ShieldX, Trash2, UserCheck, X } from "lucide-react";
+import { Activity, Bot, Check, Copy, Globe, Layers, Power, ShieldAlert, ShieldCheck, ShieldX, Trash2, UserCheck, X } from "lucide-react";
+import {
+  disable as disableAutostart,
+  enable as enableAutostart,
+  isEnabled as isAutostartEnabled,
+} from "@tauri-apps/plugin-autostart";
 import { toastError } from "@/lib/toast";
 import {
   addHttpClient,
@@ -54,9 +59,30 @@ export function SettingsView({ registry, onRegistryChange }: Props) {
   const [newProfile, setNewProfile] = useState("");
   const [newToken, setNewToken] = useState<string | null>(null);
   const [clientBusy, setClientBusy] = useState(false);
+  const [autostartOn, setAutostartOn] = useState(false);
 
   const httpClients = registry?.httpClients ?? [];
   const profiles = registry?.profiles ?? [];
+
+  // Launch-at-login is OS-level (managed by the autostart plugin), not registry state.
+  useEffect(() => {
+    isAutostartEnabled()
+      .then(setAutostartOn)
+      .catch(() => {});
+  }, []);
+
+  const toggleAutostart = async (on: boolean) => {
+    setBusy(true);
+    try {
+      if (on) await enableAutostart();
+      else await disableAutostart();
+      setAutostartOn(on);
+    } catch (e) {
+      toastError(`Couldn't ${on ? "enable" : "disable"} launch at login: ${e}`);
+    } finally {
+      setBusy(false);
+    }
+  };
 
   async function addClient() {
     if (!newLabel.trim()) return;
@@ -172,6 +198,19 @@ export function SettingsView({ registry, onRegistryChange }: Props) {
 
   return (
     <div className="mx-auto flex max-w-2xl flex-col gap-6">
+      <section className="flex flex-col gap-2">
+        <h2 className="text-xs font-medium tracking-wide text-muted-foreground uppercase">
+          General
+        </h2>
+        {toggle(
+          Power,
+          autostartOn,
+          "text-info",
+          "Launch at login",
+          "Start Toolport in the tray when you sign in, so it can hold tool calls for approval even before you open it",
+          toggleAutostart,
+        )}
+      </section>
       <section className="flex flex-col gap-2">
         <h2 className="text-xs font-medium tracking-wide text-muted-foreground uppercase">
           Discovery


### PR DESCRIPTION
Makes Toolport live in the system tray (Windows) / menu bar (macOS) so it keeps running in the background — which is what makes the just-shipped HITL approval feature actually usable (a held call fail-closed-denies if the app isn't running).

## What's in it
- **Close-to-tray:** the window's X hides it instead of quitting; the gateway + approval broker stay alive. A one-time notification explains it the first time (persisted marker). **Quit** is explicit, from the tray menu, and fully exits.
- **Tray menu** (Open / Quit), left-click opens the window, and the **tooltip reflects the pending-approval count** so a held call is visible even when the window's hidden.
- **Launch at login** (opt-in, Settings → General) via `tauri-plugin-autostart`; auto-launch passes `--hidden` so it starts straight to the tray. The window is created hidden (`visible:false`) and shown in `setup()` unless `--hidden`, so a normal launch never flashes.
- **Single-instance** relaunch now *shows* the window (not just focuses), so re-launching while hidden in the tray brings it back.
- macOS keeps its dock icon.

## Verified
- Full workspace compiles; `tsc --noEmit` clean; `cargo audit` exits 0 (no new advisories from the autostart deps).
- Manually verified on Windows: tray icon appears, close-to-tray hides + notifies, reopen works.

Note: in `tauri dev` the close-to-tray notification is attributed to "Windows PowerShell" (unpackaged app has no registered Start Menu AUMID); the installed release shows "Toolport" via the NSIS-created Start Menu shortcut. Default-OFF features unchanged.