### PR TITLE
[codex] Address security audit gaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,13 +91,11 @@ fixes both.
 - **Tool integrity (rug-pull + poisoning detection).** Toolport fingerprints each tool
   when you connect a server and flags it if the definition later changes or a server
   quietly adds one (a "rug pull"), or if a description or schema carries injection-like
-  content ("tool poisoning"). Detection only, on by default, entirely local
-  ([details](docs/specs/mcp-integrity.md)).
+  content ("tool poisoning"). Detection only, on by default, entirely local.
 - **Content defense (anti-agentjacking).** When a tool _returns_ untrusted content (a
   Sentry error, a web page, an issue body) with injection-like instructions, Toolport
   flags it and marks it as external data, not instructions, the separation that blunts
-  indirect prompt injection. Never blocks, on by default
-  ([details](docs/specs/content-defense.md)).
+  indirect prompt injection. Never blocks, on by default.
 - **Governance and audit.** Toggle any tool on or off, or hide every destructive tool
   from every client with one switch. Every call is recorded with per-server latency and
   error rates.
@@ -216,8 +214,7 @@ gateway entry, written for you when you connect a client:
 at any `/v1/embeddings` endpoint (LM Studio, Ollama, or a cloud provider) to blend in
 embedding similarity for paraphrased queries: `CONDUIT_SEMANTIC=on`,
 `CONDUIT_EMBED_ENDPOINT`, `CONDUIT_EMBED_MODEL`, plus optional `CONDUIT_EMBED_KEY`
