### PR TITLE
fix(integrity): stop false 'baseline lost' alarms from empty/mid-swap pins reads

### DIFF
--- a/src-tauri/src/integrity.rs
+++ b/src-tauri/src/integrity.rs
@@ -251,13 +251,39 @@ fn load_pins(profile: Option<&str>) -> PinsLoad {
     if !path.exists() {
         return PinsLoad::Fresh;
     }
-    match std::fs::read_to_string(&path)
-        .ok()
-        .and_then(|s| serde_json::from_str::<BTreeMap<String, PinRepr>>(&s).ok())
-    {
-        Some(pins) => PinsLoad::Loaded(pins.into_iter().map(|(k, v)| (k, v.into())).collect()),
-        None => PinsLoad::Corrupt,
+    // Every connected client spawns its own gateway, and they all share this one pins file.
+    // A read that lands in the moment between another gateway's temp-write and its atomic
+    // rename can occasionally see the file mid-swap on some filesystems, and a write that was
+    // interrupted can leave it empty. Neither is tampering, so neither should raise the loud
+    // "integrity baseline lost" alarm: an empty file is just "nothing pinned yet", and a
+    // transient bad read clears on a quick retry. Only content that is genuinely present and
+    // still won't parse after the retries is treated as Corrupt (which stays loud, because
+    // that is what baseline tampering actually looks like).
+    for attempt in 0..3 {
+        let raw = match std::fs::read_to_string(&path) {
+            Ok(s) => s,
+            // The file existed a moment ago; a read error here is transient (another process
+            // replacing it). Retry, then fall through to Corrupt only if it persists.
+            Err(_) if attempt < 2 => {
+                std::thread::sleep(std::time::Duration::from_millis(15));
+                continue;
+            }
+            Err(_) => return PinsLoad::Corrupt,
+        };
+        if raw.trim().is_empty() {
+            return PinsLoad::Fresh;
+        }
+        match serde_json::from_str::<BTreeMap<String, PinRepr>>(&raw) {
+            Ok(pins) => {
+                return PinsLoad::Loaded(pins.into_iter().map(|(k, v)| (k, v.into())).collect());
+            }
+            Err(_) if attempt < 2 => {
+                std::thread::sleep(std::time::Duration::from_millis(15));
+            }
+            Err(_) => return PinsLoad::Corrupt,
+        }
     }
+    PinsLoad::Corrupt
 }
 
 fn save_pins(profile: Option<&str>, pins: &Pins) {
@@ -1330,6 +1356,32 @@ mod tests {
         if let Some(p) = pins_path(profile) {
             let _ = std::fs::remove_file(p);
         }
+    }
+
+    #[test]
+    fn empty_pins_file_is_fresh_not_corrupt() {
+        // A write that was interrupted (or a gateway crash mid-swap) can leave the shared
+        // pins file empty. That is not baseline tampering, so it must NOT raise the loud
+        // "integrity baseline lost" alarm; it reads as "nothing pinned yet".
+        let profile = Some("empty-pins-unit");
+        let path = pins_path(profile).expect("profile path");
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+
+        std::fs::write(&path, "").unwrap();
+        assert!(matches!(load_pins(profile), PinsLoad::Fresh), "empty file is Fresh");
+
+        std::fs::write(&path, "   \n\t ").unwrap();
+        assert!(matches!(load_pins(profile), PinsLoad::Fresh), "whitespace-only file is Fresh");
+
+        // Genuinely present-but-unparseable content still trips the loud path.
+        std::fs::write(&path, "{ this is not json").unwrap();
+        assert!(matches!(load_pins(profile), PinsLoad::Corrupt), "garbage is still Corrupt");
+
+        // A valid baseline round-trips as Loaded.
+        std::fs::write(&path, r#"{"srv__a":"deadbeef"}"#).unwrap();
+        assert!(matches!(load_pins(profile), PinsLoad::Loaded(_)), "valid pins load");
+
+        let _ = std::fs::remove_file(&path);
     }
 
     #[test]


### PR DESCRIPTION
## What

The `integrity baseline lost` alarm was firing for two non-tampering conditions:

- **Empty file** - an interrupted write (or a gateway killed mid-swap) can leave the shared `tool-pins.json` empty. An empty string fails JSON parse, which used to read as `Corrupt`.
- **Mid-swap read** - every connected client spawns its own gateway, and they all share one pins file. A read that lands in the moment between another gateway's temp-write and its atomic rename can briefly see the file half-swapped on some filesystems.

Both surfaced as the **loud** `integrity baseline lost` security alarm, training users to ignore it, which is exactly what we don't want a real tamper signal to be buried under.

## Fix

`load_pins` now:
- treats an empty/whitespace-only file as **Fresh** ("nothing pinned yet"), not Corrupt
- **retries** a transient read/parse failure a couple of times (15ms apart) before giving up

Content that is genuinely present and still won't parse after the retries is **still `Corrupt`** and still fires the loud alarm, because that is what baseline tampering actually looks like. The security signal is intact; only the self-inflicted false positives are gone.

## Test

New `empty_pins_file_is_fresh_not_corrupt`: empty and whitespace-only both load as Fresh, garbage is still Corrupt, valid pins still Load. 27 integrity tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when loading shared tool pin data during updates, reducing issues caused by temporary empty or partially written files.
  * Empty or whitespace-only pin files are now treated as a fresh baseline instead of an error.
  * Invalid pin data still correctly reports as corrupted when the file content is truly unreadable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->