### PR TITLE
feat(teams): report per-server usage rollups to the team server

### DIFF
--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -1803,6 +1803,9 @@ fn handle_request_with_cancel(
                     full_tokens,
                     savings::estimate_tokens(&tools),
                     catalog.len() as u64 + 1,
+                    savings::per_server_tokens(catalog, |name| {
+                        router.route_of(name).map(|(s, _)| s.to_string())
+                    }),
                 );
                 gtrace(&format!(
                     "tools/list -> {} meta-tools (lazy discovery)",
@@ -1832,6 +1835,9 @@ fn handle_request_with_cancel(
                     full_tokens,
                     savings::estimate_tokens(&tools),
                     scoped.len() as u64 + 1,
+                    savings::per_server_tokens(&scoped, |name| {
+                        router.route_of(name).map(|(s, _)| s.to_string())
+                    }),
                 );
                 gtrace(&format!(
                     "tools/list -> {} tools (grouped: {} server browse tools)",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -24,6 +24,7 @@ pub mod shaping;
 pub mod secrets;
 pub mod stacks;
 pub mod teams;
+pub mod usage_report;
 pub mod vendors;
 
 use downstream::{DownstreamServer, StdioTransport};

--- a/src-tauri/src/registry.rs
+++ b/src-tauri/src/registry.rs
@@ -343,6 +343,12 @@ pub struct TeamConnection {
     /// carries a per-member suffix that a reconstructed "v{n}" would never match.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub last_etag: Option<String>,
+    /// Usage rows already reported to the team server, "YYYY-MM-DD" (UTC) -> server id ->
+    /// [calls, tokens_saved]. The next report sends max(local rollup, this), so a local
+    /// log rotation mid-day can never shrink a count the server already has. Pruned to
+    /// the report window (today + yesterday) on every successful report.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub usage_reported: HashMap<String, HashMap<String, [u64; 2]>>,
 }
 
 /// Settings for embedding-based search re-ranking. The embedding API key, if the

--- a/src-tauri/src/savings.rs
+++ b/src-tauri/src/savings.rs
@@ -9,6 +9,7 @@
 //! its own gateway process: concurrent `O_APPEND` writes of one small line are
 //! safe, whereas a read-modify-write counter would race and lose updates.
 
+use std::collections::BTreeMap;
 use std::io::Write;
 use std::path::{Path, PathBuf};
 
@@ -46,14 +47,39 @@ pub fn estimate_tokens(tools: &[Value]) -> u64 {
     chars.div_ceil(4) as u64
 }
 
+/// Per-server share of a catalog's tool-def tokens, resolved through `route` (the
+/// router's exposed-name -> server mapping). Tools `route` can't place are skipped:
+/// mis-attributing tokens to a wrongly split server id would be worse than
+/// under-counting, and route_of only misses tools that just vanished from the routes.
+pub fn per_server_tokens(
+    tools: &[Value],
+    route: impl Fn(&str) -> Option<String>,
+) -> BTreeMap<String, u64> {
+    let mut by_server: BTreeMap<String, u64> = BTreeMap::new();
+    for t in tools {
+        let Some(server) = t.get("name").and_then(Value::as_str).and_then(&route) else {
+            continue;
+        };
+        let tokens = estimate_tokens(std::slice::from_ref(t));
+        *by_server.entry(server).or_insert(0) += tokens;
+    }
+    by_server
+}
+
 /// Record one lazy serve: the full catalog's tool-def tokens minus the meta-tools'.
 /// No-op when there's nothing to save (empty catalog / non-lazy never calls this).
-pub fn record(full_tokens: u64, meta_tokens: u64, catalog_tools: u64) {
+/// `by_server` attributes the catalog's tokens to their servers so team usage
+/// reporting can build per-server rows; empty (old callers, no routes) is fine and
+/// simply leaves this serve out of the per-server rollup.
+pub fn record(full_tokens: u64, meta_tokens: u64, catalog_tools: u64, by_server: BTreeMap<String, u64>) {
     let saved = full_tokens.saturating_sub(meta_tokens);
     if saved == 0 {
         return;
     }
-    let entry = json!({ "ts": epoch_millis() as u64, "saved": saved, "tools": catalog_tools });
+    let mut entry = json!({ "ts": epoch_millis() as u64, "saved": saved, "tools": catalog_tools });
+    if !by_server.is_empty() {
+        entry["byServer"] = json!(by_server);
+    }
     if let Some(path) = savings_path() {
         if let Some(parent) = path.parent() {
             let _ = std::fs::create_dir_all(parent);
@@ -121,17 +147,22 @@ fn fold(entries: &[Value]) -> Value {
     json!({ "ts": since, "saved": saved, "tools": peak, "loads": loads })
 }
 
-/// Cumulative savings for the in-app counter.
-pub fn summary() -> Value {
-    let entries: Vec<Value> = savings_path()
+/// Every savings line on disk, oldest first (bounded by rotation). Shared by the
+/// in-app counter and the team usage rollup.
+pub fn entries() -> Vec<Value> {
+    savings_path()
         .and_then(|p| std::fs::read_to_string(p).ok())
         .map(|c| {
             c.lines()
                 .filter_map(|l| serde_json::from_str(l).ok())
                 .collect()
         })
-        .unwrap_or_default();
-    aggregate(&entries)
+        .unwrap_or_default()
+}
+
+/// Cumulative savings for the in-app counter.
+pub fn summary() -> Value {
+    aggregate(&entries())
 }
 
 /// Pure aggregation, split out so the math is testable without touching disk.

--- a/src-tauri/src/teams.rs
+++ b/src-tauri/src/teams.rs
@@ -9,9 +9,12 @@
 //! The HTTP calls (join/pull/push) are thin; the value and the risk live in the merge,
 //! which is pure and unit-tested below.
 
-use serde_json::Value;
+use std::collections::{BTreeMap, HashMap, HashSet};
+
+use serde_json::{json, Value};
 
 use crate::registry::{EnvVar, Registry, ServerEntry, TeamConnection};
+use crate::usage_report;
 
 /// Reserved keychain slot for the member bearer token (one team connection at a time).
 pub const TEAM_TOKEN_SERVER: &str = "__conduit_team__";
@@ -219,6 +222,30 @@ pub fn push_config(server_url: &str, team_id: &str, token: &str, config: &Value)
         .ok_or_else(|| "team server did not return a version after push".to_string())
 }
 
+/// Report one UTC day's usage rollup (counts + estimates only, see `usage_report`).
+/// `Ok(true)` means the server recorded it; `Ok(false)` means the server predates the
+/// usage endpoint (404), mirroring `MembershipCheck::Unsupported` so a new client
+/// still works against an old self-hosted server.
+fn post_usage_day(
+    server_url: &str,
+    team_id: &str,
+    token: &str,
+    day: &str,
+    rows: Vec<Value>,
+) -> Result<bool, String> {
+    require_secure_team_url(server_url)?;
+    let url = format!("{}/teams/{}/usage", base(server_url), team_id);
+    match agent()
+        .post(&url)
+        .set("authorization", &format!("Bearer {token}"))
+        .send_json(json!({ "day": day, "rows": rows }))
+    {
+        Ok(_) => Ok(true),
+        Err(ureq::Error::Status(404 | 405, _)) => Ok(false),
+        Err(e) => Err(stringify(e)),
+    }
+}
+
 fn stringify(e: ureq::Error) -> String {
     match e {
         ureq::Error::Status(code, resp) => {
@@ -254,6 +281,7 @@ fn finish_connect(server_url: &str, member_name: Option<&str>, joined: Joined) -
         member_name: member_name.map(String::from),
         last_version: 0,
         last_etag: None,
+        usage_reported: HashMap::new(),
     };
     reg.team = Some(conn);
     let mut outcome = MergeOutcome::default();
@@ -363,11 +391,123 @@ fn sync_inner(wait_secs: u64) -> Result<SyncResult, String> {
         t.role = role.clone();
     }
     crate::registry::save(&reg)?;
+    // Best-effort showback after the config work: report today's/yesterday's per-server
+    // usage rollup to the team server. Any failure here must never affect the sync
+    // result — the member's config is already applied and saved.
+    report_usage(&conn, &token);
     Ok(SyncResult::Ok {
         role,
         role_changed,
         applied,
     })
+}
+
+/// Merge a fresh local rollup with what was already reported for that day, taking the
+/// max per counter. The local logs only grow within a day, so a SMALLER local number
+/// means a log rotation trimmed history — and since the server's `record_usage`
+/// upserts by replacement, re-sending the shrunken count would erase usage the server
+/// already recorded. Max is always the authoritative daily total.
+fn merge_reported(
+    local: &BTreeMap<String, usage_report::Row>,
+    reported: Option<&HashMap<String, [u64; 2]>>,
+) -> HashMap<String, [u64; 2]> {
+    let mut merged: HashMap<String, [u64; 2]> = reported.cloned().unwrap_or_default();
+    for (server, row) in local {
+        let e = merged.entry(server.clone()).or_insert([0, 0]);
+        e[0] = e[0].max(row.calls);
+        e[1] = e[1].max(row.tokens_saved);
+    }
+    merged
+}
+
+/// Best-effort usage showback: roll up today + yesterday (UTC) for THIS team's servers
+/// only (`source = "team:<id>"` — a member's personal servers are never reported) and
+/// POST the rollups. Counts and token/dollar estimates only; tool names stay local
+/// (rows are per server). Skips silently when there is nothing new, the server is too
+/// old for the endpoint, or the network is down — never fails the sync it rides on.
+fn report_usage(conn: &TeamConnection, token: &str) {
+    let tag = tag_for(&conn.team_id);
+    let (team_servers, reported) = {
+        let Ok(reg) = crate::registry::load() else { return };
+        // The user disconnected or switched teams mid-sync: report nothing.
+        match reg.team.as_ref() {
+            Some(t) if t.team_id == conn.team_id => {}
+            _ => return,
+        }
+        let ids: HashSet<String> = reg
+            .servers
+            .iter()
+            .filter(|s| s.source.as_deref() == Some(tag.as_str()))
+            .map(|s| s.id.clone())
+            .collect();
+        let reported = reg
+            .team
+            .as_ref()
+            .map(|t| t.usage_reported.clone())
+            .unwrap_or_default();
+        (ids, reported)
+    };
+    if team_servers.is_empty() {
+        return;
+    }
+    let audit_lines = crate::audit::read_recent(usize::MAX);
+    let savings_lines = crate::savings::entries();
+    let mut new_state: HashMap<String, HashMap<String, [u64; 2]>> = HashMap::new();
+    let mut changed = false;
+    for back in 0..2u64 {
+        let day = usage_report::utc_day_back(back);
+        let local = usage_report::rollup(&day, &audit_lines, &savings_lines, &team_servers);
+        let merged = merge_reported(&local, reported.get(&day));
+        if merged.is_empty() {
+            continue;
+        }
+        if reported.get(&day) == Some(&merged) {
+            // Nothing new since the last successful report: keep the watermark, skip
+            // the POST so an idle 5-minute background sync costs the server nothing.
+            new_state.insert(day, merged);
+            continue;
+        }
+        let rows: Vec<Value> = merged
+            .iter()
+            .map(|(server, [calls, saved])| {
+                json!({
+                    "server": server,
+                    "calls": calls,
+                    "tokens_saved": saved,
+                    "est_cost": usage_report::est_cost(*saved),
+                })
+            })
+            .collect();
+        match post_usage_day(&conn.server_url, &conn.team_id, token, &day, rows) {
+            Ok(true) => {
+                new_state.insert(day, merged);
+                changed = true;
+            }
+            // Old server without the endpoint: nothing to persist, don't retry the
+            // other day either.
+            Ok(false) => return,
+            // Transient failure: keep the previous watermark for this day so the next
+            // sync re-sends the full daily total.
+            Err(_) => {
+                if let Some(prev) = reported.get(&day) {
+                    new_state.insert(day, prev.clone());
+                }
+            }
+        }
+    }
+    if !changed {
+        return;
+    }
+    // Persist the watermarks on a FRESH registry (same clobber-avoidance as sync_inner:
+    // the POSTs above are network round trips another command may have raced past).
+    // `new_state` only ever holds today + yesterday, so old days prune themselves.
+    let Ok(mut reg) = crate::registry::load() else { return };
+    if let Some(t) = reg.team.as_mut() {
+        if t.team_id == conn.team_id {
+            t.usage_reported = new_state;
+            let _ = crate::registry::save(&reg);
+        }
+    }
 }
 
 /// Leave the team: remove its merged servers, clear the connection and the token.
@@ -707,6 +847,30 @@ pub fn remove_team(reg: &mut Registry, team_id: &str) {
 mod tests {
     use super::*;
     use serde_json::json;
+
+    #[test]
+    fn merge_reported_takes_the_max_per_counter() {
+        // A log rotation can shrink the local rollup mid-day; the already-reported
+        // watermark must win so the re-send never erases counts the server has.
+        let mut local = BTreeMap::new();
+        local.insert("github".to_string(), usage_report::Row { calls: 3, tokens_saved: 900 });
+        local.insert("stripe".to_string(), usage_report::Row { calls: 7, tokens_saved: 0 });
+        let mut reported = HashMap::new();
+        reported.insert("github".to_string(), [10, 100]); // rotation ate 7 calls; saved grew
+        let merged = merge_reported(&local, Some(&reported));
+        assert_eq!(merged["github"], [10, 900]); // max per counter, independently
+        assert_eq!(merged["stripe"], [7, 0]); // new server passes through
+    }
+
+    #[test]
+    fn merge_reported_keeps_servers_the_rollup_no_longer_sees() {
+        // A server reported earlier today then trimmed from the logs entirely must
+        // survive the merge, or the replacement upsert would zero it server-side.
+        let mut reported = HashMap::new();
+        reported.insert("github".to_string(), [5, 50]);
+        let merged = merge_reported(&BTreeMap::new(), Some(&reported));
+        assert_eq!(merged["github"], [5, 50]);
+    }
 
     fn base_registry() -> Registry {
         let mut r = Registry::default();

--- a/src-tauri/src/usage_report.rs
+++ b/src-tauri/src/usage_report.rs
@@ -1,0 +1,174 @@
+//! Team usage rollup: per-server daily counts from the local gateway logs.
+//!
+//! Builds the rows a member reports to their own team's server for showback
+//! (`POST /teams/{id}/usage`). Everything here is counts and estimates derived
+//! from the same `audit.jsonl` / `savings.jsonl` the in-app dashboards read:
+//! tool names, arguments, results, and secrets never leave the machine, and only
+//! servers the team itself distributed (`source = "team:<id>"`) are ever counted.
+//! This reports to the member's own team server, not to any vendor endpoint; a
+//! user who never joins a team never triggers it.
+
+use std::collections::{BTreeMap, HashSet};
+
+use serde_json::Value;
+
+/// Estimated $ per million tool-definition tokens kept out of context. Matches
+/// the in-app savings banner's default model (Claude Sonnet list input rate);
+/// the Teams dashboards label the figure "estimated, at list input rates".
+pub const EST_DOLLARS_PER_MTOK: f64 = 3.0;
+
+/// One per-server rollup row: tool calls routed + tool-def tokens kept out of
+/// agent context. The dollar figure is derived, not stored (see [`est_cost`]).
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct Row {
+    pub calls: u64,
+    pub tokens_saved: u64,
+}
+
+/// The estimated dollar value of `tokens` tool-definition tokens.
+pub fn est_cost(tokens: u64) -> f64 {
+    (tokens as f64 / 1_000_000.0) * EST_DOLLARS_PER_MTOK
+}
+
+/// "YYYY-MM-DD" (UTC) for an epoch-milliseconds timestamp. Days are bucketed in
+/// UTC so every member of a team lands in the same bucket regardless of local
+/// timezone or DST, and so the key is stable across a machine's TZ changes.
+pub fn utc_day(ts_millis: u64) -> String {
+    let (y, m, d) = civil_from_days((ts_millis / 86_400_000) as i64);
+    format!("{y:04}-{m:02}-{d:02}")
+}
+
+/// The current UTC day, `offset_back` days ago (0 = today, 1 = yesterday).
+pub fn utc_day_back(offset_back: u64) -> String {
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0);
+    utc_day(now.saturating_sub(offset_back * 86_400_000))
+}
+
+/// Days-since-epoch -> (year, month, day), proleptic Gregorian. Howard Hinnant's
+/// `civil_from_days`; used instead of pulling a date crate in for one function.
+fn civil_from_days(z: i64) -> (i64, u32, u32) {
+    let z = z + 719_468;
+    let era = if z >= 0 { z } else { z - 146_096 } / 146_097;
+    let doe = (z - era * 146_097) as u64;
+    let yoe = (doe - doe / 1_460 + doe / 36_524 - doe / 146_096) / 365;
+    let y = yoe as i64 + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = (doy - (153 * mp + 2) / 5 + 1) as u32;
+    let m = if mp < 10 { mp + 3 } else { mp - 9 } as u32;
+    (if m <= 2 { y + 1 } else { y }, m as u32, d)
+}
+
+/// Roll audit + savings lines up into per-server rows for one UTC day, counting
+/// only `team_servers`. Pure so the math is testable without touching disk; the
+/// caller feeds it the on-disk lines (see `teams::report_usage`).
+///
+/// Calls count every routed attempt, failed ones included: the dashboard figure
+/// is "tool calls routed through the gateway", and a failed downstream call was
+/// still routed. Savings lines carry a `byServer` token map (new format); lines
+/// without one (pre-attribution builds, rotation carry lines) still count in the
+/// in-app total but can't be placed per server, so they are skipped here.
+pub fn rollup(
+    day: &str,
+    audit_lines: &[Value],
+    savings_lines: &[Value],
+    team_servers: &HashSet<String>,
+) -> BTreeMap<String, Row> {
+    let mut rows: BTreeMap<String, Row> = BTreeMap::new();
+    let ts_day = |e: &Value| -> bool {
+        e.get("ts")
+            .and_then(Value::as_u64)
+            .is_some_and(|ts| utc_day(ts) == day)
+    };
+    for e in audit_lines.iter().filter(|e| ts_day(e)) {
+        let Some(server) = e.get("server").and_then(Value::as_str) else {
+            continue;
+        };
+        if !team_servers.contains(server) {
+            continue;
+        }
+        rows.entry(server.to_string()).or_default().calls += 1;
+    }
+    for e in savings_lines.iter().filter(|e| ts_day(e)) {
+        let Some(by_server) = e.get("byServer").and_then(Value::as_object) else {
+            continue;
+        };
+        for (server, tokens) in by_server {
+            if !team_servers.contains(server.as_str()) {
+                continue;
+            }
+            let row = rows.entry(server.clone()).or_default();
+            row.tokens_saved = row
+                .tokens_saved
+                .saturating_add(tokens.as_u64().unwrap_or(0));
+        }
+    }
+    rows
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn team(ids: &[&str]) -> HashSet<String> {
+        ids.iter().map(|s| s.to_string()).collect()
+    }
+
+    // 2026-07-08 00:30:00 UTC and a minute later (2026-07-08T00:00Z = 20,642 days
+    // since epoch = 1_783_468_800_000 ms).
+    const TS_A: u64 = 1_783_470_600_000;
+    const TS_B: u64 = 1_783_470_660_000;
+
+    #[test]
+    fn utc_day_formats_and_buckets() {
+        assert_eq!(utc_day(0), "1970-01-01");
+        assert_eq!(utc_day(TS_A), "2026-07-08");
+        // One millisecond before midnight stays on the previous day.
+        assert_eq!(utc_day(1_783_468_799_999), "2026-07-07");
+        assert_eq!(utc_day(1_783_468_800_000), "2026-07-08");
+    }
+
+    #[test]
+    fn rollup_counts_team_calls_only_for_the_day() {
+        let audit = vec![
+            json!({ "ts": TS_A, "server": "github", "tool": "list", "ok": true }),
+            json!({ "ts": TS_B, "server": "github", "tool": "get", "ok": false }), // failed calls count: still routed
+            json!({ "ts": TS_A, "server": "personal", "tool": "x", "ok": true }), // not a team server
+            json!({ "ts": TS_A - 86_400_000, "server": "github", "tool": "x", "ok": true }), // yesterday
+        ];
+        let rows = rollup("2026-07-08", &audit, &[], &team(&["github", "stripe"]));
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows["github"], Row { calls: 2, tokens_saved: 0 });
+    }
+
+    #[test]
+    fn rollup_attributes_savings_by_server_and_skips_unattributed_lines() {
+        let savings = vec![
+            json!({ "ts": TS_A, "saved": 900, "tools": 10, "byServer": { "github": 500, "personal": 300 } }),
+            json!({ "ts": TS_B, "saved": 100, "tools": 10, "byServer": { "github": 80 } }),
+            json!({ "ts": TS_A, "saved": 777, "tools": 10 }), // legacy line, no attribution
+        ];
+        let rows = rollup("2026-07-08", &[], &savings, &team(&["github"]));
+        assert_eq!(rows["github"], Row { calls: 0, tokens_saved: 580 });
+        assert!(!rows.contains_key("personal"));
+    }
+
+    #[test]
+    fn rollup_merges_calls_and_savings_for_one_server() {
+        let audit = vec![json!({ "ts": TS_A, "server": "github", "tool": "t", "ok": true })];
+        let savings =
+            vec![json!({ "ts": TS_B, "saved": 50, "tools": 3, "byServer": { "github": 40 } })];
+        let rows = rollup("2026-07-08", &audit, &savings, &team(&["github"]));
+        assert_eq!(rows["github"], Row { calls: 1, tokens_saved: 40 });
+    }
+
+    #[test]
+    fn est_cost_is_list_rate_per_million() {
+        assert_eq!(est_cost(0), 0.0);
+        assert_eq!(est_cost(1_000_000), EST_DOLLARS_PER_MTOK);
+    }
+}


### PR DESCRIPTION
The Teams server has had a complete showback pipeline (POST /teams/{id}/usage, dashboard + ops rollups) with **no client feeding it** - teams.rs only ever called /join, /config, and /me, so every team shows 0 calls / 0 tokens / $0 regardless of real usage. This adds the missing client side.

## What
- **savings.rs**: `record()` now takes a per-server token map; `per_server_tokens()` resolves exposed tool names through the router (`route_of`, never `__`-splitting per the router's own warning). Legacy lines and rotation carry lines skip attribution gracefully.
- **usage_report.rs** (new): pure UTC-day rollup of audit.jsonl (calls) + savings.jsonl (byServer tokens), filtered to team-sourced servers only. `est_cost` mirrors the in-app banner default ($3/MTok list input).
- **teams.rs**: `report_usage()` runs best-effort at the end of every sync. Sends `max(local rollup, already-reported)` for today + yesterday, so a mid-day log rotation can never shrink a count the server already recorded (the server upserts by replacement). Skips the POST when nothing changed; 404 = old server, tolerated like `/me`; never fails the sync it rides on.
- **registry.rs**: `TeamConnection.usage_reported` watermarks, pruned to the 2-day window.

## Privacy ("no phone home" holds)
Reports go to the member's **own team server** - the one they joined and already sync config from - never to a vendor endpoint. Only servers that team distributed (`source = "team:<id>"`) are counted; counts and estimates only; tool names, args, results, and secrets stay on the machine. A user who never joins a team never triggers any of this.

## Verified
- 312 lib tests pass, including new rollup / merge-max / UTC-day-bucket tests
- Payload shape + replacement semantics exercised against a live conduit-teams server (re-push replaced the day''s rows; totals correct: 17 = replaced 10 + kept 7)