### PR TITLE
feat(audit): record agent-control toggles with proof of the scope decision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ Entries before the rename below shipped under the project's former name, Conduit
   that "Known servers" list are now filtered to the client's scope, so an out-of-scope
   server is indistinguishable from a non-existent one. (Only reachable when the global
   "Allow agent control" opt-in is on.)
+- **Agent-control toggles are audited with proof of the scope decision.** Each
+  `enable_server` / `disable_server` attempt writes an `agent_control.server_toggle`
+  audit record (client, profile, requested target, decision, and whether the lookup was
+  scoped). A denied out-of-scope attempt records `resolvedServerId: null`, so the audit
+  itself carries the guarantee that the denial never resolved or named an out-of-scope
+  server.
 - **`fetch_result` is now scoped to the client that produced the result.** In HTTP mode
   one gateway serves every registered client from a shared result cache with sequential
   `r{n}` cursors, so a scoped client could read another client's large-result body by

--- a/src-tauri/src/audit.rs
+++ b/src-tauri/src/audit.rs
@@ -87,6 +87,64 @@ pub fn record_held(server: &str, tool: &str, client: Option<&str>) {
     write_line(&entry);
 }
 
+/// Build the audit entry for an agent-control server toggle. Pure (no I/O) so the
+/// scope-proof invariant is unit-testable: on a denied out-of-scope attempt the lookup
+/// never resolves the target, so `resolvedServerId` is null and the record can't reveal
+/// whether an out-of-scope server exists. `decision` is one of `enabled`, `disabled`,
+/// `noop_already`, `unresolved`, `agent_control_off`.
+fn agent_toggle_entry(
+    client: Option<&str>,
+    profile: &str,
+    action: &str,
+    requested_target: &str,
+    resolved_server_id: Option<&str>,
+    decision: &str,
+    scoped: bool,
+) -> Value {
+    let ok = matches!(decision, "enabled" | "disabled" | "noop_already");
+    let mut entry = json!({
+        "ts": epoch_millis() as u64,
+        // A synthetic server/tool pair so the audit table renders this like any row.
+        "server": "agent-control",
+        "tool": action,
+        "ok": ok,
+        "event": "agent_control.server_toggle",
+        "requestedTarget": requested_target,
+        // Null on a scoped miss: the whole point is that a denial doesn't name (or even
+        // confirm the existence of) an out-of-scope server.
+        "resolvedServerId": resolved_server_id,
+        "decision": decision,
+        "knownListScope": if scoped { "client_allowed_only" } else { "all" },
+        "profile": profile,
+    });
+    if let Some(c) = client.filter(|c| !c.is_empty()) {
+        entry["client"] = json!(c);
+    }
+    entry
+}
+
+/// Record an agent-control server toggle (toolport_enable_server / _disable_server) to
+/// the audit log, so the log carries proof of the scope decision, not just the behavior.
+pub fn record_agent_toggle(
+    client: Option<&str>,
+    profile: &str,
+    action: &str,
+    requested_target: &str,
+    resolved_server_id: Option<&str>,
+    decision: &str,
+    scoped: bool,
+) {
+    write_line(&agent_toggle_entry(
+        client,
+        profile,
+        action,
+        requested_target,
+        resolved_server_id,
+        decision,
+        scoped,
+    ));
+}
+
 /// Append one entry as a single JSON line. A single `write_all` (not `writeln!`, which
 /// can issue several write syscalls) keeps the many client-spawned gateways that share
 /// this file from interleaving each other's bytes into corrupt JSON.
