### PR TITLE
feat(discovery): show why each tool ranked in the search trace

### DIFF
--- a/src-tauri/src/bin/conduit-gateway.rs
+++ b/src-tauri/src/bin/conduit-gateway.rs
@@ -795,6 +795,44 @@ fn semantic_rerank<'a>(
     Some(out)
 }
 
+/// Human-readable "why this tool" for the search trace: which query terms hit the
+/// tool's name vs its description. Reuses the same tokenizer and synonyms the ranker
+/// scores with, so the explanation reflects the real match (minus IDF weighting).
+/// Bounded so a long query can't bloat a trace line; an empty result means the tool
+/// surfaced without a keyword hit (a semantic match, or a pinned prerequisite).
+fn explain_match(query: &str, tool: &Value) -> Vec<String> {
+    use std::collections::HashSet;
+    let name = tool.get("name").and_then(Value::as_str).unwrap_or("");
+    let desc = tool.get("description").and_then(Value::as_str).unwrap_or("");
+    let name_set: HashSet<String> = search_tokens(name).into_iter().collect();
+    let desc_set: HashSet<String> = index_tokens(desc).into_iter().collect();
+    let mut out: Vec<String> = Vec::new();
+    let mut seen: HashSet<String> = HashSet::new();
+    for qt in index_tokens(query) {
+        let cands = std::iter::once(qt.as_str()).chain(synonym_group(qt.as_str()).iter().copied());
+        for c in cands {
+            let field = if name_set.contains(c) {
+                Some("name")
+            } else if desc_set.contains(c) {
+                Some("desc")
+            } else {
+                None
+            };
+            if let Some(f) = field {
+                let label = format!("{c} ({f})");
+                if seen.insert(label.clone()) {
+                    out.push(label);
+                }
+                break; // best (name-preferred) field for this query token
+            }
+        }
+        if out.len() >= 6 {
+            break;
+        }
+    }
+    out
+}
+
 /// Project selected tools to search results, bounding the total size of their
 /// (sometimes enormous) input schemas. Lazy discovery exists to keep the agent's
 /// context small, so one server's giant schemas must not blow it up: the top
