### PR TITLE
Harden approvals (fingerprint-bound), destructive detection, and diagnostics redaction

### DIFF
--- a/src-tauri/src/approval.rs
+++ b/src-tauri/src/approval.rs
@@ -67,6 +67,10 @@ pub struct ApprovalRequest {
     pub reason: ApprovalReason,
     /// The exact arguments the human is approving.
     pub arguments: serde_json::Value,
+    /// Fingerprint of the current tool definition, when the gateway can resolve it.
+    /// Allowlist entries include this so a tool definition change re-requires approval.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tool_fingerprint: Option<String>,
 }
 
 /// The broker's answer to an [`ApprovalRequest`].
@@ -128,6 +132,12 @@ pub fn allow_key(server: &str, tool: &str) -> String {
     format!("{server}/{tool}")
 }
 
+/// Fingerprint-bound allow key. This is intentionally distinct from the legacy
+/// `server/tool` key so old broad allows don't silently keep bypassing approval.
+pub fn fingerprint_allow_key(server: &str, tool: &str, fingerprint: &str) -> String {
+    format!("{}/{}/{}", server, tool, fingerprint)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -180,17 +190,31 @@ mod tests {
             tool: "drop_table".into(),
             reason: ApprovalReason::Destructive,
             arguments: serde_json::json!({ "table": "users" }),
+            tool_fingerprint: Some("v2:abc".into()),
         };
         let round: ApprovalRequest =
             serde_json::from_str(&serde_json::to_string(&req).unwrap()).unwrap();
         assert_eq!(round.tool, "drop_table");
         assert_eq!(round.reason, ApprovalReason::Destructive);
         assert_eq!(round.arguments["table"], "users");
+        assert_eq!(round.tool_fingerprint.as_deref(), Some("v2:abc"));
 
         let dec: ApprovalDecision =
             serde_json::from_str(&serde_json::to_string(&ApprovalDecision::Approved).unwrap())
                 .unwrap();
         assert!(dec.is_approved());
+    }
+
+    #[test]
+    fn fingerprint_allow_key_binds_definition() {
+        assert_eq!(
+            fingerprint_allow_key("db", "drop_table", "v2:abc"),
+            "db/drop_table/v2:abc"
+        );
+        assert_ne!(
+            fingerprint_allow_key("db", "drop_table", "v2:abc"),
+            allow_key("db", "drop_table")
+        );
     }
 
     #[test]

