### PR TITLE
fix(ui): correct Enable/Disable-all gating + name the profile delete dialog

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -473,7 +473,12 @@ function App() {
                       {servers.length > 0 && (
                         <DropdownMenuItem
                           onClick={handleToggleAll}
-                          disabled={busyId !== null}
+                          // Gate on the flag handleToggleAll actually sets (togglingAll),
+                          // not just busyId, so it can't be re-fired mid-run. Disabled
+                          // while a search is active: it acts on ALL servers, so it must
+                          // not silently toggle ones hidden by the filter.
+                          disabled={togglingAll || busyId !== null || query.trim() !== ""}
+                          title={query.trim() !== "" ? "Clear the search to enable or disable all servers" : undefined}
                         >
                           <ServerOff className="mr-2 size-4" />
                           <span>

--- a/src/components/ProfileBar.tsx
+++ b/src/components/ProfileBar.tsx
@@ -104,7 +104,7 @@ export function ProfileBar({ registry, onChange }: Props) {
               <Trash2 className="size-4" />
             </Button>
           }
-          title="Delete this profile?"
+          title={`Delete "${registry.profiles.find((p) => p.id === activeId)?.name ?? "this profile"}"?`}
           description="This removes the profile and its server scoping. Your servers and their secrets are not deleted."
           confirmLabel="Delete"
           destructive


### PR DESCRIPTION
From the 2026-07-03 frontend audit:

- **Enable/Disable-all mis-gated (#2):** the menu item was `disabled={busyId !== null}`, but `handleToggleAll` guards on and sets `togglingAll` (never `busyId`) — so it wasn't disabled during its own run and could be re-fired. Now gated on `togglingAll`.
- **Toggle-all ignores the search filter (#6):** it acts on ALL servers via `setAllEnabled`, so searching "github" then "Disable all" disabled *everything*. Now disabled while a query is active (with a title explaining why), so it can't silently toggle filtered-out servers.
- **Profile delete dialog un-named (#3):** "Delete this profile?" → `Delete "Work"?`.

`npm run build` (tsc + vite) clean.