### PR TITLE
feat(hitl): approve-for-session and always-allow to curb approval fatigue

### DIFF
--- a/src-tauri/src/approval.rs
+++ b/src-tauri/src/approval.rs
@@ -113,6 +113,13 @@ pub fn gate_reason(
     }
 }
 
+/// The stable key for the "allow this tool past approval" lists (per-session in the broker,
+/// persistent in the registry). One definition so both sides agree. `server` is already the
+/// sanitized prefix, so `server/tool` is unambiguous.
+pub fn allow_key(server: &str, tool: &str) -> String {
+    format!("{server}/{tool}")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src-tauri/src/approval_broker.rs
+++ b/src-tauri/src/approval_broker.rs
@@ -12,7 +12,7 @@
 //! human decides in the app UI; a fail-closed timeout denies. Transport is loopback
 //! TCP + token for now; hardening to a named-pipe / uds is a follow-up.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::io::{BufRead, BufReader, Write};
 use std::net::{TcpListener, TcpStream};
 use std::sync::mpsc::{channel, Sender};
@@ -51,6 +51,11 @@ struct Inner {
     token: String,
     /// id -> parked connection. Bounded by `MAX_PENDING`.
     pending: Mutex<HashMap<String, Waiter>>,
+    /// Ephemeral per-session "always allow" set of `server/tool` keys. A matching call
+    /// auto-approves without prompting; cleared on app restart (the persistent list lives
+    /// in the registry). "Approve for this session" adds here; "Always allow" adds here
+    /// AND to the registry.
+    session_allow: Mutex<HashSet<String>>,
 }
 
 /// Cap on simultaneously-pending approvals, so a misbehaving client can't grow the
@@ -75,10 +80,11 @@ impl ApprovalBroker {
             .collect()
     }
 
-    /// Deliver a human decision for `id`. `Err` if the id is unknown (already resolved
-    /// or timed out). Sending is best-effort: a parked connection that already timed out
-    /// has dropped its receiver, which is harmless.
-    pub fn decide(&self, id: &str, approved: bool) -> Result<(), String> {
+    /// Deliver a human decision for `id`, returning the resolved call's view (so the caller
+    /// can apply an "allow this tool" scope from its server/tool). `Err` if the id is unknown
+    /// (already resolved or timed out). Sending is best-effort: a parked connection that
+    /// already timed out has dropped its receiver, which is harmless.
+    pub fn decide(&self, id: &str, approved: bool) -> Result<PendingView, String> {
         let waiter = self
             .inner
             .pending
@@ -93,10 +99,50 @@ impl ApprovalBroker {
                     ApprovalDecision::Denied
                 };
                 let _ = w.decide.send(d);
-                Ok(())
+                Ok(w.view)
             }
             None => Err("no pending approval with that id (it may have expired)".into()),
         }
+    }
+
+    /// Add a `server/tool` key to the ephemeral session allowlist (auto-approve until the
+    /// app restarts). Both "approve for session" and "always allow" add here so the
+    /// decision takes effect immediately for later matching calls.
+    pub fn add_session_allow(&self, key: String) {
+        self.inner
+            .session_allow
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .insert(key);
+    }
+
+    /// Remove a key from the session allowlist (used when the user revokes it).
+    pub fn remove_session_allow(&self, key: &str) {
+        self.inner
+            .session_allow
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .remove(key);
+    }
+
+    /// Snapshot the session allowlist for the UI.
+    pub fn session_allowed(&self) -> Vec<String> {
+        self.inner
+            .session_allow
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .iter()
+            .cloned()
+            .collect()
+    }
+
+    /// Whether a key is in the ephemeral session allowlist.
+    fn session_contains(&self, key: &str) -> bool {
+        self.inner
+            .session_allow
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .contains(key)
     }
 }
 
@@ -115,6 +161,7 @@ pub fn start(app: AppHandle) -> ApprovalBroker {
         inner: Arc::new(Inner {
             token: token.clone(),
             pending: Mutex::new(HashMap::new()),
+            session_allow: Mutex::new(HashSet::new()),
         }),
     };
 
@@ -182,6 +229,20 @@ fn handle_conn(stream: TcpStream, broker: ApprovalBroker, app: AppHandle) {
         return;
     }
 
