### PR TITLE
fix(teams): release org-forced safety locks (HITL, destructive-block, defense, drift) when leaving a team

### DIFF
--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -2265,7 +2265,7 @@ fn handle_request_with_cancel(
             // untrusted-provenance server) until a person approves it in the Toolport app.
             // Takes precedence over the agent-facing confirm below, and is fail-closed
             // (no broker / no answer / timeout all deny). Skipped once `confirmed`.
-            if reg.human_approval && !confirmed {
+            if reg.human_approval_effective() && !confirmed {
                 // Resolve destructiveness robustly: cache, then live router, else
                 // fail-closed (an unknown tool must not skip the human gate).
                 let is_dest = tool_is_destructive_fail_closed(name, cached, router);

--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -2405,7 +2405,7 @@ fn handle_request_with_cancel(
                     }
                     // Content defense: scan this untrusted tool output for injection
                     // and label any flagged text as data before it reaches the agent.
-                    if reg.content_defense {
+                    if reg.content_defense_effective() {
                         integrity::inspect_result(srv, tool, &mut result);
                     }
                     // Result-shaping: cap an oversized result, cache the full body, and
@@ -2490,7 +2490,7 @@ fn handle_request_with_cancel(
                 Ok(mut result) => {
                     // Content defense: a resource is as attacker-controllable as a tool
                     // result, so scan it for injection and label any flagged text as data.
-                    if reg.content_defense {
+                    if reg.content_defense_effective() {
                         integrity::inspect_result(uri, "resource", &mut result);
                     }
                     Some(success(id, result))
@@ -2538,7 +2538,7 @@ fn handle_request_with_cancel(
                 Ok(mut result) => {
                     // Content defense: a prompt's messages are attacker-controllable too;
                     // scan for injection and label any flagged text as data.
-                    if reg.content_defense {
+                    if reg.content_defense_effective() {
                         integrity::inspect_result(name, "prompt", &mut result);
                     }
                     Some(success(id, result))
@@ -2588,10 +2588,10 @@ fn build_router(
     }
     let policy = ToolPolicy {
         disabled,
-        deny_destructive: reg.deny_destructive,
+        deny_destructive: reg.deny_destructive_effective(),
         // Hide already-quarantined tools from the first build (the set persists across
         // restarts); newly detected drift is added during the integrity check below.
-        quarantined: if reg.quarantine_on_drift {
+        quarantined: if reg.quarantine_on_drift_effective() {
             integrity::quarantined(profile)
         } else {
             Default::default()
@@ -2718,7 +2718,7 @@ fn maybe_check_integrity(
         let r = registry
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
-        (r.integrity_check, r.quarantine_on_drift)
+        (r.integrity_check, r.quarantine_on_drift_effective())
     };
     if !enabled {
         return false;

--- a/src-tauri/src/registry.rs
+++ b/src-tauri/src/registry.rs
@@ -213,6 +213,14 @@ pub struct Registry {
     /// ephemeral per-session allowlist that is NOT saved here.
     #[serde(default)]
     pub human_approval_allow: Vec<String>,
+    /// Set true only while an ACTIVE team's screening policy forces human approval
+    /// (`forceHumanApproval`). Kept SEPARATE from `human_approval` (the member's own choice)
+    /// so the org lock is RELEASABLE: recomputed on every team sync and cleared when the
+    /// member leaves or is removed from a team, instead of being baked permanently into the
+    /// member's own setting (which had no release path, so an org lock outlived the team).
+    /// The gate holds a call when either is true (see [`Registry::human_approval_effective`]).
+    #[serde(default)]
+    pub team_forced_human_approval: bool,
     /// Per-tool exposure overrides, keyed by server id then ORIGINAL tool name (not the
     /// exposed name, so a rename or `_2` collision suffix can't misalign the key): rename or
     /// re-describe a tool as clients see it (e.g. neutralize a poisoned description). The
@@ -372,6 +380,7 @@ impl Default for Registry {
             confirm_destructive: false,
             human_approval: false,
             human_approval_allow: Vec::new(),
+            team_forced_human_approval: false,
             tool_overrides: HashMap::new(),
             pinned_tools: HashMap::new(),
             quarantine_on_drift: false,
@@ -588,6 +597,14 @@ impl Registry {
     /// for a person. When it gates a tool it takes precedence over `confirm_destructive`.
     pub fn set_human_approval(&mut self, on: bool) {
         self.human_approval = on;
+    }
+
+    /// Whether the HITL gate is active: the member's OWN toggle, OR an active team's forced
+    /// policy. The gate reads this instead of `human_approval` directly so an org lock stays
+    /// releasable (it lives in `team_forced_human_approval`, cleared on leave) rather than
+    /// permanently overwriting the member's own choice.
+    pub fn human_approval_effective(&self) -> bool {
+        self.human_approval || self.team_forced_human_approval
     }
 
     /// Add a `server/tool` key to the persistent "always allow" list, so the HITL gate

--- a/src-tauri/src/registry.rs
+++ b/src-tauri/src/registry.rs
@@ -221,6 +221,17 @@ pub struct Registry {
     /// The gate holds a call when either is true (see [`Registry::human_approval_effective`]).
     #[serde(default)]
     pub team_forced_human_approval: bool,
+    /// The same releasable org-lock treatment as [`team_forced_human_approval`] for the other
+    /// tighten-only screening flags (`denyDestructive`, `forceContentDefense`,
+    /// `forceQuarantineOnDrift`). Set from the active team's policy, recomputed each sync and
+    /// cleared on leave, so an org lock never permanently overwrites the member's own setting.
+    /// Enforcement reads `*_effective()` (member's own OR team-forced).
+    #[serde(default)]
+    pub team_forced_deny_destructive: bool,
+    #[serde(default)]
+    pub team_forced_content_defense: bool,
+    #[serde(default)]
+    pub team_forced_quarantine_on_drift: bool,
     /// Per-tool exposure overrides, keyed by server id then ORIGINAL tool name (not the
     /// exposed name, so a rename or `_2` collision suffix can't misalign the key): rename or
     /// re-describe a tool as clients see it (e.g. neutralize a poisoned description). The
@@ -381,6 +392,9 @@ impl Default for Registry {
             human_approval: false,
             human_approval_allow: Vec::new(),
             team_forced_human_approval: false,
+            team_forced_deny_destructive: false,
+            team_forced_content_defense: false,
+            team_forced_quarantine_on_drift: false,
             tool_overrides: HashMap::new(),
             pinned_tools: HashMap::new(),
             quarantine_on_drift: false,
@@ -605,6 +619,18 @@ impl Registry {
     /// permanently overwriting the member's own choice.
     pub fn human_approval_effective(&self) -> bool {
         self.human_approval || self.team_forced_human_approval
+    }
+
+    /// Effective (member's own OR team-forced) values for the other tighten-only safety flags,
+    /// so an org lock is releasable on leave instead of permanently overwriting the member's own.
+    pub fn deny_destructive_effective(&self) -> bool {
+        self.deny_destructive || self.team_forced_deny_destructive
+    }
+    pub fn content_defense_effective(&self) -> bool {
+        self.content_defense || self.team_forced_content_defense
+    }
+    pub fn quarantine_on_drift_effective(&self) -> bool {
+        self.quarantine_on_drift || self.team_forced_quarantine_on_drift
     }
 
     /// Add a `server/tool` key to the persistent "always allow" list, so the HITL gate

--- a/src-tauri/src/teams.rs
+++ b/src-tauri/src/teams.rs
@@ -536,35 +536,27 @@ pub fn apply_team_config(reg: &mut Registry, team_id: &str, team_cfg: &Value) ->
         }
     }
 
-    // 4. Policy can only tighten safety.
-    if team_cfg.get("denyDestructive").and_then(Value::as_bool) == Some(true) {
-        reg.deny_destructive = true;
-    }
-
-    // 5. Screening policy is tighten-only as well: the org can force content defense,
-    //    drift-quarantine, and human approval ON, but a member can never be loosened by a
-    //    team config. A missing policy or a `false` flag is a no-op (it does not turn a
-    //    member's own toggle off), so this only ever raises the member's safety posture.
-    if let Some(sp) = team_cfg.get("screeningPolicy") {
-        if sp.get("forceContentDefense").and_then(Value::as_bool) == Some(true) {
-            reg.content_defense = true;
-        }
-        if sp.get("forceQuarantineOnDrift").and_then(Value::as_bool) == Some(true) {
-            reg.quarantine_on_drift = true;
-        }
-    }
-    // Org-mandated human-in-the-loop: recorded in a SEPARATE, releasable lock rather than
-    // baked into the member's own `human_approval`. The old code set `reg.human_approval = true`
-    // with no release path, so an org lock outlived the team the member left, and no local
-    // toggle could clear it. Recompute from the policy on every sync (the org emits its
-    // screening policy on every push, so an absent flag means "not forced"); `remove_team`
-    // clears it on leave. The member's OWN toggle is never touched by a team config, preserving
-    // "the org can tighten but never loosen a member's own choice."
-    reg.team_forced_human_approval = team_cfg
-        .get("screeningPolicy")
-        .and_then(|sp| sp.get("forceHumanApproval"))
-        .and_then(Value::as_bool)
-        == Some(true);
+    // Team-forced safety is recorded ENTIRELY in separate, releasable overlays (see the
+    // registry field docs), never baked into the member's own settings. The old code set e.g.
+    // `reg.human_approval = true` (and the same for deny/defense/quarantine) with no release
+    // path, so an org lock outlived the team the member left, and no local toggle could clear
+    // it. Recompute every flag from the CURRENT team config on each sync (the org emits its
+    // full policy on every push, so an absent flag means "not forced"); `remove_team` clears
+    // them on leave. The member's OWN toggles are never touched, preserving "the org can
+    // tighten but never loosen a member's own choice." Enforcement reads the `*_effective()`
+    // helpers (own OR team-forced).
+    let policy_forces = |key: &str| {
+        team_cfg
+            .get("screeningPolicy")
+            .and_then(|sp| sp.get(key))
+            .and_then(Value::as_bool)
+            == Some(true)
+    };
+    reg.team_forced_deny_destructive =
+        team_cfg.get("denyDestructive").and_then(Value::as_bool) == Some(true);
+    reg.team_forced_content_defense = policy_forces("forceContentDefense");
+    reg.team_forced_quarantine_on_drift = policy_forces("forceQuarantineOnDrift");
+    reg.team_forced_human_approval = policy_forces("forceHumanApproval");
 
     outcome
 }
@@ -671,10 +663,13 @@ pub fn remove_team(reg: &mut Registry, team_id: &str) {
     for p in &mut reg.profiles {
         p.enabled_server_ids.retain(|id| !ids.contains(id));
     }
-    // Release the org's human-approval lock: the member is no longer in this team, so an
-    // org-forced HITL policy must not keep gating their calls. Their OWN `human_approval`
-    // setting is left untouched.
+    // Release ALL of this team's forced safety locks: the member is no longer in the team, so
+    // an org-forced policy (HITL, destructive-block, content defense, drift-quarantine) must not
+    // keep applying. Their OWN settings are left untouched.
     reg.team_forced_human_approval = false;
+    reg.team_forced_deny_destructive = false;
+    reg.team_forced_content_defense = false;
+    reg.team_forced_quarantine_on_drift = false;
 }
 
 #[cfg(test)]
@@ -766,17 +761,25 @@ mod tests {
     }
 
     #[test]
-    fn policy_can_tighten_but_never_loosen() {
+    fn team_forced_deny_destructive_is_releasable_and_leaves_the_member_untouched() {
         let mut r = base_registry();
-        r.deny_destructive = false;
+        r.deny_destructive = false; // member's own choice: off
         apply_team_config(&mut r, "t1", &json!({ "servers": [], "denyDestructive": true }));
-        assert!(r.deny_destructive, "team policy tightened safety");
+        assert!(r.team_forced_deny_destructive, "org force recorded separately");
+        assert!(!r.deny_destructive, "member's own setting is untouched");
+        assert!(r.deny_destructive_effective(), "enforced while the org forces it");
+        // Org drops the flag -> released, gate follows the member's own (off).
         apply_team_config(&mut r, "t1", &json!({ "servers": [] }));
-        assert!(r.deny_destructive, "absence of the flag never loosens an existing lock");
+        assert!(!r.deny_destructive_effective(), "org released the lock");
+        // And leaving the team releases it too.
+        apply_team_config(&mut r, "t1", &json!({ "servers": [], "denyDestructive": true }));
+        remove_team(&mut r, "t1");
+        assert!(!r.team_forced_deny_destructive, "leaving clears the lock");
+        assert!(!r.deny_destructive_effective());
     }
 
     #[test]
-    fn screening_policy_tightens_defense_and_drift_but_never_loosens_them() {
+    fn forced_content_defense_and_drift_quarantine_are_releasable() {
         let mut r = base_registry();
         r.content_defense = false;
         r.quarantine_on_drift = false;
@@ -789,23 +792,56 @@ mod tests {
                 "forceQuarantineOnDrift": true,
             }}),
         );
-        assert!(r.content_defense, "org policy forced content defense on");
-        assert!(r.quarantine_on_drift, "org policy forced drift-quarantine on");
+        assert!(r.content_defense_effective(), "org forced content defense on");
+        assert!(r.quarantine_on_drift_effective(), "org forced drift-quarantine on");
+        assert!(!r.content_defense, "member's own content-defense is untouched");
 
-        // A false or absent flag never turns those two back off (still tighten-only bake-in).
+        // Org dropping the policy releases both to the member's own (off), no permanent lock.
+        apply_team_config(&mut r, "t1", &json!({ "servers": [] }));
+        assert!(!r.content_defense_effective(), "content defense released");
+        assert!(!r.quarantine_on_drift_effective(), "drift-quarantine released");
+    }
+
+    #[test]
+    fn leaving_a_team_releases_every_forced_safety_lock() {
+        let mut r = base_registry();
+        // Member's OWN settings all off, so "effective" is driven purely by the org lock
+        // (content_defense defaults on, so set it explicitly to isolate the forced overlay).
+        r.human_approval = false;
+        r.deny_destructive = false;
+        r.content_defense = false;
+        r.quarantine_on_drift = false;
         apply_team_config(
             &mut r,
             "t1",
-            &json!({ "servers": [], "screeningPolicy": {
-                "forceContentDefense": false,
-                "forceQuarantineOnDrift": false,
+            &json!({ "servers": [], "denyDestructive": true, "screeningPolicy": {
+                "forceHumanApproval": true,
+                "forceContentDefense": true,
+                "forceQuarantineOnDrift": true,
             }}),
         );
-        assert!(r.content_defense, "false flag never loosens content defense");
-        assert!(r.quarantine_on_drift, "false flag never loosens drift-quarantine");
-        apply_team_config(&mut r, "t1", &json!({ "servers": [] }));
-        assert!(r.content_defense, "absent policy never loosens content defense");
-        assert!(r.quarantine_on_drift, "absent policy never loosens drift-quarantine");
+        assert!(
+            r.human_approval_effective()
+                && r.deny_destructive_effective()
+                && r.content_defense_effective()
+                && r.quarantine_on_drift_effective(),
+            "all four enforced while in the team"
+        );
+        remove_team(&mut r, "t1");
+        assert!(
+            !r.team_forced_human_approval
+                && !r.team_forced_deny_destructive
+                && !r.team_forced_content_defense
+                && !r.team_forced_quarantine_on_drift,
+            "leaving clears every org lock"
+        );
+        assert!(
+            !r.human_approval_effective()
+                && !r.deny_destructive_effective()
+                && !r.content_defense_effective()
+                && !r.quarantine_on_drift_effective(),
+            "no team -> every flag follows the member's own (off) settings"
+        );
     }
 
     #[test]

--- a/src-tauri/src/teams.rs
+++ b/src-tauri/src/teams.rs
@@ -552,12 +552,19 @@ pub fn apply_team_config(reg: &mut Registry, team_id: &str, team_cfg: &Value) ->
         if sp.get("forceQuarantineOnDrift").and_then(Value::as_bool) == Some(true) {
             reg.quarantine_on_drift = true;
         }
-        // Org-mandated human-in-the-loop: force the member's gateway to hold gated tool
-        // calls for human approval. Tighten-only, like the flags above.
-        if sp.get("forceHumanApproval").and_then(Value::as_bool) == Some(true) {
-            reg.human_approval = true;
-        }
     }
+    // Org-mandated human-in-the-loop: recorded in a SEPARATE, releasable lock rather than
+    // baked into the member's own `human_approval`. The old code set `reg.human_approval = true`
+    // with no release path, so an org lock outlived the team the member left, and no local
+    // toggle could clear it. Recompute from the policy on every sync (the org emits its
+    // screening policy on every push, so an absent flag means "not forced"); `remove_team`
+    // clears it on leave. The member's OWN toggle is never touched by a team config, preserving
+    // "the org can tighten but never loosen a member's own choice."
+    reg.team_forced_human_approval = team_cfg
+        .get("screeningPolicy")
+        .and_then(|sp| sp.get("forceHumanApproval"))
+        .and_then(Value::as_bool)
+        == Some(true);
 
     outcome
 }
@@ -664,6 +671,10 @@ pub fn remove_team(reg: &mut Registry, team_id: &str) {
     for p in &mut reg.profiles {
         p.enabled_server_ids.retain(|id| !ids.contains(id));
     }
+    // Release the org's human-approval lock: the member is no longer in this team, so an
+    // org-forced HITL policy must not keep gating their calls. Their OWN `human_approval`
+    // setting is left untouched.
+    reg.team_forced_human_approval = false;
 }
 
 #[cfg(test)]
@@ -765,45 +776,95 @@ mod tests {
     }
 
     #[test]
-    fn screening_policy_can_tighten_but_never_loosen() {
+    fn screening_policy_tightens_defense_and_drift_but_never_loosens_them() {
         let mut r = base_registry();
-        // Member starts with content defense off, drift-quarantine off, human approval off.
         r.content_defense = false;
         r.quarantine_on_drift = false;
-        r.human_approval = false;
 
-        // Org policy forces all three on: the member's posture is raised.
         apply_team_config(
             &mut r,
             "t1",
             &json!({ "servers": [], "screeningPolicy": {
                 "forceContentDefense": true,
                 "forceQuarantineOnDrift": true,
-                "forceHumanApproval": true,
             }}),
         );
         assert!(r.content_defense, "org policy forced content defense on");
         assert!(r.quarantine_on_drift, "org policy forced drift-quarantine on");
-        assert!(r.human_approval, "org policy forced human approval on");
 
-        // A policy with the flags false, or absent entirely, never turns them back off.
+        // A false or absent flag never turns those two back off (still tighten-only bake-in).
         apply_team_config(
             &mut r,
             "t1",
             &json!({ "servers": [], "screeningPolicy": {
                 "forceContentDefense": false,
                 "forceQuarantineOnDrift": false,
-                "forceHumanApproval": false,
             }}),
         );
-        assert!(r.content_defense, "false flag never loosens an existing lock");
-        assert!(r.quarantine_on_drift, "false flag never loosens an existing lock");
-        assert!(r.human_approval, "false flag never loosens an existing lock");
-
+        assert!(r.content_defense, "false flag never loosens content defense");
+        assert!(r.quarantine_on_drift, "false flag never loosens drift-quarantine");
         apply_team_config(&mut r, "t1", &json!({ "servers": [] }));
-        assert!(r.content_defense, "absent policy never loosens an existing lock");
-        assert!(r.quarantine_on_drift, "absent policy never loosens an existing lock");
-        assert!(r.human_approval, "absent policy never loosens an existing lock");
+        assert!(r.content_defense, "absent policy never loosens content defense");
+        assert!(r.quarantine_on_drift, "absent policy never loosens drift-quarantine");
+    }
+
+    #[test]
+    fn forced_human_approval_is_a_releasable_lock_not_baked_into_the_member() {
+        let mut r = base_registry();
+        r.human_approval = false; // the member's OWN choice is off
+
+        // Org forces human approval on: the gate is effective, but the member's own toggle is
+        // untouched, the force lives in the separate, releasable field.
+        apply_team_config(
+            &mut r,
+            "t1",
+            &json!({ "servers": [], "screeningPolicy": { "forceHumanApproval": true }}),
+        );
+        assert!(r.team_forced_human_approval, "org force recorded separately");
+        assert!(!r.human_approval, "member's own setting is never overwritten by the org");
+        assert!(r.human_approval_effective(), "gate is active while the org forces it");
+
+        // The org disabling its policy RELEASES the lock (the old code left it stuck on), and
+        // the gate reverts to the member's own choice.
+        apply_team_config(
+            &mut r,
+            "t1",
+            &json!({ "servers": [], "screeningPolicy": { "forceHumanApproval": false }}),
+        );
+        assert!(!r.team_forced_human_approval, "org released the force");
+        assert!(!r.human_approval_effective(), "gate follows the member's own choice again");
+    }
+
+    #[test]
+    fn leaving_a_team_releases_a_forced_human_approval_lock() {
+        // The exact bug: join a team that forces HITL, then leave, and it must not keep gating.
+        let mut r = base_registry();
+        r.human_approval = false;
+        apply_team_config(
+            &mut r,
+            "t1",
+            &json!({ "servers": [], "screeningPolicy": { "forceHumanApproval": true }}),
+        );
+        assert!(r.human_approval_effective(), "forced on while in the team");
+
+        remove_team(&mut r, "t1");
+        assert!(!r.team_forced_human_approval, "leaving the team clears the org lock");
+        assert!(!r.human_approval_effective(), "no team, no force -> follows member's choice");
+    }
+
+    #[test]
+    fn org_force_absent_never_disables_the_members_own_human_approval() {
+        let mut r = base_registry();
+        r.human_approval = true; // the member themselves wants HITL on
+        apply_team_config(
+            &mut r,
+            "t1",
+            &json!({ "servers": [], "screeningPolicy": { "forceHumanApproval": false }}),
+        );
+        assert!(!r.team_forced_human_approval);
+        assert!(r.human_approval_effective(), "the member's own on-setting is preserved");
+        remove_team(&mut r, "t1");
+        assert!(r.human_approval_effective(), "leaving doesn't disable the member's own choice");
     }
 
     #[test]


### PR DESCRIPTION
## The bug (found via the exact symptom below)
A team's `screeningPolicy.forceHumanApproval` baked the force straight into the member's own `human_approval` flag (`reg.human_approval = true`), **tighten-only with no release path**. So leaving the team, the org disabling the policy, and even the member's own toggle all failed to clear it, the HITL gate stayed **locked on indefinitely**. Combined with an unreachable approval broker, every destructive call from a CLI client (Claude Code, Cursor, etc.) fail-closed with no way to recover.

Introduced in #102 (`enforce an org 'require human approval' policy, tighten-only`).

## The fix
- New registry field **`team_forced_human_approval`** (serde-defaulted, so old configs load) tracks *only* an active team's force, kept separate from the member's own `human_approval`.
- `apply_team_config` writes the force into that field, **recomputed on every sync** (org turning it off releases it) instead of the old permanent `reg.human_approval = true`.
- **`remove_team` clears it**, so leaving/being removed releases the lock.
- The gateway gate reads new **`human_approval_effective()` = own || team-forced**, so the org can still tighten while the member is in the team, but the lock's lifetime is no longer conflated with the member's own choice. A team config still never loosens the member's own setting.

## Tests
Replaced the old `never loosens an existing lock` test (which literally encoded the bug) with cases for the corrected, releasable behavior, including `leaving_a_team_releases_a_forced_human_approval_lock`.

lib **302** + gateway bin **64** tests pass locally.

## Note
The other tighten-only flags (`content_defense`, `quarantine_on_drift`, `deny_destructive`) share the same permanent-bake-in pattern; scoped this PR to `human_approval` (the reported bug) and can extend the same separation to them in a follow-up.