### PR TITLE
chore(gateway): rename conduit-gateway binary to toolport-gateway

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Thanks for your interest. Toolport is a local-first MCP gateway and manager: a
 Tauri desktop app (Rust backend + React/TypeScript frontend) plus a separate
-`conduit-gateway` binary that AI clients spawn.
+`toolport-gateway` binary that AI clients spawn.
 
 Want to ask a question, float an idea, or talk through a change before you build
 it? Join the [Discord](https://discord.gg/Xsn27MxdBA). New contributors welcome,
@@ -24,11 +24,11 @@ On macOS/Linux, see the platform notes in the [README troubleshooting](README.md
 
 ### What hot-reloads vs what needs a rebuild
 
-| You changed                                             | What happens                                                                                                                                |
-| ------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
-| React/TS frontend (`src/`)                              | Vite hot-reloads instantly — no restart needed                                                                                              |
-| Rust backend (`src-tauri/src/`)                         | `npm run tauri dev` recompiles and restarts the app automatically                                                                           |
-| Gateway binary (`src-tauri/src/bin/conduit-gateway.rs`) | **Not rebuilt by `tauri dev`.** Run `npm run build:gateway` after changes, then restart any connected clients so they re-spawn the gateway. |
+| You changed                                              | What happens                                                                                                                                |
+| -------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| React/TS frontend (`src/`)                               | Vite hot-reloads instantly — no restart needed                                                                                              |
+| Rust backend (`src-tauri/src/`)                          | `npm run tauri dev` recompiles and restarts the app automatically                                                                           |
+| Gateway binary (`src-tauri/src/bin/toolport-gateway.rs`) | **Not rebuilt by `tauri dev`.** Run `npm run build:gateway` after changes, then restart any connected clients so they re-spawn the gateway. |
 
 The gateway is a separate binary that AI clients spawn as a subprocess. Packaged
 releases bundle it, but when running from source you must build it manually:
@@ -112,7 +112,7 @@ server in the UI takes effect without restarting the client.
 
 - **Gateway "not found" when running from source.** `npm run tauri dev` builds
   the app but not the gateway sidecar. Run `npm run build:gateway` once (and
-  again after any change to `conduit-gateway.rs`).
+  again after any change to `toolport-gateway.rs`).
 
 - **macOS keychain prompts in dev.** An unsigned dev build gets an unstable
   code-signing identity, so the keychain re-prompts or denies reads. A signed
@@ -137,7 +137,7 @@ For end-user troubleshooting (OAuth, AppImage, VS Code), see the
   - `router.rs` - aggregating tools/resources and routing calls.
   - `oauth.rs` / `secrets.rs` / `remote.rs` - auth and the OS keychain.
   - `catalog.rs` - the curated + registry server catalog.
-  - `bin/conduit-gateway.rs` - the gateway binary clients connect to.
+  - `bin/toolport-gateway.rs` - the gateway binary clients connect to.
 
 ## Before you open a PR
 

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Toolport has two pieces:
 
 1. **The desktop app** (Tauri + React) where you manage servers, profiles,
    credentials, and which clients are connected.
-2. **The gateway binary** (`conduit-gateway`) that each AI client launches over
+2. **The gateway binary** (`toolport-gateway`) that each AI client launches over
    stdio. It reads Toolport's registry, connects to the enabled downstream servers
    (stdio or remote HTTP/SSE), and routes tool calls to the right one. Tool names
    are namespaced per server (`stripe__list_charges`) so they never collide.
@@ -129,7 +129,7 @@ Toolport has two pieces:
 AI client (Cursor / Claude / Codex / Antigravity / ...)
         │  stdio MCP
         ▼
-  conduit-gateway  ──reads──►  registry.json + OS keychain
+  toolport-gateway  ──reads──►  registry.json + OS keychain
         │  routes tools/calls
         ▼
   downstream MCP servers (Stripe, Supabase, GitHub, ...)
@@ -177,7 +177,7 @@ Use this when Codex has already created its `~/.codex/` directory.
 
 1. In Toolport, add or enable the MCP servers you want Codex to use.
 2. Open **Clients**, select **Codex**, optionally choose a profile, and click **Connect to Toolport**.
-3. Toolport updates `~/.codex/config.toml` with a single `[mcp_servers.conduit]` entry. That entry runs the resolved `conduit-gateway` binary; existing Codex TOML keys and other MCP servers are preserved, and an existing config is backed up before the write.
+3. Toolport updates `~/.codex/config.toml` with a single `[mcp_servers.conduit]` entry. That entry runs the resolved `toolport-gateway` binary; existing Codex TOML keys and other MCP servers are preserved, and an existing config is backed up before the write.
 4. Start a new Codex session so it re-reads the config. In Toolport, the Codex row changes to **connected to Toolport**; in Codex, Toolport-managed tools are served through the one `conduit` MCP server. With lazy discovery enabled, Codex gets Toolport's compact search tools instead of every downstream tool up front.
 
 Gotcha: when running Toolport from source, build the gateway first with `npm run build:gateway`. The desktop dev server does not build the separate binary that Codex spawns, so Codex will report the gateway as missing until that binary exists.
@@ -187,7 +187,7 @@ Gotcha: when running Toolport from source, build the gateway first with `npm run
 The gateway speaks HTTP/OpenAPI natively, so Open WebUI (and any OpenAPI tool
 client) connects straight to Toolport, no bridge or proxy. Flip on **Settings ->
 Integrations -> Open WebUI / HTTP endpoint** in the app (or run
-`conduit-gateway --http 8765`), then add `http://localhost:8765` as an OpenAPI
+`toolport-gateway --http 8765`), then add `http://localhost:8765` as an OpenAPI
 tool server. See [docs/openwebui.md](docs/openwebui.md). The same endpoint serves
 any HTTP/OpenAPI MCP consumer (n8n, LibreChat, custom agents).
 
