### PR TITLE
fix(ui): shell-aware args tokenizer for space-containing paths

### DIFF
--- a/src/components/ServerDialog.tsx
+++ b/src/components/ServerDialog.tsx
@@ -18,6 +18,7 @@ import {
   testServer,
   updateServer,
 } from "@/lib/api";
+import { formatArgs, parseArgs } from "@/lib/args";
 import type { Registry, ServerEntry, Transport } from "@/lib/types";
 import { Button } from "@/components/ui/button";
 import {
@@ -72,7 +73,7 @@ export function ServerDialog({
     name: initial?.name ?? "",
     transport: (initial?.transport ?? "stdio") as Transport,
     command: initial?.command ?? "",
-    args: initial?.args.join(" ") ?? "",
+    args: formatArgs(initial?.args ?? []),
     url: initial?.url ?? "",
   });
   // Env vars (API keys etc.). Values are vaulted in the OS keychain, never stored
@@ -111,7 +112,7 @@ export function ServerDialog({
         name: initial?.name ?? "",
         transport: (initial?.transport ?? "stdio") as Transport,
         command: initial?.command ?? "",
-        args: initial?.args.join(" ") ?? "",
+        args: formatArgs(initial?.args ?? []),
         url: initial?.url ?? "",
       });
       setEnvRows(initial?.env.map((e) => ({ key: e.key, value: "" })) ?? []);
@@ -154,7 +155,7 @@ export function ServerDialog({
         name: s.name || "",
         transport: (s.transport === "unknown" ? "stdio" : s.transport) as Transport,
         command: s.command ?? "",
-        args: s.args.join(" "),
+        args: formatArgs(s.args),
         url: s.url ?? "",
       });
       setEnvRows(
@@ -190,7 +191,7 @@ export function ServerDialog({
       name: form.name.trim(),
       transport: form.transport,
       command: isStdio ? form.command.trim() || null : null,
-      args: isStdio ? form.args.split(/\s+/).filter(Boolean) : [],
+      args: isStdio ? parseArgs(form.args) : [],
       env: declared.map((r) => ({
         key: r.key.trim(),
         value: withSecretValues && r.value ? r.value : null,
@@ -363,7 +364,9 @@ export function ServerDialog({
                 <Label htmlFor="srv-args">Arguments</Label>
                 <Input
                   id="srv-args"
-                  placeholder="-y @modelcontextprotocol/server-filesystem"
+                  placeholder={
+                    '-y @scope/package  (quote paths with spaces, e.g. "/Applications/My App.app/tool")'
+                  }
                   value={form.args}
                   onChange={(e) => set("args", e.target.value)}
                 />


### PR DESCRIPTION
## Problem

`ServerDialog.tsx` used a naive `.split(/\s+/)` to parse the Arguments field and `.join(" ")` to format it back. Any path containing spaces — e.g. `/Applications/Open Design.app/.../daemon-cli.mjs` — was split into multiple arguments, crashing the server at spawn:

```
Error: Cannot find module '/Applications/Open'
'open-design' failed: downstream server exited (status 1)
```

## Fix

Added a shell-aware tokenizer (`parseArgs`) and formatter (`formatArgs`) that:
- Respect single and double quotes for paths with spaces
- Escape backslashes and double quotes inside double quotes
- Are provable inverses: `parseArgs(formatArgs(x)) === x` for all inputs

Replaced all 4 buggy call sites in `ServerDialog.tsx`:
- Line 51: `initial?.args.join(" ")` → `formatArgs(initial?.args ?? [])`
- Line 90: same pattern (dialog reopen reset)
- Line 133: `s.args.join(" ")` → `formatArgs(s.args)` (paste-from-config)
- Line 169: `form.args.split(/\s+/).filter(Boolean)` → `parseArgs(form.args)` (build entry)

The placeholder text now hints that quoting is supported.

## Testing

52 test cases covering:
- The original Open Design bug regression
- Double/single-quoted paths with spaces
- Backslash escaping (Windows paths, trailing backslashes)
- Empty quotes producing empty-string args
- Adjacent quoted segment concatenation
- Unicode/CJK/emoji
- Unterminated quotes
- Round-trip property for all of the above

```bash
npx tsx src/lib/args.test.ts   # 52 passed, 0 failed
npx tsc --noEmit               # clean
npm run build                  # clean
```

## Notes

The 5 other `.join(" ")` call sites in the codebase (`RegistryServerRow`, `ClientDetail`, `ShareDialog`, `CatalogView`, `TeamsView`) are display-only — they render `command + args` as a read-only string and never re-parse. Out of scope for this fix but worth a follow-up for display consistency.

## DCO

Signed-off-by: Brad Hallett <brad@bradhallett>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how server arguments are displayed and saved, especially for values that include spaces or quotes.
  * Updated the arguments field to preserve formatting more reliably when reopening the dialog or importing from client settings.
  * Refreshed the input example to better show how to enter paths with spaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->