### PR TITLE
feat(provenance): Tool identities panel (alias -> server/profile + fingerprint)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,12 @@ Entries before the rename below shipped under the project's former name, Conduit
   Realistic results are far under the cap, so detection is unaffected in practice.
 
 ### Added
+- **Tool identities (capability provenance).** A new Activity panel shows what each
+  model-visible tool name actually maps to: its source server and the profiles that
+  enable it, the pinned definition fingerprint drift detection checks against, and when
+  the tool was first seen / last changed. Prefixing helps the model pick a tool; this
+  lets a human verify what crossed the boundary. (The integrity baseline now tracks
+  first-seen / last-changed per tool to power it.)
 - **Teams can require human approval org-wide.** A team admin can turn on "Require
   human approval" in the Teams policy, and every member's gateway then holds gated
   tool calls for a person to approve. Like the other org policies, it's tighten-only:

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -27,7 +27,7 @@ pub mod teams;
 pub mod vendors;
 
 use downstream::{DownstreamServer, StdioTransport};
-use registry::{Registry, ServerEntry};
+use registry::{Profile, Registry, ServerEntry};
 
 type RegistryState = Mutex<Registry>;
 
@@ -1013,6 +1013,110 @@ fn clear_search_traces() -> Result<(), String> {
     Ok(())
 }
 
+/// One exposed tool's verifiable identity: the model-visible alias joined back to its
+/// source server + the profiles that enable it, plus the integrity fingerprint and
+/// when the definition was first seen / last changed. This is the "capability
+/// provenance" view: prefixing helps the model pick a tool, this helps a human verify
+/// what actually crossed the boundary.
+#[derive(serde::Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+struct ToolIdentity {
+    /// Model-visible exposed name (the integrity pin key).
+    alias: String,
+    /// Resolved source server id, or empty if the alias couldn't be attributed (a
+    /// renamed tool whose alias no longer carries its `server__` prefix; its exact
+    /// provenance needs the deeper gateway integration, tracked separately).
+    server_id: String,
+    server_name: String,
+    /// Names of the profiles whose enabled set includes this server.
+    profiles: Vec<String>,
+    /// Upstream tool name, taken as the alias suffix after `server__`.
+    upstream: String,
+    /// Version-prefixed fingerprint of the pinned definition (drift detection compares
+    /// against this exact value).
+    fingerprint: String,
+    first_seen: u64,
+    last_changed: u64,
+    quarantined: bool,
+}
+
+/// Assemble the identity rows. Pure (no state/IO) so the alias->server attribution is
+/// unit-testable.
+fn build_tool_identities(
+    baselines: &std::collections::BTreeMap<String, integrity::ToolBaseline>,
+    quarantined: &std::collections::BTreeSet<String>,
+    servers: &[ServerEntry],
+    profiles: &[Profile],
+) -> Vec<ToolIdentity> {
+    // Exposed prefix (sanitize_segment(id)) -> server. Matching by the KNOWN prefixes
+    // (longest wins) is robust against a server id that itself contains `__`, unlike a
+    // naive split on the first separator.
+    let prefixed: Vec<(String, &ServerEntry)> = servers
+        .iter()
+        .map(|s| (router::sanitize_segment(&s.id), s))
+        .collect();
+    baselines
+        .iter()
+        .map(|(alias, base)| {
+            let mut server: Option<&ServerEntry> = None;
+            let mut upstream = String::new();
+            let mut best_len = 0usize;
+            for (prefix, srv) in &prefixed {
+                if let Some(rest) = alias
+                    .strip_prefix(prefix.as_str())
+                    .and_then(|r| r.strip_prefix("__"))
+                {
+                    if prefix.len() > best_len || server.is_none() {
+                        best_len = prefix.len();
+                        server = Some(srv);
+                        upstream = rest.to_string();
+                    }
+                }
+            }
+            let (server_id, server_name) =
+                server.map(|s| (s.id.clone(), s.name.clone())).unwrap_or_default();
+            let profile_names = if server_id.is_empty() {
+                Vec::new()
+            } else {
+                profiles
+                    .iter()
+                    .filter(|p| p.enabled_server_ids.contains(&server_id))
+                    .map(|p| p.name.clone())
+                    .collect()
+            };
+            ToolIdentity {
+                alias: alias.clone(),
+                server_id,
+                server_name,
+                profiles: profile_names,
+                upstream,
+                fingerprint: base.fingerprint.clone(),
+                first_seen: base.first_seen,
+                last_changed: base.last_changed,
+                quarantined: quarantined.contains(alias),
+            }
+        })
+        .collect()
+}
+
+/// The capability-provenance table: every pinned tool's identity for the active
+/// profile, newest-changed first. Empty until the gateway has pinned a baseline.
+#[tauri::command]
+fn list_tool_identities(state: State<RegistryState>) -> Vec<ToolIdentity> {
+    let reg = state
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let profile = reg.active_profile_id.as_deref();
+    let mut ids = build_tool_identities(
+        &integrity::baselines(profile),
+        &integrity::quarantined(profile),
+        &reg.servers,
+        &reg.profiles,
+    );
+    ids.sort_by(|a, b| b.last_changed.cmp(&a.last_changed).then(a.alias.cmp(&b.alias)));
+    ids
+}
+
 /// Toggle quarantine-on-drift. When enabled, the gateway hides and blocks a high-risk
 /// tool (poisoned definition, or a destructive tool whose definition changed/appeared)
 /// that drifts from its pinned baseline, until the user re-approves it.