@@ -296,7 +296,7 @@ The frontend is typechecked with `npx tsc --noEmit`.
   attempt keeps the callback port reserved for a few minutes and can cause a
   "state mismatch" on the next try.
 - **A client reports the gateway "was not found" (running from source).** Build
-  the gateway binary once: `cd src-tauri && cargo build --bin conduit-gateway`.
+  the gateway binary once: `cd src-tauri && cargo build --bin toolport-gateway`.
   `npm run tauri dev` builds the app but not this separate binary; packaged
   releases bundle it, so installed users never hit this.
 - **Repeated macOS keychain prompts / "could not read secret from the keychain"
@@ -371,6 +371,6 @@ Pricing, the self-host quickstart, and checkout are all at
 ## License
 
 [MIT](LICENSE), and the local app and gateway always will be. Toolport follows an
-open-core model: the desktop app and `conduit-gateway` are free and open source, and
+open-core model: the desktop app and `toolport-gateway` are free and open source, and
 Toolport Teams (above) funds the free app. Anything you contribute here is MIT and
 benefits everyone, see [CONTRIBUTING.md](CONTRIBUTING.md).

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -32,7 +32,7 @@ profile-scoped client writes `tool-cache-<profile>.json`; the unscoped default i
 
 ```bash
 # 1. Build the gateway
-npm run build:gateway        # or: cargo build --release --bin conduit-gateway
+npm run build:gateway        # or: cargo build --release --bin toolport-gateway
 
 # 2. Connect a few servers in Toolport, and edit the TASKS in bench.js to match them.
 

--- a/benchmark/bench-sweep.mjs
+++ b/benchmark/bench-sweep.mjs
@@ -99,7 +99,7 @@ try {
 }
 
 function defaultGateway() {
-  const exe = process.platform === "win32" ? "conduit-gateway.exe" : "conduit-gateway";
+  const exe = process.platform === "win32" ? "toolport-gateway.exe" : "toolport-gateway";
   const release = join(ROOT, "src-tauri", "target", "release", exe);
   const debug = join(ROOT, "src-tauri", "target", "debug", exe);
   if (existsSync(release)) return release;

--- a/benchmark/bench.js
+++ b/benchmark/bench.js
@@ -12,7 +12,7 @@
 // the mcpico benchmark, so the numbers are directly comparable.
 //
 // Prereqs:
-//   1. Build the gateway:   npm run build:gateway   (or: cargo build --release --bin conduit-gateway)
+//   1. Build the gateway:   npm run build:gateway   (or: cargo build --release --bin toolport-gateway)
 //   2. Connect some servers in Toolport (the tasks below should match what you have).
 //   3. Run a local OpenAI-compatible LLM:
 //        - LM Studio: start the server (default http://localhost:1234)
@@ -52,7 +52,7 @@ const TASKS = [
 ];
 
 function defaultGateway() {
-  const exe = process.platform === "win32" ? "conduit-gateway.exe" : "conduit-gateway";
+  const exe = process.platform === "win32" ? "toolport-gateway.exe" : "toolport-gateway";
   const release = join(ROOT, "src-tauri", "target", "release", exe);
   const debug = join(ROOT, "src-tauri", "target", "debug", exe);
   if (existsSync(release)) return release;

--- a/benchmark/latency.mjs
+++ b/benchmark/latency.mjs
@@ -21,7 +21,7 @@ import { dirname, join } from "node:path";
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const DEBUG = join(__dirname, "..", "src-tauri", "target", "debug");
 const exe = (n) => join(DEBUG, process.platform === "win32" ? `${n}.exe` : n);
-const GATEWAY = exe("conduit-gateway");
+const GATEWAY = exe("toolport-gateway");
 const MOCK = exe("mock-mcp-server");
 const N = Math.max(20, Number(process.argv[2] || 200));
 

--- a/benchmark/retrieval.mjs
+++ b/benchmark/retrieval.mjs
@@ -39,7 +39,7 @@ const CONNECT_WAIT_MS = Number(process.env.CONNECT_WAIT_MS || 12000);
 const K = Number(process.env.K || 10); // results to request / rank within
 
 function defaultGateway() {
-  const exe = process.platform === "win32" ? "conduit-gateway.exe" : "conduit-gateway";
+  const exe = process.platform === "win32" ? "toolport-gateway.exe" : "toolport-gateway";
   const release = join(ROOT, "src-tauri", "target", "release", exe);
   const debug = join(ROOT, "src-tauri", "target", "debug", exe);
   return existsSync(release) ? release : debug;

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -288,7 +288,7 @@ Phase 2 - Client integration
 - [x] Migrate-on-connect: import a client's servers, leave it gateway-only
 - [x] Live propagation (registry mtime bump -> gateway rebuild -> tools/list_changed)
 - [x] Registry path anchored to a non-virtualized home path (MSIX desync fix)
-- [x] Bundle conduit-gateway as a sidecar so the installed path survives in
+- [x] Bundle toolport-gateway as a sidecar so the installed path survives in
       production (externalBin via merge config `tauri.bundle.conf.json`, staged by
       `scripts/prepare-sidecar.mjs`; `resolve_gateway_path` finds the dev name or
       the packaged `-<triple>` name). Shipping in signed releases.

--- a/docs/SIGNING.md
+++ b/docs/SIGNING.md
@@ -140,7 +140,7 @@ fall back to the right-click → Open workaround in the README).
 ## Gotcha: the bundled gateway must be signed too
 
 Notarization rejects any unsigned executable in the bundle, including the
-`conduit-gateway` sidecar. Tauri signs bundled binaries during `tauri build` when
+`toolport-gateway` sidecar. Tauri signs bundled binaries during `tauri build` when
 signing is configured, so this should be automatic. If the first notarization run
 fails citing an unsigned binary, that's the gateway, we'll add an explicit sign
 step for it in the workflow.

--- a/docs/design/hitl-approval-queue.md
+++ b/docs/design/hitl-approval-queue.md
@@ -14,14 +14,14 @@ it is worth building to a high bar rather than the minimal one.
 ## Architecture constraints (verified against the code)
 
 1. **Many gateway processes, not one.** Each stdio client (Claude Desktop, Cursor, Claude
-   Code) spawns its own `conduit-gateway` over stdio; the app also supervises one in
+   Code) spawns its own `toolport-gateway` over stdio; the app also supervises one in
    `--http` mode (`lib.rs:1470-1541`). `ConfirmGuard` is in-memory **per process**
-   (`conduit-gateway.rs:914-974`).
+   (`toolport-gateway.rs:914-974`).
 2. **No inbound control channel to a gateway** today; app->gateway is one-way via files
-   under `~/.conduit/`, polled by mtime every ~1000ms (`conduit-gateway.rs:2073-2142`).
+   under `~/.conduit/`, polled by mtime every ~1000ms (`toolport-gateway.rs:2073-2142`).
 3. Observability today = shared JSONL the app polls (`inspect.jsonl` ring-50,
    `audit.jsonl`).
-4. Existing destructive interception in `process_request` (`conduit-gateway.rs:1599-1642`):
+4. Existing destructive interception in `process_request` (`toolport-gateway.rs:1599-1642`):
    token stored in `ConfirmGuard`, returned to the model as an `isError` preview, replayed
    via `toolport_confirm` (`:1362-1389`), 60s TTL, `is_destructive` = `annotations.destructiveHint`.
 5. Frontend (`src/components/`): `ActivityView.tsx` + `SettingsView.tsx`; the quarantine

--- a/docs/macos-keychain-test-runbook.md
+++ b/docs/macos-keychain-test-runbook.md
@@ -31,7 +31,7 @@ npx tauri build --config src-tauri/tauri.bundle.conf.json
 ```
 
 This produces `src-tauri/target/release/bundle/macos/Toolport.app` with the bare
