### PR TITLE
fix(provenance): read tool identities across all profiles, not the active one

### DIFF
--- a/src-tauri/src/integrity.rs
+++ b/src-tauri/src/integrity.rs
@@ -399,6 +399,86 @@ pub fn baselines(profile: Option<&str>) -> BTreeMap<String, ToolBaseline> {
     }
 }
 
+/// Aggregate baselines across ALL profile pin files (`tool-pins.json` +
+/// `tool-pins-<slug>.json`), merged by tool name. The gateway keys pins by the
+/// `CONDUIT_PROFILE` it ran under (often None -> `tool-pins.json`), so the identity view
+/// must union every profile's pins rather than guess a single one. For a tool seen in
+/// several profiles: earliest first_seen, latest last_changed, and the fingerprint from
+/// the most recent change.
+pub fn all_baselines() -> BTreeMap<String, ToolBaseline> {
+    let mut merged: BTreeMap<String, ToolBaseline> = BTreeMap::new();
+    let Some(dir) = crate::registry::conduit_dir() else {
+        return merged;
+    };
+    let Ok(entries) = std::fs::read_dir(&dir) else {
+        return merged;
+    };
+    for entry in entries.flatten() {
+        let fname = entry.file_name();
+        let Some(name) = fname.to_str() else { continue };
+        if !(name.starts_with("tool-pins") && name.ends_with(".json")) {
+            continue;
+        }
+        let Ok(s) = std::fs::read_to_string(entry.path()) else {
+            continue;
+        };
+        let Ok(pins) = serde_json::from_str::<BTreeMap<String, PinRepr>>(&s) else {
+            continue;
+        };
+        for (tool, repr) in pins {
+            let p: Pin = repr.into();
+            let base = ToolBaseline {
+                fingerprint: p.fp,
+                first_seen: p.first_seen,
+                last_changed: p.last_changed,
+            };
+            merged
+                .entry(tool)
+                .and_modify(|e| {
+                    if base.first_seen != 0
+                        && (e.first_seen == 0 || base.first_seen < e.first_seen)
+                    {
+                        e.first_seen = base.first_seen;
+                    }
+                    if base.last_changed >= e.last_changed {
+                        e.last_changed = base.last_changed;
+                        e.fingerprint = base.fingerprint.clone();
+                    }
+                })
+                .or_insert(base);
+        }
+    }
+    merged
+}
+
+/// The set of quarantined tool names across ALL profiles, for the identity view's badge.
+pub fn all_quarantined_names() -> BTreeSet<String> {
+    let mut out = BTreeSet::new();
+    let Some(dir) = crate::registry::conduit_dir() else {
+        return out;
+    };
+    let Ok(entries) = std::fs::read_dir(&dir) else {
+        return out;
+    };
+    for entry in entries.flatten() {
+        let fname = entry.file_name();
+        let Some(name) = fname.to_str() else { continue };
+        let is_q = name
+            .strip_prefix("quarantine")
+            .and_then(|r| r.strip_suffix(".json"))
+            .is_some();
+        if !is_q {
+            continue;
+        }
+        if let Ok(s) = std::fs::read_to_string(entry.path()) {
+            if let Ok(q) = serde_json::from_str::<Quarantine>(&s) {
+                out.extend(q.into_keys());
+            }
+        }
+    }
+    out
+}
+
 // ===== Quarantine: block high-risk tools after a drift until re-approved =====
 //
 // `check` is detection-only and re-baselines as it goes, so quarantine keeps its own

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1116,16 +1116,17 @@ fn build_tool_identities(
 }
 
 /// The capability-provenance table: every pinned tool's identity for the active
-/// profile, newest-changed first. Empty until the gateway has pinned a baseline.
+/// newest-changed first. Aggregates pins across all profiles, because the gateway keys
+/// pins by the CONDUIT_PROFILE it ran under (often None -> tool-pins.json), which need
+/// not equal the app's active profile. Empty until the gateway has pinned a baseline.
 #[tauri::command]
 fn list_tool_identities(state: State<RegistryState>) -> Vec<ToolIdentity> {
     let reg = state
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner);
-    let profile = reg.active_profile_id.as_deref();
     let mut ids = build_tool_identities(
-        &integrity::baselines(profile),
-        &integrity::quarantined(profile),
+        &integrity::all_baselines(),
+        &integrity::all_quarantined_names(),
         &reg.servers,
         &reg.profiles,
     );


### PR DESCRIPTION
Follow-up to #124. The Tool identities panel was empty because `list_tool_identities` read baselines under `reg.active_profile_id` (`Some("default")` → `tool-pins-default.json`), but the gateway keys pins by the `CONDUIT_PROFILE` it ran under (unset → the fallback `tool-pins.json`). Read profile != write profile → empty panel despite hundreds of baselined tools (would've been empty in prod, not just dev).

Adds `integrity::all_baselines()` + `all_quarantined_names()` that glob every `tool-pins*.json` / `quarantine*.json` and merge (earliest first_seen, latest last_changed). **Verified live in the dev app — the panel now lists all 378 baselined tools.**