### PR TITLE
fix(overrides): resolve provenance via route map + key overrides by original tool

### DIFF
--- a/src-tauri/src/bin/conduit-gateway.rs
+++ b/src-tauri/src/bin/conduit-gateway.rs
@@ -1603,7 +1603,17 @@ fn handle_request(
             };
             let name = name.as_str();
 
-            let (srv, tool) = name.split_once("__").unwrap_or(("?", name));
+            // Resolve the call's real (server, original tool) from the router's route map,
+            // NOT by splitting the exposed name on `__`. A renamed tool (via a tool override)
+            // or a server id containing `__` would otherwise mis-derive the server and
+            // silently weaken the scope guard and the HITL untrusted-provenance check below.
+            let (server_id, tool_name) = router
+                .route_of(name)
+                .map(|(s, t)| (s.to_string(), t.to_string()))
+                .unwrap_or_else(|| (String::new(), name.to_string()));
+            let srv_owned = sanitize_segment(&server_id);
+            let srv = srv_owned.as_str();
+            let tool = tool_name.as_str();
 
             // Scope guard: a registered HTTP client may only call tools on the
             // servers its token is allowed to see (a no-op when unscoped). Search

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -931,22 +931,24 @@ fn revoke_allowed_tool(
     Ok(())
 }
 