-gateway at `Toolport.app/Contents/MacOS/conduit-gateway`.
+gateway at `Toolport.app/Contents/MacOS/toolport-gateway`.
 
 ## (b) Sign + package (wrap the gateway as a nested .app)
 
@@ -49,7 +49,7 @@ APP=/path/to/Toolport.app ./scripts/macos-sign-local.sh
 
 The script:
 
-- moves the gateway into `Toolport.app/Contents/Helpers/ConduitGateway.app`,
+- moves the gateway into `Toolport.app/Contents/Helpers/ToolportGateway.app`,
 - embeds the gateway provisioning profile there,
 - leaves a symlink at the old bare path for backward compat,
 - signs inside-out and prints the `keychain-access-groups` entitlement plus each
@@ -60,10 +60,10 @@ It is idempotent: re-running rebuilds the helper bundle and re-signs.
 Confirm the layout:
 
 ```
-ls -l "src-tauri/target/release/bundle/macos/Toolport.app/Contents/MacOS/conduit-gateway"
-# -> a symlink: conduit-gateway -> ../Helpers/ConduitGateway.app/Contents/MacOS/conduit-gateway
+ls -l "src-tauri/target/release/bundle/macos/Toolport.app/Contents/MacOS/toolport-gateway"
+# -> a symlink: toolport-gateway -> ../Helpers/ToolportGateway.app/Contents/MacOS/toolport-gateway
 
-file "src-tauri/target/release/bundle/macos/Toolport.app/Contents/Helpers/ConduitGateway.app/Contents/MacOS/conduit-gateway"
+file "src-tauri/target/release/bundle/macos/Toolport.app/Contents/Helpers/ToolportGateway.app/Contents/MacOS/toolport-gateway"
 # -> Mach-O ... (the real binary)
 ```
 
@@ -90,7 +90,7 @@ entitlements + embedded profile that authorize the same access group, the read
 must succeed silently (no keychain password dialog).
 
 ```
-GW="src-tauri/target/release/bundle/macos/Toolport.app/Contents/Helpers/ConduitGateway.app/Contents/MacOS/conduit-gateway"
+GW="src-tauri/target/release/bundle/macos/Toolport.app/Contents/Helpers/ToolportGateway.app/Contents/MacOS/toolport-gateway"
 
 # Spawn it the way a client does (stdio MCP). Either point a real client at it,
 # or drive a quick MCP handshake. The point is that the gateway resolves the
@@ -102,7 +102,7 @@ To exercise the actual secret read, start the gateway so it proxies the server y
 configured in step (c) (it resolves that server's API key from the shared keychain
 group), then issue a tool call that requires the key. Watch for:
 
-- NO keychain "conduit-gateway wants to use your confidential information" prompt.
+- NO keychain "toolport-gateway wants to use your confidential information" prompt.
 - The proxied call succeeds (the gateway found and used the secret).
 
 You can also confirm the value round-trips with `security` IF you know the service
@@ -142,12 +142,12 @@ Prove that a binary WITHOUT the team's access-group entitlement cannot read the
 secret. Copy the gateway out and re-sign it ad-hoc (no entitlements, no team):
 
 ```
-cp "$GW" /tmp/conduit-gateway-adhoc
-codesign --force -s - /tmp/conduit-gateway-adhoc   # ad-hoc, strips entitlements
-codesign -d --entitlements - /tmp/conduit-gateway-adhoc 2>&1 | grep -i keychain || echo "no keychain-access-groups (expected)"
+cp "$GW" /tmp/toolport-gateway-adhoc
+codesign --force -s - /tmp/toolport-gateway-adhoc   # ad-hoc, strips entitlements
+codesign -d --entitlements - /tmp/toolport-gateway-adhoc 2>&1 | grep -i keychain || echo "no keychain-access-groups (expected)"
 
 # Now try to read the same secret with the ad-hoc binary's identity.
-/tmp/conduit-gateway-adhoc ...   # attempt the same secret-backed proxied call
+/tmp/toolport-gateway-adhoc ...   # attempt the same secret-backed proxied call
 ```
 
 Expected result: the read is DENIED. You should see either:

--- a/docs/openwebui.md
+++ b/docs/openwebui.md
@@ -12,7 +12,7 @@ Integrations -> "Open WebUI / HTTP endpoint"**, flip it on, and copy the **URL**
 (`http://localhost:8765`) and the **token** it shows. The app supervises the
 gateway for you and shuts it down when you quit.
 
