### PR TITLE
[codex] prep v1.5.1 release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ dist-ssr
 /server.json
 
 # Editor directories and files
+.claude/
 .vscode/*
 !.vscode/extensions.json
 .idea

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,48 @@ Entries before the rename below shipped under the project's former name, Conduit
 
 ## [Unreleased]
 
+## [1.5.1] - 2026-07-06
+
+A focused safety and gateway-control patch release. The headline fix is the
+human-in-the-loop approval path: approval failures are now diagnosable, audited,
+and resilient to stale broker descriptors instead of collapsing into a vague
+timeout.
+
+### Added
+
+- **Grouped discovery mode.** `CONDUIT_DISCOVERY=grouped` now advertises the lazy
+  meta-tools plus one `help_<server>` browse tool per connected server, giving
+  weaker/local models an enumerable middle ground between the tiny lazy surface and
+  the full catalog.
+- **Per-registry discovery mode.** Discovery mode can now be stored in the registry
+  (`lazy`, `grouped`, or `full`) instead of only being controlled by a process env
+  var.
+- **MCP request cancellation forwarding.** The gateway now proxies cancellation
+  signals down to the active downstream request path, so canceled client work can
+  stop instead of continuing pointlessly in the background.
+- **HIL decision audit records.** Approval decisions now record the gate reason,
+  decision kind, held duration, and a canonical `argsHash` without storing raw
+  arguments.
+
+### Changed
+
+- **HIL approval failures are legible.** A dead or stale approval broker is reported
+  as `unreachable`, distinct from a human timeout, and the gateway re-reads the broker
+  descriptor once to self-heal the common app-restart/rebound-port race.
+- **Lazy search recall improved.** Added dispute/chargeback and token/tokenize
+  synonym coverage, improving the local recall fixture from 87% to 96% at 10.
+
+### Fixed
+
+- **Packaged Windows gateways escape MSIX filesystem virtualization.** The app and
+  gateway now agree on the same real data directory, avoiding stale registry and
+  approval files from Windows app-container redirection.
+- **Several high-severity audit findings were closed.** The pass tightened external
+  URL opening, catalog/import handling, and content-defense scanning, including a
+  result-side evasion found during the app audit.
+- **Release hygiene.** Version metadata now targets `1.5.1`, and local `.claude/`
+  session artifacts are ignored so they cannot drift into release commits.
+
 ## [1.5.0] - 2026-07-05
 
 A robustness release (the gateway, app, and Teams client now recover cleanly from

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "conduit",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "conduit",
-      "version": "1.5.0",
+      "version": "1.5.1",
       "dependencies": {
         "@fontsource-variable/geist": "^5.2.9",
         "@tailwindcss/vite": "^4.3.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "conduit",
   "private": true,
-  "version": "1.5.0",
+  "version": "1.5.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -604,7 +604,7 @@ dependencies = [
 
 [[package]]
 name = "conduit"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "base64 0.22.1",
  "chacha20poly1305",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conduit"
-version = "1.5.0"
+version = "1.5.1"
 description = "Local MCP gateway: manage all your MCP servers in one place, set up once and shared by every AI client, with ~90% fewer tokens per request"
 authors = ["South Forge AI"]
 edition = "2021"
@@ -57,4 +57,3 @@ core-foundation = "0.10"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 keyring = { version = "3", features = ["sync-secret-service", "crypto-rust"] }
-

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Toolport",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "identifier": "com.tsout.conduit",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## Summary
- bump Toolport app/package versions from 1.5.0 to 1.5.1
- refresh npm and Cargo lockfiles for the patch version
- ignore local .claude session artifacts so release prep stays clean

## Validation
- `cargo check --manifest-path src-tauri\Cargo.toml` passed
- `npm run test:rust` passed: 290 Rust lib/bin tests + 64 gateway tests
- `npm test` passed: 56 Vitest tests
- `npm run build` passed

## Notes
- `npm test -- --runInBand` was attempted first, but Vitest does not support Jest's `--runInBand`; reran with the project command successfully.
- No release tag was created yet; this PR is for CodeRabbit review before tagging/publishing.