@@ -1759,6 +1797,25 @@ fn handle_request(
                     .iter()
                     .filter_map(|m| m.get("name").and_then(|v| v.as_str()).map(str::to_string))
                     .collect();
+                // Per-result "why it surfaced": rank, the query terms it matched (name
+                // vs description), and whether it's a prepended pinned prerequisite
+                // rather than a query hit. Turns "which tools" into "why this tool".
+                let ranking: Vec<Value> = matches
+                    .iter()
+                    .enumerate()
+                    .map(|(i, m)| {
+                        json!({
+                            "name": m.get("name").and_then(Value::as_str).unwrap_or(""),
+                            "rank": i + 1,
+                            "matched": explain_match(query, m),
+                            "pinned": i < pins_added,
+                        })
+                    })
+                    .collect();
+                // Reflects the configured ranker (semantic re-rank falls back to lexical
+                // on any embedding failure, so this is the intended mode, not a per-call
+                // guarantee it succeeded).
+                let mode = if sem_cfg.is_active() { "semantic" } else { "lexical" };
                 searchtrace::record(
                     client,
                     query,
@@ -1770,6 +1827,8 @@ fn handle_request(
                     savings::estimate_tokens(&matches),
                     savings::estimate_tokens(source),
                     escalate,
+                    &ranking,
+                    mode,
                 );
                 return Some(success(
                     id,
@@ -4326,6 +4385,25 @@ mod tests {
         assert!(names.contains(&"toolport_call_tool"));
         assert!(names.contains(&"toolport_fetch_result"));
         assert!(!names.contains(&"resend__send_email"));
+    }
+
+    #[test]
+    fn explain_match_reports_hits_and_ignores_misses() {
+        let tool = json!({
+            "name": "acme__send_email",
+            "description": "Send an email message to a recipient.",
+        });
+        // A query term present in the tool is reported as a match.
+        let why = explain_match("email", &tool);
+        assert!(!why.is_empty(), "expected a match, got {why:?}");
+        assert!(why.iter().any(|m| m.contains("email")), "got {why:?}");
+        // A term absent from both name and description contributes nothing.
+        assert!(
+            explain_match("quantum", &tool).is_empty(),
+            "unexpected match for an absent term"
+        );
+        // A pinned/semantic-only surface (no lexical overlap) yields no explanation.
+        assert!(explain_match("", &tool).is_empty());
     }
 
     #[test]

--- a/src-tauri/src/searchtrace.rs
+++ b/src-tauri/src/searchtrace.rs
@@ -54,6 +54,11 @@ fn cap_chars(s: &str, max: usize) -> String {
 /// One recorded search. `flat_tokens` is what advertising the whole (scoped) catalog
 /// would cost per request; `returned_tokens` is what this search's results cost. The
 /// difference is the tool-definition context lazy discovery kept out on this turn.
+///
+/// `ranking` explains why each returned tool surfaced: one entry per result (in result
+/// order) of `{ name, rank, matched, pinned }`, so the Discovery panel can answer "why
+/// this tool" not just "which tools". `mode` is the ranker the search used (`lexical`
+/// or `semantic`). Both are additive; older traces have neither.
 #[allow(clippy::too_many_arguments)]
 pub fn record(
     client: Option<&str>,
@@ -66,6 +71,8 @@ pub fn record(
     returned_tokens: u64,
     flat_tokens: u64,
     escalated: bool,
+    ranking: &[Value],
+    mode: &str,
 ) {
     let stored_names: Vec<&String> = names.iter().take(MAX_NAMES).collect();
     let mut entry = json!({
@@ -79,7 +86,12 @@ pub fn record(
         "flatTokens": flat_tokens,
         "savedTokens": flat_tokens.saturating_sub(returned_tokens),
         "escalated": escalated,
+        "mode": mode,
     });
+    if !ranking.is_empty() {
+        let stored_ranking: Vec<&Value> = ranking.iter().take(MAX_NAMES).collect();
+        entry["ranking"] = json!(stored_ranking);
+    }
     if let Some(s) = server_filter.filter(|s| !s.trim().is_empty()) {
         entry["server"] = json!(s);
     }
@@ -164,8 +176,8 @@ mod tests {
     fn record_then_read_returns_newest_first() {
         let _g = TEST_LOCK.lock().unwrap();
         clear();
-        record(Some("cursor"), "list products", None, "stripe__list", &["stripe__list".into()], 1, 3, 120, 5000, false);
-        record(None, "send email", Some("resend"), "resend__send", &["resend__send".into()], 1, 1, 90, 5000, false);
+        record(Some("cursor"), "list products", None, "stripe__list", &["stripe__list".into()], 1, 3, 120, 5000, false, &[], "lexical");
+        record(None, "send email", Some("resend"), "resend__send", &["resend__send".into()], 1, 1, 90, 5000, false, &[], "lexical");
         let recent = read_recent(10);
         assert_eq!(recent.len(), 2);
         // Newest first.
@@ -179,12 +191,39 @@ mod tests {
     }
 
     #[test]
+    fn ranking_and_mode_are_recorded_and_capped() {
+        let _g = TEST_LOCK.lock().unwrap();
+        clear();
+        // Ranking with more than MAX_NAMES entries; only MAX_NAMES are stored.
+        let ranking: Vec<Value> = (0..40)
+            .map(|i| {
+                json!({ "name": format!("srv__t{i}"), "rank": i + 1, "matched": ["list (name)"], "pinned": false })
+            })
+            .collect();
+        record(None, "list", None, "srv__t0", &["srv__t0".into()], 40, 40, 100, 200, false, &ranking, "semantic");
+        let e = &read_recent(1)[0];
+        assert_eq!(e["mode"], "semantic");
+        let r = e["ranking"].as_array().unwrap();
+        assert_eq!(r.len(), MAX_NAMES);
+        assert_eq!(r[0]["name"], "srv__t0");
+        assert_eq!(r[0]["rank"], 1);
+        assert_eq!(r[0]["matched"][0], "list (name)");
+        // Empty ranking is omitted entirely (older-style call), but mode still records.
+        clear();
+        record(None, "x", None, "", &[], 0, 0, 0, 5000, false, &[], "lexical");
+        let e = &read_recent(1)[0];
+        assert_eq!(e["mode"], "lexical");
+        assert!(e.get("ranking").is_none());
+        clear();
+    }
+
+    #[test]
     fn query_is_capped_and_names_are_limited() {
         let _g = TEST_LOCK.lock().unwrap();
         clear();
         let long_q = "x".repeat(500);
         let many: Vec<String> = (0..40).map(|i| format!("srv__t{i}")).collect();
-        record(None, &long_q, None, "srv__t0", &many, 40, 40, 100, 200, false);
+        record(None, &long_q, None, "srv__t0", &many, 40, 40, 100, 200, false, &[], "lexical");
         let e = &read_recent(1)[0];
         let stored_q = e["query"].as_str().unwrap();
         // Capped to MAX_QUERY_CHARS (+ the ellipsis), never the full 500.
@@ -197,7 +236,7 @@ mod tests {
     fn no_match_search_is_still_recorded() {
         let _g = TEST_LOCK.lock().unwrap();
         clear();
-        record(None, "nonexistent capability", None, "", &[], 0, 0, 0, 5000, false);
+        record(None, "nonexistent capability", None, "", &[], 0, 0, 0, 5000, false, &[], "lexical");
         let e = &read_recent(1)[0];
         assert_eq!(e["returned"], 0);
         assert_eq!(e["top"], "");

--- a/src/components/ActivityView.tsx
+++ b/src/components/ActivityView.tsx
@@ -725,6 +725,11 @@ function DiscoveryRow({ t }: { t: SearchTrace }) {
             loop-broken
           </span>
         )}
+        {t.mode === "semantic" && (
+          <span className="shrink-0 rounded bg-owned/10 px-1.5 py-0.5 text-[11px] text-owned">
+            semantic
+          </span>
+        )}
         <span className="ml-auto shrink-0 text-xs tabular-nums text-muted-foreground">
           {hit ? `${t.returned} of ${t.total}` : "no match"}
         </span>
@@ -735,20 +740,48 @@ function DiscoveryRow({ t }: { t: SearchTrace }) {
       {open && (
         <div className="border-t border-border/50 bg-muted/20 px-3 py-2 pl-9 text-xs">
           {hit ? (
-            <div className="mb-2 flex flex-wrap gap-1">
-              {t.names.map((n) => (
-                <span
-                  key={n}
-                  className={`rounded px-1.5 py-0.5 font-mono text-[11px] ${
-                    n === t.top
-                      ? "bg-owned/15 text-owned"
-                      : "bg-muted text-muted-foreground"
-                  }`}
-                >
-                  {n}
-                </span>
-              ))}
-            </div>
+            t.ranking && t.ranking.length > 0 ? (
+              <div className="mb-2 space-y-1">
+                {t.ranking.map((r) => (
+                  <div key={r.name} className="flex items-baseline gap-2">
+                    <span className="w-5 shrink-0 text-right tabular-nums text-[11px] text-muted-foreground">
+                      #{r.rank}
+                    </span>
+                    <span
+                      className={`shrink-0 font-mono text-[11px] ${
+                        r.name === t.top ? "text-owned" : "text-foreground"
+                      }`}
+                    >
+                      {r.name}
+                    </span>
+                    <span className="min-w-0 truncate text-[11px] text-muted-foreground">
+                      {r.pinned
+                        ? "pinned prerequisite"
+                        : r.matched.length > 0
+                          ? `matched ${r.matched.join(", ")}`
+                          : t.mode === "semantic"
+                            ? "semantic match"
+                            : "—"}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <div className="mb-2 flex flex-wrap gap-1">
+                {t.names.map((n) => (
+                  <span
+                    key={n}
+                    className={`rounded px-1.5 py-0.5 font-mono text-[11px] ${
+                      n === t.top
+                        ? "bg-owned/15 text-owned"
+                        : "bg-muted text-muted-foreground"
+                    }`}
+                  >
+                    {n}
+                  </span>
+                ))}
+              </div>
+            )
           ) : (
             <div className="mb-2 text-muted-foreground">No tools matched this query.</div>
           )}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -100,6 +100,23 @@ export interface SearchTrace {
   savedTokens: number;
   /** The loop-breaker fired: repeated searches kept landing on the same top tool. */
   escalated: boolean;
+  /** Ranker used: keyword-only (`lexical`) or semantic re-rank. Absent on older traces. */
+  mode?: "lexical" | "semantic";
+  /** Per-result explanation, in result order: why each tool surfaced. Absent on older
+   * traces (fall back to `names`). */
+  ranking?: SearchTraceRank[];
+}
+
+/** Why one tool surfaced in a lazy-discovery search. */
+export interface SearchTraceRank {
+  name: string;
+  /** 1-based position in the returned results. */
+  rank: number;
+  /** Query terms this tool matched, e.g. "products (name)". Empty when it surfaced
+   * without a keyword hit (a semantic match or a pinned prerequisite). */
+  matched: string[];
+  /** A pinned prerequisite prepended ahead of the ranked matches, not a query hit. */
+  pinned: boolean;
 }
 
 /** One exposed tool's verifiable identity: the model-visible alias joined back to its


### PR DESCRIPTION
## What

The Discovery panel (1.2.0) shows what a lazy-discovery search returned and its token cost, but not **why** each tool surfaced. This adds that.

- **`searchtrace`** now records, per result (in result order): `rank`, the query terms it `matched` (name vs description), and whether it was a `pinned` prerequisite rather than a query hit. Plus a `mode` marker (lexical vs semantic).
- New **`explain_match()`** in the gateway derives the "why" by reusing the ranker's own tokenizer + synonyms, so the explanation reflects the real match (bounded so a long query can't bloat a trace line).
- **Activity → Discovery** renders it: each result shows `#rank name — matched <terms>` (or "pinned prerequisite" / "semantic match"), and a `semantic` badge on the row when semantic re-rank was on.

Additive and backward-compatible: traces written before this (no `ranking`/`mode`) fall back to the existing tool-name chips.

## Why

Answers "why did this tool get picked, and what did the model see" — the visibility asked for on the r/LocalLLaMA launch thread, and the natural next step after the Discovery panel.

## Tests

- `searchtrace`: new test for ranking storage + cap + mode; existing tests updated.
- gateway: new `explain_match` test (hits, misses, empty).
- Frontend: tsc clean, lint 0 errors, 52 vitest pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Search results now include clearer “why this tool” explanations.
  * Expanded discovery results can now show ranked matches, including pinned items and highlighted matches.
  * Semantic searches are now labeled in the results view for easier scanning.

* **Bug Fixes**
  * Improved how matching terms are detected so empty or non-matching queries no longer show misleading match details.
  * Search trace details now preserve the search mode consistently, even when no ranking list is present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->