### PR TITLE
app: clear-filter affordances + Playground empty/auth states

### DIFF
--- a/src/components/ActivityView.tsx
+++ b/src/components/ActivityView.tsx
@@ -1572,11 +1572,25 @@ export function ActivityView({
 
           <div className="flex flex-col gap-1">
             {visible.length === 0 ? (
-              <p className="py-12 text-center text-sm text-muted-foreground">
-                {errorsOnly && !serverFilter
-                  ? `No errors in the last ${entries.length} calls.`
-                  : "No calls match this filter."}
-              </p>
+              <div className="flex flex-col items-center gap-2 py-12 text-center">
+                <p className="text-sm text-muted-foreground">
+                  {errorsOnly && !serverFilter
+                    ? `No errors in the last ${entries.length} calls.`
+                    : "No calls match this filter."}
+                </p>
+                {(serverFilter || errorsOnly) && (
+                  <button
+                    onClick={() => {
+                      setServerFilter("");
+                      setErrorsOnly(false);
+                    }}
+                    className="inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1 text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+                  >
+                    <X className="size-3.5" />
+                    Clear filter
+                  </button>
+                )}
+              </div>
             ) : (
               visible.map((e, i) => (
                 <CallRow key={`${e.ts}-${e.server}-${e.tool}-${i}`} e={e} />

--- a/src/components/CatalogView.tsx
+++ b/src/components/CatalogView.tsx
@@ -301,6 +301,16 @@ export function CatalogView({ registry, onAdded }: Props) {
                   ? "Try a provider name, app name, or shorter query. You can also clear the search to browse popular servers."
                   : "Use search to query the MCP Registry, or try again later if the browse list stays empty."}
               </p>
+              {results !== null && (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="mt-2"
+                  onClick={() => setQuery("")}
+                >
+                  Clear search
+                </Button>
+              )}
             </div>
           )
         )

--- a/src/components/CatalogView.tsx
+++ b/src/components/CatalogView.tsx
@@ -233,7 +233,7 @@ export function CatalogView({ registry, onAdded }: Props) {
             ? `${shown.length} result${shown.length === 1 ? "" : "s"} (popular picks first, then the MCP Registry)`
             : "Popular servers"}
         </span>
-        {results !== null && (
+        {results !== null && shown.length > 0 && (
           <button className="hover:text-foreground" onClick={() => setQuery("")}>
             Clear search
           </button>

--- a/src/components/PlaygroundView.tsx
+++ b/src/components/PlaygroundView.tsx
@@ -306,7 +306,7 @@ function ArgField({ name, schema, required, value, onChange }: FieldProps) {
  * (missing/expired credentials, 401/403) rather than a generic transport error? If so
  * we point the user at the server's Secrets dialog instead of showing a raw backend string. */
 function looksLikeAuthError(message: string): boolean {
-  return /\b(401|403|unauthori[sz]ed|forbidden|authenticat|invalid.{0,15}(token|api.?key|credential)|missing.{0,15}(token|api.?key|credential)|expired.{0,15}(token|credential)|not.{0,15}logged.?in|access.{0,15}denied)\b/i.test(
+  return /\b(401|403|unauthori[sz]ed|forbidden|authenticat\w*|invalid.{0,15}(token|api.?key|credentials?)|missing.{0,15}(token|api.?key|credentials?)|expired.{0,15}(token|credentials?)|not.{0,15}logged.?in|access.{0,15}denied)\b/i.test(
     message,
   );
 }

--- a/src/components/PlaygroundView.tsx
+++ b/src/components/PlaygroundView.tsx
@@ -302,6 +302,15 @@ function ArgField({ name, schema, required, value, onChange }: FieldProps) {
   );
 }
 
+/** Heuristic: does a tool-list failure look like the server needing authentication
+ * (missing/expired credentials, 401/403) rather than a generic transport error? If so
+ * we point the user at the server's Secrets dialog instead of showing a raw backend string. */
+function looksLikeAuthError(message: string): boolean {
+  return /\b(401|403|unauthori[sz]ed|forbidden|authenticat|invalid.{0,15}(token|api.?key|credential)|missing.{0,15}(token|api.?key|credential)|expired.{0,15}(token|credential)|not.{0,15}logged.?in|access.{0,15}denied)\b/i.test(
+    message,
+  );
+}
+
 /** Inline "connecting…" line shared by the resource/prompt panels. */
 function Connecting({ label = "Connecting to server…" }: { label?: string }) {
   return (
@@ -890,7 +899,29 @@ export function PlaygroundView({ registry, onRegistryChange }: PlaygroundProps) 
             </div>
           )}
 
-          {toolsError && <Callout variant="danger">{toolsError}</Callout>}
+          {toolsError &&
+            (looksLikeAuthError(toolsError) ? (
+              <Callout variant="warning">
+                <span className="font-medium">
+                  {serverEntry?.name ?? "This server"} needs authentication.
+                </span>{" "}
+                Listing its tools failed with what looks like an auth error. Open{" "}
+                <span className="font-medium">Servers</span>, pick this server, and add
+                its credentials (the key icon / Secrets) before testing here.
+                <p className="mt-1.5 font-mono text-xs break-words opacity-70">
+                  {toolsError}
+                </p>
+              </Callout>
+            ) : (
+              <Callout variant="danger">{toolsError}</Callout>
+            ))}
+
+          {/* Server connected but exposes no tools at all. */}
+          {!loadingTools && !toolsError && tools && tools.length === 0 && (
+            <p className="text-sm text-muted-foreground">
+              This server advertises no tools.
+            </p>
+          )}
 
           {/* Tool list: click to test, switch to enable/disable per client */}
           {tools && tools.length > 0 && (
@@ -915,9 +946,18 @@ export function PlaygroundView({ registry, onRegistryChange }: PlaygroundProps) 
                 </div>
               )}
               {filteredTools.length === 0 ? (
-                <p className="rounded-lg border border-dashed px-3 py-6 text-center text-sm text-muted-foreground">
-                  No tools match "{toolFilter.trim()}".
-                </p>
+                <div className="flex flex-col items-center gap-2 rounded-lg border border-dashed px-3 py-6 text-center">
+                  <p className="text-sm text-muted-foreground">
+                    No tools match "{toolFilter.trim()}".
+                  </p>
+                  <button
+                    onClick={() => setToolFilter("")}
+                    className="inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1 text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+                  >
+                    <X className="size-3.5" />
+                    Clear filter
+                  </button>
+                </div>
               ) : (
                 <div className="flex flex-col divide-y rounded-lg border">
                   {filteredTools.map((t) => {
@@ -1022,13 +1062,19 @@ export function PlaygroundView({ registry, onRegistryChange }: PlaygroundProps) 
               </div>
 
               {rawMode ? (
-                <textarea
-                  value={rawJson}
-                  onChange={(e) => setRawJson(e.target.value)}
-                  rows={6}
-                  spellCheck={false}
-                  className="w-full rounded-md border border-input bg-transparent px-3 py-2 font-mono text-xs shadow-sm focus-visible:ring-3 focus-visible:ring-ring/50 focus-visible:outline-none"
-                />
+                <div className="flex flex-col gap-1.5">
+                  <span className="text-xs text-muted-foreground">
+                    Raw-JSON mode: type the full arguments object yourself. The generated
+                    form is bypassed.
+                  </span>
+                  <textarea
+                    value={rawJson}
+                    onChange={(e) => setRawJson(e.target.value)}
+                    rows={6}
+                    spellCheck={false}
+                    className="w-full rounded-md border border-input bg-transparent px-3 py-2 font-mono text-xs shadow-sm focus-visible:ring-3 focus-visible:ring-ring/50 focus-visible:outline-none"
+                  />
+                </div>
               ) : Object.keys(props).length === 0 ? (
                 <p className="text-sm text-muted-foreground">
                   This tool takes no arguments.


### PR DESCRIPTION
Two isolated frontend UX-completeness items from the robustness-sprint backlog. No refactors, no backend changes.

## 1. Clear-filter affordances on zero-match states

- **ActivityView** (recent-calls filter): when the server-select + Errors-only filters yield zero rows, the empty state now shows a **Clear filter** button that resets both (`serverFilter` and `errorsOnly`). Previously the user had to reset the Select and un-press the toggle by hand.
- **PlaygroundView** (tool-name filter): the "No tools match …" state now offers a **Clear filter** button that empties the filter field.
- **CatalogView** (registry search): the no-results state now offers a **Clear search** button. The header's existing clear control is far from the empty-state message, so this puts the affordance where the user is looking.

## 2. Playground empty / auth states (`PlaygroundView.tsx`)

- **Zero tools**: a connected server that exposes no tools now renders an explicit "This server advertises no tools." line, mirroring how the Resources and Prompts panels already handle their empty cases, instead of a blank panel.
- **Auth-looking failures**: when listing a server's tools fails with something that looks like an auth error (401/403, "unauthorized", "invalid/missing/expired token/api key/credential", etc.), the Playground shows a `warning` Callout that names the server and points the user to add its credentials under **Servers** (the Secrets/key control), rather than dumping a raw backend string. The raw error is still shown, muted, underneath. Non-auth failures keep the existing danger Callout.
- **Raw-JSON label**: the raw-JSON arguments textarea now carries a small label noting the generated form is bypassed and you type the full arguments object yourself.

## Verification

- `npx tsc --noEmit` — passes clean.
- `npx eslint src/components/PlaygroundView.tsx src/components/ActivityView.tsx src/components/CatalogView.tsx` — **0 errors**, 9 pre-existing warnings (all `set-state-in-effect` / `exhaustive-deps` in untouched effect bodies). No new warnings on the changed lines.
