### PR TITLE
teams: clarify connect field accepts an invite or connect code

### DIFF
--- a/src/components/TeamsView.tsx
+++ b/src/components/TeamsView.tsx
@@ -100,7 +100,7 @@ export function TeamsView({
         throw new Error(urlError);
       }
       if (!inviteCode.trim()) {
-        throw new Error("Invite code is required.");
+        throw new Error("An invite or connect code is required.");
       }
       const r = await teamConnect(
         serverUrl.trim(),
@@ -279,12 +279,16 @@ export function TeamsView({
               </span>
             </label>
             <label className="grid gap-1 text-sm">
-              <span className="text-muted-foreground">Invite code</span>
+              <span className="text-muted-foreground">Invite or connect code</span>
               <Input
-                placeholder="Paste your invite code"
+                placeholder="Paste your invite or connect code"
                 value={inviteCode}
                 onChange={(e) => setInviteCode(e.target.value)}
               />
+              <span className="text-xs text-muted-foreground">
+                An invite code joins you to a team. A connect code links this device to a
+                seat you already have.
+              </span>
             </label>
             <label className="grid gap-1 text-sm">
               <span className="text-muted-foreground">Your name (optional)</span>


### PR DESCRIPTION
Small copy fix on the desktop Teams connect form.

The field is labeled **"Invite code"**, but the Teams dashboard also mints a **connect code** (to bind an existing member's new device to their seat). A new user couldn't tell whether they were joining a team, linking a device, or accepting an invite — and both codes go to the same connect endpoint.

- Relabel the field → **"Invite or connect code"**
- Update the placeholder and the empty-field error message to match
- Add a one-line hint under the input: *"An invite code joins you to a team. A connect code links this device to a seat you already have."*

Copy only — no behavior change (the endpoint already accepts either). Prettier + eslint pre-commit hooks pass.

Context: from a Teams activation/onboarding audit. A companion trust batch (webhook SSRF, command parsing, billing, pricing copy) is in toolport-teams#86. The related "prompt for local secrets after connect" nudge is deliberately deferred (needs post-connect data plumbing) rather than half-built pre-launch.