-/// Set (or clear) a per-tool exposure override, keyed by the exposed (`server__tool`) name:
-/// rename the tool and/or replace its description as clients see it (the latter locally
-/// neutralizes a poisoned description). Empty/blank name and description clears the override.
-/// The call still routes to the original downstream tool; gateways pick up the change via
-/// the registry watcher.
+/// Set (or clear) a per-tool exposure override, keyed by `(server, original tool)`: rename
+/// the tool and/or replace its description as clients see it (the latter locally neutralizes
+/// a poisoned description). Empty/blank name and description clears the override. The call
+/// still routes to the original downstream tool; gateways pick up the change via the registry
+/// watcher.
 #[tauri::command]
 fn set_tool_override(
     state: State<RegistryState>,
-    exposed: String,
+    server: String,
+    tool: String,
     name: Option<String>,
     description: Option<String>,
 ) -> Result<Registry, String> {
     let norm = |s: Option<String>| s.map(|v| v.trim().to_string()).filter(|v| !v.is_empty());
     let mut reg = state.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
     reg.set_tool_override(
-        exposed,
+        server,
+        tool,
         registry::ToolOverride { name: norm(name), description: norm(description) },
     );
     registry::save(&reg)?;
@@ -955,9 +957,13 @@ fn set_tool_override(
 
 /// Remove a tool's exposure override, restoring the server's own name and description.
 #[tauri::command]
-fn clear_tool_override(state: State<RegistryState>, exposed: String) -> Result<Registry, String> {
+fn clear_tool_override(
+    state: State<RegistryState>,
+    server: String,
+    tool: String,
+) -> Result<Registry, String> {
     let mut reg = state.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
-    reg.clear_tool_override(&exposed);
+    reg.clear_tool_override(&server, &tool);
     registry::save(&reg)?;
     Ok(reg.clone())
 }

--- a/src-tauri/src/registry.rs
+++ b/src-tauri/src/registry.rs
@@ -171,11 +171,12 @@ pub struct Registry {
     /// ephemeral per-session allowlist that is NOT saved here.
     #[serde(default)]
     pub human_approval_allow: Vec<String>,
-    /// Per-tool exposure overrides, keyed by the exposed (`server__tool`) name: rename or
+    /// Per-tool exposure overrides, keyed by server id then ORIGINAL tool name (not the
+    /// exposed name, so a rename or `_2` collision suffix can't misalign the key): rename or
     /// re-describe a tool as clients see it (e.g. neutralize a poisoned description). The
     /// call still routes to the original downstream tool.
     #[serde(default)]
-    pub tool_overrides: HashMap<String, ToolOverride>,
+    pub tool_overrides: HashMap<String, HashMap<String, ToolOverride>>,
     /// Quarantine-on-drift: when true, a high-risk tool (poisoned definition, or a
     /// destructive tool whose definition changed/appeared) that drifts from its pinned
     /// baseline is hidden and blocked from every client until the user re-approves it.
@@ -521,19 +522,26 @@ impl Registry {
         self.human_approval_allow.iter().any(|k| k == key)
     }
 
-    /// Set (or replace) the exposure override for an exposed (`server__tool`) name. An
-    /// override with both fields cleared is removed rather than stored empty.
-    pub fn set_tool_override(&mut self, exposed: String, ov: ToolOverride) {
+    /// Set (or replace) the exposure override for a `(server, original tool)`. An override
+    /// with both fields cleared is removed rather than stored empty (and the server's map is
+    /// dropped when it becomes empty).
+    pub fn set_tool_override(&mut self, server: String, tool: String, ov: ToolOverride) {
         if ov.name.is_none() && ov.description.is_none() {
-            self.tool_overrides.remove(&exposed);
+            self.clear_tool_override(&server, &tool);
         } else {
-            self.tool_overrides.insert(exposed, ov);
+            self.tool_overrides.entry(server).or_default().insert(tool, ov);
         }
     }
 
-    /// Remove any override for an exposed tool name (restore the server's own definition).
-    pub fn clear_tool_override(&mut self, exposed: &str) {
-        self.tool_overrides.remove(exposed);
+    /// Remove any override for a `(server, original tool)` (restore the server's own
+    /// definition), dropping the server's map when it becomes empty.
+    pub fn clear_tool_override(&mut self, server: &str, tool: &str) {
+        if let Some(m) = self.tool_overrides.get_mut(server) {
+            m.remove(tool);
+            if m.is_empty() {
+                self.tool_overrides.remove(server);
+            }
+        }
     }
 
     /// Set lazy discovery mode (gateway exposes meta-tools vs the full catalog).

--- a/src-tauri/src/router.rs
+++ b/src-tauri/src/router.rs
@@ -185,10 +185,11 @@ pub struct Router {
     seen: HashSet<String>,
     /// What may be exposed; applied as each server is added.
     policy: ToolPolicy,
-    /// Per-tool exposure overrides (rename / re-describe), keyed by the ORIGINAL exposed
-    /// (`server__tool`) name. Applied while indexing; the route still points at the real
+    /// Per-tool exposure overrides (rename / re-describe), keyed by server id then ORIGINAL
+    /// tool name (NOT the exposed name, so a rename or a `_2` collision suffix can't
+    /// misalign the key). Applied while indexing; the route still points at the real
     /// downstream tool, so a rename never changes where a call goes.
-    overrides: HashMap<String, ToolOverride>,
+    overrides: HashMap<String, HashMap<String, ToolOverride>>,
     /// Exposed name -> why it's hidden, for a clear message if a hidden tool is
     /// still called by name (e.g. via conduit_call_tool).
     blocked: HashMap<String, String>,
@@ -233,8 +234,16 @@ impl Router {
 
     /// Set the per-tool exposure overrides. Must be called BEFORE `add`/`refresh`, since
     /// they're applied while indexing each server's tools.
-    pub fn set_overrides(&mut self, overrides: HashMap<String, ToolOverride>) {
+    pub fn set_overrides(&mut self, overrides: HashMap<String, HashMap<String, ToolOverride>>) {
         self.overrides = overrides;
+    }
+
+    /// The real `(server id, original tool name)` an exposed name routes to, or `None` if
+    /// unknown. Callers that need a call's provenance or server-scoping MUST use this rather
+    /// than string-splitting the exposed name on `__` — that split silently mis-derives the
+    /// server for a renamed tool (overrides) or any server id containing `__`.
+    pub fn route_of(&self, exposed: &str) -> Option<(&str, &str)> {
+        self.routes.get(exposed).map(|(s, t)| (s.as_str(), t.as_str()))
     }
 
     /// Index one server's advertised tools/resources/prompts into the exposed
@@ -263,8 +272,9 @@ impl Router {
             // Apply the user's exposure override (keyed by the ORIGINAL exposed name).
             // Cloned to owned so we don't hold a borrow of `self.overrides` across the
             // `self.seen` mutation below.
-            let ov_name = self.overrides.get(&exposed).and_then(|o| o.name.clone());
-            let ov_desc = self.overrides.get(&exposed).and_then(|o| o.description.clone());
+            let ov = self.overrides.get(server_id).and_then(|m| m.get(orig));
+            let ov_name = ov.and_then(|o| o.name.clone());
+            let ov_desc = ov.and_then(|o| o.description.clone());
             // Rename changes ONLY the client-facing name; the route below still points at
             // the real downstream tool, so a call never goes anywhere new. A rename that is
             // empty or would collide with an existing exposed name is ignored (keep the
@@ -686,16 +696,17 @@ mod tests {
     #[test]
     fn tool_overrides_rename_and_redescribe() {
         let mut router = Router::new();
-        let mut overrides = HashMap::new();
-        overrides.insert(
-            "srv__echo".to_string(),
+        // Keyed by (server id, ORIGINAL tool name), not the exposed name.
+        let mut srv = HashMap::new();
+        srv.insert(
+            "echo".to_string(),
             ToolOverride { name: Some("say".into()), description: Some("say it back".into()) },
         );
-        overrides.insert(
-            "srv__add".to_string(),
+        srv.insert(
+            "add".to_string(),
             ToolOverride { name: None, description: Some("cleaned".into()) },
         );
-        router.set_overrides(overrides);
+        router.set_overrides(HashMap::from([("srv".to_string(), srv)]));
         router.add(mock_server("srv"));
 
         let tools = router.aggregated_tools();
@@ -721,12 +732,11 @@ mod tests {
         // add is indexed after echo, so renaming add -> "srv__echo" (already taken) must
         // fall back to add's original name, keeping routing unambiguous.
         let mut router = Router::new();
-        let mut overrides = HashMap::new();
-        overrides.insert(
-            "srv__add".to_string(),
+        let srv = HashMap::from([(
+            "add".to_string(),
             ToolOverride { name: Some("srv__echo".into()), description: None },
-        );
-        router.set_overrides(overrides);
+        )]);
+        router.set_overrides(HashMap::from([("srv".to_string(), srv)]));
         router.add(mock_server("srv"));
 
         let tools = router.aggregated_tools();
@@ -735,6 +745,24 @@ mod tests {
         assert!(names.contains(&"srv__add"), "add fell back to its own name");
         assert_eq!(router.route_call("srv__echo", json!({})).unwrap()["content"][0]["text"], "srv:echo");
         assert_eq!(router.route_call("srv__add", json!({})).unwrap()["content"][0]["text"], "srv:add");
+    }
+
+    #[test]
+    fn route_of_resolves_renamed_tool_to_real_server_and_original_tool() {
+        // The gate derives provenance/scoping from route_of, NOT by splitting the exposed
+        // name. A renamed tool must still resolve to its real (server, original tool) so the
+        // untrusted-source HITL check and per-client scoping aren't silently bypassed.
+        let mut router = Router::new();
+        let srv = HashMap::from([(
+            "echo".to_string(),
+            ToolOverride { name: Some("say".into()), description: None },
+        )]);
+        router.set_overrides(HashMap::from([("srv".to_string(), srv)]));
+        router.add(mock_server("srv"));
+
+        assert_eq!(router.route_of("say"), Some(("srv", "echo")), "renamed tool resolves to origin");
+        assert_eq!(router.route_of("srv__add"), Some(("srv", "add")), "normal tool resolves");
+        assert_eq!(router.route_of("nope"), None, "unknown name resolves to nothing");
     }
 
     #[test]

--- a/src/components/PlaygroundView.tsx
+++ b/src/components/PlaygroundView.tsx
@@ -51,20 +51,10 @@ function isDestructive(tool: McpTool): boolean {
   return tool.annotations?.destructiveHint === true || tool.destructiveHint === true;
 }
 
-/** Mirror of the gateway's `sanitize_segment`: keep [A-Za-z0-9_], everything else -> `_`. */
-function sanitizeSegment(s: string): string {
-  return s.replace(/[^A-Za-z0-9_]/g, "_");
-}
-
-/** The exposed (client-facing) name for a tool, matching the gateway's namespacing. This
- * is the key the registry stores tool overrides under. */
-function exposedName(serverId: string, tool: string): string {
-  return `${sanitizeSegment(serverId)}__${sanitizeSegment(tool)}`;
-}
-
 /** Editor to rename / re-describe a tool as clients see it (the security lever: locally
  * neutralize a misleading or injection-laden description). Collapsed by default; the call
- * still routes to the original downstream tool. */
+ * still routes to the original downstream tool. Overrides are keyed by (server, original
+ * tool name), so they're stable across renames and collision suffixes. */
 function ToolOverrideEditor({
   serverId,
   tool,
@@ -76,8 +66,7 @@ function ToolOverrideEditor({
   registry: Registry | null;
   onRegistryChange: (r: Registry) => void;
 }) {
-  const exposed = exposedName(serverId, tool.name);
-  const current = registry?.toolOverrides?.[exposed];
+  const current = registry?.toolOverrides?.[serverId]?.[tool.name];
   const [open, setOpen] = useState(false);
   const [name, setName] = useState("");
   const [description, setDescription] = useState("");
@@ -89,14 +78,16 @@ function ToolOverrideEditor({
     setDescription(current?.description ?? "");
     setOpen(false);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [exposed]);
+  }, [serverId, tool.name]);
 
   const hasOverride = !!current;
 
   const save = async () => {
     setBusy(true);
     try {
-      onRegistryChange(await setToolOverride(exposed, name || null, description || null));
+      onRegistryChange(
+        await setToolOverride(serverId, tool.name, name || null, description || null),
+      );
     } catch (e) {
       toastError(`Couldn't save override: ${e}`);
     } finally {
@@ -106,7 +97,7 @@ function ToolOverrideEditor({
   const reset = async () => {
     setBusy(true);
     try {
-      onRegistryChange(await clearToolOverride(exposed));
+      onRegistryChange(await clearToolOverride(serverId, tool.name));
       setName("");
       setDescription("");
     } catch (e) {
@@ -146,13 +137,13 @@ function ToolOverrideEditor({
             <span className="text-muted-foreground">
               Name{" "}
               <span className="text-muted-foreground/60">
-                (blank keeps <span className="font-mono">{exposed}</span>)
+                (blank keeps <span className="font-mono">{tool.name}</span>)
               </span>
             </span>
             <input
               value={name}
               onChange={(e) => setName(e.target.value)}
-              placeholder={exposed}
+              placeholder={tool.name}
               className="rounded-md border border-input bg-transparent px-2.5 py-1.5 font-mono text-xs shadow-sm focus-visible:ring-1 focus-visible:ring-ring focus-visible:outline-none"
             />
           </label>

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -205,20 +205,21 @@ export function revokeAllowedTool(key: string): Promise<void> {
   return invoke<void>("revoke_allowed_tool", { key });
 }
 
-/** Set (or clear) a per-tool exposure override, keyed by exposed `server__tool` name:
+/** Set (or clear) a per-tool exposure override, keyed by `(server, original tool)`:
  * rename and/or replace the description clients see. Blank name + description clears it.
  * The call still routes to the original downstream tool. */
 export function setToolOverride(
-  exposed: string,
+  server: string,
+  tool: string,
   name: string | null,
   description: string | null,
 ): Promise<Registry> {
-  return invoke<Registry>("set_tool_override", { exposed, name, description });
+  return invoke<Registry>("set_tool_override", { server, tool, name, description });
 }
 
 /** Remove a tool's exposure override, restoring the server's own name + description. */
-export function clearToolOverride(exposed: string): Promise<Registry> {
-  return invoke<Registry>("clear_tool_override", { exposed });
+export function clearToolOverride(server: string, tool: string): Promise<Registry> {
+  return invoke<Registry>("clear_tool_override", { server, tool });
 }
 
 /** Toggle live request/response inspection (opt-in, off by default). When on, the

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -318,8 +318,8 @@ export interface AllowedTool {
   persistent: boolean;
 }
 
-/** A per-tool exposure override, keyed in `Registry.toolOverrides` by the exposed
- * (`server__tool`) name. Rename and/or replace the description clients see; the call still
+/** A per-tool exposure override, keyed in `Registry.toolOverrides` by server id then
+ * original tool name. Rename and/or replace the description clients see; the call still
  * routes to the original downstream tool. */
 export interface ToolOverride {
   name?: string;
@@ -331,8 +331,8 @@ export interface Registry {
   servers: ServerEntry[];
   profiles: Profile[];
   activeProfileId: string | null;
-  /** Per-tool exposure overrides (rename / re-describe), keyed by exposed `server__tool` name. */
-  toolOverrides?: Record<string, ToolOverride>;
+  /** Per-tool exposure overrides (rename / re-describe), keyed by server id then original tool name. */
+  toolOverrides?: Record<string, Record<string, ToolOverride>>;
   /** Global switch: hide and block every destructive-hinted tool. */
   denyDestructive?: boolean;
   /** Per-call confirmation: intercept destructive tools with a preview + token. */


### PR DESCRIPTION
Fixes the regression cluster the fresh-eyes review found in the just-merged tool-overrides feature (#88), all rooted in deriving a call's `(server, tool)` by string-splitting the exposed name.

- **HIGH: renamed tool bypassed the untrusted-source HITL gate** (and broke per-client scoping). The gate used `name.split_once("__")`, so a rename yielded `srv="?"` → provenance lookup never matched → a non-destructive tool from a shared/registry server ran with no approval. Fixed by resolving `(server_id, original_tool)` from the router's route map via a new `Router::route_of`. Also fixes pre-existing fragility for server ids containing `__`.
- **HIGH: overrides silently ignored for `_2` collided tools** (frontend keyed by base exposed name, router used the suffixed one) → re-describing a poisoned collided tool had no effect. Fixed by keying overrides by `(server id, original tool name)` end to end, stable across renames/collisions.

**Verified:** 230 lib tests pass incl. a new `route_of` test; tsc + full workspace compile; no new deps. Overrides are unreleased (past v1.1.0).