### PR TITLE
feat(app): surface when the backend can't be reached (#168)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,6 +18,7 @@ import {
   ServerOff,
   Store,
   TriangleAlert,
+  WifiOff,
 } from "lucide-react";
 import { toast } from "sonner";
 import { toastError } from "@/lib/toast";
@@ -76,6 +77,7 @@ const SettingsView = lazy(() =>
   import("@/components/SettingsView").then((m) => ({ default: m.SettingsView })),
 );
 import { Button } from "@/components/ui/button";
+import { Callout } from "@/components/Callout";
 import { Input } from "@/components/ui/input";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -94,6 +96,12 @@ function App() {
   const [activityKey, setActivityKey] = useState(0);
   const [health, setHealth] = useState<Record<string, ProbeResult>>({});
   const [probing, setProbing] = useState(false);
+  // Whether the app's Rust backend answered the last health probe. `probe_servers`
+  // returns per-server failures as ok:false results; a *thrown* invoke instead means
+  // the backend itself didn't respond, and without this the server badges would sit
+  // on "Checking…" forever with no explanation. Optimistic default so the banner
+  // only appears after a real failure.
+  const [backendReachable, setBackendReachable] = useState(true);
   const [query, setQuery] = useState("");
   const [onboarded, setOnboarded] = useState(
     () => localStorage.getItem("conduit.onboarded") === "1",
@@ -127,11 +135,14 @@ function App() {
     try {
       const results = await probeServers();
       setHealth(Object.fromEntries(results.map((r) => [r.serverId, r])));
+      setBackendReachable(true);
       return results;
     } catch {
       // Non-fatal: badges just stay in "checking". Record that it threw so a manual
-      // refresh reports the failure instead of a false success (both return []).
+      // refresh reports the failure instead of a false success (both return []), and
+      // surface a persistent banner so the stale badges aren't read as real status.
       probeErroredRef.current = true;
+      setBackendReachable(false);
       return [];
     } finally {
       setProbing(false);
@@ -510,6 +521,29 @@ function App() {
               </Button>
             </div>
           </header>
+
+          {!backendReachable && (
+            <Callout
+              variant="warning"
+              role="status"
+              className="mx-6 mt-3 flex items-center gap-3"
+            >
+              <WifiOff className="size-4 shrink-0" aria-hidden="true" />
+              <span className="min-w-0 flex-1">
+                Toolport's backend didn't respond to the last health check, so server
+                status below may be stale.
+              </span>
+              <Button
+                variant="outline"
+                size="sm"
+                className="shrink-0"
+                onClick={() => void reprobe()}
+                disabled={probing}
+              >
+                Retry
+              </Button>
+            </Callout>
+          )}
 
           <ScrollArea className="min-h-0 flex-1">
             <div className="p-6">

--- a/src/components/Callout.tsx
+++ b/src/components/Callout.tsx
@@ -12,14 +12,17 @@ interface Props {
   variant?: keyof typeof VARIANTS;
   className?: string;
   children: ReactNode;
+  /** ARIA role, e.g. "status" or "alert" for banners that should be announced. */
+  role?: string;
 }
 
 /** A tinted message banner. One source of truth for the success / warning / info /
  * danger notice boxes that views used to hand-roll with inconsistent padding, radius,
  * and opacity. Colors come from the semantic accent tokens. */
-export function Callout({ variant = "info", className, children }: Props) {
+export function Callout({ variant = "info", className, children, role }: Props) {
   return (
     <div
+      role={role}
       className={cn("rounded-lg border px-3 py-2 text-sm", VARIANTS[variant], className)}
     >
       {children}


### PR DESCRIPTION
Closes #168.

## Problem
`probe_servers` runs in the app's own Rust backend via Tauri `invoke`. Per-server failures come back as `ok:false` results, but a **thrown** invoke means the backend itself didn't respond. Today that's swallowed into a transient ref (`reprobe`'s catch), so every server badge sits on 'Checking…' indefinitely with no explanation — users conclude their servers broke, when it's Toolport that's unreachable. A gateway product should surface its own up/down state.

## Change
- New `backendReachable` state (optimistic default). `reprobe` sets it `true` on a successful probe and `false` when the invoke throws (the skipped/in-flight path leaves it untouched, so it never flips spuriously).
- A persistent warning banner between the header and the scroll area with a **Retry** (re-runs the probe); it auto-clears the moment a probe succeeds.
- Small optional `role` passthrough added to the shared `Callout` so the banner is announced (`role=status`).

## Scope / verification
tsc clean, lint 0 errors, 52 tests pass. Note: the app has no component-test infra yet (all current tests are pure-logic in `args.test.ts` — the thin-coverage finding from the audit), so this is verified by types + review of the probe-throw path rather than a rendered test. Forcing a real backend-probe failure in a full Tauri build wasn't practical here.

First Tier-A build item from the 2026-07-04 fresh-eyes audit.