### PR TITLE
Robustness sprint: nothing fails silently (app + gateway + Teams edge cases)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -186,6 +186,27 @@ The 2026-07-01 block above supersedes the ordering; these remain the detailed ba
       ("a lot of users here use pi for local agent coding"). Registered pi as a
       `JsonMcpServers` client writing its Pi-owned global config at `~/.pi/agent/mcp.json`
       (home-anchored), mirroring the Cursor/BoltAI writers. Bound for the next release.
+- [ ] **Two-layer / hybrid tool search (the "Zillow isn't near 'house'" miss).** Suggested
+      by MajMin5 (r/LocalLLaMA), who independently built the same lazy loader and validated
+      the pattern. Pure semantic (embedding) search misses tools whose name/description
+      doesn't embed near the query even though the association is common knowledge (search
+      "home information" → embeddings skip a `zillow` tool). His fix was a slow LLM fallback
+      (ask a small model "which of these tools fit <task>?"). Our cheaper version: (a) a
+      genuine **hybrid ranker** (lexical/BM25 blended with the existing semantic score, not
+      semantic-alone), and (b) **broaden the candidate set when top scores are low-confidence**
+      so the (already capable) calling model can reason over descriptions instead of us
+      hiding them. Optionally a `search_tools_deep` meta-tool that returns more candidates +
+      full descriptions. No mandatory local model — the client model IS the reasoning layer.
+      Ties into the open "per-candidate lexical+semantic scores" search-trace follow-up. (M)
+- [ ] **Per-client discovery mode + raw/direct passthrough.** Also from MajMin5: clients that
+      already do their own tool-gating/deferral (Claude Desktop, LibreChat, and Claude Code's
+      tool-search) pay a wasteful double hop when forced through our meta-tools (load meta-tools
+      → search → load tool → call) versus just seeing the tools directly and using their native
+      logic. Today `lazy_discovery` is a single **global** bool in the registry (registry.rs);
+      make it **per-client** (and consider auto-defaulting self-managing clients to the direct
+      catalog, weak/local models to lazy). This is the client-agnostic story finished: one
+      place to configure servers, right discovery surface per client. (His stdio→HTTP + mobile
+      asks we already cover — the gateway speaks HTTP/OpenAPI natively.) (M)
 
 ## The core decision: Toolport is a gateway, not a file editor
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -208,6 +208,55 @@ The 2026-07-01 block above supersedes the ordering; these remain the detailed ba
       place to configure servers, right discovery surface per client. (His stdio→HTTP + mobile
       asks we already cover — the gateway speaks HTTP/OpenAPI natively.) (M)
 
