### PR TITLE
feat(teams): enforce an org "require human approval" policy (tighten-only)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ Entries before the rename below shipped under the project's former name, Conduit
 
 ## [Unreleased]
 
+### Added
+- **Teams can require human approval org-wide.** A team admin can turn on "Require
+  human approval" in the Teams policy, and every member's gateway then holds gated
+  tool calls for a person to approve. Like the other org policies, it's tighten-only:
+  it can force approval on for the team but can never turn a member's own setting off.
+
 ### Changed
 - **The HTTP gateway now handles requests concurrently.** Each request runs on its
   own worker, so a slow downstream server or a tool call held for human approval (up

--- a/src-tauri/src/teams.rs
+++ b/src-tauri/src/teams.rs
@@ -243,6 +243,7 @@ fn team_export(reg: &Registry) -> Value {
         "screeningPolicy": {
             "forceContentDefense": reg.content_defense,
             "forceQuarantineOnDrift": reg.quarantine_on_drift,
+            "forceHumanApproval": reg.human_approval,
         },
     })
 }
@@ -364,16 +365,21 @@ pub fn apply_team_config(reg: &mut Registry, team_id: &str, team_cfg: &Value) ->
         reg.deny_destructive = true;
     }
 
-    // 5. Screening policy is tighten-only as well: the org can force content defense and
-    //    drift-quarantine ON, but a member can never be loosened by a team config. A
-    //    missing policy or a `false` flag is a no-op (it does not turn a member's own
-    //    toggle off), so this only ever raises the member's safety posture.
+    // 5. Screening policy is tighten-only as well: the org can force content defense,
+    //    drift-quarantine, and human approval ON, but a member can never be loosened by a
+    //    team config. A missing policy or a `false` flag is a no-op (it does not turn a
+    //    member's own toggle off), so this only ever raises the member's safety posture.
     if let Some(sp) = team_cfg.get("screeningPolicy") {
         if sp.get("forceContentDefense").and_then(Value::as_bool) == Some(true) {
             reg.content_defense = true;
         }
         if sp.get("forceQuarantineOnDrift").and_then(Value::as_bool) == Some(true) {
             reg.quarantine_on_drift = true;
+        }
+        // Org-mandated human-in-the-loop: force the member's gateway to hold gated tool
+        // calls for human approval. Tighten-only, like the flags above.
+        if sp.get("forceHumanApproval").and_then(Value::as_bool) == Some(true) {
+            reg.human_approval = true;
         }
     }
 
@@ -585,21 +591,24 @@ mod tests {
     #[test]
     fn screening_policy_can_tighten_but_never_loosen() {
         let mut r = base_registry();
-        // Member starts with content defense off and drift-quarantine off.
+        // Member starts with content defense off, drift-quarantine off, human approval off.
         r.content_defense = false;
         r.quarantine_on_drift = false;
+        r.human_approval = false;
 
-        // Org policy forces both on: the member's posture is raised.
+        // Org policy forces all three on: the member's posture is raised.
         apply_team_config(
             &mut r,
             "t1",
             &json!({ "servers": [], "screeningPolicy": {
                 "forceContentDefense": true,
                 "forceQuarantineOnDrift": true,
+                "forceHumanApproval": true,
             }}),
         );
         assert!(r.content_defense, "org policy forced content defense on");
         assert!(r.quarantine_on_drift, "org policy forced drift-quarantine on");
+        assert!(r.human_approval, "org policy forced human approval on");
 
         // A policy with the flags false, or absent entirely, never turns them back off.
         apply_team_config(
@@ -608,14 +617,17 @@ mod tests {
             &json!({ "servers": [], "screeningPolicy": {
                 "forceContentDefense": false,
                 "forceQuarantineOnDrift": false,
+                "forceHumanApproval": false,
             }}),
         );
         assert!(r.content_defense, "false flag never loosens an existing lock");
         assert!(r.quarantine_on_drift, "false flag never loosens an existing lock");
+        assert!(r.human_approval, "false flag never loosens an existing lock");
 
         apply_team_config(&mut r, "t1", &json!({ "servers": [] }));
         assert!(r.content_defense, "absent policy never loosens an existing lock");
         assert!(r.quarantine_on_drift, "absent policy never loosens an existing lock");
+        assert!(r.human_approval, "absent policy never loosens an existing lock");
     }
 
     #[test]
@@ -625,10 +637,12 @@ mod tests {
         let mut r = base_registry();
         r.content_defense = true;
         r.quarantine_on_drift = true;
+        r.human_approval = true;
         let cfg = team_export(&r);
         let sp = cfg.get("screeningPolicy").expect("policy is emitted");
         assert_eq!(sp.get("forceContentDefense").and_then(Value::as_bool), Some(true));
         assert_eq!(sp.get("forceQuarantineOnDrift").and_then(Value::as_bool), Some(true));
+        assert_eq!(sp.get("forceHumanApproval").and_then(Value::as_bool), Some(true));
     }
 
     #[test]


### PR DESCRIPTION
## What

Adds `forceHumanApproval` to the org screening policy, so a Teams admin can mandate human-in-the-loop approval across the whole team. Enforcement side (this repo); the dashboard toggle that sets it is a paired PR in toolport-teams.

## Change (mirrors the existing `forceContentDefense` / `forceQuarantineOnDrift`)

- `apply_team_config`: `screeningPolicy.forceHumanApproval == true` forces `reg.human_approval = true`. **Tighten-only** — a `false`/absent flag never turns a member's own setting off.
- `team_export`: reports the member's current `human_approval` as `forceHumanApproval` so a desktop push never wipes a dashboard-set policy.

## Tests

- Extended `screening_policy_can_tighten_but_never_loosen` (force-on, then false/absent never loosens) and `team_export_round_trips_screening_policy` to cover the new flag. 235 lib tests green.

Independent-safe: with only this side merged the flag is dormant (no UI sets it); with only the UI side merged, older gateways just ignore the flag. No breakage either way.