### PR TITLE
gateway: registry-driven discovery-mode toggle (lazy/grouped/full)

### DIFF
--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -215,12 +215,71 @@ fn disable_server_tool_def() -> Value {
 // there is no new execution surface. Enabled per-client via the env var; grouped
 // implies not-lazy (the lazy resolver only returns true for `=lazy`).
 
-/// True when this gateway runs in grouped discovery mode. Read fresh: the env var is
-/// process-constant and this is never on a hot path.
+/// The three tool-discovery modes. Resolved once at gateway start (env or registry)
+/// and cached in `DISCOVERY_MODE`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DiscoveryMode {
+    Lazy,
+    Grouped,
+    Full,
+}
+
+static DISCOVERY_MODE: std::sync::OnceLock<DiscoveryMode> = std::sync::OnceLock::new();
+
+/// Resolve the discovery mode: an explicit `CONDUIT_DISCOVERY` env var wins (per
+/// client), otherwise the registry's `discovery_mode` override, otherwise its
+/// `lazy_discovery` bool. A SET-but-unrecognized env value maps to `Full`, matching
+/// the pre-3-way behavior (env was `== "lazy"` ? lazy : not-lazy) so nothing regresses.
+fn resolve_discovery_mode() -> DiscoveryMode {
+    let env = std::env::var("CONDUIT_DISCOVERY").ok();
+    let reg = registry::load_resolved().ok();
+    resolve_mode_from(
+        env.as_deref(),
+        reg.as_ref().and_then(|r| r.discovery_mode.as_deref()),
+        reg.as_ref().map(|r| r.lazy_discovery).unwrap_or(true),
+    )
+}
+
+/// Pure precedence: env override, then the registry's `discovery_mode`, then its
+/// `lazy_discovery` bool. A SET env value that isn't lazy/grouped resolves to Full
+/// (exactly the old `env == "lazy" ? lazy : not-lazy`); an unrecognized registry
+/// override is ignored (falls through to the bool).
+fn resolve_mode_from(
+    env: Option<&str>,
+    registry_mode: Option<&str>,
+    lazy_discovery: bool,
+) -> DiscoveryMode {
+    if let Some(v) = env {
+        return match v.trim().to_ascii_lowercase().as_str() {
+            "lazy" => DiscoveryMode::Lazy,
+            "grouped" => DiscoveryMode::Grouped,
+            _ => DiscoveryMode::Full,
+        };
+    }
+    if let Some(m) = registry_mode {
+        match m.trim().to_ascii_lowercase().as_str() {
+            "grouped" => return DiscoveryMode::Grouped,
+            "full" => return DiscoveryMode::Full,
+            "lazy" => return DiscoveryMode::Lazy,
+            _ => {}
+        }
+    }
+    if lazy_discovery {
+        DiscoveryMode::Lazy
+    } else {
+        DiscoveryMode::Full
+    }
+}
+
+/// The resolved mode. Defaults to `Lazy` before `main` sets it (only unit tests, which
+/// don't run `main` and test the grouped helpers directly, ever observe that default).
+fn discovery_mode() -> DiscoveryMode {
+    DISCOVERY_MODE.get().copied().unwrap_or(DiscoveryMode::Lazy)
+}
+
+/// True when this gateway runs in grouped discovery mode (see [`grouped_tool_defs`]).
 fn grouped_discovery() -> bool {
-    std::env::var("CONDUIT_DISCOVERY")
-        .map(|v| v.eq_ignore_ascii_case("grouped"))
-        .unwrap_or(false)
+    discovery_mode() == DiscoveryMode::Grouped
 }
 
 /// The server prefix of a *namespaced* tool (`server__tool`). `None` for a bare name
@@ -3830,16 +3889,14 @@ fn main() {
         std::process::exit(0);
     }
 
