### PR TITLE
Settings: security panels distinguish poll failure from empty

### DIFF
--- a/src/components/SettingsView.tsx
+++ b/src/components/SettingsView.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import {
   Activity,
   Bot,
@@ -276,7 +276,10 @@ export function SettingsView({ registry, onRegistryChange }: Props) {
     }
   }
 
-  useEffect(() => {
+  // One-shot (not polled): the status only changes when the user toggles it here.
+  // Exposed as a callback so a failed initial read can be retried explicitly, rather
+  // than leaving the panel wedged until an app restart.
+  const loadBridge = useCallback(() => {
     httpBridgeStatus()
       .then((s) => {
         setBridge(s);
@@ -284,6 +287,9 @@ export function SettingsView({ registry, onRegistryChange }: Props) {
       })
       .catch(() => setBridgeError(true));
   }, []);
+  useEffect(() => {
+    loadBridge();
+  }, [loadBridge]);
 
   useEffect(() => {
     const load = () =>
@@ -621,12 +627,22 @@ export function SettingsView({ registry, onRegistryChange }: Props) {
             <Switch
               checked={!!bridge?.running}
               onCheckedChange={toggleBridge}
-              disabled={bridgeBusy || (bridgeError && bridge === null)}
+              disabled={bridgeBusy}
             />
           </label>
           {bridgeError && bridge === null && (
-            <p className="text-xs text-muted-foreground">
-              Couldn&apos;t read the HTTP endpoint status. The gateway may be starting up.
+            <p className="flex items-center gap-1.5 text-xs text-muted-foreground">
+              <span>
+                Couldn&apos;t read the HTTP endpoint status. The gateway may be starting
+                up.
+              </span>
+              <button
+                type="button"
+                onClick={loadBridge}
+                className="shrink-0 font-medium text-foreground underline underline-offset-2 hover:text-primary"
+              >
+                Retry
+              </button>
             </p>
           )}
           {bridge?.running && bridge.url && (

--- a/src/components/SettingsView.tsx
+++ b/src/components/SettingsView.tsx
@@ -212,8 +212,11 @@ export function SettingsView({ registry, onRegistryChange }: Props) {
   const liveInspect = registry?.liveInspect ?? false;
   const [busy, setBusy] = useState(false);
   const [quarantined, setQuarantined] = useState<QuarantinedTool[]>([]);
+  const [quarantineError, setQuarantineError] = useState(false);
   const [allowedTools, setAllowedTools] = useState<AllowedTool[]>([]);
+  const [allowedError, setAllowedError] = useState(false);
   const [bridge, setBridge] = useState<HttpBridgeStatus | null>(null);
+  const [bridgeError, setBridgeError] = useState(false);
   const [bridgeBusy, setBridgeBusy] = useState(false);
   const [copied, setCopied] = useState<string | null>(null);
   const [newLabel, setNewLabel] = useState("");
@@ -275,15 +278,23 @@ export function SettingsView({ registry, onRegistryChange }: Props) {
 
   useEffect(() => {
     httpBridgeStatus()
-      .then(setBridge)
-      .catch(() => {});
+      .then((s) => {
+        setBridge(s);
+        setBridgeError(false);
+      })
+      .catch(() => setBridgeError(true));
   }, []);
 
   useEffect(() => {
     const load = () =>
       listQuarantined()
-        .then(setQuarantined)
-        .catch(() => {});
+        .then((q) => {
+          setQuarantined(q);
+          setQuarantineError(false);
+        })
+        // A failed poll must not read as "nothing quarantined": keep any prior
+        // list and flag the error so the panel can say the status is stale.
+        .catch(() => setQuarantineError(true));
     load();
     // Quarantine happens asynchronously in the gateway, so poll to keep the list fresh.
     const id = setInterval(load, 15000);
@@ -304,8 +315,11 @@ export function SettingsView({ registry, onRegistryChange }: Props) {
   useEffect(() => {
     const load = () =>
       listAllowedTools()
-        .then(setAllowedTools)
-        .catch(() => {});
+        .then((t) => {
+          setAllowedTools(t);
+          setAllowedError(false);
+        })
+        .catch(() => setAllowedError(true));
     load();
     const id = setInterval(load, 10000);
     return () => clearInterval(id);
@@ -324,6 +338,7 @@ export function SettingsView({ registry, onRegistryChange }: Props) {
     setBridgeBusy(true);
     try {
       setBridge(on ? await startHttpBridge() : await stopHttpBridge());
+      setBridgeError(false);
     } catch (e) {
       toastError(`Couldn't ${on ? "start" : "stop"} the HTTP endpoint: ${e}`);
     } finally {
@@ -516,13 +531,19 @@ export function SettingsView({ registry, onRegistryChange }: Props) {
           "Off by default. While on, Toolport captures each tool call's arguments and results to a small local, ephemeral buffer (the last 50 calls) so you can inspect them in Activity. This is separate from the audit log, never leaves your machine, and is cleared when you turn it off or restart the gateway.",
           applyLiveInspect,
         )}
+        {quarantined.length === 0 && quarantineError && (
+          <div className="flex items-center gap-2 rounded-md border border-destructive/30 bg-destructive/5 px-3 py-2 text-xs text-muted-foreground">
+            <ShieldX className="size-4 shrink-0 text-destructive" />
+            <span>Couldn&apos;t read quarantine status. Retrying every 15s.</span>
+          </div>
+        )}
         {quarantined.length > 0 && (
           <div className="flex flex-col gap-2 rounded-md border border-destructive/30 bg-destructive/5 px-3 py-2.5">
             <div className="flex items-center gap-2">
               <ShieldX className="size-4 shrink-0 text-destructive" />
               <span className="text-sm font-medium">Quarantined tools</span>
               <span className="text-xs text-muted-foreground">
-                blocked until you re-approve
+                {quarantineError ? "status may be stale" : "blocked until you re-approve"}
               </span>
             </div>
             <ul className="flex flex-col gap-1.5">
@@ -545,12 +566,20 @@ export function SettingsView({ registry, onRegistryChange }: Props) {
             </ul>
           </div>
         )}
+        {allowedTools.length === 0 && allowedError && (
+          <div className="flex items-center gap-2 rounded-md border border-border bg-muted/20 px-3 py-2 text-xs text-muted-foreground">
+            <UserCheck className="size-4 shrink-0 text-info" />
+            <span>Couldn&apos;t read the allowed-tools list. Retrying every 10s.</span>
+          </div>
+        )}
         {allowedTools.length > 0 && (
           <div className="flex flex-col gap-2 rounded-md border border-border bg-muted/20 px-3 py-2.5">
             <div className="flex items-center gap-2">
               <UserCheck className="size-4 shrink-0 text-info" />
               <span className="text-sm font-medium">Allowed tools</span>
-              <span className="text-xs text-muted-foreground">skip human approval</span>
+              <span className="text-xs text-muted-foreground">
+                {allowedError ? "list may be stale" : "skip human approval"}
+              </span>
             </div>
             <ul className="flex flex-col gap-1.5">
               {allowedTools.map((t) => (
@@ -592,9 +621,14 @@ export function SettingsView({ registry, onRegistryChange }: Props) {
             <Switch
               checked={!!bridge?.running}
               onCheckedChange={toggleBridge}
-              disabled={bridgeBusy}
+              disabled={bridgeBusy || (bridgeError && bridge === null)}
             />
           </label>
+          {bridgeError && bridge === null && (
+            <p className="text-xs text-muted-foreground">
+              Couldn&apos;t read the HTTP endpoint status. The gateway may be starting up.
+            </p>
+          )}
           {bridge?.running && bridge.url && (
             <>
               <div className="flex items-center gap-2 rounded border bg-muted/40 px-2 py-1.5">


### PR DESCRIPTION
## Settings security panels distinguish a failed poll from "empty"

Continues the "nothing fails silently" pass into the Settings screen. Three status polls each did `.catch(() => {})`, so a failed fetch looked identical to "nothing here":

- **Quarantined tools** and **Allowed tools** panels are `length > 0 &&`-gated, so a failed initial load hid them completely. For the quarantine panel that's a real problem: a silent failure could mask tools the gateway has actually *blocked*, and the user would never know.
- The **HTTP endpoint** toggle showed **off** whenever the status was merely unreadable (e.g. gateway still starting), which reads as "the bridge is off."

Each poll now tracks an error flag:
- On failure with no data, the panel shows a subtle *"Couldn't read … Retrying every Ns"* note instead of vanishing.
- If a list had loaded before, it stays visible and the header says *"may be stale"* rather than dropping to empty.
- The bridge shows an inline *"status unavailable"* line and disables the toggle instead of implying off.
- Any successful load/toggle clears the flag.

tsc + eslint clean. Frontend-only; ships in the next desktop release.
