### PR TITLE
Bold UI redesign: navy + orange brand, cohesive across every tab

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -400,16 +400,7 @@ function App() {
           }}
         />
 
-        <main
-          className="flex min-w-0 flex-1 flex-col"
-          style={{
-            // A soft orange wash across the top of the content, keyed to the accent token,
-            // so the orange controls read as part of an accented environment instead of
-            // isolated dots on navy. Two layers for depth; non-scrolling (it's on <main>).
-            backgroundImage:
-              "radial-gradient(900px 480px at 88% 2%, color-mix(in oklch, var(--primary) 22%, transparent), transparent 60%), radial-gradient(700px 360px at 30% -8%, color-mix(in oklch, var(--primary) 9%, transparent), transparent 62%)",
-          }}
-        >
+        <main className="flex min-w-0 flex-1 flex-col">
           <header className="flex items-center justify-between gap-4 border-b px-6 py-4">
             <div className="min-w-0 flex-1">
               <h1 className="truncate text-lg font-semibold tracking-tight">

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -433,11 +433,7 @@ function App() {
                             ? "MCP client"
                             : loading || !registry
                               ? "Loading…"
-                              : `${enabledCount} of ${servers.length} enabled` +
-                                (connectedCount ? ` · ${connectedCount} connected` : "") +
-                                (attentionCount
-                                  ? ` · ${attentionCount} need${attentionCount === 1 ? "s" : ""} attention`
-                                  : "")}
+                              : "One gateway in front of every MCP server you run"}
               </p>
             </div>
             <div className="flex shrink-0 items-center gap-2">
@@ -563,6 +559,12 @@ function App() {
                   </div>
                 ) : (
                   <div className="flex flex-col gap-5">
+                    <StatusBar
+                      total={servers.length}
+                      connected={connectedCount}
+                      attention={attentionCount}
+                      disabled={servers.length - enabledCount}
+                    />
                     <ServerGroup
                       title="Needs attention"
                       dot="bg-warning"
@@ -617,6 +619,52 @@ function App() {
   );
 }
 
+/** At-a-glance server health as a row of chips: the primary status summary, promoted out
+ * of the grey header caption into a scannable status bar with the same semantic dots the
+ * groups use. */
+function StatusBar({
+  total,
+  connected,
+  attention,
+  disabled,
+}: {
+  total: number;
+  connected: number;
+  attention: number;
+  disabled: number;
+}) {
+  const chip =
+    "inline-flex items-center gap-2 rounded-full border border-border/60 bg-card/50 px-3 py-1.5 text-xs font-semibold";
+  const dot = "size-1.5 rounded-full";
+  return (
+    <div className="flex flex-wrap gap-2">
+      <span className={chip}>
+        <span className="tabular-nums">{total}</span>
+        <span className="font-normal text-muted-foreground">servers</span>
+      </span>
+      <span className={chip}>
+        <span className={`${dot} bg-success`} />
+        <span className="tabular-nums">{connected}</span>
+        <span className="font-normal text-muted-foreground">connected</span>
+      </span>
+      {attention > 0 && (
+        <span className={`${chip} border-warning/40`}>
+          <span className={`${dot} bg-warning`} />
+          <span className="tabular-nums">{attention}</span>
+          <span className="font-normal text-muted-foreground">
+            need{attention === 1 ? "s" : ""} attention
+          </span>
+        </span>
+      )}
+      <span className={chip}>
+        <span className={`${dot} bg-muted-foreground/40`} />
+        <span className="tabular-nums">{disabled}</span>
+        <span className="font-normal text-muted-foreground">disabled</span>
+      </span>
+    </div>
+  );
+}
+
 /** A titled, collapsible section of server rows. Renders nothing when empty, so
  * the page only shows the buckets that have servers. Collapse state persists per
  * group; the Disabled bucket starts collapsed. */
