### PR TITLE
chore: add ESLint with TypeScript, React hooks, and CI enforcement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,9 @@ jobs:
       - name: Check formatting
         run: npm run format:check
 
+      - name: Lint
+        run: npm run lint
+
       # Frontend type-check + build (`build` is `tsc && vite build`). Also produces
       # dist/, which tauri-build expects when compiling the Rust crate below.
       - name: Frontend type-check + build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,11 @@ jobs:
 
       - run: npm ci
 
+      # Enforce consistent formatting before anything else — fails fast on
+      # formatting-only issues so the contributor doesn't wait for a full build.
+      - name: Check formatting
+        run: npm run format:check
+
       # Frontend type-check + build (`build` is `tsc && vite build`). Also produces
       # dist/, which tauri-build expects when compiling the Rust crate below.
       - name: Frontend type-check + build

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,13 @@
+# Build artifacts
+dist/
+src-tauri/target/
+src-tauri/binaries/
+
+# Dependencies
+node_modules/
+
+# Lockfile (formatting churn with no value)
+package-lock.json
+
+# Generated/external
+src-tauri/gen/

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,10 @@
+{
+  "semi": true,
+  "singleQuote": false,
+  "tabWidth": 2,
+  "trailingComma": "all",
+  "printWidth": 90,
+  "bracketSpacing": true,
+  "arrowParens": "always",
+  "endOfLine": "lf"
+}

--- a/BENCHMARK.md
+++ b/BENCHMARK.md
@@ -1,7 +1,7 @@
 # Toolport token benchmark
 
 **Routing MCP servers through Toolport's lazy discovery cut total tokens 74-91% at the
-SAME task success rate**, measured on a frontier model and graded for *correct answers*,
+SAME task success rate**, measured on a frontier model and graded for _correct answers_,
 not just completion. Every task completed correctly in both modes, and the savings grow
 as you add servers. The reduction comes from not loading every tool's schema into the
 model's context on every request.
@@ -29,16 +29,16 @@ Reproduce it yourself: [`benchmark/`](benchmark/).
 End-to-end tokens to complete the three tasks (median of 5 runs), both modes graded:
 
 | Servers | Tools | Flat tokens | Lazy tokens | Reduction | Correct (flat / lazy) |
-|---|---|---|---|---|---|
-| 3 | 63 | 179,181 | 47,095 | **74%** | 15/15 · 15/15 |
-| 6 | 183 | 471,775 | 40,354 | **91%** | 15/15 · 15/15 |
+| ------- | ----- | ----------- | ----------- | --------- | --------------------- |
+| 3       | 63    | 179,181     | 47,095      | **74%**   | 15/15 · 15/15         |
+| 6       | 183   | 471,775     | 40,354      | **91%**   | 15/15 · 15/15         |
 
 Two things stand out:
 
-- **Identical task success.** Every task completed *correctly* in both modes, 30/30.
+- **Identical task success.** Every task completed _correctly_ in both modes, 30/30.
   Lazy discovery did not trade accuracy for tokens.
 - **The savings grow with your catalog.** Flat's cost more than doubled as servers went
-  3 → 6 (it re-sends every tool schema on every call), while lazy's actually *dropped*
+  3 → 6 (it re-sends every tool schema on every call), while lazy's actually _dropped_
   (47K → 40K), it pays a flat ~450-token meta-tool overhead no matter how many servers
   you connect. Per-request tool-definition overhead: flat **19,002 → 51,533**, lazy a
   constant **451**.
@@ -57,32 +57,32 @@ at a real Toolport catalog (no model needed, it just measures the tool definitio
 and the gap widens fast. On a live 14-server setup of **415 tools**, the definitions
 an agent loads on **every request** measure:
 
-| | Per request |
-|---|---|
-| Without Toolport (all 415 tools) | **164,880 tokens** |
-| With Toolport (3 meta-tools, flat) | **660 tokens** |
-| Reduction | **99.6%** |
+|                                    | Per request        |
+| ---------------------------------- | ------------------ |
+| Without Toolport (all 415 tools)   | **164,880 tokens** |
+| With Toolport (3 meta-tools, flat) | **660 tokens**     |
+| Reduction                          | **99.6%**          |
 
 The cost is dominated by a few large servers:
 
-| Server | Tools | Definition tokens |
-|---|---|---|
-| RevenueCat | 93 | 42,370 |
-| GitHub | 44 | 27,913 |
-| Resend | 83 | 26,045 |
-| Cloudflare (observability) | 8 | 5,948 |
-| Stripe | 11 | 5,214 |
-| Vercel | 20 | 5,029 |
-| Supabase | 29 | 4,897 |
-| (5 more) | ... | ... |
+| Server                     | Tools | Definition tokens |
+| -------------------------- | ----- | ----------------- |
+| RevenueCat                 | 93    | 42,370            |
+| GitHub                     | 44    | 27,913            |
+| Resend                     | 83    | 26,045            |
+| Cloudflare (observability) | 8     | 5,948             |
+| Stripe                     | 11    | 5,214             |
+| Vercel                     | 20    | 5,029             |
+| Supabase                   | 29    | 4,897             |
+| (5 more)                   | ...   | ...               |
 
-At ~165k tokens of definitions *per request*, that catalog barely fits in most
+At ~165k tokens of definitions _per request_, that catalog barely fits in most
 models' context alongside real work. On a subscription with usage caps (Claude
 Pro/Max, Cursor, and the like) you feel that directly as runway: cutting ~99% of
 always-on tool tokens is roughly that much more headroom for real work before you
 hit a limit, and prompt caching doesn't stretch a usage cap the way it discounts a
 bill. Toolport's meta-tools stay flat no matter how many servers you add, which is
-why the reduction *grows* with your setup (90% at 62 tools, 99.6% at 415).
+why the reduction _grows_ with your setup (90% at 62 tools, 99.6% at 415).
 
 The measured average here is ~397 tokens per tool, consistent with the ~387 the
 public [calculator](https://toolport.app/calculator) uses.
@@ -94,11 +94,11 @@ it with [`benchmark/latency.mjs`](benchmark/latency.mjs), which spawns the gatew
 against an instant mock downstream so the number is purely Toolport's own overhead
 (no model, no network, no API keys):
 
-| Operation | Median |
-|---|---|
-| Handshake (one-time, per gateway start) | ~21 ms |
-| `tools/list` (lazy, 3 tools) | ~0.2 ms |
-| `toolport_search_tools` | ~0.1 ms |
+| Operation                                                    | Median        |
+| ------------------------------------------------------------ | ------------- |
+| Handshake (one-time, per gateway start)                      | ~21 ms        |
+| `tools/list` (lazy, 3 tools)                                 | ~0.2 ms       |
+| `toolport_search_tools`                                      | ~0.1 ms       |
 | A tool call through Toolport vs. calling the server directly | **+~0.75 ms** |
 
 Toolport adds well under a millisecond to a tool call. Real MCP servers take tens to
@@ -109,7 +109,7 @@ run it on yours: `node benchmark/latency.mjs`.)
 ## Honest caveats
 
 - **Scope:** one frontier model (GPT-5.5), one machine, three read-only "list" tasks, 5
-  runs each. Treat the *direction* (a large, consistent reduction at equal correctness) as
+  runs each. Treat the _direction_ (a large, consistent reduction at equal correctness) as
   the signal, not the exact percentage. The deterministic overhead numbers above need no
   such caveat, they're exact.
 - **Correctness is graded, not eyeballed.** A run counts only if the answer contains the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Entries before the rename below shipped under the project's former name, Conduit
 ## [1.2.0] - 2026-07-03
 
 ### Security
+
 - **Closed several bypasses in the stdio spawn guard** (the supply-chain check that
   refuses code-smuggling launch args on a spawned server). Two rounds of adversarial
   review found a booby-trapped (team- or registry-sourced) config could still reach code
@@ -50,7 +51,7 @@ Entries before the rename below shipped under the project's former name, Conduit
   keeps the gateway running, instead of unwinding out and dropping the whole MCP
   connection (defense-in-depth for the primary local transport).
 - **HTTP clients are scoped on resources and prompts too.** A registered HTTP/OpenAPI
-  client scoped to a subset of servers could still read *any* connected server's
+  client scoped to a subset of servers could still read _any_ connected server's
   resources and prompts (`resources/read` / `prompts/get` ignored the scope); they now
   enforce the same allowed-server set as tool calls.
 - **Closed three tool-supply-chain detection gaps** from an internal audit: a tool's
@@ -70,6 +71,7 @@ Entries before the rename below shipped under the project's former name, Conduit
   Realistic results are far under the cap, so detection is unaffected in practice.
 
 ### Added
+
 - **Pi coding agent is now a supported client.** Toolport detects Pi, imports its
   configured MCP servers, and installs/removes the gateway entry in Pi's global config
   (`~/.pi/agent/mcp.json`), the same one-click flow as Cursor and the other clients.
@@ -97,6 +99,7 @@ Entries before the rename below shipped under the project's former name, Conduit
   Local and bounded, and it stores tool names only (never arguments or results).
 
 ### Changed
+
 - **The HTTP gateway now handles requests concurrently.** Each request runs on its
   own worker, so a slow downstream server or a tool call held for human approval (up
   to two minutes) no longer blocks other requests, live setting toggles, or
@@ -114,6 +117,7 @@ Entries before the rename below shipped under the project's former name, Conduit
   scope dropdown was also widened so "All enabled servers" is no longer clipped.
 
 ### Fixed
+
 - **macOS: monochrome menu-bar glyph, and no more Dock-and-menu-bar at once.** The
   tray now uses a template image (the Toolport porthole mark), so macOS tints it to
   match every other menu-bar item instead of showing the full-color app icon. And the
@@ -144,6 +148,7 @@ Entries before the rename below shipped under the project's former name, Conduit
 ## [1.1.0] - 2026-07-02
 
 ### Added
+
 - **Human-in-the-loop tool approval (opt-in).** With "Require human approval" on, Toolport
   holds any destructive or untrusted-server tool call and raises a desktop notification until
   you approve or deny it in the app. Fail-closed: if no decision is made in time, the call is
@@ -155,6 +160,7 @@ Entries before the rename below shipped under the project's former name, Conduit
   (Settings > General).
 
 ### Changed
+
 - **Security notices are tiered by severity, so real threats aren't buried.** Risky
   tool-definition drift (a destructive tool changing, a tool dropping a readOnly/destructive
   safety annotation, or poisoned content) stays a loud, actionable notice; benign vendor
@@ -162,12 +168,14 @@ Entries before the rename below shipped under the project's former name, Conduit
   across restarts, and duplicate notices from multiple clients are collapsed.
 
 ### Fixed
+
 - Cleaned up leftover "Conduit" references in a few spots (the Teams connect URL placeholder,
   the "download from releases" link, and the exported setup filename).
 
 ## [1.0.1] - 2026-07-02
 
 ### Fixed
+
 - **Windows: upgraders now show "Toolport" in the Start menu.** After the rename, an
   in-place update from Conduit left the old "Conduit" shortcut and green icon behind
   (the bundle identifier is intentionally unchanged so your data and secrets carry
@@ -194,11 +202,13 @@ Entries before the rename below shipped under the project's former name, Conduit
 ## [0.9.4] - 2026-07-01
 
 ### Added
+
 - **Registry backup and recovery.** A `registry.json.bak` sibling keeps the
   last-known-good server list; Conduit recovers from it if `registry.json` is deleted
   or corrupted, so a bad write or an accidental wipe no longer loses your servers.
 
 ### Fixed
+
 - **Per-server head-of-line blocking.** The gateway releases the per-server lock during
   a downstream backoff, so one server's 429 rate-limit no longer stalls other concurrent
   calls to that same server.
@@ -206,11 +216,13 @@ Entries before the rename below shipped under the project's former name, Conduit
   cap (10s), so a misconfigured or hostile server can't park a call for minutes.
 
 ### Docs
+
 - Codex setup walkthrough in the README.
 
 ## [0.9.3] - 2026-07-01
 
 ### Security
+
 - **macOS: no more keychain prompts on update.** Secrets now live in the macOS
   data-protection keychain under a team-scoped shared access group, and the gateway
   ships as a nested notarized helper that shares that group. The gateway reads the
@@ -219,17 +231,20 @@ Entries before the rename below shipped under the project's former name, Conduit
   never touch disk.
 
 ### Added
+
 - **Quarantine-on-drift.** High-risk tool-definition changes (a poisoned definition, or
   a destructive tool that changed or newly appeared) are blocked until you re-approve.
 - **Headless encrypted-file secret backend** (`CONDUIT_SECRET_KEY`) for server/self-host
   use where no OS keychain is available.
 
 ### Changed
+
 - Teams pricing is $12/seat (was $20). Smaller initial bundle via code-splitting.
 
 ## [0.9.2] - 2026-06-30
 
 ### Added
+
 - **Catalog: configure-on-add** (enter keys while adding a server), **self-hosted
   servers** (n8n, Langfuse), and more entries (DataForSEO, Chrome DevTools, Railway,
   Twilio, Postiz).
@@ -237,6 +252,7 @@ Entries before the rename below shipped under the project's former name, Conduit
 - **Paste a config snippet** to auto-fill the Add Server dialog.
 
 ### Fixed
+
 - Remote servers refresh an expired OAuth token on a mid-session 401 and retry, no manual
   reconnect.
 - Teams only soft-syncs servers the member opts into (no silent RCE from team config).
@@ -244,6 +260,7 @@ Entries before the rename below shipped under the project's former name, Conduit
 ## [0.9.1] - 2026-06-29
 
 ### Added
+
 - **New stack: Web scraping & automation.** An eighth role bundle (Firecrawl,
   Tavily, Playwright, Browserbase, Apify) for agents that search, scrape, and
   drive real browsers.
@@ -256,6 +273,7 @@ Entries before the rename below shipped under the project's former name, Conduit
 ## [0.9.0] - 2026-06-29
 
 ### Added
+
 - **Stacks: role-based server bundles.** Pick what you work on (full-stack web,
   backend & data, infra & DevOps, AI & ML, product & design, founder, research)
   and Conduit sets up a matching set of MCP servers in one click. Stacks appear at
@@ -271,10 +289,12 @@ Entries before the rename below shipped under the project's former name, Conduit
 - **New catalog servers:** Linode (Akamai) cloud, and Qdrant (vector store for RAG).
 
 ### Fixed
+
 - The scoped-client scope picker in Settings rendered an unthemed white dropdown
   in dark mode; it now uses the app's themed select.
 
 ### Internal
+
 - Groundwork for concurrent tool routing (per-server interior mutability in the
   router; no behavior change yet), and a fix for an XDG env race that could flake
   a path test on CI.
@@ -282,6 +302,7 @@ Entries before the rename below shipped under the project's former name, Conduit
 ## [0.8.0] - 2026-06-28
 
 ### Added
+
 - **Multi-tenant HTTP bridge (per-client scoping).** Register HTTP clients in
   Settings → Integrations, each with its own bearer token and profile. One bridge
   process serves them all and resolves every request's token to its own set of
@@ -305,6 +326,7 @@ Entries before the rename below shipped under the project's former name, Conduit
   scheme, and real error responses, so OpenAPI clients can model auth and failures.
 
 ### Changed
+
 - **HTTP bridge auth tightened.** Once any scoped client is registered, the bridge
   rejects unauthenticated requests even when no global token is set. CORS no longer
   reflects the caller's Origin or sends credentials, and cross-site browser
@@ -314,6 +336,7 @@ Entries before the rename below shipped under the project's former name, Conduit
   call may already have executed.
 
 ### Security
+
 - Constant-time comparison for the bridge bearer token.
 - The SSRF connect-guard now also blocks IPv6 link-local and cloud-metadata
   addresses (including the AWS IPv6 metadata address), not just IPv4 169.254.x.
@@ -325,6 +348,7 @@ Entries before the rename below shipped under the project's former name, Conduit
   "string" on content fields (only identifier-typed params).
 
 ### Removed
+
 - **"Add to catalog" (promote-to-catalog).** It only pinned a server you already had into
   a local discovery view, with no sync or sharing, so it added clutter without real value.
   Browse Catalog still does what matters: discover and add new servers (curated set + live
@@ -333,6 +357,7 @@ Entries before the rename below shipped under the project's former name, Conduit
 ## [0.7.0] - 2026-06-28
 
 ### Added
+
 - **Native HTTP/OpenAPI transport.** Run the gateway with `conduit-gateway --http <port>`
   (or `CONDUIT_HTTP=<port>`) and it serves an OpenAPI spec plus a POST endpoint per tool,
   so Open WebUI and any OpenAPI tool client connect straight to Conduit with no mcpo,
@@ -349,6 +374,7 @@ Entries before the rename below shipped under the project's former name, Conduit
   recovery hint is appended whenever a call fails.
 
 ### Security
+
 - **The HTTP endpoint now requires a bearer token.** The app auto-generates one, shows it
   in Settings -> Integrations, and you paste it into the client (Open WebUI: the tool
   server's API key / Bearer auth). This closes a credential-CSRF: the `localhost` bind does
@@ -358,12 +384,14 @@ Entries before the rename below shipped under the project's former name, Conduit
   reflected headers so a crafted request can't inject or crash a listener.
 
 ### Changed
+
 - **Windows installers are now code-signed** via Azure Trusted Signing (publisher name
   shows; SmartScreen reputation still builds with downloads).
 
 ## [0.6.0] - 2026-06-27
 
 ### Changed
+
 - **The server list is a dense, scannable list now.** The bulky three-column cards are
   replaced by compact grouped rows: toggle, status, name, source, tool count, and
   transport on one line, with the command and per-server actions (secrets, duplicate,
@@ -386,12 +414,14 @@ Entries before the rename below shipped under the project's former name, Conduit
   tool-testing surface.
 
 ### Added
+
 - **Three more catalog servers:** Perplexity, Kubernetes, and Todoist.
 - **A confirmation step before destructive actions.** Removing a server, deleting a
   profile, disconnecting a client, or leaving a team now asks first and says what
   survives (your secrets stay in the keychain, your own servers are untouched).
 
 ### Fixed
+
 - The manual Refresh always confirms now ("Refreshed"), even when a health probe is
   already running, so the click is never silent.
 - Hardened the first-run wizard's resume-after-catalog flow against future regressions.
@@ -413,11 +443,13 @@ Entries before the rename below shipped under the project's former name, Conduit
 ## [0.5.2] - 2026-06-27
 
 ### Added
+
 - **More one-click catalog servers.** Added MongoDB, Elasticsearch, Airtable, Exa,
   Tavily, Apify, Browserbase, and the Sequential Thinking, Memory, and Time reference
   servers, every package name verified.
 
 ### Changed
+
 - **A calmer Servers header.** The duplicate Browse catalog button is gone (it's
   already in the sidebar), Search and Add server stay up front, and the occasional
   actions (Import, Enable/Disable all) move into a `...` overflow menu so the header no
@@ -427,6 +459,7 @@ Entries before the rename below shipped under the project's former name, Conduit
   separate Check health action has been folded into it.
 
 ### Fixed
+
 - **Onboarding no longer drops you mid-setup.** Browsing the catalog from the first-run
   wizard used to end onboarding before the Connect-a-client step; it now resumes there
   when you return, so new users don't silently skip connecting a client.
@@ -437,6 +470,7 @@ Entries before the rename below shipped under the project's former name, Conduit
 ## [0.5.1] - 2026-06-27
 
 ### Fixed
+
 - **macOS: the keychain prompts are gone.** The `conduit-gateway` helper that your
   AI clients launch now reads your vaulted secrets (API keys, OAuth/bearer tokens)
   with no keychain password prompt. Newly saved secrets get this automatically;
@@ -452,11 +486,13 @@ caps and filters what the gateway will fetch and sync, and adds accessibility an
 UI polish.
 
 ### Fixed
+
 - **The sidebar action bar stays put.** It's pinned to the bottom of the server
   list and always visible instead of appearing only when you scroll to the end,
   and undetected clients collapse under a disclosure so the list stays short.
 
 ### Security
+
 - **Hardened the anti-agentjacking scan.** Tool results are normalized before
   scanning (lowercase, invisible/zero-width/bidi stripping, homoglyph and
   full-width folding) and base64-decoded payloads are scanned too, so injection
@@ -480,10 +516,12 @@ UI polish.
   cleanup after a failed connect.
 
 ### Accessibility
+
 - **Respects "reduce motion."** When the OS prefers reduced motion, Conduit zeroes
   out spinners, pulses, dialog and tooltip zooms, and transitions.
 
 ### Internal
+
 - **CI on every PR**: frontend build, Rust library tests, and a gateway build
   check now run on pull requests across the project.
 - **macOS:** newer secrets use the ACL-free SecItem keychain path, with a one-time
@@ -493,11 +531,13 @@ UI polish.
 - Removed leftover Vite/Tauri scaffold files and shipped a real favicon.
 
 ### Thanks
+
 - @bradhallett (#26) for the macOS keychain migration work.
 
 ## [0.4.2] - 2026-06-26
 
 ### Added
+
 - **Conduit Teams (beta), desktop side.** A new Teams tab connects your local Conduit
   to a self-hosted Conduit Teams server and syncs a shared MCP server set into your
   registry. Keys never leave your machine: only the server set syncs, and you
@@ -505,6 +545,7 @@ UI polish.
 - **Composio** in the curated catalog (connect agents to 1,000+ apps via MCP). (#23)
 
 ### Fixed
+
 - **Custom API keys now reach HTTP servers.** A remote/HTTP server that uses a manually
   vaulted secret (e.g. a `BEARER` key) gets it injected as the bearer token, not just
   OAuth tokens, so "Manage secrets" works for HTTP servers. (#22)
@@ -515,6 +556,7 @@ UI polish.
   config round-trips correctly. (#25)
 
 ### Internal
+
 - **macOS secret storage moved to the SecItem keychain API** for new entries, which
   avoids the per-application ACLs behind repeated keychain prompts (#21). If you're on
   macOS and still see prompts, they're from entries created by older versions: clear
@@ -522,11 +564,13 @@ UI polish.
   confirmed prompt-elimination claim is pending validation on signed release builds.
 
 ### Thanks
+
 - @bradhallett (#21, #22, #23, #25) and @BharadwajKanneveti (#24).
 
 ## [0.4.1] - 2026-06-26
 
 ### Changed
+
 - **Windows installers are now code-signed** via Azure Trusted Signing, so the
   SmartScreen "unknown publisher" warning is gone (reputation still accrues with
   downloads). macOS was already signed and notarized; Linux remains unsigned as
@@ -539,6 +583,7 @@ boundary (both tool definitions and tool results), searches by meaning, can be
 driven by the agent on your terms, and supports two more clients.
 
 ### Added
+
 - **Tool-definition integrity (rug-pull + poisoning detection).** The gateway
   fingerprints every tool when a server is first connected and diffs it on each
   refresh. If a previously-approved tool's definition changes, or a known server adds
@@ -547,7 +592,7 @@ driven by the agent on your terms, and supports two more clients.
   jumping) when first seen or when it changes. Both surface as notices in the Activity
   view. Detection only, never blocks; on by default (`integrityCheck`), fully local.
   New `get_security_events` command + `security.jsonl`.
-- **Content defense (anti-agentjacking).** The gateway scans untrusted tool *results*
+- **Content defense (anti-agentjacking).** The gateway scans untrusted tool _results_
   for injection-like content and, on a hit, wraps the offending text with a provenance
   marker ("external data, not instructions") before the agent sees it, plus records a
   security notice. Information-preserving (the original text stays inside the marker),
@@ -559,7 +604,7 @@ driven by the agent on your terms, and supports two more clients.
   OpenAI-compatible `/v1/embeddings` endpoint. Tool embeddings are cached on disk; on
   any failure it falls back to pure lexical, so it can only add signal, never degrade.
   New `benchmark/retrieval.mjs` measures retrieval recall (lexical vs semantic).
-- **Controllable MCP (opt-in agent control).** A new *Allow agent control* switch
+- **Controllable MCP (opt-in agent control).** A new _Allow agent control_ switch
   (off by default) lets an agent enable or disable servers through the gateway
   (`conduit_enable_server` / `conduit_disable_server`). The destructive-tool block
   stays user-only, so granting it can't let an agent escalate past your governance;
@@ -570,6 +615,7 @@ driven by the agent on your terms, and supports two more clients.
   intelligence) were added to the curated catalog.
 
 ### Changed
+
 - Benchmark suite: added a graded server-sweep harness (`bench-sweep.mjs`) that grades
   answers for correctness, not just completion, and expanded `token-cost.mjs`
   (context-window share, scaling curve, per-tool distribution, multi-volume dollar
@@ -577,10 +623,12 @@ driven by the agent on your terms, and supports two more clients.
   tokens at the same graded task success.
 
 ### Fixed
+
 - The Playground policy toggles lay out as an even responsive grid instead of
   orphaning the third switch onto its own row.
 
 ### Internal
+
 - Release pipeline wired for Windows Authenticode signing via Azure Trusted Signing,
   gated and inert until the signing secrets are configured (changes nothing until the
   certificate is ready).
@@ -588,26 +636,31 @@ driven by the agent on your terms, and supports two more clients.
 ## [0.3.18] - 2026-06-25
 
 ### Added
+
 - **Ask your agent what Conduit is saving you.** `conduit_status` now reports the
   tokens lazy discovery has kept out of context, a dollar estimate at Claude Sonnet
   input rates, the number of tool-list loads, and your biggest catalog collapse.
 
 ### Changed
+
 - The in-app savings model picker and the public calculator group models by provider
   (Anthropic, OpenAI, Google), with a custom-price option on the calculator.
 
 ### Fixed
+
 - Native select dropdowns render readable in the dark theme (no more light text on a
   light popup).
 
 ## [0.3.17] - 2026-06-25
 
 ### Added
+
 - **Token economics card.** The Activity tab shows the dollar value of what lazy
   discovery has saved you, with a model-price selector and a one-click Share that
-  copies a "Conduit saved me ~X tokens (~$Y)" snippet.
+  copies a "Conduit saved me ~~X tokens (~~$Y)" snippet.
 
 ### Security
+
 - Hardened three findings from an internal audit: OAuth PKCE/state generation now
   fails loudly instead of silently returning zeros if the OS RNG is unavailable;
   file writes use a unique atomic-write temp name (no torn writes under concurrent
@@ -616,6 +669,7 @@ driven by the agent on your terms, and supports two more clients.
 ## [0.3.16] - 2026-06-25
 
 ### Added
+
 - **Live tool refresh.** When a connected server changes its own tool set
   mid-session (via `tools/list_changed`), Conduit re-queries it in place, so new
   or removed tools reach your agent without a restart.
@@ -629,6 +683,7 @@ driven by the agent on your terms, and supports two more clients.
 ## [0.3.15] - 2026-06-23
 
 ### Fixed
+
 - Clean, all-platforms build of the tokens-saved counter. v0.3.14's Linux job was
   OOM-killed mid-compile, leaving no Linux build or updater manifest; the pipeline
   now gives the Linux runner enough disk and swap, so auto-update works on all four
@@ -637,6 +692,7 @@ driven by the agent on your terms, and supports two more clients.
 ## [0.3.14] - 2026-06-23
 
 ### Fixed
+
 - The v0.3.12 "tokens saved" counter was missing from the release binaries (a CI
   build cache compiled a stale library from before the command existed). The
   pipeline now builds the workspace from scratch, so the counter ships.
@@ -644,6 +700,7 @@ driven by the agent on your terms, and supports two more clients.
 ## [0.3.12] - 2026-06-23
 
 ### Added
+
 - **"Tokens saved" counter in Activity.** A running estimate of the
   tool-definition tokens lazy discovery has kept out of your agent's context, with
   tool-list loads, your biggest catalog collapse, and since-when. No setup.
@@ -651,11 +708,13 @@ driven by the agent on your terms, and supports two more clients.
 ## [0.3.11] - 2026-06-22
 
 ### Improved
+
 - **Cleaner search index.** The gateway strips boilerplate and stopwords from tool
   descriptions and queries before indexing, so `conduit_search_tools` ranks on the
   words that actually distinguish one tool from another.
 
 ### Added
+
 - **BENCHMARK.md** with a reproducible harness: ~97% less tool-definition overhead
   per request and ~90% fewer total tokens at the same task success rate (3 servers,
   62 tools, local model, repeated runs).
@@ -663,6 +722,7 @@ driven by the agent on your terms, and supports two more clients.
 ## [0.3.10] - 2026-06-22
 
 ### Improved
+
 - **Tool search ranks the right tool more often.** When a query mixed a common word
   with a specific one (e.g. "list products"), keyword matching could surface a generic
   "list" tool instead of the products one. Search now tokenizes queries and tools
@@ -674,6 +734,7 @@ driven by the agent on your terms, and supports two more clients.
 ## [0.3.9] - 2026-06-22
 
 ### Added
+
 - **Two more clients: Jan and Goose** (17 supported in total). Jan uses the standard
   `mcpServers` JSON; Goose is the first YAML client, its MCP servers live under a
   top-level `extensions:` map in `config.yaml`. Both detect, connect with one click,
@@ -681,6 +742,7 @@ driven by the agent on your terms, and supports two more clients.
   also holds Goose's model settings and built-in extensions).
 
 ### Fixed
+
 - **Required tool parameters now work from grammar-constrained local clients.** Some
   local runtimes (e.g. Jan) force the model's output to match the tool schema, and
   `conduit_call_tool`'s `arguments` declared no properties, so the model could only
@@ -697,6 +759,7 @@ driven by the agent on your terms, and supports two more clients.
 ## [0.3.8] - 2026-06-21
 
 ### Improved
+
 - **Faster, more decisive tool search, especially with local models.** Search now
   leads with the single best match and tells the model to call it; the remaining
   results come back as a compact menu (name + a one-line description, no schema)
@@ -713,6 +776,7 @@ driven by the agent on your terms, and supports two more clients.
 ## [0.3.7] - 2026-06-21
 
 ### Added
+
 - **Five more clients: Zed, LM Studio, Warp, Amazon Q, and Kiro.** Conduit detects
   each, installs the gateway with one click, and imports its existing servers.
   - Zed keeps MCP servers under `context_servers` in its `settings.json`, which is
@@ -725,6 +789,7 @@ driven by the agent on your terms, and supports two more clients.
     `~/.aws/amazonq/mcp.json`, `~/.kiro/settings/mcp.json`).
 
 ### Fixed
+
 - Client detection now reflects whether an app is actually installed, not merely
   whether an MCP config file happens to exist. The old "config file's parent dir"
   heuristic was wrong for some clients: Claude Code's config lives at `~/.claude.json`
@@ -735,6 +800,7 @@ driven by the agent on your terms, and supports two more clients.
 ## [0.3.6] - 2026-06-21
 
 ### Fixed
+
 - Lazy-discovery tool search is far more reliable on multi-server setups. A tool
   that exists could read as missing (so an agent would wrongly conclude a server
   was "read only"): the default result limit was too low with no signal that
@@ -752,6 +818,7 @@ driven by the agent on your terms, and supports two more clients.
 ## [0.3.5] - 2026-06-21
 
 ### Security
+
 - Importing a shared setup now previews exactly what it will run (each server's
   command, args, and url) and imports only on confirmation, and flags entries that
   spawn a shell. A shared config can no longer slip an unseen command past you.
@@ -761,6 +828,7 @@ driven by the agent on your terms, and supports two more clients.
 - Set an explicit Content-Security-Policy for the app window.
 
 ### Fixed
+
 - Registry writes are atomic, so a crash mid-write can't corrupt your server set.
 - A corrupt registry no longer silently makes every tool vanish: the gateway keeps
   serving the last good tool list and logs the problem.
@@ -768,6 +836,7 @@ driven by the agent on your terms, and supports two more clients.
   packaged and unpackaged installs.
 
 ### Changed
+
 - Onboarding's final step reflects what you actually set up and explains lazy
   discovery; the empty state offers a "Browse catalog" action; the New Profile
   dialog explains that profiles scope servers, not credentials.
@@ -776,6 +845,7 @@ driven by the agent on your terms, and supports two more clients.
 ## [0.3.4] - 2026-06-21
 
 ### Fixed
+
 - Client config writes are now atomic (temp file + rename), so a crash or full
   disk mid-write can't truncate a client's MCP config.
 - One unresponsive stdio server no longer stalls the whole gateway: the connect
@@ -789,6 +859,7 @@ driven by the agent on your terms, and supports two more clients.
 ## [0.3.3] - 2026-06-21
 
 ### Added
+
 - First-run onboarding wizard: detect clients, add your first servers (import,
   one-click popular starters, or the catalog), and connect a client. Re-run it
   anytime from the sidebar footer.
@@ -799,6 +870,7 @@ driven by the agent on your terms, and supports two more clients.
 - Per-tool breakdown in the Activity dashboard, plus server and errors-only filters.
 
 ### Changed
+
 - Reliability: gateway recovers from a poisoned lock, the audit log rotates so it
   can't grow unbounded, more tolerant SSE id matching, and a guard against
   overlapping health probes (which curbed macOS keychain prompt storms).
@@ -806,6 +878,7 @@ driven by the agent on your terms, and supports two more clients.
 ## [0.3.2] - 2026-06-20
 
 ### Added
+
 - Signed and notarized macOS builds (Apple Silicon + Intel), alongside Windows
   and Linux, via a tag-triggered release pipeline.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,6 +64,21 @@ npm run format        # format all files in place
 npm run format:check  # check only (fails without writing — same as CI)
 ```
 
+### Linting
+
+ESLint catches code-quality issues and React anti-patterns. The CI runs it on
+every PR:
+
+```bash
+npm run lint        # check
+npm run lint:fix    # auto-fix what it can
+```
+
+Warnings are non-blocking. If you see a `react-hooks/set-state-in-effect`
+warning, it's usually the standard Tauri pattern of loading data from the Rust
+backend in a `useEffect` — review it for unnecessary re-renders, but it won't
+block the build.
+
 ### Debugging
 
 **Gateway verbose logging:** the gateway writes an always-on log (connection

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,10 +24,10 @@ On macOS/Linux, see the platform notes in the [README troubleshooting](README.md
 
 ### What hot-reloads vs what needs a rebuild
 
-| You changed | What happens |
-|-------------|-------------|
-| React/TS frontend (`src/`) | Vite hot-reloads instantly — no restart needed |
-| Rust backend (`src-tauri/src/`) | `npm run tauri dev` recompiles and restarts the app automatically |
+| You changed                                             | What happens                                                                                                                                |
+| ------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| React/TS frontend (`src/`)                              | Vite hot-reloads instantly — no restart needed                                                                                              |
+| Rust backend (`src-tauri/src/`)                         | `npm run tauri dev` recompiles and restarts the app automatically                                                                           |
 | Gateway binary (`src-tauri/src/bin/conduit-gateway.rs`) | **Not rebuilt by `tauri dev`.** Run `npm run build:gateway` after changes, then restart any connected clients so they re-spawn the gateway. |
 
 The gateway is a separate binary that AI clients spawn as a subprocess. Packaged
@@ -53,6 +53,16 @@ The Rust suite includes unit tests in each module (`clients`, `catalog`,
 `registry`, `router`, `oauth`, etc.) and an integration test
 (`tests/list_changed.rs`) that exercises the gateway's live tool-change
 notification path.
+
+### Formatting
+
+Prettier enforces consistent formatting across the frontend and docs. The CI
+checks this on every PR, but you can fix issues locally before pushing:
+
+```bash
+npm run format        # format all files in place
+npm run format:check  # check only (fails without writing — same as CI)
+```
 
 ### Debugging
 
@@ -104,7 +114,7 @@ For end-user troubleshooting (OAuth, AppImage, VS Code), see the
 ## Before you open a PR
 
 Run the [tests described above](#running-tests). Please match the surrounding
-style: the code favors small, well-commented functions that explain the *why*.
+style: the code favors small, well-commented functions that explain the _why_.
 Keep comments at the density of the file you're editing.
 
 ## Good places to start
@@ -182,15 +192,15 @@ is in `src-tauri/src/clients.rs`.
 
 Check the client's config file and match it to a `Format` variant:
 
-| Format | Config shape | Existing clients |
-|--------|-------------|-----------------|
-| `JsonMcpServers` | `{"mcpServers": {...}}` | Claude Desktop, Cursor, Windsurf |
-| `JsonServers` | `{"servers": {...}}` | VS Code |
-| `JsonContextServers` | `{"context_servers": {...}}` (JSONC) | Zed |
-| `TomlMcpServers` | `[mcp_servers.name]` | Codex |
-| `YamlExtensions` | `extensions:` map (Goose shape: `cmd`/`envs`) | Goose |
-| `YamlMcpServers` | `mcp_servers:` map (Hermes shape: `command`/`env`) | Hermes |
-| `YamlMcpServersList` | `mcpServers:` list | Continue |
+| Format               | Config shape                                       | Existing clients                 |
+| -------------------- | -------------------------------------------------- | -------------------------------- |
+| `JsonMcpServers`     | `{"mcpServers": {...}}`                            | Claude Desktop, Cursor, Windsurf |
+| `JsonServers`        | `{"servers": {...}}`                               | VS Code                          |
+| `JsonContextServers` | `{"context_servers": {...}}` (JSONC)               | Zed                              |
+| `TomlMcpServers`     | `[mcp_servers.name]`                               | Codex                            |
+| `YamlExtensions`     | `extensions:` map (Goose shape: `cmd`/`envs`)      | Goose                            |
+| `YamlMcpServers`     | `mcp_servers:` map (Hermes shape: `command`/`env`) | Hermes                           |
+| `YamlMcpServersList` | `mcpServers:` list                                 | Continue                         |
 
 If the client uses a genuinely new format, add a variant to `enum Format` and a
 parse function (follow the pattern of `parse_json` or `parse_toml`).
@@ -233,6 +243,7 @@ Follow the existing conventions — at minimum:
 
 - A registration test confirming the client appears in `defs()` with the right
   format:
+
   ```rust
   #[test]
   fn my_client_is_registered() {

--- a/README.md
+++ b/README.md
@@ -40,10 +40,10 @@ catalog (see [BENCHMARK.md](BENCHMARK.md)). That holds whether you run one AI to
 or five, on cloud models (where tokens are your bill) or local ones (where tool defs
 eat your context window).
 
-| | | |
-|:---:|:---:|:---:|
-| ![Lazy discovery surfaces only the tools a task needs](docs/feature-lazy.png) | ![One gateway, every AI client](docs/feature-clients.png) | ![Flags rug-pulls and poisoned tools before a client can call them](docs/feature-security.png) |
-| **Fewer tokens** - lazy discovery keeps context flat no matter how many servers you connect | **One config, every client** - set up a server once, every AI tool shares it | **Supply-chain security** - rug-pull and tool-poisoning detection on the path |
+|                                                                                             |                                                                              |                                                                                                |
+| :-----------------------------------------------------------------------------------------: | :--------------------------------------------------------------------------: | :--------------------------------------------------------------------------------------------: |
+|        ![Lazy discovery surfaces only the tools a task needs](docs/feature-lazy.png)        |          ![One gateway, every AI client](docs/feature-clients.png)           | ![Flags rug-pulls and poisoned tools before a client can call them](docs/feature-security.png) |
+| **Fewer tokens** - lazy discovery keeps context flat no matter how many servers you connect | **One config, every client** - set up a server once, every AI tool shares it |         **Supply-chain security** - rug-pull and tool-poisoning detection on the path          |
 
 <!-- TODO(toolport): add product screenshots + a demo video, re-captured from the rebranded (Toolport) build, after the release is cut. -->
 
@@ -93,7 +93,7 @@ fixes both.
   quietly adds one (a "rug pull"), or if a description or schema carries injection-like
   content ("tool poisoning"). Detection only, on by default, entirely local
   ([details](docs/specs/mcp-integrity.md)).
-- **Content defense (anti-agentjacking).** When a tool *returns* untrusted content (a
+- **Content defense (anti-agentjacking).** When a tool _returns_ untrusted content (a
   Sentry error, a web page, an issue body) with injection-like instructions, Toolport
   flags it and marks it as external data, not instructions, the separation that blunts
   indirect prompt injection. Never blocks, on by default
@@ -146,28 +146,28 @@ Toolport auto-detects these **20 AI clients**, installs the gateway into each wi
 click, and can import a client's existing servers. It writes the config file shown
 below for you, so you never have to edit these by hand.
 
-| Client | Config file | Format |
-| --- | --- | --- |
-| Claude Desktop | `<config>/Claude/claude_desktop_config.json` | JSON (`mcpServers`) |
-| Claude Code | `~/.claude.json` | JSON (`mcpServers`) |
-| Cursor | `~/.cursor/mcp.json` | JSON (`mcpServers`) |
-| VS Code | `<config>/Code/User/mcp.json` | JSON (`servers`) |
-| Windsurf | `~/.codeium/windsurf/mcp_config.json` | JSON (`mcpServers`) |
-| Codex | `~/.codex/config.toml` | TOML (`mcp_servers`) |
-| Continue | `~/.continue/config.yaml` | YAML (`mcpServers`) |
-| Antigravity | `~/.gemini/config/mcp_config.json` | JSON (`mcpServers`) |
-| Gemini CLI | `~/.gemini/settings.json` | JSON (`mcpServers`) |
-| Cline | `<config>/Code/User/globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json` | JSON (`mcpServers`) |
-| Roo Code | `<config>/Code/User/globalStorage/rooveterinaryinc.roo-cline/settings/mcp_settings.json` | JSON (`mcpServers`) |
-| Warp | `~/.warp/.mcp.json` | JSON (`mcpServers`) |
-| Amazon Q | `~/.aws/amazonq/mcp.json` | JSON (`mcpServers`) |
-| Kiro | `~/.kiro/settings/mcp.json` | JSON (`mcpServers`) |
-| Zed | `~/.config/zed/settings.json` | JSON (`context_servers`) |
-| LM Studio | `~/.lmstudio/mcp.json` | JSON (`mcpServers`) |
-| Jan | `<data>/Jan/data/mcp_config.json` | JSON (`mcpServers`) |
-| BoltAI | `~/.boltai/mcp.json` | JSON (`mcpServers`) |
-| Goose | `~/.config/goose/config.yaml` | YAML (`extensions`) |
-| Hermes | `~/.hermes/config.yaml` | YAML (`mcp_servers`) |
+| Client         | Config file                                                                                | Format                   |
+| -------------- | ------------------------------------------------------------------------------------------ | ------------------------ |
+| Claude Desktop | `<config>/Claude/claude_desktop_config.json`                                               | JSON (`mcpServers`)      |
+| Claude Code    | `~/.claude.json`                                                                           | JSON (`mcpServers`)      |
+| Cursor         | `~/.cursor/mcp.json`                                                                       | JSON (`mcpServers`)      |
+| VS Code        | `<config>/Code/User/mcp.json`                                                              | JSON (`servers`)         |
+| Windsurf       | `~/.codeium/windsurf/mcp_config.json`                                                      | JSON (`mcpServers`)      |
+| Codex          | `~/.codex/config.toml`                                                                     | TOML (`mcp_servers`)     |
+| Continue       | `~/.continue/config.yaml`                                                                  | YAML (`mcpServers`)      |
+| Antigravity    | `~/.gemini/config/mcp_config.json`                                                         | JSON (`mcpServers`)      |
+| Gemini CLI     | `~/.gemini/settings.json`                                                                  | JSON (`mcpServers`)      |
+| Cline          | `<config>/Code/User/globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json` | JSON (`mcpServers`)      |
+| Roo Code       | `<config>/Code/User/globalStorage/rooveterinaryinc.roo-cline/settings/mcp_settings.json`   | JSON (`mcpServers`)      |
+| Warp           | `~/.warp/.mcp.json`                                                                        | JSON (`mcpServers`)      |
+| Amazon Q       | `~/.aws/amazonq/mcp.json`                                                                  | JSON (`mcpServers`)      |
+| Kiro           | `~/.kiro/settings/mcp.json`                                                                | JSON (`mcpServers`)      |
+| Zed            | `~/.config/zed/settings.json`                                                              | JSON (`context_servers`) |
+| LM Studio      | `~/.lmstudio/mcp.json`                                                                     | JSON (`mcpServers`)      |
+| Jan            | `<data>/Jan/data/mcp_config.json`                                                          | JSON (`mcpServers`)      |
+| BoltAI         | `~/.boltai/mcp.json`                                                                       | JSON (`mcpServers`)      |
+| Goose          | `~/.config/goose/config.yaml`                                                              | YAML (`extensions`)      |
+| Hermes         | `~/.hermes/config.yaml`                                                                    | YAML (`mcp_servers`)     |
 
 `<config>` is your OS application-config dir (`%APPDATA%` on Windows, `~/Library/Application Support` on macOS, `~/.config` on Linux); `<data>` is the data dir (`~/.local/share` on Linux, the same as `<config>` elsewhere). Zed and Goose paths vary slightly by OS; Toolport resolves the right one automatically.
 
@@ -338,7 +338,7 @@ latency/error stats, resources + prompts proxying, and a tool playground. See
 
 - **Linux only, glib `VariantStrIter` soundness ([RUSTSEC-2024-0429](https://rustsec.org/advisories/RUSTSEC-2024-0429)).**
   Tauri's Linux webview stack pulls in `glib` 0.18 transitively (`wry → webkit2gtk →
-  gtk 0.18 → glib 0.18`). The fix only exists in `glib` 0.20+, and the gtk-0.18
+gtk 0.18 → glib 0.18`). The fix only exists in `glib` 0.20+, and the gtk-0.18
   binding line, which is what Tauri 2 uses on Linux, hard-pins `glib = "^0.18"`, so
   the patched release cannot be selected without moving the whole webview stack. The
   bug is a soundness/null-deref crash (not remote code execution), is confined to the

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -25,7 +25,7 @@ from the [Releases](https://github.com/tsouth89/toolport/releases) page.
 - **Local-first.** Toolport runs entirely on your machine. The desktop app is a
   manager; the gateway is a local process each AI client spawns over stdio. There
   is **no Toolport server, account, or telemetry**, nothing phones home. The only
-  network traffic is between the gateway and the upstream MCP servers *you*
+  network traffic is between the gateway and the upstream MCP servers _you_
   configure.
 - **Secrets in the OS keychain.** API keys and OAuth tokens are stored in the
   platform keychain (macOS Keychain, Windows Credential Manager, Linux Secret

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -58,10 +58,10 @@ And the summary line: tools exposed (flat vs 3), total-token delta as a percent,
 
 ## Reading the results honestly
 
-- **Small sample.** A handful of tasks and single runs are noisy. Run it a few times; treat the *direction* as the signal, not the exact percentage.
+- **Small sample.** A handful of tasks and single runs are noisy. Run it a few times; treat the _direction_ as the signal, not the exact percentage.
 - **The trade-off is real and intentional.** Lazy mode trades extra tool calls (search → call) for fewer total tokens. The table shows both so you're not hiding the round-trip cost.
 - **Flat mode may error** on small models, dumping every tool schema can overflow the context window. That's a finding, not a bug: it's exactly the failure lazy discovery avoids. The harness records it as an error rather than crashing.
-- **Savings concentrate on smaller models** (mcpico saw ~60% on a 9B, ~8% on a 35B). Run it on a small *and* a mid model to show that, it's the local-model story.
+- **Savings concentrate on smaller models** (mcpico saw ~60% on a 9B, ~8% on a 35B). Run it on a small _and_ a mid model to show that, it's the local-model story.
 
 ## Caveats
 

--- a/benchmark/bench-sweep.mjs
+++ b/benchmark/bench-sweep.mjs
@@ -69,9 +69,25 @@ const OUT_DIR = process.env.OUT_DIR || HERE;
 // string, so "done" can't hide a wrong or "I couldn't do it" answer. No local file =
 // tasks run ungraded (correct shows as n/a).
 const TASKS = [
-  { name: "stripe-products", required: "stripe", expect: [], prompt: "List my Stripe products (just the names)." },
-  { name: "neon-projects", required: "neon", expect: [], prompt: "List my Neon projects (just the names)." },
-  { name: "vercel-projects", required: "vercel", expect: [], prompt: "List my Vercel projects. If a team id is required, find it first, then use it." },
+  {
+    name: "stripe-products",
+    required: "stripe",
+    expect: [],
+    prompt: "List my Stripe products (just the names).",
+  },
+  {
+    name: "neon-projects",
+    required: "neon",
+    expect: [],
+    prompt: "List my Neon projects (just the names).",
+  },
+  {
+    name: "vercel-projects",
+    required: "vercel",
+    expect: [],
+    prompt:
+      "List my Vercel projects. If a team id is required, find it first, then use it.",
+  },
 ];
 
 // Fill `expect` from the local, gitignored ground-truth file if it exists.
@@ -93,7 +109,8 @@ function defaultGateway() {
 
 function conduitDir() {
   if (platform() === "win32") return join(homedir(), "AppData", "Roaming", "Conduit");
-  if (platform() === "darwin") return join(homedir(), "Library", "Application Support", "Conduit");
+  if (platform() === "darwin")
+    return join(homedir(), "Library", "Application Support", "Conduit");
   return join(process.env.XDG_CONFIG_HOME || join(homedir(), ".config"), "Conduit");
 }
 
@@ -122,7 +139,9 @@ function planSweep(reg) {
     .map((x) => Number(x.trim()))
     .filter((n) => Number.isFinite(n) && n > 0);
   const maxN = required.length + noise.length;
-  const counts = (want.length ? want : [required.length, required.length + 3, required.length + 7, maxN])
+  const counts = (
+    want.length ? want : [required.length, required.length + 3, required.length + 7, maxN]
+  )
     .map((n) => Math.min(maxN, Math.max(required.length, n)))
     .filter((n, i, a) => a.indexOf(n) === i)
     .sort((a, b) => a - b);
@@ -151,11 +170,18 @@ function writeTempRegistry(dir, reg, serverIds, lazy) {
 class Gateway {
   constructor(regPath, discovery) {
     this.proc = spawn(GATEWAY, [], {
-      env: { ...process.env, CONDUIT_REGISTRY: regPath, CONDUIT_PROFILE: "sweep", CONDUIT_DISCOVERY: discovery },
+      env: {
+        ...process.env,
+        CONDUIT_REGISTRY: regPath,
+        CONDUIT_PROFILE: "sweep",
+        CONDUIT_DISCOVERY: discovery,
+      },
       stdio: ["pipe", "pipe", "ignore"],
     });
     this.proc.on("error", (e) => {
-      console.error(`\nCould not start gateway at ${GATEWAY}: ${e.message}\nBuild it: npm run build:gateway`);
+      console.error(
+        `\nCould not start gateway at ${GATEWAY}: ${e.message}\nBuild it: npm run build:gateway`,
+      );
       process.exit(1);
     });
     this.rl = createInterface({ input: this.proc.stdout });
@@ -163,35 +189,66 @@ class Gateway {
     this.id = 0;
     this.rl.on("line", (line) => {
       let msg;
-      try { msg = JSON.parse(line); } catch { return; }
+      try {
+        msg = JSON.parse(line);
+      } catch {
+        return;
+      }
       const cb = msg.id != null && this.pending.get(msg.id);
-      if (cb) { this.pending.delete(msg.id); cb(msg); }
+      if (cb) {
+        this.pending.delete(msg.id);
+        cb(msg);
+      }
     });
   }
   rpc(method, params) {
     const id = ++this.id;
     return new Promise((resolve) => {
       this.pending.set(id, resolve);
-      this.proc.stdin.write(JSON.stringify({ jsonrpc: "2.0", id, method, params }) + "\n");
+      this.proc.stdin.write(
+        JSON.stringify({ jsonrpc: "2.0", id, method, params }) + "\n",
+      );
     });
   }
   async init() {
-    await this.rpc("initialize", { protocolVersion: "2024-11-05", capabilities: {}, clientInfo: { name: "conduit-sweep", version: "1" } });
+    await this.rpc("initialize", {
+      protocolVersion: "2024-11-05",
+      capabilities: {},
+      clientInfo: { name: "conduit-sweep", version: "1" },
+    });
     await new Promise((r) => setTimeout(r, CONNECT_WAIT_MS));
   }
-  async tools() { return (await this.rpc("tools/list", {})).result?.tools || []; }
-  async call(name, args) { const r = await this.rpc("tools/call", { name, arguments: args || {} }); return r.result ?? r.error ?? {}; }
-  stop() { try { this.proc.kill(); } catch {} }
+  async tools() {
+    return (await this.rpc("tools/list", {})).result?.tools || [];
+  }
+  async call(name, args) {
+    const r = await this.rpc("tools/call", { name, arguments: args || {} });
+    return r.result ?? r.error ?? {};
+  }
+  stop() {
+    try {
+      this.proc.kill();
+    } catch {}
+  }
 }
 
 function normalizeParams(schema) {
-  const s = schema && typeof schema === "object" && !Array.isArray(schema) ? { ...schema } : {};
+  const s =
+    schema && typeof schema === "object" && !Array.isArray(schema) ? { ...schema } : {};
   if (!s.type) s.type = "object";
-  if (s.type === "object" && (s.properties == null || typeof s.properties !== "object")) s.properties = {};
+  if (s.type === "object" && (s.properties == null || typeof s.properties !== "object"))
+    s.properties = {};
   return s;
 }
 const toOpenAITools = (mcp) =>
-  mcp.map((t) => ({ type: "function", function: { name: t.name, description: t.description || "", parameters: normalizeParams(t.inputSchema) } }));
+  mcp.map((t) => ({
+    type: "function",
+    function: {
+      name: t.name,
+      description: t.description || "",
+      parameters: normalizeParams(t.inputSchema),
+    },
+  }));
 
 async function chat(messages, tools) {
   const headers = {
@@ -206,25 +263,43 @@ async function chat(messages, tools) {
   // stale completion (it's recomputed at temperature 0), so leaving it on just
   // makes a token-heavy flat run much cheaper. Set BENCH_NOCACHE=1 only if you want
   // to force fully independent samples (e.g. for variance analysis).
-  const noCache = ["1", "true", "yes", "on"].includes((process.env.BENCH_NOCACHE || "").toLowerCase());
+  const noCache = ["1", "true", "yes", "on"].includes(
+    (process.env.BENCH_NOCACHE || "").toLowerCase(),
+  );
   let res;
   for (let attempt = 0; ; attempt++) {
     const msgs =
       noCache && messages[0]?.role === "system"
-        ? [{ ...messages[0], content: `${messages[0].content}\n[uncached: ${randomUUID()}]` }, ...messages.slice(1)]
+        ? [
+            {
+              ...messages[0],
+              content: `${messages[0].content}\n[uncached: ${randomUUID()}]`,
+            },
+            ...messages.slice(1),
+          ]
         : messages;
-    const body = JSON.stringify({ model: MODEL, messages: msgs, tools, tool_choice: "auto", temperature: 0 });
+    const body = JSON.stringify({
+      model: MODEL,
+      messages: msgs,
+      tools,
+      tool_choice: "auto",
+      temperature: 0,
+    });
     res = await fetch(LLM_URL, { method: "POST", headers, body });
     if (res.ok) break;
     if ((res.status === 429 || res.status >= 500) && attempt < 6) {
       const ra = Number(res.headers.get("retry-after"));
-      const waitMs = Number.isFinite(ra) && ra > 0 ? ra * 1000 : Math.min(30000, 1000 * 2 ** attempt);
+      const waitMs =
+        Number.isFinite(ra) && ra > 0 ? ra * 1000 : Math.min(30000, 1000 * 2 ** attempt);
       await new Promise((r) => setTimeout(r, waitMs));
       continue;
     }
     break;
   }
-  if (!res.ok) throw new Error(`LLM ${res.status}: ${(await res.text().catch(() => "")).slice(0, 300)}`);
+  if (!res.ok)
+    throw new Error(
+      `LLM ${res.status}: ${(await res.text().catch(() => "")).slice(0, 300)}`,
+    );
   return res.json();
 }
 
@@ -241,10 +316,17 @@ async function measureOverhead(tools) {
 
 async function runTask(gw, oaiTools, prompt) {
   const messages = [
-    { role: "system", content: "You are a helpful assistant. Use the available tools to complete the task, then give a short final answer." },
+    {
+      role: "system",
+      content:
+        "You are a helpful assistant. Use the available tools to complete the task, then give a short final answer.",
+    },
     { role: "user", content: prompt },
   ];
-  let tokens = 0, calls = 0, done = false, error = null;
+  let tokens = 0,
+    calls = 0,
+    done = false,
+    error = null;
   try {
     for (let steps = 0; steps < MAX_STEPS; steps++) {
       const res = await chat(messages, oaiTools);
@@ -253,29 +335,46 @@ async function runTask(gw, oaiTools, prompt) {
       if (!m) break;
       messages.push(m);
       const toolCalls = m.tool_calls || [];
-      if (toolCalls.length === 0) { done = true; break; }
+      if (toolCalls.length === 0) {
+        done = true;
+        break;
+      }
       for (const c of toolCalls) {
         calls++;
         let args = {};
-        try { args = JSON.parse(c.function.arguments || "{}"); } catch {}
+        try {
+          args = JSON.parse(c.function.arguments || "{}");
+        } catch {}
         const result = await gw.call(c.function.name, args);
-        messages.push({ role: "tool", tool_call_id: c.id, content: JSON.stringify(result).slice(0, TOOL_RESULT_CAP) });
+        messages.push({
+          role: "tool",
+          tool_call_id: c.id,
+          content: JSON.stringify(result).slice(0, TOOL_RESULT_CAP),
+        });
       }
     }
   } catch (e) {
     error = e.message;
   }
-  const answer = messages
-    .filter((m) => m.role === "assistant" && typeof m.content === "string" && m.content.trim())
-    .pop()?.content || "";
+  const answer =
+    messages
+      .filter(
+        (m) =>
+          m.role === "assistant" && typeof m.content === "string" && m.content.trim(),
+      )
+      .pop()?.content || "";
   return { tokens, calls, done, error, answer };
 }
 
-const median = (xs) => { const s = [...xs].sort((a, b) => a - b); return s[Math.floor((s.length - 1) / 2)]; };
+const median = (xs) => {
+  const s = [...xs].sort((a, b) => a - b);
+  return s[Math.floor((s.length - 1) / 2)];
+};
 
 // An answer that looks like a failure/apology rather than a result. Used so a
 // "done" agent that gave up ("I couldn't list them") never counts as correct.
-const ERROR_LIKE = /\b(error|failed|unable|couldn'?t|can ?not|can'?t|unauthor|forbidden|denied|no access|not authenticated|don'?t have)\b/i;
+const ERROR_LIKE =
+  /\b(error|failed|unable|couldn'?t|can ?not|can'?t|unauthor|forbidden|denied|no access|not authenticated|don'?t have)\b/i;
 
 // Grade a single answer against the task's ground-truth `expect` list:
 //   true/false when graded, null when the task has no `expect` (ungraded).
@@ -329,7 +428,8 @@ async function benchAt(regPath, count, serverIds, mode) {
   const { reg } = loadRealRegistry();
   const sweep = planSweep(reg);
   console.log("sweep plan (servers always include the task servers):");
-  for (const s of sweep) console.log(`  ${String(s.count).padStart(2)} servers: ${s.serverIds.join(", ")}`);
+  for (const s of sweep)
+    console.log(`  ${String(s.count).padStart(2)} servers: ${s.serverIds.join(", ")}`);
 
   const dir = mkdtempSync(join(tmpdir(), "conduit-sweep-"));
   const results = [];
@@ -376,10 +476,28 @@ async function benchAt(regPath, count, serverIds, mode) {
   mkdirSync(OUT_DIR, { recursive: true });
 
   // --- CSV (one row per server-count x mode x task) ---
-  const csv = ["servers,mode,toolCount,overheadTokens,overflow,task,medianTokens,loTokens,hiTokens,done,correct,graded,runs"];
+  const csv = [
+    "servers,mode,toolCount,overheadTokens,overflow,task,medianTokens,loTokens,hiTokens,done,correct,graded,runs",
+  ];
   for (const r of results)
     for (const t of r.tasks)
-      csv.push([r.count, r.mode, r.toolCount, r.overhead.tokens ?? "", r.overhead.overflow, t.task, t.median, t.lo, t.hi, t.done, t.correct ?? "", t.graded, RUNS].join(","));
+      csv.push(
+        [
+          r.count,
+          r.mode,
+          r.toolCount,
+          r.overhead.tokens ?? "",
+          r.overhead.overflow,
+          t.task,
+          t.median,
+          t.lo,
+          t.hi,
+          t.done,
+          t.correct ?? "",
+          t.graded,
+          RUNS,
+        ].join(","),
+      );
   const csvPath = join(OUT_DIR, "sweep-results.csv");
   writeFileSync(csvPath, csv.join("\n") + "\n");
 
@@ -390,7 +508,9 @@ async function benchAt(regPath, count, serverIds, mode) {
       const grade = t.graded ? ` [${t.correct}/${RUNS} correct]` : " [ungraded]";
       ans.push(`## ${r.count} servers / ${r.mode} / ${t.task}${grade}`);
       if (!t.samples.some((s) => s)) ans.push("(no answer, e.g. context overflow)");
-      t.samples.forEach((s, i) => s && ans.push(`  sample ${i + 1}: ${s.replace(/\s+/g, " ")}`));
+      t.samples.forEach(
+        (s, i) => s && ans.push(`  sample ${i + 1}: ${s.replace(/\s+/g, " ")}`),
+      );
       ans.push("");
     }
   }
@@ -405,7 +525,14 @@ async function benchAt(regPath, count, serverIds, mode) {
     const totalDone = r.tasks.reduce((a, t) => a + t.done, 0);
     const graded = r.tasks.some((t) => t.graded);
     const totalCorrect = r.tasks.reduce((a, t) => a + (t.correct ?? 0), 0);
-    o[r.mode] = { tools: r.toolCount, overhead: r.overhead, totalTok, totalDone, totalCorrect, graded };
+    o[r.mode] = {
+      tools: r.toolCount,
+      overhead: r.overhead,
+      totalTok,
+      totalDone,
+      totalCorrect,
+      graded,
+    };
     byCount.set(r.count, o);
   }
   const denom = TASKS.length * RUNS;
@@ -419,11 +546,17 @@ async function benchAt(regPath, count, serverIds, mode) {
     `|---|---|---|---|---|---|---|---|${anyGraded ? "---|---|" : ""}`,
   ];
   for (const o of [...byCount.values()].sort((a, b) => a.count - b.count)) {
-    const f = o.full, l = o.lazy;
+    const f = o.full,
+      l = o.lazy;
     const fOv = f?.overhead.overflow ? "OVERFLOW" : (f?.overhead.tokens ?? "?");
-    const red = f?.totalTok && l?.totalTok ? `${Math.round((1 - l.totalTok / f.totalTok) * 100)}%` : "—";
+    const red =
+      f?.totalTok && l?.totalTok
+        ? `${Math.round((1 - l.totalTok / f.totalTok) * 100)}%`
+        : "—";
     const correctCols = anyGraded ? ` ${cScore(f)} | ${cScore(l)} |` : "";
-    md.push(`| ${o.count} (${f?.tools ?? "?"} tools) | ${fOv} | ${l?.overhead.tokens ?? "?"} | ${f?.totalTok ?? "—"} | ${l?.totalTok ?? "—"} | ${red} | ${f?.totalDone ?? 0}/${denom} | ${l?.totalDone ?? 0}/${denom} |${correctCols}`);
+    md.push(
+      `| ${o.count} (${f?.tools ?? "?"} tools) | ${fOv} | ${l?.overhead.tokens ?? "?"} | ${f?.totalTok ?? "—"} | ${l?.totalTok ?? "—"} | ${red} | ${f?.totalDone ?? 0}/${denom} | ${l?.totalDone ?? 0}/${denom} |${correctCols}`,
+    );
   }
   const mdPath = join(OUT_DIR, "sweep-summary.md");
   writeFileSync(mdPath, md.join("\n") + "\n");

--- a/benchmark/bench.js
+++ b/benchmark/bench.js
@@ -44,7 +44,11 @@ const TOOL_RESULT_CAP = 8000; // trim huge tool outputs so one result can't skew
 const TASKS = [
   { name: "stripe-products", prompt: "List my Stripe products (just the names)." },
   { name: "neon-projects", prompt: "List my Neon projects (just the names)." },
-  { name: "vercel-projects", prompt: "List my Vercel projects. If a team id is required, find it first, then use it." },
+  {
+    name: "vercel-projects",
+    prompt:
+      "List my Vercel projects. If a team id is required, find it first, then use it.",
+  },
 ];
 
 function defaultGateway() {
@@ -73,16 +77,25 @@ class Gateway {
     this.id = 0;
     this.rl.on("line", (line) => {
       let msg;
-      try { msg = JSON.parse(line); } catch { return; }
+      try {
+        msg = JSON.parse(line);
+      } catch {
+        return;
+      }
       const cb = msg.id != null && this.pending.get(msg.id);
-      if (cb) { this.pending.delete(msg.id); cb(msg); }
+      if (cb) {
+        this.pending.delete(msg.id);
+        cb(msg);
+      }
     });
   }
   rpc(method, params) {
     const id = ++this.id;
     return new Promise((resolve) => {
       this.pending.set(id, resolve);
-      this.proc.stdin.write(JSON.stringify({ jsonrpc: "2.0", id, method, params }) + "\n");
+      this.proc.stdin.write(
+        JSON.stringify({ jsonrpc: "2.0", id, method, params }) + "\n",
+      );
     });
   }
   async init() {
@@ -102,14 +115,19 @@ class Gateway {
     const r = await this.rpc("tools/call", { name, arguments: args || {} });
     return r.result ?? r.error ?? {};
   }
-  stop() { try { this.proc.kill(); } catch {} }
+  stop() {
+    try {
+      this.proc.kill();
+    } catch {}
+  }
 }
 
 // OpenAI function-calling (and strict runtimes like LM Studio) require `parameters`
 // to be an object schema WITH a `properties` field, even for zero-arg tools. MCP
 // tools legitimately ship a bare {"type":"object"}, so normalize before sending.
 function normalizeParams(schema) {
-  const s = schema && typeof schema === "object" && !Array.isArray(schema) ? { ...schema } : {};
+  const s =
+    schema && typeof schema === "object" && !Array.isArray(schema) ? { ...schema } : {};
   if (!s.type) s.type = "object";
   if (s.type === "object" && (s.properties == null || typeof s.properties !== "object")) {
     s.properties = {};
@@ -146,7 +164,13 @@ async function chat(messages, tools) {
   const res = await fetch(LLM_URL, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ model: MODEL, messages, tools, tool_choice: "auto", temperature: 0 }),
+    body: JSON.stringify({
+      model: MODEL,
+      messages,
+      tools,
+      tool_choice: "auto",
+      temperature: 0,
+    }),
   });
   if (!res.ok) {
     const body = await res.text().catch(() => "");
@@ -157,10 +181,18 @@ async function chat(messages, tools) {
 
 async function runTask(gw, oaiTools, prompt) {
   const messages = [
-    { role: "system", content: "You are a helpful assistant. Use the available tools to complete the task, then give a short final answer." },
+    {
+      role: "system",
+      content:
+        "You are a helpful assistant. Use the available tools to complete the task, then give a short final answer.",
+    },
     { role: "user", content: prompt },
   ];
-  let tokens = 0, calls = 0, steps = 0, done = false, error = null;
+  let tokens = 0,
+    calls = 0,
+    steps = 0,
+    done = false,
+    error = null;
   try {
     for (; steps < MAX_STEPS; steps++) {
       const res = await chat(messages, oaiTools);
@@ -169,11 +201,16 @@ async function runTask(gw, oaiTools, prompt) {
       if (!m) break;
       messages.push(m);
       const toolCalls = m.tool_calls || [];
-      if (toolCalls.length === 0) { done = true; break; } // produced a final answer
+      if (toolCalls.length === 0) {
+        done = true;
+        break;
+      } // produced a final answer
       for (const c of toolCalls) {
         calls++;
         let args = {};
-        try { args = JSON.parse(c.function.arguments || "{}"); } catch {}
+        try {
+          args = JSON.parse(c.function.arguments || "{}");
+        } catch {}
         const result = await gw.call(c.function.name, args);
         messages.push({
           role: "tool",
@@ -185,7 +222,8 @@ async function runTask(gw, oaiTools, prompt) {
   } catch (e) {
     error = e.message; // e.g. flat mode overflowing the model's context window
   }
-  const answer = messages.filter((m) => m.role === "assistant" && m.content).pop()?.content || "";
+  const answer =
+    messages.filter((m) => m.role === "assistant" && m.content).pop()?.content || "";
   return { tokens, calls, steps, done, error, answer: answer.slice(0, 200) };
 }
 
@@ -199,9 +237,10 @@ async function benchMode(discovery) {
   const mcpTools = await gw.tools();
   const oaiTools = toOpenAITools(mcpTools);
   const overhead = await measureToolOverhead(oaiTools);
-  const ov = overhead.tokens != null
-    ? `${overhead.tokens} tok/request${overhead.overflow ? " (OVERFLOWS context)" : ""}`
-    : "unknown";
+  const ov =
+    overhead.tokens != null
+      ? `${overhead.tokens} tok/request${overhead.overflow ? " (OVERFLOWS context)" : ""}`
+      : "unknown";
   console.log(`\n[${discovery}] ${mcpTools.length} tools, tool-def overhead: ${ov}`);
   const rows = [];
   for (const task of TASKS) {
@@ -211,10 +250,18 @@ async function benchMode(discovery) {
     const median = toks[Math.floor((toks.length - 1) / 2)];
     const done = trials.filter((t) => t.done).length;
     const err = trials.find((t) => t.error)?.error;
-    rows.push({ task: task.name, tokens: median, lo: toks[0], hi: toks[toks.length - 1], done });
+    rows.push({
+      task: task.name,
+      tokens: median,
+      lo: toks[0],
+      hi: toks[toks.length - 1],
+      done,
+    });
     const range = RUNS > 1 ? ` (${toks[0]}-${toks[toks.length - 1]})` : "";
     const status = err ? `ERROR (${String(err).slice(0, 60)})` : `${done}/${RUNS} done`;
-    console.log(`  ${task.name.padEnd(16)} median ${String(median).padStart(6)} tok${range}  ${status}`);
+    console.log(
+      `  ${task.name.padEnd(16)} median ${String(median).padStart(6)} tok${range}  ${status}`,
+    );
   }
   gw.stop();
   return { toolCount: mcpTools.length, overhead, rows };
@@ -223,7 +270,7 @@ async function benchMode(discovery) {
 function totals(modeRows) {
   return modeRows.reduce(
     (a, r) => ({ tokens: a.tokens + (r.tokens || 0), done: a.done + (r.done || 0) }),
-    { tokens: 0, done: 0 }
+    { tokens: 0, done: 0 },
   );
 }
 
@@ -249,27 +296,44 @@ function totals(modeRows) {
   const flat = await benchMode("full");
   const lazy = await benchMode("lazy");
 
-  const tf = totals(flat.rows), tl = totals(lazy.rows);
-  const fmtOv = (o) => o.tokens != null
-    ? `${o.tokens}${o.overflow ? " (overflows context)" : ""}`
-    : "unknown";
-  const ovPct = flat.overhead.tokens && lazy.overhead.tokens
-    ? Math.round((1 - lazy.overhead.tokens / flat.overhead.tokens) * 100)
-    : null;
+  const tf = totals(flat.rows),
+    tl = totals(lazy.rows);
+  const fmtOv = (o) =>
+    o.tokens != null
+      ? `${o.tokens}${o.overflow ? " (overflows context)" : ""}`
+      : "unknown";
+  const ovPct =
+    flat.overhead.tokens && lazy.overhead.tokens
+      ? Math.round((1 - lazy.overhead.tokens / flat.overhead.tokens) * 100)
+      : null;
 
   console.log("\n=== summary ===");
   console.log(`tools exposed:        flat ${flat.toolCount}   lazy ${lazy.toolCount}`);
-  console.log(`tool-def overhead:    flat ${fmtOv(flat.overhead)}   lazy ${fmtOv(lazy.overhead)} tok/request` +
-    (ovPct != null ? `   (${ovPct}% less, EVERY request)` : ""));
+  console.log(
+    `tool-def overhead:    flat ${fmtOv(flat.overhead)}   lazy ${fmtOv(lazy.overhead)} tok/request` +
+      (ovPct != null ? `   (${ovPct}% less, EVERY request)` : ""),
+  );
   const denom = TASKS.length * RUNS;
-  console.log(`tasks completed:      flat ${tf.done}/${denom}   lazy ${tl.done}/${denom}   (${RUNS} run(s)/task)`);
+  console.log(
+    `tasks completed:      flat ${tf.done}/${denom}   lazy ${tl.done}/${denom}   (${RUNS} run(s)/task)`,
+  );
   if (tf.done > 0) {
     const pct = tf.tokens ? Math.round((1 - tl.tokens / tf.tokens) * 100) : 0;
-    console.log(`median tokens (sum):  flat ${tf.tokens}   lazy ${tl.tokens}   (${pct >= 0 ? "-" : "+"}${Math.abs(pct)}%)`);
+    console.log(
+      `median tokens (sum):  flat ${tf.tokens}   lazy ${tl.tokens}   (${pct >= 0 ? "-" : "+"}${Math.abs(pct)}%)`,
+    );
   } else {
-    console.log(`lazy median tokens:   ${tl.tokens} summed across tasks (flat couldn't run, its tool list overflowed the model)`);
+    console.log(
+      `lazy median tokens:   ${tl.tokens} summed across tasks (flat couldn't run, its tool list overflowed the model)`,
+    );
   }
-  console.log("\nThe headline metric is tool-def overhead: the tokens EVERY request pays just to");
-  console.log("list tools. Flat pays it on every call; lazy advertises 3 meta-tools. Set RUNS=5");
-  console.log("for medians; eyeball the answers for correctness; treat the direction as signal.");
+  console.log(
+    "\nThe headline metric is tool-def overhead: the tokens EVERY request pays just to",
+  );
+  console.log(
+    "list tools. Flat pays it on every call; lazy advertises 3 meta-tools. Set RUNS=5",
+  );
+  console.log(
+    "for medians; eyeball the answers for correctness; treat the direction as signal.",
+  );
 })();

--- a/benchmark/latency.mjs
+++ b/benchmark/latency.mjs
@@ -25,7 +25,10 @@ const GATEWAY = exe("conduit-gateway");
 const MOCK = exe("mock-mcp-server");
 const N = Math.max(20, Number(process.argv[2] || 200));
 
-for (const [label, p] of [["gateway", GATEWAY], ["mock server", MOCK]]) {
+for (const [label, p] of [
+  ["gateway", GATEWAY],
+  ["mock server", MOCK],
+]) {
   if (!existsSync(p)) {
     console.error(
       `Missing ${label} at ${p}\nBuild it first:\n  cargo build --manifest-path src-tauri/Cargo.toml --bins`,
@@ -71,7 +74,9 @@ function client(proc) {
       new Promise((res) => {
         const myId = ++id;
         pending.set(myId, res);
-        proc.stdin.write(JSON.stringify({ jsonrpc: "2.0", id: myId, method, params }) + "\n");
+        proc.stdin.write(
+          JSON.stringify({ jsonrpc: "2.0", id: myId, method, params }) + "\n",
+        );
       }),
     notify: (method, params) =>
       proc.stdin.write(JSON.stringify({ jsonrpc: "2.0", method, params }) + "\n"),
@@ -103,7 +108,14 @@ async function main() {
     JSON.stringify({
       version: 1,
       servers: [
-        { id: "mock", name: "Mock", transport: "stdio", command: MOCK, args: [], env: [] },
+        {
+          id: "mock",
+          name: "Mock",
+          transport: "stdio",
+          command: MOCK,
+          args: [],
+          env: [],
+        },
       ],
       profiles: [{ id: "bench", name: "Bench", enabledServerIds: ["mock"] }],
       activeProfileId: "bench",
@@ -128,7 +140,12 @@ async function main() {
 
   // 2) Through the gateway.
   const gw = spawn(GATEWAY, [], {
-    env: { ...process.env, CONDUIT_REGISTRY: regPath, CONDUIT_PROFILE: "bench", CONDUIT_DISCOVERY: "lazy" },
+    env: {
+      ...process.env,
+      CONDUIT_REGISTRY: regPath,
+      CONDUIT_PROFILE: "bench",
+      CONDUIT_DISCOVERY: "lazy",
+    },
     stdio: ["pipe", "pipe", "ignore"],
   });
   const g = client(gw);
@@ -139,11 +156,19 @@ async function main() {
   for (let k = 0; k < 15; k++) await g.call("tools/list", {}); // warm up
   const list = await loop(() => g.call("tools/list", {}), N);
   const search = await loop(
-    () => g.call("tools/call", { name: "toolport_search_tools", arguments: { query: "a", limit: 25 } }),
+    () =>
+      g.call("tools/call", {
+        name: "toolport_search_tools",
+        arguments: { query: "a", limit: 25 },
+      }),
     N,
   );
   const gwCall = await loop(
-    () => g.call("tools/call", { name: "toolport_call_tool", arguments: { name: `mock__${bare}`, arguments: {} } }),
+    () =>
+      g.call("tools/call", {
+        name: "toolport_call_tool",
+        arguments: { name: `mock__${bare}`, arguments: {} },
+      }),
     N,
   );
 
@@ -156,7 +181,9 @@ async function main() {
   const row = (label, x) =>
     `  ${label.padEnd(28)}${x.median.toFixed(2).padStart(6)} ms   (p95 ${x.p95.toFixed(2)})`;
   console.log(`\nToolport gateway latency  (mock downstream, ${N} iterations, median)\n`);
-  console.log(`  ${"handshake (one-time)".padEnd(28)}${handshake.toFixed(2).padStart(6)} ms`);
+  console.log(
+    `  ${"handshake (one-time)".padEnd(28)}${handshake.toFixed(2).padStart(6)} ms`,
+  );
   console.log(row("tools/list (lazy, 3 tools)", list));
   console.log(row("toolport_search_tools", search));
   console.log(row("toolport_call_tool -> mock", gwCall));
@@ -168,7 +195,9 @@ async function main() {
   console.log(
     `     Real servers take tens to hundreds of ms each, so that overhead is noise,`,
   );
-  console.log(`     and it buys ~90% fewer tokens. See BENCHMARK.md for the token numbers.\n`);
+  console.log(
+    `     and it buys ~90% fewer tokens. See BENCHMARK.md for the token numbers.\n`,
+  );
 }
 
 main().catch((e) => {

--- a/benchmark/retrieval.mjs
+++ b/benchmark/retrieval.mjs
@@ -53,21 +53,65 @@ const GATEWAY = process.env.GATEWAY || defaultGateway();
 const CASES = [
   // --- direct (should be easy). Tightened to the actual action tool name so a
   //     loose substring (e.g. any "...project...") can't count as a false hit. ---
-  { q: "list my stripe products", want: ["list_products", "stripe_api_read", "search_stripe_resources"], kind: "direct" },
+  {
+    q: "list my stripe products",
+    want: ["list_products", "stripe_api_read", "search_stripe_resources"],
+    kind: "direct",
+  },
   { q: "list my neon projects", want: ["list_projects"], kind: "direct" },
   { q: "list my vercel projects", want: ["list_projects"], kind: "direct" },
-  { q: "list my github repositories", want: ["list_repositor", "search_repositor"], kind: "direct" },
+  {
+    q: "list my github repositories",
+    want: ["list_repositor", "search_repositor"],
+    kind: "direct",
+  },
   // --- paraphrased / indirect (the hard cases) ---
-  { q: "charge a customer's credit card", want: ["payment_intent", "create_charge", "stripe_api_write"], kind: "paraphrase" },
-  { q: "who are my paying customers", want: ["list_customer", "search_customer", "customer"], kind: "paraphrase" },
-  { q: "open a pull request for my branch", want: ["create_pull_request", "pull_request"], kind: "paraphrase" },
-  { q: "spin up a database branch to test a migration", want: ["create_branch", "prepare_database_migration"], kind: "paraphrase" },
-  { q: "run a SQL query against my database", want: ["run_sql", "execute_sql", "run_query", "execute_postgres"], kind: "paraphrase" },
-  { q: "send a welcome email to a new signup", want: ["send_email", "send-email", "emails_send"], kind: "paraphrase" },
-  { q: "roll back my last deployment", want: ["rollback", "redeploy", "promote", "revert"], kind: "paraphrase" },
-  { q: "what's my revenue this month", want: ["revenue", "overview_metric", "list_metric", "balance"], kind: "paraphrase" },
+  {
+    q: "charge a customer's credit card",
+    want: ["payment_intent", "create_charge", "stripe_api_write"],
+    kind: "paraphrase",
+  },
+  {
+    q: "who are my paying customers",
+    want: ["list_customer", "search_customer", "customer"],
+    kind: "paraphrase",
+  },
+  {
+    q: "open a pull request for my branch",
+    want: ["create_pull_request", "pull_request"],
+    kind: "paraphrase",
+  },
+  {
+    q: "spin up a database branch to test a migration",
+    want: ["create_branch", "prepare_database_migration"],
+    kind: "paraphrase",
+  },
+  {
+    q: "run a SQL query against my database",
+    want: ["run_sql", "execute_sql", "run_query", "execute_postgres"],
+    kind: "paraphrase",
+  },
+  {
+    q: "send a welcome email to a new signup",
+    want: ["send_email", "send-email", "emails_send"],
+    kind: "paraphrase",
+  },
+  {
+    q: "roll back my last deployment",
+    want: ["rollback", "redeploy", "promote", "revert"],
+    kind: "paraphrase",
+  },
+  {
+    q: "what's my revenue this month",
+    want: ["revenue", "overview_metric", "list_metric", "balance"],
+    kind: "paraphrase",
+  },
   { q: "refund a payment", want: ["refund"], kind: "paraphrase" },
-  { q: "inspect my supabase database schema", want: ["list_tables", "execute_sql", "list_extensions"], kind: "paraphrase" },
+  {
+    q: "inspect my supabase database schema",
+    want: ["list_tables", "execute_sql", "list_extensions"],
+    kind: "paraphrase",
+  },
 ];
 
 // --- minimal MCP-over-stdio client ---
@@ -78,7 +122,9 @@ class Gateway {
       stdio: ["pipe", "pipe", "ignore"],
     });
     this.proc.on("error", (e) => {
-      console.error(`Could not start gateway at ${GATEWAY}: ${e.message}\nBuild it: npm run build:gateway`);
+      console.error(
+        `Could not start gateway at ${GATEWAY}: ${e.message}\nBuild it: npm run build:gateway`,
+      );
       process.exit(1);
     });
     this.rl = createInterface({ input: this.proc.stdout });
@@ -86,29 +132,49 @@ class Gateway {
     this.id = 0;
     this.rl.on("line", (line) => {
       let m;
-      try { m = JSON.parse(line); } catch { return; }
+      try {
+        m = JSON.parse(line);
+      } catch {
+        return;
+      }
       const cb = m.id != null && this.pending.get(m.id);
-      if (cb) { this.pending.delete(m.id); cb(m); }
+      if (cb) {
+        this.pending.delete(m.id);
+        cb(m);
+      }
     });
   }
   rpc(method, params) {
     const id = ++this.id;
     return new Promise((resolve) => {
       this.pending.set(id, resolve);
-      this.proc.stdin.write(JSON.stringify({ jsonrpc: "2.0", id, method, params }) + "\n");
+      this.proc.stdin.write(
+        JSON.stringify({ jsonrpc: "2.0", id, method, params }) + "\n",
+      );
     });
   }
   async init() {
-    await this.rpc("initialize", { protocolVersion: "2024-11-05", capabilities: {}, clientInfo: { name: "retrieval-bench", version: "1" } });
+    await this.rpc("initialize", {
+      protocolVersion: "2024-11-05",
+      capabilities: {},
+      clientInfo: { name: "retrieval-bench", version: "1" },
+    });
     await new Promise((r) => setTimeout(r, CONNECT_WAIT_MS));
   }
   async search(query, limit) {
-    const r = await this.rpc("tools/call", { name: "toolport_search_tools", arguments: { query, limit } });
+    const r = await this.rpc("tools/call", {
+      name: "toolport_search_tools",
+      arguments: { query, limit },
+    });
     const text = r.result?.content?.[0]?.text ?? "";
     // The result embeds the matches as a JSON-ish block; pull tool names in order.
     return [...text.matchAll(/"name"\s*:\s*"([^"]+)"/g)].map((m) => m[1]);
   }
-  stop() { try { this.proc.kill(); } catch {} }
+  stop() {
+    try {
+      this.proc.kill();
+    } catch {}
+  }
 }
 
 function rankOf(names, want) {
@@ -121,7 +187,9 @@ function rankOf(names, want) {
 
 (async () => {
   console.log(`gateway: ${GATEWAY}`);
-  const semOn = ["on", "1", "true", "yes"].includes((process.env.CONDUIT_SEMANTIC || "").toLowerCase());
+  const semOn = ["on", "1", "true", "yes"].includes(
+    (process.env.CONDUIT_SEMANTIC || "").toLowerCase(),
+  );
   console.log(
     semOn
       ? `mode:    SEMANTIC (embed: ${process.env.CONDUIT_EMBED_MODEL || "?"} @ ${process.env.CONDUIT_EMBED_ENDPOINT || "?"})`
@@ -138,7 +206,8 @@ function rankOf(names, want) {
     rows.push({ ...c, rank, top: names.slice(0, 3) });
     const status = rank === 0 ? "MISS" : `#${rank}`;
     console.log(`  [${c.kind.padEnd(10)}] ${status.padStart(5)}  ${c.q}`);
-    if (rank === 0) console.log(`           top results: ${names.slice(0, 5).join(", ") || "(none)"}`);
+    if (rank === 0)
+      console.log(`           top results: ${names.slice(0, 5).join(", ") || "(none)"}`);
   }
   gw.stop();
 
@@ -146,7 +215,10 @@ function rankOf(names, want) {
   const hit5 = rows.filter((r) => r.rank > 0 && r.rank <= 5).length;
   const mrr = rows.reduce((a, r) => a + (r.rank > 0 ? 1 / r.rank : 0), 0) / rows.length;
   const byKind = (k) => rows.filter((r) => r.kind === k);
-  const recall5 = (rs) => rs.length ? `${rs.filter((r) => r.rank > 0 && r.rank <= 5).length}/${rs.length}` : "0/0";
+  const recall5 = (rs) =>
+    rs.length
+      ? `${rs.filter((r) => r.rank > 0 && r.rank <= 5).length}/${rs.length}`
+      : "0/0";
 
   console.log("\n=== summary ===");
   console.log(`recall@1:  ${hit1}/${rows.length}`);
@@ -156,9 +228,16 @@ function rankOf(names, want) {
   console.log(`  paraphrase cases recall@5: ${recall5(byKind("paraphrase"))}`);
   const misses = rows.filter((r) => r.rank === 0);
   if (misses.length) {
-    console.log(`\nmisses (${misses.length}) — a real gap if you have the capability connected:`);
-    for (const m of misses) console.log(`  - "${m.q}"  (wanted name containing: ${m.want.join(" / ")})`);
+    console.log(
+      `\nmisses (${misses.length}) — a real gap if you have the capability connected:`,
+    );
+    for (const m of misses)
+      console.log(`  - "${m.q}"  (wanted name containing: ${m.want.join(" / ")})`);
   }
-  console.log("\nParaphrase recall is the number that backs (or breaks) the 'never misses a tool'");
-  console.log("claim. If it's low, that's the case for semantic search; see docs/specs/semantic-search.md.");
+  console.log(
+    "\nParaphrase recall is the number that backs (or breaks) the 'never misses a tool'",
+  );
+  console.log(
+    "claim. If it's low, that's the case for semantic search; see docs/specs/semantic-search.md.",
+  );
 })();

--- a/benchmark/token-cost.mjs
+++ b/benchmark/token-cost.mjs
@@ -20,7 +20,8 @@ import { join } from "node:path";
 // Toolport's data dir, matching the gateway's registry::conduit_dir().
 function conduitDir() {
   if (platform() === "win32") return join(homedir(), "AppData", "Roaming", "Conduit");
-  if (platform() === "darwin") return join(homedir(), "Library", "Application Support", "Conduit");
+  if (platform() === "darwin")
+    return join(homedir(), "Library", "Application Support", "Conduit");
   return join(process.env.XDG_CONFIG_HOME || join(homedir(), ".config"), "Conduit");
 }
 
@@ -82,7 +83,9 @@ for (const r of rows) {
 }
 console.log("");
 console.log(`Without Toolport:  ${fmt(total)} tokens / request`);
-console.log(`With Toolport:     ${fmt(LAZY_FLOOR)} tokens / request (3 meta-tools, flat)`);
+console.log(
+  `With Toolport:     ${fmt(LAZY_FLOOR)} tokens / request (3 meta-tools, flat)`,
+);
 console.log(`Reduction:        ${reduction}%`);
 
 // --- 2. Per-tool distribution ---
@@ -103,23 +106,29 @@ const WINDOWS = [
   ["Gemini 2.5 (1M)", 1000000],
 ];
 console.log("");
-console.log(`Context window eaten by ${fmt(total)} tokens of definitions, before any real work:`);
+console.log(
+  `Context window eaten by ${fmt(total)} tokens of definitions, before any real work:`,
+);
 for (const [name, w] of WINDOWS) {
   const pct = (total / w) * 100;
-  console.log(`  ${name.padEnd(24)} ${pct > 100 ? ">100%  (OVERFLOWS, can't even load the tools)" : pct.toFixed(1) + "%"}`);
+  console.log(
+    `  ${name.padEnd(24)} ${pct > 100 ? ">100%  (OVERFLOWS, can't even load the tools)" : pct.toFixed(1) + "%"}`,
+  );
 }
 
 // --- 4. Scaling: reduction grows with tool count ---
 // Uses the measured mean tokens/tool from THIS catalog, so the curve is grounded
 // in real schemas. Lazy's floor is fixed at 3 meta-tools no matter the size.
 console.log("");
-console.log(`Scaling (def-overhead reduction vs tool count, at ${fmt(meanPerTool)} tok/tool measured here):`);
+console.log(
+  `Scaling (def-overhead reduction vs tool count, at ${fmt(meanPerTool)} tok/tool measured here):`,
+);
 console.log("  tools    flat tokens    lazy    reduction");
 for (const n of [3, 10, 25, 50, 100, 200, tools.length]) {
   const flat = Math.round(n * meanPerTool);
   const red = (1 - LAZY_FLOOR / flat) * 100;
   console.log(
-    `  ${String(n).padStart(5)}    ${fmt(flat).padStart(10)}    ${fmt(LAZY_FLOOR).padStart(4)}    ${(red > 0 ? red.toFixed(1) : "0.0")}%`,
+    `  ${String(n).padStart(5)}    ${fmt(flat).padStart(10)}    ${fmt(LAZY_FLOOR).padStart(4)}    ${red > 0 ? red.toFixed(1) : "0.0"}%`,
   );
 }
 const breakeven = Math.ceil(LAZY_FLOOR / meanPerTool);
@@ -135,7 +144,9 @@ const PRICES = [
 ];
 const VOLUMES = [50, 200, 1000];
 console.log("");
-console.log(`Monthly $ saved (re-sending ${fmt(saved)} tokens/request that lazy mode doesn't):`);
+console.log(
+  `Monthly $ saved (re-sending ${fmt(saved)} tokens/request that lazy mode doesn't):`,
+);
 console.log("  model".padEnd(28) + VOLUMES.map((v) => `${v}/day`.padStart(12)).join(""));
 for (const [label, price] of PRICES) {
   let line = "  " + label.padEnd(26);

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -57,11 +57,13 @@ fix is reload-under-lock at every app mutation or a gateway→app cache-refresh 
 low real exposure since the gateway only writes when `allow_agent_control` is on).
 
 **In flight**
+
 - ~~Teams **org screening policy** (Phase 1): tighten-only `forceContentDefense` /
   `forceQuarantineOnDrift`.~~ **Shipped**, and extended with `forceHumanApproval`
   (org-mandated HITL). Plan in `docs/drafts/parry-teams-plan.md`.
 
 **Tier 1 - security + cheap parity (do first)**
+
 - [x] **Stdio spawn hardening.** Refuse code-smuggling / container-escape args
       (interpreter inline-eval + module-preload, docker `--privileged` / host-mount /
       `--cap-add` / host-namespace) before spawning a stdio server, so a
@@ -69,13 +71,14 @@ low real exposure since the gateway only writes when `allow_agent_control` is on
       launcher into arbitrary code execution. `screen_spawn_command` in
       `downstream.rs`, on every spawn path. (S)
 - [~] **Identity attribution in the audit line.** The client label is now threaded
-      through dispatch and stamped into `audit.rs`/`inspect.rs` records (#95). Remaining:
-      a per-caller filter in the Activity view. (S)
+  through dispatch and stamped into `audit.rs`/`inspect.rs` records (#95). Remaining:
+  a per-caller filter in the Activity view. (S)
 - [x] **Tool overrides (rename / re-describe) SHIPPED (#88, #89):** a user can rename or
       replace a tool's description as clients see it (neutralizing a poisoned description
       in place). Param-pin/override defaults is the remaining piece.
 
 **Tier 2 - parity on real gaps**
+
 - [ ] Tool Groups (cross-server reusable collections) + allow/block ACL with an
       explicit `default-allow`/`default-block` posture per client, generalizing
       profiles. (M)
@@ -85,6 +88,7 @@ low real exposure since the gateway only writes when `allow_agent_control` is on
       ships) so remote/network clients connect natively. (M)
 
 **Strategic**
+
 - [x] **Human-in-the-loop approval queue. SHIPPED** (v1.1.0 + follow-ups): the gateway
       holds a gated call and the app prompts to approve/deny, fail-closed on timeout;
       plus tray/menu-bar run, OS notification, approve-for-session/always-allow, exact
@@ -102,6 +106,7 @@ HTTP/security surface). Ordered by impact within each track. (S/M/L = effort.)
 The 2026-07-01 block above supersedes the ordering; these remain the detailed backlog.
 
 ### Security (most shipped in v0.7.0; residuals)
+
 - [x] HTTP bridge **bearer token** (required, OPTIONS preflight exempt), fail-closed
       on non-loopback bind, 4 MB body cap, sanitized reflected headers, `catch_unwind`
       per request. Closed the credential-CSRF (a browser tab can reach `localhost`).
@@ -113,6 +118,7 @@ The 2026-07-01 block above supersedes the ordering; these remain the detailed ba
       longer blocks other callers. (A per-request read timeout for slowloris is still open.)
 
 ### New-user UX (first 10 minutes; scaffolding is strong, these are the sharp edges)
+
 - [ ] **Backend failures render as innocent empty states.** Gateway down ->
       Activity shows "No tool calls yet", not "can't reach backend, retry".
       Distinguish error from empty (CatalogView already does). Top UX fix. (M)
@@ -126,6 +132,7 @@ The 2026-07-01 block above supersedes the ordering; these remain the detailed ba
       `vendorFromKey` fallback for unknown keys. (S each)
 
 ### Robustness / tech debt
+
 - [ ] **Tool-cache versioning.** The gateway serves the on-disk cache verbatim with
       no version tag, so catalog-logic changes don't take effect until a server
       toggles or the cache is deleted. Wrap in `{version, tools}`, discard on
@@ -137,6 +144,7 @@ The 2026-07-01 block above supersedes the ordering; these remain the detailed ba
       `semantic.rs` (blend math, embed cache). (M)
 
 ### Strategic / differentiators (what makes it amazing)
+
 - [ ] **OAuth client registration + per-client server scoping.** A client
       authenticates to Toolport, shows up in the app, you assign which servers it
       sees. Profiles already do half. This is Sigiz's explicit ask AND the proper
@@ -158,6 +166,7 @@ The 2026-07-01 block above supersedes the ordering; these remain the detailed ba
       publish pending) as the funnel + a demo of lazy discovery + result-shaping.
 
 **Community-requested (2026-07-03, r/LocalLLaMA launch thread):**
+
 - [x] **Lazy-discovery search trace / observability.** Shipped (#114) as the Activity
       **Discovery** panel: every `toolport_search_tools` call records the query, the
       matched tool names, which won (top), and the ground-truth per-turn token overhead
@@ -215,16 +224,16 @@ flips every weakness:
   machine. All servers moved to connectors.
 - Connectors + OAuth tokens live in `%APPDATA%\Claude\config.json` as
   **DPAPI-encrypted** blobs (Chromium safeStorage, `v10` prefix). Not readable.
-- Connector *names* (Clerk, GitHub, Pax8, revenuecat, Supabase, Vercel, Stripe,
+- Connector _names_ (Clerk, GitHub, Pax8, revenuecat, Supabase, Vercel, Stripe,
   expo) DO appear in plaintext in the Chromium LevelDB/IndexedDB stores for the
   `claude.ai` origin.
 - BUT those stores are **locked while Claude is running**, the schema is
   undocumented Chromium IndexedDB, and the real source of truth is the user's
   Anthropic account (server-side sync), not a local file.
 
-**Verdict:** local read-only *inventory* of connector names is possible but
+**Verdict:** local read-only _inventory_ of connector names is possible but
 fragile and operationally awkward (locked DBs, undocumented schema, account-side
-truth). It is NOT a foundation to build *management* on. This confirms the
+truth). It is NOT a foundation to build _management_ on. This confirms the
 gateway architecture: Toolport cannot manage Claude's connectors directly, so it
 becomes one connector that fans out to everything it manages. A best-effort,
 read-only "connectors detected (view-only)" panel is worth showing for the
@@ -243,6 +252,7 @@ mutate their live client setup unattended).
 ## Build order
 
 Phase 0 - Foundation
+
 - [x] Tauri + React + Rust scaffold, 0 vulns
 - [x] Client adapter readers (import/discovery): detect clients, parse JSON/TOML
 - [x] Toolport registry: own source-of-truth store (servers, profiles, enabled)
@@ -252,6 +262,7 @@ Phase 0 - Foundation
 - [x] OS keychain module for secrets
 
 Phase 1 - The gateway
+
 - [x] MCP stdio server (initialize, tools/list, tools/call)
 - [x] Downstream MCP client: spawn/connect real servers, multiplex tools (namespaced)
 - [x] Live reconfig + `tools/list_changed` on toggle (registry file watcher)
@@ -262,6 +273,7 @@ Phase 1 - The gateway
 - [x] Tool-name sanitizing (clients drop hyphenated names) + cache-poisoning guard
 
 Phase 1.5 - Remote auth
+
 - [x] Token auth: vault a bearer token per http server, injected by gateway
 - [x] OAuth 2.1 flow: discovery + DCR + PKCE + loopback + exchange
 - [x] OAuth token refresh on 401/expiry
@@ -269,6 +281,7 @@ Phase 1.5 - Remote auth
       vendor hints, live propagation to connected clients
 
 Phase 2 - Client integration
+
 - [x] "Install Toolport into client X" (surgical, backs up, preserves others)
 - [x] Uninstall (surgical remove)
 - [x] Client detail reframed as connect + import sources
@@ -281,6 +294,7 @@ Phase 2 - Client integration
       the packaged `-<triple>` name). Shipping in signed releases.
 
 Phase 3 - Scaling & UX
+
 - [x] Lazy discovery: `CONDUIT_DISCOVERY=lazy` exposes 3 meta-tools (search/call)
 - [x] Per-agent scoping: `CONDUIT_PROFILE` + per-client profile picker, per-profile cache
 - [x] Catalog: curated popular set + live official MCP Registry search, type-ahead
@@ -289,6 +303,7 @@ Phase 3 - Scaling & UX
 ## Next (tiered)
 
 Tier 2 - feature completeness (in progress)
+
 - [x] Per-tool enable/disable + destructive-tool deny-list (UI toggles; gateway
       hides+blocks; global destructiveHint switch)
 - [x] Tool playground: invoke any tool from the app and see the result
@@ -306,7 +321,7 @@ Tier 2 - feature completeness (in progress)
       into the lexical ranker so paraphrased needs surface the right tool. Pluggable
       `/v1/embeddings` endpoint, disk-cached, lexical fallback. Recall measured by
       `benchmark/retrieval.mjs`. See `docs/specs/semantic-search.md`.
-- [x] Content defense (agentjacking): scan untrusted tool *results* for injection and
+- [x] Content defense (agentjacking): scan untrusted tool _results_ for injection and
       wrap flagged content with a "data, not instructions" provenance marker before the
       agent sees it. Detection + labeling, never blocks, on by default. See
       `docs/specs/content-defense.md`.
@@ -314,6 +329,7 @@ Tier 2 - feature completeness (in progress)
       taxonomy; opt-in lossy result shaping / dangerous-call gating (content-defense Tier 2).
 
 Tier 3 - launch prep
+
 - [x] Bundle the gateway sidecar; signed/notarized macOS installers (Win/Linux
       unsigned with documented bypass); cargo-audit in CI.
 - [x] Verify macOS / Linux (signed mac dmgs arm64 + Intel, Linux deb/AppImage;
@@ -327,13 +343,14 @@ Tier 3 - launch prep
 - [x] Launch: Product Hunt, MCP registries (Glama/mcp.so/awesome-mcp listed)
 
 Tier 4 - teams / enterprise (paid)
+
 - [ ] Hosted/remote gateway, shared/synced config, RBAC/SSO
 - [ ] Policy engine (allow/deny tools, approval gates), audit export
 - [ ] Secret-vault integrations (1Password, Vault, cloud secret managers)
 
 ## Security invariants (do not regress)
 
-- Backend never sends secret *values* to the UI; env var names only.
+- Backend never sends secret _values_ to the UI; env var names only.
 - Secrets live in the OS keychain, never in Toolport's registry file or any
   client config.
 - Snapshot every client config before modifying it; modifications are reversible.

--- a/docs/SIGNING.md
+++ b/docs/SIGNING.md
@@ -11,12 +11,12 @@ self-signed certificate does not help end users.
 
 ## Options
 
-| Option | Cost | Notes |
-|---|---|---|
-| **Azure Trusted Signing** | ~$10/month | Cheapest real option. Cloud-based, no cert file to manage. Requires an Azure account and identity verification; orgs need 3+ years of history (individuals are eligible). Chains to a Microsoft-operated trusted root and shows your validated publisher name. It is **standard, not EV**, signing, so SmartScreen reputation still accrues with downloads and an early install may still warn. |
-| **OV certificate** (Sectigo, DigiCert, etc.) | ~$100 to $400/year | Standard cert. SmartScreen reputation builds over time/downloads, so early downloads may still warn briefly. Usually requires a hardware token (or cloud HSM) now. |
-| **EV certificate** | ~$300 to $600/year | Instant SmartScreen reputation, no warning from day one. Hardware token required. |
-| **Ship unsigned (interim)** | free | Fine for an early beta. Users click "More info → Run anyway". Document the bypass in release notes. |
+| Option                                       | Cost               | Notes                                                                                                                                                                                                                                                                                                                                                                                           |
+| -------------------------------------------- | ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Azure Trusted Signing**                    | ~$10/month         | Cheapest real option. Cloud-based, no cert file to manage. Requires an Azure account and identity verification; orgs need 3+ years of history (individuals are eligible). Chains to a Microsoft-operated trusted root and shows your validated publisher name. It is **standard, not EV**, signing, so SmartScreen reputation still accrues with downloads and an early install may still warn. |
+| **OV certificate** (Sectigo, DigiCert, etc.) | ~$100 to $400/year | Standard cert. SmartScreen reputation builds over time/downloads, so early downloads may still warn briefly. Usually requires a hardware token (or cloud HSM) now.                                                                                                                                                                                                                              |
+| **EV certificate**                           | ~$300 to $600/year | Instant SmartScreen reputation, no warning from day one. Hardware token required.                                                                                                                                                                                                                                                                                                               |
+| **Ship unsigned (interim)**                  | free               | Fine for an early beta. Users click "More info → Run anyway". Document the bypass in release notes.                                                                                                                                                                                                                                                                                             |
 
 For a pre-launch beta with no budget, shipping unsigned and documenting the
 bypass is the pragmatic choice. Reputation also accrues as more people run it.
@@ -61,6 +61,7 @@ the bundled gateway sidecar, and the NSIS installer during the build (before the
 updater `.sig` is computed, so auto-update keeps working).
 
 **One-time Azure setup:**
+
 1. Create an **Artifact Signing (Trusted Signing) account** + complete **Individual**
    identity validation, then create a **Public Trust certificate profile**. Note the
    account name, the certificate profile name, and the account's endpoint URI (e.g.
@@ -68,24 +69,24 @@ updater `.sig` is computed, so auto-update keeps working).
 2. Create a **service principal** for CI (Entra ID → App registrations → new
    registration → add a client secret).
 3. On the signing **account → Access control (IAM)**, assign that app the
-   **"Trusted Signing Certificate Profile Signer"** role (this is the *signer* role,
-   distinct from the *Identity Verifier* role you assign to yourself).
+   **"Trusted Signing Certificate Profile Signer"** role (this is the _signer_ role,
+   distinct from the _Identity Verifier_ role you assign to yourself).
 
 **GitHub secrets to add** (Settings → Secrets and variables → Actions → Secrets):
 
-| Secret | Value |
-|---|---|
-| `AZURE_TENANT_ID` | the app registration's Directory (tenant) ID |
-| `AZURE_CLIENT_ID` | the app registration's Application (client) ID |
-| `AZURE_CLIENT_SECRET` | the client secret value |
+| Secret                | Value                                          |
+| --------------------- | ---------------------------------------------- |
+| `AZURE_TENANT_ID`     | the app registration's Directory (tenant) ID   |
+| `AZURE_CLIENT_ID`     | the app registration's Application (client) ID |
+| `AZURE_CLIENT_SECRET` | the client secret value                        |
 
 **GitHub variables to add** (same page → Variables tab):
 
-| Variable | Value |
-|---|---|
-| `AZURE_SIGNING_PROFILE` | your certificate profile name (**required**) |
+| Variable                 | Value                                                     |
+| ------------------------ | --------------------------------------------------------- |
+| `AZURE_SIGNING_PROFILE`  | your certificate profile name (**required**)              |
 | `AZURE_SIGNING_ENDPOINT` | optional, defaults to `https://eus.codesigning.azure.net` |
-| `AZURE_SIGNING_ACCOUNT` | optional, defaults to `southforgesigning` |
+| `AZURE_SIGNING_ACCOUNT`  | optional, defaults to `southforgesigning`                 |
 
 With those set, the next `v*` tag produces a **signed** Windows installer. SmartScreen
 reputation still accrues with downloads, but the "unknown publisher" warning is gone
@@ -123,14 +124,14 @@ Developer ID cert (not an iOS distribution cert).
 The release workflow already passes these env vars to the macOS build; set them as
 repository secrets (Settings → Secrets and variables → Actions):
 
-| Secret | Value |
-|---|---|
-| `APPLE_CERTIFICATE` | base64 of the `.p12`: `base64 -i cert.p12 \| pbcopy` |
-| `APPLE_CERTIFICATE_PASSWORD` | the password you set when exporting the `.p12` |
-| `APPLE_SIGNING_IDENTITY` | `Developer ID Application: Your Name (TEAMID)` (exact string from Keychain Access) |
-| `APPLE_ID` | your Apple ID email |
-| `APPLE_PASSWORD` | the app-specific password from step 3 |
-| `APPLE_TEAM_ID` | the 10-char Team ID |
+| Secret                       | Value                                                                              |
+| ---------------------------- | ---------------------------------------------------------------------------------- |
+| `APPLE_CERTIFICATE`          | base64 of the `.p12`: `base64 -i cert.p12 \| pbcopy`                               |
+| `APPLE_CERTIFICATE_PASSWORD` | the password you set when exporting the `.p12`                                     |
+| `APPLE_SIGNING_IDENTITY`     | `Developer ID Application: Your Name (TEAMID)` (exact string from Keychain Access) |
+| `APPLE_ID`                   | your Apple ID email                                                                |
+| `APPLE_PASSWORD`             | the app-specific password from step 3                                              |
+| `APPLE_TEAM_ID`              | the 10-char Team ID                                                                |
 
 With those set, a tagged build produces a **signed, notarized** `.dmg`, no
 Gatekeeper warning. Without them, the macOS build is simply unsigned (and users

--- a/docs/design/hitl-approval-queue.md
+++ b/docs/design/hitl-approval-queue.md
@@ -4,10 +4,10 @@ Status: P1 IMPLEMENTED in PR #82 (2026-07-02, rev 2 architecture). Remaining bef
 
 ## Goal
 
-Let a human approve or deny sensitive tool calls *out-of-band* before they execute,
+Let a human approve or deny sensitive tool calls _out-of-band_ before they execute,
 holding the call until a decision (or a fail-closed timeout). Distinct from the existing
-**agent-facing** `toolport_confirm`, where the *model* re-confirms its own destructive
-call. HITL puts a *person* in the loop through the Toolport app. This is a genuine
+**agent-facing** `toolport_confirm`, where the _model_ re-confirms its own destructive
+call. HITL puts a _person_ in the loop through the Toolport app. This is a genuine
 security differentiator (the "approval queue" gap vs. Lunar MCPX / IBM ContextForge), so
 it is worth building to a high bar rather than the minimal one.
 
@@ -44,6 +44,7 @@ readable only by processes that can already read `~/.conduit/`, the same trust b
 secrets).
 
 Flow for a gated call:
+
 1. Gateway (`process_request`) reads the endpoint+token, **connects to the app**, and sends
    `{ client, server, tool, args, provenance, ts }` authenticated by the token.
 2. The app shows it in a **Pending Approvals** queue (ActivityView) plus a prominent OS
@@ -54,7 +55,7 @@ Flow for a gated call:
 
 **Why this is the best-in-class choice, it wins on every axis the two alternatives lose:**
 
-- **Coverage:** every gateway process dials *out* to the one app broker, so stdio clients
+- **Coverage:** every gateway process dials _out_ to the one app broker, so stdio clients
   are covered, not just the app's own `--http` gateway.
 - **No args on disk:** arguments travel over the socket and stay in memory. The disk only
   ever holds the endpoint descriptor (no payloads). This is the decisive privacy win.
@@ -79,7 +80,7 @@ Flow for a gated call:
 1. **Blocking, not async.** Hold the agent's call until a decision; the agent just sees a
    slower tool and gets the real result or a denial. Async (return-pending-then-replay)
    leaks approval mechanics into the agent and creates a "looks failed" window. A parked
-   call blocking that client's *other* calls is acceptable and arguably desirable (don't let
+   call blocking that client's _other_ calls is acceptable and arguably desirable (don't let
    the agent race ahead of a pending sensitive action); other clients are separate processes
    and unaffected.
 2. **Scope: layered, security-first default.** v1 gates (a) `destructiveHint` tools AND

--- a/docs/macos-keychain-test-runbook.md
+++ b/docs/macos-keychain-test-runbook.md
@@ -48,6 +48,7 @@ APP=/path/to/Toolport.app ./scripts/macos-sign-local.sh
 ```
 
 The script:
+
 - moves the gateway into `Toolport.app/Contents/Helpers/ConduitGateway.app`,
 - embeds the gateway provisioning profile there,
 - leaves a symlink at the old bare path for backward compat,

--- a/docs/screenshots/README.md
+++ b/docs/screenshots/README.md
@@ -2,10 +2,10 @@
 
 Drop PNGs here with these exact names; the main README references them.
 
-| File | Capture |
-|---|---|
-| `servers.png` | The "All servers" view, with a few servers and their status dots. |
-| `activity.png` | The Activity view showing the per-server latency / error-rate panel. |
+| File             | Capture                                                                                                            |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------ |
+| `servers.png`    | The "All servers" view, with a few servers and their status dots.                                                  |
+| `activity.png`   | The Activity view showing the per-server latency / error-rate panel.                                               |
 | `playground.png` | The Playground: the lazy-discovery + destructive-tool switches and a tool's argument form (ideally with a result). |
 
 How to capture on Windows: `Win` + `Shift` + `S`, drag over the app window,

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,50 @@
+import js from "@eslint/js";
+import tseslint from "typescript-eslint";
+import reactHooks from "eslint-plugin-react-hooks";
+import reactRefresh from "eslint-plugin-react-refresh";
+import prettierConfig from "eslint-config-prettier";
+import globals from "globals";
+
+export default tseslint.config(
+  // Ignore build output and deps (Prettier handles its own ignores).
+  {
+    ignores: ["dist/", "node_modules/", "src-tauri/"],
+  },
+
+  // Base JS + TypeScript recommended rules.
+  js.configs.recommended,
+  ...tseslint.configs.recommended,
+
+  // Project source files.
+  {
+    files: ["src/**/*.{ts,tsx}"],
+    languageOptions: {
+      ecmaVersion: 2020,
+      globals: globals.browser,
+      parserOptions: {
+        ecmaFeatures: { jsx: true },
+      },
+    },
+    plugins: {
+      "react-hooks": reactHooks,
+      "react-refresh": reactRefresh,
+    },
+    rules: {
+      ...reactHooks.configs.recommended.rules,
+      "react-refresh/only-export-components": [
+        "warn",
+        { allowConstantExport: true },
+      ],
+      // React 19's hooks plugin added set-state-in-effect and refs-during-render
+      // as errors. In a Tauri desktop app there's no Suspense or RSC, so loading
+      // data from the Rust backend via setState-in-useEffect is the standard
+      // pattern. These are legitimate code-quality signals, not bugs — downgrade
+      // to warnings so they surface without blocking the build.
+      "react-hooks/set-state-in-effect": "warn",
+      "react-hooks/refs": "warn",
+    },
+  },
+
+  // Turn off all rules that conflict with Prettier (formatting concerns).
+  prettierConfig,
+);

--- a/glama.json
+++ b/glama.json
@@ -1,6 +1,4 @@
 {
   "$schema": "https://glama.ai/mcp/schemas/server.json",
-  "maintainers": [
-    "tsouth89"
-  ]
+  "maintainers": ["tsouth89"]
 }

--- a/index.html
+++ b/index.html
@@ -2,7 +2,10 @@
 <html lang="en" class="dark">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 512 512'%3E%3Ccircle cx='256' cy='256' r='195' fill='none' stroke='%231E3A66' stroke-width='90'/%3E%3Ccircle cx='256' cy='256' r='52' fill='%23F97316'/%3E%3C/svg%3E" />
+    <link
+      rel="icon"
+      href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 512 512'%3E%3Ccircle cx='256' cy='256' r='195' fill='none' stroke='%231E3A66' stroke-width='90'/%3E%3Ccircle cx='256' cy='256' r='52' fill='%23F97316'/%3E%3C/svg%3E"
+    />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Toolport</title>
   </head>

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@tauri-apps/plugin-process": "^2.3.1",
         "@tauri-apps/plugin-updater": "^2.10.1",
         "class-variance-authority": "^0.7.1",
-        "clsx": "^2.1.1",
+        "clsx": "2.1.1",
         "lucide-react": "^1.21.0",
         "next-themes": "^0.4.6",
         "radix-ui": "^1.6.0",
@@ -30,19 +30,24 @@
         "tw-animate-css": "^1.4.0"
       },
       "devDependencies": {
+        "@eslint/js": "^10.0.1",
         "@tauri-apps/cli": "^2",
         "@types/react": "^19.1.8",
         "@types/react-dom": "^19.1.6",
         "@vitejs/plugin-react": "^4.6.0",
+        "eslint": "^10.6.0",
+        "eslint-config-prettier": "^10.1.8",
+        "eslint-plugin-react-hooks": "^7.1.1",
+        "eslint-plugin-react-refresh": "^0.5.3",
+        "globals": "^17.7.0",
         "prettier": "^3.9.4",
         "typescript": "~5.8.3",
+        "typescript-eslint": "^8.62.1",
         "vite": "^7.0.4"
       }
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
-      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.29.7",
@@ -55,8 +60,6 @@
     },
     "node_modules/@babel/compat-data": {
       "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
-      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -64,8 +67,6 @@
     },
     "node_modules/@babel/core": {
       "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
-      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
@@ -94,8 +95,6 @@
     },
     "node_modules/@babel/generator": {
       "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
-      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.29.7",
@@ -110,8 +109,6 @@
     },
     "node_modules/@babel/helper-annotate-as-pure": {
       "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.29.7.tgz",
-      "integrity": "sha512-OoK6239jHPuSQOoS0kfTVKn0b/rVTk0seKq4Gd2UMLtmOVLjDC0ki3e+c90Trqv2gMfvJFqkiljrr568+qddiw==",
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.29.7"
@@ -122,8 +119,6 @@
     },
     "node_modules/@babel/helper-compilation-targets": {
       "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
-      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
       "license": "MIT",
       "dependencies": {
         "@babel/compat-data": "^7.29.7",
@@ -138,8 +133,6 @@
     },
     "node_modules/@babel/helper-create-class-features-plugin": {
       "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.29.7.tgz",
-      "integrity": "sha512-IY3ZD9Tmooqr3TUhc3DUWxiuo8xx1DWLhd5M7hQ+ZWJamqM2BbalrBJb2MisSLoYorOj75U03qULCxQTY9r3hg==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.29.7",
@@ -159,8 +152,6 @@
     },
     "node_modules/@babel/helper-globals": {
       "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
-      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -168,8 +159,6 @@
     },
     "node_modules/@babel/helper-member-expression-to-functions": {
       "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.29.7.tgz",
-      "integrity": "sha512-j+7JYmk1JYDtACIGj0QJqqWZjoUpMoEikQGADMaHgCMCSDqd2+P32rfcibUNrGOMWrlzK1WJBdxrB3JJQZwWtg==",
       "license": "MIT",
       "dependencies": {
         "@babel/traverse": "^7.29.7",
@@ -181,8 +170,6 @@
     },
     "node_modules/@babel/helper-module-imports": {
       "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
-      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
       "license": "MIT",
       "dependencies": {
         "@babel/traverse": "^7.29.7",
@@ -194,8 +181,6 @@
     },
     "node_modules/@babel/helper-module-transforms": {
       "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
-      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-module-imports": "^7.29.7",
@@ -211,8 +196,6 @@
     },
     "node_modules/@babel/helper-optimise-call-expression": {
       "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.29.7.tgz",
-      "integrity": "sha512-+kmGVjcT9RGYzoDwdwEqEvGgKe3BYq+O1iGzjFubaNgZHwYHP6lsF2Yghf4kEuv9BV7tYDZ913aBW9am6YKong==",
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.29.7"
@@ -223,8 +206,6 @@
     },
     "node_modules/@babel/helper-plugin-utils": {
       "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
-      "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -232,8 +213,6 @@
     },
     "node_modules/@babel/helper-replace-supers": {
       "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.29.7.tgz",
-      "integrity": "sha512-atfGXWSeCiF4DnKZIfmJfQRkSw9b9gNNXR1kqKjbhG4pGYCOnkp8OcTB8E3NXjBu8NpheSnOeNKz8KT7UNFTmQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-member-expression-to-functions": "^7.29.7",
@@ -249,8 +228,6 @@
     },
     "node_modules/@babel/helper-skip-transparent-expression-wrappers": {
       "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.29.7.tgz",
-      "integrity": "sha512-brcMGQaVzIeUb+6/bs1Av0f8YuNNjKY2JyvfRCsFuFsdKccEQ5Ges2y74D74NZ1Rz8lKJ9ksJkfqwQFJ/iNEyQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/traverse": "^7.29.7",
@@ -262,8 +239,6 @@
     },
     "node_modules/@babel/helper-string-parser": {
       "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
-      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -271,8 +246,6 @@
     },
     "node_modules/@babel/helper-validator-identifier": {
       "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
-      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -280,8 +253,6 @@
     },
     "node_modules/@babel/helper-validator-option": {
       "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
-      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -289,8 +260,6 @@
     },
     "node_modules/@babel/helpers": {
       "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
-      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
       "license": "MIT",
       "dependencies": {
         "@babel/template": "^7.29.7",
@@ -302,8 +271,6 @@
     },
     "node_modules/@babel/parser": {
       "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
-      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.29.7"
@@ -317,8 +284,6 @@
     },
     "node_modules/@babel/plugin-syntax-jsx": {
       "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.29.7.tgz",
-      "integrity": "sha512-TSu8+mHCoEaaCDEZ0I3+6mvTBYR4PCxQwf2z9/r5Tbztv6NaLR3B9thGTTxX2WGuGHJqRiAbKPeGTJ5XWXVg6A==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.29.7"
@@ -332,8 +297,6 @@
     },
     "node_modules/@babel/plugin-syntax-typescript": {
       "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.29.7.tgz",
-      "integrity": "sha512-ngr+82Sh0xMz25TPCZi+nC2iTzjfCdWS2ONXTp/PtSCHCgaCNBpdMqgvJ2ccdLlClVZ7sisIgB914j/JFe+RZA==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.29.7"
@@ -347,8 +310,6 @@
     },
     "node_modules/@babel/plugin-transform-modules-commonjs": {
       "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.29.7.tgz",
-      "integrity": "sha512-j0vCldybPC5b5dwCQOJ21uKtHzt7hxLygJTg9eF1ScfaikEDNfzn94XoW5Fi+seBR0nCyL23xaBFFkq7dTM8XQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-module-transforms": "^7.29.7",
@@ -363,8 +324,6 @@
     },
     "node_modules/@babel/plugin-transform-react-jsx-self": {
       "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.29.7.tgz",
-      "integrity": "sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -379,8 +338,6 @@
     },
     "node_modules/@babel/plugin-transform-react-jsx-source": {
       "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.29.7.tgz",
-      "integrity": "sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -395,8 +352,6 @@
     },
     "node_modules/@babel/plugin-transform-typescript": {
       "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.29.7.tgz",
-      "integrity": "sha512-jK52h8LaLc7JarhQV2ofeFMts4H7vnOXnqZNA6fYglBTZewRBE51KWt3BUltW1P+KoPsYkHoJeXePuz4zo2LMw==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.29.7",
@@ -414,8 +369,6 @@
     },
     "node_modules/@babel/preset-typescript": {
       "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.29.7.tgz",
-      "integrity": "sha512-/Foi8vKY2EVbed/1eZx0gJEEwHAIxogrySI7rULcRIvhZzbvoE/b5qG5Ghc0WKAFKOHA9SD1x7RsFlOYdutIiQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.29.7",
@@ -433,8 +386,6 @@
     },
     "node_modules/@babel/template": {
       "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
-      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
@@ -447,8 +398,6 @@
     },
     "node_modules/@babel/traverse": {
       "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
-      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
@@ -465,8 +414,6 @@
     },
     "node_modules/@babel/types": {
       "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
-      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.29.7",
@@ -478,8 +425,6 @@
     },
     "node_modules/@dotenvx/dotenvx": {
       "version": "1.74.2",
-      "resolved": "https://registry.npmjs.org/@dotenvx/dotenvx/-/dotenvx-1.74.2.tgz",
-      "integrity": "sha512-UucMF9L95sVr/feRojWB/NIc5R+CzoiiXq7rd7sWppYA7j6CIH5bu5bQCuoJ0HJxQARR0Ecg4bYot3ilo100lw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "commander": "^11.1.0",
@@ -508,8 +453,6 @@
     },
     "node_modules/@dotenvx/dotenvx/node_modules/commander": {
       "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
-      "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16"
@@ -517,8 +460,6 @@
     },
     "node_modules/@dotenvx/dotenvx/node_modules/define-lazy-prop": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
-      "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -526,8 +467,6 @@
     },
     "node_modules/@dotenvx/dotenvx/node_modules/execa": {
       "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
-      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
       "license": "MIT",
       "dependencies": {
         "cross-spawn": "^7.0.3",
@@ -549,8 +488,6 @@
     },
     "node_modules/@dotenvx/dotenvx/node_modules/get-stream": {
       "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
-      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -561,8 +498,6 @@
     },
     "node_modules/@dotenvx/dotenvx/node_modules/human-signals": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
-      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=10.17.0"
@@ -570,8 +505,6 @@
     },
     "node_modules/@dotenvx/dotenvx/node_modules/is-docker": {
       "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
-      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
       "license": "MIT",
       "bin": {
         "is-docker": "cli.js"
@@ -585,8 +518,6 @@
     },
     "node_modules/@dotenvx/dotenvx/node_modules/is-stream": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
-      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -597,8 +528,6 @@
     },
     "node_modules/@dotenvx/dotenvx/node_modules/is-wsl": {
       "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
-      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
       "license": "MIT",
       "dependencies": {
         "is-docker": "^2.0.0"
@@ -609,8 +538,6 @@
     },
     "node_modules/@dotenvx/dotenvx/node_modules/npm-run-path": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
-      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.0.0"
@@ -621,8 +548,6 @@
     },
     "node_modules/@dotenvx/dotenvx/node_modules/open": {
       "version": "8.4.2",
-      "resolved": "https://registry.npmjs.org/open/-/open-8.4.2.tgz",
-      "integrity": "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==",
       "license": "MIT",
       "dependencies": {
         "define-lazy-prop": "^2.0.0",
@@ -638,14 +563,10 @@
     },
     "node_modules/@dotenvx/dotenvx/node_modules/signal-exit": {
       "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "license": "ISC"
     },
     "node_modules/@dotenvx/dotenvx/node_modules/strip-final-newline": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
-      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -653,8 +574,6 @@
     },
     "node_modules/@ecies/ciphers": {
       "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/@ecies/ciphers/-/ciphers-0.2.6.tgz",
-      "integrity": "sha512-patgsRPKGkhhoBjETV4XxD0En4ui5fbX0hzayqI3M8tvNMGUoUvmyYAIWwlxBc1KX5cturfqByYdj5bYGRpN9g==",
       "license": "MIT",
       "engines": {
         "bun": ">=1",
@@ -731,8 +650,6 @@
     },
     "node_modules/@esbuild/darwin-arm64": {
       "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
-      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
       "cpu": [
         "arm64"
       ],
@@ -1081,10 +998,136 @@
         "node": ">=18"
       }
     },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.23.5",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.5.tgz",
+      "integrity": "sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^3.0.5",
+        "debug": "^4.3.1",
+        "minimatch": "^10.2.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.6.0.tgz",
+      "integrity": "sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.2.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.2.1.tgz",
+      "integrity": "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-10.0.1.tgz",
+      "integrity": "sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "eslint": "^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.5.tgz",
+      "integrity": "sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.2.tgz",
+      "integrity": "sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.2.1",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
     "node_modules/@floating-ui/core": {
       "version": "1.7.5",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
-      "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
       "license": "MIT",
       "dependencies": {
         "@floating-ui/utils": "^0.2.11"
@@ -1092,8 +1135,6 @@
     },
     "node_modules/@floating-ui/dom": {
       "version": "1.7.6",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
-      "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
       "license": "MIT",
       "dependencies": {
         "@floating-ui/core": "^1.7.5",
@@ -1102,8 +1143,6 @@
     },
     "node_modules/@floating-ui/react-dom": {
       "version": "2.1.8",
-      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.8.tgz",
-      "integrity": "sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==",
       "license": "MIT",
       "dependencies": {
         "@floating-ui/dom": "^1.7.6"
@@ -1115,14 +1154,10 @@
     },
     "node_modules/@floating-ui/utils": {
       "version": "0.2.11",
-      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
-      "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
       "license": "MIT"
     },
     "node_modules/@fontsource-variable/geist": {
       "version": "5.2.9",
-      "resolved": "https://registry.npmjs.org/@fontsource-variable/geist/-/geist-5.2.9.tgz",
-      "integrity": "sha512-TP+QSBG3wxKGPE33CbMy/L0Nu3qvJ6Fy81Yc4LnQ95xH+i+cfEp8fyU8/kfV14YwszxIFPhnoMTbjL71waVpyQ==",
       "license": "OFL-1.1",
       "funding": {
         "url": "https://github.com/sponsors/ayuhito"
@@ -1130,8 +1165,6 @@
     },
     "node_modules/@hono/node-server": {
       "version": "1.19.14",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
-      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
       "license": "MIT",
       "engines": {
         "node": ">=18.14.1"
@@ -1140,10 +1173,74 @@
         "hono": "^4"
       }
     },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
-      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
-      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -1152,8 +1249,6 @@
     },
     "node_modules/@jridgewell/remapping": {
       "version": "2.3.5",
-      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
-      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
       "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
@@ -1162,8 +1257,6 @@
     },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
-      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -1171,14 +1264,10 @@
     },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
-      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
-      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -1187,8 +1276,6 @@
     },
     "node_modules/@modelcontextprotocol/sdk": {
       "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
-      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
       "license": "MIT",
       "dependencies": {
         "@hono/node-server": "^1.19.9",
@@ -1227,8 +1314,6 @@
     },
     "node_modules/@noble/ciphers": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
-      "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
       "license": "MIT",
       "engines": {
         "node": "^14.21.3 || >=16"
@@ -1239,8 +1324,6 @@
     },
     "node_modules/@noble/curves": {
       "version": "1.9.7",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
-      "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "1.8.0"
@@ -1254,8 +1337,6 @@
     },
     "node_modules/@noble/hashes": {
       "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
-      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
       "license": "MIT",
       "engines": {
         "node": "^14.21.3 || >=16"
@@ -1266,8 +1347,6 @@
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
-      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "2.0.5",
@@ -1279,8 +1358,6 @@
     },
     "node_modules/@nodelib/fs.stat": {
       "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
-      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -1288,8 +1365,6 @@
     },
     "node_modules/@nodelib/fs.walk": {
       "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
-      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.scandir": "2.1.5",
@@ -1301,20 +1376,14 @@
     },
     "node_modules/@radix-ui/number": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/number/-/number-1.1.2.tgz",
-      "integrity": "sha512-ceTwaxc4I5IOi97DgCotl3pqiyRGvffcc0oOsE2dQYaJOFIDsDt4VWG6xEbg1QePv9QWausCEIppud/tJ1wNig==",
       "license": "MIT"
     },
     "node_modules/@radix-ui/primitive": {
       "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.4.tgz",
-      "integrity": "sha512-7AdCK9PQyiljKoBDbN8OuctCbd/esdwZPQ8RtOE3SsyQtUpiPb+ND75q0jEhC1m1ecBI0MFNeLJvwIh9iKHRcQ==",
       "license": "MIT"
     },
     "node_modules/@radix-ui/react-accessible-icon": {
       "version": "1.1.10",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-accessible-icon/-/react-accessible-icon-1.1.10.tgz",
-      "integrity": "sha512-TraSwZUqTcVbiDV2/RXzAXC7aeVVXchq0daPFZE7zAxYFaMzjOUggLOfQH9KFLgRizuwVKZO/crveV1eeO3/ZQ==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-visually-hidden": "1.2.6"
@@ -1336,8 +1405,6 @@
     },
     "node_modules/@radix-ui/react-accordion": {
       "version": "1.2.14",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-accordion/-/react-accordion-1.2.14.tgz",
-      "integrity": "sha512-iE8YB9nmTBH8zd73ofBISZ8JCzgMoMkATJr7qDwa6u5F1+7mTM81V6fa71jgZ65rpjVpecDf1vSnwIFP9Ly1zw==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.4",
@@ -1367,8 +1434,6 @@
     },
     "node_modules/@radix-ui/react-alert-dialog": {
       "version": "1.1.17",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-alert-dialog/-/react-alert-dialog-1.1.17.tgz",
-      "integrity": "sha512-563ygGeyWPrxyVCNp7OV4rE2aIXhFPknpFyo4wbDlcyMMPZ6ySh+zC5WTvY0ZFLgPTg/QB6tA8PyDQyJ2b4cPg==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.4",
@@ -1394,8 +1459,6 @@
     },
     "node_modules/@radix-ui/react-arrow": {
       "version": "1.1.10",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.10.tgz",
-      "integrity": "sha512-j2VTDz1vgCsmuG0k5lBfOcM8n5JPFqZBcMryasFjHYMhwxYL5SRUV5lMSUpRdNtw3D/Sv8pzJtrlAgkssYSsQQ==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-primitive": "2.1.6"
@@ -1417,8 +1480,6 @@
     },
     "node_modules/@radix-ui/react-aspect-ratio": {
       "version": "1.1.10",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-aspect-ratio/-/react-aspect-ratio-1.1.10.tgz",
-      "integrity": "sha512-kbI7NrqhDeuytYrq7JjAsoXczvL8wgj2tc1MyaYWm+50bMKHCHQtVWCryslx4cCpmCTTkBcwQckE4CmmGV2haQ==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-primitive": "2.1.6"
@@ -1440,8 +1501,6 @@
     },
     "node_modules/@radix-ui/react-avatar": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-avatar/-/react-avatar-1.2.0.tgz",
-      "integrity": "sha512-am/CwltXtmtdtP+5FbYblYDnMa/zuKcMJP1i3/SJMDXXfj2mG+BTqLH2wucqeyyiQMursUtg/5cK+Nh2pCaSOA==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-context": "1.1.4",
@@ -1467,8 +1526,6 @@
     },
     "node_modules/@radix-ui/react-checkbox": {
       "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-checkbox/-/react-checkbox-1.3.5.tgz",
-      "integrity": "sha512-pREzrmNnVwGvYaBoM64huTRK7B3lrTRuwj8A9nwhPiEtMb+yudiWh6zWAqEtP0Dzd5+iBa1Ki7V1pCxV8ExMdA==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.4",
@@ -1497,8 +1554,6 @@
     },
     "node_modules/@radix-ui/react-collapsible": {
       "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-collapsible/-/react-collapsible-1.1.14.tgz",
-      "integrity": "sha512-9bT+FvifX1FK2Mj6UEsTdyu0cN3JaA3KdfhaBao+ONrYFy/pyOy3TU1TNw7iOk1o+0hOEq67RojlUUmoFGwxyA==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.4",
@@ -1527,8 +1582,6 @@
     },
     "node_modules/@radix-ui/react-collection": {
       "version": "1.1.10",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.10.tgz",
-      "integrity": "sha512-IVVz4EvBcKjrzKgof714qDnz/SzQAkLA2Emh5edlHbgcE6fNd3Un6CJLlaYcnm8N4JmAtzQgse4dOKxcD2yc9g==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-compose-refs": "1.1.3",
@@ -1553,8 +1606,6 @@
     },
     "node_modules/@radix-ui/react-compose-refs": {
       "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.3.tgz",
-      "integrity": "sha512-rYOP8OMnuuPMQF1uhPVlGNcCDlkokKqGFE3JcxFViIkAXP7EvFWUliJAstrapypaBLJNHbZL6jGhbVDGTwmVhA==",
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",
@@ -1568,8 +1619,6 @@
     },
     "node_modules/@radix-ui/react-context": {
       "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.4.tgz",
-      "integrity": "sha512-QwH4PO5urrbO+FaGd5Aglg+YJgWTyyuZ3g/6mKvsqraLkglDdckw9JafgL5McL5VEJ6EPNduPaT3ZE9BttDAqg==",
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",
@@ -1583,8 +1632,6 @@
     },
     "node_modules/@radix-ui/react-context-menu": {
       "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-context-menu/-/react-context-menu-2.3.1.tgz",
-      "integrity": "sha512-XbrxS68W5dyiE4fAb96yvJwSVU5x66B20A99sD5Mk3xSWK/LqeOnx6TZnim1KieMjXS/CTFq8reOAjWxas2G8Q==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.4",
@@ -1610,8 +1657,6 @@
     },
     "node_modules/@radix-ui/react-dialog": {
       "version": "1.1.17",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.17.tgz",
-      "integrity": "sha512-TDTYmpdq8dI2+Xgvgj9AJ8Ghqq+Eph/TRVEdaFQPDItIY+6QSkU7MJMeevw1568Yw/2Ijz8BTphPSP2XejKphw==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.4",
@@ -1646,8 +1691,6 @@
     },
     "node_modules/@radix-ui/react-direction": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.2.tgz",
-      "integrity": "sha512-C3vFhbyi4SW3PmbAi6Awpu4OzJtd0MxGurvSsYtr7p7nM8RNB3VAF3CUmnp2j50knpkrRcB7+ycVXzgLgF6yNA==",
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",
@@ -1661,8 +1704,6 @@
     },
     "node_modules/@radix-ui/react-dismissable-layer": {
       "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.13.tgz",
-      "integrity": "sha512-2v+zNAWWe0ySxgC0D0yeXMPQ23xZVgXZTerTz+JKlmdRj6gfTqmCcR29jb6d290DezXPGgruHWDX/vYUebtErg==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.4",
@@ -1688,8 +1729,6 @@
     },
     "node_modules/@radix-ui/react-dropdown-menu": {
       "version": "2.1.18",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-dropdown-menu/-/react-dropdown-menu-2.1.18.tgz",
-      "integrity": "sha512-PZGV82gFk0WltDRI//SsG28ZIjlo9ANTmoNYg0jLNzXXiDsAy5PkOOYQaVD1pPxY6t7gxffb1QMD6qaUvsBZdw==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.4",
@@ -1717,8 +1756,6 @@
     },
     "node_modules/@radix-ui/react-focus-guards": {
       "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.4.tgz",
-      "integrity": "sha512-cot/aB/mOm0IYVYTTmQcEEK1M48lZWi8FlYe5nDPQQ8NYZUlXEFgncJ9p2Kzer3RKSrY7cTTpEMLZKNo9QoP5Q==",
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",
@@ -1732,8 +1769,6 @@
     },
     "node_modules/@radix-ui/react-focus-scope": {
       "version": "1.1.10",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.10.tgz",
-      "integrity": "sha512-Fas/lXQqhVvqwAb64s5RFeHiHYElZ6SUQbZaNd6EkfhP/Al7wTIQ9WIR4QVX475tlu5yFCEdDcJH6/UwsZjMWw==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-compose-refs": "1.1.3",
@@ -1757,8 +1792,6 @@
     },
     "node_modules/@radix-ui/react-form": {
       "version": "0.1.10",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-form/-/react-form-0.1.10.tgz",
-      "integrity": "sha512-1NfuvctVtX4sU3Mmq/IdrR8UunxiCMiVg3A5UENKhFzxUBeOyaQQ+lmaQaV7Tc8cqvBKsJL3/KGBsixK0D8WFg==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.4",
@@ -1785,8 +1818,6 @@
     },
     "node_modules/@radix-ui/react-hover-card": {
       "version": "1.1.17",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-hover-card/-/react-hover-card-1.1.17.tgz",
-      "integrity": "sha512-GjZQIEANVkuuWeztlKz6QEHe31ZX2iDfHzcTMCQVZXC0JyQrgfKWSC+LOOEw6aVV64zyjzobIzSA4AU4eKWrHA==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.4",
@@ -1816,8 +1847,6 @@
     },
     "node_modules/@radix-ui/react-id": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.2.tgz",
-      "integrity": "sha512-orBC88futVpqCmhX1p4cvquNHsELQ+w+vBJnuj3ftETI5bJb0bZn3Tqu3SWN2IOcPycTnMGnhwoermvISt72sA==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-use-layout-effect": "1.1.2"
@@ -1834,8 +1863,6 @@
     },
     "node_modules/@radix-ui/react-label": {
       "version": "2.1.10",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-label/-/react-label-2.1.10.tgz",
-      "integrity": "sha512-ib0zvq2ZsAqKm5tRnqGJn3vOxSgIts5ToxsXT0q1S/GfLD1Zj7UOEnkw8u2w6sRmn47djpQWuSU1DCL1R29/yw==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-primitive": "2.1.6"
@@ -1857,8 +1884,6 @@
     },
     "node_modules/@radix-ui/react-menu": {
       "version": "2.1.18",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-menu/-/react-menu-2.1.18.tgz",
-      "integrity": "sha512-lj8Rxjtn6zJq1oSbE/uDtAwCbB9BnxgHD+8MwJMuTh6u1dPamYhW9iuELr/Z8d0D/UysFblYYHeBPwi7T4k0YQ==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.4",
@@ -1897,8 +1922,6 @@
     },
     "node_modules/@radix-ui/react-menubar": {
       "version": "1.1.18",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-menubar/-/react-menubar-1.1.18.tgz",
-      "integrity": "sha512-hX7EGx/oFq6DPY27GQuP/2wP48GHf5LG6r06VgNJlG+znmDS8OfopZcRcGly3L4lsB9FqpmLx6JQSE9P3BUpyw==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.4",
@@ -1929,8 +1952,6 @@
     },
     "node_modules/@radix-ui/react-navigation-menu": {
       "version": "1.2.16",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-navigation-menu/-/react-navigation-menu-1.2.16.tgz",
-      "integrity": "sha512-nJ0SkrSQgudyYhMiYeHA1ayLVuduEJCFLan1RZZN7c9kqzzCFLaU9kuy81uNtqzweM9YaQPgWzxi9MwQ9jZ04g==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.4",
@@ -1965,8 +1986,6 @@
     },
     "node_modules/@radix-ui/react-one-time-password-field": {
       "version": "0.1.10",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-one-time-password-field/-/react-one-time-password-field-0.1.10.tgz",
-      "integrity": "sha512-GHkcJ+WVj91At+OvUVTD4R3W0/wxw9t/sG5xFUBYXaCbtWiooZX5Md376QjJqgH4VsVyXrbVNHO2O4NYcmjfVg==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/number": "1.1.2",
@@ -1999,8 +2018,6 @@
     },
     "node_modules/@radix-ui/react-password-toggle-field": {
       "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-password-toggle-field/-/react-password-toggle-field-0.1.5.tgz",
-      "integrity": "sha512-fVuA82u0b/fClpbEJv8yp1nU9eSvoSEOERsU/hhf3FXGPIvkmE7oEaHEu8poowoXO39/Va7zq2E0TUcYr1dBRg==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.4",
@@ -2029,8 +2046,6 @@
     },
     "node_modules/@radix-ui/react-popover": {
       "version": "1.1.17",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-popover/-/react-popover-1.1.17.tgz",
-      "integrity": "sha512-/YSAOdJ7YJvdn7bn5sdSx2egW+SKY+u7O5RyAVs94Ymrg2fg5QTSFPMRkzvhGyFuE4/qsmPBdrwYoZMZh/4f+g==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.4",
@@ -2066,8 +2081,6 @@
     },
     "node_modules/@radix-ui/react-popper": {
       "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.3.1.tgz",
-      "integrity": "sha512-bhnq/0DEPTi2lsOD3J5rTL65qUKHbKbhqHsmN9TMiclSXpipi651ooUKPPp6G5lF/WiHBdn1s0Wuqsn+myVAvw==",
       "license": "MIT",
       "dependencies": {
         "@floating-ui/react-dom": "^2.0.0",
@@ -2098,8 +2111,6 @@
     },
     "node_modules/@radix-ui/react-portal": {
       "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.12.tgz",
-      "integrity": "sha512-m309havGzsjLHHaIX50G5PlvRs3xkgPCsGk/5PTvYm8D5q33yG0J7w/712PTOhid7NTaFETtnSXjngHQavvhVw==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-primitive": "2.1.6",
@@ -2122,8 +2133,6 @@
     },
     "node_modules/@radix-ui/react-presence": {
       "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.6.tgz",
-      "integrity": "sha512-zdTk4PlUO0E18HnZ3wYbW0KkJJxWCdiNYp6g6X1PtONFhxVkg01vliTJAmwIszU6mHiyBOoW9P0rAugl5/hULQ==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-use-layout-effect": "1.1.2"
@@ -2145,8 +2154,6 @@
     },
     "node_modules/@radix-ui/react-primitive": {
       "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.6.tgz",
-      "integrity": "sha512-wetd0QI77DbvrPpTAvH1SqOxsYF2wZe5TNxqwOd5Ty4XDpV3dpV0s8K/1MGMJBeY5o7lg8ub5VIt1Ub+yVen6g==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-slot": "1.3.0"
@@ -2168,8 +2175,6 @@
     },
     "node_modules/@radix-ui/react-progress": {
       "version": "1.1.10",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-progress/-/react-progress-1.1.10.tgz",
-      "integrity": "sha512-JYzEg60lk79PwKM27WZyKd7PW8O4OM5jOaFfRPfOyeXmMw7tLJh5kSj+CEjVTehszuwml/AdCzPGMXBTGf4BBw==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-context": "1.1.4",
@@ -2192,8 +2197,6 @@
     },
     "node_modules/@radix-ui/react-radio-group": {
       "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-radio-group/-/react-radio-group-1.4.1.tgz",
-      "integrity": "sha512-/SSxZdKEo2Eo29FFRKd06EfFDYp8HryKg0WYg7QLXaydPzl52YfSvCH2a3QDBRdtcuwACroJT8UVjQVgOJ7P9A==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.4",
@@ -2224,8 +2227,6 @@
     },
     "node_modules/@radix-ui/react-roving-focus": {
       "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.13.tgz",
-      "integrity": "sha512-9gkwneI0guf8JDmrFxPjJF6Ozzgioyw+/lonYNCwefS9ZHA05er0BVHiXr+LbWGHxUfczvMY6G1oiZZi1VzjRw==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.4",
@@ -2255,8 +2256,6 @@
     },
     "node_modules/@radix-ui/react-scroll-area": {
       "version": "1.2.12",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-scroll-area/-/react-scroll-area-1.2.12.tgz",
-      "integrity": "sha512-xuafVzQiTCLsyEjakowTdG3OgTXsmO7IdCiO77otIa+z44xoLNs9Do5eg7POFumIOCjtG6djfm6RKUKpUa/csA==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/number": "1.1.2",
@@ -2286,8 +2285,6 @@
     },
     "node_modules/@radix-ui/react-select": {
       "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-select/-/react-select-2.3.1.tgz",
-      "integrity": "sha512-w6eDvY78LE9ZUiNnXCA1QVK8RYN7k9galFv09kjVydJqBAgHd7Y9A6h0UJ/6DCZNGZMZrB2ohcSW1Bo9d8+wWA==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/number": "1.1.2",
@@ -2330,8 +2327,6 @@
     },
     "node_modules/@radix-ui/react-separator": {
       "version": "1.1.10",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-separator/-/react-separator-1.1.10.tgz",
-      "integrity": "sha512-Y6K6jLQCVfCnTL2MEtGxDLffkhNfEfHsEg3Wa8JU+IWdn3EWbLXd3OuOfQRN7p/W/cUce1WyTk3QeuAoDBzN9g==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-primitive": "2.1.6"
@@ -2353,8 +2348,6 @@
     },
     "node_modules/@radix-ui/react-slider": {
       "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-slider/-/react-slider-1.4.1.tgz",
-      "integrity": "sha512-r91WSpQucNGFKAIxT8FT0H0zyjd5tJlqObLp7LOMV4z49KoDCwjy01w3vDOU4e1wxhF9IgjYco7SB6byOW7Buw==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/number": "1.1.2",
@@ -2386,8 +2379,6 @@
     },
     "node_modules/@radix-ui/react-slot": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.3.0.tgz",
-      "integrity": "sha512-MojKku4U/miO8Av4Dkb+ctMAQx7JmY96LmtDQlAarCRtd7rN52QCSzBF+XAvr5S6coSVj9HEPBgHAHKEJVk/WA==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-compose-refs": "1.1.3"
@@ -2404,8 +2395,6 @@
     },
     "node_modules/@radix-ui/react-switch": {
       "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-switch/-/react-switch-1.3.1.tgz",
-      "integrity": "sha512-55bQtCnOB0BohomSHi6qvQXpJEEqUGDm6hRrM0Bph5OXwhSegqkd8IqgBAQkM1IlgUlWZIxpxRcpOEfRIgimyw==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.4",
@@ -2433,8 +2422,6 @@
     },
     "node_modules/@radix-ui/react-tabs": {
       "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-tabs/-/react-tabs-1.1.15.tgz",
-      "integrity": "sha512-kxc9gI6/HfcU4nfMMVS3AmQK414kbU1IE6UCJmMmxjhO3cRPXOyYnmvyKD+ODt7q56nRq9l7Wovi6uaGwKgMlg==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.4",
@@ -2463,8 +2450,6 @@
     },
     "node_modules/@radix-ui/react-toast": {
       "version": "1.2.17",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-toast/-/react-toast-1.2.17.tgz",
-      "integrity": "sha512-uL4kyyWy000pPL43fGGCV5qT6ZchCWEQZOSlkYiPwPt8Hy1iW38RjeptIvz1/SZesrW6Vn58Ct3sV7tfEfiAbw==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.4",
@@ -2497,8 +2482,6 @@
     },
     "node_modules/@radix-ui/react-toggle": {
       "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-toggle/-/react-toggle-1.1.12.tgz",
-      "integrity": "sha512-AsAVsYNZIlRBsci7BhE+QyQeKd1h6TffJYt+lF0QQkd5OpQ3klfIByPsCb4G0h/Fq6PJwh1FYNluzBFYzhk4+w==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.4",
@@ -2522,8 +2505,6 @@
     },
     "node_modules/@radix-ui/react-toggle-group": {
       "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-toggle-group/-/react-toggle-group-1.1.13.tgz",
-      "integrity": "sha512-Xb9PLtlvU66F36LiKba6dFswu6V2mDkgidO4fNSbQHQwmZ9ObxMIO17MN/LJ4aWJecVuSVLAHPZjyeMzJrgeiA==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.4",
@@ -2551,8 +2532,6 @@
     },
     "node_modules/@radix-ui/react-toolbar": {
       "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-toolbar/-/react-toolbar-1.1.13.tgz",
-      "integrity": "sha512-Za1l4f6fzTkGgz/iynAMN8iaqiKff2wm2/QwiLmHPtDQreWEBrvSimgQFIekxMUdRPhILM7xdIXxuS/o/DGZag==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.4",
@@ -2580,8 +2559,6 @@
     },
     "node_modules/@radix-ui/react-tooltip": {
       "version": "1.2.10",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-tooltip/-/react-tooltip-1.2.10.tgz",
-      "integrity": "sha512-NlNe8D0dWEpVfXFli90IO6X07Josx/b1iu98tDnx9Xv0HT4wLIL+m2VOheMHhK7qbp2HoTBqALEFzGyZs/levw==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.4",
@@ -2614,8 +2591,6 @@
     },
     "node_modules/@radix-ui/react-use-callback-ref": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.2.tgz",
-      "integrity": "sha512-xCso9j1/u8sEgP1RNHjFrXJLApL8LiqOkI1R4ywuN00rxWdYg4oQXuwKLS3i0j5NWLromUD27/4nlxj2UFVvIw==",
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",
@@ -2629,8 +2604,6 @@
     },
     "node_modules/@radix-ui/react-use-controllable-state": {
       "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.3.tgz",
-      "integrity": "sha512-PLzC90MS+ReootmjC597dvopoelpZ8Q61HJkDXZSExitIq7PL55vHNnesAHwguHK0aPfBnpdNzQtv1uliaqQrA==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-use-effect-event": "0.0.3",
@@ -2648,8 +2621,6 @@
     },
     "node_modules/@radix-ui/react-use-effect-event": {
       "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.3.tgz",
-      "integrity": "sha512-6c8ZqvPTWILEKnyVkP53EGRCcpnJiKTC21sS/6R1GF5xKyHJJWQEPfkqlcgUkdRQivd6tb23abUwe4ngWmY0JA==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-use-layout-effect": "1.1.2"
@@ -2666,8 +2637,6 @@
     },
     "node_modules/@radix-ui/react-use-escape-keydown": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.1.2.tgz",
-      "integrity": "sha512-2uVLvLjgO7NZCWw01/FdqRwmA42J0BcjPMUCA+koFEOAb+zjqIP7SiFz/7zWPrKnVmSqr76Omq2ALyCuX4dhLw==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-use-callback-ref": "1.1.2"
@@ -2684,8 +2653,6 @@
     },
     "node_modules/@radix-ui/react-use-is-hydrated": {
       "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-is-hydrated/-/react-use-is-hydrated-0.1.1.tgz",
-      "integrity": "sha512-qwOiz4Tjo8CNnrOLAYUMXeZwDzXgXpvK4TKQPmWLECM9XoWvA6+0Z2/7Ag3A4ivjS4ovbLJPbskkxioFyBhr8A==",
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",
@@ -2699,8 +2666,6 @@
     },
     "node_modules/@radix-ui/react-use-layout-effect": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.2.tgz",
-      "integrity": "sha512-jrBWOxZITuGcnjRCM2t2U5ZPkCLxD+Ym6DjfssS5haTj2iiak/DOb64JeN6OdLfLgptb6/e2kKR+ZuTrGoZTPA==",
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",
@@ -2714,8 +2679,6 @@
     },
     "node_modules/@radix-ui/react-use-previous": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-previous/-/react-use-previous-1.1.2.tgz",
-      "integrity": "sha512-IGBQPtRFdhN6MQ8dbegVmBq1LVZluya3F1jWY+puIcQC3MHctRwTDSBWCkL/3ZcnMJLTMJ++Z+ktmvg0F89iCw==",
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",
@@ -2729,8 +2692,6 @@
     },
     "node_modules/@radix-ui/react-use-rect": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-rect/-/react-use-rect-1.1.2.tgz",
-      "integrity": "sha512-d8a+bBY/FxikNPlgJJoaBHZX+zKVbWHYJGTLnLvveQgFSTntkGdEKv3JDtHrMS0DNYpllz2nRsTLGLKYttbpmw==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/rect": "1.1.2"
@@ -2747,8 +2708,6 @@
     },
     "node_modules/@radix-ui/react-use-size": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.2.tgz",
-      "integrity": "sha512-giWQp+4mxjBPt4KZ0MmyuykFNWfbDxKt4x+fPkRYmgRFJSbCZFzUglvMb/Kjn38tm10YP4ufiQZDx3zna4LU6w==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-use-layout-effect": "1.1.2"
@@ -2765,8 +2724,6 @@
     },
     "node_modules/@radix-ui/react-visually-hidden": {
       "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.2.6.tgz",
-      "integrity": "sha512-jCE0WljWifTI4niIMCll06kGpsJTAPiZVU9H4WR1N6qW7At9ystHbN7dDB+we2xH535roFHj7qKS+RGj0FMDWQ==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-primitive": "2.1.6"
@@ -2788,14 +2745,10 @@
     },
     "node_modules/@radix-ui/rect": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.2.tgz",
-      "integrity": "sha512-xnXE7wG13PI+cxieVssYXlQJuYVRhH9NBoxt3KNwzghDIA69GMm7d4wXRouHIYjE+KvS6U/MsMO73NdS2MH9ZA==",
       "license": "MIT"
     },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.27",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
-      "integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
       "dev": true,
       "license": "MIT"
     },
@@ -2827,8 +2780,6 @@
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
       "version": "4.62.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.0.tgz",
-      "integrity": "sha512-BqCoMoIbn0keKys+dEAdBa70EtOwV1bEsQCUgU9FdiZmmMge/Zk7LlkYGqbrdHR+Frnt0E1FOanly+rlwvvQzw==",
       "cpu": [
         "arm64"
       ],
@@ -2884,6 +2835,9 @@
       "cpu": [
         "arm"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2896,6 +2850,9 @@
       "integrity": "sha512-2as0LgT7qQpyceQq6VUJYnumUMUrgGQCWIiDIN9DE0/tglsk6o66uCB4f3djRawAltvfCNLyZZrsqbPA6inCsA==",
       "cpu": [
         "arm"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2910,6 +2867,9 @@
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2922,6 +2882,9 @@
       "integrity": "sha512-Ful8pM/2yYI83PViWdFdpZhdI8HJ5qsXANe5atypbHDf+KIBBDsZsbyy8hbXnULVvW9NsTh5DHwbcBftyLTfiw==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2936,6 +2899,9 @@
       "cpu": [
         "loong64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2948,6 +2914,9 @@
       "integrity": "sha512-m9tsJz54LUXkSYM8+8PG81B9IKK5r+2T0clMq4QrS16xFosufU7firBDAZEsDheDs7wTlP7h3++S7lMsU955HA==",
       "cpu": [
         "loong64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2962,6 +2931,9 @@
       "cpu": [
         "ppc64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2974,6 +2946,9 @@
       "integrity": "sha512-vRWUAbYLGHBZS6Q8Msb2sfnf1fvJf+47t8l/TwOerM2qArzy+IeNMTHrYLHXh95h8MoatPHI5hhSZNs+mGXKPg==",
       "cpu": [
         "ppc64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2988,6 +2963,9 @@
       "cpu": [
         "riscv64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3000,6 +2978,9 @@
       "integrity": "sha512-krrCDilhXOwFkSkO3Wm9I/f9H0L92XHHwy2fwxjukxIbh0dem8gZqOW5Y8BsHrpJv5qwlRBV+Wl4ZFyRWhUpwg==",
       "cpu": [
         "riscv64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3014,6 +2995,9 @@
       "cpu": [
         "s390x"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3027,6 +3011,9 @@
       "cpu": [
         "x64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3039,6 +3026,9 @@
       "integrity": "sha512-eRZevouTH2i1HeAVLqJuLnt256krQkGY0TN6WsTmsIhuzbh457HuWDMakKwmi0Cjadux983CoSr8Lim2QhUIFw==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3126,14 +3116,10 @@
     },
     "node_modules/@sec-ant/readable-stream": {
       "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
-      "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==",
       "license": "MIT"
     },
     "node_modules/@sindresorhus/merge-streams": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
-      "integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -3144,8 +3130,6 @@
     },
     "node_modules/@tailwindcss/node": {
       "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.1.tgz",
-      "integrity": "sha512-6NDaqRoAMSXD1mr/RXu0HBvNE9a2n5tHPsxu9XHLws8o4Twes5rBM2205SUUiJ9goAtadrN6xTGX0UDEwp/N4A==",
       "license": "MIT",
       "dependencies": {
         "@jridgewell/remapping": "^2.3.5",
@@ -3159,8 +3143,6 @@
     },
     "node_modules/@tailwindcss/oxide": {
       "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.3.1.tgz",
-      "integrity": "sha512-yVPyo8RNkabVr3O2EhHEE0Rewu7YKzc1DhIqfL46LKveFrmu9XbDazNOJY7/GRuvw1h6u3utWnR29H/p5JPlgA==",
       "license": "MIT",
       "engines": {
         "node": ">= 20"
@@ -3198,8 +3180,6 @@
     },
     "node_modules/@tailwindcss/oxide-darwin-arm64": {
       "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.3.1.tgz",
-      "integrity": "sha512-hVnWLwv+e/l7c4WKyVtHVrIPvYdqWHjRB3MDIqARynzFtnQg85kmQEFCbV9Ja0VVx4xXTIiDWY60Y7iz/iNoDA==",
       "cpu": [
         "arm64"
       ],
@@ -3267,6 +3247,9 @@
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3282,6 +3265,9 @@
       "integrity": "sha512-Bwv9KwOvE0VKa86xPFif9b9c3Y1NxOV1P0gLti/IYaWEsQYZXDlxfGEtA8mdDZ7SG3wyNXAWYT5SIn3giL57oA==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3299,6 +3285,9 @@
       "cpu": [
         "x64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3314,6 +3303,9 @@
       "integrity": "sha512-M+P/91qJ6uILLw4k2G93GMDRAXj61SMvFQYt39AqvUqYgExXpLL5aepfns7sj4HiAQeolirQF9E0lzRvdf4zPQ==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3387,8 +3379,6 @@
     },
     "node_modules/@tailwindcss/vite": {
       "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.3.1.tgz",
-      "integrity": "sha512-hItDHuIIlEV61R+faXu66s1K36aTurO/Qw0e45Vskz57gXl9pWOT6eg3zmcEui6CZXddbN7zd41bwmvag4JGwQ==",
       "license": "MIT",
       "dependencies": {
         "@tailwindcss/node": "4.3.1",
@@ -3401,8 +3391,6 @@
     },
     "node_modules/@tauri-apps/api": {
       "version": "2.11.1",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/api/-/api-2.11.1.tgz",
-      "integrity": "sha512-M2FPuYND2m+wh5hfW9ZpSdxMPdEJovPBWwoHJmwUpysTYNHaOkVFN419m/K0LIgjb/7KU2vBgsUepJWugQCvAA==",
       "license": "Apache-2.0 OR MIT",
       "funding": {
         "type": "opencollective",
@@ -3411,8 +3399,6 @@
     },
     "node_modules/@tauri-apps/cli": {
       "version": "2.11.2",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli/-/cli-2.11.2.tgz",
-      "integrity": "sha512-bk3HemqvGRoy+5D/dVMUQHKMYLglD0jVnMm/0iGMH6ufZ+p8r14m6BpIixwij3PBvZdvORUp1YifTD8QxVZ1Nw==",
       "dev": true,
       "license": "Apache-2.0 OR MIT",
       "bin": {
@@ -3441,8 +3427,6 @@
     },
     "node_modules/@tauri-apps/cli-darwin-arm64": {
       "version": "2.11.2",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-darwin-arm64/-/cli-darwin-arm64-2.11.2.tgz",
-      "integrity": "sha512-+4UZzLt+eOAEQCwgd+TqKgyUJMrvx+BgdXLLaqJYmPqzP+nE6YZr/hY6CWLYGQb8jFn99jEkmC6uA3tNvamA1w==",
       "cpu": [
         "arm64"
       ],
@@ -3498,6 +3482,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
@@ -3515,6 +3502,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
@@ -3532,6 +3522,9 @@
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
@@ -3549,6 +3542,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
@@ -3566,6 +3562,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
@@ -3628,8 +3627,6 @@
     },
     "node_modules/@tauri-apps/plugin-autostart": {
       "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-autostart/-/plugin-autostart-2.5.1.tgz",
-      "integrity": "sha512-zS/xx7yzveCcotkA+8TqkI2lysmG2wvQXv2HGAVExITmnFfHAdj1arGsbbfs3o6EktRHf6l34pJxc3YGG2mg7w==",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@tauri-apps/api": "^2.8.0"
@@ -3637,8 +3634,6 @@
     },
     "node_modules/@tauri-apps/plugin-dialog": {
       "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-dialog/-/plugin-dialog-2.7.1.tgz",
-      "integrity": "sha512-OK1UBXYt+ojcmxMktzzuyonYIFta8CmAASpX+CA+DTGK24KlHjhYI6x2iOJ/TjZF4N7/ACK1oFmEOjIY9IhzOQ==",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@tauri-apps/api": "^2.11.0"
@@ -3646,8 +3641,6 @@
     },
     "node_modules/@tauri-apps/plugin-opener": {
       "version": "2.5.4",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-opener/-/plugin-opener-2.5.4.tgz",
-      "integrity": "sha512-1HnPkb+AmgO29HBazm4uPLKB+r7zzcTBW1d0fyYp1uP+jwtpoiNDGKMMzz58SFp49nOIrxdE3aUJtT57lfO9CQ==",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@tauri-apps/api": "^2.11.0"
@@ -3655,8 +3648,6 @@
     },
     "node_modules/@tauri-apps/plugin-process": {
       "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-process/-/plugin-process-2.3.1.tgz",
-      "integrity": "sha512-nCa4fGVaDL/B9ai03VyPOjfAHRHSBz5v6F/ObsB73r/dA3MHHhZtldaDMIc0V/pnUw9ehzr2iEG+XkSEyC0JJA==",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@tauri-apps/api": "^2.8.0"
@@ -3664,8 +3655,6 @@
     },
     "node_modules/@tauri-apps/plugin-updater": {
       "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-updater/-/plugin-updater-2.10.1.tgz",
-      "integrity": "sha512-NFYMg+tWOZPJdzE/PpFj2qfqwAWwNS3kXrb1tm1gnBJ9mYzZ4WDRrwy8udzWoAnfGCHLuePNLY1WVCNHnh3eRA==",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@tauri-apps/api": "^2.10.1"
@@ -3673,8 +3662,6 @@
     },
     "node_modules/@ts-morph/common": {
       "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.27.0.tgz",
-      "integrity": "sha512-Wf29UqxWDpc+i61k3oIOzcUfQt79PIT9y/MWfAGlrkjg6lBC1hwDECLXPVJAhWjiGbfBCxZd65F/LIZF3+jeJQ==",
       "license": "MIT",
       "dependencies": {
         "fast-glob": "^3.3.3",
@@ -3684,8 +3671,6 @@
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
-      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
-      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3698,8 +3683,6 @@
     },
     "node_modules/@types/babel__generator": {
       "version": "7.27.0",
-      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
-      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3708,8 +3691,6 @@
     },
     "node_modules/@types/babel__template": {
       "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
-      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3719,24 +3700,32 @@
     },
     "node_modules/@types/babel__traverse": {
       "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
-      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/esrecurse": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
+      "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
-      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "19.2.17",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
-      "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -3745,8 +3734,6 @@
     },
     "node_modules/@types/react-dom": {
       "version": "19.2.3",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
-      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
@@ -3755,14 +3742,253 @@
     },
     "node_modules/@types/validate-npm-package-name": {
       "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@types/validate-npm-package-name/-/validate-npm-package-name-4.0.2.tgz",
-      "integrity": "sha512-lrpDziQipxCEeK5kWxvljWYhUvOiB2A9izZd9B2AFarYAkqZshb4lPbRs7zKEic6eGtH8V/2qJW+dPp9OtF6bw==",
       "license": "MIT"
+    },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.62.1.tgz",
+      "integrity": "sha512-4EQM77WgVNxj7OkL/5b/D/xZsw00G577+UriYTC7JF5opcF3T2AuoeY7ueLaZgSVjSgCS6yOAJB5bRGLPSJUzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.62.1",
+        "@typescript-eslint/type-utils": "8.62.1",
+        "@typescript-eslint/utils": "8.62.1",
+        "@typescript-eslint/visitor-keys": "8.62.1",
+        "ignore": "^7.0.5",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.62.1",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.62.1.tgz",
+      "integrity": "sha512-sPhE4iHuJDSvoAiec+Ro8JyXw8f0ql13HFR82P99nCm9GwTEKG0KYLvDe6REk8BCXuit6vJAv/Yxg5ABaNS2rA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.62.1",
+        "@typescript-eslint/types": "8.62.1",
+        "@typescript-eslint/typescript-estree": "8.62.1",
+        "@typescript-eslint/visitor-keys": "8.62.1",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.62.1.tgz",
+      "integrity": "sha512-yQ3RgY5RkSBpsNS1Bx/JQEcA24FOSdfGktoyprAr5u18390UQdtVcfnEv4nIrIshNnavlVyZBKxQwT1fIAE6cg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.62.1",
+        "@typescript-eslint/types": "^8.62.1",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.62.1.tgz",
+      "integrity": "sha512-r4d249KbQ1SFdpeStvob8Ih6aPPIzfqllPVOtvhve6ZcpuVcYo5/7zUWckKpHE7StASX4kTKZTLf0WQm/wPkcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.62.1",
+        "@typescript-eslint/visitor-keys": "8.62.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.62.1.tgz",
+      "integrity": "sha512-xadytJqX9vJVQ2fdQjkcIVigwaOJNWkpjdLt6cEQ+xPnrI1fkp+/jZE/I97k9KUjqtpd25i0HeyZf3T6dutv2g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.62.1.tgz",
+      "integrity": "sha512-aXM5xlqXiTxPibXB93cLAURfT3rlizf7uMXISCXy66Isr/9hISJx3yDsKl0L7lKa51b8JpFuNKby0/O0pEm9jg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.62.1",
+        "@typescript-eslint/typescript-estree": "8.62.1",
+        "@typescript-eslint/utils": "8.62.1",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.62.1.tgz",
+      "integrity": "sha512-ooCzJFaf+Hg+uG6fA3NRFGuFjlfNlDhBthbv4ZPU/0elCAFUfnyXUvf/WOpHz/jYwSmvU2GkR2LtyUfy1AxZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.62.1.tgz",
+      "integrity": "sha512-xMcW9oP9u7fAMXYs9A65CVmtLQe2r//oXINHfi8HV+oiqhih17sbLdhXr4540YWlgpDKQdY854OL5ZrdCiQsAA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.62.1",
+        "@typescript-eslint/tsconfig-utils": "8.62.1",
+        "@typescript-eslint/types": "8.62.1",
+        "@typescript-eslint/visitor-keys": "8.62.1",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.62.1.tgz",
+      "integrity": "sha512-sHtbPfuKNZCG+ih8SyjjucqRntSVmp8XgL5u6o9mAhiSn8ds5o/M/XdM0abweme2Tln3szOstOrZ9OXitvPh0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.62.1",
+        "@typescript-eslint/types": "8.62.1",
+        "@typescript-eslint/typescript-estree": "8.62.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.62.1.tgz",
+      "integrity": "sha512-4g3BLxfdTMy8iZG0MaBkadnlRrCJ74cQiFbyEVMrkwIoqdyaXXQM22cotDvrl4x28wgIZ9rEJRoM+mmhSJpJ1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.62.1",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
-      "integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3782,8 +4008,6 @@
     },
     "node_modules/accepts": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
-      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
       "license": "MIT",
       "dependencies": {
         "mime-types": "^3.0.0",
@@ -3793,10 +4017,31 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/acorn": {
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
     "node_modules/agent-base": {
       "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
-      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 14"
@@ -3804,8 +4049,6 @@
     },
     "node_modules/ajv": {
       "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
-      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -3820,8 +4063,6 @@
     },
     "node_modules/ajv-formats": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
-      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.0.0"
@@ -3837,8 +4078,6 @@
     },
     "node_modules/ansi-colors": {
       "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
-      "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -3846,8 +4085,6 @@
     },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -3855,14 +4092,10 @@
     },
     "node_modules/argparse": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "license": "Python-2.0"
     },
     "node_modules/aria-hidden": {
       "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
-      "integrity": "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.0.0"
@@ -3873,8 +4106,6 @@
     },
     "node_modules/ast-types": {
       "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.16.1.tgz",
-      "integrity": "sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.0.1"
@@ -3885,8 +4116,6 @@
     },
     "node_modules/atomically": {
       "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/atomically/-/atomically-1.7.0.tgz",
-      "integrity": "sha512-Xcz9l0z7y9yQ9rdDaxlmaI4uJHf/T8g9hOEzJcsEqX2SjCj4J20uK7+ldkDHMbpJDK76wF7xEIgxc/vSlsfw5w==",
       "license": "MIT",
       "engines": {
         "node": ">=10.12.0"
@@ -3894,8 +4123,6 @@
     },
     "node_modules/balanced-match": {
       "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
       "license": "MIT",
       "engines": {
         "node": "18 || 20 || >=22"
@@ -3903,8 +4130,6 @@
     },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.38",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.38.tgz",
-      "integrity": "sha512-31/02mVB4yuQU6adKk5SlY6m+mxDwUq5KZkyYgnLrrKl7TEm1+3PyDtDBz2kOv/wxZz41GHsvV1A/u6RmiyBvw==",
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"
@@ -3915,8 +4140,6 @@
     },
     "node_modules/body-parser": {
       "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
-      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
       "license": "MIT",
       "dependencies": {
         "bytes": "^3.1.2",
@@ -3939,8 +4162,6 @@
     },
     "node_modules/body-parser/node_modules/content-type": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
-      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -3952,8 +4173,6 @@
     },
     "node_modules/brace-expansion": {
       "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -3964,8 +4183,6 @@
     },
     "node_modules/braces": {
       "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
-      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "license": "MIT",
       "dependencies": {
         "fill-range": "^7.1.1"
@@ -3976,8 +4193,6 @@
     },
     "node_modules/browserslist": {
       "version": "4.28.2",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
-      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
       "funding": [
         {
           "type": "opencollective",
@@ -4009,8 +4224,6 @@
     },
     "node_modules/bundle-name": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
-      "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
       "license": "MIT",
       "dependencies": {
         "run-applescript": "^7.0.0"
@@ -4024,8 +4237,6 @@
     },
     "node_modules/bytes": {
       "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
-      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -4033,8 +4244,6 @@
     },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
-      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -4046,8 +4255,6 @@
     },
     "node_modules/call-bound": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
-      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -4062,8 +4269,6 @@
     },
     "node_modules/callsites": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
-      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -4071,8 +4276,6 @@
     },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001799",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
-      "integrity": "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==",
       "funding": [
         {
           "type": "opencollective",
@@ -4091,8 +4294,6 @@
     },
     "node_modules/chalk": {
       "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
-      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
       "license": "MIT",
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
@@ -4103,8 +4304,6 @@
     },
     "node_modules/class-variance-authority": {
       "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.1.tgz",
-      "integrity": "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==",
       "license": "Apache-2.0",
       "dependencies": {
         "clsx": "^2.1.1"
@@ -4115,8 +4314,6 @@
     },
     "node_modules/cli-cursor": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
-      "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
       "license": "MIT",
       "dependencies": {
         "restore-cursor": "^5.0.0"
@@ -4130,8 +4327,6 @@
     },
     "node_modules/cli-spinners": {
       "version": "2.9.2",
-      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
-      "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -4142,8 +4337,6 @@
     },
     "node_modules/clsx": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
-      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -4151,14 +4344,10 @@
     },
     "node_modules/code-block-writer": {
       "version": "13.0.3",
-      "resolved": "https://registry.npmjs.org/code-block-writer/-/code-block-writer-13.0.3.tgz",
-      "integrity": "sha512-Oofo0pq3IKnsFtuHqSF7TqBfr71aeyZDVJ0HpmqB7FBM2qEigL0iPONSCZSO9pE9dZTAxANe5XHG9Uy0YMv8cg==",
       "license": "MIT"
     },
     "node_modules/commander": {
       "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
-      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
       "license": "MIT",
       "engines": {
         "node": ">=20"
@@ -4166,8 +4355,6 @@
     },
     "node_modules/conf": {
       "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/conf/-/conf-10.2.0.tgz",
-      "integrity": "sha512-8fLl9F04EJqjSqH+QjITQfJF8BrOVaYr1jewVgSRAEWePfxT0sku4w2hrGQ60BC/TNLGQ2pgxNlTbWQmMPFvXg==",
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.6.3",
@@ -4190,8 +4377,6 @@
     },
     "node_modules/conf/node_modules/ajv-formats": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
-      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.0.0"
@@ -4207,14 +4392,10 @@
     },
     "node_modules/conf/node_modules/json-schema-typed": {
       "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-7.0.3.tgz",
-      "integrity": "sha512-7DE8mpG+/fVw+dTpjbxnx47TaMnDfOI1jwft9g1VybltZCduyRQPJPvc+zzKY9WPHxhPWczyFuYa6I8Mw4iU5A==",
       "license": "BSD-2-Clause"
     },
     "node_modules/conf/node_modules/semver": {
       "version": "7.8.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
-      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -4225,8 +4406,6 @@
     },
     "node_modules/content-disposition": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
-      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -4238,8 +4417,6 @@
     },
     "node_modules/content-type": {
       "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
-      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -4247,14 +4424,10 @@
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
-      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "license": "MIT"
     },
     "node_modules/cookie": {
       "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
-      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -4262,8 +4435,6 @@
     },
     "node_modules/cookie-signature": {
       "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
-      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
       "license": "MIT",
       "engines": {
         "node": ">=6.6.0"
@@ -4271,8 +4442,6 @@
     },
     "node_modules/cors": {
       "version": "2.8.6",
-      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
-      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
       "license": "MIT",
       "dependencies": {
         "object-assign": "^4",
@@ -4288,8 +4457,6 @@
     },
     "node_modules/cosmiconfig": {
       "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.2.tgz",
-      "integrity": "sha512-gtTZxTDau1wL7Y7zifc2dd8jHSK/k6BTx/2Xp/BpdlAdnlYWFVt7qhJqgwi7637yRwRQ3qL4ZidbB4I8tA5VOg==",
       "license": "MIT",
       "dependencies": {
         "env-paths": "^2.2.1",
@@ -4314,8 +4481,6 @@
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
-      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -4328,14 +4493,10 @@
     },
     "node_modules/cross-spawn/node_modules/isexe": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
     },
     "node_modules/cross-spawn/node_modules/which": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -4349,8 +4510,6 @@
     },
     "node_modules/cssesc": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
-      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
       "license": "MIT",
       "bin": {
         "cssesc": "bin/cssesc"
@@ -4361,15 +4520,11 @@
     },
     "node_modules/csstype": {
       "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
-      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "devOptional": true,
       "license": "MIT"
     },
     "node_modules/data-uri-to-buffer": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
-      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -4377,8 +4532,6 @@
     },
     "node_modules/debounce-fn": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/debounce-fn/-/debounce-fn-4.0.0.tgz",
-      "integrity": "sha512-8pYCQiL9Xdcg0UPSD3d+0KMlOjp+KGU5EPwYddgzQ7DATsg4fuUDjQtsYLmWjnk2obnNHgV3vE2Y4jejSOJVBQ==",
       "license": "MIT",
       "dependencies": {
         "mimic-fn": "^3.0.0"
@@ -4392,8 +4545,6 @@
     },
     "node_modules/debug": {
       "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -4409,8 +4560,6 @@
     },
     "node_modules/dedent": {
       "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.2.tgz",
-      "integrity": "sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA==",
       "license": "MIT",
       "peerDependencies": {
         "babel-plugin-macros": "^3.1.0"
@@ -4421,10 +4570,15 @@
         }
       }
     },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/deepmerge": {
       "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
-      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -4432,8 +4586,6 @@
     },
     "node_modules/default-browser": {
       "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.0.tgz",
-      "integrity": "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==",
       "license": "MIT",
       "dependencies": {
         "bundle-name": "^4.1.0",
@@ -4448,8 +4600,6 @@
     },
     "node_modules/default-browser-id": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz",
-      "integrity": "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -4460,8 +4610,6 @@
     },
     "node_modules/define-lazy-prop": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
-      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -4472,8 +4620,6 @@
     },
     "node_modules/depd": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
-      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -4481,8 +4627,6 @@
     },
     "node_modules/detect-libc": {
       "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
-      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -4490,14 +4634,10 @@
     },
     "node_modules/detect-node-es": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
-      "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
       "license": "MIT"
     },
     "node_modules/diff": {
       "version": "8.0.4",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
-      "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
@@ -4505,8 +4645,6 @@
     },
     "node_modules/dot-prop": {
       "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-6.0.1.tgz",
-      "integrity": "sha512-tE7ztYzXHIeyvc7N+hR3oi7FIbf/NIjVP9hmAt3yMXzrQ072/fpjGLx2GxNxGxUl5V73MEqYzioOMoVhGMJ5cA==",
       "license": "MIT",
       "dependencies": {
         "is-obj": "^2.0.0"
@@ -4520,8 +4658,6 @@
     },
     "node_modules/dotenv": {
       "version": "17.4.2",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
-      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
@@ -4532,8 +4668,6 @@
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
-      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -4546,8 +4680,6 @@
     },
     "node_modules/eciesjs": {
       "version": "0.4.18",
-      "resolved": "https://registry.npmjs.org/eciesjs/-/eciesjs-0.4.18.tgz",
-      "integrity": "sha512-wG99Zcfcys9fZux7Cft8BAX/YrOJLJSZ3jyYPfhZHqN2E+Ffx+QXBDsv3gubEgPtV6dTzJMSQUwk1H98/t/0wQ==",
       "license": "MIT",
       "dependencies": {
         "@ecies/ciphers": "^0.2.5",
@@ -4563,26 +4695,18 @@
     },
     "node_modules/ee-first": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.376",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.376.tgz",
-      "integrity": "sha512-cUVA7/RvbFTEuw/i3obUwDTRIXojaxkResf+ibByPFxjc6XK3VNtcQXV0NSbAlJ0FMjcJGgftVVB4Qo184EXvA==",
       "license": "ISC"
     },
     "node_modules/emoji-regex": {
       "version": "10.6.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
-      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
       "license": "MIT"
     },
     "node_modules/encodeurl": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
-      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -4590,8 +4714,6 @@
     },
     "node_modules/enhanced-resolve": {
       "version": "5.21.6",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.21.6.tgz",
-      "integrity": "sha512-aNnGCvbJ/RIyWo1IuhNdVjnNF+EjH9wpzpNHt+ci/m9He9LJvUN8wrCcXjp9cWsGNAuvSpVFTx/vraAFQ8qGjQ==",
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.4",
@@ -4603,8 +4725,6 @@
     },
     "node_modules/enquirer": {
       "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.4.1.tgz",
-      "integrity": "sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==",
       "license": "MIT",
       "dependencies": {
         "ansi-colors": "^4.1.1",
@@ -4616,8 +4736,6 @@
     },
     "node_modules/env-paths": {
       "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
-      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -4625,8 +4743,6 @@
     },
     "node_modules/error-ex": {
       "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
-      "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
       "license": "MIT",
       "dependencies": {
         "is-arrayish": "^0.2.1"
@@ -4634,8 +4750,6 @@
     },
     "node_modules/es-define-property": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
-      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -4643,8 +4757,6 @@
     },
     "node_modules/es-errors": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
-      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -4652,8 +4764,6 @@
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
-      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -4664,8 +4774,6 @@
     },
     "node_modules/esbuild": {
       "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
-      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -4705,8 +4813,6 @@
     },
     "node_modules/escalade": {
       "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
-      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -4714,14 +4820,290 @@
     },
     "node_modules/escape-html": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
       "license": "MIT"
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.6.0.tgz",
+      "integrity": "sha512-6lVbcqSodALYo+4ELD0heG6lFiFxnLMuLkiMi2qV8LMp54N8tE8FT1GMH+ev4Ti00nFjNze2+Su6DsV5OQW3Dg==",
+      "dev": true,
+      "license": "MIT",
+      "workspaces": [
+        "packages/*"
+      ],
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.2",
+        "@eslint/config-array": "^0.23.5",
+        "@eslint/config-helpers": "^0.6.0",
+        "@eslint/core": "^1.2.1",
+        "@eslint/plugin-kit": "^0.7.2",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^9.1.2",
+        "eslint-visitor-keys": "^5.0.1",
+        "espree": "^11.2.0",
+        "esquery": "^1.7.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "minimatch": "^10.2.4",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-config-prettier": {
+      "version": "10.1.8",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz",
+      "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-config-prettier"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-react-hooks": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.1.1.tgz",
+      "integrity": "sha512-f2I7Gw6JbvCexzIInuSbZpfdQ44D7iqdWX01FKLvrPgqxoE7oMj8clOfto8U6vYiz4yd5oKu39rRSVOe1zRu0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.24.4",
+        "@babel/parser": "^7.24.4",
+        "hermes-parser": "^0.25.1",
+        "zod": "^3.25.0 || ^4.0.0",
+        "zod-validation-error": "^3.5.0 || ^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-react-refresh": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-refresh/-/eslint-plugin-react-refresh-0.5.3.tgz",
+      "integrity": "sha512-5EMmLCV98Pi4o/f/3DP/v/tNqLHMIc9I8LKClNDWhZ9JTho89/kQcitCXQBMG7sAfVRK0Ie3T2EDOzp1YXYiVA==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "eslint": "^9 || ^10"
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
+      "integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@types/esrecurse": "^4.3.1",
+        "@types/estree": "^1.0.8",
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/eslint/node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/eslint/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/eslint/node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/espree": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
+      "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^5.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
     },
     "node_modules/esprima": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
       "license": "BSD-2-Clause",
       "bin": {
         "esparse": "bin/esparse.js",
@@ -4731,10 +5113,54 @@
         "node": ">=4"
       }
     },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/etag": {
       "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
-      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -4742,8 +5168,6 @@
     },
     "node_modules/eventsource": {
       "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
-      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
       "license": "MIT",
       "dependencies": {
         "eventsource-parser": "^3.0.1"
@@ -4754,8 +5178,6 @@
     },
     "node_modules/eventsource-parser": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
-      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
@@ -4763,8 +5185,6 @@
     },
     "node_modules/execa": {
       "version": "9.6.1",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-9.6.1.tgz",
-      "integrity": "sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==",
       "license": "MIT",
       "dependencies": {
         "@sindresorhus/merge-streams": "^4.0.0",
@@ -4789,8 +5209,6 @@
     },
     "node_modules/express": {
       "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
-      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
       "dependencies": {
         "accepts": "^2.0.0",
@@ -4832,8 +5250,6 @@
     },
     "node_modules/express-rate-limit": {
       "version": "8.5.2",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
-      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
       "license": "MIT",
       "dependencies": {
         "ip-address": "^10.2.0"
@@ -4850,14 +5266,10 @@
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "license": "MIT"
     },
     "node_modules/fast-glob": {
       "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
-      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -4870,10 +5282,22 @@
         "node": ">=8.6.0"
       }
     },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fast-uri": {
       "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",
@@ -4888,8 +5312,6 @@
     },
     "node_modules/fastq": {
       "version": "1.20.1",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
-      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
@@ -4897,8 +5319,6 @@
     },
     "node_modules/fdir": {
       "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
-      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
       "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
@@ -4914,8 +5334,6 @@
     },
     "node_modules/fetch-blob": {
       "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
-      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
       "funding": [
         {
           "type": "github",
@@ -4937,8 +5355,6 @@
     },
     "node_modules/figures": {
       "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
-      "integrity": "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==",
       "license": "MIT",
       "dependencies": {
         "is-unicode-supported": "^2.0.0"
@@ -4950,10 +5366,21 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/fill-range": {
       "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
-      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -4964,8 +5391,6 @@
     },
     "node_modules/finalhandler": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
-      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
       "license": "MIT",
       "dependencies": {
         "debug": "^4.4.0",
@@ -4985,8 +5410,6 @@
     },
     "node_modules/find-up": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-      "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
       "license": "MIT",
       "dependencies": {
         "locate-path": "^3.0.0"
@@ -4995,10 +5418,29 @@
         "node": ">=6"
       }
     },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/formdata-polyfill": {
       "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
-      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
       "license": "MIT",
       "dependencies": {
         "fetch-blob": "^3.1.2"
@@ -5009,8 +5451,6 @@
     },
     "node_modules/forwarded": {
       "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
-      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -5018,8 +5458,6 @@
     },
     "node_modules/fresh": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
-      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -5027,8 +5465,6 @@
     },
     "node_modules/fs-extra": {
       "version": "11.3.5",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.5.tgz",
-      "integrity": "sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==",
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",
@@ -5041,9 +5477,6 @@
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5055,8 +5488,6 @@
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
-      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -5064,14 +5495,10 @@
     },
     "node_modules/fuzzysort": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fuzzysort/-/fuzzysort-3.1.0.tgz",
-      "integrity": "sha512-sR9BNCjBg6LNgwvxlBd0sBABvQitkLzoVY9MYYROQVX/FvfJ4Mai9LsGhDgd8qYdds0bY77VzYd5iuB+v5rwQQ==",
       "license": "MIT"
     },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
-      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
-      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -5079,8 +5506,6 @@
     },
     "node_modules/get-east-asian-width": {
       "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
-      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -5091,8 +5516,6 @@
     },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
-      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -5115,8 +5538,6 @@
     },
     "node_modules/get-nonce": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
-      "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==",
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -5124,8 +5545,6 @@
     },
     "node_modules/get-own-enumerable-keys": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/get-own-enumerable-keys/-/get-own-enumerable-keys-1.0.0.tgz",
-      "integrity": "sha512-PKsK2FSrQCyxcGHsGrLDcK0lx+0Ke+6e8KFFozA9/fIQLhQzPaRvJFdcz7+Axg3jUH/Mq+NI4xa5u/UT2tQskA==",
       "license": "MIT",
       "engines": {
         "node": ">=14.16"
@@ -5136,8 +5555,6 @@
     },
     "node_modules/get-proto": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
-      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -5149,8 +5566,6 @@
     },
     "node_modules/get-stream": {
       "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
-      "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
       "license": "MIT",
       "dependencies": {
         "@sec-ant/readable-stream": "^0.4.1",
@@ -5165,8 +5580,6 @@
     },
     "node_modules/glob-parent": {
       "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
@@ -5175,10 +5588,21 @@
         "node": ">= 6"
       }
     },
+    "node_modules/globals": {
+      "version": "17.7.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.7.0.tgz",
+      "integrity": "sha512-Czmyns5dUsq4seFBR/Kdydhmo8y9kC79hiSkPn0YcGtNnYWnrgt0vjrSjx9tspoDGWm2CMarffRuLjM4xUz8xg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
-      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -5189,14 +5613,10 @@
     },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "license": "ISC"
     },
     "node_modules/has-symbols": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
-      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -5207,8 +5627,6 @@
     },
     "node_modules/hasown": {
       "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
-      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -5217,10 +5635,25 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hermes-estree": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.25.1.tgz",
+      "integrity": "sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/hermes-parser": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.25.1.tgz",
+      "integrity": "sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hermes-estree": "0.25.1"
+      }
+    },
     "node_modules/hono": {
       "version": "4.12.26",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.26.tgz",
-      "integrity": "sha512-uyZtpnYxM9CmQ7QsQknM4zN8EftNqhON1qYeIKM0Se67CCEe2c44xyGURwB0axX2fBDu1dqHrHAc1hmNT8ITkw==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -5228,8 +5661,6 @@
     },
     "node_modules/http-errors": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
-      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
       "license": "MIT",
       "dependencies": {
         "depd": "~2.0.0",
@@ -5248,8 +5679,6 @@
     },
     "node_modules/https-proxy-agent": {
       "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
-      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
       "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.2",
@@ -5261,8 +5690,6 @@
     },
     "node_modules/human-signals": {
       "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-8.0.1.tgz",
-      "integrity": "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18.18.0"
@@ -5270,8 +5697,6 @@
     },
     "node_modules/iconv-lite": {
       "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
-      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -5286,8 +5711,6 @@
     },
     "node_modules/ignore": {
       "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
-      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
       "license": "MIT",
       "engines": {
         "node": ">= 4"
@@ -5295,8 +5718,6 @@
     },
     "node_modules/import-fresh": {
       "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
-      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
       "license": "MIT",
       "dependencies": {
         "parent-module": "^1.0.0",
@@ -5309,16 +5730,22 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
     },
     "node_modules/ip-address": {
       "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -5326,8 +5753,6 @@
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
-      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.10"
@@ -5335,14 +5760,10 @@
     },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
       "license": "MIT"
     },
     "node_modules/is-docker": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
-      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
       "license": "MIT",
       "bin": {
         "is-docker": "cli.js"
@@ -5356,8 +5777,6 @@
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -5365,8 +5784,6 @@
     },
     "node_modules/is-glob": {
       "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
-      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -5377,8 +5794,6 @@
     },
     "node_modules/is-in-ssh": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-in-ssh/-/is-in-ssh-1.0.0.tgz",
-      "integrity": "sha512-jYa6Q9rH90kR1vKB6NM7qqd1mge3Fx4Dhw5TVlK1MUBqhEOuCagrEHMevNuCcbECmXZ0ThXkRm+Ymr51HwEPAw==",
       "license": "MIT",
       "engines": {
         "node": ">=20"
@@ -5389,8 +5804,6 @@
     },
     "node_modules/is-inside-container": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
-      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
       "license": "MIT",
       "dependencies": {
         "is-docker": "^3.0.0"
@@ -5407,8 +5820,6 @@
     },
     "node_modules/is-interactive": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-2.0.0.tgz",
-      "integrity": "sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==",
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -5419,8 +5830,6 @@
     },
     "node_modules/is-number": {
       "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
@@ -5428,8 +5837,6 @@
     },
     "node_modules/is-obj": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
-      "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5437,8 +5844,6 @@
     },
     "node_modules/is-plain-obj": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
-      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -5449,14 +5854,10 @@
     },
     "node_modules/is-promise": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
-      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
       "license": "MIT"
     },
     "node_modules/is-regexp": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-3.1.0.tgz",
-      "integrity": "sha512-rbku49cWloU5bSMI+zaRaXdQHXnthP6DZ/vLnfdSKyL4zUzuWnomtOEiZZOd+ioQ+avFo/qau3KPTc7Fjy1uPA==",
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -5467,8 +5868,6 @@
     },
     "node_modules/is-stream": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
-      "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -5479,8 +5878,6 @@
     },
     "node_modules/is-unicode-supported": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
-      "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -5491,8 +5888,6 @@
     },
     "node_modules/is-wsl": {
       "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
-      "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
       "license": "MIT",
       "dependencies": {
         "is-inside-container": "^1.0.0"
@@ -5506,8 +5901,6 @@
     },
     "node_modules/isexe": {
       "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.5.tgz",
-      "integrity": "sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w==",
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=18"
@@ -5515,8 +5908,6 @@
     },
     "node_modules/jiti": {
       "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
-      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
@@ -5524,8 +5915,6 @@
     },
     "node_modules/jose": {
       "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
-      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
@@ -5533,14 +5922,10 @@
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "license": "MIT"
     },
     "node_modules/js-yaml": {
       "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
       "funding": [
         {
           "type": "github",
@@ -5561,8 +5946,6 @@
     },
     "node_modules/jsesc": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
-      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
       "license": "MIT",
       "bin": {
         "jsesc": "bin/jsesc"
@@ -5571,28 +5954,34 @@
         "node": ">=6"
       }
     },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
-      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
     },
     "node_modules/json-schema-typed": {
       "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
-      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
       "license": "BSD-2-Clause"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/json5": {
       "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
-      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "license": "MIT",
       "bin": {
         "json5": "lib/cli.js"
@@ -5603,8 +5992,6 @@
     },
     "node_modules/jsonfile": {
       "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
-      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
       "license": "MIT",
       "dependencies": {
         "universalify": "^2.0.0"
@@ -5613,19 +6000,39 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
     "node_modules/kleur": {
       "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
-      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
       "license": "MIT",
       "engines": {
         "node": ">=6"
       }
     },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/lightningcss": {
       "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
-      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
       "license": "MPL-2.0",
       "dependencies": {
         "detect-libc": "^2.0.3"
@@ -5673,8 +6080,6 @@
     },
     "node_modules/lightningcss-darwin-arm64": {
       "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
-      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
       "cpu": [
         "arm64"
       ],
@@ -5758,6 +6163,9 @@
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5777,6 +6185,9 @@
       "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -5798,6 +6209,9 @@
       "cpu": [
         "x64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5817,6 +6231,9 @@
       "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -5873,14 +6290,10 @@
     },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
-      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "license": "MIT"
     },
     "node_modules/locate-path": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-      "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
       "license": "MIT",
       "dependencies": {
         "p-locate": "^3.0.0",
@@ -5892,8 +6305,6 @@
     },
     "node_modules/log-symbols": {
       "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-6.0.0.tgz",
-      "integrity": "sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.3.0",
@@ -5908,8 +6319,6 @@
     },
     "node_modules/log-symbols/node_modules/is-unicode-supported": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz",
-      "integrity": "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==",
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -5920,8 +6329,6 @@
     },
     "node_modules/lru-cache": {
       "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
@@ -5929,8 +6336,6 @@
     },
     "node_modules/lucide-react": {
       "version": "1.21.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.21.0.tgz",
-      "integrity": "sha512-reEZMXq8Qdd5jg5XYkQ5TR1fB/GiQ7ih4vcrthYDtgjSDwh0i6/YLiGjsWsIwgN49gpAnd4J2elSNzncMEEUUQ==",
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
@@ -5938,8 +6343,6 @@
     },
     "node_modules/magic-string": {
       "version": "0.30.21",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
-      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
@@ -5947,8 +6350,6 @@
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
-      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -5956,8 +6357,6 @@
     },
     "node_modules/media-typer": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
-      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -5965,8 +6364,6 @@
     },
     "node_modules/merge-descriptors": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
-      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -5977,14 +6374,10 @@
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
-      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
       "license": "MIT"
     },
     "node_modules/merge2": {
       "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
-      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -5992,8 +6385,6 @@
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
-      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "license": "MIT",
       "dependencies": {
         "braces": "^3.0.3",
@@ -6005,8 +6396,6 @@
     },
     "node_modules/micromatch/node_modules/picomatch": {
       "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
-      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -6017,8 +6406,6 @@
     },
     "node_modules/mime-db": {
       "version": "1.54.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
-      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -6026,8 +6413,6 @@
     },
     "node_modules/mime-types": {
       "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
-      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
       "license": "MIT",
       "dependencies": {
         "mime-db": "^1.54.0"
@@ -6042,8 +6427,6 @@
     },
     "node_modules/mimic-fn": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-3.1.0.tgz",
-      "integrity": "sha512-Ysbi9uYW9hFyfrThdDEQuykN4Ey6BuwPD2kpI5ES/nFTDn/98yxYNLZJcgUAKPT/mcrLLKaGzJR9YVxJrIdASQ==",
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -6051,8 +6434,6 @@
     },
     "node_modules/mimic-function": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
-      "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -6063,8 +6444,6 @@
     },
     "node_modules/minimatch": {
       "version": "10.2.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "brace-expansion": "^5.0.5"
@@ -6078,8 +6457,6 @@
     },
     "node_modules/minimist": {
       "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -6087,14 +6464,10 @@
     },
     "node_modules/ms": {
       "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
     "node_modules/nanoid": {
       "version": "3.3.13",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.13.tgz",
-      "integrity": "sha512-sPdqC6ByMVVGvF1ynvvMo0/o+oD1VX7DaHhijt1bFgjvBkHBib4t49GoNDhf2NDta4oeUNlaGbSt5K7qjZ955Q==",
       "funding": [
         {
           "type": "github",
@@ -6109,10 +6482,15 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/negotiator": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
-      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -6120,8 +6498,6 @@
     },
     "node_modules/next-themes": {
       "version": "0.4.6",
-      "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.4.6.tgz",
-      "integrity": "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==",
       "license": "MIT",
       "peerDependencies": {
         "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc",
@@ -6130,9 +6506,6 @@
     },
     "node_modules/node-domexception": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
-      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
-      "deprecated": "Use your platform's native DOMException instead",
       "funding": [
         {
           "type": "github",
@@ -6150,8 +6523,6 @@
     },
     "node_modules/node-fetch": {
       "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
-      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
       "license": "MIT",
       "dependencies": {
         "data-uri-to-buffer": "^4.0.0",
@@ -6168,8 +6539,6 @@
     },
     "node_modules/node-releases": {
       "version": "2.0.48",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.48.tgz",
-      "integrity": "sha512-1uz8041X6LoI6ZSdZacM9lVY28vuzDlSKitnpbSNK0RfKoIJkX29NBPVEFXhnuSuEOA9Ww0xnPJ+ILWbGAv8DA==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -6177,8 +6546,6 @@
     },
     "node_modules/npm-run-path": {
       "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
-      "integrity": "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==",
       "license": "MIT",
       "dependencies": {
         "path-key": "^4.0.0",
@@ -6193,8 +6560,6 @@
     },
     "node_modules/npm-run-path/node_modules/path-key": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
-      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -6205,8 +6570,6 @@
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -6214,8 +6577,6 @@
     },
     "node_modules/object-inspect": {
       "version": "1.13.4",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
-      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -6226,8 +6587,6 @@
     },
     "node_modules/object-treeify": {
       "version": "1.1.33",
-      "resolved": "https://registry.npmjs.org/object-treeify/-/object-treeify-1.1.33.tgz",
-      "integrity": "sha512-EFVjAYfzWqWsBMRHPMAXLCDIJnpMhdWAqR7xG6M6a2cs6PMFpl/+Z20w9zDW4vkxOFfddegBKq9Rehd0bxWE7A==",
       "license": "MIT",
       "engines": {
         "node": ">= 10"
@@ -6235,8 +6594,6 @@
     },
     "node_modules/on-finished": {
       "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
-      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
       "license": "MIT",
       "dependencies": {
         "ee-first": "1.1.1"
@@ -6247,8 +6604,6 @@
     },
     "node_modules/once": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -6256,8 +6611,6 @@
     },
     "node_modules/onetime": {
       "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
-      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
       "license": "MIT",
       "dependencies": {
         "mimic-fn": "^2.1.0"
@@ -6271,8 +6624,6 @@
     },
     "node_modules/onetime/node_modules/mimic-fn": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -6280,8 +6631,6 @@
     },
     "node_modules/open": {
       "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/open/-/open-11.0.0.tgz",
-      "integrity": "sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw==",
       "license": "MIT",
       "dependencies": {
         "default-browser": "^5.4.0",
@@ -6298,10 +6647,26 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/ora": {
       "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/ora/-/ora-8.2.0.tgz",
-      "integrity": "sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw==",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.3.0",
@@ -6323,8 +6688,6 @@
     },
     "node_modules/ora/node_modules/ansi-regex": {
       "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
-      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -6335,8 +6698,6 @@
     },
     "node_modules/ora/node_modules/strip-ansi": {
       "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
-      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^6.2.2"
@@ -6350,8 +6711,6 @@
     },
     "node_modules/p-limit": {
       "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
       "license": "MIT",
       "dependencies": {
         "p-try": "^2.0.0"
@@ -6365,8 +6724,6 @@
     },
     "node_modules/p-locate": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-      "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
       "license": "MIT",
       "dependencies": {
         "p-limit": "^2.0.0"
@@ -6377,8 +6734,6 @@
     },
     "node_modules/p-try": {
       "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -6386,8 +6741,6 @@
     },
     "node_modules/parent-module": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
-      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
       "license": "MIT",
       "dependencies": {
         "callsites": "^3.0.0"
@@ -6398,8 +6751,6 @@
     },
     "node_modules/parse-json": {
       "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
-      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
@@ -6416,8 +6767,6 @@
     },
     "node_modules/parse-ms": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-4.0.0.tgz",
-      "integrity": "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -6428,8 +6777,6 @@
     },
     "node_modules/parseurl": {
       "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
-      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -6437,14 +6784,10 @@
     },
     "node_modules/path-browserify": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
-      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
       "license": "MIT"
     },
     "node_modules/path-exists": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-      "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -6452,8 +6795,6 @@
     },
     "node_modules/path-key": {
       "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -6461,8 +6802,6 @@
     },
     "node_modules/path-to-regexp": {
       "version": "8.4.2",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
-      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -6471,14 +6810,10 @@
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
-      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -6489,8 +6824,6 @@
     },
     "node_modules/pkce-challenge": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
-      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.20.0"
@@ -6498,8 +6831,6 @@
     },
     "node_modules/pkg-up": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-3.1.0.tgz",
-      "integrity": "sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==",
       "license": "MIT",
       "dependencies": {
         "find-up": "^3.0.0"
@@ -6510,8 +6841,6 @@
     },
     "node_modules/postcss": {
       "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "funding": [
         {
           "type": "opencollective",
@@ -6538,8 +6867,6 @@
     },
     "node_modules/postcss-selector-parser": {
       "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.4.tgz",
-      "integrity": "sha512-HeP7D2wyhkR+XaK6v4W8oRF62Dsz4flyuczALJp61GckGm42u1saSSJ/0auvcBqxs3jMRFEcPK34At/0JBKdOg==",
       "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
@@ -6551,14 +6878,22 @@
     },
     "node_modules/powershell-utils": {
       "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/powershell-utils/-/powershell-utils-0.1.0.tgz",
-      "integrity": "sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==",
       "license": "MIT",
       "engines": {
         "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/prettier": {
@@ -6579,8 +6914,6 @@
     },
     "node_modules/pretty-ms": {
       "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-9.3.0.tgz",
-      "integrity": "sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==",
       "license": "MIT",
       "dependencies": {
         "parse-ms": "^4.0.0"
@@ -6594,8 +6927,6 @@
     },
     "node_modules/prompts": {
       "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
-      "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
       "license": "MIT",
       "dependencies": {
         "kleur": "^3.0.3",
@@ -6607,8 +6938,6 @@
     },
     "node_modules/prompts/node_modules/kleur": {
       "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
-      "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -6616,8 +6945,6 @@
     },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
-      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
       "license": "MIT",
       "dependencies": {
         "forwarded": "0.2.0",
@@ -6627,10 +6954,18 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/qs": {
       "version": "6.15.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
-      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
@@ -6644,8 +6979,6 @@
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
-      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
       "funding": [
         {
           "type": "github",
@@ -6664,8 +6997,6 @@
     },
     "node_modules/radix-ui": {
       "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/radix-ui/-/radix-ui-1.6.0.tgz",
-      "integrity": "sha512-EUEC70O03EgxWMP5aoqfBZ6iLC5bczFagGy7zhSYRt8o5DP7IWNiP3ywetse3L9b8843ExB0OGWZvgbYVJuNeg==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.4",
@@ -6741,8 +7072,6 @@
     },
     "node_modules/range-parser": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
-      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -6750,8 +7079,6 @@
     },
     "node_modules/raw-body": {
       "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
-      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
       "license": "MIT",
       "dependencies": {
         "bytes": "~3.1.2",
@@ -6765,8 +7092,6 @@
     },
     "node_modules/react": {
       "version": "19.2.7",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
-      "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -6774,8 +7099,6 @@
     },
     "node_modules/react-dom": {
       "version": "19.2.7",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
-      "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
       "license": "MIT",
       "dependencies": {
         "scheduler": "^0.27.0"
@@ -6786,8 +7109,6 @@
     },
     "node_modules/react-refresh": {
       "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
-      "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6796,8 +7117,6 @@
     },
     "node_modules/react-remove-scroll": {
       "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.2.tgz",
-      "integrity": "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==",
       "license": "MIT",
       "dependencies": {
         "react-remove-scroll-bar": "^2.3.7",
@@ -6821,8 +7140,6 @@
     },
     "node_modules/react-remove-scroll-bar": {
       "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz",
-      "integrity": "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==",
       "license": "MIT",
       "dependencies": {
         "react-style-singleton": "^2.2.2",
@@ -6843,8 +7160,6 @@
     },
     "node_modules/react-style-singleton": {
       "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
-      "integrity": "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==",
       "license": "MIT",
       "dependencies": {
         "get-nonce": "^1.0.0",
@@ -6865,8 +7180,6 @@
     },
     "node_modules/recast": {
       "version": "0.23.11",
-      "resolved": "https://registry.npmjs.org/recast/-/recast-0.23.11.tgz",
-      "integrity": "sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA==",
       "license": "MIT",
       "dependencies": {
         "ast-types": "^0.16.1",
@@ -6881,8 +7194,6 @@
     },
     "node_modules/require-from-string": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -6890,8 +7201,6 @@
     },
     "node_modules/resolve-from": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -6899,8 +7208,6 @@
     },
     "node_modules/restore-cursor": {
       "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
-      "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
       "license": "MIT",
       "dependencies": {
         "onetime": "^7.0.0",
@@ -6915,8 +7222,6 @@
     },
     "node_modules/restore-cursor/node_modules/onetime": {
       "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
-      "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
       "license": "MIT",
       "dependencies": {
         "mimic-function": "^5.0.0"
@@ -6930,8 +7235,6 @@
     },
     "node_modules/reusify": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
-      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
       "license": "MIT",
       "engines": {
         "iojs": ">=1.0.0",
@@ -6940,8 +7243,6 @@
     },
     "node_modules/rollup": {
       "version": "4.62.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.0.tgz",
-      "integrity": "sha512-nc72Wgq62I7rtDV4izT5/aaS0zxy3kttkinf9586ApknY3jZO9NYsmtc24fUckA0X7Q2v+ML4a15pdUlV5V/jA==",
       "license": "MIT",
       "dependencies": {
         "@types/estree": "1.0.9"
@@ -6984,8 +7285,6 @@
     },
     "node_modules/router": {
       "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
-      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
       "license": "MIT",
       "dependencies": {
         "debug": "^4.4.0",
@@ -7000,8 +7299,6 @@
     },
     "node_modules/run-applescript": {
       "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
-      "integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -7012,8 +7309,6 @@
     },
     "node_modules/run-parallel": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
-      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
       "funding": [
         {
           "type": "github",
@@ -7035,20 +7330,14 @@
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
     },
     "node_modules/scheduler": {
       "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
-      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "license": "MIT"
     },
     "node_modules/semver": {
       "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -7056,8 +7345,6 @@
     },
     "node_modules/send": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
-      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
       "license": "MIT",
       "dependencies": {
         "debug": "^4.4.3",
@@ -7082,8 +7369,6 @@
     },
     "node_modules/serve-static": {
       "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
-      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
       "license": "MIT",
       "dependencies": {
         "encodeurl": "^2.0.0",
@@ -7101,14 +7386,10 @@
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
-      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "license": "ISC"
     },
     "node_modules/shadcn": {
       "version": "4.11.0",
-      "resolved": "https://registry.npmjs.org/shadcn/-/shadcn-4.11.0.tgz",
-      "integrity": "sha512-UV0cchFea9hO7poV1CuEP0wvmYjpAqcxCKdy23bndl2Du2ARtDs8A4xdzfhUjDBeOW1nNpJ6lXmsEpsply2SfQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.28.0",
@@ -7151,8 +7432,6 @@
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
-      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -7163,8 +7442,6 @@
     },
     "node_modules/shebang-regex": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -7172,8 +7449,6 @@
     },
     "node_modules/side-channel": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
-      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -7191,8 +7466,6 @@
     },
     "node_modules/side-channel-list": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
-      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -7207,8 +7480,6 @@
     },
     "node_modules/side-channel-map": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
-      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -7225,8 +7496,6 @@
     },
     "node_modules/side-channel-weakmap": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
-      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -7244,8 +7513,6 @@
     },
     "node_modules/signal-exit": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
       "license": "ISC",
       "engines": {
         "node": ">=14"
@@ -7256,14 +7523,10 @@
     },
     "node_modules/sisteransi": {
       "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
-      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
       "license": "MIT"
     },
     "node_modules/sonner": {
       "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.7.tgz",
-      "integrity": "sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==",
       "license": "MIT",
       "peerDependencies": {
         "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
@@ -7272,8 +7535,6 @@
     },
     "node_modules/source-map": {
       "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -7281,8 +7542,6 @@
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
-      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -7290,8 +7549,6 @@
     },
     "node_modules/statuses": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
-      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -7299,8 +7556,6 @@
     },
     "node_modules/stdin-discarder": {
       "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.2.2.tgz",
-      "integrity": "sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -7311,8 +7566,6 @@
     },
     "node_modules/string-width": {
       "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
-      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^10.3.0",
@@ -7328,8 +7581,6 @@
     },
     "node_modules/string-width/node_modules/ansi-regex": {
       "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
-      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -7340,8 +7591,6 @@
     },
     "node_modules/string-width/node_modules/strip-ansi": {
       "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
-      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^6.2.2"
@@ -7355,8 +7604,6 @@
     },
     "node_modules/stringify-object": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-5.0.0.tgz",
-      "integrity": "sha512-zaJYxz2FtcMb4f+g60KsRNFOpVMUyuJgA51Zi5Z1DOTC3S59+OQiVOzE9GZt0x72uBGWKsQIuBKeF9iusmKFsg==",
       "license": "BSD-2-Clause",
       "dependencies": {
         "get-own-enumerable-keys": "^1.0.0",
@@ -7372,8 +7619,6 @@
     },
     "node_modules/stringify-object/node_modules/is-obj": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-3.0.0.tgz",
-      "integrity": "sha512-IlsXEHOjtKhpN8r/tRFj2nDyTmHvcfNeu/nrRIcXE17ROeatXchkojffa1SpdqW4cr/Fj6QkEf/Gn4zf6KKvEQ==",
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -7384,8 +7629,6 @@
     },
     "node_modules/strip-ansi": {
       "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -7396,8 +7639,6 @@
     },
     "node_modules/strip-bom": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -7405,8 +7646,6 @@
     },
     "node_modules/strip-final-newline": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
-      "integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -7417,8 +7656,6 @@
     },
     "node_modules/systeminformation": {
       "version": "5.31.7",
-      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.31.7.tgz",
-      "integrity": "sha512-/8NC53e5nP9nmhn42/ncdOkyJnOoue/Vy+tJOyUGd1Yv66G069wK4rrziwhrqDETgk78CudTQupw5z19S5uoZw==",
       "license": "MIT",
       "os": [
         "darwin",
@@ -7443,8 +7680,6 @@
     },
     "node_modules/tailwind-merge": {
       "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.6.0.tgz",
-      "integrity": "sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -7453,14 +7688,10 @@
     },
     "node_modules/tailwindcss": {
       "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.1.tgz",
-      "integrity": "sha512-hk+TB1m+K8CYNrP6rjQaq/Y+4Zylwpa87mLYBKCunwnnQ9p+fHb7kmSfGqyEJoxF/O6CDyABWVFEafNSYKll+Q==",
       "license": "MIT"
     },
     "node_modules/tapable": {
       "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
-      "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -7472,14 +7703,10 @@
     },
     "node_modules/tiny-invariant": {
       "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
-      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
       "license": "MIT"
     },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
-      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
@@ -7494,8 +7721,6 @@
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
       "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
@@ -7506,17 +7731,26 @@
     },
     "node_modules/toidentifier": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
-      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
       }
     },
+    "node_modules/ts-api-utils": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
+      }
+    },
     "node_modules/ts-morph": {
       "version": "26.0.0",
-      "resolved": "https://registry.npmjs.org/ts-morph/-/ts-morph-26.0.0.tgz",
-      "integrity": "sha512-ztMO++owQnz8c/gIENcM9XfCEzgoGphTv+nKpYNM1bgsdOVC/jRZuEBf6N+mLLDNg68Kl+GgUZfOySaRiG1/Ug==",
       "license": "MIT",
       "dependencies": {
         "@ts-morph/common": "~0.27.0",
@@ -7525,8 +7759,6 @@
     },
     "node_modules/tsconfig-paths": {
       "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.2.0.tgz",
-      "integrity": "sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==",
       "license": "MIT",
       "dependencies": {
         "json5": "^2.2.2",
@@ -7539,23 +7771,30 @@
     },
     "node_modules/tslib": {
       "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
     },
     "node_modules/tw-animate-css": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/tw-animate-css/-/tw-animate-css-1.4.0.tgz",
-      "integrity": "sha512-7bziOlRqH0hJx80h/3mbicLW7o8qLsH5+RaLR2t+OHM3D0JlWGODQKQ4cxbK7WlvmUxpcj6Kgu6EKqjrGFe3QQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Wombosvideo"
       }
     },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/type-is": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
-      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
       "license": "MIT",
       "dependencies": {
         "content-type": "^2.0.0",
@@ -7572,8 +7811,6 @@
     },
     "node_modules/type-is/node_modules/content-type": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
-      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -7585,8 +7822,6 @@
     },
     "node_modules/typescript": {
       "version": "5.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
-      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
@@ -7597,10 +7832,32 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/typescript-eslint": {
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.62.1.tgz",
+      "integrity": "sha512-vymnnM5g0AKQDSAyfP12nMIBvgwgA42syg74kkuZ4x1VuTzwQKwc5h9rGxeShCjny5o+zWAb6OEoz7XLgrIkIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "8.62.1",
+        "@typescript-eslint/parser": "8.62.1",
+        "@typescript-eslint/typescript-estree": "8.62.1",
+        "@typescript-eslint/utils": "8.62.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
     "node_modules/undici": {
       "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"
@@ -7608,8 +7865,6 @@
     },
     "node_modules/unicorn-magic": {
       "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
-      "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -7620,8 +7875,6 @@
     },
     "node_modules/universalify": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"
@@ -7629,8 +7882,6 @@
     },
     "node_modules/unpipe": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -7638,8 +7889,6 @@
     },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
-      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
       "funding": [
         {
           "type": "opencollective",
@@ -7666,10 +7915,18 @@
         "browserslist": ">= 4.21.0"
       }
     },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
     "node_modules/use-callback-ref": {
       "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
-      "integrity": "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.0.0"
@@ -7689,8 +7946,6 @@
     },
     "node_modules/use-sidecar": {
       "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.3.tgz",
-      "integrity": "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==",
       "license": "MIT",
       "dependencies": {
         "detect-node-es": "^1.1.0",
@@ -7711,14 +7966,10 @@
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
     },
     "node_modules/validate-npm-package-name": {
       "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-7.0.2.tgz",
-      "integrity": "sha512-hVDIBwsRruT73PbK7uP5ebUt+ezEtCmzZz3F59BSr2F6OVFnJ/6h8liuvdLrQ88Xmnk6/+xGGuq+pG9WwTuy3A==",
       "license": "ISC",
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
@@ -7726,8 +7977,6 @@
     },
     "node_modules/vary": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
-      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -7735,8 +7984,6 @@
     },
     "node_modules/vite": {
       "version": "7.3.5",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.5.tgz",
-      "integrity": "sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==",
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.27.0",
@@ -7809,8 +8056,6 @@
     },
     "node_modules/web-streams-polyfill": {
       "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
-      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -7818,8 +8063,6 @@
     },
     "node_modules/which": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/which/-/which-4.0.0.tgz",
-      "integrity": "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==",
       "license": "ISC",
       "dependencies": {
         "isexe": "^3.1.1"
@@ -7831,16 +8074,22 @@
         "node": "^16.13.0 || >=18.0.0"
       }
     },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
     },
     "node_modules/wsl-utils": {
       "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.3.1.tgz",
-      "integrity": "sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==",
       "license": "MIT",
       "dependencies": {
         "is-wsl": "^3.1.0",
@@ -7855,14 +8104,23 @@
     },
     "node_modules/yallist": {
       "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "license": "ISC"
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/yocto-spinner": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/yocto-spinner/-/yocto-spinner-1.2.0.tgz",
-      "integrity": "sha512-Yw0hUB6UA3o4YUgKy3oSe9a4cxoaZ9sBfYDw+JSxo6Id0KoJGoxzPA24qqUXYKBWABs/zDSGTz9kww7t3F0XGw==",
       "license": "MIT",
       "dependencies": {
         "yoctocolors": "^2.1.1"
@@ -7876,8 +8134,6 @@
     },
     "node_modules/yoctocolors": {
       "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.2.tgz",
-      "integrity": "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -7888,8 +8144,6 @@
     },
     "node_modules/zod": {
       "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
@@ -7897,11 +8151,22 @@
     },
     "node_modules/zod-to-json-schema": {
       "version": "3.25.2",
-      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
-      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
       "license": "ISC",
       "peerDependencies": {
         "zod": "^3.25.28 || ^4"
+      }
+    },
+    "node_modules/zod-validation-error": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/zod-validation-error/-/zod-validation-error-4.0.2.tgz",
+      "integrity": "sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "conduit",
-  "version": "1.0.1",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "conduit",
-      "version": "1.0.1",
+      "version": "1.2.0",
       "dependencies": {
         "@fontsource-variable/geist": "^5.2.9",
         "@tailwindcss/vite": "^4.3.1",
@@ -34,6 +34,7 @@
         "@types/react": "^19.1.8",
         "@types/react-dom": "^19.1.6",
         "@vitejs/plugin-react": "^4.6.0",
+        "prettier": "^3.9.4",
         "typescript": "~5.8.3",
         "vite": "^7.0.4"
       }
@@ -6558,6 +6559,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.9.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.4.tgz",
+      "integrity": "sha512-yWG/o/4oJfo036EKAfK6ACAoDOfHeRHx4tuxkfBZiauURiaSmYwlpOr5LQqKtIkRD2z1PLteme2WoxEnj4tHTg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/pretty-ms": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
     "build:bundle": "npm run build && npm run prepare:sidecar",
     "tauri:bundle": "tauri build --config src-tauri/tauri.bundle.conf.json --bundles nsis",
     "format": "prettier --write .",
-    "format:check": "prettier --check ."
+    "format:check": "prettier --check .",
+    "lint": "eslint src/",
+    "lint:fix": "eslint src/ --fix"
   },
   "dependencies": {
     "@fontsource-variable/geist": "^5.2.9",
@@ -25,7 +27,7 @@
     "@tauri-apps/plugin-process": "^2.3.1",
     "@tauri-apps/plugin-updater": "^2.10.1",
     "class-variance-authority": "^0.7.1",
-    "clsx": "^2.1.1",
+    "clsx": "2.1.1",
     "lucide-react": "^1.21.0",
     "next-themes": "^0.4.6",
     "radix-ui": "^1.6.0",
@@ -38,12 +40,19 @@
     "tw-animate-css": "^1.4.0"
   },
   "devDependencies": {
+    "@eslint/js": "^10.0.1",
     "@tauri-apps/cli": "^2",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
     "@vitejs/plugin-react": "^4.6.0",
+    "eslint": "^10.6.0",
+    "eslint-config-prettier": "^10.1.8",
+    "eslint-plugin-react-hooks": "^7.1.1",
+    "eslint-plugin-react-refresh": "^0.5.3",
+    "globals": "^17.7.0",
     "prettier": "^3.9.4",
     "typescript": "~5.8.3",
+    "typescript-eslint": "^8.62.1",
     "vite": "^7.0.4"
   },
   "overrides": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     "build:gateway": "cargo build --manifest-path src-tauri/Cargo.toml --bin conduit-gateway",
     "prepare:sidecar": "node scripts/prepare-sidecar.mjs",
     "build:bundle": "npm run build && npm run prepare:sidecar",
-    "tauri:bundle": "tauri build --config src-tauri/tauri.bundle.conf.json --bundles nsis"
+    "tauri:bundle": "tauri build --config src-tauri/tauri.bundle.conf.json --bundles nsis",
+    "format": "prettier --write .",
+    "format:check": "prettier --check ."
   },
   "dependencies": {
     "@fontsource-variable/geist": "^5.2.9",
@@ -40,6 +42,7 @@
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
     "@vitejs/plugin-react": "^4.6.0",
+    "prettier": "^3.9.4",
     "typescript": "~5.8.3",
     "vite": "^7.0.4"
   },

--- a/scripts/prepare-sidecar.mjs
+++ b/scripts/prepare-sidecar.mjs
@@ -7,7 +7,14 @@
 // triple (e.g. "x86_64-apple-darwin") to cross-build the gateway for that target.
 // Pass `--debug` to stage a debug build instead.
 import { execSync } from "node:child_process";
-import { mkdirSync, copyFileSync, existsSync, writeFileSync, chmodSync, rmSync } from "node:fs";
+import {
+  mkdirSync,
+  copyFileSync,
+  existsSync,
+  writeFileSync,
+  chmodSync,
+  rmSync,
+} from "node:fs";
 import { join } from "node:path";
 
 function hostTriple() {
@@ -32,7 +39,9 @@ function gatewayPathFor(triple) {
 
 function buildGateway(triple) {
   const targetArg = triple ? `--target ${triple} ` : "";
-  console.log(`[sidecar] building conduit-gateway (${profile}) ${triple ? "for " + triple : "(host)"}`);
+  console.log(
+    `[sidecar] building conduit-gateway (${profile}) ${triple ? "for " + triple : "(host)"}`,
+  );
   execSync(`cargo build ${debug ? "" : "--release "}${targetArg}--bin conduit-gateway`, {
     cwd: "src-tauri",
     stdio: "inherit",

--- a/src-tauri/tauri.bundle.conf.json
+++ b/src-tauri/tauri.bundle.conf.json
@@ -5,8 +5,6 @@
   },
   "bundle": {
     "createUpdaterArtifacts": true,
-    "externalBin": [
-      "binaries/conduit-gateway"
-    ]
+    "externalBin": ["binaries/conduit-gateway"]
   }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -241,9 +241,7 @@ function App() {
     const h = health[s.id];
     return h && !h.ok ? "attention" : "active";
   };
-  const attentionCount = servers.filter(
-    (s) => groupOf(s) === "attention",
-  ).length;
+  const attentionCount = servers.filter((s) => groupOf(s) === "attention").length;
 
   const q = query.trim().toLowerCase();
   const matches = (s: ServerEntry) =>
@@ -279,10 +277,8 @@ function App() {
   // (which flips gatewayInstalled) doesn't unmount the dialog. Existing users,
   // and anyone who has dismissed it, never see it.
   useEffect(() => {
-    if (onboarded || showOnboarding || resumeAtConnect || loading || !registry)
-      return;
-    const fresh =
-      servers.length === 0 && !clients.some((c) => c.gatewayInstalled);
+    if (onboarded || showOnboarding || resumeAtConnect || loading || !registry) return;
+    const fresh = servers.length === 0 && !clients.some((c) => c.gatewayInstalled);
     if (fresh) setShowOnboarding(true);
   }, [
     onboarded,
@@ -438,9 +434,7 @@ function App() {
                             : loading || !registry
                               ? "Loading…"
                               : `${enabledCount} of ${servers.length} enabled` +
-                                (connectedCount
-                                  ? ` · ${connectedCount} connected`
-                                  : "") +
+                                (connectedCount ? ` · ${connectedCount} connected` : "") +
                                 (attentionCount
                                   ? ` · ${attentionCount} need${attentionCount === 1 ? "s" : ""} attention`
                                   : "")}
@@ -475,7 +469,7 @@ function App() {
                       </Button>
                     </DropdownMenuTrigger>
 
-                   <DropdownMenuContent align="end" className="w-38">
+                    <DropdownMenuContent align="end" className="w-38">
                       <DropdownMenuItem onClick={handleImport}>
                         <Download className="mr-2 size-4" />
                         <span>Import</span>
@@ -489,7 +483,11 @@ function App() {
                           // while a search is active: it acts on ALL servers, so it must
                           // not silently toggle ones hidden by the filter.
                           disabled={togglingAll || busyId !== null || query.trim() !== ""}
-                          title={query.trim() !== "" ? "Clear the search to enable or disable all servers" : undefined}
+                          title={
+                            query.trim() !== ""
+                              ? "Clear the search to enable or disable all servers"
+                              : undefined
+                          }
                         >
                           <ServerOff className="mr-2 size-4" />
                           <span>
@@ -528,70 +526,67 @@ function App() {
                   </div>
                 }
               >
-              {view === "activity" ? (
-                <ActivityView refreshKey={activityKey} registry={registry} />
-              ) : view === "catalog" ? (
-                <CatalogView registry={registry} onAdded={setRegistry} />
-              ) : view === "playground" ? (
-                <PlaygroundView
-                  registry={registry}
-                  onRegistryChange={setRegistry}
-                />
-              ) : view === "teams" ? (
-                <TeamsView registry={registry} onRegistryChange={setRegistry} />
-              ) : view === "settings" ? (
-                <SettingsView registry={registry} onRegistryChange={setRegistry} />
-              ) : selectedClient ? (
-                <ClientDetail
-                  client={selectedClient}
-                  registry={registry}
-                  onChanged={load}
-                  onRegistryChange={setRegistry}
-                />
-              ) : loading && registry === null ? (
-                <div className="flex flex-col gap-2">
-                  {Array.from({ length: 6 }).map((_, i) => (
-                    <Skeleton key={i} className="h-11 w-full rounded-lg" />
-                  ))}
-                </div>
-              ) : error ? (
-                <ErrorState message={error} />
-              ) : servers.length === 0 ? (
-                <EmptyState
-                  importable={importable}
-                  onImport={handleImport}
-                  onBrowseCatalog={() => selectView("catalog")}
-                />
-              ) : visible.length === 0 ? (
-                <div className="py-16 text-center text-sm text-muted-foreground">
-                  No servers match "{query}".
-                </div>
-              ) : (
-                <div className="flex flex-col gap-5">
-                  <ServerGroup
-                    title="Needs attention"
-                    dot="bg-warning"
-                    count={grouped.attention.length}
-                  >
-                    {grouped.attention.map(serverRow)}
-                  </ServerGroup>
-                  <ServerGroup
-                    title="Active"
-                    dot="bg-success"
-                    count={grouped.active.length}
-                  >
-                    {grouped.active.map(serverRow)}
-                  </ServerGroup>
-                  <ServerGroup
-                    title="Disabled"
-                    dot="bg-muted-foreground/40"
-                    count={grouped.disabled.length}
-                    defaultCollapsed
-                  >
-                    {grouped.disabled.map(serverRow)}
-                  </ServerGroup>
-                </div>
-              )}
+                {view === "activity" ? (
+                  <ActivityView refreshKey={activityKey} registry={registry} />
+                ) : view === "catalog" ? (
+                  <CatalogView registry={registry} onAdded={setRegistry} />
+                ) : view === "playground" ? (
+                  <PlaygroundView registry={registry} onRegistryChange={setRegistry} />
+                ) : view === "teams" ? (
+                  <TeamsView registry={registry} onRegistryChange={setRegistry} />
+                ) : view === "settings" ? (
+                  <SettingsView registry={registry} onRegistryChange={setRegistry} />
+                ) : selectedClient ? (
+                  <ClientDetail
+                    client={selectedClient}
+                    registry={registry}
+                    onChanged={load}
+                    onRegistryChange={setRegistry}
+                  />
+                ) : loading && registry === null ? (
+                  <div className="flex flex-col gap-2">
+                    {Array.from({ length: 6 }).map((_, i) => (
+                      <Skeleton key={i} className="h-11 w-full rounded-lg" />
+                    ))}
+                  </div>
+                ) : error ? (
+                  <ErrorState message={error} />
+                ) : servers.length === 0 ? (
+                  <EmptyState
+                    importable={importable}
+                    onImport={handleImport}
+                    onBrowseCatalog={() => selectView("catalog")}
+                  />
+                ) : visible.length === 0 ? (
+                  <div className="py-16 text-center text-sm text-muted-foreground">
+                    No servers match "{query}".
+                  </div>
+                ) : (
+                  <div className="flex flex-col gap-5">
+                    <ServerGroup
+                      title="Needs attention"
+                      dot="bg-warning"
+                      count={grouped.attention.length}
+                    >
+                      {grouped.attention.map(serverRow)}
+                    </ServerGroup>
+                    <ServerGroup
+                      title="Active"
+                      dot="bg-success"
+                      count={grouped.active.length}
+                    >
+                      {grouped.active.map(serverRow)}
+                    </ServerGroup>
+                    <ServerGroup
+                      title="Disabled"
+                      dot="bg-muted-foreground/40"
+                      count={grouped.disabled.length}
+                      defaultCollapsed
+                    >
+                      {grouped.disabled.map(serverRow)}
+                    </ServerGroup>
+                  </div>
+                )}
               </Suspense>
             </div>
           </ScrollArea>
@@ -599,21 +594,21 @@ function App() {
       </div>
       {showOnboarding && registry && (
         <Suspense fallback={null}>
-        <Onboarding
-          key={onboardingStep}
-          initialStep={onboardingStep}
-          clients={clients}
-          registry={registry}
-          onRegistryChange={setRegistry}
-          onClientsRefresh={load}
-          onBrowseCatalog={() => {
-            setShowOnboarding(false);
-            setResumeAtConnect(true);
-            selectView("catalog");
-          }}
-          onProbe={reprobe}
-          onFinish={finishOnboarding}
-        />
+          <Onboarding
+            key={onboardingStep}
+            initialStep={onboardingStep}
+            clients={clients}
+            registry={registry}
+            onRegistryChange={setRegistry}
+            onClientsRefresh={load}
+            onBrowseCatalog={() => {
+              setShowOnboarding(false);
+              setResumeAtConnect(true);
+              selectView("catalog");
+            }}
+            onProbe={reprobe}
+            onFinish={finishOnboarding}
+          />
         </Suspense>
       )}
       <PendingApprovals />
@@ -724,19 +719,14 @@ function ErrorState({ message }: { message: string }) {
           {import.meta.env.DEV ? (
             <>
               Make sure you're running the desktop app with{" "}
-              <code className="font-mono">npm run tauri dev</code>, not the
-              browser-only dev server.
+              <code className="font-mono">npm run tauri dev</code>, not the browser-only
+              dev server.
             </>
           ) : (
-            <>
-              Toolport's backend didn't start. Try quitting and reopening the
-              app.
-            </>
+            <>Toolport's backend didn't start. Try quitting and reopening the app.</>
           )}
         </p>
-        <p className="mt-2 font-mono text-xs text-muted-foreground/70">
-          {message}
-        </p>
+        <p className="mt-2 font-mono text-xs text-muted-foreground/70">{message}</p>
       </div>
     </div>
   );

--- a/src/components/ActivityView.tsx
+++ b/src/components/ActivityView.tsx
@@ -195,9 +195,9 @@ function SecurityResting() {
     <div className="mb-4 flex items-center gap-2 rounded-lg border border-border/60 bg-muted/30 px-4 py-2.5 text-xs text-muted-foreground">
       <ShieldCheck className="size-4 shrink-0 text-owned" />
       <span>
-        <span className="font-medium text-foreground">Protection active.</span>{" "}
-        Toolport watches every tool for tampering (rug pulls), poisoned definitions,
-        and injected output (agentjacking). No issues right now.
+        <span className="font-medium text-foreground">Protection active.</span> Toolport
+        watches every tool for tampering (rug pulls), poisoned definitions, and injected
+        output (agentjacking). No issues right now.
       </span>
     </div>
   );
@@ -224,9 +224,7 @@ function SecurityNotices({
         className="flex w-full items-center gap-2 text-left"
       >
         <ShieldAlert className="size-4 shrink-0 text-warning" />
-        <h3 className="text-sm font-medium text-warning">
-          Tool security notices
-        </h3>
+        <h3 className="text-sm font-medium text-warning">Tool security notices</h3>
         <span className="rounded-full bg-warning/15 px-1.5 py-0.5 text-xs font-medium text-warning">
           {events.length}
         </span>
@@ -240,19 +238,17 @@ function SecurityNotices({
         <>
           <p className="mt-2 mb-3 max-w-2xl text-xs text-muted-foreground">
             A tool changed after you approved it, a tool's definition contains
-            instruction-like content, or a tool returned data that looks like
-            injected instructions. Usually benign, but it's how rug pulls, tool
-            poisoning, and agentjacking work, so Toolport flags it (and labels
-            suspicious tool output as data). Dismiss the ones you've reviewed.
+            instruction-like content, or a tool returned data that looks like injected
+            instructions. Usually benign, but it's how rug pulls, tool poisoning, and
+            agentjacking work, so Toolport flags it (and labels suspicious tool output as
+            data). Dismiss the ones you've reviewed.
           </p>
           <ul className="space-y-1.5 text-xs">
             {events.slice(0, 10).map((e) => {
               const badge = eventBadge(e);
               return (
                 <li key={renderKey(e)} className="flex items-center gap-2">
-                  <span
-                    className={`rounded px-1.5 py-0.5 font-medium ${badge.cls}`}
-                  >
+                  <span className={`rounded px-1.5 py-0.5 font-medium ${badge.cls}`}>
                     {badge.label}
                   </span>
                   <code className="font-mono text-foreground">{e.tool}</code>
@@ -400,9 +396,7 @@ function SavingsBanner({ savings }: { savings: SavingsSummary }) {
       <div className="mt-2 flex flex-wrap items-end gap-x-6 gap-y-1">
         <span className="text-3xl font-semibold tabular-nums text-success">
           ≈ {fmtTokens(savings.tokensSaved)}{" "}
-          <span className="text-base font-normal text-muted-foreground">
-            tokens
-          </span>
+          <span className="text-base font-normal text-muted-foreground">tokens</span>
         </span>
         <span className="text-xl font-semibold tabular-nums text-muted-foreground">
           ≈ {fmtDollars(dollars)}
@@ -440,8 +434,8 @@ function SavingsBanner({ savings }: { savings: SavingsSummary }) {
         </button>
       </div>
       <p className="mt-2.5 text-xs text-muted-foreground">
-        {details.join(" · ")}. Estimated, counted once per tool-list load. Clients
-        with built-in tool search (Claude, VS Code) benefit less.
+        {details.join(" · ")}. Estimated, counted once per tool-list load. Clients with
+        built-in tool search (Claude, VS Code) benefit less.
       </p>
     </div>
   );
@@ -533,9 +527,7 @@ function CallRow({ e }: { e: AuditEntry }) {
           hasDetail ? "cursor-pointer hover:bg-muted/30" : ""
         }`}
         onClick={() => hasDetail && setOpen((o) => !o)}
-        {...(hasDetail
-          ? { role: "button", "aria-expanded": open, tabIndex: 0 }
-          : {})}
+        {...(hasDetail ? { role: "button", "aria-expanded": open, tabIndex: 0 } : {})}
       >
         {hasDetail ? (
           <ChevronRight
@@ -590,18 +582,12 @@ function StatsPanel({ stats }: { stats: AuditStats }) {
     <div className="mb-6 flex flex-col gap-3">
       <div className="grid grid-cols-3 gap-3">
         <div className="rounded-lg border p-3">
-          <div className="text-2xl font-semibold tabular-nums">
-            {stats.total}
-          </div>
+          <div className="text-2xl font-semibold tabular-nums">{stats.total}</div>
           <div className="text-xs text-muted-foreground">calls logged</div>
         </div>
         <div className="rounded-lg border p-3">
-          <div className="text-2xl font-semibold tabular-nums">
-            {stats.errors}
-          </div>
-          <div className="text-xs text-muted-foreground">
-            errors ({errPct}%)
-          </div>
+          <div className="text-2xl font-semibold tabular-nums">{stats.errors}</div>
+          <div className="text-xs text-muted-foreground">errors ({errPct}%)</div>
         </div>
         <div className="rounded-lg border p-3">
           <div className="text-2xl font-semibold tabular-nums">
@@ -754,7 +740,9 @@ function DiscoveryRow({ t }: { t: SearchTrace }) {
                 <span
                   key={n}
                   className={`rounded px-1.5 py-0.5 font-mono text-[11px] ${
-                    n === t.top ? "bg-owned/15 text-owned" : "bg-muted text-muted-foreground"
+                    n === t.top
+                      ? "bg-owned/15 text-owned"
+                      : "bg-muted text-muted-foreground"
                   }`}
                 >
                   {n}
@@ -766,10 +754,14 @@ function DiscoveryRow({ t }: { t: SearchTrace }) {
           )}
           <div className="text-muted-foreground">
             Put{" "}
-            <span className="font-medium text-foreground">≈{fmtTokens(t.returnedTokens)}</span>{" "}
+            <span className="font-medium text-foreground">
+              ≈{fmtTokens(t.returnedTokens)}
+            </span>{" "}
             tokens of tool schemas into context, vs{" "}
-            <span className="font-medium text-foreground">≈{fmtTokens(t.flatTokens)}</span> to load
-            the whole catalog
+            <span className="font-medium text-foreground">
+              ≈{fmtTokens(t.flatTokens)}
+            </span>{" "}
+            to load the whole catalog
             {t.flatTokens > 0 ? <> ({pct}% less this turn).</> : "."}
           </div>
         </div>
@@ -934,9 +926,9 @@ function ToolIdentities({ refreshKey }: { refreshKey: number }) {
         <>
           <p className="mt-2 mb-3 max-w-2xl text-xs text-muted-foreground">
             What each model-visible tool name actually maps to: its source server and
-            profiles, the pinned definition fingerprint drift detection checks against, and
-            when it was first seen or last changed. Prefixing helps the model pick a tool;
-            this helps you verify what crossed the boundary.
+            profiles, the pinned definition fingerprint drift detection checks against,
+            and when it was first seen or last changed. Prefixing helps the model pick a
+            tool; this helps you verify what crossed the boundary.
           </p>
           <div className="flex flex-col gap-1">
             {rows.map((t) => (
@@ -987,10 +979,10 @@ function LiveInspector({ refreshKey }: { refreshKey: number }) {
       {open && (
         <>
           <p className="mt-2 mb-3 max-w-2xl text-xs text-muted-foreground">
-            Ephemeral, local, opt-in. While live inspection is on, Toolport keeps the
-            last 50 tool calls' arguments and results here so you can inspect them.
-            This buffer is separate from the audit log, never leaves your machine, and
-            clears when you turn inspection off or restart the gateway.
+            Ephemeral, local, opt-in. While live inspection is on, Toolport keeps the last
+            50 tool calls' arguments and results here so you can inspect them. This buffer
+            is separate from the audit log, never leaves your machine, and clears when you
+            turn inspection off or restart the gateway.
           </p>
           {entries.length === 0 ? (
             <p className="py-6 text-center text-sm text-muted-foreground">
@@ -1057,7 +1049,9 @@ export function ActivityView({
     };
   }, [refreshKey]);
 
-  const liveSecurity = dedupeSecurity(security).filter((e) => !dismissed.has(securityKey(e)));
+  const liveSecurity = dedupeSecurity(security).filter(
+    (e) => !dismissed.has(securityKey(e)),
+  );
   // Split loud/actionable signal from benign churn so vendor revisions don't bury a real
   // poison or privilege-escalation flag (the failure this whole surface exists to avoid).
   const highSecurity = liveSecurity.filter((e) => eventSeverity(e) === "high");
@@ -1088,9 +1082,7 @@ export function ActivityView({
       <DiscoveryTraces refreshKey={refreshKey} />
       <ToolIdentities refreshKey={refreshKey} />
       {registry?.liveInspect ? <LiveInspector refreshKey={refreshKey} /> : null}
-      {savings && savings.tokensSaved > 0 ? (
-        <SavingsBanner savings={savings} />
-      ) : null}
+      {savings && savings.tokensSaved > 0 ? <SavingsBanner savings={savings} /> : null}
     </>
   );
 
@@ -1100,8 +1092,7 @@ export function ActivityView({
   );
 
   const visible = (entries ?? []).filter(
-    (e) =>
-      (!serverFilter || e.server === serverFilter) && (!errorsOnly || !e.ok),
+    (e) => (!serverFilter || e.server === serverFilter) && (!errorsOnly || !e.ok),
   );
 
   if (entries === null) {
@@ -1124,9 +1115,8 @@ export function ActivityView({
           <div>
             <p className="font-medium">Couldn't load activity</p>
             <p className="max-w-md text-sm text-muted-foreground">
-              Toolport couldn't reach the gateway or read the audit log. This is
-              not an empty log, if the gateway isn't running, start it and
-              refresh.
+              Toolport couldn't reach the gateway or read the audit log. This is not an
+              empty log, if the gateway isn't running, start it and refresh.
             </p>
           </div>
         </div>
@@ -1143,8 +1133,8 @@ export function ActivityView({
           <div>
             <p className="font-medium">No tool calls yet</p>
             <p className="max-w-md text-sm text-muted-foreground">
-              Once a client runs a tool through Toolport, every call is recorded
-              here, with per-server latency and error rates.
+              Once a client runs a tool through Toolport, every call is recorded here,
+              with per-server latency and error rates.
             </p>
           </div>
         </div>

--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -34,17 +34,8 @@ import { gatherDiagnostics, getSavingsSummary, openDataDir } from "@/lib/api";
 import { fmtTokens } from "@/lib/utils";
 import { checkForUpdate, installUpdate } from "@/lib/updater";
 import { Button } from "@/components/ui/button";
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { ProfileBar } from "@/components/ProfileBar";
 import { ShareDialog } from "@/components/ShareDialog";
 
@@ -124,8 +115,7 @@ function VersionFooter({
         description: "You can download it manually from the releases page.",
         action: {
           label: "Open",
-          onClick: () =>
-            openUrl("https://github.com/tsouth89/toolport/releases/latest"),
+          onClick: () => openUrl("https://github.com/tsouth89/toolport/releases/latest"),
         },
       });
     }
@@ -200,9 +190,7 @@ function VersionFooter({
           onClick={async () => {
             try {
               await navigator.clipboard.writeText(await gatherDiagnostics());
-              toast.success(
-                "Diagnostics copied, paste them into your bug report",
-              );
+              toast.success("Diagnostics copied, paste them into your bug report");
             } catch {
               toastError("Could not copy diagnostics");
             }
@@ -277,8 +265,7 @@ function UpdateNotes({
  * bottom. */
 function sortClients(clients: DetectedClient[]): DetectedClient[] {
   const present = (c: DetectedClient) => (c.appPresent ? 1 : 0);
-  const count = (c: DetectedClient) =>
-    c.servers.length + c.pluginServers.length;
+  const count = (c: DetectedClient) => c.servers.length + c.pluginServers.length;
   return [...clients].sort((a, b) => {
     if (present(a) !== present(b)) return present(b) - present(a);
     if (count(a) !== count(b)) return count(b) - count(a);
@@ -350,9 +337,7 @@ function ClientRow({ client, importCount, selected, onSelect }: RowProps) {
           ) : client.usesConnectors ? (
             <Puzzle className="size-3.5 shrink-0 text-info" />
           ) : (
-            <span
-              className={`size-2 shrink-0 rounded-full ${dotClass[status]}`}
-            />
+            <span className={`size-2 shrink-0 rounded-full ${dotClass[status]}`} />
           )}
           <span className="truncate">{client.name}</span>
           <span className="ml-auto flex shrink-0 items-center gap-1.5">
@@ -388,9 +373,7 @@ function ClientRow({ client, importCount, selected, onSelect }: RowProps) {
             Manages servers as account connectors, outside the config file.
           </p>
         )}
-        {client.error && (
-          <p className="mt-1 text-xs text-warning">{client.error}</p>
-        )}
+        {client.error && <p className="mt-1 text-xs text-warning">{client.error}</p>}
       </TooltipContent>
     </Tooltip>
   );
@@ -488,9 +471,7 @@ export function AppSidebar({
         </svg>
         <div className="leading-tight">
           <div className="font-semibold tracking-tight">Toolport</div>
-          <div className="text-xs text-muted-foreground">
-            MCP control center
-          </div>
+          <div className="text-xs text-muted-foreground">MCP control center</div>
         </div>
       </div>
 
@@ -520,9 +501,7 @@ export function AppSidebar({
           {navItem(ScrollText, "Activity", view === "activity", () =>
             onSelectView("activity"),
           )}
-          {navItem(Users, "Teams", view === "teams", () =>
-            onSelectView("teams"),
-          )}
+          {navItem(Users, "Teams", view === "teams", () => onSelectView("teams"))}
           {navItem(Settings, "Settings", view === "settings", () =>
             onSelectView("settings"),
           )}
@@ -536,7 +515,10 @@ export function AppSidebar({
           >
             <Zap className="size-3.5 shrink-0 text-success" />
             <span className="text-muted-foreground">
-              <span className="font-semibold text-foreground">{fmtTokens(savings.tokensSaved)}</span> tokens saved
+              <span className="font-semibold text-foreground">
+                {fmtTokens(savings.tokensSaved)}
+              </span>{" "}
+              tokens saved
             </span>
           </button>
         )}
@@ -548,8 +530,8 @@ export function AppSidebar({
           <nav className="flex flex-col gap-0.5">
             {clients.length === 0 ? (
               <p className="px-2.5 py-1.5 text-xs text-muted-foreground">
-                No MCP clients found. Install Claude Desktop, Cursor, or another
-                supported tool, then refresh.
+                No MCP clients found. Install Claude Desktop, Cursor, or another supported
+                tool, then refresh.
               </p>
             ) : (
               <>
@@ -558,9 +540,7 @@ export function AppSidebar({
                     key={client.id}
                     client={client}
                     importCount={importableServers(client, registry).length}
-                    selected={
-                      view === "servers" && selectedClientId === client.id
-                    }
+                    selected={view === "servers" && selectedClientId === client.id}
                     onSelect={() => onSelectClient(client.id)}
                   />
                 ))}
@@ -581,12 +561,8 @@ export function AppSidebar({
                         <ClientRow
                           key={client.id}
                           client={client}
-                          importCount={
-                            importableServers(client, registry).length
-                          }
-                          selected={
-                            view === "servers" && selectedClientId === client.id
-                          }
+                          importCount={importableServers(client, registry).length}
+                          selected={view === "servers" && selectedClientId === client.id}
                           onSelect={() => onSelectClient(client.id)}
                         />
                       ))}
@@ -598,10 +574,7 @@ export function AppSidebar({
         </div>
       </div>
 
-      <VersionFooter
-        onImport={onRegistryChange}
-        onReplay={onReplayOnboarding}
-      />
+      <VersionFooter onImport={onRegistryChange} onReplay={onReplayOnboarding} />
     </aside>
   );
 }

--- a/src/components/Callout.tsx
+++ b/src/components/Callout.tsx
@@ -20,11 +20,7 @@ interface Props {
 export function Callout({ variant = "info", className, children }: Props) {
   return (
     <div
-      className={cn(
-        "rounded-lg border px-3 py-2 text-sm",
-        VARIANTS[variant],
-        className,
-      )}
+      className={cn("rounded-lg border px-3 py-2 text-sm", VARIANTS[variant], className)}
     >
       {children}
     </div>

--- a/src/components/CatalogView.tsx
+++ b/src/components/CatalogView.tsx
@@ -91,11 +91,7 @@ export function CatalogView({ registry, onAdded }: Props) {
    * user-supplied URL, or args the user should review). False = safe to
    * immediate-add with no configuration. */
   function needsConfig(entry: CatalogEntry): boolean {
-    return (
-      entry.urlHint != null ||
-      entry.envKeys.length > 0 ||
-      entry.args.length > 0
-    );
+    return entry.urlHint != null || entry.envKeys.length > 0 || entry.args.length > 0;
   }
 
   async function add(entry: CatalogEntry) {
@@ -133,9 +129,7 @@ export function CatalogView({ registry, onAdded }: Props) {
    * user at the credential steps for the ones that need them. */
   async function setupStack(stack: Stack) {
     setStackBusy(stack.id);
-    const existing = new Set(
-      (registry?.servers ?? []).map((s) => s.name.toLowerCase()),
-    );
+    const existing = new Set((registry?.servers ?? []).map((s) => s.name.toLowerCase()));
     let added = 0;
     let needCreds = 0;
     try {
@@ -158,12 +152,15 @@ export function CatalogView({ registry, onAdded }: Props) {
       if (added === 0) {
         toast.success(`${stack.name}: every server is already in Toolport`);
       } else {
-        toast.success(`Added ${added} server${added === 1 ? "" : "s"} from ${stack.name}`, {
-          description:
-            needCreds > 0
-              ? `${needCreds} need credentials. Open "Setup steps" for the links.`
-              : "Enable them under Servers.",
-        });
+        toast.success(
+          `Added ${added} server${added === 1 ? "" : "s"} from ${stack.name}`,
+          {
+            description:
+              needCreds > 0
+                ? `${needCreds} need credentials. Open "Setup steps" for the links.`
+                : "Enable them under Servers.",
+          },
+        );
       }
     } catch (e) {
       toastError(`Couldn't finish setting up ${stack.name}: ${e}`);
@@ -235,17 +232,12 @@ export function CatalogView({ registry, onAdded }: Props) {
         browsing && popularLoading ? (
           <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
             {Array.from({ length: 6 }).map((_, i) => (
-              <div
-                key={i}
-                className="h-28 animate-pulse rounded-lg border bg-muted/30"
-              />
+              <div key={i} className="h-28 animate-pulse rounded-lg border bg-muted/30" />
             ))}
           </div>
         ) : browsing && popularError ? (
           <div className="flex flex-col items-center gap-3 py-20 text-center">
-            <p className="text-sm text-muted-foreground">
-              Couldn't load the catalog.
-            </p>
+            <p className="text-sm text-muted-foreground">Couldn't load the catalog.</p>
             <Button variant="outline" size="sm" onClick={reloadPopular}>
               Try again
             </Button>
@@ -282,9 +274,7 @@ export function CatalogView({ registry, onAdded }: Props) {
           ))}
         </div>
       ) : (
-        <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
-          {shown.map(card)}
-        </div>
+        <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">{shown.map(card)}</div>
       )}
       {configEntry && (
         <ServerDialog
@@ -424,7 +414,9 @@ function StackCard({
           {stack.servers.map((e) => (
             <div key={e.name} className="text-[11px] leading-snug">
               <span className="font-medium text-foreground">{e.name}</span>
-              {e.setupHint && <span className="text-muted-foreground">: {e.setupHint}</span>}
+              {e.setupHint && (
+                <span className="text-muted-foreground">: {e.setupHint}</span>
+              )}
               {e.credentialsUrl && (
                 <button
                   onClick={() => openUrl(e.credentialsUrl!)}
@@ -456,9 +448,7 @@ function Provenance({ entry }: { entry: CatalogEntry }) {
       <ShieldCheck className={`size-3 shrink-0 ${tier.cls}`} />
       <span className={tier.cls}>{tier.label}</span>
       {entry.publisher && (
-        <span className="truncate text-muted-foreground/70">
-          · {entry.publisher}
-        </span>
+        <span className="truncate text-muted-foreground/70">· {entry.publisher}</span>
       )}
     </div>
   );
@@ -494,14 +484,16 @@ function CatalogCard({
           )}
         </div>
         <div className="flex shrink-0 items-center gap-1">
-
           <TransportPill transport={entry.transport} />
         </div>
       </div>
       <p className="line-clamp-2 min-h-8 text-xs text-muted-foreground">
         {entry.description}
       </p>
-      <code title={target} className="truncate font-mono text-[11px] text-muted-foreground/70">
+      <code
+        title={target}
+        className="truncate font-mono text-[11px] text-muted-foreground/70"
+      >
         {target}
       </code>
       <Provenance entry={entry} />

--- a/src/components/ClientDetail.tsx
+++ b/src/components/ClientDetail.tsx
@@ -1,5 +1,15 @@
 import { useEffect, useState } from "react";
-import { ArrowRight, Check, Download, Link2, Plug, PlugZap, Puzzle, Shuffle, TriangleAlert } from "lucide-react";
+import {
+  ArrowRight,
+  Check,
+  Download,
+  Link2,
+  Plug,
+  PlugZap,
+  Puzzle,
+  Shuffle,
+  TriangleAlert,
+} from "lucide-react";
 import { toast } from "sonner";
 import { toastError } from "@/lib/toast";
 import { addServer, installGateway, migrateClient, uninstallGateway } from "@/lib/api";
@@ -36,12 +46,7 @@ interface Props {
   onRegistryChange: (registry: Registry) => void;
 }
 
-export function ClientDetail({
-  client,
-  registry,
-  onChanged,
-  onRegistryChange,
-}: Props) {
+export function ClientDetail({ client, registry, onChanged, onRegistryChange }: Props) {
   const [busy, setBusy] = useState(false);
   // "" = expose all enabled servers (follow active profile); else scope to one.
   const [profile, setProfile] = useState("");
@@ -90,9 +95,7 @@ export function ClientDetail({
   }
   // Servers configured directly in the client (not the gateway) that migrate
   // would move into Toolport and strip from the client's config.
-  const movable = client.servers.filter(
-    (s) => s.name.toLowerCase() !== "conduit",
-  );
+  const movable = client.servers.filter((s) => s.name.toLowerCase() !== "conduit");
 
   async function migrate() {
     setBusy(true);
@@ -240,14 +243,17 @@ export function ClientDetail({
           )}
           {!present && !installed && (
             <p className="mt-1 text-xs text-warning">
-              {client.name} doesn't appear to be installed here. Install it first,
-              then connect.
+              {client.name} doesn't appear to be installed here. Install it first, then
+              connect.
             </p>
           )}
         </div>
         <div className="flex shrink-0 items-center gap-2">
           {profiles.length > 1 && (
-            <Select value={profile || "__all__"} onValueChange={(v) => setProfile(v === "__all__" ? "" : v)}>
+            <Select
+              value={profile || "__all__"}
+              onValueChange={(v) => setProfile(v === "__all__" ? "" : v)}
+            >
               <SelectTrigger size="sm" className="w-52">
                 <SelectValue />
               </SelectTrigger>
@@ -296,8 +302,8 @@ export function ClientDetail({
       </div>
 
       <p className="text-sm text-muted-foreground">
-        Connect points {client.name} at Toolport so it uses your managed servers.
-        Import copies this client's own servers into Toolport so it can manage them.
+        Connect points {client.name} at Toolport so it uses your managed servers. Import
+        copies this client's own servers into Toolport so it can manage them.
       </p>
 
       {client.usesConnectors && (
@@ -308,9 +314,9 @@ export function ClientDetail({
               <p className="font-medium">{client.name} manages servers as connectors</p>
               <p className="mt-1 text-muted-foreground">
                 Those live in {client.name}'s Customize → Connectors and sync to your
-                account, outside the local config files Toolport reads. Connecting Toolport
-                adds a local gateway entry so your Toolport-managed servers appear in{" "}
-                {client.name} too.
+                account, outside the local config files Toolport reads. Connecting
+                Toolport adds a local gateway entry so your Toolport-managed servers
+                appear in {client.name} too.
               </p>
             </div>
           </CardContent>
@@ -351,29 +357,29 @@ export function ClientDetail({
           </div>
         </div>
         <p className="mb-1 text-xs text-muted-foreground">
-          The servers {client.name} already has, from its config and any plugins
-          (tagged below).
+          The servers {client.name} already has, from its config and any plugins (tagged
+          below).
         </p>
         <ul className="mb-3 space-y-0.5 text-xs text-muted-foreground">
           <li>
-            <span className="font-medium text-foreground">Import</span> copies a
-            server into Toolport; {client.name} keeps its own copy.
+            <span className="font-medium text-foreground">Import</span> copies a server
+            into Toolport; {client.name} keeps its own copy.
           </li>
           <li>
-            <span className="font-medium text-foreground">Move config in</span>{" "}
-            copies it, then removes it from {client.name}'s config so the gateway is
-            the only source (plugin servers stay, only {client.name} can remove
-            those). This is the cutover that actually saves context.
+            <span className="font-medium text-foreground">Move config in</span> copies it,
+            then removes it from {client.name}'s config so the gateway is the only source
+            (plugin servers stay, only {client.name} can remove those). This is the
+            cutover that actually saves context.
           </li>
         </ul>
         {installed && toImport.length > 0 && movable.length > 0 && (
           <p className="mb-3 -mt-1 inline-flex items-start gap-1.5 rounded-md bg-warning/10 px-2 py-1 text-xs text-warning">
             <TriangleAlert className="mt-0.5 size-3.5 shrink-0" />
             <span>
-              {client.name} is already connected to Toolport. Import on its own
-              leaves a copy here too, so these tools load twice, once directly and
-              once through the gateway. Use <span className="font-medium">Move
-              config in</span> to avoid that.
+              {client.name} is already connected to Toolport. Import on its own leaves a
+              copy here too, so these tools load twice, once directly and once through the
+              gateway. Use <span className="font-medium">Move config in</span> to avoid
+              that.
             </span>
           </p>
         )}
@@ -422,13 +428,16 @@ export function ClientDetail({
                 {movable.length} server{movable.length === 1 ? "" : "s"}
               </span>{" "}
               from {client.name} into Toolport, then rewrites {client.name}'s config so it
-              uses <span className="font-medium text-foreground">only the Toolport gateway</span>.
-              The original config is backed up first.
+              uses{" "}
+              <span className="font-medium text-foreground">
+                only the Toolport gateway
+              </span>
+              . The original config is backed up first.
             </p>
             <p className="rounded-md bg-warning/10 p-2 text-xs text-warning">
-              Secret values (API keys, tokens) aren't carried over, they stay only
-              in the backed-up config. After migrating, re-enter them under each
-              server's secrets so the gateway can connect.
+              Secret values (API keys, tokens) aren't carried over, they stay only in the
+              backed-up config. After migrating, re-enter them under each server's secrets
+              so the gateway can connect.
             </p>
             <div className="rounded-md bg-muted/40 p-2 font-mono text-xs text-muted-foreground">
               {movable.map((s) => s.name).join(", ")}
@@ -436,15 +445,16 @@ export function ClientDetail({
             {client.pluginServers.length > 0 && (
               <p className="text-xs text-muted-foreground">
                 Note: {client.pluginServers.length} server
-                {client.pluginServers.length === 1 ? "" : "s"} managed by{" "}
-                {client.name}'s plugins or extensions can't be moved, only{" "}
-                {client.name} controls those. They stay where they are (you can
-                still import a copy above).
+                {client.pluginServers.length === 1 ? "" : "s"} managed by {client.name}'s
+                plugins or extensions can't be moved, only {client.name} controls those.
+                They stay where they are (you can still import a copy above).
               </p>
             )}
             {profiles.length > 1 && (
               <div className="flex items-center justify-between gap-2">
-                <span className="text-xs text-muted-foreground">Scope this client to</span>
+                <span className="text-xs text-muted-foreground">
+                  Scope this client to
+                </span>
                 <Select
                   value={profile || "__all__"}
                   onValueChange={(v) => setProfile(v === "__all__" ? "" : v)}
@@ -465,7 +475,11 @@ export function ClientDetail({
             )}
           </div>
           <DialogFooter>
-            <Button variant="outline" onClick={() => setMigrateOpen(false)} disabled={busy}>
+            <Button
+              variant="outline"
+              onClick={() => setMigrateOpen(false)}
+              disabled={busy}
+            >
               Cancel
             </Button>
             <Button onClick={migrate} disabled={busy}>
@@ -493,10 +507,7 @@ function ServerMiniCard({
   onImport: () => void;
 }) {
   return (
-    <Card
-      aria-disabled={imported}
-      className={`gap-0 ${imported ? "opacity-70" : ""}`}
-    >
+    <Card aria-disabled={imported} className={`gap-0 ${imported ? "opacity-70" : ""}`}>
       <CardContent className="flex flex-col gap-2 p-3">
         <div className="flex items-center justify-between gap-2">
           <div className="flex min-w-0 items-center gap-1.5">

--- a/src/components/ConfirmDialog.tsx
+++ b/src/components/ConfirmDialog.tsx
@@ -54,20 +54,13 @@ export function ConfirmDialog({
   return (
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger asChild>{trigger}</DialogTrigger>
-      <DialogContent
-        className="sm:max-w-sm"
-        onClick={(e) => e.stopPropagation()}
-      >
+      <DialogContent className="sm:max-w-sm" onClick={(e) => e.stopPropagation()}>
         <DialogHeader>
           <DialogTitle>{title}</DialogTitle>
           {description && <DialogDescription>{description}</DialogDescription>}
         </DialogHeader>
         <DialogFooter>
-          <Button
-            variant="ghost"
-            onClick={() => setOpen(false)}
-            disabled={busy}
-          >
+          <Button variant="ghost" onClick={() => setOpen(false)} disabled={busy}>
             {cancelLabel}
           </Button>
           <Button

--- a/src/components/Onboarding.tsx
+++ b/src/components/Onboarding.tsx
@@ -11,12 +11,7 @@ import {
 } from "lucide-react";
 import { toast } from "sonner";
 import { toastError } from "@/lib/toast";
-import {
-  addCatalogServer,
-  importServers,
-  installGateway,
-  listStacks,
-} from "@/lib/api";
+import { addCatalogServer, importServers, installGateway, listStacks } from "@/lib/api";
 import {
   importableServers,
   isGatewayServer,
@@ -149,13 +144,7 @@ function StepHeader({
   );
 }
 
-function Welcome({
-  present,
-  onNext,
-}: {
-  present: DetectedClient[];
-  onNext: () => void;
-}) {
+function Welcome({ present, onNext }: { present: DetectedClient[]; onNext: () => void }) {
   const names = present.map((c) => c.name);
   const found =
     names.length === 0
@@ -164,11 +153,9 @@ function Welcome({
   return (
     <>
       <StepHeader icon={<Waypoints className="size-5" />} title="Welcome to Toolport">
-        One local gateway for all your MCP servers, shared by every AI tool, so your
-        agent loads 3 tools instead of hundreds (up to 91% fewer tokens) and every
-        server is watched for tampering and prompt injection.
-        {" "}
-        {found}
+        One local gateway for all your MCP servers, shared by every AI tool, so your agent
+        loads 3 tools instead of hundreds (up to 91% fewer tokens) and every server is
+        watched for tampering and prompt injection. {found}
       </StepHeader>
       <Button onClick={onNext} className="self-start">
         Get started
@@ -260,8 +247,8 @@ function AddServers({
   return (
     <>
       <StepHeader icon={<Download className="size-5" />} title="Add your first servers">
-        Pick what you work on and Toolport sets up a matching stack. You can also
-        import from your other tools or browse the full catalog.
+        Pick what you work on and Toolport sets up a matching stack. You can also import
+        from your other tools or browse the full catalog.
       </StepHeader>
 
       <div className="flex flex-col gap-3">
@@ -388,14 +375,14 @@ function ConnectClients({
   return (
     <>
       <StepHeader icon={<Link2 className="size-5" />} title="Connect a client">
-        Point a tool at Toolport. It connects once, then sees every server you
-        enable here, no per-tool setup.
+        Point a tool at Toolport. It connects once, then sees every server you enable
+        here, no per-tool setup.
       </StepHeader>
 
       {present.length === 0 ? (
         <p className="rounded-md bg-muted/50 px-3 py-2 text-sm text-muted-foreground">
-          No clients detected yet. Install Claude Desktop, Cursor, VS Code, or
-          another supported tool, then connect it from the sidebar.
+          No clients detected yet. Install Claude Desktop, Cursor, VS Code, or another
+          supported tool, then connect it from the sidebar.
         </p>
       ) : (
         <div className="flex flex-col gap-2">
@@ -474,8 +461,7 @@ function Done({
     };
   }, [serverCount, onProbe]);
 
-  const nameFor = (id: string) =>
-    registry.servers.find((s) => s.id === id)?.name ?? id;
+  const nameFor = (id: string) => registry.servers.find((s) => s.id === id)?.name ?? id;
   const broken = (health ?? []).filter((r) => !r.ok && !r.authRequired);
 
   const ready = serverCount > 0 && connectedCount > 0;
@@ -496,15 +482,14 @@ function Done({
             Toolport now manages {serverCount} server
             {serverCount === 1 ? "" : "s"} across {connectedCount} connected tool
             {connectedCount === 1 ? "" : "s"}. Toggle one on or off and your clients
-            update live, no restart. Each client loads 3 search tools instead of
-            every tool, up to 91% fewer tokens at the same task success. And Toolport watches
+            update live, no restart. Each client loads 3 search tools instead of every
+            tool, up to 91% fewer tokens at the same task success. And Toolport watches
             every server for tampering and prompt injection, see Activity.
           </>
         ) : (
           <>
-            You haven't {missing} yet. You can do both any time from the main
-            screen: add or import servers, then connect a client so your tools share
-            them.
+            You haven't {missing} yet. You can do both any time from the main screen: add
+            or import servers, then connect a client so your tools share them.
           </>
         )}
       </StepHeader>
@@ -516,8 +501,8 @@ function Done({
             {broken.map((r) => nameFor(r.serverId)).join(", ")}
           </span>
           <span className="text-xs text-muted-foreground">
-            They likely need a runtime that isn't installed (Node/npx or Python/uvx),
-            or the command needs a fix. Retry from each server's card once it's sorted.
+            They likely need a runtime that isn't installed (Node/npx or Python/uvx), or
+            the command needs a fix. Retry from each server's card once it's sorted.
           </span>
         </div>
       )}

--- a/src/components/PendingApprovals.tsx
+++ b/src/components/PendingApprovals.tsx
@@ -14,23 +14,24 @@ const TIMEOUT_MS = 120_000;
 type Reason = PendingApproval["reason"];
 
 /** How each gate reason presents: label, badge tone, and an icon. */
-const REASON: Record<Reason, { label: string; className: string; Icon: typeof Trash2 }> = {
-  destructive: {
-    label: "Destructive",
-    className: "bg-destructive/10 text-destructive",
-    Icon: Trash2,
-  },
-  untrusted_source: {
-    label: "Untrusted source",
-    className: "bg-warning/15 text-warning",
-    Icon: Globe,
-  },
-  destructive_and_untrusted: {
-    label: "Destructive · untrusted",
-    className: "bg-destructive/10 text-destructive",
-    Icon: Trash2,
-  },
-};
+const REASON: Record<Reason, { label: string; className: string; Icon: typeof Trash2 }> =
+  {
+    destructive: {
+      label: "Destructive",
+      className: "bg-destructive/10 text-destructive",
+      Icon: Trash2,
+    },
+    untrusted_source: {
+      label: "Untrusted source",
+      className: "bg-warning/15 text-warning",
+      Icon: Globe,
+    },
+    destructive_and_untrusted: {
+      label: "Destructive · untrusted",
+      className: "bg-destructive/10 text-destructive",
+      Icon: Trash2,
+    },
+  };
 
 /**
  * The human-in-the-loop approval queue: tool calls the gateway is holding until you
@@ -145,8 +146,8 @@ export function PendingApprovals() {
         {/* Announce count changes to screen readers without re-announcing on every countdown
          * tick (the visible timer lives elsewhere; this text only changes when the count does). */}
         <div aria-live="assertive" className="sr-only">
-          {pending.length} tool call{pending.length > 1 ? "s" : ""} awaiting your approval. Press
-          Escape to deny.
+          {pending.length} tool call{pending.length > 1 ? "s" : ""} awaiting your
+          approval. Press Escape to deny.
         </div>
         <header className="flex items-center gap-3 border-b border-border/60 px-4 py-3">
           <span className="flex size-8 shrink-0 items-center justify-center rounded-full bg-warning/15 text-warning">
@@ -155,7 +156,8 @@ export function PendingApprovals() {
           <div className="min-w-0">
             <div className="text-sm font-semibold leading-tight">Approval required</div>
             <div className="text-xs text-muted-foreground">
-              {pending.length} tool call{pending.length > 1 ? "s" : ""} held — no decision auto-denies
+              {pending.length} tool call{pending.length > 1 ? "s" : ""} held — no decision
+              auto-denies
             </div>
           </div>
         </header>
@@ -166,9 +168,13 @@ export function PendingApprovals() {
             // Count down to the broker's authoritative deadline; fall back to
             // first-sighting + timeout only if deadlineMs is somehow absent, so the
             // timer is never blank.
-            const deadline = a.deadlineMs || (seenAt.current.get(a.id) ?? now) + TIMEOUT_MS;
+            const deadline =
+              a.deadlineMs || (seenAt.current.get(a.id) ?? now) + TIMEOUT_MS;
             const remaining = Math.max(0, Math.ceil((deadline - now) / 1000));
-            const pct = Math.max(0, Math.min(100, (remaining / (TIMEOUT_MS / 1000)) * 100));
+            const pct = Math.max(
+              0,
+              Math.min(100, (remaining / (TIMEOUT_MS / 1000)) * 100),
+            );
             const urgent = remaining <= 20;
             const isBusy = resolving.has(a.id);
             return (
@@ -178,7 +184,9 @@ export function PendingApprovals() {
                     <div className="flex items-center gap-1.5 font-mono text-sm">
                       <span className="truncate text-muted-foreground">{a.server}</span>
                       <span className="text-muted-foreground/50">/</span>
-                      <span className="truncate font-medium text-foreground">{a.tool}</span>
+                      <span className="truncate font-medium text-foreground">
+                        {a.tool}
+                      </span>
                     </div>
                     {a.client && (
                       <div className="mt-1 flex items-center gap-1.5 text-xs text-muted-foreground">

--- a/src/components/PlaygroundView.tsx
+++ b/src/components/PlaygroundView.tsx
@@ -118,7 +118,9 @@ function ToolOverrideEditor({
         className="flex w-full items-center gap-2 px-3 py-2 text-xs text-muted-foreground"
       >
         <Pencil className="size-3.5 shrink-0" />
-        <span className="font-medium text-foreground/80">Override how clients see this tool</span>
+        <span className="font-medium text-foreground/80">
+          Override how clients see this tool
+        </span>
         {hasOverride && (
           <span className="rounded-full bg-info/15 px-1.5 py-0.5 text-[10px] font-medium text-info">
             active
@@ -132,8 +134,8 @@ function ToolOverrideEditor({
         <div className="flex flex-col gap-2.5 border-t border-border/60 px-3 py-3">
           <p className="text-xs text-muted-foreground">
             Rename the tool or replace its description as every client sees it, e.g. to
-            neutralize a misleading or injection-laden description. The call still runs the
-            original server tool.
+            neutralize a misleading or injection-laden description. The call still runs
+            the original server tool.
           </p>
           <label className="flex flex-col gap-1 text-xs">
             <span className="text-muted-foreground">
@@ -150,7 +152,9 @@ function ToolOverrideEditor({
             />
           </label>
           <label className="flex flex-col gap-1 text-xs">
-            <span className="text-muted-foreground">Description (blank keeps the server's)</span>
+            <span className="text-muted-foreground">
+              Description (blank keeps the server's)
+            </span>
             <textarea
               value={description}
               onChange={(e) => setDescription(e.target.value)}
@@ -164,7 +168,12 @@ function ToolOverrideEditor({
               Save override
             </Button>
             {hasOverride && (
-              <Button size="sm" variant="outline" onClick={() => void reset()} disabled={busy}>
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={() => void reset()}
+                disabled={busy}
+              >
                 Reset to original
               </Button>
             )}
@@ -177,7 +186,9 @@ function ToolOverrideEditor({
 
 /** First declared type of a JSON-schema property (schemas may list several). */
 function primaryType(schema: JsonSchemaProp): string {
-  return Array.isArray(schema.type) ? schema.type[0] ?? "string" : schema.type ?? "string";
+  return Array.isArray(schema.type)
+    ? (schema.type[0] ?? "string")
+    : (schema.type ?? "string");
 }
 
 /** Turn a form field's raw value into the JSON type the schema expects. */
@@ -204,7 +215,9 @@ function renderResult(result: ToolCallResult): string {
   const blocks = result.content ?? [];
   if (blocks.length === 0) return JSON.stringify(result, null, 2);
   return blocks
-    .map((b) => (b.type === "text" && b.text != null ? b.text : JSON.stringify(b, null, 2)))
+    .map((b) =>
+      b.type === "text" && b.text != null ? b.text : JSON.stringify(b, null, 2),
+    )
     .join("\n");
 }
 
@@ -465,9 +478,7 @@ function PromptsPanel({ serverId }: { serverId: string }) {
   if (error) return <Callout variant="danger">{error}</Callout>;
   if (!prompts || prompts.length === 0) {
     return (
-      <p className="text-sm text-muted-foreground">
-        This server advertises no prompts.
-      </p>
+      <p className="text-sm text-muted-foreground">This server advertises no prompts.</p>
     );
   }
 
@@ -487,9 +498,7 @@ function PromptsPanel({ serverId }: { serverId: string }) {
                 p.name === selected ? "bg-accent" : "hover:bg-muted/40"
               }`}
             >
-              <span className="truncate font-mono text-sm">
-                {p.title ?? p.name}
-              </span>
+              <span className="truncate font-mono text-sm">{p.title ?? p.name}</span>
               {p.description && (
                 <span className="line-clamp-1 text-xs text-muted-foreground">
                   {p.description}
@@ -513,7 +522,10 @@ function PromptsPanel({ serverId }: { serverId: string }) {
             <div className="flex flex-col gap-4">
               {(prompt.arguments ?? []).map((a) => (
                 <div key={a.name} className="flex flex-col gap-1.5">
-                  <Label htmlFor={`prompt-arg-${a.name}`} className="flex items-center gap-1.5">
+                  <Label
+                    htmlFor={`prompt-arg-${a.name}`}
+                    className="flex items-center gap-1.5"
+                  >
                     <span className="font-mono text-xs">{a.name}</span>
                     {a.required && <span className="text-destructive">*</span>}
                   </Label>
@@ -603,10 +615,7 @@ export function PlaygroundView({ registry, onRegistryChange }: PlaygroundProps) 
     [tools, selectedTool],
   );
   const props = tool?.inputSchema?.properties ?? {};
-  const required = useMemo(
-    () => new Set(tool?.inputSchema?.required ?? []),
-    [tool],
-  );
+  const required = useMemo(() => new Set(tool?.inputSchema?.required ?? []), [tool]);
 
   const serverEntry = useMemo(
     () => servers.find((s) => s.id === serverId) ?? null,
@@ -683,7 +692,9 @@ export function PlaygroundView({ registry, onRegistryChange }: PlaygroundProps) 
     }
     const missing = [...required].filter((k) => !(k in out));
     if (missing.length > 0) {
-      return { error: `Fill in required field${missing.length === 1 ? "" : "s"}: ${missing.join(", ")}` };
+      return {
+        error: `Fill in required field${missing.length === 1 ? "" : "s"}: ${missing.join(", ")}`,
+      };
     }
     return out;
   }
@@ -716,8 +727,8 @@ export function PlaygroundView({ registry, onRegistryChange }: PlaygroundProps) 
         <div>
           <p className="font-medium">No servers to test</p>
           <p className="max-w-md text-sm text-muted-foreground">
-            Add a server to Toolport, then come back here to invoke its tools and
-            see the raw results, without wiring up a client first.
+            Add a server to Toolport, then come back here to invoke its tools and see the
+            raw results, without wiring up a client first.
           </p>
         </div>
       </div>
@@ -777,184 +788,184 @@ export function PlaygroundView({ registry, onRegistryChange }: PlaygroundProps) 
       {tab === "tools" && (
         <>
           {loadingTools && (
-        <div className="flex items-center gap-2 text-sm text-muted-foreground">
-          <Loader2 className="size-4 animate-spin" /> Connecting to server…
-        </div>
-      )}
-
-      {toolsError && <Callout variant="danger">{toolsError}</Callout>}
-
-      {/* Tool list: click to test, switch to enable/disable per client */}
-      {tools && tools.length > 0 && (
-        <div className="flex flex-col gap-1.5">
-          <Label className="text-xs text-muted-foreground">
-            Tools ({tools.length})
-          </Label>
-          <div className="flex flex-col divide-y rounded-lg border">
-            {tools.map((t) => {
-              const destructive = isDestructive(t);
-              const exposed = isExposed(t);
-              const selected = t.name === selectedTool;
-              const perToolOff = disabledSet.has(t.name);
-              const pinned = pinnedSet.has(t.name);
-              return (
-                <div
-                  key={t.name}
-                  className={`flex items-center gap-3 px-3 py-2 ${selected ? "bg-accent" : ""}`}
-                >
-                  <button
-                    onClick={() => setSelectedTool(t.name)}
-                    aria-pressed={selected}
-                    className="flex min-w-0 flex-1 flex-col items-start gap-0.5 text-left"
-                  >
-                    <span className="flex min-w-0 items-center gap-2">
-                      <span className="truncate font-mono text-sm">{t.name}</span>
-                      {destructive && (
-                        <Badge
-                          variant="outline"
-                          className="border-warning/40 text-warning"
-                        >
-                          destructive
-                        </Badge>
-                      )}
-                      {!exposed && (
-                        <span className="text-xs text-muted-foreground">hidden</span>
-                      )}
-                    </span>
-                    {t.description && (
-                      <span className="line-clamp-1 text-xs text-muted-foreground">
-                        {t.description}
-                      </span>
-                    )}
-                  </button>
-                  <button
-                    onClick={() => togglePin(t.name, !pinned)}
-                    disabled={policyBusy}
-                    title={
-                      pinned
-                        ? "Pinned: always surfaced in lazy-discovery search"
-                        : "Pin as a prerequisite (always surfaced in search)"
-                    }
-                    aria-label={pinned ? `Unpin ${t.name}` : `Pin ${t.name}`}
-                    aria-pressed={pinned}
-                    className="shrink-0 rounded p-1 hover:bg-muted disabled:opacity-50"
-                  >
-                    <Pin
-                      className={`size-4 ${
-                        pinned ? "fill-current text-owned" : "text-muted-foreground"
-                      }`}
-                    />
-                  </button>
-                  <Switch
-                    checked={!perToolOff}
-                    onCheckedChange={(on) => toggleTool(t.name, on)}
-                    disabled={policyBusy}
-                    aria-label={`Enable ${t.name}`}
-                  />
-                </div>
-              );
-            })}
-          </div>
-          {denyDestructive && (
-            <p className="text-xs text-muted-foreground">
-              Destructive tools are hidden from clients by the global switch even
-              when individually enabled.
-            </p>
-          )}
-        </div>
-      )}
-
-      {/* Argument form for the selected tool */}
-      {tool && (
-        <div className="flex flex-col gap-4 rounded-lg border bg-card p-4">
-          {tool.description && (
-            <p className="text-sm text-muted-foreground">{tool.description}</p>
-          )}
-          {!isExposed(tool) && (
-            <p className="flex items-center gap-1.5 text-xs text-warning">
-              <ShieldAlert className="size-3.5" />
-              Hidden from clients by policy. You can still test it here.
-            </p>
-          )}
-
-          {serverId && (
-            <ToolOverrideEditor
-              serverId={serverId}
-              tool={tool}
-              registry={registry}
-              onRegistryChange={onRegistryChange}
-            />
-          )}
-
-          <div className="flex items-center justify-between">
-            <span className="text-xs font-medium tracking-wide text-muted-foreground uppercase">
-              Arguments
-            </span>
-            <label className="flex items-center gap-2 text-xs text-muted-foreground">
-              Raw JSON
-              <Switch checked={rawMode} onCheckedChange={setRawMode} />
-            </label>
-          </div>
-
-          {rawMode ? (
-            <textarea
-              value={rawJson}
-              onChange={(e) => setRawJson(e.target.value)}
-              rows={6}
-              spellCheck={false}
-              className="w-full rounded-md border border-input bg-transparent px-3 py-2 font-mono text-xs shadow-sm focus-visible:ring-1 focus-visible:ring-ring focus-visible:outline-none"
-            />
-          ) : Object.keys(props).length === 0 ? (
-            <p className="text-sm text-muted-foreground">
-              This tool takes no arguments.
-            </p>
-          ) : (
-            <div className="flex flex-col gap-4">
-              {Object.entries(props).map(([name, schema]) => (
-                <ArgField
-                  key={name}
-                  name={name}
-                  schema={schema as JsonSchemaProp}
-                  required={required.has(name)}
-                  value={args[name]}
-                  onChange={(v) => setArgs((a) => ({ ...a, [name]: v }))}
-                />
-              ))}
+            <div className="flex items-center gap-2 text-sm text-muted-foreground">
+              <Loader2 className="size-4 animate-spin" /> Connecting to server…
             </div>
           )}
 
-          <div>
-            <Button onClick={run} disabled={calling} size="sm">
-              {calling ? (
-                <Loader2 className="size-4 animate-spin" />
-              ) : (
-                <Play className="size-4" />
+          {toolsError && <Callout variant="danger">{toolsError}</Callout>}
+
+          {/* Tool list: click to test, switch to enable/disable per client */}
+          {tools && tools.length > 0 && (
+            <div className="flex flex-col gap-1.5">
+              <Label className="text-xs text-muted-foreground">
+                Tools ({tools.length})
+              </Label>
+              <div className="flex flex-col divide-y rounded-lg border">
+                {tools.map((t) => {
+                  const destructive = isDestructive(t);
+                  const exposed = isExposed(t);
+                  const selected = t.name === selectedTool;
+                  const perToolOff = disabledSet.has(t.name);
+                  const pinned = pinnedSet.has(t.name);
+                  return (
+                    <div
+                      key={t.name}
+                      className={`flex items-center gap-3 px-3 py-2 ${selected ? "bg-accent" : ""}`}
+                    >
+                      <button
+                        onClick={() => setSelectedTool(t.name)}
+                        aria-pressed={selected}
+                        className="flex min-w-0 flex-1 flex-col items-start gap-0.5 text-left"
+                      >
+                        <span className="flex min-w-0 items-center gap-2">
+                          <span className="truncate font-mono text-sm">{t.name}</span>
+                          {destructive && (
+                            <Badge
+                              variant="outline"
+                              className="border-warning/40 text-warning"
+                            >
+                              destructive
+                            </Badge>
+                          )}
+                          {!exposed && (
+                            <span className="text-xs text-muted-foreground">hidden</span>
+                          )}
+                        </span>
+                        {t.description && (
+                          <span className="line-clamp-1 text-xs text-muted-foreground">
+                            {t.description}
+                          </span>
+                        )}
+                      </button>
+                      <button
+                        onClick={() => togglePin(t.name, !pinned)}
+                        disabled={policyBusy}
+                        title={
+                          pinned
+                            ? "Pinned: always surfaced in lazy-discovery search"
+                            : "Pin as a prerequisite (always surfaced in search)"
+                        }
+                        aria-label={pinned ? `Unpin ${t.name}` : `Pin ${t.name}`}
+                        aria-pressed={pinned}
+                        className="shrink-0 rounded p-1 hover:bg-muted disabled:opacity-50"
+                      >
+                        <Pin
+                          className={`size-4 ${
+                            pinned ? "fill-current text-owned" : "text-muted-foreground"
+                          }`}
+                        />
+                      </button>
+                      <Switch
+                        checked={!perToolOff}
+                        onCheckedChange={(on) => toggleTool(t.name, on)}
+                        disabled={policyBusy}
+                        aria-label={`Enable ${t.name}`}
+                      />
+                    </div>
+                  );
+                })}
+              </div>
+              {denyDestructive && (
+                <p className="text-xs text-muted-foreground">
+                  Destructive tools are hidden from clients by the global switch even when
+                  individually enabled.
+                </p>
               )}
-              {calling ? "Calling…" : "Call tool"}
-            </Button>
-          </div>
-        </div>
-      )}
+            </div>
+          )}
 
-      {/* Call error (transport / connection failure) */}
-      {callError && <Callout variant="danger">{callError}</Callout>}
+          {/* Argument form for the selected tool */}
+          {tool && (
+            <div className="flex flex-col gap-4 rounded-lg border bg-card p-4">
+              {tool.description && (
+                <p className="text-sm text-muted-foreground">{tool.description}</p>
+              )}
+              {!isExposed(tool) && (
+                <p className="flex items-center gap-1.5 text-xs text-warning">
+                  <ShieldAlert className="size-3.5" />
+                  Hidden from clients by policy. You can still test it here.
+                </p>
+              )}
 
-      {/* Result */}
-      {result && (
-        <div className="flex flex-col gap-2">
-          <div className="flex items-center gap-2 text-sm font-medium">
-            {result.isError ? (
-              <XCircle className="size-4 text-destructive" />
-            ) : (
-              <CheckCircle2 className="size-4 text-success" />
-            )}
-            {result.isError ? "Tool returned an error" : "Result"}
-          </div>
-          <pre className="max-h-96 overflow-auto rounded-lg border bg-muted/40 p-3 font-mono text-xs whitespace-pre-wrap">
-            {renderResult(result)}
-          </pre>
-        </div>
-      )}
+              {serverId && (
+                <ToolOverrideEditor
+                  serverId={serverId}
+                  tool={tool}
+                  registry={registry}
+                  onRegistryChange={onRegistryChange}
+                />
+              )}
+
+              <div className="flex items-center justify-between">
+                <span className="text-xs font-medium tracking-wide text-muted-foreground uppercase">
+                  Arguments
+                </span>
+                <label className="flex items-center gap-2 text-xs text-muted-foreground">
+                  Raw JSON
+                  <Switch checked={rawMode} onCheckedChange={setRawMode} />
+                </label>
+              </div>
+
+              {rawMode ? (
+                <textarea
+                  value={rawJson}
+                  onChange={(e) => setRawJson(e.target.value)}
+                  rows={6}
+                  spellCheck={false}
+                  className="w-full rounded-md border border-input bg-transparent px-3 py-2 font-mono text-xs shadow-sm focus-visible:ring-1 focus-visible:ring-ring focus-visible:outline-none"
+                />
+              ) : Object.keys(props).length === 0 ? (
+                <p className="text-sm text-muted-foreground">
+                  This tool takes no arguments.
+                </p>
+              ) : (
+                <div className="flex flex-col gap-4">
+                  {Object.entries(props).map(([name, schema]) => (
+                    <ArgField
+                      key={name}
+                      name={name}
+                      schema={schema as JsonSchemaProp}
+                      required={required.has(name)}
+                      value={args[name]}
+                      onChange={(v) => setArgs((a) => ({ ...a, [name]: v }))}
+                    />
+                  ))}
+                </div>
+              )}
+
+              <div>
+                <Button onClick={run} disabled={calling} size="sm">
+                  {calling ? (
+                    <Loader2 className="size-4 animate-spin" />
+                  ) : (
+                    <Play className="size-4" />
+                  )}
+                  {calling ? "Calling…" : "Call tool"}
+                </Button>
+              </div>
+            </div>
+          )}
+
+          {/* Call error (transport / connection failure) */}
+          {callError && <Callout variant="danger">{callError}</Callout>}
+
+          {/* Result */}
+          {result && (
+            <div className="flex flex-col gap-2">
+              <div className="flex items-center gap-2 text-sm font-medium">
+                {result.isError ? (
+                  <XCircle className="size-4 text-destructive" />
+                ) : (
+                  <CheckCircle2 className="size-4 text-success" />
+                )}
+                {result.isError ? "Tool returned an error" : "Result"}
+              </div>
+              <pre className="max-h-96 overflow-auto rounded-lg border bg-muted/40 p-3 font-mono text-xs whitespace-pre-wrap">
+                {renderResult(result)}
+              </pre>
+            </div>
+          )}
         </>
       )}
     </div>

--- a/src/components/ProfileBar.tsx
+++ b/src/components/ProfileBar.tsx
@@ -2,11 +2,7 @@ import { useState } from "react";
 import { Plus, Trash2 } from "lucide-react";
 import { toast } from "sonner";
 import { toastError } from "@/lib/toast";
-import {
-  createProfile,
-  deleteProfile,
-  setActiveProfile,
-} from "@/lib/api";
+import { createProfile, deleteProfile, setActiveProfile } from "@/lib/api";
 import type { Registry } from "@/lib/types";
 import {
   Select,
@@ -119,8 +115,8 @@ export function ProfileBar({ registry, onChange }: Props) {
           </DialogHeader>
           <p className="text-xs text-muted-foreground">
             A profile is a set of servers a client can see. Credentials live on each
-            server, not the profile, so to keep separate work and personal accounts,
-            add the server twice and put one in each profile.
+            server, not the profile, so to keep separate work and personal accounts, add
+            the server twice and put one in each profile.
           </p>
           <div className="flex flex-col gap-2 py-2">
             <Label htmlFor="profile-name">Name</Label>

--- a/src/components/RegistryServerRow.tsx
+++ b/src/components/RegistryServerRow.tsx
@@ -1,12 +1,5 @@
 import { useState } from "react";
-import {
-  ChevronDown,
-  Copy,
-  KeyRound,
-  LogIn,
-  Pencil,
-  Trash2,
-} from "lucide-react";
+import { ChevronDown, Copy, KeyRound, LogIn, Pencil, Trash2 } from "lucide-react";
 import type { ProbeResult, Registry, ServerEntry } from "@/lib/types";
 import { Switch } from "@/components/ui/switch";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
@@ -95,9 +88,7 @@ export function RegistryServerRow({
           : "Disabled";
 
   // Next free "Name (N)" for the duplicate-for-another-account action.
-  const existingNames = new Set(
-    registry?.servers.map((s) => s.name.toLowerCase()) ?? [],
-  );
+  const existingNames = new Set(registry?.servers.map((s) => s.name.toLowerCase()) ?? []);
   const baseName = server.name.replace(/\s\(\d+\)$/, "");
   let duplicateName = `${baseName} (2)`;
   let index = 2;
@@ -134,9 +125,7 @@ export function RegistryServerRow({
           role="status"
         />
 
-        <span className="min-w-0 truncate text-sm font-medium">
-          {server.name}
-        </span>
+        <span className="min-w-0 truncate text-sm font-medium">{server.name}</span>
 
         {server.source && (
           <span className="hidden max-w-40 shrink-0 truncate rounded bg-muted px-1.5 py-0.5 text-[11px] text-muted-foreground md:inline">
@@ -161,11 +150,7 @@ export function RegistryServerRow({
               }
             />
           ) : (
-            <StatusLabel
-              status={status}
-              label={label}
-              error={health?.error ?? null}
-            />
+            <StatusLabel status={status} label={label} error={health?.error ?? null} />
           )}
 
           <TransportPill transport={server.transport} />
@@ -178,16 +163,12 @@ export function RegistryServerRow({
             }}
             aria-expanded={expanded}
             aria-label={
-              expanded
-                ? `Hide ${server.name} details`
-                : `Show ${server.name} details`
+              expanded ? `Hide ${server.name} details` : `Show ${server.name} details`
             }
             className="rounded p-0.5 text-muted-foreground/50 transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
           >
             <ChevronDown
-              className={`size-4 transition-transform ${
-                expanded ? "rotate-180" : ""
-              }`}
+              className={`size-4 transition-transform ${expanded ? "rotate-180" : ""}`}
               aria-hidden="true"
             />
           </button>
@@ -276,10 +257,7 @@ function StatusLabel({
   error: string | null;
 }) {
   const text = (
-    <span
-      aria-hidden="true"
-      className="text-xs whitespace-nowrap text-muted-foreground"
-    >
+    <span aria-hidden="true" className="text-xs whitespace-nowrap text-muted-foreground">
       {label}
     </span>
   );

--- a/src/components/SecretsDialog.tsx
+++ b/src/components/SecretsDialog.tsx
@@ -367,16 +367,16 @@ export function SecretsDialog({ server, onSaved, trigger, onChanged }: Props) {
                       </Button>
                       {!oauthBusy && /mac/i.test(navigator.userAgent) && (
                         <p className="text-[11px] text-muted-foreground">
-                          On macOS, set Chrome or Brave as your default browser
-                          first. Safari can block the local sign-in redirect.
+                          On macOS, set Chrome or Brave as your default browser first.
+                          Safari can block the local sign-in redirect.
                         </p>
                       )}
                       {oauthBusy && (
                         <p className="text-[11px] text-muted-foreground">
-                          Finish signing in and approve access in your browser. If
-                          the page is blank, your default browser (e.g. Safari) may
-                          block the local redirect, use Chrome or Brave, or paste an
-                          access token above instead.
+                          Finish signing in and approve access in your browser. If the
+                          page is blank, your default browser (e.g. Safari) may block the
+                          local redirect, use Chrome or Brave, or paste an access token
+                          above instead.
                         </p>
                       )}
                     </>
@@ -384,7 +384,8 @@ export function SecretsDialog({ server, onSaved, trigger, onChanged }: Props) {
 
                   {authInfo?.kind === "token" && (
                     <p className="text-[11px] text-muted-foreground">
-                      This server needs a pasted token. OAuth sign-in isn't available here.
+                      This server needs a pasted token. OAuth sign-in isn't available
+                      here.
                     </p>
                   )}
                 </>

--- a/src/components/ServerDialog.tsx
+++ b/src/components/ServerDialog.tsx
@@ -1,8 +1,23 @@
 import { useState, type ReactNode } from "react";
-import { AlertTriangle, CheckCircle2, ChevronDown, ChevronRight, ClipboardPaste, Loader2, Plus, X } from "lucide-react";
+import {
+  AlertTriangle,
+  CheckCircle2,
+  ChevronDown,
+  ChevronRight,
+  ClipboardPaste,
+  Loader2,
+  Plus,
+  X,
+} from "lucide-react";
 import { toast } from "sonner";
 import { toastError } from "@/lib/toast";
-import { addServer, parseServerSnippet, setSecret, testServer, updateServer } from "@/lib/api";
+import {
+  addServer,
+  parseServerSnippet,
+  setSecret,
+  testServer,
+  updateServer,
+} from "@/lib/api";
 import type { Registry, ServerEntry, Transport } from "@/lib/types";
 import { Button } from "@/components/ui/button";
 import {
@@ -42,7 +57,16 @@ interface Props {
   urlHint?: string;
 }
 
-export function ServerDialog({ trigger, onSaved, editId, initial, existingNames, autoOpen, onClose, urlHint }: Props) {
+export function ServerDialog({
+  trigger,
+  onSaved,
+  editId,
+  initial,
+  existingNames,
+  autoOpen,
+  onClose,
+  urlHint,
+}: Props) {
   const [open, setOpen] = useState(autoOpen ?? false);
   const [form, setForm] = useState({
     name: initial?.name ?? "",
@@ -230,9 +254,7 @@ export function ServerDialog({ trigger, onSaved, editId, initial, existingNames,
       // Vault any values the user entered now. setSecret keys by server id. For a
       // new server, add_server appends it, so it's the last entry - resolving by
       // name would pick the wrong one if two servers share a name.
-      const id = editing
-        ? editId
-        : result.servers[result.servers.length - 1]?.id;
+      const id = editing ? editId : result.servers[result.servers.length - 1]?.id;
       if (id) {
         for (const r of declared) {
           if (r.value) result = await setSecret(id, r.key.trim(), r.value);
@@ -277,7 +299,9 @@ export function ServerDialog({ trigger, onSaved, editId, initial, existingNames,
               <div className="flex flex-col gap-2 border-t px-3 pb-3 pt-2">
                 <textarea
                   className="min-h-[100px] w-full resize-y rounded-md bg-muted/50 p-2 font-mono text-xs"
-                  placeholder={"Paste a config snippet from any client:\n\n• Claude Code: claude mcp add-json ...\n• Cursor/Windsurf/Antigravity: {\"mcpServers\": ...}\n• VS Code: {\"servers\": ...}\n• Codex: [mcp_servers.name]\n• Zed: {\"context_servers\": ...}"}
+                  placeholder={
+                    'Paste a config snippet from any client:\n\n• Claude Code: claude mcp add-json ...\n• Cursor/Windsurf/Antigravity: {"mcpServers": ...}\n• VS Code: {"servers": ...}\n• Codex: [mcp_servers.name]\n• Zed: {"context_servers": ...}'
+                  }
                   value={pasteText}
                   onChange={(e) => setPasteText(e.target.value)}
                 />
@@ -367,8 +391,8 @@ export function ServerDialog({ trigger, onSaved, editId, initial, existingNames,
             <Label>Environment variables</Label>
             <p className="-mt-1 text-xs text-muted-foreground">
               API keys and other secrets the server needs (e.g.{" "}
-              <code className="font-mono">RESEND_API_KEY</code>). Values are stored
-              in your OS keychain, never in the config.
+              <code className="font-mono">RESEND_API_KEY</code>). Values are stored in
+              your OS keychain, never in the config.
             </p>
             {envRows.map((row, i) => (
               <div key={i} className="flex items-center gap-2">
@@ -380,7 +404,9 @@ export function ServerDialog({ trigger, onSaved, editId, initial, existingNames,
                 />
                 <Input
                   type="password"
-                  placeholder={initial?.env.some((e) => e.key === row.key) ? "•••• (saved)" : "value"}
+                  placeholder={
+                    initial?.env.some((e) => e.key === row.key) ? "•••• (saved)" : "value"
+                  }
                   value={row.value}
                   onChange={(e) => setEnvRow(i, "value", e.target.value)}
                 />
@@ -406,7 +432,10 @@ export function ServerDialog({ trigger, onSaved, editId, initial, existingNames,
             </Button>
           </div>
 
-          {(errors.length > 0 || duplicateName || test.status === "ok" || test.status === "fail") && (
+          {(errors.length > 0 ||
+            duplicateName ||
+            test.status === "ok" ||
+            test.status === "fail") && (
             <div className="flex flex-col gap-1.5 text-xs">
               {errors.map((msg) => (
                 <p key={msg} className="text-destructive">
@@ -417,8 +446,8 @@ export function ServerDialog({ trigger, onSaved, editId, initial, existingNames,
                 <p className="flex items-start gap-1.5 text-amber-600 dark:text-amber-500">
                   <AlertTriangle className="mt-0.5 size-3.5 shrink-0" />
                   <span>
-                    Another server is already named "{nameTrim}". That's fine for multiple accounts;
-                    it'll be saved as a separate entry.
+                    Another server is already named "{nameTrim}". That's fine for multiple
+                    accounts; it'll be saved as a separate entry.
                   </span>
                 </p>
               )}

--- a/src/components/SettingsView.tsx
+++ b/src/components/SettingsView.tsx
@@ -1,5 +1,19 @@
 import { useEffect, useState } from "react";
-import { Activity, Bot, Check, Copy, Globe, Layers, Power, ShieldAlert, ShieldCheck, ShieldX, Trash2, UserCheck, X } from "lucide-react";
+import {
+  Activity,
+  Bot,
+  Check,
+  Copy,
+  Globe,
+  Layers,
+  Power,
+  ShieldAlert,
+  ShieldCheck,
+  ShieldX,
+  Trash2,
+  UserCheck,
+  X,
+} from "lucide-react";
 import {
   disable as disableAutostart,
   enable as enableAutostart,
@@ -117,7 +131,10 @@ export function SettingsView({ registry, onRegistryChange }: Props) {
   }, []);
 
   useEffect(() => {
-    const load = () => listQuarantined().then(setQuarantined).catch(() => {});
+    const load = () =>
+      listQuarantined()
+        .then(setQuarantined)
+        .catch(() => {});
     load();
     // Quarantine happens asynchronously in the gateway, so poll to keep the list fresh.
     const id = setInterval(load, 15000);
@@ -136,7 +153,10 @@ export function SettingsView({ registry, onRegistryChange }: Props) {
   // Tools the user allowed to skip human approval. Polled because "always allow" is chosen
   // from the approval overlay (a different component), so this keeps the list in sync.
   useEffect(() => {
-    const load = () => listAllowedTools().then(setAllowedTools).catch(() => {});
+    const load = () =>
+      listAllowedTools()
+        .then(setAllowedTools)
+        .catch(() => {});
     load();
     const id = setInterval(load, 10000);
     return () => clearInterval(id);
@@ -172,17 +192,16 @@ export function SettingsView({ registry, onRegistryChange }: Props) {
     );
   };
 
-  const apply =
-    (fn: (v: boolean) => Promise<Registry>) => async (v: boolean) => {
-      setBusy(true);
-      try {
-        onRegistryChange(await fn(v));
-      } catch (e) {
-        toastError(`Couldn't update the setting: ${e}`);
-      } finally {
-        setBusy(false);
-      }
-    };
+  const apply = (fn: (v: boolean) => Promise<Registry>) => async (v: boolean) => {
+    setBusy(true);
+    try {
+      onRegistryChange(await fn(v));
+    } catch (e) {
+      toastError(`Couldn't update the setting: ${e}`);
+    } finally {
+      setBusy(false);
+    }
+  };
 
   // Live inspection needs a step the plain `apply` helper doesn't: when turned OFF,
   // clear the ephemeral capture ring so nothing lingers on disk.
@@ -379,7 +398,9 @@ export function SettingsView({ registry, onRegistryChange }: Props) {
           {bridge?.running && bridge.url && (
             <>
               <div className="flex items-center gap-2 rounded border bg-muted/40 px-2 py-1.5">
-                <span className="shrink-0 text-[11px] font-medium text-muted-foreground">URL</span>
+                <span className="shrink-0 text-[11px] font-medium text-muted-foreground">
+                  URL
+                </span>
                 <code className="min-w-0 flex-1 truncate text-xs">{bridge.url}</code>
                 <button
                   type="button"
@@ -415,9 +436,10 @@ export function SettingsView({ registry, onRegistryChange }: Props) {
                 </div>
               )}
               <p className="text-xs text-muted-foreground">
-                In Open WebUI: Settings &rarr; Tools &rarr; add the URL as an OpenAPI server and paste
-                the token as its API key (Bearer auth), then set Function Calling to Native (per chat).
-                The token stops other local apps from calling your tools.
+                In Open WebUI: Settings &rarr; Tools &rarr; add the URL as an OpenAPI
+                server and paste the token as its API key (Bearer auth), then set Function
+                Calling to Native (per chat). The token stops other local apps from
+                calling your tools.
               </p>
 
               <div className="mt-1 flex flex-col gap-2 rounded border bg-muted/20 p-2.5">
@@ -434,7 +456,9 @@ export function SettingsView({ registry, onRegistryChange }: Props) {
                   <ul className="flex flex-col gap-1">
                     {httpClients.map((c) => (
                       <li key={c.id} className="flex items-center gap-2 text-xs">
-                        <span className="truncate font-medium">{c.label || "(unnamed)"}</span>
+                        <span className="truncate font-medium">
+                          {c.label || "(unnamed)"}
+                        </span>
                         <span className="shrink-0 rounded bg-muted px-1.5 py-0.5 text-[11px] text-muted-foreground">
                           {c.profile || "all servers"}
                         </span>

--- a/src/components/ShareDialog.tsx
+++ b/src/components/ShareDialog.tsx
@@ -242,9 +242,8 @@ export function ShareDialog({ trigger, onImported }: Props) {
         {preview ? (
           <div className="flex flex-col gap-4 py-1">
             <p className="text-xs text-muted-foreground">
-              These servers come from a shared file. Each runs the command shown when
-              you enable it, so review them before importing. You'll add your own keys
-              after.
+              These servers come from a shared file. Each runs the command shown when you
+              enable it, so review them before importing. You'll add your own keys after.
             </p>
             <div className="flex max-h-72 flex-col gap-2 overflow-y-auto">
               {preview.map((item, i) => (
@@ -252,11 +251,18 @@ export function ShareDialog({ trigger, onImported }: Props) {
               ))}
             </div>
             <div className="flex items-center justify-between gap-2 border-t pt-3">
-              <Button variant="ghost" onClick={() => setPreview(null)} disabled={busyAction !== null}>
+              <Button
+                variant="ghost"
+                onClick={() => setPreview(null)}
+                disabled={busyAction !== null}
+              >
                 <ArrowLeft className="size-4" />
                 Back
               </Button>
-              <Button onClick={confirmImport} disabled={busyAction !== null || newCount === 0}>
+              <Button
+                onClick={confirmImport}
+                disabled={busyAction !== null || newCount === 0}
+              >
                 {busyAction === "import" ? (
                   <>
                     <Loader2 className="size-4 animate-spin" />
@@ -446,7 +452,11 @@ export function ShareDialog({ trigger, onImported }: Props) {
                     </>
                   )}
                 </Button>
-                <Button variant="outline" onClick={loadFromFile} disabled={busyAction !== null}>
+                <Button
+                  variant="outline"
+                  onClick={loadFromFile}
+                  disabled={busyAction !== null}
+                >
                   {busyAction === "preview-file" ? (
                     <>
                       <Loader2 className="size-4 animate-spin" />
@@ -471,9 +481,7 @@ export function ShareDialog({ trigger, onImported }: Props) {
 /** One reviewable server: name, what it runs, and a flag if it spawns a shell. */
 function ImportRow({ item }: { item: ImportItem }) {
   const runs =
-    item.command != null
-      ? [item.command, ...item.args].join(" ")
-      : (item.url ?? "");
+    item.command != null ? [item.command, ...item.args].join(" ") : (item.url ?? "");
   const shell = runsShell(item.command);
   const privateHost = isPrivateHostUrl(item.url);
   return (
@@ -488,9 +496,7 @@ function ImportRow({ item }: { item: ImportItem }) {
         )}
       </div>
       {runs && (
-        <p className="mt-1 font-mono text-xs break-all text-muted-foreground">
-          {runs}
-        </p>
+        <p className="mt-1 font-mono text-xs break-all text-muted-foreground">{runs}</p>
       )}
       {shell && (
         <p className="mt-1.5 flex items-center gap-1.5 text-xs text-warning">

--- a/src/components/TeamsView.tsx
+++ b/src/components/TeamsView.tsx
@@ -1,12 +1,26 @@
 import { useEffect, useState } from "react";
-import { RefreshCw, LogOut, Upload, ShieldCheck, Users, Server, AlertTriangle } from "lucide-react";
+import {
+  RefreshCw,
+  LogOut,
+  Upload,
+  ShieldCheck,
+  Users,
+  Server,
+  AlertTriangle,
+} from "lucide-react";
 import { listen } from "@tauri-apps/api/event";
 import { Button } from "@/components/ui/button";
 import { ConfirmDialog } from "@/components/ConfirmDialog";
 import { Callout } from "@/components/Callout";
 import { TransportPill } from "@/components/TransportPill";
 import { Input } from "@/components/ui/input";
-import { teamConnect, teamSync, teamDisconnect, teamPush, setServerEnabled } from "@/lib/api";
+import {
+  teamConnect,
+  teamSync,
+  teamDisconnect,
+  teamPush,
+  setServerEnabled,
+} from "@/lib/api";
 import { isEnabled, activeProfile } from "@/lib/types";
 import type { Registry } from "@/lib/types";
 
@@ -29,7 +43,9 @@ export function TeamsView({
 }) {
   const team = registry?.team ?? null;
   const isAdmin = team?.role === "admin";
-  const teamServers = (registry?.servers ?? []).filter((s) => s.source?.startsWith("team:"));
+  const teamServers = (registry?.servers ?? []).filter((s) =>
+    s.source?.startsWith("team:"),
+  );
 
   const [serverUrl, setServerUrl] = useState(HOSTED_TEAMS_URL);
   const [inviteCode, setInviteCode] = useState("");
@@ -80,7 +96,11 @@ export function TeamsView({
       if (!serverUrl.trim() || !inviteCode.trim()) {
         throw new Error("Server URL and invite code are both required.");
       }
-      const r = await teamConnect(serverUrl.trim(), inviteCode.trim(), memberName.trim() || undefined);
+      const r = await teamConnect(
+        serverUrl.trim(),
+        inviteCode.trim(),
+        memberName.trim() || undefined,
+      );
       onRegistryChange(r);
       setInviteCode("");
       setNotice("Connected. The team's servers were added to your active profile.");
@@ -141,9 +161,9 @@ export function TeamsView({
         <div className="rounded-xl border bg-card p-5">
           <h3 className="text-sm font-medium">Connect to a team</h3>
           <p className="mt-1 mb-4 max-w-prose text-sm text-muted-foreground">
-            Paste your team's Toolport Teams server URL and an invite code from your admin.
-            The team's MCP servers will appear in your active profile. Your keys never leave
-            your machine, you'll add each server's secrets locally afterward.
+            Paste your team's Toolport Teams server URL and an invite code from your
+            admin. The team's MCP servers will appear in your active profile. Your keys
+            never leave your machine, you'll add each server's secrets locally afterward.
           </p>
           <div className="grid gap-3">
             <label className="grid gap-1 text-sm">
@@ -192,14 +212,22 @@ export function TeamsView({
                     {team.role}
                   </span>
                 </div>
-                <p className="mt-1 truncate text-sm text-muted-foreground">{team.serverUrl}</p>
+                <p className="mt-1 truncate text-sm text-muted-foreground">
+                  {team.serverUrl}
+                </p>
                 <p className="mt-0.5 text-xs text-muted-foreground">
-                  Team {team.teamId} · config v{team.lastVersion ?? 0} · {teamServers.length}{" "}
-                  shared {teamServers.length === 1 ? "server" : "servers"}
+                  Team {team.teamId} · config v{team.lastVersion ?? 0} ·{" "}
+                  {teamServers.length} shared{" "}
+                  {teamServers.length === 1 ? "server" : "servers"}
                 </p>
               </div>
               <div className="flex shrink-0 gap-2">
-                <Button variant="outline" size="sm" onClick={onSync} disabled={busy !== null}>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={onSync}
+                  disabled={busy !== null}
+                >
                   <RefreshCw className="size-3.5" />
                   {busy === "sync" ? "Syncing…" : "Sync now"}
                 </Button>
@@ -226,7 +254,8 @@ export function TeamsView({
                     <ShieldCheck className="size-3.5 text-success" /> Admin
                   </div>
                   <p className="text-xs text-muted-foreground">
-                    Push your current server set to the team. Secret values are never sent.
+                    Push your current server set to the team. Secret values are never
+                    sent.
                   </p>
                 </div>
                 <Button size="sm" onClick={onPush} disabled={busy !== null}>
@@ -241,7 +270,8 @@ export function TeamsView({
             <h3 className="mb-1 text-sm font-medium">Shared servers</h3>
             {teamServers.length === 0 ? (
               <p className="text-sm text-muted-foreground">
-                No servers from the team yet. An admin pushes the set, then Sync brings it here.
+                No servers from the team yet. An admin pushes the set, then Sync brings it
+                here.
               </p>
             ) : (
               <>
@@ -251,7 +281,7 @@ export function TeamsView({
                     const isLocal = s.transport === "stdio" || !!s.command;
                     const detail = s.command
                       ? [s.command, ...(s.args ?? [])].join(" ")
-                      : s.url ?? "";
+                      : (s.url ?? "");
                     return (
                       <li
                         key={s.id}
@@ -285,7 +315,12 @@ export function TeamsView({
                             </div>
                             <ConfirmDialog
                               trigger={
-                                <Button size="sm" variant="outline" disabled={busy !== null} className="shrink-0">
+                                <Button
+                                  size="sm"
+                                  variant="outline"
+                                  disabled={busy !== null}
+                                  className="shrink-0"
+                                >
                                   Enable
                                 </Button>
                               }
@@ -305,7 +340,8 @@ export function TeamsView({
                   })}
                 </ul>
                 <p className="mt-3 text-xs text-muted-foreground">
-                  Add each server's secrets in the Servers tab, they stay in your OS keychain.
+                  Add each server's secrets in the Servers tab, they stay in your OS
+                  keychain.
                 </p>
               </>
             )}

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,8 +1,8 @@
-import * as React from "react"
-import { cva, type VariantProps } from "class-variance-authority"
-import { Slot } from "radix-ui"
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+import { Slot } from "radix-ui";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 const badgeVariants = cva(
   "group/badge inline-flex h-5 w-fit shrink-0 items-center justify-center gap-1 overflow-hidden rounded-4xl border border-transparent px-2 py-0.5 text-xs font-medium whitespace-nowrap transition-all focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&>svg]:pointer-events-none [&>svg]:size-3!",
@@ -10,22 +10,20 @@ const badgeVariants = cva(
     variants: {
       variant: {
         default: "bg-primary text-primary-foreground [a]:hover:bg-primary/80",
-        secondary:
-          "bg-secondary text-secondary-foreground [a]:hover:bg-secondary/80",
+        secondary: "bg-secondary text-secondary-foreground [a]:hover:bg-secondary/80",
         destructive:
           "bg-destructive/10 text-destructive focus-visible:ring-destructive/20 dark:bg-destructive/20 dark:focus-visible:ring-destructive/40 [a]:hover:bg-destructive/20",
         outline:
           "border-border text-foreground [a]:hover:bg-muted [a]:hover:text-muted-foreground",
-        ghost:
-          "hover:bg-muted hover:text-muted-foreground dark:hover:bg-muted/50",
+        ghost: "hover:bg-muted hover:text-muted-foreground dark:hover:bg-muted/50",
         link: "text-primary underline-offset-4 hover:underline",
       },
     },
     defaultVariants: {
       variant: "default",
     },
-  }
-)
+  },
+);
 
 function Badge({
   className,
@@ -34,7 +32,7 @@ function Badge({
   ...props
 }: React.ComponentProps<"span"> &
   VariantProps<typeof badgeVariants> & { asChild?: boolean }) {
-  const Comp = asChild ? Slot.Root : "span"
+  const Comp = asChild ? Slot.Root : "span";
 
   return (
     <Comp
@@ -43,7 +41,7 @@ function Badge({
       className={cn(badgeVariants({ variant }), className)}
       {...props}
     />
-  )
+  );
 }
 
-export { Badge, badgeVariants }
+export { Badge, badgeVariants };

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,8 +1,8 @@
-import * as React from "react"
-import { cva, type VariantProps } from "class-variance-authority"
-import { Slot } from "radix-ui"
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+import { Slot } from "radix-ui";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 const buttonVariants = cva(
   "group/button inline-flex shrink-0 items-center justify-center rounded-lg border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
@@ -38,8 +38,8 @@ const buttonVariants = cva(
       variant: "default",
       size: "default",
     },
-  }
-)
+  },
+);
 
 function Button({
   className,
@@ -49,9 +49,9 @@ function Button({
   ...props
 }: React.ComponentProps<"button"> &
   VariantProps<typeof buttonVariants> & {
-    asChild?: boolean
+    asChild?: boolean;
   }) {
-  const Comp = asChild ? Slot.Root : "button"
+  const Comp = asChild ? Slot.Root : "button";
 
   return (
     <Comp
@@ -61,7 +61,7 @@ function Button({
       className={cn(buttonVariants({ variant, size, className }))}
       {...props}
     />
-  )
+  );
 }
 
-export { Button, buttonVariants }
+export { Button, buttonVariants };

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,6 +1,6 @@
-import * as React from "react"
+import * as React from "react";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 function Card({
   className,
@@ -13,11 +13,11 @@ function Card({
       data-size={size}
       className={cn(
         "group/card flex flex-col gap-(--card-spacing) overflow-hidden rounded-xl bg-card py-(--card-spacing) text-sm text-card-foreground ring-1 ring-foreground/10 [--card-spacing:--spacing(4)] has-data-[slot=card-footer]:pb-0 has-[>img:first-child]:pt-0 data-[size=sm]:[--card-spacing:--spacing(3)] data-[size=sm]:has-data-[slot=card-footer]:pb-0 *:[img:first-child]:rounded-t-xl *:[img:last-child]:rounded-b-xl",
-        className
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
 function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
@@ -26,11 +26,11 @@ function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
       data-slot="card-header"
       className={cn(
         "group/card-header @container/card-header grid auto-rows-min items-start gap-1 rounded-t-xl px-(--card-spacing) has-data-[slot=card-action]:grid-cols-[1fr_auto] has-data-[slot=card-description]:grid-rows-[auto_auto] [.border-b]:pb-(--card-spacing)",
-        className
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
 function CardTitle({ className, ...props }: React.ComponentProps<"div">) {
@@ -39,11 +39,11 @@ function CardTitle({ className, ...props }: React.ComponentProps<"div">) {
       data-slot="card-title"
       className={cn(
         "font-heading text-base leading-snug font-medium group-data-[size=sm]/card:text-sm",
-        className
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
 function CardDescription({ className, ...props }: React.ComponentProps<"div">) {
@@ -53,7 +53,7 @@ function CardDescription({ className, ...props }: React.ComponentProps<"div">) {
       className={cn("text-sm text-muted-foreground", className)}
       {...props}
     />
-  )
+  );
 }
 
 function CardAction({ className, ...props }: React.ComponentProps<"div">) {
@@ -62,11 +62,11 @@ function CardAction({ className, ...props }: React.ComponentProps<"div">) {
       data-slot="card-action"
       className={cn(
         "col-start-2 row-span-2 row-start-1 self-start justify-self-end",
-        className
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
 function CardContent({ className, ...props }: React.ComponentProps<"div">) {
@@ -76,7 +76,7 @@ function CardContent({ className, ...props }: React.ComponentProps<"div">) {
       className={cn("px-(--card-spacing)", className)}
       {...props}
     />
-  )
+  );
 }
 
 function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
@@ -85,11 +85,11 @@ function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
       data-slot="card-footer"
       className={cn(
         "flex items-center rounded-b-xl border-t bg-muted/50 p-(--card-spacing)",
-        className
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
 export {
@@ -100,4 +100,4 @@ export {
   CardAction,
   CardDescription,
   CardContent,
-}
+};

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -1,32 +1,26 @@
-import * as React from "react"
-import { Dialog as DialogPrimitive } from "radix-ui"
+import * as React from "react";
+import { Dialog as DialogPrimitive } from "radix-ui";
 
-import { cn } from "@/lib/utils"
-import { Button } from "@/components/ui/button"
-import { XIcon } from "lucide-react"
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+import { XIcon } from "lucide-react";
 
-function Dialog({
-  ...props
-}: React.ComponentProps<typeof DialogPrimitive.Root>) {
-  return <DialogPrimitive.Root data-slot="dialog" {...props} />
+function Dialog({ ...props }: React.ComponentProps<typeof DialogPrimitive.Root>) {
+  return <DialogPrimitive.Root data-slot="dialog" {...props} />;
 }
 
 function DialogTrigger({
   ...props
 }: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
-  return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />
+  return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />;
 }
 
-function DialogPortal({
-  ...props
-}: React.ComponentProps<typeof DialogPrimitive.Portal>) {
-  return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />
+function DialogPortal({ ...props }: React.ComponentProps<typeof DialogPrimitive.Portal>) {
+  return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />;
 }
 
-function DialogClose({
-  ...props
-}: React.ComponentProps<typeof DialogPrimitive.Close>) {
-  return <DialogPrimitive.Close data-slot="dialog-close" {...props} />
+function DialogClose({ ...props }: React.ComponentProps<typeof DialogPrimitive.Close>) {
+  return <DialogPrimitive.Close data-slot="dialog-close" {...props} />;
 }
 
 function DialogOverlay({
@@ -38,11 +32,11 @@ function DialogOverlay({
       data-slot="dialog-overlay"
       className={cn(
         "fixed inset-0 isolate z-50 bg-black/10 duration-100 supports-backdrop-filter:backdrop-blur-xs data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0",
-        className
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
 function DialogContent({
@@ -51,7 +45,7 @@ function DialogContent({
   showCloseButton = true,
   ...props
 }: React.ComponentProps<typeof DialogPrimitive.Content> & {
-  showCloseButton?: boolean
+  showCloseButton?: boolean;
 }) {
   return (
     <DialogPortal>
@@ -60,27 +54,22 @@ function DialogContent({
         data-slot="dialog-content"
         className={cn(
           "fixed top-1/2 left-1/2 z-50 grid max-h-[85vh] w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 overflow-y-auto rounded-xl bg-popover p-4 text-sm text-popover-foreground ring-1 ring-foreground/10 duration-100 outline-none sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
-          className
+          className,
         )}
         {...props}
       >
         {children}
         {showCloseButton && (
           <DialogPrimitive.Close data-slot="dialog-close" asChild>
-            <Button
-              variant="ghost"
-              className="absolute top-2 right-2"
-              size="icon-sm"
-            >
-              <XIcon
-              />
+            <Button variant="ghost" className="absolute top-2 right-2" size="icon-sm">
+              <XIcon />
               <span className="sr-only">Close</span>
             </Button>
           </DialogPrimitive.Close>
         )}
       </DialogPrimitive.Content>
     </DialogPortal>
-  )
+  );
 }
 
 function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
@@ -90,7 +79,7 @@ function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
       className={cn("flex flex-col gap-2", className)}
       {...props}
     />
-  )
+  );
 }
 
 function DialogFooter({
@@ -99,14 +88,14 @@ function DialogFooter({
   children,
   ...props
 }: React.ComponentProps<"div"> & {
-  showCloseButton?: boolean
+  showCloseButton?: boolean;
 }) {
   return (
     <div
       data-slot="dialog-footer"
       className={cn(
         "-mx-4 -mb-4 flex flex-col-reverse gap-2 rounded-b-xl border-t bg-muted/50 p-4 sm:flex-row sm:justify-end",
-        className
+        className,
       )}
       {...props}
     >
@@ -117,7 +106,7 @@ function DialogFooter({
         </DialogPrimitive.Close>
       )}
     </div>
-  )
+  );
 }
 
 function DialogTitle({
@@ -127,13 +116,10 @@ function DialogTitle({
   return (
     <DialogPrimitive.Title
       data-slot="dialog-title"
-      className={cn(
-        "font-heading text-base leading-none font-medium",
-        className
-      )}
+      className={cn("font-heading text-base leading-none font-medium", className)}
       {...props}
     />
-  )
+  );
 }
 
 function DialogDescription({
@@ -145,11 +131,11 @@ function DialogDescription({
       data-slot="dialog-description"
       className={cn(
         "text-sm text-muted-foreground *:[a]:underline *:[a]:underline-offset-3 *:[a]:hover:text-foreground",
-        className
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
 export {
@@ -163,4 +149,4 @@ export {
   DialogPortal,
   DialogTitle,
   DialogTrigger,
-}
+};

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -1,32 +1,25 @@
-import * as React from "react"
-import { DropdownMenu as DropdownMenuPrimitive } from "radix-ui"
+import * as React from "react";
+import { DropdownMenu as DropdownMenuPrimitive } from "radix-ui";
 
-import { cn } from "@/lib/utils"
-import { CheckIcon, ChevronRightIcon } from "lucide-react"
+import { cn } from "@/lib/utils";
+import { CheckIcon, ChevronRightIcon } from "lucide-react";
 
 function DropdownMenu({
   ...props
 }: React.ComponentProps<typeof DropdownMenuPrimitive.Root>) {
-  return <DropdownMenuPrimitive.Root data-slot="dropdown-menu" {...props} />
+  return <DropdownMenuPrimitive.Root data-slot="dropdown-menu" {...props} />;
 }
 
 function DropdownMenuPortal({
   ...props
 }: React.ComponentProps<typeof DropdownMenuPrimitive.Portal>) {
-  return (
-    <DropdownMenuPrimitive.Portal data-slot="dropdown-menu-portal" {...props} />
-  )
+  return <DropdownMenuPrimitive.Portal data-slot="dropdown-menu-portal" {...props} />;
 }
 
 function DropdownMenuTrigger({
   ...props
 }: React.ComponentProps<typeof DropdownMenuPrimitive.Trigger>) {
-  return (
-    <DropdownMenuPrimitive.Trigger
-      data-slot="dropdown-menu-trigger"
-      {...props}
-    />
-  )
+  return <DropdownMenuPrimitive.Trigger data-slot="dropdown-menu-trigger" {...props} />;
 }
 
 function DropdownMenuContent({
@@ -41,19 +34,20 @@ function DropdownMenuContent({
         data-slot="dropdown-menu-content"
         sideOffset={sideOffset}
         align={align}
-        className={cn("z-50 max-h-(--radix-dropdown-menu-content-available-height) w-(--radix-dropdown-menu-trigger-width) min-w-32 origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-lg bg-popover p-1 text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:overflow-hidden data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95", className )}
+        className={cn(
+          "z-50 max-h-(--radix-dropdown-menu-content-available-height) w-(--radix-dropdown-menu-trigger-width) min-w-32 origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-lg bg-popover p-1 text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:overflow-hidden data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+          className,
+        )}
         {...props}
       />
     </DropdownMenuPrimitive.Portal>
-  )
+  );
 }
 
 function DropdownMenuGroup({
   ...props
 }: React.ComponentProps<typeof DropdownMenuPrimitive.Group>) {
-  return (
-    <DropdownMenuPrimitive.Group data-slot="dropdown-menu-group" {...props} />
-  )
+  return <DropdownMenuPrimitive.Group data-slot="dropdown-menu-group" {...props} />;
 }
 
 function DropdownMenuItem({
@@ -62,8 +56,8 @@ function DropdownMenuItem({
   variant = "default",
   ...props
 }: React.ComponentProps<typeof DropdownMenuPrimitive.Item> & {
-  inset?: boolean
-  variant?: "default" | "destructive"
+  inset?: boolean;
+  variant?: "default" | "destructive";
 }) {
   return (
     <DropdownMenuPrimitive.Item
@@ -72,11 +66,11 @@ function DropdownMenuItem({
       data-variant={variant}
       className={cn(
         "group/dropdown-menu-item relative flex cursor-default items-center gap-1.5 rounded-md px-1.5 py-1 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground data-inset:pl-7 data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 data-[variant=destructive]:focus:text-destructive dark:data-[variant=destructive]:focus:bg-destructive/20 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 data-[variant=destructive]:*:[svg]:text-destructive",
-        className
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
 function DropdownMenuCheckboxItem({
@@ -86,7 +80,7 @@ function DropdownMenuCheckboxItem({
   inset,
   ...props
 }: React.ComponentProps<typeof DropdownMenuPrimitive.CheckboxItem> & {
-  inset?: boolean
+  inset?: boolean;
 }) {
   return (
     <DropdownMenuPrimitive.CheckboxItem
@@ -94,7 +88,7 @@ function DropdownMenuCheckboxItem({
       data-inset={inset}
       className={cn(
         "relative flex cursor-default items-center gap-1.5 rounded-md py-1 pr-8 pl-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground focus:**:text-accent-foreground data-inset:pl-7 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
-        className
+        className,
       )}
       checked={checked}
       {...props}
@@ -104,24 +98,20 @@ function DropdownMenuCheckboxItem({
         data-slot="dropdown-menu-checkbox-item-indicator"
       >
         <DropdownMenuPrimitive.ItemIndicator>
-          <CheckIcon
-          />
+          <CheckIcon />
         </DropdownMenuPrimitive.ItemIndicator>
       </span>
       {children}
     </DropdownMenuPrimitive.CheckboxItem>
-  )
+  );
 }
 
 function DropdownMenuRadioGroup({
   ...props
 }: React.ComponentProps<typeof DropdownMenuPrimitive.RadioGroup>) {
   return (
-    <DropdownMenuPrimitive.RadioGroup
-      data-slot="dropdown-menu-radio-group"
-      {...props}
-    />
-  )
+    <DropdownMenuPrimitive.RadioGroup data-slot="dropdown-menu-radio-group" {...props} />
+  );
 }
 
 function DropdownMenuRadioItem({
@@ -130,7 +120,7 @@ function DropdownMenuRadioItem({
   inset,
   ...props
 }: React.ComponentProps<typeof DropdownMenuPrimitive.RadioItem> & {
-  inset?: boolean
+  inset?: boolean;
 }) {
   return (
     <DropdownMenuPrimitive.RadioItem
@@ -138,7 +128,7 @@ function DropdownMenuRadioItem({
       data-inset={inset}
       className={cn(
         "relative flex cursor-default items-center gap-1.5 rounded-md py-1 pr-8 pl-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground focus:**:text-accent-foreground data-inset:pl-7 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
-        className
+        className,
       )}
       {...props}
     >
@@ -147,13 +137,12 @@ function DropdownMenuRadioItem({
         data-slot="dropdown-menu-radio-item-indicator"
       >
         <DropdownMenuPrimitive.ItemIndicator>
-          <CheckIcon
-          />
+          <CheckIcon />
         </DropdownMenuPrimitive.ItemIndicator>
       </span>
       {children}
     </DropdownMenuPrimitive.RadioItem>
-  )
+  );
 }
 
 function DropdownMenuLabel({
@@ -161,7 +150,7 @@ function DropdownMenuLabel({
   inset,
   ...props
 }: React.ComponentProps<typeof DropdownMenuPrimitive.Label> & {
-  inset?: boolean
+  inset?: boolean;
 }) {
   return (
     <DropdownMenuPrimitive.Label
@@ -169,11 +158,11 @@ function DropdownMenuLabel({
       data-inset={inset}
       className={cn(
         "px-1.5 py-1 text-xs font-medium text-muted-foreground data-inset:pl-7",
-        className
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
 function DropdownMenuSeparator({
@@ -186,29 +175,26 @@ function DropdownMenuSeparator({
       className={cn("-mx-1 my-1 h-px bg-border", className)}
       {...props}
     />
-  )
+  );
 }
 
-function DropdownMenuShortcut({
-  className,
-  ...props
-}: React.ComponentProps<"span">) {
+function DropdownMenuShortcut({ className, ...props }: React.ComponentProps<"span">) {
   return (
     <span
       data-slot="dropdown-menu-shortcut"
       className={cn(
         "ml-auto text-xs tracking-widest text-muted-foreground group-focus/dropdown-menu-item:text-accent-foreground",
-        className
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
 function DropdownMenuSub({
   ...props
 }: React.ComponentProps<typeof DropdownMenuPrimitive.Sub>) {
-  return <DropdownMenuPrimitive.Sub data-slot="dropdown-menu-sub" {...props} />
+  return <DropdownMenuPrimitive.Sub data-slot="dropdown-menu-sub" {...props} />;
 }
 
 function DropdownMenuSubTrigger({
@@ -217,7 +203,7 @@ function DropdownMenuSubTrigger({
   children,
   ...props
 }: React.ComponentProps<typeof DropdownMenuPrimitive.SubTrigger> & {
-  inset?: boolean
+  inset?: boolean;
 }) {
   return (
     <DropdownMenuPrimitive.SubTrigger
@@ -225,14 +211,14 @@ function DropdownMenuSubTrigger({
       data-inset={inset}
       className={cn(
         "flex cursor-default items-center gap-1.5 rounded-md px-1.5 py-1 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground data-inset:pl-7 data-open:bg-accent data-open:text-accent-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
-        className
+        className,
       )}
       {...props}
     >
       {children}
       <ChevronRightIcon className="ml-auto" />
     </DropdownMenuPrimitive.SubTrigger>
-  )
+  );
 }
 
 function DropdownMenuSubContent({
@@ -242,10 +228,13 @@ function DropdownMenuSubContent({
   return (
     <DropdownMenuPrimitive.SubContent
       data-slot="dropdown-menu-sub-content"
-      className={cn("z-50 min-w-[96px] origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden rounded-lg bg-popover p-1 text-popover-foreground shadow-lg ring-1 ring-foreground/10 duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95", className )}
+      className={cn(
+        "z-50 min-w-[96px] origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden rounded-lg bg-popover p-1 text-popover-foreground shadow-lg ring-1 ring-foreground/10 duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+        className,
+      )}
       {...props}
     />
-  )
+  );
 }
 
 export {
@@ -264,4 +253,4 @@ export {
   DropdownMenuSub,
   DropdownMenuSubTrigger,
   DropdownMenuSubContent,
-}
+};

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,6 +1,6 @@
-import * as React from "react"
+import * as React from "react";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 function Input({ className, type, ...props }: React.ComponentProps<"input">) {
   return (
@@ -9,11 +9,11 @@ function Input({ className, type, ...props }: React.ComponentProps<"input">) {
       data-slot="input"
       className={cn(
         "h-8 w-full min-w-0 rounded-lg border border-input bg-transparent px-2.5 py-1 text-base transition-colors outline-none file:inline-flex file:h-6 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
-        className
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
-export { Input }
+export { Input };

--- a/src/components/ui/label.tsx
+++ b/src/components/ui/label.tsx
@@ -1,7 +1,7 @@
-import * as React from "react"
-import { Label as LabelPrimitive } from "radix-ui"
+import * as React from "react";
+import { Label as LabelPrimitive } from "radix-ui";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 function Label({
   className,
@@ -12,11 +12,11 @@ function Label({
       data-slot="label"
       className={cn(
         "flex items-center gap-2 text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50",
-        className
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
-export { Label }
+export { Label };

--- a/src/components/ui/scroll-area.tsx
+++ b/src/components/ui/scroll-area.tsx
@@ -1,9 +1,9 @@
-"use client"
+"use client";
 
-import * as React from "react"
-import { ScrollArea as ScrollAreaPrimitive } from "radix-ui"
+import * as React from "react";
+import { ScrollArea as ScrollAreaPrimitive } from "radix-ui";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 function ScrollArea({
   className,
@@ -25,7 +25,7 @@ function ScrollArea({
       <ScrollBar />
       <ScrollAreaPrimitive.Corner />
     </ScrollAreaPrimitive.Root>
-  )
+  );
 }
 
 function ScrollBar({
@@ -40,7 +40,7 @@ function ScrollBar({
       orientation={orientation}
       className={cn(
         "flex touch-none p-px transition-colors select-none data-horizontal:h-2.5 data-horizontal:flex-col data-horizontal:border-t data-horizontal:border-t-transparent data-vertical:h-full data-vertical:w-2.5 data-vertical:border-l data-vertical:border-l-transparent",
-        className
+        className,
       )}
       {...props}
     >
@@ -49,7 +49,7 @@ function ScrollBar({
         className="relative flex-1 rounded-full bg-border"
       />
     </ScrollAreaPrimitive.ScrollAreaScrollbar>
-  )
+  );
 }
 
-export { ScrollArea, ScrollBar }
+export { ScrollArea, ScrollBar };

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -1,15 +1,13 @@
-"use client"
+"use client";
 
-import * as React from "react"
-import { Select as SelectPrimitive } from "radix-ui"
+import * as React from "react";
+import { Select as SelectPrimitive } from "radix-ui";
 
-import { cn } from "@/lib/utils"
-import { ChevronDownIcon, CheckIcon, ChevronUpIcon } from "lucide-react"
+import { cn } from "@/lib/utils";
+import { ChevronDownIcon, CheckIcon, ChevronUpIcon } from "lucide-react";
 
-function Select({
-  ...props
-}: React.ComponentProps<typeof SelectPrimitive.Root>) {
-  return <SelectPrimitive.Root data-slot="select" {...props} />
+function Select({ ...props }: React.ComponentProps<typeof SelectPrimitive.Root>) {
+  return <SelectPrimitive.Root data-slot="select" {...props} />;
 }
 
 function SelectGroup({
@@ -22,13 +20,11 @@ function SelectGroup({
       className={cn("scroll-my-1 p-1", className)}
       {...props}
     />
-  )
+  );
 }
 
-function SelectValue({
-  ...props
-}: React.ComponentProps<typeof SelectPrimitive.Value>) {
-  return <SelectPrimitive.Value data-slot="select-value" {...props} />
+function SelectValue({ ...props }: React.ComponentProps<typeof SelectPrimitive.Value>) {
+  return <SelectPrimitive.Value data-slot="select-value" {...props} />;
 }
 
 function SelectTrigger({
@@ -37,7 +33,7 @@ function SelectTrigger({
   children,
   ...props
 }: React.ComponentProps<typeof SelectPrimitive.Trigger> & {
-  size?: "sm" | "default"
+  size?: "sm" | "default";
 }) {
   return (
     <SelectPrimitive.Trigger
@@ -45,7 +41,7 @@ function SelectTrigger({
       data-size={size}
       className={cn(
         "flex w-fit items-center justify-between gap-1.5 rounded-lg border border-input bg-transparent py-2 pr-2 pl-2.5 text-sm whitespace-nowrap transition-colors outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 data-placeholder:text-muted-foreground data-[size=default]:h-8 data-[size=sm]:h-7 data-[size=sm]:rounded-[min(var(--radius-md),10px)] *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-1.5 dark:bg-input/30 dark:hover:bg-input/50 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
-        className
+        className,
       )}
       {...props}
     >
@@ -54,7 +50,7 @@ function SelectTrigger({
         <ChevronDownIcon className="pointer-events-none size-4 text-muted-foreground" />
       </SelectPrimitive.Icon>
     </SelectPrimitive.Trigger>
-  )
+  );
 }
 
 function SelectContent({
@@ -69,7 +65,12 @@ function SelectContent({
       <SelectPrimitive.Content
         data-slot="select-content"
         data-align-trigger={position === "item-aligned"}
-        className={cn("relative z-50 max-h-(--radix-select-content-available-height) min-w-36 origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-lg bg-popover text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-100 data-[align-trigger=true]:animate-none data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95", position ==="popper"&&"data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1", className )}
+        className={cn(
+          "relative z-50 max-h-(--radix-select-content-available-height) min-w-36 origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-lg bg-popover text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-100 data-[align-trigger=true]:animate-none data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+          position === "popper" &&
+            "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
+          className,
+        )}
         position={position}
         align={align}
         {...props}
@@ -79,7 +80,7 @@ function SelectContent({
           data-position={position}
           className={cn(
             "data-[position=popper]:h-(--radix-select-trigger-height) data-[position=popper]:w-full data-[position=popper]:min-w-(--radix-select-trigger-width)",
-            position === "popper" && ""
+            position === "popper" && "",
           )}
         >
           {children}
@@ -87,7 +88,7 @@ function SelectContent({
         <SelectScrollDownButton />
       </SelectPrimitive.Content>
     </SelectPrimitive.Portal>
-  )
+  );
 }
 
 function SelectLabel({
@@ -100,7 +101,7 @@ function SelectLabel({
       className={cn("px-1.5 py-1 text-xs text-muted-foreground", className)}
       {...props}
     />
-  )
+  );
 }
 
 function SelectItem({
@@ -113,7 +114,7 @@ function SelectItem({
       data-slot="select-item"
       className={cn(
         "relative flex w-full cursor-default items-center gap-1.5 rounded-md py-1 pr-8 pl-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
-        className
+        className,
       )}
       {...props}
     >
@@ -124,7 +125,7 @@ function SelectItem({
       </span>
       <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
     </SelectPrimitive.Item>
-  )
+  );
 }
 
 function SelectSeparator({
@@ -137,7 +138,7 @@ function SelectSeparator({
       className={cn("pointer-events-none -mx-1 my-1 h-px bg-border", className)}
       {...props}
     />
-  )
+  );
 }
 
 function SelectScrollUpButton({
@@ -149,14 +150,13 @@ function SelectScrollUpButton({
       data-slot="select-scroll-up-button"
       className={cn(
         "z-10 flex cursor-default items-center justify-center bg-popover py-1 [&_svg:not([class*='size-'])]:size-4",
-        className
+        className,
       )}
       {...props}
     >
-      <ChevronUpIcon
-      />
+      <ChevronUpIcon />
     </SelectPrimitive.ScrollUpButton>
-  )
+  );
 }
 
 function SelectScrollDownButton({
@@ -168,14 +168,13 @@ function SelectScrollDownButton({
       data-slot="select-scroll-down-button"
       className={cn(
         "z-10 flex cursor-default items-center justify-center bg-popover py-1 [&_svg:not([class*='size-'])]:size-4",
-        className
+        className,
       )}
       {...props}
     >
-      <ChevronDownIcon
-      />
+      <ChevronDownIcon />
     </SelectPrimitive.ScrollDownButton>
-  )
+  );
 }
 
 export {
@@ -189,4 +188,4 @@ export {
   SelectSeparator,
   SelectTrigger,
   SelectValue,
-}
+};

--- a/src/components/ui/separator.tsx
+++ b/src/components/ui/separator.tsx
@@ -1,7 +1,7 @@
-import * as React from "react"
-import { Separator as SeparatorPrimitive } from "radix-ui"
+import * as React from "react";
+import { Separator as SeparatorPrimitive } from "radix-ui";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 function Separator({
   className,
@@ -16,11 +16,11 @@ function Separator({
       orientation={orientation}
       className={cn(
         "shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch",
-        className
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
-export { Separator }
+export { Separator };

--- a/src/components/ui/skeleton.tsx
+++ b/src/components/ui/skeleton.tsx
@@ -1,4 +1,4 @@
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 function Skeleton({ className, ...props }: React.ComponentProps<"div">) {
   return (
@@ -7,7 +7,7 @@ function Skeleton({ className, ...props }: React.ComponentProps<"div">) {
       className={cn("animate-pulse rounded-md bg-muted", className)}
       {...props}
     />
-  )
+  );
 }
 
-export { Skeleton }
+export { Skeleton };

--- a/src/components/ui/sonner.tsx
+++ b/src/components/ui/sonner.tsx
@@ -1,32 +1,28 @@
-"use client"
+"use client";
 
-import { useTheme } from "next-themes"
-import { Toaster as Sonner, type ToasterProps } from "sonner"
-import { CircleCheckIcon, InfoIcon, TriangleAlertIcon, OctagonXIcon, Loader2Icon } from "lucide-react"
+import { useTheme } from "next-themes";
+import { Toaster as Sonner, type ToasterProps } from "sonner";
+import {
+  CircleCheckIcon,
+  InfoIcon,
+  TriangleAlertIcon,
+  OctagonXIcon,
+  Loader2Icon,
+} from "lucide-react";
 
 const Toaster = ({ ...props }: ToasterProps) => {
-  const { theme = "system" } = useTheme()
+  const { theme = "system" } = useTheme();
 
   return (
     <Sonner
       theme={theme as ToasterProps["theme"]}
       className="toaster group"
       icons={{
-        success: (
-          <CircleCheckIcon className="size-4" />
-        ),
-        info: (
-          <InfoIcon className="size-4" />
-        ),
-        warning: (
-          <TriangleAlertIcon className="size-4" />
-        ),
-        error: (
-          <OctagonXIcon className="size-4" />
-        ),
-        loading: (
-          <Loader2Icon className="size-4 animate-spin" />
-        ),
+        success: <CircleCheckIcon className="size-4" />,
+        info: <InfoIcon className="size-4" />,
+        warning: <TriangleAlertIcon className="size-4" />,
+        error: <OctagonXIcon className="size-4" />,
+        loading: <Loader2Icon className="size-4 animate-spin" />,
       }}
       style={
         {
@@ -43,7 +39,7 @@ const Toaster = ({ ...props }: ToasterProps) => {
       }}
       {...props}
     />
-  )
-}
+  );
+};
 
-export { Toaster }
+export { Toaster };

--- a/src/components/ui/switch.tsx
+++ b/src/components/ui/switch.tsx
@@ -1,14 +1,14 @@
-import * as React from "react"
-import { Switch as SwitchPrimitive } from "radix-ui"
+import * as React from "react";
+import { Switch as SwitchPrimitive } from "radix-ui";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 function Switch({
   className,
   size = "default",
   ...props
 }: React.ComponentProps<typeof SwitchPrimitive.Root> & {
-  size?: "sm" | "default"
+  size?: "sm" | "default";
 }) {
   return (
     <SwitchPrimitive.Root
@@ -16,7 +16,7 @@ function Switch({
       data-size={size}
       className={cn(
         "peer group/switch relative inline-flex shrink-0 items-center rounded-full border border-transparent transition-all outline-none after:absolute after:-inset-x-3 after:-inset-y-2 focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 data-[size=default]:h-[18.4px] data-[size=default]:w-[32px] data-[size=sm]:h-[14px] data-[size=sm]:w-[24px] dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 data-checked:bg-primary data-unchecked:bg-input dark:data-unchecked:bg-input/80 data-disabled:cursor-not-allowed data-disabled:opacity-50",
-        className
+        className,
       )}
       {...props}
     >
@@ -25,7 +25,7 @@ function Switch({
         className="pointer-events-none block rounded-full bg-background ring-0 transition-transform group-data-[size=default]/switch:size-4 group-data-[size=sm]/switch:size-3 group-data-[size=default]/switch:data-checked:translate-x-[calc(100%-2px)] group-data-[size=sm]/switch:data-checked:translate-x-[calc(100%-2px)] dark:data-checked:bg-primary-foreground group-data-[size=default]/switch:data-unchecked:translate-x-0 group-data-[size=sm]/switch:data-unchecked:translate-x-0 dark:data-unchecked:bg-foreground"
       />
     </SwitchPrimitive.Root>
-  )
+  );
 }
 
-export { Switch }
+export { Switch };

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -1,6 +1,6 @@
-import * as React from "react"
+import * as React from "react";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
   return (
@@ -8,11 +8,11 @@ function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
       data-slot="textarea"
       className={cn(
         "w-full min-w-0 rounded-lg border border-input bg-transparent px-2.5 py-2 text-sm transition-colors outline-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:bg-input/30",
-        className
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
-export { Textarea }
+export { Textarea };

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -1,7 +1,7 @@
-import * as React from "react"
-import { Tooltip as TooltipPrimitive } from "radix-ui"
+import * as React from "react";
+import { Tooltip as TooltipPrimitive } from "radix-ui";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 function TooltipProvider({
   delayDuration = 0,
@@ -13,19 +13,17 @@ function TooltipProvider({
       delayDuration={delayDuration}
       {...props}
     />
-  )
+  );
 }
 
-function Tooltip({
-  ...props
-}: React.ComponentProps<typeof TooltipPrimitive.Root>) {
-  return <TooltipPrimitive.Root data-slot="tooltip" {...props} />
+function Tooltip({ ...props }: React.ComponentProps<typeof TooltipPrimitive.Root>) {
+  return <TooltipPrimitive.Root data-slot="tooltip" {...props} />;
 }
 
 function TooltipTrigger({
   ...props
 }: React.ComponentProps<typeof TooltipPrimitive.Trigger>) {
-  return <TooltipPrimitive.Trigger data-slot="tooltip-trigger" {...props} />
+  return <TooltipPrimitive.Trigger data-slot="tooltip-trigger" {...props} />;
 }
 
 function TooltipContent({
@@ -41,7 +39,7 @@ function TooltipContent({
         sideOffset={sideOffset}
         className={cn(
           "z-50 inline-flex w-fit max-w-xs origin-(--radix-tooltip-content-transform-origin) items-center gap-1.5 rounded-md bg-foreground px-3 py-1.5 text-xs text-background has-data-[slot=kbd]:pr-1.5 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 **:data-[slot=kbd]:relative **:data-[slot=kbd]:isolate **:data-[slot=kbd]:z-50 **:data-[slot=kbd]:rounded-sm data-[state=delayed-open]:animate-in data-[state=delayed-open]:fade-in-0 data-[state=delayed-open]:zoom-in-95 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
-          className
+          className,
         )}
         {...props}
       >
@@ -49,7 +47,7 @@ function TooltipContent({
         <TooltipPrimitive.Arrow className="z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px] bg-foreground fill-foreground" />
       </TooltipPrimitive.Content>
     </TooltipPrimitive.Portal>
-  )
+  );
 }
 
-export { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger }
+export { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger };

--- a/src/index.css
+++ b/src/index.css
@@ -6,140 +6,140 @@
 @custom-variant dark (&:is(.dark *));
 
 @theme inline {
-    --font-heading: var(--font-sans);
-    --font-sans: 'Geist Variable', sans-serif;
-    --color-sidebar-ring: var(--sidebar-ring);
-    --color-sidebar-border: var(--sidebar-border);
-    --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
-    --color-sidebar-accent: var(--sidebar-accent);
-    --color-sidebar-primary-foreground: var(--sidebar-primary-foreground);
-    --color-sidebar-primary: var(--sidebar-primary);
-    --color-sidebar-foreground: var(--sidebar-foreground);
-    --color-sidebar: var(--sidebar);
-    --color-chart-5: var(--chart-5);
-    --color-chart-4: var(--chart-4);
-    --color-chart-3: var(--chart-3);
-    --color-chart-2: var(--chart-2);
-    --color-chart-1: var(--chart-1);
-    --color-ring: var(--ring);
-    --color-input: var(--input);
-    --color-border: var(--border);
-    --color-destructive: var(--destructive);
-    --color-success: var(--success);
-    --color-warning: var(--warning);
-    --color-info: var(--info);
-    --color-owned: var(--owned);
-    --color-accent-foreground: var(--accent-foreground);
-    --color-accent: var(--accent);
-    --color-muted-foreground: var(--muted-foreground);
-    --color-muted: var(--muted);
-    --color-secondary-foreground: var(--secondary-foreground);
-    --color-secondary: var(--secondary);
-    --color-primary-foreground: var(--primary-foreground);
-    --color-primary: var(--primary);
-    --color-popover-foreground: var(--popover-foreground);
-    --color-popover: var(--popover);
-    --color-card-foreground: var(--card-foreground);
-    --color-card: var(--card);
-    --color-foreground: var(--foreground);
-    --color-background: var(--background);
-    --radius-sm: calc(var(--radius) * 0.6);
-    --radius-md: calc(var(--radius) * 0.8);
-    --radius-lg: var(--radius);
-    --radius-xl: calc(var(--radius) * 1.4);
-    --radius-2xl: calc(var(--radius) * 1.8);
-    --radius-3xl: calc(var(--radius) * 2.2);
-    --radius-4xl: calc(var(--radius) * 2.6);
+  --font-heading: var(--font-sans);
+  --font-sans: "Geist Variable", sans-serif;
+  --color-sidebar-ring: var(--sidebar-ring);
+  --color-sidebar-border: var(--sidebar-border);
+  --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
+  --color-sidebar-accent: var(--sidebar-accent);
+  --color-sidebar-primary-foreground: var(--sidebar-primary-foreground);
+  --color-sidebar-primary: var(--sidebar-primary);
+  --color-sidebar-foreground: var(--sidebar-foreground);
+  --color-sidebar: var(--sidebar);
+  --color-chart-5: var(--chart-5);
+  --color-chart-4: var(--chart-4);
+  --color-chart-3: var(--chart-3);
+  --color-chart-2: var(--chart-2);
+  --color-chart-1: var(--chart-1);
+  --color-ring: var(--ring);
+  --color-input: var(--input);
+  --color-border: var(--border);
+  --color-destructive: var(--destructive);
+  --color-success: var(--success);
+  --color-warning: var(--warning);
+  --color-info: var(--info);
+  --color-owned: var(--owned);
+  --color-accent-foreground: var(--accent-foreground);
+  --color-accent: var(--accent);
+  --color-muted-foreground: var(--muted-foreground);
+  --color-muted: var(--muted);
+  --color-secondary-foreground: var(--secondary-foreground);
+  --color-secondary: var(--secondary);
+  --color-primary-foreground: var(--primary-foreground);
+  --color-primary: var(--primary);
+  --color-popover-foreground: var(--popover-foreground);
+  --color-popover: var(--popover);
+  --color-card-foreground: var(--card-foreground);
+  --color-card: var(--card);
+  --color-foreground: var(--foreground);
+  --color-background: var(--background);
+  --radius-sm: calc(var(--radius) * 0.6);
+  --radius-md: calc(var(--radius) * 0.8);
+  --radius-lg: var(--radius);
+  --radius-xl: calc(var(--radius) * 1.4);
+  --radius-2xl: calc(var(--radius) * 1.8);
+  --radius-3xl: calc(var(--radius) * 2.2);
+  --radius-4xl: calc(var(--radius) * 2.6);
 }
 
 :root {
-    color-scheme: light;
-    --background: oklch(1 0 0);
-    --foreground: oklch(0.145 0 0);
-    --card: oklch(1 0 0);
-    --card-foreground: oklch(0.145 0 0);
-    --popover: oklch(1 0 0);
-    --popover-foreground: oklch(0.145 0 0);
-    --primary: oklch(0.205 0 0);
-    --primary-foreground: oklch(0.985 0 0);
-    --secondary: oklch(0.97 0 0);
-    --secondary-foreground: oklch(0.205 0 0);
-    --muted: oklch(0.97 0 0);
-    --muted-foreground: oklch(0.556 0 0);
-    --accent: oklch(0.97 0 0);
-    --accent-foreground: oklch(0.205 0 0);
-    --destructive: oklch(0.577 0.245 27.325);
-    /* Semantic accent tokens, one shade each, so success/warning/info/owned render
+  color-scheme: light;
+  --background: oklch(1 0 0);
+  --foreground: oklch(0.145 0 0);
+  --card: oklch(1 0 0);
+  --card-foreground: oklch(0.145 0 0);
+  --popover: oklch(1 0 0);
+  --popover-foreground: oklch(0.145 0 0);
+  --primary: oklch(0.205 0 0);
+  --primary-foreground: oklch(0.985 0 0);
+  --secondary: oklch(0.97 0 0);
+  --secondary-foreground: oklch(0.205 0 0);
+  --muted: oklch(0.97 0 0);
+  --muted-foreground: oklch(0.556 0 0);
+  --accent: oklch(0.97 0 0);
+  --accent-foreground: oklch(0.205 0 0);
+  --destructive: oklch(0.577 0.245 27.325);
+  /* Semantic accent tokens, one shade each, so success/warning/info/owned render
        identically across every view (the audit found these drifting 300/400/500).
        Values are the Tailwind v4 *-400 palette: emerald, amber, violet, sky. */
-    --success: oklch(0.765 0.177 163.223);
-    --warning: oklch(0.828 0.189 84.429);
-    --info: oklch(0.702 0.183 293.541);
-    --owned: oklch(0.746 0.16 232.661);
-    --border: oklch(0.922 0 0);
-    --input: oklch(0.922 0 0);
-    --ring: oklch(0.708 0 0);
-    --chart-1: oklch(0.87 0 0);
-    --chart-2: oklch(0.556 0 0);
-    --chart-3: oklch(0.439 0 0);
-    --chart-4: oklch(0.371 0 0);
-    --chart-5: oklch(0.269 0 0);
-    --radius: 0.625rem;
-    --sidebar: oklch(0.985 0 0);
-    --sidebar-foreground: oklch(0.145 0 0);
-    --sidebar-primary: oklch(0.205 0 0);
-    --sidebar-primary-foreground: oklch(0.985 0 0);
-    --sidebar-accent: oklch(0.97 0 0);
-    --sidebar-accent-foreground: oklch(0.205 0 0);
-    --sidebar-border: oklch(0.922 0 0);
-    --sidebar-ring: oklch(0.708 0 0);
+  --success: oklch(0.765 0.177 163.223);
+  --warning: oklch(0.828 0.189 84.429);
+  --info: oklch(0.702 0.183 293.541);
+  --owned: oklch(0.746 0.16 232.661);
+  --border: oklch(0.922 0 0);
+  --input: oklch(0.922 0 0);
+  --ring: oklch(0.708 0 0);
+  --chart-1: oklch(0.87 0 0);
+  --chart-2: oklch(0.556 0 0);
+  --chart-3: oklch(0.439 0 0);
+  --chart-4: oklch(0.371 0 0);
+  --chart-5: oklch(0.269 0 0);
+  --radius: 0.625rem;
+  --sidebar: oklch(0.985 0 0);
+  --sidebar-foreground: oklch(0.145 0 0);
+  --sidebar-primary: oklch(0.205 0 0);
+  --sidebar-primary-foreground: oklch(0.985 0 0);
+  --sidebar-accent: oklch(0.97 0 0);
+  --sidebar-accent-foreground: oklch(0.205 0 0);
+  --sidebar-border: oklch(0.922 0 0);
+  --sidebar-ring: oklch(0.708 0 0);
 }
 
 .dark {
-    color-scheme: dark;
-    --background: oklch(0.145 0 0);
-    --foreground: oklch(0.985 0 0);
-    --card: oklch(0.205 0 0);
-    --card-foreground: oklch(0.985 0 0);
-    --popover: oklch(0.205 0 0);
-    --popover-foreground: oklch(0.985 0 0);
-    --primary: oklch(0.922 0 0);
-    --primary-foreground: oklch(0.205 0 0);
-    --secondary: oklch(0.269 0 0);
-    --secondary-foreground: oklch(0.985 0 0);
-    --muted: oklch(0.269 0 0);
-    --muted-foreground: oklch(0.708 0 0);
-    --accent: oklch(0.269 0 0);
-    --accent-foreground: oklch(0.985 0 0);
-    --destructive: oklch(0.704 0.191 22.216);
-    --border: oklch(1 0 0 / 10%);
-    --input: oklch(1 0 0 / 15%);
-    --ring: oklch(0.556 0 0);
-    --chart-1: oklch(0.87 0 0);
-    --chart-2: oklch(0.556 0 0);
-    --chart-3: oklch(0.439 0 0);
-    --chart-4: oklch(0.371 0 0);
-    --chart-5: oklch(0.269 0 0);
-    --sidebar: oklch(0.205 0 0);
-    --sidebar-foreground: oklch(0.985 0 0);
-    --sidebar-primary: oklch(0.488 0.243 264.376);
-    --sidebar-primary-foreground: oklch(0.985 0 0);
-    --sidebar-accent: oklch(0.269 0 0);
-    --sidebar-accent-foreground: oklch(0.985 0 0);
-    --sidebar-border: oklch(1 0 0 / 10%);
-    --sidebar-ring: oklch(0.556 0 0);
+  color-scheme: dark;
+  --background: oklch(0.145 0 0);
+  --foreground: oklch(0.985 0 0);
+  --card: oklch(0.205 0 0);
+  --card-foreground: oklch(0.985 0 0);
+  --popover: oklch(0.205 0 0);
+  --popover-foreground: oklch(0.985 0 0);
+  --primary: oklch(0.922 0 0);
+  --primary-foreground: oklch(0.205 0 0);
+  --secondary: oklch(0.269 0 0);
+  --secondary-foreground: oklch(0.985 0 0);
+  --muted: oklch(0.269 0 0);
+  --muted-foreground: oklch(0.708 0 0);
+  --accent: oklch(0.269 0 0);
+  --accent-foreground: oklch(0.985 0 0);
+  --destructive: oklch(0.704 0.191 22.216);
+  --border: oklch(1 0 0 / 10%);
+  --input: oklch(1 0 0 / 15%);
+  --ring: oklch(0.556 0 0);
+  --chart-1: oklch(0.87 0 0);
+  --chart-2: oklch(0.556 0 0);
+  --chart-3: oklch(0.439 0 0);
+  --chart-4: oklch(0.371 0 0);
+  --chart-5: oklch(0.269 0 0);
+  --sidebar: oklch(0.205 0 0);
+  --sidebar-foreground: oklch(0.985 0 0);
+  --sidebar-primary: oklch(0.488 0.243 264.376);
+  --sidebar-primary-foreground: oklch(0.985 0 0);
+  --sidebar-accent: oklch(0.269 0 0);
+  --sidebar-accent-foreground: oklch(0.985 0 0);
+  --sidebar-border: oklch(1 0 0 / 10%);
+  --sidebar-ring: oklch(0.556 0 0);
 }
 
 @layer base {
   * {
     @apply border-border outline-ring/50;
-    }
+  }
   body {
     @apply bg-background text-foreground;
-    }
+  }
   html {
     @apply font-sans;
-    }
+  }
 }
 
 /* Respect the OS reduced-motion preference: zero out the spinners, pulses, dialog

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -103,10 +103,7 @@ export interface AddedHttpClient {
 
 /** Register an HTTP-bridge client scoped to a profile (empty = all servers).
  * Returns the one-time plaintext token to paste into the client. */
-export function addHttpClient(
-  label: string,
-  profile?: string,
-): Promise<AddedHttpClient> {
+export function addHttpClient(label: string, profile?: string): Promise<AddedHttpClient> {
   return invoke<AddedHttpClient>("add_http_client", { label, profile });
 }
 
@@ -496,10 +493,7 @@ export function previewImport(json: string): Promise<ImportItem[]> {
 }
 
 /** Enable or disable every server in a profile at once. */
-export function setAllEnabled(
-  profileId: string,
-  enabled: boolean,
-): Promise<Registry> {
+export function setAllEnabled(profileId: string, enabled: boolean): Promise<Registry> {
   return invoke<Registry>("set_all_enabled", { profileId, enabled });
 }
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -2,12 +2,7 @@ export type Transport = "stdio" | "http" | "sse" | "unknown";
 
 /** The main content views, selected from the sidebar. */
 export type View =
-  | "servers"
-  | "activity"
-  | "catalog"
-  | "playground"
-  | "teams"
-  | "settings";
+  "servers" | "activity" | "catalog" | "playground" | "teams" | "settings";
 
 export interface McpServer {
   name: string;
@@ -453,11 +448,8 @@ export function importableServers(
   client: DetectedClient,
   registry: Registry | null,
 ): McpServer[] {
-  const have = new Set(
-    (registry?.servers ?? []).map((s) => s.name.toLowerCase()),
-  );
+  const have = new Set((registry?.servers ?? []).map((s) => s.name.toLowerCase()));
   return [...client.servers, ...client.pluginServers].filter(
-    (s) =>
-      s.name.toLowerCase() !== "conduit" && !have.has(s.name.toLowerCase()),
+    (s) => s.name.toLowerCase() !== "conduit" && !have.has(s.name.toLowerCase()),
   );
 }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,8 +1,8 @@
-import { clsx, type ClassValue } from "clsx"
-import { twMerge } from "tailwind-merge"
+import { clsx, type ClassValue } from "clsx";
+import { twMerge } from "tailwind-merge";
 
 export function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs))
+  return twMerge(clsx(inputs));
 }
 
 /**
@@ -11,7 +11,7 @@ export function cn(...inputs: ClassValue[]) {
  * same rounded figure for the same number.
  */
 export function fmtTokens(n: number): string {
-  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`
-  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`
-  return `${n}`
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`;
+  return `${n}`;
 }


### PR DESCRIPTION
## Summary

Adds ESLint with TypeScript and React hooks rules, plus CI enforcement.

**Based on #132 (Prettier).** Merge #132 first, then this one — no conflicts.

## What changed

- **`eslint.config.mjs`** — flat config (ESLint 9 standard):
  - `typescript-eslint` recommended rules
  - `eslint-plugin-react-hooks` recommended (exhaustive-deps, rules-of-hooks)
  - `eslint-plugin-react-refresh` (fast-refresh compatibility)
  - `eslint-config-prettier` (disables formatting rules that conflict with Prettier)
- **CI** — adds a `Lint` step after `npm ci`, before the build
- **CONTRIBUTING.md** — documents the lint commands and the `set-state-in-effect` warning context

## Rule design decisions

| Rule | Severity | Why |
|------|----------|-----|
| `typescript-eslint/recommended` | error | Real bug-catching: unused vars, type-unsafe patterns |
| `react-hooks/rules-of-hooks` | error | Fundamental React correctness |
| `react-hooks/exhaustive-deps` | warn | Often intentional in Tauri IPC patterns |
| `react-hooks/set-state-in-effect` | warn (downgraded from error) | Standard Tauri pattern: no Suspense/RSC for loading data from Rust backend |
| `react-hooks/refs` | warn (downgraded from error) | Same reason — review-only signal |
| `react-refresh/only-export-components` | warn | Fast-refresh hygiene |

## Current state

```
0 errors, 20 warnings
```

Warnings are non-blocking — CI passes.

## DCO

Signed-off-by: Brad Hallett <brad@bradhallett.com>