-> Prefer the command line? `conduit-gateway --http 8765` (or `CONDUIT_HTTP=8765`)
+> Prefer the command line? `toolport-gateway --http 8765` (or `CONDUIT_HTTP=8765`)
 > does the same thing; set `CONDUIT_HTTP_TOKEN=<your-token>` to require auth (the
 > app does this automatically). It serves an OpenAPI spec at
 > `http://localhost:8765/openapi.json` and a POST endpoint per tool.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "tsc && vite build",
     "preview": "vite preview",
     "tauri": "tauri",
-    "build:gateway": "cargo build --manifest-path src-tauri/Cargo.toml --bin conduit-gateway",
+    "build:gateway": "cargo build --manifest-path src-tauri/Cargo.toml --bin toolport-gateway",
     "prepare:sidecar": "node scripts/prepare-sidecar.mjs",
     "build:bundle": "npm run build && npm run prepare:sidecar",
     "tauri:bundle": "tauri build --config src-tauri/tauri.bundle.conf.json --bundles nsis",

--- a/scripts/macos-sign-local.sh
+++ b/scripts/macos-sign-local.sh
@@ -5,13 +5,13 @@
 # LOCAL macOS sign + package flow for the keychain-access-group wrapper (Phase 2).
 #
 # What it does:
-#   1. Finds the bare conduit-gateway binary inside a built Toolport.app.
+#   1. Finds the bare toolport-gateway binary inside a built Toolport.app.
 #   2. Rebuilds it as a nested helper bundle:
-#        Toolport.app/Contents/Helpers/ConduitGateway.app
+#        Toolport.app/Contents/Helpers/ToolportGateway.app
 #      so the gateway can carry its OWN embedded provisioning profile (a bare
 #      Mach-O cannot embed a .provisionprofile; only a bundle can).
 #   3. Leaves a symlink at the OLD bare path
-#        Toolport.app/Contents/MacOS/conduit-gateway
+#        Toolport.app/Contents/MacOS/toolport-gateway
 #      pointing at the nested binary, so existing client configs that spawn the
 #      old path keep working.
 #   4. Codesigns inside-out (no --deep): gateway bundle first, then the outer app,
@@ -48,8 +48,8 @@ GW_ENTITLEMENTS="$REPO_ROOT/src-tauri/Gateway.entitlements"
 
 # Identifiers (must match the entitlements + profiles).
 GW_BUNDLE_ID="com.tsout.conduit.gateway"
-GW_EXECUTABLE="conduit-gateway"
-HELPER_APP_NAME="ConduitGateway.app"
+GW_EXECUTABLE="toolport-gateway"
+HELPER_APP_NAME="ToolportGateway.app"
 
 # A version string for the helper Info.plist. Pull it from the app's own
 # Info.plist if available, else fall back.
@@ -113,16 +113,19 @@ HELPERS_DIR="$APP/Contents/Helpers"
 HELPER_APP="$HELPERS_DIR/$HELPER_APP_NAME"
 HELPER_BIN="$HELPER_APP/Contents/MacOS/$GW_EXECUTABLE"
 SYMLINK_PATH="$APP/Contents/MacOS/$GW_EXECUTABLE"
+# Pre-rename bare path, kept as a SECOND symlink so client configs written by an
+# older Toolport (which spawn `conduit-gateway`) keep resolving to the same binary.
+LEGACY_SYMLINK_PATH="$APP/Contents/MacOS/conduit-gateway"
 
 # ---------------------------------------------------------------------------
 # 1. Locate the gateway binary inside the app.
-#    It is EITHER the bare Mach-O at Contents/MacOS/conduit-gateway (fresh build),
+#    It is EITHER the bare Mach-O at Contents/MacOS/toolport-gateway (fresh build),
 #    OR already inside the nested helper bundle (re-run). We must not pick up the
 #    backward-compat symlink as the "real" binary.
 # ---------------------------------------------------------------------------
 bold "[1/5] Locating the gateway binary inside the app"
 
-# Find every candidate named conduit-gateway, skipping symlinks (-type f).
+# Find every candidate named toolport-gateway, skipping symlinks (-type f).
 # (Portable read loop instead of `mapfile`, which is bash 4+ only; macOS ships bash 3.2.)
 CANDIDATES=()
 while IFS= read -r _candidate; do
@@ -174,14 +177,15 @@ echo "  helper version = $HELPER_VERSION"
 bold "[2/5] Building nested helper bundle: $HELPER_APP"
 
 # Stash the real binary aside so we can rebuild the bundle from a clean slate.
-TMP_BIN="$(mktemp "${TMPDIR:-/tmp}/conduit-gateway.XXXXXX")"
+TMP_BIN="$(mktemp "${TMPDIR:-/tmp}/toolport-gateway.XXXXXX")"
 cp -f "$REAL_BIN" "$TMP_BIN"
 chmod +x "$TMP_BIN"
 
 # Remove any prior helper bundle and the bare/symlink path, then recreate. This
 # is what makes the script idempotent: every run rebuilds from $TMP_BIN.
 rm -rf "$HELPER_APP"
-rm -f "$SYMLINK_PATH"      # also removes a stale symlink or a leftover bare binary
+rm -f "$SYMLINK_PATH"         # also removes a stale symlink or a leftover bare binary
+rm -f "$LEGACY_SYMLINK_PATH"  # and any stale pre-rename compat symlink
 mkdir -p "$HELPER_APP/Contents/MacOS"
 
 # (a) the binary, moved into the helper bundle.
@@ -199,9 +203,9 @@ cat > "$HELPER_APP/Contents/Info.plist" <<PLIST
 	<key>CFBundleExecutable</key>
 	<string>$GW_EXECUTABLE</string>
 	<key>CFBundleName</key>