--- a/src-tauri/src/approval_broker.rs
+++ b/src-tauri/src/approval_broker.rs
@@ -36,6 +36,7 @@ pub struct PendingView {
     pub client: Option<String>,
     pub server: String,
     pub tool: String,
+    pub tool_fingerprint: Option<String>,
     pub reason: ApprovalReason,
     pub arguments: serde_json::Value,
     /// Wall-clock epoch-millis when this call auto-denies (park time + the fail-closed
@@ -55,10 +56,10 @@ struct Inner {
     token: String,
     /// id -> parked connection. Bounded by `MAX_PENDING`.
     pending: Mutex<HashMap<String, Waiter>>,
-    /// Ephemeral per-session "always allow" set of `server/tool` keys. A matching call
-    /// auto-approves without prompting; cleared on app restart (the persistent list lives
-    /// in the registry). "Approve for this session" adds here; "Always allow" adds here
-    /// AND to the registry.
+    /// Ephemeral per-session "always allow" set of fingerprint-bound `server/tool/fingerprint`
+    /// keys. A matching call auto-approves without prompting; cleared on app restart (the
+    /// persistent list lives in the registry). "Approve for this session" adds here; "Always
+    /// allow" adds here AND to the registry.
     session_allow: Mutex<HashSet<String>>,
 }
 
@@ -288,18 +289,20 @@ fn handle_conn(stream: TcpStream, broker: ApprovalBroker, app: AppHandle) {
         return;
     }
 
-    // Auto-approve if the user already allowed this tool - per session (broker) or
-    // persistently (registry). Skips the prompt entirely so "approve for this session"
-    // and "always allow this tool" actually stick for later matching calls.
-    let key = crate::approval::allow_key(&req.server, &req.tool);
-    if broker.session_contains(&key) || registry_allows(&app, &key) {
-        let _ = out.set_write_timeout(Some(Duration::from_secs(10)));
-        let _ = writeln!(
-            out,
-            "{}",
-            serde_json::to_string(&ApprovalDecision::Approved).unwrap_or_default()
-        );
-        return;
+    // Auto-approve only if the current tool definition matches a fingerprint-bound allow.
+    // Legacy broad `server/tool` entries are intentionally ignored: a tool definition that
+    // changed since approval should re-prompt instead of inheriting a stale bypass.
+    if let Some(fp) = req.tool_fingerprint.as_deref() {
+        let key = crate::approval::fingerprint_allow_key(&req.server, &req.tool, fp);
+        if broker.session_contains(&key) || registry_allows(&app, &key) {
+            let _ = out.set_write_timeout(Some(Duration::from_secs(10)));
+            let _ = writeln!(
+                out,
+                "{}",
+                serde_json::to_string(&ApprovalDecision::Approved).unwrap_or_default()
+            );
+            return;
+        }
     }
 
     let view = PendingView {
@@ -307,6 +310,7 @@ fn handle_conn(stream: TcpStream, broker: ApprovalBroker, app: AppHandle) {
         client: req.client.clone(),
         server: req.server.clone(),
         tool: req.tool.clone(),
+        tool_fingerprint: req.tool_fingerprint.clone(),
         reason: req.reason,
         arguments: req.arguments.clone(),
         // Stamp the deadline now, right before we park on `recv_timeout` below.
@@ -411,6 +415,7 @@ mod tests {
             client: None,
             server: "s".into(),
             tool: "drop".into(),
+            tool_fingerprint: Some("v2:abc".into()),
             reason: ApprovalReason::Destructive,
             arguments: serde_json::json!({}),
             deadline_ms: deadline_ms_from_now(),
@@ -470,7 +475,7 @@ mod tests {
     #[test]
     fn session_allow_round_trips_and_decide_returns_view() {
         let b = broker();
-        let key = crate::approval::allow_key("db", "db__read");
+        let key = crate::approval::fingerprint_allow_key("db", "db__read", "v2:abc");
         assert!(!b.session_contains(&key));
         b.add_session_allow(key.clone());
         assert!(b.session_contains(&key));

--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -1493,7 +1493,11 @@ fn tool_fingerprint_for(name: &str, cached: &[Value], router: &Router) -> Option
             .find(|t| t.get("name").and_then(|n| n.as_str()) == Some(name))
             .map(integrity::fingerprint)
     };
-    lookup(cached).or_else(|| lookup(&router.aggregated_tools()))
+    // Prefer the LIVE router definition (what actually dispatches) so a drifted
+    // tool re-prompts instead of matching an approval bound to its stale cached
+    // form. `cached` is only a cold-start fallback before downstream servers
+    // connect and the router has nothing to aggregate yet.
+    lookup(&router.aggregated_tools()).or_else(|| lookup(cached))
 }
 
 /// Keep only tools whose server prefix is in `allowed`. `None` = no scoping

--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -1486,6 +1486,16 @@ fn tool_is_destructive_fail_closed(name: &str, cached: &[Value], router: &Router
     true
 }
 
+fn tool_fingerprint_for(name: &str, cached: &[Value], router: &Router) -> Option<String> {
+    let lookup = |tools: &[Value]| {
+        tools
+            .iter()
+            .find(|t| t.get("name").and_then(|n| n.as_str()) == Some(name))
+            .map(integrity::fingerprint)
+    };
+    lookup(cached).or_else(|| lookup(&router.aggregated_tools()))
+}
+
 /// Keep only tools whose server prefix is in `allowed`. `None` = no scoping
 /// (every tool passes). A meta-tool (no `server__` namespace, e.g.
 /// `toolport_search_tools`) is always kept, since it isn't owned by any
@@ -2273,6 +2283,7 @@ fn handle_request_with_cancel(
                         tool: tool.to_string(),
                         reason,
                         arguments: arguments.clone(),
+                        tool_fingerprint: tool_fingerprint_for(name, cached, router),
                     });
                     let held_ms = t0.elapsed().as_millis() as u64;
                     if !decision.is_approved() {
@@ -3991,6 +4002,7 @@ fn main() {
             registry::Registry::default()
         }
     };
+    inspect::clear();
     let registry = Arc::new(Mutex::new(loaded));
     // Empty router + cached catalog: the handshake and tools/list answer instantly
     // (from cache), while downstream servers connect in the background for the
@@ -4192,6 +4204,7 @@ mod tests {
             tool: "drop".into(),
             reason: approval::ApprovalReason::Destructive,
             arguments: serde_json::json!({}),
+            tool_fingerprint: Some("v2:abc".into()),
         };
         // No endpoint descriptor (Toolport app not running) -> Unreachable (fail-closed),
         // distinct from a human Timeout so the caller can explain *why* it was blocked.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -589,8 +589,8 @@ fn registry_summary(reg: &Registry) -> String {
     for s in &reg.servers {
         let on = if reg.is_enabled(&active, &s.id) { "on" } else { "off" };
         let target = match (&s.command, &s.url) {
-            (Some(cmd), _) => format!("{cmd} {}", s.args.join(" ")).trim().to_string(),
-            (None, Some(url)) => url.clone(),
+            (Some(cmd), _) => safe_command_target(cmd, &s.args),
+            (None, Some(url)) => redact_url_userinfo(url),
             _ => String::new(),
         };
         let _ = writeln!(out, "  [{on}] {} ({}) {}", s.id, s.transport, target);
@@ -609,6 +609,21 @@ fn registry_summary(reg: &Registry) -> String {
         let _ = writeln!(out, "  {}: [{}]", p.name, p.enabled_server_ids.join(", "));
     }
     out
+}
+
+fn safe_command_target(cmd: &str, args: &[String]) -> String {
+    let mut parts = Vec::with_capacity(args.len() + 1);
+    parts.push(redact_arg_for_sharing(cmd));
+    parts.extend(args.iter().map(|arg| redact_arg_for_sharing(arg)));
+    parts.join(" ").trim().to_string()
+}
+
+fn redact_arg_for_sharing(arg: &str) -> String {
+    if arg_looks_secret(arg) {
+        "<redacted>".to_string()
+    } else {
+        redact_url_userinfo(arg)
+    }
 }
 
 /// The last `n` lines of the always-on gateway log, or a friendly note when it
@@ -878,7 +893,11 @@ fn decide_approval(
 ) -> Result<(), String> {
     let view = broker.decide(&id, approved)?;
     if approved && scope != "once" {
-        let key = approval::allow_key(&view.server, &view.tool);
+        let fp = view.tool_fingerprint.as_deref().ok_or_else(|| {
+            "could not allow this tool because its definition fingerprint is unavailable"
+                .to_string()
+        })?;
+        let key = approval::fingerprint_allow_key(&view.server, &view.tool, fp);
         broker.add_session_allow(key.clone());
         if scope == "always" {
             let mut reg = state.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
@@ -911,9 +930,12 @@ fn list_allowed_tools(
         let reg = state.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
         reg.human_approval_allow.clone()
     };
-    let split = |key: &str| match key.split_once('/') {
-        Some((s, t)) => (s.to_string(), t.to_string()),
-        None => (String::new(), key.to_string()),
+    let split = |key: &str| {
+        let mut parts = key.splitn(3, '/');
+        match (parts.next(), parts.next()) {
+            (Some(s), Some(t)) => (s.to_string(), t.to_string()),
+            _ => (String::new(), key.to_string()),
+        }
     };
     let mut out: Vec<AllowedTool> = persistent
         .iter()
@@ -2065,6 +2087,10 @@ pub fn run() {
         });
     }
 
+    if !registry.live_inspect {
+        inspect::clear();
+    }
+
     tauri::Builder::default()
         // Single-instance must be registered first. With its `deep-link` feature
         // a second launch carrying a conduit:// URL is forwarded to the deep-link
@@ -2610,5 +2636,43 @@ mod tests {
         assert!(!s.contains("sk-live-xyz"), "secret value leaked: {s}");
         // The launch command is present for debugging.
         assert!(s.contains("(stdio) npx"), "missing launch line: {s}");
+    }
+
+    #[test]
+    fn diagnostics_redacts_inline_arg_and_url_secrets() {
+        let mut reg = Registry::default();
+        reg.add_server(ServerEntry {
+            id: "pg".into(),
+            name: "Postgres".into(),
+            transport: "stdio".into(),
+            command: Some("npx".into()),
+            args: vec![
+                "@modelcontextprotocol/server-postgres".into(),
+                "postgresql://admin:hunter2@db.example.com/app".into(),
+                "--token=sk-live-xyz".into(),
+                "https://api.example.com/path".into(),
+            ],
+            env: vec![],
+            url: None,
+            source: None,
+            disabled_tools: vec![],
+        });
+        reg.add_server(ServerEntry {
+            id: "remote".into(),
+            name: "Remote".into(),
+            transport: "http".into(),
+            command: None,
+            args: vec![],
+            env: vec![],
+            url: Some("https://user:hunter2@mcp.example.com/mcp".into()),
+            source: None,
+            disabled_tools: vec![],
+        });
+
+        let s = registry_summary(&reg);
+        assert!(!s.contains("hunter2"), "secret value leaked: {s}");
+        assert!(!s.contains("sk-live-xyz"), "secret token leaked: {s}");
+        assert!(s.contains("<redacted>"), "missing redaction marker: {s}");
+        assert!(s.contains("https://api.example.com/path"), "safe URL was over-redacted: {s}");
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -893,16 +893,19 @@ fn decide_approval(
 ) -> Result<(), String> {
     let view = broker.decide(&id, approved)?;
     if approved && scope != "once" {
-        let fp = view.tool_fingerprint.as_deref().ok_or_else(|| {
-            "could not allow this tool because its definition fingerprint is unavailable"
-                .to_string()
-        })?;
-        let key = approval::fingerprint_allow_key(&view.server, &view.tool, fp);
-        broker.add_session_allow(key.clone());
-        if scope == "always" {
-            let mut reg = state.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
-            reg.allow_tool(key);
-            registry::save(&reg)?;
+        // Persist only when we can bind the allow to the current definition
+        // fingerprint. If it's unavailable (the tool is no longer resolvable),
+        // the call itself already went through via `decide` above; we simply
+        // can't remember it, so degrade to a one-time approval rather than
+        // returning an error for a decision that already succeeded.
+        if let Some(fp) = view.tool_fingerprint.as_deref() {
+            let key = approval::fingerprint_allow_key(&view.server, &view.tool, fp);
+            broker.add_session_allow(key.clone());
+            if scope == "always" {
+                let mut reg = state.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+                reg.allow_tool(key);
+                registry::save(&reg)?;
+            }
         }
     }
     Ok(())
@@ -930,24 +933,28 @@ fn list_allowed_tools(
         let reg = state.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
         reg.human_approval_allow.clone()
     };
-    let split = |key: &str| {
+    // Only fingerprint-bound `server/tool/<fingerprint>` keys still auto-approve;
+    // the broker ignores legacy broad `server/tool` entries, so they must not be
+    // surfaced here as active allows (that would misreport an inert entry as live).
+    let parse = |key: &str| -> Option<(String, String)> {
         let mut parts = key.splitn(3, '/');
-        match (parts.next(), parts.next()) {
-            (Some(s), Some(t)) => (s.to_string(), t.to_string()),
-            _ => (String::new(), key.to_string()),
+        match (parts.next(), parts.next(), parts.next()) {
+            (Some(s), Some(t), Some(_fp)) => Some((s.to_string(), t.to_string())),
+            _ => None,
         }
     };
     let mut out: Vec<AllowedTool> = persistent
         .iter()
-        .map(|k| {
-            let (server, tool) = split(k);
-            AllowedTool { key: k.clone(), server, tool, persistent: true }
+        .filter_map(|k| {
+            let (server, tool) = parse(k)?;
+            Some(AllowedTool { key: k.clone(), server, tool, persistent: true })
         })
         .collect();
     for k in broker.session_allowed() {
         if !persistent.contains(&k) {
-            let (server, tool) = split(&k);
-            out.push(AllowedTool { key: k, server, tool, persistent: false });
+            if let Some((server, tool)) = parse(&k) {
+                out.push(AllowedTool { key: k, server, tool, persistent: false });
+            }
         }
     }
     out

--- a/src-tauri/src/router.rs
+++ b/src-tauri/src/router.rs
@@ -111,15 +111,67 @@ fn inline_node(node: &mut Value, root: &Value, active: &mut HashSet<String>) {
     }
 }
 
-/// True if a tool advertises `destructiveHint: true` (MCP tool annotations).
-/// Accepts the spec's nested `annotations.destructiveHint` and a top-level
-/// fallback some servers emit.
+/// True if a tool advertises `destructiveHint: true` (MCP tool annotations), or
+/// has an obvious write/delete verb when no explicit hint is present. Accepts the
+/// spec's nested `annotations.destructiveHint` and a top-level fallback some
+/// servers emit. An explicit `false` hint wins over the name fallback.
 pub fn is_destructive(tool: &Value) -> bool {
-    tool.get("annotations")
+    if let Some(hint) = tool
+        .get("annotations")
         .and_then(|a| a.get("destructiveHint"))
         .and_then(|v| v.as_bool())
         .or_else(|| tool.get("destructiveHint").and_then(|v| v.as_bool()))
+    {
+        return hint;
+    }
+
+    tool.get("name")
+        .and_then(Value::as_str)
+        .map(name_looks_destructive)
         .unwrap_or(false)
+}
+
+fn name_looks_destructive(name: &str) -> bool {
+    let mut tokens = name
+        .split(|c: char| !c.is_ascii_alphanumeric())
+        .flat_map(split_camel_lower);
+    tokens.any(|t| {
+        matches!(
+            t.as_str(),
+            "create"
+                | "delete"
+                | "destroy"
+                | "drop"
+                | "execute"
+                | "insert"
+                | "post"
+                | "publish"
+                | "remove"
+                | "run"
+                | "send"
+                | "truncate"
+                | "update"
+                | "write"
+        )
+    })
+}
+
+fn split_camel_lower(word: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut start = 0;
+    let chars: Vec<(usize, char)> = word.char_indices().collect();
+    for window in chars.windows(2) {
+        let (idx, ch) = window[0];
+        let (_, next) = window[1];
+        if idx > start && ch.is_ascii_lowercase() && next.is_ascii_uppercase() {
+            out.push(word[start..idx + ch.len_utf8()].to_ascii_lowercase());
+            start = idx + ch.len_utf8();
+        }
+    }
+    if start < word.len() {
+        out.push(word[start..].to_ascii_lowercase());
+    }
+    out
 }
 
 /// Which downstream tools the gateway is allowed to expose. Default-allow: an
@@ -1158,6 +1210,18 @@ mod tests {
         assert!(is_destructive(&json!({ "destructiveHint": true }))); // top-level fallback
         assert!(!is_destructive(&json!({ "annotations": { "destructiveHint": false } })));
         assert!(!is_destructive(&json!({ "name": "x" })));
+    }
+
+    #[test]
+    fn is_destructive_falls_back_to_obvious_write_verbs() {
+        assert!(is_destructive(&json!({ "name": "delete_file" })));
+        assert!(is_destructive(&json!({ "name": "sendEmail" })));
+        assert!(is_destructive(&json!({ "name": "run_query" })));
+        assert!(!is_destructive(&json!({ "name": "list_files" })));
+        assert!(!is_destructive(&json!({
+            "name": "delete_file",
+            "annotations": { "destructiveHint": false }
+        })));
     }
 
     #[test]

--- a/src-tauri/src/router.rs
+++ b/src-tauri/src/router.rs
@@ -144,15 +144,24 @@ fn name_looks_destructive(name: &str) -> bool {
                 | "drop"
                 | "execute"
                 | "insert"
+                | "move"
+                | "patch"
                 | "post"
                 | "publish"
                 | "remove"
+                | "rename"
+                | "replace"
                 | "run"
                 | "send"
                 | "truncate"
                 | "update"
+                | "upload"
                 | "write"
         )
+        // `edit`/`modify` are deliberately omitted: they overlap with the benign
+        // description-churn class that integrity drift tiering keeps quiet (see
+        // `drift_severity_tiers_loud_vs_benign`), and widening them there would
+        // trade the alert-fatigue win for louder, lower-signal drift alerts.
     })
 }
 
@@ -1217,6 +1226,9 @@ mod tests {
         assert!(is_destructive(&json!({ "name": "delete_file" })));
         assert!(is_destructive(&json!({ "name": "sendEmail" })));
         assert!(is_destructive(&json!({ "name": "run_query" })));
+        assert!(is_destructive(&json!({ "name": "rename_branch" })));
+        assert!(is_destructive(&json!({ "name": "uploadObject" })));
+        assert!(is_destructive(&json!({ "name": "patch_record" })));
         assert!(!is_destructive(&json!({ "name": "list_files" })));
         assert!(!is_destructive(&json!({
             "name": "delete_file",

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -352,6 +352,7 @@ export interface PendingApproval {
   client: string | null;
   server: string;
   tool: string;
+  toolFingerprint?: string | null;
   reason: "destructive" | "untrusted_source" | "destructive_and_untrusted";
   arguments: unknown;
   /** Wall-clock epoch-ms when this call auto-denies; the overlay counts down to it. */


### PR DESCRIPTION
Reviewing Codex's finished work from the deferred audit backlog. Three security-hardening changes, each with tests. Full lib (299) + gateway bin (64) suites pass, no new clippy warnings.

## 1. Fingerprint-bound approvals
Allowlist entries are now keyed `server/tool/<fingerprint>` instead of a broad `server/tool`. A tool whose definition changes since approval re-prompts instead of inheriting a stale bypass (closes the rug-pull gap).

- `ApprovalRequest`/`PendingView` carry `tool_fingerprint`; the gateway resolves it via `integrity::fingerprint` over the cached/aggregated tool.
- Auto-approve only matches fingerprint-bound keys. **Legacy broad `server/tool` entries are intentionally ignored** so a changed definition can't inherit a stale bypass. Existing users re-approve once.
- Explicit `destructiveHint: false` still wins over any name heuristic.

## 2. Name-based destructive fallback
`is_destructive` now catches obvious write/delete verbs (create/delete/drop/run/send/publish/update/…) when a server emits no `destructiveHint`, so the HITL confirm gate and the destructive-deny switch fail toward caution. An explicit `false` hint overrides the fallback.

## 3. Diagnostics secret redaction
`registry_summary` now redacts inline secret args and URL userinfo (reusing `arg_looks_secret` / `redact_url_userinfo`) before diagnostics are shared, and the inspect ring is cleared on startup when live inspection is off.

## Behavior notes for reviewers
- Users with existing persistent allowlists will be re-prompted once (deliberate).
- The destructive name-fallback broadens what the destructive gate catches; direction is fail-safe but may increase prompts for un-annotated servers.