### PR TITLE
Tighten release readiness docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ terminal. The package name is `toolport`.
 
 ```bash
 # Update to a newer version: just install the new .deb, it upgrades in place.
-sudo apt install ./Toolport_1.5.0_amd64.deb
+sudo apt install ./Toolport_1.5.1_amd64.deb
 
 # Uninstall (keeps your config + saved secrets).
 sudo apt remove toolport

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -6,8 +6,8 @@ Releases are built by CI on a version tag (`.github/workflows/release.yml`).
    - `src-tauri/tauri.conf.json` (`version`), drives the installer filename
    - `src-tauri/Cargo.toml` (`version`)
    - `package.json` (`version`)
-   - `server.json` (TWO fields: the top-level `version` and the npm package `version`)
    - `src-tauri/Cargo.lock` (run `cargo check` after bumping `Cargo.toml` to refresh it)
+   - `server.json` only when publishing a matching standalone `@tsouth89/conduit-gateway` package
 2. Commit the bump.
 3. Tag and push:
 


### PR DESCRIPTION
## Summary
- Update the README Linux `.deb` example from `1.5.0` to the current `1.5.1` release filename.
- Clarify that `server.json` should only be bumped when publishing a matching standalone `@tsouth89/conduit-gateway` package, since that package is not currently published on npm.

## Release-readiness audit notes
- App version metadata is aligned across `package.json`, `src-tauri/tauri.conf.json`, and `src-tauri/Cargo.toml` at `1.5.1`.
- `server.json` remains untouched because `npm view @tsouth89/conduit-gateway version` returns 404; bumping it would point registry metadata at a non-existent package.

## Verification
- npm run lint
- npm run test
- npm run audit:prod
- cargo audit
- npm run build
- npm run test:rust:windows
- npm run prepare:sidecar
- npx prettier --check README.md docs/RELEASING.md
- git diff --check

Notes:
- `cargo audit` reports only the existing allowed unmaintained transitive warnings.
- `npm run lint` passes with the existing warning set.
- Local Windows `npm run format:check` still reports broad pre-existing formatting/line-ending noise across untouched files, so this PR uses targeted Prettier verification for the touched docs.
- The first `npm run prepare:sidecar` attempt hit a 2-minute local timeout during the release Rust build; rerunning with a longer timeout completed successfully.