### PR TITLE
gateway: HIL approval-broker reliability + decision audit trail

### DIFF
--- a/src-tauri/src/approval.rs
+++ b/src-tauri/src/approval.rs
@@ -77,13 +77,21 @@ pub enum ApprovalDecision {
     Approved,
     /// A human denied; the call is refused.
     Denied,
-    /// No human decided in time (fail-closed); the caller treats this as a deny.
+    /// A human was asked but did not decide within the fail-closed window; treated as a deny.
     Timeout,
+    /// The gateway could not reach a live approval broker: no endpoint descriptor, a dead
+    /// endpoint, or the transport failed before the request was ever handed off. Distinct
+    /// from [`Timeout`] (a human *was* asked and didn't answer) so the agent-facing message
+    /// and any audit can tell "the approval service is down" apart from "you didn't approve
+    /// in time". Still fail-closed - it never lets the call proceed. The broker never sends
+    /// this; it is only ever produced gateway-side.
+    Unreachable,
 }
 
 impl ApprovalDecision {
     /// The security-critical predicate: ONLY an explicit human approval lets the call
-    /// proceed. Denied, Timeout, and (at the call site) any transport error all block.
+    /// proceed. Denied, Timeout, Unreachable, and (at the call site) any transport error
+    /// all block.
     pub fn is_approved(self) -> bool {
         matches!(self, ApprovalDecision::Approved)
     }
@@ -147,6 +155,19 @@ mod tests {
         assert!(ApprovalDecision::Approved.is_approved());
         assert!(!ApprovalDecision::Denied.is_approved());
         assert!(!ApprovalDecision::Timeout.is_approved());
+        // Unreachable is fail-closed exactly like the other non-approvals.
+        assert!(!ApprovalDecision::Unreachable.is_approved());
+    }
+
+    #[test]
+    fn unreachable_is_a_distinct_serde_variant() {
+        // The variant must round-trip (it flows through the same decision type), and be
+        // distinct from Timeout so callers can tell the two failure modes apart.
+        let s = serde_json::to_string(&ApprovalDecision::Unreachable).unwrap();
+        assert_eq!(s, "\"unreachable\"");
+        let back: ApprovalDecision = serde_json::from_str(&s).unwrap();
+        assert_eq!(back, ApprovalDecision::Unreachable);
+        assert_ne!(ApprovalDecision::Unreachable, ApprovalDecision::Timeout);
     }
 
     #[test]

--- a/src-tauri/src/approval_broker.rs
+++ b/src-tauri/src/approval_broker.rs
@@ -188,14 +188,31 @@ pub fn start(app: AppHandle) -> ApprovalBroker {
                         endpoint: format!("127.0.0.1:{port}"),
                         token,
                     };
+                    let path = dir.join(ENDPOINT_FILE);
                     // A stale descriptor (app crashed) points at a dead port, so a gateway
-                    // connect fails and denies - fail-closed either way.
+                    // connect fails and denies - fail-closed either way. The gateway also
+                    // re-reads the descriptor and retries once, which self-heals the case
+                    // where the app restarted and rebound to a new port.
                     // Written via atomic_write so the HITL endpoint + auth token land
                     // owner-only (0600) on Unix rather than world-readable: a same-user
                     // process reading the token could otherwise spoof approval decisions.
                     let _ = crate::registry::atomic_write(
-                        &dir.join(ENDPOINT_FILE),
+                        &path,
                         &serde_json::to_string(&desc).unwrap_or_default(),
+                    );
+                    // Record WHERE we published, into the same always-on log the gateway
+                    // writes its `dir_resolution=` line to. If a client-spawned gateway
+                    // resolves the data dir differently from the app (MSIX virtualization,
+                    // a differently-spelled HOME), that mismatch is now a one-line read
+                    // instead of a multi-hour hunt - it was the root cause of a live
+                    // "HITL blocks every call but no prompt appears" incident.
+                    log_broker_event(&format!(
+                        "bound 127.0.0.1:{port}; endpoint published at {}",
+                        path.display()
+                    ));
+                } else {
+                    log_broker_event(
+                        "conduit_dir() unavailable; endpoint NOT published (HITL fails closed)",
                     );
                 }
                 let accept_broker = broker.clone();
