### PR TITLE
Proxy MCP request cancellation

### DIFF
--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -2837,6 +2837,67 @@ fn process_request(
     )
 }
 
+fn write_stdio_response(
+    stdout: &Arc<Mutex<std::io::Stdout>>,
+    response: &Value,
+    stdout_broken: &Arc<AtomicBool>,
+) -> bool {
+    let result = {
+        let mut out = stdout
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        writeln!(out, "{response}").and_then(|_| out.flush())
+    };
+    if let Err(err) = result {
+        stdout_broken.store(true, Ordering::SeqCst);
+        glog(&format!("stdio client write failed; stopping reader loop: {err}"));
+        return false;
+    }
+    true
+}
+
+fn handle_stdio_request(
+    state: GatewayState,
+    req: Value,
+    request_key: String,
+    search_guard: Arc<SearchGuard>,
+    confirm_guard: Arc<ConfirmGuard>,
+    cancel_registry: downstream::CancelRegistry,
+    stdout_broken: Arc<AtomicBool>,
+) {
+    let cancel_context = cancel_registry.context(request_key.clone());
+    // A panic in a handler must not kill the gateway: catch it, log it, and
+    // return a JSON-RPC internal error for this request unless the client
+    // cancelled it while it was in flight.
+    let response = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        process_request(
+            &state,
+            &req,
+            &search_guard,
+            &confirm_guard,
+            None,
+            Some(cancel_context),
+            None,
+        )
+    }))
+    .unwrap_or_else(|_| {
+        let id = req.get("id").cloned().unwrap_or(Value::Null);
+        glog("panic while handling a request; returned an internal error, gateway still up");
+        Some(error(id, -32603, "internal error"))
+    });
+
+    if cancel_registry.is_cancelled(&request_key) {
+        glog(&format!("suppressing response for cancelled request {request_key}"));
+        cancel_registry.finish_client_request(&request_key);
+        return;
+    }
+    cancel_registry.finish_client_request(&request_key);
+
+    if let Some(resp) = response {
+        let _ = write_stdio_response(&state.stdout, &resp, &stdout_broken);
+    }
+}
+
 /// Resolve the HTTP port. `--http [port]` on the command line wins; otherwise
 /// `CONDUIT_HTTP=<port>` is the direct env form, and a truthy `CONDUIT_HTTP`
 /// falls back to `CONDUIT_HTTP_PORT` or 8765. Absent everywhere -> stdio mode.
@@ -3142,11 +3203,12 @@ fn handle_http(
 /// an unauthenticated caller from forcing the gateway to buffer a huge body.
 const MAX_HTTP_BODY: u64 = 4 * 1024 * 1024;
 
-/// Cap on concurrently-handled HTTP requests (across both loopback listeners). Each
-/// in-flight request runs on its own worker thread; past this many, new requests are
-/// handled inline (serially) rather than spawning without bound. Sized well above any
-/// realistic local concurrency: the approval broker caps simultaneous holds at 64, and
-/// non-held calls finish in milliseconds, so this backstop is only ever a flood guard.
+/// Cap on concurrently-handled gateway requests. HTTP and stdio both use this
+/// worker backstop so their concurrency semantics do not drift. Past this many,
+/// new requests are handled inline (serially) rather than spawning without bound.
+/// Sized well above any realistic local concurrency: the approval broker caps
+/// simultaneous holds at 64, and non-held calls finish in milliseconds, so this
+/// backstop is only ever a flood guard.
 const MAX_HTTP_INFLIGHT: usize = 256;
 
 /// Parse a `Bearer <token>` Authorization value. Pure, so it's unit-testable.
@@ -3265,6 +3327,53 @@ impl Drop for InflightGuard {
     }
 }
 
