### PR TITLE
feat(gateway): MCP sampling and elicitation passthrough (#167)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -87,8 +87,8 @@ low real exposure since the gateway only writes when `allow_agent_control` is on
 - [~] **Streamable-HTTP upstream transport** — `POST /mcp` and `GET /mcp` listen stream ship
   (session ids, JSON-RPC, selective SSE responses; see `docs/headless.md` +
   `docker-compose.example.yml`). OpenAPI HTTP mode already shipped for Open WebUI.
-  Remaining: server→client RPC passthrough — **roots** shipped (stdio downstream);
-  sampling / elicitation still open (#167). (M)
+  Remaining: HTTP downstream server-initiated RPC (#167). Roots, sampling, and
+  elicitation passthrough to the upstream MCP client ship for stdio + HTTP MCP. (M)
 
 **Strategic**
 
@@ -383,7 +383,7 @@ Tier 2 - feature completeness (in progress)
       hides+blocks; global destructiveHint switch)
 - [x] Tool playground: invoke any tool from the app and see the result
 - [x] Proxy resources + prompts (capability-gated discovery, namespaced prompts,
-      uri-routed resources); sampling / elicitation passthrough still TODO
+      uri-routed resources); sampling / elicitation passthrough shipped for stdio downstream
 - [x] Observability: per-server latency (avg/p95), success/error rates, per-tool
       breakdown, and server/errors-only filters (Activity dashboard)
 - [x] Tool-definition integrity / rug-pull detection: fingerprint tools on connect,

--- a/docs/headless.md
+++ b/docs/headless.md
@@ -18,7 +18,7 @@ Current streamable-HTTP scope:
 - `POST /mcp` returns JSON-RPC responses as JSON by default.
 - If `Accept` prefers `text/event-stream`, `POST /mcp` returns a single SSE `message` event and closes.
 - `GET /mcp` opens a long-lived SSE listen stream for server→client JSON-RPC (keepalive comments every 30s when idle).
-- **Server-initiated RPC passthrough** (#167): when the MCP client declares `roots`, `sampling`, or `elicitation` at `initialize`, downstream `roots/list`, `sampling/createMessage`, and `elicitation/create` are forwarded to the client (120s timeout for interactive calls). `notifications/roots/list_changed` from the client is forwarded to all downstream servers. Stdio downstream only (HTTP downstream server-initiated RPC is a follow-up).
+- **Server-initiated RPC passthrough** (#167): when the MCP client declares `roots`, `sampling`, or `elicitation` at `initialize`, stdio downstream servers can call `roots/list`, `sampling/createMessage`, and `elicitation/create`; the gateway forwards those to the upstream MCP client over stdio or HTTP MCP (`GET /mcp` listen). Interactive calls use a 120s upstream timeout. `notifications/roots/list_changed` from the client is forwarded to all downstream servers. HTTP **downstream** server-initiated RPC is not supported yet.
 
 Auth is the same bearer token as today (`CONDUIT_HTTP_TOKEN` or a registered
 `httpClients[]` entry). Non-loopback binds **require** a token.

--- a/docs/headless.md
+++ b/docs/headless.md
@@ -18,7 +18,7 @@ Current streamable-HTTP scope:
 - `POST /mcp` returns JSON-RPC responses as JSON by default.
 - If `Accept` prefers `text/event-stream`, `POST /mcp` returns a single SSE `message` event and closes.
 - `GET /mcp` opens a long-lived SSE listen stream for server→client JSON-RPC (keepalive comments every 30s when idle).
-- **Roots passthrough** (#167 slice): when the MCP client declares `roots` at `initialize`, downstream `roots/list` is answered from the client; `notifications/roots/list_changed` from the client is forwarded to all downstream servers. Stdio downstream only (HTTP downstream server-initiated RPC is a follow-up).
+- **Server-initiated RPC passthrough** (#167): when the MCP client declares `roots`, `sampling`, or `elicitation` at `initialize`, downstream `roots/list`, `sampling/createMessage`, and `elicitation/create` are forwarded to the client (120s timeout for interactive calls). `notifications/roots/list_changed` from the client is forwarded to all downstream servers. Stdio downstream only (HTTP downstream server-initiated RPC is a follow-up).
 
 Auth is the same bearer token as today (`CONDUIT_HTTP_TOKEN` or a registered
 `httpClients[]` entry). Non-loopback binds **require** a token.

--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -3062,13 +3062,21 @@ struct GatewayState {
     /// Streamable-HTTP MCP sessions (`Mcp-Session-Id` → state). Only used when
     /// `http` is true; empty for stdio gateways.
     mcp_sessions: Arc<Mutex<HashMap<String, Arc<McpSession>>>>,
-    /// Client-declared filesystem roots (stdio gateway). Per-session copy lives on
+    /// Client-declared upstream capabilities (stdio gateway). Per-session copy on
     /// [`McpSession`] for HTTP MCP clients.
-    client_roots: Arc<Mutex<ClientRootsState>>,
+    client_upstream: Arc<Mutex<ClientUpstreamCaps>>,
     /// Forward server-initiated JSON-RPC to the stdio upstream client.
     stdio_upstream: Arc<StdioUpstream>,
-    /// Answers downstream `roots/list` (and future server-initiated RPC).
+    /// Answers downstream server-initiated RPC (roots, sampling, elicitation).
     server_handler: ServerRequestHandler,
+}
+
+/// Client capabilities the upstream MCP client declared at `initialize`.
+#[derive(Clone, Default)]
+struct ClientUpstreamCaps {
+    roots: ClientRootsState,
+    sampling: bool,
+    elicitation: bool,
 }
 
 /// Roots the upstream MCP client exposed at `initialize`.
@@ -3096,6 +3104,10 @@ impl StdioUpstream {
     }
 
     fn call(&self, method: &str, params: Value) -> Result<Value, String> {
+        self.call_timeout(method, params, upstream_rpc_timeout(method))
+    }
+
+    fn call_timeout(&self, method: &str, params: Value, timeout: Duration) -> Result<Value, String> {
         let id = self.next_id.fetch_add(1, Ordering::Relaxed);
         let id_key = id.to_string();
         let (tx, rx) = std::sync::mpsc::channel();
@@ -3112,7 +3124,7 @@ impl StdioUpstream {
         out.flush().map_err(|e| e.to_string())?;
         drop(out);
         let resp = rx
-            .recv_timeout(Duration::from_secs(30))
+            .recv_timeout(timeout)
             .map_err(|_| "upstream client did not answer".to_string())?;
         if let Some(err) = resp.get("error") {
             return Err(err.to_string());
@@ -3150,7 +3162,7 @@ struct McpSession {
     closed: AtomicBool,
     listener_active: AtomicBool,
     wait: (Mutex<()>, Condvar),
-    client_roots: Mutex<ClientRootsState>,
+    client_upstream: Mutex<ClientUpstreamCaps>,
     upstream_pending: Mutex<HashMap<String, std::sync::mpsc::Sender<Value>>>,
     next_upstream_id: AtomicI64,
 }
@@ -3163,13 +3175,22 @@ impl McpSession {
             closed: AtomicBool::new(false),
             listener_active: AtomicBool::new(false),
             wait: (Mutex::new(()), Condvar::new()),
-            client_roots: Mutex::new(ClientRootsState::default()),
+            client_upstream: Mutex::new(ClientUpstreamCaps::default()),
             upstream_pending: Mutex::new(HashMap::new()),
             next_upstream_id: AtomicI64::new(1),
         }
     }
 
     fn upstream_call(&self, method: &str, params: Value) -> Result<Value, String> {
+        self.upstream_call_timeout(method, params, upstream_rpc_timeout(method))
+    }
+
+    fn upstream_call_timeout(
+        &self,
+        method: &str,
+        params: Value,
+        timeout: Duration,
+    ) -> Result<Value, String> {
         let id = self.next_upstream_id.fetch_add(1, Ordering::Relaxed);
         let id_key = id.to_string();
         let (tx, rx) = std::sync::mpsc::channel();
@@ -3181,7 +3202,7 @@ impl McpSession {
         let json_str = serde_json::to_string(&req).map_err(|e| e.to_string())?;
         self.push_message(json_str);
         let resp = rx
-            .recv_timeout(Duration::from_secs(30))
+            .recv_timeout(timeout)
             .map_err(|_| "upstream MCP client did not answer".to_string())?;
         if let Some(err) = resp.get("error") {
             return Err(err.to_string());
@@ -3398,15 +3419,14 @@ fn cancellation_reason(req: &Value) -> Option<&str> {
         .and_then(|r| r.as_str())
 }
 
-fn capture_client_roots_from_init(state: &mut ClientRootsState, params: Option<&Value>) {
+fn capture_client_upstream_from_init(state: &mut ClientUpstreamCaps, params: Option<&Value>) {
     let Some(params) = params else {
         return;
     };
-    let roots_cap = params
-        .get("capabilities")
-        .and_then(|c| c.get("roots"));
-    state.supported = roots_cap.is_some();
-    state.list_changed = roots_cap
+    let caps = params.get("capabilities");
+    let roots_cap = caps.and_then(|c| c.get("roots"));
+    state.roots.supported = roots_cap.is_some();
+    state.roots.list_changed = roots_cap
         .and_then(|r| r.get("listChanged"))
         .and_then(|v| v.as_bool())
         .unwrap_or(false);
@@ -3415,39 +3435,89 @@ fn capture_client_roots_from_init(state: &mut ClientRootsState, params: Option<&
         .and_then(|r| r.get("roots"))
         .and_then(|a| a.as_array())
     {
-        state.roots = roots.clone();
+        state.roots.roots = roots.clone();
+    }
+    state.sampling = caps.and_then(|c| c.get("sampling")).is_some();
+    state.elicitation = caps.and_then(|c| c.get("elicitation")).is_some();
+}
+
+const UPSTREAM_RPC_TIMEOUT: Duration = Duration::from_secs(30);
+const UPSTREAM_INTERACTIVE_TIMEOUT: Duration = Duration::from_secs(120);
+
+fn upstream_rpc_timeout(method: &str) -> Duration {
+    match method {
+        "sampling/createMessage" | "elicitation/create" => UPSTREAM_INTERACTIVE_TIMEOUT,
+        _ => UPSTREAM_RPC_TIMEOUT,
+    }
+}
+
+fn client_supports_server_rpc(caps: &ClientUpstreamCaps, method: &str) -> bool {
+    match method {
+        "roots/list" => caps.roots.supported,
+        "sampling/createMessage" => caps.sampling,
+        "elicitation/create" => caps.elicitation,
+        _ => false,
+    }
+}
+
+fn upstream_rpc_params(method: &str, req: &Value) -> Value {
+    match method {
+        "roots/list" => json!({}),
+        _ => req.get("params").cloned().unwrap_or_else(|| json!({})),
+    }
+}
+
+fn upstream_json_rpc_response(id: Value, result: Result<Value, String>) -> Value {
+    match result {
+        Ok(result) => json!({ "jsonrpc": "2.0", "id": id, "result": result }),
+        Err(message) => json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "error": { "code": -32603, "message": message }
+        }),
     }
 }
 
 fn make_server_request_handler(
-    client_roots: Arc<Mutex<ClientRootsState>>,
+    client_upstream: Arc<Mutex<ClientUpstreamCaps>>,
     stdio_upstream: Arc<StdioUpstream>,
     mcp_sessions: Arc<Mutex<HashMap<String, Arc<McpSession>>>>,
     http: bool,
 ) -> ServerRequestHandler {
     Arc::new(move |req| {
         let method = req.get("method").and_then(|m| m.as_str())?;
-        let id = req.get("id")?.clone();
-        match method {
-            "roots/list" => {
-                let result = if http {
-                    let sid = ACTIVE_MCP_SESSION.with(|cell| cell.borrow().clone())?;
-                    let sessions = mcp_sessions.lock().ok()?;
-                    let session = sessions.get(&sid)?;
-                    session.upstream_call("roots/list", json!({})).ok()
-                } else if client_roots
-                    .lock()
-                    .map(|cr| cr.supported)
-                    .unwrap_or(false)
-                {
-                    stdio_upstream.call("roots/list", json!({})).ok()
-                } else {
-                    None
-                }?;
-                Some(json!({ "jsonrpc": "2.0", "id": id, "result": result }))
-            }
-            _ => None,
+        if !matches!(
+            method,
+            "roots/list" | "sampling/createMessage" | "elicitation/create"
+        ) {
+            return None;
         }
+        let id = req.get("id")?.clone();
+        if !client_upstream
+            .lock()
+            .map(|caps| client_supports_server_rpc(&caps, method))
+            .unwrap_or(false)
+        {
+            return Some(json!({
+                "jsonrpc": "2.0",
+                "id": id,
+                "error": {
+                    "code": -32601,
+                    "message": format!("upstream client does not support {method}")
+                }
+            }));
+        }
+        let params = upstream_rpc_params(method, req);
+        let timeout = upstream_rpc_timeout(method);
+        let result = if http {
+            let sid = ACTIVE_MCP_SESSION.with(|cell| cell.borrow().clone())?;
+            let sessions = mcp_sessions.lock().ok()?;
+            let session = sessions.get(&sid)?;
+            session.upstream_call_timeout(method, params, timeout)
+        } else {
+            stdio_upstream.call_timeout(method, params, timeout)
+        };
+        Some(upstream_json_rpc_response(id, result))
     })
 }
 
@@ -3487,8 +3557,8 @@ fn process_request(
     }
 
     if method == "initialize" && !state.http {
-        if let Ok(mut cr) = state.client_roots.lock() {
-            capture_client_roots_from_init(&mut cr, req.get("params"));
+        if let Ok(mut caps) = state.client_upstream.lock() {
+            capture_client_upstream_from_init(&mut caps, req.get("params"));
         }
     }
 
@@ -4133,8 +4203,8 @@ fn handle_mcp_http(
             if is_initialize {
                 if let Ok(sessions) = state.mcp_sessions.lock() {
                     if let Some(sess) = sessions.get(&session_id) {
-                        if let Ok(mut cr) = sess.client_roots.lock() {
-                            capture_client_roots_from_init(&mut cr, req.get("params"));
+                        if let Ok(mut caps) = sess.client_upstream.lock() {
+                            capture_client_upstream_from_init(&mut caps, req.get("params"));
                         }
                     }
                 }
@@ -4805,10 +4875,10 @@ fn main() {
     // tool set mid-session propagates to the client instead of being dropped.
     let downstream_dirty = Arc::new(AtomicU8::new(0));
     let mcp_sessions = Arc::new(Mutex::new(HashMap::new()));
-    let client_roots = Arc::new(Mutex::new(ClientRootsState::default()));
+    let client_upstream = Arc::new(Mutex::new(ClientUpstreamCaps::default()));
     let stdio_upstream = Arc::new(StdioUpstream::new(Arc::clone(&stdout)));
     let server_handler = make_server_request_handler(
-        Arc::clone(&client_roots),
+        Arc::clone(&client_upstream),
         Arc::clone(&stdio_upstream),
         Arc::clone(&mcp_sessions),
         http_mode,
@@ -4902,7 +4972,7 @@ fn main() {
         profile: profile.clone(),
         http: http_mode,
         mcp_sessions,
-        client_roots,
+        client_upstream,
         stdio_upstream,
         server_handler,
     };
@@ -5002,17 +5072,38 @@ mod tests {
     use super::*;
 
     #[test]
-    fn capture_client_roots_records_capabilities_and_initial_roots() {
-        let mut state = ClientRootsState::default();
+    fn capture_client_upstream_records_roots_sampling_and_elicitation() {
+        let mut state = ClientUpstreamCaps::default();
         let params = json!({
-            "capabilities": { "roots": { "listChanged": true } },
+            "capabilities": {
+                "roots": { "listChanged": true },
+                "sampling": {},
+                "elicitation": {}
+            },
             "roots": { "roots": [{ "uri": "file:///tmp", "name": "tmp" }] }
         });
-        capture_client_roots_from_init(&mut state, Some(&params));
-        assert!(state.supported);
-        assert!(state.list_changed);
-        assert_eq!(state.roots.len(), 1);
-        assert_eq!(state.roots[0]["uri"], "file:///tmp");
+        capture_client_upstream_from_init(&mut state, Some(&params));
+        assert!(state.roots.supported);
+        assert!(state.roots.list_changed);
+        assert!(state.sampling);
+        assert!(state.elicitation);
+        assert_eq!(state.roots.roots.len(), 1);
+        assert_eq!(state.roots.roots[0]["uri"], "file:///tmp");
+    }
+
+    #[test]
+    fn client_supports_server_rpc_matches_declared_capabilities() {
+        let caps = ClientUpstreamCaps {
+            roots: ClientRootsState {
+                supported: true,
+                ..Default::default()
+            },
+            sampling: true,
+            elicitation: false,
+        };
+        assert!(client_supports_server_rpc(&caps, "roots/list"));
+        assert!(client_supports_server_rpc(&caps, "sampling/createMessage"));
+        assert!(!client_supports_server_rpc(&caps, "elicitation/create"));
     }
 
     /// The security-critical guarantee: the human-approval broker denies (never
@@ -5098,10 +5189,10 @@ mod tests {
     fn http_state(lazy: bool) -> GatewayState {
         let stdout = Arc::new(Mutex::new(std::io::stdout()));
         let mcp_sessions = Arc::new(Mutex::new(HashMap::new()));
-        let client_roots = Arc::new(Mutex::new(ClientRootsState::default()));
+        let client_upstream = Arc::new(Mutex::new(ClientUpstreamCaps::default()));
         let stdio_upstream = Arc::new(StdioUpstream::new(Arc::clone(&stdout)));
         let server_handler = make_server_request_handler(
-            Arc::clone(&client_roots),
+            Arc::clone(&client_upstream),
             Arc::clone(&stdio_upstream),
             Arc::clone(&mcp_sessions),
             true,
@@ -5118,7 +5209,7 @@ mod tests {
             profile: None,
             http: true,
             mcp_sessions,
-            client_roots,
+            client_upstream,
             stdio_upstream,
             server_handler,
         }

--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -3114,18 +3114,34 @@ impl StdioUpstream {
         self.pending
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
-            .insert(id_key, tx);
+            .insert(id_key.clone(), tx);
         let req = json!({ "jsonrpc": "2.0", "id": id, "method": method, "params": params });
-        let mut out = self
-            .stdout
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
-        writeln!(out, "{req}").map_err(|e| e.to_string())?;
-        out.flush().map_err(|e| e.to_string())?;
-        drop(out);
-        let resp = rx
-            .recv_timeout(timeout)
-            .map_err(|_| "upstream client did not answer".to_string())?;
+        let send = {
+            let mut out = self
+                .stdout
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            writeln!(out, "{req}")
+                .and_then(|_| out.flush())
+                .map_err(|e| e.to_string())
+        };
+        if let Err(e) = send {
+            self.pending
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .remove(&id_key);
+            return Err(e);
+        }
+        let resp = match rx.recv_timeout(timeout) {
+            Ok(v) => v,
+            Err(_) => {
+                self.pending
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner)
+                    .remove(&id_key);
+                return Err("upstream client did not answer".to_string());
+            }
+        };
         if let Some(err) = resp.get("error") {
             return Err(err.to_string());
         }
@@ -3197,13 +3213,29 @@ impl McpSession {
         self.upstream_pending
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
-            .insert(id_key, tx);
+            .insert(id_key.clone(), tx);
         let req = json!({ "jsonrpc": "2.0", "id": id, "method": method, "params": params });
-        let json_str = serde_json::to_string(&req).map_err(|e| e.to_string())?;
+        let json_str = match serde_json::to_string(&req) {
+            Ok(s) => s,
+            Err(e) => {
+                self.upstream_pending
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner)
+                    .remove(&id_key);
+                return Err(e.to_string());
+            }
+        };
         self.push_message(json_str);
-        let resp = rx
-            .recv_timeout(timeout)
-            .map_err(|_| "upstream MCP client did not answer".to_string())?;
+        let resp = match rx.recv_timeout(timeout) {
+            Ok(v) => v,
+            Err(_) => {
+                self.upstream_pending
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner)
+                    .remove(&id_key);
+                return Err("upstream MCP client did not answer".to_string());
+            }
+        };
         if let Some(err) = resp.get("error") {
             return Err(err.to_string());
         }
@@ -3420,6 +3452,7 @@ fn cancellation_reason(req: &Value) -> Option<&str> {
 }
 
 fn capture_client_upstream_from_init(state: &mut ClientUpstreamCaps, params: Option<&Value>) {
+    *state = ClientUpstreamCaps::default();
     let Some(params) = params else {
         return;
     };
@@ -3478,6 +3511,17 @@ fn upstream_json_rpc_response(id: Value, result: Result<Value, String>) -> Value
     }
 }
 
+fn upstream_client_unsupported(id: Value, method: &str) -> Value {
+    json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "error": {
+            "code": -32601,
+            "message": format!("upstream client does not support {method}")
+        }
+    })
+}
+
 fn make_server_request_handler(
     client_upstream: Arc<Mutex<ClientUpstreamCaps>>,
     stdio_upstream: Arc<StdioUpstream>,
@@ -3493,28 +3537,31 @@ fn make_server_request_handler(
             return None;
         }
         let id = req.get("id")?.clone();
-        if !client_upstream
-            .lock()
-            .map(|caps| client_supports_server_rpc(&caps, method))
-            .unwrap_or(false)
-        {
-            return Some(json!({
-                "jsonrpc": "2.0",
-                "id": id,
-                "error": {
-                    "code": -32601,
-                    "message": format!("upstream client does not support {method}")
-                }
-            }));
-        }
         let params = upstream_rpc_params(method, req);
         let timeout = upstream_rpc_timeout(method);
         let result = if http {
             let sid = ACTIVE_MCP_SESSION.with(|cell| cell.borrow().clone())?;
-            let sessions = mcp_sessions.lock().ok()?;
-            let session = sessions.get(&sid)?;
+            let session = {
+                let sessions = mcp_sessions.lock().ok()?;
+                sessions.get(&sid).cloned()?
+            };
+            let supported = session
+                .client_upstream
+                .lock()
+                .map(|caps| client_supports_server_rpc(&caps, method))
+                .unwrap_or(false);
+            if !supported {
+                return Some(upstream_client_unsupported(id, method));
+            }
             session.upstream_call_timeout(method, params, timeout)
         } else {
+            let supported = client_upstream
+                .lock()
+                .map(|caps| client_supports_server_rpc(&caps, method))
+                .unwrap_or(false);
+            if !supported {
+                return Some(upstream_client_unsupported(id, method));
+            }
             stdio_upstream.call_timeout(method, params, timeout)
         };
         Some(upstream_json_rpc_response(id, result))
@@ -5089,6 +5136,18 @@ mod tests {
         assert!(state.elicitation);
         assert_eq!(state.roots.roots.len(), 1);
         assert_eq!(state.roots.roots[0]["uri"], "file:///tmp");
+    }
+
+    #[test]
+    fn capture_client_upstream_resets_stale_capabilities_on_reinitialize() {
+        let mut state = ClientUpstreamCaps {
+            sampling: true,
+            elicitation: true,
+            ..Default::default()
+        };
+        capture_client_upstream_from_init(&mut state, Some(&json!({"capabilities": {}})));
+        assert!(!state.sampling);
+        assert!(!state.elicitation);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Generalize client capability tracking (ClientUpstreamCaps) beyond roots to include sampling and elicitation
- Forward downstream `sampling/createMessage` and `elicitation/create` to the upstream MCP client (stdio + HTTP MCP via GET /mcp listen)
- Use 120s timeout for interactive upstream RPC; return JSON-RPC errors when the client lacks capability or does not answer
- Update headless docs and ROADMAP

## Test plan
- [x] cargo test --bin toolport-gateway (full suite)
- [ ] Manual: downstream server that calls sampling/createMessage mid tools/call through stdio gateway


Made with [Cursor](https://cursor.com)