### PR TITLE
Audit fixes: LOW/robustness batch (self-heal single-flight, thread cap, config UX, frontend, CI pinning)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,13 +51,16 @@ jobs:
       AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
       AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
     steps:
-      - uses: actions/checkout@v7
+      # Third-party actions are pinned to full commit SHAs (not mutable tags): this
+      # workflow holds the Apple/Azure/Tauri signing secrets, so a compromised upstream
+      # tag must not be able to inject code into a signed release. Version in the comment.
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 20
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
 
       # Windows runs downstream `.cmd`/`.bat` shims (e.g. npx.cmd) through cmd.exe;
       # Rust 1.77.2 fixed batch-file argument escaping (CVE-2024-24576 / BatBadBut).
@@ -176,7 +179,7 @@ jobs:
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
 
       - name: Draft release with the installers
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3
         with:
           draft: true
           generate_release_notes: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,13 @@ jobs:
       # Third-party actions are pinned to full commit SHAs (not mutable tags): this
       # workflow holds the Apple/Azure/Tauri signing secrets, so a compromised upstream
       # tag must not be able to inject code into a signed release. Version in the comment.
+      # persist-credentials: false so the GITHUB_TOKEN isn't left in .git/config where a
+      # malicious npm/cargo dependency install script (run with the signing secrets in
+      # env) could read and exfiltrate it. Nothing here uses the persisted credential:
+      # the only token use is an explicit GH_TOKEN env var on the manifest step.
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:

