### PR TITLE
chore(release): 1.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,26 @@ Entries before the rename below shipped under the project's former name, Conduit
 
 ## [Unreleased]
 
+## [1.5.2] - 2026-07-07
+
 Post-1.5.1 security and robustness batch from a multi-dimension gateway audit
-(#203 HIGH, #204 MEDIUM, #205 LOW/robustness). All batches ship with regression
-tests; full suite green.
+(#203 HIGH, #204 MEDIUM, #205 LOW/robustness), plus a follow-on hardening pass
+(#207). All batches ship with regression tests; full suite green.
 
 ### Security
 
+- **Approvals are now bound to the tool definition.** A "for this session" or "always" allow
+  is keyed to a fingerprint of the exact tool definition it was granted for, resolved from
+  the live server. If a server later changes that tool (a rug-pull), the call re-prompts
+  instead of inheriting the old approval; legacy broad allows are ignored, so existing users
+  re-approve once. (#207)
+- **Broader destructive-tool detection.** When a server omits the MCP `destructiveHint`, the
+  approval gate now also treats obvious write/delete verbs in the tool name (delete, drop,
+  send, publish, truncate, upload, ...) as destructive, failing toward caution. An explicit
+  `destructiveHint: false` still wins. (#207)
+- **Secret redaction in shareable diagnostics.** The diagnostics summary now redacts inline
+  secret arguments and credentials embedded in server URLs, and clears the live-inspection
+  buffer on startup when inspection is off. (#207)
 - **Spawn-guard bypass via attached inline-eval flags.** The dangerous-flag guard only
   matched interpreter flags as standalone argv tokens, so the attached form
   (`python -c<code>`, `ruby -e<code>`) from a booby-trapped server config slipped past and

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "conduit",
   "private": true,
-  "version": "1.5.1",
+  "version": "1.5.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -604,7 +604,7 @@ dependencies = [
 
 [[package]]
 name = "conduit"
-version = "1.5.1"
+version = "1.5.2"
 dependencies = [
  "base64 0.22.1",
  "chacha20poly1305",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conduit"
-version = "1.5.1"
+version = "1.5.2"
 description = "Local MCP gateway: manage all your MCP servers in one place, set up once and shared by every AI client, with ~90% fewer tokens per request"
 authors = ["South Forge AI"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Toolport",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "identifier": "com.tsout.conduit",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
Cut v1.5.2 (patch) ahead of tonight's PH Teams launch. Bundles the post-1.5.1 audit hardening batch already merged to main (#203–#207).

**Version bump (4 files):** package.json, src-tauri/Cargo.toml, src-tauri/tauri.conf.json, src-tauri/Cargo.lock → 1.5.2. CHANGELOG stamped `[1.5.2] - 2026-07-07` with the #207 entries added.

**What ships since v1.5.1:**
- Security (#203 HIGH): spawn-guard inline-eval bypass; (#204 MEDIUM): OAuth DNS-rebind SSRF + cleartext-exchange bypass; router-lock availability.
- Robustness (#205 LOW): self-heal single-flight, thread cap, config-read cap, frontend polish, CI action pinning.
- Hardening (#207): fingerprint-bound approvals (rug-pull re-prompt), broader destructive-tool detection, diagnostics secret redaction.

No code changes in this PR beyond the version/changelog bump. On merge, tag `v1.5.2` triggers the signed 4-platform draft build; publish is a separate manual step after verification.