### PR TITLE
fix(integrity): treat an empty pins file as a lost baseline, not a silent wipe

### DIFF
--- a/src-tauri/src/integrity.rs
+++ b/src-tauri/src/integrity.rs
@@ -253,12 +253,11 @@ fn load_pins(profile: Option<&str>) -> PinsLoad {
     }
     // Every connected client spawns its own gateway, and they all share this one pins file.
     // A read that lands in the moment between another gateway's temp-write and its atomic
-    // rename can occasionally see the file mid-swap on some filesystems, and a write that was
-    // interrupted can leave it empty. Neither is tampering, so neither should raise the loud
-    // "integrity baseline lost" alarm: an empty file is just "nothing pinned yet", and a
-    // transient bad read clears on a quick retry. Only content that is genuinely present and
-    // still won't parse after the retries is treated as Corrupt (which stays loud, because
-    // that is what baseline tampering actually looks like).
+    // rename can occasionally see the file mid-swap on some filesystems. That transient bad
+    // read clears on a quick retry, so it should NOT raise the loud "integrity baseline lost"
+    // alarm. But a file that is genuinely present and still won't parse after the retries -
+    // including an EMPTY one - is a lost baseline and stays Corrupt (loud), because that is
+    // what baseline tampering actually looks like.
     for attempt in 0..3 {
         let raw = match std::fs::read_to_string(&path) {
             Ok(s) => s,
@@ -271,7 +270,17 @@ fn load_pins(profile: Option<&str>) -> PinsLoad {
             Err(_) => return PinsLoad::Corrupt,
         };
         if raw.trim().is_empty() {
-            return PinsLoad::Fresh;
+            // An empty baseline file is a LOST baseline, not a fresh start: atomic_write
+            // (temp + fsync + rename) never leaves an empty file, so emptiness means it was
+            // truncated - a crash mid foreign write, or an attacker wiping it to silently
+            // reset drift detection. Returning Fresh here would silently re-baseline whatever
+            // tools are present now (re-trusting a poisoned definition with zero signal), so
+            // retry a transient empty read, then treat a persistently-empty file as Corrupt.
+            if attempt < 2 {
+                std::thread::sleep(std::time::Duration::from_millis(15));
+                continue;
+            }
+            return PinsLoad::Corrupt;
         }
         match serde_json::from_str::<BTreeMap<String, PinRepr>>(&raw) {
             Ok(pins) => {
@@ -1482,23 +1491,31 @@ mod tests {
     }
 
     #[test]
-    fn empty_pins_file_is_fresh_not_corrupt() {
-        // A write that was interrupted (or a gateway crash mid-swap) can leave the shared
-        // pins file empty. That is not baseline tampering, so it must NOT raise the loud
-        // "integrity baseline lost" alarm; it reads as "nothing pinned yet".
+    fn empty_pins_file_is_corrupt_not_a_silent_wipe() {
+        // atomic_write never leaves an empty pins file, so an empty one means the baseline
+        // was truncated (a crash mid foreign write, or an attacker wiping it to reset drift
+        // detection). It must trip the LOUD path, never a silent re-baseline: returning Fresh
+        // would re-trust whatever tools are present now with no signal. A transient mid-swap
+        // read is handled by the retry, not by treating empty as benign.
         let profile = Some("empty-pins-unit");
         let path = pins_path(profile).expect("profile path");
         std::fs::create_dir_all(path.parent().unwrap()).unwrap();
 
         std::fs::write(&path, "").unwrap();
-        assert!(matches!(load_pins(profile), PinsLoad::Fresh), "empty file is Fresh");
+        assert!(
+            matches!(load_pins(profile), PinsLoad::Corrupt),
+            "empty file is a lost baseline (loud), not a silent Fresh wipe"
+        );
 
         std::fs::write(&path, "   \n\t ").unwrap();
-        assert!(matches!(load_pins(profile), PinsLoad::Fresh), "whitespace-only file is Fresh");
+        assert!(
+            matches!(load_pins(profile), PinsLoad::Corrupt),
+            "whitespace-only file is also a lost baseline"
+        );
 
-        // Genuinely present-but-unparseable content still trips the loud path.
+        // Genuinely present-but-unparseable content also trips the loud path.
         std::fs::write(&path, "{ this is not json").unwrap();
-        assert!(matches!(load_pins(profile), PinsLoad::Corrupt), "garbage is still Corrupt");
+        assert!(matches!(load_pins(profile), PinsLoad::Corrupt), "garbage is Corrupt");
 
         // A valid baseline round-trips as Loaded.
         std::fs::write(&path, r#"{"srv__a":"deadbeef"}"#).unwrap();


### PR DESCRIPTION
## Security follow-up to #149 (found in adversarial review)

#149 made an empty/whitespace `tool-pins.json` return `PinsLoad::Fresh` to avoid a false "integrity baseline lost" alarm. Review flagged this as a **silent baseline wipe**:

- `atomic_write` (temp + fsync + rename) **never leaves an empty file**, so emptiness is not a benign interrupted-write artifact - it means the baseline was **truncated**: a crash mid *foreign* write, or an attacker wiping it to reset drift detection.
- Returning `Fresh` made `check` silently re-baseline whatever tools are present *now* - re-trusting a potentially-poisoned definition **with zero signal**. That's the exact fail-open the loud `Corrupt` path exists to prevent ("silently re-baselining is exactly what an attacker who can touch the config dir wants").

## Fix

The genuine false-alarm cause - a mid-swap read landing during another gateway's rename - is handled by the **retry**, which stays. The empty→`Fresh` special case is removed:

- Empty/whitespace now **retries a transient read**, then falls to `Corrupt` (loud), exactly like any other unreadable baseline.
- A truncation-based baseline wipe is now **visible** (`pins_load_failed`, high severity) instead of silent.
- Real transient mid-swap reads still don't alarm (retry catches them); genuinely-present-but-unparseable content is still `Corrupt`; a missing file is still `Fresh` (first run).

## Test

`empty_pins_file_is_fresh_not_corrupt` → renamed `empty_pins_file_is_corrupt_not_a_silent_wipe`, now asserting empty **and** whitespace-only both read as `Corrupt` (loud), garbage stays `Corrupt`, valid pins still `Loaded`. 28 integrity tests pass.

No behavior change for the legitimate cases #149 targeted; this only closes the truncation fail-open.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Empty or whitespace-only pins files are now treated as corrupted instead of a fresh start.
  * Added resilience for brief read failures during file swaps by allowing a small number of retries.
  * Updated validation coverage so empty, whitespace-only, and invalid pins content are consistently flagged as corrupted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->