-    // Lazy discovery resolves from an explicit env override first (per-client),
-    // then the registry's global setting. Reading the registry means lazy mode
-    // applies to EVERY client, including ones that don't forward env vars to the
-    // gateway process (e.g. Antigravity) or servers added by hand in a client UI.
-    let lazy = match std::env::var("CONDUIT_DISCOVERY") {
-        Ok(v) => v.eq_ignore_ascii_case("lazy"),
-        Err(_) => registry::load_resolved()
-            .map(|r| r.lazy_discovery)
-            .unwrap_or(true),
-    };
+    // Discovery mode resolves from an explicit env override first (per-client), then
+    // the registry (its `discovery_mode` override, else the `lazy_discovery` bool), so
+    // it applies to EVERY client, including ones that don't forward env vars to the
+    // gateway (e.g. Antigravity). Resolved once and cached; `lazy` is derived so its
+    // behavior is unchanged, and grouped mode reads the same cached value.
+    let mode = resolve_discovery_mode();
+    let _ = DISCOVERY_MODE.set(mode);
+    let lazy = matches!(mode, DiscoveryMode::Lazy);
     // Per-client scoping: this gateway exposes only the named profile's servers.
     let profile = std::env::var("CONDUIT_PROFILE")
         .ok()
@@ -5393,6 +5450,32 @@ mod tests {
         assert_eq!(grouped_help_target("toolport_status"), None);
         assert_eq!(grouped_help_target("help_"), None);
         assert_eq!(grouped_help_target("github__create"), None);
+    }
+
+    #[test]
+    fn discovery_mode_precedence_and_no_regression() {
+        use DiscoveryMode::*;
+        // Env override wins over everything (per-client).
+        assert_eq!(resolve_mode_from(Some("grouped"), Some("lazy"), true), Grouped);
+        assert_eq!(resolve_mode_from(Some("lazy"), None, false), Lazy);
+        assert_eq!(resolve_mode_from(Some("full"), Some("grouped"), true), Full);
+        assert_eq!(resolve_mode_from(Some(" GROUPED "), None, true), Grouped);
+        // Old behavior preserved: a SET-but-unrecognized/empty env is Full (was the
+        // `env == "lazy" ? lazy : not-lazy` branch), NOT a fall-through to the registry.
+        assert_eq!(resolve_mode_from(Some("typo"), Some("grouped"), true), Full);
+        assert_eq!(resolve_mode_from(Some(""), Some("grouped"), true), Full);
+
+        // No env: the registry override wins over the lazy_discovery bool.
+        assert_eq!(resolve_mode_from(None, Some("grouped"), true), Grouped);
+        assert_eq!(resolve_mode_from(None, Some("full"), true), Full);
+        assert_eq!(resolve_mode_from(None, Some("lazy"), false), Lazy);
+        // An unrecognized override is ignored, falling through to the bool.
+        assert_eq!(resolve_mode_from(None, Some("weird"), true), Lazy);
+
+        // BACK-COMPAT: no env, no discovery_mode override (every pre-existing registry)
+        // resolves to exactly the old lazy_discovery bool behavior.
+        assert_eq!(resolve_mode_from(None, None, true), Lazy);
+        assert_eq!(resolve_mode_from(None, None, false), Full);
     }
 
     #[test]

