### PR TITLE
chore: add Prettier formatting with CI enforcement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,11 @@ jobs:
 
       - run: npm ci
 
+      # Enforce consistent formatting before anything else — fails fast on
+      # formatting-only issues so the contributor doesn't wait for a full build.
+      - name: Check formatting
+        run: npm run format:check
+
       # Frontend type-check + build (`build` is `tsc && vite build`). Also produces
       # dist/, which tauri-build expects when compiling the Rust crate below.
       - name: Frontend type-check + build

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,13 @@
+# Build artifacts
+dist/
+src-tauri/target/
+src-tauri/binaries/
+
+# Dependencies
+node_modules/
+
+# Lockfile (formatting churn with no value)
+package-lock.json
+
+# Generated/external
+src-tauri/gen/

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,10 @@
+{
+  "semi": true,
+  "singleQuote": false,
+  "tabWidth": 2,
+  "trailingComma": "all",
+  "printWidth": 90,
+  "bracketSpacing": true,
+  "arrowParens": "always",
+  "endOfLine": "lf"
+}

--- a/BENCHMARK.md
+++ b/BENCHMARK.md
@@ -1,7 +1,7 @@
 # Toolport token benchmark
 
 **Routing MCP servers through Toolport's lazy discovery cut total tokens 74-91% at the
-SAME task success rate**, measured on a frontier model and graded for *correct answers*,
+SAME task success rate**, measured on a frontier model and graded for _correct answers_,
 not just completion. Every task completed correctly in both modes, and the savings grow
 as you add servers. The reduction comes from not loading every tool's schema into the
 model's context on every request.
@@ -29,16 +29,16 @@ Reproduce it yourself: [`benchmark/`](benchmark/).
 End-to-end tokens to complete the three tasks (median of 5 runs), both modes graded:
 
 | Servers | Tools | Flat tokens | Lazy tokens | Reduction | Correct (flat / lazy) |
-|---|---|---|---|---|---|
-| 3 | 63 | 179,181 | 47,095 | **74%** | 15/15 · 15/15 |
-| 6 | 183 | 471,775 | 40,354 | **91%** | 15/15 · 15/15 |
+| ------- | ----- | ----------- | ----------- | --------- | --------------------- |
+| 3       | 63    | 179,181     | 47,095      | **74%**   | 15/15 · 15/15         |
+| 6       | 183   | 471,775     | 40,354      | **91%**   | 15/15 · 15/15         |
 
 Two things stand out:
 
-- **Identical task success.** Every task completed *correctly* in both modes, 30/30.
+- **Identical task success.** Every task completed _correctly_ in both modes, 30/30.
   Lazy discovery did not trade accuracy for tokens.
 - **The savings grow with your catalog.** Flat's cost more than doubled as servers went
-  3 → 6 (it re-sends every tool schema on every call), while lazy's actually *dropped*
+  3 → 6 (it re-sends every tool schema on every call), while lazy's actually _dropped_
   (47K → 40K), it pays a flat ~450-token meta-tool overhead no matter how many servers
   you connect. Per-request tool-definition overhead: flat **19,002 → 51,533**, lazy a
   constant **451**.
@@ -57,32 +57,32 @@ at a real Toolport catalog (no model needed, it just measures the tool definitio
 and the gap widens fast. On a live 14-server setup of **415 tools**, the definitions
 an agent loads on **every request** measure:
 
-| | Per request |
-|---|---|
-| Without Toolport (all 415 tools) | **164,880 tokens** |
-| With Toolport (3 meta-tools, flat) | **660 tokens** |
-| Reduction | **99.6%** |
+|                                    | Per request        |
+| ---------------------------------- | ------------------ |
+| Without Toolport (all 415 tools)   | **164,880 tokens** |
+| With Toolport (3 meta-tools, flat) | **660 tokens**     |
+| Reduction                          | **99.6%**          |
 
 The cost is dominated by a few large servers:
 
-| Server | Tools | Definition tokens |
-|---|---|---|
-| RevenueCat | 93 | 42,370 |
-| GitHub | 44 | 27,913 |
-| Resend | 83 | 26,045 |
-| Cloudflare (observability) | 8 | 5,948 |
-| Stripe | 11 | 5,214 |
-| Vercel | 20 | 5,029 |
-| Supabase | 29 | 4,897 |
-| (5 more) | ... | ... |
+| Server                     | Tools | Definition tokens |
+| -------------------------- | ----- | ----------------- |
+| RevenueCat                 | 93    | 42,370            |
+| GitHub                     | 44    | 27,913            |
+| Resend                     | 83    | 26,045            |
+| Cloudflare (observability) | 8     | 5,948             |
+| Stripe                     | 11    | 5,214             |
+| Vercel                     | 20    | 5,029             |
+| Supabase                   | 29    | 4,897             |
+| (5 more)                   | ...   | ...               |
 
-At ~165k tokens of definitions *per request*, that catalog barely fits in most
+At ~165k tokens of definitions _per request_, that catalog barely fits in most
 models' context alongside real work. On a subscription with usage caps (Claude
 Pro/Max, Cursor, and the like) you feel that directly as runway: cutting ~99% of
 always-on tool tokens is roughly that much more headroom for real work before you
 hit a limit, and prompt caching doesn't stretch a usage cap the way it discounts a
 bill. Toolport's meta-tools stay flat no matter how many servers you add, which is
-why the reduction *grows* with your setup (90% at 62 tools, 99.6% at 415).
+why the reduction _grows_ with your setup (90% at 62 tools, 99.6% at 415).
 
 The measured average here is ~397 tokens per tool, consistent with the ~387 the
 public [calculator](https://toolport.app/calculator) uses.
@@ -94,11 +94,11 @@ it with [`benchmark/latency.mjs`](benchmark/latency.mjs), which spawns the gatew
 against an instant mock downstream so the number is purely Toolport's own overhead
 (no model, no network, no API keys):
 
-| Operation | Median |
-|---|---|
-| Handshake (one-time, per gateway start) | ~21 ms |
-| `tools/list` (lazy, 3 tools) | ~0.2 ms |
-| `toolport_search_tools` | ~0.1 ms |
+| Operation                                                    | Median        |
+| ------------------------------------------------------------ | ------------- |
+| Handshake (one-time, per gateway start)                      | ~21 ms        |
+| `tools/list` (lazy, 3 tools)                                 | ~0.2 ms       |
+| `toolport_search_tools`                                      | ~0.1 ms       |
 | A tool call through Toolport vs. calling the server directly | **+~0.75 ms** |
 
 Toolport adds well under a millisecond to a tool call. Real MCP servers take tens to
@@ -109,7 +109,7 @@ run it on yours: `node benchmark/latency.mjs`.)
 ## Honest caveats
 
 - **Scope:** one frontier model (GPT-5.5), one machine, three read-only "list" tasks, 5
-  runs each. Treat the *direction* (a large, consistent reduction at equal correctness) as
+  runs each. Treat the _direction_ (a large, consistent reduction at equal correctness) as
   the signal, not the exact percentage. The deterministic overhead numbers above need no
   such caveat, they're exact.
 - **Correctness is graded, not eyeballed.** A run counts only if the answer contains the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Entries before the rename below shipped under the project's former name, Conduit
 ## [1.2.0] - 2026-07-03
 
 ### Security
+
 - **Closed several bypasses in the stdio spawn guard** (the supply-chain check that
   refuses code-smuggling launch args on a spawned server). Two rounds of adversarial
   review found a booby-trapped (team- or registry-sourced) config could still reach code
@@ -50,7 +51,7 @@ Entries before the rename below shipped under the project's former name, Conduit
   keeps the gateway running, instead of unwinding out and dropping the whole MCP
   connection (defense-in-depth for the primary local transport).
 - **HTTP clients are scoped on resources and prompts too.** A registered HTTP/OpenAPI
-  client scoped to a subset of servers could still read *any* connected server's
+  client scoped to a subset of servers could still read _any_ connected server's
   resources and prompts (`resources/read` / `prompts/get` ignored the scope); they now
   enforce the same allowed-server set as tool calls.
 - **Closed three tool-supply-chain detection gaps** from an internal audit: a tool's
@@ -70,6 +71,7 @@ Entries before the rename below shipped under the project's former name, Conduit
   Realistic results are far under the cap, so detection is unaffected in practice.
 
 ### Added
+
 - **Pi coding agent is now a supported client.** Toolport detects Pi, imports its
   configured MCP servers, and installs/removes the gateway entry in Pi's global config
   (`~/.pi/agent/mcp.json`), the same one-click flow as Cursor and the other clients.
@@ -97,6 +99,7 @@ Entries before the rename below shipped under the project's former name, Conduit
   Local and bounded, and it stores tool names only (never arguments or results).
 
 ### Changed
+
 - **The HTTP gateway now handles requests concurrently.** Each request runs on its
   own worker, so a slow downstream server or a tool call held for human approval (up
   to two minutes) no longer blocks other requests, live setting toggles, or
@@ -114,6 +117,7 @@ Entries before the rename below shipped under the project's former name, Conduit
   scope dropdown was also widened so "All enabled servers" is no longer clipped.
 
 ### Fixed
+
 - **macOS: monochrome menu-bar glyph, and no more Dock-and-menu-bar at once.** The
   tray now uses a template image (the Toolport porthole mark), so macOS tints it to
   match every other menu-bar item instead of showing the full-color app icon. And the
@@ -144,6 +148,7 @@ Entries before the rename below shipped under the project's former name, Conduit
 ## [1.1.0] - 2026-07-02
 
 ### Added
+
 - **Human-in-the-loop tool approval (opt-in).** With "Require human approval" on, Toolport
   holds any destructive or untrusted-server tool call and raises a desktop notification until
   you approve or deny it in the app. Fail-closed: if no decision is made in time, the call is
@@ -155,6 +160,7 @@ Entries before the rename below shipped under the project's former name, Conduit
   (Settings > General).
 
 ### Changed
+
 - **Security notices are tiered by severity, so real threats aren't buried.** Risky
   tool-definition drift (a destructive tool changing, a tool dropping a readOnly/destructive
   safety annotation, or poisoned content) stays a loud, actionable notice; benign vendor
@@ -162,12 +168,14 @@ Entries before the rename below shipped under the project's former name, Conduit
   across restarts, and duplicate notices from multiple clients are collapsed.
 
 ### Fixed
+
 - Cleaned up leftover "Conduit" references in a few spots (the Teams connect URL placeholder,
   the "download from releases" link, and the exported setup filename).
 
 ## [1.0.1] - 2026-07-02
 
 ### Fixed
