### PR TITLE
chore: repo config — blame-ignore-revs + CodeRabbit settings

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,41 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+language: en-US
+early_access: false
+reviews:
+  # "chill" keeps it to substantive findings instead of nitpicking every line.
+  profile: chill
+  # Advisory only — CodeRabbit should never block a merge with a change request.
+  request_changes_workflow: false
+  high_level_summary: true
+  poem: false
+  review_status: true
+  collapse_walkthrough: true
+  auto_review:
+    enabled: true
+    drafts: false
+  # Skip generated / vendored / build output so reviews stay signal-heavy.
+  path_filters:
+    - "!**/package-lock.json"
+    - "!**/*.lock"
+    - "!dist/**"
+    - "!src-tauri/target/**"
+    - "!**/*.min.*"
+  path_instructions:
+    - path: "src/**/*.{ts,tsx}"
+      instructions: >-
+        React + TypeScript frontend. Formatting and lint style are enforced by
+        Prettier and ESLint in CI, so do NOT comment on formatting, semicolons,
+        quotes, or import order. Focus on logic correctness, React hooks
+        dependencies, state handling, and accessibility.
+    - path: "src-tauri/**/*.rs"
+      instructions: >-
+        Rust (Tauri app + MCP gateway). rustfmt/clippy own style, so skip it.
+        Focus on correctness, panics/unwraps, and the security guards
+        (spawn-guard, client scoping, tool-supply-chain checks) where a
+        regression is high-impact.
+    - path: "**/*.test.ts"
+      instructions: >-
+        Vitest tests. Prefer flagging missing edge cases or incorrect
+        expectations over stylistic suggestions.
+chat:
+  auto_reply: true

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,7 @@
+# Revisions listed here are skipped by `git blame` (bulk reformats, not real
+# authorship changes). Enable locally with:
+#   git config blame.ignoreRevsFile .git-blame-ignore-revs
+# GitHub honors this file automatically.
+
+# Tree-wide Prettier reformat of the frontend (#132).
+1649252581513d87fa200e4a52e03a81f4ab9a4c


### PR DESCRIPTION
Two small repo-config additions, follow-up to the frontend tooling merge (#135):

- **`.git-blame-ignore-revs`** — records the tree-wide Prettier reformat commit (#132) so `git blame` and GitHub skip past it to the real prior authorship.
- **`.coderabbit.yaml`** — chill review profile, advisory only (never blocks a merge), skips lockfiles/build output, and tells CodeRabbit not to comment on formatting/style (Prettier + ESLint own that now) so its reviews stay signal-heavy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the blame ignore list to exclude a repository-wide formatting revision from `git blame` results.
  * Refreshed automated code review configuration to improve review behavior, skip generated/lock files, and tailor review guidance for different frontend and backend file types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->