### PR TITLE
harden(gateway): catch handler panics on the stdio transport too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ Entries before the rename below shipped under the project's former name, Conduit
   overflowed the paging math into an invalid byte slice that panicked; on the stdio
   transport (no panic guard) that took down the whole gateway process. The offset math
   now saturates.
+- **The stdio transport now catches handler panics like the HTTP one already did.** A
+  panic while handling a request returns a JSON-RPC internal error for that request and
+  keeps the gateway running, instead of unwinding out and dropping the whole MCP
+  connection (defense-in-depth for the primary local transport).
 - **HTTP clients are scoped on resources and prompts too.** A registered HTTP/OpenAPI
   client scoped to a subset of servers could still read *any* connected server's
   resources and prompts (`resources/read` / `prompts/get` ignored the scope); they now

--- a/src-tauri/src/bin/conduit-gateway.rs
+++ b/src-tauri/src/bin/conduit-gateway.rs
@@ -3360,8 +3360,18 @@ fn main() {
             "request: {}",
             req.get("method").and_then(|m| m.as_str()).unwrap_or("")
         ));
-        let response =
-            process_request(&state, &req, &search_guard, &confirm_guard, None, None);
+        // A panic in a handler must not unwind out of this loop and kill the gateway:
+        // stdio has no supervisor (unlike the HTTP listener, which catches per request),
+        // so one panic would drop the whole MCP connection and take every tool with it.
+        // Catch it, log it, and return a JSON-RPC internal error for this request.
+        let response = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            process_request(&state, &req, &search_guard, &confirm_guard, None, None)
+        }))
+        .unwrap_or_else(|_| {
+            let id = req.get("id").cloned().unwrap_or(Value::Null);
+            glog("panic while handling a request; returned an internal error, gateway still up");
+            Some(error(id, -32603, "internal error"))
+        });
         if let Some(resp) = response {
             let mut out = state
                 .stdout


### PR DESCRIPTION
The HTTP listener already wraps each request in `catch_unwind` (a handler panic becomes a 500). The **stdio** loop called `process_request` directly, so any handler panic would unwind out of the loop and **kill the gateway process** — dropping the whole MCP connection and every tool with it. Stdio is the primary local mode (Claude Desktop, Cursor).

This mirrors the HTTP guard: catch the panic, log it, and return a JSON-RPC `-32603` internal error for that request while keeping the gateway running.

Complements #118 (which fixed the specific `fetch_result` overflow that exposed this) with a general backstop against any future handler panic. `cargo check` clean.

Note: the stdio read loop isn't unit-testable in isolation (it consumes stdin), so there's no new test; the change is a near-verbatim mirror of the proven HTTP `catch_unwind` path using the existing `error(id, code, msg)` helper.