### PR TITLE
feat(overrides): rename or re-describe any tool as clients see it

### DIFF
--- a/src-tauri/src/bin/conduit-gateway.rs
+++ b/src-tauri/src/bin/conduit-gateway.rs
@@ -1928,6 +1928,9 @@ fn build_router(
         .collect();
 
     let mut router = Router::with_policy(policy);
+    // Per-tool exposure overrides (rename / re-describe) must be set before indexing,
+    // since they're applied as each server's tools are added.
+    router.set_overrides(reg.tool_overrides.clone());
     for handle in handles {
         if let Ok(Some(ds)) = handle.join() {
             router.add(ds);

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -931,6 +931,37 @@ fn revoke_allowed_tool(
     Ok(())
 }
 
+/// Set (or clear) a per-tool exposure override, keyed by the exposed (`server__tool`) name:
+/// rename the tool and/or replace its description as clients see it (the latter locally
+/// neutralizes a poisoned description). Empty/blank name and description clears the override.
+/// The call still routes to the original downstream tool; gateways pick up the change via
+/// the registry watcher.
+#[tauri::command]
+fn set_tool_override(
+    state: State<RegistryState>,
+    exposed: String,
+    name: Option<String>,
+    description: Option<String>,
+) -> Result<Registry, String> {
+    let norm = |s: Option<String>| s.map(|v| v.trim().to_string()).filter(|v| !v.is_empty());
+    let mut reg = state.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+    reg.set_tool_override(
+        exposed,
+        registry::ToolOverride { name: norm(name), description: norm(description) },
+    );
+    registry::save(&reg)?;
+    Ok(reg.clone())
+}
+
+/// Remove a tool's exposure override, restoring the server's own name and description.
+#[tauri::command]
+fn clear_tool_override(state: State<RegistryState>, exposed: String) -> Result<Registry, String> {
+    let mut reg = state.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+    reg.clear_tool_override(&exposed);
+    registry::save(&reg)?;
+    Ok(reg.clone())
+}
+
 /// Toggle live request/response inspection. When enabled, the gateway captures each
 /// tool call's args + result into a small, separate, ephemeral local ring
 /// (`inspect.jsonl`, last 50 calls, each body size-capped) that the Activity view can
@@ -1873,6 +1904,8 @@ pub fn run() {
             decide_approval,
             list_allowed_tools,
             revoke_allowed_tool,
+            set_tool_override,
+            clear_tool_override,
             set_live_inspect,
             get_inspect_log,
             clear_inspect_log,

--- a/src-tauri/src/registry.rs
+++ b/src-tauri/src/registry.rs
@@ -117,6 +117,24 @@ pub fn sha256_hex(s: &str) -> String {
     format!("{:x}", h.finalize())
 }
 
+/// A user override for how one tool is exposed to clients, keyed in the registry by the
+/// tool's exposed (namespaced `server__tool`) name. Lets the user rename a tool or replace
+/// its description - the latter is the security lever: locally neutralize a poisoned or
+/// injection-laden description without waiting on the upstream server. Overrides only touch
+/// the EXPOSED definition; the call still routes to the original downstream tool. (Pinning
+/// input params is a planned follow-up and not in this struct yet.)
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ToolOverride {
+    /// A replacement client-facing name (sanitized to a valid tool name; ignored if it
+    /// would collide with another exposed tool).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    /// A replacement description shown to the client instead of the server's own.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Registry {
@@ -153,6 +171,11 @@ pub struct Registry {
     /// ephemeral per-session allowlist that is NOT saved here.
     #[serde(default)]
     pub human_approval_allow: Vec<String>,
+    /// Per-tool exposure overrides, keyed by the exposed (`server__tool`) name: rename or
+    /// re-describe a tool as clients see it (e.g. neutralize a poisoned description). The
+    /// call still routes to the original downstream tool.
+    #[serde(default)]
+    pub tool_overrides: HashMap<String, ToolOverride>,
     /// Quarantine-on-drift: when true, a high-risk tool (poisoned definition, or a
     /// destructive tool whose definition changed/appeared) that drifts from its pinned
     /// baseline is hidden and blocked from every client until the user re-approves it.
@@ -287,6 +310,7 @@ impl Default for Registry {
             confirm_destructive: false,
             human_approval: false,
             human_approval_allow: Vec::new(),
+            tool_overrides: HashMap::new(),
             quarantine_on_drift: false,
             lazy_discovery: true,
             allow_agent_control: false,
@@ -495,6 +519,21 @@ impl Registry {
     /// Whether a `server/tool` key is on the persistent always-allow list.
     pub fn is_tool_allowed(&self, key: &str) -> bool {
         self.human_approval_allow.iter().any(|k| k == key)
+    }
+
+    /// Set (or replace) the exposure override for an exposed (`server__tool`) name. An
+    /// override with both fields cleared is removed rather than stored empty.
+    pub fn set_tool_override(&mut self, exposed: String, ov: ToolOverride) {
+        if ov.name.is_none() && ov.description.is_none() {
+            self.tool_overrides.remove(&exposed);
+        } else {
+            self.tool_overrides.insert(exposed, ov);
+        }
+    }
+
+    /// Remove any override for an exposed tool name (restore the server's own definition).
+    pub fn clear_tool_override(&mut self, exposed: &str) {
+        self.tool_overrides.remove(exposed);
     }
 
     /// Set lazy discovery mode (gateway exposes meta-tools vs the full catalog).

--- a/src-tauri/src/router.rs
+++ b/src-tauri/src/router.rs
@@ -20,6 +20,7 @@ use serde_json::{json, Value};
 use crate::downstream::{
     backoff_delay, DownstreamServer, TransportError, HTTP_MAX_RETRIES, HTTP_RETRY_CAP,
 };
+use crate::registry::ToolOverride;
 
 /// The delay before a retry attempt. Prefers a server-advertised `Retry-After`,
 /// else our exponential backoff, but never longer than `HTTP_RETRY_CAP` so a
@@ -184,6 +185,10 @@ pub struct Router {
     seen: HashSet<String>,
     /// What may be exposed; applied as each server is added.
     policy: ToolPolicy,
+    /// Per-tool exposure overrides (rename / re-describe), keyed by the ORIGINAL exposed
+    /// (`server__tool`) name. Applied while indexing; the route still points at the real
+    /// downstream tool, so a rename never changes where a call goes.
+    overrides: HashMap<String, ToolOverride>,
     /// Exposed name -> why it's hidden, for a clear message if a hidden tool is
     /// still called by name (e.g. via conduit_call_tool).
     blocked: HashMap<String, String>,
@@ -226,6 +231,12 @@ impl Router {
         }
     }
 
+    /// Set the per-tool exposure overrides. Must be called BEFORE `add`/`refresh`, since
+    /// they're applied while indexing each server's tools.
+    pub fn set_overrides(&mut self, overrides: HashMap<String, ToolOverride>) {
+        self.overrides = overrides;
+    }
+
     /// Index one server's advertised tools/resources/prompts into the exposed
     /// aggregation (names, routes, policy). Shared by `add` (a new server) and
     /// `rebuild_aggregation` (after a refresh); the call order is the exposed-name
@@ -249,6 +260,29 @@ impl Router {
                 continue;
             }
             let mut t = tool.clone();
+            // Apply the user's exposure override (keyed by the ORIGINAL exposed name).
+            // Cloned to owned so we don't hold a borrow of `self.overrides` across the
+            // `self.seen` mutation below.
+            let ov_name = self.overrides.get(&exposed).and_then(|o| o.name.clone());
+            let ov_desc = self.overrides.get(&exposed).and_then(|o| o.description.clone());
+            // Rename changes ONLY the client-facing name; the route below still points at
+            // the real downstream tool, so a call never goes anywhere new. A rename that is
+            // empty or would collide with an existing exposed name is ignored (keep the
+            // original) so routing stays unambiguous.
+            let exposed = match ov_name {
+                Some(new) => {
+                    let cand = sanitize_segment(&new);
+                    if !cand.is_empty() && self.seen.insert(cand.clone()) {
+                        cand
+                    } else {
+                        exposed
+                    }
+                }
+                None => exposed,
+            };
+            if let Some(desc) = ov_desc {
+                t["description"] = json!(desc);
+            }
             t["name"] = json!(exposed);
             if let Some(schema) = t.get_mut("inputSchema") {
                 inline_refs(schema);
@@ -647,6 +681,60 @@ mod tests {
         let result = router.route_call("postgres__add", json!({ "a": 1 })).unwrap();
         let text = result["content"][0]["text"].as_str().unwrap();
         assert_eq!(text, "postgres:add");
+    }
+
+    #[test]
+    fn tool_overrides_rename_and_redescribe() {
+        let mut router = Router::new();
+        let mut overrides = HashMap::new();
+        overrides.insert(
+            "srv__echo".to_string(),
+            ToolOverride { name: Some("say".into()), description: Some("say it back".into()) },
+        );
+        overrides.insert(
+            "srv__add".to_string(),
+            ToolOverride { name: None, description: Some("cleaned".into()) },
+        );
+        router.set_overrides(overrides);
+        router.add(mock_server("srv"));
+
+        let tools = router.aggregated_tools();
+        let by_name: HashMap<&str, &Value> =
+            tools.iter().map(|t| (t["name"].as_str().unwrap(), t)).collect();
+
+        // echo is renamed to "say" (its original exposed name is gone) and re-described.
+        assert!(by_name.contains_key("say"));
+        assert!(!by_name.contains_key("srv__echo"));
+        assert_eq!(by_name["say"]["description"], "say it back");
+        // add keeps its name, description replaced (the poisoned-desc neutralize case).
+        assert_eq!(by_name["srv__add"]["description"], "cleaned");
+
+        // The renamed tool STILL routes to the original downstream tool (echo).
+        let out = router.route_call("say", json!({})).unwrap();
+        assert_eq!(out["content"][0]["text"], "srv:echo");
+        let out = router.route_call("srv__add", json!({})).unwrap();
+        assert_eq!(out["content"][0]["text"], "srv:add");
+    }
+
+    #[test]
+    fn rename_to_an_already_taken_name_is_ignored() {
+        // add is indexed after echo, so renaming add -> "srv__echo" (already taken) must
+        // fall back to add's original name, keeping routing unambiguous.
+        let mut router = Router::new();
+        let mut overrides = HashMap::new();
+        overrides.insert(
+            "srv__add".to_string(),
+            ToolOverride { name: Some("srv__echo".into()), description: None },
+        );
+        router.set_overrides(overrides);
+        router.add(mock_server("srv"));
+
+        let tools = router.aggregated_tools();
+        let names: Vec<&str> = tools.iter().map(|t| t["name"].as_str().unwrap()).collect();
+        assert!(names.contains(&"srv__echo"), "the real echo keeps the name");
+        assert!(names.contains(&"srv__add"), "add fell back to its own name");
+        assert_eq!(router.route_call("srv__echo", json!({})).unwrap()["content"][0]["text"], "srv:echo");
+        assert_eq!(router.route_call("srv__add", json!({})).unwrap()["content"][0]["text"], "srv:add");
     }
 
     #[test]

--- a/src/components/PlaygroundView.tsx
+++ b/src/components/PlaygroundView.tsx
@@ -1,10 +1,12 @@
 import { useEffect, useMemo, useState } from "react";
 import {
   CheckCircle2,
+  ChevronRight,
   FileText,
   FlaskConical,
   Loader2,
   MessageSquare,
+  Pencil,
   Play,
   ShieldAlert,
   XCircle,
@@ -12,12 +14,14 @@ import {
 import { toastError } from "@/lib/toast";
 import {
   callTool,
+  clearToolOverride,
   getPrompt,
   listServerPrompts,
   listServerResources,
   listServerTools,
   readResource,
   setToolEnabled,
+  setToolOverride,
 } from "@/lib/api";
 import type {
   JsonSchemaProp,
@@ -45,6 +49,137 @@ import {
 /** A tool is destructive if it carries the MCP `destructiveHint` annotation. */
 function isDestructive(tool: McpTool): boolean {
   return tool.annotations?.destructiveHint === true || tool.destructiveHint === true;
+}
+
+/** Mirror of the gateway's `sanitize_segment`: keep [A-Za-z0-9_], everything else -> `_`. */
+function sanitizeSegment(s: string): string {
+  return s.replace(/[^A-Za-z0-9_]/g, "_");
+}
+
+/** The exposed (client-facing) name for a tool, matching the gateway's namespacing. This
+ * is the key the registry stores tool overrides under. */
+function exposedName(serverId: string, tool: string): string {
+  return `${sanitizeSegment(serverId)}__${sanitizeSegment(tool)}`;
+}
+
+/** Editor to rename / re-describe a tool as clients see it (the security lever: locally
+ * neutralize a misleading or injection-laden description). Collapsed by default; the call
+ * still routes to the original downstream tool. */
+function ToolOverrideEditor({
+  serverId,
+  tool,
+  registry,
+  onRegistryChange,
+}: {
+  serverId: string;
+  tool: McpTool;
+  registry: Registry | null;
+  onRegistryChange: (r: Registry) => void;
+}) {
+  const exposed = exposedName(serverId, tool.name);
+  const current = registry?.toolOverrides?.[exposed];
+  const [open, setOpen] = useState(false);
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+  const [busy, setBusy] = useState(false);
+
+  // Re-sync the fields (and collapse) whenever the selected tool changes.
+  useEffect(() => {
+    setName(current?.name ?? "");
+    setDescription(current?.description ?? "");
+    setOpen(false);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [exposed]);
+
+  const hasOverride = !!current;
+
+  const save = async () => {
+    setBusy(true);
+    try {
+      onRegistryChange(await setToolOverride(exposed, name || null, description || null));
+    } catch (e) {
+      toastError(`Couldn't save override: ${e}`);
+    } finally {
+      setBusy(false);
+    }
+  };
+  const reset = async () => {
+    setBusy(true);
+    try {
+      onRegistryChange(await clearToolOverride(exposed));
+      setName("");
+      setDescription("");
+    } catch (e) {
+      toastError(`Couldn't clear override: ${e}`);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="rounded-md border border-border/60 bg-muted/20">
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        aria-expanded={open}
+        className="flex w-full items-center gap-2 px-3 py-2 text-xs text-muted-foreground"
+      >
+        <Pencil className="size-3.5 shrink-0" />
+        <span className="font-medium text-foreground/80">Override how clients see this tool</span>
+        {hasOverride && (
+          <span className="rounded-full bg-info/15 px-1.5 py-0.5 text-[10px] font-medium text-info">
+            active
+          </span>
+        )}
+        <ChevronRight
+          className={`ml-auto size-3.5 transition-transform ${open ? "rotate-90" : ""}`}
+        />
+      </button>
+      {open && (
+        <div className="flex flex-col gap-2.5 border-t border-border/60 px-3 py-3">
+          <p className="text-xs text-muted-foreground">
+            Rename the tool or replace its description as every client sees it, e.g. to
+            neutralize a misleading or injection-laden description. The call still runs the
+            original server tool.
+          </p>
+          <label className="flex flex-col gap-1 text-xs">
+            <span className="text-muted-foreground">
+              Name{" "}
+              <span className="text-muted-foreground/60">
+                (blank keeps <span className="font-mono">{exposed}</span>)
+              </span>
+            </span>
+            <input
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder={exposed}
+              className="rounded-md border border-input bg-transparent px-2.5 py-1.5 font-mono text-xs shadow-sm focus-visible:ring-1 focus-visible:ring-ring focus-visible:outline-none"
+            />
+          </label>
+          <label className="flex flex-col gap-1 text-xs">
+            <span className="text-muted-foreground">Description (blank keeps the server's)</span>
+            <textarea
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              rows={3}
+              placeholder={tool.description ?? "(server's description)"}
+              className="rounded-md border border-input bg-transparent px-2.5 py-1.5 text-xs shadow-sm focus-visible:ring-1 focus-visible:ring-ring focus-visible:outline-none"
+            />
+          </label>
+          <div className="flex gap-2">
+            <Button size="sm" onClick={() => void save()} disabled={busy}>
+              Save override
+            </Button>
+            {hasOverride && (
+              <Button size="sm" variant="outline" onClick={() => void reset()} disabled={busy}>
+                Reset to original
+              </Button>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
 }
 
 /** First declared type of a JSON-schema property (schemas may list several). */
@@ -712,6 +847,15 @@ export function PlaygroundView({ registry, onRegistryChange }: PlaygroundProps) 
               <ShieldAlert className="size-3.5" />
               Hidden from clients by policy. You can still test it here.
             </p>
+          )}
+
+          {serverId && (
+            <ToolOverrideEditor
+              serverId={serverId}
+              tool={tool}
+              registry={registry}
+              onRegistryChange={onRegistryChange}
+            />
           )}
 
           <div className="flex items-center justify-between">

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -205,6 +205,22 @@ export function revokeAllowedTool(key: string): Promise<void> {
   return invoke<void>("revoke_allowed_tool", { key });
 }
 
+/** Set (or clear) a per-tool exposure override, keyed by exposed `server__tool` name:
+ * rename and/or replace the description clients see. Blank name + description clears it.
+ * The call still routes to the original downstream tool. */
+export function setToolOverride(
+  exposed: string,
+  name: string | null,
+  description: string | null,
+): Promise<Registry> {
+  return invoke<Registry>("set_tool_override", { exposed, name, description });
+}
+
+/** Remove a tool's exposure override, restoring the server's own name + description. */
+export function clearToolOverride(exposed: string): Promise<Registry> {
+  return invoke<Registry>("clear_tool_override", { exposed });
+}
+
 /** Toggle live request/response inspection (opt-in, off by default). When on, the
  * gateway captures each tool call's args + result into a small ephemeral local ring. */
 export function setLiveInspect(enabled: boolean): Promise<Registry> {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -318,11 +318,21 @@ export interface AllowedTool {
   persistent: boolean;
 }
 
+/** A per-tool exposure override, keyed in `Registry.toolOverrides` by the exposed
+ * (`server__tool`) name. Rename and/or replace the description clients see; the call still
+ * routes to the original downstream tool. */
+export interface ToolOverride {
+  name?: string;
+  description?: string;
+}
+
 export interface Registry {
   version: number;
   servers: ServerEntry[];
   profiles: Profile[];
   activeProfileId: string | null;
+  /** Per-tool exposure overrides (rename / re-describe), keyed by exposed `server__tool` name. */
+  toolOverrides?: Record<string, ToolOverride>;
   /** Global switch: hide and block every destructive-hinted tool. */
   denyDestructive?: boolean;
   /** Per-call confirmation: intercept destructive tools with a preview + token. */


### PR DESCRIPTION
Adds per-tool **exposure overrides** (parity with Lunar/MetaMCP, plus a security angle).

## What
In **Playground**, each selected tool gets an *"Override how clients see this tool"* editor:
- **Rename** the client-facing tool name.
- **Re-describe** - replace the description clients see. This is the security lever: locally **neutralize a misleading or injection-laden ("poisoned") tool description** without waiting on the upstream server to fix it.

Overrides are stored in the registry keyed by the exposed `server__tool` name and touch **only the exposed definition** - `Router::index_server` applies them, but the route still points at the original downstream tool, so **a rename never changes where a call goes**. A rename that's blank or would collide with an existing exposed name is ignored (routing stays unambiguous). Gateways pick up changes via the registry watcher.

## Scope
V1 = **rename + re-describe** (pure exposure transforms, no call-path risk). **Pinning/hiding input params** is the planned V2 (needs call-arg injection + schema stripping).

## Verified
- 229 lib tests pass, incl. 2 new router tests: a renamed tool still routes to its original downstream tool, and a colliding rename falls back to the original name. `tsc --noEmit` clean, full workspace compiles. No new dependencies.
- Runtime click-through (set an override, confirm the client sees it) is best confirmed live; the routing invariants are unit-tested.