### PR TITLE
chore(release): v1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ Entries before the rename below shipped under the project's former name, Conduit
 
 ## [Unreleased]
 
+## [1.3.0] - 2026-07-04
+
+### Added
+
+- **Discovery now shows why each tool ranked.** The lazy-discovery search trace
+  (Activity → Discovery) records, per result, its rank, the query terms it matched
+  (name vs description), whether it was a pinned prerequisite, and the ranker used
+  (lexical vs semantic). You can now see not just which tools a search returned, but
+  why, and what the model was handed.
+
+### Changed
+
+- **The gateway binary is now `toolport-gateway`** (was `conduit-gateway`; the macOS
+  helper bundle is `ToolportGateway.app`). Existing client integrations keep working:
+  detection and path resolution accept both names, macOS ships a compatibility symlink,
+  and on launch Toolport re-points any client config still naming the old binary to the
+  new one (each config is backed up first). Keychain and stored data are untouched: the
+  keychain service, access group, master key, bundle id, and data directory are all
+  unchanged, so no secrets or servers are lost across the update.
+
 ## [1.2.0] - 2026-07-03
 
 ### Security

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "conduit",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "conduit",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "dependencies": {
         "@fontsource-variable/geist": "^5.2.9",
         "@tailwindcss/vite": "^4.3.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "conduit",
   "private": true,
-  "version": "1.2.0",
+  "version": "1.3.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -604,7 +604,7 @@ dependencies = [
 
 [[package]]
 name = "conduit"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "base64 0.22.1",
  "chacha20poly1305",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conduit"
-version = "1.2.0"
+version = "1.3.0"
 description = "Local MCP gateway: manage all your MCP servers in one place, set up once and shared by every AI client, with ~90% fewer tokens per request"
 authors = ["South Forge AI"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Toolport",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "identifier": "com.tsout.conduit",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
Release prep for **v1.3.0**. Bumps the version across package.json, Cargo.toml, tauri.conf.json (and both lockfiles) and adds the CHANGELOG section.

Ships since v1.2.0:
- **#137** Discovery now shows *why* each tool ranked (rank, matched terms, lexical/semantic mode)
- **#139** gateway binary `conduit-gateway` → `toolport-gateway` (Mac-verified keychain + dual symlink)
- **#140** cosmetic `conduit:` → `toolport:` log prefixes
- **#141** launch-time re-point migration so existing client configs survive the rename on every platform

Frozen identity strings (keychain service, access group, master key, bundle id, data dir) unchanged. After merge, tagging `v1.3.0` builds a **draft** release for final verification before any publish.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Search results now show why each tool was ranked, including matched terms, rank, pin/prerequisite status, and ranking source.

* **Changed**
  * The app has been updated to version 1.3.0.
  * The gateway binary has been renamed to `toolport-gateway`, with updated macOS app naming and automatic configuration updates on launch.
  * Existing keychain and stored data remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->