+fn try_acquire_inflight(inflight: &Arc<AtomicUsize>) -> Option<InflightGuard> {
+    let mut current = inflight.load(Ordering::Relaxed);
+    loop {
+        if current >= MAX_HTTP_INFLIGHT {
+            return None;
+        }
+        match inflight.compare_exchange_weak(
+            current,
+            current + 1,
+            Ordering::AcqRel,
+            Ordering::Relaxed,
+        ) {
+            Ok(_) => return Some(InflightGuard(Arc::clone(inflight))),
+            Err(next) => current = next,
+        }
+    }
+}
+
+fn spawn_or_run_inflight<F>(
+    inflight: &Arc<AtomicUsize>,
+    job: F,
+) -> Option<std::thread::JoinHandle<()>>
+where
+    F: FnOnce() + Send + 'static,
+{
+    let Some(guard) = try_acquire_inflight(inflight) else {
+        job();
+        return None;
+    };
+    Some(std::thread::spawn(move || {
+        let _dec = guard;
+        job();
+    }))
+}
+
+fn reap_finished_workers(workers: &mut Vec<std::thread::JoinHandle<()>>) {
+    let mut i = 0;
+    while i < workers.len() {
+        if workers[i].is_finished() {
+            let handle = workers.swap_remove(i);
+            let _ = handle.join();
+        } else {
+            i += 1;
+        }
+    }
+}
+
 fn serve_http_loop(
     server: tiny_http::Server,
     state: GatewayState,
@@ -3274,27 +3383,13 @@ fn serve_http_loop(
 ) {
     let inflight = Arc::new(AtomicUsize::new(0));
     for request in server.incoming_requests() {
-        // Backstop against a pathological flood: never exceed the cap. At the cap we
-        // handle inline (degrading to serial for the overflow) rather than spawn
-        // unbounded threads or drop the request. Realistic local concurrency, bounded
-        // by the broker's own hold cap plus a handful of fast calls, stays far below it.
-        if inflight.load(Ordering::Relaxed) >= MAX_HTTP_INFLIGHT {
-            handle_connection(request, &state, &token, &search, &confirm);
-            continue;
-        }
-        inflight.fetch_add(1, Ordering::Relaxed);
-        let (state, token, search, confirm, inflight) = (
+        let (state, token, search, confirm) = (
             state.clone(),
             token.clone(),
             Arc::clone(&search),
             Arc::clone(&confirm),
-            Arc::clone(&inflight),
         );
-        std::thread::spawn(move || {
-            // Decrement on the way out even if a handler panics before the response
-            // (a panic outside handle_http's catch_unwind), so the count can't leak
-            // and wedge the pool at the cap.
-            let _dec = InflightGuard(inflight);
+        let _ = spawn_or_run_inflight(&inflight, move || {
             handle_connection(request, &state, &token, &search, &confirm);
         });
     }
@@ -3651,7 +3746,14 @@ fn main() {
     let search_guard = Arc::new(SearchGuard::default());
     let confirm_guard = Arc::new(ConfirmGuard::new());
     let cancel_registry = downstream::CancelRegistry::new();
+    let stdio_inflight = Arc::new(AtomicUsize::new(0));
+    let stdout_broken = Arc::new(AtomicBool::new(false));
+    let mut stdio_workers = Vec::new();
     for line in stdin.lock().lines() {
+        reap_finished_workers(&mut stdio_workers);
+        if stdout_broken.load(Ordering::SeqCst) {
+            break;
+        }
         let line = match line {
             Ok(l) => l,
             Err(_) => break,
@@ -3681,52 +3783,38 @@ fn main() {
             let _ = process_request(&state, &req, &search_guard, &confirm_guard, None, None, None);
             continue;
         };
-        cancel_registry.begin_client_request(request_key.clone());
+        if !cancel_registry.begin_client_request(request_key.clone()) {
+            gtrace(&format!("rejected duplicate in-flight request id {request_key}"));
+            let id = req.get("id").cloned().unwrap_or(Value::Null);
+            let resp = error(id, -32600, "duplicate in-flight request id");
+            if !write_stdio_response(&state.stdout, &resp, &stdout_broken) {
+                break;
+            }
+            continue;
+        }
 
         let state = state.clone();
         let search_guard = Arc::clone(&search_guard);
         let confirm_guard = Arc::clone(&confirm_guard);
         let cancel_registry = cancel_registry.clone();
-        std::thread::spawn(move || {
-            let cancel_context = cancel_registry.context(request_key.clone());
-            // A panic in a handler must not kill the gateway: catch it, log it, and
-            // return a JSON-RPC internal error for this request unless the client
-            // cancelled it while it was in flight.
-            let response = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                process_request(
-                    &state,
-                    &req,
-                    &search_guard,
-                    &confirm_guard,
-                    None,
-                    Some(cancel_context),
-                    None,
-                )
-            }))
-            .unwrap_or_else(|_| {
-                let id = req.get("id").cloned().unwrap_or(Value::Null);
-                glog(
-                    "panic while handling a request; returned an internal error, gateway still up",
-                );
-                Some(error(id, -32603, "internal error"))
-            });
-
-            if cancel_registry.is_cancelled(&request_key) {
-                glog(&format!("suppressing response for cancelled request {request_key}"));
-                cancel_registry.finish_client_request(&request_key);
-                return;
-            }
-            cancel_registry.finish_client_request(&request_key);
-
-            if let Some(resp) = response {
-                let mut out = state
-                    .stdout
-                    .lock()
-                    .unwrap_or_else(std::sync::PoisonError::into_inner);
-                let _ = writeln!(out, "{resp}");
-                let _ = out.flush();
-            }
-        });
+        let stdout_broken_for_worker = Arc::clone(&stdout_broken);
+        let job = move || {
+            handle_stdio_request(
+                state,
+                req,
+                request_key,
+                search_guard,
+                confirm_guard,
+                cancel_registry,
+                stdout_broken_for_worker,
+            );
+        };
+        if let Some(handle) = spawn_or_run_inflight(&stdio_inflight, job) {
+            stdio_workers.push(handle);
+        }
+    }
+    for worker in stdio_workers {
+        let _ = worker.join();
     }
 }
 
@@ -3915,6 +4003,19 @@ mod tests {
         // The slow call still completes correctly.
         let slow_resp = slow.join().unwrap();
         assert!(slow_resp.contains("done"), "slow response was: {slow_resp}");
+    }
+
+    #[test]
+    fn inflight_guard_caps_and_releases_workers() {
+        let inflight = Arc::new(AtomicUsize::new(0));
+        let guards: Vec<_> = (0..MAX_HTTP_INFLIGHT)
+            .map(|_| try_acquire_inflight(&inflight).expect("permit under cap"))
+            .collect();
+
+        assert!(try_acquire_inflight(&inflight).is_none());
+        drop(guards);
+        assert_eq!(inflight.load(Ordering::SeqCst), 0);
+        assert!(try_acquire_inflight(&inflight).is_some());
     }
 
     #[test]

--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -1446,6 +1446,7 @@ fn request_human_decision(mut req: approval::ApprovalRequest) -> approval::Appro
     decide_via_broker(desc, &mut req)
 }
 
+#[cfg(test)]
 #[allow(clippy::too_many_arguments)]
 fn handle_request(
     req: &Value,
@@ -1457,6 +1458,28 @@ fn handle_request(
     guard: &SearchGuard,
     confirm: &ConfirmGuard,
     allowed: Option<&std::collections::HashSet<String>>,
+    // The client this request is attributed to (a registered HTTP client's audit
+    // label), threaded in rather than stored on the shared router so concurrent
+    // requests can't cross-contaminate and dispatch needn't hold the router lock.
+    client: Option<&str>,
+) -> Option<Value> {
+    handle_request_with_cancel(
+        req, reg, router, cached, lazy, profile, guard, confirm, allowed, None, client,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn handle_request_with_cancel(
+    req: &Value,
+    reg: &Registry,
+    router: &Router,
+    cached: &[Value],
+    lazy: bool,
+    profile: Option<&str>,
+    guard: &SearchGuard,
+    confirm: &ConfirmGuard,
+    allowed: Option<&std::collections::HashSet<String>>,
+    cancel: Option<downstream::CancelContext>,
     // The client this request is attributed to (a registered HTTP client's audit
     // label), threaded in rather than stored on the shared router so concurrent
     // requests can't cross-contaminate and dispatch needn't hold the router lock.
@@ -2039,7 +2062,7 @@ fn handle_request(
             };
 
             let started = Instant::now();
-            match router.route_call(name, arguments) {
+            match router.route_call_with_cancel(name, arguments, cancel.clone()) {
                 Ok(mut result) => {
                     let ok = !result
                         .get("isError")
@@ -2145,7 +2168,7 @@ fn handle_request(
                     return Some(error(id, -32602, &format!("Toolport: no server owns resource '{uri}'")));
                 }
             }
-            match router.read_resource(uri) {
+            match router.read_resource_with_cancel(uri, cancel.clone()) {
                 Ok(mut result) => {
                     // Content defense: a resource is as attacker-controllable as a tool
                     // result, so scan it for injection and label any flagged text as data.
@@ -2193,7 +2216,7 @@ fn handle_request(
                     return Some(error(id, -32602, &format!("Toolport: no route for prompt '{name}'")));
                 }
             }
-            match router.get_prompt(name, arguments) {
+            match router.get_prompt_with_cancel(name, arguments, cancel.clone()) {
                 Ok(mut result) => {
                     // Content defense: a prompt's messages are attacker-controllable too;
                     // scan for injection and label any flagged text as data.
@@ -2672,6 +2695,33 @@ struct GatewayState {
     http: bool,
 }
 
+fn rpc_id_key(v: &Value) -> Option<String> {
+    match v {
+        Value::Number(n) => Some(n.to_string()),
+        Value::String(s) => Some(s.clone()),
+        _ => None,
+    }
+}
+
+fn request_id_key(req: &Value) -> Option<String> {
+    req.get("id").filter(|id| !id.is_null()).and_then(rpc_id_key)
+}
+
+fn cancellation_request_id(req: &Value) -> Option<String> {
+    if req.get("method").and_then(|m| m.as_str()) != Some("notifications/cancelled") {
+        return None;
+    }
+    req.get("params")
+        .and_then(|p| p.get("requestId"))
+        .and_then(rpc_id_key)
+}
+
+fn cancellation_reason(req: &Value) -> Option<&str> {
+    req.get("params")
+        .and_then(|p| p.get("reason"))
+        .and_then(|r| r.as_str())
+}
+
 /// One request in, one response out: wait for a cold cache / live router when
 /// the method needs it, self-heal an empty router on a call, then dispatch.
 /// Shared by the stdio loop and the HTTP server so they can't diverge.
@@ -2681,6 +2731,7 @@ fn process_request(
     guard: &SearchGuard,
     confirm: &ConfirmGuard,
     allowed: Option<&std::collections::HashSet<String>>,
+    cancel: Option<downstream::CancelContext>,
     client: Option<&str>,
 ) -> Option<Value> {
     let method = req.get("method").and_then(|m| m.as_str()).unwrap_or("");
@@ -2771,7 +2822,7 @@ fn process_request(
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner)
         .clone();
-    handle_request(
+    handle_request_with_cancel(
         req,
         &reg,
         &router,
@@ -2781,6 +2832,7 @@ fn process_request(
         guard,
         confirm,
         allowed,
+        cancel,
         client,
     )
 }
@@ -3056,7 +3108,7 @@ fn handle_http(
                 "method": "tools/call",
                 "params": { "name": name, "arguments": args }
             });
-            match process_request(state, &req, guard, confirm, allowed, client) {
+            match process_request(state, &req, guard, confirm, allowed, None, client) {
                 Some(resp) => {
                     if let Some(err) = resp.get("error") {
                         let msg = err.get("message").and_then(|m| m.as_str()).unwrap_or("error");
@@ -3596,8 +3648,9 @@ fn main() {
     let stdin = std::io::stdin();
     // stdio serves one client on one thread, so no sharing is needed, but the guards
     // are now interior-mutable (&self methods) to match the shared HTTP path.
-    let search_guard = SearchGuard::default();
-    let confirm_guard = ConfirmGuard::new();
+    let search_guard = Arc::new(SearchGuard::default());
+    let confirm_guard = Arc::new(ConfirmGuard::new());
+    let cancel_registry = downstream::CancelRegistry::new();
     for line in stdin.lock().lines() {
         let line = match line {
             Ok(l) => l,
@@ -3615,28 +3668,65 @@ fn main() {
             "request: {}",
             req.get("method").and_then(|m| m.as_str()).unwrap_or("")
         ));
-        // A panic in a handler must not unwind out of this loop and kill the gateway:
-        // stdio has no supervisor (unlike the HTTP listener, which catches per request),
-        // so one panic would drop the whole MCP connection and take every tool with it.
-        // Catch it, log it, and return a JSON-RPC internal error for this request.
-        let response = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            process_request(&state, &req, &search_guard, &confirm_guard, None, None)
-        }))
-        .unwrap_or_else(|_| {
-            let id = req.get("id").cloned().unwrap_or(Value::Null);
-            glog("panic while handling a request; returned an internal error, gateway still up");
-            Some(error(id, -32603, "internal error"))
-        });
-        if let Some(resp) = response {
-            let mut out = state
-                .stdout
-                .lock()
-                .unwrap_or_else(std::sync::PoisonError::into_inner);
-            if writeln!(out, "{resp}").is_err() {
-                break;
+        if let Some(cancel_id) = cancellation_request_id(&req) {
+            if cancel_registry.cancel(&cancel_id, cancellation_reason(&req)) {
+                glog(&format!("client cancelled in-flight request {cancel_id}"));
+            } else {
+                gtrace(&format!("ignored cancellation for unknown request {cancel_id}"));
             }
-            let _ = out.flush();
+            continue;
         }
+
+        let Some(request_key) = request_id_key(&req) else {
+            let _ = process_request(&state, &req, &search_guard, &confirm_guard, None, None, None);
+            continue;
+        };
+        cancel_registry.begin_client_request(request_key.clone());
+
+        let state = state.clone();
+        let search_guard = Arc::clone(&search_guard);
+        let confirm_guard = Arc::clone(&confirm_guard);
+        let cancel_registry = cancel_registry.clone();
+        std::thread::spawn(move || {
+            let cancel_context = cancel_registry.context(request_key.clone());
+            // A panic in a handler must not kill the gateway: catch it, log it, and
+            // return a JSON-RPC internal error for this request unless the client
+            // cancelled it while it was in flight.
+            let response = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                process_request(
+                    &state,
+                    &req,
+                    &search_guard,
+                    &confirm_guard,
+                    None,
+                    Some(cancel_context),
+                    None,
+                )
+            }))
+            .unwrap_or_else(|_| {
+                let id = req.get("id").cloned().unwrap_or(Value::Null);
+                glog(
+                    "panic while handling a request; returned an internal error, gateway still up",
+                );
+                Some(error(id, -32603, "internal error"))
+            });
+
+            if cancel_registry.is_cancelled(&request_key) {
+                glog(&format!("suppressing response for cancelled request {request_key}"));
+                cancel_registry.finish_client_request(&request_key);
+                return;
+            }
+            cancel_registry.finish_client_request(&request_key);
+
+            if let Some(resp) = response {
+                let mut out = state
+                    .stdout
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner);
+                let _ = writeln!(out, "{resp}");
+                let _ = out.flush();
+            }
+        });
     }
 }
 

--- a/src-tauri/src/downstream.rs
+++ b/src-tauri/src/downstream.rs
@@ -80,8 +80,14 @@ pub struct CancelRegistry {
 #[derive(Default)]
 struct CancelState {
     active: HashSet<String>,
-    cancelled: HashSet<String>,
+    cancelled: HashMap<String, CancelledRequest>,
     in_flight: HashMap<String, CancelEntry>,
+}
+
+#[derive(Clone, Default)]
+struct CancelledRequest {
+    reason: Option<String>,
+    forwarded: bool,
 }
 
 #[derive(Clone)]
@@ -107,9 +113,13 @@ impl CancelRegistry {
         Self::default()
     }
 
-    pub fn begin_client_request(&self, client_request_id: String) {
+    pub fn begin_client_request(&self, client_request_id: String) -> bool {
         let mut state = self.inner.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+        if state.active.contains(&client_request_id) {
+            return false;
+        }
         state.active.insert(client_request_id);
+        true
     }
 
     pub fn finish_client_request(&self, client_request_id: &str) {
@@ -127,18 +137,23 @@ impl CancelRegistry {
     /// stdio downstream, forward `notifications/cancelled` with that downstream id.
     /// Returns true when the referenced client request is still active.
     pub fn cancel(&self, client_request_id: &str, reason: Option<&str>) -> bool {
-        let entry = {
+        let forward = {
             let mut state = self.inner.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
             if !state.active.contains(client_request_id) {
                 return false;
             }
-            state.cancelled.insert(client_request_id.to_string());
-            state.in_flight.get(client_request_id).cloned()
-        };
-        if let Some(entry) = entry {
-            if let Err(err) = entry.send_cancel(reason) {
-                eprintln!("toolport: failed to forward cancellation downstream: {err}");
+            let reason = normalize_cancel_reason(reason);
+            let cancelled = state
+                .cancelled
+                .entry(client_request_id.to_string())
+                .or_default();
+            if reason.is_some() {
+                cancelled.reason = reason;
             }
+            prepare_cancel_forward(&mut state, client_request_id)
+        };
+        if let Some((entry, reason)) = forward {
+            entry.send_cancel_async(reason);
         }
         true
     }
@@ -148,20 +163,39 @@ impl CancelRegistry {
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
             .cancelled
-            .contains(client_request_id)
+            .contains_key(client_request_id)
+    }
+
+    fn forward_cancel_if_ready(&self, client_request_id: &str) {
+        let forward = {
+            let mut state = self.inner.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+            prepare_cancel_forward(&mut state, client_request_id)
+        };
+        if let Some((entry, reason)) = forward {
+            entry.send_cancel_async(reason);
+        }
     }
 
     fn register(&self, client_request_id: String, entry: CancelEntry) -> CancelGuard {
-        self.inner
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
-            .in_flight
-            .insert(client_request_id.clone(), entry);
+        let mut state = self.inner.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+        state.in_flight.insert(client_request_id.clone(), entry);
+        if let Some(cancelled) = state.cancelled.get_mut(&client_request_id) {
+            cancelled.forwarded = false;
+        }
         CancelGuard { client_request_id, registry: self.clone() }
     }
 }
 
 impl CancelEntry {
+    fn send_cancel_async(&self, reason: Option<String>) {
+        let entry = self.clone();
+        std::thread::spawn(move || {
+            if let Err(err) = entry.send_cancel(reason.as_deref()) {
+                eprintln!("toolport: failed to forward cancellation downstream: {err}");
+            }
+        });
+    }
+
     fn send_cancel(&self, reason: Option<&str>) -> Result<(), String> {
         let mut params = serde_json::Map::new();
         params.insert("requestId".to_string(), self.downstream_id.clone());
@@ -177,6 +211,25 @@ impl CancelEntry {
         writeln!(stdin, "{msg}").map_err(|e| e.to_string())?;
         stdin.flush().map_err(|e| e.to_string())
     }
+}
+
+fn normalize_cancel_reason(reason: Option<&str>) -> Option<String> {
+    reason
+        .filter(|s| !s.trim().is_empty())
+        .map(std::string::ToString::to_string)
+}
+
+fn prepare_cancel_forward(
+    state: &mut CancelState,
+    client_request_id: &str,
+) -> Option<(CancelEntry, Option<String>)> {
+    let cancelled = state.cancelled.get_mut(client_request_id)?;
+    if cancelled.forwarded {
+        return None;
+    }
+    let entry = state.in_flight.get(client_request_id)?.clone();
+    cancelled.forwarded = true;
+    Some((entry, cancelled.reason.clone()))
 }
 
 impl Drop for CancelGuard {
@@ -349,8 +402,13 @@ pub trait Transport: Send {
         &mut self,
         method: &str,
         params: Value,
-        _cancel: Option<CancelContext>,
+        cancel: Option<CancelContext>,
     ) -> Result<Value, TransportError> {
+        if cancel.is_some() {
+            downstream_trace(&format!(
+                "cancellation not supported for downstream transport method {method}"
+            ));
+        }
         self.request(method, params)
     }
     fn notify(&mut self, method: &str, params: Value) -> Result<(), TransportError>;
@@ -363,6 +421,26 @@ pub trait Transport: Send {
     /// tools during startup doesn't trigger a needless rebuild. Default no-op:
     /// transports without a live notification stream ignore it.
     fn arm_tools_watch(&mut self) {}
+}
+
+fn downstream_trace(msg: &str) {
+    if std::env::var_os("CONDUIT_DEBUG").is_none() {
+        return;
+    }
+    let Some(path) = crate::registry::gateway_log_path() else {
+        eprintln!("toolport: {msg}");
+        return;
+    };
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    if let Ok(mut file) = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+    {
+        let _ = writeln!(file, "{msg}");
+    }
 }
 
 /// Bitmask of which downstream list a `notifications/.../list_changed` announces.
@@ -950,7 +1028,7 @@ impl Transport for StdioTransport {
         }
         if let Some((registry, client_request_id)) = cancel_after_write {
             if registry.is_cancelled(&client_request_id) {
-                registry.cancel(&client_request_id, None);
+                registry.forward_cancel_if_ready(&client_request_id);
             }
         }
         let _cancel_guard = cancel_guard;
@@ -1502,13 +1580,38 @@ mod tests {
         let registry = CancelRegistry::new();
         assert!(!registry.cancel("7", Some("too slow")));
 
-        registry.begin_client_request("7".to_string());
+        assert!(registry.begin_client_request("7".to_string()));
         assert!(registry.cancel("7", Some("too slow")));
         assert!(registry.is_cancelled("7"));
 
         registry.finish_client_request("7");
         assert!(!registry.is_cancelled("7"));
         assert!(!registry.cancel("7", None));
+    }
+
+    #[test]
+    fn cancel_registry_rejects_duplicate_active_ids() {
+        let registry = CancelRegistry::new();
+        assert!(registry.begin_client_request("7".to_string()));
+        assert!(!registry.begin_client_request("7".to_string()));
+
+        registry.finish_client_request("7");
+        assert!(registry.begin_client_request("7".to_string()));
+    }
+
+    #[test]
+    fn cancel_registry_persists_reason_for_deferred_forward() {
+        let registry = CancelRegistry::new();
+        assert!(registry.begin_client_request("7".to_string()));
+        assert!(registry.cancel("7", Some("too slow")));
+
+        let state = registry
+            .inner
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let cancelled = state.cancelled.get("7").expect("cancelled state");
+        assert_eq!(cancelled.reason.as_deref(), Some("too slow"));
+        assert!(!cancelled.forwarded);
     }
 
     fn argv(parts: &[&str]) -> Vec<String> {

--- a/src-tauri/src/downstream.rs
+++ b/src-tauri/src/downstream.rs
@@ -6,6 +6,7 @@
 //! its tools. The transport is abstracted so the router can be tested with a mock
 //! instead of spawning real processes.
 
+use std::collections::{HashMap, HashSet};
 use std::io::{BufRead, BufReader, Read, Write};
 use std::path::Path;
 use std::process::{Child, ChildStdin, Command, Stdio};
@@ -66,6 +67,127 @@ pub enum TransportError {
         retry_after: Option<Duration>,
         message: String,
     },
+}
+
+/// Tracks client-side JSON-RPC request ids that are currently proxied to a
+/// downstream stdio server. A later `notifications/cancelled` from the client can
+/// forward cancellation to the downstream server's own request id.
+#[derive(Clone, Default)]
+pub struct CancelRegistry {
+    inner: Arc<Mutex<CancelState>>,
+}
+
+#[derive(Default)]
+struct CancelState {
+    active: HashSet<String>,
+    cancelled: HashSet<String>,
+    in_flight: HashMap<String, CancelEntry>,
+}
+
+#[derive(Clone)]
+struct CancelEntry {
+    stdin: Arc<Mutex<ChildStdin>>,
+    downstream_id: Value,
+}
+
+/// Cancellation context for one proxied client request.
+#[derive(Clone)]
+pub struct CancelContext {
+    client_request_id: String,
+    registry: CancelRegistry,
+}
+
+struct CancelGuard {
+    client_request_id: String,
+    registry: CancelRegistry,
+}
+
+impl CancelRegistry {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn begin_client_request(&self, client_request_id: String) {
+        let mut state = self.inner.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+        state.active.insert(client_request_id);
+    }
+
+    pub fn finish_client_request(&self, client_request_id: &str) {
+        let mut state = self.inner.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+        state.active.remove(client_request_id);
+        state.cancelled.remove(client_request_id);
+        state.in_flight.remove(client_request_id);
+    }
+
+    pub fn context(&self, client_request_id: String) -> CancelContext {
+        CancelContext { client_request_id, registry: self.clone() }
+    }
+
+    /// Mark an active client request as cancelled and, if it has already reached a
+    /// stdio downstream, forward `notifications/cancelled` with that downstream id.
+    /// Returns true when the referenced client request is still active.
+    pub fn cancel(&self, client_request_id: &str, reason: Option<&str>) -> bool {
+        let entry = {
+            let mut state = self.inner.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+            if !state.active.contains(client_request_id) {
+                return false;
+            }
+            state.cancelled.insert(client_request_id.to_string());
+            state.in_flight.get(client_request_id).cloned()
+        };
+        if let Some(entry) = entry {
+            if let Err(err) = entry.send_cancel(reason) {
+                eprintln!("toolport: failed to forward cancellation downstream: {err}");
+            }
+        }
+        true
+    }
+
+    pub fn is_cancelled(&self, client_request_id: &str) -> bool {
+        self.inner
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .cancelled
+            .contains(client_request_id)
+    }
+
+    fn register(&self, client_request_id: String, entry: CancelEntry) -> CancelGuard {
+        self.inner
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .in_flight
+            .insert(client_request_id.clone(), entry);
+        CancelGuard { client_request_id, registry: self.clone() }
+    }
+}
+
+impl CancelEntry {
+    fn send_cancel(&self, reason: Option<&str>) -> Result<(), String> {
+        let mut params = serde_json::Map::new();
+        params.insert("requestId".to_string(), self.downstream_id.clone());
+        if let Some(reason) = reason.filter(|s| !s.trim().is_empty()) {
+            params.insert("reason".to_string(), Value::String(reason.to_string()));
+        }
+        let msg = json!({
+            "jsonrpc": "2.0",
+            "method": "notifications/cancelled",
+            "params": Value::Object(params)
+        });
+        let mut stdin = self.stdin.lock().map_err(|_| "downstream stdin lock poisoned".to_string())?;
+        writeln!(stdin, "{msg}").map_err(|e| e.to_string())?;
+        stdin.flush().map_err(|e| e.to_string())
+    }
+}
+
+impl Drop for CancelGuard {
+    fn drop(&mut self) {
+        self.registry
+            .inner
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .in_flight
+            .remove(&self.client_request_id);
+    }
 }
 
 impl TransportError {
@@ -223,6 +345,14 @@ pub fn resolve_command(command: &str) -> String {
 /// A bidirectional JSON-RPC channel to one downstream server.
 pub trait Transport: Send {
     fn request(&mut self, method: &str, params: Value) -> Result<Value, TransportError>;
+    fn request_with_cancel(
+        &mut self,
+        method: &str,
+        params: Value,
+        _cancel: Option<CancelContext>,
+    ) -> Result<Value, TransportError> {
+        self.request(method, params)
+    }
     fn notify(&mut self, method: &str, params: Value) -> Result<(), TransportError>;
     /// Bound how long a single `request` waits for its response. Used to fail the
     /// connect handshake fast. Default no-op: transports with their own fixed
@@ -587,7 +717,7 @@ fn container_escape_flag(args: &[String]) -> Option<&str> {
 /// (a blocking `read_line` on an unresponsive child would otherwise hang forever).
 pub struct StdioTransport {
     child: Child,
-    stdin: ChildStdin,
+    stdin: Arc<Mutex<ChildStdin>>,
     rx: Receiver<String>,
     /// Tail of the child's stderr, drained on a background thread. A server that
     /// dies on startup (bad package name, missing API key) explains itself here,
@@ -682,7 +812,7 @@ impl StdioTransport {
         let mut child = cmd
             .spawn()
             .map_err(|e| format!("failed to spawn '{command}': {e}"))?;
-        let stdin = child.stdin.take().ok_or("no child stdin")?;
+        let stdin = Arc::new(Mutex::new(child.stdin.take().ok_or("no child stdin")?));
         let stdout = child.stdout.take().ok_or("no child stdout")?;
         let stderr = child.stderr.take().ok_or("no child stderr")?;
 
@@ -782,14 +912,48 @@ impl StdioTransport {
 
 impl Transport for StdioTransport {
     fn request(&mut self, method: &str, params: Value) -> Result<Value, TransportError> {
+        self.request_with_cancel(method, params, None)
+    }
+
+    fn request_with_cancel(
+        &mut self,
+        method: &str,
+        params: Value,
+        cancel: Option<CancelContext>,
+    ) -> Result<Value, TransportError> {
         let id = self.next_id;
         self.next_id += 1;
-        let msg = json!({ "jsonrpc": "2.0", "id": id, "method": method, "params": params });
+        let downstream_id = json!(id);
+        let msg = json!({ "jsonrpc": "2.0", "id": downstream_id.clone(), "method": method, "params": params });
+
         // A broken stdin pipe means the child is gone: a health failure, not a protocol error.
-        writeln!(self.stdin, "{msg}").map_err(|e| TransportError::Unavailable(e.to_string()))?;
-        self.stdin
-            .flush()
-            .map_err(|e| TransportError::Unavailable(e.to_string()))?;
+        let mut cancel_after_write = None;
+        let cancel_guard;
+        {
+            let mut stdin = self.stdin.lock().map_err(|_| {
+                TransportError::Unavailable("downstream stdin lock poisoned".into())
+            })?;
+            cancel_guard = if let Some(ctx) = cancel {
+                let client_request_id = ctx.client_request_id.clone();
+                let registry = ctx.registry.clone();
+                let guard = registry.register(
+                    client_request_id.clone(),
+                    CancelEntry { stdin: Arc::clone(&self.stdin), downstream_id },
+                );
+                cancel_after_write = Some((registry, client_request_id));
+                Some(guard)
+            } else {
+                None
+            };
+            writeln!(stdin, "{msg}").map_err(|e| TransportError::Unavailable(e.to_string()))?;
+            stdin.flush().map_err(|e| TransportError::Unavailable(e.to_string()))?;
+        }
+        if let Some((registry, client_request_id)) = cancel_after_write {
+            if registry.is_cancelled(&client_request_id) {
+                registry.cancel(&client_request_id, None);
+            }
+        }
+        let _cancel_guard = cancel_guard;
 
         // Read until the response with our id arrives, skipping notifications.
         // The deadline bounds the whole wait so an unresponsive server fails fast
@@ -818,7 +982,7 @@ impl Transport for StdioTransport {
                 Ok(v) => v,
                 Err(_) => continue,
             };
-            if value.get("id").and_then(|i| i.as_i64()) == Some(id) {
+            if ids_match(value.get("id"), Some(&json!(id))) {
                 if let Some(err) = value.get("error") {
                     return Err(TransportError::Fatal(err.to_string()));
                 }
@@ -829,8 +993,12 @@ impl Transport for StdioTransport {
 
     fn notify(&mut self, method: &str, params: Value) -> Result<(), TransportError> {
         let msg = json!({ "jsonrpc": "2.0", "method": method, "params": params });
-        writeln!(self.stdin, "{msg}").map_err(|e| TransportError::Fatal(e.to_string()))?;
-        self.stdin.flush().map_err(|e| TransportError::Fatal(e.to_string()))
+        let mut stdin = self
+            .stdin
+            .lock()
+            .map_err(|_| TransportError::Fatal("downstream stdin lock poisoned".into()))?;
+        writeln!(stdin, "{msg}").map_err(|e| TransportError::Fatal(e.to_string()))?;
+        stdin.flush().map_err(|e| TransportError::Fatal(e.to_string()))
     }
 
     fn set_read_timeout(&mut self, timeout: Duration) {
@@ -1229,20 +1397,52 @@ impl DownstreamServer {
     }
 
     pub fn call(&mut self, tool: &str, arguments: Value) -> Result<Value, TransportError> {
-        self.transport
-            .request("tools/call", json!({ "name": tool, "arguments": arguments }))
+        self.call_with_cancel(tool, arguments, None)
+    }
+
+    pub fn call_with_cancel(
+        &mut self,
+        tool: &str,
+        arguments: Value,
+        cancel: Option<CancelContext>,
+    ) -> Result<Value, TransportError> {
+        self.transport.request_with_cancel(
+            "tools/call",
+            json!({ "name": tool, "arguments": arguments }),
+            cancel,
+        )
     }
 
     /// Read one resource by its (original, downstream) uri.
     pub fn read_resource(&mut self, uri: &str) -> Result<Value, TransportError> {
+        self.read_resource_with_cancel(uri, None)
+    }
+
+    pub fn read_resource_with_cancel(
+        &mut self,
+        uri: &str,
+        cancel: Option<CancelContext>,
+    ) -> Result<Value, TransportError> {
         self.transport
-            .request("resources/read", json!({ "uri": uri }))
+            .request_with_cancel("resources/read", json!({ "uri": uri }), cancel)
     }
 
     /// Get one prompt by its (original, downstream) name.
     pub fn get_prompt(&mut self, name: &str, arguments: Value) -> Result<Value, TransportError> {
-        self.transport
-            .request("prompts/get", json!({ "name": name, "arguments": arguments }))
+        self.get_prompt_with_cancel(name, arguments, None)
+    }
+
+    pub fn get_prompt_with_cancel(
+        &mut self,
+        name: &str,
+        arguments: Value,
+        cancel: Option<CancelContext>,
+    ) -> Result<Value, TransportError> {
+        self.transport.request_with_cancel(
+            "prompts/get",
+            json!({ "name": name, "arguments": arguments }),
+            cancel,
+        )
     }
 }
 
@@ -1257,7 +1457,10 @@ fn extract_array(result: &Value, key: &str) -> Vec<Value> {
 
 #[cfg(test)]
 mod tests {
-    use super::{resolve_command, screen_resolved_addrs, screen_spawn_command, screen_spawn_env};
+    use super::{
+        resolve_command, screen_resolved_addrs, screen_spawn_command, screen_spawn_env,
+        CancelRegistry,
+    };
 
     #[test]
     fn ssrf_resolver_screens_resolved_addresses() {
@@ -1292,6 +1495,20 @@ mod tests {
     #[test]
     fn paths_with_extension_pass_through() {
         assert_eq!(resolve_command("C:\\tools\\foo.exe"), "C:\\tools\\foo.exe");
+    }
+
+    #[test]
+    fn cancel_registry_tracks_active_requests() {
+        let registry = CancelRegistry::new();
+        assert!(!registry.cancel("7", Some("too slow")));
+
+        registry.begin_client_request("7".to_string());
+        assert!(registry.cancel("7", Some("too slow")));
+        assert!(registry.is_cancelled("7"));
+
+        registry.finish_client_request("7");
+        assert!(!registry.is_cancelled("7"));
+        assert!(!registry.cancel("7", None));
     }
 
     fn argv(parts: &[&str]) -> Vec<String> {

--- a/src-tauri/src/router.rs
+++ b/src-tauri/src/router.rs
@@ -1253,7 +1253,7 @@ mod tests {
         let mut router = Router::new();
         router.add(ds);
         let registry = CancelRegistry::new();
-        registry.begin_client_request("99".to_string());
+        assert!(registry.begin_client_request("99".to_string()));
 
         let result = router
             .route_call_with_cancel(

--- a/src-tauri/src/router.rs
+++ b/src-tauri/src/router.rs
@@ -19,7 +19,8 @@ use std::time::{Duration, Instant};
 use serde_json::{json, Value};
 
 use crate::downstream::{
-    backoff_delay, DownstreamServer, TransportError, HTTP_MAX_RETRIES, HTTP_RETRY_CAP,
+    backoff_delay, CancelContext, DownstreamServer, TransportError, HTTP_MAX_RETRIES,
+    HTTP_RETRY_CAP,
 };
 use crate::registry::ToolOverride;
 
@@ -628,6 +629,15 @@ impl Router {
     /// server, so concurrent calls to different servers run in parallel while
     /// calls to the same server (one stdio pipe) serialize.
     pub fn route_call(&self, exposed_name: &str, arguments: Value) -> Result<Value, String> {
+        self.route_call_with_cancel(exposed_name, arguments, None)
+    }
+
+    pub fn route_call_with_cancel(
+        &self,
+        exposed_name: &str,
+        arguments: Value,
+        cancel: Option<CancelContext>,
+    ) -> Result<Value, String> {
         if let Some(reason) = self.blocked.get(exposed_name) {
             return Err(format!("tool '{exposed_name}' is {reason}"));
         }
@@ -637,7 +647,9 @@ impl Router {
             .cloned()
             .ok_or_else(|| format!("no route for tool '{exposed_name}'"))?;
         let slot = self.slot_for(&server_id)?;
-        self.call_with_retry(&slot, |server| server.call(&tool, arguments.clone()))
+        self.call_with_retry(&slot, |server| {
+            server.call_with_cancel(&tool, arguments.clone(), cancel.clone())
+        })
     }
 
     /// Every downstream resource, uris unchanged.
@@ -665,32 +677,53 @@ impl Router {
     /// Read a resource by uri from whichever server advertised it. `&self`: locks
     /// only the owning server (see `route_call`).
     pub fn read_resource(&self, uri: &str) -> Result<Value, String> {
+        self.read_resource_with_cancel(uri, None)
+    }
+
+    pub fn read_resource_with_cancel(
+        &self,
+        uri: &str,
+        cancel: Option<CancelContext>,
+    ) -> Result<Value, String> {
         let server_id = self
             .resource_routes
             .get(uri)
             .cloned()
             .ok_or_else(|| format!("no server owns resource '{uri}'"))?;
         let slot = self.slot_for(&server_id)?;
-        self.call_with_retry(&slot, |server| server.read_resource(uri))
+        self.call_with_retry(&slot, |server| {
+            server.read_resource_with_cancel(uri, cancel.clone())
+        })
     }
 
     /// Get a prompt by its exposed name, forwarding the server's real name.
     /// `&self`: locks only the owning server (see `route_call`).
     pub fn get_prompt(&self, exposed_name: &str, arguments: Value) -> Result<Value, String> {
+        self.get_prompt_with_cancel(exposed_name, arguments, None)
+    }
+
+    pub fn get_prompt_with_cancel(
+        &self,
+        exposed_name: &str,
+        arguments: Value,
+        cancel: Option<CancelContext>,
+    ) -> Result<Value, String> {
         let (server_id, name) = self
             .prompt_routes
             .get(exposed_name)
             .cloned()
             .ok_or_else(|| format!("no route for prompt '{exposed_name}'"))?;
         let slot = self.slot_for(&server_id)?;
-        self.call_with_retry(&slot, |server| server.get_prompt(&name, arguments.clone()))
+        self.call_with_retry(&slot, |server| {
+            server.get_prompt_with_cancel(&name, arguments.clone(), cancel.clone())
+        })
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::atomic::{AtomicU32, Ordering};
+    use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
     use std::sync::Arc;
     use std::time::{Duration, Instant};
 
@@ -806,7 +839,7 @@ mod tests {
         assert_eq!(schema["properties"]["alias"]["minLength"], 1);
         assert!(!serde_json::to_string(&schema).unwrap().contains("$ref"));
     }
-    use crate::downstream::{DownstreamServer, Transport};
+    use crate::downstream::{CancelRegistry, DownstreamServer, Transport};
 
     /// A fake downstream server: advertises `echo` + `add`, echoes calls back.
     struct MockTransport {
@@ -1169,6 +1202,70 @@ mod tests {
         let result = router.read_resource("postgres://readme").unwrap();
         assert_eq!(result["contents"][0]["text"], "postgres-body");
         assert!(router.read_resource("nope://x").is_err());
+    }
+
+    #[test]
+    fn route_call_passes_cancel_context_to_transport() {
+        struct CancelAware {
+            saw_cancel: Arc<AtomicBool>,
+        }
+
+        impl Transport for CancelAware {
+            fn request(&mut self, method: &str, _params: Value) -> Result<Value, TransportError> {
+                match method {
+                    "initialize" => Ok(json!({ "protocolVersion": "2025-06-18" })),
+                    "tools/list" => Ok(json!({ "tools": [{ "name": "echo", "description": "" }] })),
+                    other => Err(TransportError::Fatal(format!("unexpected method {other}"))),
+                }
+            }
+
+            fn request_with_cancel(
+                &mut self,
+                method: &str,
+                params: Value,
+                cancel: Option<CancelContext>,
+            ) -> Result<Value, TransportError> {
+                match method {
+                    "tools/call" => {
+                        self.saw_cancel.store(cancel.is_some(), Ordering::SeqCst);
+                        Ok(json!({
+                            "content": [{ "type": "text", "text": "ok" }],
+                            "isError": false
+                        }))
+                    }
+                    _ => self.request(method, params),
+                }
+            }
+
+            fn notify(&mut self, _method: &str, _params: Value) -> Result<(), TransportError> {
+                Ok(())
+            }
+        }
+
+        let saw_cancel = Arc::new(AtomicBool::new(false));
+        let ds = DownstreamServer::connect(
+            "s".into(),
+            Box::new(CancelAware {
+                saw_cancel: Arc::clone(&saw_cancel),
+            }),
+        )
+        .unwrap();
+        let mut router = Router::new();
+        router.add(ds);
+        let registry = CancelRegistry::new();
+        registry.begin_client_request("99".to_string());
+
+        let result = router
+            .route_call_with_cancel(
+                "s__echo",
+                json!({}),
+                Some(registry.context("99".to_string())),
+            )
+            .unwrap();
+
+        assert_eq!(result["content"][0]["text"], "ok");
+        assert!(saw_cancel.load(Ordering::SeqCst));
+        registry.finish_client_request("99");
     }
 
     #[test]


### PR DESCRIPTION
## What and why

Refs #166. This implements the request-cancellation quick-win slice without touching resource subscribe/unsubscribe, logging passthrough, or pagination.

- Tracks active client JSON-RPC request ids in the stdio gateway.
- Handles client `notifications/cancelled` notifications by forwarding cancellation to the selected downstream stdio server using the downstream request id.
- Bounds stdio request workers with the same `MAX_HTTP_INFLIGHT` / `InflightGuard` mechanism used by the HTTP loop, running inline once the cap is saturated.
- Moves downstream cancel forwarding off the stdin-reading thread so a blocked child stdin pipe cannot stop the gateway from reading more client messages.
- Rejects duplicate in-flight JSON-RPC ids, preserves cancellation reasons for deferred forwards, and drains stdio workers on stdin EOF.
- Suppresses responses for client requests that were cancelled while in flight.
- Keeps the HTTP gateway path unchanged. Downstream cancellation forwarding is stdio-only for now; remote HTTP transports emit a debug trace when cancellation is supplied but unsupported.

## Testing

- [x] `npm run build` passes
- [x] `npm run test` passes
- [x] `npm run audit:prod` passes
- [ ] `npm run test:rust` passes (not run as a full unfiltered command in this follow-up because the two existing `secrets::tests::master_key_*` tests have hung locally; see notes below)
- [ ] Ran the app (`npm run tauri dev`) and checked the change by hand

Additional validation run locally:

- `git diff --check` passed.
- `npm run format:check` passed.
- `npm run lint` exited 0 with existing warnings.
- `npx tsc --noEmit` passed.
- `npm run build:gateway` passed with an existing `unused_mut` warning in `src/downstream.rs`.
- `cargo test --manifest-path src-tauri/Cargo.toml cancel -- --nocapture` passed.
- `cargo test --manifest-path src-tauri/Cargo.toml inflight_guard -- --nocapture` passed.
- `cargo test --manifest-path src-tauri/Cargo.toml --test list_changed --test circuit_breaker` passed.
- `cargo test --manifest-path src-tauri/Cargo.toml --lib --bins --quiet -- --skip master_key_does_not_activate_file_backend --skip master_key_ensure_then_read_is_idempotent` passed: 282 lib tests passed, 4 ignored, 2 filtered out; 59 bin tests passed.

## Notes

- This intentionally does not claim to close #166; other listed quick-win slices remain.
- No secrets, keys, or personal paths are included in the diff.
- I used Codex assistance to prepare this patch.
