### PR TITLE
feat(servers): confirm before disabling all servers (#172)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -78,11 +78,15 @@ const SettingsView = lazy(() =>
 );
 import { Button } from "@/components/ui/button";
 import { Callout } from "@/components/Callout";
+import { ConfirmDialog } from "@/components/ConfirmDialog";
 import { Input } from "@/components/ui/input";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Skeleton } from "@/components/ui/skeleton";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { Toaster } from "@/components/ui/sonner";
+
+/** Above this many servers, "Disable all" asks for confirmation first. */
+const BULK_DISABLE_CONFIRM_MIN = 3;
 
 function App() {
   const [registry, setRegistry] = useState<Registry | null>(null);
@@ -91,6 +95,9 @@ function App() {
   const [loading, setLoading] = useState(true);
   const [busyId, setBusyId] = useState<string | null>(null);
   const [togglingAll, setTogglingAll] = useState(false);
+  // Gates the "Disable all" bulk action behind a confirm when it turns off more
+  // than a couple of servers, so one menu click can't silently kill a big set.
+  const [confirmDisableAll, setConfirmDisableAll] = useState(false);
   const [selectedClientId, setSelectedClientId] = useState<string | null>(null);
   const [view, setView] = useState<View>("servers");
   const [activityKey, setActivityKey] = useState(0);
@@ -484,7 +491,18 @@ function App() {
 
                       {servers.length > 0 && (
                         <DropdownMenuItem
-                          onClick={handleToggleAll}
+                          onClick={() => {
+                            // "Disable all" only shows when every server is enabled,
+                            // so it turns off `servers.length`. Confirm when that's
+                            // more than a couple; "Enable all" and small sets go
+                            // straight through.
+                            const disabling = enabledCount >= servers.length;
+                            if (disabling && servers.length > BULK_DISABLE_CONFIRM_MIN) {
+                              setConfirmDisableAll(true);
+                            } else {
+                              void handleToggleAll();
+                            }
+                          }}
                           // Gate on the flag handleToggleAll actually sets (togglingAll),
                           // not just busyId, so it can't be re-fired mid-run. Disabled
                           // while a search is active: it acts on ALL servers, so it must
@@ -648,6 +666,15 @@ function App() {
         </Suspense>
       )}
       <PendingApprovals />
+      <ConfirmDialog
+        open={confirmDisableAll}
+        onOpenChange={setConfirmDisableAll}
+        title="Disable all servers?"
+        description={`This turns off all ${servers.length} servers for this profile. Clients will lose their tools until you re-enable them.`}
+        confirmLabel="Disable all"
+        destructive
+        onConfirm={handleToggleAll}
+      />
       <Toaster position="bottom-right" />
     </TooltipProvider>
   );

--- a/src/components/ConfirmDialog.tsx
+++ b/src/components/ConfirmDialog.tsx
@@ -11,8 +11,9 @@ import {
 import { Button } from "@/components/ui/button";
 
 interface Props {
-  /** The control that opens the confirm (rendered via DialogTrigger asChild). */
-  trigger: ReactNode;
+  /** The control that opens the confirm (rendered via DialogTrigger asChild).
+   * Optional when the dialog is driven in controlled mode via `open`. */
+  trigger?: ReactNode;
   title: string;
   description?: ReactNode;
   confirmLabel?: string;
@@ -21,6 +22,10 @@ interface Props {
   destructive?: boolean;
   /** Runs on confirm; the dialog closes when it resolves. Errors keep it open. */
   onConfirm: () => void | Promise<void>;
+  /** Controlled open state. Omit for the default trigger-driven (uncontrolled) use. */
+  open?: boolean;
+  /** Notified on open/close in controlled mode (and alongside internal state). */
+  onOpenChange?: (open: boolean) => void;
 }
 
 /** A lightweight confirm gate for irreversible actions (remove, delete, leave).
@@ -33,9 +38,19 @@ export function ConfirmDialog({
   cancelLabel = "Cancel",
   destructive = false,
   onConfirm,
+  open: openProp,
+  onOpenChange,
 }: Props) {
-  const [open, setOpen] = useState(false);
+  const [openState, setOpenState] = useState(false);
   const [busy, setBusy] = useState(false);
+  // Controlled when an `open` prop is supplied (e.g. opened from a menu item),
+  // otherwise self-managed by the trigger.
+  const isControlled = openProp !== undefined;
+  const open = isControlled ? openProp : openState;
+  const setOpen = (o: boolean) => {
+    if (!isControlled) setOpenState(o);
+    onOpenChange?.(o);
+  };
 
   async function handleConfirm() {
     setBusy(true);
@@ -53,7 +68,7 @@ export function ConfirmDialog({
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>
-      <DialogTrigger asChild>{trigger}</DialogTrigger>
+      {trigger && <DialogTrigger asChild>{trigger}</DialogTrigger>}
       <DialogContent className="sm:max-w-sm" onClick={(e) => e.stopPropagation()}>
         <DialogHeader>
           <DialogTitle>{title}</DialogTitle>


### PR DESCRIPTION
First item from the product-flow polish cluster (#172).

## Problem
"Disable all" turned off every server for the active profile on a single dropdown click, with no confirmation. Easy to hit by accident, and costly to undo: every connected client loses its tools until you re-enable and re-probe.

## Change
- Gate "Disable all" behind a confirm when it affects more than a few servers (`BULK_DISABLE_CONFIRM_MIN`). "Enable all" (non-destructive) and small sets go straight through.
- `ConfirmDialog` gains an optional **controlled** `open`/`onOpenChange` (and `trigger` is now optional), so it can be opened from the dropdown item. Fully backward-compatible with every existing trigger-based caller.

## Verification
tsc clean, lint 0 errors, 52 tests pass.

Remaining under #172: re-authenticate prompt, Playground tool search, profile→server visibility, onboarding error recovery.