### PR TITLE
feat(activity): export the audit log to CSV or JSON (#171)

### DIFF
--- a/src-tauri/src/audit.rs
+++ b/src-tauri/src/audit.rs
@@ -347,9 +347,96 @@ fn aggregate(entries: &[Value]) -> Value {
     })
 }
 
+/// The columns exported to CSV, in order. Keys match the audit entry JSON.
+const CSV_COLUMNS: &[&str] = &[
+    "ts",
+    "server",
+    "tool",
+    "client",
+    "ok",
+    "held",
+    "durationMs",
+    "action",
+    "error",
+];
+
+/// Render audit `entries` as CSV (RFC-4180-ish: CRLF rows, quoted cells, doubled
+/// internal quotes). Any cell whose text begins with a spreadsheet formula trigger
+/// is prefixed with `'` so opening the file in Excel/Sheets can't execute it: the
+/// audit log holds tool names and error text from untrusted downstream servers.
+pub fn to_csv(entries: &[Value]) -> String {
+    let mut out = String::new();
+    out.push_str(&CSV_COLUMNS.join(","));
+    out.push_str("\r\n");
+    for e in entries {
+        let row: Vec<String> = CSV_COLUMNS.iter().map(|col| csv_cell(e.get(*col))).collect();
+        out.push_str(&row.join(","));
+        out.push_str("\r\n");
+    }
+    out
+}
+
+/// One CSV cell: stringify the JSON value, neutralize a leading formula trigger,
+/// then quote and escape.
+fn csv_cell(value: Option<&Value>) -> String {
+    let raw = match value {
+        None | Some(Value::Null) => String::new(),
+        Some(Value::String(s)) => s.clone(),
+        Some(v) => v.to_string(),
+    };
+    // Formula-injection guard (OWASP): a cell starting with one of these could be
+    // executed as a formula by a spreadsheet, so shift it behind a quote.
+    let guarded = if raw
+        .starts_with(['=', '+', '-', '@', '\t', '\r'])
+    {
+        format!("'{raw}")
+    } else {
+        raw
+    };
+    format!("\"{}\"", guarded.replace('"', "\"\""))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn to_csv_has_header_and_a_row() {
+        let entries = vec![json!({
+            "ts": 1, "server": "gh", "tool": "search", "ok": true, "durationMs": 42
+        })];
+        let csv = to_csv(&entries);
+        assert!(csv.starts_with(
+            "ts,server,tool,client,ok,held,durationMs,action,error\r\n"
+        ));
+        assert!(csv.contains("\"gh\""));
+        assert!(csv.contains("\"search\""));
+        assert!(csv.contains("\"42\""));
+        // A missing column renders as an empty quoted cell, not the word "null".
+        assert!(csv.contains("\"\""));
+        assert!(!csv.contains("null"));
+        assert!(csv.ends_with("\r\n"));
+    }
+
+    #[test]
+    fn to_csv_neutralizes_formula_injection() {
+        // A malicious tool name / error that a spreadsheet would execute as a formula.
+        let csv = to_csv(&[json!({
+            "tool": "=cmd|'/c calc'!A1", "error": "@SUM(1+1)"
+        })]);
+        assert!(csv.contains("\"'=cmd|'/c calc'!A1\""), "got {csv}");
+        assert!(csv.contains("\"'@SUM(1+1)\""), "got {csv}");
+        // A benign value is left untouched (no stray leading quote).
+        let benign = to_csv(&[json!({ "tool": "search" })]);
+        assert!(benign.contains("\"search\""));
+        assert!(!benign.contains("'search"));
+    }
+
+    #[test]
+    fn to_csv_escapes_embedded_quotes() {
+        let csv = to_csv(&[json!({ "error": "he said \"hi\"" })]);
+        assert!(csv.contains("\"he said \"\"hi\"\"\""), "got {csv}");
+    }
 
     #[test]
     fn agent_toggle_denial_record_proves_scope_without_leaking() {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1433,6 +1433,21 @@ fn export_config_to_path(
     std::fs::write(&path, json).map_err(|e| format!("Couldn't write the file: {e}"))
 }
 
+/// Export the audit log to a file (path from a save dialog). `format` is "csv" or
+/// "json". CSV is formula-injection-safe (see `audit::to_csv`) since tool names and
+/// error text come from untrusted downstream servers. Exports the full retained
+/// log, which the audit module already caps.
+#[tauri::command]
+fn export_audit_to_path(path: String, format: String) -> Result<(), String> {
+    let entries = audit::read_recent(usize::MAX);
+    let body = if format == "csv" {
+        audit::to_csv(&entries)
+    } else {
+        serde_json::to_string_pretty(&entries).map_err(|e| e.to_string())?
+    };
+    std::fs::write(&path, body).map_err(|e| format!("Couldn't write the file: {e}"))
+}
+
 /// Public endpoint that turns a shared setup into a `toolport.app/s/<id>` link.
 const SHARE_ENDPOINT: &str = "https://toolport.app/api/share";
 
@@ -2108,6 +2123,7 @@ pub fn run() {
             set_all_enabled,
             export_config,
             export_config_to_path,
+            export_audit_to_path,
             share_stack,
             fetch_shared_setup,
             take_pending_shared,

--- a/src/components/ActivityView.tsx
+++ b/src/components/ActivityView.tsx
@@ -4,6 +4,7 @@ import {
   AlertTriangle,
   CheckCircle2,
   ChevronRight,
+  Download,
   Fingerprint,
   History,
   ScrollText,
@@ -18,8 +19,10 @@ import {
 import { toast } from "sonner";
 import { fmtTokens } from "@/lib/utils";
 import { toastError } from "@/lib/toast";
+import { save } from "@tauri-apps/plugin-dialog";
 import { Input } from "@/components/ui/input";
 import {
+  exportAuditToPath,
   getAuditLog,
   getAuditStats,
   getInspectLog,
@@ -1352,6 +1355,27 @@ export function ActivityView({
     };
   }, [refreshKey]);
 
+  // Export the full retained audit log. The save dialog offers CSV and JSON; the
+  // chosen extension picks the format. CSV is formula-injection-safe in the backend.
+  async function exportLog() {
+    try {
+      const path = await save({
+        title: "Export activity log",
+        defaultPath: "toolport-activity.csv",
+        filters: [
+          { name: "CSV", extensions: ["csv"] },
+          { name: "JSON", extensions: ["json"] },
+        ],
+      });
+      if (!path) return;
+      const format = path.toLowerCase().endsWith(".json") ? "json" : "csv";
+      await exportAuditToPath(path, format);
+      toast.success("Exported activity log");
+    } catch (e) {
+      toastError(`Couldn't export the log: ${e}`);
+    }
+  }
+
   const liveSecurity = dedupeSecurity(security).filter(
     (e) => !dismissed.has(securityKey(e)),
   );
@@ -1487,19 +1511,29 @@ export function ActivityView({
       {banner}
       {stats && <StatsPanel stats={stats} />}
 
-      <button
-        onClick={() => setLogOpen((v) => !v)}
-        aria-expanded={logOpen}
-        className="mb-2 flex w-full items-center gap-2 text-sm font-medium text-muted-foreground transition-colors hover:text-foreground"
-      >
-        <ChevronRight
-          className={`size-4 transition-transform ${logOpen ? "rotate-90" : ""}`}
-        />
-        Recent calls
-        <span className="text-xs font-normal text-muted-foreground/70">
-          last {entries.length} {entries.length === 1 ? "call" : "calls"}
-        </span>
-      </button>
+      <div className="mb-2 flex items-center gap-2">
+        <button
+          onClick={() => setLogOpen((v) => !v)}
+          aria-expanded={logOpen}
+          className="flex flex-1 items-center gap-2 text-sm font-medium text-muted-foreground transition-colors hover:text-foreground"
+        >
+          <ChevronRight
+            className={`size-4 transition-transform ${logOpen ? "rotate-90" : ""}`}
+          />
+          Recent calls
+          <span className="text-xs font-normal text-muted-foreground/70">
+            last {entries.length} {entries.length === 1 ? "call" : "calls"}
+          </span>
+        </button>
+        <button
+          onClick={() => void exportLog()}
+          title="Export the full activity log to a file (CSV or JSON)"
+          className="flex shrink-0 items-center gap-1.5 rounded-md border px-2.5 py-1 text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none"
+        >
+          <Download className="size-3.5" aria-hidden="true" />
+          Export
+        </button>
+      </div>
 
       {logOpen && (
         <>

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -466,6 +466,11 @@ export function exportConfigToPath(
   });
 }
 
+/** Export the audit/activity log to a file (path from a save dialog). */
+export function exportAuditToPath(path: string, format: "csv" | "json"): Promise<void> {
+  return invoke<void>("export_audit_to_path", { path, format });
+}
+
 /** Turn a shareable setup (from exportConfig) into a toolport.app/s/<id> link. */
 export function shareStack(setupJson: string): Promise<string> {
   return invoke<string>("share_stack", { setupJson });


### PR DESCRIPTION
Closes #171.

## Problem
Activity was view-only. No way to hand a call trace to a vendor, keep a compliance record, or debug a failed multi-step run outside the app (only screenshots / manual copy).

## Change
- **`export_audit_to_path(path, format)`** command writes the full retained audit log. **CSV is formula-injection-safe**: any cell whose text starts with `= + - @` (or tab/CR) is shifted behind a `'`, since tool names and error strings come from untrusted downstream servers. JSON is pretty-printed.
- Activity gets an always-visible **Export** button beside "Recent calls"; the save dialog offers CSV/JSON and the chosen file extension picks the format.
- Reuses the existing save-dialog + write-to-path pattern (`export_config_to_path`) and `@tauri-apps/plugin-dialog`.

## Verification
`audit::to_csv` unit tests (header/rows, formula-injection neutralization, embedded-quote escaping) + 9 audit tests green; tsc + lint clean. Respects the governance boundary — the audit log never stored args/results, and this exports exactly those fields.