### PR TITLE
polish(clients): connection state as the sidebar signal + clearer import vs move

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,15 @@ Entries before the rename below shipped under the project's former name, Conduit
   server-config reloads. The dispatcher already released its locks before the
   downstream call and the approval wait; the accept loop now hands each request to a
   worker instead of serving them one at a time.
+- **Clearer client list and import view.** The client sidebar now surfaces connection
+  state as the signal instead of the import backlog: connected clients read as a plain
+  status (the count of importable servers moved to a small badge), and only
+  not-connected / not-found / error clients carry a status word, so the one client that
+  isn't wired up stands out instead of being buried under a wall of "connected". In a
+  client's detail, "Move config in" is now the emphasized action (it's the real cutover
+  that saves context), "Import" is clearly framed as a copy, and a note warns when
+  importing into an already-connected client would load its tools twice. The profile
+  scope dropdown was also widened so "All enabled servers" is no longer clipped.
 
 ### Fixed
 - **Approval prompt is keyboard- and screen-reader-accessible.** When a held call

--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -4,6 +4,7 @@ import {
   ChevronRight,
   ClipboardList,
   Compass,
+  Download,
   FlaskConical,
   FolderOpen,
   Layers,
@@ -297,7 +298,9 @@ function statusOf(client: DetectedClient): ClientStatus {
 }
 
 const dotClass: Record<ClientStatus, string> = {
-  active: "bg-success",
+  // These dots only render for NOT-connected clients (connected ones use the
+  // green chain icon), so none of them should be green - green means connected.
+  active: "bg-muted-foreground/50",
   empty: "bg-muted-foreground/40",
   error: "bg-warning",
   missing: "bg-muted-foreground/20",
@@ -318,16 +321,20 @@ function ClientRow({ client, importCount, selected, onSelect }: RowProps) {
   const missing = status === "missing";
   const connected = client.gatewayInstalled;
 
-  const right =
+  // Label the exception, not the rule. The green chain icon already says
+  // "connected", so we don't repeat the word on every row - that just buries the
+  // one row that isn't connected under a wall of green. Only non-connected /
+  // error / missing states get a status word, so "not connected" actually stands
+  // out. The import backlog is a separate, secondary badge either way.
+  const statusWord =
     status === "error"
       ? "error"
       : status === "missing"
         ? "not found"
-        : importCount > 0
-          ? `${importCount} to import`
-          : connected
-            ? "connected"
-            : "ready";
+        : connected
+          ? null
+          : "not connected";
+  const showBadge = importCount > 0 && status !== "error" && status !== "missing";
 
   return (
     <Tooltip>
@@ -348,12 +355,22 @@ function ClientRow({ client, importCount, selected, onSelect }: RowProps) {
             />
           )}
           <span className="truncate">{client.name}</span>
-          <span
-            className={`ml-auto shrink-0 text-xs ${
-              importCount > 0 ? "text-owned" : "text-muted-foreground"
-            }`}
-          >
-            {right}
+          <span className="ml-auto flex shrink-0 items-center gap-1.5">
+            {showBadge && (
+              <span className="inline-flex items-center gap-0.5 rounded-full bg-owned/15 px-1.5 text-[10px] font-medium text-owned">
+                <Download className="size-2.5" />
+                {importCount}
+              </span>
+            )}
+            {statusWord && (
+              <span
+                className={`text-xs ${
+                  status === "error" ? "text-warning" : "text-muted-foreground"
+                }`}
+              >
+                {statusWord}
+              </span>
+            )}
           </span>
         </button>
       </TooltipTrigger>

--- a/src/components/ClientDetail.tsx
+++ b/src/components/ClientDetail.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { ArrowRight, Check, Download, Link2, Plug, PlugZap, Puzzle, Shuffle } from "lucide-react";
+import { ArrowRight, Check, Download, Link2, Plug, PlugZap, Puzzle, Shuffle, TriangleAlert } from "lucide-react";
 import { toast } from "sonner";
 import { toastError } from "@/lib/toast";
 import { addServer, installGateway, migrateClient, uninstallGateway } from "@/lib/api";
@@ -248,7 +248,7 @@ export function ClientDetail({
         <div className="flex shrink-0 items-center gap-2">
           {profiles.length > 1 && (
             <Select value={profile || "__all__"} onValueChange={(v) => setProfile(v === "__all__" ? "" : v)}>
-              <SelectTrigger size="sm" className="w-40">
+              <SelectTrigger size="sm" className="w-52">
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
@@ -327,7 +327,7 @@ export function ClientDetail({
             {toImport.length > 0 && (
               <Button
                 size="sm"
-                variant="outline"
+                variant="ghost"
                 className="h-7 px-2 text-xs"
                 onClick={handleImportAll}
                 disabled={busy}
@@ -339,7 +339,7 @@ export function ClientDetail({
             {movable.length > 0 && (
               <Button
                 size="sm"
-                variant="outline"
+                variant="default"
                 className="h-7 px-2 text-xs"
                 onClick={() => setMigrateOpen(true)}
                 disabled={busy}
@@ -350,13 +350,33 @@ export function ClientDetail({
             )}
           </div>
         </div>
-        <p className="mb-3 text-xs text-muted-foreground">
+        <p className="mb-1 text-xs text-muted-foreground">
           The servers {client.name} already has, from its config and any plugins
-          (tagged below). Import what you want Toolport to manage; it becomes the
-          source of truth and serves them back through the gateway. "Move config in"
-          also clears the config-file ones out of {client.name}, plugin servers stay
-          (only {client.name} can remove those).
+          (tagged below).
         </p>
+        <ul className="mb-3 space-y-0.5 text-xs text-muted-foreground">
+          <li>
+            <span className="font-medium text-foreground">Import</span> copies a
+            server into Toolport; {client.name} keeps its own copy.
+          </li>
+          <li>
+            <span className="font-medium text-foreground">Move config in</span>{" "}
+            copies it, then removes it from {client.name}'s config so the gateway is
+            the only source (plugin servers stay, only {client.name} can remove
+            those). This is the cutover that actually saves context.
+          </li>
+        </ul>
+        {installed && toImport.length > 0 && movable.length > 0 && (
+          <p className="mb-3 -mt-1 inline-flex items-start gap-1.5 rounded-md bg-warning/10 px-2 py-1 text-xs text-warning">
+            <TriangleAlert className="mt-0.5 size-3.5 shrink-0" />
+            <span>
+              {client.name} is already connected to Toolport. Import on its own
+              leaves a copy here too, so these tools load twice, once directly and
+              once through the gateway. Use <span className="font-medium">Move
+              config in</span> to avoid that.
+            </span>
+          </p>
+        )}
 
         {allServers.length === 0 ? (
           <p className="text-sm text-muted-foreground">
@@ -429,7 +449,7 @@ export function ClientDetail({
                   value={profile || "__all__"}
                   onValueChange={(v) => setProfile(v === "__all__" ? "" : v)}
                 >
-                  <SelectTrigger size="sm" className="w-40">
+                  <SelectTrigger size="sm" className="w-52">
                     <SelectValue />
                   </SelectTrigger>
                   <SelectContent>


### PR DESCRIPTION
UI polish from a live review pass in the dev app.

**Sidebar** — connection state is now the signal, not the import backlog:
- The green chain icon carries "connected", so the word is dropped from every row (it used to wall over the one client that isn't connected). Only not-connected / not-found / error rows get a status word, so the exception stands out.
- The importable-server count moves to a small `↓N` badge.
- Not-connected dots are no longer green (green is reserved for connected).

**Client detail** — Import vs Move was ambiguous:
- "Move config in" is now the emphasized primary action (the real cutover that saves context); "Import" is a quiet secondary and is explicitly framed as a *copy*.
- The dense paragraph became a two-line definition of copy-vs-move.
- A warning calls out that importing into an already-connected client loads its tools twice.
- The profile-scope dropdown was widened (`w-40`→`w-52`) so "All enabled servers" is no longer clipped behind the chevron.

Frontend-only; `tsc --noEmit` clean; verified live via HMR in the dev app.