### PR TITLE
chore(release): 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,30 @@ All notable changes to Toolport are documented here. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/); versions match the GitHub releases.
 Entries before the rename below shipped under the project's former name, Conduit.
 
+## [1.1.0] - 2026-07-02
+
+### Added
+- **Human-in-the-loop tool approval (opt-in).** With "Require human approval" on, Toolport
+  holds any destructive or untrusted-server tool call and raises a desktop notification until
+  you approve or deny it in the app. Fail-closed: if no decision is made in time, the call is
+  denied. Off by default.
+- **Runs in the tray / menu bar.** Closing the window now keeps Toolport running in the
+  background (system tray on Windows, menu bar on macOS) so it can hold tool calls for approval
+  while you work; the tray tooltip shows how many are waiting. Quit explicitly from the tray menu.
+- **Launch at login (opt-in).** Start Toolport hidden in the tray when you sign in
+  (Settings > General).
+
+### Changed
+- **Security notices are tiered by severity, so real threats aren't buried.** Risky
+  tool-definition drift (a destructive tool changing, a tool dropping a readOnly/destructive
+  safety annotation, or poisoned content) stays a loud, actionable notice; benign vendor
+  revisions move to a quiet, collapsible "Recent tool changes" history. Dismissals now stick
+  across restarts, and duplicate notices from multiple clients are collapsed.
+
+### Fixed
+- Cleaned up leftover "Conduit" references in a few spots (the Teams connect URL placeholder,
+  the "download from releases" link, and the exported setup filename).
+
 ## [1.0.1] - 2026-07-02
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "conduit",
   "private": true,
-  "version": "1.0.1",
+  "version": "1.1.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -598,7 +598,7 @@ dependencies = [
 
 [[package]]
 name = "conduit"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
  "base64 0.22.1",
  "chacha20poly1305",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conduit"
-version = "1.0.1"
+version = "1.1.0"
 description = "Local MCP gateway: manage all your MCP servers in one place, set up once and shared by every AI client, with ~90% fewer tokens per request"
 authors = ["South Forge AI"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Toolport",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "identifier": "com.tsout.conduit",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
Version bump + CHANGELOG for **v1.1.0**. Bundles four features merged since v1.0.1:

- HITL human-in-the-loop tool approval (#82)
- OS notifications on held calls + approval-UI polish + branding fixes (#83)
- Severity-tiered security notices (#84)
- Tray / menu-bar background running + launch-at-login (#85)

Bumps `package.json`, `src-tauri/tauri.conf.json`, `Cargo.toml`, `Cargo.lock` to 1.1.0 (`server.json` is the separate gateway manifest, left at its own version). On merge, tag `v1.1.0` builds the signed draft release.