@@ -211,6 +228,30 @@ pub fn start(app: AppHandle) -> ApprovalBroker {
         Err(_) => { /* inert broker; HITL never fires, gateways fail-closed */ }
     }
     broker
+}
+
+/// Append a line to the shared, always-on gateway log, so the broker's bind/publish
+/// location sits right next to the gateway's `dir_resolution=` line. Best-effort: a logging
+/// failure never touches an approval decision.
+fn log_broker_event(msg: &str) {
+    if let Some(path) = crate::registry::gateway_log_path() {
+        use std::io::Write;
+        if let Ok(mut f) = std::fs::OpenOptions::new().create(true).append(true).open(path) {
+            let _ = writeln!(f, "[broker] {msg}");
+        }
+    }
+}
+
+/// Best-effort removal of the endpoint descriptor on app shutdown, so a gateway that dials
+/// after the app is gone reads no descriptor (a clean `Unreachable`) instead of connecting
+/// to a dead port left behind. Safe to call when none exists. Call ONLY on final exit, not
+/// on a cancelable exit-request: while the broker is still bound the descriptor must stand.
+pub fn clear_endpoint() {
+    if let Some(dir) = crate::registry::conduit_dir() {
+        if std::fs::remove_file(dir.join(ENDPOINT_FILE)).is_ok() {
+            log_broker_event("endpoint descriptor cleared on shutdown");
+        }
+    }
 }
 
 /// Serve one gateway connection: read the request, authenticate it, park it for a human

--- a/src-tauri/src/audit.rs
+++ b/src-tauri/src/audit.rs
@@ -87,6 +87,106 @@ pub fn record_held(server: &str, tool: &str, client: Option<&str>) {
     write_line(&entry);
 }
 
+/// Build the audit entry for a gated HITL decision. Pure (no I/O) so it's unit-testable.
+/// Kept `ok:true` + `held:true` so it stays out of the error rate and the existing
+/// held-row UI renders it unchanged; the added fields (`kind`, `reason`, `decision`,
+/// `argsHash`) let a governance / Approvals view tell *why* a call was gated and *which*
+/// way it resolved (denied vs no-response vs unreachable) apart - which the old flat
+/// `record_held` collapsed into one indistinguishable record. `reason` is the snake_case
+/// [`crate::approval::ApprovalReason`]; `decision` is `approved` | `denied` | `no_response`
+/// | `unreachable`. The RAW arguments are never stored - only `argsHash` - so the log
+/// proves which exact call was decided without persisting secrets/PII from arguments.
+fn decision_entry(
+    server: &str,
+    tool: &str,
+    client: Option<&str>,
+    reason: &str,
+    decision: &str,
+    args_hash: &str,
+    duration_ms: Option<u64>,
+) -> Value {
+    let mut entry = json!({
+        "ts": epoch_millis() as u64,
+        "server": server,
+        "tool": tool,
+        "ok": true,
+        "held": true,
+        "kind": "approval",
+        "reason": reason,
+        "decision": decision,
+        "argsHash": args_hash,
+    });
+    if let Some(ms) = duration_ms {
+        entry["durationMs"] = json!(ms);
+    }
+    if let Some(c) = client.filter(|c| !c.is_empty()) {
+        entry["client"] = json!(c);
+    }
+    entry
+}
+
+/// Record a gated HITL decision (the human approved/denied it, it timed out, or the
+/// broker was unreachable). Replaces the flat `record_held` on the approval path so the
+/// audit can distinguish the outcomes. Hashes the arguments; never stores them raw.
+pub fn record_decision(
+    server: &str,
+    tool: &str,
+    client: Option<&str>,
+    reason: &str,
+    decision: &str,
+    args: &Value,
+    duration_ms: Option<u64>,
+) {
+    write_line(&decision_entry(
+        server,
+        tool,
+        client,
+        reason,
+        decision,
+        &args_hash(args),
+        duration_ms,
+    ));
+}
+
+/// A stable SHA-256 (hex) of a call's arguments over a canonical JSON serialization
+/// (object keys sorted recursively), so the same logical call always hashes the same
+/// regardless of key order. This is the content-binding foundation: it proves "the exact
+/// call that was approved is the one that ran" without persisting the arguments themselves.
+pub fn args_hash(value: &Value) -> String {
+    use sha2::{Digest, Sha256};
+    let mut hasher = Sha256::new();
+    hasher.update(canonical_json(value).as_bytes());
+    hasher.finalize().iter().map(|b| format!("{b:02x}")).collect()
+}
+
+/// Serialize `value` to canonical JSON: object keys sorted recursively so the string (and
+/// therefore its hash) is independent of key insertion order. Scalars defer to serde's
+/// stringification; only object key ordering is normalized.
+fn canonical_json(value: &Value) -> String {
+    match value {
+        Value::Object(map) => {
+            let mut keys: Vec<&String> = map.keys().collect();
+            keys.sort();
+            let inner: Vec<String> = keys
+                .into_iter()
+                .map(|k| {
+                    format!(
+                        "{}:{}",
+                        serde_json::to_string(k).unwrap_or_default(),
+                        canonical_json(&map[k])
+                    )
+                })
+                .collect();
+            format!("{{{}}}", inner.join(","))
+        }
+        Value::Array(arr) => {
+            let inner: Vec<String> = arr.iter().map(canonical_json).collect();
+            format!("[{}]", inner.join(","))
+        }
+        other => other.to_string(),
+    }
+}
+
 /// Build the audit entry for an agent-control server toggle. Pure (no I/O) so the
 /// scope-proof invariant is unit-testable: on a denied out-of-scope attempt the lookup
 /// never resolves the target, so `resolvedServerId` is null and the record can't reveal