+
 - **Windows: upgraders now show "Toolport" in the Start menu.** After the rename, an
   in-place update from Conduit left the old "Conduit" shortcut and green icon behind
   (the bundle identifier is intentionally unchanged so your data and secrets carry
@@ -194,11 +202,13 @@ Entries before the rename below shipped under the project's former name, Conduit
 ## [0.9.4] - 2026-07-01
 
 ### Added
+
 - **Registry backup and recovery.** A `registry.json.bak` sibling keeps the
   last-known-good server list; Conduit recovers from it if `registry.json` is deleted
   or corrupted, so a bad write or an accidental wipe no longer loses your servers.
 
 ### Fixed
+
 - **Per-server head-of-line blocking.** The gateway releases the per-server lock during
   a downstream backoff, so one server's 429 rate-limit no longer stalls other concurrent
   calls to that same server.
@@ -206,11 +216,13 @@ Entries before the rename below shipped under the project's former name, Conduit
   cap (10s), so a misconfigured or hostile server can't park a call for minutes.
 
 ### Docs
+
 - Codex setup walkthrough in the README.
 
 ## [0.9.3] - 2026-07-01
 
 ### Security
+
 - **macOS: no more keychain prompts on update.** Secrets now live in the macOS
   data-protection keychain under a team-scoped shared access group, and the gateway
   ships as a nested notarized helper that shares that group. The gateway reads the
@@ -219,17 +231,20 @@ Entries before the rename below shipped under the project's former name, Conduit
   never touch disk.
 
 ### Added
+
 - **Quarantine-on-drift.** High-risk tool-definition changes (a poisoned definition, or
   a destructive tool that changed or newly appeared) are blocked until you re-approve.
 - **Headless encrypted-file secret backend** (`CONDUIT_SECRET_KEY`) for server/self-host
   use where no OS keychain is available.
 
 ### Changed
+
 - Teams pricing is $12/seat (was $20). Smaller initial bundle via code-splitting.
 
 ## [0.9.2] - 2026-06-30
 
 ### Added
+
 - **Catalog: configure-on-add** (enter keys while adding a server), **self-hosted
   servers** (n8n, Langfuse), and more entries (DataForSEO, Chrome DevTools, Railway,
   Twilio, Postiz).
@@ -237,6 +252,7 @@ Entries before the rename below shipped under the project's former name, Conduit
 - **Paste a config snippet** to auto-fill the Add Server dialog.
 
 ### Fixed
+
 - Remote servers refresh an expired OAuth token on a mid-session 401 and retry, no manual
   reconnect.
 - Teams only soft-syncs servers the member opts into (no silent RCE from team config).
@@ -244,6 +260,7 @@ Entries before the rename below shipped under the project's former name, Conduit
 ## [0.9.1] - 2026-06-29
 
 ### Added
+
 - **New stack: Web scraping & automation.** An eighth role bundle (Firecrawl,
   Tavily, Playwright, Browserbase, Apify) for agents that search, scrape, and
   drive real browsers.
@@ -256,6 +273,7 @@ Entries before the rename below shipped under the project's former name, Conduit
 ## [0.9.0] - 2026-06-29
 
 ### Added
+
 - **Stacks: role-based server bundles.** Pick what you work on (full-stack web,
   backend & data, infra & DevOps, AI & ML, product & design, founder, research)
   and Conduit sets up a matching set of MCP servers in one click. Stacks appear at
@@ -271,10 +289,12 @@ Entries before the rename below shipped under the project's former name, Conduit
 - **New catalog servers:** Linode (Akamai) cloud, and Qdrant (vector store for RAG).
 
 ### Fixed
+
 - The scoped-client scope picker in Settings rendered an unthemed white dropdown
   in dark mode; it now uses the app's themed select.
 
 ### Internal
+
 - Groundwork for concurrent tool routing (per-server interior mutability in the
   router; no behavior change yet), and a fix for an XDG env race that could flake
   a path test on CI.
@@ -282,6 +302,7 @@ Entries before the rename below shipped under the project's former name, Conduit
 ## [0.8.0] - 2026-06-28
 
 ### Added
+
 - **Multi-tenant HTTP bridge (per-client scoping).** Register HTTP clients in
   Settings → Integrations, each with its own bearer token and profile. One bridge
   process serves them all and resolves every request's token to its own set of
@@ -305,6 +326,7 @@ Entries before the rename below shipped under the project's former name, Conduit
   scheme, and real error responses, so OpenAPI clients can model auth and failures.
 
 ### Changed
+
 - **HTTP bridge auth tightened.** Once any scoped client is registered, the bridge
   rejects unauthenticated requests even when no global token is set. CORS no longer
   reflects the caller's Origin or sends credentials, and cross-site browser
@@ -314,6 +336,7 @@ Entries before the rename below shipped under the project's former name, Conduit
   call may already have executed.
 
 ### Security
+
 - Constant-time comparison for the bridge bearer token.
 - The SSRF connect-guard now also blocks IPv6 link-local and cloud-metadata
   addresses (including the AWS IPv6 metadata address), not just IPv4 169.254.x.
@@ -325,6 +348,7 @@ Entries before the rename below shipped under the project's former name, Conduit
   "string" on content fields (only identifier-typed params).
 
 ### Removed
+
 - **"Add to catalog" (promote-to-catalog).** It only pinned a server you already had into
   a local discovery view, with no sync or sharing, so it added clutter without real value.
   Browse Catalog still does what matters: discover and add new servers (curated set + live
@@ -333,6 +357,7 @@ Entries before the rename below shipped under the project's former name, Conduit
 ## [0.7.0] - 2026-06-28
 
 ### Added
+
 - **Native HTTP/OpenAPI transport.** Run the gateway with `conduit-gateway --http <port>`
   (or `CONDUIT_HTTP=<port>`) and it serves an OpenAPI spec plus a POST endpoint per tool,
   so Open WebUI and any OpenAPI tool client connect straight to Conduit with no mcpo,
@@ -349,6 +374,7 @@ Entries before the rename below shipped under the project's former name, Conduit
   recovery hint is appended whenever a call fails.
 
 ### Security
+
 - **The HTTP endpoint now requires a bearer token.** The app auto-generates one, shows it
   in Settings -> Integrations, and you paste it into the client (Open WebUI: the tool
   server's API key / Bearer auth). This closes a credential-CSRF: the `localhost` bind does
@@ -358,12 +384,14 @@ Entries before the rename below shipped under the project's former name, Conduit
   reflected headers so a crafted request can't inject or crash a listener.
 
 ### Changed
+
 - **Windows installers are now code-signed** via Azure Trusted Signing (publisher name
   shows; SmartScreen reputation still builds with downloads).
 
 ## [0.6.0] - 2026-06-27
 
 ### Changed
+
 - **The server list is a dense, scannable list now.** The bulky three-column cards are
   replaced by compact grouped rows: toggle, status, name, source, tool count, and
   transport on one line, with the command and per-server actions (secrets, duplicate,
@@ -386,12 +414,14 @@ Entries before the rename below shipped under the project's former name, Conduit
   tool-testing surface.
 
 ### Added
+
 - **Three more catalog servers:** Perplexity, Kubernetes, and Todoist.
 - **A confirmation step before destructive actions.** Removing a server, deleting a
   profile, disconnecting a client, or leaving a team now asks first and says what
   survives (your secrets stay in the keychain, your own servers are untouched).
 
 ### Fixed
+
 - The manual Refresh always confirms now ("Refreshed"), even when a health probe is
   already running, so the click is never silent.
 - Hardened the first-run wizard's resume-after-catalog flow against future regressions.
@@ -413,11 +443,13 @@ Entries before the rename below shipped under the project's former name, Conduit
 ## [0.5.2] - 2026-06-27
 
 ### Added
+
 - **More one-click catalog servers.** Added MongoDB, Elasticsearch, Airtable, Exa,
   Tavily, Apify, Browserbase, and the Sequential Thinking, Memory, and Time reference
   servers, every package name verified.
 
 ### Changed
+
 - **A calmer Servers header.** The duplicate Browse catalog button is gone (it's
   already in the sidebar), Search and Add server stay up front, and the occasional
   actions (Import, Enable/Disable all) move into a `...` overflow menu so the header no
@@ -427,6 +459,7 @@ Entries before the rename below shipped under the project's former name, Conduit
   separate Check health action has been folded into it.
 
 ### Fixed
+
 - **Onboarding no longer drops you mid-setup.** Browsing the catalog from the first-run
   wizard used to end onboarding before the Connect-a-client step; it now resumes there
   when you return, so new users don't silently skip connecting a client.
@@ -437,6 +470,7 @@ Entries before the rename below shipped under the project's former name, Conduit
 ## [0.5.1] - 2026-06-27
 
 ### Fixed
+
 - **macOS: the keychain prompts are gone.** The `conduit-gateway` helper that your
   AI clients launch now reads your vaulted secrets (API keys, OAuth/bearer tokens)
   with no keychain password prompt. Newly saved secrets get this automatically;
@@ -452,11 +486,13 @@ caps and filters what the gateway will fetch and sync, and adds accessibility an
 UI polish.
 
 ### Fixed
+
 - **The sidebar action bar stays put.** It's pinned to the bottom of the server
   list and always visible instead of appearing only when you scroll to the end,
   and undetected clients collapse under a disclosure so the list stays short.
 
 ### Security
+
 - **Hardened the anti-agentjacking scan.** Tool results are normalized before
   scanning (lowercase, invisible/zero-width/bidi stripping, homoglyph and
   full-width folding) and base64-decoded payloads are scanned too, so injection
@@ -480,10 +516,12 @@ UI polish.
   cleanup after a failed connect.
 
 ### Accessibility
+
 - **Respects "reduce motion."** When the OS prefers reduced motion, Conduit zeroes
   out spinners, pulses, dialog and tooltip zooms, and transitions.
 
 ### Internal
+
 - **CI on every PR**: frontend build, Rust library tests, and a gateway build
   check now run on pull requests across the project.
 - **macOS:** newer secrets use the ACL-free SecItem keychain path, with a one-time
@@ -493,11 +531,13 @@ UI polish.
 - Removed leftover Vite/Tauri scaffold files and shipped a real favicon.
 
 ### Thanks
+
 - @bradhallett (#26) for the macOS keychain migration work.
 
 ## [0.4.2] - 2026-06-26
 
 ### Added
+
 - **Conduit Teams (beta), desktop side.** A new Teams tab connects your local Conduit
   to a self-hosted Conduit Teams server and syncs a shared MCP server set into your
   registry. Keys never leave your machine: only the server set syncs, and you
@@ -505,6 +545,7 @@ UI polish.
 - **Composio** in the curated catalog (connect agents to 1,000+ apps via MCP). (#23)
 
 ### Fixed
+
 - **Custom API keys now reach HTTP servers.** A remote/HTTP server that uses a manually
   vaulted secret (e.g. a `BEARER` key) gets it injected as the bearer token, not just
   OAuth tokens, so "Manage secrets" works for HTTP servers. (#22)
@@ -515,6 +556,7 @@ UI polish.
   config round-trips correctly. (#25)
 
 ### Internal
+
 - **macOS secret storage moved to the SecItem keychain API** for new entries, which
   avoids the per-application ACLs behind repeated keychain prompts (#21). If you're on
   macOS and still see prompts, they're from entries created by older versions: clear
@@ -522,11 +564,13 @@ UI polish.
   confirmed prompt-elimination claim is pending validation on signed release builds.
 
 ### Thanks
+
 - @bradhallett (#21, #22, #23, #25) and @BharadwajKanneveti (#24).
 
 ## [0.4.1] - 2026-06-26
 
 ### Changed
+
 - **Windows installers are now code-signed** via Azure Trusted Signing, so the
   SmartScreen "unknown publisher" warning is gone (reputation still accrues with
   downloads). macOS was already signed and notarized; Linux remains unsigned as
@@ -539,6 +583,7 @@ boundary (both tool definitions and tool results), searches by meaning, can be
 driven by the agent on your terms, and supports two more clients.
 
 ### Added
+
 - **Tool-definition integrity (rug-pull + poisoning detection).** The gateway
   fingerprints every tool when a server is first connected and diffs it on each
   refresh. If a previously-approved tool's definition changes, or a known server adds
@@ -547,7 +592,7 @@ driven by the agent on your terms, and supports two more clients.
   jumping) when first seen or when it changes. Both surface as notices in the Activity
   view. Detection only, never blocks; on by default (`integrityCheck`), fully local.
   New `get_security_events` command + `security.jsonl`.
-- **Content defense (anti-agentjacking).** The gateway scans untrusted tool *results*
+- **Content defense (anti-agentjacking).** The gateway scans untrusted tool _results_
   for injection-like content and, on a hit, wraps the offending text with a provenance
   marker ("external data, not instructions") before the agent sees it, plus records a
   security notice. Information-preserving (the original text stays inside the marker),
@@ -559,7 +604,7 @@ driven by the agent on your terms, and supports two more clients.
   OpenAI-compatible `/v1/embeddings` endpoint. Tool embeddings are cached on disk; on
   any failure it falls back to pure lexical, so it can only add signal, never degrade.
   New `benchmark/retrieval.mjs` measures retrieval recall (lexical vs semantic).
-- **Controllable MCP (opt-in agent control).** A new *Allow agent control* switch
+- **Controllable MCP (opt-in agent control).** A new _Allow agent control_ switch
   (off by default) lets an agent enable or disable servers through the gateway
   (`conduit_enable_server` / `conduit_disable_server`). The destructive-tool block
   stays user-only, so granting it can't let an agent escalate past your governance;
@@ -570,6 +615,7 @@ driven by the agent on your terms, and supports two more clients.
   intelligence) were added to the curated catalog.
 
 ### Changed
+
 - Benchmark suite: added a graded server-sweep harness (`bench-sweep.mjs`) that grades
   answers for correctness, not just completion, and expanded `token-cost.mjs`
   (context-window share, scaling curve, per-tool distribution, multi-volume dollar
@@ -577,10 +623,12 @@ driven by the agent on your terms, and supports two more clients.
   tokens at the same graded task success.
 
 ### Fixed
+
 - The Playground policy toggles lay out as an even responsive grid instead of
   orphaning the third switch onto its own row.
 
 ### Internal
+
 - Release pipeline wired for Windows Authenticode signing via Azure Trusted Signing,
   gated and inert until the signing secrets are configured (changes nothing until the
   certificate is ready).
@@ -588,26 +636,31 @@ driven by the agent on your terms, and supports two more clients.
 ## [0.3.18] - 2026-06-25
 
 ### Added
+
 - **Ask your agent what Conduit is saving you.** `conduit_status` now reports the
   tokens lazy discovery has kept out of context, a dollar estimate at Claude Sonnet
   input rates, the number of tool-list loads, and your biggest catalog collapse.
 
 ### Changed
+
 - The in-app savings model picker and the public calculator group models by provider
   (Anthropic, OpenAI, Google), with a custom-price option on the calculator.
 
 ### Fixed
+
 - Native select dropdowns render readable in the dark theme (no more light text on a
   light popup).
 
 ## [0.3.17] - 2026-06-25
 
 ### Added
+
 - **Token economics card.** The Activity tab shows the dollar value of what lazy
   discovery has saved you, with a model-price selector and a one-click Share that
-  copies a "Conduit saved me ~X tokens (~$Y)" snippet.
+  copies a "Conduit saved me ~~X tokens (~~$Y)" snippet.
 
 ### Security
+
 - Hardened three findings from an internal audit: OAuth PKCE/state generation now
   fails loudly instead of silently returning zeros if the OS RNG is unavailable;
   file writes use a unique atomic-write temp name (no torn writes under concurrent
@@ -616,6 +669,7 @@ driven by the agent on your terms, and supports two more clients.
 ## [0.3.16] - 2026-06-25
 
 ### Added
+
 - **Live tool refresh.** When a connected server changes its own tool set
   mid-session (via `tools/list_changed`), Conduit re-queries it in place, so new
   or removed tools reach your agent without a restart.
@@ -629,6 +683,7 @@ driven by the agent on your terms, and supports two more clients.
 ## [0.3.15] - 2026-06-23
 
 ### Fixed
+
 - Clean, all-platforms build of the tokens-saved counter. v0.3.14's Linux job was
   OOM-killed mid-compile, leaving no Linux build or updater manifest; the pipeline
   now gives the Linux runner enough disk and swap, so auto-update works on all four
@@ -637,6 +692,7 @@ driven by the agent on your terms, and supports two more clients.
 ## [0.3.14] - 2026-06-23
 
 ### Fixed
+
 - The v0.3.12 "tokens saved" counter was missing from the release binaries (a CI
   build cache compiled a stale library from before the command existed). The
   pipeline now builds the workspace from scratch, so the counter ships.
@@ -644,6 +700,7 @@ driven by the agent on your terms, and supports two more clients.
 ## [0.3.12] - 2026-06-23
 
 ### Added
+
 - **"Tokens saved" counter in Activity.** A running estimate of the
   tool-definition tokens lazy discovery has kept out of your agent's context, with
   tool-list loads, your biggest catalog collapse, and since-when. No setup.
@@ -651,11 +708,13 @@ driven by the agent on your terms, and supports two more clients.
 ## [0.3.11] - 2026-06-22
 
 ### Improved
+
 - **Cleaner search index.** The gateway strips boilerplate and stopwords from tool
   descriptions and queries before indexing, so `conduit_search_tools` ranks on the
   words that actually distinguish one tool from another.
 
 ### Added
+
 - **BENCHMARK.md** with a reproducible harness: ~97% less tool-definition overhead
   per request and ~90% fewer total tokens at the same task success rate (3 servers,
   62 tools, local model, repeated runs).
@@ -663,6 +722,7 @@ driven by the agent on your terms, and supports two more clients.
 ## [0.3.10] - 2026-06-22
 
 ### Improved
+
 - **Tool search ranks the right tool more often.** When a query mixed a common word
   with a specific one (e.g. "list products"), keyword matching could surface a generic
   "list" tool instead of the products one. Search now tokenizes queries and tools
@@ -674,6 +734,7 @@ driven by the agent on your terms, and supports two more clients.
 ## [0.3.9] - 2026-06-22
 
 ### Added
+
 - **Two more clients: Jan and Goose** (17 supported in total). Jan uses the standard
   `mcpServers` JSON; Goose is the first YAML client, its MCP servers live under a
   top-level `extensions:` map in `config.yaml`. Both detect, connect with one click,
@@ -681,6 +742,7 @@ driven by the agent on your terms, and supports two more clients.
   also holds Goose's model settings and built-in extensions).
 
 ### Fixed
+
 - **Required tool parameters now work from grammar-constrained local clients.** Some
   local runtimes (e.g. Jan) force the model's output to match the tool schema, and
   `conduit_call_tool`'s `arguments` declared no properties, so the model could only
@@ -697,6 +759,7 @@ driven by the agent on your terms, and supports two more clients.
 ## [0.3.8] - 2026-06-21
 
 ### Improved
+
 - **Faster, more decisive tool search, especially with local models.** Search now
   leads with the single best match and tells the model to call it; the remaining
   results come back as a compact menu (name + a one-line description, no schema)
@@ -713,6 +776,7 @@ driven by the agent on your terms, and supports two more clients.
 ## [0.3.7] - 2026-06-21
 
 ### Added
+
 - **Five more clients: Zed, LM Studio, Warp, Amazon Q, and Kiro.** Conduit detects
   each, installs the gateway with one click, and imports its existing servers.
   - Zed keeps MCP servers under `context_servers` in its `settings.json`, which is
@@ -725,6 +789,7 @@ driven by the agent on your terms, and supports two more clients.
     `~/.aws/amazonq/mcp.json`, `~/.kiro/settings/mcp.json`).
 
 ### Fixed
+
 - Client detection now reflects whether an app is actually installed, not merely
   whether an MCP config file happens to exist. The old "config file's parent dir"
   heuristic was wrong for some clients: Claude Code's config lives at `~/.claude.json`
@@ -735,6 +800,7 @@ driven by the agent on your terms, and supports two more clients.
 ## [0.3.6] - 2026-06-21
 
 ### Fixed
+
 - Lazy-discovery tool search is far more reliable on multi-server setups. A tool
   that exists could read as missing (so an agent would wrongly conclude a server
   was "read only"): the default result limit was too low with no signal that
@@ -752,6 +818,7 @@ driven by the agent on your terms, and supports two more clients.
 ## [0.3.5] - 2026-06-21
 
 ### Security
+
 - Importing a shared setup now previews exactly what it will run (each server's
   command, args, and url) and imports only on confirmation, and flags entries that
   spawn a shell. A shared config can no longer slip an unseen command past you.
@@ -761,6 +828,7 @@ driven by the agent on your terms, and supports two more clients.
 - Set an explicit Content-Security-Policy for the app window.
 
 ### Fixed
+
 - Registry writes are atomic, so a crash mid-write can't corrupt your server set.
 - A corrupt registry no longer silently makes every tool vanish: the gateway keeps
   serving the last good tool list and logs the problem.
@@ -768,6 +836,7 @@ driven by the agent on your terms, and supports two more clients.
   packaged and unpackaged installs.
 
 ### Changed
+
 - Onboarding's final step reflects what you actually set up and explains lazy
   discovery; the empty state offers a "Browse catalog" action; the New Profile
   dialog explains that profiles scope servers, not credentials.
@@ -776,6 +845,7 @@ driven by the agent on your terms, and supports two more clients.
 ## [0.3.4] - 2026-06-21
 
 ### Fixed
+
 - Client config writes are now atomic (temp file + rename), so a crash or full
   disk mid-write can't truncate a client's MCP config.
 - One unresponsive stdio server no longer stalls the whole gateway: the connect
@@ -789,6 +859,7 @@ driven by the agent on your terms, and supports two more clients.
 ## [0.3.3] - 2026-06-21
 
 ### Added
+
 - First-run onboarding wizard: detect clients, add your first servers (import,
   one-click popular starters, or the catalog), and connect a client. Re-run it
   anytime from the sidebar footer.
@@ -799,6 +870,7 @@ driven by the agent on your terms, and supports two more clients.
 - Per-tool breakdown in the Activity dashboard, plus server and errors-only filters.
 
 ### Changed
+
 - Reliability: gateway recovers from a poisoned lock, the audit log rotates so it
   can't grow unbounded, more tolerant SSE id matching, and a guard against
   overlapping health probes (which curbed macOS keychain prompt storms).
@@ -806,6 +878,7 @@ driven by the agent on your terms, and supports two more clients.
 ## [0.3.2] - 2026-06-20
 
 ### Added
+
 - Signed and notarized macOS builds (Apple Silicon + Intel), alongside Windows
   and Linux, via a tag-triggered release pipeline.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,10 +24,10 @@ On macOS/Linux, see the platform notes in the [README troubleshooting](README.md
 
 ### What hot-reloads vs what needs a rebuild
 
-| You changed | What happens |
-|-------------|-------------|
-| React/TS frontend (`src/`) | Vite hot-reloads instantly — no restart needed |
-| Rust backend (`src-tauri/src/`) | `npm run tauri dev` recompiles and restarts the app automatically |
+| You changed                                             | What happens                                                                                                                                |
+| ------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| React/TS frontend (`src/`)                              | Vite hot-reloads instantly — no restart needed                                                                                              |
+| Rust backend (`src-tauri/src/`)                         | `npm run tauri dev` recompiles and restarts the app automatically                                                                           |
 | Gateway binary (`src-tauri/src/bin/conduit-gateway.rs`) | **Not rebuilt by `tauri dev`.** Run `npm run build:gateway` after changes, then restart any connected clients so they re-spawn the gateway. |
 
 The gateway is a separate binary that AI clients spawn as a subprocess. Packaged
@@ -53,6 +53,16 @@ The Rust suite includes unit tests in each module (`clients`, `catalog`,
 `registry`, `router`, `oauth`, etc.) and an integration test
 (`tests/list_changed.rs`) that exercises the gateway's live tool-change
 notification path.
+
+### Formatting
+
+Prettier enforces consistent formatting across the frontend and docs. The CI
+checks this on every PR, but you can fix issues locally before pushing:
+
+```bash
+npm run format        # format all files in place
+npm run format:check  # check only (fails without writing — same as CI)
+```
 
 ### Debugging
 
@@ -104,7 +114,7 @@ For end-user troubleshooting (OAuth, AppImage, VS Code), see the
 ## Before you open a PR
 
 Run the [tests described above](#running-tests). Please match the surrounding
-style: the code favors small, well-commented functions that explain the *why*.
+style: the code favors small, well-commented functions that explain the _why_.
 Keep comments at the density of the file you're editing.
 
 ## Good places to start
@@ -182,15 +192,15 @@ is in `src-tauri/src/clients.rs`.
 
 Check the client's config file and match it to a `Format` variant:
 
-| Format | Config shape | Existing clients |
-|--------|-------------|-----------------|
-| `JsonMcpServers` | `{"mcpServers": {...}}` | Claude Desktop, Cursor, Windsurf |
-| `JsonServers` | `{"servers": {...}}` | VS Code |
-| `JsonContextServers` | `{"context_servers": {...}}` (JSONC) | Zed |
-| `TomlMcpServers` | `[mcp_servers.name]` | Codex |
-| `YamlExtensions` | `extensions:` map (Goose shape: `cmd`/`envs`) | Goose |
-| `YamlMcpServers` | `mcp_servers:` map (Hermes shape: `command`/`env`) | Hermes |
-| `YamlMcpServersList` | `mcpServers:` list | Continue |
+| Format               | Config shape                                       | Existing clients                 |
+| -------------------- | -------------------------------------------------- | -------------------------------- |
+| `JsonMcpServers`     | `{"mcpServers": {...}}`                            | Claude Desktop, Cursor, Windsurf |
+| `JsonServers`        | `{"servers": {...}}`                               | VS Code                          |
+| `JsonContextServers` | `{"context_servers": {...}}` (JSONC)               | Zed                              |
+| `TomlMcpServers`     | `[mcp_servers.name]`                               | Codex                            |
+| `YamlExtensions`     | `extensions:` map (Goose shape: `cmd`/`envs`)      | Goose                            |
+| `YamlMcpServers`     | `mcp_servers:` map (Hermes shape: `command`/`env`) | Hermes                           |
+| `YamlMcpServersList` | `mcpServers:` list                                 | Continue                         |
 
 If the client uses a genuinely new format, add a variant to `enum Format` and a
 parse function (follow the pattern of `parse_json` or `parse_toml`).
@@ -233,6 +243,7 @@ Follow the existing conventions — at minimum:
 
 - A registration test confirming the client appears in `defs()` with the right
   format:
+
   ```rust
   #[test]
   fn my_client_is_registered() {

--- a/README.md
+++ b/README.md
@@ -40,10 +40,10 @@ catalog (see [BENCHMARK.md](BENCHMARK.md)). That holds whether you run one AI to
 or five, on cloud models (where tokens are your bill) or local ones (where tool defs
 eat your context window).
 
-| | | |
-|:---:|:---:|:---:|
-| ![Lazy discovery surfaces only the tools a task needs](docs/feature-lazy.png) | ![One gateway, every AI client](docs/feature-clients.png) | ![Flags rug-pulls and poisoned tools before a client can call them](docs/feature-security.png) |
-| **Fewer tokens** - lazy discovery keeps context flat no matter how many servers you connect | **One config, every client** - set up a server once, every AI tool shares it | **Supply-chain security** - rug-pull and tool-poisoning detection on the path |
+|                                                                                             |                                                                              |                                                                                                |
+| :-----------------------------------------------------------------------------------------: | :--------------------------------------------------------------------------: | :--------------------------------------------------------------------------------------------: |
+|        ![Lazy discovery surfaces only the tools a task needs](docs/feature-lazy.png)        |          ![One gateway, every AI client](docs/feature-clients.png)           | ![Flags rug-pulls and poisoned tools before a client can call them](docs/feature-security.png) |
+| **Fewer tokens** - lazy discovery keeps context flat no matter how many servers you connect | **One config, every client** - set up a server once, every AI tool shares it |         **Supply-chain security** - rug-pull and tool-poisoning detection on the path          |
 
 <!-- TODO(toolport): add product screenshots + a demo video, re-captured from the rebranded (Toolport) build, after the release is cut. -->
 
@@ -93,7 +93,7 @@ fixes both.
   quietly adds one (a "rug pull"), or if a description or schema carries injection-like
   content ("tool poisoning"). Detection only, on by default, entirely local
   ([details](docs/specs/mcp-integrity.md)).
-- **Content defense (anti-agentjacking).** When a tool *returns* untrusted content (a
+- **Content defense (anti-agentjacking).** When a tool _returns_ untrusted content (a
   Sentry error, a web page, an issue body) with injection-like instructions, Toolport
   flags it and marks it as external data, not instructions, the separation that blunts
   indirect prompt injection. Never blocks, on by default
@@ -146,28 +146,28 @@ Toolport auto-detects these **20 AI clients**, installs the gateway into each wi
 click, and can import a client's existing servers. It writes the config file shown
 below for you, so you never have to edit these by hand.
 
-| Client | Config file | Format |
-| --- | --- | --- |
-| Claude Desktop | `<config>/Claude/claude_desktop_config.json` | JSON (`mcpServers`) |
-| Claude Code | `~/.claude.json` | JSON (`mcpServers`) |
-| Cursor | `~/.cursor/mcp.json` | JSON (`mcpServers`) |
-| VS Code | `<config>/Code/User/mcp.json` | JSON (`servers`) |
-| Windsurf | `~/.codeium/windsurf/mcp_config.json` | JSON (`mcpServers`) |
-| Codex | `~/.codex/config.toml` | TOML (`mcp_servers`) |
-| Continue | `~/.continue/config.yaml` | YAML (`mcpServers`) |
-| Antigravity | `~/.gemini/config/mcp_config.json` | JSON (`mcpServers`) |
-| Gemini CLI | `~/.gemini/settings.json` | JSON (`mcpServers`) |
-| Cline | `<config>/Code/User/globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json` | JSON (`mcpServers`) |
-| Roo Code | `<config>/Code/User/globalStorage/rooveterinaryinc.roo-cline/settings/mcp_settings.json` | JSON (`mcpServers`) |
-| Warp | `~/.warp/.mcp.json` | JSON (`mcpServers`) |
-| Amazon Q | `~/.aws/amazonq/mcp.json` | JSON (`mcpServers`) |
-| Kiro | `~/.kiro/settings/mcp.json` | JSON (`mcpServers`) |
-| Zed | `~/.config/zed/settings.json` | JSON (`context_servers`) |
-| LM Studio | `~/.lmstudio/mcp.json` | JSON (`mcpServers`) |
-| Jan | `<data>/Jan/data/mcp_config.json` | JSON (`mcpServers`) |
-| BoltAI | `~/.boltai/mcp.json` | JSON (`mcpServers`) |
-| Goose | `~/.config/goose/config.yaml` | YAML (`extensions`) |
-| Hermes | `~/.hermes/config.yaml` | YAML (`mcp_servers`) |
+| Client         | Config file                                                                                | Format                   |
+| -------------- | ------------------------------------------------------------------------------------------ | ------------------------ |
+| Claude Desktop | `<config>/Claude/claude_desktop_config.json`                                               | JSON (`mcpServers`)      |
+| Claude Code    | `~/.claude.json`                                                                           | JSON (`mcpServers`)      |
+| Cursor         | `~/.cursor/mcp.json`                                                                       | JSON (`mcpServers`)      |
+| VS Code        | `<config>/Code/User/mcp.json`                                                              | JSON (`servers`)         |
+| Windsurf       | `~/.codeium/windsurf/mcp_config.json`                                                      | JSON (`mcpServers`)      |
+| Codex          | `~/.codex/config.toml`                                                                     | TOML (`mcp_servers`)     |
+| Continue       | `~/.continue/config.yaml`                                                                  | YAML (`mcpServers`)      |
+| Antigravity    | `~/.gemini/config/mcp_config.json`                                                         | JSON (`mcpServers`)      |
+| Gemini CLI     | `~/.gemini/settings.json`                                                                  | JSON (`mcpServers`)      |
+| Cline          | `<config>/Code/User/globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json` | JSON (`mcpServers`)      |
+| Roo Code       | `<config>/Code/User/globalStorage/rooveterinaryinc.roo-cline/settings/mcp_settings.json`   | JSON (`mcpServers`)      |
+| Warp           | `~/.warp/.mcp.json`                                                                        | JSON (`mcpServers`)      |
+| Amazon Q       | `~/.aws/amazonq/mcp.json`                                                                  | JSON (`mcpServers`)      |
+| Kiro           | `~/.kiro/settings/mcp.json`                                                                | JSON (`mcpServers`)      |
+| Zed            | `~/.config/zed/settings.json`                                                              | JSON (`context_servers`) |
+| LM Studio      | `~/.lmstudio/mcp.json`                                                                     | JSON (`mcpServers`)      |
+| Jan            | `<data>/Jan/data/mcp_config.json`                                                          | JSON (`mcpServers`)      |
+| BoltAI         | `~/.boltai/mcp.json`                                                                       | JSON (`mcpServers`)      |
+| Goose          | `~/.config/goose/config.yaml`                                                              | YAML (`extensions`)      |
+| Hermes         | `~/.hermes/config.yaml`                                                                    | YAML (`mcp_servers`)     |
 
 `<config>` is your OS application-config dir (`%APPDATA%` on Windows, `~/Library/Application Support` on macOS, `~/.config` on Linux); `<data>` is the data dir (`~/.local/share` on Linux, the same as `<config>` elsewhere). Zed and Goose paths vary slightly by OS; Toolport resolves the right one automatically.
 
@@ -338,7 +338,7 @@ latency/error stats, resources + prompts proxying, and a tool playground. See
 
 - **Linux only, glib `VariantStrIter` soundness ([RUSTSEC-2024-0429](https://rustsec.org/advisories/RUSTSEC-2024-0429)).**
   Tauri's Linux webview stack pulls in `glib` 0.18 transitively (`wry → webkit2gtk →
-  gtk 0.18 → glib 0.18`). The fix only exists in `glib` 0.20+, and the gtk-0.18
+gtk 0.18 → glib 0.18`). The fix only exists in `glib` 0.20+, and the gtk-0.18
   binding line, which is what Tauri 2 uses on Linux, hard-pins `glib = "^0.18"`, so
   the patched release cannot be selected without moving the whole webview stack. The
   bug is a soundness/null-deref crash (not remote code execution), is confined to the

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -25,7 +25,7 @@ from the [Releases](https://github.com/tsouth89/toolport/releases) page.
 - **Local-first.** Toolport runs entirely on your machine. The desktop app is a
   manager; the gateway is a local process each AI client spawns over stdio. There
   is **no Toolport server, account, or telemetry**, nothing phones home. The only
-  network traffic is between the gateway and the upstream MCP servers *you*
+  network traffic is between the gateway and the upstream MCP servers _you_
   configure.
 - **Secrets in the OS keychain.** API keys and OAuth tokens are stored in the
   platform keychain (macOS Keychain, Windows Credential Manager, Linux Secret

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -58,10 +58,10 @@ And the summary line: tools exposed (flat vs 3), total-token delta as a percent,
 
 ## Reading the results honestly
 
-- **Small sample.** A handful of tasks and single runs are noisy. Run it a few times; treat the *direction* as the signal, not the exact percentage.
+- **Small sample.** A handful of tasks and single runs are noisy. Run it a few times; treat the _direction_ as the signal, not the exact percentage.
 - **The trade-off is real and intentional.** Lazy mode trades extra tool calls (search → call) for fewer total tokens. The table shows both so you're not hiding the round-trip cost.
 - **Flat mode may error** on small models, dumping every tool schema can overflow the context window. That's a finding, not a bug: it's exactly the failure lazy discovery avoids. The harness records it as an error rather than crashing.
-- **Savings concentrate on smaller models** (mcpico saw ~60% on a 9B, ~8% on a 35B). Run it on a small *and* a mid model to show that, it's the local-model story.
+- **Savings concentrate on smaller models** (mcpico saw ~60% on a 9B, ~8% on a 35B). Run it on a small _and_ a mid model to show that, it's the local-model story.
 
 ## Caveats
 

--- a/benchmark/bench-sweep.mjs
+++ b/benchmark/bench-sweep.mjs
@@ -69,9 +69,25 @@ const OUT_DIR = process.env.OUT_DIR || HERE;
 // string, so "done" can't hide a wrong or "I couldn't do it" answer. No local file =
 // tasks run ungraded (correct shows as n/a).
 const TASKS = [
-  { name: "stripe-products", required: "stripe", expect: [], prompt: "List my Stripe products (just the names)." },
-  { name: "neon-projects", required: "neon", expect: [], prompt: "List my Neon projects (just the names)." },
-  { name: "vercel-projects", required: "vercel", expect: [], prompt: "List my Vercel projects. If a team id is required, find it first, then use it." },
+  {
+    name: "stripe-products",
+    required: "stripe",
+    expect: [],
+    prompt: "List my Stripe products (just the names).",
+  },
+  {
+    name: "neon-projects",
+    required: "neon",
+    expect: [],
+    prompt: "List my Neon projects (just the names).",
+  },
+  {
+    name: "vercel-projects",
+    required: "vercel",
+    expect: [],
+    prompt:
+      "List my Vercel projects. If a team id is required, find it first, then use it.",
+  },
 ];
 
 // Fill `expect` from the local, gitignored ground-truth file if it exists.
@@ -93,7 +109,8 @@ function defaultGateway() {
 
 function conduitDir() {
   if (platform() === "win32") return join(homedir(), "AppData", "Roaming", "Conduit");
-  if (platform() === "darwin") return join(homedir(), "Library", "Application Support", "Conduit");
+  if (platform() === "darwin")
+    return join(homedir(), "Library", "Application Support", "Conduit");
   return join(process.env.XDG_CONFIG_HOME || join(homedir(), ".config"), "Conduit");
 }
 
@@ -122,7 +139,9 @@ function planSweep(reg) {
     .map((x) => Number(x.trim()))
     .filter((n) => Number.isFinite(n) && n > 0);
   const maxN = required.length + noise.length;
-  const counts = (want.length ? want : [required.length, required.length + 3, required.length + 7, maxN])
+  const counts = (
+    want.length ? want : [required.length, required.length + 3, required.length + 7, maxN]
+  )
     .map((n) => Math.min(maxN, Math.max(required.length, n)))
     .filter((n, i, a) => a.indexOf(n) === i)
     .sort((a, b) => a - b);
@@ -151,11 +170,18 @@ function writeTempRegistry(dir, reg, serverIds, lazy) {
 class Gateway {
   constructor(regPath, discovery) {
     this.proc = spawn(GATEWAY, [], {
-      env: { ...process.env, CONDUIT_REGISTRY: regPath, CONDUIT_PROFILE: "sweep", CONDUIT_DISCOVERY: discovery },
+      env: {
+        ...process.env,
+        CONDUIT_REGISTRY: regPath,
+        CONDUIT_PROFILE: "sweep",
+        CONDUIT_DISCOVERY: discovery,
+      },
       stdio: ["pipe", "pipe", "ignore"],
     });
     this.proc.on("error", (e) => {
-      console.error(`\nCould not start gateway at ${GATEWAY}: ${e.message}\nBuild it: npm run build:gateway`);
+      console.error(
+        `\nCould not start gateway at ${GATEWAY}: ${e.message}\nBuild it: npm run build:gateway`,
+      );
       process.exit(1);
     });
     this.rl = createInterface({ input: this.proc.stdout });
@@ -163,35 +189,66 @@ class Gateway {
     this.id = 0;
     this.rl.on("line", (line) => {
       let msg;
-      try { msg = JSON.parse(line); } catch { return; }
+      try {
+        msg = JSON.parse(line);
+      } catch {
+        return;
+      }
       const cb = msg.id != null && this.pending.get(msg.id);
-      if (cb) { this.pending.delete(msg.id); cb(msg); }
+      if (cb) {
+        this.pending.delete(msg.id);
+        cb(msg);
+      }
     });
   }
   rpc(method, params) {
     const id = ++this.id;
     return new Promise((resolve) => {
       this.pending.set(id, resolve);
-      this.proc.stdin.write(JSON.stringify({ jsonrpc: "2.0", id, method, params }) + "\n");
+      this.proc.stdin.write(
+        JSON.stringify({ jsonrpc: "2.0", id, method, params }) + "\n",
+      );
     });
   }
   async init() {
-    await this.rpc("initialize", { protocolVersion: "2024-11-05", capabilities: {}, clientInfo: { name: "conduit-sweep", version: "1" } });
+    await this.rpc("initialize", {
+      protocolVersion: "2024-11-05",
+      capabilities: {},
+      clientInfo: { name: "conduit-sweep", version: "1" },
+    });
     await new Promise((r) => setTimeout(r, CONNECT_WAIT_MS));
   }
-  async tools() { return (await this.rpc("tools/list", {})).result?.tools || []; }
-  async call(name, args) { const r = await this.rpc("tools/call", { name, arguments: args || {} }); return r.result ?? r.error ?? {}; }
-  stop() { try { this.proc.kill(); } catch {} }
+  async tools() {
+    return (await this.rpc("tools/list", {})).result?.tools || [];
+  }
+  async call(name, args) {
+    const r = await this.rpc("tools/call", { name, arguments: args || {} });
+    return r.result ?? r.error ?? {};
+  }
+  stop() {
+    try {
+      this.proc.kill();
+    } catch {}
+  }
 }
 
 function normalizeParams(schema) {
-  const s = schema && typeof schema === "object" && !Array.isArray(schema) ? { ...schema } : {};
+  const s =
+    schema && typeof schema === "object" && !Array.isArray(schema) ? { ...schema } : {};
   if (!s.type) s.type = "object";
-  if (s.type === "object" && (s.properties == null || typeof s.properties !== "object")) s.properties = {};
+  if (s.type === "object" && (s.properties == null || typeof s.properties !== "object"))
+    s.properties = {};
   return s;
 }
 const toOpenAITools = (mcp) =>
-  mcp.map((t) => ({ type: "function", function: { name: t.name, description: t.description || "", parameters: normalizeParams(t.inputSchema) } }));
+  mcp.map((t) => ({
+    type: "function",
+    function: {
+      name: t.name,
+      description: t.description || "",
+      parameters: normalizeParams(t.inputSchema),
+    },
+  }));
 
 async function chat(messages, tools) {
   const headers = {
@@ -206,25 +263,43 @@ async function chat(messages, tools) {
   // stale completion (it's recomputed at temperature 0), so leaving it on just
   // makes a token-heavy flat run much cheaper. Set BENCH_NOCACHE=1 only if you want
   // to force fully independent samples (e.g. for variance analysis).
-  const noCache = ["1", "true", "yes", "on"].includes((process.env.BENCH_NOCACHE || "").toLowerCase());
+  const noCache = ["1", "true", "yes", "on"].includes(
+    (process.env.BENCH_NOCACHE || "").toLowerCase(),
+  );
   let res;
   for (let attempt = 0; ; attempt++) {
     const msgs =
       noCache && messages[0]?.role === "system"
-        ? [{ ...messages[0], content: `${messages[0].content}\n[uncached: ${randomUUID()}]` }, ...messages.slice(1)]
+        ? [
+            {
+              ...messages[0],
+              content: `${messages[0].content}\n[uncached: ${randomUUID()}]`,
+            },
+            ...messages.slice(1),
+          ]
         : messages;
-    const body = JSON.stringify({ model: MODEL, messages: msgs, tools, tool_choice: "auto", temperature: 0 });
+    const body = JSON.stringify({
+      model: MODEL,
+      messages: msgs,
+      tools,
+      tool_choice: "auto",
+      temperature: 0,
+    });
     res = await fetch(LLM_URL, { method: "POST", headers, body });
     if (res.ok) break;
     if ((res.status === 429 || res.status >= 500) && attempt < 6) {
       const ra = Number(res.headers.get("retry-after"));
-      const waitMs = Number.isFinite(ra) && ra > 0 ? ra * 1000 : Math.min(30000, 1000 * 2 ** attempt);
+      const waitMs =
+        Number.isFinite(ra) && ra > 0 ? ra * 1000 : Math.min(30000, 1000 * 2 ** attempt);
       await new Promise((r) => setTimeout(r, waitMs));
       continue;
     }
     break;
   }
-  if (!res.ok) throw new Error(`LLM ${res.status}: ${(await res.text().catch(() => "")).slice(0, 300)}`);
+  if (!res.ok)
+    throw new Error(
+      `LLM ${res.status}: ${(await res.text().catch(() => "")).slice(0, 300)}`,
+    );
   return res.json();
 }
 
@@ -241,10 +316,17 @@ async function measureOverhead(tools) {
 
 async function runTask(gw, oaiTools, prompt) {
   const messages = [
-    { role: "system", content: "You are a helpful assistant. Use the available tools to complete the task, then give a short final answer." },
+    {
+      role: "system",
+      content:
+        "You are a helpful assistant. Use the available tools to complete the task, then give a short final answer.",
+    },
     { role: "user", content: prompt },
   ];
-  let tokens = 0, calls = 0, done = false, error = null;
+  let tokens = 0,
+    calls = 0,
+    done = false,
+    error = null;
   try {
     for (let steps = 0; steps < MAX_STEPS; steps++) {
       const res = await chat(messages, oaiTools);
@@ -253,29 +335,46 @@ async function runTask(gw, oaiTools, prompt) {
       if (!m) break;
       messages.push(m);
       const toolCalls = m.tool_calls || [];
-      if (toolCalls.length === 0) { done = true; break; }
+      if (toolCalls.length === 0) {
+        done = true;
+        break;
+      }
       for (const c of toolCalls) {
         calls++;
         let args = {};
-        try { args = JSON.parse(c.function.arguments || "{}"); } catch {}
+        try {
+          args = JSON.parse(c.function.arguments || "{}");
+        } catch {}
         const result = await gw.call(c.function.name, args);
-        messages.push({ role: "tool", tool_call_id: c.id, content: JSON.stringify(result).slice(0, TOOL_RESULT_CAP) });
+        messages.push({
+          role: "tool",
+          tool_call_id: c.id,
+          content: JSON.stringify(result).slice(0, TOOL_RESULT_CAP),
+        });
       }
     }
   } catch (e) {
     error = e.message;
   }
-  const answer = messages
-    .filter((m) => m.role === "assistant" && typeof m.content === "string" && m.content.trim())
-    .pop()?.content || "";
+  const answer =
+    messages
+      .filter(
+        (m) =>
+          m.role === "assistant" && typeof m.content === "string" && m.content.trim(),
+      )
+      .pop()?.content || "";
   return { tokens, calls, done, error, answer };
 }
 
-const median = (xs) => { const s = [...xs].sort((a, b) => a - b); return s[Math.floor((s.length - 1) / 2)]; };
+const median = (xs) => {
+  const s = [...xs].sort((a, b) => a - b);
+  return s[Math.floor((s.length - 1) / 2)];
+};
 
 // An answer that looks like a failure/apology rather than a result. Used so a
 // "done" agent that gave up ("I couldn't list them") never counts as correct.
-const ERROR_LIKE = /\b(error|failed|unable|couldn'?t|can ?not|can'?t|unauthor|forbidden|denied|no access|not authenticated|don'?t have)\b/i;
+const ERROR_LIKE =
+  /\b(error|failed|unable|couldn'?t|can ?not|can'?t|unauthor|forbidden|denied|no access|not authenticated|don'?t have)\b/i;
 
 // Grade a single answer against the task's ground-truth `expect` list:
 //   true/false when graded, null when the task has no `expect` (ungraded).
@@ -329,7 +428,8 @@ async function benchAt(regPath, count, serverIds, mode) {
   const { reg } = loadRealRegistry();
   const sweep = planSweep(reg);
   console.log("sweep plan (servers always include the task servers):");
-  for (const s of sweep) console.log(`  ${String(s.count).padStart(2)} servers: ${s.serverIds.join(", ")}`);
+  for (const s of sweep)
+    console.log(`  ${String(s.count).padStart(2)} servers: ${s.serverIds.join(", ")}`);
 
   const dir = mkdtempSync(join(tmpdir(), "conduit-sweep-"));
   const results = [];
@@ -376,10 +476,28 @@ async function benchAt(regPath, count, serverIds, mode) {
   mkdirSync(OUT_DIR, { recursive: true });
 
   // --- CSV (one row per server-count x mode x task) ---
-  const csv = ["servers,mode,toolCount,overheadTokens,overflow,task,medianTokens,loTokens,hiTokens,done,correct,graded,runs"];
+  const csv = [
+    "servers,mode,toolCount,overheadTokens,overflow,task,medianTokens,loTokens,hiTokens,done,correct,graded,runs",
+  ];
   for (const r of results)
     for (const t of r.tasks)
-      csv.push([r.count, r.mode, r.toolCount, r.overhead.tokens ?? "", r.overhead.overflow, t.task, t.median, t.lo, t.hi, t.done, t.correct ?? "", t.graded, RUNS].join(","));
+      csv.push(
+        [
+          r.count,
+          r.mode,
+          r.toolCount,
+          r.overhead.tokens ?? "",
+          r.overhead.overflow,
+          t.task,
+          t.median,
+          t.lo,
+          t.hi,
+          t.done,
+          t.correct ?? "",
+          t.graded,
+          RUNS,
+        ].join(","),
+      );
   const csvPath = join(OUT_DIR, "sweep-results.csv");
   writeFileSync(csvPath, csv.join("\n") + "\n");
 
@@ -390,7 +508,9 @@ async function benchAt(regPath, count, serverIds, mode) {
       const grade = t.graded ? ` [${t.correct}/${RUNS} correct]` : " [ungraded]";
       ans.push(`## ${r.count} servers / ${r.mode} / ${t.task}${grade}`);
       if (!t.samples.some((s) => s)) ans.push("(no answer, e.g. context overflow)");
-      t.samples.forEach((s, i) => s && ans.push(`  sample ${i + 1}: ${s.replace(/\s+/g, " ")}`));
+      t.samples.forEach(
+        (s, i) => s && ans.push(`  sample ${i + 1}: ${s.replace(/\s+/g, " ")}`),
+      );
       ans.push("");
     }
   }
@@ -405,7 +525,14 @@ async function benchAt(regPath, count, serverIds, mode) {
     const totalDone = r.tasks.reduce((a, t) => a + t.done, 0);
     const graded = r.tasks.some((t) => t.graded);
     const totalCorrect = r.tasks.reduce((a, t) => a + (t.correct ?? 0), 0);
-    o[r.mode] = { tools: r.toolCount, overhead: r.overhead, totalTok, totalDone, totalCorrect, graded };
+    o[r.mode] = {
+      tools: r.toolCount,
+      overhead: r.overhead,
+      totalTok,
+      totalDone,
+      totalCorrect,
+      graded,
+    };
     byCount.set(r.count, o);
   }
   const denom = TASKS.length * RUNS;
@@ -419,11 +546,17 @@ async function benchAt(regPath, count, serverIds, mode) {
     `|---|---|---|---|---|---|---|---|${anyGraded ? "---|---|" : ""}`,
   ];
   for (const o of [...byCount.values()].sort((a, b) => a.count - b.count)) {
-    const f = o.full, l = o.lazy;
+    const f = o.full,
+      l = o.lazy;
     const fOv = f?.overhead.overflow ? "OVERFLOW" : (f?.overhead.tokens ?? "?");
-    const red = f?.totalTok && l?.totalTok ? `${Math.round((1 - l.totalTok / f.totalTok) * 100)}%` : "—";
+    const red =
+      f?.totalTok && l?.totalTok
+        ? `${Math.round((1 - l.totalTok / f.totalTok) * 100)}%`
+        : "—";
     const correctCols = anyGraded ? ` ${cScore(f)} | ${cScore(l)} |` : "";
-    md.push(`| ${o.count} (${f?.tools ?? "?"} tools) | ${fOv} | ${l?.overhead.tokens ?? "?"} | ${f?.totalTok ?? "—"} | ${l?.totalTok ?? "—"} | ${red} | ${f?.totalDone ?? 0}/${denom} | ${l?.totalDone ?? 0}/${denom} |${correctCols}`);
+    md.push(
+      `| ${o.count} (${f?.tools ?? "?"} tools) | ${fOv} | ${l?.overhead.tokens ?? "?"} | ${f?.totalTok ?? "—"} | ${l?.totalTok ?? "—"} | ${red} | ${f?.totalDone ?? 0}/${denom} | ${l?.totalDone ?? 0}/${denom} |${correctCols}`,
+    );
   }
   const mdPath = join(OUT_DIR, "sweep-summary.md");
   writeFileSync(mdPath, md.join("\n") + "\n");

--- a/benchmark/bench.js
+++ b/benchmark/bench.js
@@ -44,7 +44,11 @@ const TOOL_RESULT_CAP = 8000; // trim huge tool outputs so one result can't skew
 const TASKS = [
   { name: "stripe-products", prompt: "List my Stripe products (just the names)." },
   { name: "neon-projects", prompt: "List my Neon projects (just the names)." },
-  { name: "vercel-projects", prompt: "List my Vercel projects. If a team id is required, find it first, then use it." },
+  {
+    name: "vercel-projects",
+    prompt:
+      "List my Vercel projects. If a team id is required, find it first, then use it.",
+  },
 ];
 
 function defaultGateway() {
@@ -73,16 +77,25 @@ class Gateway {
     this.id = 0;
     this.rl.on("line", (line) => {
       let msg;
-      try { msg = JSON.parse(line); } catch { return; }
+      try {
+        msg = JSON.parse(line);
+      } catch {
+        return;
+      }
       const cb = msg.id != null && this.pending.get(msg.id);
-      if (cb) { this.pending.delete(msg.id); cb(msg); }
+      if (cb) {
+        this.pending.delete(msg.id);
+        cb(msg);
+      }
     });
   }
   rpc(method, params) {
     const id = ++this.id;
     return new Promise((resolve) => {
       this.pending.set(id, resolve);
-      this.proc.stdin.write(JSON.stringify({ jsonrpc: "2.0", id, method, params }) + "\n");
+      this.proc.stdin.write(
+        JSON.stringify({ jsonrpc: "2.0", id, method, params }) + "\n",
+      );
     });
   }
   async init() {
@@ -102,14 +115,19 @@ class Gateway {
     const r = await this.rpc("tools/call", { name, arguments: args || {} });
     return r.result ?? r.error ?? {};
   }
-  stop() { try { this.proc.kill(); } catch {} }
+  stop() {
+    try {
+      this.proc.kill();
+    } catch {}
+  }
 }
 
 // OpenAI function-calling (and strict runtimes like LM Studio) require `parameters`
 // to be an object schema WITH a `properties` field, even for zero-arg tools. MCP
 // tools legitimately ship a bare {"type":"object"}, so normalize before sending.
 function normalizeParams(schema) {
-  const s = schema && typeof schema === "object" && !Array.isArray(schema) ? { ...schema } : {};
+  const s =
+    schema && typeof schema === "object" && !Array.isArray(schema) ? { ...schema } : {};
   if (!s.type) s.type = "object";
   if (s.type === "object" && (s.properties == null || typeof s.properties !== "object")) {
     s.properties = {};
@@ -146,7 +164,13 @@ async function chat(messages, tools) {
   const res = await fetch(LLM_URL, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ model: MODEL, messages, tools, tool_choice: "auto", temperature: 0 }),
+    body: JSON.stringify({
+      model: MODEL,
+      messages,
+      tools,
+      tool_choice: "auto",
+      temperature: 0,
+    }),
   });
   if (!res.ok) {
     const body = await res.text().catch(() => "");
@@ -157,10 +181,18 @@ async function chat(messages, tools) {
 
 async function runTask(gw, oaiTools, prompt) {
   const messages = [
-    { role: "system", content: "You are a helpful assistant. Use the available tools to complete the task, then give a short final answer." },
+    {
+      role: "system",
+      content:
+        "You are a helpful assistant. Use the available tools to complete the task, then give a short final answer.",
+    },
     { role: "user", content: prompt },
   ];
-  let tokens = 0, calls = 0, steps = 0, done = false, error = null;
+  let tokens = 0,
+    calls = 0,
+    steps = 0,
+    done = false,
+    error = null;
   try {
     for (; steps < MAX_STEPS; steps++) {
       const res = await chat(messages, oaiTools);
@@ -169,11 +201,16 @@ async function runTask(gw, oaiTools, prompt) {
       if (!m) break;
       messages.push(m);
       const toolCalls = m.tool_calls || [];
-      if (toolCalls.length === 0) { done = true; break; } // produced a final answer
+      if (toolCalls.length === 0) {
+        done = true;
+        break;
+      } // produced a final answer
       for (const c of toolCalls) {
         calls++;
         let args = {};
-        try { args = JSON.parse(c.function.arguments || "{}"); } catch {}
+        try {
+          args = JSON.parse(c.function.arguments || "{}");
+        } catch {}
         const result = await gw.call(c.function.name, args);
         messages.push({
           role: "tool",
@@ -185,7 +222,8 @@ async function runTask(gw, oaiTools, prompt) {
   } catch (e) {
     error = e.message; // e.g. flat mode overflowing the model's context window
   }
-  const answer = messages.filter((m) => m.role === "assistant" && m.content).pop()?.content || "";
+  const answer =
+    messages.filter((m) => m.role === "assistant" && m.content).pop()?.content || "";
   return { tokens, calls, steps, done, error, answer: answer.slice(0, 200) };
 }
 
@@ -199,9 +237,10 @@ async function benchMode(discovery) {
   const mcpTools = await gw.tools();
   const oaiTools = toOpenAITools(mcpTools);
   const overhead = await measureToolOverhead(oaiTools);
-  const ov = overhead.tokens != null
-    ? `${overhead.tokens} tok/request${overhead.overflow ? " (OVERFLOWS context)" : ""}`
-    : "unknown";
+  const ov =
+    overhead.tokens != null
+      ? `${overhead.tokens} tok/request${overhead.overflow ? " (OVERFLOWS context)" : ""}`
+      : "unknown";
   console.log(`\n[${discovery}] ${mcpTools.length} tools, tool-def overhead: ${ov}`);
   const rows = [];
   for (const task of TASKS) {
@@ -211,10 +250,18 @@ async function benchMode(discovery) {
     const median = toks[Math.floor((toks.length - 1) / 2)];
     const done = trials.filter((t) => t.done).length;
     const err = trials.find((t) => t.error)?.error;
-    rows.push({ task: task.name, tokens: median, lo: toks[0], hi: toks[toks.length - 1], done });
+    rows.push({
+      task: task.name,
+      tokens: median,
+      lo: toks[0],
+      hi: toks[toks.length - 1],
+      done,
+    });
     const range = RUNS > 1 ? ` (${toks[0]}-${toks[toks.length - 1]})` : "";
     const status = err ? `ERROR (${String(err).slice(0, 60)})` : `${done}/${RUNS} done`;
-    console.log(`  ${task.name.padEnd(16)} median ${String(median).padStart(6)} tok${range}  ${status}`);
+    console.log(
+      `  ${task.name.padEnd(16)} median ${String(median).padStart(6)} tok${range}  ${status}`,
+    );
   }
   gw.stop();
   return { toolCount: mcpTools.length, overhead, rows };
@@ -223,7 +270,7 @@ async function benchMode(discovery) {
 function totals(modeRows) {
   return modeRows.reduce(
     (a, r) => ({ tokens: a.tokens + (r.tokens || 0), done: a.done + (r.done || 0) }),
-    { tokens: 0, done: 0 }
+    { tokens: 0, done: 0 },
   );
 }
 
@@ -249,27 +296,44 @@ function totals(modeRows) {
   const flat = await benchMode("full");
   const lazy = await benchMode("lazy");
 
-  const tf = totals(flat.rows), tl = totals(lazy.rows);
-  const fmtOv = (o) => o.tokens != null
-    ? `${o.tokens}${o.overflow ? " (overflows context)" : ""}`
-    : "unknown";
-  const ovPct = flat.overhead.tokens && lazy.overhead.tokens
-    ? Math.round((1 - lazy.overhead.tokens / flat.overhead.tokens) * 100)
-    : null;
+  const tf = totals(flat.rows),
+    tl = totals(lazy.rows);
+  const fmtOv = (o) =>
+    o.tokens != null
+      ? `${o.tokens}${o.overflow ? " (overflows context)" : ""}`
+      : "unknown";
+  const ovPct =
+    flat.overhead.tokens && lazy.overhead.tokens
+      ? Math.round((1 - lazy.overhead.tokens / flat.overhead.tokens) * 100)
+      : null;
 
   console.log("\n=== summary ===");
   console.log(`tools exposed:        flat ${flat.toolCount}   lazy ${lazy.toolCount}`);
-  console.log(`tool-def overhead:    flat ${fmtOv(flat.overhead)}   lazy ${fmtOv(lazy.overhead)} tok/request` +
-    (ovPct != null ? `   (${ovPct}% less, EVERY request)` : ""));
+  console.log(
+    `tool-def overhead:    flat ${fmtOv(flat.overhead)}   lazy ${fmtOv(lazy.overhead)} tok/request` +
+      (ovPct != null ? `   (${ovPct}% less, EVERY request)` : ""),
+  );
   const denom = TASKS.length * RUNS;
-  console.log(`tasks completed:      flat ${tf.done}/${denom}   lazy ${tl.done}/${denom}   (${RUNS} run(s)/task)`);
+  console.log(
+    `tasks completed:      flat ${tf.done}/${denom}   lazy ${tl.done}/${denom}   (${RUNS} run(s)/task)`,
+  );
   if (tf.done > 0) {
     const pct = tf.tokens ? Math.round((1 - tl.tokens / tf.tokens) * 100) : 0;
-    console.log(`median tokens (sum):  flat ${tf.tokens}   lazy ${tl.tokens}   (${pct >= 0 ? "-" : "+"}${Math.abs(pct)}%)`);
+    console.log(
+      `median tokens (sum):  flat ${tf.tokens}   lazy ${tl.tokens}   (${pct >= 0 ? "-" : "+"}${Math.abs(pct)}%)`,
+    );
   } else {
-    console.log(`lazy median tokens:   ${tl.tokens} summed across tasks (flat couldn't run, its tool list overflowed the model)`);
+    console.log(
+      `lazy median tokens:   ${tl.tokens} summed across tasks (flat couldn't run, its tool list overflowed the model)`,
+    );
   }
-  console.log("\nThe headline metric is tool-def overhead: the tokens EVERY request pays just to");
-  console.log("list tools. Flat pays it on every call; lazy advertises 3 meta-tools. Set RUNS=5");
-  console.log("for medians; eyeball the answers for correctness; treat the direction as signal.");
+  console.log(
+    "\nThe headline metric is tool-def overhead: the tokens EVERY request pays just to",
+  );
+  console.log(
+    "list tools. Flat pays it on every call; lazy advertises 3 meta-tools. Set RUNS=5",
+  );
+  console.log(
+    "for medians; eyeball the answers for correctness; treat the direction as signal.",
+  );
 })();

--- a/benchmark/latency.mjs
+++ b/benchmark/latency.mjs
@@ -25,7 +25,10 @@ const GATEWAY = exe("conduit-gateway");
 const MOCK = exe("mock-mcp-server");
 const N = Math.max(20, Number(process.argv[2] || 200));
 
-for (const [label, p] of [["gateway", GATEWAY], ["mock server", MOCK]]) {
+for (const [label, p] of [
+  ["gateway", GATEWAY],
+  ["mock server", MOCK],
+]) {
   if (!existsSync(p)) {
     console.error(
       `Missing ${label} at ${p}\nBuild it first:\n  cargo build --manifest-path src-tauri/Cargo.toml --bins`,
@@ -71,7 +74,9 @@ function client(proc) {
       new Promise((res) => {
         const myId = ++id;
         pending.set(myId, res);
-        proc.stdin.write(JSON.stringify({ jsonrpc: "2.0", id: myId, method, params }) + "\n");
+        proc.stdin.write(
+          JSON.stringify({ jsonrpc: "2.0", id: myId, method, params }) + "\n",
+        );
       }),
     notify: (method, params) =>
       proc.stdin.write(JSON.stringify({ jsonrpc: "2.0", method, params }) + "\n"),
@@ -103,7 +108,14 @@ async function main() {
     JSON.stringify({
       version: 1,
       servers: [
-        { id: "mock", name: "Mock", transport: "stdio", command: MOCK, args: [], env: [] },
+        {
+          id: "mock",
+          name: "Mock",
+          transport: "stdio",
+          command: MOCK,
+          args: [],
+          env: [],
+        },
       ],
       profiles: [{ id: "bench", name: "Bench", enabledServerIds: ["mock"] }],
       activeProfileId: "bench",
@@ -128,7 +140,12 @@ async function main() {
 
   // 2) Through the gateway.
   const gw = spawn(GATEWAY, [], {
-    env: { ...process.env, CONDUIT_REGISTRY: regPath, CONDUIT_PROFILE: "bench", CONDUIT_DISCOVERY: "lazy" },
+    env: {
+      ...process.env,
+      CONDUIT_REGISTRY: regPath,
+      CONDUIT_PROFILE: "bench",
+      CONDUIT_DISCOVERY: "lazy",
+    },
     stdio: ["pipe", "pipe", "ignore"],
   });
   const g = client(gw);
@@ -139,11 +156,19 @@ async function main() {
   for (let k = 0; k < 15; k++) await g.call("tools/list", {}); // warm up
   const list = await loop(() => g.call("tools/list", {}), N);
   const search = await loop(
-    () => g.call("tools/call", { name: "toolport_search_tools", arguments: { query: "a", limit: 25 } }),
+    () =>
+      g.call("tools/call", {
+        name: "toolport_search_tools",
+        arguments: { query: "a", limit: 25 },
+      }),
     N,
   );
   const gwCall = await loop(
-    () => g.call("tools/call", { name: "toolport_call_tool", arguments: { name: `mock__${bare}`, arguments: {} } }),
+    () =>
+      g.call("tools/call", {
+        name: "toolport_call_tool",
+        arguments: { name: `mock__${bare}`, arguments: {} },
+      }),
     N,
   );
 
@@ -156,7 +181,9 @@ async function main() {
   const row = (label, x) =>
     `  ${label.padEnd(28)}${x.median.toFixed(2).padStart(6)} ms   (p95 ${x.p95.toFixed(2)})`;
   console.log(`\nToolport gateway latency  (mock downstream, ${N} iterations, median)\n`);
-  console.log(`  ${"handshake (one-time)".padEnd(28)}${handshake.toFixed(2).padStart(6)} ms`);
+  console.log(
+    `  ${"handshake (one-time)".padEnd(28)}${handshake.toFixed(2).padStart(6)} ms`,
+  );
   console.log(row("tools/list (lazy, 3 tools)", list));
   console.log(row("toolport_search_tools", search));
   console.log(row("toolport_call_tool -> mock", gwCall));
@@ -168,7 +195,9 @@ async function main() {
   console.log(
     `     Real servers take tens to hundreds of ms each, so that overhead is noise,`,
   );
-  console.log(`     and it buys ~90% fewer tokens. See BENCHMARK.md for the token numbers.\n`);
+  console.log(
+    `     and it buys ~90% fewer tokens. See BENCHMARK.md for the token numbers.\n`,
+  );
 }
 
 main().catch((e) => {

--- a/benchmark/retrieval.mjs
+++ b/benchmark/retrieval.mjs
@@ -53,21 +53,65 @@ const GATEWAY = process.env.GATEWAY || defaultGateway();
 const CASES = [
   // --- direct (should be easy). Tightened to the actual action tool name so a
   //     loose substring (e.g. any "...project...") can't count as a false hit. ---
-  { q: "list my stripe products", want: ["list_products", "stripe_api_read", "search_stripe_resources"], kind: "direct" },
+  {
+    q: "list my stripe products",
+    want: ["list_products", "stripe_api_read", "search_stripe_resources"],
+    kind: "direct",
+  },
   { q: "list my neon projects", want: ["list_projects"], kind: "direct" },
   { q: "list my vercel projects", want: ["list_projects"], kind: "direct" },
-  { q: "list my github repositories", want: ["list_repositor", "search_repositor"], kind: "direct" },
+  {
+    q: "list my github repositories",
+    want: ["list_repositor", "search_repositor"],
+    kind: "direct",
+  },
   // --- paraphrased / indirect (the hard cases) ---
-  { q: "charge a customer's credit card", want: ["payment_intent", "create_charge", "stripe_api_write"], kind: "paraphrase" },
-  { q: "who are my paying customers", want: ["list_customer", "search_customer", "customer"], kind: "paraphrase" },
-  { q: "open a pull request for my branch", want: ["create_pull_request", "pull_request"], kind: "paraphrase" },
-  { q: "spin up a database branch to test a migration", want: ["create_branch", "prepare_database_migration"], kind: "paraphrase" },
-  { q: "run a SQL query against my database", want: ["run_sql", "execute_sql", "run_query", "execute_postgres"], kind: "paraphrase" },
-  { q: "send a welcome email to a new signup", want: ["send_email", "send-email", "emails_send"], kind: "paraphrase" },
-  { q: "roll back my last deployment", want: ["rollback", "redeploy", "promote", "revert"], kind: "paraphrase" },
-  { q: "what's my revenue this month", want: ["revenue", "overview_metric", "list_metric", "balance"], kind: "paraphrase" },
+  {
+    q: "charge a customer's credit card",
+    want: ["payment_intent", "create_charge", "stripe_api_write"],
+    kind: "paraphrase",
+  },
+  {
+    q: "who are my paying customers",
+    want: ["list_customer", "search_customer", "customer"],
+    kind: "paraphrase",
+  },
+  {
+    q: "open a pull request for my branch",
+    want: ["create_pull_request", "pull_request"],
+    kind: "paraphrase",
+  },
+  {
+    q: "spin up a database branch to test a migration",
+    want: ["create_branch", "prepare_database_migration"],
+    kind: "paraphrase",
+  },
+  {
+    q: "run a SQL query against my database",
+    want: ["run_sql", "execute_sql", "run_query", "execute_postgres"],
+    kind: "paraphrase",
+  },
+  {
+    q: "send a welcome email to a new signup",
+    want: ["send_email", "send-email", "emails_send"],
+    kind: "paraphrase",
+  },
+  {
+    q: "roll back my last deployment",
+    want: ["rollback", "redeploy", "promote", "revert"],
+    kind: "paraphrase",
+  },
+  {
+    q: "what's my revenue this month",
+    want: ["revenue", "overview_metric", "list_metric", "balance"],
+    kind: "paraphrase",
+  },
   { q: "refund a payment", want: ["refund"], kind: "paraphrase" },
-  { q: "inspect my supabase database schema", want: ["list_tables", "execute_sql", "list_extensions"], kind: "paraphrase" },
+  {
+    q: "inspect my supabase database schema",
+    want: ["list_tables", "execute_sql", "list_extensions"],
+    kind: "paraphrase",
+  },
 ];
 
 // --- minimal MCP-over-stdio client ---
@@ -78,7 +122,9 @@ class Gateway {
       stdio: ["pipe", "pipe", "ignore"],
     });
     this.proc.on("error", (e) => {
-      console.error(`Could not start gateway at ${GATEWAY}: ${e.message}\nBuild it: npm run build:gateway`);
+      console.error(
+        `Could not start gateway at ${GATEWAY}: ${e.message}\nBuild it: npm run build:gateway`,
+      );
       process.exit(1);
     });
     this.rl = createInterface({ input: this.proc.stdout });
@@ -86,29 +132,49 @@ class Gateway {
     this.id = 0;
     this.rl.on("line", (line) => {
       let m;
-      try { m = JSON.parse(line); } catch { return; }
+      try {
+        m = JSON.parse(line);
+      } catch {
+        return;
+      }
       const cb = m.id != null && this.pending.get(m.id);
-      if (cb) { this.pending.delete(m.id); cb(m); }
+      if (cb) {
+        this.pending.delete(m.id);
+        cb(m);
+      }
     });
   }
   rpc(method, params) {
     const id = ++this.id;
     return new Promise((resolve) => {
       this.pending.set(id, resolve);
-      this.proc.stdin.write(JSON.stringify({ jsonrpc: "2.0", id, method, params }) + "\n");
+      this.proc.stdin.write(
+        JSON.stringify({ jsonrpc: "2.0", id, method, params }) + "\n",
+      );
     });
   }
   async init() {
-    await this.rpc("initialize", { protocolVersion: "2024-11-05", capabilities: {}, clientInfo: { name: "retrieval-bench", version: "1" } });
+    await this.rpc("initialize", {
+      protocolVersion: "2024-11-05",
+      capabilities: {},
+      clientInfo: { name: "retrieval-bench", version: "1" },
+    });
     await new Promise((r) => setTimeout(r, CONNECT_WAIT_MS));
   }
   async search(query, limit) {
-    const r = await this.rpc("tools/call", { name: "toolport_search_tools", arguments: { query, limit } });
+    const r = await this.rpc("tools/call", {
+      name: "toolport_search_tools",
+      arguments: { query, limit },
+    });
     const text = r.result?.content?.[0]?.text ?? "";
     // The result embeds the matches as a JSON-ish block; pull tool names in order.
     return [...text.matchAll(/"name"\s*:\s*"([^"]+)"/g)].map((m) => m[1]);
   }
-  stop() { try { this.proc.kill(); } catch {} }
+  stop() {
+    try {
+      this.proc.kill();
+    } catch {}
+  }
 }
 
 function rankOf(names, want) {
@@ -121,7 +187,9 @@ function rankOf(names, want) {
 
 (async () => {
   console.log(`gateway: ${GATEWAY}`);
-  const semOn = ["on", "1", "true", "yes"].includes((process.env.CONDUIT_SEMANTIC || "").toLowerCase());
+  const semOn = ["on", "1", "true", "yes"].includes(
+    (process.env.CONDUIT_SEMANTIC || "").toLowerCase(),
+  );
   console.log(
     semOn
       ? `mode:    SEMANTIC (embed: ${process.env.CONDUIT_EMBED_MODEL || "?"} @ ${process.env.CONDUIT_EMBED_ENDPOINT || "?"})`
@@ -138,7 +206,8 @@ function rankOf(names, want) {
     rows.push({ ...c, rank, top: names.slice(0, 3) });
     const status = rank === 0 ? "MISS" : `#${rank}`;
     console.log(`  [${c.kind.padEnd(10)}] ${status.padStart(5)}  ${c.q}`);
-    if (rank === 0) console.log(`           top results: ${names.slice(0, 5).join(", ") || "(none)"}`);
+    if (rank === 0)
+      console.log(`           top results: ${names.slice(0, 5).join(", ") || "(none)"}`);
   }
   gw.stop();
 
@@ -146,7 +215,10 @@ function rankOf(names, want) {
   const hit5 = rows.filter((r) => r.rank > 0 && r.rank <= 5).length;
   const mrr = rows.reduce((a, r) => a + (r.rank > 0 ? 1 / r.rank : 0), 0) / rows.length;
   const byKind = (k) => rows.filter((r) => r.kind === k);
-  const recall5 = (rs) => rs.length ? `${rs.filter((r) => r.rank > 0 && r.rank <= 5).length}/${rs.length}` : "0/0";
+  const recall5 = (rs) =>
+    rs.length
+      ? `${rs.filter((r) => r.rank > 0 && r.rank <= 5).length}/${rs.length}`
+      : "0/0";
 
   console.log("\n=== summary ===");
   console.log(`recall@1:  ${hit1}/${rows.length}`);
@@ -156,9 +228,16 @@ function rankOf(names, want) {
   console.log(`  paraphrase cases recall@5: ${recall5(byKind("paraphrase"))}`);
   const misses = rows.filter((r) => r.rank === 0);
   if (misses.length) {
-    console.log(`\nmisses (${misses.length}) — a real gap if you have the capability connected:`);
-    for (const m of misses) console.log(`  - "${m.q}"  (wanted name containing: ${m.want.join(" / ")})`);
+    console.log(
+      `\nmisses (${misses.length}) — a real gap if you have the capability connected:`,
+    );
+    for (const m of misses)
+      console.log(`  - "${m.q}"  (wanted name containing: ${m.want.join(" / ")})`);
   }
-  console.log("\nParaphrase recall is the number that backs (or breaks) the 'never misses a tool'");
-  console.log("claim. If it's low, that's the case for semantic search; see docs/specs/semantic-search.md.");
+  console.log(
+    "\nParaphrase recall is the number that backs (or breaks) the 'never misses a tool'",
+  );
+  console.log(
+    "claim. If it's low, that's the case for semantic search; see docs/specs/semantic-search.md.",
+  );
 })();

--- a/benchmark/token-cost.mjs
+++ b/benchmark/token-cost.mjs
@@ -20,7 +20,8 @@ import { join } from "node:path";
 // Toolport's data dir, matching the gateway's registry::conduit_dir().
 function conduitDir() {
   if (platform() === "win32") return join(homedir(), "AppData", "Roaming", "Conduit");
-  if (platform() === "darwin") return join(homedir(), "Library", "Application Support", "Conduit");
+  if (platform() === "darwin")
+    return join(homedir(), "Library", "Application Support", "Conduit");
   return join(process.env.XDG_CONFIG_HOME || join(homedir(), ".config"), "Conduit");
 }
 
@@ -82,7 +83,9 @@ for (const r of rows) {
 }
 console.log("");
 console.log(`Without Toolport:  ${fmt(total)} tokens / request`);
-console.log(`With Toolport:     ${fmt(LAZY_FLOOR)} tokens / request (3 meta-tools, flat)`);
+console.log(
+  `With Toolport:     ${fmt(LAZY_FLOOR)} tokens / request (3 meta-tools, flat)`,
+);
 console.log(`Reduction:        ${reduction}%`);
 
 // --- 2. Per-tool distribution ---
@@ -103,23 +106,29 @@ const WINDOWS = [
   ["Gemini 2.5 (1M)", 1000000],
 ];
 console.log("");
-console.log(`Context window eaten by ${fmt(total)} tokens of definitions, before any real work:`);
+console.log(
+  `Context window eaten by ${fmt(total)} tokens of definitions, before any real work:`,
+);
 for (const [name, w] of WINDOWS) {
   const pct = (total / w) * 100;
-  console.log(`  ${name.padEnd(24)} ${pct > 100 ? ">100%  (OVERFLOWS, can't even load the tools)" : pct.toFixed(1) + "%"}`);
+  console.log(
+    `  ${name.padEnd(24)} ${pct > 100 ? ">100%  (OVERFLOWS, can't even load the tools)" : pct.toFixed(1) + "%"}`,
+  );
 }
 
 // --- 4. Scaling: reduction grows with tool count ---
 // Uses the measured mean tokens/tool from THIS catalog, so the curve is grounded
 // in real schemas. Lazy's floor is fixed at 3 meta-tools no matter the size.
 console.log("");
-console.log(`Scaling (def-overhead reduction vs tool count, at ${fmt(meanPerTool)} tok/tool measured here):`);
+console.log(
+  `Scaling (def-overhead reduction vs tool count, at ${fmt(meanPerTool)} tok/tool measured here):`,
+);
 console.log("  tools    flat tokens    lazy    reduction");
 for (const n of [3, 10, 25, 50, 100, 200, tools.length]) {
   const flat = Math.round(n * meanPerTool);
   const red = (1 - LAZY_FLOOR / flat) * 100;
   console.log(
-    `  ${String(n).padStart(5)}    ${fmt(flat).padStart(10)}    ${fmt(LAZY_FLOOR).padStart(4)}    ${(red > 0 ? red.toFixed(1) : "0.0")}%`,
+    `  ${String(n).padStart(5)}    ${fmt(flat).padStart(10)}    ${fmt(LAZY_FLOOR).padStart(4)}    ${red > 0 ? red.toFixed(1) : "0.0"}%`,
   );
 }
 const breakeven = Math.ceil(LAZY_FLOOR / meanPerTool);
@@ -135,7 +144,9 @@ const PRICES = [
 ];
 const VOLUMES = [50, 200, 1000];
 console.log("");
-console.log(`Monthly $ saved (re-sending ${fmt(saved)} tokens/request that lazy mode doesn't):`);
+console.log(
+  `Monthly $ saved (re-sending ${fmt(saved)} tokens/request that lazy mode doesn't):`,
+);
 console.log("  model".padEnd(28) + VOLUMES.map((v) => `${v}/day`.padStart(12)).join(""));
 for (const [label, price] of PRICES) {
   let line = "  " + label.padEnd(26);

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -57,11 +57,13 @@ fix is reload-under-lock at every app mutation or a gateway→app cache-refresh 
 low real exposure since the gateway only writes when `allow_agent_control` is on).
 
 **In flight**
+
 - ~~Teams **org screening policy** (Phase 1): tighten-only `forceContentDefense` /
   `forceQuarantineOnDrift`.~~ **Shipped**, and extended with `forceHumanApproval`
   (org-mandated HITL). Plan in `docs/drafts/parry-teams-plan.md`.
 
 **Tier 1 - security + cheap parity (do first)**
+
 - [x] **Stdio spawn hardening.** Refuse code-smuggling / container-escape args
       (interpreter inline-eval + module-preload, docker `--privileged` / host-mount /
       `--cap-add` / host-namespace) before spawning a stdio server, so a
@@ -69,13 +71,14 @@ low real exposure since the gateway only writes when `allow_agent_control` is on
       launcher into arbitrary code execution. `screen_spawn_command` in
       `downstream.rs`, on every spawn path. (S)
 - [~] **Identity attribution in the audit line.** The client label is now threaded
-      through dispatch and stamped into `audit.rs`/`inspect.rs` records (#95). Remaining:
-      a per-caller filter in the Activity view. (S)
+  through dispatch and stamped into `audit.rs`/`inspect.rs` records (#95). Remaining:
+  a per-caller filter in the Activity view. (S)
 - [x] **Tool overrides (rename / re-describe) SHIPPED (#88, #89):** a user can rename or
       replace a tool's description as clients see it (neutralizing a poisoned description
       in place). Param-pin/override defaults is the remaining piece.
 
 **Tier 2 - parity on real gaps**
+
 - [ ] Tool Groups (cross-server reusable collections) + allow/block ACL with an
       explicit `default-allow`/`default-block` posture per client, generalizing
       profiles. (M)
@@ -85,6 +88,7 @@ low real exposure since the gateway only writes when `allow_agent_control` is on
       ships) so remote/network clients connect natively. (M)
 
 **Strategic**
+
 - [x] **Human-in-the-loop approval queue. SHIPPED** (v1.1.0 + follow-ups): the gateway
       holds a gated call and the app prompts to approve/deny, fail-closed on timeout;
       plus tray/menu-bar run, OS notification, approve-for-session/always-allow, exact
@@ -102,6 +106,7 @@ HTTP/security surface). Ordered by impact within each track. (S/M/L = effort.)
 The 2026-07-01 block above supersedes the ordering; these remain the detailed backlog.
 
 ### Security (most shipped in v0.7.0; residuals)
+
 - [x] HTTP bridge **bearer token** (required, OPTIONS preflight exempt), fail-closed
       on non-loopback bind, 4 MB body cap, sanitized reflected headers, `catch_unwind`
       per request. Closed the credential-CSRF (a browser tab can reach `localhost`).
@@ -113,6 +118,7 @@ The 2026-07-01 block above supersedes the ordering; these remain the detailed ba
       longer blocks other callers. (A per-request read timeout for slowloris is still open.)
 
 ### New-user UX (first 10 minutes; scaffolding is strong, these are the sharp edges)
+
 - [ ] **Backend failures render as innocent empty states.** Gateway down ->
       Activity shows "No tool calls yet", not "can't reach backend, retry".
       Distinguish error from empty (CatalogView already does). Top UX fix. (M)
@@ -126,6 +132,7 @@ The 2026-07-01 block above supersedes the ordering; these remain the detailed ba
       `vendorFromKey` fallback for unknown keys. (S each)
 
 ### Robustness / tech debt
+
 - [ ] **Tool-cache versioning.** The gateway serves the on-disk cache verbatim with
       no version tag, so catalog-logic changes don't take effect until a server
       toggles or the cache is deleted. Wrap in `{version, tools}`, discard on
@@ -137,6 +144,7 @@ The 2026-07-01 block above supersedes the ordering; these remain the detailed ba
       `semantic.rs` (blend math, embed cache). (M)
 
 ### Strategic / differentiators (what makes it amazing)
+
 - [ ] **OAuth client registration + per-client server scoping.** A client
       authenticates to Toolport, shows up in the app, you assign which servers it
       sees. Profiles already do half. This is Sigiz's explicit ask AND the proper
@@ -158,6 +166,7 @@ The 2026-07-01 block above supersedes the ordering; these remain the detailed ba
       publish pending) as the funnel + a demo of lazy discovery + result-shaping.
 
 **Community-requested (2026-07-03, r/LocalLLaMA launch thread):**
+
 - [x] **Lazy-discovery search trace / observability.** Shipped (#114) as the Activity
       **Discovery** panel: every `toolport_search_tools` call records the query, the
       matched tool names, which won (top), and the ground-truth per-turn token overhead
@@ -215,16 +224,16 @@ flips every weakness:
   machine. All servers moved to connectors.
 - Connectors + OAuth tokens live in `%APPDATA%\Claude\config.json` as
   **DPAPI-encrypted** blobs (Chromium safeStorage, `v10` prefix). Not readable.
-- Connector *names* (Clerk, GitHub, Pax8, revenuecat, Supabase, Vercel, Stripe,
+- Connector _names_ (Clerk, GitHub, Pax8, revenuecat, Supabase, Vercel, Stripe,
   expo) DO appear in plaintext in the Chromium LevelDB/IndexedDB stores for the
   `claude.ai` origin.
 - BUT those stores are **locked while Claude is running**, the schema is
   undocumented Chromium IndexedDB, and the real source of truth is the user's
   Anthropic account (server-side sync), not a local file.
 
-**Verdict:** local read-only *inventory* of connector names is possible but
+**Verdict:** local read-only _inventory_ of connector names is possible but
 fragile and operationally awkward (locked DBs, undocumented schema, account-side
-truth). It is NOT a foundation to build *management* on. This confirms the
+truth). It is NOT a foundation to build _management_ on. This confirms the
 gateway architecture: Toolport cannot manage Claude's connectors directly, so it
 becomes one connector that fans out to everything it manages. A best-effort,
 read-only "connectors detected (view-only)" panel is worth showing for the
@@ -243,6 +252,7 @@ mutate their live client setup unattended).
 ## Build order
 
 Phase 0 - Foundation
+
 - [x] Tauri + React + Rust scaffold, 0 vulns
 - [x] Client adapter readers (import/discovery): detect clients, parse JSON/TOML
 - [x] Toolport registry: own source-of-truth store (servers, profiles, enabled)
@@ -252,6 +262,7 @@ Phase 0 - Foundation
 - [x] OS keychain module for secrets
 
 Phase 1 - The gateway
+
 - [x] MCP stdio server (initialize, tools/list, tools/call)
 - [x] Downstream MCP client: spawn/connect real servers, multiplex tools (namespaced)
 - [x] Live reconfig + `tools/list_changed` on toggle (registry file watcher)
@@ -262,6 +273,7 @@ Phase 1 - The gateway
 - [x] Tool-name sanitizing (clients drop hyphenated names) + cache-poisoning guard
 
 Phase 1.5 - Remote auth
+
 - [x] Token auth: vault a bearer token per http server, injected by gateway
 - [x] OAuth 2.1 flow: discovery + DCR + PKCE + loopback + exchange
 - [x] OAuth token refresh on 401/expiry
@@ -269,6 +281,7 @@ Phase 1.5 - Remote auth
       vendor hints, live propagation to connected clients
 
 Phase 2 - Client integration
+
 - [x] "Install Toolport into client X" (surgical, backs up, preserves others)
 - [x] Uninstall (surgical remove)
 - [x] Client detail reframed as connect + import sources
@@ -281,6 +294,7 @@ Phase 2 - Client integration
       the packaged `-<triple>` name). Shipping in signed releases.
 
 Phase 3 - Scaling & UX
+
 - [x] Lazy discovery: `CONDUIT_DISCOVERY=lazy` exposes 3 meta-tools (search/call)
 - [x] Per-agent scoping: `CONDUIT_PROFILE` + per-client profile picker, per-profile cache
 - [x] Catalog: curated popular set + live official MCP Registry search, type-ahead
@@ -289,6 +303,7 @@ Phase 3 - Scaling & UX
 ## Next (tiered)
 
 Tier 2 - feature completeness (in progress)
+
 - [x] Per-tool enable/disable + destructive-tool deny-list (UI toggles; gateway
       hides+blocks; global destructiveHint switch)
 - [x] Tool playground: invoke any tool from the app and see the result
@@ -306,7 +321,7 @@ Tier 2 - feature completeness (in progress)
       into the lexical ranker so paraphrased needs surface the right tool. Pluggable
       `/v1/embeddings` endpoint, disk-cached, lexical fallback. Recall measured by
       `benchmark/retrieval.mjs`. See `docs/specs/semantic-search.md`.
-- [x] Content defense (agentjacking): scan untrusted tool *results* for injection and
+- [x] Content defense (agentjacking): scan untrusted tool _results_ for injection and
       wrap flagged content with a "data, not instructions" provenance marker before the
       agent sees it. Detection + labeling, never blocks, on by default. See
       `docs/specs/content-defense.md`.
@@ -314,6 +329,7 @@ Tier 2 - feature completeness (in progress)
       taxonomy; opt-in lossy result shaping / dangerous-call gating (content-defense Tier 2).
 
 Tier 3 - launch prep
+
 - [x] Bundle the gateway sidecar; signed/notarized macOS installers (Win/Linux
       unsigned with documented bypass); cargo-audit in CI.
 - [x] Verify macOS / Linux (signed mac dmgs arm64 + Intel, Linux deb/AppImage;
@@ -327,13 +343,14 @@ Tier 3 - launch prep
 - [x] Launch: Product Hunt, MCP registries (Glama/mcp.so/awesome-mcp listed)
 
 Tier 4 - teams / enterprise (paid)
+
 - [ ] Hosted/remote gateway, shared/synced config, RBAC/SSO
 - [ ] Policy engine (allow/deny tools, approval gates), audit export
 - [ ] Secret-vault integrations (1Password, Vault, cloud secret managers)
 
 ## Security invariants (do not regress)
 
-- Backend never sends secret *values* to the UI; env var names only.
+- Backend never sends secret _values_ to the UI; env var names only.
 - Secrets live in the OS keychain, never in Toolport's registry file or any
   client config.
 - Snapshot every client config before modifying it; modifications are reversible.

--- a/docs/SIGNING.md
+++ b/docs/SIGNING.md
@@ -11,12 +11,12 @@ self-signed certificate does not help end users.
 
 ## Options
 
-| Option | Cost | Notes |
-|---|---|---|
-| **Azure Trusted Signing** | ~$10/month | Cheapest real option. Cloud-based, no cert file to manage. Requires an Azure account and identity verification; orgs need 3+ years of history (individuals are eligible). Chains to a Microsoft-operated trusted root and shows your validated publisher name. It is **standard, not EV**, signing, so SmartScreen reputation still accrues with downloads and an early install may still warn. |
-| **OV certificate** (Sectigo, DigiCert, etc.) | ~$100 to $400/year | Standard cert. SmartScreen reputation builds over time/downloads, so early downloads may still warn briefly. Usually requires a hardware token (or cloud HSM) now. |
-| **EV certificate** | ~$300 to $600/year | Instant SmartScreen reputation, no warning from day one. Hardware token required. |
-| **Ship unsigned (interim)** | free | Fine for an early beta. Users click "More info → Run anyway". Document the bypass in release notes. |
+| Option                                       | Cost               | Notes                                                                                                                                                                                                                                                                                                                                                                                           |
+| -------------------------------------------- | ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Azure Trusted Signing**                    | ~$10/month         | Cheapest real option. Cloud-based, no cert file to manage. Requires an Azure account and identity verification; orgs need 3+ years of history (individuals are eligible). Chains to a Microsoft-operated trusted root and shows your validated publisher name. It is **standard, not EV**, signing, so SmartScreen reputation still accrues with downloads and an early install may still warn. |
+| **OV certificate** (Sectigo, DigiCert, etc.) | ~$100 to $400/year | Standard cert. SmartScreen reputation builds over time/downloads, so early downloads may still warn briefly. Usually requires a hardware token (or cloud HSM) now.                                                                                                                                                                                                                              |
+| **EV certificate**                           | ~$300 to $600/year | Instant SmartScreen reputation, no warning from day one. Hardware token required.                                                                                                                                                                                                                                                                                                               |
+| **Ship unsigned (interim)**                  | free               | Fine for an early beta. Users click "More info → Run anyway". Document the bypass in release notes.                                                                                                                                                                                                                                                                                             |
 
 For a pre-launch beta with no budget, shipping unsigned and documenting the
 bypass is the pragmatic choice. Reputation also accrues as more people run it.
@@ -61,6 +61,7 @@ the bundled gateway sidecar, and the NSIS installer during the build (before the
 updater `.sig` is computed, so auto-update keeps working).
 
 **One-time Azure setup:**
+
 1. Create an **Artifact Signing (Trusted Signing) account** + complete **Individual**
    identity validation, then create a **Public Trust certificate profile**. Note the
    account name, the certificate profile name, and the account's endpoint URI (e.g.
@@ -68,24 +69,24 @@ updater `.sig` is computed, so auto-update keeps working).
 2. Create a **service principal** for CI (Entra ID → App registrations → new
    registration → add a client secret).
 3. On the signing **account → Access control (IAM)**, assign that app the
-   **"Trusted Signing Certificate Profile Signer"** role (this is the *signer* role,
-   distinct from the *Identity Verifier* role you assign to yourself).
+   **"Trusted Signing Certificate Profile Signer"** role (this is the _signer_ role,
+   distinct from the _Identity Verifier_ role you assign to yourself).
 
 **GitHub secrets to add** (Settings → Secrets and variables → Actions → Secrets):
 
-| Secret | Value |
-|---|---|
-| `AZURE_TENANT_ID` | the app registration's Directory (tenant) ID |
-| `AZURE_CLIENT_ID` | the app registration's Application (client) ID |
-| `AZURE_CLIENT_SECRET` | the client secret value |
+| Secret                | Value                                          |
+| --------------------- | ---------------------------------------------- |
+| `AZURE_TENANT_ID`     | the app registration's Directory (tenant) ID   |
+| `AZURE_CLIENT_ID`     | the app registration's Application (client) ID |
+| `AZURE_CLIENT_SECRET` | the client secret value                        |
 
 **GitHub variables to add** (same page → Variables tab):
 
-| Variable | Value |
-|---|---|
-| `AZURE_SIGNING_PROFILE` | your certificate profile name (**required**) |
+| Variable                 | Value                                                     |
+| ------------------------ | --------------------------------------------------------- |
+| `AZURE_SIGNING_PROFILE`  | your certificate profile name (**required**)              |
 | `AZURE_SIGNING_ENDPOINT` | optional, defaults to `https://eus.codesigning.azure.net` |
-| `AZURE_SIGNING_ACCOUNT` | optional, defaults to `southforgesigning` |
+| `AZURE_SIGNING_ACCOUNT`  | optional, defaults to `southforgesigning`                 |
 
 With those set, the next `v*` tag produces a **signed** Windows installer. SmartScreen
 reputation still accrues with downloads, but the "unknown publisher" warning is gone
@@ -123,14 +124,14 @@ Developer ID cert (not an iOS distribution cert).
 The release workflow already passes these env vars to the macOS build; set them as
 repository secrets (Settings → Secrets and variables → Actions):
 
-| Secret | Value |
-|---|---|
-| `APPLE_CERTIFICATE` | base64 of the `.p12`: `base64 -i cert.p12 \| pbcopy` |
-| `APPLE_CERTIFICATE_PASSWORD` | the password you set when exporting the `.p12` |
-| `APPLE_SIGNING_IDENTITY` | `Developer ID Application: Your Name (TEAMID)` (exact string from Keychain Access) |
-| `APPLE_ID` | your Apple ID email |
-| `APPLE_PASSWORD` | the app-specific password from step 3 |
-| `APPLE_TEAM_ID` | the 10-char Team ID |
+| Secret                       | Value                                                                              |
+| ---------------------------- | ---------------------------------------------------------------------------------- |
+| `APPLE_CERTIFICATE`          | base64 of the `.p12`: `base64 -i cert.p12 \| pbcopy`                               |
+| `APPLE_CERTIFICATE_PASSWORD` | the password you set when exporting the `.p12`                                     |
+| `APPLE_SIGNING_IDENTITY`     | `Developer ID Application: Your Name (TEAMID)` (exact string from Keychain Access) |
+| `APPLE_ID`                   | your Apple ID email                                                                |
+| `APPLE_PASSWORD`             | the app-specific password from step 3                                              |
+| `APPLE_TEAM_ID`              | the 10-char Team ID                                                                |
 
 With those set, a tagged build produces a **signed, notarized** `.dmg`, no
 Gatekeeper warning. Without them, the macOS build is simply unsigned (and users

--- a/docs/design/hitl-approval-queue.md
+++ b/docs/design/hitl-approval-queue.md
@@ -4,10 +4,10 @@ Status: P1 IMPLEMENTED in PR #82 (2026-07-02, rev 2 architecture). Remaining bef
 
 ## Goal
 
-Let a human approve or deny sensitive tool calls *out-of-band* before they execute,
+Let a human approve or deny sensitive tool calls _out-of-band_ before they execute,
 holding the call until a decision (or a fail-closed timeout). Distinct from the existing
-**agent-facing** `toolport_confirm`, where the *model* re-confirms its own destructive
-call. HITL puts a *person* in the loop through the Toolport app. This is a genuine
+**agent-facing** `toolport_confirm`, where the _model_ re-confirms its own destructive
+call. HITL puts a _person_ in the loop through the Toolport app. This is a genuine
 security differentiator (the "approval queue" gap vs. Lunar MCPX / IBM ContextForge), so
 it is worth building to a high bar rather than the minimal one.
 
@@ -44,6 +44,7 @@ readable only by processes that can already read `~/.conduit/`, the same trust b
 secrets).
 
 Flow for a gated call:
+
 1. Gateway (`process_request`) reads the endpoint+token, **connects to the app**, and sends
    `{ client, server, tool, args, provenance, ts }` authenticated by the token.
 2. The app shows it in a **Pending Approvals** queue (ActivityView) plus a prominent OS
@@ -54,7 +55,7 @@ Flow for a gated call:
 
 **Why this is the best-in-class choice, it wins on every axis the two alternatives lose:**
 
-- **Coverage:** every gateway process dials *out* to the one app broker, so stdio clients
+- **Coverage:** every gateway process dials _out_ to the one app broker, so stdio clients
   are covered, not just the app's own `--http` gateway.
 - **No args on disk:** arguments travel over the socket and stay in memory. The disk only
   ever holds the endpoint descriptor (no payloads). This is the decisive privacy win.
@@ -79,7 +80,7 @@ Flow for a gated call:
 1. **Blocking, not async.** Hold the agent's call until a decision; the agent just sees a
    slower tool and gets the real result or a denial. Async (return-pending-then-replay)
    leaks approval mechanics into the agent and creates a "looks failed" window. A parked
-   call blocking that client's *other* calls is acceptable and arguably desirable (don't let
+   call blocking that client's _other_ calls is acceptable and arguably desirable (don't let
    the agent race ahead of a pending sensitive action); other clients are separate processes
    and unaffected.
 2. **Scope: layered, security-first default.** v1 gates (a) `destructiveHint` tools AND

--- a/docs/macos-keychain-test-runbook.md
+++ b/docs/macos-keychain-test-runbook.md
@@ -48,6 +48,7 @@ APP=/path/to/Toolport.app ./scripts/macos-sign-local.sh
 ```
 
 The script:
+
 - moves the gateway into `Toolport.app/Contents/Helpers/ConduitGateway.app`,
 - embeds the gateway provisioning profile there,
 - leaves a symlink at the old bare path for backward compat,

--- a/docs/screenshots/README.md
+++ b/docs/screenshots/README.md
@@ -2,10 +2,10 @@
 
 Drop PNGs here with these exact names; the main README references them.
 
-| File | Capture |
-|---|---|
-| `servers.png` | The "All servers" view, with a few servers and their status dots. |
-| `activity.png` | The Activity view showing the per-server latency / error-rate panel. |
+| File             | Capture                                                                                                            |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------ |
+| `servers.png`    | The "All servers" view, with a few servers and their status dots.                                                  |
+| `activity.png`   | The Activity view showing the per-server latency / error-rate panel.                                               |
 | `playground.png` | The Playground: the lazy-discovery + destructive-tool switches and a tool's argument form (ideally with a result). |
 
 How to capture on Windows: `Win` + `Shift` + `S`, drag over the app window,

--- a/glama.json
+++ b/glama.json
@@ -1,6 +1,4 @@
 {
   "$schema": "https://glama.ai/mcp/schemas/server.json",
-  "maintainers": [
-    "tsouth89"
-  ]
+  "maintainers": ["tsouth89"]
 }

--- a/index.html
+++ b/index.html
@@ -2,7 +2,10 @@
 <html lang="en" class="dark">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 512 512'%3E%3Ccircle cx='256' cy='256' r='195' fill='none' stroke='%231E3A66' stroke-width='90'/%3E%3Ccircle cx='256' cy='256' r='52' fill='%23F97316'/%3E%3C/svg%3E" />
+    <link
+      rel="icon"
+      href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 512 512'%3E%3Ccircle cx='256' cy='256' r='195' fill='none' stroke='%231E3A66' stroke-width='90'/%3E%3Ccircle cx='256' cy='256' r='52' fill='%23F97316'/%3E%3C/svg%3E"
+    />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Toolport</title>
   </head>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "conduit",
-  "version": "1.0.1",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "conduit",
-      "version": "1.0.1",
+      "version": "1.2.0",
       "dependencies": {
         "@fontsource-variable/geist": "^5.2.9",
         "@tailwindcss/vite": "^4.3.1",
@@ -34,6 +34,7 @@
         "@types/react": "^19.1.8",
         "@types/react-dom": "^19.1.6",
         "@vitejs/plugin-react": "^4.6.0",
+        "prettier": "^3.9.4",
         "typescript": "~5.8.3",
         "vite": "^7.0.4"
       }
@@ -6558,6 +6559,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.9.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.4.tgz",
+      "integrity": "sha512-yWG/o/4oJfo036EKAfK6ACAoDOfHeRHx4tuxkfBZiauURiaSmYwlpOr5LQqKtIkRD2z1PLteme2WoxEnj4tHTg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/pretty-ms": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     "build:gateway": "cargo build --manifest-path src-tauri/Cargo.toml --bin conduit-gateway",
     "prepare:sidecar": "node scripts/prepare-sidecar.mjs",
     "build:bundle": "npm run build && npm run prepare:sidecar",
-    "tauri:bundle": "tauri build --config src-tauri/tauri.bundle.conf.json --bundles nsis"
+    "tauri:bundle": "tauri build --config src-tauri/tauri.bundle.conf.json --bundles nsis",
+    "format": "prettier --write .",
+    "format:check": "prettier --check ."
   },
   "dependencies": {
     "@fontsource-variable/geist": "^5.2.9",
@@ -40,6 +42,7 @@
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
     "@vitejs/plugin-react": "^4.6.0",
+    "prettier": "^3.9.4",
     "typescript": "~5.8.3",
     "vite": "^7.0.4"
   },

--- a/scripts/prepare-sidecar.mjs
+++ b/scripts/prepare-sidecar.mjs
@@ -7,7 +7,14 @@
 // triple (e.g. "x86_64-apple-darwin") to cross-build the gateway for that target.
 // Pass `--debug` to stage a debug build instead.
 import { execSync } from "node:child_process";
-import { mkdirSync, copyFileSync, existsSync, writeFileSync, chmodSync, rmSync } from "node:fs";
+import {
+  mkdirSync,
+  copyFileSync,
+  existsSync,
+  writeFileSync,
+  chmodSync,
+  rmSync,
+} from "node:fs";
 import { join } from "node:path";
 
 function hostTriple() {
@@ -32,7 +39,9 @@ function gatewayPathFor(triple) {
 
 function buildGateway(triple) {
   const targetArg = triple ? `--target ${triple} ` : "";
-  console.log(`[sidecar] building conduit-gateway (${profile}) ${triple ? "for " + triple : "(host)"}`);
+  console.log(
+    `[sidecar] building conduit-gateway (${profile}) ${triple ? "for " + triple : "(host)"}`,
+  );
   execSync(`cargo build ${debug ? "" : "--release "}${targetArg}--bin conduit-gateway`, {
     cwd: "src-tauri",
     stdio: "inherit",

--- a/src-tauri/tauri.bundle.conf.json
+++ b/src-tauri/tauri.bundle.conf.json
@@ -5,8 +5,6 @@
   },
   "bundle": {
     "createUpdaterArtifacts": true,
-    "externalBin": [
-      "binaries/conduit-gateway"
-    ]
+    "externalBin": ["binaries/conduit-gateway"]
   }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -241,9 +241,7 @@ function App() {
     const h = health[s.id];
     return h && !h.ok ? "attention" : "active";
   };
-  const attentionCount = servers.filter(
-    (s) => groupOf(s) === "attention",
-  ).length;
+  const attentionCount = servers.filter((s) => groupOf(s) === "attention").length;
 
   const q = query.trim().toLowerCase();
   const matches = (s: ServerEntry) =>
@@ -279,10 +277,8 @@ function App() {
   // (which flips gatewayInstalled) doesn't unmount the dialog. Existing users,
   // and anyone who has dismissed it, never see it.
   useEffect(() => {
-    if (onboarded || showOnboarding || resumeAtConnect || loading || !registry)
-      return;
-    const fresh =
-      servers.length === 0 && !clients.some((c) => c.gatewayInstalled);
+    if (onboarded || showOnboarding || resumeAtConnect || loading || !registry) return;
+    const fresh = servers.length === 0 && !clients.some((c) => c.gatewayInstalled);
     if (fresh) setShowOnboarding(true);
   }, [
     onboarded,
@@ -438,9 +434,7 @@ function App() {
                             : loading || !registry
                               ? "Loading…"
                               : `${enabledCount} of ${servers.length} enabled` +
-                                (connectedCount
-                                  ? ` · ${connectedCount} connected`
-                                  : "") +
+                                (connectedCount ? ` · ${connectedCount} connected` : "") +
                                 (attentionCount
                                   ? ` · ${attentionCount} need${attentionCount === 1 ? "s" : ""} attention`
                                   : "")}
@@ -475,7 +469,7 @@ function App() {
                       </Button>
                     </DropdownMenuTrigger>
 
-                   <DropdownMenuContent align="end" className="w-38">
+                    <DropdownMenuContent align="end" className="w-38">
                       <DropdownMenuItem onClick={handleImport}>
                         <Download className="mr-2 size-4" />
                         <span>Import</span>
@@ -489,7 +483,11 @@ function App() {
                           // while a search is active: it acts on ALL servers, so it must
                           // not silently toggle ones hidden by the filter.
                           disabled={togglingAll || busyId !== null || query.trim() !== ""}
-                          title={query.trim() !== "" ? "Clear the search to enable or disable all servers" : undefined}
+                          title={
+                            query.trim() !== ""
+                              ? "Clear the search to enable or disable all servers"
+                              : undefined
+                          }
                         >
                           <ServerOff className="mr-2 size-4" />
                           <span>
@@ -528,70 +526,67 @@ function App() {
                   </div>
                 }
               >
-              {view === "activity" ? (
-                <ActivityView refreshKey={activityKey} registry={registry} />
-              ) : view === "catalog" ? (
-                <CatalogView registry={registry} onAdded={setRegistry} />
-              ) : view === "playground" ? (
-                <PlaygroundView
-                  registry={registry}
-                  onRegistryChange={setRegistry}
-                />
-              ) : view === "teams" ? (
-                <TeamsView registry={registry} onRegistryChange={setRegistry} />
-              ) : view === "settings" ? (
-                <SettingsView registry={registry} onRegistryChange={setRegistry} />
-              ) : selectedClient ? (
-                <ClientDetail
-                  client={selectedClient}
-                  registry={registry}
-                  onChanged={load}
-                  onRegistryChange={setRegistry}
-                />
-              ) : loading && registry === null ? (
-                <div className="flex flex-col gap-2">
-                  {Array.from({ length: 6 }).map((_, i) => (
-                    <Skeleton key={i} className="h-11 w-full rounded-lg" />
-                  ))}
-                </div>
-              ) : error ? (
-                <ErrorState message={error} />
-              ) : servers.length === 0 ? (
-                <EmptyState
-                  importable={importable}
-                  onImport={handleImport}
-                  onBrowseCatalog={() => selectView("catalog")}
-                />
-              ) : visible.length === 0 ? (
-                <div className="py-16 text-center text-sm text-muted-foreground">
-                  No servers match "{query}".
-                </div>
-              ) : (
-                <div className="flex flex-col gap-5">
-                  <ServerGroup
-                    title="Needs attention"
-                    dot="bg-warning"
-                    count={grouped.attention.length}
-                  >
-                    {grouped.attention.map(serverRow)}
-                  </ServerGroup>
-                  <ServerGroup
-                    title="Active"
-                    dot="bg-success"
-                    count={grouped.active.length}
-                  >
-                    {grouped.active.map(serverRow)}
-                  </ServerGroup>
-                  <ServerGroup
-                    title="Disabled"
-                    dot="bg-muted-foreground/40"
-                    count={grouped.disabled.length}
-                    defaultCollapsed
-                  >
-                    {grouped.disabled.map(serverRow)}
-                  </ServerGroup>
-                </div>
-              )}
+                {view === "activity" ? (
+                  <ActivityView refreshKey={activityKey} registry={registry} />
+                ) : view === "catalog" ? (
+                  <CatalogView registry={registry} onAdded={setRegistry} />
+                ) : view === "playground" ? (
+                  <PlaygroundView registry={registry} onRegistryChange={setRegistry} />
+                ) : view === "teams" ? (
+                  <TeamsView registry={registry} onRegistryChange={setRegistry} />
+                ) : view === "settings" ? (
+                  <SettingsView registry={registry} onRegistryChange={setRegistry} />
+                ) : selectedClient ? (
+                  <ClientDetail
+                    client={selectedClient}
+                    registry={registry}
+                    onChanged={load}
+                    onRegistryChange={setRegistry}
+                  />
+                ) : loading && registry === null ? (
+                  <div className="flex flex-col gap-2">
+                    {Array.from({ length: 6 }).map((_, i) => (
+                      <Skeleton key={i} className="h-11 w-full rounded-lg" />
+                    ))}
+                  </div>
+                ) : error ? (
+                  <ErrorState message={error} />
+                ) : servers.length === 0 ? (
+                  <EmptyState
+                    importable={importable}
+                    onImport={handleImport}
+                    onBrowseCatalog={() => selectView("catalog")}
+                  />
+                ) : visible.length === 0 ? (
+                  <div className="py-16 text-center text-sm text-muted-foreground">
+                    No servers match "{query}".
+                  </div>
+                ) : (
+                  <div className="flex flex-col gap-5">
+                    <ServerGroup
+                      title="Needs attention"
+                      dot="bg-warning"
+                      count={grouped.attention.length}
+                    >
+                      {grouped.attention.map(serverRow)}
+                    </ServerGroup>
+                    <ServerGroup
+                      title="Active"
+                      dot="bg-success"
+                      count={grouped.active.length}
+                    >
+                      {grouped.active.map(serverRow)}
+                    </ServerGroup>
+                    <ServerGroup
+                      title="Disabled"
+                      dot="bg-muted-foreground/40"
+                      count={grouped.disabled.length}
+                      defaultCollapsed
+                    >
+                      {grouped.disabled.map(serverRow)}
+                    </ServerGroup>
+                  </div>
+                )}
               </Suspense>
             </div>
           </ScrollArea>
@@ -599,21 +594,21 @@ function App() {
       </div>
       {showOnboarding && registry && (
         <Suspense fallback={null}>
-        <Onboarding
-          key={onboardingStep}
-          initialStep={onboardingStep}
-          clients={clients}
-          registry={registry}
-          onRegistryChange={setRegistry}
-          onClientsRefresh={load}
-          onBrowseCatalog={() => {
-            setShowOnboarding(false);
-            setResumeAtConnect(true);
-            selectView("catalog");
-          }}
-          onProbe={reprobe}
-          onFinish={finishOnboarding}
-        />
+          <Onboarding
+            key={onboardingStep}
+            initialStep={onboardingStep}
+            clients={clients}
+            registry={registry}
+            onRegistryChange={setRegistry}
+            onClientsRefresh={load}
+            onBrowseCatalog={() => {
+              setShowOnboarding(false);
+              setResumeAtConnect(true);
+              selectView("catalog");
+            }}
+            onProbe={reprobe}
+            onFinish={finishOnboarding}
+          />
         </Suspense>
       )}
       <PendingApprovals />
@@ -724,19 +719,14 @@ function ErrorState({ message }: { message: string }) {
           {import.meta.env.DEV ? (
             <>
               Make sure you're running the desktop app with{" "}
-              <code className="font-mono">npm run tauri dev</code>, not the
-              browser-only dev server.
+              <code className="font-mono">npm run tauri dev</code>, not the browser-only
+              dev server.
             </>
           ) : (
-            <>
-              Toolport's backend didn't start. Try quitting and reopening the
-              app.
-            </>
+            <>Toolport's backend didn't start. Try quitting and reopening the app.</>
           )}
         </p>
-        <p className="mt-2 font-mono text-xs text-muted-foreground/70">
-          {message}
-        </p>
+        <p className="mt-2 font-mono text-xs text-muted-foreground/70">{message}</p>
       </div>
     </div>
   );

--- a/src/components/ActivityView.tsx
+++ b/src/components/ActivityView.tsx
@@ -195,9 +195,9 @@ function SecurityResting() {
     <div className="mb-4 flex items-center gap-2 rounded-lg border border-border/60 bg-muted/30 px-4 py-2.5 text-xs text-muted-foreground">
       <ShieldCheck className="size-4 shrink-0 text-owned" />
       <span>
-        <span className="font-medium text-foreground">Protection active.</span>{" "}
-        Toolport watches every tool for tampering (rug pulls), poisoned definitions,
-        and injected output (agentjacking). No issues right now.
+        <span className="font-medium text-foreground">Protection active.</span> Toolport
+        watches every tool for tampering (rug pulls), poisoned definitions, and injected
+        output (agentjacking). No issues right now.
       </span>
     </div>
   );
@@ -224,9 +224,7 @@ function SecurityNotices({
         className="flex w-full items-center gap-2 text-left"
       >
         <ShieldAlert className="size-4 shrink-0 text-warning" />
-        <h3 className="text-sm font-medium text-warning">
-          Tool security notices
-        </h3>
+        <h3 className="text-sm font-medium text-warning">Tool security notices</h3>
         <span className="rounded-full bg-warning/15 px-1.5 py-0.5 text-xs font-medium text-warning">
           {events.length}
         </span>
@@ -240,19 +238,17 @@ function SecurityNotices({
         <>
           <p className="mt-2 mb-3 max-w-2xl text-xs text-muted-foreground">
             A tool changed after you approved it, a tool's definition contains
-            instruction-like content, or a tool returned data that looks like
-            injected instructions. Usually benign, but it's how rug pulls, tool
-            poisoning, and agentjacking work, so Toolport flags it (and labels
-            suspicious tool output as data). Dismiss the ones you've reviewed.
+            instruction-like content, or a tool returned data that looks like injected
+            instructions. Usually benign, but it's how rug pulls, tool poisoning, and
+            agentjacking work, so Toolport flags it (and labels suspicious tool output as
+            data). Dismiss the ones you've reviewed.
           </p>
           <ul className="space-y-1.5 text-xs">
             {events.slice(0, 10).map((e) => {
               const badge = eventBadge(e);
               return (
                 <li key={renderKey(e)} className="flex items-center gap-2">
-                  <span
-                    className={`rounded px-1.5 py-0.5 font-medium ${badge.cls}`}
-                  >
+                  <span className={`rounded px-1.5 py-0.5 font-medium ${badge.cls}`}>
                     {badge.label}
                   </span>
                   <code className="font-mono text-foreground">{e.tool}</code>
@@ -400,9 +396,7 @@ function SavingsBanner({ savings }: { savings: SavingsSummary }) {
       <div className="mt-2 flex flex-wrap items-end gap-x-6 gap-y-1">
         <span className="text-3xl font-semibold tabular-nums text-success">
           ≈ {fmtTokens(savings.tokensSaved)}{" "}
-          <span className="text-base font-normal text-muted-foreground">
-            tokens
-          </span>
+          <span className="text-base font-normal text-muted-foreground">tokens</span>
         </span>
         <span className="text-xl font-semibold tabular-nums text-muted-foreground">
           ≈ {fmtDollars(dollars)}
@@ -440,8 +434,8 @@ function SavingsBanner({ savings }: { savings: SavingsSummary }) {
         </button>
       </div>
       <p className="mt-2.5 text-xs text-muted-foreground">
-        {details.join(" · ")}. Estimated, counted once per tool-list load. Clients
-        with built-in tool search (Claude, VS Code) benefit less.
+        {details.join(" · ")}. Estimated, counted once per tool-list load. Clients with
+        built-in tool search (Claude, VS Code) benefit less.
       </p>
     </div>
   );
@@ -533,9 +527,7 @@ function CallRow({ e }: { e: AuditEntry }) {
           hasDetail ? "cursor-pointer hover:bg-muted/30" : ""
         }`}
         onClick={() => hasDetail && setOpen((o) => !o)}
-        {...(hasDetail
-          ? { role: "button", "aria-expanded": open, tabIndex: 0 }
-          : {})}
+        {...(hasDetail ? { role: "button", "aria-expanded": open, tabIndex: 0 } : {})}
       >
         {hasDetail ? (
           <ChevronRight
@@ -590,18 +582,12 @@ function StatsPanel({ stats }: { stats: AuditStats }) {
     <div className="mb-6 flex flex-col gap-3">
       <div className="grid grid-cols-3 gap-3">
         <div className="rounded-lg border p-3">
-          <div className="text-2xl font-semibold tabular-nums">
-            {stats.total}
-          </div>
+          <div className="text-2xl font-semibold tabular-nums">{stats.total}</div>
           <div className="text-xs text-muted-foreground">calls logged</div>
         </div>
         <div className="rounded-lg border p-3">
-          <div className="text-2xl font-semibold tabular-nums">
-            {stats.errors}
-          </div>
-          <div className="text-xs text-muted-foreground">
-            errors ({errPct}%)
-          </div>
+          <div className="text-2xl font-semibold tabular-nums">{stats.errors}</div>
+          <div className="text-xs text-muted-foreground">errors ({errPct}%)</div>
         </div>
         <div className="rounded-lg border p-3">
           <div className="text-2xl font-semibold tabular-nums">
@@ -754,7 +740,9 @@ function DiscoveryRow({ t }: { t: SearchTrace }) {
                 <span
                   key={n}
                   className={`rounded px-1.5 py-0.5 font-mono text-[11px] ${
-                    n === t.top ? "bg-owned/15 text-owned" : "bg-muted text-muted-foreground"
+                    n === t.top
+                      ? "bg-owned/15 text-owned"
+                      : "bg-muted text-muted-foreground"
                   }`}
                 >
                   {n}
@@ -766,10 +754,14 @@ function DiscoveryRow({ t }: { t: SearchTrace }) {
           )}
           <div className="text-muted-foreground">
             Put{" "}
-            <span className="font-medium text-foreground">≈{fmtTokens(t.returnedTokens)}</span>{" "}
+            <span className="font-medium text-foreground">
+              ≈{fmtTokens(t.returnedTokens)}
+            </span>{" "}
             tokens of tool schemas into context, vs{" "}
-            <span className="font-medium text-foreground">≈{fmtTokens(t.flatTokens)}</span> to load
-            the whole catalog
+            <span className="font-medium text-foreground">
+              ≈{fmtTokens(t.flatTokens)}
+            </span>{" "}
+            to load the whole catalog
             {t.flatTokens > 0 ? <> ({pct}% less this turn).</> : "."}
           </div>
         </div>
@@ -934,9 +926,9 @@ function ToolIdentities({ refreshKey }: { refreshKey: number }) {
         <>
           <p className="mt-2 mb-3 max-w-2xl text-xs text-muted-foreground">
             What each model-visible tool name actually maps to: its source server and
-            profiles, the pinned definition fingerprint drift detection checks against, and
-            when it was first seen or last changed. Prefixing helps the model pick a tool;
-            this helps you verify what crossed the boundary.
+            profiles, the pinned definition fingerprint drift detection checks against,
+            and when it was first seen or last changed. Prefixing helps the model pick a
+            tool; this helps you verify what crossed the boundary.
           </p>
           <div className="flex flex-col gap-1">
             {rows.map((t) => (
@@ -987,10 +979,10 @@ function LiveInspector({ refreshKey }: { refreshKey: number }) {
       {open && (
         <>
           <p className="mt-2 mb-3 max-w-2xl text-xs text-muted-foreground">
-            Ephemeral, local, opt-in. While live inspection is on, Toolport keeps the
-            last 50 tool calls' arguments and results here so you can inspect them.
-            This buffer is separate from the audit log, never leaves your machine, and
-            clears when you turn inspection off or restart the gateway.
+            Ephemeral, local, opt-in. While live inspection is on, Toolport keeps the last
+            50 tool calls' arguments and results here so you can inspect them. This buffer
+            is separate from the audit log, never leaves your machine, and clears when you
+            turn inspection off or restart the gateway.
           </p>
           {entries.length === 0 ? (
             <p className="py-6 text-center text-sm text-muted-foreground">
@@ -1057,7 +1049,9 @@ export function ActivityView({
     };
   }, [refreshKey]);
 
-  const liveSecurity = dedupeSecurity(security).filter((e) => !dismissed.has(securityKey(e)));
+  const liveSecurity = dedupeSecurity(security).filter(
+    (e) => !dismissed.has(securityKey(e)),
+  );
   // Split loud/actionable signal from benign churn so vendor revisions don't bury a real
   // poison or privilege-escalation flag (the failure this whole surface exists to avoid).
   const highSecurity = liveSecurity.filter((e) => eventSeverity(e) === "high");
@@ -1088,9 +1082,7 @@ export function ActivityView({
       <DiscoveryTraces refreshKey={refreshKey} />
       <ToolIdentities refreshKey={refreshKey} />
       {registry?.liveInspect ? <LiveInspector refreshKey={refreshKey} /> : null}
-      {savings && savings.tokensSaved > 0 ? (
-        <SavingsBanner savings={savings} />
-      ) : null}
+      {savings && savings.tokensSaved > 0 ? <SavingsBanner savings={savings} /> : null}
     </>
   );
 
@@ -1100,8 +1092,7 @@ export function ActivityView({
   );
 
   const visible = (entries ?? []).filter(
-    (e) =>
-      (!serverFilter || e.server === serverFilter) && (!errorsOnly || !e.ok),
+    (e) => (!serverFilter || e.server === serverFilter) && (!errorsOnly || !e.ok),
   );
 
   if (entries === null) {
@@ -1124,9 +1115,8 @@ export function ActivityView({
           <div>
             <p className="font-medium">Couldn't load activity</p>
             <p className="max-w-md text-sm text-muted-foreground">
-              Toolport couldn't reach the gateway or read the audit log. This is
-              not an empty log, if the gateway isn't running, start it and
-              refresh.
+              Toolport couldn't reach the gateway or read the audit log. This is not an
+              empty log, if the gateway isn't running, start it and refresh.
             </p>
           </div>
         </div>
@@ -1143,8 +1133,8 @@ export function ActivityView({
           <div>
             <p className="font-medium">No tool calls yet</p>
             <p className="max-w-md text-sm text-muted-foreground">
-              Once a client runs a tool through Toolport, every call is recorded
-              here, with per-server latency and error rates.
+              Once a client runs a tool through Toolport, every call is recorded here,
+              with per-server latency and error rates.
             </p>
           </div>
         </div>

--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -34,17 +34,8 @@ import { gatherDiagnostics, getSavingsSummary, openDataDir } from "@/lib/api";
 import { fmtTokens } from "@/lib/utils";
 import { checkForUpdate, installUpdate } from "@/lib/updater";
 import { Button } from "@/components/ui/button";
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { ProfileBar } from "@/components/ProfileBar";
 import { ShareDialog } from "@/components/ShareDialog";
 
@@ -124,8 +115,7 @@ function VersionFooter({
         description: "You can download it manually from the releases page.",
         action: {
           label: "Open",
-          onClick: () =>
-            openUrl("https://github.com/tsouth89/toolport/releases/latest"),
+          onClick: () => openUrl("https://github.com/tsouth89/toolport/releases/latest"),
         },
       });
     }
@@ -200,9 +190,7 @@ function VersionFooter({
           onClick={async () => {
             try {
               await navigator.clipboard.writeText(await gatherDiagnostics());
-              toast.success(
-                "Diagnostics copied, paste them into your bug report",
-              );
+              toast.success("Diagnostics copied, paste them into your bug report");
             } catch {
               toastError("Could not copy diagnostics");
             }
@@ -277,8 +265,7 @@ function UpdateNotes({
  * bottom. */
 function sortClients(clients: DetectedClient[]): DetectedClient[] {
   const present = (c: DetectedClient) => (c.appPresent ? 1 : 0);
-  const count = (c: DetectedClient) =>
-    c.servers.length + c.pluginServers.length;
+  const count = (c: DetectedClient) => c.servers.length + c.pluginServers.length;
   return [...clients].sort((a, b) => {
     if (present(a) !== present(b)) return present(b) - present(a);
     if (count(a) !== count(b)) return count(b) - count(a);
@@ -350,9 +337,7 @@ function ClientRow({ client, importCount, selected, onSelect }: RowProps) {
           ) : client.usesConnectors ? (
             <Puzzle className="size-3.5 shrink-0 text-info" />
           ) : (
-            <span
-              className={`size-2 shrink-0 rounded-full ${dotClass[status]}`}
-            />
+            <span className={`size-2 shrink-0 rounded-full ${dotClass[status]}`} />
           )}
           <span className="truncate">{client.name}</span>
           <span className="ml-auto flex shrink-0 items-center gap-1.5">
@@ -388,9 +373,7 @@ function ClientRow({ client, importCount, selected, onSelect }: RowProps) {
             Manages servers as account connectors, outside the config file.
           </p>
         )}
-        {client.error && (
-          <p className="mt-1 text-xs text-warning">{client.error}</p>
-        )}
+        {client.error && <p className="mt-1 text-xs text-warning">{client.error}</p>}
       </TooltipContent>
     </Tooltip>
   );
@@ -488,9 +471,7 @@ export function AppSidebar({
         </svg>
         <div className="leading-tight">
           <div className="font-semibold tracking-tight">Toolport</div>
-          <div className="text-xs text-muted-foreground">
-            MCP control center
-          </div>
+          <div className="text-xs text-muted-foreground">MCP control center</div>
         </div>
       </div>
 
@@ -520,9 +501,7 @@ export function AppSidebar({
           {navItem(ScrollText, "Activity", view === "activity", () =>
             onSelectView("activity"),
           )}
-          {navItem(Users, "Teams", view === "teams", () =>
-            onSelectView("teams"),
-          )}
+          {navItem(Users, "Teams", view === "teams", () => onSelectView("teams"))}
           {navItem(Settings, "Settings", view === "settings", () =>
             onSelectView("settings"),
           )}
@@ -536,7 +515,10 @@ export function AppSidebar({
           >
             <Zap className="size-3.5 shrink-0 text-success" />
             <span className="text-muted-foreground">
-              <span className="font-semibold text-foreground">{fmtTokens(savings.tokensSaved)}</span> tokens saved
+              <span className="font-semibold text-foreground">
+                {fmtTokens(savings.tokensSaved)}
+              </span>{" "}
+              tokens saved
             </span>
           </button>
         )}
@@ -548,8 +530,8 @@ export function AppSidebar({
           <nav className="flex flex-col gap-0.5">
             {clients.length === 0 ? (
               <p className="px-2.5 py-1.5 text-xs text-muted-foreground">
-                No MCP clients found. Install Claude Desktop, Cursor, or another
-                supported tool, then refresh.
+                No MCP clients found. Install Claude Desktop, Cursor, or another supported
+                tool, then refresh.
               </p>
             ) : (
               <>
@@ -558,9 +540,7 @@ export function AppSidebar({
                     key={client.id}
                     client={client}
                     importCount={importableServers(client, registry).length}
-                    selected={
-                      view === "servers" && selectedClientId === client.id
-                    }
+                    selected={view === "servers" && selectedClientId === client.id}
                     onSelect={() => onSelectClient(client.id)}
                   />
                 ))}
@@ -581,12 +561,8 @@ export function AppSidebar({
                         <ClientRow
                           key={client.id}
                           client={client}
-                          importCount={
-                            importableServers(client, registry).length
-                          }
-                          selected={
-                            view === "servers" && selectedClientId === client.id
-                          }
+                          importCount={importableServers(client, registry).length}
+                          selected={view === "servers" && selectedClientId === client.id}
                           onSelect={() => onSelectClient(client.id)}
                         />
                       ))}
@@ -598,10 +574,7 @@ export function AppSidebar({
         </div>
       </div>
 
-      <VersionFooter
-        onImport={onRegistryChange}
-        onReplay={onReplayOnboarding}
-      />
+      <VersionFooter onImport={onRegistryChange} onReplay={onReplayOnboarding} />
     </aside>
   );
 }

--- a/src/components/Callout.tsx
+++ b/src/components/Callout.tsx
@@ -20,11 +20,7 @@ interface Props {
 export function Callout({ variant = "info", className, children }: Props) {
   return (
     <div
-      className={cn(
-        "rounded-lg border px-3 py-2 text-sm",
-        VARIANTS[variant],
-        className,
-      )}
+      className={cn("rounded-lg border px-3 py-2 text-sm", VARIANTS[variant], className)}
     >
       {children}
     </div>

--- a/src/components/CatalogView.tsx
+++ b/src/components/CatalogView.tsx
@@ -91,11 +91,7 @@ export function CatalogView({ registry, onAdded }: Props) {
    * user-supplied URL, or args the user should review). False = safe to
    * immediate-add with no configuration. */
   function needsConfig(entry: CatalogEntry): boolean {
-    return (
-      entry.urlHint != null ||
-      entry.envKeys.length > 0 ||
-      entry.args.length > 0
-    );
+    return entry.urlHint != null || entry.envKeys.length > 0 || entry.args.length > 0;
   }
 
   async function add(entry: CatalogEntry) {
@@ -133,9 +129,7 @@ export function CatalogView({ registry, onAdded }: Props) {
    * user at the credential steps for the ones that need them. */
   async function setupStack(stack: Stack) {
     setStackBusy(stack.id);
-    const existing = new Set(
-      (registry?.servers ?? []).map((s) => s.name.toLowerCase()),
-    );
+    const existing = new Set((registry?.servers ?? []).map((s) => s.name.toLowerCase()));
     let added = 0;
     let needCreds = 0;
     try {
@@ -158,12 +152,15 @@ export function CatalogView({ registry, onAdded }: Props) {
       if (added === 0) {
         toast.success(`${stack.name}: every server is already in Toolport`);
       } else {
-        toast.success(`Added ${added} server${added === 1 ? "" : "s"} from ${stack.name}`, {
-          description:
-            needCreds > 0
-              ? `${needCreds} need credentials. Open "Setup steps" for the links.`
-              : "Enable them under Servers.",
-        });
+        toast.success(
+          `Added ${added} server${added === 1 ? "" : "s"} from ${stack.name}`,
+          {
+            description:
+              needCreds > 0
+                ? `${needCreds} need credentials. Open "Setup steps" for the links.`
+                : "Enable them under Servers.",
+          },
+        );
       }
     } catch (e) {
       toastError(`Couldn't finish setting up ${stack.name}: ${e}`);
@@ -235,17 +232,12 @@ export function CatalogView({ registry, onAdded }: Props) {
         browsing && popularLoading ? (
           <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
             {Array.from({ length: 6 }).map((_, i) => (
-              <div
-                key={i}
-                className="h-28 animate-pulse rounded-lg border bg-muted/30"
-              />
+              <div key={i} className="h-28 animate-pulse rounded-lg border bg-muted/30" />
             ))}
           </div>
         ) : browsing && popularError ? (
           <div className="flex flex-col items-center gap-3 py-20 text-center">
-            <p className="text-sm text-muted-foreground">
-              Couldn't load the catalog.
-            </p>
+            <p className="text-sm text-muted-foreground">Couldn't load the catalog.</p>
             <Button variant="outline" size="sm" onClick={reloadPopular}>
               Try again
             </Button>
@@ -282,9 +274,7 @@ export function CatalogView({ registry, onAdded }: Props) {
           ))}
         </div>
       ) : (
-        <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
-          {shown.map(card)}
-        </div>
+        <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">{shown.map(card)}</div>
       )}
       {configEntry && (
         <ServerDialog
@@ -424,7 +414,9 @@ function StackCard({
           {stack.servers.map((e) => (
             <div key={e.name} className="text-[11px] leading-snug">
               <span className="font-medium text-foreground">{e.name}</span>
-              {e.setupHint && <span className="text-muted-foreground">: {e.setupHint}</span>}
+              {e.setupHint && (
+                <span className="text-muted-foreground">: {e.setupHint}</span>
+              )}
               {e.credentialsUrl && (
                 <button
                   onClick={() => openUrl(e.credentialsUrl!)}
@@ -456,9 +448,7 @@ function Provenance({ entry }: { entry: CatalogEntry }) {
       <ShieldCheck className={`size-3 shrink-0 ${tier.cls}`} />
       <span className={tier.cls}>{tier.label}</span>
       {entry.publisher && (
-        <span className="truncate text-muted-foreground/70">
-          · {entry.publisher}
-        </span>
+        <span className="truncate text-muted-foreground/70">· {entry.publisher}</span>
       )}
     </div>
   );
@@ -494,14 +484,16 @@ function CatalogCard({
           )}
         </div>
         <div className="flex shrink-0 items-center gap-1">
-
           <TransportPill transport={entry.transport} />
         </div>
       </div>
       <p className="line-clamp-2 min-h-8 text-xs text-muted-foreground">
         {entry.description}
       </p>
-      <code title={target} className="truncate font-mono text-[11px] text-muted-foreground/70">
+      <code
+        title={target}
+        className="truncate font-mono text-[11px] text-muted-foreground/70"
+      >
         {target}
       </code>
       <Provenance entry={entry} />

--- a/src/components/ClientDetail.tsx
+++ b/src/components/ClientDetail.tsx
@@ -1,5 +1,15 @@
 import { useEffect, useState } from "react";
-import { ArrowRight, Check, Download, Link2, Plug, PlugZap, Puzzle, Shuffle, TriangleAlert } from "lucide-react";
+import {
+  ArrowRight,
+  Check,
+  Download,
+  Link2,
+  Plug,
+  PlugZap,
+  Puzzle,
+  Shuffle,
+  TriangleAlert,
+} from "lucide-react";
 import { toast } from "sonner";
 import { toastError } from "@/lib/toast";
 import { addServer, installGateway, migrateClient, uninstallGateway } from "@/lib/api";
@@ -36,12 +46,7 @@ interface Props {
   onRegistryChange: (registry: Registry) => void;
 }
 
-export function ClientDetail({
-  client,
-  registry,
-  onChanged,
-  onRegistryChange,
-}: Props) {
+export function ClientDetail({ client, registry, onChanged, onRegistryChange }: Props) {
   const [busy, setBusy] = useState(false);
   // "" = expose all enabled servers (follow active profile); else scope to one.
   const [profile, setProfile] = useState("");
@@ -90,9 +95,7 @@ export function ClientDetail({
   }
   // Servers configured directly in the client (not the gateway) that migrate
   // would move into Toolport and strip from the client's config.
-  const movable = client.servers.filter(
-    (s) => s.name.toLowerCase() !== "conduit",
-  );
+  const movable = client.servers.filter((s) => s.name.toLowerCase() !== "conduit");
 
   async function migrate() {
     setBusy(true);
@@ -240,14 +243,17 @@ export function ClientDetail({
           )}
           {!present && !installed && (
             <p className="mt-1 text-xs text-warning">
-              {client.name} doesn't appear to be installed here. Install it first,
-              then connect.
+              {client.name} doesn't appear to be installed here. Install it first, then
+              connect.
             </p>
           )}
         </div>
         <div className="flex shrink-0 items-center gap-2">
           {profiles.length > 1 && (
-            <Select value={profile || "__all__"} onValueChange={(v) => setProfile(v === "__all__" ? "" : v)}>
+            <Select
+              value={profile || "__all__"}
+              onValueChange={(v) => setProfile(v === "__all__" ? "" : v)}
+            >
               <SelectTrigger size="sm" className="w-52">
                 <SelectValue />
               </SelectTrigger>
@@ -296,8 +302,8 @@ export function ClientDetail({
       </div>
 
       <p className="text-sm text-muted-foreground">
-        Connect points {client.name} at Toolport so it uses your managed servers.
-        Import copies this client's own servers into Toolport so it can manage them.
+        Connect points {client.name} at Toolport so it uses your managed servers. Import
+        copies this client's own servers into Toolport so it can manage them.
       </p>
 
       {client.usesConnectors && (
@@ -308,9 +314,9 @@ export function ClientDetail({
               <p className="font-medium">{client.name} manages servers as connectors</p>
               <p className="mt-1 text-muted-foreground">
                 Those live in {client.name}'s Customize → Connectors and sync to your
-                account, outside the local config files Toolport reads. Connecting Toolport
-                adds a local gateway entry so your Toolport-managed servers appear in{" "}
-                {client.name} too.
+                account, outside the local config files Toolport reads. Connecting
+                Toolport adds a local gateway entry so your Toolport-managed servers
+                appear in {client.name} too.
               </p>
             </div>
           </CardContent>
@@ -351,29 +357,29 @@ export function ClientDetail({
           </div>
         </div>
         <p className="mb-1 text-xs text-muted-foreground">
-          The servers {client.name} already has, from its config and any plugins
-          (tagged below).
+          The servers {client.name} already has, from its config and any plugins (tagged
+          below).
         </p>
         <ul className="mb-3 space-y-0.5 text-xs text-muted-foreground">
           <li>
-            <span className="font-medium text-foreground">Import</span> copies a
-            server into Toolport; {client.name} keeps its own copy.
+            <span className="font-medium text-foreground">Import</span> copies a server
+            into Toolport; {client.name} keeps its own copy.
           </li>
           <li>
-            <span className="font-medium text-foreground">Move config in</span>{" "}
-            copies it, then removes it from {client.name}'s config so the gateway is
-            the only source (plugin servers stay, only {client.name} can remove
-            those). This is the cutover that actually saves context.
+            <span className="font-medium text-foreground">Move config in</span> copies it,
+            then removes it from {client.name}'s config so the gateway is the only source
+            (plugin servers stay, only {client.name} can remove those). This is the
+            cutover that actually saves context.
           </li>
         </ul>
         {installed && toImport.length > 0 && movable.length > 0 && (
           <p className="mb-3 -mt-1 inline-flex items-start gap-1.5 rounded-md bg-warning/10 px-2 py-1 text-xs text-warning">
             <TriangleAlert className="mt-0.5 size-3.5 shrink-0" />
             <span>
-              {client.name} is already connected to Toolport. Import on its own
-              leaves a copy here too, so these tools load twice, once directly and
-              once through the gateway. Use <span className="font-medium">Move
-              config in</span> to avoid that.
+              {client.name} is already connected to Toolport. Import on its own leaves a
+              copy here too, so these tools load twice, once directly and once through the
+              gateway. Use <span className="font-medium">Move config in</span> to avoid
+              that.
             </span>
           </p>
         )}
@@ -422,13 +428,16 @@ export function ClientDetail({
                 {movable.length} server{movable.length === 1 ? "" : "s"}
               </span>{" "}
               from {client.name} into Toolport, then rewrites {client.name}'s config so it
-              uses <span className="font-medium text-foreground">only the Toolport gateway</span>.
-              The original config is backed up first.
+              uses{" "}
+              <span className="font-medium text-foreground">
+                only the Toolport gateway
+              </span>
+              . The original config is backed up first.
             </p>
             <p className="rounded-md bg-warning/10 p-2 text-xs text-warning">
-              Secret values (API keys, tokens) aren't carried over, they stay only
-              in the backed-up config. After migrating, re-enter them under each
-              server's secrets so the gateway can connect.
+              Secret values (API keys, tokens) aren't carried over, they stay only in the
+              backed-up config. After migrating, re-enter them under each server's secrets
+              so the gateway can connect.
             </p>
             <div className="rounded-md bg-muted/40 p-2 font-mono text-xs text-muted-foreground">
               {movable.map((s) => s.name).join(", ")}
@@ -436,15 +445,16 @@ export function ClientDetail({
             {client.pluginServers.length > 0 && (
               <p className="text-xs text-muted-foreground">
                 Note: {client.pluginServers.length} server
-                {client.pluginServers.length === 1 ? "" : "s"} managed by{" "}
-                {client.name}'s plugins or extensions can't be moved, only{" "}
-                {client.name} controls those. They stay where they are (you can
-                still import a copy above).
+                {client.pluginServers.length === 1 ? "" : "s"} managed by {client.name}'s
+                plugins or extensions can't be moved, only {client.name} controls those.
+                They stay where they are (you can still import a copy above).
               </p>
             )}
             {profiles.length > 1 && (
               <div className="flex items-center justify-between gap-2">
-                <span className="text-xs text-muted-foreground">Scope this client to</span>
+                <span className="text-xs text-muted-foreground">
+                  Scope this client to
+                </span>
                 <Select
                   value={profile || "__all__"}
                   onValueChange={(v) => setProfile(v === "__all__" ? "" : v)}
@@ -465,7 +475,11 @@ export function ClientDetail({
             )}
           </div>
           <DialogFooter>
-            <Button variant="outline" onClick={() => setMigrateOpen(false)} disabled={busy}>
+            <Button
+              variant="outline"
+              onClick={() => setMigrateOpen(false)}
+              disabled={busy}
+            >
               Cancel
             </Button>
             <Button onClick={migrate} disabled={busy}>
@@ -493,10 +507,7 @@ function ServerMiniCard({
   onImport: () => void;
 }) {
   return (
-    <Card
-      aria-disabled={imported}
-      className={`gap-0 ${imported ? "opacity-70" : ""}`}
-    >
+    <Card aria-disabled={imported} className={`gap-0 ${imported ? "opacity-70" : ""}`}>
       <CardContent className="flex flex-col gap-2 p-3">
         <div className="flex items-center justify-between gap-2">
           <div className="flex min-w-0 items-center gap-1.5">

--- a/src/components/ConfirmDialog.tsx
+++ b/src/components/ConfirmDialog.tsx
@@ -54,20 +54,13 @@ export function ConfirmDialog({
   return (
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger asChild>{trigger}</DialogTrigger>
-      <DialogContent
-        className="sm:max-w-sm"
-        onClick={(e) => e.stopPropagation()}
-      >
+      <DialogContent className="sm:max-w-sm" onClick={(e) => e.stopPropagation()}>
         <DialogHeader>
           <DialogTitle>{title}</DialogTitle>
           {description && <DialogDescription>{description}</DialogDescription>}
         </DialogHeader>
         <DialogFooter>
-          <Button
-            variant="ghost"
-            onClick={() => setOpen(false)}
-            disabled={busy}
-          >
+          <Button variant="ghost" onClick={() => setOpen(false)} disabled={busy}>
             {cancelLabel}
           </Button>
           <Button

--- a/src/components/Onboarding.tsx
+++ b/src/components/Onboarding.tsx
@@ -11,12 +11,7 @@ import {
 } from "lucide-react";
 import { toast } from "sonner";
 import { toastError } from "@/lib/toast";
-import {
-  addCatalogServer,
-  importServers,
-  installGateway,
-  listStacks,
-} from "@/lib/api";
+import { addCatalogServer, importServers, installGateway, listStacks } from "@/lib/api";
 import {
   importableServers,
   isGatewayServer,
@@ -149,13 +144,7 @@ function StepHeader({
   );
 }
 
-function Welcome({
-  present,
-  onNext,
-}: {
-  present: DetectedClient[];
-  onNext: () => void;
-}) {
+function Welcome({ present, onNext }: { present: DetectedClient[]; onNext: () => void }) {
   const names = present.map((c) => c.name);
   const found =
     names.length === 0
@@ -164,11 +153,9 @@ function Welcome({
   return (
     <>
       <StepHeader icon={<Waypoints className="size-5" />} title="Welcome to Toolport">
-        One local gateway for all your MCP servers, shared by every AI tool, so your
-        agent loads 3 tools instead of hundreds (up to 91% fewer tokens) and every
-        server is watched for tampering and prompt injection.
-        {" "}
-        {found}
+        One local gateway for all your MCP servers, shared by every AI tool, so your agent
+        loads 3 tools instead of hundreds (up to 91% fewer tokens) and every server is
+        watched for tampering and prompt injection. {found}
       </StepHeader>
       <Button onClick={onNext} className="self-start">
         Get started
@@ -260,8 +247,8 @@ function AddServers({
   return (
     <>
       <StepHeader icon={<Download className="size-5" />} title="Add your first servers">
-        Pick what you work on and Toolport sets up a matching stack. You can also
-        import from your other tools or browse the full catalog.
+        Pick what you work on and Toolport sets up a matching stack. You can also import
+        from your other tools or browse the full catalog.
       </StepHeader>
 
       <div className="flex flex-col gap-3">
@@ -388,14 +375,14 @@ function ConnectClients({
   return (
     <>
       <StepHeader icon={<Link2 className="size-5" />} title="Connect a client">
-        Point a tool at Toolport. It connects once, then sees every server you
-        enable here, no per-tool setup.
+        Point a tool at Toolport. It connects once, then sees every server you enable
+        here, no per-tool setup.
       </StepHeader>
 
       {present.length === 0 ? (
         <p className="rounded-md bg-muted/50 px-3 py-2 text-sm text-muted-foreground">
-          No clients detected yet. Install Claude Desktop, Cursor, VS Code, or
-          another supported tool, then connect it from the sidebar.
+          No clients detected yet. Install Claude Desktop, Cursor, VS Code, or another
+          supported tool, then connect it from the sidebar.
         </p>
       ) : (
         <div className="flex flex-col gap-2">
@@ -474,8 +461,7 @@ function Done({
     };
   }, [serverCount, onProbe]);
 
-  const nameFor = (id: string) =>
-    registry.servers.find((s) => s.id === id)?.name ?? id;
+  const nameFor = (id: string) => registry.servers.find((s) => s.id === id)?.name ?? id;
   const broken = (health ?? []).filter((r) => !r.ok && !r.authRequired);
 
   const ready = serverCount > 0 && connectedCount > 0;
@@ -496,15 +482,14 @@ function Done({
             Toolport now manages {serverCount} server
             {serverCount === 1 ? "" : "s"} across {connectedCount} connected tool
             {connectedCount === 1 ? "" : "s"}. Toggle one on or off and your clients
-            update live, no restart. Each client loads 3 search tools instead of
-            every tool, up to 91% fewer tokens at the same task success. And Toolport watches
+            update live, no restart. Each client loads 3 search tools instead of every
+            tool, up to 91% fewer tokens at the same task success. And Toolport watches
             every server for tampering and prompt injection, see Activity.
           </>
         ) : (
           <>
-            You haven't {missing} yet. You can do both any time from the main
-            screen: add or import servers, then connect a client so your tools share
-            them.
+            You haven't {missing} yet. You can do both any time from the main screen: add
+            or import servers, then connect a client so your tools share them.
           </>
         )}
       </StepHeader>
@@ -516,8 +501,8 @@ function Done({
             {broken.map((r) => nameFor(r.serverId)).join(", ")}
           </span>
           <span className="text-xs text-muted-foreground">
-            They likely need a runtime that isn't installed (Node/npx or Python/uvx),
-            or the command needs a fix. Retry from each server's card once it's sorted.
+            They likely need a runtime that isn't installed (Node/npx or Python/uvx), or
+            the command needs a fix. Retry from each server's card once it's sorted.
           </span>
         </div>
       )}

--- a/src/components/PendingApprovals.tsx
+++ b/src/components/PendingApprovals.tsx
@@ -14,23 +14,24 @@ const TIMEOUT_MS = 120_000;
 type Reason = PendingApproval["reason"];
 
 /** How each gate reason presents: label, badge tone, and an icon. */
-const REASON: Record<Reason, { label: string; className: string; Icon: typeof Trash2 }> = {
-  destructive: {
-    label: "Destructive",
-    className: "bg-destructive/10 text-destructive",
-    Icon: Trash2,
-  },
-  untrusted_source: {
-    label: "Untrusted source",
-    className: "bg-warning/15 text-warning",
-    Icon: Globe,
-  },
-  destructive_and_untrusted: {
-    label: "Destructive · untrusted",
-    className: "bg-destructive/10 text-destructive",
-    Icon: Trash2,
-  },
-};
+const REASON: Record<Reason, { label: string; className: string; Icon: typeof Trash2 }> =
+  {
+    destructive: {
+      label: "Destructive",
+      className: "bg-destructive/10 text-destructive",
+      Icon: Trash2,
+    },
+    untrusted_source: {
+      label: "Untrusted source",
+      className: "bg-warning/15 text-warning",
+      Icon: Globe,
+    },
+    destructive_and_untrusted: {
+      label: "Destructive · untrusted",
+      className: "bg-destructive/10 text-destructive",
+      Icon: Trash2,
+    },
+  };
 
 /**
  * The human-in-the-loop approval queue: tool calls the gateway is holding until you
@@ -145,8 +146,8 @@ export function PendingApprovals() {
         {/* Announce count changes to screen readers without re-announcing on every countdown
          * tick (the visible timer lives elsewhere; this text only changes when the count does). */}
         <div aria-live="assertive" className="sr-only">
-          {pending.length} tool call{pending.length > 1 ? "s" : ""} awaiting your approval. Press
-          Escape to deny.
+          {pending.length} tool call{pending.length > 1 ? "s" : ""} awaiting your
+          approval. Press Escape to deny.
         </div>
         <header className="flex items-center gap-3 border-b border-border/60 px-4 py-3">
           <span className="flex size-8 shrink-0 items-center justify-center rounded-full bg-warning/15 text-warning">
@@ -155,7 +156,8 @@ export function PendingApprovals() {
           <div className="min-w-0">
             <div className="text-sm font-semibold leading-tight">Approval required</div>
             <div className="text-xs text-muted-foreground">
-              {pending.length} tool call{pending.length > 1 ? "s" : ""} held — no decision auto-denies
+              {pending.length} tool call{pending.length > 1 ? "s" : ""} held — no decision
+              auto-denies
             </div>
           </div>
         </header>
@@ -166,9 +168,13 @@ export function PendingApprovals() {
             // Count down to the broker's authoritative deadline; fall back to
             // first-sighting + timeout only if deadlineMs is somehow absent, so the
             // timer is never blank.
-            const deadline = a.deadlineMs || (seenAt.current.get(a.id) ?? now) + TIMEOUT_MS;
+            const deadline =
+              a.deadlineMs || (seenAt.current.get(a.id) ?? now) + TIMEOUT_MS;
             const remaining = Math.max(0, Math.ceil((deadline - now) / 1000));
-            const pct = Math.max(0, Math.min(100, (remaining / (TIMEOUT_MS / 1000)) * 100));
+            const pct = Math.max(
+              0,
+              Math.min(100, (remaining / (TIMEOUT_MS / 1000)) * 100),
+            );
             const urgent = remaining <= 20;
             const isBusy = resolving.has(a.id);
             return (
@@ -178,7 +184,9 @@ export function PendingApprovals() {
                     <div className="flex items-center gap-1.5 font-mono text-sm">
                       <span className="truncate text-muted-foreground">{a.server}</span>
                       <span className="text-muted-foreground/50">/</span>
-                      <span className="truncate font-medium text-foreground">{a.tool}</span>
+                      <span className="truncate font-medium text-foreground">
+                        {a.tool}
+                      </span>
                     </div>
                     {a.client && (
                       <div className="mt-1 flex items-center gap-1.5 text-xs text-muted-foreground">

--- a/src/components/PlaygroundView.tsx
+++ b/src/components/PlaygroundView.tsx
@@ -118,7 +118,9 @@ function ToolOverrideEditor({
         className="flex w-full items-center gap-2 px-3 py-2 text-xs text-muted-foreground"
       >
         <Pencil className="size-3.5 shrink-0" />
-        <span className="font-medium text-foreground/80">Override how clients see this tool</span>
+        <span className="font-medium text-foreground/80">
+          Override how clients see this tool
+        </span>
         {hasOverride && (
           <span className="rounded-full bg-info/15 px-1.5 py-0.5 text-[10px] font-medium text-info">
             active
@@ -132,8 +134,8 @@ function ToolOverrideEditor({
         <div className="flex flex-col gap-2.5 border-t border-border/60 px-3 py-3">
           <p className="text-xs text-muted-foreground">
             Rename the tool or replace its description as every client sees it, e.g. to
-            neutralize a misleading or injection-laden description. The call still runs the
-            original server tool.
+            neutralize a misleading or injection-laden description. The call still runs
+            the original server tool.
           </p>
           <label className="flex flex-col gap-1 text-xs">
             <span className="text-muted-foreground">
@@ -150,7 +152,9 @@ function ToolOverrideEditor({
             />
           </label>
           <label className="flex flex-col gap-1 text-xs">
-            <span className="text-muted-foreground">Description (blank keeps the server's)</span>
+            <span className="text-muted-foreground">
+              Description (blank keeps the server's)
+            </span>
             <textarea
               value={description}
               onChange={(e) => setDescription(e.target.value)}
@@ -164,7 +168,12 @@ function ToolOverrideEditor({
               Save override
             </Button>
             {hasOverride && (
-              <Button size="sm" variant="outline" onClick={() => void reset()} disabled={busy}>
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={() => void reset()}
+                disabled={busy}
+              >
                 Reset to original
               </Button>
             )}
@@ -177,7 +186,9 @@ function ToolOverrideEditor({
 
 /** First declared type of a JSON-schema property (schemas may list several). */
 function primaryType(schema: JsonSchemaProp): string {
-  return Array.isArray(schema.type) ? schema.type[0] ?? "string" : schema.type ?? "string";
+  return Array.isArray(schema.type)
+    ? (schema.type[0] ?? "string")
+    : (schema.type ?? "string");
 }
 
 /** Turn a form field's raw value into the JSON type the schema expects. */
@@ -204,7 +215,9 @@ function renderResult(result: ToolCallResult): string {
   const blocks = result.content ?? [];
   if (blocks.length === 0) return JSON.stringify(result, null, 2);
   return blocks
-    .map((b) => (b.type === "text" && b.text != null ? b.text : JSON.stringify(b, null, 2)))
+    .map((b) =>
+      b.type === "text" && b.text != null ? b.text : JSON.stringify(b, null, 2),
+    )
     .join("\n");
 }
 
@@ -465,9 +478,7 @@ function PromptsPanel({ serverId }: { serverId: string }) {
   if (error) return <Callout variant="danger">{error}</Callout>;
   if (!prompts || prompts.length === 0) {
     return (
-      <p className="text-sm text-muted-foreground">
-        This server advertises no prompts.
-      </p>
+      <p className="text-sm text-muted-foreground">This server advertises no prompts.</p>
     );
   }
 
@@ -487,9 +498,7 @@ function PromptsPanel({ serverId }: { serverId: string }) {
                 p.name === selected ? "bg-accent" : "hover:bg-muted/40"
               }`}
             >
-              <span className="truncate font-mono text-sm">
-                {p.title ?? p.name}
-              </span>
+              <span className="truncate font-mono text-sm">{p.title ?? p.name}</span>
               {p.description && (
                 <span className="line-clamp-1 text-xs text-muted-foreground">
                   {p.description}
@@ -513,7 +522,10 @@ function PromptsPanel({ serverId }: { serverId: string }) {
             <div className="flex flex-col gap-4">
               {(prompt.arguments ?? []).map((a) => (
                 <div key={a.name} className="flex flex-col gap-1.5">
-                  <Label htmlFor={`prompt-arg-${a.name}`} className="flex items-center gap-1.5">
+                  <Label
+                    htmlFor={`prompt-arg-${a.name}`}
+                    className="flex items-center gap-1.5"
+                  >
                     <span className="font-mono text-xs">{a.name}</span>
                     {a.required && <span className="text-destructive">*</span>}
                   </Label>
@@ -603,10 +615,7 @@ export function PlaygroundView({ registry, onRegistryChange }: PlaygroundProps) 
     [tools, selectedTool],
   );
   const props = tool?.inputSchema?.properties ?? {};
-  const required = useMemo(
-    () => new Set(tool?.inputSchema?.required ?? []),
-    [tool],
-  );
+  const required = useMemo(() => new Set(tool?.inputSchema?.required ?? []), [tool]);
 
   const serverEntry = useMemo(
     () => servers.find((s) => s.id === serverId) ?? null,
@@ -683,7 +692,9 @@ export function PlaygroundView({ registry, onRegistryChange }: PlaygroundProps) 
     }
     const missing = [...required].filter((k) => !(k in out));
     if (missing.length > 0) {
-      return { error: `Fill in required field${missing.length === 1 ? "" : "s"}: ${missing.join(", ")}` };
+      return {
+        error: `Fill in required field${missing.length === 1 ? "" : "s"}: ${missing.join(", ")}`,
+      };
     }
     return out;
   }
@@ -716,8 +727,8 @@ export function PlaygroundView({ registry, onRegistryChange }: PlaygroundProps) 
         <div>
           <p className="font-medium">No servers to test</p>
           <p className="max-w-md text-sm text-muted-foreground">
-            Add a server to Toolport, then come back here to invoke its tools and
-            see the raw results, without wiring up a client first.
+            Add a server to Toolport, then come back here to invoke its tools and see the
+            raw results, without wiring up a client first.
           </p>
         </div>
       </div>
@@ -777,184 +788,184 @@ export function PlaygroundView({ registry, onRegistryChange }: PlaygroundProps) 
       {tab === "tools" && (
         <>
           {loadingTools && (
-        <div className="flex items-center gap-2 text-sm text-muted-foreground">
-          <Loader2 className="size-4 animate-spin" /> Connecting to server…
-        </div>
-      )}
-
-      {toolsError && <Callout variant="danger">{toolsError}</Callout>}
-
-      {/* Tool list: click to test, switch to enable/disable per client */}
-      {tools && tools.length > 0 && (
-        <div className="flex flex-col gap-1.5">
-          <Label className="text-xs text-muted-foreground">
-            Tools ({tools.length})
-          </Label>
-          <div className="flex flex-col divide-y rounded-lg border">
-            {tools.map((t) => {
-              const destructive = isDestructive(t);
-              const exposed = isExposed(t);
-              const selected = t.name === selectedTool;
-              const perToolOff = disabledSet.has(t.name);
-              const pinned = pinnedSet.has(t.name);
-              return (
-                <div
-                  key={t.name}
-                  className={`flex items-center gap-3 px-3 py-2 ${selected ? "bg-accent" : ""}`}
-                >
-                  <button
-                    onClick={() => setSelectedTool(t.name)}
-                    aria-pressed={selected}
-                    className="flex min-w-0 flex-1 flex-col items-start gap-0.5 text-left"
-                  >
-                    <span className="flex min-w-0 items-center gap-2">
-                      <span className="truncate font-mono text-sm">{t.name}</span>
-                      {destructive && (
-                        <Badge
-                          variant="outline"
-                          className="border-warning/40 text-warning"
-                        >
-                          destructive
-                        </Badge>
-                      )}
-                      {!exposed && (
-                        <span className="text-xs text-muted-foreground">hidden</span>
-                      )}
-                    </span>
-                    {t.description && (
-                      <span className="line-clamp-1 text-xs text-muted-foreground">
-                        {t.description}
-                      </span>
-                    )}
-                  </button>
-                  <button
-                    onClick={() => togglePin(t.name, !pinned)}
-                    disabled={policyBusy}
-                    title={
-                      pinned
-                        ? "Pinned: always surfaced in lazy-discovery search"
-                        : "Pin as a prerequisite (always surfaced in search)"
-                    }
-                    aria-label={pinned ? `Unpin ${t.name}` : `Pin ${t.name}`}
-                    aria-pressed={pinned}
-                    className="shrink-0 rounded p-1 hover:bg-muted disabled:opacity-50"
-                  >
-                    <Pin
-                      className={`size-4 ${
-                        pinned ? "fill-current text-owned" : "text-muted-foreground"
-                      }`}
-                    />
-                  </button>
-                  <Switch
-                    checked={!perToolOff}
-                    onCheckedChange={(on) => toggleTool(t.name, on)}
-                    disabled={policyBusy}
-                    aria-label={`Enable ${t.name}`}
-                  />
-                </div>
-              );
-            })}
-          </div>
-          {denyDestructive && (
-            <p className="text-xs text-muted-foreground">
-              Destructive tools are hidden from clients by the global switch even
-              when individually enabled.
-            </p>
-          )}
-        </div>
-      )}
-
-      {/* Argument form for the selected tool */}
-      {tool && (
-        <div className="flex flex-col gap-4 rounded-lg border bg-card p-4">
-          {tool.description && (
-            <p className="text-sm text-muted-foreground">{tool.description}</p>
-          )}
-          {!isExposed(tool) && (
-            <p className="flex items-center gap-1.5 text-xs text-warning">
-              <ShieldAlert className="size-3.5" />
-              Hidden from clients by policy. You can still test it here.
-            </p>
-          )}
-
-          {serverId && (
-            <ToolOverrideEditor
-              serverId={serverId}
-              tool={tool}
-              registry={registry}
-              onRegistryChange={onRegistryChange}
-            />
-          )}
-
-          <div className="flex items-center justify-between">
-            <span className="text-xs font-medium tracking-wide text-muted-foreground uppercase">
-              Arguments
-            </span>
-            <label className="flex items-center gap-2 text-xs text-muted-foreground">
-              Raw JSON
-              <Switch checked={rawMode} onCheckedChange={setRawMode} />
-            </label>
-          </div>
-
-          {rawMode ? (
-            <textarea
-              value={rawJson}
-              onChange={(e) => setRawJson(e.target.value)}
-              rows={6}
-              spellCheck={false}
-              className="w-full rounded-md border border-input bg-transparent px-3 py-2 font-mono text-xs shadow-sm focus-visible:ring-1 focus-visible:ring-ring focus-visible:outline-none"
-            />
-          ) : Object.keys(props).length === 0 ? (
-            <p className="text-sm text-muted-foreground">
-              This tool takes no arguments.
-            </p>
-          ) : (
-            <div className="flex flex-col gap-4">
-              {Object.entries(props).map(([name, schema]) => (
-                <ArgField
-                  key={name}
-                  name={name}
-                  schema={schema as JsonSchemaProp}
-                  required={required.has(name)}
-                  value={args[name]}
-                  onChange={(v) => setArgs((a) => ({ ...a, [name]: v }))}
-                />
-              ))}
+            <div className="flex items-center gap-2 text-sm text-muted-foreground">
+              <Loader2 className="size-4 animate-spin" /> Connecting to server…
             </div>
           )}
 
-          <div>
-            <Button onClick={run} disabled={calling} size="sm">
-              {calling ? (
-                <Loader2 className="size-4 animate-spin" />
-              ) : (
-                <Play className="size-4" />
+          {toolsError && <Callout variant="danger">{toolsError}</Callout>}
+
+          {/* Tool list: click to test, switch to enable/disable per client */}
+          {tools && tools.length > 0 && (
+            <div className="flex flex-col gap-1.5">
+              <Label className="text-xs text-muted-foreground">
+                Tools ({tools.length})
+              </Label>
+              <div className="flex flex-col divide-y rounded-lg border">
+                {tools.map((t) => {
+                  const destructive = isDestructive(t);
+                  const exposed = isExposed(t);
+                  const selected = t.name === selectedTool;
+                  const perToolOff = disabledSet.has(t.name);
+                  const pinned = pinnedSet.has(t.name);
+                  return (
+                    <div
+                      key={t.name}
+                      className={`flex items-center gap-3 px-3 py-2 ${selected ? "bg-accent" : ""}`}
+                    >
+                      <button
+                        onClick={() => setSelectedTool(t.name)}
+                        aria-pressed={selected}
+                        className="flex min-w-0 flex-1 flex-col items-start gap-0.5 text-left"
+                      >
+                        <span className="flex min-w-0 items-center gap-2">
+                          <span className="truncate font-mono text-sm">{t.name}</span>
+                          {destructive && (
+                            <Badge
+                              variant="outline"
+                              className="border-warning/40 text-warning"
+                            >
+                              destructive
+                            </Badge>
+                          )}
+                          {!exposed && (
+                            <span className="text-xs text-muted-foreground">hidden</span>
+                          )}
+                        </span>
+                        {t.description && (
+                          <span className="line-clamp-1 text-xs text-muted-foreground">
+                            {t.description}
+                          </span>
+                        )}
+                      </button>
+                      <button
+                        onClick={() => togglePin(t.name, !pinned)}
+                        disabled={policyBusy}
+                        title={
+                          pinned
+                            ? "Pinned: always surfaced in lazy-discovery search"
+                            : "Pin as a prerequisite (always surfaced in search)"
+                        }
+                        aria-label={pinned ? `Unpin ${t.name}` : `Pin ${t.name}`}
+                        aria-pressed={pinned}
+                        className="shrink-0 rounded p-1 hover:bg-muted disabled:opacity-50"
+                      >
+                        <Pin
+                          className={`size-4 ${
+                            pinned ? "fill-current text-owned" : "text-muted-foreground"
+                          }`}
+                        />
+                      </button>
+                      <Switch
+                        checked={!perToolOff}
+                        onCheckedChange={(on) => toggleTool(t.name, on)}
+                        disabled={policyBusy}
+                        aria-label={`Enable ${t.name}`}
+                      />
+                    </div>
+                  );
+                })}
+              </div>
+              {denyDestructive && (
+                <p className="text-xs text-muted-foreground">
+                  Destructive tools are hidden from clients by the global switch even when
+                  individually enabled.
+                </p>
               )}
-              {calling ? "Calling…" : "Call tool"}
-            </Button>
-          </div>
-        </div>
-      )}
+            </div>
+          )}
 
-      {/* Call error (transport / connection failure) */}
-      {callError && <Callout variant="danger">{callError}</Callout>}
+          {/* Argument form for the selected tool */}
+          {tool && (
+            <div className="flex flex-col gap-4 rounded-lg border bg-card p-4">
+              {tool.description && (
+                <p className="text-sm text-muted-foreground">{tool.description}</p>
+              )}
+              {!isExposed(tool) && (
+                <p className="flex items-center gap-1.5 text-xs text-warning">
+                  <ShieldAlert className="size-3.5" />
+                  Hidden from clients by policy. You can still test it here.
+                </p>
+              )}
 
-      {/* Result */}
-      {result && (
-        <div className="flex flex-col gap-2">
-          <div className="flex items-center gap-2 text-sm font-medium">
-            {result.isError ? (
-              <XCircle className="size-4 text-destructive" />
-            ) : (
-              <CheckCircle2 className="size-4 text-success" />
-            )}
-            {result.isError ? "Tool returned an error" : "Result"}
-          </div>
-          <pre className="max-h-96 overflow-auto rounded-lg border bg-muted/40 p-3 font-mono text-xs whitespace-pre-wrap">
-            {renderResult(result)}
-          </pre>
-        </div>
-      )}
+              {serverId && (
+                <ToolOverrideEditor
+                  serverId={serverId}
+                  tool={tool}
+                  registry={registry}
+                  onRegistryChange={onRegistryChange}
+                />
+              )}
+
+              <div className="flex items-center justify-between">
+                <span className="text-xs font-medium tracking-wide text-muted-foreground uppercase">
+                  Arguments
+                </span>
+                <label className="flex items-center gap-2 text-xs text-muted-foreground">
+                  Raw JSON
+                  <Switch checked={rawMode} onCheckedChange={setRawMode} />
+                </label>
+              </div>
+
+              {rawMode ? (
+                <textarea
+                  value={rawJson}
+                  onChange={(e) => setRawJson(e.target.value)}
+                  rows={6}
+                  spellCheck={false}
+                  className="w-full rounded-md border border-input bg-transparent px-3 py-2 font-mono text-xs shadow-sm focus-visible:ring-1 focus-visible:ring-ring focus-visible:outline-none"
+                />
+              ) : Object.keys(props).length === 0 ? (
+                <p className="text-sm text-muted-foreground">
+                  This tool takes no arguments.
+                </p>
+              ) : (
+                <div className="flex flex-col gap-4">
+                  {Object.entries(props).map(([name, schema]) => (
+                    <ArgField
+                      key={name}
+                      name={name}
+                      schema={schema as JsonSchemaProp}
+                      required={required.has(name)}
+                      value={args[name]}
+                      onChange={(v) => setArgs((a) => ({ ...a, [name]: v }))}
+                    />
+                  ))}
+                </div>
+              )}
+
+              <div>
+                <Button onClick={run} disabled={calling} size="sm">
+                  {calling ? (
+                    <Loader2 className="size-4 animate-spin" />
+                  ) : (
+                    <Play className="size-4" />
+                  )}
+                  {calling ? "Calling…" : "Call tool"}
+                </Button>
+              </div>
+            </div>
+          )}
+
+          {/* Call error (transport / connection failure) */}
+          {callError && <Callout variant="danger">{callError}</Callout>}
+
+          {/* Result */}
+          {result && (
+            <div className="flex flex-col gap-2">
+              <div className="flex items-center gap-2 text-sm font-medium">
+                {result.isError ? (
+                  <XCircle className="size-4 text-destructive" />
+                ) : (
+                  <CheckCircle2 className="size-4 text-success" />
+                )}
+                {result.isError ? "Tool returned an error" : "Result"}
+              </div>
+              <pre className="max-h-96 overflow-auto rounded-lg border bg-muted/40 p-3 font-mono text-xs whitespace-pre-wrap">
+                {renderResult(result)}
+              </pre>
+            </div>
+          )}
         </>
       )}
     </div>

--- a/src/components/ProfileBar.tsx
+++ b/src/components/ProfileBar.tsx
@@ -2,11 +2,7 @@ import { useState } from "react";
 import { Plus, Trash2 } from "lucide-react";
 import { toast } from "sonner";
 import { toastError } from "@/lib/toast";
-import {
-  createProfile,
-  deleteProfile,
-  setActiveProfile,
-} from "@/lib/api";
+import { createProfile, deleteProfile, setActiveProfile } from "@/lib/api";
 import type { Registry } from "@/lib/types";
 import {
   Select,
@@ -119,8 +115,8 @@ export function ProfileBar({ registry, onChange }: Props) {
           </DialogHeader>
           <p className="text-xs text-muted-foreground">
             A profile is a set of servers a client can see. Credentials live on each
-            server, not the profile, so to keep separate work and personal accounts,
-            add the server twice and put one in each profile.
+            server, not the profile, so to keep separate work and personal accounts, add
+            the server twice and put one in each profile.
           </p>
           <div className="flex flex-col gap-2 py-2">
             <Label htmlFor="profile-name">Name</Label>

--- a/src/components/RegistryServerRow.tsx
+++ b/src/components/RegistryServerRow.tsx
@@ -1,12 +1,5 @@
 import { useState } from "react";
-import {
-  ChevronDown,
-  Copy,
-  KeyRound,
-  LogIn,
-  Pencil,
-  Trash2,
-} from "lucide-react";
+import { ChevronDown, Copy, KeyRound, LogIn, Pencil, Trash2 } from "lucide-react";
 import type { ProbeResult, Registry, ServerEntry } from "@/lib/types";
 import { Switch } from "@/components/ui/switch";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
@@ -95,9 +88,7 @@ export function RegistryServerRow({
           : "Disabled";
 
   // Next free "Name (N)" for the duplicate-for-another-account action.
-  const existingNames = new Set(
-    registry?.servers.map((s) => s.name.toLowerCase()) ?? [],
-  );
+  const existingNames = new Set(registry?.servers.map((s) => s.name.toLowerCase()) ?? []);
   const baseName = server.name.replace(/\s\(\d+\)$/, "");
   let duplicateName = `${baseName} (2)`;
   let index = 2;
@@ -134,9 +125,7 @@ export function RegistryServerRow({
           role="status"
         />
 
-        <span className="min-w-0 truncate text-sm font-medium">
-          {server.name}
-        </span>
+        <span className="min-w-0 truncate text-sm font-medium">{server.name}</span>
 
         {server.source && (
           <span className="hidden max-w-40 shrink-0 truncate rounded bg-muted px-1.5 py-0.5 text-[11px] text-muted-foreground md:inline">
@@ -161,11 +150,7 @@ export function RegistryServerRow({
               }
             />
           ) : (
-            <StatusLabel
-              status={status}
-              label={label}
-              error={health?.error ?? null}
-            />
+            <StatusLabel status={status} label={label} error={health?.error ?? null} />
           )}
 
           <TransportPill transport={server.transport} />
@@ -178,16 +163,12 @@ export function RegistryServerRow({
             }}
             aria-expanded={expanded}
             aria-label={
-              expanded
-                ? `Hide ${server.name} details`
-                : `Show ${server.name} details`
+              expanded ? `Hide ${server.name} details` : `Show ${server.name} details`
             }
             className="rounded p-0.5 text-muted-foreground/50 transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
           >
             <ChevronDown
-              className={`size-4 transition-transform ${
-                expanded ? "rotate-180" : ""
-              }`}
+              className={`size-4 transition-transform ${expanded ? "rotate-180" : ""}`}
               aria-hidden="true"
             />
           </button>
@@ -276,10 +257,7 @@ function StatusLabel({
   error: string | null;
 }) {
   const text = (
-    <span
-      aria-hidden="true"
-      className="text-xs whitespace-nowrap text-muted-foreground"
-    >
+    <span aria-hidden="true" className="text-xs whitespace-nowrap text-muted-foreground">
       {label}
     </span>
   );

--- a/src/components/SecretsDialog.tsx
+++ b/src/components/SecretsDialog.tsx
@@ -367,16 +367,16 @@ export function SecretsDialog({ server, onSaved, trigger, onChanged }: Props) {
                       </Button>
                       {!oauthBusy && /mac/i.test(navigator.userAgent) && (
                         <p className="text-[11px] text-muted-foreground">
-                          On macOS, set Chrome or Brave as your default browser
-                          first. Safari can block the local sign-in redirect.
+                          On macOS, set Chrome or Brave as your default browser first.
+                          Safari can block the local sign-in redirect.
                         </p>
                       )}
                       {oauthBusy && (
                         <p className="text-[11px] text-muted-foreground">
-                          Finish signing in and approve access in your browser. If
-                          the page is blank, your default browser (e.g. Safari) may
-                          block the local redirect, use Chrome or Brave, or paste an
-                          access token above instead.
+                          Finish signing in and approve access in your browser. If the
+                          page is blank, your default browser (e.g. Safari) may block the
+                          local redirect, use Chrome or Brave, or paste an access token
+                          above instead.
                         </p>
                       )}
                     </>
@@ -384,7 +384,8 @@ export function SecretsDialog({ server, onSaved, trigger, onChanged }: Props) {
 
                   {authInfo?.kind === "token" && (
                     <p className="text-[11px] text-muted-foreground">
-                      This server needs a pasted token. OAuth sign-in isn't available here.
+                      This server needs a pasted token. OAuth sign-in isn't available
+                      here.
                     </p>
                   )}
                 </>

--- a/src/components/ServerDialog.tsx
+++ b/src/components/ServerDialog.tsx
@@ -1,8 +1,23 @@
 import { useState, type ReactNode } from "react";
-import { AlertTriangle, CheckCircle2, ChevronDown, ChevronRight, ClipboardPaste, Loader2, Plus, X } from "lucide-react";
+import {
+  AlertTriangle,
+  CheckCircle2,
+  ChevronDown,
+  ChevronRight,
+  ClipboardPaste,
+  Loader2,
+  Plus,
+  X,
+} from "lucide-react";
 import { toast } from "sonner";
 import { toastError } from "@/lib/toast";
-import { addServer, parseServerSnippet, setSecret, testServer, updateServer } from "@/lib/api";
+import {
+  addServer,
+  parseServerSnippet,
+  setSecret,
+  testServer,
+  updateServer,
+} from "@/lib/api";
 import type { Registry, ServerEntry, Transport } from "@/lib/types";
 import { Button } from "@/components/ui/button";
 import {
@@ -42,7 +57,16 @@ interface Props {
   urlHint?: string;
 }
 
-export function ServerDialog({ trigger, onSaved, editId, initial, existingNames, autoOpen, onClose, urlHint }: Props) {
+export function ServerDialog({
+  trigger,
+  onSaved,
+  editId,
+  initial,
+  existingNames,
+  autoOpen,
+  onClose,
+  urlHint,
+}: Props) {
   const [open, setOpen] = useState(autoOpen ?? false);
   const [form, setForm] = useState({
     name: initial?.name ?? "",
@@ -230,9 +254,7 @@ export function ServerDialog({ trigger, onSaved, editId, initial, existingNames,
       // Vault any values the user entered now. setSecret keys by server id. For a
       // new server, add_server appends it, so it's the last entry - resolving by
       // name would pick the wrong one if two servers share a name.
-      const id = editing
-        ? editId
-        : result.servers[result.servers.length - 1]?.id;
+      const id = editing ? editId : result.servers[result.servers.length - 1]?.id;
       if (id) {
         for (const r of declared) {
           if (r.value) result = await setSecret(id, r.key.trim(), r.value);
@@ -277,7 +299,9 @@ export function ServerDialog({ trigger, onSaved, editId, initial, existingNames,
               <div className="flex flex-col gap-2 border-t px-3 pb-3 pt-2">
                 <textarea
                   className="min-h-[100px] w-full resize-y rounded-md bg-muted/50 p-2 font-mono text-xs"
-                  placeholder={"Paste a config snippet from any client:\n\n• Claude Code: claude mcp add-json ...\n• Cursor/Windsurf/Antigravity: {\"mcpServers\": ...}\n• VS Code: {\"servers\": ...}\n• Codex: [mcp_servers.name]\n• Zed: {\"context_servers\": ...}"}
+                  placeholder={
+                    'Paste a config snippet from any client:\n\n• Claude Code: claude mcp add-json ...\n• Cursor/Windsurf/Antigravity: {"mcpServers": ...}\n• VS Code: {"servers": ...}\n• Codex: [mcp_servers.name]\n• Zed: {"context_servers": ...}'
+                  }
                   value={pasteText}
                   onChange={(e) => setPasteText(e.target.value)}
                 />
@@ -367,8 +391,8 @@ export function ServerDialog({ trigger, onSaved, editId, initial, existingNames,
             <Label>Environment variables</Label>
             <p className="-mt-1 text-xs text-muted-foreground">
               API keys and other secrets the server needs (e.g.{" "}
-              <code className="font-mono">RESEND_API_KEY</code>). Values are stored
-              in your OS keychain, never in the config.
+              <code className="font-mono">RESEND_API_KEY</code>). Values are stored in
+              your OS keychain, never in the config.
             </p>
             {envRows.map((row, i) => (
               <div key={i} className="flex items-center gap-2">
@@ -380,7 +404,9 @@ export function ServerDialog({ trigger, onSaved, editId, initial, existingNames,
                 />
                 <Input
                   type="password"
-                  placeholder={initial?.env.some((e) => e.key === row.key) ? "•••• (saved)" : "value"}
+                  placeholder={
+                    initial?.env.some((e) => e.key === row.key) ? "•••• (saved)" : "value"
+                  }
                   value={row.value}
                   onChange={(e) => setEnvRow(i, "value", e.target.value)}
                 />
@@ -406,7 +432,10 @@ export function ServerDialog({ trigger, onSaved, editId, initial, existingNames,
             </Button>
           </div>
 
-          {(errors.length > 0 || duplicateName || test.status === "ok" || test.status === "fail") && (
+          {(errors.length > 0 ||
+            duplicateName ||
+            test.status === "ok" ||
+            test.status === "fail") && (
             <div className="flex flex-col gap-1.5 text-xs">
               {errors.map((msg) => (
                 <p key={msg} className="text-destructive">
@@ -417,8 +446,8 @@ export function ServerDialog({ trigger, onSaved, editId, initial, existingNames,
                 <p className="flex items-start gap-1.5 text-amber-600 dark:text-amber-500">
                   <AlertTriangle className="mt-0.5 size-3.5 shrink-0" />
                   <span>
-                    Another server is already named "{nameTrim}". That's fine for multiple accounts;
-                    it'll be saved as a separate entry.
+                    Another server is already named "{nameTrim}". That's fine for multiple
+                    accounts; it'll be saved as a separate entry.
                   </span>
                 </p>
               )}

--- a/src/components/SettingsView.tsx
+++ b/src/components/SettingsView.tsx
@@ -1,5 +1,19 @@
 import { useEffect, useState } from "react";
-import { Activity, Bot, Check, Copy, Globe, Layers, Power, ShieldAlert, ShieldCheck, ShieldX, Trash2, UserCheck, X } from "lucide-react";
+import {
+  Activity,
+  Bot,
+  Check,
+  Copy,
+  Globe,
+  Layers,
+  Power,
+  ShieldAlert,
+  ShieldCheck,
+  ShieldX,
+  Trash2,
+  UserCheck,
+  X,
+} from "lucide-react";
 import {
   disable as disableAutostart,
   enable as enableAutostart,
@@ -117,7 +131,10 @@ export function SettingsView({ registry, onRegistryChange }: Props) {
   }, []);
 
   useEffect(() => {
-    const load = () => listQuarantined().then(setQuarantined).catch(() => {});
+    const load = () =>
+      listQuarantined()
+        .then(setQuarantined)
+        .catch(() => {});
     load();
     // Quarantine happens asynchronously in the gateway, so poll to keep the list fresh.
     const id = setInterval(load, 15000);
@@ -136,7 +153,10 @@ export function SettingsView({ registry, onRegistryChange }: Props) {
   // Tools the user allowed to skip human approval. Polled because "always allow" is chosen
   // from the approval overlay (a different component), so this keeps the list in sync.
   useEffect(() => {
-    const load = () => listAllowedTools().then(setAllowedTools).catch(() => {});
+    const load = () =>
+      listAllowedTools()
+        .then(setAllowedTools)
+        .catch(() => {});
     load();
     const id = setInterval(load, 10000);
     return () => clearInterval(id);
@@ -172,17 +192,16 @@ export function SettingsView({ registry, onRegistryChange }: Props) {
     );
   };
 
-  const apply =
-    (fn: (v: boolean) => Promise<Registry>) => async (v: boolean) => {
-      setBusy(true);
-      try {
-        onRegistryChange(await fn(v));
-      } catch (e) {
-        toastError(`Couldn't update the setting: ${e}`);
-      } finally {
-        setBusy(false);
-      }
-    };
+  const apply = (fn: (v: boolean) => Promise<Registry>) => async (v: boolean) => {
+    setBusy(true);
+    try {
+      onRegistryChange(await fn(v));
+    } catch (e) {
+      toastError(`Couldn't update the setting: ${e}`);
+    } finally {
+      setBusy(false);
+    }
+  };
 
   // Live inspection needs a step the plain `apply` helper doesn't: when turned OFF,
   // clear the ephemeral capture ring so nothing lingers on disk.
@@ -379,7 +398,9 @@ export function SettingsView({ registry, onRegistryChange }: Props) {
           {bridge?.running && bridge.url && (
             <>
               <div className="flex items-center gap-2 rounded border bg-muted/40 px-2 py-1.5">
-                <span className="shrink-0 text-[11px] font-medium text-muted-foreground">URL</span>
+                <span className="shrink-0 text-[11px] font-medium text-muted-foreground">
+                  URL
+                </span>
                 <code className="min-w-0 flex-1 truncate text-xs">{bridge.url}</code>
                 <button
                   type="button"
@@ -415,9 +436,10 @@ export function SettingsView({ registry, onRegistryChange }: Props) {
                 </div>
               )}
               <p className="text-xs text-muted-foreground">
-                In Open WebUI: Settings &rarr; Tools &rarr; add the URL as an OpenAPI server and paste
-                the token as its API key (Bearer auth), then set Function Calling to Native (per chat).
-                The token stops other local apps from calling your tools.
+                In Open WebUI: Settings &rarr; Tools &rarr; add the URL as an OpenAPI
+                server and paste the token as its API key (Bearer auth), then set Function
+                Calling to Native (per chat). The token stops other local apps from
+                calling your tools.
               </p>
 
               <div className="mt-1 flex flex-col gap-2 rounded border bg-muted/20 p-2.5">
@@ -434,7 +456,9 @@ export function SettingsView({ registry, onRegistryChange }: Props) {
                   <ul className="flex flex-col gap-1">
                     {httpClients.map((c) => (
                       <li key={c.id} className="flex items-center gap-2 text-xs">
-                        <span className="truncate font-medium">{c.label || "(unnamed)"}</span>
+                        <span className="truncate font-medium">
+                          {c.label || "(unnamed)"}
+                        </span>
                         <span className="shrink-0 rounded bg-muted px-1.5 py-0.5 text-[11px] text-muted-foreground">
                           {c.profile || "all servers"}
                         </span>

--- a/src/components/ShareDialog.tsx
+++ b/src/components/ShareDialog.tsx
@@ -242,9 +242,8 @@ export function ShareDialog({ trigger, onImported }: Props) {
         {preview ? (
           <div className="flex flex-col gap-4 py-1">
             <p className="text-xs text-muted-foreground">
-              These servers come from a shared file. Each runs the command shown when
-              you enable it, so review them before importing. You'll add your own keys
-              after.
+              These servers come from a shared file. Each runs the command shown when you
+              enable it, so review them before importing. You'll add your own keys after.
             </p>
             <div className="flex max-h-72 flex-col gap-2 overflow-y-auto">
               {preview.map((item, i) => (
@@ -252,11 +251,18 @@ export function ShareDialog({ trigger, onImported }: Props) {
               ))}
             </div>
             <div className="flex items-center justify-between gap-2 border-t pt-3">
-              <Button variant="ghost" onClick={() => setPreview(null)} disabled={busyAction !== null}>
+              <Button
+                variant="ghost"
+                onClick={() => setPreview(null)}
+                disabled={busyAction !== null}
+              >
                 <ArrowLeft className="size-4" />
                 Back
               </Button>
-              <Button onClick={confirmImport} disabled={busyAction !== null || newCount === 0}>
+              <Button
+                onClick={confirmImport}
+                disabled={busyAction !== null || newCount === 0}
+              >
                 {busyAction === "import" ? (
                   <>
                     <Loader2 className="size-4 animate-spin" />
@@ -446,7 +452,11 @@ export function ShareDialog({ trigger, onImported }: Props) {
                     </>
                   )}
                 </Button>
-                <Button variant="outline" onClick={loadFromFile} disabled={busyAction !== null}>
+                <Button
+                  variant="outline"
+                  onClick={loadFromFile}
+                  disabled={busyAction !== null}
+                >
                   {busyAction === "preview-file" ? (
                     <>
                       <Loader2 className="size-4 animate-spin" />
@@ -471,9 +481,7 @@ export function ShareDialog({ trigger, onImported }: Props) {
 /** One reviewable server: name, what it runs, and a flag if it spawns a shell. */
 function ImportRow({ item }: { item: ImportItem }) {
   const runs =
-    item.command != null
-      ? [item.command, ...item.args].join(" ")
-      : (item.url ?? "");
+    item.command != null ? [item.command, ...item.args].join(" ") : (item.url ?? "");
   const shell = runsShell(item.command);
   const privateHost = isPrivateHostUrl(item.url);
   return (
@@ -488,9 +496,7 @@ function ImportRow({ item }: { item: ImportItem }) {
         )}
       </div>
       {runs && (
-        <p className="mt-1 font-mono text-xs break-all text-muted-foreground">
-          {runs}
-        </p>
+        <p className="mt-1 font-mono text-xs break-all text-muted-foreground">{runs}</p>
       )}
       {shell && (
         <p className="mt-1.5 flex items-center gap-1.5 text-xs text-warning">

--- a/src/components/TeamsView.tsx
+++ b/src/components/TeamsView.tsx
@@ -1,12 +1,26 @@
 import { useEffect, useState } from "react";
-import { RefreshCw, LogOut, Upload, ShieldCheck, Users, Server, AlertTriangle } from "lucide-react";
+import {
+  RefreshCw,
+  LogOut,
+  Upload,
+  ShieldCheck,
+  Users,
+  Server,
+  AlertTriangle,
+} from "lucide-react";
 import { listen } from "@tauri-apps/api/event";
 import { Button } from "@/components/ui/button";
 import { ConfirmDialog } from "@/components/ConfirmDialog";
 import { Callout } from "@/components/Callout";
 import { TransportPill } from "@/components/TransportPill";
 import { Input } from "@/components/ui/input";
-import { teamConnect, teamSync, teamDisconnect, teamPush, setServerEnabled } from "@/lib/api";
+import {
+  teamConnect,
+  teamSync,
+  teamDisconnect,
+  teamPush,
+  setServerEnabled,
+} from "@/lib/api";
 import { isEnabled, activeProfile } from "@/lib/types";
 import type { Registry } from "@/lib/types";
 
@@ -29,7 +43,9 @@ export function TeamsView({
 }) {
   const team = registry?.team ?? null;
   const isAdmin = team?.role === "admin";
-  const teamServers = (registry?.servers ?? []).filter((s) => s.source?.startsWith("team:"));
+  const teamServers = (registry?.servers ?? []).filter((s) =>
+    s.source?.startsWith("team:"),
+  );
 
   const [serverUrl, setServerUrl] = useState(HOSTED_TEAMS_URL);
   const [inviteCode, setInviteCode] = useState("");
@@ -80,7 +96,11 @@ export function TeamsView({
       if (!serverUrl.trim() || !inviteCode.trim()) {
         throw new Error("Server URL and invite code are both required.");
       }
-      const r = await teamConnect(serverUrl.trim(), inviteCode.trim(), memberName.trim() || undefined);
+      const r = await teamConnect(
+        serverUrl.trim(),
+        inviteCode.trim(),
+        memberName.trim() || undefined,
+      );
       onRegistryChange(r);
       setInviteCode("");
       setNotice("Connected. The team's servers were added to your active profile.");
@@ -141,9 +161,9 @@ export function TeamsView({
         <div className="rounded-xl border bg-card p-5">
           <h3 className="text-sm font-medium">Connect to a team</h3>
           <p className="mt-1 mb-4 max-w-prose text-sm text-muted-foreground">
-            Paste your team's Toolport Teams server URL and an invite code from your admin.
-            The team's MCP servers will appear in your active profile. Your keys never leave
-            your machine, you'll add each server's secrets locally afterward.
+            Paste your team's Toolport Teams server URL and an invite code from your
+            admin. The team's MCP servers will appear in your active profile. Your keys
+            never leave your machine, you'll add each server's secrets locally afterward.
           </p>
           <div className="grid gap-3">
             <label className="grid gap-1 text-sm">
@@ -192,14 +212,22 @@ export function TeamsView({
                     {team.role}
                   </span>
                 </div>
-                <p className="mt-1 truncate text-sm text-muted-foreground">{team.serverUrl}</p>
+                <p className="mt-1 truncate text-sm text-muted-foreground">
+                  {team.serverUrl}
+                </p>
                 <p className="mt-0.5 text-xs text-muted-foreground">
-                  Team {team.teamId} · config v{team.lastVersion ?? 0} · {teamServers.length}{" "}
-                  shared {teamServers.length === 1 ? "server" : "servers"}
+                  Team {team.teamId} · config v{team.lastVersion ?? 0} ·{" "}
+                  {teamServers.length} shared{" "}
+                  {teamServers.length === 1 ? "server" : "servers"}
                 </p>
               </div>
               <div className="flex shrink-0 gap-2">
-                <Button variant="outline" size="sm" onClick={onSync} disabled={busy !== null}>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={onSync}
+                  disabled={busy !== null}
+                >
                   <RefreshCw className="size-3.5" />
                   {busy === "sync" ? "Syncing…" : "Sync now"}
                 </Button>
@@ -226,7 +254,8 @@ export function TeamsView({
                     <ShieldCheck className="size-3.5 text-success" /> Admin
                   </div>
                   <p className="text-xs text-muted-foreground">
-                    Push your current server set to the team. Secret values are never sent.
+                    Push your current server set to the team. Secret values are never
+                    sent.
                   </p>
                 </div>
                 <Button size="sm" onClick={onPush} disabled={busy !== null}>
@@ -241,7 +270,8 @@ export function TeamsView({
             <h3 className="mb-1 text-sm font-medium">Shared servers</h3>
             {teamServers.length === 0 ? (
               <p className="text-sm text-muted-foreground">
-                No servers from the team yet. An admin pushes the set, then Sync brings it here.
+                No servers from the team yet. An admin pushes the set, then Sync brings it
+                here.
               </p>
             ) : (
               <>
@@ -251,7 +281,7 @@ export function TeamsView({
                     const isLocal = s.transport === "stdio" || !!s.command;
                     const detail = s.command
                       ? [s.command, ...(s.args ?? [])].join(" ")
-                      : s.url ?? "";
+                      : (s.url ?? "");
                     return (
                       <li
                         key={s.id}
@@ -285,7 +315,12 @@ export function TeamsView({
                             </div>
                             <ConfirmDialog
                               trigger={
-                                <Button size="sm" variant="outline" disabled={busy !== null} className="shrink-0">
+                                <Button
+                                  size="sm"
+                                  variant="outline"
+                                  disabled={busy !== null}
+                                  className="shrink-0"
+                                >
                                   Enable
                                 </Button>
                               }
@@ -305,7 +340,8 @@ export function TeamsView({
                   })}
                 </ul>
                 <p className="mt-3 text-xs text-muted-foreground">
-                  Add each server's secrets in the Servers tab, they stay in your OS keychain.
+                  Add each server's secrets in the Servers tab, they stay in your OS
+                  keychain.
                 </p>
               </>
             )}

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,8 +1,8 @@
-import * as React from "react"
-import { cva, type VariantProps } from "class-variance-authority"
-import { Slot } from "radix-ui"
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+import { Slot } from "radix-ui";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 const badgeVariants = cva(
   "group/badge inline-flex h-5 w-fit shrink-0 items-center justify-center gap-1 overflow-hidden rounded-4xl border border-transparent px-2 py-0.5 text-xs font-medium whitespace-nowrap transition-all focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&>svg]:pointer-events-none [&>svg]:size-3!",
@@ -10,22 +10,20 @@ const badgeVariants = cva(
     variants: {
       variant: {
         default: "bg-primary text-primary-foreground [a]:hover:bg-primary/80",
-        secondary:
-          "bg-secondary text-secondary-foreground [a]:hover:bg-secondary/80",
+        secondary: "bg-secondary text-secondary-foreground [a]:hover:bg-secondary/80",
         destructive:
           "bg-destructive/10 text-destructive focus-visible:ring-destructive/20 dark:bg-destructive/20 dark:focus-visible:ring-destructive/40 [a]:hover:bg-destructive/20",
         outline:
           "border-border text-foreground [a]:hover:bg-muted [a]:hover:text-muted-foreground",
-        ghost:
-          "hover:bg-muted hover:text-muted-foreground dark:hover:bg-muted/50",
+        ghost: "hover:bg-muted hover:text-muted-foreground dark:hover:bg-muted/50",
         link: "text-primary underline-offset-4 hover:underline",
       },
     },
     defaultVariants: {
       variant: "default",
     },
-  }
-)
+  },
+);
 
 function Badge({
   className,
@@ -34,7 +32,7 @@ function Badge({
   ...props
 }: React.ComponentProps<"span"> &
   VariantProps<typeof badgeVariants> & { asChild?: boolean }) {
-  const Comp = asChild ? Slot.Root : "span"
+  const Comp = asChild ? Slot.Root : "span";
 
   return (
     <Comp
@@ -43,7 +41,7 @@ function Badge({
       className={cn(badgeVariants({ variant }), className)}
       {...props}
     />
-  )
+  );
 }
 
-export { Badge, badgeVariants }
+export { Badge, badgeVariants };

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,8 +1,8 @@
-import * as React from "react"
-import { cva, type VariantProps } from "class-variance-authority"
-import { Slot } from "radix-ui"
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+import { Slot } from "radix-ui";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 const buttonVariants = cva(
   "group/button inline-flex shrink-0 items-center justify-center rounded-lg border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
@@ -38,8 +38,8 @@ const buttonVariants = cva(
       variant: "default",
       size: "default",
     },
-  }
-)
+  },
+);
 
 function Button({
   className,
@@ -49,9 +49,9 @@ function Button({
   ...props
 }: React.ComponentProps<"button"> &
   VariantProps<typeof buttonVariants> & {
-    asChild?: boolean
+    asChild?: boolean;
   }) {
-  const Comp = asChild ? Slot.Root : "button"
+  const Comp = asChild ? Slot.Root : "button";
 
   return (
     <Comp
@@ -61,7 +61,7 @@ function Button({
       className={cn(buttonVariants({ variant, size, className }))}
       {...props}
     />
-  )
+  );
 }
 
-export { Button, buttonVariants }
+export { Button, buttonVariants };

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,6 +1,6 @@
-import * as React from "react"
+import * as React from "react";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 function Card({
   className,
@@ -13,11 +13,11 @@ function Card({
       data-size={size}
       className={cn(
         "group/card flex flex-col gap-(--card-spacing) overflow-hidden rounded-xl bg-card py-(--card-spacing) text-sm text-card-foreground ring-1 ring-foreground/10 [--card-spacing:--spacing(4)] has-data-[slot=card-footer]:pb-0 has-[>img:first-child]:pt-0 data-[size=sm]:[--card-spacing:--spacing(3)] data-[size=sm]:has-data-[slot=card-footer]:pb-0 *:[img:first-child]:rounded-t-xl *:[img:last-child]:rounded-b-xl",
-        className
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
 function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
@@ -26,11 +26,11 @@ function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
       data-slot="card-header"
       className={cn(
         "group/card-header @container/card-header grid auto-rows-min items-start gap-1 rounded-t-xl px-(--card-spacing) has-data-[slot=card-action]:grid-cols-[1fr_auto] has-data-[slot=card-description]:grid-rows-[auto_auto] [.border-b]:pb-(--card-spacing)",
-        className
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
 function CardTitle({ className, ...props }: React.ComponentProps<"div">) {
@@ -39,11 +39,11 @@ function CardTitle({ className, ...props }: React.ComponentProps<"div">) {
       data-slot="card-title"
       className={cn(
         "font-heading text-base leading-snug font-medium group-data-[size=sm]/card:text-sm",
-        className
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
 function CardDescription({ className, ...props }: React.ComponentProps<"div">) {
@@ -53,7 +53,7 @@ function CardDescription({ className, ...props }: React.ComponentProps<"div">) {
       className={cn("text-sm text-muted-foreground", className)}
       {...props}
     />
-  )
+  );
 }
 
 function CardAction({ className, ...props }: React.ComponentProps<"div">) {
@@ -62,11 +62,11 @@ function CardAction({ className, ...props }: React.ComponentProps<"div">) {
       data-slot="card-action"
       className={cn(
         "col-start-2 row-span-2 row-start-1 self-start justify-self-end",
-        className
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
 function CardContent({ className, ...props }: React.ComponentProps<"div">) {
@@ -76,7 +76,7 @@ function CardContent({ className, ...props }: React.ComponentProps<"div">) {
       className={cn("px-(--card-spacing)", className)}
       {...props}
     />
-  )
+  );
 }
 
 function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
@@ -85,11 +85,11 @@ function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
       data-slot="card-footer"
       className={cn(
         "flex items-center rounded-b-xl border-t bg-muted/50 p-(--card-spacing)",
-        className
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
 export {
@@ -100,4 +100,4 @@ export {
   CardAction,
   CardDescription,
   CardContent,
-}
+};

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -1,32 +1,26 @@
-import * as React from "react"
-import { Dialog as DialogPrimitive } from "radix-ui"
+import * as React from "react";
+import { Dialog as DialogPrimitive } from "radix-ui";
 
-import { cn } from "@/lib/utils"
-import { Button } from "@/components/ui/button"
-import { XIcon } from "lucide-react"
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+import { XIcon } from "lucide-react";
 
-function Dialog({
-  ...props
-}: React.ComponentProps<typeof DialogPrimitive.Root>) {
-  return <DialogPrimitive.Root data-slot="dialog" {...props} />
+function Dialog({ ...props }: React.ComponentProps<typeof DialogPrimitive.Root>) {
+  return <DialogPrimitive.Root data-slot="dialog" {...props} />;
 }
 
 function DialogTrigger({
   ...props
 }: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
-  return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />
+  return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />;
 }
 
-function DialogPortal({
-  ...props
-}: React.ComponentProps<typeof DialogPrimitive.Portal>) {
-  return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />
+function DialogPortal({ ...props }: React.ComponentProps<typeof DialogPrimitive.Portal>) {
+  return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />;
 }
 
-function DialogClose({
-  ...props
-}: React.ComponentProps<typeof DialogPrimitive.Close>) {
-  return <DialogPrimitive.Close data-slot="dialog-close" {...props} />
+function DialogClose({ ...props }: React.ComponentProps<typeof DialogPrimitive.Close>) {
+  return <DialogPrimitive.Close data-slot="dialog-close" {...props} />;
 }
 
 function DialogOverlay({
@@ -38,11 +32,11 @@ function DialogOverlay({
       data-slot="dialog-overlay"
       className={cn(
         "fixed inset-0 isolate z-50 bg-black/10 duration-100 supports-backdrop-filter:backdrop-blur-xs data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0",
-        className
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
 function DialogContent({
@@ -51,7 +45,7 @@ function DialogContent({
   showCloseButton = true,
   ...props
 }: React.ComponentProps<typeof DialogPrimitive.Content> & {
-  showCloseButton?: boolean
+  showCloseButton?: boolean;
 }) {
   return (
     <DialogPortal>
@@ -60,27 +54,22 @@ function DialogContent({
         data-slot="dialog-content"
         className={cn(
           "fixed top-1/2 left-1/2 z-50 grid max-h-[85vh] w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 overflow-y-auto rounded-xl bg-popover p-4 text-sm text-popover-foreground ring-1 ring-foreground/10 duration-100 outline-none sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
-          className
+          className,
         )}
         {...props}
       >
         {children}
         {showCloseButton && (
           <DialogPrimitive.Close data-slot="dialog-close" asChild>
-            <Button
-              variant="ghost"
-              className="absolute top-2 right-2"
-              size="icon-sm"
-            >
-              <XIcon
-              />
+            <Button variant="ghost" className="absolute top-2 right-2" size="icon-sm">
+              <XIcon />
               <span className="sr-only">Close</span>
             </Button>
           </DialogPrimitive.Close>
         )}
       </DialogPrimitive.Content>
     </DialogPortal>
-  )
+  );
 }
 
 function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
@@ -90,7 +79,7 @@ function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
       className={cn("flex flex-col gap-2", className)}
       {...props}
     />
-  )
+  );
 }
 
 function DialogFooter({
@@ -99,14 +88,14 @@ function DialogFooter({
   children,
   ...props
 }: React.ComponentProps<"div"> & {
-  showCloseButton?: boolean
+  showCloseButton?: boolean;
 }) {
   return (
     <div
       data-slot="dialog-footer"
       className={cn(
         "-mx-4 -mb-4 flex flex-col-reverse gap-2 rounded-b-xl border-t bg-muted/50 p-4 sm:flex-row sm:justify-end",
-        className
+        className,
       )}
       {...props}
     >
@@ -117,7 +106,7 @@ function DialogFooter({
         </DialogPrimitive.Close>
       )}
     </div>
-  )
+  );
 }
 
 function DialogTitle({
@@ -127,13 +116,10 @@ function DialogTitle({
   return (
     <DialogPrimitive.Title
       data-slot="dialog-title"
-      className={cn(
-        "font-heading text-base leading-none font-medium",
-        className
-      )}
+      className={cn("font-heading text-base leading-none font-medium", className)}
       {...props}
     />
-  )
+  );
 }
 
 function DialogDescription({
@@ -145,11 +131,11 @@ function DialogDescription({
       data-slot="dialog-description"
       className={cn(
         "text-sm text-muted-foreground *:[a]:underline *:[a]:underline-offset-3 *:[a]:hover:text-foreground",
-        className
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
 export {
@@ -163,4 +149,4 @@ export {
   DialogPortal,
   DialogTitle,
   DialogTrigger,
-}
+};

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -1,32 +1,25 @@
-import * as React from "react"
-import { DropdownMenu as DropdownMenuPrimitive } from "radix-ui"
+import * as React from "react";
+import { DropdownMenu as DropdownMenuPrimitive } from "radix-ui";
 
-import { cn } from "@/lib/utils"
-import { CheckIcon, ChevronRightIcon } from "lucide-react"
+import { cn } from "@/lib/utils";
+import { CheckIcon, ChevronRightIcon } from "lucide-react";
 
 function DropdownMenu({
   ...props
 }: React.ComponentProps<typeof DropdownMenuPrimitive.Root>) {
-  return <DropdownMenuPrimitive.Root data-slot="dropdown-menu" {...props} />
+  return <DropdownMenuPrimitive.Root data-slot="dropdown-menu" {...props} />;
 }
 
 function DropdownMenuPortal({
   ...props
 }: React.ComponentProps<typeof DropdownMenuPrimitive.Portal>) {
-  return (
-    <DropdownMenuPrimitive.Portal data-slot="dropdown-menu-portal" {...props} />
-  )
+  return <DropdownMenuPrimitive.Portal data-slot="dropdown-menu-portal" {...props} />;
 }
 
 function DropdownMenuTrigger({
   ...props
 }: React.ComponentProps<typeof DropdownMenuPrimitive.Trigger>) {
-  return (
-    <DropdownMenuPrimitive.Trigger
-      data-slot="dropdown-menu-trigger"
-      {...props}
-    />
-  )
+  return <DropdownMenuPrimitive.Trigger data-slot="dropdown-menu-trigger" {...props} />;
 }
 
 function DropdownMenuContent({
@@ -41,19 +34,20 @@ function DropdownMenuContent({
         data-slot="dropdown-menu-content"
         sideOffset={sideOffset}
         align={align}
-        className={cn("z-50 max-h-(--radix-dropdown-menu-content-available-height) w-(--radix-dropdown-menu-trigger-width) min-w-32 origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-lg bg-popover p-1 text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:overflow-hidden data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95", className )}
+        className={cn(
+          "z-50 max-h-(--radix-dropdown-menu-content-available-height) w-(--radix-dropdown-menu-trigger-width) min-w-32 origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-lg bg-popover p-1 text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:overflow-hidden data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+          className,
+        )}
         {...props}
       />
     </DropdownMenuPrimitive.Portal>
-  )
+  );
 }
 
 function DropdownMenuGroup({
   ...props
 }: React.ComponentProps<typeof DropdownMenuPrimitive.Group>) {
-  return (
-    <DropdownMenuPrimitive.Group data-slot="dropdown-menu-group" {...props} />
-  )
+  return <DropdownMenuPrimitive.Group data-slot="dropdown-menu-group" {...props} />;
 }
 
 function DropdownMenuItem({
@@ -62,8 +56,8 @@ function DropdownMenuItem({
   variant = "default",
   ...props
 }: React.ComponentProps<typeof DropdownMenuPrimitive.Item> & {
-  inset?: boolean
-  variant?: "default" | "destructive"
+  inset?: boolean;
+  variant?: "default" | "destructive";
 }) {
   return (
     <DropdownMenuPrimitive.Item
@@ -72,11 +66,11 @@ function DropdownMenuItem({
       data-variant={variant}
       className={cn(
         "group/dropdown-menu-item relative flex cursor-default items-center gap-1.5 rounded-md px-1.5 py-1 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground data-inset:pl-7 data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 data-[variant=destructive]:focus:text-destructive dark:data-[variant=destructive]:focus:bg-destructive/20 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 data-[variant=destructive]:*:[svg]:text-destructive",
-        className
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
 function DropdownMenuCheckboxItem({
@@ -86,7 +80,7 @@ function DropdownMenuCheckboxItem({
   inset,
   ...props
 }: React.ComponentProps<typeof DropdownMenuPrimitive.CheckboxItem> & {
-  inset?: boolean
+  inset?: boolean;
 }) {
   return (
     <DropdownMenuPrimitive.CheckboxItem
@@ -94,7 +88,7 @@ function DropdownMenuCheckboxItem({
       data-inset={inset}
       className={cn(
         "relative flex cursor-default items-center gap-1.5 rounded-md py-1 pr-8 pl-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground focus:**:text-accent-foreground data-inset:pl-7 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
-        className
+        className,
       )}
       checked={checked}
       {...props}
@@ -104,24 +98,20 @@ function DropdownMenuCheckboxItem({
         data-slot="dropdown-menu-checkbox-item-indicator"
       >
         <DropdownMenuPrimitive.ItemIndicator>
-          <CheckIcon
-          />
+          <CheckIcon />
         </DropdownMenuPrimitive.ItemIndicator>
       </span>
       {children}
     </DropdownMenuPrimitive.CheckboxItem>
-  )
+  );
 }
 
 function DropdownMenuRadioGroup({
   ...props
 }: React.ComponentProps<typeof DropdownMenuPrimitive.RadioGroup>) {
   return (
-    <DropdownMenuPrimitive.RadioGroup
-      data-slot="dropdown-menu-radio-group"
-      {...props}
-    />
-  )
+    <DropdownMenuPrimitive.RadioGroup data-slot="dropdown-menu-radio-group" {...props} />
+  );
 }
 
 function DropdownMenuRadioItem({
@@ -130,7 +120,7 @@ function DropdownMenuRadioItem({
   inset,
   ...props
 }: React.ComponentProps<typeof DropdownMenuPrimitive.RadioItem> & {
-  inset?: boolean
+  inset?: boolean;
 }) {
   return (
     <DropdownMenuPrimitive.RadioItem
@@ -138,7 +128,7 @@ function DropdownMenuRadioItem({
       data-inset={inset}
       className={cn(
         "relative flex cursor-default items-center gap-1.5 rounded-md py-1 pr-8 pl-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground focus:**:text-accent-foreground data-inset:pl-7 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
-        className
+        className,
       )}
       {...props}
     >
@@ -147,13 +137,12 @@ function DropdownMenuRadioItem({
         data-slot="dropdown-menu-radio-item-indicator"
       >
         <DropdownMenuPrimitive.ItemIndicator>
-          <CheckIcon
-          />
+          <CheckIcon />
         </DropdownMenuPrimitive.ItemIndicator>
       </span>
       {children}
     </DropdownMenuPrimitive.RadioItem>
-  )
+  );
 }
 
 function DropdownMenuLabel({
@@ -161,7 +150,7 @@ function DropdownMenuLabel({
   inset,
   ...props
 }: React.ComponentProps<typeof DropdownMenuPrimitive.Label> & {
-  inset?: boolean
+  inset?: boolean;
 }) {
   return (
     <DropdownMenuPrimitive.Label
@@ -169,11 +158,11 @@ function DropdownMenuLabel({
       data-inset={inset}
       className={cn(
         "px-1.5 py-1 text-xs font-medium text-muted-foreground data-inset:pl-7",
-        className
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
 function DropdownMenuSeparator({
@@ -186,29 +175,26 @@ function DropdownMenuSeparator({
       className={cn("-mx-1 my-1 h-px bg-border", className)}
       {...props}
     />
-  )
+  );
 }
 
-function DropdownMenuShortcut({
-  className,
-  ...props
-}: React.ComponentProps<"span">) {
+function DropdownMenuShortcut({ className, ...props }: React.ComponentProps<"span">) {
   return (
     <span
       data-slot="dropdown-menu-shortcut"
       className={cn(
         "ml-auto text-xs tracking-widest text-muted-foreground group-focus/dropdown-menu-item:text-accent-foreground",
-        className
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
 function DropdownMenuSub({
   ...props
 }: React.ComponentProps<typeof DropdownMenuPrimitive.Sub>) {
-  return <DropdownMenuPrimitive.Sub data-slot="dropdown-menu-sub" {...props} />
+  return <DropdownMenuPrimitive.Sub data-slot="dropdown-menu-sub" {...props} />;
 }
 
 function DropdownMenuSubTrigger({
@@ -217,7 +203,7 @@ function DropdownMenuSubTrigger({
   children,
   ...props
 }: React.ComponentProps<typeof DropdownMenuPrimitive.SubTrigger> & {
-  inset?: boolean
+  inset?: boolean;
 }) {
   return (
     <DropdownMenuPrimitive.SubTrigger
@@ -225,14 +211,14 @@ function DropdownMenuSubTrigger({
       data-inset={inset}
       className={cn(
         "flex cursor-default items-center gap-1.5 rounded-md px-1.5 py-1 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground data-inset:pl-7 data-open:bg-accent data-open:text-accent-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
-        className
+        className,
       )}
       {...props}
     >
       {children}
       <ChevronRightIcon className="ml-auto" />
     </DropdownMenuPrimitive.SubTrigger>
-  )
+  );
 }
 
 function DropdownMenuSubContent({
@@ -242,10 +228,13 @@ function DropdownMenuSubContent({
   return (
     <DropdownMenuPrimitive.SubContent
       data-slot="dropdown-menu-sub-content"
-      className={cn("z-50 min-w-[96px] origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden rounded-lg bg-popover p-1 text-popover-foreground shadow-lg ring-1 ring-foreground/10 duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95", className )}
+      className={cn(
+        "z-50 min-w-[96px] origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden rounded-lg bg-popover p-1 text-popover-foreground shadow-lg ring-1 ring-foreground/10 duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+        className,
+      )}
       {...props}
     />
-  )
+  );
 }
 
 export {
@@ -264,4 +253,4 @@ export {
   DropdownMenuSub,
   DropdownMenuSubTrigger,
   DropdownMenuSubContent,
-}
+};

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,6 +1,6 @@
-import * as React from "react"
+import * as React from "react";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 function Input({ className, type, ...props }: React.ComponentProps<"input">) {
   return (
@@ -9,11 +9,11 @@ function Input({ className, type, ...props }: React.ComponentProps<"input">) {
       data-slot="input"
       className={cn(
         "h-8 w-full min-w-0 rounded-lg border border-input bg-transparent px-2.5 py-1 text-base transition-colors outline-none file:inline-flex file:h-6 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
-        className
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
-export { Input }
+export { Input };

--- a/src/components/ui/label.tsx
+++ b/src/components/ui/label.tsx
@@ -1,7 +1,7 @@
-import * as React from "react"
-import { Label as LabelPrimitive } from "radix-ui"
+import * as React from "react";
+import { Label as LabelPrimitive } from "radix-ui";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 function Label({
   className,
@@ -12,11 +12,11 @@ function Label({
       data-slot="label"
       className={cn(
         "flex items-center gap-2 text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50",
-        className
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
-export { Label }
+export { Label };

--- a/src/components/ui/scroll-area.tsx
+++ b/src/components/ui/scroll-area.tsx
@@ -1,9 +1,9 @@
-"use client"
+"use client";
 
-import * as React from "react"
-import { ScrollArea as ScrollAreaPrimitive } from "radix-ui"
+import * as React from "react";
+import { ScrollArea as ScrollAreaPrimitive } from "radix-ui";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 function ScrollArea({
   className,
@@ -25,7 +25,7 @@ function ScrollArea({
       <ScrollBar />
       <ScrollAreaPrimitive.Corner />
     </ScrollAreaPrimitive.Root>
-  )
+  );
 }
 
 function ScrollBar({
@@ -40,7 +40,7 @@ function ScrollBar({
       orientation={orientation}
       className={cn(
         "flex touch-none p-px transition-colors select-none data-horizontal:h-2.5 data-horizontal:flex-col data-horizontal:border-t data-horizontal:border-t-transparent data-vertical:h-full data-vertical:w-2.5 data-vertical:border-l data-vertical:border-l-transparent",
-        className
+        className,
       )}
       {...props}
     >
@@ -49,7 +49,7 @@ function ScrollBar({
         className="relative flex-1 rounded-full bg-border"
       />
     </ScrollAreaPrimitive.ScrollAreaScrollbar>
-  )
+  );
 }
 
-export { ScrollArea, ScrollBar }
+export { ScrollArea, ScrollBar };

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -1,15 +1,13 @@
-"use client"
+"use client";
 
-import * as React from "react"
-import { Select as SelectPrimitive } from "radix-ui"
+import * as React from "react";
+import { Select as SelectPrimitive } from "radix-ui";
 
-import { cn } from "@/lib/utils"
-import { ChevronDownIcon, CheckIcon, ChevronUpIcon } from "lucide-react"
+import { cn } from "@/lib/utils";
+import { ChevronDownIcon, CheckIcon, ChevronUpIcon } from "lucide-react";
 
-function Select({
-  ...props
-}: React.ComponentProps<typeof SelectPrimitive.Root>) {
-  return <SelectPrimitive.Root data-slot="select" {...props} />
+function Select({ ...props }: React.ComponentProps<typeof SelectPrimitive.Root>) {
+  return <SelectPrimitive.Root data-slot="select" {...props} />;
 }
 
 function SelectGroup({
@@ -22,13 +20,11 @@ function SelectGroup({
       className={cn("scroll-my-1 p-1", className)}
       {...props}
     />
-  )
+  );
 }
 
-function SelectValue({
-  ...props
-}: React.ComponentProps<typeof SelectPrimitive.Value>) {
-  return <SelectPrimitive.Value data-slot="select-value" {...props} />
+function SelectValue({ ...props }: React.ComponentProps<typeof SelectPrimitive.Value>) {
+  return <SelectPrimitive.Value data-slot="select-value" {...props} />;
 }
 
 function SelectTrigger({
@@ -37,7 +33,7 @@ function SelectTrigger({
   children,
   ...props
 }: React.ComponentProps<typeof SelectPrimitive.Trigger> & {
-  size?: "sm" | "default"
+  size?: "sm" | "default";
 }) {
   return (
     <SelectPrimitive.Trigger
@@ -45,7 +41,7 @@ function SelectTrigger({
       data-size={size}
       className={cn(
         "flex w-fit items-center justify-between gap-1.5 rounded-lg border border-input bg-transparent py-2 pr-2 pl-2.5 text-sm whitespace-nowrap transition-colors outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 data-placeholder:text-muted-foreground data-[size=default]:h-8 data-[size=sm]:h-7 data-[size=sm]:rounded-[min(var(--radius-md),10px)] *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-1.5 dark:bg-input/30 dark:hover:bg-input/50 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
-        className
+        className,
       )}
       {...props}
     >
@@ -54,7 +50,7 @@ function SelectTrigger({
         <ChevronDownIcon className="pointer-events-none size-4 text-muted-foreground" />
       </SelectPrimitive.Icon>
     </SelectPrimitive.Trigger>
-  )
+  );
 }
 
 function SelectContent({
@@ -69,7 +65,12 @@ function SelectContent({
       <SelectPrimitive.Content
         data-slot="select-content"
         data-align-trigger={position === "item-aligned"}
-        className={cn("relative z-50 max-h-(--radix-select-content-available-height) min-w-36 origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-lg bg-popover text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-100 data-[align-trigger=true]:animate-none data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95", position ==="popper"&&"data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1", className )}
+        className={cn(
+          "relative z-50 max-h-(--radix-select-content-available-height) min-w-36 origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-lg bg-popover text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-100 data-[align-trigger=true]:animate-none data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+          position === "popper" &&
+            "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
+          className,
+        )}
         position={position}
         align={align}
         {...props}
@@ -79,7 +80,7 @@ function SelectContent({
           data-position={position}
           className={cn(
             "data-[position=popper]:h-(--radix-select-trigger-height) data-[position=popper]:w-full data-[position=popper]:min-w-(--radix-select-trigger-width)",
-            position === "popper" && ""
+            position === "popper" && "",
           )}
         >
           {children}
@@ -87,7 +88,7 @@ function SelectContent({
         <SelectScrollDownButton />
       </SelectPrimitive.Content>
     </SelectPrimitive.Portal>
-  )
+  );
 }
 
 function SelectLabel({
@@ -100,7 +101,7 @@ function SelectLabel({
       className={cn("px-1.5 py-1 text-xs text-muted-foreground", className)}
       {...props}
     />
-  )
+  );
 }
 
 function SelectItem({
@@ -113,7 +114,7 @@ function SelectItem({
       data-slot="select-item"
       className={cn(
         "relative flex w-full cursor-default items-center gap-1.5 rounded-md py-1 pr-8 pl-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
-        className
+        className,
       )}
       {...props}
     >
@@ -124,7 +125,7 @@ function SelectItem({
       </span>
       <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
     </SelectPrimitive.Item>
-  )
+  );
 }
 
 function SelectSeparator({
@@ -137,7 +138,7 @@ function SelectSeparator({
       className={cn("pointer-events-none -mx-1 my-1 h-px bg-border", className)}
       {...props}
     />
-  )
+  );
 }
 
 function SelectScrollUpButton({
@@ -149,14 +150,13 @@ function SelectScrollUpButton({
       data-slot="select-scroll-up-button"
       className={cn(
         "z-10 flex cursor-default items-center justify-center bg-popover py-1 [&_svg:not([class*='size-'])]:size-4",
-        className
+        className,
       )}
       {...props}
     >
-      <ChevronUpIcon
-      />
+      <ChevronUpIcon />
     </SelectPrimitive.ScrollUpButton>
-  )
+  );
 }
 
 function SelectScrollDownButton({
@@ -168,14 +168,13 @@ function SelectScrollDownButton({
       data-slot="select-scroll-down-button"
       className={cn(
         "z-10 flex cursor-default items-center justify-center bg-popover py-1 [&_svg:not([class*='size-'])]:size-4",
-        className
+        className,
       )}
       {...props}
     >
-      <ChevronDownIcon
-      />
+      <ChevronDownIcon />
     </SelectPrimitive.ScrollDownButton>
-  )
+  );
 }
 
 export {
@@ -189,4 +188,4 @@ export {
   SelectSeparator,
   SelectTrigger,
   SelectValue,
-}
+};

--- a/src/components/ui/separator.tsx
+++ b/src/components/ui/separator.tsx
@@ -1,7 +1,7 @@
-import * as React from "react"
-import { Separator as SeparatorPrimitive } from "radix-ui"
+import * as React from "react";
+import { Separator as SeparatorPrimitive } from "radix-ui";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 function Separator({
   className,
@@ -16,11 +16,11 @@ function Separator({
       orientation={orientation}
       className={cn(
         "shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch",
-        className
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
-export { Separator }
+export { Separator };

--- a/src/components/ui/skeleton.tsx
+++ b/src/components/ui/skeleton.tsx
@@ -1,4 +1,4 @@
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 function Skeleton({ className, ...props }: React.ComponentProps<"div">) {
   return (
@@ -7,7 +7,7 @@ function Skeleton({ className, ...props }: React.ComponentProps<"div">) {
       className={cn("animate-pulse rounded-md bg-muted", className)}
       {...props}
     />
-  )
+  );
 }
 
-export { Skeleton }
+export { Skeleton };

--- a/src/components/ui/sonner.tsx
+++ b/src/components/ui/sonner.tsx
@@ -1,32 +1,28 @@
-"use client"
+"use client";
 
-import { useTheme } from "next-themes"
-import { Toaster as Sonner, type ToasterProps } from "sonner"
-import { CircleCheckIcon, InfoIcon, TriangleAlertIcon, OctagonXIcon, Loader2Icon } from "lucide-react"
+import { useTheme } from "next-themes";
+import { Toaster as Sonner, type ToasterProps } from "sonner";
+import {
+  CircleCheckIcon,
+  InfoIcon,
+  TriangleAlertIcon,
+  OctagonXIcon,
+  Loader2Icon,
+} from "lucide-react";
 
 const Toaster = ({ ...props }: ToasterProps) => {
-  const { theme = "system" } = useTheme()
+  const { theme = "system" } = useTheme();
 
   return (
     <Sonner
       theme={theme as ToasterProps["theme"]}
       className="toaster group"
       icons={{
-        success: (
-          <CircleCheckIcon className="size-4" />
-        ),
-        info: (
-          <InfoIcon className="size-4" />
-        ),
-        warning: (
-          <TriangleAlertIcon className="size-4" />
-        ),
-        error: (
-          <OctagonXIcon className="size-4" />
-        ),
-        loading: (
-          <Loader2Icon className="size-4 animate-spin" />
-        ),
+        success: <CircleCheckIcon className="size-4" />,
+        info: <InfoIcon className="size-4" />,
+        warning: <TriangleAlertIcon className="size-4" />,
+        error: <OctagonXIcon className="size-4" />,
+        loading: <Loader2Icon className="size-4 animate-spin" />,
       }}
       style={
         {
@@ -43,7 +39,7 @@ const Toaster = ({ ...props }: ToasterProps) => {
       }}
       {...props}
     />
-  )
-}
+  );
+};
 
-export { Toaster }
+export { Toaster };

--- a/src/components/ui/switch.tsx
+++ b/src/components/ui/switch.tsx
@@ -1,14 +1,14 @@
-import * as React from "react"
-import { Switch as SwitchPrimitive } from "radix-ui"
+import * as React from "react";
+import { Switch as SwitchPrimitive } from "radix-ui";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 function Switch({
   className,
   size = "default",
   ...props
 }: React.ComponentProps<typeof SwitchPrimitive.Root> & {
-  size?: "sm" | "default"
+  size?: "sm" | "default";
 }) {
   return (
     <SwitchPrimitive.Root
@@ -16,7 +16,7 @@ function Switch({
       data-size={size}
       className={cn(
         "peer group/switch relative inline-flex shrink-0 items-center rounded-full border border-transparent transition-all outline-none after:absolute after:-inset-x-3 after:-inset-y-2 focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 data-[size=default]:h-[18.4px] data-[size=default]:w-[32px] data-[size=sm]:h-[14px] data-[size=sm]:w-[24px] dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 data-checked:bg-primary data-unchecked:bg-input dark:data-unchecked:bg-input/80 data-disabled:cursor-not-allowed data-disabled:opacity-50",
-        className
+        className,
       )}
       {...props}
     >
@@ -25,7 +25,7 @@ function Switch({
         className="pointer-events-none block rounded-full bg-background ring-0 transition-transform group-data-[size=default]/switch:size-4 group-data-[size=sm]/switch:size-3 group-data-[size=default]/switch:data-checked:translate-x-[calc(100%-2px)] group-data-[size=sm]/switch:data-checked:translate-x-[calc(100%-2px)] dark:data-checked:bg-primary-foreground group-data-[size=default]/switch:data-unchecked:translate-x-0 group-data-[size=sm]/switch:data-unchecked:translate-x-0 dark:data-unchecked:bg-foreground"
       />
     </SwitchPrimitive.Root>
-  )
+  );
 }
 
-export { Switch }
+export { Switch };

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -1,6 +1,6 @@
-import * as React from "react"
+import * as React from "react";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
   return (
@@ -8,11 +8,11 @@ function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
       data-slot="textarea"
       className={cn(
         "w-full min-w-0 rounded-lg border border-input bg-transparent px-2.5 py-2 text-sm transition-colors outline-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:bg-input/30",
-        className
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
-export { Textarea }
+export { Textarea };

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -1,7 +1,7 @@
-import * as React from "react"
-import { Tooltip as TooltipPrimitive } from "radix-ui"
+import * as React from "react";
+import { Tooltip as TooltipPrimitive } from "radix-ui";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 function TooltipProvider({
   delayDuration = 0,
@@ -13,19 +13,17 @@ function TooltipProvider({
       delayDuration={delayDuration}
       {...props}
     />
-  )
+  );
 }
 
-function Tooltip({
-  ...props
-}: React.ComponentProps<typeof TooltipPrimitive.Root>) {
-  return <TooltipPrimitive.Root data-slot="tooltip" {...props} />
+function Tooltip({ ...props }: React.ComponentProps<typeof TooltipPrimitive.Root>) {
+  return <TooltipPrimitive.Root data-slot="tooltip" {...props} />;
 }
 
 function TooltipTrigger({
   ...props
 }: React.ComponentProps<typeof TooltipPrimitive.Trigger>) {
-  return <TooltipPrimitive.Trigger data-slot="tooltip-trigger" {...props} />
+  return <TooltipPrimitive.Trigger data-slot="tooltip-trigger" {...props} />;
 }
 
 function TooltipContent({
@@ -41,7 +39,7 @@ function TooltipContent({
         sideOffset={sideOffset}
         className={cn(
           "z-50 inline-flex w-fit max-w-xs origin-(--radix-tooltip-content-transform-origin) items-center gap-1.5 rounded-md bg-foreground px-3 py-1.5 text-xs text-background has-data-[slot=kbd]:pr-1.5 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 **:data-[slot=kbd]:relative **:data-[slot=kbd]:isolate **:data-[slot=kbd]:z-50 **:data-[slot=kbd]:rounded-sm data-[state=delayed-open]:animate-in data-[state=delayed-open]:fade-in-0 data-[state=delayed-open]:zoom-in-95 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
-          className
+          className,
         )}
         {...props}
       >
@@ -49,7 +47,7 @@ function TooltipContent({
         <TooltipPrimitive.Arrow className="z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px] bg-foreground fill-foreground" />
       </TooltipPrimitive.Content>
     </TooltipPrimitive.Portal>
-  )
+  );
 }
 
-export { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger }
+export { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger };

--- a/src/index.css
+++ b/src/index.css
@@ -6,140 +6,140 @@
 @custom-variant dark (&:is(.dark *));
 
 @theme inline {
-    --font-heading: var(--font-sans);
-    --font-sans: 'Geist Variable', sans-serif;
-    --color-sidebar-ring: var(--sidebar-ring);
-    --color-sidebar-border: var(--sidebar-border);
-    --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
-    --color-sidebar-accent: var(--sidebar-accent);
-    --color-sidebar-primary-foreground: var(--sidebar-primary-foreground);
-    --color-sidebar-primary: var(--sidebar-primary);
-    --color-sidebar-foreground: var(--sidebar-foreground);
-    --color-sidebar: var(--sidebar);
-    --color-chart-5: var(--chart-5);
-    --color-chart-4: var(--chart-4);
-    --color-chart-3: var(--chart-3);
-    --color-chart-2: var(--chart-2);
-    --color-chart-1: var(--chart-1);
-    --color-ring: var(--ring);
-    --color-input: var(--input);
-    --color-border: var(--border);
-    --color-destructive: var(--destructive);
-    --color-success: var(--success);
-    --color-warning: var(--warning);
-    --color-info: var(--info);
-    --color-owned: var(--owned);
-    --color-accent-foreground: var(--accent-foreground);
-    --color-accent: var(--accent);
-    --color-muted-foreground: var(--muted-foreground);
-    --color-muted: var(--muted);
-    --color-secondary-foreground: var(--secondary-foreground);
-    --color-secondary: var(--secondary);
-    --color-primary-foreground: var(--primary-foreground);
-    --color-primary: var(--primary);
-    --color-popover-foreground: var(--popover-foreground);
-    --color-popover: var(--popover);
-    --color-card-foreground: var(--card-foreground);
-    --color-card: var(--card);
-    --color-foreground: var(--foreground);
-    --color-background: var(--background);
-    --radius-sm: calc(var(--radius) * 0.6);
-    --radius-md: calc(var(--radius) * 0.8);
-    --radius-lg: var(--radius);
-    --radius-xl: calc(var(--radius) * 1.4);
-    --radius-2xl: calc(var(--radius) * 1.8);
-    --radius-3xl: calc(var(--radius) * 2.2);
-    --radius-4xl: calc(var(--radius) * 2.6);
+  --font-heading: var(--font-sans);
+  --font-sans: "Geist Variable", sans-serif;
+  --color-sidebar-ring: var(--sidebar-ring);
+  --color-sidebar-border: var(--sidebar-border);
+  --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
+  --color-sidebar-accent: var(--sidebar-accent);
+  --color-sidebar-primary-foreground: var(--sidebar-primary-foreground);
+  --color-sidebar-primary: var(--sidebar-primary);
+  --color-sidebar-foreground: var(--sidebar-foreground);
+  --color-sidebar: var(--sidebar);
+  --color-chart-5: var(--chart-5);
+  --color-chart-4: var(--chart-4);
+  --color-chart-3: var(--chart-3);
+  --color-chart-2: var(--chart-2);
+  --color-chart-1: var(--chart-1);
+  --color-ring: var(--ring);
+  --color-input: var(--input);
+  --color-border: var(--border);
+  --color-destructive: var(--destructive);
+  --color-success: var(--success);
+  --color-warning: var(--warning);
+  --color-info: var(--info);
+  --color-owned: var(--owned);
+  --color-accent-foreground: var(--accent-foreground);
+  --color-accent: var(--accent);
+  --color-muted-foreground: var(--muted-foreground);
+  --color-muted: var(--muted);
+  --color-secondary-foreground: var(--secondary-foreground);
+  --color-secondary: var(--secondary);
+  --color-primary-foreground: var(--primary-foreground);
+  --color-primary: var(--primary);
+  --color-popover-foreground: var(--popover-foreground);
+  --color-popover: var(--popover);
+  --color-card-foreground: var(--card-foreground);
+  --color-card: var(--card);
+  --color-foreground: var(--foreground);
+  --color-background: var(--background);
+  --radius-sm: calc(var(--radius) * 0.6);
+  --radius-md: calc(var(--radius) * 0.8);
+  --radius-lg: var(--radius);
+  --radius-xl: calc(var(--radius) * 1.4);
+  --radius-2xl: calc(var(--radius) * 1.8);
+  --radius-3xl: calc(var(--radius) * 2.2);
+  --radius-4xl: calc(var(--radius) * 2.6);
 }
 
 :root {
-    color-scheme: light;
-    --background: oklch(1 0 0);
-    --foreground: oklch(0.145 0 0);
-    --card: oklch(1 0 0);
-    --card-foreground: oklch(0.145 0 0);
-    --popover: oklch(1 0 0);
-    --popover-foreground: oklch(0.145 0 0);
-    --primary: oklch(0.205 0 0);
-    --primary-foreground: oklch(0.985 0 0);
-    --secondary: oklch(0.97 0 0);
-    --secondary-foreground: oklch(0.205 0 0);
-    --muted: oklch(0.97 0 0);
-    --muted-foreground: oklch(0.556 0 0);
-    --accent: oklch(0.97 0 0);
-    --accent-foreground: oklch(0.205 0 0);
-    --destructive: oklch(0.577 0.245 27.325);
-    /* Semantic accent tokens, one shade each, so success/warning/info/owned render
+  color-scheme: light;
+  --background: oklch(1 0 0);
+  --foreground: oklch(0.145 0 0);
+  --card: oklch(1 0 0);
+  --card-foreground: oklch(0.145 0 0);
+  --popover: oklch(1 0 0);
+  --popover-foreground: oklch(0.145 0 0);
+  --primary: oklch(0.205 0 0);
+  --primary-foreground: oklch(0.985 0 0);
+  --secondary: oklch(0.97 0 0);
+  --secondary-foreground: oklch(0.205 0 0);
+  --muted: oklch(0.97 0 0);
+  --muted-foreground: oklch(0.556 0 0);
+  --accent: oklch(0.97 0 0);
+  --accent-foreground: oklch(0.205 0 0);
+  --destructive: oklch(0.577 0.245 27.325);
+  /* Semantic accent tokens, one shade each, so success/warning/info/owned render
        identically across every view (the audit found these drifting 300/400/500).
        Values are the Tailwind v4 *-400 palette: emerald, amber, violet, sky. */
-    --success: oklch(0.765 0.177 163.223);
-    --warning: oklch(0.828 0.189 84.429);
-    --info: oklch(0.702 0.183 293.541);
-    --owned: oklch(0.746 0.16 232.661);
-    --border: oklch(0.922 0 0);
-    --input: oklch(0.922 0 0);
-    --ring: oklch(0.708 0 0);
-    --chart-1: oklch(0.87 0 0);
-    --chart-2: oklch(0.556 0 0);
-    --chart-3: oklch(0.439 0 0);
-    --chart-4: oklch(0.371 0 0);
-    --chart-5: oklch(0.269 0 0);
-    --radius: 0.625rem;
-    --sidebar: oklch(0.985 0 0);
-    --sidebar-foreground: oklch(0.145 0 0);
-    --sidebar-primary: oklch(0.205 0 0);
-    --sidebar-primary-foreground: oklch(0.985 0 0);
-    --sidebar-accent: oklch(0.97 0 0);
-    --sidebar-accent-foreground: oklch(0.205 0 0);
-    --sidebar-border: oklch(0.922 0 0);
-    --sidebar-ring: oklch(0.708 0 0);
+  --success: oklch(0.765 0.177 163.223);
+  --warning: oklch(0.828 0.189 84.429);
+  --info: oklch(0.702 0.183 293.541);
+  --owned: oklch(0.746 0.16 232.661);
+  --border: oklch(0.922 0 0);
+  --input: oklch(0.922 0 0);
+  --ring: oklch(0.708 0 0);
+  --chart-1: oklch(0.87 0 0);
+  --chart-2: oklch(0.556 0 0);
+  --chart-3: oklch(0.439 0 0);
+  --chart-4: oklch(0.371 0 0);
+  --chart-5: oklch(0.269 0 0);
+  --radius: 0.625rem;
+  --sidebar: oklch(0.985 0 0);
+  --sidebar-foreground: oklch(0.145 0 0);
+  --sidebar-primary: oklch(0.205 0 0);
+  --sidebar-primary-foreground: oklch(0.985 0 0);
+  --sidebar-accent: oklch(0.97 0 0);
+  --sidebar-accent-foreground: oklch(0.205 0 0);
+  --sidebar-border: oklch(0.922 0 0);
+  --sidebar-ring: oklch(0.708 0 0);
 }
 
 .dark {
-    color-scheme: dark;
-    --background: oklch(0.145 0 0);
-    --foreground: oklch(0.985 0 0);
-    --card: oklch(0.205 0 0);
-    --card-foreground: oklch(0.985 0 0);
-    --popover: oklch(0.205 0 0);
-    --popover-foreground: oklch(0.985 0 0);
-    --primary: oklch(0.922 0 0);
-    --primary-foreground: oklch(0.205 0 0);
-    --secondary: oklch(0.269 0 0);
-    --secondary-foreground: oklch(0.985 0 0);
-    --muted: oklch(0.269 0 0);
-    --muted-foreground: oklch(0.708 0 0);
-    --accent: oklch(0.269 0 0);
-    --accent-foreground: oklch(0.985 0 0);
-    --destructive: oklch(0.704 0.191 22.216);
-    --border: oklch(1 0 0 / 10%);
-    --input: oklch(1 0 0 / 15%);
-    --ring: oklch(0.556 0 0);
-    --chart-1: oklch(0.87 0 0);
-    --chart-2: oklch(0.556 0 0);
-    --chart-3: oklch(0.439 0 0);
-    --chart-4: oklch(0.371 0 0);
-    --chart-5: oklch(0.269 0 0);
-    --sidebar: oklch(0.205 0 0);
-    --sidebar-foreground: oklch(0.985 0 0);
-    --sidebar-primary: oklch(0.488 0.243 264.376);
-    --sidebar-primary-foreground: oklch(0.985 0 0);
-    --sidebar-accent: oklch(0.269 0 0);
-    --sidebar-accent-foreground: oklch(0.985 0 0);
-    --sidebar-border: oklch(1 0 0 / 10%);
-    --sidebar-ring: oklch(0.556 0 0);
+  color-scheme: dark;
+  --background: oklch(0.145 0 0);
+  --foreground: oklch(0.985 0 0);
+  --card: oklch(0.205 0 0);
+  --card-foreground: oklch(0.985 0 0);
+  --popover: oklch(0.205 0 0);
+  --popover-foreground: oklch(0.985 0 0);
+  --primary: oklch(0.922 0 0);
+  --primary-foreground: oklch(0.205 0 0);
+  --secondary: oklch(0.269 0 0);
+  --secondary-foreground: oklch(0.985 0 0);
+  --muted: oklch(0.269 0 0);
+  --muted-foreground: oklch(0.708 0 0);
+  --accent: oklch(0.269 0 0);
+  --accent-foreground: oklch(0.985 0 0);
+  --destructive: oklch(0.704 0.191 22.216);
+  --border: oklch(1 0 0 / 10%);
+  --input: oklch(1 0 0 / 15%);
+  --ring: oklch(0.556 0 0);
+  --chart-1: oklch(0.87 0 0);
+  --chart-2: oklch(0.556 0 0);
+  --chart-3: oklch(0.439 0 0);
+  --chart-4: oklch(0.371 0 0);
+  --chart-5: oklch(0.269 0 0);
+  --sidebar: oklch(0.205 0 0);
+  --sidebar-foreground: oklch(0.985 0 0);
+  --sidebar-primary: oklch(0.488 0.243 264.376);
+  --sidebar-primary-foreground: oklch(0.985 0 0);
+  --sidebar-accent: oklch(0.269 0 0);
+  --sidebar-accent-foreground: oklch(0.985 0 0);
+  --sidebar-border: oklch(1 0 0 / 10%);
+  --sidebar-ring: oklch(0.556 0 0);
 }
 
 @layer base {
   * {
     @apply border-border outline-ring/50;
-    }
+  }
   body {
     @apply bg-background text-foreground;
-    }
+  }
   html {
     @apply font-sans;
-    }
+  }
 }
 
 /* Respect the OS reduced-motion preference: zero out the spinners, pulses, dialog

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -103,10 +103,7 @@ export interface AddedHttpClient {
 
 /** Register an HTTP-bridge client scoped to a profile (empty = all servers).
  * Returns the one-time plaintext token to paste into the client. */
-export function addHttpClient(
-  label: string,
-  profile?: string,
-): Promise<AddedHttpClient> {
+export function addHttpClient(label: string, profile?: string): Promise<AddedHttpClient> {
   return invoke<AddedHttpClient>("add_http_client", { label, profile });
 }
 
@@ -496,10 +493,7 @@ export function previewImport(json: string): Promise<ImportItem[]> {
 }
 
 /** Enable or disable every server in a profile at once. */
-export function setAllEnabled(
-  profileId: string,
-  enabled: boolean,
-): Promise<Registry> {
+export function setAllEnabled(profileId: string, enabled: boolean): Promise<Registry> {
   return invoke<Registry>("set_all_enabled", { profileId, enabled });
 }
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -2,12 +2,7 @@ export type Transport = "stdio" | "http" | "sse" | "unknown";
 
 /** The main content views, selected from the sidebar. */
 export type View =
-  | "servers"
-  | "activity"
-  | "catalog"
-  | "playground"
-  | "teams"
-  | "settings";
+  "servers" | "activity" | "catalog" | "playground" | "teams" | "settings";
 
 export interface McpServer {
   name: string;
@@ -453,11 +448,8 @@ export function importableServers(
   client: DetectedClient,
   registry: Registry | null,
 ): McpServer[] {
-  const have = new Set(
-    (registry?.servers ?? []).map((s) => s.name.toLowerCase()),
-  );
+  const have = new Set((registry?.servers ?? []).map((s) => s.name.toLowerCase()));
   return [...client.servers, ...client.pluginServers].filter(
-    (s) =>
-      s.name.toLowerCase() !== "conduit" && !have.has(s.name.toLowerCase()),
+    (s) => s.name.toLowerCase() !== "conduit" && !have.has(s.name.toLowerCase()),
   );
 }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,8 +1,8 @@
-import { clsx, type ClassValue } from "clsx"
-import { twMerge } from "tailwind-merge"
+import { clsx, type ClassValue } from "clsx";
+import { twMerge } from "tailwind-merge";
 
 export function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs))
+  return twMerge(clsx(inputs));
 }
 
 /**
@@ -11,7 +11,7 @@ export function cn(...inputs: ClassValue[]) {
  * same rounded figure for the same number.
  */
 export function fmtTokens(n: number): string {
-  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`
-  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`
-  return `${n}`
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`;
+  return `${n}`;
 }


### PR DESCRIPTION
## Summary

Adds Prettier with CI enforcement to the Toolport frontend and docs.

## What changed

- **`.prettierrc.json`** — config matching the project's intended style (2-space indent, double quotes, semicolons, trailing commas, 90-char width).
- **`.prettierignore`** — excludes `dist/`, `node_modules/`, `package-lock.json`, and build artifacts.
- **Tree-wide reformat.** This normalizes the whole frontend to that style: the entire `src/` tree (~35 files) plus peripheral files (`index.html`, benchmark scripts, `scripts/prepare-sidecar.mjs`, `src-tauri/tauri.bundle.conf.json`, and several markdown docs). The changes are formatting-only, mostly semicolon and quote-style normalization; no logic changes.
- **`package.json`** — adds `npm run format` (write) and `npm run format:check` (check).
- **CI** — adds a `Check formatting` step before the build, failing fast on formatting-only issues.
- **CONTRIBUTING.md** — documents the format commands.

> Note: because this reformats the whole tree, the Prettier commit is recorded in `.git-blame-ignore-revs` so `git blame` skips past it.

## Why Prettier first (before ESLint/Vitest)

Highest-noise change (touches the whole tree). Doing it first establishes the formatting baseline the ESLint and Vitest PRs build on.

## Validation

```bash
npm run format:check   # All matched files use Prettier code style!
npx tsc --noEmit       # clean
npm run build          # clean
```