-(endpoint auth) and `CONDUIT_EMBED_BLEND`. See
-[docs/specs/semantic-search.md](docs/specs/semantic-search.md).
+(endpoint auth) and `CONDUIT_EMBED_BLEND`.
 
 **Multiple accounts for the same service.** Credentials belong to a server, not a
 profile. To use, say, a work and a personal GitHub, add GitHub twice as two

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -22,11 +22,12 @@ from the [Releases](https://github.com/tsouth89/toolport/releases) page.
 
 ## Security design
 
-- **Local-first.** Toolport runs entirely on your machine. The desktop app is a
-  manager; the gateway is a local process each AI client spawns over stdio. There
-  is **no Toolport server, account, or telemetry**, nothing phones home. The only
-  network traffic is between the gateway and the upstream MCP servers _you_
-  configure.
+- **Local-first.** Toolport's core gateway runs on your machine. The desktop app
+  is a manager; the gateway is a local process each AI client spawns over stdio.
+  There is no telemetry. Routine tool traffic is between the gateway and the
+  upstream MCP servers _you_ configure. Optional hosted features make explicit
+  user-initiated requests: shared setup links use `toolport.app`, and Teams uses
+  the team server URL you choose.
 - **Secrets in the OS keychain.** API keys and OAuth tokens are stored in the
   platform keychain (macOS Keychain, Windows Credential Manager, Linux Secret
   Service), never in plaintext config files and never written to logs.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "conduit",
-  "version": "1.3.0",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "conduit",
-      "version": "1.3.0",
+      "version": "1.5.0",
       "dependencies": {
         "@fontsource-variable/geist": "^5.2.9",
         "@tailwindcss/vite": "^4.3.1",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -64,9 +64,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arbitrary"

--- a/src-tauri/src/teams.rs
+++ b/src-tauri/src/teams.rs
@@ -31,6 +31,36 @@ fn base(server_url: &str) -> String {
     server_url.trim_end_matches('/').to_string()
 }
 
+/// Team bearer tokens must not ride over cleartext except to a local dev server.
+fn require_secure_team_url(server_url: &str) -> Result<(), String> {
+    let lower = server_url.trim().to_ascii_lowercase();
+    if lower.starts_with("https://") {
+        return Ok(());
+    }
+    if !lower.starts_with("http://") {
+        return Err("team server URL must start with https://".to_string());
+    }
+
+    let host = crate::oauth::host_of_url(server_url).unwrap_or_default();
+    let loopback = host.eq_ignore_ascii_case("localhost")
+        || host.to_ascii_lowercase().ends_with(".localhost")
+        || host.parse::<std::net::IpAddr>().ok().map_or(false, |ip| match ip {
+            std::net::IpAddr::V4(v4) => v4.is_loopback(),
+            std::net::IpAddr::V6(v6) => {
+                v6.is_loopback()
+                    || v6
+                        .to_ipv4_mapped()
+                        .map(|v4| v4.is_loopback())
+                        .unwrap_or(false)
+            }
+        });
+    if loopback {
+        Ok(())
+    } else {
+        Err("team server URL must use https:// unless it is loopback HTTP for local development".to_string())
+    }
+}
+
 /// A ureq agent with a connect + read timeout. The team commands run on the Tauri
 /// command thread, so a slow or black-holed team server must not hang the UI: bare
 /// `ureq::get/post/put` have no timeout, this does.
@@ -51,6 +81,7 @@ pub struct Joined {
 
 /// Redeem an invite code, returning the member token, team id, and role.
 pub fn join(server_url: &str, invite_code: &str, member_name: Option<&str>) -> Result<Joined, String> {
+    require_secure_team_url(server_url)?;
     let url = format!("{}/join", base(server_url));
     let body = serde_json::json!({ "invite_code": invite_code, "member_name": member_name });
     let resp = agent().post(&url).send_json(body).map_err(stringify)?;
@@ -74,6 +105,7 @@ pub fn pull_config(
     token: &str,
     last_version: i64,
 ) -> Result<Option<(i64, Value)>, String> {
+    require_secure_team_url(server_url)?;
     let url = format!("{}/teams/{}/config", base(server_url), team_id);
     let etag = format!("\"v{last_version}\"");
     let req = agent()
@@ -122,6 +154,7 @@ pub enum MembershipCheck {
 /// 401/403 (the authoritative "you're no longer a member" signal); any transport
 /// error is surfaced as `Err` so a flaky network doesn't masquerade as removal.
 pub fn fetch_me(server_url: &str, team_id: &str, token: &str) -> Result<MembershipCheck, String> {
+    require_secure_team_url(server_url)?;
     let url = format!("{}/teams/{}/me", base(server_url), team_id);
     match agent()
         .get(&url)
@@ -146,6 +179,7 @@ pub fn fetch_me(server_url: &str, team_id: &str, token: &str) -> Result<Membersh
 
 /// Admin push of the team config. Returns the new version.
 pub fn push_config(server_url: &str, team_id: &str, token: &str, config: &Value) -> Result<i64, String> {
+    require_secure_team_url(server_url)?;
     let url = format!("{}/teams/{}/config", base(server_url), team_id);
     let body = serde_json::json!({ "config": config });
     let resp = agent()
@@ -743,6 +777,17 @@ mod tests {
         assert_eq!(sp.get("forceContentDefense").and_then(Value::as_bool), Some(true));
         assert_eq!(sp.get("forceQuarantineOnDrift").and_then(Value::as_bool), Some(true));
         assert_eq!(sp.get("forceHumanApproval").and_then(Value::as_bool), Some(true));
+    }
+
+    #[test]
+    fn team_url_requires_https_except_loopback_http() {
+        assert!(require_secure_team_url("https://teams.example.com").is_ok());
+        assert!(require_secure_team_url("http://127.0.0.1:8787").is_ok());
+        assert!(require_secure_team_url("http://localhost:8787").is_ok());
+        assert!(require_secure_team_url("http://[::1]:8787").is_ok());
+        assert!(require_secure_team_url("http://192.168.1.10:8787").is_err());
+        assert!(require_secure_team_url("http://teams.example.com").is_err());
+        assert!(require_secure_team_url("teams.example.com").is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Require Toolport Teams server URLs to use HTTPS, allowing HTTP only for loopback local development, before invite redemption or member-token requests.
- Update the Rust lockfile to move `anyhow` from 1.0.102 to 1.0.103.
- Correct release/docs hygiene: sync the package lock root version to 1.5.0, remove README links to ignored spec files, and clarify optional hosted share/Teams traffic in SECURITY.md.

## Why

The audit found a real bearer-token transport gap in the Teams client, a current RustSec advisory resolved by a compatible dependency update, and public documentation that either linked to untracked local files or overstated the app's network behavior.

## Validation

- `npm run lint` (passes with existing warnings)
- `npm test -- --run`
- `npm audit --omit=dev`
- `npm run build`
- `cargo audit` (no `anyhow` advisory remains; still reports allowed unmaintained transitive warnings)
- `cargo test --lib`

Note: full binary/integration Rust tests that rebuild `target/debug/toolport-gateway.exe` were blocked locally by already-running `toolport-gateway.exe` processes holding the debug binary.
