### PR TITLE
feat(clients): add Pi coding agent as a managed MCP client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,10 @@ Entries before the rename below shipped under the project's former name, Conduit
   Realistic results are far under the cap, so detection is unaffected in practice.
 
 ### Added
+- **Pi coding agent is now a supported client.** Toolport detects Pi, imports its
+  configured MCP servers, and installs/removes the gateway entry in Pi's global config
+  (`~/.pi/agent/mcp.json`), the same one-click flow as Cursor and the other clients.
+  (Requested on the r/LocalLLaMA launch thread.)
 - **Pin a tool as a lazy-discovery prerequisite.** Mark a load-bearing tool (auth,
   list-before-act, or one whose description doesn't match the model's keywords) with the
   pin toggle in the tool list, and lazy-discovery search will always surface it with its

--- a/src-tauri/src/clients.rs
+++ b/src-tauri/src/clients.rs
@@ -185,6 +185,7 @@ fn resolve_client_config_path(
         "claude-desktop" => config.join("Claude").join("claude_desktop_config.json"),
         "cursor" => home.join(".cursor").join("mcp.json"),
         "boltai" => home.join(".boltai").join("mcp.json"),
+        "pi" => home.join(".pi").join("agent").join("mcp.json"),
         "vscode" => config.join("Code").join("User").join("mcp.json"),
         "windsurf" => home
             .join(".codeium")
@@ -258,6 +259,7 @@ fn resolve_client_config_path_linux(client_id: &str, home: &std::path::Path) -> 
         "claude-desktop" => config.join("Claude").join("claude_desktop_config.json"),
         "cursor" => home.join(".cursor").join("mcp.json"),
         "boltai" => home.join(".boltai").join("mcp.json"),
+        "pi" => home.join(".pi").join("agent").join("mcp.json"),
         "vscode" => config.join("Code").join("User").join("mcp.json"),
         "windsurf" => home
             .join(".codeium")
@@ -334,6 +336,13 @@ fn cursor_path() -> Option<PathBuf> {
 
 fn boltai_path() -> Option<PathBuf> {
     client_config_path("boltai")
+}
+
+/// Pi coding agent reads its Pi-owned global MCP config from ~/.pi/agent/mcp.json
+/// (standard `mcpServers` shape; pi's optional `lifecycle`/`idleTimeout` keys are
+/// left unset so it uses its defaults). Home-anchored, identical on every OS.
+fn pi_path() -> Option<PathBuf> {
+    client_config_path("pi")
 }
 
 fn vscode_path() -> Option<PathBuf> {
@@ -670,6 +679,14 @@ fn defs() -> Vec<ClientDef> {
             format: Format::JsonMcpServers,
             uses_connectors: false,
             path: boltai_path,
+            plugin_scan: None,
+        },
+        ClientDef {
+            id: "pi",
+            name: "Pi",
+            format: Format::JsonMcpServers,
+            uses_connectors: false,
+            path: pi_path,
             plugin_scan: None,
         },
         ClientDef {
@@ -3084,6 +3101,9 @@ bad = "not-a-table"
     fn client_config_paths_are_stable_across_platforms() {
         let cases: &[(&str, fn(&Path, Platform) -> PathBuf)] = &[
             ("cursor", |home, _| home.join(".cursor").join("mcp.json")),
+            ("pi", |home, _| {
+                home.join(".pi").join("agent").join("mcp.json")
+            }),
             ("vscode", |home, platform| {
                 roaming_config_dir(home, platform)
                     .join("Code")


### PR DESCRIPTION
Adds **Pi** (pi.dev / `pi-coding-agent`) to the detected/writable client list, requested on the r/LocalLLaMA launch thread.

Pi reads a standard `mcpServers` JSON from its Pi-owned global config at `~/.pi/agent/mcp.json` (home-anchored, same on every OS), so it maps directly onto the existing `Format::JsonMcpServers` writers — Toolport can now detect Pi, import its servers, and install/remove the gateway entry exactly like Cursor/BoltAI. Pi's optional `lifecycle`/`idleTimeout` keys are left unset so it applies its own defaults.

**Changes**
- `pi` path in both `resolve_client_config_path` and the Linux variant
- `pi_path()` + a `ClientDef { id: "pi", name: "Pi", JsonMcpServers }`
- a cross-platform case in `client_config_paths_are_stable_across_platforms`

The client list UI is data-driven (uniform icon + backend `name`), so Pi shows up automatically with no frontend change.

**Tests:** `cargo test --lib clients::` → 61 passed. The path tests iterate every registered client, so Pi's resolution is covered on the current platform and across all three.