@@ -1934,6 +2038,7 @@ pub fn run() {
             clear_inspect_log,
             get_search_traces,
             clear_search_traces,
+            list_tool_identities,
             set_quarantine_on_drift,
             list_quarantined,
             release_quarantine,
@@ -2083,6 +2188,67 @@ mod tests {
             source: None,
             disabled_tools: vec![],
         }
+    }
+
+    fn plain_server(id: &str, name: &str) -> ServerEntry {
+        ServerEntry {
+            id: id.into(),
+            name: name.into(),
+            transport: "stdio".into(),
+            command: Some("x".into()),
+            args: vec![],
+            env: vec![],
+            url: None,
+            source: None,
+            disabled_tools: vec![],
+        }
+    }
+
+    #[test]
+    fn tool_identities_attribute_alias_to_server_and_profiles() {
+        use std::collections::{BTreeMap, BTreeSet};
+        let servers = vec![plain_server("gh", "GitHub"), plain_server("my-server", "My Server")];
+        let profiles = vec![Profile {
+            id: "default".into(),
+            name: "Default".into(),
+            enabled_server_ids: vec!["gh".into()],
+        }];
+        let mut baselines = BTreeMap::new();
+        let bl = |fp: &str, fs: u64, lc: u64| integrity::ToolBaseline {
+            fingerprint: fp.into(),
+            first_seen: fs,
+            last_changed: lc,
+        };
+        baselines.insert("gh__create_issue".to_string(), bl("v2:abc", 100, 200));
+        baselines.insert("my_server__do_thing".to_string(), bl("v2:def", 50, 60));
+        baselines.insert("orphan_alias".to_string(), bl("v2:ghi", 1, 2));
+        let quarantined: BTreeSet<String> =
+            ["gh__create_issue".to_string()].into_iter().collect();
+
+        let ids = build_tool_identities(&baselines, &quarantined, &servers, &profiles);
+        let get = |a: &str| ids.iter().find(|i| i.alias == a).cloned().unwrap();
+
+        let gh = get("gh__create_issue");
+        assert_eq!(gh.server_id, "gh");
+        assert_eq!(gh.server_name, "GitHub");
+        assert_eq!(gh.upstream, "create_issue");
+        assert_eq!(gh.profiles, vec!["Default".to_string()]);
+        assert_eq!(gh.fingerprint, "v2:abc");
+        assert!(gh.quarantined);
+
+        // The REAL server id ("my-server") is recovered even though its exposed prefix
+        // is the sanitized "my_server". Not enabled in any profile -> empty profiles.
+        let my = get("my_server__do_thing");
+        assert_eq!(my.server_id, "my-server");
+        assert_eq!(my.upstream, "do_thing");
+        assert!(my.profiles.is_empty());
+        assert!(!my.quarantined);
+
+        // An alias matching no server prefix is honestly left unattributed, not guessed.
+        let orphan = get("orphan_alias");
+        assert_eq!(orphan.server_id, "");
+        assert_eq!(orphan.server_name, "");
+        assert!(orphan.profiles.is_empty());
     }
 
     #[test]

