### PR TITLE
polish(ui): pre-release contrast + token fixes, and changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,51 @@ Entries before the rename below shipped under the project's former name, Conduit
 
 ## [Unreleased]
 
+### Added
+
+- **A full visual redesign.** Toolport moves to its brand palette, a deep navy
+  ground with a single orange accent, applied consistently across every tab. Server
+  health now reads as a colored word (not just an 8px dot), the Servers header is a
+  scannable status bar, and the transport label is demoted to neutral so color means
+  health, not metadata.
+- **The connect flow shows the product.** Pointing a client that isn't connected yet
+  now leads with a `client -> Toolport -> your servers` diagram and a clear call to
+  action, instead of a wall of prose.
+- **Tool identities are searchable and grouped by server.** Activity → Tool identities
+  collapses hundreds of tools into per-server sections with a filter box: type a server
+  name to see its whole block, or a tool name to jump to it.
+- **A security posture summary in Settings.** The Security section opens with a
+  one-line read of whether you're protected (guarded / partly / unprotected) and what's
+  active, so you don't have to decode every toggle.
+- **Tool-poison flags now show the matched text.** A flagged tool definition surfaces a
+  short, de-obfuscated excerpt of exactly what tripped the scan, so the alert is
+  verifiable instead of an opaque label.
+
+### Changed
+
+- **The Activity tab is calmer.** New/first-seen tools no longer flood the security
+  lane; recurring notices collapse into a single counted row; the per-server stats table
+  and discovery panel are collapsed by default; the recent-calls log shows all calls
+  rather than defaulting to an errors-only view that read as "everything is failing."
+
+### Fixed
+
+- **First-seen destructive tools are no longer quarantined.** A destructive tool simply
+  appearing for the first time is inventory, not a rug-pull, and no longer gets blocked
+  behind a wall of re-approvals (the call is still gated by the block/confirm/approval
+  policies). Legacy quarantine entries from the old behavior auto-clear.
+- **No more spurious "integrity baseline lost" alarms** from an empty or mid-swap read
+  of the shared pin file, while a genuinely truncated baseline is still treated as
+  tampering (loud), not silently rebuilt.
+- **A benign tool description no longer trips the poison scanner.** The stealth-directive
+  check now requires a real concealment target, so a formatting note like "do not mention
+  if a column is boolean" on a legitimate server is not flagged.
+- **The connect view no longer describes buttons that aren't there,** and no longer lists
+  Toolport's own gateway entry as one of the servers a client can reach (the managed count
+  now matches the Servers list).
+- **Corrected a Settings pointer** in the tool-identity history note that referenced an
+  integrity-checking toggle which does not exist (integrity checking is always on).
+
 ## [1.3.0] - 2026-07-04
 
 ### Added

--- a/src/components/CatalogView.tsx
+++ b/src/components/CatalogView.tsx
@@ -469,7 +469,7 @@ function Provenance({ entry }: { entry: CatalogEntry }) {
       <ShieldCheck className={`size-3 shrink-0 ${tier.cls}`} />
       <span className={tier.cls}>{tier.label}</span>
       {entry.publisher && (
-        <span className="truncate text-muted-foreground/70">· {entry.publisher}</span>
+        <span className="truncate text-muted-foreground">· {entry.publisher}</span>
       )}
     </div>
   );
