### PR TITLE
chore(clippy): use slice contains() over iter().any() in first_flag

### DIFF
--- a/src-tauri/src/downstream.rs
+++ b/src-tauri/src/downstream.rs
@@ -321,7 +321,7 @@ fn first_flag<'a>(args: &'a [String], flags: &[&str]) -> Option<&'a str> {
     args.iter().find(|a| {
         let al = a.to_ascii_lowercase();
         let head = al.split('=').next().unwrap_or(&al);
-        flags.iter().any(|f| head == *f)
+        flags.contains(&head)
     }).map(|a| a.as_str())
 }
 


### PR DESCRIPTION
Silences the workspace's only clippy warning (`clippy::manual_contains` in `downstream.rs`). Behavior identical; `cargo clippy --lib` is now clean, lib tests green.