### PR TITLE
chore(release): 1.5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,28 @@ Entries before the rename below shipped under the project's former name, Conduit
 
 ## [Unreleased]
 
+## [1.5.3] - 2026-07-08
+
+Teams reliability and activation batch, ahead of the Teams launch.
+
+### Fixed
+
+- **Org-forced safety locks are released when you leave a team.** A team that enforced
+  human-in-the-loop approval, destructive-tool blocking, content defense, or
+  quarantine-on-drift used to bake that setting permanently into the member's own settings,
+  so leaving the team left the lock stuck on with no way to turn it back off. These org
+  forces are now tracked separately from your own settings and cleared the moment you leave;
+  your own toggles are never touched. (#209)
+
+### Added
+
+- **"Joining a team?" onboarding path.** The first-run wizard now offers first-class
+  invite-code entry, so a team member who was told to install Toolport can join their team
+  immediately instead of clicking through solo setup to look for it. (#210)
+- **Near-instant team policy sync.** Members now long-poll the team config, so an admin's
+  policy or access change in the dashboard enforces on member machines in about a second
+  instead of at the next poll interval. Falls back cleanly against an older team server. (#211)
+
 ## [1.5.2] - 2026-07-07
 
 Post-1.5.1 security and robustness batch from a multi-dimension gateway audit

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "conduit",
   "private": true,
-  "version": "1.5.2",
+  "version": "1.5.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -604,7 +604,7 @@ dependencies = [
 
 [[package]]
 name = "conduit"
-version = "1.5.2"
+version = "1.5.3"
 dependencies = [
  "base64 0.22.1",
  "chacha20poly1305",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conduit"
-version = "1.5.2"
+version = "1.5.3"
 description = "Local MCP gateway: manage all your MCP servers in one place, set up once and shared by every AI client, with ~90% fewer tokens per request"
 authors = ["South Forge AI"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Toolport",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "identifier": "com.tsout.conduit",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
Cuts **1.5.3** ahead of the Teams launch. Bundles the three PRs merged tonight:

- **#209 — Fixed: org-forced safety locks release on leave.** The stuck human-approval / destructive-block / content-defense / quarantine lock. This is the reason to ship now: it bites the join-a-team → leave churn we'll see as people try Teams.
- **#210 — Added: "Joining a team?" onboarding path.** First-class invite-code entry so team members aren't stranded in solo setup.
- **#211 — Added: near-instant team policy sync** (long-poll). Pairs with the already-deployed conduit-teams `GET /config?wait=` endpoint; falls back cleanly against an older server.

Version bumped in package.json, tauri.conf.json, Cargo.toml, Cargo.lock; CHANGELOG updated.

**On merge + tag `v1.5.3`, the release pipeline builds a DRAFT** (Win / macOS arm64 + Intel / Linux). Publishing the draft is left to the maintainer.