### PR TITLE
fix(clients): re-point existing client configs after the gateway rename

### DIFF
--- a/src-tauri/src/clients.rs
+++ b/src-tauri/src/clients.rs
@@ -2472,10 +2472,136 @@ pub fn migrate_to_gateway(client_id: &str, profile: Option<&str>) -> Result<Writ
     write_servers(client_id, &[gateway_entry(profile)?])
 }
 
+/// Whether a client's stored gateway command should be re-pointed: it names the
+/// pre-rename binary (`conduit-gateway`), or its path no longer exists on disk, and
+/// it isn't already the current path.
+fn gateway_command_is_stale(stored: &str, current: &str) -> bool {
+    if stored.is_empty() || stored == current {
+        return false;
+    }
+    stored.to_lowercase().contains("conduit-gateway") || !Path::new(stored).exists()
+}
+
+/// Best-effort read of the gateway entry's `CONDUIT_PROFILE` from raw client-config
+/// text, format-tolerantly (JSON `"CONDUIT_PROFILE": "x"`, TOML `= "x"`, YAML `: x`).
+/// The parsed `McpServer` drops env VALUES (they can be secret), so a re-point reads
+/// the profile here to preserve per-client scoping. None if absent/unparseable, in
+/// which case the re-point falls back to the unscoped default, which widens access
+/// rather than breaking it.
+fn profile_from_config_text(content: &str) -> Option<String> {
+    let idx = content.find("CONDUIT_PROFILE")?;
+    let mut rest = content[idx + "CONDUIT_PROFILE".len()..].trim_start();
+    rest = rest.strip_prefix('"').unwrap_or(rest).trim_start(); // JSON key's closing quote
+    rest = rest.trim_start_matches([':', '=']).trim_start(); // the key/value separator
+    if let Some(after) = rest.strip_prefix('"') {
+        let val = after.split('"').next().unwrap_or("").trim();
+        return (!val.is_empty()).then(|| val.to_string());
+    }
+    // Unquoted YAML bareword: up to whitespace / structural punctuation.
+    let val: String = rest
+        .chars()
+        .take_while(|c| !c.is_whitespace() && !matches!(c, ',' | '}' | ']'))
+        .collect();
+    let val = val.trim();
+    (!val.is_empty()).then(|| val.to_string())
+}
+
+fn read_gateway_profile(client_id: &str) -> Option<String> {
+    let def = find_def(client_id)?;
+    let path = (def.path)()?;
+    let content = read_config_file(&path).ok()?;
+    profile_from_config_text(&content)
+}
+
+/// Re-point client configs whose gateway entry still names the pre-rename binary
+/// (or a path that no longer exists) to the current gateway. This closes the
+/// backward-compat gap the `conduit-gateway` -> `toolport-gateway` rename opened on
+/// platforms without the macOS compat symlink (Windows/Linux), where an existing
+/// client would otherwise spawn a binary that no longer exists.
+///
+/// Idempotent (an entry already on the current path is skipped, so it's a no-op
+/// after the first launch), surgical (`install_gateway` rewrites only the gateway
+/// entry and backs the config up first), and profile-preserving. Guarded so it never
+/// writes a path that doesn't exist. Returns the ids of clients it re-pointed.
+pub fn repoint_stale_gateways() -> Vec<String> {
+    let Some(current) = resolve_gateway_path().map(|p| p.to_string_lossy().into_owned()) else {
+        return Vec::new();
+    };
+    // Never re-point onto a binary that isn't there (resolve_gateway_path returns a
+    // best-guess path even when nothing is found, for clearer error messages).
+    if !Path::new(&current).exists() {
+        return Vec::new();
+    }
+    let mut repointed = Vec::new();
+    for client in detect_clients() {
+        if !client.gateway_installed || !client.config_exists || client.error.is_some() {
+            continue;
+        }
+        let stored = client
+            .servers
+            .iter()
+            .find(|s| s.name.eq_ignore_ascii_case(GATEWAY_ENTRY_NAME))
+            .and_then(|s| s.command.as_deref())
+            .unwrap_or("");
+        if !gateway_command_is_stale(stored, &current) {
+            continue;
+        }
+        let profile = read_gateway_profile(&client.id);
+        if install_gateway(&client.id, profile.as_deref()).is_ok() {
+            repointed.push(client.id.clone());
+        }
+    }
+    repointed
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::registry::EnvVar;
+
+    #[test]
+    fn gateway_command_stale_detection() {
+        let current = "/opt/toolport/toolport-gateway";
+        // Names the pre-rename binary -> stale (even though this test path is fake).
+        assert!(gateway_command_is_stale(
+            "/Applications/Toolport.app/Contents/MacOS/conduit-gateway",
+            current
+        ));
+        // Points at a path that doesn't exist -> stale.
+        assert!(gateway_command_is_stale(
+            "/nonexistent/toolport-gateway-xyz-does-not-exist",
+            current
+        ));
+        // Already the current path -> not stale (short-circuits before the fs check).
+        assert!(!gateway_command_is_stale(current, current));
+        // Empty -> not stale.
+        assert!(!gateway_command_is_stale("", current));
+    }
+
+    #[test]
+    fn profile_extracted_across_config_formats() {
+        // JSON
+        assert_eq!(
+            profile_from_config_text(r#"{"env":{"CONDUIT_PROFILE":"work"}}"#).as_deref(),
+            Some("work")
+        );
+        // TOML
+        assert_eq!(
+            profile_from_config_text("CONDUIT_PROFILE = \"billing\"").as_deref(),
+            Some("billing")
+        );
+        // YAML, quoted and bareword
+        assert_eq!(
+            profile_from_config_text("  CONDUIT_PROFILE: \"dev\"\n").as_deref(),
+            Some("dev")
+        );
+        assert_eq!(
+            profile_from_config_text("env:\n  CONDUIT_PROFILE: staging\n").as_deref(),
+            Some("staging")
+        );
+        // Absent
+        assert_eq!(profile_from_config_text(r#"{"env":{"OTHER":"x"}}"#), None);
+    }
 
     #[test]
     fn app_present_distinguishes_installed_from_absent() {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2160,6 +2160,22 @@ pub fn run() {
             let handle = app.handle().clone();
             std::thread::spawn(move || watch_registry_for_app(handle));
 
+            // One-time, idempotent migration: after the conduit-gateway ->
+            // toolport-gateway rename, re-point any existing client whose config
+            // still names the old binary (Windows/Linux have no compat symlink, so
+            // that path no longer exists). Surgical + backed up; a no-op once every
+            // client is on the current path.
+            std::thread::spawn(|| {
+                let repointed = clients::repoint_stale_gateways();
+                if !repointed.is_empty() {
+                    eprintln!(
+                        "toolport: re-pointed {} client config(s) to the renamed gateway: {}",
+                        repointed.len(),
+                        repointed.join(", ")
+                    );
+                }
+            });
+
             // Start the human-approval broker: it publishes a loopback endpoint that every
             // gateway process dials into, and holds gated tool calls until the user approves
             // or denies them here. Always managed so the approve/deny commands have state.


### PR DESCRIPTION
Closes the backward-compat hole the gateway rename (#139) opened on **Windows/Linux**.

## The problem
An existing client's config holds an **absolute path** to `conduit-gateway(.exe)`. After an update it's now `toolport-gateway`, and the old path is gone. macOS is saved by the dual **symlink**; Windows/Linux have no such thing, so that client silently fails to spawn the gateway (and both-name detection still shows it "connected," masking the break).

## The fix
On launch (background thread), `repoint_stale_gateways()` re-points any client whose gateway entry names the old binary or points at a missing path → the current binary, via `install_gateway`.

- **Idempotent** — skips entries already on the current path, so it's a no-op after the first launch.
- **Surgical** — rewrites only the gateway entry, backs up the config first (reuses the existing install path).
- **Guarded** — never writes a path that doesn't exist (`resolve_gateway_path` returns a best-guess even on miss).
- **Profile-preserving** — reads `CONDUIT_PROFILE` from the raw config (the parsed `McpServer` drops env values), so a scoped client stays scoped.
- Also cleans up the macOS "re-point to the nested path" TODO in one mechanism.

## Tests
- `gateway_command_stale_detection` (old name / missing path / already-current / empty)
- `profile_extracted_across_config_formats` (JSON, TOML, quoted + bareword YAML)
- All 63 existing clients tests still pass; gateway bin + lib cargo-check clean.

## Verifies the Windows concern
This is the fix for the exact test we discussed: an existing Windows client with an old `conduit-gateway.exe` config should now **silently start working again on first launch** of the updated app.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Existing client setups that still pointed to an outdated gateway entry are now automatically updated on startup.
  * Improved handling for clients with scoped configurations, helping preserve the correct profile settings during the update.
  * Added broader support for different configuration formats so affected clients are more reliably detected and repaired.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->