### PR TITLE
fix(ui): one canonical fmtTokens so Activity and Sidebar agree

### DIFF
--- a/src/components/ActivityView.tsx
+++ b/src/components/ActivityView.tsx
@@ -14,6 +14,7 @@ import {
   XCircle,
 } from "lucide-react";
 import { toast } from "sonner";
+import { fmtTokens } from "@/lib/utils";
 import { toastError } from "@/lib/toast";
 import {
   getAuditLog,
@@ -45,13 +46,6 @@ import {
 function fmtMs(ms: number | null): string {
   if (ms == null) return "-";
   return ms >= 1000 ? `${(ms / 1000).toFixed(1)} s` : `${ms} ms`;
-}
-
-/** Compact token count: "1.84M", "23.4k", or the raw number when small. */
-function fmtTokens(n: number): string {
-  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(2)}M`;
-  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`;
-  return `${n}`;
 }
 
 /** Models for the dollar estimate, input-token list prices ($/1M), grouped by

--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -30,6 +30,7 @@ import {
   type View,
 } from "@/lib/types";
 import { gatherDiagnostics, getSavingsSummary, openDataDir } from "@/lib/api";
+import { fmtTokens } from "@/lib/utils";
 import { checkForUpdate, installUpdate } from "@/lib/updater";
 import { Button } from "@/components/ui/button";
 import {
@@ -420,12 +421,6 @@ export function AppSidebar({
       clearInterval(id);
     };
   }, []);
-  const fmtTokens = (n: number) =>
-    n >= 1_000_000
-      ? `${(n / 1_000_000).toFixed(1)}M`
-      : n >= 1_000
-        ? `${Math.round(n / 1_000)}K`
-        : `${n}`;
 
   // One sidebar nav row. The active row gets the accent background, a foreground
   // icon (not muted), and aria-current so screen readers announce the selection.

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -4,3 +4,14 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+/**
+ * Format a token count compactly: 1_234_567 -> "1.2M", 12_345 -> "12.3k".
+ * Single source of truth so every surface (Activity, Sidebar, ...) shows the
+ * same rounded figure for the same number.
+ */
+export function fmtTokens(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`
+  return `${n}`
+}


### PR DESCRIPTION
The Activity view and the sidebar each defined their own token formatter with divergent rounding:

- Activity: `1.84M` (2-decimal), `23.4k` (lowercase)
- Sidebar: `1.8M` (1-decimal), `23K` (rounded, uppercase)

So the same tokens-saved number rendered differently depending on where you looked. This hoists a single `fmtTokens` into `lib/utils` (`1.8M` / `23.4k`) and uses it in both surfaces.

Typecheck clean.