### PR TITLE
fix(branding): point share endpoint + copy at toolport.app; fix stale docs

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -7,10 +7,14 @@ that exposes 3 meta-tools the agent searches on demand, so context stays flat:
 measured ~90% fewer tokens at the same task success. This document is the working
 spec, capturing the architecture decision and the build order.
 
-**Status (2026-07-01):** v0.9.4 published. Signed/notarized macOS (Apple Silicon +
-Intel, data-protection keychain + nested gateway, no keychain prompts on update),
-Windows (Azure Trusted Signing), Linux (deb/AppImage) via a tag-triggered pipeline +
-in-app auto-updater. 20 clients. Shipping: lazy discovery, OAuth/key auth
+**Status (2026-07-03):** v1.1.0 published (renamed Conduit -> Toolport at v1.0.0).
+Signed/notarized macOS (Apple Silicon + Intel, data-protection keychain + nested
+gateway, no keychain prompts on update), Windows (Azure Trusted Signing), Linux
+(deb/AppImage) via a tag-triggered pipeline + in-app auto-updater. 20 clients.
+Recently shipped: human-in-the-loop tool approval (with approve-for-session and
+per-tool overrides), tray/menu-bar background running + launch-at-login, desktop
+notifications on held calls, and severity-tiered security notices. Shipping: lazy
+discovery, OAuth/key auth
 with live propagation, catalog, import/migrate, per-tool + destructive-tool
 governance, audit log, resources/prompts proxying, tool playground, semantic search,
 rug-pull + injection + agentjacking detection, result-shaping Tier 1. **v0.7.0 made
@@ -269,7 +273,7 @@ Tier 3 - launch prep
       unsigned with documented bypass); cargo-audit in CI.
 - [x] Verify macOS / Linux (signed mac dmgs arm64 + Intel, Linux deb/AppImage;
       tested across Windows/macOS/Ubuntu VMs)
-- [x] Marketing site (conduitmcp.app) with demo video.
+- [x] Marketing site (toolport.app) with demo video.
 - [x] In-app auto-updater (Tauri v2 updater plugin + signed `latest.json` from the
       release pipeline). Live from v0.3.3 onward.
 - [x] First-run onboarding wizard (detect clients, add servers, connect a client).

--- a/docs/openwebui.md
+++ b/docs/openwebui.md
@@ -44,8 +44,10 @@ That's it. Ask for something one of your servers does ("list my recent emails",
 
 - **Local-only by default.** The gateway binds `127.0.0.1`, so only this machine
   can reach it. If you run Open WebUI in Docker, set `CONDUIT_HTTP_HOST=0.0.0.0`
-  and point the tool server at `http://host.docker.internal:8765`. The HTTP
-  surface is unauthenticated, so only expose it (`0.0.0.0`) on a trusted network.
+  and point the tool server at `http://host.docker.internal:8765`. A loopback bind
+  may run without a token, but a non-loopback bind (`0.0.0.0`) **requires**
+  `CONDUIT_HTTP_TOKEN` (the gateway refuses to bind non-loopback without one); still
+  only expose it on a trusted network.
 - **Lazy vs full discovery.** Lazy (default) keeps the model's context tiny and
   is best for capable models. For a weaker local model, `CONDUIT_DISCOVERY=full`
   scoped to a small profile exposes the tools directly (no search step) so the

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1295,8 +1295,8 @@ fn export_config_to_path(
     std::fs::write(&path, json).map_err(|e| format!("Couldn't write the file: {e}"))
 }
 
-/// Public endpoint that turns a shared setup into a `conduitmcp.app/s/<id>` link.
-const SHARE_ENDPOINT: &str = "https://conduitmcp.app/api/share";
+/// Public endpoint that turns a shared setup into a `toolport.app/s/<id>` link.
+const SHARE_ENDPOINT: &str = "https://toolport.app/api/share";
 
 /// POST a shareable setup (the secret-stripped JSON from `export_config`) to the
 /// share service and return the short link to copy. The service stores it with a

--- a/src/components/ActivityView.tsx
+++ b/src/components/ActivityView.tsx
@@ -55,7 +55,7 @@ function fmtTokens(n: number): string {
 }
 
 /** Models for the dollar estimate, input-token list prices ($/1M), grouped by
- *  provider. Matches the public calculator at conduitmcp.app/calculator. */
+ *  provider. Matches the public calculator at toolport.app/calculator. */
 const SAVINGS_MODELS = [
   {
     group: "Anthropic",
@@ -380,7 +380,7 @@ function SavingsBanner({ savings }: { savings: SavingsSummary }) {
   const share = async () => {
     const text =
       `Toolport keeps ~${fmtTokens(savings.tokensSaved)} tokens of MCP tool definitions out of my agent's ` +
-      `context so far. One local gateway for all my MCP servers: conduitmcp.app`;
+      `context so far. One local gateway for all my MCP servers: toolport.app`;
     try {
       await navigator.clipboard.writeText(text);
       toast.success("Savings copied, paste them anywhere");

--- a/src/components/ShareDialog.tsx
+++ b/src/components/ShareDialog.tsx
@@ -67,7 +67,7 @@ export function ShareDialog({ trigger, onImported }: Props) {
   // The user's servers and which to include in the shared stack (default all).
   const [servers, setServers] = useState<{ name: string; transport: string }[]>([]);
   const [selected, setSelected] = useState<Set<string>>(new Set());
-  // A generated share link (conduitmcp.app/s/...), cleared when the export changes.
+  // A generated share link (toolport.app/s/...), cleared when the export changes.
   const [shareLink, setShareLink] = useState("");
   const [linking, setLinking] = useState(false);
 

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -436,7 +436,7 @@ export function exportConfigToPath(
   });
 }
 
-/** Turn a shareable setup (from exportConfig) into a conduitmcp.app/s/<id> link. */
+/** Turn a shareable setup (from exportConfig) into a toolport.app/s/<id> link. */
 export function shareStack(setupJson: string): Promise<string> {
   return invoke<string>("share_stack", { setupJson });
 }


### PR DESCRIPTION
Residual `conduitmcp.app` (pre-rename domain) references from the review:
- **Share endpoint** POSTed to `conduitmcp.app/api/share` → repointed to the canonical `toolport.app/api/share` (verified OPTIONS→204). Future-proofs sharing before the old domain is retired.
- **"Share my savings" clipboard text** advertised the dead domain → `toolport.app`.
- **openwebui.md** self-contradiction on HTTP auth → now correctly states loopback may run tokenless, non-loopback requires `CONDUIT_HTTP_TOKEN`.
- **ROADMAP.md** stale "v0.9.4 published" → v1.1.0 + shipped features; marketing domain → toolport.app.

Note: README's `docker pull ghcr.io/tsouth89/conduit-teams` is intentionally left — the ghcr image name is a kept internal identifier (like `conduit-gateway`). tsc clean, no logic change beyond the share host.