--- a/src-tauri/src/audit.rs
+++ b/src-tauri/src/audit.rs
@@ -319,7 +319,7 @@ fn latency(durs: &mut [u64]) -> (Option<u64>, Option<u64>) {
     if durs.is_empty() {
         return (None, None);
     }
-    let sum: u64 = durs.iter().sum();
+    let sum: u64 = durs.iter().copied().fold(0u64, u64::saturating_add);
     let avg = sum / durs.len() as u64;
     durs.sort_unstable();
     // Nearest-rank p95.

--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -3011,6 +3011,11 @@ struct GatewayState {
     stdout: Arc<Mutex<std::io::Stdout>>,
     ready: Arc<AtomicBool>,
     downstream_dirty: Arc<AtomicU8>,
+    /// Serializes the self-heal rebuild so a startup burst of concurrent tools/call
+    /// workers that all observe an empty router don't each spawn the full server set
+    /// (single-flight). The winner rebuilds; the others block here, then re-check
+    /// server_count under the router lock and skip.
+    rebuild_lock: Arc<Mutex<()>>,
     lazy: bool,
     profile: Option<String>,
     /// True when this process is the HTTP/OpenAPI bridge (vs a stdio client's
@@ -3086,40 +3091,57 @@ fn process_request(
             .server_count()
             == 0
     {
-        let reg = state
-            .registry
+        // Single-flight: serialize the rebuild so a startup burst of concurrent
+        // tools/call workers doesn't have each one spawn the full server set (and
+        // then drop all but one, killing their just-spawned children). The winner
+        // holds this lock while it rebuilds; the others block, then the double-check
+        // below sees a non-empty router and skips.
+        let _rebuild = state
+            .rebuild_lock
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let still_empty = state
+            .router
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
-            .clone();
-        let built = build_router(
-            &reg,
-            state.profile.as_deref(),
-            state.http,
-            &state.downstream_dirty,
-        );
-        if built.server_count() > 0 {
-            let tools = built.aggregated_tools();
-            *state
-                .router
+            .server_count()
+            == 0;
+        if still_empty {
+            let reg = state
+                .registry
                 .lock()
-                .unwrap_or_else(std::sync::PoisonError::into_inner) = Arc::new(built);
-            if !tools.is_empty() {
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .clone();
+            let built = build_router(
+                &reg,
+                state.profile.as_deref(),
+                state.http,
+                &state.downstream_dirty,
+            );
+            if built.server_count() > 0 {
+                let tools = built.aggregated_tools();
                 *state
-                    .cached_tools
-                    .lock()
-                    .unwrap_or_else(std::sync::PoisonError::into_inner) = tools.clone();
-                save_tool_cache(&tools, state.profile.as_deref());
-            }
-            glog(&format!(
-                "self-heal: rebuilt router ({} servers, {} tools)",
-                state
                     .router
                     .lock()
-                    .unwrap_or_else(std::sync::PoisonError::into_inner)
-                    .server_count(),
-                tools.len()
-            ));
-            notify_tools_changed(&state.stdout);
+                    .unwrap_or_else(std::sync::PoisonError::into_inner) = Arc::new(built);
+                if !tools.is_empty() {
+                    *state
+                        .cached_tools
+                        .lock()
+                        .unwrap_or_else(std::sync::PoisonError::into_inner) = tools.clone();
+                    save_tool_cache(&tools, state.profile.as_deref());
+                }
+                glog(&format!(
+                    "self-heal: rebuilt router ({} servers, {} tools)",
+                    state
+                        .router
+                        .lock()
+                        .unwrap_or_else(std::sync::PoisonError::into_inner)
+                        .server_count(),
+                    tools.len()
+                ));
+                notify_tools_changed(&state.stdout);
+            }
         }
     }
 
@@ -4060,6 +4082,7 @@ fn main() {
         stdout: Arc::clone(&stdout),
         ready: Arc::clone(&ready),
         downstream_dirty: Arc::clone(&downstream_dirty),
+        rebuild_lock: Arc::new(Mutex::new(())),
         lazy,
         profile: profile.clone(),
         http: http_mode,
@@ -4243,6 +4266,7 @@ mod tests {
             stdout: Arc::new(Mutex::new(std::io::stdout())),
             ready: Arc::new(AtomicBool::new(true)),
             downstream_dirty: Arc::new(AtomicU8::new(0)),
+            rebuild_lock: Arc::new(Mutex::new(())),
             lazy,
             profile: None,
             http: true,

--- a/src-tauri/src/clients.rs
+++ b/src-tauri/src/clients.rs
@@ -1524,11 +1524,15 @@ fn epoch_millis() -> u128 {
         .unwrap_or(0)
 }
 
-/// Largest client config we'll read into memory or back up. Real MCP client
-/// configs are a few KB; this cap stops a maliciously large file, or a config
-/// symlinked to a huge or special file (a device, a FIFO), from exhausting
-/// memory or filling the disk via the backup dir.
-const MAX_CONFIG_BYTES: u64 = 8 * 1024 * 1024;
+/// Largest client config we'll read into memory or back up. Most MCP client configs
+/// are a few KB, but whole-app-state files legitimately grow large - notably Claude
+/// Code's `~/.claude.json`, which stores project/session history and routinely reaches
+/// tens of MB for active users. An 8 MB cap hard-blocked those users from ever
+/// connecting Claude Code through the gateway (install errored on the read), so the
+/// bound is 64 MB: generous enough for real whole-app-state files while still capping
+/// memory. The device/FIFO/directory case is handled separately by the `is_file`
+/// check, so this only guards against an abnormally huge regular file.
+const MAX_CONFIG_BYTES: u64 = 64 * 1024 * 1024;
 
 /// Read a client config to a string, refusing anything that isn't a regular file
 /// (after following symlinks, so a benign symlinked dotfile still works but a

--- a/src-tauri/src/downstream.rs
+++ b/src-tauri/src/downstream.rs
@@ -186,13 +186,32 @@ impl CancelRegistry {
     }
 }
 
+/// Cap on concurrently-forwarding cancellation threads. The forward is a best-effort
+/// `writeln!` to the child's stdin, which blocks if the child isn't draining its pipe.
+/// Without a cap, repeated cancellation of a wedged downstream would leak one blocked
+/// thread per cancel; past the cap we drop the notification instead.
+static CANCEL_THREADS_INFLIGHT: std::sync::atomic::AtomicUsize =
+    std::sync::atomic::AtomicUsize::new(0);
+const MAX_CANCEL_THREADS: usize = 64;
+
 impl CancelEntry {
     fn send_cancel_async(&self, reason: Option<String>) {
+        // Reserve a slot; if too many forwards are already blocked (a downstream that
+        // stopped draining its stdin), drop this one rather than leak another thread.
+        if CANCEL_THREADS_INFLIGHT.fetch_add(1, Ordering::SeqCst) >= MAX_CANCEL_THREADS {
+            CANCEL_THREADS_INFLIGHT.fetch_sub(1, Ordering::SeqCst);
+            eprintln!(
+                "toolport: dropping cancellation forward (>{MAX_CANCEL_THREADS} already blocked; \
+                 downstream not draining stdin)"
+            );
+            return;
+        }
         let entry = self.clone();
         std::thread::spawn(move || {
             if let Err(err) = entry.send_cancel(reason.as_deref()) {
                 eprintln!("toolport: failed to forward cancellation downstream: {err}");
             }
+            CANCEL_THREADS_INFLIGHT.fetch_sub(1, Ordering::SeqCst);
         });
     }
 

--- a/src-tauri/src/savings.rs
+++ b/src-tauri/src/savings.rs
@@ -110,8 +110,8 @@ fn fold(entries: &[Value]) -> Value {
     let mut peak = 0u64;
     let mut since = 0u64;
     for e in entries {
-        saved += e.get("saved").and_then(Value::as_u64).unwrap_or(0);
-        loads += e.get("loads").and_then(Value::as_u64).unwrap_or(1);
+        saved = saved.saturating_add(e.get("saved").and_then(Value::as_u64).unwrap_or(0));
+        loads = loads.saturating_add(e.get("loads").and_then(Value::as_u64).unwrap_or(1));
         peak = peak.max(e.get("tools").and_then(Value::as_u64).unwrap_or(0));
         let ts = e.get("ts").and_then(Value::as_u64).unwrap_or(0);
         if ts > 0 && (since == 0 || ts < since) {

--- a/src/components/ActivityView.tsx
+++ b/src/components/ActivityView.tsx
@@ -215,6 +215,27 @@ function loadDismissed(): Set<string> {
   }
 }
 
+/** Upper bound on remembered dismissals, so the persisted set can't grow without
+ * limit across sessions. Well above any realistic count of distinct findings. */
+const MAX_DISMISSED = 500;
+
+/** Add keys to the dismissed set, cap it to the most-recent MAX_DISMISSED (Set
+ * preserves insertion order, so slicing the tail keeps the newest), and persist.
+ * Returns the new set for use as React state. */
+function addDismissed(prev: Set<string>, keys: string[]): Set<string> {
+  const merged = new Set(prev);
+  for (const k of keys) merged.add(k);
+  const arr = [...merged];
+  const next =
+    arr.length > MAX_DISMISSED ? new Set(arr.slice(arr.length - MAX_DISMISSED)) : merged;
+  try {
+    localStorage.setItem(SECURITY_DISMISSED_KEY, JSON.stringify([...next]));
+  } catch {
+    // ignore storage failures; the dismissal just won't persist
+  }
+  return next;
+}
+
 /** Calm, always-on "you're protected" state, shown whenever there are no live
  * security notices. A protection the user never sees builds no trust, so we make
  * the integrity + content-defense watch visible even when nothing is wrong. */
@@ -1399,30 +1420,12 @@ export function ActivityView({
     (e) => eventSeverity(e) !== "high" || isNewTool(e),
   );
   const dismissSecurity = (e: SecurityEvent) => {
-    setDismissed((prev) => {
-      const next = new Set(prev);
-      next.add(securityKey(e));
-      try {
-        localStorage.setItem(SECURITY_DISMISSED_KEY, JSON.stringify([...next]));
-      } catch {
-        // ignore storage failures; the dismissal just won't persist
-      }
-      return next;
-    });
+    setDismissed((prev) => addDismissed(prev, [securityKey(e)]));
   };
   // Clear a whole batch at once (the quiet lane can hold dozens of first-sightings after
   // a re-baseline; making the user dismiss each would just recreate the noise problem).
   const dismissAllSecurity = (events: SecurityEvent[]) => {
-    setDismissed((prev) => {
-      const next = new Set(prev);
-      for (const e of events) next.add(securityKey(e));
-      try {
-        localStorage.setItem(SECURITY_DISMISSED_KEY, JSON.stringify([...next]));
-      } catch {
-        // ignore storage failures; the dismissal just won't persist
-      }
-      return next;
-    });
+    setDismissed((prev) => addDismissed(prev, events.map(securityKey)));
   };
 
   const banner = (

--- a/src/components/PendingApprovals.tsx
+++ b/src/components/PendingApprovals.tsx
@@ -169,7 +169,7 @@ export function PendingApprovals() {
             // first-sighting + timeout only if deadlineMs is somehow absent, so the
             // timer is never blank.
             const seen = seenAt.current.get(a.id) ?? now;
-            const deadline = a.deadlineMs || seen + TIMEOUT_MS;
+            const deadline = a.deadlineMs ?? seen + TIMEOUT_MS;
             const remaining = Math.max(0, Math.ceil((deadline - now) / 1000));
             // Scale the bar against the ACTUAL window (deadline - first sighting), not
             // the hardcoded TIMEOUT_MS, so it stays accurate even if the gateway's

--- a/src/components/PendingApprovals.tsx
+++ b/src/components/PendingApprovals.tsx
@@ -168,13 +168,14 @@ export function PendingApprovals() {
             // Count down to the broker's authoritative deadline; fall back to
             // first-sighting + timeout only if deadlineMs is somehow absent, so the
             // timer is never blank.
-            const deadline =
-              a.deadlineMs || (seenAt.current.get(a.id) ?? now) + TIMEOUT_MS;
+            const seen = seenAt.current.get(a.id) ?? now;
+            const deadline = a.deadlineMs || seen + TIMEOUT_MS;
             const remaining = Math.max(0, Math.ceil((deadline - now) / 1000));
-            const pct = Math.max(
-              0,
-              Math.min(100, (remaining / (TIMEOUT_MS / 1000)) * 100),
-            );
+            // Scale the bar against the ACTUAL window (deadline - first sighting), not
+            // the hardcoded TIMEOUT_MS, so it stays accurate even if the gateway's
+            // timeout ever drifts from this constant.
+            const totalMs = Math.max(1000, deadline - seen);
+            const pct = Math.max(0, Math.min(100, ((deadline - now) / totalMs) * 100));
             const urgent = remaining <= 20;
             const isBusy = resolving.has(a.id);
             return (

--- a/src/components/SettingsView.tsx
+++ b/src/components/SettingsView.tsx
@@ -4,6 +4,8 @@ import {
   Bot,
   Check,
   Copy,
+  Eye,
+  EyeOff,
   Globe,
   Layers,
   Pin,
@@ -217,6 +219,9 @@ export function SettingsView({ registry, onRegistryChange }: Props) {
   const [allowedError, setAllowedError] = useState(false);
   const [bridge, setBridge] = useState<HttpBridgeStatus | null>(null);
   const [bridgeError, setBridgeError] = useState(false);
+  // Mask the bridge bearer token by default (grants any local process access to all
+  // the user's tools); reveal on demand.
+  const [showToken, setShowToken] = useState(false);
   const [bridgeBusy, setBridgeBusy] = useState(false);
   const [copied, setCopied] = useState<string | null>(null);
   const [newLabel, setNewLabel] = useState("");
@@ -670,7 +675,22 @@ export function SettingsView({ registry, onRegistryChange }: Props) {
                   <span className="shrink-0 text-[11px] font-medium text-muted-foreground">
                     Token
                   </span>
-                  <code className="min-w-0 flex-1 truncate text-xs">{bridge.token}</code>
+                  <code className="min-w-0 flex-1 truncate text-xs">
+                    {showToken ? bridge.token : "•".repeat(24)}
+                  </code>
+                  <button
+                    type="button"
+                    onClick={() => setShowToken((s) => !s)}
+                    title={showToken ? "Hide token" : "Reveal token"}
+                    aria-label={showToken ? "Hide token" : "Reveal token"}
+                    className="shrink-0 rounded p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
+                  >
+                    {showToken ? (
+                      <EyeOff className="size-3.5" />
+                    ) : (
+                      <Eye className="size-3.5" />
+                    )}
+                  </button>
                   <button
                     type="button"
                     onClick={() => copy(bridge.token!, "token")}

--- a/src/components/ShareDialog.tsx
+++ b/src/components/ShareDialog.tsx
@@ -94,9 +94,21 @@ export function ShareDialog({ trigger, onImported }: Props) {
   useEffect(() => {
     if (!open) return;
     setShareLink(""); // the export changed, so any prior link is stale
+    // Guard against out-of-order responses: this effect re-fires on every keystroke
+    // of name/description, and two in-flight exportConfig calls can resolve in either
+    // order. Without this, a slower earlier response could overwrite the preview with
+    // stale content. Only the latest effect run is allowed to commit its result.
+    let cancelled = false;
     exportConfig(name, description, shareFilter)
-      .then(setExported)
-      .catch(() => setExported(""));
+      .then((v) => {
+        if (!cancelled) setExported(v);
+      })
+      .catch(() => {
+        if (!cancelled) setExported("");
+      });
+    return () => {
+      cancelled = true;
+    };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open, name, description, selected, servers]);
 
@@ -226,7 +238,7 @@ export function ShareDialog({ trigger, onImported }: Props) {
       cancelled = true;
       unlisten?.();
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+     
   }, []);
 
   const newCount = preview?.filter((i) => i.isNew).length ?? 0;

--- a/src/components/ShareDialog.tsx
+++ b/src/components/ShareDialog.tsx
@@ -238,7 +238,6 @@ export function ShareDialog({ trigger, onImported }: Props) {
       cancelled = true;
       unlisten?.();
     };
-     
   }, []);
 
   const newCount = preview?.filter((i) => i.isNew).length ?? 0;


### PR DESCRIPTION
The remaining lower-severity backlog from the 2026-07-07 audit, after the HIGH (#203) and MEDIUM (#204) batches. All green: 296 lib + 64 gateway-bin tests pass, frontend tsc clean + eslint 0 errors + production build succeeds, no new clippy warnings.

## Backend (Rust)
- **Self-heal thundering herd** (`toolport-gateway.rs`): a startup burst of concurrent `tools/call` workers could each observe an empty router and independently rebuild it, spawning the full server set N times before dropping all but one. Serialize the rebuild behind a dedicated lock with a double-check (single-flight).
- **`send_cancel_async` thread leak** (`downstream.rs`): the detached cancel-forward thread does a blocking `writeln!` to the child's stdin; a wedged downstream could leak one blocked thread per cancel. Cap concurrent forwarders at 64 and drop past that.
- **Non-saturating arithmetic** (`savings.rs`, `audit.rs`): the last plain `u64 +=`/`sum` on the aggregation hot paths → `saturating_add` (debug-panic-only, consistency with the rest).
- **8MB config cap** (`clients.rs`): raised to 64MB so heavy Claude Code users (whose `~/.claude.json` reaches tens of MB) can install; the device/FIFO/dir case is already handled by the `is_file` check.

## Frontend (React/TS)
- **Bridge token masked** (`SettingsView.tsx`): the HTTP-bridge bearer token (grants any local process access to all tools) was plaintext + re-shown every visit → masked by default with an Eye/EyeOff reveal.
- **Approval-bar scaling** (`PendingApprovals.tsx`): countdown width used a hardcoded `TIMEOUT_MS` denominator → scale against the actual window (`deadlineMs` - first sighting).
- **Stale export guard** (`ShareDialog.tsx`): the per-keystroke export effect had no ordering guard → `cancelled` flag so only the latest run commits.
- **Dismissed-set cap** (`ActivityView.tsx`): the localStorage dismissed set grew unbounded → capped to the most-recent 500.

## CI / hygiene
- **Pinned release-workflow actions** to commit SHAs (`release.yml` holds the signing secrets); CI/audit workflows left on tags (lower risk).
- Removed stray 0-byte `license-signing.key` / `license-signing.keycd` local artifacts (were untracked).

## Deliberately not included
- Confirm-token owner-scoping in HTTP mode: already safe in practice (128-bit token + post-unwrap scope guard); threading `owner` through `PendingCall` is churn for a defense-in-depth nicety, skipped pre-launch.
- Secrets file-backend KDF (bare SHA-256): changing it breaks decryption of existing `secrets.enc` files, so it needs a versioned/salted migration - too risky to rush; left for a dedicated change.
- Config comment-loss + registry cross-process race: known/deferred, need design not a quick patch.