@@ -292,6 +350,37 @@ fn aggregate(entries: &[Value]) -> Value {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn agent_toggle_denial_record_proves_scope_without_leaking() {
+        // A scoped client's out-of-scope toggle: the lookup never resolves the target,
+        // so the record must carry resolvedServerId=null, decision=unresolved, and a
+        // client-scoped known-list flag, and must NOT name any out-of-scope server.
+        let e = agent_toggle_entry(
+            Some("cursor-work"),
+            "coding",
+            "enable",
+            "Beta",
+            None,
+            "unresolved",
+            true,
+        );
+        assert_eq!(e["event"], "agent_control.server_toggle");
+        assert!(e["resolvedServerId"].is_null(), "a scoped miss must not resolve a server");
+        assert_eq!(e["decision"], "unresolved");
+        assert_eq!(e["knownListScope"], "client_allowed_only");
+        assert_eq!(e["ok"], false);
+        assert_eq!(e["requestedTarget"], "Beta");
+        assert_eq!(e["client"], "cursor-work");
+
+        // A successful in-scope toggle resolves the real server id and reads as ok.
+        let ok = agent_toggle_entry(None, "coding", "disable", "gh", Some("gh"), "disabled", true);
+        assert_eq!(ok["resolvedServerId"], "gh");
+        assert_eq!(ok["decision"], "disabled");
+        assert_eq!(ok["ok"], true);
+        // Unattributed (local/stdio) call omits the client field entirely.
+        assert!(ok.get("client").is_none());
+    }
 
     #[test]
     fn latency_avg_and_p95() {

--- a/src-tauri/src/bin/conduit-gateway.rs
+++ b/src-tauri/src/bin/conduit-gateway.rs
@@ -219,8 +219,25 @@ fn set_server_enabled_via_agent(
     // "Known servers" list is filtered to it, so agent control can't toggle another
     // tenant's server or enumerate the full registry across tenants.
     allowed: Option<&std::collections::HashSet<String>>,
+    // The calling client (a registered HTTP client's label), for the audit record.
+    client: Option<&str>,
 ) -> Result<String, String> {
+    // Every resolved outcome is stamped into the audit log so it carries proof of the
+    // scope decision, not just the resulting behavior (see audit::record_agent_toggle).
+    let action = if enable { "enable" } else { "disable" };
+    let scoped = allowed.is_some();
+    let toggle_profile = || profile.or(reg.active_profile_id.as_deref()).unwrap_or("");
+
     if !reg.allow_agent_control {
+        audit::record_agent_toggle(
+            client,
+            toggle_profile(),
+            action,
+            target.trim(),
+            None,
+            "agent_control_off",
+            scoped,
+        );
         return Err(
             "Toolport: agent control is off. The user must turn on \"Allow agent control\" \
             in Toolport before an agent can enable or disable servers."
@@ -238,24 +255,34 @@ fn set_server_enabled_via_agent(
     // out-of-scope server is indistinguishable from a non-existent one.
     let in_scope =
         |s: &ServerEntry| allowed.map_or(true, |set| set.contains(&sanitize_segment(&s.id)));
-    let server = reg
-        .servers
-        .iter()
-        .find(|s| {
-            in_scope(s) && (s.id.eq_ignore_ascii_case(target) || s.name.eq_ignore_ascii_case(target))
-        })
-        .ok_or_else(|| {
+    let server = match reg.servers.iter().find(|s| {
+        in_scope(s) && (s.id.eq_ignore_ascii_case(target) || s.name.eq_ignore_ascii_case(target))
+    }) {
+        Some(s) => s,
+        None => {
+            // Denied/not-found: resolved_server_id stays null, so the record can't
+            // reveal whether an out-of-scope server with this name exists.
+            audit::record_agent_toggle(
+                client,
+                toggle_profile(),
+                action,
+                target,
+                None,
+                "unresolved",
+                scoped,
+            );
             let known: Vec<&str> = reg
                 .servers
                 .iter()
                 .filter(|s| in_scope(s))
                 .map(|s| s.name.as_str())
                 .collect();
-            format!(
+            return Err(format!(
                 "Toolport: no server matches \"{target}\". Known servers: {}.",
                 known.join(", ")
-            )
-        })?;
+            ));
+        }
+    };
     let server_id = server.id.clone();
     let server_name = server.name.clone();
     let profile_id = profile
@@ -268,9 +295,27 @@ fn set_server_enabled_via_agent(
     let mut fresh = registry::load_from(path)
         .map_err(|e| format!("Toolport: could not read the registry ({e})."))?;
     if !fresh.allow_agent_control {
+        audit::record_agent_toggle(
+            client,
+            &profile_id,
+            action,
+            target,
+            Some(&server_id),
+            "agent_control_off",
+            scoped,
+        );
         return Err("Toolport: agent control is off.".to_string());
     }
     if fresh.is_enabled(&profile_id, &server_id) == enable {
+        audit::record_agent_toggle(
+            client,
+            &profile_id,
+            action,
+            target,
+            Some(&server_id),
+            "noop_already",
+            scoped,
+        );
         return Ok(format!(
             "{server_name} is already {}.",
             if enable { "on" } else { "off" }
@@ -279,6 +324,15 @@ fn set_server_enabled_via_agent(
     fresh.set_server_enabled(&profile_id, &server_id, enable)?;
     registry::save_to(path, &fresh)
         .map_err(|e| format!("Toolport: could not save the registry ({e})."))?;
+    audit::record_agent_toggle(
+        client,
+        &profile_id,
+        action,
+        target,
+        Some(&server_id),
+        if enable { "enabled" } else { "disabled" },
+        scoped,
+    );
     glog(&format!(
         "agent control: {} server '{server_id}' in profile '{profile_id}'",
         if enable { "ENABLED" } else { "DISABLED" }
@@ -1687,9 +1741,9 @@ fn handle_request(
                     .and_then(|v| v.as_str())
                     .unwrap_or("");
                 let result = match registry::resolved_path() {
-                    Some(p) => {
-                        set_server_enabled_via_agent(reg, profile, &p, target, enable, allowed)
-                    }
+                    Some(p) => set_server_enabled_via_agent(
+                        reg, profile, &p, target, enable, allowed, client,
+                    ),
                     None => Err("Toolport: could not locate the registry file.".to_string()),
                 };
                 let (text, is_error) = match result {
@@ -3997,7 +4051,7 @@ mod tests {
         let reg = registry::load_from(&path).unwrap();
 
         // Gated off: refused, and nothing on disk changes.
-        assert!(set_server_enabled_via_agent(&reg, Some("p"), &path, "Beta", true, None).is_err());
+        assert!(set_server_enabled_via_agent(&reg, Some("p"), &path, "Beta", true, None, None).is_err());
         assert!(!registry::load_from(&path).unwrap().is_enabled("p", "b"));
 
         // Opt in (persisting it so the fresh-copy re-check passes), then enable
@@ -4005,14 +4059,14 @@ mod tests {
         let mut reg2 = reg.clone();
         reg2.allow_agent_control = true;
         registry::save_to(&path, &reg2).unwrap();
-        let ok = set_server_enabled_via_agent(&reg2, Some("p"), &path, "beta", true, None);
+        let ok = set_server_enabled_via_agent(&reg2, Some("p"), &path, "beta", true, None, None);
         assert!(ok.is_ok(), "enable should succeed: {ok:?}");
         assert!(registry::load_from(&path).unwrap().is_enabled("p", "b"));
         // The destructive-tool safety switch is never reachable from agent control.
         assert!(!registry::load_from(&path).unwrap().deny_destructive);
 
         // Unknown server: helpful error naming the known ones.
-        let bad = set_server_enabled_via_agent(&reg2, Some("p"), &path, "nope", true, None);
+        let bad = set_server_enabled_via_agent(&reg2, Some("p"), &path, "nope", true, None, None);
         assert!(bad.as_ref().is_err());
         assert!(bad.unwrap_err().contains("Alpha"));
 
@@ -4037,7 +4091,7 @@ mod tests {
 
         // Toggling Beta (out of scope) by name is refused, and Beta stays untouched.
         let refused =
-            set_server_enabled_via_agent(&reg, Some("p"), &path, "Beta", true, Some(&allowed));
+            set_server_enabled_via_agent(&reg, Some("p"), &path, "Beta", true, Some(&allowed), None);
         assert!(refused.is_err(), "out-of-scope toggle must be refused");
         assert!(
             !registry::load_from(&path).unwrap().is_enabled("p", "b"),
@@ -4046,13 +4100,13 @@ mod tests {
 
         // The "Known servers" list on a miss must not enumerate out-of-scope servers:
         // a non-matching target so Beta only appears if it leaked from the list.
-        let miss = set_server_enabled_via_agent(&reg, Some("p"), &path, "zzz", true, Some(&allowed));
+        let miss = set_server_enabled_via_agent(&reg, Some("p"), &path, "zzz", true, Some(&allowed), None);
         let msg = miss.unwrap_err();
         assert!(msg.contains("Alpha"), "in-scope server should be listed: {msg}");
         assert!(!msg.contains("Beta"), "out-of-scope name leaked in Known servers: {msg}");
 
         // An in-scope server still resolves (Alpha is already on -> idempotent OK).
-        let ok = set_server_enabled_via_agent(&reg, Some("p"), &path, "Alpha", true, Some(&allowed));
+        let ok = set_server_enabled_via_agent(&reg, Some("p"), &path, "Alpha", true, Some(&allowed), None);
         assert!(ok.is_ok(), "in-scope toggle should resolve: {ok:?}");
 
         let _ = std::fs::remove_file(&path);


### PR DESCRIPTION
Follow-up to the #120 scope fix, and to [caioribeiroclw-pixel's suggestion on that PR](https://github.com/tsouth89/toolport/pull/120#issuecomment-4877965138): the audit should carry proof of the scope decision, not just the enforced behavior.

Every `toolport_enable_server` / `toolport_disable_server` attempt now writes an `agent_control.server_toggle` audit record:

```
{ event, client, profile, requestedTarget, resolvedServerId, decision, knownListScope, ok }
```

`decision` is one of `enabled` / `disabled` / `noop_already` / `unresolved` / `agent_control_off`. On a **denied out-of-scope** attempt the target is never resolved, so `resolvedServerId` is `null` and `knownListScope` is `client_allowed_only` — the record itself proves the denial didn't resolve or name an out-of-scope server (no existence oracle).

The entry builder (`agent_toggle_entry`) is pure, so the no-leak invariant is unit-tested without touching the shared audit file. The record uses a synthetic `server: "agent-control"` label so the existing audit table renders it as a normal row.

247 lib + 56 gateway tests pass.