--- a/src-tauri/src/registry.rs
+++ b/src-tauri/src/registry.rs
@@ -240,6 +240,13 @@ pub struct Registry {
     /// Defaults on, since clients commonly cap the tool list.
     #[serde(default = "default_true")]
     pub lazy_discovery: bool,
+    /// Discovery-mode override: `"lazy"` | `"grouped"` | `"full"`. When set, it takes
+    /// precedence over `lazy_discovery`; `None` (the default, and every pre-existing
+    /// registry) falls back to that bool. An explicit `CONDUIT_DISCOVERY` env var still
+    /// overrides this. Lets a user pick grouped mode once - for weak/local models that
+    /// browse per-server instead of searching - instead of setting a per-client env var.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub discovery_mode: Option<String>,
     /// Opt-in agent control: when true, an agent may turn servers on or off via
     /// the gateway's `conduit_enable_server` / `conduit_disable_server` tools.
     /// Off by default. The `deny_destructive` safety switch is never agent-
@@ -369,6 +376,7 @@ impl Default for Registry {
             pinned_tools: HashMap::new(),
             quarantine_on_drift: false,
             lazy_discovery: true,
+            discovery_mode: None,
             allow_agent_control: false,
             integrity_check: true,
             content_defense: true,
@@ -625,6 +633,25 @@ impl Registry {
     /// Set lazy discovery mode (gateway exposes meta-tools vs the full catalog).
     pub fn set_lazy_discovery(&mut self, lazy: bool) {
         self.lazy_discovery = lazy;
+    }
+
+    /// Set the discovery-mode override. `"lazy"`/`"grouped"`/`"full"` are honored;
+    /// any other value (including clearing to the empty string) resets to `None`, so
+    /// resolution falls back to `lazy_discovery`. Keeps `lazy_discovery` in sync for
+    /// the "lazy"/"full" cases so an older gateway reading only that bool still agrees.
+    pub fn set_discovery_mode(&mut self, mode: &str) {
+        match mode.trim().to_ascii_lowercase().as_str() {
+            "lazy" => {
+                self.discovery_mode = Some("lazy".into());
+                self.lazy_discovery = true;
+            }
+            "full" => {
+                self.discovery_mode = Some("full".into());
+                self.lazy_discovery = false;
+            }
+            "grouped" => self.discovery_mode = Some("grouped".into()),
+            _ => self.discovery_mode = None,
+        }
     }
 
     /// Turn live request/response inspection on or off. When on, the gateway
@@ -1203,6 +1230,35 @@ mod tests {
     fn cannot_remove_last_profile() {
         let mut r = Registry::default();
         assert!(r.remove_profile("default").is_err());
+    }
+
+    #[test]
+    fn discovery_mode_setter_and_backcompat() {
+        let mut r = Registry::default();
+        // Absent by default (and every pre-existing registry).
+        assert_eq!(r.discovery_mode, None);
+        assert!(r.lazy_discovery);
+
+        r.set_discovery_mode("grouped");
+        assert_eq!(r.discovery_mode.as_deref(), Some("grouped"));
+        // grouped doesn't touch the bool; lazy/full keep it in sync for old gateways.
+        r.set_discovery_mode("full");
+        assert_eq!(r.discovery_mode.as_deref(), Some("full"));
+        assert!(!r.lazy_discovery);
+        r.set_discovery_mode("lazy");
+        assert_eq!(r.discovery_mode.as_deref(), Some("lazy"));
+        assert!(r.lazy_discovery);
+        // An unknown value clears the override (falls back to lazy_discovery).
+        r.set_discovery_mode("nonsense");
+        assert_eq!(r.discovery_mode, None);
+
+        // Serde: None is skipped, so a default registry serializes exactly as before
+        // (no new key), and that JSON - which lacks the field, like every old registry -
+        // round-trips back to None.
+        let json = serde_json::to_string(&Registry::default()).unwrap();
+        assert!(!json.contains("discovery_mode"), "None must not be serialized");
+        let back: Registry = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.discovery_mode, None);
     }
 
     #[test]


### PR DESCRIPTION
Follow-up to the grouped discovery mode (b8cbe96). Adds a registry `discovery_mode` override so lazy/grouped/full can be selected per install and applies to **every** client, not just ones that forward `CONDUIT_DISCOVERY` to the gateway.

- `DiscoveryMode { Lazy, Grouped, Full }` resolved once at startup (pure `resolve_mode_from`), cached in a `OnceLock`.
- `registry`: `discovery_mode: Option<String>` + `set_discovery_mode`.
- Env `CONDUIT_DISCOVERY` still takes precedence; `lazy` derived so existing behavior is unchanged when unset.

Tested: 345 tests pass (282 lib + 63 gateway).