+    // Auto-approve if the user already allowed this tool - per session (broker) or
+    // persistently (registry). Skips the prompt entirely so "approve for this session"
+    // and "always allow this tool" actually stick for later matching calls.
+    let key = crate::approval::allow_key(&req.server, &req.tool);
+    if broker.session_contains(&key) || registry_allows(&app, &key) {
+        let _ = out.set_write_timeout(Some(Duration::from_secs(10)));
+        let _ = writeln!(
+            out,
+            "{}",
+            serde_json::to_string(&ApprovalDecision::Approved).unwrap_or_default()
+        );
+        return;
+    }
+
     let view = PendingView {
         id: req.id.clone(),
         client: req.client.clone(),
@@ -239,6 +300,18 @@ fn handle_conn(stream: TcpStream, broker: ApprovalBroker, app: AppHandle) {
     );
 }
 
+/// Whether the tool `key` is on the registry's persistent always-allow list. Reads the
+/// app-managed registry state; false if unavailable.
+fn registry_allows(app: &AppHandle, key: &str) -> bool {
+    app.try_state::<Mutex<crate::registry::Registry>>()
+        .map(|s| {
+            s.lock()
+                .unwrap_or_else(PoisonError::into_inner)
+                .is_tool_allowed(key)
+        })
+        .unwrap_or(false)
+}
+
 /// Notify the human that a call is held: an OS notification plus a taskbar-attention
 /// flash on the main window. Best-effort and non-blocking - if either fails (permission
 /// off, no window) the in-app overlay is still the source of truth. We flash rather than
@@ -265,6 +338,7 @@ mod tests {
             inner: Arc::new(Inner {
                 token: "tok".into(),
                 pending: Mutex::new(HashMap::new()),
+                session_allow: Mutex::new(HashSet::new()),
             }),
         }
     }
