### PR TITLE
feat(discovery): pin tools as prerequisites always surfaced in search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,12 @@ Entries before the rename below shipped under the project's former name, Conduit
   Realistic results are far under the cap, so detection is unaffected in practice.
 
 ### Added
+- **Pin a tool as a lazy-discovery prerequisite.** Mark a load-bearing tool (auth,
+  list-before-act, or one whose description doesn't match the model's keywords) with the
+  pin toggle in the tool list, and lazy-discovery search will always surface it with its
+  full schema, regardless of the query's match score, so it's never hidden behind
+  discovery. Pinned tools stay scoped to the client and are capped so a large pin set
+  can't itself bloat a result. (Requested on the r/LocalLLaMA launch thread.)
 - **Tool identities (capability provenance).** A new Activity panel shows what each
   model-visible tool name actually maps to: its source server and the profiles that
   enable it, the pinned definition fingerprint drift detection checks against, and when

--- a/src-tauri/src/bin/conduit-gateway.rs
+++ b/src-tauri/src/bin/conduit-gateway.rs
@@ -1651,6 +1651,38 @@ fn handle_request(
                 if escalate {
                     matches.truncate(1); // only the best match, no distractions
                 }
+                // Always surface pinned prerequisite tools (with their full schema),
+                // even if the query didn't rank them, so a load-bearing tool (auth /
+                // list-before-act, or one whose description doesn't match the keywords)
+                // is never hidden behind lazy discovery. Scoped (source is already the
+                // client's catalog) and capped so a big pin set can't itself bloat.
+                if !reg.pinned_tools.is_empty() {
+                    let have: std::collections::HashSet<&str> = matches
+                        .iter()
+                        .filter_map(|m| m.get("name").and_then(Value::as_str))
+                        .collect();
+                    let mut pinned: Vec<Value> = source
+                        .iter()
+                        .filter(|t| {
+                            t.get("name")
+                                .and_then(Value::as_str)
+                                .map(|n| !have.contains(n))
+                                .unwrap_or(false)
+                                && t.get("name")
+                                    .and_then(Value::as_str)
+                                    .and_then(|n| router.route_of(n))
+                                    .map(|(srv, orig)| reg.is_tool_pinned(srv, orig))
+                                    .unwrap_or(false)
+                        })
+                        .take(10)
+                        .cloned()
+                        .collect();
+                    if !pinned.is_empty() {
+                        // Prepend so prerequisites lead the results.
+                        pinned.append(&mut matches);
+                        matches = pinned;
+                    }
+                }
                 // Tell the agent when results were truncated, so a buried tool isn't
                 // mistaken for a missing capability.
                 let more = if total > matches.len() && !escalate {

--- a/src-tauri/src/bin/conduit-gateway.rs
+++ b/src-tauri/src/bin/conduit-gateway.rs
@@ -1656,6 +1656,7 @@ fn handle_request(
                 // list-before-act, or one whose description doesn't match the keywords)
                 // is never hidden behind lazy discovery. Scoped (source is already the
                 // client's catalog) and capped so a big pin set can't itself bloat.
+                let mut pins_added = 0usize;
                 if !reg.pinned_tools.is_empty() {
                     let have: std::collections::HashSet<&str> = matches
                         .iter()
@@ -1679,6 +1680,7 @@ fn handle_request(
                         .collect();
                     if !pinned.is_empty() {
                         // Prepend so prerequisites lead the results.
+                        pins_added = pinned.len();
                         pinned.append(&mut matches);
                         matches = pinned;
                     }
@@ -1710,6 +1712,15 @@ fn handle_request(
                 } else {
                     ""
                 };
+                // Pinned prerequisites are prepended (not query-ranked), so name them so
+                // the "top match" directive below isn't confused with the leading rows.
+                let pin_note = if pins_added > 0 {
+                    format!(
+                        " ({pins_added} pinned prerequisite tool(s) listed first, before the ranked matches.)"
+                    )
+                } else {
+                    String::new()
+                };
                 let lead = if matches.is_empty() {
                     format!(
                         "No tools matched{scope}. Try different keywords, or call toolport_status to \
@@ -1724,7 +1735,7 @@ fn handle_request(
                         "You have searched {} times and keep getting the same top tool, `{top}`. It \
                          is the best match and its full input schema is below - call toolport_call_tool \
                          now with name \"{top}\". Searching again will keep returning this. Only if \
-                         `{top}` genuinely cannot do the task, call toolport_status to see other servers.",
+                         `{top}` genuinely cannot do the task, call toolport_status to see other servers.{pin_note}",
                         repeats
                     )
                 } else {
@@ -1734,7 +1745,7 @@ fn handle_request(
                     format!(
                         "Found {total} matching tool(s){scope}. Top match: `{top}` - its full input \
                          schema is included below, so call it now with toolport_call_tool (name: \
-                         \"{top}\") if it fits. Only search again if none of these match.{more}{schema_note}"
+                         \"{top}\") if it fits. Only search again if none of these match.{pin_note}{more}{schema_note}"
                     )
                 };
                 let text = format!(

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -806,6 +806,22 @@ fn set_tool_enabled(
     Ok(reg.clone())
 }
 
+/// Pin (or unpin) a tool as a lazy-discovery prerequisite: search always surfaces a
+/// pinned tool with its full schema, regardless of the query's match score, so a
+/// load-bearing tool is never hidden. Propagates live via the registry watcher.
+#[tauri::command]
+fn set_tool_pinned(
+    state: State<RegistryState>,
+    server_id: String,
+    tool: String,
+    pinned: bool,
+) -> Result<Registry, String> {
+    let mut reg = state.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+    reg.set_tool_pinned(&server_id, &tool, pinned);
+    registry::save(&reg)?;
+    Ok(reg.clone())
+}
+
 /// Flip the global destructive-tool deny switch. When on, the gateway hides and
 /// blocks every tool annotated `destructiveHint: true` across all servers.
 #[tauri::command]
@@ -2024,6 +2040,7 @@ pub fn run() {
             remove_http_client,
             call_tool,
             set_tool_enabled,
+            set_tool_pinned,
             set_deny_destructive,
             set_confirm_destructive,
             set_human_approval,

--- a/src-tauri/src/registry.rs
+++ b/src-tauri/src/registry.rs
@@ -209,6 +209,13 @@ pub struct Registry {
     /// call still routes to the original downstream tool.
     #[serde(default)]
     pub tool_overrides: HashMap<String, HashMap<String, ToolOverride>>,
+    /// Tools pinned as lazy-discovery prerequisites, keyed by server id -> original tool
+    /// names. Search always surfaces a pinned tool (with its schema) regardless of the
+    /// query's match score, so a load-bearing tool (auth, list-before-act, one whose
+    /// description doesn't match the user's keywords) is never hidden behind lazy
+    /// discovery. Empty = nothing pinned.
+    #[serde(default)]
+    pub pinned_tools: HashMap<String, Vec<String>>,
     /// Quarantine-on-drift: when true, a high-risk tool (poisoned definition, or a
     /// destructive tool whose definition changed/appeared) that drifts from its pinned
     /// baseline is hidden and blocked from every client until the user re-approves it.
@@ -344,6 +351,7 @@ impl Default for Registry {
             human_approval: false,
             human_approval_allow: Vec::new(),
             tool_overrides: HashMap::new(),
+            pinned_tools: HashMap::new(),
             quarantine_on_drift: false,
             lazy_discovery: true,
             allow_agent_control: false,
@@ -508,6 +516,29 @@ impl Registry {
             .find(|s| s.id == server_id)
             .map(|s| !s.disabled_tools.iter().any(|t| t == tool))
             .unwrap_or(true)
+    }
+
+    /// Pin or unpin a tool as a lazy-discovery prerequisite (by ORIGINAL tool name).
+    /// Idempotent; drops the server's entry when its last pin is removed.
+    pub fn set_tool_pinned(&mut self, server_id: &str, tool: &str, pinned: bool) {
+        let list = self.pinned_tools.entry(server_id.to_string()).or_default();
+        let present = list.iter().any(|t| t == tool);
+        if pinned && !present {
+            list.push(tool.to_string());
+        } else if !pinned && present {
+            list.retain(|t| t != tool);
+        }
+        if list.is_empty() {
+            self.pinned_tools.remove(server_id);
+        }
+    }
+
+    /// Whether a tool is pinned as a prerequisite (default: not pinned).
+    pub fn is_tool_pinned(&self, server_id: &str, tool: &str) -> bool {
+        self.pinned_tools
+            .get(server_id)
+            .map(|l| l.iter().any(|t| t == tool))
+            .unwrap_or(false)
     }
 
     /// Set the global destructive-tool deny switch. Mutually exclusive with
@@ -997,6 +1028,27 @@ mod tests {
         r.set_tool_enabled(&id, "create_issue", true).unwrap();
         assert!(r.is_tool_enabled(&id, "create_issue"));
         assert!(r.servers.iter().find(|s| s.id == id).unwrap().disabled_tools.is_empty());
+    }
+
+    #[test]
+    fn tool_pin_is_idempotent_and_prunes_empty() {
+        let mut r = Registry::default();
+        let id = r.add_server(sample_server("github"));
+        // Default: nothing pinned.
+        assert!(!r.is_tool_pinned(&id, "create_issue"));
+        // Pin, then double-pin doesn't duplicate.
+        r.set_tool_pinned(&id, "create_issue", true);
+        r.set_tool_pinned(&id, "create_issue", true);
+        assert!(r.is_tool_pinned(&id, "create_issue"));
+        assert_eq!(r.pinned_tools.get(&id).map(Vec::len), Some(1));
+        // A second pin adds to the same server's list.
+        r.set_tool_pinned(&id, "list_issues", true);
+        assert_eq!(r.pinned_tools.get(&id).map(Vec::len), Some(2));
+        // Unpinning the last one prunes the server entry entirely.
+        r.set_tool_pinned(&id, "create_issue", false);
+        r.set_tool_pinned(&id, "list_issues", false);
+        assert!(!r.is_tool_pinned(&id, "create_issue"));
+        assert!(r.pinned_tools.get(&id).is_none());
     }
 
     #[test]

--- a/src/components/PlaygroundView.tsx
+++ b/src/components/PlaygroundView.tsx
@@ -7,6 +7,7 @@ import {
   Loader2,
   MessageSquare,
   Pencil,
+  Pin,
   Play,
   ShieldAlert,
   XCircle,
@@ -21,6 +22,7 @@ import {
   listServerTools,
   readResource,
   setToolEnabled,
+  setToolPinned,
   setToolOverride,
 } from "@/lib/api";
 import type {
@@ -614,6 +616,10 @@ export function PlaygroundView({ registry, onRegistryChange }: PlaygroundProps) 
     () => new Set(serverEntry?.disabledTools ?? []),
     [serverEntry],
   );
+  const pinnedSet = useMemo(
+    () => new Set(serverId ? (registry?.pinnedTools?.[serverId] ?? []) : []),
+    [registry, serverId],
+  );
 
   /** Is this tool exposed to clients right now? (per-tool off, or destructive
    * while the global switch is on, both hide it at the gateway.) */
@@ -630,6 +636,18 @@ export function PlaygroundView({ registry, onRegistryChange }: PlaygroundProps) 
       onRegistryChange(await setToolEnabled(serverId, toolName, enabled));
     } catch (e) {
       toastError(`Couldn't update the tool: ${e}`);
+    } finally {
+      setPolicyBusy(false);
+    }
+  }
+
+  async function togglePin(toolName: string, pinned: boolean) {
+    if (!serverId) return;
+    setPolicyBusy(true);
+    try {
+      onRegistryChange(await setToolPinned(serverId, toolName, pinned));
+    } catch (e) {
+      toastError(`Couldn't pin the tool: ${e}`);
     } finally {
       setPolicyBusy(false);
     }
@@ -778,6 +796,7 @@ export function PlaygroundView({ registry, onRegistryChange }: PlaygroundProps) 
               const exposed = isExposed(t);
               const selected = t.name === selectedTool;
               const perToolOff = disabledSet.has(t.name);
+              const pinned = pinnedSet.has(t.name);
               return (
                 <div
                   key={t.name}
@@ -807,6 +826,24 @@ export function PlaygroundView({ registry, onRegistryChange }: PlaygroundProps) 
                         {t.description}
                       </span>
                     )}
+                  </button>
+                  <button
+                    onClick={() => togglePin(t.name, !pinned)}
+                    disabled={policyBusy}
+                    title={
+                      pinned
+                        ? "Pinned: always surfaced in lazy-discovery search"
+                        : "Pin as a prerequisite (always surfaced in search)"
+                    }
+                    aria-label={pinned ? `Unpin ${t.name}` : `Pin ${t.name}`}
+                    aria-pressed={pinned}
+                    className="shrink-0 rounded p-1 hover:bg-muted disabled:opacity-50"
+                  >
+                    <Pin
+                      className={`size-4 ${
+                        pinned ? "fill-current text-owned" : "text-muted-foreground"
+                      }`}
+                    />
                   </button>
                   <Switch
                     checked={!perToolOff}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -162,6 +162,15 @@ export function setToolEnabled(
   return invoke<Registry>("set_tool_enabled", { serverId, tool, enabled });
 }
 
+/** Pin/unpin a tool as a lazy-discovery prerequisite (search always surfaces it). */
+export function setToolPinned(
+  serverId: string,
+  tool: string,
+  pinned: boolean,
+): Promise<Registry> {
+  return invoke<Registry>("set_tool_pinned", { serverId, tool, pinned });
+}
+
 /** Toggle the global destructive-tool deny switch. */
 export function setDenyDestructive(deny: boolean): Promise<Registry> {
   return invoke<Registry>("set_deny_destructive", { deny });

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -370,6 +370,8 @@ export interface Registry {
   activeProfileId: string | null;
   /** Per-tool exposure overrides (rename / re-describe), keyed by server id then original tool name. */
   toolOverrides?: Record<string, Record<string, ToolOverride>>;
+  /** Tools pinned as lazy-discovery prerequisites, keyed by server id -> original tool names. */
+  pinnedTools?: Record<string, string[]>;
   /** Global switch: hide and block every destructive-hinted tool. */
   denyDestructive?: boolean;
   /** Per-call confirmation: intercept destructive tools with a preview + token. */


### PR DESCRIPTION
The r/LocalLLaMA request (kevrex5): lazy discovery hides tools whose description doesn't match the query's keywords, which can bury a **load-bearing** tool (auth, list-before-act). This lets you pin such tools so search always surfaces them.

## What
- **Registry**: `pinned_tools` (server id -> original tool names), a top-level map like `tool_overrides` (no `ServerEntry` literal churn). `set_tool_pinned` / `is_tool_pinned`, idempotent + prunes an empty entry.
- **Gateway**: the `toolport_search_tools` handler force-includes pinned **in-scope** tools (with full schema) that the query didn't rank, prepended so prerequisites lead. Scoped (`source` is already the client's catalog), capped at 10 so a big pin set can't bloat a result, attribution via `router.route_of` (not name-splitting).
- **UI**: a Pin toggle per tool in PlaygroundView's tool list.

## Left open for your review
It touches the lazy-discovery search path and adds UI I can't visually verify, so please give it a look in the running app (pin a tool, confirm it shows in search even for an unrelated query). An adversarial review of the search-path change is running.

256 lib tests pass (new registry test), `tsc` + gateway `cargo check` clean.