### PR TITLE
[codex] Improve catalog empty state copy

### DIFF
--- a/src/components/CatalogView.tsx
+++ b/src/components/CatalogView.tsx
@@ -236,12 +236,15 @@ export function CatalogView({ registry, onAdded }: Props) {
             ))}
           </div>
         ) : browsing && popularError ? (
-          <div className="flex flex-col items-center gap-3 py-20 text-center">
+          <div
+            role="status"
+            aria-live="polite"
+            className="flex flex-col items-center gap-3 py-20 text-center"
+          >
             <div>
               <p className="font-medium">Catalog could not load</p>
               <p className="max-w-md text-sm text-muted-foreground">
-                Toolport could not load the curated picks. Check that the desktop app is
-                still running, then try again.
+                Toolport could not load the curated picks. Try again in a moment.
               </p>
             </div>
             <Button variant="outline" size="sm" onClick={reloadPopular}>
@@ -250,16 +253,20 @@ export function CatalogView({ registry, onAdded }: Props) {
           </div>
         ) : (
           !loading && (
-            <div className="flex flex-col items-center gap-1 py-20 text-center">
+            <div
+              role="status"
+              aria-live="polite"
+              className="flex flex-col items-center gap-1 py-20 text-center"
+            >
               <p className="font-medium">
                 {results !== null
                   ? `No catalog results for "${query}"`
-                  : "Catalog unavailable"}
+                  : "No popular servers available"}
               </p>
               <p className="max-w-md text-sm text-muted-foreground">
                 {results !== null
                   ? "Try a provider name, app name, or shorter query. You can also clear the search to browse popular servers."
-                  : "Try again in a moment, or reopen Toolport if the catalog stays empty."}
+                  : "Use search to query the MCP Registry, or try again later if the browse list stays empty."}
               </p>
             </div>
           )

--- a/src/components/CatalogView.tsx
+++ b/src/components/CatalogView.tsx
@@ -237,19 +237,32 @@ export function CatalogView({ registry, onAdded }: Props) {
           </div>
         ) : browsing && popularError ? (
           <div className="flex flex-col items-center gap-3 py-20 text-center">
-            <p className="text-sm text-muted-foreground">Couldn't load the catalog.</p>
+            <div>
+              <p className="font-medium">Catalog could not load</p>
+              <p className="max-w-md text-sm text-muted-foreground">
+                Toolport could not load the curated picks. Check that the desktop app is
+                still running, then try again.
+              </p>
+            </div>
             <Button variant="outline" size="sm" onClick={reloadPopular}>
               Try again
             </Button>
           </div>
         ) : (
-          <p className="py-20 text-center text-sm text-muted-foreground">
-            {loading
-              ? ""
-              : results !== null
-                ? `No servers match "${query}".`
-                : "Catalog unavailable."}
-          </p>
+          !loading && (
+            <div className="flex flex-col items-center gap-1 py-20 text-center">
+              <p className="font-medium">
+                {results !== null
+                  ? `No catalog results for "${query}"`
+                  : "Catalog unavailable"}
+              </p>
+              <p className="max-w-md text-sm text-muted-foreground">
+                {results !== null
+                  ? "Try a provider name, app name, or shorter query. You can also clear the search to browse popular servers."
+                  : "Try again in a moment, or reopen Toolport if the catalog stays empty."}
+              </p>
+            </div>
+          )
         )
       ) : browsing ? (
         <div className="flex flex-col gap-6">


### PR DESCRIPTION
## What and why

Fixes #58.

This keeps the polish pass to one screen: the Catalog view. It makes the catalog load failure and no-results states more specific and actionable without changing behavior.

The change intentionally avoids `src/components/ActivityView.tsx` and `src/components/SettingsView.tsx`, which are already touched by owner PRs #143 and #144.

## Testing

- [x] `npm run format:check` passes
- [x] `npm run lint` passes with existing warnings only
- [x] `npm run test` passes
- [x] `npx tsc --noEmit` passes
- [x] `npm run build` passes
- [x] `cargo test --manifest-path src-tauri/Cargo.toml --lib --bins` passes
- [x] `npm run build:gateway` passes with the existing `unused_mut` warning in `src/downstream.rs`
- [ ] Ran the app (`npm run tauri dev`) and checked the change by hand

## Notes

No secrets, keys, or personal paths are included in the diff.

AI assistance disclosure: this PR was prepared with Codex.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated the catalog empty-state UI to clearly differentiate between: search with no results, catalog unavailable, and curated picks failing during browsing.
  * Added a dedicated “Catalog could not load” panel with a “Try again” action.
* **Bug Fixes**
  * Replaced the generic error/fallback copy with state-specific messaging and improved retry guidance.
  * Enhanced accessibility for status updates using appropriate live-region behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->