### PR TITLE
fix(activity): quiet the new-tool flood, batch benign notices

### DIFF
--- a/src/components/ActivityView.tsx
+++ b/src/components/ActivityView.tsx
@@ -292,34 +292,44 @@ function SecurityNotices({
 function QuietDriftHistory({
   events,
   onDismiss,
+  onDismissAll,
 }: {
   events: SecurityEvent[];
   onDismiss: (e: SecurityEvent) => void;
+  onDismissAll: () => void;
 }) {
   const [open, setOpen] = useState(false);
   return (
     <div className="mb-4 rounded-lg border border-border/60 bg-muted/20 p-3">
-      <button
-        onClick={() => setOpen((v) => !v)}
-        aria-expanded={open}
-        className="flex w-full items-center gap-2 text-left text-xs text-muted-foreground"
-      >
-        <History className="size-3.5 shrink-0" />
-        <span className="font-medium text-foreground/80">Recent tool changes</span>
-        <span className="rounded-full bg-muted px-1.5 py-0.5 font-medium">
-          {events.length}
-        </span>
-        <ChevronRight
-          className={`ml-auto size-3.5 transition-transform ${open ? "rotate-90" : ""}`}
-        />
-      </button>
+      <div className="flex w-full items-center gap-2 text-xs text-muted-foreground">
+        <button
+          onClick={() => setOpen((v) => !v)}
+          aria-expanded={open}
+          className="flex flex-1 items-center gap-2 text-left"
+        >
+          <History className="size-3.5 shrink-0" />
+          <span className="font-medium text-foreground/80">New &amp; changed tools</span>
+          <span className="rounded-full bg-muted px-1.5 py-0.5 font-medium">
+            {events.length}
+          </span>
+          <ChevronRight
+            className={`ml-auto size-3.5 transition-transform ${open ? "rotate-90" : ""}`}
+          />
+        </button>
+        <button
+          onClick={onDismissAll}
+          className="shrink-0 rounded px-2 py-0.5 font-medium text-muted-foreground/70 transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-border"
+        >
+          Dismiss all
+        </button>
+      </div>
       {open && (
         <>
           <p className="mt-2 mb-2 max-w-2xl text-xs text-muted-foreground">
-            Benign, non-destructive definition changes on tools you've already approved
-            (vendors revise beta tools server-side). Kept for the record, not flagged as a
-            risk. Dismiss any you've reviewed, they'll stay quiet if the same change
-            recurs.
+            New tools first seen, and benign, non-destructive changes to tools you've
+            already approved (vendors revise beta tools server-side). Kept for the record,
+            not flagged as a risk, the approval and destructive-tool gates still guard
+            every call. Dismiss any you've reviewed.
           </p>
           <ul className="space-y-1 text-xs">
             {events.slice(0, 20).map((e) => (
@@ -821,7 +831,18 @@ function DiscoveryTraces({ refreshKey }: { refreshKey: number }) {
     };
   }, [refreshKey]);
 
-  if (entries.length === 0) return null;
+  if (entries.length === 0)
+    return (
+      <div className="mb-6 rounded-lg border border-border/60 bg-muted/20 p-4 text-xs text-muted-foreground">
+        <div className="mb-1 flex items-center gap-2">
+          <Search className="size-4 shrink-0 text-owned" />
+          <span className="font-medium text-foreground/80">Discovery</span>
+        </div>
+        With lazy discovery on, this shows every tool search your agents run, what
+        matched, why it ranked, and the context tokens it kept out of the model. Nothing
+        searched yet.
+      </div>
+    );
 
   return (
     <div className="mb-6 rounded-lg border border-owned/30 bg-owned/[0.04] p-4">
@@ -1087,12 +1108,41 @@ export function ActivityView({
   );
   // Split loud/actionable signal from benign churn so vendor revisions don't bury a real
   // poison or privilege-escalation flag (the failure this whole surface exists to avoid).
-  const highSecurity = liveSecurity.filter((e) => eventSeverity(e) === "high");
-  const infoSecurity = liveSecurity.filter((e) => eventSeverity(e) === "info");
+  //
+  // A tool FIRST APPEARING is inventory, not a rug-pull: you never approved it, so it
+  // can't have changed under you, and the destructive-tool + approval gates still guard
+  // the actual call. So "added" always goes to the quiet lane, even when the new tool is
+  // destructive (e.g. a server exposing `delete_*`). That keeps a bulk first-baseline
+  // from masquerading as a wall of alarms. The loud lane stays for what genuinely needs
+  // a human: poison, injected results, and a tool you already approved CHANGING.
+  const isNewTool = (e: SecurityEvent) =>
+    e.change === "added" &&
+    e.type !== "tool_poison_flag" &&
+    e.type !== "result_injection";
+  const highSecurity = liveSecurity.filter(
+    (e) => eventSeverity(e) === "high" && !isNewTool(e),
+  );
+  const infoSecurity = liveSecurity.filter(
+    (e) => eventSeverity(e) !== "high" || isNewTool(e),
+  );
   const dismissSecurity = (e: SecurityEvent) => {
     setDismissed((prev) => {
       const next = new Set(prev);
       next.add(securityKey(e));
+      try {
+        localStorage.setItem(SECURITY_DISMISSED_KEY, JSON.stringify([...next]));
+      } catch {
+        // ignore storage failures; the dismissal just won't persist
+      }
+      return next;
+    });
+  };
+  // Clear a whole batch at once (the quiet lane can hold dozens of first-sightings after
+  // a re-baseline; making the user dismiss each would just recreate the noise problem).
+  const dismissAllSecurity = (events: SecurityEvent[]) => {
+    setDismissed((prev) => {
+      const next = new Set(prev);
+      for (const e of events) next.add(securityKey(e));
       try {
         localStorage.setItem(SECURITY_DISMISSED_KEY, JSON.stringify([...next]));
       } catch {
@@ -1110,7 +1160,11 @@ export function ActivityView({
         <SecurityResting />
       )}
       {infoSecurity.length > 0 ? (
-        <QuietDriftHistory events={infoSecurity} onDismiss={dismissSecurity} />
+        <QuietDriftHistory
+          events={infoSecurity}
+          onDismiss={dismissSecurity}
+          onDismissAll={() => dismissAllSecurity(infoSecurity)}
+        />
       ) : null}
       <DiscoveryTraces refreshKey={refreshKey} />
       <ToolIdentities refreshKey={refreshKey} />

--- a/src/components/ActivityView.tsx
+++ b/src/components/ActivityView.tsx
@@ -928,10 +928,22 @@ function ToolIdentityRow({ t }: { t: ToolIdentity }) {
             <dd>{t.profiles.length ? t.profiles.join(", ") : "-"}</dd>
             <dt className="text-muted-foreground">Fingerprint</dt>
             <dd className="font-mono break-all">{t.fingerprint || "-"}</dd>
-            <dt className="text-muted-foreground">First seen</dt>
-            <dd>{fmtDate(t.firstSeen)}</dd>
-            <dt className="text-muted-foreground">Last changed</dt>
-            <dd>{fmtDate(t.lastChanged)}</dd>
+            {t.firstSeen > 0 ? (
+              <>
+                <dt className="text-muted-foreground">First seen</dt>
+                <dd>{fmtDate(t.firstSeen)}</dd>
+                <dt className="text-muted-foreground">Last changed</dt>
+                <dd>{fmtDate(t.lastChanged)}</dd>
+              </>
+            ) : (
+              <>
+                <dt className="text-muted-foreground">History</dt>
+                <dd className="text-muted-foreground/80">
+                  Turn on integrity checking in Settings to track when this tool was first
+                  seen and when it last changed.
+                </dd>
+              </>
+            )}
           </dl>
         </div>
       )}


### PR DESCRIPTION
First of the UX cohesion pass (mockup direction approved). Sorts Activity's security surface into **loud/actionable** vs **calm/telemetry**.

## The bug
A *new tool appearing* was being treated like a security alarm. Because drift detection marks a **destructive** new tool high-severity, reconnecting a server that exposes `delete_*` / `run_sql` tools dumped 20-30 items into the loud panel to clear one at a time, from doing nothing but listing projects.

## The fix (principle)
A new tool is **inventory, not a rug-pull**: you never approved it, so it can't have changed under you, and the destructive-tool + approval gates still guard the actual call. So:
- **All `added` events → the quiet lane**, even destructive ones.
- **Loud lane keeps only** poison, injected results, and a tool you *already approved* changing (the real rug-pull).
- Quiet lane ("New & changed tools") gets **Dismiss all**.
- **"All clear" resting state** now shows when nothing genuine needs review.
- **Discovery panel** shows a one-line hint instead of hiding when empty (so the 1.3.0 feature is discoverable).

Self-contained, only ActivityView consumes these events. tsc clean, 0 lint errors, 52 vitest pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a **“Dismiss all”** action for the quiet security history to clear multiple items at once.
  * Discovery traces now display a persistent informational empty state when no entries are available.
* **Bug Fixes**
  * Improved security activity prioritization by treating first-seen inventory events as non-actionable, keeping the main banner focused on more relevant alerts.
* **UI Updates**
  * Updated tool identity trace rows to show either timestamp-based “First seen/Last changed” details or a clear “History” prompt when integrity checking data is missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->