### PR TITLE
harden(gateway): fsync atomic write, reject empty bearer, constant-time token match

### DIFF
--- a/src-tauri/src/bin/conduit-gateway.rs
+++ b/src-tauri/src/bin/conduit-gateway.rs
@@ -2829,7 +2829,12 @@ const MAX_HTTP_INFLIGHT: usize = 256;
 /// Parse a `Bearer <token>` Authorization value. Pure, so it's unit-testable.
 fn parse_bearer(auth_value: &str) -> Option<&str> {
     let (scheme, tok) = auth_value.split_once(' ')?;
-    scheme.eq_ignore_ascii_case("bearer").then(|| tok.trim())
+    // Reject an empty token (`Bearer ` with only whitespace): returning Some("") would
+    // otherwise be looked up as a real bearer, a fail-open shape.
+    scheme
+        .eq_ignore_ascii_case("bearer")
+        .then(|| tok.trim())
+        .filter(|t| !t.is_empty())
 }
 
 /// Strip control characters and bound the length of a header value we reflect
@@ -3862,6 +3867,9 @@ mod tests {
         assert_eq!(parse_bearer("Basic abc"), None);
         assert_eq!(parse_bearer("abc"), None);
         assert_eq!(parse_bearer(""), None);
+        // An empty/whitespace-only token must be rejected, not returned as Some("").
+        assert_eq!(parse_bearer("Bearer "), None);
+        assert_eq!(parse_bearer("Bearer    "), None);
     }
 
     #[test]

--- a/src-tauri/src/registry.rs
+++ b/src-tauri/src/registry.rs
@@ -36,11 +36,28 @@ pub fn atomic_write(path: &Path, contents: &str) -> Result<(), String> {
         std::process::id(),
         seq
     ));
-    std::fs::write(&tmp, contents).map_err(|e| e.to_string())?;
+    {
+        use std::io::Write;
+        let mut f = std::fs::File::create(&tmp).map_err(|e| e.to_string())?;
+        f.write_all(contents.as_bytes()).map_err(|e| e.to_string())?;
+        // Flush the data to stable storage BEFORE the rename, so a crash/power loss
+        // can't make the rename durable while the file's blocks aren't — which would
+        // leave a truncated registry.json. `fs::write` + `rename` alone did not.
+        f.sync_all().map_err(|e| e.to_string())?;
+    }
     std::fs::rename(&tmp, path).map_err(|e| {
         let _ = std::fs::remove_file(&tmp);
         e.to_string()
-    })
+    })?;
+    // Best-effort: fsync the containing directory so the rename entry itself is durable
+    // (Unix). Opening a directory as a File fails on Windows, where NTFS journals the
+    // rename anyway, so the error is ignored.
+    if let Some(dir) = path.parent() {
+        if let Ok(d) = std::fs::File::open(dir) {
+            let _ = d.sync_all();
+        }
+    }
+    Ok(())
 }
 const DEFAULT_PROFILE_ID: &str = "default";
 
@@ -115,6 +132,21 @@ pub fn sha256_hex(s: &str) -> String {
     let mut h = Sha256::new();
     h.update(s.as_bytes());
     format!("{:x}", h.finalize())
+}
+
+/// Constant-time byte equality, so a token-hash comparison can't leak the stored
+/// hash prefix through early-exit timing (consistent with the gateway's other token
+/// checks). A length mismatch short-circuits; length isn't secret for a fixed-width hash.
+fn ct_eq(a: &str, b: &str) -> bool {
+    let (a, b) = (a.as_bytes(), b.as_bytes());
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut diff = 0u8;
+    for (x, y) in a.iter().zip(b) {
+        diff |= x ^ y;
+    }
+    diff == 0
 }
 
 /// A user override for how one tool is exposed to clients, keyed in the registry by the
@@ -674,7 +706,7 @@ impl Registry {
     /// SHA-256, if any. The bridge uses this to resolve a bearer to its scope.
     pub fn http_client_for_token(&self, token: &str) -> Option<&HttpClient> {
         let h = sha256_hex(token);
-        self.http_clients.iter().find(|c| c.token_sha256 == h)
+        self.http_clients.iter().find(|c| ct_eq(&c.token_sha256, &h))
     }
 }
 


### PR DESCRIPTION
Three small hardening fixes from the 2026-07-03 audit:

- **`atomic_write` durability** — `fs::write` + `rename` with no fsync; a crash could make the rename durable while data blocks weren't (truncated `registry.json`). Now `sync_all()` the temp before rename + best-effort dir fsync after (Unix; no-op on Windows).
- **Empty bearer** — `parse_bearer("Bearer ")` returned `Some("")`, then looked up as a real token (fail-open shape). Now rejected.
- **Constant-time token match** — `http_client_for_token` compared hashes with `==` (short-circuits) while the env-token path uses constant-time. Routed through a constant-time `ct_eq` for consistency (values compared are hashes, so the leak is a hash prefix, not the token — defense in depth).

Tests: `parse_bearer` empty cases added; `atomic_write_replaces_and_leaves_no_temp` still green; 254 lib+bin tests green.