@@ -511,10 +511,7 @@ function CatalogCard({
       <p className="line-clamp-2 min-h-8 text-xs text-muted-foreground">
         {entry.description}
       </p>
-      <code
-        title={target}
-        className="truncate font-mono text-[11px] text-muted-foreground/70"
-      >
+      <code title={target} className="truncate font-mono text-2xs text-muted-foreground">
         {target}
       </code>
       <Provenance entry={entry} />

--- a/src/components/ClientDetail.tsx
+++ b/src/components/ClientDetail.tsx
@@ -570,7 +570,7 @@ function GatewayFlow({ clientName, servers }: { clientName: string; servers: str
       </div>
       <div className={`${link} bg-gradient-to-r from-border to-primary`} />
       <div className="flex flex-col items-center gap-2 text-center">
-        <div className="grid size-16 place-items-center rounded-2xl border border-primary/45 bg-primary/10 shadow-[0_0_0_5px_rgba(239,147,80,.09),0_16px_34px_-16px_rgba(239,147,80,.5)]">
+        <div className="grid size-16 place-items-center rounded-2xl border border-primary/45 bg-primary/10 shadow-[0_0_0_5px_color-mix(in_oklch,var(--primary)_12%,transparent),0_16px_34px_-16px_color-mix(in_oklch,var(--primary)_50%,transparent)]">
           <svg width="30" height="30" viewBox="0 0 32 32" aria-hidden="true">
             <circle
               cx="16"

--- a/src/components/ServerDialog.tsx
+++ b/src/components/ServerDialog.tsx
@@ -446,7 +446,7 @@ export function ServerDialog({
                 </p>
               ))}
               {duplicateName && (
-                <p className="flex items-start gap-1.5 text-amber-600 dark:text-amber-500">
+                <p className="flex items-start gap-1.5 text-warning">
                   <AlertTriangle className="mt-0.5 size-3.5 shrink-0" />
                   <span>
                     Another server is already named "{nameTrim}". That's fine for multiple
@@ -455,7 +455,7 @@ export function ServerDialog({
                 </p>
               )}
               {test.status === "ok" && (
-                <p className="flex items-start gap-1.5 text-emerald-600 dark:text-emerald-500">
+                <p className="flex items-start gap-1.5 text-success">
                   <CheckCircle2 className="mt-0.5 size-3.5 shrink-0" />
                   <span>{test.message}</span>
                 </p>

--- a/src/components/TransportPill.tsx
+++ b/src/components/TransportPill.tsx
@@ -17,7 +17,7 @@ export function TransportPill({ transport }: { transport: Transport }) {
   return (
     <span
       aria-label={`Transport: ${m.label}`}
-      className="inline-flex items-center gap-1 font-mono text-2xs text-muted-foreground/70"
+      className="inline-flex items-center gap-1 font-mono text-2xs text-muted-foreground"
     >
       <Icon className="size-3 opacity-70" aria-hidden="true" />
       <span aria-hidden="true">{m.label}</span>

--- a/src/components/ui/switch.tsx
+++ b/src/components/ui/switch.tsx
@@ -15,14 +15,14 @@ function Switch({
       data-slot="switch"
       data-size={size}
       className={cn(
-        "peer group/switch relative inline-flex shrink-0 items-center rounded-full border border-transparent transition-all outline-none after:absolute after:-inset-x-3 after:-inset-y-2 focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 data-[size=default]:h-[18.4px] data-[size=default]:w-[32px] data-[size=sm]:h-[14px] data-[size=sm]:w-[24px] dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 data-checked:bg-primary data-unchecked:bg-input dark:data-unchecked:bg-input/80 data-disabled:cursor-not-allowed data-disabled:opacity-50",
+        "peer group/switch relative inline-flex shrink-0 items-center rounded-full border border-transparent transition-all outline-none after:absolute after:-inset-x-3 after:-inset-y-2 focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 data-[size=default]:h-[18.4px] data-[size=default]:w-[32px] data-[size=sm]:h-[14px] data-[size=sm]:w-[24px] dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 data-checked:bg-primary/80 data-unchecked:bg-input dark:data-unchecked:bg-input/80 data-disabled:cursor-not-allowed data-disabled:opacity-50",
         className,
       )}
       {...props}
     >
       <SwitchPrimitive.Thumb
         data-slot="switch-thumb"
-        className="pointer-events-none block rounded-full bg-background ring-0 transition-transform group-data-[size=default]/switch:size-4 group-data-[size=sm]/switch:size-3 group-data-[size=default]/switch:data-checked:translate-x-[calc(100%-2px)] group-data-[size=sm]/switch:data-checked:translate-x-[calc(100%-2px)] dark:data-checked:bg-primary-foreground group-data-[size=default]/switch:data-unchecked:translate-x-0 group-data-[size=sm]/switch:data-unchecked:translate-x-0 dark:data-unchecked:bg-foreground"
+        className="pointer-events-none block rounded-full bg-background ring-0 transition-transform group-data-[size=default]/switch:size-4 group-data-[size=sm]/switch:size-3 group-data-[size=default]/switch:data-checked:translate-x-[calc(100%-2px)] group-data-[size=sm]/switch:data-checked:translate-x-[calc(100%-2px)] dark:data-checked:bg-foreground group-data-[size=default]/switch:data-unchecked:translate-x-0 group-data-[size=sm]/switch:data-unchecked:translate-x-0 dark:data-unchecked:bg-foreground"
       />
     </SwitchPrimitive.Root>
   );

--- a/src/index.css
+++ b/src/index.css
@@ -82,7 +82,7 @@
        Values are the Tailwind v4 *-400 palette: emerald, amber, violet, sky. */
   --success: oklch(0.765 0.177 163.223);
   --warning: oklch(0.828 0.189 84.429);
-  --info: oklch(0.702 0.183 293.541);
+  --info: oklch(0.74 0.165 293.541);
   --owned: oklch(0.746 0.16 232.661);
   --border: oklch(0.922 0 0);
   --input: oklch(0.922 0 0);
@@ -123,12 +123,14 @@
   --secondary: oklch(0.305 0.05 258);
   --secondary-foreground: oklch(0.965 0.008 250);
   --muted: oklch(0.305 0.05 258);
-  --muted-foreground: oklch(0.735 0.032 255);
+  /* Raised from 0.735 to reach ~4.5:1 (AA) on the navy card/bg for secondary text. */
+  --muted-foreground: oklch(0.78 0.03 255);
   --accent: oklch(0.345 0.056 258);
   --accent-foreground: oklch(0.965 0.008 250);
   --destructive: oklch(0.704 0.191 22.216);
-  --border: oklch(0.72 0.05 258 / 16%);
-  --input: oklch(0.72 0.05 258 / 20%);
+  /* 22% (was 16%) so card edges and row dividers actually read against the navy. */
+  --border: oklch(0.72 0.05 258 / 22%);
+  --input: oklch(0.72 0.05 258 / 22%);
   --ring: oklch(0.71 0.16 48);
   --chart-1: oklch(0.71 0.185 48);
   --chart-2: oklch(0.746 0.16 232.661);
@@ -141,7 +143,7 @@
   --sidebar-primary-foreground: oklch(0.24 0.06 48);
   --sidebar-accent: oklch(0.305 0.05 258);
   --sidebar-accent-foreground: oklch(0.965 0.008 250);
-  --sidebar-border: oklch(0.72 0.05 258 / 16%);
+  --sidebar-border: oklch(0.72 0.05 258 / 22%);
   --sidebar-ring: oklch(0.71 0.16 48);
 }
 


### PR DESCRIPTION
Pre-release polish from an adversarial contrast-verified review of the Bold redesign (no ship-blockers found; these are the real legibility fixes):

- **ServerDialog** raw `amber-600`/`emerald-600` → semantic `text-warning`/`text-success` (rendered off-palette on navy).
- **`--muted-foreground` 0.735 → 0.78** to clear ~4.5:1 (AA) for secondary text on navy (was ~3.6:1).
- Dropped **`text-muted-foreground/70`** from genuine text (transport pill, catalog publisher + command) where the alpha tipped it to ~2.3:1.
- **`--info`** nudged lighter (violet Team badge was ~3.5:1).
- **`--border`/`--input` 16% → 22%** so card edges and row dividers read against navy.
- **GatewayFlow glow** keyed to `--primary` (color-mix) instead of a frozen rgba.
- **CHANGELOG** `[Unreleased]` drafted for the release.

Deferred (judgment call, flagged to owner): the review noted every enabled toggle is now orange, which is a lot of accent on a full Servers list. Left as-is (on = active = brand) pending a call.

`tsc`, `vite build` clean.