### PR TITLE
sec(files): write data-dir files owner-only (0600) on Unix (#169)

### DIFF
--- a/src-tauri/src/approval_broker.rs
+++ b/src-tauri/src/approval_broker.rs
@@ -190,9 +190,12 @@ pub fn start(app: AppHandle) -> ApprovalBroker {
                     };
                     // A stale descriptor (app crashed) points at a dead port, so a gateway
                     // connect fails and denies - fail-closed either way.
-                    let _ = std::fs::write(
-                        dir.join(ENDPOINT_FILE),
-                        serde_json::to_string(&desc).unwrap_or_default(),
+                    // Written via atomic_write so the HITL endpoint + auth token land
+                    // owner-only (0600) on Unix rather than world-readable: a same-user
+                    // process reading the token could otherwise spoof approval decisions.
+                    let _ = crate::registry::atomic_write(
+                        &dir.join(ENDPOINT_FILE),
+                        &serde_json::to_string(&desc).unwrap_or_default(),
                     );
                 }
                 let accept_broker = broker.clone();

--- a/src-tauri/src/registry.rs
+++ b/src-tauri/src/registry.rs
@@ -39,6 +39,16 @@ pub fn atomic_write(path: &Path, contents: &str) -> Result<(), String> {
     {
         use std::io::Write;
         let mut f = std::fs::File::create(&tmp).map_err(|e| e.to_string())?;
+        // Restrict to owner-only (0600) BEFORE writing, so secrets.enc, the registry,
+        // pins, and the audit log are never world-readable, not even for the brief
+        // window before the content lands, under a permissive umask on a shared or
+        // headless host. No-op on Windows (NTFS ACLs inherit from the parent dir).
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            f.set_permissions(std::fs::Permissions::from_mode(0o600))
+                .map_err(|e| e.to_string())?;
+        }
         f.write_all(contents.as_bytes()).map_err(|e| e.to_string())?;
         // Flush the data to stable storage BEFORE the rename, so a crash/power loss
         // can't make the rename durable while the file's blocks aren't — which would
@@ -1158,6 +1168,22 @@ mod tests {
             .filter_map(|e| e.ok())
             .any(|e| e.file_name().to_string_lossy().starts_with(&prefix));
         assert!(!leftover, "temp file left behind after a successful write");
+        std::fs::remove_file(&path).ok();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn atomic_write_is_owner_only() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = std::env::temp_dir();
+        let path = dir.join(format!("conduit-perm-{}.json", std::process::id()));
+        atomic_write(&path, "secret").unwrap();
+        let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600, "atomic_write must produce an owner-only file");
+        // Re-writing an existing file keeps it owner-only.
+        atomic_write(&path, "secret2").unwrap();
+        let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600, "overwrite must stay owner-only");
         std::fs::remove_file(&path).ok();
     }
 


### PR DESCRIPTION
Closes #169.

## Problem
`registry::atomic_write` created files via `File::create` with no explicit mode, so on Unix they inherited the umask (world-readable on a permissive host). That covers **registry.json, secrets.enc (file backend), tool pins, and the audit log**. Separately, the HITL approval-endpoint descriptor (endpoint + auth token) was written with a plain `fs::write`, also default-perms.

Low risk on a single-user desktop; real on shared/headless hosts, where another user could read secrets/pins or read the HITL token to spoof approval decisions.

## Change
- `atomic_write`: set the temp file to `0600` **before** writing content (so it's never briefly world-readable), then rename. `#[cfg(unix)]`; no-op on Windows (NTFS ACLs inherit).
- Route the approval-endpoint write through `atomic_write` so it's atomic **and** `0600`.
- New `#[cfg(unix)]` test asserting `atomic_write` yields an owner-only file (create + overwrite).

## Verification
263 Rust lib tests pass on Windows; the new perms test runs on the Linux/macOS CI jobs. tsc/lint unaffected (Rust-only).

Tier-A security item from the 2026-07-04 fresh-eyes audit. Note: directory-level `0700` hardening was left out to keep this focused — `0600` on the files already prevents other users reading their contents regardless of dir perms.