### PR TITLE
feat(gateway): per-server circuit breaker for dead/hung servers (#170)

### DIFF
--- a/src-tauri/src/bin/mock-mcp-server.rs
+++ b/src-tauri/src/bin/mock-mcp-server.rs
@@ -24,6 +24,8 @@ fn tool_list(grown: bool) -> Value {
                 "inputSchema": { "type": "object", "properties": { "a": { "type": "number" }, "b": { "type": "number" } } } }),
         json!({ "name": "grow", "description": "Add a new tool and announce tools/list_changed.",
                 "inputSchema": { "type": "object", "properties": {} } }),
+        json!({ "name": "die", "description": "Exit the process to simulate a mid-session crash.",
+                "inputSchema": { "type": "object", "properties": {} } }),
     ];
     if grown {
         tools.push(json!({ "name": "greet", "description": "Greet someone by name.",
@@ -91,6 +93,11 @@ fn handle(req: &Value, grown: &mut bool) -> Option<Value> {
                 "grow" => {
                     *grown = true;
                     "grew: greet is now available".to_string()
+                }
+                "die" => {
+                    // Crash without responding, so the gateway sees the connection die
+                    // (used to exercise the circuit breaker).
+                    std::process::exit(0);
                 }
                 "greet" => {
                     let who = args.get("name").and_then(|t| t.as_str()).unwrap_or("there");

--- a/src-tauri/src/downstream.rs
+++ b/src-tauri/src/downstream.rs
@@ -51,8 +51,14 @@ pub(crate) const HTTP_RETRY_CAP: Duration = Duration::from_secs(10);
 /// instead of blocking every other agent queued on the same server.
 #[derive(Debug, Clone)]
 pub enum TransportError {
-    /// Non-retryable: the request was processed (or is structurally invalid).
+    /// Non-retryable protocol/application error: the request reached the server and it
+    /// responded with an error (or the response was structurally invalid). Does NOT
+    /// count against server health - a bad tool call is not a dead server.
     Fatal(String),
+    /// The server is unreachable or unresponsive (a read timed out, or the connection
+    /// died). Distinct from `Fatal` so the circuit breaker can trip on a genuinely
+    /// dead/hung server without counting ordinary error responses against it.
+    Unavailable(String),
     /// Retryable: a 429 rate-limit or a connection that never reached the server.
     /// `retry_after` carries the server-advertised delay (Retry-After) if present;
     /// the caller falls back to its own exponential backoff when `None`.
@@ -62,10 +68,20 @@ pub enum TransportError {
     },
 }
 
+impl TransportError {
+    /// True if this reflects the server being unreachable/unhealthy (timeout, dead
+    /// connection, or exhausted connection/rate-limit retries) rather than a normal
+    /// protocol or application error. Only these trip the per-server circuit breaker.
+    pub fn is_health_failure(&self) -> bool {
+        matches!(self, TransportError::Unavailable(_) | TransportError::Retry { .. })
+    }
+}
+
 impl std::fmt::Display for TransportError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             TransportError::Fatal(msg) => write!(f, "{msg}"),
+            TransportError::Unavailable(msg) => write!(f, "{msg}"),
             TransportError::Retry { message, .. } => write!(f, "{message}"),
         }
     }
@@ -735,8 +751,11 @@ impl Transport for StdioTransport {
         let id = self.next_id;
         self.next_id += 1;
         let msg = json!({ "jsonrpc": "2.0", "id": id, "method": method, "params": params });
-        writeln!(self.stdin, "{msg}").map_err(|e| TransportError::Fatal(e.to_string()))?;
-        self.stdin.flush().map_err(|e| TransportError::Fatal(e.to_string()))?;
+        // A broken stdin pipe means the child is gone: a health failure, not a protocol error.
+        writeln!(self.stdin, "{msg}").map_err(|e| TransportError::Unavailable(e.to_string()))?;
+        self.stdin
+            .flush()
+            .map_err(|e| TransportError::Unavailable(e.to_string()))?;
 
         // Read until the response with our id arrives, skipping notifications.
         // The deadline bounds the whole wait so an unresponsive server fails fast
@@ -749,10 +768,12 @@ impl Transport for StdioTransport {
             let line = match self.rx.recv_timeout(remaining) {
                 Ok(l) => l,
                 Err(RecvTimeoutError::Timeout) => {
-                    return Err(TransportError::Fatal(format!("timed out waiting for '{method}' response")))
+                    return Err(TransportError::Unavailable(format!(
+                        "timed out waiting for '{method}' response"
+                    )))
                 }
                 Err(RecvTimeoutError::Disconnected) => {
-                    return Err(TransportError::Fatal(self.closed_error()))
+                    return Err(TransportError::Unavailable(self.closed_error()))
                 }
             };
             let trimmed = line.trim();

--- a/src-tauri/src/router.rs
+++ b/src-tauri/src/router.rs
@@ -14,6 +14,7 @@
 
 use std::collections::{BTreeSet, HashMap, HashSet};
 use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
 
 use serde_json::{json, Value};
 
@@ -169,6 +170,54 @@ impl ToolPolicy {
 struct ServerSlot {
     id: String,
     inner: Mutex<DownstreamServer>,
+    /// Fast-fail state for a server that keeps failing (dead/hung), so we don't pay
+    /// its full read timeout on every call once it's clearly down.
+    breaker: Mutex<Breaker>,
+}
+
+/// After this many consecutive health failures, a server's circuit opens.
+const BREAKER_FAILURE_THRESHOLD: u32 = 3;
+/// How long a tripped circuit stays open before one probe call is let through.
+const BREAKER_COOLDOWN: Duration = Duration::from_secs(20);
+
+/// Per-server circuit breaker. Once a server racks up consecutive health failures
+/// (timeouts / dead connections), the circuit opens and calls fast-fail for a
+/// cooldown instead of each one waiting out the read timeout and piling up worker
+/// threads. `now` is passed in so the transitions are unit-testable without sleeping.
+#[derive(Default)]
+struct Breaker {
+    consecutive_failures: u32,
+    open_until: Option<Instant>,
+}
+
+impl Breaker {
+    /// Remaining open time if the circuit is tripped at `now`. A circuit whose
+    /// cooldown has elapsed transitions to half-open here (clears `open_until` and
+    /// returns `None`) so the next call probes the server.
+    fn open_remaining(&mut self, now: Instant) -> Option<Duration> {
+        match self.open_until {
+            Some(t) if now < t => Some(t - now),
+            Some(_) => {
+                self.open_until = None;
+                None
+            }
+            None => None,
+        }
+    }
+
+    /// A successful call closes the circuit and clears the failure streak.
+    fn record_success(&mut self) {
+        self.consecutive_failures = 0;
+        self.open_until = None;
+    }
+
+    /// A health failure; opens the circuit once the streak hits the threshold.
+    fn record_failure(&mut self, now: Instant) {
+        self.consecutive_failures = self.consecutive_failures.saturating_add(1);
+        if self.consecutive_failures >= BREAKER_FAILURE_THRESHOLD {
+            self.open_until = Some(now + BREAKER_COOLDOWN);
+        }
+    }
 }
 
 /// Cloneable so the dispatcher can hold the live router as a `Mutex<Arc<Router>>`,
@@ -321,6 +370,7 @@ impl Router {
         self.servers.push(Arc::new(ServerSlot {
             id: id.clone(),
             inner: Mutex::new(server),
+            breaker: Mutex::new(Breaker::default()),
         }));
         self.by_id.insert(id, idx);
     }
@@ -448,6 +498,21 @@ impl Router {
     where
         F: FnMut(&mut DownstreamServer) -> Result<T, TransportError>,
     {
+        // Circuit breaker: a server that just failed repeatedly is fast-failed here,
+        // BEFORE taking its `inner` lock, so a dead/hung server neither pays its full
+        // read timeout again nor queues callers behind an in-flight timing-out call.
+        if let Some(remaining) = slot
+            .breaker
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .open_remaining(Instant::now())
+        {
+            return Err(format!(
+                "server '{}' is temporarily unavailable (too many recent failures; retrying in {}s)",
+                slot.id,
+                remaining.as_secs() + 1
+            ));
+        }
         let mut attempt = 0u32;
         loop {
             let result = {
@@ -455,14 +520,31 @@ impl Router {
                 f(&mut server)
             };
             match result {
-                Ok(v) => return Ok(v),
+                Ok(v) => {
+                    slot.breaker
+                        .lock()
+                        .unwrap_or_else(std::sync::PoisonError::into_inner)
+                        .record_success();
+                    return Ok(v);
+                }
                 Err(TransportError::Retry { retry_after, message }) if attempt < HTTP_MAX_RETRIES => {
                     let wait = retry_wait(retry_after, attempt);
                     eprintln!("conduit: retrying downstream call after {wait:?}: {message}");
                     std::thread::sleep(wait);
                     attempt += 1;
                 }
-                Err(e) => return Err(e.to_string()),
+                Err(e) => {
+                    // Only a health failure (timeout / dead connection / exhausted
+                    // retries) counts toward the breaker; a normal error response does
+                    // not disable the server.
+                    if e.is_health_failure() {
+                        slot.breaker
+                            .lock()
+                            .unwrap_or_else(std::sync::PoisonError::into_inner)
+                            .record_failure(Instant::now());
+                    }
+                    return Err(e.to_string());
+                }
             }
         }
     }
@@ -536,7 +618,44 @@ mod tests {
     use super::*;
     use std::sync::atomic::{AtomicU32, Ordering};
     use std::sync::Arc;
-    use std::time::Duration;
+    use std::time::{Duration, Instant};
+
+    #[test]
+    fn breaker_opens_after_threshold_then_half_opens_after_cooldown() {
+        let t0 = Instant::now();
+        let mut b = Breaker::default();
+        // Below the threshold the circuit stays closed.
+        for _ in 0..BREAKER_FAILURE_THRESHOLD - 1 {
+            b.record_failure(t0);
+            assert!(b.open_remaining(t0).is_none(), "closed below threshold");
+        }
+        // The threshold-th consecutive failure opens it.
+        b.record_failure(t0);
+        let rem = b.open_remaining(t0).expect("circuit should be open");
+        assert!(rem > Duration::ZERO && rem <= BREAKER_COOLDOWN);
+        // Still open partway through the cooldown.
+        assert!(b.open_remaining(t0 + BREAKER_COOLDOWN / 2).is_some());
+        // Once the cooldown elapses it half-opens: a probe is let through (None) and
+        // the tripped state is cleared.
+        assert!(b.open_remaining(t0 + BREAKER_COOLDOWN).is_none());
+        assert!(b.open_remaining(t0 + BREAKER_COOLDOWN).is_none());
+    }
+
+    #[test]
+    fn breaker_success_resets_the_streak() {
+        let t0 = Instant::now();
+        let mut b = Breaker::default();
+        b.record_failure(t0);
+        b.record_failure(t0);
+        b.record_success(); // a good call clears the streak
+        // Two failures alone no longer open it (needs THRESHOLD consecutive).
+        b.record_failure(t0);
+        b.record_failure(t0);
+        assert!(b.open_remaining(t0).is_none(), "success reset the streak");
+        // The threshold-th consecutive failure opens it.
+        b.record_failure(t0);
+        assert!(b.open_remaining(t0).is_some());
+    }
 
     #[test]
     fn retry_wait_clamps_large_retry_after() {

--- a/src-tauri/tests/circuit_breaker.rs
+++ b/src-tauri/tests/circuit_breaker.rs
@@ -1,0 +1,48 @@
+//! End-to-end check for the per-server circuit breaker.
+//!
+//! Drives the real `mock-mcp-server` binary and calls its `die` tool, which exits
+//! the process mid-session. Every subsequent call then hits a dead connection; once
+//! the failure streak crosses the threshold the breaker opens and the next call is
+//! fast-failed WITHOUT waiting on the (dead) connection. This pins down that a
+//! crashed/hung server stops costing every caller its full read timeout.
+
+use std::sync::atomic::AtomicU8;
+use std::sync::Arc;
+
+use conduit_lib::downstream::{DownstreamServer, StdioTransport};
+use conduit_lib::router::Router;
+use serde_json::json;
+
+#[test]
+fn circuit_opens_after_a_server_dies_and_fast_fails() {
+    let mock = env!("CARGO_BIN_EXE_mock-mcp-server");
+    let dirty = Arc::new(AtomicU8::new(0));
+    let transport = StdioTransport::spawn_watched(mock, &[], &[], dirty).expect("spawn mock");
+    let server =
+        DownstreamServer::connect("mock".to_string(), Box::new(transport)).expect("connect mock");
+    let mut router = Router::new();
+    router.add(server);
+
+    // Kill the server mid-session: this call gets no response (connection dies) and is
+    // health failure #1.
+    let _ = router.route_call("mock__die", json!({}));
+
+    // The next calls hit the now-dead connection. Failures #2 and #3 open the circuit
+    // (threshold is 3). Each returns an error, but from the dead transport, not the breaker.
+    for _ in 0..2 {
+        assert!(
+            router.route_call("mock__echo", json!({ "text": "x" })).is_err(),
+            "a call to a dead server should error"
+        );
+    }
+
+    // Now the breaker is open: the next call is fast-failed by the breaker itself,
+    // identifiable by its message, rather than being sent to the dead connection.
+    let err = router
+        .route_call("mock__echo", json!({ "text": "x" }))
+        .expect_err("call should fail");
+    assert!(
+        err.contains("temporarily unavailable"),
+        "expected a circuit-open fast-fail, got: {err}"
+    );
+}


### PR DESCRIPTION
Closes #170.

## Problem
A downstream server that hangs or dies made **every** call to it pay the full read timeout (30s), serially, piling up worker threads. The audit called this the '30s hang cliff.'

## Change
A per-server **circuit breaker** in the router's call funnel (`call_with_retry`, which every tool/resource/prompt call goes through):
- After **3 consecutive health failures** the circuit **opens**; calls fast-fail for a **20s cooldown**, then half-open lets one probe through.
- The breaker is checked **before** taking the server's lock, so a dead server doesn't queue callers behind an in-flight timing-out call.

To avoid tripping on ordinary errors, `TransportError` gains an **`Unavailable`** variant for timeout / dead-connection / broken-pipe (health failures), while a JSON-RPC error response stays **`Fatal`**. Only `Unavailable` and exhausted `Retry` (`is_health_failure()`) count toward the breaker, so a model calling a tool with bad args a few times never disables the server.

## Tests
- Deterministic `Breaker` state-machine unit tests (time is injected, no sleeps): opens at threshold, half-opens after cooldown, success resets the streak.
- End-to-end `tests/circuit_breaker.rs`: a new mock `die` tool crashes the process mid-session; the test asserts the breaker fast-fails after the streak, identifiable by its message.
- 267 lib + 57 gateway + 2 integration tests green; clippy clean (no new warnings).

Part of the post-1.4 reliability work. Follow-ups remain under #166/#167.