-	<string>ConduitGateway</string>
+	<string>ToolportGateway</string>
 	<key>CFBundleDisplayName</key>
-	<string>Conduit Gateway</string>
+	<string>Toolport Gateway</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleInfoDictionaryVersion</key>
@@ -224,17 +228,24 @@ cp -f "$GW_PROFILE" "$HELPER_APP/Contents/embedded.provisionprofile"
 green "  helper bundle assembled"
 
 # ---------------------------------------------------------------------------
-# 3. Backward-compat symlink at the OLD bare gateway path.
-#    Contents/MacOS/conduit-gateway -> ../Helpers/ConduitGateway.app/Contents/MacOS/conduit-gateway
+# 3. Bare-path symlinks -> nested binary.
+#    Contents/MacOS/toolport-gateway -> ../Helpers/ToolportGateway.app/Contents/MacOS/toolport-gateway  (current)
+#    Contents/MacOS/conduit-gateway  -> (same target)                                                    (pre-rename compat)
+#    Both let a client spawn either path and reach the same signed, profile-bearing
+#    gateway, so configs written by an older Toolport keep working after the rename.
 # ---------------------------------------------------------------------------
-bold "[3/5] Linking old bare path -> nested binary (backward compat)"
-ln -s "../Helpers/$HELPER_APP_NAME/Contents/MacOS/$GW_EXECUTABLE" "$SYMLINK_PATH"
-[[ -L "$SYMLINK_PATH" ]] || die "Failed to create backward-compat symlink at $SYMLINK_PATH"
-# Resolve it to confirm it points at the real binary.
+bold "[3/5] Linking bare paths -> nested binary (current + backward compat)"
+GW_TARGET="../Helpers/$HELPER_APP_NAME/Contents/MacOS/$GW_EXECUTABLE"
+ln -s "$GW_TARGET" "$SYMLINK_PATH"
+[[ -L "$SYMLINK_PATH" ]] || die "Failed to create symlink at $SYMLINK_PATH"
+ln -s "$GW_TARGET" "$LEGACY_SYMLINK_PATH"
+[[ -L "$LEGACY_SYMLINK_PATH" ]] || die "Failed to create backward-compat symlink at $LEGACY_SYMLINK_PATH"
+# Resolve both to confirm they point at the real binary.
 if ! readlink "$SYMLINK_PATH" >/dev/null 2>&1; then
   die "Symlink at $SYMLINK_PATH does not resolve"
 fi
 green "  symlink: $SYMLINK_PATH -> $(readlink "$SYMLINK_PATH")"
+green "  compat:  $LEGACY_SYMLINK_PATH -> $(readlink "$LEGACY_SYMLINK_PATH")"
 
 # ---------------------------------------------------------------------------
 # 4. Codesign INSIDE-OUT (no --deep): gateway bundle first, then the outer app.

--- a/scripts/prepare-sidecar.mjs
+++ b/scripts/prepare-sidecar.mjs
@@ -1,5 +1,5 @@
-// Build the conduit-gateway binary and stage it where Tauri's `externalBin`
-// bundler expects it: `src-tauri/binaries/conduit-gateway-<target-triple><ext>`.
+// Build the toolport-gateway binary and stage it where Tauri's `externalBin`
+// bundler expects it: `src-tauri/binaries/toolport-gateway-<target-triple><ext>`.
 // Runs as part of `beforeBuildCommand`, so a packaged app always ships a gateway
 // matching the target.
 //
@@ -34,15 +34,15 @@ mkdirSync(destDir, { recursive: true });
 
 function gatewayPathFor(triple) {
   const sub = triple ? join(triple, profile) : profile;
-  return join("src-tauri", "target", sub, `conduit-gateway${ext}`);
+  return join("src-tauri", "target", sub, `toolport-gateway${ext}`);
 }
 
 function buildGateway(triple) {
   const targetArg = triple ? `--target ${triple} ` : "";
   console.log(
-    `[sidecar] building conduit-gateway (${profile}) ${triple ? "for " + triple : "(host)"}`,
+    `[sidecar] building toolport-gateway (${profile}) ${triple ? "for " + triple : "(host)"}`,
   );
-  execSync(`cargo build ${debug ? "" : "--release "}${targetArg}--bin conduit-gateway`, {
+  execSync(`cargo build ${debug ? "" : "--release "}${targetArg}--bin toolport-gateway`, {
     cwd: "src-tauri",
     stdio: "inherit",
   });
@@ -53,7 +53,7 @@ function buildGateway(triple) {
 
 // The staged file must carry the triple Tauri will look for at bundle time.
 const stagedTriple = requested || hostTriple();
-const dest = join(destDir, `conduit-gateway-${stagedTriple}${ext}`);
+const dest = join(destDir, `toolport-gateway-${stagedTriple}${ext}`);
 
 // Break the chicken-and-egg: the gateway's own build (via the shared build.rs ->
 // tauri_build) validates this externalBin path exists at compile time. Seed a

--- a/src-tauri/Gateway.entitlements
+++ b/src-tauri/Gateway.entitlements
@@ -2,7 +2,7 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<!-- Application Identifier for the standalone conduit-gateway binary. Must
+	<!-- Application Identifier for the standalone toolport-gateway binary. Must
 	     match its embedded provisioning profile and the keychain access group
 	     prefix (Team ID V4YZPC7T6G). -->
 	<key>com.apple.application-identifier</key>

--- a/src-tauri/src/approval_broker.rs
+++ b/src-tauri/src/approval_broker.rs
@@ -1,9 +1,9 @@
 //! App-side HITL approval broker.
 //!
-//! The Toolport app hosts this broker; every `conduit-gateway` process (one per stdio
+//! The Toolport app hosts this broker; every `toolport-gateway` process (one per stdio
 //! client, plus the app's `--http` bridge) dials OUT to it when it holds a gated tool
 //! call, and blocks reading for the decision. This is the counterpart to the gateway's
-//! `request_human_decision` (see `bin/conduit-gateway.rs`).
+//! `request_human_decision` (see `bin/toolport-gateway.rs`).
 //!
 //! Protocol: the gateway connects over loopback TCP, sends one JSON line
 //! ([`ApprovalRequest`]) carrying the shared token, and reads one JSON line back

--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -1462,7 +1462,7 @@ fn handle_request(
                         "resources": { "listChanged": true },
                         "prompts": { "listChanged": true }
                     },
-                    "serverInfo": { "name": "conduit-gateway", "version": env!("CARGO_PKG_VERSION") }
+                    "serverInfo": { "name": "toolport-gateway", "version": env!("CARGO_PKG_VERSION") }
                 }),
             ))
         }