@@ -666,7 +714,7 @@ function ServerGroup({
         <span className="text-xs text-muted-foreground/70">{count}</span>
       </button>
       {!collapsed && (
-        <div className="overflow-hidden rounded-xl border border-border/60">
+        <div className="overflow-hidden rounded-xl border border-border/60 bg-card/40 shadow-[0_1px_0_rgba(255,255,255,.02)_inset,0_10px_28px_-24px_rgba(0,0,0,.9)]">
           {children}
         </div>
       )}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -403,11 +403,11 @@ function App() {
         <main
           className="flex min-w-0 flex-1 flex-col"
           style={{
-            // A soft orange wash at the top of the content, keyed to the accent token, so
-            // the orange controls (toggles, buttons) read as part of an accented
-            // environment instead of isolated dots on flat navy. Subtle and non-scrolling.
+            // A soft orange wash across the top of the content, keyed to the accent token,
+            // so the orange controls read as part of an accented environment instead of
+            // isolated dots on navy. Two layers for depth; non-scrolling (it's on <main>).
             backgroundImage:
-              "radial-gradient(1100px 460px at 82% -12%, color-mix(in oklch, var(--primary) 10%, transparent), transparent 58%)",
+              "radial-gradient(900px 480px at 88% 2%, color-mix(in oklch, var(--primary) 22%, transparent), transparent 60%), radial-gradient(700px 360px at 30% -8%, color-mix(in oklch, var(--primary) 9%, transparent), transparent 62%)",
           }}
         >
           <header className="flex items-center justify-between gap-4 border-b px-6 py-4">

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -400,7 +400,16 @@ function App() {
           }}
         />
 
-        <main className="flex min-w-0 flex-1 flex-col">
+        <main
+          className="flex min-w-0 flex-1 flex-col"
+          style={{
+            // A soft orange wash at the top of the content, keyed to the accent token, so
+            // the orange controls (toggles, buttons) read as part of an accented
+            // environment instead of isolated dots on flat navy. Subtle and non-scrolling.
+            backgroundImage:
+              "radial-gradient(1100px 460px at 82% -12%, color-mix(in oklch, var(--primary) 10%, transparent), transparent 58%)",
+          }}
+        >
           <header className="flex items-center justify-between gap-4 border-b px-6 py-4">
             <div className="min-w-0 flex-1">
               <h1 className="truncate text-lg font-semibold tracking-tight">

--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -433,10 +433,10 @@ export function AppSidebar({
     <button
       onClick={onClick}
       aria-current={active ? "page" : undefined}
-      className={`${NAV_ITEM} ${active ? "bg-accent" : ""}`}
+      className={`${NAV_ITEM} ${active ? "bg-accent font-medium text-foreground" : "text-muted-foreground"}`}
     >
       <Icon
-        className={`size-4 shrink-0 ${active ? "text-foreground" : "text-muted-foreground"}`}
+        className={`size-4 shrink-0 ${active ? "text-primary" : "text-muted-foreground"}`}
       />
       <span>{label}</span>
     </button>

--- a/src/components/CatalogView.tsx
+++ b/src/components/CatalogView.tsx
@@ -7,6 +7,7 @@ import { addServer, listStacks, popularCatalog, searchCatalog } from "@/lib/api"
 import type { CatalogEntry, Registry, ServerEntry, Stack } from "@/lib/types";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { Skeleton } from "@/components/ui/skeleton";
 import { TransportPill } from "@/components/TransportPill";
 import { ServerDialog } from "@/components/ServerDialog";
 
@@ -232,7 +233,7 @@ export function CatalogView({ registry, onAdded }: Props) {
         browsing && popularLoading ? (
           <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
             {Array.from({ length: 6 }).map((_, i) => (
-              <div key={i} className="h-28 animate-pulse rounded-lg border bg-muted/30" />
+              <Skeleton key={i} className="h-28 rounded-lg" />
             ))}
           </div>
         ) : browsing && popularError ? (

--- a/src/components/ClientDetail.tsx
+++ b/src/components/ClientDetail.tsx
@@ -4,6 +4,7 @@ import {
   Check,
   Download,
   Link2,
+  Monitor,
   Plug,
   PlugZap,
   Puzzle,
@@ -336,15 +337,27 @@ export function ClientDetail({ client, registry, onChanged, onRegistryChange }: 
             </div>
           )}
         </div>
+      ) : scopeServerCount(profile) > 0 ? (
+        <div className="flex flex-col gap-4">
+          <p className="max-w-prose text-sm text-muted-foreground">
+            Connect {client.name} once and it reaches your{" "}
+            <span className="font-medium text-foreground">
+              {scopeServerCount(profile)} managed server
+              {scopeServerCount(profile) === 1 ? "" : "s"}
+            </span>{" "}
+            through one gateway, no re-wiring per project. Your keys stay in your
+            keychain.
+          </p>
+          <GatewayFlow
+            clientName={client.name}
+            servers={scopeServers(profile).map((s) => s.name)}
+          />
+        </div>
       ) : (
-        <p className="text-sm text-muted-foreground">
-          Point {client.name} at Toolport to use your{" "}
-          <span className="font-medium text-foreground">
-            {scopeServerCount(profile)} managed server
-            {scopeServerCount(profile) === 1 ? "" : "s"}
-          </span>{" "}
-          from one place, no re-wiring per project. Or import {client.name}&apos;s own
-          servers into Toolport below.
+        <p className="max-w-prose text-sm text-muted-foreground">
+          Connect {client.name}, then enable servers under{" "}
+          <span className="font-medium text-foreground">All servers</span> and
+          they&apos;ll all route through Toolport, no per-client setup.
         </p>
       )}
 
@@ -365,76 +378,74 @@ export function ClientDetail({ client, registry, onChanged, onRegistryChange }: 
         </Card>
       )}
 
-      {/* Import: client servers are sources to pull into Toolport, nothing more. */}
-      <div>
-        <div className="mb-1 flex items-center justify-between gap-2">
-          <span className="text-xs font-medium tracking-wide text-muted-foreground uppercase">
-            Import into Toolport
-          </span>
-          <div className="flex items-center gap-1.5">
-            {toImport.length > 0 && (
-              <Button
-                size="sm"
-                variant="ghost"
-                className="h-7 px-2 text-xs"
-                onClick={handleImportAll}
-                disabled={busy}
-              >
-                <Download className="size-3" />
-                Import all ({toImport.length})
-              </Button>
-            )}
-            {movable.length > 0 && (
-              <Button
-                size="sm"
-                variant="default"
-                className="h-7 px-2 text-xs"
-                onClick={() => setMigrateOpen(true)}
-                disabled={busy}
-              >
-                <Shuffle className="size-3" />
-                Move config in ({movable.length})
-              </Button>
-            )}
-          </div>
-        </div>
-        <details className="mb-2">
-          <summary className="cursor-pointer text-xs font-medium text-muted-foreground/80 hover:text-foreground">
-            How importing works
-          </summary>
-          <ul className="mt-1.5 mb-1 space-y-0.5 text-xs text-muted-foreground">
-            <li>
-              <span className="font-medium text-foreground">Import</span> copies a server
-              into Toolport; {client.name} keeps its own copy.
-            </li>
-            <li>
-              <span className="font-medium text-foreground">Move config in</span> copies
-              it, then removes it from {client.name}'s config so the gateway is the only
-              source (plugin servers stay). The cutover that actually saves context.
-            </li>
-          </ul>
-        </details>
-        {installed && toImport.length > 0 && movable.length > 0 && (
-          <p className="mb-3 -mt-1 inline-flex items-start gap-1.5 rounded-md bg-warning/10 px-2 py-1 text-xs text-warning">
-            <TriangleAlert className="mt-0.5 size-3.5 shrink-0" />
-            <span>
-              {client.name} is already connected to Toolport. Import on its own leaves a
-              copy here too, so these tools load twice, once directly and once through the
-              gateway. Use <span className="font-medium">Move config in</span> to avoid
-              that.
+      {/* Import: client servers are sources to pull into Toolport. The WHOLE block only
+          renders when the client actually has servers of its own to import - otherwise it
+          used to show a header + a "how importing works" explainer describing Import / Move
+          buttons that weren't on screen (an AI-agent client with no own servers). */}
+      {allServers.length > 0 && (
+        <div>
+          <div className="mb-1 flex items-center justify-between gap-2">
+            <span className="text-2xs font-semibold tracking-[0.09em] text-muted-foreground uppercase">
+              Import into Toolport
             </span>
-          </p>
-        )}
+            <div className="flex items-center gap-1.5">
+              {toImport.length > 0 && (
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  className="h-7 px-2 text-xs"
+                  onClick={handleImportAll}
+                  disabled={busy}
+                >
+                  <Download className="size-3" />
+                  Import all ({toImport.length})
+                </Button>
+              )}
+              {movable.length > 0 && (
+                <Button
+                  size="sm"
+                  variant="default"
+                  className="h-7 px-2 text-xs"
+                  onClick={() => setMigrateOpen(true)}
+                  disabled={busy}
+                >
+                  <Shuffle className="size-3" />
+                  Move config in ({movable.length})
+                </Button>
+              )}
+            </div>
+          </div>
+          <details className="mb-2">
+            <summary className="cursor-pointer text-xs font-medium text-muted-foreground/80 hover:text-foreground">
+              How importing works
+            </summary>
+            <ul className="mt-1.5 mb-1 space-y-0.5 text-xs text-muted-foreground">
+              <li>
+                <span className="font-medium text-foreground">Import</span> copies a
+                server into Toolport; {client.name} keeps its own copy.
+              </li>
+              {movable.length > 0 && (
+                <li>
+                  <span className="font-medium text-foreground">Move config in</span>{" "}
+                  copies it, then removes it from {client.name}'s config so the gateway is
+                  the only source (plugin servers stay). The cutover that actually saves
+                  context.
+                </li>
+              )}
+            </ul>
+          </details>
+          {installed && toImport.length > 0 && movable.length > 0 && (
+            <p className="mb-3 -mt-1 inline-flex items-start gap-1.5 rounded-md bg-warning/10 px-2 py-1 text-xs text-warning">
+              <TriangleAlert className="mt-0.5 size-3.5 shrink-0" />
+              <span>
+                {client.name} is already connected to Toolport. Import on its own leaves a
+                copy here too, so these tools load twice, once directly and once through
+                the gateway. Use <span className="font-medium">Move config in</span> to
+                avoid that.
+              </span>
+            </p>
+          )}
 
-        {allServers.length === 0 ? (
-          <p className="text-sm text-muted-foreground">
-            {client.usesConnectors
-              ? "No local servers in the config file to import."
-              : installed
-                ? `${client.name} has no servers of its own, it's already using Toolport's.`
-                : "Nothing configured in this client to import."}
-          </p>
-        ) : (
           <div className="grid gap-2 sm:grid-cols-2">
             {allServers.map((server) => (
               <ServerMiniCard
@@ -447,18 +458,18 @@ export function ClientDetail({ client, registry, onChanged, onRegistryChange }: 
               />
             ))}
           </div>
-        )}
 
-        {toImport.length === 0 && allServers.length > 0 && (
-          <p className="mt-3 inline-flex items-center gap-1.5 text-xs text-success">
-            <Check className="size-3.5" />
-            Everything here is already in Toolport. Manage it under{" "}
-            <span className="inline-flex items-center gap-0.5 font-medium">
-              All servers <ArrowRight className="size-3" />
-            </span>
-          </p>
-        )}
-      </div>
+          {toImport.length === 0 && (
+            <p className="mt-3 inline-flex items-center gap-1.5 text-xs text-success">
+              <Check className="size-3.5" />
+              Everything here is already in Toolport. Manage it under{" "}
+              <span className="inline-flex items-center gap-0.5 font-medium">
+                All servers <ArrowRight className="size-3" />
+              </span>
+            </p>
+          )}
+        </div>
+      )}
 
       <Dialog open={migrateOpen} onOpenChange={setMigrateOpen}>
         <DialogContent className="sm:max-w-md">
@@ -533,6 +544,60 @@ export function ClientDetail({ client, registry, onChanged, onRegistryChange }: 
           </DialogFooter>
         </DialogContent>
       </Dialog>
+    </div>
+  );
+}
+
+/** The product in one glance: client -> Toolport gateway -> the servers it reaches. Shows
+ * the pitch concretely instead of describing it in prose. */
+function GatewayFlow({ clientName, servers }: { clientName: string; servers: string[] }) {
+  const shown = servers.slice(0, 4);
+  const extra = servers.length - shown.length;
+  const link = "mb-7 h-px w-8 shrink-0";
+  return (
+    <div className="flex flex-wrap items-center justify-center gap-1 rounded-xl border border-border/60 bg-card/40 px-4 py-5">
+      <div className="flex flex-col items-center gap-2 text-center">
+        <div className="grid size-14 place-items-center rounded-2xl border border-border bg-secondary text-xl">
+          <Monitor className="size-6 text-muted-foreground" />
+        </div>
+        <div className="text-2xs font-semibold">{clientName}</div>
+      </div>
+      <div className={`${link} bg-gradient-to-r from-border to-primary`} />
+      <div className="flex flex-col items-center gap-2 text-center">
+        <div className="grid size-16 place-items-center rounded-2xl border border-primary/45 bg-primary/10 shadow-[0_0_0_5px_rgba(239,147,80,.09),0_16px_34px_-16px_rgba(239,147,80,.5)]">
+          <svg width="30" height="30" viewBox="0 0 32 32" aria-hidden="true">
+            <circle
+              cx="16"
+              cy="16"
+              r="13"
+              fill="none"
+              stroke="var(--brand)"
+              strokeWidth="2.5"
+            />
+            <circle cx="16" cy="16" r="5" fill="var(--brand)" />
+          </svg>
+        </div>
+        <div className="text-2xs font-semibold">
+          Toolport
+          <span className="block font-normal text-muted-foreground">gateway</span>
+        </div>
+      </div>
+      <div className={`${link} bg-gradient-to-r from-primary to-border`} />
+      <div className="flex flex-col gap-1">
+        {shown.map((s) => (
+          <span
+            key={s}
+            className="rounded-md border border-border/60 bg-card px-2 py-1 font-mono text-2xs text-muted-foreground"
+          >
+            {s}
+          </span>
+        ))}
+        {extra > 0 && (
+          <span className="px-2 font-mono text-2xs text-muted-foreground/60">
+            +{extra} more
+          </span>
+        )}
+      </div>
     </div>
   );
 }

--- a/src/components/ClientDetail.tsx
+++ b/src/components/ClientDetail.tsx
@@ -16,6 +16,7 @@ import { toastError } from "@/lib/toast";
 import { addServer, installGateway, migrateClient, uninstallGateway } from "@/lib/api";
 import {
   importableServers,
+  isGatewayServer,
   type DetectedClient,
   type McpServer,
   type Registry,
@@ -72,7 +73,11 @@ export function ClientDetail({ client, registry, onChanged, onRegistryChange }: 
       ? profiles.find((p) => p.name.toLowerCase() === scopeName.toLowerCase())
       : (profiles.find((p) => p.id === registry?.activeProfileId) ?? profiles[0]);
     if (!target) return 0;
-    const ids = new Set((registry?.servers ?? []).map((s) => s.id));
+    // Exclude Toolport's own gateway entry so the count matches the Servers list (which
+    // filters it out) instead of over-counting by one.
+    const ids = new Set(
+      (registry?.servers ?? []).filter((s) => !isGatewayServer(s)).map((s) => s.id),
+    );
     return target.enabledServerIds.filter((id) => ids.has(id)).length;
   }
 
@@ -84,8 +89,9 @@ export function ClientDetail({ client, registry, onChanged, onRegistryChange }: 
       : (profiles.find((p) => p.id === registry?.activeProfileId) ?? profiles[0]);
     if (!target) return [];
     const enabled = new Set(target.enabledServerIds);
+    // Never surface the gateway's own "conduit" entry as a reachable server.
     return (registry?.servers ?? [])
-      .filter((s) => enabled.has(s.id))
+      .filter((s) => enabled.has(s.id) && !isGatewayServer(s))
       .map((s) => ({ id: s.id, name: s.name }));
   }
 

--- a/src/components/Onboarding.tsx
+++ b/src/components/Onboarding.tsx
@@ -6,8 +6,11 @@ import {
   Link2,
   Loader2,
   Plus,
+  ShieldCheck,
+  Sparkles,
   Store,
   Waypoints,
+  Workflow,
 } from "lucide-react";
 import { toast } from "sonner";
 import { toastError } from "@/lib/toast";
@@ -148,15 +151,44 @@ function Welcome({ present, onNext }: { present: DetectedClient[]; onNext: () =>
   const names = present.map((c) => c.name);
   const found =
     names.length === 0
-      ? "We didn't detect any MCP clients yet. You can still add servers now, then connect a client once it's installed."
-      : `We found ${listJoin(names)} on your machine. Toolport will sit between your tools and your servers, so you set each one up once.`;
+      ? "No MCP clients detected yet, you can still add servers now and connect a client once it's installed."
+      : `Found ${listJoin(names)} on your machine, ready to point at the gateway.`;
+  const benefits = [
+    {
+      icon: Workflow,
+      title: "One gateway for every tool",
+      body: "Set each MCP server up once; every AI client shares it.",
+    },
+    {
+      icon: Sparkles,
+      title: "Up to 91% fewer tokens",
+      body: "Your agent loads a few meta-tools instead of hundreds of schemas.",
+    },
+    {
+      icon: ShieldCheck,
+      title: "Watched for tampering",
+      body: "Every server is checked for rug-pulls and prompt injection.",
+    },
+  ];
   return (
     <>
       <StepHeader icon={<Waypoints className="size-5" />} title="Welcome to Toolport">
-        One local gateway for all your MCP servers, shared by every AI tool, so your agent
-        loads 3 tools instead of hundreds (up to 91% fewer tokens) and every server is
-        watched for tampering and prompt injection. {found}
+        One local gateway for all your MCP servers, shared by every AI tool.
       </StepHeader>
+      <div className="grid gap-2.5">
+        {benefits.map(({ icon: Icon, title, body }) => (
+          <div key={title} className="flex items-start gap-3">
+            <div className="mt-0.5 flex size-7 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary">
+              <Icon className="size-4" />
+            </div>
+            <div>
+              <div className="text-sm font-medium">{title}</div>
+              <div className="text-xs text-muted-foreground">{body}</div>
+            </div>
+          </div>
+        ))}
+      </div>
+      <p className="text-sm text-muted-foreground">{found}</p>
       <Button onClick={onNext} className="self-start">
         Get started
         <ArrowRight className="size-4" />

--- a/src/components/PlaygroundView.tsx
+++ b/src/components/PlaygroundView.tsx
@@ -1,7 +1,9 @@
 import { useEffect, useMemo, useState } from "react";
 import {
+  Check,
   CheckCircle2,
   ChevronRight,
+  Copy,
   FileText,
   FlaskConical,
   Loader2,
@@ -148,7 +150,7 @@ function ToolOverrideEditor({
               value={name}
               onChange={(e) => setName(e.target.value)}
               placeholder={tool.name}
-              className="rounded-md border border-input bg-transparent px-2.5 py-1.5 font-mono text-xs shadow-sm focus-visible:ring-1 focus-visible:ring-ring focus-visible:outline-none"
+              className="rounded-md border border-input bg-transparent px-2.5 py-1.5 font-mono text-xs shadow-sm focus-visible:ring-3 focus-visible:ring-ring/50 focus-visible:outline-none"
             />
           </label>
           <label className="flex flex-col gap-1 text-xs">
@@ -160,7 +162,7 @@ function ToolOverrideEditor({
               onChange={(e) => setDescription(e.target.value)}
               rows={3}
               placeholder={tool.description ?? "(server's description)"}
-              className="rounded-md border border-input bg-transparent px-2.5 py-1.5 text-xs shadow-sm focus-visible:ring-1 focus-visible:ring-ring focus-visible:outline-none"
+              className="rounded-md border border-input bg-transparent px-2.5 py-1.5 text-xs shadow-sm focus-visible:ring-3 focus-visible:ring-ring/50 focus-visible:outline-none"
             />
           </label>
           <div className="flex gap-2">
@@ -307,13 +309,41 @@ function Connecting({ label = "Connecting to server…" }: { label?: string }) {
   );
 }
 
-/** A raw MCP result rendered as pretty JSON (or text). */
+/** Copy-to-clipboard button with a brief confirmation, for raw result / JSON blocks. */
+function CopyButton({ text }: { text: string }) {
+  const [copied, setCopied] = useState(false);
+  return (
+    <button
+      type="button"
+      aria-label="Copy to clipboard"
+      onClick={async () => {
+        try {
+          await navigator.clipboard.writeText(text);
+          setCopied(true);
+          setTimeout(() => setCopied(false), 1200);
+        } catch {
+          /* clipboard unavailable; no-op */
+        }
+      }}
+      className="ml-auto inline-flex items-center gap-1 rounded-md px-1.5 py-0.5 text-2xs font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+    >
+      {copied ? <Check className="size-3" /> : <Copy className="size-3" />}
+      {copied ? "Copied" : "Copy"}
+    </button>
+  );
+}
+
+/** A raw MCP result rendered as pretty JSON (or text), with a copy button. */
 function ResultBlock({ title, value }: { title: string; value: unknown }) {
+  const text = typeof value === "string" ? value : JSON.stringify(value, null, 2);
   return (
     <div className="flex flex-col gap-2">
-      <div className="text-sm font-medium">{title}</div>
+      <div className="flex items-center gap-2">
+        <div className="text-sm font-medium">{title}</div>
+        <CopyButton text={text} />
+      </div>
       <pre className="max-h-96 overflow-auto rounded-lg border bg-muted/40 p-3 font-mono text-xs whitespace-pre-wrap">
-        {typeof value === "string" ? value : JSON.stringify(value, null, 2)}
+        {text}
       </pre>
     </div>
   );
@@ -820,14 +850,7 @@ export function PlaygroundView({ registry, onRegistryChange }: PlaygroundProps) 
                       >
                         <span className="flex min-w-0 items-center gap-2">
                           <span className="truncate font-mono text-sm">{t.name}</span>
-                          {destructive && (
-                            <Badge
-                              variant="outline"
-                              className="border-warning/40 text-warning"
-                            >
-                              destructive
-                            </Badge>
-                          )}
+                          {destructive && <Badge variant="warning">destructive</Badge>}
                           {!exposed && (
                             <span className="text-xs text-muted-foreground">hidden</span>
                           )}
@@ -913,7 +936,7 @@ export function PlaygroundView({ registry, onRegistryChange }: PlaygroundProps) 
                   onChange={(e) => setRawJson(e.target.value)}
                   rows={6}
                   spellCheck={false}
-                  className="w-full rounded-md border border-input bg-transparent px-3 py-2 font-mono text-xs shadow-sm focus-visible:ring-1 focus-visible:ring-ring focus-visible:outline-none"
+                  className="w-full rounded-md border border-input bg-transparent px-3 py-2 font-mono text-xs shadow-sm focus-visible:ring-3 focus-visible:ring-ring/50 focus-visible:outline-none"
                 />
               ) : Object.keys(props).length === 0 ? (
                 <p className="text-sm text-muted-foreground">
@@ -960,8 +983,15 @@ export function PlaygroundView({ registry, onRegistryChange }: PlaygroundProps) 
                   <CheckCircle2 className="size-4 text-success" />
                 )}
                 {result.isError ? "Tool returned an error" : "Result"}
+                <CopyButton text={renderResult(result)} />
               </div>
-              <pre className="max-h-96 overflow-auto rounded-lg border bg-muted/40 p-3 font-mono text-xs whitespace-pre-wrap">
+              <pre
+                className={`max-h-96 overflow-auto rounded-lg border p-3 font-mono text-xs whitespace-pre-wrap ${
+                  result.isError
+                    ? "border-destructive/40 bg-destructive/5"
+                    : "bg-muted/40"
+                }`}
+              >
                 {renderResult(result)}
               </pre>
             </div>

--- a/src/components/RegistryServerRow.tsx
+++ b/src/components/RegistryServerRow.tsx
@@ -34,10 +34,21 @@ function statusOf(enabled: boolean, health?: ProbeResult): Status {
 
 const DOT: Record<Status, string> = {
   disabled: "bg-muted-foreground/40",
-  checking: "bg-muted-foreground/40 animate-pulse",
+  // Distinct hue so "checking" survives without its pulse under prefers-reduced-motion.
+  checking: "bg-info/70 animate-pulse",
   connected: "bg-success",
   "needs-auth": "bg-warning",
   error: "bg-destructive",
+};
+
+// The status word carries the color too, not just the 8px dot, so a broken or
+// needs-attention server reads at a glance instead of hinging on a tiny dot.
+const STATUS_TEXT: Record<Status, string> = {
+  disabled: "text-muted-foreground",
+  checking: "text-muted-foreground",
+  connected: "text-muted-foreground",
+  "needs-auth": "text-warning",
+  error: "text-destructive",
 };
 
 function statusAriaLabel(status: Status, label: string): string {
@@ -275,7 +286,10 @@ function StatusLabel({
   error: string | null;
 }) {
   const text = (
-    <span aria-hidden="true" className="text-xs whitespace-nowrap text-muted-foreground">
+    <span
+      aria-hidden="true"
+      className={`text-xs font-medium whitespace-nowrap ${STATUS_TEXT[status]}`}
+    >
       {label}
     </span>
   );

--- a/src/components/SettingsView.tsx
+++ b/src/components/SettingsView.tsx
@@ -142,6 +142,64 @@ interface Props {
   onRegistryChange: (registry: Registry) => void;
 }
 
+/** A one-line security posture readout at the top of the Security section, so the user can
+ * tell at a glance whether they're protected instead of mentally AND-ing every toggle. */
+function PostureSummary({
+  denyDestructive,
+  confirmDestructive,
+  humanApproval,
+  quarantineOnDrift,
+}: {
+  denyDestructive: boolean;
+  confirmDestructive: boolean;
+  humanApproval: boolean;
+  quarantineOnDrift: boolean;
+}) {
+  const active = [
+    humanApproval && "human approval required",
+    denyDestructive && "destructive tools blocked",
+    confirmDestructive && "destructive calls confirmed",
+    quarantineOnDrift && "drifted tools quarantined",
+  ].filter(Boolean) as string[];
+  // A hard gate (block or human-approval) = guarded; softer measures alone = partial.
+  const gated = humanApproval || denyDestructive;
+  const state = gated ? "guarded" : active.length > 0 ? "partial" : "open";
+  const meta = {
+    guarded: {
+      Icon: ShieldCheck,
+      ring: "border-success/30 bg-success/5",
+      tint: "text-success",
+      label: "Protected",
+    },
+    partial: {
+      Icon: ShieldAlert,
+      ring: "border-warning/35 bg-warning/5",
+      tint: "text-warning",
+      label: "Partly protected",
+    },
+    open: {
+      Icon: ShieldX,
+      ring: "border-destructive/35 bg-destructive/5",
+      tint: "text-destructive",
+      label: "Unprotected",
+    },
+  }[state];
+  const { Icon } = meta;
+  return (
+    <div className={`flex items-start gap-3 rounded-lg border p-3 ${meta.ring}`}>
+      <Icon className={`mt-0.5 size-4 shrink-0 ${meta.tint}`} />
+      <p className="text-sm">
+        <span className={`font-medium ${meta.tint}`}>{meta.label}.</span>{" "}
+        <span className="text-muted-foreground">
+          {state === "open"
+            ? "No blocking or approval is active, so every tool call runs unattended."
+            : `Active: ${active.join(", ")}.`}
+        </span>
+      </p>
+    </div>
+  );
+}
+
 /** Global discovery + security policy. These apply to every client uniformly, so
  * they live here rather than in the per-server Playground. */
 export function SettingsView({ registry, onRegistryChange }: Props) {
@@ -357,6 +415,12 @@ export function SettingsView({ registry, onRegistryChange }: Props) {
         <h2 className="text-xs font-medium tracking-wide text-muted-foreground uppercase">
           Security
         </h2>
+        <PostureSummary
+          denyDestructive={denyDestructive}
+          confirmDestructive={confirmDestructive}
+          humanApproval={humanApproval}
+          quarantineOnDrift={quarantineOnDrift}
+        />
         {toggle(
           ShieldAlert,
           denyDestructive,

--- a/src/components/TeamsView.tsx
+++ b/src/components/TeamsView.tsx
@@ -9,6 +9,7 @@ import {
   AlertTriangle,
 } from "lucide-react";
 import { listen } from "@tauri-apps/api/event";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { ConfirmDialog } from "@/components/ConfirmDialog";
 import { Callout } from "@/components/Callout";
@@ -161,10 +162,41 @@ export function TeamsView({
         <div className="rounded-xl border bg-card p-5">
           <h3 className="text-sm font-medium">Connect to a team</h3>
           <p className="mt-1 mb-4 max-w-prose text-sm text-muted-foreground">
-            Paste your team's Toolport Teams server URL and an invite code from your
-            admin. The team's MCP servers will appear in your active profile. Your keys
-            never leave your machine, you'll add each server's secrets locally afterward.
+            Join your team's Toolport Teams server and its shared MCP servers appear in
+            your active profile, kept in sync as your admin updates them.
           </p>
+          <div className="mb-5 grid gap-2.5 sm:grid-cols-3">
+            {[
+              {
+                icon: Server,
+                title: "Shared server set",
+                body: "Your admin curates the MCP servers; they show up in your profile.",
+              },
+              {
+                icon: ShieldCheck,
+                title: "Keys stay local",
+                body: "The team holds config only, never a secret. You vault keys on your machine.",
+              },
+              {
+                icon: RefreshCw,
+                title: "Always in sync",
+                body: "One source of truth; updates arrive when you Sync.",
+              },
+            ].map(({ icon: Icon, title, body }) => (
+              <div
+                key={title}
+                className="rounded-lg border border-border/60 bg-muted/20 p-3"
+              >
+                <div className="flex items-center gap-1.5 text-sm font-medium">
+                  <Icon className="size-3.5 text-primary" />
+                  {title}
+                </div>
+                <p className="mt-1 text-2xs leading-relaxed text-muted-foreground">
+                  {body}
+                </p>
+              </div>
+            ))}
+          </div>
           <div className="grid gap-3">
             <label className="grid gap-1 text-sm">
               <span className="text-muted-foreground">Team server URL</span>
@@ -292,13 +324,13 @@ export function TeamsView({
                           <span className="truncate font-medium">{s.name}</span>
                           <TransportPill transport={s.transport} />
                           {on ? (
-                            <span className="ml-auto flex shrink-0 items-center gap-1 text-xs text-success">
-                              <ShieldCheck className="size-3.5" /> on
-                            </span>
+                            <Badge variant="success" className="ml-auto shrink-0">
+                              <ShieldCheck className="size-3" /> on
+                            </Badge>
                           ) : (
-                            <span className="ml-auto flex shrink-0 items-center gap-1 text-xs text-warning">
-                              <AlertTriangle className="size-3.5" /> needs review
-                            </span>
+                            <Badge variant="warning" className="ml-auto shrink-0">
+                              <AlertTriangle className="size-3" /> needs review
+                            </Badge>
                           )}
                         </div>
                         {!on && (

--- a/src/components/TransportPill.tsx
+++ b/src/components/TransportPill.tsx
@@ -1,30 +1,14 @@
 import { Globe, HelpCircle, Radio, Terminal } from "lucide-react";
 import type { Transport } from "@/lib/types";
 
-const meta: Record<
-  Transport,
-  { label: string; icon: typeof Terminal; className: string }
-> = {
-  stdio: {
-    label: "stdio",
-    icon: Terminal,
-    className: "text-success border-success/30 bg-success/10",
-  },
-  http: {
-    label: "http",
-    icon: Globe,
-    className: "text-owned border-owned/30 bg-owned/10",
-  },
-  sse: {
-    label: "sse",
-    icon: Radio,
-    className: "text-info border-info/30 bg-info/10",
-  },
-  unknown: {
-    label: "unknown",
-    icon: HelpCircle,
-    className: "text-muted-foreground border-border bg-muted",
-  },
+// Transport is low-value, near-constant metadata, so it renders NEUTRAL: the icon plus a
+// muted mono label. Semantic colors (green/amber/red) are reserved exclusively for health,
+// so a healthy stdio server no longer shows two unrelated greens next to each other.
+const meta: Record<Transport, { label: string; icon: typeof Terminal }> = {
+  stdio: { label: "stdio", icon: Terminal },
+  http: { label: "http", icon: Globe },
+  sse: { label: "sse", icon: Radio },
+  unknown: { label: "unknown", icon: HelpCircle },
 };
 
 export function TransportPill({ transport }: { transport: Transport }) {
@@ -33,9 +17,9 @@ export function TransportPill({ transport }: { transport: Transport }) {
   return (
     <span
       aria-label={`Transport: ${m.label}`}
-      className={`inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-xs font-medium ${m.className}`}
+      className="inline-flex items-center gap-1 font-mono text-2xs text-muted-foreground/70"
     >
-      <Icon className="size-3" aria-hidden="true" />
+      <Icon className="size-3 opacity-70" aria-hidden="true" />
       <span aria-hidden="true">{m.label}</span>
     </span>
   );

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -13,6 +13,10 @@ const badgeVariants = cva(
         secondary: "bg-secondary text-secondary-foreground [a]:hover:bg-secondary/80",
         destructive:
           "bg-destructive/10 text-destructive focus-visible:ring-destructive/20 dark:bg-destructive/20 dark:focus-visible:ring-destructive/40 [a]:hover:bg-destructive/20",
+        success: "bg-success/12 text-success dark:bg-success/16",
+        warning: "bg-warning/14 text-warning dark:bg-warning/16",
+        info: "bg-info/12 text-info dark:bg-info/16",
+        owned: "bg-owned/12 text-owned dark:bg-owned/16",
         outline:
           "border-border text-foreground [a]:hover:bg-muted [a]:hover:text-muted-foreground",
         ghost: "hover:bg-muted hover:text-muted-foreground dark:hover:bg-muted/50",

--- a/src/components/ui/empty-state.tsx
+++ b/src/components/ui/empty-state.tsx
@@ -1,0 +1,38 @@
+import type { ReactNode } from "react";
+import { cn } from "@/lib/utils";
+
+/**
+ * One center-stacked empty / first-run / error state, replacing ~5 near-identical copies.
+ * Icon + title + one-line description + an optional action row.
+ */
+export function EmptyState({
+  icon,
+  title,
+  description,
+  action,
+  className,
+}: {
+  icon?: ReactNode;
+  title: ReactNode;
+  description?: ReactNode;
+  action?: ReactNode;
+  className?: string;
+}) {
+  return (
+    <div
+      className={cn(
+        "flex flex-col items-center justify-center gap-3 py-20 text-center",
+        className,
+      )}
+    >
+      {icon && <div className="text-muted-foreground/50 [&_svg]:size-10">{icon}</div>}
+      <div className="space-y-1">
+        <p className="font-medium">{title}</p>
+        {description && (
+          <p className="mx-auto max-w-md text-sm text-muted-foreground">{description}</p>
+        )}
+      </div>
+      {action && <div className="mt-1 flex items-center gap-2">{action}</div>}
+    </div>
+  );
+}

--- a/src/components/ui/section-header.tsx
+++ b/src/components/ui/section-header.tsx
@@ -1,0 +1,50 @@
+import type { ReactNode } from "react";
+import { cn } from "@/lib/utils";
+
+const DOT: Record<string, string> = {
+  success: "bg-success",
+  warning: "bg-warning",
+  danger: "bg-destructive",
+  muted: "bg-muted-foreground/60",
+  brand: "bg-primary",
+};
+
+/**
+ * The one uppercase micro-header used across every view. Replaces ~14 hand-rolled copies
+ * that had drifted to three different sizes. Optional leading status dot, a count pill, a
+ * leading icon, and a right-aligned action slot.
+ */
+export function SectionHeader({
+  children,
+  tone,
+  count,
+  icon,
+  action,
+  className,
+}: {
+  children: ReactNode;
+  tone?: keyof typeof DOT;
+  count?: number;
+  icon?: ReactNode;
+  action?: ReactNode;
+  className?: string;
+}) {
+  return (
+    <div
+      className={cn(
+        "mb-2 flex items-center gap-2 text-2xs font-semibold tracking-[0.09em] text-muted-foreground uppercase",
+        className,
+      )}
+    >
+      {tone && <span className={cn("size-1.5 shrink-0 rounded-full", DOT[tone])} />}
+      {icon}
+      <span>{children}</span>
+      {count != null && (
+        <span className="rounded-full bg-secondary px-2 py-px text-2xs font-semibold tracking-normal text-muted-foreground tabular-nums">
+          {count}
+        </span>
+      )}
+      {action && <span className="ml-auto flex items-center gap-1.5">{action}</span>}
+    </div>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -105,45 +105,44 @@
 
 .dark {
   color-scheme: dark;
-  /* Navy-biased neutral ramp: a faint blue hue (H~262) at low chroma on the greys gives
-     the whole app a deep-navy feel that reads more intentional than flat grey, while
-     lightness is preserved so contrast is unchanged. Orange is the single hero accent. */
-  --background: oklch(0.15 0.017 262);
-  --foreground: oklch(0.965 0.006 260);
-  --card: oklch(0.208 0.022 262);
-  --card-foreground: oklch(0.965 0.006 260);
-  --popover: oklch(0.208 0.022 262);
-  --popover-foreground: oklch(0.965 0.006 260);
-  /* Match the LOGO's coral-orange hue (~48), not an amber (~55): the yellower hue on a
-     dark ground read as "Halloween" and looked like a different orange than the mark. Kept
-     a hair lighter than --brand purely so dark ink stays legible on filled buttons. */
-  --primary: oklch(0.72 0.16 48);
-  --primary-foreground: oklch(0.24 0.055 48);
-  --brand: oklch(0.7 0.17 47);
-  --brand-foreground: oklch(0.24 0.055 48);
-  --secondary: oklch(0.272 0.024 262);
-  --secondary-foreground: oklch(0.965 0.006 260);
-  --muted: oklch(0.272 0.024 262);
-  --muted-foreground: oklch(0.72 0.026 262);
-  --accent: oklch(0.302 0.028 262);
-  --accent-foreground: oklch(0.965 0.006 260);
+  /* Deep-NAVY neutral ramp keyed to the brand navy (#1E3A66, H~258). The greys carry a
+     real blue chroma so the app reads navy + orange (the brand), not black + orange. Dark
+     enough to stay a comfortable dark UI; lightness rises through the ramp for elevation. */
+  --background: oklch(0.19 0.046 258);
+  --foreground: oklch(0.965 0.008 250);
+  --card: oklch(0.238 0.052 258);
+  --card-foreground: oklch(0.965 0.008 250);
+  --popover: oklch(0.238 0.052 258);
+  --popover-foreground: oklch(0.965 0.008 250);
+  /* The real brand orange (#F97316) at the logo's coral hue (~48) - one hero accent. A
+     hair lighter than --brand so dark ink stays legible on filled buttons. */
+  --primary: oklch(0.71 0.185 48);
+  --primary-foreground: oklch(0.24 0.06 48);
+  --brand: oklch(0.705 0.19 48);
+  --brand-foreground: oklch(0.24 0.06 48);
+  --secondary: oklch(0.305 0.05 258);
+  --secondary-foreground: oklch(0.965 0.008 250);
+  --muted: oklch(0.305 0.05 258);
+  --muted-foreground: oklch(0.735 0.032 255);
+  --accent: oklch(0.345 0.056 258);
+  --accent-foreground: oklch(0.965 0.008 250);
   --destructive: oklch(0.704 0.191 22.216);
-  --border: oklch(0.82 0.04 262 / 12%);
-  --input: oklch(0.82 0.04 262 / 16%);
-  --ring: oklch(0.72 0.15 48);
-  --chart-1: oklch(0.72 0.16 48);
+  --border: oklch(0.72 0.05 258 / 16%);
+  --input: oklch(0.72 0.05 258 / 20%);
+  --ring: oklch(0.71 0.16 48);
+  --chart-1: oklch(0.71 0.185 48);
   --chart-2: oklch(0.746 0.16 232.661);
   --chart-3: oklch(0.765 0.177 163.223);
   --chart-4: oklch(0.828 0.189 84.429);
   --chart-5: oklch(0.702 0.183 293.541);
-  --sidebar: oklch(0.128 0.018 262);
-  --sidebar-foreground: oklch(0.965 0.006 260);
-  --sidebar-primary: oklch(0.72 0.16 48);
-  --sidebar-primary-foreground: oklch(0.24 0.055 48);
-  --sidebar-accent: oklch(0.272 0.024 262);
-  --sidebar-accent-foreground: oklch(0.965 0.006 260);
-  --sidebar-border: oklch(0.82 0.04 262 / 12%);
-  --sidebar-ring: oklch(0.72 0.15 48);
+  --sidebar: oklch(0.165 0.045 258);
+  --sidebar-foreground: oklch(0.965 0.008 250);
+  --sidebar-primary: oklch(0.71 0.185 48);
+  --sidebar-primary-foreground: oklch(0.24 0.06 48);
+  --sidebar-accent: oklch(0.305 0.05 258);
+  --sidebar-accent-foreground: oklch(0.965 0.008 250);
+  --sidebar-border: oklch(0.72 0.05 258 / 16%);
+  --sidebar-ring: oklch(0.71 0.16 48);
 }
 
 @layer base {

--- a/src/index.css
+++ b/src/index.css
@@ -66,8 +66,8 @@
   --popover-foreground: oklch(0.145 0 0);
   /* Softened brand orange as the primary action color (the pure logo shade lives in
      --brand, reserved for the mark). One hero accent; semantics stay success/warn/etc. */
-  --primary: oklch(0.72 0.145 52);
-  --primary-foreground: oklch(0.22 0.05 55);
+  --primary: oklch(0.68 0.16 48);
+  --primary-foreground: oklch(0.24 0.055 48);
   --brand: oklch(0.7 0.17 47);
   --brand-foreground: oklch(0.22 0.05 55);
   --secondary: oklch(0.97 0 0);
@@ -114,10 +114,13 @@
   --card-foreground: oklch(0.965 0.006 260);
   --popover: oklch(0.208 0.022 262);
   --popover-foreground: oklch(0.965 0.006 260);
-  --primary: oklch(0.75 0.13 55);
-  --primary-foreground: oklch(0.22 0.05 55);
+  /* Match the LOGO's coral-orange hue (~48), not an amber (~55): the yellower hue on a
+     dark ground read as "Halloween" and looked like a different orange than the mark. Kept
+     a hair lighter than --brand purely so dark ink stays legible on filled buttons. */
+  --primary: oklch(0.72 0.16 48);
+  --primary-foreground: oklch(0.24 0.055 48);
   --brand: oklch(0.7 0.17 47);
-  --brand-foreground: oklch(0.22 0.05 55);
+  --brand-foreground: oklch(0.24 0.055 48);
   --secondary: oklch(0.272 0.024 262);
   --secondary-foreground: oklch(0.965 0.006 260);
   --muted: oklch(0.272 0.024 262);
@@ -127,20 +130,20 @@
   --destructive: oklch(0.704 0.191 22.216);
   --border: oklch(0.82 0.04 262 / 12%);
   --input: oklch(0.82 0.04 262 / 16%);
-  --ring: oklch(0.75 0.12 55);
-  --chart-1: oklch(0.75 0.13 55);
+  --ring: oklch(0.72 0.15 48);
+  --chart-1: oklch(0.72 0.16 48);
   --chart-2: oklch(0.746 0.16 232.661);
   --chart-3: oklch(0.765 0.177 163.223);
   --chart-4: oklch(0.828 0.189 84.429);
   --chart-5: oklch(0.702 0.183 293.541);
   --sidebar: oklch(0.128 0.018 262);
   --sidebar-foreground: oklch(0.965 0.006 260);
-  --sidebar-primary: oklch(0.75 0.13 55);
-  --sidebar-primary-foreground: oklch(0.22 0.05 55);
+  --sidebar-primary: oklch(0.72 0.16 48);
+  --sidebar-primary-foreground: oklch(0.24 0.055 48);
   --sidebar-accent: oklch(0.272 0.024 262);
   --sidebar-accent-foreground: oklch(0.965 0.006 260);
   --sidebar-border: oklch(0.82 0.04 262 / 12%);
-  --sidebar-ring: oklch(0.75 0.12 55);
+  --sidebar-ring: oklch(0.72 0.15 48);
 }
 
 @layer base {

--- a/src/index.css
+++ b/src/index.css
@@ -29,6 +29,10 @@
   --color-warning: var(--warning);
   --color-info: var(--info);
   --color-owned: var(--owned);
+  --color-brand: var(--brand);
+  --color-brand-foreground: var(--brand-foreground);
+  --text-2xs: 0.6875rem;
+  --text-2xs--line-height: 1rem;
   --color-accent-foreground: var(--accent-foreground);
   --color-accent: var(--accent);
   --color-muted-foreground: var(--muted-foreground);
@@ -60,8 +64,12 @@
   --card-foreground: oklch(0.145 0 0);
   --popover: oklch(1 0 0);
   --popover-foreground: oklch(0.145 0 0);
-  --primary: oklch(0.205 0 0);
-  --primary-foreground: oklch(0.985 0 0);
+  /* Softened brand orange as the primary action color (the pure logo shade lives in
+     --brand, reserved for the mark). One hero accent; semantics stay success/warn/etc. */
+  --primary: oklch(0.72 0.145 52);
+  --primary-foreground: oklch(0.22 0.05 55);
+  --brand: oklch(0.7 0.17 47);
+  --brand-foreground: oklch(0.22 0.05 55);
   --secondary: oklch(0.97 0 0);
   --secondary-foreground: oklch(0.205 0 0);
   --muted: oklch(0.97 0 0);
@@ -97,37 +105,42 @@
 
 .dark {
   color-scheme: dark;
-  --background: oklch(0.145 0 0);
-  --foreground: oklch(0.985 0 0);
-  --card: oklch(0.205 0 0);
-  --card-foreground: oklch(0.985 0 0);
-  --popover: oklch(0.205 0 0);
-  --popover-foreground: oklch(0.985 0 0);
-  --primary: oklch(0.922 0 0);
-  --primary-foreground: oklch(0.205 0 0);
-  --secondary: oklch(0.269 0 0);
-  --secondary-foreground: oklch(0.985 0 0);
-  --muted: oklch(0.269 0 0);
-  --muted-foreground: oklch(0.708 0 0);
-  --accent: oklch(0.269 0 0);
-  --accent-foreground: oklch(0.985 0 0);
+  /* Navy-biased neutral ramp: a faint blue hue (H~262) at low chroma on the greys gives
+     the whole app a deep-navy feel that reads more intentional than flat grey, while
+     lightness is preserved so contrast is unchanged. Orange is the single hero accent. */
+  --background: oklch(0.15 0.017 262);
+  --foreground: oklch(0.965 0.006 260);
+  --card: oklch(0.208 0.022 262);
+  --card-foreground: oklch(0.965 0.006 260);
+  --popover: oklch(0.208 0.022 262);
+  --popover-foreground: oklch(0.965 0.006 260);
+  --primary: oklch(0.75 0.13 55);
+  --primary-foreground: oklch(0.22 0.05 55);
+  --brand: oklch(0.7 0.17 47);
+  --brand-foreground: oklch(0.22 0.05 55);
+  --secondary: oklch(0.272 0.024 262);
+  --secondary-foreground: oklch(0.965 0.006 260);
+  --muted: oklch(0.272 0.024 262);
+  --muted-foreground: oklch(0.72 0.026 262);
+  --accent: oklch(0.302 0.028 262);
+  --accent-foreground: oklch(0.965 0.006 260);
   --destructive: oklch(0.704 0.191 22.216);
-  --border: oklch(1 0 0 / 10%);
-  --input: oklch(1 0 0 / 15%);
-  --ring: oklch(0.556 0 0);
-  --chart-1: oklch(0.87 0 0);
-  --chart-2: oklch(0.556 0 0);
-  --chart-3: oklch(0.439 0 0);
-  --chart-4: oklch(0.371 0 0);
-  --chart-5: oklch(0.269 0 0);
-  --sidebar: oklch(0.205 0 0);
-  --sidebar-foreground: oklch(0.985 0 0);
-  --sidebar-primary: oklch(0.488 0.243 264.376);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.269 0 0);
-  --sidebar-accent-foreground: oklch(0.985 0 0);
-  --sidebar-border: oklch(1 0 0 / 10%);
-  --sidebar-ring: oklch(0.556 0 0);
+  --border: oklch(0.82 0.04 262 / 12%);
+  --input: oklch(0.82 0.04 262 / 16%);
+  --ring: oklch(0.75 0.12 55);
+  --chart-1: oklch(0.75 0.13 55);
+  --chart-2: oklch(0.746 0.16 232.661);
+  --chart-3: oklch(0.765 0.177 163.223);
+  --chart-4: oklch(0.828 0.189 84.429);
+  --chart-5: oklch(0.702 0.183 293.541);
+  --sidebar: oklch(0.128 0.018 262);
+  --sidebar-foreground: oklch(0.965 0.006 260);
+  --sidebar-primary: oklch(0.75 0.13 55);
+  --sidebar-primary-foreground: oklch(0.22 0.05 55);
+  --sidebar-accent: oklch(0.272 0.024 262);
+  --sidebar-accent-foreground: oklch(0.965 0.006 260);
+  --sidebar-border: oklch(0.82 0.04 262 / 12%);
+  --sidebar-ring: oklch(0.75 0.12 55);
 }
 
 @layer base {


### PR DESCRIPTION
The app-wide Bold redesign, built tab by tab against a 4-agent look-and-feel audit and reviewed live throughout. Dark-only app; every change is on the shipped Geist typeface.

## The through-line
The app read as **black + orange** (Halloween) with an inverted hierarchy (transport metadata shouting, health whispering). This rekeys it to the **brand palette** (navy `#1E3A66`, orange `#F97316`, both sourced from the brand kit's `gen_brand.py`) and fixes the hierarchy, on one shared token + component foundation so every tab moves together.

## Foundation (lifts every tab at once)
- **Navy-biased neutral ramp** keyed to the brand navy — real blue chroma so the app reads navy, not near-black.
- **Orange as `--primary`** (softened to the logo's coral hue, dark ink on fills) → primary buttons, checked switches, active nav, focus rings all go brand-orange automatically. Pure logo shade kept as `--brand`.
- **Semantic `Badge` variants** (success/warning/info/owned — the tokens existed, the CVA didn't expose them), a **`text-2xs`** type token (retires ~40 arbitrary `text-[11px]`), and shared **`SectionHeader`** + **`EmptyState`** primitives (replaced ~14 and ~5 hand-rolled copies).
- A soft **ambient orange wash** on the content area (radial gradient keyed to `--primary`) so the accent belongs to the environment.

## Per tab
- **Servers**: grey caption → scannable **status-bar chips**; **transport neutralized** (was competing with health in green/violet); **status shown as a colored word**, not just an 8px dot; subtle card elevation.
- **Connect flow**: fixed the **phantom-button bug** (import block + "how importing works" only render when there's actually something to import); rebuilt the disconnected state as a pitch with a **`Client → Toolport → servers` topology**; graceful zero-server case. Also fixed the gateway leaking into the topology as **"conduit"** and the count reading 15 instead of 14.
- **Sidebar**: active nav item gets an **orange icon**, tying the accent into the chrome.
- **Teams**: not-connected form gained a **3-point value strip**; status chips use semantic badges.
- **Settings**: a **security posture summary** (Protected / Partly / Unprotected + what's active) so protection reads at a glance.
- **Playground**: **copy button** on results, **error-tinted** result container, semantic destructive badge, focus-ring consistency (`ring-1`→`ring-3`).
- **Catalog**: shared `<Skeleton>` loading; transport neutralized by the foundation.
- **Onboarding**: dense Welcome paragraph → three scannable benefit rows.

## Verification
`tsc` clean · `eslint` clean (only pre-existing warnings) · `vite build` passes (5.5s). Reviewed live in `tauri dev` at each step; no Rust changes.

Direction reference: the approved Bold mockup (real Geist, token tile) that this implements.