### PR TITLE
fix(activity): tool-identity 'no history' copy points at a setting that doesn't exist

### DIFF
--- a/src/components/ActivityView.tsx
+++ b/src/components/ActivityView.tsx
@@ -1025,8 +1025,9 @@ function ToolIdentityRow({ t }: { t: ToolIdentity }) {
               <>
                 <dt className="text-muted-foreground">History</dt>
                 <dd className="text-muted-foreground/80">
-                  Turn on integrity checking in Settings to track when this tool was first
-                  seen and when it last changed.
+                  This tool&apos;s baseline predates first-seen tracking, so it has no
+                  dates yet. Toolport fills them in automatically the next time a client
+                  lists tools through the gateway.
                 </dd>
               </>
             )}


### PR DESCRIPTION
In **Activity → Tool identities → (a tool)**, when a tool has no first-seen/last-changed date the history line reads *"Turn on integrity checking in Settings…"*. But there is **no such toggle** anywhere in the app, and `integrity_check` defaults to **on** with no setter, so the instruction points at a control that doesn't exist and a feature that's already running.

A tool with no date is simply a **legacy pin** from before timestamp tracking; `integrity::check` backfills the date on its next run. Reworded the empty state to say that (it fills in automatically) instead of naming a phantom setting. Copy-only, no behavior change.