@@ -2721,7 +2721,7 @@ fn process_request(
 /// `CONDUIT_HTTP=<port>` is the direct env form, and a truthy `CONDUIT_HTTP`
 /// falls back to `CONDUIT_HTTP_PORT` or 8765. Absent everywhere -> stdio mode.
 fn http_port() -> Option<u16> {
-    // CLI flag: `conduit-gateway --http` (default 8765) or `--http 9000`.
+    // CLI flag: `toolport-gateway --http` (default 8765) or `--http 9000`.
     let args: Vec<String> = std::env::args().collect();
     if let Some(i) = args.iter().position(|a| a == "--http") {
         let port = args
@@ -3080,14 +3080,14 @@ fn serve_http(state: GatewayState, port: u16) {
     // anyone who can reach the port, so refuse to bind one without a token.
     if !loopback && token.is_none() {
         eprintln!(
-            "conduit-gateway: refusing to bind {host}:{port} without CONDUIT_HTTP_TOKEN. \
+            "toolport-gateway: refusing to bind {host}:{port} without CONDUIT_HTTP_TOKEN. \
              A non-loopback HTTP endpoint would be unauthenticated. Set a token, or bind 127.0.0.1."
         );
         std::process::exit(1);
     }
     if token.is_none() {
         eprintln!(
-            "conduit-gateway: WARNING - HTTP endpoint has no token; any local process (including a \
+            "toolport-gateway: WARNING - HTTP endpoint has no token; any local process (including a \
              web page open in your browser) can call your tools. Set CONDUIT_HTTP_TOKEN to require auth."
         );
     }
@@ -3117,7 +3117,7 @@ fn serve_http(state: GatewayState, port: u16) {
     let server = match tiny_http::Server::http((host.as_str(), port)) {
         Ok(s) => s,
         Err(e) => {
-            eprintln!("conduit-gateway: could not bind HTTP {host}:{port}: {e}");
+            eprintln!("toolport-gateway: could not bind HTTP {host}:{port}: {e}");
             std::process::exit(1);
         }
     };
@@ -3126,7 +3126,7 @@ fn serve_http(state: GatewayState, port: u16) {
         token.is_some()
     ));
     eprintln!(
-        "conduit-gateway: HTTP/OpenAPI on http://localhost:{port}  (OpenAPI spec at /openapi.json)"
+        "toolport-gateway: HTTP/OpenAPI on http://localhost:{port}  (OpenAPI spec at /openapi.json)"
     );
     serve_http_loop(server, state, token, search, confirm);
 }
@@ -3306,7 +3306,7 @@ fn handle_connection(
 }
 
 fn main() {
-    // Diagnostic: `conduit-gateway --selftest-secrets` reads every vaulted secret
+    // Diagnostic: `toolport-gateway --selftest-secrets` reads every vaulted secret
     // from THIS (gateway) process and reports. Used to validate the macOS keychain
     // shared-access ACL: this runs as a separate process from the app, exactly the
     // cross-process read path. If it reads the secrets with NO keychain prompt, the
@@ -3400,7 +3400,7 @@ fn main() {
             // We keep running on a default so the gateway stays up, and the on-disk
             // tool cache still answers tools/list from the last good build.
             eprintln!(
-                "conduit-gateway: could not load registry ({e}); serving cached tools only. \
+                "toolport-gateway: could not load registry ({e}); serving cached tools only. \
                  Fix or recreate the registry to restore full functionality."
             );
             glog(&format!("load_resolved ERR: {e}"));

--- a/src-tauri/src/clients.rs
+++ b/src-tauri/src/clients.rs
@@ -108,7 +108,12 @@ pub fn is_gateway_server(server: &ServerEntry) -> bool {
         || server
             .command
             .as_deref()
-            .map(|c| c.to_lowercase().contains("conduit-gateway"))
+            .map(|c| {
+                let c = c.to_lowercase();
+                // Match the current name and the pre-rename one, so a client
+                // configured by an older Toolport is still recognized as ours.
+                c.contains("toolport-gateway") || c.contains("conduit-gateway")
+            })
             .unwrap_or(false)
 }
 
@@ -2206,7 +2211,7 @@ pub fn write_servers(client_id: &str, servers: &[ServerEntry]) -> Result<WriteOu
 // Gateway install
 //
 // "Installing Toolport into a client" means adding a single entry to that
-// client's config that runs the conduit-gateway binary. The client then talks
+// client's config that runs the toolport-gateway binary. The client then talks
 // only to Toolport, which routes to everything behind it. This is a surgical
 // edit: existing servers (and their secret env values) are left untouched.
 // ---------------------------------------------------------------------------
@@ -2216,33 +2221,39 @@ pub(crate) fn resolve_gateway_path() -> Option<PathBuf> {
     let dir = exe.parent()?;
     let ext = std::env::consts::EXE_SUFFIX;
     // Dev / `cargo run`, and most packaged builds: the gateway sits next to the app
-    // binary as `conduit-gateway` (Tauri strips the sidecar's target-triple suffix
+    // binary as `toolport-gateway` (Tauri strips the sidecar's target-triple suffix
     // when installing). True for Windows (install dir), macOS (.app/Contents/MacOS),
-    // and the Linux .deb (/usr/bin).
-    let plain = dir.join(format!("conduit-gateway{ext}"));
+    // and the Linux .deb (/usr/bin). `conduit-gateway` is the pre-rename name, kept
+    // as a fallback so an install updated in place still resolves.
+    let plain = dir.join(format!("toolport-gateway{ext}"));
+    let plain_legacy = dir.join(format!("conduit-gateway{ext}"));
 
     // macOS signed bundle: the keychain-access-group wrapper (scripts/macos-sign-local.sh)
     // re-homes the gateway into a nested helper bundle so it can carry its own
     // embedded provisioning profile:
-    //     Conduit.app/Contents/Helpers/ConduitGateway.app/Contents/MacOS/conduit-gateway
+    //     Toolport.app/Contents/Helpers/ToolportGateway.app/Contents/MacOS/toolport-gateway
     // The app binary runs from Toolport.app/Contents/MacOS, so `dir` is that
-    // directory. Prefer the nested binary when it exists. The old bare path
-    // (Contents/MacOS/conduit-gateway) is kept as a SYMLINK to this same binary by
-    // the signing script for backward compatibility with already-written client
-    // configs, so spawning either path reaches the same signed, profile-bearing
-    // gateway. (Existing-install client-config rewrite to the nested path is a
-    // later concern; not handled here.)
+    // directory. Prefer the nested binary when it exists. Both bare paths
+    // (Contents/MacOS/{toolport,conduit}-gateway) are kept as SYMLINKs to this same
+    // binary by the signing script, so spawning either reaches the same signed,
+    // profile-bearing gateway and older client configs still work. The pre-rename
+    // helper (ConduitGateway.app) is checked as a fallback for an in-place update.
     #[cfg(target_os = "macos")]
     {
-        let nested = dir
-            .join("..")
-            .join("Helpers")
-            .join("ConduitGateway.app")
-            .join("Contents")
-            .join("MacOS")
-            .join("conduit-gateway");
-        if nested.exists() {
-            return Some(nested);
+        for (app, exe) in [
+            ("ToolportGateway.app", "toolport-gateway"),
+            ("ConduitGateway.app", "conduit-gateway"),
+        ] {
+            let nested = dir
+                .join("..")
+                .join("Helpers")
+                .join(app)
+                .join("Contents")
+                .join("MacOS")
+                .join(exe);
+            if nested.exists() {
+                return Some(nested);
+            }
         }
     }
 
@@ -2251,20 +2262,29 @@ pub(crate) fn resolve_gateway_path() -> Option<PathBuf> {
     // it would be dead by the time a client tries to spawn it. Copy the gateway to a
     // stable per-user location and hand clients that path. ($APPIMAGE is only set
     // when running inside an AppImage.)
-    if std::env::var_os("APPIMAGE").is_some() && plain.exists() {
-        if let Some(stable) = stable_gateway_copy(&plain) {
-            return Some(stable);
+    if std::env::var_os("APPIMAGE").is_some() {
+        for src in [&plain, &plain_legacy] {
+            if src.exists() {
+                if let Some(stable) = stable_gateway_copy(src) {
+                    return Some(stable);
+                }
+            }
         }
     }
 
     if plain.exists() {
         return Some(plain);
     }
+    if plain_legacy.exists() {
+        return Some(plain_legacy);
+    }
     // Packaged fallback: a sidecar that kept its `-<target-triple>` suffix.
     if let Some(triple) = option_env!("CONDUIT_TARGET_TRIPLE").filter(|t| !t.is_empty()) {
-        let suffixed = dir.join(format!("conduit-gateway-{triple}{ext}"));
-        if suffixed.exists() {
-            return Some(suffixed);
+        for name in ["toolport-gateway", "conduit-gateway"] {
+            let suffixed = dir.join(format!("{name}-{triple}{ext}"));
+            if suffixed.exists() {
+                return Some(suffixed);
+            }
         }
     }
     // Fall back to the plain path so callers surface a clear "not found" error
@@ -2278,7 +2298,9 @@ pub(crate) fn resolve_gateway_path() -> Option<PathBuf> {
 fn stable_gateway_copy(src: &std::path::Path) -> Option<PathBuf> {
     let dest_dir = crate::registry::conduit_dir()?.join("bin");
     std::fs::create_dir_all(&dest_dir).ok()?;
-    let dest = dest_dir.join("conduit-gateway");
+    // Keep the source's filename so the stable copy matches whichever binary name
+    // (toolport-gateway, or the legacy conduit-gateway) was found next to the app.
+    let dest = dest_dir.join(src.file_name()?);
     let stale = match (std::fs::metadata(&dest), std::fs::metadata(src)) {
         (Ok(d), Ok(s)) => d.len() != s.len(),
         _ => true,
@@ -2299,7 +2321,7 @@ fn stable_gateway_copy(src: &std::path::Path) -> Option<PathBuf> {
 }
 
 fn gateway_entry(profile: Option<&str>) -> Result<ServerEntry, String> {
-    let path = resolve_gateway_path().ok_or("Could not locate the conduit-gateway binary")?;
+    let path = resolve_gateway_path().ok_or("Could not locate the toolport-gateway binary")?;
     let env_var = |k: &str, v: &str| crate::registry::EnvVar {
         key: k.to_string(),
         value: Some(v.to_string()),

--- a/src-tauri/src/downstream.rs
+++ b/src-tauri/src/downstream.rs
@@ -1067,7 +1067,7 @@ impl DownstreamServer {
             json!({
                 "protocolVersion": PROTOCOL_VERSION,
                 "capabilities": {},
-                "clientInfo": { "name": "conduit-gateway", "version": env!("CARGO_PKG_VERSION") }
+                "clientInfo": { "name": "toolport-gateway", "version": env!("CARGO_PKG_VERSION") }
             }),
         ).map_err(|e| e.to_string())?;
         let caps = init.get("capabilities");

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -31,7 +31,7 @@ use registry::{Profile, Registry, ServerEntry};
 
 type RegistryState = Mutex<Registry>;
 
-/// Tracks the optional `conduit-gateway --http` child the app supervises so
+/// Tracks the optional `toolport-gateway --http` child the app supervises so
 /// HTTP/OpenAPI clients (Open WebUI and the like) can connect with one click,
 /// no terminal. Only one runs at a time; the app kills it on exit.
 #[derive(Default)]
@@ -1751,7 +1751,7 @@ fn http_bridge_alive(bridge: &mut HttpBridge) -> bool {
     alive
 }
 
-/// Start `conduit-gateway --http <port>` as a supervised child so HTTP/OpenAPI
+/// Start `toolport-gateway --http <port>` as a supervised child so HTTP/OpenAPI
 /// clients can connect. Idempotent: if it's already running, returns the current
 /// status; otherwise spawns the bundled gateway binary and tracks it.
 #[tauri::command]
@@ -1774,7 +1774,7 @@ fn start_http_bridge(
         ));
     }
     let bin = clients::resolve_gateway_path()
-        .ok_or_else(|| "conduit-gateway binary not found next to the app".to_string())?;
+        .ok_or_else(|| "toolport-gateway binary not found next to the app".to_string())?;
     // Auto-generate a bearer token the client must send on every request.
     // Without it, any local process (including a web page open in the user's
     // browser) could POST to the port and run their tools.

--- a/src-tauri/src/secrets.rs
+++ b/src-tauri/src/secrets.rs
@@ -146,7 +146,7 @@ mod platform {
     }
 
     /// Create a generic-password item in the **legacy** keychain that BOTH the
-    /// Toolport app and the `conduit-gateway` binary can read with no keychain
+    /// Toolport app and the `toolport-gateway` binary can read with no keychain
     /// prompt: build a legacy `SecAccess` whose trusted-applications list names
     /// both binaries and pass it as `kSecAttrAccess` on `SecItemAdd`. Setting the
     /// ACL atomically at creation avoids the keychain-password prompt that a

--- a/src-tauri/tauri.bundle.conf.json
+++ b/src-tauri/tauri.bundle.conf.json
@@ -5,6 +5,6 @@
   },
   "bundle": {
     "createUpdaterArtifacts": true,
-    "externalBin": ["binaries/conduit-gateway"]
+    "externalBin": ["binaries/toolport-gateway"]
   }
 }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -306,7 +306,7 @@ export interface HttpBridgeStatus {
   token: string | null;
 }
 
-/** Start the supervised conduit-gateway HTTP/OpenAPI server (Open WebUI etc.). */
+/** Start the supervised toolport-gateway HTTP/OpenAPI server (Open WebUI etc.). */
 export function startHttpBridge(port?: number): Promise<HttpBridgeStatus> {
   return invoke<HttpBridgeStatus>("start_http_bridge", { port: port ?? null });
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -451,10 +451,14 @@ export function isEnabled(registry: Registry, serverId: string): boolean {
  * Mirrors `is_gateway_server` in the Rust backend. */
 export function isGatewayServer(server: ServerEntry): boolean {
   const name = server.name.toLowerCase();
+  const command = server.command?.toLowerCase() ?? "";
   return (
     server.id === "conduit" ||
     name === "conduit" ||
-    (server.command?.toLowerCase().includes("conduit-gateway") ?? false)
+    // Current binary name and the pre-rename one, so an entry written by an older
+    // Toolport is still recognized as the gateway.
+    command.includes("toolport-gateway") ||
+    command.includes("conduit-gateway")
   );
 }
 


### PR DESCRIPTION
Renames the standalone gateway executable **conduit-gateway → toolport-gateway** (and the macOS helper bundle **ConduitGateway.app → ToolportGateway.app**). Re-opened against `main` after #137 merged (the original #138 auto-closed when its stacked base branch was deleted). Same verified change.

## ✅ Verified on the Mac VM (2026-07-03)
Signed bundle built + `macos-sign-local.sh` ran clean:
- Both bare symlinks created: `toolport-gateway` **and** compat `conduit-gateway` → same nested binary.
- `codesign --verify --strict --deep`: valid + satisfies Designated Requirement.
- keychain-access-group `V4YZPC7T6G.com.tsout.conduit.shared` embedded; frozen bundle id `com.tsout.conduit`.
- `--selftest-secrets`: **4 secrets read OK, 0 errors, no keychain prompt** via BOTH the new binary and the legacy compat symlink.

## Keychain + data safety
Every identity string that gates keychain/data is **frozen and grep-verified**: service `conduit-mcp`, access group `…conduit.shared`, master key `__conduit_master_key__`, bundle id `com.tsout.conduit`, entitlement IDs, provisioning-profile filenames, the `Conduit` data dir, `conduit://`, the `conduit_*` meta aliases, and `CONDUIT_*` env vars.

## No existing client breaks
Detection (`is_gateway_server`/`isGatewayServer`) and `resolve_gateway_path` match **both** names; the release CI script delegates to the same (updated) `macos-sign-local.sh`, so the dual symlink ships in releases too.

## Verified
- ✅ cargo check (new bin name) + frozen ids intact; frontend tsc/lint/52 vitest green; Mac keychain proof above.
- ⚠️ First release build is the final notarization proof of the dual-symlink layout (loud failure if any, not silent — keychain identity is frozen).

Left as-is on purpose: CHANGELOG history, entry name `conduit`, the main app binary (`conduit`, = crate name), and two cosmetic `conduit:`/temp-name log strings (separate follow-up).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The gateway is now consistently named **Toolport Gateway** across the app, docs, benchmarks, and packaging.
  * Existing **legacy gateway names still work** in detection and launch paths for compatibility.

* **Bug Fixes**
  * Updated startup, signing, and install flows to use the correct bundled gateway name.
  * Improved error and status messages so they match the new gateway branding.

* **Documentation**
  * Refreshed setup, troubleshooting, and runbook instructions to reflect the new binary name and paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->