### PR TITLE
feat(gateway): HTTP downstream server-initiated RPC on SSE (#167)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -87,8 +87,8 @@ low real exposure since the gateway only writes when `allow_agent_control` is on
 - [~] **Streamable-HTTP upstream transport** — `POST /mcp` and `GET /mcp` listen stream ship
   (session ids, JSON-RPC, selective SSE responses; see `docs/headless.md` +
   `docker-compose.example.yml`). OpenAPI HTTP mode already shipped for Open WebUI.
-  Remaining: HTTP downstream server-initiated RPC (#167). Roots, sampling, and
-  elicitation passthrough to the upstream MCP client ship for stdio + HTTP MCP. (M)
+  Remaining (#167): long-lived `GET /mcp` listen on HTTP downstream for servers
+  that push server-initiated RPC outside SSE POST responses. (S)
 
 **Strategic**
 

--- a/docs/headless.md
+++ b/docs/headless.md
@@ -18,7 +18,7 @@ Current streamable-HTTP scope:
 - `POST /mcp` returns JSON-RPC responses as JSON by default.
 - If `Accept` prefers `text/event-stream`, `POST /mcp` returns a single SSE `message` event and closes.
 - `GET /mcp` opens a long-lived SSE listen stream for server→client JSON-RPC (keepalive comments every 30s when idle).
-- **Server-initiated RPC passthrough** (#167): when the MCP client declares `roots`, `sampling`, or `elicitation` at `initialize`, stdio downstream servers can call `roots/list`, `sampling/createMessage`, and `elicitation/create`; the gateway forwards those to the upstream MCP client over stdio or HTTP MCP (`GET /mcp` listen). Interactive calls use a 120s upstream timeout. `notifications/roots/list_changed` from the client is forwarded to all downstream servers. HTTP **downstream** server-initiated RPC is not supported yet.
+- **Server-initiated RPC passthrough** (#167): when the MCP client declares `roots`, `sampling`, or `elicitation` at `initialize`, downstream servers (stdio or HTTP/SSE) can call `roots/list`, `sampling/createMessage`, and `elicitation/create`; the gateway forwards those to the upstream MCP client over stdio or HTTP MCP (`GET /mcp` listen). Interactive calls use a 120s upstream timeout. `notifications/roots/list_changed` from the client is forwarded to all downstream servers. HTTP downstream answers inline during SSE `POST` responses (no separate downstream `GET /mcp` listener yet).
 
 Auth is the same bearer token as today (`CONDUIT_HTTP_TOKEN` or a registered
 `httpClients[]` entry). Non-loopback binds **require** a token.

--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -2672,7 +2672,7 @@ fn connect_one(
             Err(e) => Err(e),
         }
     } else if server.url.is_some() {
-        remote::connect_remote(server)
+        remote::connect_remote_with_handler(server, Some(Arc::clone(&server_handler)))
     } else {
         Err("no command or url".to_string())
     };

--- a/src-tauri/src/downstream.rs
+++ b/src-tauri/src/downstream.rs
@@ -1256,6 +1256,7 @@ pub struct HttpTransport {
     /// running gateway recover from a short-lived access token expiring mid-session
     /// instead of 401ing until the server is manually reconnected.
     refresh: Option<RefreshFn>,
+    server_handler: Option<ServerRequestHandler>,
 }
 
 impl HttpTransport {
@@ -1297,7 +1298,24 @@ impl HttpTransport {
             next_id: 1,
             auth,
             refresh,
+            server_handler: None,
         }
+    }
+
+    /// Answer a server-initiated JSON-RPC request inline (SSE mid-stream or
+    /// standalone). Returns true when the message was handled.
+    fn handle_inline_server_request(&mut self, v: &Value) -> Result<bool, TransportError> {
+        if !is_server_initiated_request(v) {
+            return Ok(false);
+        }
+        let Some(handler) = &self.server_handler else {
+            return Ok(false);
+        };
+        let Some(resp) = handler(v) else {
+            return Ok(false);
+        };
+        self.post(&resp, false)?;
+        Ok(true)
     }
 
     fn post(&mut self, body: &Value, expect_response: bool) -> Result<Option<Value>, TransportError> {
@@ -1397,6 +1415,9 @@ impl HttpTransport {
                         continue;
                     }
                     if let Ok(v) = serde_json::from_str::<Value>(data) {
+                        if self.handle_inline_server_request(&v)? {
+                            continue;
+                        }
                         if ids_match(v.get("id"), wanted.as_ref()) {
                             return Ok(Some(v));
                         }
@@ -1428,6 +1449,10 @@ impl Transport for HttpTransport {
         let body = json!({ "jsonrpc": "2.0", "method": method, "params": params });
         self.post(&body, false)?;
         Ok(())
+    }
+
+    fn set_server_request_handler(&mut self, handler: ServerRequestHandler) {
+        self.server_handler = Some(handler);
     }
 }
 

--- a/src-tauri/src/remote.rs
+++ b/src-tauri/src/remote.rs
@@ -7,7 +7,9 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::downstream::{DownstreamServer, HttpTransport, RefreshFn};
+use crate::downstream::{
+    DownstreamServer, HttpTransport, RefreshFn, ServerRequestHandler, Transport,
+};
 use crate::registry::ServerEntry;
 use crate::{oauth, secrets};
 
@@ -205,6 +207,15 @@ fn first_vaulted_secret(server: &ServerEntry) -> Option<String> {
 ///    OAuth. Without this fallback, "Manage secrets" tokens were silently ignored
 ///    for HTTP servers.
 pub fn connect_remote(server: &ServerEntry) -> Result<DownstreamServer, String> {
+    connect_remote_with_handler(server, None)
+}
+
+/// Like [`connect_remote`], but wires server-initiated JSON-RPC (sampling, roots, …)
+/// through `handler` when the downstream server asks mid-call.
+pub fn connect_remote_with_handler(
+    server: &ServerEntry,
+    server_handler: Option<ServerRequestHandler>,
+) -> Result<DownstreamServer, String> {
     guard_connect_target(server)?;
     let url = server.url.as_deref().unwrap_or("");
     let server_id = &server.id;
@@ -213,12 +224,18 @@ pub fn connect_remote(server: &ServerEntry) -> Result<DownstreamServer, String> 
     let block_private = is_untrusted_source(server.source.as_deref());
     let auth = secrets::get_secret(server_id, secrets::HTTP_AUTH_KEY)
         .or_else(|| first_vaulted_secret(server));
-    let transport = authed_transport(url, auth, server_id, block_private)?;
+    let mut transport = authed_transport(url, auth, server_id, block_private)?;
+    if let Some(ref handler) = server_handler {
+        transport.set_server_request_handler(handler.clone());
+    }
     match DownstreamServer::connect(server_id.to_string(), Box::new(transport)) {
         Ok(ds) => Ok(ds),
         Err(e) if is_auth_error(&e) => match refresh_token(server_id) {
             Ok(fresh) => {
-                let transport = authed_transport(url, Some(fresh), server_id, block_private)?;
+                let mut transport = authed_transport(url, Some(fresh), server_id, block_private)?;
+                if let Some(handler) = server_handler.clone() {
+                    transport.set_server_request_handler(handler);
+                }
                 DownstreamServer::connect(server_id.to_string(), Box::new(transport))
             }
             Err(_) => Err(e),


### PR DESCRIPTION
## Summary
- Wire server_request_handler on HttpTransport; answer server-initiated JSON-RPC inline during SSE POST responses
- connect_remote_with_handler for gateway builds; stdio + HTTP downstream now share the same upstream passthrough path
- Docs: clarify SSE-inline vs downstream GET listen follow-up

## Test plan
- [x] cargo test --lib --bins
- [ ] Manual: remote MCP server that sampling/createMessage during tools/call over SSE


Made with [Cursor](https://cursor.com)