### PR TITLE
feat(teams): long-poll team sync (policy edits enforce in ~1s)

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1260,21 +1260,45 @@ fn team_connect(
 #[tauri::command]
 fn team_sync(app: tauri::AppHandle, state: State<RegistryState>) -> Result<Registry, String> {
     flush_to_disk(state.inner())?;
-    match teams::sync_now()? {
+    finish_sync(&app, state.inner(), teams::sync_now()?)
+}
+
+/// Long-polling sync for the member's background loop: the config pull parks on the server
+/// for up to `wait_secs` (clamped) and returns the instant the team config view changes, so
+/// a dashboard policy edit enforces in ~1s instead of at the next interval. Otherwise
+/// identical to [`team_sync`]; the frontend re-invokes it in a loop.
+#[tauri::command]
+fn team_sync_wait(
+    app: tauri::AppHandle,
+    state: State<RegistryState>,
+    wait_secs: u64,
+) -> Result<Registry, String> {
+    flush_to_disk(state.inner())?;
+    finish_sync(&app, state.inner(), teams::sync_wait(wait_secs.min(30))?)
+}
+
+/// Apply a sync result to the shared registry state and tell the UI what happened. Shared by
+/// the immediate ([`team_sync`]) and long-polling ([`team_sync_wait`]) commands.
+fn finish_sync(
+    app: &tauri::AppHandle,
+    state: &RegistryState,
+    result: teams::SyncResult,
+) -> Result<Registry, String> {
+    match result {
         teams::SyncResult::Removed => {
-            // The member was removed; sync_now already cleared the local team. Reload
-            // so the UI drops the team, and tell it why so it can surface a notice
-            // rather than the raw error the config pull used to throw.
-            let fresh = reload_into_state(state.inner())?;
-            nudge_gateway(state.inner());
+            // The member was removed; sync already cleared the local team. Reload so the UI
+            // drops the team, and tell it why so it can surface a notice rather than the raw
+            // error the config pull used to throw.
+            let fresh = reload_into_state(state)?;
+            nudge_gateway(state);
             let _ = app.emit("team-removed", serde_json::json!({}));
             Ok(fresh)
         }
         teams::SyncResult::Ok { applied, .. } => {
             let outcome = applied.map(|(_, o)| o).unwrap_or_default();
-            let fresh = reload_into_state(state.inner())?;
-            nudge_gateway(state.inner());
-            emit_team_review(&app, outcome);
+            let fresh = reload_into_state(state)?;
+            nudge_gateway(state);
+            emit_team_review(app, outcome);
             Ok(fresh)
         }
     }
@@ -2180,6 +2204,7 @@ pub fn run() {
             set_allow_agent_control,
             team_connect,
             team_sync,
+            team_sync_wait,
             team_disconnect,
             team_push,
             set_auth_token,

--- a/src-tauri/src/teams.rs
+++ b/src-tauri/src/teams.rs
@@ -65,8 +65,15 @@ fn require_secure_team_url(server_url: &str) -> Result<(), String> {
 /// command thread, so a slow or black-holed team server must not hang the UI: bare
 /// `ureq::get/post/put` have no timeout, this does.
 fn agent() -> ureq::Agent {
+    agent_with_timeout(30)
+}
+
+/// A ureq agent with an explicit total timeout. A long-poll config pull needs a client
+/// timeout comfortably above the server's `wait` window, so the server (not the client)
+/// decides when to return.
+fn agent_with_timeout(secs: u64) -> ureq::Agent {
     ureq::AgentBuilder::new()
-        .timeout(std::time::Duration::from_secs(30))
+        .timeout(std::time::Duration::from_secs(secs))
         .build()
 }
 
@@ -105,16 +112,27 @@ pub fn pull_config(
     token: &str,
     last_version: i64,
     last_etag: Option<&str>,
+    wait_secs: u64,
 ) -> Result<Option<(i64, Value, Option<String>)>, String> {
     require_secure_team_url(server_url)?;
-    let url = format!("{}/teams/{}/config", base(server_url), team_id);
+    let mut url = format!("{}/teams/{}/config", base(server_url), team_id);
+    // Long-poll: ask the server to hold the request until the team config view changes (or
+    // `wait_secs` elapses), so a dashboard policy edit reaches us in ~1s instead of at the
+    // next cycle. Give the client a timeout above the server's window so the server decides
+    // when to return; a 304/200 the moment something changes.
+    let ag = if wait_secs > 0 {
+        url.push_str(&format!("?wait={wait_secs}"));
+        agent_with_timeout(wait_secs + 10)
+    } else {
+        agent()
+    };
     // Echo the exact ETag the server last gave us. A restricted member's ETag carries a
     // per-member access suffix ("v{n}-m{hash}"), so a reconstructed "v{n}" would never
     // 304 for them; fall back to "v{n}" only before we've ever stored one.
     let etag = last_etag
         .map(str::to_string)
         .unwrap_or_else(|| format!("\"v{last_version}\""));
-    let req = agent()
+    let req = ag
         .get(&url)
         .set("authorization", &format!("Bearer {token}"))
         .set("if-none-match", &etag);
@@ -240,7 +258,7 @@ fn finish_connect(server_url: &str, member_name: Option<&str>, joined: Joined) -
     reg.team = Some(conn);
     let mut outcome = MergeOutcome::default();
     if let Some((version, cfg, etag)) =
-        pull_config(&base(server_url), &joined.team_id, &joined.member_token, 0, None)?
+        pull_config(&base(server_url), &joined.team_id, &joined.member_token, 0, None, 0)?
     {
         outcome = apply_team_config(&mut reg, &joined.team_id, &cfg);
         if let Some(t) = reg.team.as_mut() {
@@ -270,6 +288,18 @@ pub enum SyncResult {
 }
 
 pub fn sync_now() -> Result<SyncResult, String> {
+    sync_inner(0)
+}
+
+/// Long-polling variant of [`sync_now`]: the config pull parks on the server for up to
+/// `wait_secs`, returning the instant the team's config view changes so a dashboard policy
+/// edit enforces in about a second. The membership heartbeat still runs first each cycle,
+/// so removal and role changes are caught at least once per cycle. The caller loops.
+pub fn sync_wait(wait_secs: u64) -> Result<SyncResult, String> {
+    sync_inner(wait_secs)
+}
+
+fn sync_inner(wait_secs: u64) -> Result<SyncResult, String> {
     // Snapshot only what the network calls need; do NOT hold this copy to save later.
     let conn = {
         let reg = crate::registry::load()?;
@@ -300,6 +330,7 @@ pub fn sync_now() -> Result<SyncResult, String> {
         &token,
         conn.last_version,
         conn.last_etag.as_deref(),
+        wait_secs,
     )?;
 
     // Re-load a FRESH registry now, AFTER the (possibly multi-second) network round

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -30,7 +30,7 @@ import {
   removeServer,
   setAllEnabled,
   setServerEnabled,
-  teamSync,
+  teamSyncWait,
 } from "@/lib/api";
 import {
   importableServers,
@@ -246,36 +246,48 @@ function App() {
     };
   }, []);
 
-  // Keep a team member's shared server set AND security policy current even if they
-  // never open the Teams tab: an admin tightening a force-quarantine / approval policy
-  // must reach every member, not just those who happen to click "Sync now". Runs on
-  // connect and on a modest interval; cheap when unchanged (the server 304s on an
-  // unchanged config), and not tied to the Teams view. Keyed on the team id so it
+  // Keep a team member's shared server set AND security policy current even if they never
+  // open the Teams tab: an admin tightening a force-quarantine / approval policy must reach
+  // every member near-instantly, not just those who happen to click "Sync now". This runs a
+  // continuous long-poll: each call parks on the server for up to WAIT_SECS and returns the
+  // instant the team config view changes (or the wait elapses), so a dashboard edit lands in
+  // ~1s while staying cheap when idle. Not tied to the Teams view. Keyed on the team id so it
   // starts on connect and tears down on disconnect/removal.
   const teamId = registry?.team?.teamId;
   useEffect(() => {
     if (!teamId) return;
     let cancelled = false;
-    let running = false;
-    const tick = async () => {
-      if (running || cancelled) return;
-      running = true;
-      try {
-        const fresh = await teamSync();
-        if (!cancelled) setRegistry(fresh);
-      } catch {
-        // A transient network error is fine; the next tick retries. Removal is a clean
-        // 401/403 the backend turns into a cleared team + the team-removed event, not a
-        // throw, so it won't land here.
-      } finally {
-        running = false;
+    const WAIT_SECS = 25;
+    // Floor between re-parks. A change is applied the instant it arrives (below), so this only
+    // paces the NEXT poll, never delays enforcement. It also keeps us gentle against an OLDER
+    // server that doesn't support `?wait` and so returns immediately: without a floor that would
+    // be a hot loop; with it, an old server degrades to a polite ~3s poll.
+    const FLOOR_MS = 3000;
+    const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+    const loop = async () => {
+      while (!cancelled) {
+        const started = Date.now();
+        try {
+          const fresh = await teamSyncWait(WAIT_SECS);
+          if (cancelled) break;
+          setRegistry(fresh);
+        } catch {
+          // Network blip or server down: back off before re-parking so we don't spin.
+          // Removal is a clean 401/403 the backend turns into a cleared team + the
+          // team-removed event, not a throw, so it won't land here.
+          if (cancelled) break;
+          await sleep(15000);
+          continue;
+        }
+        // If the call returned well before the wait window (a real change, already applied
+        // above, or an old server ignoring `?wait`), pace the next park.
+        const elapsed = Date.now() - started;
+        if (!cancelled && elapsed < FLOOR_MS) await sleep(FLOOR_MS - elapsed);
       }
     };
-    void tick();
-    const id = setInterval(tick, 5 * 60 * 1000);
+    void loop();
     return () => {
       cancelled = true;
-      clearInterval(id);
     };
   }, [teamId]);
 

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -343,6 +343,15 @@ export function teamSync(): Promise<Registry> {
   return invoke<Registry>("team_sync");
 }
 
+/**
+ * Long-polling sync: parks on the server for up to `waitSecs` and returns the instant the
+ * team config view changes (or the wait elapses), so a dashboard policy edit enforces in
+ * ~1s. Drive it in a loop; it returns like {@link teamSync}.
+ */
+export function teamSyncWait(waitSecs: number): Promise<Registry> {
+  return invoke<Registry>("team_sync_wait", { waitSecs });
+}
+
 /** Leave the team: remove its merged servers and clear the saved token. */
 export function teamDisconnect(): Promise<Registry> {
   return invoke<Registry>("team_disconnect");


### PR DESCRIPTION
## What

Team members kept their shared servers + security policy current by polling `GET /config` **every 5 minutes**. So when an admin tightens a `forceHumanApproval` / `forceQuarantineOnDrift` policy in the dashboard, it could take **up to 5 minutes** to enforce on a member's machine. This makes it **~1 second**.

## How

Switches the member's background sync from a 5-min interval to a **continuous long-poll** against the new `GET /config?wait=` endpoint (conduit-teams side is a companion PR):

- **`pull_config`** gains a `wait_secs` param. A waiting pull uses a client timeout *above* the server's wait window, so the server decides when to return (200 the instant the config view changes, or 304 at the timeout).
- **`sync_wait` / `team_sync_wait`** mirror `sync_now` / `team_sync` but long-poll. The membership heartbeat still runs first each cycle, so removal + role changes are caught at least once per cycle.
- **`App.tsx`** replaces `setInterval(tick, 5*60*1000)` with a long-poll loop. A change is applied the instant it arrives; a **3s floor** paces only the *next* re-park (never enforcement).

## Backward compatibility / robustness

- An **older server** that doesn't know `?wait` just ignores the query param (axum `Query` ignores unknown fields) and returns immediately. Without a floor that would be a hot loop; the 3s floor degrades it to a polite ~3s poll (still far faster than the old 5 min).
- Network blips back off 15s. Authoritative removal stays the clean 401/403 -> cleared-team + `team-removed` event path, not a throw.

## Note

Requires the companion conduit-teams PR (long-poll `GET /config`) deployed to actually get the ~1s latency; without it, the client safely falls back to the ~3s poll described above.

`tsc --noEmit` clean; `cargo build` + 299 lib tests green.