### PR TITLE
security(gateway): scope resources/read + prompts/get to the client's allowed servers

### DIFF
--- a/src-tauri/src/bin/conduit-gateway.rs
+++ b/src-tauri/src/bin/conduit-gateway.rs
@@ -1886,7 +1886,18 @@ fn handle_request(
             }
         }
         "resources/list" => {
-            let resources = router.aggregated_resources();
+            let mut resources = router.aggregated_resources();
+            // Scope to the client's allowed servers (a no-op when unscoped), so a
+            // registered HTTP client can't list another server's resources.
+            if let Some(set) = allowed {
+                resources.retain(|r| {
+                    r.get("uri")
+                        .and_then(|u| u.as_str())
+                        .and_then(|uri| router.resource_server(uri))
+                        .map(|srv| set.contains(srv))
+                        .unwrap_or(false)
+                });
+            }
             gtrace(&format!("resources/list -> {} resources", resources.len()));
             Some(success(id, json!({ "resources": resources })))
         }
@@ -1896,6 +1907,18 @@ fn handle_request(
                 .and_then(|p| p.get("uri"))
                 .and_then(|u| u.as_str())
                 .unwrap_or("");
+            // Scope guard: a registered HTTP client may only read resources on servers
+            // its token allows. Out-of-scope is reported as not-found so a scoped client
+            // can't probe another server's resource names.
+            if let Some(set) = allowed {
+                let in_scope = router
+                    .resource_server(uri)
+                    .map(|srv| set.contains(srv))
+                    .unwrap_or(false);
+                if !in_scope {
+                    return Some(error(id, -32602, &format!("Toolport: no server owns resource '{uri}'")));
+                }
+            }
             match router.read_resource(uri) {
                 Ok(mut result) => {
                     // Content defense: a resource is as attacker-controllable as a tool
@@ -1909,7 +1932,17 @@ fn handle_request(
             }
         }
         "prompts/list" => {
-            let prompts = router.aggregated_prompts();
+            let mut prompts = router.aggregated_prompts();
+            // Scope to the client's allowed servers (a no-op when unscoped).
+            if let Some(set) = allowed {
+                prompts.retain(|p| {
+                    p.get("name")
+                        .and_then(|n| n.as_str())
+                        .and_then(|name| router.prompt_server(name))
+                        .map(|srv| set.contains(srv))
+                        .unwrap_or(false)
+                });
+            }
             gtrace(&format!("prompts/list -> {} prompts", prompts.len()));
             Some(success(id, json!({ "prompts": prompts })))
         }
@@ -1923,6 +1956,17 @@ fn handle_request(
                 .and_then(|p| p.get("arguments"))
                 .cloned()
                 .unwrap_or_else(|| json!({}));
+            // Scope guard: a registered HTTP client may only fetch prompts on servers
+            // its token allows. Out-of-scope is reported as no-route (no name leak).
+            if let Some(set) = allowed {
+                let in_scope = router
+                    .prompt_server(name)
+                    .map(|srv| set.contains(srv))
+                    .unwrap_or(false);
+                if !in_scope {
+                    return Some(error(id, -32602, &format!("Toolport: no route for prompt '{name}'")));
+                }
+            }
             match router.get_prompt(name, arguments) {
                 Ok(mut result) => {
                     // Content defense: a prompt's messages are attacker-controllable too;

--- a/src-tauri/src/router.rs
+++ b/src-tauri/src/router.rs
@@ -468,6 +468,18 @@ impl Router {
         self.prompts.clone()
     }
 
+    /// The server that advertised resource `uri`, if any. Used to scope a registered
+    /// HTTP client's resource access to its allowed server set (see the gateway).
+    pub fn resource_server(&self, uri: &str) -> Option<&str> {
+        self.resource_routes.get(uri).map(String::as_str)
+    }
+
+    /// The server that owns the exposed prompt `name`, if any. Used to scope a
+    /// registered HTTP client's prompt access to its allowed server set.
+    pub fn prompt_server(&self, exposed_name: &str) -> Option<&str> {
+        self.prompt_routes.get(exposed_name).map(|(s, _)| s.as_str())
+    }
+
     /// Read a resource by uri from whichever server advertised it. `&self`: locks
     /// only the owning server (see `route_call`).
     pub fn read_resource(&self, uri: &str) -> Result<Value, String> {
@@ -646,6 +658,27 @@ mod tests {
         assert_eq!(sanitize_segment("file-system"), "file_system");
         assert_eq!(sanitize_segment("list-offerings"), "list_offerings");
         assert_eq!(sanitize_segment("already_ok"), "already_ok");
+    }
+
+    #[test]
+    fn resource_and_prompt_server_resolve_owner() {
+        let mut router = Router::new();
+        router.add(mock_server("github"));
+        router.add(mock_server("postgres"));
+        // Resources keep their server-scoped uris; the map resolves the owner.
+        assert_eq!(router.resource_server("github://readme"), Some("github"));
+        assert_eq!(router.resource_server("postgres://readme"), Some("postgres"));
+        assert_eq!(router.resource_server("unknown://x"), None);
+        // Prompts resolve by their exposed (namespaced) name.
+        let prompts = router.aggregated_prompts();
+        let gh_prompt = prompts
+            .iter()
+            .filter_map(|p| p.get("name").and_then(|n| n.as_str()))
+            .find(|n| router.prompt_server(n) == Some("github"))
+            .expect("a github prompt is exposed")
+            .to_string();
+        assert_eq!(router.prompt_server(&gh_prompt), Some("github"));
+        assert_eq!(router.prompt_server("no__such_prompt"), None);
     }
 
     #[test]


### PR DESCRIPTION
## Vulnerability

`tools/call` / `tools/list` gate on a registered HTTP client's `allowed`-server set, but **`resources/list`, `resources/read`, `prompts/list`, `prompts/get` did not** — they aggregated/read across *all* connected servers. A billing-scoped HTTP client could read any other server's resources or prompts (file contents, system prompts, embedded secrets). Content-defense ran, but scoping did not. (Found in the 2026-07-03 audit.)

## Fix

- `router.rs`: `resource_server(uri)` / `prompt_server(name)` resolve the owning server from the existing route maps.
- Gateway: all four handlers now gate on `allowed` — lists are filtered, reads/gets refuse out-of-scope with the same not-found/no-route error as a genuinely missing item (no name leak). No-op when unscoped, so local stdio is unchanged. Mirrors the `tools/call` guard.

## Tests

- New `resource_and_prompt_server_resolve_owner` (router). 236 lib + 54 bin tests green.