### PR TITLE
Add headless gateway: MCP streamable-HTTP, Docker, and env secrets

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,30 @@
+# Frontend / Node (not used by the gateway image build context)
+node_modules/
+dist/
+
+# Rust build artifacts
+src-tauri/target/
+
+# Generated Tauri assets
+src-tauri/gen/
+
+# Git and editor noise
+.git/
+.github/
+.cursor/
+.claude/
+
+# Local data and secrets — never bake into an image
+data/
+.env
+.env.*
+
+# Docs and benchmarks (not needed to compile toolport-gateway)
+docs/
+benchmark/
+*.md
+!src-tauri/**/*.md
+
+# OS / IDE
+.DS_Store
+Thumbs.db

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,46 @@
+# Headless Toolport gateway image (OpenAPI + MCP streamable-HTTP).
+# Build from the repo root:
+#   docker build -t toolport-gateway .
+#
+# Local/dev only on this branch — do not push to GHCR until you cut a release.
+
+FROM rust:1-slim AS build
+WORKDIR /src
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        pkg-config libssl-dev libdbus-1-dev libglib2.0-dev libgtk-3-dev libwebkit2gtk-4.1-dev libjavascriptcoregtk-4.1-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Cache dependency compilation: copy manifests + icons (tauri-build needs them),
+# stub the sources, build once, then rebuild with the real tree.
+COPY src-tauri/Cargo.toml src-tauri/Cargo.lock src-tauri/build.rs src-tauri/tauri.conf.json ./src-tauri/
+COPY src-tauri/icons ./src-tauri/icons
+COPY src-tauri/capabilities ./src-tauri/capabilities
+WORKDIR /src/src-tauri
+RUN mkdir -p src/bin && \
+    printf '%s\n' \
+      '#[cfg(test)] mod tests {}' \
+      'pub fn _docker_dep_stub() {}' > src/lib.rs && \
+    printf 'fn main() {}\n' > src/main.rs && \
+    printf 'fn main() {}\n' > src/bin/toolport-gateway.rs && \
+    printf 'fn main() {}\n' > src/bin/mock-mcp-server.rs && \
+    cargo build --release --bin toolport-gateway
+
+COPY src-tauri/src ./src
+RUN touch src/lib.rs src/main.rs src/bin/toolport-gateway.rs src/bin/mock-mcp-server.rs && \
+    cargo build --release --bin toolport-gateway
+
+FROM rust:1-slim
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates libssl3 libdbus-1-3 curl \
+    && rm -rf /var/lib/apt/lists/*
+WORKDIR /data
+COPY --from=build /src/src-tauri/target/release/toolport-gateway /usr/local/bin/toolport-gateway
+
+ENV CONDUIT_HTTP=8765
+ENV CONDUIT_HTTP_HOST=0.0.0.0
+ENV CONDUIT_REGISTRY=/data/registry.json
+EXPOSE 8765
+VOLUME ["/data"]
+
+# CONDUIT_HTTP_TOKEN is required for non-loopback binds (enforced by the binary).
+ENTRYPOINT ["toolport-gateway", "--http", "8765"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 WORKDIR /data
 COPY --from=build /src/src-tauri/target/release/toolport-gateway /usr/local/bin/toolport-gateway
+RUN useradd --system --uid 10001 --home-dir /data toolport \
+    && chown toolport:toolport /data
 
+USER toolport
 ENV CONDUIT_HTTP=8765
 ENV CONDUIT_HTTP_HOST=0.0.0.0
 ENV CONDUIT_REGISTRY=/data/registry.json

--- a/README.md
+++ b/README.md
@@ -204,6 +204,13 @@ Integrations -> Open WebUI / HTTP endpoint** in the app (or run
 tool server. See [docs/openwebui.md](docs/openwebui.md). The same endpoint serves
 any HTTP/OpenAPI MCP consumer (n8n, LibreChat, custom agents).
 
+### Headless / container / MCP over the network
+
+The same `--http` process also serves **MCP streamable-HTTP** at `POST /mcp`, so
+sandboxed coding agents and remote clients can use a URL instead of stdio. For
+Docker, env-file secrets, and a compose example, see
+[docs/headless.md](docs/headless.md).
+
 ## Configuration
 
 Lazy discovery, the destructive-tool block, and agent control are global settings,

--- a/data/registry.json.example
+++ b/data/registry.json.example
@@ -1,0 +1,22 @@
+{
+  "version": 1,
+  "servers": [
+    {
+      "id": "example-remote",
+      "name": "Example Remote MCP",
+      "transport": "http",
+      "url": "https://mcp.example.com/mcp",
+      "args": [],
+      "env": [],
+      "source": "manual"
+    }
+  ],
+  "profiles": [
+    {
+      "id": "default",
+      "name": "Default",
+      "enabledServerIds": ["example-remote"]
+    }
+  ],
+  "activeProfileId": "default"
+}

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -22,10 +22,13 @@ services:
       # CONDUIT_SECRET_KEY=...
       # Or inject per-server secrets directly:
       # CONDUIT_SECRET_STRIPE_SECRET_KEY=sk_...
-      # STRIPE_SECRET_KEY=sk_...
+      # STRIPE_SECRET_KEY=sk_...  (requires CONDUIT_ALLOW_BARE_SECRET_ENV below)
+      CONDUIT_ALLOW_BARE_SECRET_ENV: "1"
     restart: unless-stopped
     healthcheck:
-      test: ["CMD", "curl", "-fsS", "http://127.0.0.1:8765/"]
+      test:
+        - CMD-SHELL
+        - 'curl -fsS -H "Authorization: Bearer $$CONDUIT_HTTP_TOKEN" http://127.0.0.1:8765/'
       interval: 30s
       timeout: 5s
       retries: 3

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -1,0 +1,31 @@
+# Example headless Toolport gateway. Copy to docker-compose.yml and fill .env.
+# Local/dev only — do not push secrets or this file with real tokens.
+
+services:
+  toolport-gateway:
+    build: .
+    image: toolport-gateway:local
+    ports:
+      - "8765:8765"
+    volumes:
+      # Seed once: cp data/registry.json.example data/registry.json
+      - ./data:/data
+    env_file:
+      - .env
+    environment:
+      CONDUIT_HTTP_HOST: "0.0.0.0"
+      CONDUIT_HTTP: "8765"
+      CONDUIT_REGISTRY: /data/registry.json
+      # Required when binding 0.0.0.0 — set in .env:
+      # CONDUIT_HTTP_TOKEN=...
+      # Optional encrypted vault passphrase (if using secrets.enc):
+      # CONDUIT_SECRET_KEY=...
+      # Or inject per-server secrets directly:
+      # CONDUIT_SECRET_STRIPE_SECRET_KEY=sk_...
+      # STRIPE_SECRET_KEY=sk_...
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://127.0.0.1:8765/"]
+      interval: 30s
+      timeout: 5s
+      retries: 3

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -84,8 +84,11 @@ low real exposure since the gateway only writes when `allow_agent_control` is on
       profiles. (M)
 - [ ] **Opt-in** OTel/Prometheus exporter (`/metrics` or OTLP push), OFF by default
       so zero-infra stays the default experience; keep the in-app dashboard primary. (M)
-- [ ] Finish native **streamable-HTTP** upstream transport (OpenAPI HTTP mode already
-      ships) so remote/network clients connect natively. (M)
+- [~] **Streamable-HTTP upstream transport** — `POST /mcp` on the HTTP bridge ships
+  (session ids, JSON-RPC, selective SSE responses; see `docs/headless.md` +
+  `docker-compose.example.yml`). OpenAPI HTTP mode already shipped for Open WebUI.
+  Remaining: long-lived `GET /mcp` listen stream and server→client RPC passthrough
+  (sampling / elicitation / roots; #167). (M)
 
 **Strategic**
 

--- a/docs/headless.md
+++ b/docs/headless.md
@@ -1,0 +1,142 @@
+# Headless / container gateway
+
+Run `toolport-gateway` without the desktop app — for Docker hosts, sandboxed
+coding agents, and Open WebUI. The desktop app stays the local-first product
+(client config writers, HITL approvals, OAuth UX). This path is the same binary
+with HTTP enabled.
+
+## What you get
+
+| Endpoint                             | Use                                                                  |
+| ------------------------------------ | -------------------------------------------------------------------- |
+| `GET /openapi.json` + `POST /{tool}` | Open WebUI, n8n, LibreChat (OpenAPI)                                 |
+| `POST /mcp`                          | MCP clients over streamable-HTTP (Claude Code, Cursor remote, Pi, …) |
+| `GET /`                              | Short help text                                                      |
+
+Current streamable-HTTP scope:
+
+- `POST /mcp` returns JSON-RPC responses as JSON by default.
+- If `Accept` prefers `text/event-stream`, `POST /mcp` returns a single SSE `message` event and closes.
+- Long-lived server-initiated `GET /mcp` SSE listening is not implemented yet (`405`).
+
+Auth is the same bearer token as today (`CONDUIT_HTTP_TOKEN` or a registered
+`httpClients[]` entry). Non-loopback binds **require** a token.
+
+## Quick start (binary)
+
+```bash
+export CONDUIT_HTTP_HOST=0.0.0.0
+export CONDUIT_HTTP_TOKEN="$(openssl rand -hex 24)"
+export CONDUIT_REGISTRY=/path/to/registry.json
+# optional: encrypted vault
+# export CONDUIT_SECRET_KEY=...
+
+toolport-gateway --http 8765
+```
+
+Point Open WebUI at `http://host:8765` with the bearer token as the API key.
+Point an MCP client at `http://host:8765/mcp` (streamable-HTTP).
+
+### MCP handshake (curl)
+
+```bash
+# 1) initialize — capture Mcp-Session-Id from the response headers
+curl -sD - -o /tmp/init.json -X POST http://127.0.0.1:8765/mcp \
+  -H "Authorization: Bearer $CONDUIT_HTTP_TOKEN" \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"curl","version":"0"}}}'
+
+# 2) tools/list (reuse the session id)
+curl -s -X POST http://127.0.0.1:8765/mcp \
+  -H "Authorization: Bearer $CONDUIT_HTTP_TOKEN" \
+  -H "Content-Type: application/json" \
+  -H "Mcp-Session-Id: <session-from-step-1>" \
+  -d '{"jsonrpc":"2.0","id":2,"method":"tools/list"}'
+```
+
+## Docker
+
+```bash
+# from repo root
+docker build -t toolport-gateway .
+mkdir -p data
+cp data/registry.json.example data/registry.json
+# edit data/registry.json for your servers, then:
+cp docker-compose.example.yml docker-compose.yml
+# create .env with at least CONDUIT_HTTP_TOKEN=...
+docker compose up --build
+```
+
+Image defaults:
+
+- `CONDUIT_HTTP_HOST=0.0.0.0`
+- `CONDUIT_REGISTRY=/data/registry.json`
+- port `8765`
+- volume `/data`
+
+## Secrets without the OS keychain
+
+Resolution order when a server marks `env[].secret: true`:
+
+1. Process env `CONDUIT_SECRET_<KEY>` (preferred in compose)
+2. Process env `<KEY>` (plain `.env` convenience)
+3. Encrypted `secrets.enc` when `CONDUIT_SECRET_KEY` is set
+4. OS keychain (desktop)
+
+Example `.env`:
+
+```env
+CONDUIT_HTTP_TOKEN=replace-me
+CONDUIT_SECRET_STRIPE_SECRET_KEY=sk_live_...
+# or bare name if you prefer:
+# STRIPE_SECRET_KEY=sk_live_...
+```
+
+## Minimal `registry.json`
+
+Start from [`data/registry.json.example`](../data/registry.json.example) (remote
+MCP server — works in a minimal container with no extra runtime). Or copy a full
+`registry.json` from a machine that already runs the desktop app.
+
+A valid headless registry needs `profiles` and `activeProfileId`, not just
+`servers`:
+
+```json
+{
+  "version": 1,
+  "servers": [
+    {
+      "id": "stripe",
+      "name": "Stripe",
+      "transport": "stdio",
+      "command": "npx",
+      "args": ["-y", "@stripe/mcp"],
+      "env": [{ "key": "STRIPE_SECRET_KEY", "secret": true }],
+      "source": "manual"
+    }
+  ],
+  "profiles": [
+    {
+      "id": "default",
+      "name": "Default",
+      "enabledServerIds": ["stripe"]
+    }
+  ],
+  "activeProfileId": "default"
+}
+```
+
+Stdio servers inside the container need their runtimes (`node`/`npx`, `uv`,
+etc.) installed in the image or reached via another container on the same
+network. Remote MCP servers (`url` + streamable-HTTP downstream) need no extra
+runtime in the gateway image.
+
+## Notes
+
+- **HITL approvals** need the desktop app’s approval broker. Leave human
+  approval off (or expect fail-closed) in pure headless mode.
+- **Client config writers** (Cursor/Claude local JSON) still need the desktop
+  app or a one-time manual URL in the client config — which is what sandboxed
+  setups usually want anyway.
+- Open WebUI details: [openwebui.md](./openwebui.md).

--- a/docs/headless.md
+++ b/docs/headless.md
@@ -80,7 +80,7 @@ Image defaults:
 Resolution order when a server marks `env[].secret: true`:
 
 1. Process env `CONDUIT_SECRET_<KEY>` (preferred in compose)
-2. Process env `<KEY>` (plain `.env` convenience)
+2. Process env `<KEY>` when `CONDUIT_ALLOW_BARE_SECRET_ENV=1` (opt-in; enabled in the compose example)
 3. Encrypted `secrets.enc` when `CONDUIT_SECRET_KEY` is set
 4. OS keychain (desktop)
 
@@ -89,7 +89,8 @@ Example `.env`:
 ```env
 CONDUIT_HTTP_TOKEN=replace-me
 CONDUIT_SECRET_STRIPE_SECRET_KEY=sk_live_...
-# or bare name if you prefer:
+# or bare name with explicit opt-in (set in compose example):
+# CONDUIT_ALLOW_BARE_SECRET_ENV=1
 # STRIPE_SECRET_KEY=sk_live_...
 ```
 

--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -18,6 +18,7 @@
 //!   model searches and calls on demand, keeping context flat.
 //! - Records every tool call to a local audit log.
 
+use std::collections::HashMap;
 use std::io::{BufRead, Read, Write};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicU8, AtomicUsize, Ordering};
@@ -2640,11 +2641,15 @@ fn connect_one(server: &ServerEntry, dirty: &Arc<AtomicU8>) -> Option<Downstream
                 match secrets::get_secret_result(&server.id, &e.key) {
                     Ok(Some(v)) => env.push((e.key.clone(), v)),
                     Ok(None) => eprintln!(
-                        "toolport: '{}' needs secret '{}' but none is vaulted",
-                        server.id, e.key
+                        "toolport: '{}' needs secret '{}' but none is vaulted \
+                         (set env {}, {}, secrets.enc, or the OS keychain)",
+                        server.id,
+                        e.key,
+                        format_args!("CONDUIT_SECRET_{}", e.key),
+                        e.key
                     ),
                     Err(err) => eprintln!(
-                        "toolport: '{}' could not read secret '{}' from the keychain: {err}",
+                        "toolport: '{}' could not read secret '{}': {err}",
                         server.id, e.key
                     ),
                 }
@@ -3036,6 +3041,25 @@ struct GatewayState {
     /// True when this process is the HTTP/OpenAPI bridge (vs a stdio client's
     /// gateway). The bridge connects the union of all registered clients' servers.
     http: bool,
+    /// Streamable-HTTP MCP sessions (`Mcp-Session-Id` → last-seen). Only used when
+    /// `http` is true; empty for stdio gateways.
+    mcp_sessions: Arc<Mutex<HashMap<String, Instant>>>,
+}
+
+/// How long an idle MCP streamable-HTTP session stays valid before a request
+/// with that id gets 404 (client must re-initialize).
+const MCP_SESSION_TTL: Duration = Duration::from_secs(24 * 60 * 60);
+
+/// Cryptographically random session id (visible ASCII, per MCP streamable-HTTP).
+fn new_mcp_session_id() -> String {
+    let mut buf = [0u8; 16];
+    getrandom::getrandom(&mut buf).expect("CSPRNG unavailable");
+    buf.iter().map(|b| format!("{b:02x}")).collect()
+}
+
+/// True when `id` is a non-empty visible-ASCII session id (0x21..=0x7E).
+fn valid_mcp_session_id(id: &str) -> bool {
+    !id.is_empty() && id.bytes().all(|b| (0x21..=0x7E).contains(&b)) && id.len() <= 128
 }
 
 fn rpc_id_key(v: &Value) -> Option<String> {
@@ -3488,7 +3512,246 @@ fn result_text(resp: &Value) -> String {
     serde_json::to_string(result).unwrap_or_default()
 }
 
-/// Map one HTTP request to (status, content-type, body).
+/// HTTP handler result: status, content-type, body, plus optional extra headers
+/// (e.g. `Mcp-Session-Id` for streamable-HTTP MCP).
+struct HttpOut {
+    status: u16,
+    ctype: &'static str,
+    body: String,
+    extra: Vec<(String, String)>,
+}
+
+impl HttpOut {
+    fn new(status: u16, ctype: &'static str, body: String) -> Self {
+        Self {
+            status,
+            ctype,
+            body,
+            extra: Vec::new(),
+        }
+    }
+
+    fn with_header(mut self, name: &str, value: &str) -> Self {
+        self.extra.push((name.to_string(), value.to_string()));
+        self
+    }
+
+    fn json_err(status: u16, msg: &str) -> Self {
+        Self::new(
+            status,
+            "application/json",
+            json!({ "error": msg }).to_string(),
+        )
+    }
+}
+
+/// Touch / validate an existing MCP session. Returns Ok(session_id) or an HttpOut error.
+fn mcp_require_session(state: &GatewayState, session_hdr: Option<&str>) -> Result<String, HttpOut> {
+    let Some(sid) = session_hdr.map(str::trim).filter(|s| !s.is_empty()) else {
+        return Err(HttpOut::json_err(
+            400,
+            "missing Mcp-Session-Id (send initialize first)",
+        ));
+    };
+    if !valid_mcp_session_id(sid) {
+        return Err(HttpOut::json_err(400, "invalid Mcp-Session-Id"));
+    }
+    let mut sessions = state
+        .mcp_sessions
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    // Drop expired sessions opportunistically.
+    sessions.retain(|_, last| last.elapsed() < MCP_SESSION_TTL);
+    match sessions.get_mut(sid) {
+        Some(last) => {
+            *last = Instant::now();
+            Ok(sid.to_string())
+        }
+        None => Err(HttpOut::json_err(
+            404,
+            "unknown or expired Mcp-Session-Id; re-initialize",
+        )),
+    }
+}
+
+/// True when the client wants an SSE response body for a JSON-RPC request.
+/// Spec clients send both `application/json` and `text/event-stream`; we keep
+/// JSON as the default in that case. SSE wins only when event-stream is accepted
+/// and JSON is not (or event-stream has a higher explicit `q`).
+fn mcp_prefers_sse(accept: Option<&str>) -> bool {
+    let Some(raw) = accept.map(str::trim).filter(|s| !s.is_empty()) else {
+        return false;
+    };
+    let lower = raw.to_ascii_lowercase();
+    let q_of = |media: &str| -> Option<f32> {
+        for part in lower.split(',') {
+            let part = part.trim();
+            if !part.starts_with(media) {
+                continue;
+            }
+            let rest = part[media.len()..].trim_start();
+            if !rest.is_empty() && !rest.starts_with(';') {
+                continue;
+            }
+            let mut q = 1.0f32;
+            for param in rest.split(';').skip(1) {
+                let param = param.trim();
+                if let Some(v) = param.strip_prefix("q=") {
+                    q = v.parse().unwrap_or(1.0);
+                }
+            }
+            return Some(q);
+        }
+        None
+    };
+    let sse_q = q_of("text/event-stream");
+    let json_q = q_of("application/json");
+    match (sse_q, json_q) {
+        (Some(s), Some(j)) => s > j,
+        (Some(_), None) => true,
+        _ => false,
+    }
+}
+
+/// Wrap a single JSON-RPC message as one SSE `message` event (stream closes after).
+fn mcp_sse_body(json: &str) -> String {
+    format!("event: message\ndata: {json}\n\n")
+}
+
+fn mcp_rpc_response(status: u16, json_body: String, session_id: &str, prefer_sse: bool) -> HttpOut {
+    if prefer_sse {
+        HttpOut::new(status, "text/event-stream", mcp_sse_body(&json_body))
+            .with_header("Mcp-Session-Id", session_id)
+            .with_header("Cache-Control", "no-cache")
+    } else {
+        HttpOut::new(status, "application/json", json_body).with_header("Mcp-Session-Id", session_id)
+    }
+}
+
+/// Handle one Streamable-HTTP MCP request at `/mcp`.
+#[allow(clippy::too_many_arguments)]
+fn handle_mcp_http(
+    state: &GatewayState,
+    guard: &SearchGuard,
+    confirm: &ConfirmGuard,
+    method: &str,
+    body: &str,
+    session_hdr: Option<&str>,
+    accept: Option<&str>,
+    allowed: Option<&std::collections::HashSet<String>>,
+    client: Option<&str>,
+) -> HttpOut {
+    let prefer_sse = mcp_prefers_sse(accept);
+    match method {
+        // GET opens a long-lived SSE stream for server→client messages. We don't
+        // yet push unsolicited messages, so advertise that with 405 (allowed by
+        // the spec) rather than hanging an empty stream.
+        "GET" => HttpOut::new(
+            405,
+            "application/json",
+            json!({ "error": "SSE listen not offered; use POST /mcp for JSON-RPC" }).to_string(),
+        ),
+        "DELETE" => match mcp_require_session(state, session_hdr) {
+            Ok(sid) => {
+                state
+                    .mcp_sessions
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner)
+                    .remove(&sid);
+                HttpOut::new(204, "text/plain", String::new())
+            }
+            Err(e) => e,
+        },
+        "POST" => {
+            let req: Value = if body.trim().is_empty() {
+                return HttpOut::json_err(400, "empty JSON-RPC body");
+            } else {
+                match serde_json::from_str(body) {
+                    Ok(v) => v,
+                    Err(e) => {
+                        return HttpOut::json_err(400, &format!("invalid JSON body: {e}"));
+                    }
+                }
+            };
+
+            let method_name = req.get("method").and_then(|m| m.as_str()).unwrap_or("");
+            let has_id = req
+                .get("id")
+                .map(|id| !id.is_null())
+                .unwrap_or(false);
+            let is_initialize = method_name == "initialize";
+
+            // Session rules: initialize may omit (and gets a new id); everything
+            // else that carries a method must present a live session id.
+            let session_id = if is_initialize {
+                if let Some(existing) = session_hdr.map(str::trim).filter(|s| !s.is_empty()) {
+                    // Client re-sent a session on initialize: accept if still live,
+                    // otherwise mint a fresh one (spec: start over without the old id).
+                    match mcp_require_session(state, Some(existing)) {
+                        Ok(sid) => sid,
+                        Err(_) => {
+                            let sid = new_mcp_session_id();
+                            state
+                                .mcp_sessions
+                                .lock()
+                                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                                .insert(sid.clone(), Instant::now());
+                            sid
+                        }
+                    }
+                } else {
+                    let sid = new_mcp_session_id();
+                    state
+                        .mcp_sessions
+                        .lock()
+                        .unwrap_or_else(std::sync::PoisonError::into_inner)
+                        .insert(sid.clone(), Instant::now());
+                    sid
+                }
+            } else {
+                match mcp_require_session(state, session_hdr) {
+                    Ok(sid) => sid,
+                    Err(e) => return e,
+                }
+            };
+
+            // Notifications / JSON-RPC responses: 202 with empty body.
+            if !has_id {
+                // Still run process_request for side effects when it's a known
+                // notification that handle_request ignores (returns None).
+                let _ = process_request(state, &req, guard, confirm, allowed, None, client);
+                return HttpOut::new(202, "text/plain", String::new())
+                    .with_header("Mcp-Session-Id", &session_id);
+            }
+
+            match process_request(state, &req, guard, confirm, allowed, None, client) {
+                Some(resp) => {
+                    let body = serde_json::to_string(&resp).unwrap_or_else(|_| {
+                        json!({
+                            "jsonrpc": "2.0",
+                            "id": req.get("id").cloned().unwrap_or(Value::Null),
+                            "error": { "code": -32603, "message": "serialize failed" }
+                        })
+                        .to_string()
+                    });
+                    mcp_rpc_response(200, body, &session_id, prefer_sse)
+                }
+                None => {
+                    let body = json!({
+                        "jsonrpc": "2.0",
+                        "id": req.get("id").cloned().unwrap_or(Value::Null),
+                        "error": { "code": -32603, "message": "no response" }
+                    })
+                    .to_string();
+                    mcp_rpc_response(500, body, &session_id, prefer_sse)
+                }
+            }
+        }
+        _ => HttpOut::json_err(405, "method not allowed on /mcp"),
+    }
+}
+
+/// Map one HTTP request to status / content-type / body / extra headers.
 #[allow(clippy::too_many_arguments)]
 fn handle_http(
     state: &GatewayState,
@@ -3497,29 +3760,47 @@ fn handle_http(
     method: &str,
     path: &str,
     body: &str,
+    session_hdr: Option<&str>,
+    accept: Option<&str>,
     allowed: Option<&std::collections::HashSet<String>>,
     client: Option<&str>,
-) -> (u16, &'static str, String) {
+) -> HttpOut {
+    // Streamable-HTTP MCP endpoint (same port as OpenAPI).
+    if path == "/mcp" || path.starts_with("/mcp?") {
+        return handle_mcp_http(
+            state, guard, confirm, method, body, session_hdr, accept, allowed, client,
+        );
+    }
+
     match (method, path) {
         // CORS preflight: browsers (Open WebUI fetches tool specs client-side)
         // send OPTIONS before a cross-origin POST. Answer it so the real request
         // is allowed through. The CORS headers themselves are added to every
         // response in serve_http_loop.
-        ("OPTIONS", _) => (204, "text/plain", String::new()),
-        ("GET", "/openapi.json") => (200, "application/json", openapi_spec(state, allowed).to_string()),
-        ("GET", "/") | ("GET", "/docs") => (
+        ("OPTIONS", _) => HttpOut::new(204, "text/plain", String::new()),
+        ("GET", "/openapi.json") => HttpOut::new(
+            200,
+            "application/json",
+            openapi_spec(state, allowed).to_string(),
+        ),
+        ("GET", "/") | ("GET", "/docs") => HttpOut::new(
             200,
             "text/plain; charset=utf-8",
-            "Toolport gateway (HTTP/OpenAPI mode). OpenAPI at /openapi.json. POST a tool name with a JSON body, e.g. POST /toolport_search_tools {\"query\":\"...\"}."
+            "Toolport gateway (HTTP mode).\n\
+             OpenAPI: GET /openapi.json, POST /{tool_name} with a JSON body.\n\
+             MCP streamable-HTTP: POST /mcp with JSON-RPC (initialize, tools/list, tools/call).\n\
+             Auth: Authorization: Bearer <CONDUIT_HTTP_TOKEN>."
                 .to_string(),
         ),
         ("POST", p) => {
             let name = p.trim_start_matches('/');
             if name.is_empty() {
-                return (
-                    404,
-                    "application/json",
-                    json!({ "error": "missing tool name" }).to_string(),
+                return HttpOut::json_err(404, "missing tool name");
+            }
+            // Don't let OpenAPI POST swallow /mcp if path matching drifted.
+            if name == "mcp" {
+                return handle_mcp_http(
+                    state, guard, confirm, method, body, session_hdr, accept, allowed, client,
                 );
             }
             let args: Value = if body.trim().is_empty() {
@@ -3528,11 +3809,7 @@ fn handle_http(
                 match serde_json::from_str(body) {
                     Ok(v) => v,
                     Err(e) => {
-                        return (
-                            400,
-                            "application/json",
-                            json!({ "error": format!("invalid JSON body: {e}") }).to_string(),
-                        )
+                        return HttpOut::json_err(400, &format!("invalid JSON body: {e}"));
                     }
                 }
             };
@@ -3546,26 +3823,19 @@ fn handle_http(
                 Some(resp) => {
                     if let Some(err) = resp.get("error") {
                         let msg = err.get("message").and_then(|m| m.as_str()).unwrap_or("error");
-                        return (400, "application/json", json!({ "error": msg }).to_string());
+                        return HttpOut::json_err(400, msg);
                     }
-                    (
+                    HttpOut::new(
                         200,
                         "application/json",
-                        serde_json::to_string(&result_text(&resp)).unwrap_or_else(|_| "\"\"".into()),
+                        serde_json::to_string(&result_text(&resp))
+                            .unwrap_or_else(|_| "\"\"".into()),
                     )
                 }
-                None => (
-                    500,
-                    "application/json",
-                    json!({ "error": "no response" }).to_string(),
-                ),
+                None => HttpOut::json_err(500, "no response"),
             }
         }
-        _ => (
-            404,
-            "application/json",
-            json!({ "error": "not found" }).to_string(),
-        ),
+        _ => HttpOut::json_err(404, "not found"),
     }
 }
 
@@ -3677,11 +3947,11 @@ fn serve_http(state: GatewayState, port: u16) {
         }
     };
     glog(&format!(
-        "HTTP/OpenAPI mode on http://{host}:{port} (auth={})",
+        "HTTP mode on http://{host}:{port} (OpenAPI + MCP /mcp, auth={})",
         token.is_some()
     ));
     eprintln!(
-        "toolport-gateway: HTTP/OpenAPI on http://localhost:{port}  (OpenAPI spec at /openapi.json)"
+        "toolport-gateway: HTTP on http://localhost:{port}  (OpenAPI /openapi.json, MCP POST /mcp)"
     );
     serve_http_loop(server, state, token, search, confirm);
 }
@@ -3791,7 +4061,23 @@ fn handle_connection(
             .find(|h| h.field.equiv("Access-Control-Request-Headers"))
             .map(|h| sanitize_header_value(h.value.as_str()))
             .filter(|s| !s.is_empty())
-            .unwrap_or_else(|| "Content-Type, Authorization".to_string());
+            .unwrap_or_else(|| {
+                "Content-Type, Authorization, Mcp-Session-Id, MCP-Protocol-Version".to_string()
+            });
+
+        let session_hdr = request
+            .headers()
+            .iter()
+            .find(|h| h.field.equiv("Mcp-Session-Id"))
+            .map(|h| sanitize_header_value(h.value.as_str()))
+            .filter(|s| !s.is_empty());
+
+        let accept_hdr = request
+            .headers()
+            .iter()
+            .find(|h| h.field.equiv("Accept"))
+            .map(|h| sanitize_header_value(h.value.as_str()))
+            .filter(|s| !s.is_empty());
 
         // A browser attaches Sec-Fetch-Site to every request; a server-side caller
         // (Open WebUI's backend, curl) does not. Refuse a cross-site browser
@@ -3830,22 +4116,14 @@ fn handle_connection(
             resolve_http_scope(&reg, token.as_deref(), provided_tok)
         };
 
-        let (status, ctype, payload): (u16, &str, String) = if cross_site && method != "OPTIONS" {
-            (
-                403,
-                "application/json",
-                json!({ "error": "cross-site browser requests are not allowed" }).to_string(),
-            )
+        let out: HttpOut = if cross_site && method != "OPTIONS" {
+            HttpOut::json_err(403, "cross-site browser requests are not allowed")
         } else {
             match scope {
-                None => (
-                    401,
-                    "application/json",
-                    json!({ "error": "missing or invalid bearer token" }).to_string(),
-                ),
+                None => HttpOut::json_err(401, "missing or invalid bearer token"),
                 Some(allowed) => {
                     let mut body = String::new();
-                    if method == "POST" {
+                    if method == "POST" || method == "DELETE" {
                         let _ = request
                             .as_reader()
                             .take(MAX_HTTP_BODY)
@@ -3860,33 +4138,39 @@ fn handle_connection(
                             &method,
                             &path,
                             &body,
+                            session_hdr.as_deref(),
+                            accept_hdr.as_deref(),
                             allowed.as_ref(),
                             client_label.as_deref(),
                         )
                     }))
-                    .unwrap_or((
-                        500,
-                        "application/json",
-                        "{\"error\":\"internal error\"}".to_string(),
-                    ))
+                    .unwrap_or_else(|_| HttpOut::json_err(500, "internal error"))
                 }
             }
         };
 
-        let mut response = tiny_http::Response::from_string(payload).with_status_code(status);
-        let cors: [(&[u8], &[u8]); 4] = [
-            (b"Content-Type", ctype.as_bytes()),
+        let mut response = tiny_http::Response::from_string(out.body).with_status_code(out.status);
+        let cors: [(&[u8], &[u8]); 5] = [
+            (b"Content-Type", out.ctype.as_bytes()),
             // Auth is a bearer header, never a cookie, so credentialed CORS is
             // unnecessary. Return a wildcard Origin (never the reflected caller
             // Origin) and omit Allow-Credentials, so a malicious page can't pair a
             // reflected origin with Allow-Credentials to read a response.
             (b"Access-Control-Allow-Origin", b"*"),
-            (b"Access-Control-Allow-Methods", b"GET, POST, OPTIONS"),
+            (b"Access-Control-Allow-Methods", b"GET, POST, DELETE, OPTIONS"),
             (b"Access-Control-Allow-Headers", allow_headers.as_bytes()),
+            // Browser MCP clients need to read the session id off the response.
+            (b"Access-Control-Expose-Headers", b"Mcp-Session-Id"),
         ];
         for (name, value) in cors {
             // Skip a header that won't encode rather than panicking the thread.
             if let Ok(h) = tiny_http::Header::from_bytes(name, value) {
+                response = response.with_header(h);
+            }
+        }
+        for (name, value) in &out.extra {
+            let safe = sanitize_header_value(value);
+            if let Ok(h) = tiny_http::Header::from_bytes(name.as_bytes(), safe.as_bytes()) {
                 response = response.with_header(h);
             }
         }
@@ -4102,6 +4386,7 @@ fn main() {
         lazy,
         profile: profile.clone(),
         http: http_mode,
+        mcp_sessions: Arc::new(Mutex::new(HashMap::new())),
     };
 
     // Native HTTP/OpenAPI transport: a first-class path for HTTP tool clients
@@ -4287,6 +4572,7 @@ mod tests {
             lazy,
             profile: None,
             http: true,
+            mcp_sessions: Arc::new(Mutex::new(HashMap::new())),
         }
     }
 
@@ -4777,7 +5063,7 @@ mod tests {
         // Browsers preflight a cross-origin POST; we must answer OPTIONS so the
         // real request goes through (CORS headers themselves are added per-response).
         let state = http_state(true);
-        let (status, _, body) = handle_http(
+        let out = handle_http(
             &state,
             &SearchGuard::default(),
             &ConfirmGuard::new(),
@@ -4786,9 +5072,318 @@ mod tests {
             "",
             None,
             None,
+            None,
+            None,
         );
-        assert_eq!(status, 204);
-        assert!(body.is_empty());
+        assert_eq!(out.status, 204);
+        assert!(out.body.is_empty());
+    }
+
+    fn mcp_session_of(out: &HttpOut) -> String {
+        out.extra
+            .iter()
+            .find(|(k, _)| k.eq_ignore_ascii_case("Mcp-Session-Id"))
+            .map(|(_, v)| v.clone())
+            .expect("Mcp-Session-Id header")
+    }
+
+    #[test]
+    fn mcp_http_initialize_list_call_round_trip() {
+        // Streamable-HTTP MCP: initialize → session id → tools/list → tools/call.
+        let state = http_state(true);
+        let search = SearchGuard::default();
+        let confirm = ConfirmGuard::new();
+
+        let init = handle_http(
+            &state,
+            &search,
+            &confirm,
+            "POST",
+            "/mcp",
+            &json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": "2025-06-18",
+                    "capabilities": {},
+                    "clientInfo": { "name": "test", "version": "0" }
+                }
+            })
+            .to_string(),
+            None,
+            None,
+            None,
+            None,
+        );
+        assert_eq!(init.status, 200, "body={}", init.body);
+        assert_eq!(init.ctype, "application/json");
+        let sid = mcp_session_of(&init);
+        assert!(valid_mcp_session_id(&sid));
+        let init_body: Value = serde_json::from_str(&init.body).unwrap();
+        assert_eq!(init_body["result"]["serverInfo"]["name"], "toolport-gateway");
+
+        // Notification: 202, no JSON-RPC body.
+        let note = handle_http(
+            &state,
+            &search,
+            &confirm,
+            "POST",
+            "/mcp",
+            &json!({ "jsonrpc": "2.0", "method": "notifications/initialized" }).to_string(),
+            Some(&sid),
+            None,
+            None,
+            None,
+        );
+        assert_eq!(note.status, 202);
+
+        let list = handle_http(
+            &state,
+            &search,
+            &confirm,
+            "POST",
+            "/mcp",
+            &json!({ "jsonrpc": "2.0", "id": 2, "method": "tools/list" }).to_string(),
+            Some(&sid),
+            None,
+            None,
+            None,
+        );
+        assert_eq!(list.status, 200, "body={}", list.body);
+        let list_body: Value = serde_json::from_str(&list.body).unwrap();
+        let tools = list_body["result"]["tools"].as_array().unwrap();
+        let names: Vec<&str> = tools
+            .iter()
+            .filter_map(|t| t.get("name").and_then(|n| n.as_str()))
+            .collect();
+        assert!(names.contains(&"toolport_status"));
+        assert!(names.contains(&"toolport_search_tools"));
+
+        let call = handle_http(
+            &state,
+            &search,
+            &confirm,
+            "POST",
+            "/mcp",
+            &json!({
+                "jsonrpc": "2.0",
+                "id": 3,
+                "method": "tools/call",
+                "params": { "name": "toolport_status", "arguments": {} }
+            })
+            .to_string(),
+            Some(&sid),
+            None,
+            None,
+            None,
+        );
+        assert_eq!(call.status, 200, "body={}", call.body);
+        let call_body: Value = serde_json::from_str(&call.body).unwrap();
+        assert!(call_body.get("result").is_some());
+        assert!(call_body.get("error").is_none());
+
+        // Missing session on a non-initialize request → 400.
+        let missing = handle_http(
+            &state,
+            &search,
+            &confirm,
+            "POST",
+            "/mcp",
+            &json!({ "jsonrpc": "2.0", "id": 4, "method": "tools/list" }).to_string(),
+            None,
+            None,
+            None,
+            None,
+        );
+        assert_eq!(missing.status, 400);
+
+        // Unknown session → 404.
+        let dead = handle_http(
+            &state,
+            &search,
+            &confirm,
+            "POST",
+            "/mcp",
+            &json!({ "jsonrpc": "2.0", "id": 5, "method": "tools/list" }).to_string(),
+            Some("deadbeefdeadbeefdeadbeefdeadbeef"),
+            None,
+            None,
+            None,
+        );
+        assert_eq!(dead.status, 404);
+
+        // DELETE tears the session down.
+        let del = handle_http(
+            &state,
+            &search,
+            &confirm,
+            "DELETE",
+            "/mcp",
+            "",
+            Some(&sid),
+            None,
+            None,
+            None,
+        );
+        assert_eq!(del.status, 204);
+        let after = handle_http(
+            &state,
+            &search,
+            &confirm,
+            "POST",
+            "/mcp",
+            &json!({ "jsonrpc": "2.0", "id": 6, "method": "tools/list" }).to_string(),
+            Some(&sid),
+            None,
+            None,
+            None,
+        );
+        assert_eq!(after.status, 404);
+    }
+
+    #[test]
+    fn mcp_http_get_returns_405() {
+        let state = http_state(true);
+        let out = handle_http(
+            &state,
+            &SearchGuard::default(),
+            &ConfirmGuard::new(),
+            "GET",
+            "/mcp",
+            "",
+            None,
+            None,
+            None,
+            None,
+        );
+        assert_eq!(out.status, 405);
+    }
+
+    #[test]
+    fn mcp_http_bad_session_format_returns_400() {
+        let state = http_state(true);
+        let out = handle_http(
+            &state,
+            &SearchGuard::default(),
+            &ConfirmGuard::new(),
+            "POST",
+            "/mcp",
+            &json!({ "jsonrpc": "2.0", "id": 10, "method": "tools/list" }).to_string(),
+            Some("bad\nvalue"),
+            None,
+            None,
+            None,
+        );
+        assert_eq!(out.status, 400);
+    }
+
+    #[test]
+    fn mcp_http_delete_without_session_returns_400() {
+        let state = http_state(true);
+        let out = handle_http(
+            &state,
+            &SearchGuard::default(),
+            &ConfirmGuard::new(),
+            "DELETE",
+            "/mcp",
+            "",
+            None,
+            None,
+            None,
+            None,
+        );
+        assert_eq!(out.status, 400);
+    }
+
+    #[test]
+    fn mcp_prefers_sse_only_when_event_stream_wins() {
+        // Spec clients list both; keep JSON as the default in that case.
+        assert!(!mcp_prefers_sse(None));
+        assert!(!mcp_prefers_sse(Some(
+            "application/json, text/event-stream"
+        )));
+        assert!(!mcp_prefers_sse(Some("application/json")));
+        assert!(mcp_prefers_sse(Some("text/event-stream")));
+        assert!(mcp_prefers_sse(Some(
+            "text/event-stream;q=1, application/json;q=0.5"
+        )));
+        assert!(!mcp_prefers_sse(Some(
+            "application/json;q=1, text/event-stream;q=0.8"
+        )));
+    }
+
+    #[test]
+    fn mcp_http_sse_when_accept_prefers_event_stream() {
+        let state = http_state(true);
+        let search = SearchGuard::default();
+        let confirm = ConfirmGuard::new();
+        let init = handle_http(
+            &state,
+            &search,
+            &confirm,
+            "POST",
+            "/mcp",
+            &json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": "2025-06-18",
+                    "capabilities": {},
+                    "clientInfo": { "name": "test", "version": "0" }
+                }
+            })
+            .to_string(),
+            None,
+            Some("text/event-stream"),
+            None,
+            None,
+        );
+        assert_eq!(init.status, 200, "body={}", init.body);
+        assert_eq!(init.ctype, "text/event-stream");
+        assert!(
+            init.body.starts_with("event: message\ndata: "),
+            "{}",
+            init.body
+        );
+        assert!(init.body.contains("\"serverInfo\""));
+        let sid = mcp_session_of(&init);
+        // Dual Accept (spec default) stays JSON.
+        let list = handle_http(
+            &state,
+            &search,
+            &confirm,
+            "POST",
+            "/mcp",
+            &json!({ "jsonrpc": "2.0", "id": 2, "method": "tools/list" }).to_string(),
+            Some(&sid),
+            Some("application/json, text/event-stream"),
+            None,
+            None,
+        );
+        assert_eq!(list.ctype, "application/json");
+        assert!(list.body.starts_with('{'));
+    }
+
+    #[test]
+    fn docs_mention_mcp_endpoint() {
+        let state = http_state(true);
+        let out = handle_http(
+            &state,
+            &SearchGuard::default(),
+            &ConfirmGuard::new(),
+            "GET",
+            "/",
+            "",
+            None,
+            None,
+            None,
+            None,
+        );
+        assert_eq!(out.status, 200);
+        assert!(out.body.contains("POST /mcp"), "body={}", out.body);
+        assert!(out.body.contains("/openapi.json"));
     }
 
     #[test]

--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -3049,12 +3049,29 @@ struct GatewayState {
 /// How long an idle MCP streamable-HTTP session stays valid before a request
 /// with that id gets 404 (client must re-initialize).
 const MCP_SESSION_TTL: Duration = Duration::from_secs(24 * 60 * 60);
+/// Upper bound on concurrent MCP sessions to avoid unbounded memory growth.
+const MCP_SESSION_MAX: usize = 4096;
 
 /// Cryptographically random session id (visible ASCII, per MCP streamable-HTTP).
 fn new_mcp_session_id() -> String {
     let mut buf = [0u8; 16];
     getrandom::getrandom(&mut buf).expect("CSPRNG unavailable");
     buf.iter().map(|b| format!("{b:02x}")).collect()
+}
+
+/// Mint a new MCP session after TTL cleanup. Returns 503 when at capacity.
+fn mint_mcp_session(state: &GatewayState) -> Result<String, HttpOut> {
+    let sid = new_mcp_session_id();
+    let mut sessions = state
+        .mcp_sessions
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    sessions.retain(|_, last| last.elapsed() < MCP_SESSION_TTL);
+    if sessions.len() >= MCP_SESSION_MAX {
+        return Err(HttpOut::json_err(503, "too many MCP sessions; retry later"));
+    }
+    sessions.insert(sid.clone(), Instant::now());
+    Ok(sid)
 }
 
 /// True when `id` is a non-empty visible-ASCII session id (0x21..=0x7E).
@@ -3604,8 +3621,8 @@ fn mcp_prefers_sse(accept: Option<&str>) -> bool {
         }
         None
     };
-    let sse_q = q_of("text/event-stream");
-    let json_q = q_of("application/json");
+    let sse_q = q_of("text/event-stream").filter(|q| *q > 0.0);
+    let json_q = q_of("application/json").filter(|q| *q > 0.0);
     match (sse_q, json_q) {
         (Some(s), Some(j)) => s > j,
         (Some(_), None) => true,
@@ -3674,11 +3691,14 @@ fn handle_mcp_http(
                 }
             };
 
-            let method_name = req.get("method").and_then(|m| m.as_str()).unwrap_or("");
-            let has_id = req
-                .get("id")
-                .map(|id| !id.is_null())
-                .unwrap_or(false);
+            let Some(req_obj) = req.as_object() else {
+                return HttpOut::json_err(400, "JSON-RPC body must be an object");
+            };
+            let method_name = req_obj
+                .get("method")
+                .and_then(|m| m.as_str())
+                .unwrap_or("");
+            let has_id = req_obj.contains_key("id");
             let is_initialize = method_name == "initialize";
 
             // Session rules: initialize may omit (and gets a new id); everything
@@ -3689,24 +3709,16 @@ fn handle_mcp_http(
                     // otherwise mint a fresh one (spec: start over without the old id).
                     match mcp_require_session(state, Some(existing)) {
                         Ok(sid) => sid,
-                        Err(_) => {
-                            let sid = new_mcp_session_id();
-                            state
-                                .mcp_sessions
-                                .lock()
-                                .unwrap_or_else(std::sync::PoisonError::into_inner)
-                                .insert(sid.clone(), Instant::now());
-                            sid
-                        }
+                        Err(_) => match mint_mcp_session(state) {
+                            Ok(sid) => sid,
+                            Err(e) => return e,
+                        },
                     }
                 } else {
-                    let sid = new_mcp_session_id();
-                    state
-                        .mcp_sessions
-                        .lock()
-                        .unwrap_or_else(std::sync::PoisonError::into_inner)
-                        .insert(sid.clone(), Instant::now());
-                    sid
+                    match mint_mcp_session(state) {
+                        Ok(sid) => sid,
+                        Err(e) => return e,
+                    }
                 }
             } else {
                 match mcp_require_session(state, session_hdr) {
@@ -3765,6 +3777,10 @@ fn handle_http(
     allowed: Option<&std::collections::HashSet<String>>,
     client: Option<&str>,
 ) -> HttpOut {
+    if method == "OPTIONS" {
+        return HttpOut::new(204, "text/plain", String::new());
+    }
+
     // Streamable-HTTP MCP endpoint (same port as OpenAPI).
     if path == "/mcp" || path.starts_with("/mcp?") {
         return handle_mcp_http(
@@ -3773,11 +3789,6 @@ fn handle_http(
     }
 
     match (method, path) {
-        // CORS preflight: browsers (Open WebUI fetches tool specs client-side)
-        // send OPTIONS before a cross-origin POST. Answer it so the real request
-        // is allowed through. The CORS headers themselves are added to every
-        // response in serve_http_loop.
-        ("OPTIONS", _) => HttpOut::new(204, "text/plain", String::new()),
         ("GET", "/openapi.json") => HttpOut::new(
             200,
             "application/json",
@@ -5311,6 +5322,25 @@ mod tests {
         assert!(!mcp_prefers_sse(Some(
             "application/json;q=1, text/event-stream;q=0.8"
         )));
+        assert!(!mcp_prefers_sse(Some("text/event-stream;q=0")));
+    }
+
+    #[test]
+    fn mcp_http_options_preflight_returns_204() {
+        let state = http_state(true);
+        let out = handle_http(
+            &state,
+            &SearchGuard::default(),
+            &ConfirmGuard::new(),
+            "OPTIONS",
+            "/mcp",
+            "",
+            None,
+            None,
+            None,
+            None,
+        );
+        assert_eq!(out.status, 204);
     }
 
     #[test]

--- a/src-tauri/src/secrets.rs
+++ b/src-tauri/src/secrets.rs
@@ -776,11 +776,37 @@ pub fn get_secret(server_id: &str, key: &str) -> Option<String> {
 /// from an actual keychain failure (`Err`, e.g. the keychain is locked or denied
 /// access to this app). Callers that need to explain *why* a secret is missing
 /// use this so a read failure isn't silently treated as "never saved".
+///
+/// Resolution order for headless / container deploys:
+/// 1. Process env `CONDUIT_SECRET_<KEY>` (preferred; avoids colliding with
+///    unrelated host env vars that share a common name like `TOKEN`)
+/// 2. Process env `<KEY>` (plain env-file convenience)
+/// 3. Encrypted `secrets.enc` when `CONDUIT_SECRET_KEY` is set
+/// 4. OS keychain / platform backend
 pub fn get_secret_result(server_id: &str, key: &str) -> Result<Option<String>, String> {
+    if let Some(v) = env_secret_override(key) {
+        return Ok(Some(v));
+    }
     if file::active() {
         return file::get_secret_result(server_id, key);
     }
     platform::get_secret_result(server_id, key)
+}
+
+/// Look up a secret from the process environment for container / env-file deploys.
+/// Prefers `CONDUIT_SECRET_<KEY>`; falls back to the bare key name. Empty values
+/// are treated as unset so a blank `.env` line doesn't shadow the vault.
+fn env_secret_override(key: &str) -> Option<String> {
+    let prefixed = format!("CONDUIT_SECRET_{key}");
+    for name in [prefixed.as_str(), key] {
+        if let Ok(v) = std::env::var(name) {
+            let trimmed = v.trim();
+            if !trimmed.is_empty() {
+                return Some(trimmed.to_string());
+            }
+        }
+    }
+    None
 }
 
 pub fn delete_secret(server_id: &str, key: &str) -> Result<(), String> {
@@ -1028,6 +1054,41 @@ mod tests {
         match prev {
             Some(v) => std::env::set_var("CONDUIT_SECRET_KEY", v),
             None => std::env::remove_var("CONDUIT_SECRET_KEY"),
+        }
+    }
+
+    /// Process-env secrets win over the vault so a container can inject keys via
+    /// an env file without writing `secrets.enc`. Prefixed form beats bare key.
+    #[test]
+    fn env_secret_override_prefers_prefixed_then_bare() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let key = "TOOLPORT_ENV_SECRET_TEST";
+        let prefixed = format!("CONDUIT_SECRET_{key}");
+        let prev_bare = std::env::var(key).ok();
+        let prev_pref = std::env::var(&prefixed).ok();
+        std::env::remove_var(key);
+        std::env::remove_var(&prefixed);
+
+        assert_eq!(env_secret_override(key), None);
+
+        std::env::set_var(key, "from-bare");
+        assert_eq!(env_secret_override(key).as_deref(), Some("from-bare"));
+
+        std::env::set_var(&prefixed, "from-prefixed");
+        assert_eq!(env_secret_override(key).as_deref(), Some("from-prefixed"));
+
+        // Blank values don't count.
+        std::env::set_var(&prefixed, "   ");
+        std::env::set_var(key, "");
+        assert_eq!(env_secret_override(key), None);
+
+        match prev_bare {
+            Some(v) => std::env::set_var(key, v),
+            None => std::env::remove_var(key),
+        }
+        match prev_pref {
+            Some(v) => std::env::set_var(&prefixed, v),
+            None => std::env::remove_var(&prefixed),
         }
     }
 

--- a/src-tauri/src/secrets.rs
+++ b/src-tauri/src/secrets.rs
@@ -780,7 +780,7 @@ pub fn get_secret(server_id: &str, key: &str) -> Option<String> {
 /// Resolution order for headless / container deploys:
 /// 1. Process env `CONDUIT_SECRET_<KEY>` (preferred; avoids colliding with
 ///    unrelated host env vars that share a common name like `TOKEN`)
-/// 2. Process env `<KEY>` (plain env-file convenience)
+/// 2. Process env `<KEY>` when `CONDUIT_ALLOW_BARE_SECRET_ENV=1` (opt-in)
 /// 3. Encrypted `secrets.enc` when `CONDUIT_SECRET_KEY` is set
 /// 4. OS keychain / platform backend
 pub fn get_secret_result(server_id: &str, key: &str) -> Result<Option<String>, String> {
@@ -794,19 +794,27 @@ pub fn get_secret_result(server_id: &str, key: &str) -> Result<Option<String>, S
 }
 
 /// Look up a secret from the process environment for container / env-file deploys.
-/// Prefers `CONDUIT_SECRET_<KEY>`; falls back to the bare key name. Empty values
-/// are treated as unset so a blank `.env` line doesn't shadow the vault.
+/// Prefers `CONDUIT_SECRET_<KEY>`; falls back to the bare key name only when
+/// `CONDUIT_ALLOW_BARE_SECRET_ENV` is set. Empty values are treated as unset.
 fn env_secret_override(key: &str) -> Option<String> {
     let prefixed = format!("CONDUIT_SECRET_{key}");
-    for name in [prefixed.as_str(), key] {
-        if let Ok(v) = std::env::var(name) {
-            let trimmed = v.trim();
-            if !trimmed.is_empty() {
-                return Some(trimmed.to_string());
-            }
+    env_var_nonblank(&prefixed).or_else(|| {
+        if bare_secret_env_enabled() {
+            env_var_nonblank(key)
+        } else {
+            None
         }
-    }
-    None
+    })
+}
+
+fn bare_secret_env_enabled() -> bool {
+    std::env::var("CONDUIT_ALLOW_BARE_SECRET_ENV")
+        .ok()
+        .is_some_and(|v| matches!(v.trim().to_ascii_lowercase().as_str(), "1" | "true" | "yes"))
+}
+
+fn env_var_nonblank(name: &str) -> Option<String> {
+    std::env::var(name).ok().filter(|v| !v.trim().is_empty())
 }
 
 pub fn delete_secret(server_id: &str, key: &str) -> Result<(), String> {
@@ -1058,7 +1066,8 @@ mod tests {
     }
 
     /// Process-env secrets win over the vault so a container can inject keys via
-    /// an env file without writing `secrets.enc`. Prefixed form beats bare key.
+    /// an env file without writing `secrets.enc`. Prefixed form beats bare key;
+    /// bare keys require CONDUIT_ALLOW_BARE_SECRET_ENV.
     #[test]
     fn env_secret_override_prefers_prefixed_then_bare() {
         let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
@@ -1066,18 +1075,25 @@ mod tests {
         let prefixed = format!("CONDUIT_SECRET_{key}");
         let prev_bare = std::env::var(key).ok();
         let prev_pref = std::env::var(&prefixed).ok();
+        let prev_allow = std::env::var("CONDUIT_ALLOW_BARE_SECRET_ENV").ok();
         std::env::remove_var(key);
         std::env::remove_var(&prefixed);
+        std::env::remove_var("CONDUIT_ALLOW_BARE_SECRET_ENV");
 
         assert_eq!(env_secret_override(key), None);
 
         std::env::set_var(key, "from-bare");
+        assert_eq!(env_secret_override(key), None, "bare key blocked without opt-in");
+
+        std::env::set_var("CONDUIT_ALLOW_BARE_SECRET_ENV", "1");
         assert_eq!(env_secret_override(key).as_deref(), Some("from-bare"));
 
         std::env::set_var(&prefixed, "from-prefixed");
         assert_eq!(env_secret_override(key).as_deref(), Some("from-prefixed"));
 
-        // Blank values don't count.
+        // Preserve intentional whitespace; blank-only values don't count.
+        std::env::set_var(&prefixed, "  spaced  ");
+        assert_eq!(env_secret_override(key).as_deref(), Some("  spaced  "));
         std::env::set_var(&prefixed, "   ");
         std::env::set_var(key, "");
         assert_eq!(env_secret_override(key), None);
@@ -1089,6 +1105,10 @@ mod tests {
         match prev_pref {
             Some(v) => std::env::set_var(&prefixed, v),
             None => std::env::remove_var(&prefixed),
+        }
+        match prev_allow {
+            Some(v) => std::env::set_var("CONDUIT_ALLOW_BARE_SECRET_ENV", v),
+            None => std::env::remove_var("CONDUIT_ALLOW_BARE_SECRET_ENV"),
         }
     }
 


### PR DESCRIPTION
## Summary

- Expose **MCP streamable-HTTP** at `POST /mcp` on the existing HTTP bridge (session ids via `Mcp-Session-Id`, JSON-RPC responses, optional SSE when `Accept` prefers `text/event-stream`; `GET /mcp` returns 405 until listen stream ships)
- Add **container packaging** (`Dockerfile`, `.dockerignore`, `docker-compose.example.yml`) and **env-file secret resolution** (`CONDUIT_SECRET_<KEY>` then bare `<KEY>`, before `secrets.enc` / keychain)
- Document headless deployment in `docs/headless.md` with a valid `data/registry.json.example`; update README and ROADMAP (streamable-HTTP marked partial — #167 follow-ups remain)

## Test plan

- [x] `cargo test --bin toolport-gateway mcp_* http_* openapi_*`
- [x] `cargo test --lib secrets::tests::env_secret_override_prefers_prefixed_then_bare`
- [x] Manual curl: initialize → tools/list → tools/call round-trip on `POST /mcp`
- [x] Docker build + smoke: `/openapi.json`, `POST /mcp` init/session, SSE Accept header
- [x] OpenAPI regression: `POST /toolport_status` via existing HTTP path

## Notes

- Docker runtime uses `rust:1-slim` to avoid glibc mismatch with the Tauri-linked build; image is large until a headless-only crate split
- Long-lived `GET /mcp` listen stream and server→client RPC passthrough (sampling / elicitation / roots) are out of scope here (#167)

Made with [Cursor](https://cursor.com)