--- a/src/components/ActivityView.tsx
+++ b/src/components/ActivityView.tsx
@@ -4,6 +4,7 @@ import {
   AlertTriangle,
   CheckCircle2,
   ChevronRight,
+  Fingerprint,
   History,
   ScrollText,
   Search,
@@ -24,6 +25,7 @@ import {
   getSavingsSummary,
   getSearchTraces,
   getSecurityEvents,
+  getToolIdentities,
   type SecurityEvent,
 } from "@/lib/api";
 import type {
@@ -34,6 +36,7 @@ import type {
   SavingsSummary,
   SearchTrace,
   ServerStat,
+  ToolIdentity,
 } from "@/lib/types";
 import {
   Select,
@@ -832,6 +835,120 @@ function DiscoveryTraces({ refreshKey }: { refreshKey: number }) {
   );
 }
 
+/** One tool's identity card: the model-visible alias joined to its source server +
+ * profiles, with the pinned definition fingerprint and first-seen / last-changed. */
+function ToolIdentityRow({ t }: { t: ToolIdentity }) {
+  const [open, setOpen] = useState(false);
+  const fpShort = t.fingerprint.replace(/^v\d+:/, "").slice(0, 12) || "-";
+  const fmtDate = (ms: number) => (ms > 0 ? new Date(ms).toLocaleDateString() : "-");
+  return (
+    <div className="rounded-md border border-border/50 text-sm">
+      <div
+        className="flex cursor-pointer items-center gap-3 px-3 py-2 hover:bg-muted/30"
+        onClick={() => setOpen((o) => !o)}
+        role="button"
+        aria-expanded={open}
+        tabIndex={0}
+      >
+        <ChevronRight
+          className={`size-3.5 shrink-0 text-muted-foreground transition-transform ${
+            open ? "rotate-90" : ""
+          }`}
+        />
+        <span className="min-w-0 truncate font-mono text-xs">{t.alias}</span>
+        <span className="shrink-0 rounded bg-muted px-1.5 py-0.5 text-[11px] text-muted-foreground">
+          {t.serverName || t.serverId || "unattributed"}
+        </span>
+        {t.quarantined && (
+          <span className="shrink-0 rounded bg-warning/15 px-1.5 py-0.5 text-[11px] text-warning">
+            quarantined
+          </span>
+        )}
+        <span
+          className="ml-auto shrink-0 font-mono text-[11px] text-muted-foreground"
+          title={t.fingerprint}
+        >
+          {fpShort}
+        </span>
+      </div>
+      {open && (
+        <div className="border-t border-border/50 bg-muted/20 px-3 py-2 pl-9 text-xs">
+          <dl className="grid grid-cols-[7rem_1fr] gap-x-3 gap-y-1">
+            <dt className="text-muted-foreground">Upstream tool</dt>
+            <dd className="font-mono break-all">{t.upstream || "-"}</dd>
+            <dt className="text-muted-foreground">Source server</dt>
+            <dd>{t.serverName ? `${t.serverName} (${t.serverId})` : "unattributed"}</dd>
+            <dt className="text-muted-foreground">Profiles</dt>
+            <dd>{t.profiles.length ? t.profiles.join(", ") : "-"}</dd>
+            <dt className="text-muted-foreground">Fingerprint</dt>
+            <dd className="font-mono break-all">{t.fingerprint || "-"}</dd>
+            <dt className="text-muted-foreground">First seen</dt>
+            <dd>{fmtDate(t.firstSeen)}</dd>
+            <dt className="text-muted-foreground">Last changed</dt>
+            <dd>{fmtDate(t.lastChanged)}</dd>
+          </dl>
+        </div>
+      )}
+    </div>
+  );
+}
+
+/** Collapsible capability-provenance panel: every pinned tool's identity, so a human
+ * can verify which server/profile an alias maps to and whether its definition drifted.
+ * Self-hides until the gateway has pinned a baseline. */
+function ToolIdentities({ refreshKey }: { refreshKey: number }) {
+  const [rows, setRows] = useState<ToolIdentity[]>([]);
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    let alive = true;
+    getToolIdentities()
+      .then((r) => alive && setRows(r))
+      .catch(() => alive && setRows([]));
+    return () => {
+      alive = false;
+    };
+  }, [refreshKey]);
+
+  if (rows.length === 0) return null;
+
+  return (
+    <div className="mb-6 rounded-lg border border-border/60 bg-muted/[0.04] p-4">
+      <button
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+        className="flex w-full items-center gap-2 text-left"
+      >
+        <Fingerprint className="size-4 shrink-0 text-muted-foreground" />
+        <h3 className="text-sm font-medium">Tool identities</h3>
+        <span className="rounded-full bg-muted px-1.5 py-0.5 text-xs font-medium text-muted-foreground">
+          {rows.length}
+        </span>
+        <ChevronRight
+          className={`ml-auto size-4 text-muted-foreground transition-transform ${
+            open ? "rotate-90" : ""
+          }`}
+        />
+      </button>
+      {open && (
+        <>
+          <p className="mt-2 mb-3 max-w-2xl text-xs text-muted-foreground">
+            What each model-visible tool name actually maps to: its source server and
+            profiles, the pinned definition fingerprint drift detection checks against, and
+            when it was first seen or last changed. Prefixing helps the model pick a tool;
+            this helps you verify what crossed the boundary.
+          </p>
+          <div className="flex flex-col gap-1">
+            {rows.map((t) => (
+              <ToolIdentityRow key={t.alias} t={t} />
+            ))}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
 /** Collapsible live inspector: a local "network tab" for MCP. Only rendered while
  * live inspection is on. Lists recent captured calls, each expandable to its raw
  * request + response JSON. Ephemeral, local, opt-in. */
@@ -969,6 +1086,7 @@ export function ActivityView({
         <QuietDriftHistory events={infoSecurity} onDismiss={dismissSecurity} />
       ) : null}
       <DiscoveryTraces refreshKey={refreshKey} />
+      <ToolIdentities refreshKey={refreshKey} />
       {registry?.liveInspect ? <LiveInspector refreshKey={refreshKey} /> : null}
       {savings && savings.tokensSaved > 0 ? (
         <SavingsBanner savings={savings} />

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -18,6 +18,7 @@ import type {
   Registry,
   SavingsSummary,
   SearchTrace,
+  ToolIdentity,
   ServerEntry,
   ToolCallResult,
   Stack,
@@ -250,6 +251,12 @@ export function getSearchTraces(limit = 100): Promise<SearchTrace[]> {
 /** Clear the search-trace log. */
 export function clearSearchTraces(): Promise<void> {
   return invoke<void>("clear_search_traces");
+}
+
+/** Every pinned tool's verifiable identity (alias -> server/profiles + fingerprint +
+ * first-seen/last-changed) for the active profile. Empty until a baseline is pinned. */
+export function getToolIdentities(): Promise<ToolIdentity[]> {
+  return invoke<ToolIdentity[]>("list_tool_identities");
 }
 
 /** Toggle quarantine-on-drift: block a high-risk tool that drifted until re-approved. */

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -107,6 +107,20 @@ export interface SearchTrace {
   escalated: boolean;
 }
 
+/** One exposed tool's verifiable identity: the model-visible alias joined back to its
+ * source server + profiles, with the integrity fingerprint and first-seen/last-changed. */
+export interface ToolIdentity {
+  alias: string;
+  serverId: string;
+  serverName: string;
+  profiles: string[];
+  upstream: string;
+  fingerprint: string;
+  firstSeen: number;
+  lastChanged: number;
+  quarantined: boolean;
+}
+
 export interface ProbeResult {
   serverId: string;
   ok: boolean;


### PR DESCRIPTION
The capability-provenance / identity-map view (Option A), from the r/LocalLLaMA request + the caioribeiroclw PR comment. **Left open for your visual review** since you wanted eyes on the card.

## What it does
A new **Tool identities** panel in Activity. Each pinned tool gets a verifiable identity:
- model-visible **alias** -> resolved **source server** + the **profiles** that enable it
- **upstream tool** name
- the **definition fingerprint** drift detection compares against
- **first-seen / last-changed** (from the baseline shipped in #121)
- a **quarantined** badge when applicable

Prefixing helps the model pick a tool; this lets a human verify what actually crossed the boundary.

## How
`list_tool_identities` joins `integrity::baselines()` + `integrity::quarantined()` with the registry. Attribution matches the alias against the **known** server prefixes (longest wins), which is robust against a server id that itself contains `__` (unlike a naive split). An unattributable alias (a renamed tool) is left honestly blank, not guessed. The pure `build_tool_identities` is unit-tested (server attribution, real-id recovery from a sanitized prefix, profile join, unattributed fallback).

## Known limitation (deferred authoritative version)
The upstream name is the alias's sanitized suffix, and **renamed** tools resolve to no server. Making both exact needs the router's route map threaded into `integrity::check` (which also closes the renamed-tools-escape-drift gap I flagged) - a security-careful follow-up, deliberately not bundled here.

248 lib tests pass, `tsc --noEmit` clean. Please give the panel a look in the running app.