### PR TITLE
chore(coderabbit): quiet the per-PR notification noise

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -6,13 +6,18 @@ reviews:
   profile: chill
   # Advisory only — CodeRabbit should never block a merge with a change request.
   request_changes_workflow: false
-  high_level_summary: true
+  # Keep the per-PR inbox noise down for anyone watching the repo: drop the boilerplate
+  # summary + review-status comments so CodeRabbit only speaks up when it has an actual
+  # finding, and don't re-review on every push (the initial review still runs).
+  high_level_summary: false
   poem: false
-  review_status: true
+  review_status: false
   collapse_walkthrough: true
   auto_review:
     enabled: true
     drafts: false
+    # Review once when the PR opens, not again on each subsequent commit.
+    auto_incremental_review: false
   # Skip generated / vendored / build output so reviews stay signal-heavy.
   path_filters:
     - "!**/package-lock.json"


### PR DESCRIPTION
Anyone **watching** the repo receives an email for every CodeRabbit comment (summary, review-status, walkthrough, and a fresh review on every push). This trims what CodeRabbit posts so the review keeps its value without flooding inboxes:

- `high_level_summary: false` and `review_status: false` - drop the boilerplate comments; CodeRabbit now only comments when it has an actual finding and stays silent on a clean PR.
- `auto_review.auto_incremental_review: false` - review once when the PR opens, not again on every subsequent commit (the biggest multiplier).

Still on the `chill` profile, still advisory-only (never blocks a merge), still auto-reviews new PRs.