@@ -314,5 +388,23 @@ mod tests {
     #[test]
     fn unknown_id_errs() {
         assert!(broker().decide("nope", true).is_err());
+    }
+
+    #[test]
+    fn session_allow_round_trips_and_decide_returns_view() {
+        let b = broker();
+        let key = crate::approval::allow_key("db", "db__read");
+        assert!(!b.session_contains(&key));
+        b.add_session_allow(key.clone());
+        assert!(b.session_contains(&key));
+        assert_eq!(b.session_allowed(), vec![key.clone()]);
+        b.remove_session_allow(&key);
+        assert!(!b.session_contains(&key));
+
+        // decide now hands back the resolved view (so the command can apply an allow scope).
+        let rx = park(&b, "z");
+        let view = b.decide("z", true).unwrap();
+        assert_eq!(view.tool, "drop");
+        assert_eq!(rx.recv_timeout(Duration::from_secs(1)).unwrap(), ApprovalDecision::Approved);
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -848,14 +848,87 @@ fn list_pending_approvals(
 }
 
 /// Approve or deny a held tool call by id. The parked gateway call then runs (approve) or is
-/// refused (deny). `Err` if the id is unknown (already resolved or timed out).
+/// refused (deny). `scope` (on approve) controls whether future calls to the same tool skip
+/// the prompt: `once` (default, remember nothing), `session` (until the app restarts), or
+/// `always` (persisted). `Err` if the id is unknown (already resolved or timed out).
 #[tauri::command]
 fn decide_approval(
     broker: State<approval_broker::ApprovalBroker>,
+    state: State<RegistryState>,
     id: String,
     approved: bool,
+    scope: String,
 ) -> Result<(), String> {
-    broker.decide(&id, approved)
+    let view = broker.decide(&id, approved)?;
+    if approved && scope != "once" {
+        let key = approval::allow_key(&view.server, &view.tool);
+        broker.add_session_allow(key.clone());
+        if scope == "always" {
+            let mut reg = state.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+            reg.allow_tool(key);
+            registry::save(&reg)?;
+        }
+    }
+    Ok(())
+}
+
+/// A tool allowed to skip human approval, for the Settings "Allowed tools" list.
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct AllowedTool {
+    key: String,
+    server: String,
+    tool: String,
+    /// true = persisted ("always"); false = only for this app session.
+    persistent: bool,
+}
+
+/// Tools currently allowed to skip human approval: persistent ("always allow") from the
+/// registry, plus this session's temporary allows from the broker.
+#[tauri::command]
+fn list_allowed_tools(
+    state: State<RegistryState>,
+    broker: State<approval_broker::ApprovalBroker>,
+) -> Vec<AllowedTool> {
+    let persistent = {
+        let reg = state.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+        reg.human_approval_allow.clone()
+    };
+    let split = |key: &str| match key.split_once('/') {
+        Some((s, t)) => (s.to_string(), t.to_string()),
+        None => (String::new(), key.to_string()),
+    };
+    let mut out: Vec<AllowedTool> = persistent
+        .iter()
+        .map(|k| {
+            let (server, tool) = split(k);
+            AllowedTool { key: k.clone(), server, tool, persistent: true }
+        })
+        .collect();
+    for k in broker.session_allowed() {
+        if !persistent.contains(&k) {
+            let (server, tool) = split(&k);
+            out.push(AllowedTool { key: k, server, tool, persistent: false });
+        }
+    }
+    out
+}
+
+/// Revoke an allowed tool (re-require approval): drop it from both the persistent registry
+/// list and this session's allowlist.
+#[tauri::command]
+fn revoke_allowed_tool(
+    state: State<RegistryState>,
+    broker: State<approval_broker::ApprovalBroker>,
+    key: String,
+) -> Result<(), String> {
+    {
+        let mut reg = state.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+        reg.revoke_tool(&key);
+        registry::save(&reg)?;
+    }
+    broker.remove_session_allow(&key);
+    Ok(())
 }
 
 /// Toggle live request/response inspection. When enabled, the gateway captures each
@@ -1798,6 +1871,8 @@ pub fn run() {
             set_human_approval,
             list_pending_approvals,
             decide_approval,
+            list_allowed_tools,
+            revoke_allowed_tool,
             set_live_inspect,
             get_inspect_log,
             clear_inspect_log,

--- a/src-tauri/src/registry.rs
+++ b/src-tauri/src/registry.rs
@@ -147,6 +147,12 @@ pub struct Registry {
     /// `confirm_destructive` for the tools it gates (a human decision supersedes the agent's).
     #[serde(default)]
     pub human_approval: bool,
+    /// Tools the user chose to "always allow" past human approval, so the HITL gate skips
+    /// them. Each entry is a `server/tool` key (see `approval::allow_key`). Persisted so an
+    /// always-allowed tool stays allowed across restarts; the broker also keeps a separate
+    /// ephemeral per-session allowlist that is NOT saved here.
+    #[serde(default)]
+    pub human_approval_allow: Vec<String>,
     /// Quarantine-on-drift: when true, a high-risk tool (poisoned definition, or a
     /// destructive tool whose definition changed/appeared) that drifts from its pinned
     /// baseline is hidden and blocked from every client until the user re-approves it.
@@ -280,6 +286,7 @@ impl Default for Registry {
             deny_destructive: false,
             confirm_destructive: false,
             human_approval: false,
+            human_approval_allow: Vec::new(),
             quarantine_on_drift: false,
             lazy_discovery: true,
             allow_agent_control: false,
@@ -470,6 +477,24 @@ impl Registry {
     /// for a person. When it gates a tool it takes precedence over `confirm_destructive`.
     pub fn set_human_approval(&mut self, on: bool) {
         self.human_approval = on;
+    }
+
+    /// Add a `server/tool` key to the persistent "always allow" list, so the HITL gate
+    /// skips it. Idempotent.
+    pub fn allow_tool(&mut self, key: String) {
+        if !self.human_approval_allow.contains(&key) {
+            self.human_approval_allow.push(key);
+        }
+    }
+
+    /// Remove a key from the persistent allow list (re-require approval for that tool).
+    pub fn revoke_tool(&mut self, key: &str) {
+        self.human_approval_allow.retain(|k| k != key);
+    }
+
+    /// Whether a `server/tool` key is on the persistent always-allow list.
+    pub fn is_tool_allowed(&self, key: &str) -> bool {
+        self.human_approval_allow.iter().any(|k| k == key)
     }
 
     /// Set lazy discovery mode (gateway exposes meta-tools vs the full catalog).

--- a/src/components/PendingApprovals.tsx
+++ b/src/components/PendingApprovals.tsx
@@ -3,7 +3,7 @@ import { listen } from "@tauri-apps/api/event";
 import { Check, Globe, Loader2, Monitor, ShieldAlert, Trash2, X } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { decideApproval, listPendingApprovals } from "@/lib/api";
+import { decideApproval, listPendingApprovals, type ApprovalScope } from "@/lib/api";
 import type { PendingApproval } from "@/lib/types";
 import { toastError } from "@/lib/toast";
 
@@ -83,10 +83,10 @@ export function PendingApprovals() {
     for (const id of seenAt.current.keys()) if (!ids.has(id)) seenAt.current.delete(id);
   }, [pending]);
 
-  const decide = async (id: string, approved: boolean) => {
+  const decide = async (id: string, approved: boolean, scope: ApprovalScope = "once") => {
     setBusy(id);
     try {
-      await decideApproval(id, approved);
+      await decideApproval(id, approved, scope);
       setPending((p) => p.filter((x) => x.id !== id));
     } catch (e) {
       toastError(`Couldn't record your decision: ${e}`);
@@ -200,6 +200,26 @@ export function PendingApprovals() {
                       Approve
                     </Button>
                   </div>
+                </div>
+
+                {/* Skip the prompt for this tool next time - curbs approval fatigue. */}
+                <div className="mt-2 flex flex-wrap items-center gap-x-2.5 gap-y-1 text-xs text-muted-foreground">
+                  <span>Skip next time?</span>
+                  <button
+                    disabled={isBusy}
+                    onClick={() => void decide(a.id, true, "session")}
+                    className="font-medium text-foreground/80 underline-offset-2 hover:text-foreground hover:underline disabled:opacity-50"
+                  >
+                    Allow for this session
+                  </button>
+                  <span className="text-muted-foreground/40">·</span>
+                  <button
+                    disabled={isBusy}
+                    onClick={() => void decide(a.id, true, "always")}
+                    className="font-medium text-foreground/80 underline-offset-2 hover:text-foreground hover:underline disabled:opacity-50"
+                  >
+                    Always allow this tool
+                  </button>
                 </div>
               </li>
             );

--- a/src/components/SettingsView.tsx
+++ b/src/components/SettingsView.tsx
@@ -10,8 +10,10 @@ import {
   addHttpClient,
   clearInspectLog,
   httpBridgeStatus,
+  listAllowedTools,
   listQuarantined,
   releaseQuarantine,
+  revokeAllowedTool,
   removeHttpClient,
   setAllowAgentControl,
   setConfirmDestructive,
@@ -25,7 +27,7 @@ import {
   type HttpBridgeStatus,
   type QuarantinedTool,
 } from "@/lib/api";
-import type { Registry } from "@/lib/types";
+import type { AllowedTool, Registry } from "@/lib/types";
 import { Switch } from "@/components/ui/switch";
 import {
   Select,
@@ -52,6 +54,7 @@ export function SettingsView({ registry, onRegistryChange }: Props) {
   const liveInspect = registry?.liveInspect ?? false;
   const [busy, setBusy] = useState(false);
   const [quarantined, setQuarantined] = useState<QuarantinedTool[]>([]);
+  const [allowedTools, setAllowedTools] = useState<AllowedTool[]>([]);
   const [bridge, setBridge] = useState<HttpBridgeStatus | null>(null);
   const [bridgeBusy, setBridgeBusy] = useState(false);
   const [copied, setCopied] = useState<string | null>(null);
@@ -127,6 +130,24 @@ export function SettingsView({ registry, onRegistryChange }: Props) {
       setQuarantined(await listQuarantined());
     } catch (e) {
       toastError(`Couldn't re-approve: ${e}`);
+    }
+  };
+
+  // Tools the user allowed to skip human approval. Polled because "always allow" is chosen
+  // from the approval overlay (a different component), so this keeps the list in sync.
+  useEffect(() => {
+    const load = () => listAllowedTools().then(setAllowedTools).catch(() => {});
+    load();
+    const id = setInterval(load, 10000);
+    return () => clearInterval(id);
+  }, []);
+
+  const revokeAllowed = async (key: string) => {
+    try {
+      await revokeAllowedTool(key);
+      setAllowedTools(await listAllowedTools());
+    } catch (e) {
+      toastError(`Couldn't revoke: ${e}`);
     }
   };
 
@@ -299,6 +320,34 @@ export function SettingsView({ registry, onRegistryChange }: Props) {
                     className="ml-auto shrink-0 rounded-md border bg-background px-2 py-0.5 text-[11px] font-medium hover:bg-accent"
                   >
                     Re-approve
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+        {allowedTools.length > 0 && (
+          <div className="flex flex-col gap-2 rounded-md border border-border bg-muted/20 px-3 py-2.5">
+            <div className="flex items-center gap-2">
+              <UserCheck className="size-4 shrink-0 text-info" />
+              <span className="text-sm font-medium">Allowed tools</span>
+              <span className="text-xs text-muted-foreground">skip human approval</span>
+            </div>
+            <ul className="flex flex-col gap-1.5">
+              {allowedTools.map((t) => (
+                <li key={t.key} className="flex items-center gap-2 text-xs">
+                  <span className="min-w-0 truncate font-mono">
+                    {t.server}/{t.tool}
+                  </span>
+                  <span className="shrink-0 text-muted-foreground">
+                    {t.persistent ? "always" : "this session"}
+                  </span>
+                  <button
+                    type="button"
+                    onClick={() => void revokeAllowed(t.key)}
+                    className="ml-auto shrink-0 rounded-md border bg-background px-2 py-0.5 text-[11px] font-medium hover:bg-accent"
+                  >
+                    Revoke
                   </button>
                 </li>
               ))}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -12,6 +12,7 @@ import type {
   McpTool,
   MigrateResult,
   ParsedSnippetServer,
+  AllowedTool,
   PendingApproval,
   ProbeResult,
   Registry,
@@ -180,9 +181,28 @@ export function listPendingApprovals(): Promise<PendingApproval[]> {
   return invoke<PendingApproval[]>("list_pending_approvals");
 }
 
-/** Approve or deny a held tool call by id; the parked gateway call then runs or is refused. */
-export function decideApproval(id: string, approved: boolean): Promise<void> {
-  return invoke<void>("decide_approval", { id, approved });
+/** How long an approval sticks: `once` (this call only), `session` (until the app
+ * restarts), or `always` (persisted, skips the prompt for this tool from now on). */
+export type ApprovalScope = "once" | "session" | "always";
+
+/** Approve or deny a held tool call by id; the parked gateway call then runs or is refused.
+ * On approve, `scope` controls whether future calls to the same tool skip the prompt. */
+export function decideApproval(
+  id: string,
+  approved: boolean,
+  scope: ApprovalScope = "once",
+): Promise<void> {
+  return invoke<void>("decide_approval", { id, approved, scope });
+}
+
+/** Tools currently allowed to skip human approval (persistent "always" + this session). */
+export function listAllowedTools(): Promise<AllowedTool[]> {
+  return invoke<AllowedTool[]>("list_allowed_tools");
+}
+
+/** Revoke an allowed tool so it requires approval again. */
+export function revokeAllowedTool(key: string): Promise<void> {
+  return invoke<void>("revoke_allowed_tool", { key });
 }
 
 /** Toggle live request/response inspection (opt-in, off by default). When on, the

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -309,6 +309,15 @@ export interface PendingApproval {
   arguments: unknown;
 }
 
+/** A tool the user allowed to skip human approval (Settings "Allowed tools" list). */
+export interface AllowedTool {
+  key: string;
+  server: string;
+  tool: string;
+  /** true = persisted ("always"); false = only for this app session. */
+  persistent: boolean;
+}
+
 export interface Registry {
   version: number;
   servers: ServerEntry[];


### PR DESCRIPTION
Follow-up to HITL (#82) and the v1.1.0 release: makes "Require human approval" pleasant for daily use.

## What
Right now every gated call needs a fresh approve/deny. This adds two scopes to the approval overlay:
- **Allow for this session** - auto-approve this tool until the app restarts (broker in-memory allowlist).
- **Always allow this tool** - auto-approve persistently (registry `human_approval_allow`, survives restarts).

When a gateway dials the broker for a gated call, the broker checks the session + persistent allowlists (keyed `server/tool`) and approves immediately on a match, no prompt or notification. Fail-closed behavior is unchanged for anything not explicitly allowed.

**Settings → Security** gains an **Allowed tools** list (persistent + this-session) with per-tool **Revoke**, so every allow stays reviewable and reversible.

## Verified
- 227 lib tests pass (incl. a new broker session-allow round-trip test), `tsc --noEmit` clean, full workspace compiles.
- No new dependencies.

Runtime note: end-to-end "approve-for-session then the next call skips the prompt" is best confirmed live in the app; the unit tests cover the allowlist + decide-returns-view plumbing.