@@ -355,6 +455,10 @@ const CSV_COLUMNS: &[&str] = &[
     "client",
     "ok",
     "held",
+    "kind",
+    "reason",
+    "decision",
+    "argsHash",
     "durationMs",
     "action",
     "error",
@@ -407,7 +511,7 @@ mod tests {
         })];
         let csv = to_csv(&entries);
         assert!(csv.starts_with(
-            "ts,server,tool,client,ok,held,durationMs,action,error\r\n"
+            "ts,server,tool,client,ok,held,kind,reason,decision,argsHash,durationMs,action,error\r\n"
         ));
         assert!(csv.contains("\"gh\""));
         assert!(csv.contains("\"search\""));
@@ -537,5 +641,67 @@ mod tests {
         // Blank lines are dropped.
         assert_eq!(trimmed_tail("a\n\n\nb\n", 5), "a\nb\n");
         assert_eq!(trimmed_tail("", 5), "");
+    }
+
+    #[test]
+    fn decision_entry_records_outcome_and_never_stores_raw_args() {
+        let e = decision_entry(
+            "neon",
+            "delete_branch",
+            Some("claude"),
+            "destructive",
+            "unreachable",
+            "deadbeef",
+            Some(1234),
+        );
+        assert_eq!(e["kind"], "approval");
+        assert_eq!(e["reason"], "destructive");
+        assert_eq!(e["decision"], "unreachable");
+        assert_eq!(e["argsHash"], "deadbeef");
+        assert_eq!(e["durationMs"], 1234);
+        assert_eq!(e["client"], "claude");
+        // Held (didn't run) but ok:true so it stays out of the error rate.
+        assert_eq!(e["held"], true);
+        assert_eq!(e["ok"], true);
+        // The record is a hash + metadata only: raw arguments must never be present.
+        assert!(e.get("arguments").is_none());
+
+        // A distinct decision is distinguishable in the log - the whole point vs record_held.
+        let denied = decision_entry("s", "t", None, "untrusted_source", "denied", "h", None);
+        assert_eq!(denied["decision"], "denied");
+        assert_eq!(denied["reason"], "untrusted_source");
+        // Unattributed call omits the client field entirely.
+        assert!(denied.get("client").is_none());
+        // durationMs is optional.
+        assert!(denied.get("durationMs").is_none());
+    }
+
+    #[test]
+    fn args_hash_is_stable_across_key_order_and_binds_to_content() {
+        // Key order must not change the hash (content-binding needs a canonical form).
+        assert_eq!(
+            args_hash(&json!({ "a": 1, "b": [2, 3], "c": { "x": 1, "y": 2 } })),
+            args_hash(&json!({ "c": { "y": 2, "x": 1 }, "b": [2, 3], "a": 1 })),
+        );
+        // Different content -> different hash.
+        assert_ne!(
+            args_hash(&json!({ "table": "users" })),
+            args_hash(&json!({ "table": "orders" })),
+        );
+        // Array order IS significant (it's part of the content).
+        assert_ne!(args_hash(&json!([1, 2])), args_hash(&json!([2, 1])));
+        // It's a SHA-256: 64 lowercase hex chars, and it never echoes the raw value.
+        let h = args_hash(&json!({ "secret": "hunter2" }));
+        assert_eq!(h.len(), 64);
+        assert!(h.chars().all(|c| c.is_ascii_hexdigit()));
+        assert!(!h.contains("hunter2"));
+    }
+
+    #[test]
+    fn canonical_json_sorts_object_keys_recursively() {
+        assert_eq!(
+            canonical_json(&json!({ "b": 1, "a": { "d": 4, "c": 3 } })),
+            r#"{"a":{"c":3,"d":4},"b":1}"#,
+        );
     }
 }

