### PR TITLE
feat(a11y): keyboard-operable rows, semantic onboarding progress (#56)

### DIFF
--- a/src/components/ActivityView.tsx
+++ b/src/components/ActivityView.tsx
@@ -513,16 +513,35 @@ function ServerRow({ s }: { s: ServerStat }) {
         onClick={() => expandable && setOpen((o) => !o)}
       >
         <td className="px-3 py-2 font-medium">
-          <span className="flex min-w-0 items-center gap-1.5">
-            {expandable ? (
+          {expandable ? (
+            // Keyboard-operable disclosure lives on a real <button> inside the cell so
+            // the row keeps its table semantics; the row-level onClick stays for
+            // mouse click-anywhere and this button stops propagation to avoid a
+            // double toggle.
+            <button
+              type="button"
+              onClick={(e) => {
+                e.stopPropagation();
+                setOpen((o) => !o);
+              }}
+              aria-expanded={open}
+              className="flex min-w-0 items-center gap-1.5 rounded-sm text-left focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none"
+            >
               <ChevronRight
+                aria-hidden="true"
                 className={`size-3.5 text-muted-foreground transition-transform ${open ? "rotate-90" : ""}`}
               />
-            ) : (
+              <span className="truncate">{s.server}</span>
+              <span className="sr-only">
+                {open ? "Collapse" : "Expand"} per-tool breakdown
+              </span>
+            </button>
+          ) : (
+            <span className="flex min-w-0 items-center gap-1.5">
               <span className="inline-block size-3.5" />
-            )}
-            <span className="truncate">{s.server}</span>
-          </span>
+              <span className="truncate">{s.server}</span>
+            </span>
+          )}
         </td>
         <td className="px-3 py-2 text-right tabular-nums">{s.calls}</td>
         <td
@@ -579,14 +598,25 @@ function CallRow({ e }: { e: AuditEntry }) {
   return (
     <div className="rounded-md border border-border/50 text-sm">
       <div
-        className={`flex items-center gap-3 px-3 py-2 ${
+        className={`flex items-center gap-3 rounded-md px-3 py-2 focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none ${
           hasDetail ? "cursor-pointer hover:bg-muted/30" : ""
         }`}
         onClick={() => hasDetail && setOpen((o) => !o)}
+        onKeyDown={
+          hasDetail
+            ? (event) => {
+                if (event.key === "Enter" || event.key === " ") {
+                  event.preventDefault();
+                  setOpen((o) => !o);
+                }
+              }
+            : undefined
+        }
         {...(hasDetail ? { role: "button", "aria-expanded": open, tabIndex: 0 } : {})}
       >
         {hasDetail ? (
           <ChevronRight
+            aria-hidden="true"
             className={`size-3.5 shrink-0 text-muted-foreground transition-transform ${
               open ? "rotate-90" : ""
             }`}

--- a/src/components/Onboarding.tsx
+++ b/src/components/Onboarding.tsx
@@ -102,10 +102,18 @@ export function Onboarding({
           {steps[step]}
 
           <div className="flex items-center justify-between border-t pt-4">
-            <div className="flex items-center gap-1.5">
+            <div
+              className="flex items-center gap-1.5"
+              role="progressbar"
+              aria-valuenow={step + 1}
+              aria-valuemin={1}
+              aria-valuemax={steps.length}
+              aria-label={`Setup step ${step + 1} of ${steps.length}`}
+            >
               {steps.map((_, i) => (
                 <span
                   key={i}
+                  aria-hidden="true"
                   className={`size-1.5 rounded-full transition-colors ${
                     i === step ? "bg-success" : "bg-muted-foreground/30"
                   }`}
@@ -114,6 +122,7 @@ export function Onboarding({
             </div>
             {step < steps.length - 1 && (
               <button
+                type="button"
                 onClick={onFinish}
                 className="text-xs text-muted-foreground transition hover:text-foreground"
               >

--- a/src/components/RegistryServerRow.tsx
+++ b/src/components/RegistryServerRow.tsx
@@ -203,7 +203,9 @@ export function RegistryServerRow({
             </code>
           )}
           {status === "error" && health?.error && (
-            <p className="text-xs text-warning">{health.error}</p>
+            <p className="max-h-32 overflow-y-auto text-xs break-words whitespace-pre-wrap text-warning">
+              {health.error}
+            </p>
           )}
 
           <div className="flex flex-wrap items-center gap-1">


### PR DESCRIPTION
First increment of the accessibility pass (closes part of #56).

## What
- **Activity per-server stats rows** — the expand/collapse control is now a real focusable `<button>` inside the first cell (valid table semantics, Enter/Space activates it, visible focus ring), replacing a mouse-only clickable `<tr>`. Mouse click-anywhere on the row is preserved; the button `stopPropagation`s to avoid a double toggle.
- **Activity recent-call rows** — added an Enter/Space `onKeyDown` handler and a focus ring to the `role=button` div. It already had `aria-expanded`/`tabIndex` but no way to activate via keyboard.
- **Onboarding step dots** — wrapped in `role=progressbar` with `aria-valuenow/min/max` + label so screen readers announce position in the flow; dots marked `aria-hidden`. Skip button gets `type=button`.
- **Server error detail** (RegistryServerRow) — long error strings are now bounded (`max-h` + scroll + wrap) so they can't overflow the panel.
- Decorative chevrons marked `aria-hidden`.

## Verification
tsc clean, lint 0 errors (only pre-existing react-compiler warnings), 52 frontend tests pass.

Part of the post-1.4 software roadmap (Phase 1 of 4). Follow-ups tracked in #162/#163/#164.