### PR TITLE
feat(gateway): proxy resources/prompts list_changed notifications (#166)

### DIFF
--- a/src-tauri/src/bin/mock-mcp-server.rs
+++ b/src-tauri/src/bin/mock-mcp-server.rs
@@ -1,9 +1,10 @@
 //! A minimal MCP server used as a test fixture for the gateway's downstream
 //! proxying. Exposes `echo` (returns its `text` arg), `add` (returns `a + b`),
-//! and `grow`. Calling `grow` adds a `greet` tool to the list and emits a
-//! `notifications/tools/list_changed`, simulating a server that changes its own
-//! tool set mid-session, so the gateway's live tool-refresh can be exercised.
-//! Self-contained: no dependency on conduit_lib.
+//! and `grow`, plus a baseline resource and prompt. Calling `grow` adds a `greet`
+//! tool, a `mock://grown` resource, and a `grown_prompt`, then emits the tools,
+//! resources, and prompts `list_changed` notifications, simulating a server that
+//! changes its own catalog mid-session so the gateway's live refresh can be
+//! exercised for all three kinds. Self-contained: no dependency on conduit_lib.
 
 use std::io::{BufRead, Write};
 
@@ -31,6 +32,26 @@ fn tool_list(grown: bool) -> Value {
     json!({ "tools": tools })
 }
 
+/// The advertised resource list. `grown` adds a second resource, modeling a
+/// runtime `resources/list_changed`.
+fn resource_list(grown: bool) -> Value {
+    let mut resources = vec![json!({ "uri": "mock://base", "name": "base" })];
+    if grown {
+        resources.push(json!({ "uri": "mock://grown", "name": "grown" }));
+    }
+    json!({ "resources": resources })
+}
+
+/// The advertised prompt list. `grown` adds a second prompt, modeling a runtime
+/// `prompts/list_changed`.
+fn prompt_list(grown: bool) -> Value {
+    let mut prompts = vec![json!({ "name": "hi", "description": "Say hi." })];
+    if grown {
+        prompts.push(json!({ "name": "grown_prompt", "description": "A newly grown prompt." }));
+    }
+    json!({ "prompts": prompts })
+}
+
 /// Handle one request, returning its response. `grown` is flipped on by a `grow`
 /// call so the next `tools/list` reflects the larger set.
 fn handle(req: &Value, grown: &mut bool) -> Option<Value> {
@@ -45,11 +66,17 @@ fn handle(req: &Value, grown: &mut bool) -> Option<Value> {
             id,
             json!({
                 "protocolVersion": "2025-06-18",
-                "capabilities": { "tools": { "listChanged": true } },
+                "capabilities": {
+                    "tools": { "listChanged": true },
+                    "resources": { "listChanged": true },
+                    "prompts": { "listChanged": true }
+                },
                 "serverInfo": { "name": "mock-mcp-server", "version": "0.1.0" }
             }),
         )),
         "tools/list" => Some(success(id, tool_list(*grown))),
+        "resources/list" => Some(success(id, resource_list(*grown))),
+        "prompts/list" => Some(success(id, prompt_list(*grown))),
         "tools/call" => {
             let params = req.get("params");
             let name = params.and_then(|p| p.get("name")).and_then(|n| n.as_str()).unwrap_or("");
@@ -106,12 +133,18 @@ fn main() {
             }
             let _ = out.flush();
         }
-        // A `grow` call just changed the tool set: announce it (after the call
-        // response) so a watching gateway re-fetches and surfaces the new tool.
+        // A `grow` call just changed all three lists: announce each (after the call
+        // response) so a watching gateway re-fetches and surfaces the new entries.
         if grown && !was_grown {
-            let notif = json!({ "jsonrpc": "2.0", "method": "notifications/tools/list_changed" });
-            if writeln!(out, "{notif}").is_err() {
-                break;
+            for method in [
+                "notifications/tools/list_changed",
+                "notifications/resources/list_changed",
+                "notifications/prompts/list_changed",
+            ] {
+                let notif = json!({ "jsonrpc": "2.0", "method": method });
+                if writeln!(out, "{notif}").is_err() {
+                    return;
+                }
             }
             let _ = out.flush();
         }

--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -20,7 +20,7 @@
 
 use std::io::{BufRead, Read, Write};
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU8, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant, SystemTime};
 
@@ -28,7 +28,7 @@ use serde_json::{json, Value};
 
 use conduit_lib::audit;
 use conduit_lib::clients;
-use conduit_lib::downstream::{DownstreamServer, StdioTransport, PROTOCOL_VERSION};
+use conduit_lib::downstream::{self, DownstreamServer, StdioTransport, PROTOCOL_VERSION};
 use conduit_lib::inspect;
 use conduit_lib::integrity;
 use conduit_lib::registry::{self, Registry, ServerEntry};
@@ -2194,7 +2194,7 @@ fn build_router(
     reg: &Registry,
     profile: Option<&str>,
     http_mode: bool,
-    dirty: &Arc<AtomicBool>,
+    dirty: &Arc<AtomicU8>,
 ) -> Router {
     // In HTTP mode one process serves every registered client, so connect the
     // union of all their profiles (per-request filtering scopes each one down).
@@ -2257,7 +2257,7 @@ fn build_router(
 
 /// Connect a single enabled server (stdio with keychain secret injection, or
 /// remote with refresh-aware auth). Returns None on failure.
-fn connect_one(server: &ServerEntry, dirty: &Arc<AtomicBool>) -> Option<DownstreamServer> {
+fn connect_one(server: &ServerEntry, dirty: &Arc<AtomicU8>) -> Option<DownstreamServer> {
     let result = if let Some(command) = &server.command {
         let mut env: Vec<(String, String)> = Vec::new();
         for e in &server.env {
@@ -2311,14 +2311,17 @@ fn mtime(path: &Path) -> Option<SystemTime> {
 }
 
 fn notify_tools_changed(stdout: &Arc<Mutex<std::io::Stdout>>) {
+    notify_list_changed(stdout, "notifications/tools/list_changed");
+}
+
+/// Emit a bare JSON-RPC `list_changed` notification to the client so it re-fetches
+/// the named list. Used for resources/prompts (which have no persisted cache) and,
+/// via `notify_tools_changed`, for tools.
+fn notify_list_changed(stdout: &Arc<Mutex<std::io::Stdout>>, method: &str) {
     let mut out = stdout
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner);
-    let _ = writeln!(
-        out,
-        "{}",
-        json!({ "jsonrpc": "2.0", "method": "notifications/tools/list_changed" })
-    );
+    let _ = writeln!(out, "{}", json!({ "jsonrpc": "2.0", "method": method }));
     let _ = out.flush();
 }
 
@@ -2508,7 +2511,7 @@ fn watch_registry(
     cached_tools: Arc<Mutex<Vec<Value>>>,
     profile: Option<String>,
     http_mode: bool,
-    downstream_dirty: Arc<AtomicBool>,
+    downstream_dirty: Arc<AtomicU8>,
 ) {
     eprintln!("toolport: watching registry at {}", path.display());
     let mut last = mtime(&path);
@@ -2517,10 +2520,10 @@ fn watch_registry(
         // A live downstream server that changed its own tool set (sent
         // tools/list_changed) sets this. Swap before acting so a notification
         // arriving mid-refresh is caught on the next tick rather than lost.
-        let downstream_changed = downstream_dirty.swap(false, Ordering::SeqCst);
+        let downstream_changed = downstream_dirty.swap(0, Ordering::SeqCst);
         let current = mtime(&path);
         let file_changed = current != last;
-        if !file_changed && !downstream_changed {
+        if !file_changed && downstream_changed == 0 {
             continue;
         }
 
@@ -2553,23 +2556,46 @@ fn watch_registry(
             persist_and_emit(&tools, &cached_tools, &stdout, profile.as_deref());
             eprintln!("toolport: registry changed, sent tools/list_changed");
         } else {
-            // A live server announced a tool-list change. Re-query the existing
-            // connections in place rather than re-spawning: a runtime or
-            // session-scoped change (the usual reason a server sends this) would
-            // be lost by a fresh process that never saw it.
-            let tools = {
-                let mut guard = router
-                    .lock()
-                    .unwrap_or_else(std::sync::PoisonError::into_inner);
-                // Re-query in place on the published router (make_mut forks it only if a
-                // request still holds the prior Arc), keeping live connections.
-                let r = Arc::make_mut(&mut guard);
-                r.refresh_tools();
-                r.aggregated_tools()
-            };
-            let tools = requarantine_if_needed(&registry, &router, tools, profile.as_deref());
-            persist_and_emit(&tools, &cached_tools, &stdout, profile.as_deref());
-            eprintln!("toolport: downstream tools/list_changed, refreshed + sent");
+            // One or more live servers announced a list change. Re-query only the
+            // affected list(s) in place rather than re-spawning: a runtime or
+            // session-scoped change (the usual reason a server sends this) would be
+            // lost by a fresh process that never saw it. Each kind forwards its own
+            // notification so the client re-fetches exactly what changed. (make_mut
+            // forks the router only if a request still holds the prior Arc, keeping
+            // live connections.)
+            if downstream_changed & downstream::change::TOOLS != 0 {
+                let tools = {
+                    let mut guard = router
+                        .lock()
+                        .unwrap_or_else(std::sync::PoisonError::into_inner);
+                    let r = Arc::make_mut(&mut guard);
+                    r.refresh_tools();
+                    r.aggregated_tools()
+                };
+                let tools = requarantine_if_needed(&registry, &router, tools, profile.as_deref());
+                persist_and_emit(&tools, &cached_tools, &stdout, profile.as_deref());
+                eprintln!("toolport: downstream tools/list_changed, refreshed + sent");
+            }
+            if downstream_changed & downstream::change::RESOURCES != 0 {
+                {
+                    let mut guard = router
+                        .lock()
+                        .unwrap_or_else(std::sync::PoisonError::into_inner);
+                    Arc::make_mut(&mut guard).refresh_resources();
+                }
+                notify_list_changed(&stdout, "notifications/resources/list_changed");
+                eprintln!("toolport: downstream resources/list_changed, refreshed + sent");
+            }
+            if downstream_changed & downstream::change::PROMPTS != 0 {
+                {
+                    let mut guard = router
+                        .lock()
+                        .unwrap_or_else(std::sync::PoisonError::into_inner);
+                    Arc::make_mut(&mut guard).refresh_prompts();
+                }
+                notify_list_changed(&stdout, "notifications/prompts/list_changed");
+                eprintln!("toolport: downstream prompts/list_changed, refreshed + sent");
+            }
         }
     }
 }
@@ -2596,7 +2622,7 @@ struct GatewayState {
     cached_tools: Arc<Mutex<Vec<Value>>>,
     stdout: Arc<Mutex<std::io::Stdout>>,
     ready: Arc<AtomicBool>,
-    downstream_dirty: Arc<AtomicBool>,
+    downstream_dirty: Arc<AtomicU8>,
     lazy: bool,
     profile: Option<String>,
     /// True when this process is the HTTP/OpenAPI bridge (vs a stdio client's
@@ -3422,7 +3448,7 @@ fn main() {
     // Flipped by any downstream transport that emits notifications/tools/list_changed.
     // The registry watcher polls it and rebuilds, so a server that changes its own
     // tool set mid-session propagates to the client instead of being dropped.
-    let downstream_dirty = Arc::new(AtomicBool::new(false));
+    let downstream_dirty = Arc::new(AtomicU8::new(0));
     glog(&format!(
         "loaded tool cache: {} tools",
         cached_tools
@@ -3643,7 +3669,7 @@ mod tests {
             cached_tools: Arc::new(Mutex::new(Vec::new())),
             stdout: Arc::new(Mutex::new(std::io::stdout())),
             ready: Arc::new(AtomicBool::new(true)),
-            downstream_dirty: Arc::new(AtomicBool::new(false)),
+            downstream_dirty: Arc::new(AtomicU8::new(0)),
             lazy,
             profile: None,
             http: true,

--- a/src-tauri/src/downstream.rs
+++ b/src-tauri/src/downstream.rs
@@ -9,7 +9,7 @@
 use std::io::{BufRead, BufReader, Write};
 use std::path::Path;
 use std::process::{Child, ChildStdin, Command, Stdio};
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
 use std::sync::mpsc::{Receiver, RecvTimeoutError, Sender};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
@@ -220,23 +220,41 @@ pub trait Transport: Send {
     fn arm_tools_watch(&mut self) {}
 }
 
-/// True if `line` is a downstream `notifications/tools/list_changed` message: a
-/// JSON-RPC notification (a `method` of that name, no `id`). Lets the stdout drain
-/// spot when a server changes its own tool set mid-session.
-fn is_list_changed(line: &str) -> bool {
+/// Bitmask of which downstream list a `notifications/.../list_changed` announces.
+/// The gateway watches one flag per transport and, per set bit, re-queries that
+/// list and forwards the matching notification on to the client.
+pub mod change {
+    pub const TOOLS: u8 = 1;
+    pub const RESOURCES: u8 = 2;
+    pub const PROMPTS: u8 = 4;
+}
+
+/// Which downstream list `line` announces a change to (a [`change`] bit), or 0 if
+/// it isn't a `list_changed` notification. Lets the stdout drain spot when a server
+/// changes its own tools / resources / prompts mid-session.
+fn list_changed_kind(line: &str) -> u8 {
     // Cheap gate: skip the JSON parse for the overwhelming majority of lines
-    // (ordinary responses to our requests) that can't be this notification.
-    if !line.contains("tools/list_changed") {
-        return false;
+    // (ordinary responses to our requests) that can't be one of these.
+    if !line.contains("list_changed") {
+        return 0;
     }
-    serde_json::from_str::<Value>(line.trim())
+    match serde_json::from_str::<Value>(line.trim())
         .ok()
-        .and_then(|v| {
-            v.get("method")
-                .and_then(|m| m.as_str())
-                .map(|m| m == "notifications/tools/list_changed")
-        })
-        .unwrap_or(false)
+        .as_ref()
+        .and_then(|v| v.get("method"))
+        .and_then(|m| m.as_str())
+    {
+        Some("notifications/tools/list_changed") => change::TOOLS,
+        Some("notifications/resources/list_changed") => change::RESOURCES,
+        Some("notifications/prompts/list_changed") => change::PROMPTS,
+        _ => 0,
+    }
+}
+
+/// True if `line` is specifically a `tools/list_changed` notification.
+#[cfg(test)]
+fn is_list_changed(line: &str) -> bool {
+    list_changed_kind(line) == change::TOOLS
 }
 
 /// Forward one drained stdout line to the request loop, first flagging `dirty` if
@@ -245,12 +263,15 @@ fn is_list_changed(line: &str) -> bool {
 fn forward_line(
     line: String,
     tx: &Sender<String>,
-    dirty: &Option<Arc<AtomicBool>>,
+    dirty: &Option<Arc<AtomicU8>>,
     armed: &Arc<AtomicBool>,
 ) -> bool {
     if let Some(flag) = dirty {
-        if armed.load(Ordering::SeqCst) && is_list_changed(&line) {
-            flag.store(true, Ordering::SeqCst);
+        if armed.load(Ordering::SeqCst) {
+            let kind = list_changed_kind(&line);
+            if kind != 0 {
+                flag.fetch_or(kind, Ordering::SeqCst);
+            }
         }
     }
     tx.send(line).is_ok()
@@ -575,15 +596,16 @@ impl StdioTransport {
         Self::spawn_inner(command, args, env, None)
     }
 
-    /// Like [`spawn`], but flips `dirty` to true whenever the downstream server
-    /// emits `notifications/tools/list_changed` (after `arm_tools_watch`). The
-    /// gateway watches that flag and rebuilds, so a server changing its own tool
-    /// set mid-session reaches the client instead of being silently dropped.
+    /// Like [`spawn`], but sets a [`change`] bit in `dirty` whenever the downstream
+    /// server emits a `tools` / `resources` / `prompts` `list_changed` notification
+    /// (after `arm_tools_watch`). The gateway watches that flag and re-queries the
+    /// affected list, so a server changing its own catalog mid-session reaches the
+    /// client instead of being silently dropped.
     pub fn spawn_watched(
         command: &str,
         args: &[String],
         env: &[(String, String)],
-        dirty: Arc<AtomicBool>,
+        dirty: Arc<AtomicU8>,
     ) -> Result<Self, String> {
         Self::spawn_inner(command, args, env, Some(dirty))
     }
@@ -592,7 +614,7 @@ impl StdioTransport {
         command: &str,
         args: &[String],
         env: &[(String, String)],
-        dirty: Option<Arc<AtomicBool>>,
+        dirty: Option<Arc<AtomicU8>>,
     ) -> Result<Self, String> {
         // Supply-chain guard: refuse code-smuggling / container-escape args AND
         // code-injecting env vars before we hand the command to the OS. Applies to
@@ -1106,6 +1128,35 @@ impl DownstreamServer {
         self.transport.set_read_timeout(STDIO_READ_TIMEOUT);
     }
 
+    /// Re-fetch the resource list on the existing connection after the server
+    /// announced a `resources/list_changed`. Mirrors [`refresh_tools`]; best-effort
+    /// (an error keeps the previous list), and a no-op if the server never
+    /// advertised resources.
+    pub fn refresh_resources(&mut self) {
+        if !self.caps_resources {
+            return;
+        }
+        self.transport.set_read_timeout(STDIO_CONNECT_TIMEOUT);
+        if let Ok(r) = self.transport.request("resources/list", json!({})) {
+            self.resources = extract_array(&r, "resources");
+        }
+        self.transport.set_read_timeout(STDIO_READ_TIMEOUT);
+    }
+
+    /// Re-fetch the prompt list on the existing connection after the server
+    /// announced a `prompts/list_changed`. Mirrors [`refresh_tools`]; best-effort,
+    /// and a no-op if the server never advertised prompts.
+    pub fn refresh_prompts(&mut self) {
+        if !self.caps_prompts {
+            return;
+        }
+        self.transport.set_read_timeout(STDIO_CONNECT_TIMEOUT);
+        if let Ok(r) = self.transport.request("prompts/list", json!({})) {
+            self.prompts = extract_array(&r, "prompts");
+        }
+        self.transport.set_read_timeout(STDIO_READ_TIMEOUT);
+    }
+
     /// Fetch the resources and prompts the server advertised. Best-effort: an
     /// error or empty response just leaves the list empty. Kept out of `connect`
     /// so only the gateway (which actually proxies these) pays the cost.
@@ -1434,33 +1485,71 @@ mod tests {
     }
 
     #[test]
+    fn classifies_each_list_changed_kind() {
+        use super::{change, list_changed_kind};
+        assert_eq!(
+            list_changed_kind(r#"{"jsonrpc":"2.0","method":"notifications/tools/list_changed"}"#),
+            change::TOOLS
+        );
+        assert_eq!(
+            list_changed_kind(
+                r#"{"jsonrpc":"2.0","method":"notifications/resources/list_changed"}"#
+            ),
+            change::RESOURCES
+        );
+        assert_eq!(
+            list_changed_kind(
+                r#"{"jsonrpc":"2.0","method":"notifications/prompts/list_changed"}"#
+            ),
+            change::PROMPTS
+        );
+        // resources/updated is a different notification, not a list change.
+        assert_eq!(
+            list_changed_kind(r#"{"jsonrpc":"2.0","method":"notifications/resources/updated"}"#),
+            0
+        );
+        assert_eq!(list_changed_kind("not json"), 0);
+        assert_eq!(list_changed_kind(""), 0);
+    }
+
+    #[test]
     fn forward_line_flags_dirty_only_when_armed() {
-        use super::forward_line;
-        use std::sync::atomic::{AtomicBool, Ordering};
+        use super::{change, forward_line};
+        use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
         use std::sync::Arc;
 
         let notif = r#"{"jsonrpc":"2.0","method":"notifications/tools/list_changed"}"#;
-        let dirty = Some(Arc::new(AtomicBool::new(false)));
+        let dirty = Some(Arc::new(AtomicU8::new(0)));
         let armed = Arc::new(AtomicBool::new(false));
         let (tx, rx) = std::sync::mpsc::channel();
 
         // Unarmed (still in the handshake window): the line is forwarded but the
         // change is not acted on.
         assert!(forward_line(notif.to_string(), &tx, &dirty, &armed));
-        assert!(!dirty.as_ref().unwrap().load(Ordering::SeqCst));
+        assert_eq!(dirty.as_ref().unwrap().load(Ordering::SeqCst), 0);
         assert_eq!(rx.recv().unwrap(), notif);
 
-        // Armed: the same notification now flips the dirty flag.
+        // Armed: the same notification now sets the TOOLS bit.
         armed.store(true, Ordering::SeqCst);
         assert!(forward_line(notif.to_string(), &tx, &dirty, &armed));
-        assert!(dirty.as_ref().unwrap().load(Ordering::SeqCst));
+        assert_eq!(dirty.as_ref().unwrap().load(Ordering::SeqCst), change::TOOLS);
         assert_eq!(rx.recv().unwrap(), notif);
+
+        // A resources/list_changed sets the RESOURCES bit alongside it (OR, not
+        // overwrite), so distinct changes between watcher ticks aren't lost.
+        let res_notif = r#"{"jsonrpc":"2.0","method":"notifications/resources/list_changed"}"#;
+        assert!(forward_line(res_notif.to_string(), &tx, &dirty, &armed));
+        assert_eq!(
+            dirty.as_ref().unwrap().load(Ordering::SeqCst),
+            change::TOOLS | change::RESOURCES
+        );
+        assert_eq!(rx.recv().unwrap(), res_notif);
 
         // An ordinary line is always forwarded and never flags a change.
         let resp = r#"{"jsonrpc":"2.0","id":1,"result":{}}"#;
-        let dirty2 = Some(Arc::new(AtomicBool::new(false)));
+        let dirty2 = Some(Arc::new(AtomicU8::new(0)));
         assert!(forward_line(resp.to_string(), &tx, &dirty2, &armed));
-        assert!(!dirty2.as_ref().unwrap().load(Ordering::SeqCst));
+        assert_eq!(dirty2.as_ref().unwrap().load(Ordering::SeqCst), 0);
         assert_eq!(rx.recv().unwrap(), resp);
 
         // A closed receiver makes forward_line report "stop".

--- a/src-tauri/src/router.rs
+++ b/src-tauri/src/router.rs
@@ -367,6 +367,32 @@ impl Router {
         self.rebuild_aggregation();
     }
 
+    /// Re-query every live server's resource list (a downstream announced a
+    /// `resources/list_changed`) and rebuild the exposed aggregation in place.
+    /// Mirrors [`refresh_tools`].
+    pub fn refresh_resources(&mut self) {
+        for slot in &self.servers {
+            slot.inner
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .refresh_resources();
+        }
+        self.rebuild_aggregation();
+    }
+
+    /// Re-query every live server's prompt list (a downstream announced a
+    /// `prompts/list_changed`) and rebuild the exposed aggregation in place.
+    /// Mirrors [`refresh_tools`].
+    pub fn refresh_prompts(&mut self) {
+        for slot in &self.servers {
+            slot.inner
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .refresh_prompts();
+        }
+        self.rebuild_aggregation();
+    }
+
     /// Replace the quarantine set and re-derive the exposed aggregation so newly
     /// quarantined tools are hidden (or re-approved ones restored) without re-querying
     /// downstream. Cheap: it only re-applies the policy to the cached tool lists.

--- a/src-tauri/tests/list_changed.rs
+++ b/src-tauri/tests/list_changed.rs
@@ -1,17 +1,18 @@
-//! End-to-end check for live tool-list refresh.
+//! End-to-end check for live tools / resources / prompts refresh.
 //!
-//! Drives the real `mock-mcp-server` binary: it advertises `echo`/`add`/`grow`,
-//! and a `grow` call makes it add a `greet` tool and emit
-//! `notifications/tools/list_changed`. We assert the watched transport flags the
-//! change and that re-querying the *existing* connection surfaces the new tool.
-//! A re-spawn approach would lose the in-memory change, so this also pins down
-//! that the gateway refreshes in place rather than reconnecting.
+//! Drives the real `mock-mcp-server` binary: it advertises `echo`/`add`/`grow`
+//! plus a baseline resource and prompt, and a `grow` call makes it add a `greet`
+//! tool, a `mock://grown` resource, and a `grown_prompt`, then emit all three
+//! `list_changed` notifications. We assert the watched transport flags each kind
+//! and that re-querying the *existing* connection surfaces the new entries. A
+//! re-spawn approach would lose the in-memory change, so this also pins down that
+//! the gateway refreshes in place rather than reconnecting.
 
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicU8, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use conduit_lib::downstream::{DownstreamServer, StdioTransport};
+use conduit_lib::downstream::{change, DownstreamServer, StdioTransport};
 use conduit_lib::router::Router;
 use serde_json::json;
 
@@ -23,14 +24,33 @@ fn tool_names(router: &Router) -> Vec<String> {
         .collect()
 }
 
+fn resource_uris(router: &Router) -> Vec<String> {
+    router
+        .aggregated_resources()
+        .iter()
+        .filter_map(|r| r.get("uri").and_then(|u| u.as_str()).map(String::from))
+        .collect()
+}
+
+fn prompt_names(router: &Router) -> Vec<String> {
+    router
+        .aggregated_prompts()
+        .iter()
+        .filter_map(|p| p.get("name").and_then(|n| n.as_str()).map(String::from))
+        .collect()
+}
+
 #[test]
 fn live_tool_change_surfaces_via_refresh_without_respawn() {
     let mock = env!("CARGO_BIN_EXE_mock-mcp-server");
-    let dirty = Arc::new(AtomicBool::new(false));
+    let dirty = Arc::new(AtomicU8::new(0));
     let transport =
         StdioTransport::spawn_watched(mock, &[], &[], Arc::clone(&dirty)).expect("spawn mock");
-    let server =
+    let mut server =
         DownstreamServer::connect("mock".to_string(), Box::new(transport)).expect("connect mock");
+    // connect() only loads tools; pull the baseline resources/prompts so the
+    // router aggregates them (the gateway does this via load_resources_prompts).
+    server.load_resources_prompts();
 
     let mut router = Router::new();
     router.add(server);
@@ -40,28 +60,36 @@ fn live_tool_change_surfaces_via_refresh_without_respawn() {
     let before = tool_names(&router);
     assert!(before.contains(&"mock__grow".to_string()), "got {before:?}");
     assert!(!before.contains(&"mock__greet".to_string()), "got {before:?}");
-    assert!(!dirty.load(Ordering::SeqCst), "nothing changed yet");
+    assert!(resource_uris(&router).contains(&"mock://base".to_string()));
+    assert!(prompt_names(&router).contains(&"mock__hi".to_string()));
+    assert_eq!(dirty.load(Ordering::SeqCst), 0, "nothing changed yet");
 
-    // Drive the live server to add a tool and announce the change.
+    // Drive the live server to grow all three lists and announce each change.
     router
         .route_call("mock__grow", json!({}))
         .expect("grow call should succeed");
 
-    // The stdout drain flags dirty asynchronously once it reads the notification.
+    // The stdout drain flags dirty asynchronously once it reads the notifications.
+    // Wait until all three kinds have registered (they arrive as separate lines).
+    let want = change::TOOLS | change::RESOURCES | change::PROMPTS;
     let deadline = Instant::now() + Duration::from_secs(5);
-    while !dirty.load(Ordering::SeqCst) && Instant::now() < deadline {
+    while dirty.load(Ordering::SeqCst) & want != want && Instant::now() < deadline {
         std::thread::sleep(Duration::from_millis(10));
     }
-    assert!(
-        dirty.load(Ordering::SeqCst),
-        "tools/list_changed should have flipped the dirty flag"
+    assert_eq!(
+        dirty.load(Ordering::SeqCst) & want,
+        want,
+        "all three list_changed kinds should have set their bit"
     );
 
-    // Re-query the SAME live connection: the new tool now appears. (A re-spawned
-    // process would report the original list, so this proves the in-place path.)
+    // Re-query the SAME live connection per kind: the new entries now appear. (A
+    // re-spawned process would report the original lists, proving the in-place path.)
     router.refresh_tools();
-    let after = tool_names(&router);
-    assert!(after.contains(&"mock__greet".to_string()), "got {after:?}");
+    router.refresh_resources();
+    router.refresh_prompts();
+    assert!(tool_names(&router).contains(&"mock__greet".to_string()));
+    assert!(resource_uris(&router).contains(&"mock://grown".to_string()));
+    assert!(prompt_names(&router).contains(&"mock__grown_prompt".to_string()));
 
     // The new tool is actually callable end-to-end through the router.
     let result = router


### PR DESCRIPTION
Part of #166 (the MCP proxy-completeness quick wins).

## Problem
The gateway's `initialize` already advertises `resources.listChanged` and `prompts.listChanged`, but the downstream drain only recognized `tools/list_changed`. So a downstream server that changed its **resource** or **prompt** set mid-session was silently dropped, while the client was told the gateway supports those notifications. This makes behavior honor the advertised contract.

## Change
- **Classify by kind** — `list_changed_kind()` maps a `notifications/*/list_changed` line to a `tools`/`resources`/`prompts` bit. The per-transport change signal widens from `AtomicBool` to an `AtomicU8` bitmask, so two different changes arriving between watcher ticks accumulate (OR) instead of one clobbering the other.
- **Per-kind refresh** — `DownstreamServer::refresh_resources`/`refresh_prompts` + matching `Router` methods, mirroring the existing `refresh_tools` (in-place re-query on the live connection, no respawn; no-op if the server never advertised that capability).
- **Per-kind emit** — the registry watcher re-queries only the affected list(s) and forwards the matching client notification via a generalized `notify_list_changed`.

## Tests
- Extended `mock-mcp-server` to grow a resource (`mock://grown`) and a prompt (`grown_prompt`) on `grow` and emit all three `list_changed` notifications.
- Extended the end-to-end `tests/list_changed.rs` to assert each kind sets its bit and refreshes in place (real gateway + mock binary).
- Unit tests for the kind classifier and the bitmask OR.
- 264 lib + 57 gateway + integration all green; clippy clean (no new warnings).

Follow-ups still open under #166: request cancellation, resource subscribe/unsubscribe, logging, pagination.