### PR TITLE
Search: specificity boost so the on-the-nose tool wins near-ties

### DIFF
--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -413,6 +413,10 @@ fn tool_prefix(t: &Value) -> String {
 /// Field weights: a token hit in the tool NAME counts far more than in its description.
 const NAME_W: f64 = 3.0;
 const DESC_W: f64 = 1.0;
+/// How much a fully-on-the-nose tool name (query explains all its tokens) is boosted
+/// over a longer sibling that merely contains the same words. Small: it only tips
+/// near-ties toward the more specific tool, never overrides a stronger keyword signal.
+const NAME_SPECIFICITY_W: f64 = 0.35;
 
 /// Split a camelCase/PascalCase word into lowercased pieces ("listProjects" -> [list, projects]).
 fn split_camel(word: &str) -> Vec<String> {
@@ -715,6 +719,25 @@ fn search_catalog_with(
                         }
                     }
                     score += best;
+                }
+                // Specificity boost: a tool whose NAME is "on the nose" for the query
+                // (few tokens beyond what the query explains) beats a longer sibling that
+                // merely contains the same words. Without this the ranker ties
+                // `create_customer` with `create_customer_session` for "create customer",
+                // since both name-match every query token. Multiplicative so it only
+                // separates near-ties, never overrides a stronger IDF signal; skipped on
+                // a zero score so non-matches stay out.
+                if score > 0.0 && !name_set.is_empty() {
+                    let explained = name_set
+                        .iter()
+                        .filter(|nt| {
+                            q_tokens.iter().any(|qt| {
+                                qt == *nt || synonym_group(qt).contains(&nt.as_str())
+                            })
+                        })
+                        .count();
+                    let coverage = explained as f64 / name_set.len() as f64;
+                    score *= 1.0 + NAME_SPECIFICITY_W * coverage;
                 }
                 (score, *t)
             })
@@ -4509,6 +4532,84 @@ mod tests {
         assert!(hits.iter().any(|h| h["name"] == "rc__list_offerings"));
         assert!(!hits.iter().any(|h| h["name"] == "stripe__list_charges"));
         assert_eq!(total, 2);
+    }
+
+    /// Data-driven recall measurement (not a pass/fail unit test): set
+    /// STRIPE_TOOLS_JSON + STRIPE_INTENTS_JSON to fixture paths and run with
+    /// `--nocapture` to print recall@k of the REAL lexical ranker over a generated
+    /// tool set. No-ops (passes) when the env vars are unset, so CI is unaffected.
+    #[test]
+    fn recall_report() {
+        let (Ok(tp), Ok(ip)) = (
+            std::env::var("STRIPE_TOOLS_JSON"),
+            std::env::var("STRIPE_INTENTS_JSON"),
+        ) else {
+            return;
+        };
+        let server = std::env::var("RECALL_SERVER").unwrap_or_else(|_| "stripe".into());
+        let limit: usize = std::env::var("RECALL_LIMIT")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(25);
+        let tools: Vec<Value> =
+            serde_json::from_str(&std::fs::read_to_string(&tp).unwrap()).unwrap();
+        let intents: Vec<Value> =
+            serde_json::from_str(&std::fs::read_to_string(&ip).unwrap()).unwrap();
+        let (mut r5, mut r10, mut r25) = (0usize, 0usize, 0usize);
+        let mut misses: Vec<String> = Vec::new();
+        println!(
+            "\n=== recall @ limit {limit} over {} tools, {} intents (server={server}) ===",
+            tools.len(),
+            intents.len()
+        );
+        for it in &intents {
+            let q = it["q"].as_str().unwrap_or("");
+            let oks: Vec<&str> = it["ok"]
+                .as_array()
+                .map(|a| a.iter().filter_map(|v| v.as_str()).collect())
+                .unwrap_or_default();
+            let (hits, total) = search_catalog(&tools, q, Some(server.as_str()), limit);
+            let names: Vec<&str> = hits
+                .iter()
+                .filter_map(|h| h.get("name").and_then(|v| v.as_str()))
+                .collect();
+            let rank = oks
+                .iter()
+                .filter_map(|o| names.iter().position(|n| n == o))
+                .min();
+            match rank {
+                Some(r) => {
+                    if r < 5 {
+                        r5 += 1;
+                    }
+                    if r < 10 {
+                        r10 += 1;
+                    }
+                    r25 += 1;
+                    println!("  #{:<2} {:<34} -> {}", r + 1, q, names[r]);
+                }
+                None => {
+                    misses.push(q.to_string());
+                    println!(
+                        "  MISS   {:<34} (matched {total} tools; target not in top {limit})",
+                        q
+                    );
+                }
+            }
+        }
+        let n = intents.len().max(1) as f64;
+        println!(
+            "\n  recall@5:  {r5}/{}  ({:.0}%)\n  recall@10: {r10}/{}  ({:.0}%)\n  recall@{limit}: {r25}/{}  ({:.0}%)",
+            intents.len(),
+            100.0 * r5 as f64 / n,
+            intents.len(),
+            100.0 * r10 as f64 / n,
+            intents.len(),
+            100.0 * r25 as f64 / n
+        );
+        if !misses.is_empty() {
+            println!("  misses: {misses:?}");
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Search: specificity boost so the on-the-nose tool wins near-ties

The lazy-discovery lexical ranker sums the best hit per query token but never looks at a tool's *other* name tokens. So for "create customer," `create_customer` and `create_customer_session` score identically (both name-match every query token) and the tie breaks on arbitrary order. Real APIs are full of these sibling clusters (`create_customer`, `create_customer_session`, `create_customer_balance_transaction`, …), so the exact match often loses.

This adds a small **multiplicative** boost by *name coverage* — the fraction of a tool's name tokens the query explains. A name the query fully explains gets the full boost; a longer sibling with extra tokens gets less, so the tighter name ranks first.

- Multiplicative and capped (`NAME_SPECIFICITY_W = 0.35`) so it only separates near-ties, never overrides a stronger IDF keyword signal.
- Skipped on zero scores, so non-matches stay out.

### Measured (real ranker, 587-tool Stripe set, 20 realistic intents)
| | recall@5 | recall@10 |
|---|---|---|
| raw names, before | 75% | 90% |
| raw names, after | **80%** | 90% |
| curated names, after | **85%** | **95%** |

All 58 gateway tests pass, no regressions. Also lands `recall_report`: an env-gated, data-driven test (no-op in CI) that runs the real ranker over any generated tool set + intent fixtures, so we can measure recall for any server the same way.