+## Robustness sprint (2026-07-04, "nothing fails silently")
+
+A 3-surface completeness/edge-case audit (app UX, gateway runtime, Teams). **SHIPPED
+on branch `robustness-sprint`:** downstream **re-spawn on the breaker's half-open probe**
+(a crashed stdio child no longer stays dead until a full registry rebuild; self-heal
+only fired when EVERY server was down); **Playground call timeout + Cancel + elapsed**
+(the one true hang with no escape); **ConfirmDialog on the two credential-deleting
+actions**; **Catalog live-search error-vs-empty** with retry; **embeddings HTTP timeout**
+(a hung endpoint falls back to lexical, no stalled search); **bounded stdio read_line**
+(a newline-less multi-GB line can't grow unbounded); **shaped-result marker honesty**
+(no more "Nothing was lost" over-promise; says held-temporarily + re-run on expiry);
+**tool-cache `{version, tools}` versioning** (stale cache from an old build is discarded);
+and the whole **Teams removed-member/role/auto-sync** fix (new server `GET /me` heartbeat,
+removed members actually disconnect locally, role refreshes every sync, app-level 5-min
+background sync so policy reaches every member; deployed server-side).
+
+**Still open from the audit (not yet built):**
+
+- [ ] **Slowloris read timeout on the HTTP bridge** (tracked) — needs a socket read
+      deadline `tiny_http` doesn't expose; deferred rather than shipped as a fragile
+      threaded-read hack. Low risk (loopback bind + bearer + 4MB + inflight caps).
+- [ ] **Persist OAuth token expiry.** `authenticate_oauth` parses `expires_in` then drops
+      it (`oauth.rs`), so no "re-auth soon" UX is possible. Store issue/expiry ts; then a
+      subtle near/past-expiry hint on the server row (probe stays source of truth). (M)
+- [ ] **Post-connect success signal for first-timers** ("Toolport is now serving N servers
+      to <client>; open it and ask for tools"), and make onboarding's Done step surface
+      probe failures instead of swallowing them to `health=[]`. (M)
+- [ ] **Playground empty/auth states**: explicit "server advertises no tools" copy; detect
+      an auth-required connect failure and link to the server's Secrets dialog; label the
+      raw-JSON fallback when a schema is too complex to form-render. (S-M)
+- [ ] **Settings status panels** distinguish stale-from-poll-failure vs empty (HTTP-bridge
+      status, quarantine 15s / allowed 10s polls swallow errors). Same class as the
+      tracked Activity empty-vs-error item, different screens. (S)
+- [ ] **Client-import preview**: `handleImport` bulk-adds every importable server with only
+      a count toast; reuse the share-link `preview_import`/`ImportItem` review flow. (S-M)
+- [ ] **Recall escape hatch** for lazy discovery: a `list_server_tools`/`search_tools_deep`
+      meta-tool returning more candidates + full descriptions when a search misses, and a
+      "no match" lead that names the empty-query-with-server escape. (M, extends hybrid search)
+- [ ] **Integrity-file cross-process lock.** `tool-pins.json` / `tool-quarantine.json` are
+      atomic-write but unlocked; two gateways detecting drift at once can clobber each
+      other's quarantine set (a lost entry un-blocks a tool). Reload-under-lock or centralize
+      writes in the app. Security-adjacent sibling of the deferred registry cache-coherence. (M)
+- [ ] **Deterministic tool-collision suffixes.** `exposed_name` `_2/_3` depends on add
+      order; a removed-then-readded server can take a different slot and silently rename a
+      tool the client cached, failing in-flight calls with "no route". Derive from
+      `(server_id, tool_name)` content instead of position. (M)
+- [ ] Small: "Clear filter" buttons on zero-match states (Activity recent-calls, Playground
+      tool filter, catalog search); light credential/raw-arg client-side validation. (S)
+
 ## The core decision: Toolport is a gateway, not a file editor
 
 A tool that only edits each client's MCP JSON config is a dead end:

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -133,10 +133,9 @@ The 2026-07-01 block above supersedes the ordering; these remain the detailed ba
 
 ### Robustness / tech debt
 
-- [ ] **Tool-cache versioning.** The gateway serves the on-disk cache verbatim with
-      no version tag, so catalog-logic changes don't take effect until a server
-      toggles or the cache is deleted. Wrap in `{version, tools}`, discard on
-      mismatch. (S)
+- [x] **Tool-cache versioning SHIPPED (2026-07-04 robustness sprint):** the cache is
+      wrapped as `{version, tools}` (`TOOL_CACHE_VERSION`) and discarded on mismatch, so
+      a stale cache from an older build is rebuilt rather than served verbatim.
 - [x] **Router lock held across the downstream call SHIPPED (#95, #99):** the live
       router is a `Mutex<Arc<Router>>`; dispatch clones the Arc and releases the lock
       before the (possibly 120s-held) downstream call, and the HTTP loop is multithreaded.

--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -33,7 +33,7 @@ use conduit_lib::inspect;
 use conduit_lib::integrity;
 use conduit_lib::registry::{self, Registry, ServerEntry};
 use conduit_lib::remote;
-use conduit_lib::router::{is_destructive, sanitize_segment, Router, ToolPolicy};
+use conduit_lib::router::{is_destructive, sanitize_segment, Reconnect, Router, ToolPolicy};
 use conduit_lib::approval;
 use conduit_lib::savings;
 use conduit_lib::searchtrace;
@@ -2234,12 +2234,17 @@ fn build_router(
         },
     };
 
-    // Connect concurrently so total time is the slowest server, not the sum.
+    // Connect concurrently so total time is the slowest server, not the sum. Each
+    // thread hands back the server spec + dirty flag alongside the connection so we can
+    // build a reconnect factory (used to re-spawn it if it dies mid-session).
     let handles: Vec<_> = servers
         .into_iter()
         .map(|server| {
             let dirty = Arc::clone(dirty);
-            std::thread::spawn(move || connect_one(&server, &dirty))
+            std::thread::spawn(move || {
+                let ds = connect_one(&server, &dirty);
+                (server, dirty, ds)
+            })
         })
         .collect();
 
@@ -2248,8 +2253,12 @@ fn build_router(
     // since they're applied as each server's tools are added.
     router.set_overrides(reg.tool_overrides.clone());
     for handle in handles {
-        if let Ok(Some(ds)) = handle.join() {
-            router.add(ds);
+        if let Ok((server, dirty, Some(ds))) = handle.join() {
+            // The same `connect_one` used for the initial spawn is the reconnect
+            // factory, so a re-spawn re-injects keychain secrets and re-handshakes
+            // exactly like a fresh connect.
+            let reconnect: Reconnect = Box::new(move || connect_one(&server, &dirty));
+            router.add_with_reconnect(ds, Some(reconnect));
         }
     }
     router

--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -2492,16 +2492,26 @@ fn tool_cache_path(profile: Option<&str>) -> Option<PathBuf> {
 
 /// The namespaced tool catalog from the last successful build, so tools/list can
 /// answer instantly without waiting on downstream connections.
+/// Bump when the shape/derivation of cached tools changes (new sanitizing, projection,
+/// schema handling), so a stale on-disk cache from an older build is discarded and
+/// rebuilt rather than served verbatim until the next server toggle.
+const TOOL_CACHE_VERSION: u64 = 1;
+
 fn load_tool_cache(profile: Option<&str>) -> Vec<Value> {
     tool_cache_path(profile)
         .and_then(|p| std::fs::read_to_string(p).ok())
-        .and_then(|s| serde_json::from_str(&s).ok())
+        .and_then(|s| serde_json::from_str::<Value>(&s).ok())
+        // Only honor a cache written by this catalog version; a bare-array (pre-version)
+        // or older-version file has no matching tag and is dropped, forcing a rebuild.
+        .filter(|v| v.get("version").and_then(Value::as_u64) == Some(TOOL_CACHE_VERSION))
+        .and_then(|v| v.get("tools").and_then(Value::as_array).cloned())
         .unwrap_or_default()
 }
 
 fn save_tool_cache(tools: &[Value], profile: Option<&str>) {
     if let Some(path) = tool_cache_path(profile) {
-        if let Ok(s) = serde_json::to_string(tools) {
+        let wrapped = json!({ "version": TOOL_CACHE_VERSION, "tools": tools });
+        if let Ok(s) = serde_json::to_string(&wrapped) {
             // Atomic + unique temp: several gateways share this cache file, so a
             // torn or interleaved write would leave an inconsistent catalog.
             let _ = registry::atomic_write(&path, &s);

--- a/src-tauri/src/catalog.rs
+++ b/src-tauri/src/catalog.rs
@@ -309,20 +309,21 @@ fn popular_matching(query: &str) -> Vec<CatalogEntry> {
 /// quality), then live MCP Registry results for the long tail, de-duplicated by
 /// name. This is why popular picks like Vercel always surface even when the
 /// registry's own search doesn't return them.
-pub fn search(query: &str) -> Vec<CatalogEntry> {
+pub fn search(query: &str) -> Result<Vec<CatalogEntry>, String> {
     let mut out = popular_matching(query);
     let mut seen: std::collections::HashSet<String> =
         out.iter().map(|e| e.name.to_lowercase()).collect();
     if !query.trim().is_empty() {
-        if let Ok(registry) = search_registry(query) {
-            for e in registry {
-                if seen.insert(e.name.to_lowercase()) {
-                    out.push(e);
-                }
+        // Propagate a registry/network failure instead of swallowing it: otherwise an
+        // outage renders as an innocent "no results" in the UI with no retry. An empty
+        // registry response is `Ok(empty)`, so only a real failure surfaces as an error.
+        for e in search_registry(query)? {
+            if seen.insert(e.name.to_lowercase()) {
+                out.push(e);
             }
         }
     }
-    out
+    Ok(out)
 }
 
 /// Turn one registry `server` object into a catalog entry. Prefers a hosted

--- a/src-tauri/src/downstream.rs
+++ b/src-tauri/src/downstream.rs
@@ -6,7 +6,7 @@
 //! its tools. The transport is abstracted so the router can be tested with a mock
 //! instead of spawning real processes.
 
-use std::io::{BufRead, BufReader, Write};
+use std::io::{BufRead, BufReader, Read, Write};
 use std::path::Path;
 use std::process::{Child, ChildStdin, Command, Stdio};
 use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
@@ -96,7 +96,6 @@ impl From<String> for TransportError {
 /// Read up to `max` bytes of a ureq response body, lossily as text, never more than
 /// the cap even if the server keeps streaming.
 fn read_capped(resp: ureq::Response, max: u64) -> String {
-    use std::io::Read;
     let mut buf = Vec::new();
     let _ = resp.into_reader().take(max).read_to_end(&mut buf);
     String::from_utf8_lossy(&buf).into_owned()
@@ -674,9 +673,20 @@ impl StdioTransport {
             let mut reader = BufReader::new(stdout);
             loop {
                 let mut line = String::new();
-                match reader.read_line(&mut line) {
+                // Bound each line to the same cap as an HTTP response body: a broken or
+                // hostile server that emits one newline-less multi-gigabyte line can't
+                // grow this String without limit (a plain `read_line` would). `take`
+                // stops at the cap; a full-cap line with no terminator is a protocol
+                // violation, so we close the connection.
+                match (&mut reader).take(MAX_RESPONSE_BYTES).read_line(&mut line) {
                     Ok(0) => break,
-                    Ok(_) => {
+                    Ok(n) => {
+                        if n as u64 >= MAX_RESPONSE_BYTES && !line.ends_with('\n') {
+                            eprintln!(
+                                "toolport: downstream emitted an unterminated line >= {MAX_RESPONSE_BYTES} bytes; closing connection"
+                            );
+                            break;
+                        }
                         if !forward_line(line, &tx, &dirty, &drain_armed) {
                             break;
                         }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1231,11 +1231,24 @@ fn team_connect(
 #[tauri::command]
 fn team_sync(app: tauri::AppHandle, state: State<RegistryState>) -> Result<Registry, String> {
     flush_to_disk(state.inner())?;
-    let outcome = teams::sync_now()?.map(|(_, o)| o).unwrap_or_default();
-    let fresh = reload_into_state(state.inner())?;
-    nudge_gateway(state.inner());
-    emit_team_review(&app, outcome);
-    Ok(fresh)
+    match teams::sync_now()? {
+        teams::SyncResult::Removed => {
+            // The member was removed; sync_now already cleared the local team. Reload
+            // so the UI drops the team, and tell it why so it can surface a notice
+            // rather than the raw error the config pull used to throw.
+            let fresh = reload_into_state(state.inner())?;
+            nudge_gateway(state.inner());
+            let _ = app.emit("team-removed", serde_json::json!({}));
+            Ok(fresh)
+        }
+        teams::SyncResult::Ok { applied, .. } => {
+            let outcome = applied.map(|(_, o)| o).unwrap_or_default();
+            let fresh = reload_into_state(state.inner())?;
+            nudge_gateway(state.inner());
+            emit_team_review(&app, outcome);
+            Ok(fresh)
+        }
+    }
 }
 
 /// Tell the UI how a team config landed: how many servers need the member's review (they

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1367,7 +1367,7 @@ fn list_stacks() -> Vec<stacks::Stack> {
 /// on a blocking worker. Empty query returns popular/recent servers.
 #[tauri::command]
 async fn search_catalog(query: String) -> Result<Vec<catalog::CatalogEntry>, String> {
-    tauri::async_runtime::spawn_blocking(move || Ok(catalog::search(&query)))
+    tauri::async_runtime::spawn_blocking(move || catalog::search(&query))
         .await
         .map_err(|e| e.to_string())?
 }

--- a/src-tauri/src/router.rs
+++ b/src-tauri/src/router.rs
@@ -173,7 +173,18 @@ struct ServerSlot {
     /// Fast-fail state for a server that keeps failing (dead/hung), so we don't pay
     /// its full read timeout on every call once it's clearly down.
     breaker: Mutex<Breaker>,
+    /// Rebuild this server's connection from scratch (re-spawn a crashed stdio child
+    /// / re-dial a dropped remote). Invoked only on the breaker's half-open probe,
+    /// i.e. after the server has failed for a full cooldown, so a live server is never
+    /// needlessly re-spawned on a transient blip. `None` = not reconnectable (e.g. a
+    /// test fixture), in which case a dead server just stays fast-failed as before.
+    reconnect: Option<Reconnect>,
 }
+
+/// Factory that rebuilds a downstream connection on demand. Supplied by the gateway
+/// (which owns the registry + secret injection) so `router` stays free of spawn logic;
+/// returns `None` if the server still can't be reached.
+pub type Reconnect = Box<dyn Fn() -> Option<DownstreamServer> + Send + Sync>;
 
 /// After this many consecutive health failures, a server's circuit opens.
 const BREAKER_FAILURE_THRESHOLD: u32 = 3;
@@ -364,6 +375,13 @@ impl Router {
     }
 
     pub fn add(&mut self, server: DownstreamServer) {
+        self.add_with_reconnect(server, None);
+    }
+
+    /// Add a server whose connection can be rebuilt on demand (see [`Reconnect`]). The
+    /// router re-spawns it automatically if it dies mid-session; `add` is the
+    /// non-reconnectable variant kept for tests and callers with no factory.
+    pub fn add_with_reconnect(&mut self, server: DownstreamServer, reconnect: Option<Reconnect>) {
         let id = server.id.clone();
         self.index_server(&id, &server.tools, &server.resources, &server.prompts);
         let idx = self.servers.len();
@@ -371,6 +389,7 @@ impl Router {
             id: id.clone(),
             inner: Mutex::new(server),
             breaker: Mutex::new(Breaker::default()),
+            reconnect,
         }));
         self.by_id.insert(id, idx);
     }
@@ -501,18 +520,25 @@ impl Router {
         // Circuit breaker: a server that just failed repeatedly is fast-failed here,
         // BEFORE taking its `inner` lock, so a dead/hung server neither pays its full
         // read timeout again nor queues callers behind an in-flight timing-out call.
-        if let Some(remaining) = slot
-            .breaker
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
-            .open_remaining(Instant::now())
-        {
-            return Err(format!(
-                "server '{}' is temporarily unavailable (too many recent failures; retrying in {}s)",
-                slot.id,
-                remaining.as_secs() + 1
-            ));
-        }
+        // A call that gets past this after the cooldown is the half-open PROBE: if it
+        // still fails, the server has been down for a full cooldown and we try to
+        // re-spawn it (below) rather than fast-failing forever.
+        let is_probe = {
+            let mut breaker = slot
+                .breaker
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            if let Some(remaining) = breaker.open_remaining(Instant::now()) {
+                return Err(format!(
+                    "server '{}' is temporarily unavailable (too many recent failures; retrying in {}s)",
+                    slot.id,
+                    remaining.as_secs() + 1
+                ));
+            }
+            // Cooldown elapsed but the failure streak is still at/over threshold: this
+            // call is the half-open probe of a tripped breaker.
+            breaker.consecutive_failures >= BREAKER_FAILURE_THRESHOLD
+        };
         let mut attempt = 0u32;
         loop {
             let result = {
@@ -538,6 +564,17 @@ impl Router {
                     // retries) counts toward the breaker; a normal error response does
                     // not disable the server.
                     if e.is_health_failure() {
+                        // The server has now failed for a full cooldown and the probe
+                        // confirms it's still down. Re-spawn the connection once and
+                        // retry: this recovers a crashed stdio child or a dropped remote
+                        // that the plain breaker would otherwise fast-fail forever (its
+                        // self-heal only fires when EVERY server is dead). Gated on the
+                        // probe so a live server is never re-spawned on a transient blip.
+                        if is_probe {
+                            if let Some(v) = self.reconnect_and_retry(slot, &mut f) {
+                                return v;
+                            }
+                        }
                         slot.breaker
                             .lock()
                             .unwrap_or_else(std::sync::PoisonError::into_inner)
@@ -547,6 +584,43 @@ impl Router {
                 }
             }
         }
+    }
+
+    /// Re-spawn a slot's downstream connection and retry the call once on the fresh
+    /// transport. Returns `Some(result)` when a reconnect was attempted (so the caller
+    /// stops), or `None` when the slot has no reconnect factory (fall through to the
+    /// normal breaker-failure path). The spawn runs without holding the `inner` lock so
+    /// a slow re-spawn doesn't wedge other callers to the same server.
+    fn reconnect_and_retry<T, F>(&self, slot: &Arc<ServerSlot>, f: &mut F) -> Option<Result<T, String>>
+    where
+        F: FnMut(&mut DownstreamServer) -> Result<T, TransportError>,
+    {
+        let factory = slot.reconnect.as_ref()?;
+        eprintln!("conduit: server '{}' is down; re-spawning it", slot.id);
+        let Some(fresh) = factory() else {
+            eprintln!("conduit: re-spawn of '{}' failed; leaving it fast-failed", slot.id);
+            return None; // still unreachable: fall through to record_failure
+        };
+        let retry = {
+            let mut server = slot.inner.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+            *server = fresh; // swap the live child/connection for the fresh one
+            f(&mut server)
+        };
+        let mut breaker = slot
+            .breaker
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        Some(match retry {
+            Ok(v) => {
+                eprintln!("conduit: server '{}' recovered after re-spawn", slot.id);
+                breaker.record_success();
+                Ok(v)
+            }
+            Err(e) => {
+                breaker.record_failure(Instant::now());
+                Err(e.to_string())
+            }
+        })
     }
 
     /// Forward an exposed tool call to its owning downstream server, using that
@@ -794,6 +868,71 @@ mod tests {
         // Mirror the gateway: load resources/prompts after connect.
         ds.load_resources_prompts();
         ds
+    }
+
+    /// Handshakes fine (so it can be constructed) but every `tools/call` reports the
+    /// connection is dead - i.e. a crashed/hung stdio child mid-session.
+    struct DeadOnCallTransport;
+    impl Transport for DeadOnCallTransport {
+        fn request(&mut self, method: &str, _params: Value) -> Result<Value, TransportError> {
+            match method {
+                "initialize" => Ok(json!({ "protocolVersion": "2025-06-18", "capabilities": {} })),
+                "tools/list" => Ok(json!({ "tools": [{ "name": "echo" }] })),
+                "tools/call" => Err(TransportError::Unavailable("broken pipe".into())),
+                _ => Ok(json!({})),
+            }
+        }
+        fn notify(&mut self, _method: &str, _params: Value) -> Result<(), TransportError> {
+            Ok(())
+        }
+    }
+
+    fn dead_slot(reconnect: Option<Reconnect>) -> Arc<ServerSlot> {
+        Arc::new(ServerSlot {
+            id: "s".into(),
+            inner: Mutex::new(
+                DownstreamServer::connect("s".into(), Box::new(DeadOnCallTransport)).unwrap(),
+            ),
+            breaker: Mutex::new(Breaker::default()),
+            reconnect,
+        })
+    }
+
+    #[test]
+    fn reconnect_and_retry_recovers_a_dead_server() {
+        let router = Router::new();
+        // Factory hands back a healthy connection, mirroring a re-spawn that succeeds.
+        let slot = dead_slot(Some(Box::new(|| Some(mock_server("s")))));
+        let out = router.reconnect_and_retry(&slot, &mut |ds| ds.call("echo", json!({})));
+        // The probe re-spawned the server and the retried call went through.
+        let value = out.expect("reconnect attempted").expect("call recovered");
+        assert!(serde_json::to_string(&value).unwrap().contains("s:echo"));
+        // The live connection was swapped in, so subsequent calls hit the healthy one.
+        assert!(slot.inner.lock().unwrap().call("echo", json!({})).is_ok());
+        // A successful recovery closes the breaker.
+        assert!(slot.breaker.lock().unwrap().open_remaining(Instant::now()).is_none());
+    }
+
+    #[test]
+    fn reconnect_and_retry_gives_up_when_respawn_fails() {
+        let router = Router::new();
+        // Factory still can't reach the server (returns None): no recovery, and the
+        // caller must fall through to record the failure.
+        let slot = dead_slot(Some(Box::new(|| None)));
+        let out: Option<Result<Value, String>> =
+            router.reconnect_and_retry(&slot, &mut |ds| ds.call("echo", json!({})));
+        assert!(out.is_none(), "a failed re-spawn falls through to the breaker");
+    }
+
+    #[test]
+    fn reconnect_and_retry_noops_without_a_factory() {
+        let router = Router::new();
+        // A slot with no reconnect factory (e.g. a test fixture) behaves as before:
+        // reconnect is skipped and the breaker path handles the failure.
+        let slot = dead_slot(None);
+        let out: Option<Result<Value, String>> =
+            router.reconnect_and_retry(&slot, &mut |ds| ds.call("echo", json!({})));
+        assert!(out.is_none());
     }
 
     #[test]

--- a/src-tauri/src/semantic.rs
+++ b/src-tauri/src/semantic.rs
@@ -120,7 +120,15 @@ fn embed_batch(cfg: &SemanticConfig, inputs: &[String]) -> Option<Vec<Vec<f32>>>
     if inputs.is_empty() {
         return Some(Vec::new());
     }
-    let mut req = ureq::post(&cfg.endpoint).set("Content-Type", "application/json");
+    // A bounded agent, so a hung/slow embeddings endpoint (a wedged local Ollama/LM
+    // Studio, a black-holed cloud host) can't stall the interactive tool search
+    // indefinitely: on timeout `send_json` errors and the caller falls back to the
+    // pure-lexical ranker. Without this, the bare `ureq::post` inherits ureq's default
+    // of no read timeout and a hang here blocks the whole `search_tools` response.
+    let agent = ureq::AgentBuilder::new()
+        .timeout(std::time::Duration::from_secs(10))
+        .build();
+    let mut req = agent.post(&cfg.endpoint).set("Content-Type", "application/json");
     if let Ok(key) = std::env::var("CONDUIT_EMBED_KEY") {
         if !key.is_empty() {
             req = req.set("Authorization", &format!("Bearer {key}"));

--- a/src-tauri/src/shaping.rs
+++ b/src-tauri/src/shaping.rs
@@ -185,9 +185,9 @@ pub fn shape_result(result: &mut Value, budget: usize, owner: Option<&str>) -> b
 
     let marker = format!(
         "\n\n[Toolport shaped this result: it was ~{} KB, larger than the {} KB context \
-         budget. Showing the first {} of {} characters. The full result is cached, call \
-         conduit_fetch_result with {{\"cursor\":\"{}\",\"offset\":{}}} to read the rest. \
-         Nothing was lost.]",
+         budget. Showing the first {} of {} characters. The rest is held temporarily, call \
+         conduit_fetch_result with {{\"cursor\":\"{}\",\"offset\":{}}} to read it. If that \
+         later reports the cursor expired, just re-run this tool call for a fresh result.]",
         size / 1024,
         budget / 1024,
         head_chars,

--- a/src-tauri/src/teams.rs
+++ b/src-tauri/src/teams.rs
@@ -105,6 +105,40 @@ pub fn pull_config(
     }
 }
 
+/// Result of the `/me` membership heartbeat.
+pub enum MembershipCheck {
+    /// Still a member; carries the current (possibly changed) role.
+    Active { role: String },
+    /// The server explicitly rejected the token (401/403): the member was removed or
+    /// their token revoked. Distinct from a transport error so a mere network blip
+    /// never tears down the local team.
+    Removed,
+    /// The server has no `/me` route (an older self-host build). Fall back to the plain
+    /// config-pull behavior so a new client still works against an old server.
+    Unsupported,
+}
+
+/// Ask the team server who the caller is now. Returns `Removed` only on an explicit
+/// 401/403 (the authoritative "you're no longer a member" signal); any transport
+/// error is surfaced as `Err` so a flaky network doesn't masquerade as removal.
+pub fn fetch_me(server_url: &str, team_id: &str, token: &str) -> Result<MembershipCheck, String> {
+    let url = format!("{}/teams/{}/me", base(server_url), team_id);
+    match agent()
+        .get(&url)
+        .set("authorization", &format!("Bearer {token}"))
+        .call()
+    {
+        Ok(resp) => {
+            let v: Value = resp.into_json().map_err(|e| e.to_string())?;
+            let role = v["role"].as_str().unwrap_or("member").to_string();
+            Ok(MembershipCheck::Active { role })
+        }
+        Err(ureq::Error::Status(401 | 403, _)) => Ok(MembershipCheck::Removed),
+        Err(ureq::Error::Status(404, _)) => Ok(MembershipCheck::Unsupported),
+        Err(e) => Err(stringify(e)),
+    }
+}
+
 /// Admin push of the team config. Returns the new version.
 pub fn push_config(server_url: &str, team_id: &str, token: &str, config: &Value) -> Result<i64, String> {
     let url = format!("{}/teams/{}/config", base(server_url), team_id);
@@ -169,21 +203,64 @@ fn finish_connect(server_url: &str, member_name: Option<&str>, joined: Joined) -
 }
 
 /// Pull the latest team config and merge it. `Ok(None)` if nothing changed.
-pub fn sync_now() -> Result<Option<(i64, MergeOutcome)>, String> {
+/// The result of a sync.
+pub enum SyncResult {
+    /// The member was removed from the team; the local team servers, connection, and
+    /// token have already been cleared (via `disconnect`).
+    Removed,
+    /// Still a member. `role` is the current role (refreshed even on a config 304),
+    /// `role_changed` flags a promotion/demotion, and `applied` is `Some` only when the
+    /// shared config actually changed this sync.
+    Ok {
+        role: String,
+        role_changed: bool,
+        applied: Option<(i64, MergeOutcome)>,
+    },
+}
+
+pub fn sync_now() -> Result<SyncResult, String> {
     let mut reg = crate::registry::load()?;
     let conn = reg.team.clone().ok_or("not connected to a team")?;
     let token = load_token().ok_or("team token is missing from the keychain")?;
-    match pull_config(&conn.server_url, &conn.team_id, &token, conn.last_version)? {
-        None => Ok(None),
+
+    // Membership heartbeat first. This catches two things a config pull can't: removal
+    // (a config pull would just error on the now-invalid token, indistinguishable from a
+    // network failure) and a role change (a role change doesn't bump the config version,
+    // so the pull returns 304 and the client would keep showing stale admin controls).
+    let role = match fetch_me(&conn.server_url, &conn.team_id, &token)? {
+        MembershipCheck::Removed => {
+            // Authoritatively removed: tear down the local team so we stop running its
+            // servers and stop showing it. `disconnect` reloads + saves the registry.
+            disconnect()?;
+            return Ok(SyncResult::Removed);
+        }
+        MembershipCheck::Active { role } => role,
+        // Old server without /me: keep the last-known role and fall through to the pull.
+        MembershipCheck::Unsupported => conn.role.clone(),
+    };
+    let role_changed = role != conn.role;
+
+    let applied = match pull_config(&conn.server_url, &conn.team_id, &token, conn.last_version)? {
+        None => None,
         Some((version, cfg)) => {
             let outcome = apply_team_config(&mut reg, &conn.team_id, &cfg);
             if let Some(t) = reg.team.as_mut() {
                 t.last_version = version;
             }
-            crate::registry::save(&reg)?;
-            Ok(Some((version, outcome)))
+            Some((version, outcome))
         }
+    };
+    // Persist the refreshed role alongside any applied config, so admin-only UI tracks
+    // the member's real, current role on every sync.
+    if let Some(t) = reg.team.as_mut() {
+        t.role = role.clone();
     }
+    crate::registry::save(&reg)?;
+    Ok(SyncResult::Ok {
+        role,
+        role_changed,
+        applied,
+    })
 }
 
 /// Leave the team: remove its merged servers, clear the connection and the token.

--- a/src-tauri/src/teams.rs
+++ b/src-tauri/src/teams.rs
@@ -130,7 +130,12 @@ pub fn fetch_me(server_url: &str, team_id: &str, token: &str) -> Result<Membersh
     {
         Ok(resp) => {
             let v: Value = resp.into_json().map_err(|e| e.to_string())?;
-            let role = v["role"].as_str().unwrap_or("member").to_string();
+            // Fail noisily on a malformed 200 rather than defaulting to "member": a
+            // silent default would demote an admin's persisted role on a buggy response.
+            let role = v["role"]
+                .as_str()
+                .ok_or("membership response had no role")?
+                .to_string();
             Ok(MembershipCheck::Active { role })
         }
         Err(ureq::Error::Status(401 | 403, _)) => Ok(MembershipCheck::Removed),
@@ -219,8 +224,11 @@ pub enum SyncResult {
 }
 
 pub fn sync_now() -> Result<SyncResult, String> {
-    let mut reg = crate::registry::load()?;
-    let conn = reg.team.clone().ok_or("not connected to a team")?;
+    // Snapshot only what the network calls need; do NOT hold this copy to save later.
+    let conn = {
+        let reg = crate::registry::load()?;
+        reg.team.clone().ok_or("not connected to a team")?
+    };
     let token = load_token().ok_or("team token is missing from the keychain")?;
 
     // Membership heartbeat first. This catches two things a config pull can't: removal
@@ -240,7 +248,22 @@ pub fn sync_now() -> Result<SyncResult, String> {
     };
     let role_changed = role != conn.role;
 
-    let applied = match pull_config(&conn.server_url, &conn.team_id, &token, conn.last_version)? {
+    let pulled = pull_config(&conn.server_url, &conn.team_id, &token, conn.last_version)?;
+
+    // Re-load a FRESH registry now, AFTER the (possibly multi-second) network round
+    // trips, and apply the deltas to it. Loading at the top and saving here would clobber
+    // any change another command made to the registry while we were on the network.
+    let mut reg = crate::registry::load()?;
+    match reg.team.as_ref() {
+        // The user disconnected or switched teams mid-sync: don't apply stale results.
+        None => return Ok(SyncResult::Ok { role, role_changed, applied: None }),
+        Some(t) if t.team_id != conn.team_id => {
+            return Ok(SyncResult::Ok { role, role_changed, applied: None })
+        }
+        _ => {}
+    }
+
+    let applied = match pulled {
         None => None,
         Some((version, cfg)) => {
             let outcome = apply_team_config(&mut reg, &conn.team_id, &cfg);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -30,6 +30,7 @@ import {
   removeServer,
   setAllEnabled,
   setServerEnabled,
+  teamSync,
 } from "@/lib/api";
 import {
   importableServers,
@@ -229,6 +230,54 @@ function App() {
       void unlisten.then((f) => f());
     };
   }, []);
+
+  // The backend signals an authoritative removal from a team (a 401/403 on the
+  // membership heartbeat) so we can tell the member plainly rather than leaving them
+  // to wonder why the team's servers vanished. The registry (team already cleared) is
+  // pushed via the normal team_sync return / registry-changed path.
+  useEffect(() => {
+    const unlisten = listen("team-removed", () => {
+      toast.warning(
+        "You were removed from the team. Its shared servers have been removed from your setup.",
+      );
+    });
+    return () => {
+      void unlisten.then((f) => f());
+    };
+  }, []);
+
+  // Keep a team member's shared server set AND security policy current even if they
+  // never open the Teams tab: an admin tightening a force-quarantine / approval policy
+  // must reach every member, not just those who happen to click "Sync now". Runs on
+  // connect and on a modest interval; cheap when unchanged (the server 304s on an
+  // unchanged config), and not tied to the Teams view. Keyed on the team id so it
+  // starts on connect and tears down on disconnect/removal.
+  const teamId = registry?.team?.teamId;
+  useEffect(() => {
+    if (!teamId) return;
+    let cancelled = false;
+    let running = false;
+    const tick = async () => {
+      if (running || cancelled) return;
+      running = true;
+      try {
+        const fresh = await teamSync();
+        if (!cancelled) setRegistry(fresh);
+      } catch {
+        // A transient network error is fine; the next tick retries. Removal is a clean
+        // 401/403 the backend turns into a cleared team + the team-removed event, not a
+        // throw, so it won't land here.
+      } finally {
+        running = false;
+      }
+    };
+    void tick();
+    const id = setInterval(tick, 5 * 60 * 1000);
+    return () => {
+      cancelled = true;
+      clearInterval(id);
+    };
+  }, [teamId]);
 
   function selectClient(id: string | null) {
     setSelectedClientId(id);

--- a/src/components/CatalogView.tsx
+++ b/src/components/CatalogView.tsx
@@ -34,6 +34,10 @@ export function CatalogView({ registry, onAdded }: Props) {
   const [busy, setBusy] = useState<string | null>(null);
   const [popularLoading, setPopularLoading] = useState(true);
   const [popularError, setPopularError] = useState(false);
+  // A failed live search is distinct from a genuinely empty result: without this a
+  // network/registry failure would render as an innocent "no results for …".
+  const [searchError, setSearchError] = useState(false);
+  const [searchNonce, setSearchNonce] = useState(0);
   const [stacks, setStacks] = useState<Stack[]>([]);
   const [stackBusy, setStackBusy] = useState<string | null>(null);
   const [configEntry, setConfigEntry] = useState<CatalogEntry | null>(null);
@@ -65,10 +69,12 @@ export function CatalogView({ registry, onAdded }: Props) {
     const q = query.trim();
     if (!q) {
       setResults(null);
+      setSearchError(false);
       setLoading(false);
       return;
     }
     setLoading(true);
+    setSearchError(false);
     let cancelled = false;
     const t = setTimeout(() => {
       searchCatalog(q)
@@ -76,7 +82,12 @@ export function CatalogView({ registry, onAdded }: Props) {
           if (!cancelled) setResults(r);
         })
         .catch(() => {
-          if (!cancelled) setResults([]);
+          // Distinguish a failed search from an empty one so we can offer a retry
+          // instead of implying the registry has nothing for this query.
+          if (!cancelled) {
+            setResults([]);
+            setSearchError(true);
+          }
         })
         .finally(() => {
           if (!cancelled) setLoading(false);
@@ -86,7 +97,7 @@ export function CatalogView({ registry, onAdded }: Props) {
       cancelled = true;
       clearTimeout(t);
     };
-  }, [query]);
+  }, [query, searchNonce]);
 
   /** Returns true if the entry needs the ServerDialog (has credentials, a
    * user-supplied URL, or args the user should review). False = safe to
@@ -249,6 +260,27 @@ export function CatalogView({ registry, onAdded }: Props) {
               </p>
             </div>
             <Button variant="outline" size="sm" onClick={reloadPopular}>
+              Try again
+            </Button>
+          </div>
+        ) : !browsing && searchError ? (
+          <div
+            role="status"
+            aria-live="polite"
+            className="flex flex-col items-center gap-3 py-20 text-center"
+          >
+            <div>
+              <p className="font-medium">Search failed</p>
+              <p className="max-w-md text-sm text-muted-foreground">
+                Toolport couldn't reach the MCP Registry. Check your connection, then
+                retry.
+              </p>
+            </div>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setSearchNonce((n) => n + 1)}
+            >
               Try again
             </Button>
           </div>

--- a/src/components/PlaygroundView.tsx
+++ b/src/components/PlaygroundView.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import {
   Check,
   CheckCircle2,
@@ -13,6 +13,7 @@ import {
   Play,
   Search,
   ShieldAlert,
+  X,
   XCircle,
 } from "lucide-react";
 import { toastError } from "@/lib/toast";
@@ -619,6 +620,22 @@ export function PlaygroundView({ registry, onRegistryChange }: PlaygroundProps) 
   const [calling, setCalling] = useState(false);
   const [result, setResult] = useState<ToolCallResult | null>(null);
   const [callError, setCallError] = useState<string | null>(null);
+  // Seconds elapsed while a call is in flight, and a monotonically-increasing id used
+  // to invalidate a call the user cancelled or superseded (a Tauri invoke can't be
+  // aborted, so we stop waiting on it and ignore its eventual result).
+  const [elapsed, setElapsed] = useState(0);
+  const callSeq = useRef(0);
+  const tickerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  // If the call hasn't returned in this long, stop waiting and tell the user rather
+  // than spinning forever on a slow or wedged server.
+  const CALL_TIMEOUT_MS = 60_000;
+
+  useEffect(() => {
+    // Stop the elapsed-time ticker if the view unmounts mid-call.
+    return () => {
+      if (tickerRef.current) clearInterval(tickerRef.current);
+    };
+  }, []);
 
   // Connect to the chosen server and pull its tool list.
   useEffect(() => {
@@ -752,17 +769,47 @@ export function PlaygroundView({ registry, onRegistryChange }: PlaygroundProps) 
       setResult(null);
       return;
     }
+    const myId = ++callSeq.current;
     setCalling(true);
     setResult(null);
     setCallError(null);
+    setElapsed(0);
+    const started = Date.now();
+    if (tickerRef.current) clearInterval(tickerRef.current);
+    tickerRef.current = setInterval(() => {
+      if (callSeq.current === myId) setElapsed(Math.floor((Date.now() - started) / 1000));
+    }, 1000);
     try {
-      const r = await callTool(serverId, selectedTool, built as Record<string, unknown>);
-      setResult(r);
+      const timeout = new Promise<never>((_, reject) =>
+        setTimeout(() => reject(new Error("__timeout__")), CALL_TIMEOUT_MS),
+      );
+      const r = await Promise.race([
+        callTool(serverId, selectedTool, built as Record<string, unknown>),
+        timeout,
+      ]);
+      if (callSeq.current !== myId) return; // cancelled or superseded by a newer call
+      setResult(r as ToolCallResult);
     } catch (e) {
-      setCallError(String(e));
+      if (callSeq.current !== myId) return;
+      setCallError(
+        e instanceof Error && e.message === "__timeout__"
+          ? `No response after ${CALL_TIMEOUT_MS / 1000}s. The server may be slow or unreachable; check its status under Servers, then retry.`
+          : String(e),
+      );
     } finally {
-      setCalling(false);
+      if (tickerRef.current) clearInterval(tickerRef.current);
+      if (callSeq.current === myId) setCalling(false);
     }
+  }
+
+  // Stop waiting on an in-flight call: invalidate its id so the eventual result is
+  // dropped, and reset the UI. The downstream call still has its own server-side
+  // timeout; this just frees the user from a stuck "Calling…" state.
+  function cancelCall() {
+    callSeq.current++;
+    if (tickerRef.current) clearInterval(tickerRef.current);
+    setCalling(false);
+    setCallError("Call cancelled.");
   }
 
   if (servers.length === 0) {
@@ -996,15 +1043,21 @@ export function PlaygroundView({ registry, onRegistryChange }: PlaygroundProps) 
                 </div>
               )}
 
-              <div>
+              <div className="flex items-center gap-2">
                 <Button onClick={run} disabled={calling} size="sm">
                   {calling ? (
                     <Loader2 className="size-4 animate-spin" />
                   ) : (
                     <Play className="size-4" />
                   )}
-                  {calling ? "Calling…" : "Call tool"}
+                  {calling ? `Calling… ${elapsed}s` : "Call tool"}
                 </Button>
+                {calling && (
+                  <Button onClick={cancelCall} variant="outline" size="sm">
+                    <X className="size-4" />
+                    Cancel
+                  </Button>
+                )}
               </div>
             </div>
           )}

--- a/src/components/PlaygroundView.tsx
+++ b/src/components/PlaygroundView.tsx
@@ -797,8 +797,13 @@ export function PlaygroundView({ registry, onRegistryChange }: PlaygroundProps) 
           : String(e),
       );
     } finally {
-      if (tickerRef.current) clearInterval(tickerRef.current);
-      if (callSeq.current === myId) setCalling(false);
+      // Only tear down if we're still the current call: a cancelled/superseded call
+      // resolving late must not clear a newer call's ticker (which would freeze its
+      // elapsed timer) or flip its calling state.
+      if (callSeq.current === myId) {
+        if (tickerRef.current) clearInterval(tickerRef.current);
+        setCalling(false);
+      }
     }
   }
 

--- a/src/components/SecretsDialog.tsx
+++ b/src/components/SecretsDialog.tsx
@@ -15,6 +15,7 @@ import {
 } from "@/lib/api";
 import type { AuthInfo, Registry, ServerEntry } from "@/lib/types";
 import { Button } from "@/components/ui/button";
+import { ConfirmDialog } from "@/components/ConfirmDialog";
 import {
   Dialog,
   DialogContent,
@@ -328,20 +329,28 @@ export function SecretsDialog({ server, onSaved, trigger, onChanged }: Props) {
                         )}
                       </Button>
                       {authSet && (
-                        <Button
-                          size="icon"
-                          variant="ghost"
-                          className="size-8 shrink-0 text-muted-foreground hover:text-destructive"
-                          aria-label="Clear auth token"
-                          disabled={busyKey !== null}
-                          onClick={clearAuth}
-                        >
-                          {busyKey === "auth-clear" ? (
-                            <Loader2 className="size-4 animate-spin" />
-                          ) : (
-                            <Trash2 className="size-4" />
-                          )}
-                        </Button>
+                        <ConfirmDialog
+                          destructive
+                          title="Remove this credential?"
+                          description="The saved credential is deleted from your keychain. You'll need to authenticate this server again before it works."
+                          confirmLabel="Remove"
+                          onConfirm={clearAuth}
+                          trigger={
+                            <Button
+                              size="icon"
+                              variant="ghost"
+                              className="size-8 shrink-0 text-muted-foreground hover:text-destructive"
+                              aria-label="Clear auth token"
+                              disabled={busyKey !== null}
+                            >
+                              {busyKey === "auth-clear" ? (
+                                <Loader2 className="size-4 animate-spin" />
+                              ) : (
+                                <Trash2 className="size-4" />
+                              )}
+                            </Button>
+                          }
+                        />
                       )}
                     </div>
                   </div>
@@ -461,20 +470,28 @@ export function SecretsDialog({ server, onSaved, trigger, onChanged }: Props) {
                       )}
                     </Button>
                     {vaulted[key] && (
-                      <Button
-                        size="icon"
-                        variant="ghost"
-                        className="size-8 shrink-0 text-muted-foreground hover:text-destructive"
-                        aria-label={`Remove ${key}`}
-                        disabled={busyKey !== null}
-                        onClick={() => remove(key)}
-                      >
-                        {busyKey === `remove:${key}` ? (
-                          <Loader2 className="size-4 animate-spin" />
-                        ) : (
-                          <Trash2 className="size-4" />
-                        )}
-                      </Button>
+                      <ConfirmDialog
+                        destructive
+                        title={`Remove the ${vendorFromKey(key)} API key?`}
+                        description="The saved key is deleted from your keychain. You'll need to paste it again before this server works."
+                        confirmLabel="Remove"
+                        onConfirm={() => remove(key)}
+                        trigger={
+                          <Button
+                            size="icon"
+                            variant="ghost"
+                            className="size-8 shrink-0 text-muted-foreground hover:text-destructive"
+                            aria-label={`Remove ${key}`}
+                            disabled={busyKey !== null}
+                          >
+                            {busyKey === `remove:${key}` ? (
+                              <Loader2 className="size-4 animate-spin" />
+                            ) : (
+                              <Trash2 className="size-4" />
+                            )}
+                          </Button>
+                        }
+                      />
                     )}
                   </div>
                 </div>


### PR DESCRIPTION
## "Nothing fails silently" — a completeness/robustness sprint

From a 3-surface audit (app UX, gateway runtime, Teams). The theme: fix the flows that *look* handled but silently fail. Foundations were confirmed solid (last-admin guards, seat-race safety, Stripe reconciliation, tighten-only policy, SSRF, HITL), so these are the remaining edges.

### Tier 0 — the three dead-ends
- **Re-spawn a crashed downstream on the breaker's half-open probe.** A stdio child that dies previously stayed dead until a full registry rebuild — the breaker tripped/half-opened but never reconnected, and self-heal only fires when *every* server is down. Each slot now carries a reconnect factory (`connect_one`, so keychain secrets are re-injected); the probe re-spawns once and retries. Gated on the probe so a live server is never re-spawned on a blip. (+3 tests)
- **Teams: actually cut off removed members, refresh role, auto-sync.** New server `GET /teams/{id}/me` heartbeat (role + 401/403-if-removed). Sync now disconnects a removed member locally instead of running the team's servers forever, refreshes role every sync (a role-only change 304s the config pull, so `/me` is how a demotion reaches the client), and never tears down the team on a mere network error. Adds an app-level 5-min background sync so an admin's policy change reaches every member, not just those who click "Sync now". Falls back cleanly against an older server with no `/me`. *(server side already deployed)*
- **Playground call timeout + Cancel + elapsed.** The one true hang with no escape, on the screen users open to diagnose a server.

### Tier 1 — quick wins
- ConfirmDialog on the two credential-deleting actions (clear auth, remove key)
- Embeddings HTTP call time-boxed (10s) → falls back to lexical instead of stalling every search
- Bounded stdio `read_line` so a newline-less multi-GB line can't grow the buffer unbounded
- Shaped-result marker stops over-promising "Nothing was lost" (says held-temporarily + re-run on expiry)
- Tool-cache wrapped as `{version, tools}` and discarded on version mismatch
- Catalog live-search failure shows a distinct "search failed" + retry, not an innocent "no results"

### Deferred (tracked, not shipped)
- Slowloris HTTP read timeout — `tiny_http` exposes no socket read deadline; the alternatives are fragile. Low risk (loopback bind + bearer + 4MB + inflight caps).

### Notes
- Full desktop test suite green (272 + 57), typecheck + lint clean.
- Remaining audit backlog logged in `docs/ROADMAP.md` (app/gateway) and, in the Teams repo, `docs/backlog.md`.
