### PR TITLE
feat(hitl): count the approval timer down to the broker's exact deadline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ Entries before the rename below shipped under the project's former name, Conduit
   appears, focus moves into the prompt, Escape denies the oldest pending call, and
   the count is announced. Also removed a brief flicker where a just-decided row
   could momentarily reappear.
+- **The approval countdown is now exact.** It counts down to the broker's real
+  fail-closed deadline instead of approximating from when the overlay first appeared,
+  so the timer matches the moment the call actually auto-denies.
 - Large tool results paged via `fetch_result` no longer re-scan the whole cached
   body on each page.
 - A failed confirmation (e.g. removing a server) keeps its dialog open cleanly

--- a/src-tauri/src/approval_broker.rs
+++ b/src-tauri/src/approval_broker.rs
@@ -38,6 +38,10 @@ pub struct PendingView {
     pub tool: String,
     pub reason: ApprovalReason,
     pub arguments: serde_json::Value,
+    /// Wall-clock epoch-millis when this call auto-denies (park time + the fail-closed
+    /// timeout). The UI counts down to this exactly, instead of approximating from when
+    /// it first saw the request. App and broker share one clock, so it's accurate.
+    pub deadline_ms: u64,
 }
 
 /// A gateway connection parked waiting for a human decision.
@@ -61,6 +65,17 @@ struct Inner {
 /// Cap on simultaneously-pending approvals, so a misbehaving client can't grow the
 /// queue without bound. Beyond this, new requests are denied immediately.
 const MAX_PENDING: usize = 64;
+
+/// The wall-clock epoch-millis deadline for a newly parked approval: now plus the
+/// fail-closed timeout. Matches the broker's own `recv_timeout` below, so the UI's
+/// countdown to it lands on the same moment the call actually auto-denies.
+fn deadline_ms_from_now() -> u64 {
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0);
+    now + DEFAULT_TIMEOUT_SECS * 1000
+}
 
 /// Handle to the broker, managed as Tauri state so the approve/deny commands can reach it.
 #[derive(Clone)]
@@ -250,6 +265,8 @@ fn handle_conn(stream: TcpStream, broker: ApprovalBroker, app: AppHandle) {
         tool: req.tool.clone(),
         reason: req.reason,
         arguments: req.arguments.clone(),
+        // Stamp the deadline now, right before we park on `recv_timeout` below.
+        deadline_ms: deadline_ms_from_now(),
     };
     let (tx, rx) = channel::<ApprovalDecision>();
     {
@@ -352,6 +369,7 @@ mod tests {
             tool: "drop".into(),
             reason: ApprovalReason::Destructive,
             arguments: serde_json::json!({}),
+            deadline_ms: deadline_ms_from_now(),
         };
         b.inner
             .pending
@@ -388,6 +406,21 @@ mod tests {
     #[test]
     fn unknown_id_errs() {
         assert!(broker().decide("nope", true).is_err());
+    }
+
+    #[test]
+    fn deadline_is_about_the_timeout_out() {
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_millis() as u64;
+        let d = deadline_ms_from_now();
+        let target = DEFAULT_TIMEOUT_SECS * 1000;
+        // ~timeout out; allow a few seconds of slack for a slow CI scheduler.
+        assert!(
+            d >= now + target - 3_000 && d <= now + target + 3_000,
+            "deadline {d} not ~{target}ms past {now}"
+        );
     }
 
     #[test]

--- a/src/components/PendingApprovals.tsx
+++ b/src/components/PendingApprovals.tsx
@@ -45,8 +45,8 @@ export function PendingApprovals() {
   // resolved event / poll (NOT optimistically), so a poll landing before the backend
   // reflects the decision can't flicker the row back looking un-decided.
   const [resolving, setResolving] = useState<Set<string>>(new Set());
-  // When we first saw each id, so the countdown starts from first sighting (the broker
-  // deadline is authoritative; this is a close, honest approximation for the UI).
+  // Fallback only: first-sighting time per id, used to drive the countdown if a pending
+  // entry ever lacks the broker's authoritative deadlineMs (older backend / transient).
   const seenAt = useRef<Map<string, number>>(new Map());
   const [now, setNow] = useState(() => Date.now());
   const dialogRef = useRef<HTMLDivElement>(null);
@@ -163,8 +163,11 @@ export function PendingApprovals() {
         <ul className="max-h-[70vh] divide-y divide-border/60 overflow-auto">
           {pending.map((a) => {
             const reason = REASON[a.reason];
-            const started = seenAt.current.get(a.id) ?? now;
-            const remaining = Math.max(0, Math.ceil((TIMEOUT_MS - (now - started)) / 1000));
+            // Count down to the broker's authoritative deadline; fall back to
+            // first-sighting + timeout only if deadlineMs is somehow absent, so the
+            // timer is never blank.
+            const deadline = a.deadlineMs || (seenAt.current.get(a.id) ?? now) + TIMEOUT_MS;
+            const remaining = Math.max(0, Math.ceil((deadline - now) / 1000));
             const pct = Math.max(0, Math.min(100, (remaining / (TIMEOUT_MS / 1000)) * 100));
             const urgent = remaining <= 20;
             const isBusy = resolving.has(a.id);

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -307,6 +307,8 @@ export interface PendingApproval {
   tool: string;
   reason: "destructive" | "untrusted_source" | "destructive_and_untrusted";
   arguments: unknown;
+  /** Wall-clock epoch-ms when this call auto-denies; the overlay counts down to it. */
+  deadlineMs: number;
 }
 
 /** A tool the user allowed to skip human approval (Settings "Allowed tools" list). */


### PR DESCRIPTION
## What

The approval overlay's countdown was approximated from when the UI *first saw* a held call (`seenAt`), which can drift from the broker's actual fail-closed deadline by up to the 2s poll interval. This makes it exact.

## Change

- `PendingView` gains a `deadline_ms` (wall-clock epoch-ms), stamped at park time as `now + DEFAULT_TIMEOUT_SECS`, right before the broker parks on `recv_timeout`. Serialized as `deadlineMs`.
- The overlay counts down to `deadlineMs`. App and broker share one clock (same machine), so the timer lands exactly on the moment the call auto-denies.
- `seenAt` is kept only as a fallback if `deadlineMs` is ever absent, so the timer is never blank.

## Tests

- New `deadline_is_about_the_timeout_out` asserts the stamped deadline is ~`DEFAULT_TIMEOUT_SECS` out.
- Full suite green: 235 lib + 54 bin; frontend type-checks + builds.