--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -1519,38 +1519,106 @@ fn read_endpoint_descriptor() -> Option<approval::EndpointDescriptor> {
     serde_json::from_str(&raw).ok()
 }
 
-/// Ask the app broker for a human decision on `req`. FAIL-CLOSED: a missing endpoint, a
-/// failed connect, any I/O error, or a read timeout all return `Timeout` (a deny). The
-/// arguments travel over the socket and never touch disk. Transport is loopback TCP +
-/// token for now; hardening to an OS-permissioned named-pipe / uds is a follow-up.
+/// The outcome of a single dial to the approval broker. Separating "we never reached a
+/// live broker" from "a broker answered" lets the caller retry a *stale* endpoint (the app
+/// just restarted and rebound to a new port) without ever re-prompting a human who was
+/// already asked.
+enum BrokerAttempt {
+    /// A broker received the request and answered (Approved / Denied / Timeout).
+    Decided(approval::ApprovalDecision),
+    /// We never handed the request to a live broker: no descriptor, connect refused, or the
+    /// transport failed before the request went across. No human was asked, so a retry
+    /// against a freshly-read descriptor is safe.
+    Unreachable,
+}
+
+/// One dial to the broker described by `desc`. FAIL-CLOSED throughout: the arguments travel
+/// over the socket and never touch disk. Transport is loopback TCP + token for now;
+/// hardening to an OS-permissioned named-pipe / uds is a follow-up.
+///
+/// The key invariant: `Unreachable` is returned ONLY when the request never reached a
+/// broker (so no human saw it). Once the request is written, any later failure - including
+/// the read timeout that means "the human didn't answer" - is a `Decided(Timeout)`, so we
+/// never retry in a way that could double-prompt.
+fn try_decide_once(
+    desc: Option<approval::EndpointDescriptor>,
+    req: &mut approval::ApprovalRequest,
+) -> BrokerAttempt {
+    use std::io::{BufRead, BufReader, Write};
+    use std::net::TcpStream;
+    let Some(desc) = desc else { return BrokerAttempt::Unreachable };
+    req.token = desc.token.clone();
+    let Ok(mut stream) = TcpStream::connect(&desc.endpoint) else {
+        return BrokerAttempt::Unreachable;
+    };
+    let _ = stream.set_write_timeout(Some(Duration::from_secs(10)));
+    let _ = stream.set_read_timeout(Some(Duration::from_secs(approval::DEFAULT_TIMEOUT_SECS)));
+    let Ok(line) = serde_json::to_string(req) else {
+        // We connected but can't serialize our own request: not a reachability problem, so
+        // don't spin on retry. Fail closed.
+        return BrokerAttempt::Decided(approval::ApprovalDecision::Timeout);
+    };
+    if stream.write_all(line.as_bytes()).is_err() || stream.write_all(b"\n").is_err() {
+        // The request never made it across, so no human was asked: safe to re-dial.
+        return BrokerAttempt::Unreachable;
+    }
+    let _ = stream.flush();
+    let mut resp = String::new();
+    match BufReader::new(stream).read_line(&mut resp) {
+        // Connected and the peer closed with no answer: not a healthy broker. No human was
+        // shown a prompt (the broker's pre-prompt reject paths close silently), so re-dial.
+        Ok(0) => BrokerAttempt::Unreachable,
+        Ok(_) => {
+            let t = resp.trim();
+            if t.is_empty() {
+                BrokerAttempt::Unreachable
+            } else {
+                // A parseable decision is authoritative; an unparseable line is fail-closed
+                // as a Timeout (a real broker answered, so this is not a retry case).
+                BrokerAttempt::Decided(
+                    serde_json::from_str::<approval::ApprovalDecision>(t)
+                        .unwrap_or(approval::ApprovalDecision::Timeout),
+                )
+            }
+        }
+        // A read error AFTER we sent the request is the "human didn't answer in time" path
+        // (read timeout) or a mid-wait drop. Either way the broker had our request, so this
+        // is a genuine no-decision Timeout - never retry (that would re-prompt).
+        Err(_) => BrokerAttempt::Decided(approval::ApprovalDecision::Timeout),
+    }
+}
+
+/// Ask the app broker for a human decision on `req`, reading the endpoint descriptor once.
+/// Collapses an unreachable broker to the `Unreachable` decision (still fail-closed). Kept
+/// as a thin, dependency-free entry point for unit tests; `request_human_decision` is the
+/// production path with the self-healing retry.
 fn decide_via_broker(
     desc: Option<approval::EndpointDescriptor>,
     req: &mut approval::ApprovalRequest,
 ) -> approval::ApprovalDecision {
-    use std::io::{BufRead, BufReader, Write};
-    use std::net::TcpStream;
-    let deny = approval::ApprovalDecision::Timeout;
-    let Some(desc) = desc else { return deny };
-    req.token = desc.token.clone();
-    let Ok(mut stream) = TcpStream::connect(&desc.endpoint) else { return deny };
-    let _ = stream.set_write_timeout(Some(Duration::from_secs(10)));
-    let _ = stream.set_read_timeout(Some(Duration::from_secs(approval::DEFAULT_TIMEOUT_SECS)));
-    let Ok(line) = serde_json::to_string(req) else { return deny };
-    if stream.write_all(line.as_bytes()).is_err() || stream.write_all(b"\n").is_err() {
-        return deny;
+    match try_decide_once(desc, req) {
+        BrokerAttempt::Decided(d) => d,
+        BrokerAttempt::Unreachable => approval::ApprovalDecision::Unreachable,
     }
-    let _ = stream.flush();
-    let mut resp = String::new();
-    if BufReader::new(stream).read_line(&mut resp).is_err() || resp.trim().is_empty() {
-        return deny;
-    }
-    serde_json::from_str::<approval::ApprovalDecision>(resp.trim()).unwrap_or(deny)
 }
 
 /// Hold a gated tool call until a human decides via the Toolport app (or it fails closed).
+///
+/// If the first dial can't reach a live broker, re-read the descriptor and retry once: the
+/// app may have just restarted and rebound to a new port, leaving the descriptor we first
+/// read stale. This self-heals that race without ever failing open - two unreachable dials
+/// return `Unreachable`, which is still a deny.
 fn request_human_decision(mut req: approval::ApprovalRequest) -> approval::ApprovalDecision {
-    let desc = read_endpoint_descriptor();
-    decide_via_broker(desc, &mut req)
+    match try_decide_once(read_endpoint_descriptor(), &mut req) {
+        BrokerAttempt::Decided(d) => d,
+        BrokerAttempt::Unreachable => match try_decide_once(read_endpoint_descriptor(), &mut req) {
+            BrokerAttempt::Decided(d) => d,
+            BrokerAttempt::Unreachable => {
+                gtrace("approval broker unreachable after retry; failing closed (Unreachable)");
+                approval::ApprovalDecision::Unreachable
+            }
+        },
+    }
 }
 
 #[cfg(test)]
@@ -2137,6 +2205,7 @@ fn handle_request_with_cancel(
                     .map(|s| matches!(s.source.as_deref(), Some("shared") | Some("registry")))
                     .unwrap_or(false);
                 if let Some(reason) = approval::gate_reason(true, is_dest, untrusted) {
+                    let t0 = std::time::Instant::now();
                     let decision = request_human_decision(approval::ApprovalRequest {
                         token: String::new(),
                         id: new_correlation_id(),
@@ -2146,13 +2215,35 @@ fn handle_request_with_cancel(
                         reason,
                         arguments: arguments.clone(),
                     });
+                    let held_ms = t0.elapsed().as_millis() as u64;
                     if !decision.is_approved() {
-                        let why = if decision == approval::ApprovalDecision::Denied {
-                            "was denied by a human reviewer"
-                        } else {
-                            "was not approved in time (the Toolport app may be closed)"
+                        let why = match decision {
+                            approval::ApprovalDecision::Denied => "was denied by a human reviewer",
+                            approval::ApprovalDecision::Unreachable => {
+                                "could not be approved because the Toolport approval service was \
+                                 unreachable (is the Toolport app running?)"
+                            }
+                            _ => "was not approved in time (the Toolport app may be closed)",
                         };
-                        audit::record_held(srv, tool, client);
+                        // Governance audit: the gate reason and which non-approval outcome
+                        // (denied / no-response / unreachable), plus a content hash of the
+                        // exact call - never the raw args. Replaces the flat record_held so
+                        // the three failure modes are no longer indistinguishable in the log.
+                        let reason_str = match reason {
+                            approval::ApprovalReason::Destructive => "destructive",
+                            approval::ApprovalReason::UntrustedSource => "untrusted_source",
+                            approval::ApprovalReason::DestructiveAndUntrusted => {
+                                "destructive_and_untrusted"
+                            }
+                        };
+                        let decision_str = match decision {
+                            approval::ApprovalDecision::Denied => "denied",
+                            approval::ApprovalDecision::Unreachable => "unreachable",
+                            _ => "no_response",
+                        };
+                        audit::record_decision(
+                            srv, tool, client, reason_str, decision_str, &arguments, Some(held_ms),
+                        );
                         return Some(success(
                             id,
                             json!({
@@ -4002,16 +4093,22 @@ mod tests {
             reason: approval::ApprovalReason::Destructive,
             arguments: serde_json::json!({}),
         };
-        // No endpoint descriptor (Toolport app not running) -> deny.
+        // No endpoint descriptor (Toolport app not running) -> Unreachable (fail-closed),
+        // distinct from a human Timeout so the caller can explain *why* it was blocked.
         let mut r = mk();
-        assert!(!decide_via_broker(None, &mut r).is_approved());
-        // A published endpoint that refuses the connection -> deny.
+        let d = decide_via_broker(None, &mut r);
+        assert!(!d.is_approved());
+        assert_eq!(d, approval::ApprovalDecision::Unreachable);
+        // A published endpoint that refuses the connection -> also Unreachable (we never
+        // handed the request to a broker), so request_human_decision may retry a re-read.
         let mut r = mk();
         let bad = Some(approval::EndpointDescriptor {
             endpoint: "127.0.0.1:1".into(),
             token: "t".into(),
         });
-        assert!(!decide_via_broker(bad, &mut r).is_approved());
+        let d = decide_via_broker(bad, &mut r);
+        assert!(!d.is_approved());
+        assert_eq!(d, approval::ApprovalDecision::Unreachable);
     }
 
     fn router() -> Router {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2288,6 +2288,12 @@ pub fn run() {
                     }
                 }
             }
+            // On FINAL exit only (not a cancelable ExitRequested), remove the approval
+            // endpoint descriptor so a gateway dialing after we're gone reads no broker
+            // (a clean Unreachable) rather than connecting to the dead port we left behind.
+            if matches!(event, tauri::RunEvent::Exit) {
+                approval_broker::clear_endpoint();
+            }
         });
 }
 


### PR DESCRIPTION
**Fixes a live HIL incident**: a stale `approval-endpoint.json` pointed the gateway at a dead broker port, so every gated call fail-closed as a timeout with no prompt ever shown. HIL enforcement worked; the broker was just unreachable and the failure was indistinguishable from a real timeout.

**Part A - reliability**
- `ApprovalDecision::Unreachable` (fail-closed, distinct from `Timeout`).
- `try_decide_once` splits *never-reached-a-broker* from *a broker answered*; `request_human_decision` re-reads the descriptor and retries once on `Unreachable`, self-healing the app-rebound-to-a-new-port race. Agent-facing message now says "approval service unreachable" vs "not approved in time".
- Broker logs its published endpoint path to the always-on `gateway.log` (surfaces an app-vs-gateway data-dir mismatch instantly) and clears the descriptor on final exit.

**Part B - decision audit trail**
- `audit::record_decision` + pure `decision_entry` builder + `args_hash` (canonical-JSON SHA-256; raw args never stored). Records the gate reason, outcome (denied/no_response/unreachable), a content hash, and held duration, replacing the flat `record_held`. CSV export gains `kind,reason,decision,argsHash`.

347 tests pass (285 lib + 62 gateway).