### PR TITLE
Harden verification workflow

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,8 +8,10 @@
 
 <!-- How did you verify this? -->
 
-- [ ] `cargo test --manifest-path src-tauri/Cargo.toml` passes
-- [ ] `npx tsc --noEmit && npm run build` passes
+- [ ] `npm run build` passes
+- [ ] `npm run test` passes
+- [ ] `npm run audit:prod` passes
+- [ ] `npm run test:rust` passes (`npm run test:rust:windows` on Windows if the debug gateway binary is locked)
 - [ ] Ran the app (`npm run tauri dev`) and checked the change by hand
 
 ## Notes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,9 @@ jobs:
 
       - run: npm ci
 
+      - name: Production dependency audit
+        run: npm run audit:prod
+
       # Enforce consistent formatting before anything else — fails fast on
       # formatting-only issues so the contributor doesn't wait for a full build.
       - name: Check formatting
@@ -73,4 +76,4 @@ jobs:
       # tests too; checking only that the binary compiled let a gateway test fail
       # silently, so run them.
       - name: Rust tests (lib + binaries)
-        run: cargo test --manifest-path src-tauri/Cargo.toml --lib --bins
+        run: npm run test:rust

--- a/package.json
+++ b/package.json
@@ -18,6 +18,9 @@
     "lint:fix": "eslint src/ --fix",
     "test": "vitest run",
     "test:watch": "vitest",
+    "test:rust": "cargo test --manifest-path src-tauri/Cargo.toml --lib --bins",
+    "test:rust:windows": "powershell -ExecutionPolicy Bypass -File scripts/test-rust-windows.ps1",
+    "audit:prod": "npm audit --omit=dev",
     "prepare": "husky"
   },
   "dependencies": {

--- a/scripts/test-rust-windows.ps1
+++ b/scripts/test-rust-windows.ps1
@@ -1,0 +1,16 @@
+$ErrorActionPreference = "Stop"
+
+$repoRoot = Resolve-Path (Join-Path $PSScriptRoot "..")
+$gateway = Join-Path $repoRoot "src-tauri\target\debug\toolport-gateway.exe"
+$resolvedGateway = if (Test-Path $gateway) { (Resolve-Path $gateway).Path } else { $null }
+
+if ($resolvedGateway) {
+  Get-Process toolport-gateway -ErrorAction SilentlyContinue |
+    Where-Object { $_.Path -and ((Resolve-Path $_.Path).Path -eq $resolvedGateway) } |
+    ForEach-Object {
+      Write-Host "Stopping debug gateway process $($_.Id) so cargo can rebuild $resolvedGateway"
+      Stop-Process -Id $_.Id -Force
+    }
+}
+
+cargo test --manifest-path (Join-Path $repoRoot "src-tauri\Cargo.toml") --lib --bins

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -64,9 +64,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arbitrary"

--- a/src/components/TeamsView.tsx
+++ b/src/components/TeamsView.tsx
@@ -22,6 +22,7 @@ import {
   teamPush,
   setServerEnabled,
 } from "@/lib/api";
+import { teamUrlError } from "@/lib/teamUrl";
 import { isEnabled, activeProfile } from "@/lib/types";
 import type { Registry } from "@/lib/types";
 
@@ -94,8 +95,12 @@ export function TeamsView({
 
   const onConnect = () =>
     run("connect", async () => {
-      if (!serverUrl.trim() || !inviteCode.trim()) {
-        throw new Error("Server URL and invite code are both required.");
+      const urlError = teamUrlError(serverUrl);
+      if (urlError) {
+        throw new Error(urlError);
+      }
+      if (!inviteCode.trim()) {
+        throw new Error("Invite code is required.");
       }
       const r = await teamConnect(
         serverUrl.trim(),

--- a/src/lib/teamUrl.test.ts
+++ b/src/lib/teamUrl.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+
+import { teamUrlError } from "./teamUrl";
+
+describe("teamUrlError", () => {
+  it("accepts https team servers", () => {
+    expect(teamUrlError("https://teams.example.com")).toBeNull();
+  });
+
+  it("accepts loopback http for local development", () => {
+    expect(teamUrlError("http://127.0.0.1:8787")).toBeNull();
+    expect(teamUrlError("http://localhost:8787")).toBeNull();
+    expect(teamUrlError("http://[::1]:8787")).toBeNull();
+  });
+
+  it("rejects cleartext public or LAN team servers", () => {
+    expect(teamUrlError("http://teams.example.com")).toMatch(/https/);
+    expect(teamUrlError("http://192.168.1.10:8787")).toMatch(/https/);
+  });
+
+  it("rejects missing or malformed URLs", () => {
+    expect(teamUrlError("")).toMatch(/required/);
+    expect(teamUrlError("teams.example.com")).toMatch(/https/);
+  });
+});

--- a/src/lib/teamUrl.ts
+++ b/src/lib/teamUrl.ts
@@ -1,0 +1,26 @@
+export function teamUrlError(raw: string): string | null {
+  const value = raw.trim();
+  if (!value) return "Server URL is required.";
+
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    return "Team server URL must start with https://.";
+  }
+
+  if (url.protocol === "https:") return null;
+  if (url.protocol !== "http:") return "Team server URL must start with https://.";
+
+  const host = url.hostname.toLowerCase();
+  const loopback =
+    host === "localhost" ||
+    host.endsWith(".localhost") ||
+    host === "127.0.0.1" ||
+    host === "::1" ||
+    host === "[::1]";
+
+  return loopback
+    ? null
+    : "Team server URL must use https:// unless it is loopback HTTP for local development.";
+}


### PR DESCRIPTION
## Summary
- Add shared team server URL validation in the Teams UI, allowing HTTPS everywhere and loopback HTTP only for local development.
- Add focused URL validation tests and a Windows Rust test helper that stops only this checkout's debug gateway binary when it locks test builds.
- Add production npm audit coverage to CI/package scripts, reuse the Rust test script in CI, update the PR checklist, and bump anyhow to 1.0.103.

## Verification
- npm run lint
- npm run test
- npm run audit:prod
- npm run test:rust:windows
- npm run build
- cargo audit
- npx prettier --check .github/PULL_REQUEST_TEMPLATE.md .github/workflows/ci.yml package.json src/components/TeamsView.tsx src/lib/teamUrl.ts src/lib/teamUrl.test.ts

Note: whole-repo npm run format:check still reports many pre-existing Windows checkout line-ending/style changes in untouched files, so this PR uses targeted Prettier verification for the touched frontend/docs files.