### PR TITLE
feat(observability): Discovery panel — what lazy discovery searched + its per-turn token cost

### DIFF
--- a/src-tauri/src/bin/conduit-gateway.rs
+++ b/src-tauri/src/bin/conduit-gateway.rs
@@ -36,6 +36,7 @@ use conduit_lib::remote;
 use conduit_lib::router::{is_destructive, sanitize_segment, Router, ToolPolicy};
 use conduit_lib::approval;
 use conduit_lib::savings;
+use conduit_lib::searchtrace;
 use conduit_lib::secrets;
 use conduit_lib::semantic;
 use conduit_lib::shaping;
@@ -1635,6 +1636,25 @@ fn handle_request(
                 let text = format!(
                     "{lead}\n\n{}",
                     serde_json::to_string_pretty(&matches).unwrap_or_default()
+                );
+                // Record the trace: the ground-truth cost of what THIS search returned
+                // vs. what advertising the whole (scoped) catalog would cost per turn.
+                // Being in-path, we know both exactly rather than estimating from logs.
+                let returned_names: Vec<String> = matches
+                    .iter()
+                    .filter_map(|m| m.get("name").and_then(|v| v.as_str()).map(str::to_string))
+                    .collect();
+                searchtrace::record(
+                    client,
+                    query,
+                    server,
+                    &top,
+                    &returned_names,
+                    matches.len(),
+                    total,
+                    savings::estimate_tokens(&matches),
+                    savings::estimate_tokens(source),
+                    escalate,
                 );
                 return Some(success(
                     id,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -18,6 +18,7 @@ pub mod registry;
 pub mod remote;
 pub mod router;
 pub mod savings;
+pub mod searchtrace;
 pub mod semantic;
 pub mod shaping;
 pub mod secrets;
@@ -996,6 +997,22 @@ fn clear_inspect_log() -> Result<(), String> {
     Ok(())
 }
 
+/// Recent lazy-discovery search traces (newest first): what the model searched for,
+/// which tools matched, and the tool-definition tokens the results cost vs. loading
+/// the whole catalog. The in-path proof that lazy discovery is working. Empty when
+/// nothing has searched yet.
+#[tauri::command]
+fn get_search_traces(limit: usize) -> Vec<serde_json::Value> {
+    searchtrace::read_recent(limit)
+}
+
+/// Clear the search-trace log (delete `search-trace.jsonl`).
+#[tauri::command]
+fn clear_search_traces() -> Result<(), String> {
+    searchtrace::clear();
+    Ok(())
+}
+
 /// Toggle quarantine-on-drift. When enabled, the gateway hides and blocks a high-risk
 /// tool (poisoned definition, or a destructive tool whose definition changed/appeared)
 /// that drifts from its pinned baseline, until the user re-approves it.
@@ -1915,6 +1932,8 @@ pub fn run() {
             set_live_inspect,
             get_inspect_log,
             clear_inspect_log,
+            get_search_traces,
+            clear_search_traces,
             set_quarantine_on_drift,
             list_quarantined,
             release_quarantine,

--- a/src-tauri/src/searchtrace.rs
+++ b/src-tauri/src/searchtrace.rs
@@ -1,0 +1,208 @@
+//! Lazy-discovery search traces: a bounded, local record of what the model actually
+//! searched for and what the gateway handed back.
+//!
+//! This is the in-path answer to "how do I know lazy discovery is working, and what
+//! is it costing me?" Because Toolport IS the gateway, it knows the ground truth a
+//! post-hoc log reader can only estimate: the exact query, which tools matched, and
+//! the tool-definition tokens the returned schemas cost THIS turn versus what loading
+//! the whole catalog would have. Each `toolport_search_tools` call appends one line.
+//!
+//! Kept lean and non-sensitive: the model-authored query is capped, and only tool
+//! NAMES (never their schemas, arguments, or results) are stored. Like the audit and
+//! savings logs it is append-only (each connected client spawns its own gateway, so
+//! concurrent `O_APPEND` of one small line is safe) and never leaves the machine.
+
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use serde_json::{json, Value};
+
+/// Trim the log once it passes this size. A line is a few hundred bytes and a search
+/// happens per model turn, so this is a long, bounded window.
+const MAX_TRACE_BYTES: u64 = 512 * 1024;
+/// Recent lines kept on rotation; older lines are dropped (unlike savings, there is
+/// no cumulative total to preserve, so trimming just discards the oldest traces).
+const KEEP_LINES: usize = 500;
+/// Cap the stored query so a pathological (model-authored) query can't bloat a line.
+const MAX_QUERY_CHARS: usize = 200;
+/// Cap how many matched tool names we store per trace.
+const MAX_NAMES: usize = 25;
+
+fn trace_path() -> Option<PathBuf> {
+    // Same anchor as the registry/audit/savings logs, so the app and every
+    // client-spawned gateway (some under MSIX virtualization) share one file.
+    Some(crate::registry::conduit_dir()?.join("search-trace.jsonl"))
+}
+
+fn epoch_millis() -> u128 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis())
+        .unwrap_or(0)
+}
+
+/// Truncate `s` to at most `max` chars on a char boundary (never mid-codepoint).
+fn cap_chars(s: &str, max: usize) -> String {
+    if s.chars().count() <= max {
+        return s.to_string();
+    }
+    let mut out: String = s.chars().take(max).collect();
+    out.push('…');
+    out
+}
+
+/// One recorded search. `flat_tokens` is what advertising the whole (scoped) catalog
+/// would cost per request; `returned_tokens` is what this search's results cost. The
+/// difference is the tool-definition context lazy discovery kept out on this turn.
+#[allow(clippy::too_many_arguments)]
+pub fn record(
+    client: Option<&str>,
+    query: &str,
+    server_filter: Option<&str>,
+    top: &str,
+    names: &[String],
+    returned: usize,
+    total: usize,
+    returned_tokens: u64,
+    flat_tokens: u64,
+    escalated: bool,
+) {
+    let stored_names: Vec<&String> = names.iter().take(MAX_NAMES).collect();
+    let mut entry = json!({
+        "ts": epoch_millis() as u64,
+        "query": cap_chars(query, MAX_QUERY_CHARS),
+        "top": top,
+        "names": stored_names,
+        "returned": returned as u64,
+        "total": total as u64,
+        "returnedTokens": returned_tokens,
+        "flatTokens": flat_tokens,
+        "savedTokens": flat_tokens.saturating_sub(returned_tokens),
+        "escalated": escalated,
+    });
+    if let Some(s) = server_filter.filter(|s| !s.trim().is_empty()) {
+        entry["server"] = json!(s);
+    }
+    if let Some(c) = client.filter(|c| !c.is_empty()) {
+        entry["client"] = json!(c);
+    }
+    write_line(&entry);
+}
+
+/// Append one entry as a single JSON line, then rotate if the file has grown large.
+/// A single `write_all` (not `writeln!`) keeps the many client-spawned gateways that
+/// share this file from interleaving each other's bytes into corrupt JSON.
+fn write_line(entry: &Value) {
+    let Some(path) = trace_path() else {
+        return;
+    };
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    if let Ok(mut file) = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&path)
+    {
+        let _ = file.write_all(format!("{entry}\n").as_bytes());
+    }
+    rotate_if_large(&path);
+}
+
+/// Keep only the most recent `KEEP_LINES` once the file exceeds the cap. Best-effort:
+/// a failure never affects the search that triggered it.
+fn rotate_if_large(path: &Path) {
+    let size = std::fs::metadata(path).map(|m| m.len()).unwrap_or(0);
+    if size <= MAX_TRACE_BYTES {
+        return;
+    }
+    let Ok(content) = std::fs::read_to_string(path) else {
+        return;
+    };
+    let lines: Vec<&str> = content.lines().filter(|l| !l.trim().is_empty()).collect();
+    if lines.len() <= KEEP_LINES {
+        return;
+    }
+    let start = lines.len() - KEEP_LINES;
+    let mut trimmed = lines[start..].join("\n");
+    trimmed.push('\n');
+    let _ = crate::registry::atomic_write(path, &trimmed);
+}
+
+/// The most recent `limit` traces, newest first.
+pub fn read_recent(limit: usize) -> Vec<Value> {
+    let Some(path) = trace_path() else {
+        return Vec::new();
+    };
+    let Ok(content) = std::fs::read_to_string(&path) else {
+        return Vec::new();
+    };
+    content
+        .lines()
+        .rev()
+        .filter_map(|line| serde_json::from_str(line).ok())
+        .take(limit)
+        .collect()
+}
+
+/// Delete the trace log (called when the user clears it from Activity).
+pub fn clear() {
+    if let Some(path) = trace_path() {
+        let _ = std::fs::remove_file(path);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    // One file per machine, so these can't run concurrently. Serialize + reset.
+    static TEST_LOCK: Mutex<()> = Mutex::new(());
+
+    #[test]
+    fn record_then_read_returns_newest_first() {
+        let _g = TEST_LOCK.lock().unwrap();
+        clear();
+        record(Some("cursor"), "list products", None, "stripe__list", &["stripe__list".into()], 1, 3, 120, 5000, false);
+        record(None, "send email", Some("resend"), "resend__send", &["resend__send".into()], 1, 1, 90, 5000, false);
+        let recent = read_recent(10);
+        assert_eq!(recent.len(), 2);
+        // Newest first.
+        assert_eq!(recent[0]["query"], "send email");
+        assert_eq!(recent[0]["server"], "resend");
+        assert_eq!(recent[0]["savedTokens"], 5000 - 90);
+        assert_eq!(recent[1]["query"], "list products");
+        assert_eq!(recent[1]["client"], "cursor");
+        assert_eq!(recent[1]["total"], 3);
+        clear();
+    }
+
+    #[test]
+    fn query_is_capped_and_names_are_limited() {
+        let _g = TEST_LOCK.lock().unwrap();
+        clear();
+        let long_q = "x".repeat(500);
+        let many: Vec<String> = (0..40).map(|i| format!("srv__t{i}")).collect();
+        record(None, &long_q, None, "srv__t0", &many, 40, 40, 100, 200, false);
+        let e = &read_recent(1)[0];
+        let stored_q = e["query"].as_str().unwrap();
+        // Capped to MAX_QUERY_CHARS (+ the ellipsis), never the full 500.
+        assert!(stored_q.chars().count() <= MAX_QUERY_CHARS + 1, "query not capped: {}", stored_q.chars().count());
+        assert_eq!(e["names"].as_array().unwrap().len(), MAX_NAMES);
+        clear();
+    }
+
+    #[test]
+    fn no_match_search_is_still_recorded() {
+        let _g = TEST_LOCK.lock().unwrap();
+        clear();
+        record(None, "nonexistent capability", None, "", &[], 0, 0, 0, 5000, false);
+        let e = &read_recent(1)[0];
+        assert_eq!(e["returned"], 0);
+        assert_eq!(e["top"], "");
+        // A miss still shows what a full catalog would have cost.
+        assert_eq!(e["flatTokens"], 5000);
+        clear();
+    }
+}

--- a/src/components/ActivityView.tsx
+++ b/src/components/ActivityView.tsx
@@ -6,6 +6,7 @@ import {
   ChevronRight,
   History,
   ScrollText,
+  Search,
   Share2,
   ShieldAlert,
   ShieldCheck,
@@ -21,6 +22,7 @@ import {
   getAuditStats,
   getInspectLog,
   getSavingsSummary,
+  getSearchTraces,
   getSecurityEvents,
   type SecurityEvent,
 } from "@/lib/api";
@@ -30,6 +32,7 @@ import type {
   InspectEntry,
   Registry,
   SavingsSummary,
+  SearchTrace,
   ServerStat,
 } from "@/lib/types";
 import {
@@ -698,6 +701,137 @@ function InspectRow({ e }: { e: InspectEntry }) {
   );
 }
 
+/** One recorded search: the query, what matched, and how much tool-definition context
+ * this search put into the model vs. loading the whole catalog. Expands to the full
+ * list of returned tool names. */
+function DiscoveryRow({ t }: { t: SearchTrace }) {
+  const [open, setOpen] = useState(false);
+  const pct = t.flatTokens > 0 ? Math.round((t.savedTokens / t.flatTokens) * 100) : 0;
+  const hit = t.returned > 0;
+  return (
+    <div className="rounded-md border border-border/50 text-sm">
+      <div
+        className="flex cursor-pointer items-center gap-3 px-3 py-2 hover:bg-muted/30"
+        onClick={() => setOpen((o) => !o)}
+        role="button"
+        aria-expanded={open}
+        tabIndex={0}
+      >
+        <ChevronRight
+          className={`size-3.5 shrink-0 text-muted-foreground transition-transform ${
+            open ? "rotate-90" : ""
+          }`}
+        />
+        <Search className="size-4 shrink-0 text-owned" />
+        <span className="min-w-0 truncate font-mono text-xs">
+          &ldquo;{t.query || "(empty)"}&rdquo;
+        </span>
+        {t.client && (
+          <span className="shrink-0 rounded bg-muted px-1.5 py-0.5 text-[11px] text-muted-foreground">
+            {t.client}
+          </span>
+        )}
+        {t.escalated && (
+          <span className="shrink-0 rounded bg-warning/15 px-1.5 py-0.5 text-[11px] text-warning">
+            loop-broken
+          </span>
+        )}
+        <span className="ml-auto shrink-0 text-xs tabular-nums text-muted-foreground">
+          {hit ? `${t.returned} of ${t.total}` : "no match"}
+        </span>
+        <span className="shrink-0 text-xs text-muted-foreground">
+          {new Date(t.ts).toLocaleTimeString()}
+        </span>
+      </div>
+      {open && (
+        <div className="border-t border-border/50 bg-muted/20 px-3 py-2 pl-9 text-xs">
+          {hit ? (
+            <div className="mb-2 flex flex-wrap gap-1">
+              {t.names.map((n) => (
+                <span
+                  key={n}
+                  className={`rounded px-1.5 py-0.5 font-mono text-[11px] ${
+                    n === t.top ? "bg-owned/15 text-owned" : "bg-muted text-muted-foreground"
+                  }`}
+                >
+                  {n}
+                </span>
+              ))}
+            </div>
+          ) : (
+            <div className="mb-2 text-muted-foreground">No tools matched this query.</div>
+          )}
+          <div className="text-muted-foreground">
+            Put{" "}
+            <span className="font-medium text-foreground">≈{fmtTokens(t.returnedTokens)}</span>{" "}
+            tokens of tool schemas into context, vs{" "}
+            <span className="font-medium text-foreground">≈{fmtTokens(t.flatTokens)}</span> to load
+            the whole catalog
+            {t.flatTokens > 0 ? <> ({pct}% less this turn).</> : "."}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+/** Collapsible discovery panel: the in-path proof that lazy discovery is working.
+ * Lists recent toolport_search_tools calls with what matched and the exact per-turn
+ * tool-definition token overhead. Self-hides until something has searched. Always-on,
+ * local, bounded. */
+function DiscoveryTraces({ refreshKey }: { refreshKey: number }) {
+  const [entries, setEntries] = useState<SearchTrace[]>([]);
+  const [open, setOpen] = useState(true);
+
+  useEffect(() => {
+    let alive = true;
+    getSearchTraces(100)
+      .then((e) => alive && setEntries(e))
+      .catch(() => alive && setEntries([]));
+    return () => {
+      alive = false;
+    };
+  }, [refreshKey]);
+
+  if (entries.length === 0) return null;
+
+  return (
+    <div className="mb-6 rounded-lg border border-owned/30 bg-owned/[0.04] p-4">
+      <button
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+        className="flex w-full items-center gap-2 text-left"
+      >
+        <Search className="size-4 shrink-0 text-owned" />
+        <h3 className="text-sm font-medium">Discovery</h3>
+        <span className="rounded-full bg-owned/15 px-1.5 py-0.5 text-xs font-medium text-owned">
+          {entries.length}
+        </span>
+        <ChevronRight
+          className={`ml-auto size-4 text-muted-foreground transition-transform ${
+            open ? "rotate-90" : ""
+          }`}
+        />
+      </button>
+      {open && (
+        <>
+          <p className="mt-2 mb-3 max-w-2xl text-xs text-muted-foreground">
+            What the model searched for and what Toolport handed back. Each search returns
+            only the matching tools, so just those schemas enter context instead of every
+            tool on every turn. Match counts are exact; token figures are an ≈ estimate.
+            Local and bounded: tool names only, never arguments or results.
+          </p>
+          <div className="flex flex-col gap-1">
+            {entries.map((t, i) => (
+              <DiscoveryRow key={`${t.ts}-${i}`} t={t} />
+            ))}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
 /** Collapsible live inspector: a local "network tab" for MCP. Only rendered while
  * live inspection is on. Lists recent captured calls, each expandable to its raw
  * request + response JSON. Ephemeral, local, opt-in. */
@@ -834,6 +968,7 @@ export function ActivityView({
       {infoSecurity.length > 0 ? (
         <QuietDriftHistory events={infoSecurity} onDismiss={dismissSecurity} />
       ) : null}
+      <DiscoveryTraces refreshKey={refreshKey} />
       {registry?.liveInspect ? <LiveInspector refreshKey={refreshKey} /> : null}
       {savings && savings.tokensSaved > 0 ? (
         <SavingsBanner savings={savings} />

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -17,6 +17,7 @@ import type {
   ProbeResult,
   Registry,
   SavingsSummary,
+  SearchTrace,
   ServerEntry,
   ToolCallResult,
   Stack,
@@ -237,6 +238,18 @@ export function getInspectLog(limit = 50): Promise<InspectEntry[]> {
 /** Clear the live-inspection ring so no captured args/results linger. */
 export function clearInspectLog(): Promise<void> {
   return invoke<void>("clear_inspect_log");
+}
+
+/** Recent lazy-discovery search traces (newest first): what the model searched for,
+ * which tools matched, and the tool-definition tokens the results cost vs. loading the
+ * whole catalog. Empty until something has searched. */
+export function getSearchTraces(limit = 100): Promise<SearchTrace[]> {
+  return invoke<SearchTrace[]>("get_search_traces", { limit });
+}
+
+/** Clear the search-trace log. */
+export function clearSearchTraces(): Promise<void> {
+  return invoke<void>("clear_search_traces");
 }
 
 /** Toggle quarantine-on-drift: block a high-risk tool that drifted until re-approved. */

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -86,6 +86,27 @@ export interface InspectEntry {
   durationMs?: number;
 }
 
+/** One lazy-discovery search: what the model searched for and what came back, with
+ * the ground-truth token cost of the results vs. loading the whole catalog. */
+export interface SearchTrace {
+  ts: number;
+  client?: string;
+  query: string;
+  server?: string;
+  top: string;
+  names: string[];
+  returned: number;
+  total: number;
+  /** Tool-definition tokens the returned schemas cost this turn (≈). */
+  returnedTokens: number;
+  /** Tool-definition tokens advertising the whole (scoped) catalog would cost (≈). */
+  flatTokens: number;
+  /** flatTokens - returnedTokens: the context kept out of the model this turn. */
+  savedTokens: number;
+  /** The loop-breaker fired: repeated searches kept landing on the same top tool. */
+  escalated: boolean;
+}
+
 export interface ProbeResult {
   serverId: string;
   ok: boolean;


### PR DESCRIPTION
## What

Adds a **Discovery** panel to Activity that records every `toolport_search_tools` call: the query, which tools matched, and the ground-truth tool-definition token overhead the results cost **this turn** vs. loading the whole catalog.

This is the Reddit-requested observability feature (someone on the r/LocalLLaMA thread asked how to know lazy discovery is actually working). The angle: because Toolport is **in the request path**, it knows the exact query, the exact tools returned, and the exact per-turn token delta — where a post-hoc log/telemetry reader can only estimate.

## How

- **`searchtrace.rs`** — a bounded, append-only, local ring log (mirrors `savings.rs` / `inspect.rs`). The model-authored query is length-capped, only tool **names** are stored (never arguments or results), and it reuses `savings::estimate_tokens` so the numbers match the in-app savings counter.
- **Gateway hook** in the `toolport_search_tools` handler records one trace per search: returned-schema tokens vs full-(scoped)-catalog tokens.
- **`get_search_traces` / `clear_search_traces`** commands + api bindings + a `SearchTrace` type.
- **Activity 'Discovery' panel** — expandable rows (query → matched tools + per-turn savings), self-hides until something has searched.

## Privacy

Always-on but local and bounded, consistent with the audit/savings logs. Tool names + counts + token estimates only; no args/results (those stay behind opt-in Live inspection). Panel copy states this.

## Tests

3 new module tests (newest-first read, query/name caps, no-match still recorded). 243 lib tests pass, `cargo check` clean, `tsc --noEmit` clean.