### PR TITLE
ci(docker): publish toolport-gateway image to GHCR

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,63 @@
+name: Publish gateway image
+
+# Builds the headless toolport-gateway Docker image and pushes to GHCR on main/tags.
+# Self-hosters can `docker pull ghcr.io/tsouth89/toolport-gateway:latest` without
+# compiling locally. After the first run, make the package public in GitHub
+# (Package settings -> Change visibility -> Public) for anonymous pulls.
+
+on:
+  push:
+    branches: [main]
+    tags: ["v*"]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: docker-gateway-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  # Pinned name (not ${{ github.repository }}) so repo renames don't break pulls.
+  IMAGE: ghcr.io/tsouth89/toolport-gateway
+
+jobs:
+  publish:
+    name: build + push image
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Image tags + labels
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE }}
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=ref,event=tag
+            type=sha,format=short
+
+      - name: Build + push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -31,6 +31,8 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - uses: docker/setup-buildx-action@v3
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 # Headless Toolport gateway image (OpenAPI + MCP streamable-HTTP).
 # Build from the repo root:
 #   docker build -t toolport-gateway .
-#
-# Local/dev only on this branch — do not push to GHCR until you cut a release.
+# Published to ghcr.io/tsouth89/toolport-gateway on push to main (see
+# .github/workflows/docker-publish.yml).
 
 FROM rust:1-slim AS build
 WORKDIR /src
@@ -29,7 +29,7 @@ COPY src-tauri/src ./src
 RUN touch src/lib.rs src/main.rs src/bin/toolport-gateway.rs src/bin/mock-mcp-server.rs && \
     cargo build --release --bin toolport-gateway
 
-FROM rust:1-slim
+FROM debian:bookworm-slim
 RUN apt-get update && apt-get install -y --no-install-recommends \
         ca-certificates libssl3 libdbus-1-3 curl \
     && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 # Published to ghcr.io/tsouth89/toolport-gateway on push to main (see
 # .github/workflows/docker-publish.yml).
 
-FROM rust:1-slim AS build
+FROM rust:1-slim-bookworm AS build
 WORKDIR /src
 RUN apt-get update && apt-get install -y --no-install-recommends \
         pkg-config libssl-dev libdbus-1-dev libglib2.0-dev libgtk-3-dev libwebkit2gtk-4.1-dev libjavascriptcoregtk-4.1-dev \

--- a/README.md
+++ b/README.md
@@ -209,7 +209,8 @@ any HTTP/OpenAPI MCP consumer (n8n, LibreChat, custom agents).
 The same `--http` process also serves **MCP streamable-HTTP** at `POST /mcp`, so
 sandboxed coding agents and remote clients can use a URL instead of stdio. For
 Docker, env-file secrets, and a compose example, see
-[docs/headless.md](docs/headless.md).
+[docs/headless.md](docs/headless.md). Prebuilt image:
+`docker pull ghcr.io/tsouth89/toolport-gateway:latest` (published from `main`).
 
 ## Configuration
 

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -1,10 +1,14 @@
 # Example headless Toolport gateway. Copy to docker-compose.yml and fill .env.
-# Local/dev only — do not push secrets or this file with real tokens.
+#
+# Option A — pull the published image (after GHCR package is public):
+#   image: ghcr.io/tsouth89/toolport-gateway:latest
+# Option B — build locally:
+#   build: .
 
 services:
   toolport-gateway:
     build: .
-    image: toolport-gateway:local
+    image: ghcr.io/tsouth89/toolport-gateway:latest
     ports:
       - "8765:8765"
     volumes:

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -87,8 +87,9 @@ low real exposure since the gateway only writes when `allow_agent_control` is on
 - [~] **Streamable-HTTP upstream transport** — `POST /mcp` and `GET /mcp` listen stream ship
   (session ids, JSON-RPC, selective SSE responses; see `docs/headless.md` +
   `docker-compose.example.yml`). OpenAPI HTTP mode already shipped for Open WebUI.
-  Remaining (#167): long-lived `GET /mcp` listen on HTTP downstream for servers
-  that push server-initiated RPC outside SSE POST responses. (S)
+  **GHCR:** `ghcr.io/tsouth89/toolport-gateway` published from `main`. Optional
+  follow-up: long-lived `GET /mcp` listen on HTTP downstream for servers that push
+  RPC outside SSE POST responses. (S)
 
 **Strategic**
 

--- a/docs/headless.md
+++ b/docs/headless.md
@@ -58,6 +58,22 @@ curl -s -X POST http://127.0.0.1:8765/mcp \
 
 ## Docker
 
+### Pull from GHCR (recommended)
+
+After the first CI publish, make the package public (GitHub → Packages →
+`toolport-gateway` → Package settings → Change visibility). Then:
+
+```bash
+docker pull ghcr.io/tsouth89/toolport-gateway:latest
+mkdir -p data
+cp data/registry.json.example data/registry.json
+cp docker-compose.example.yml docker-compose.yml
+# create .env with at least CONDUIT_HTTP_TOKEN=...
+docker compose up -d
+```
+
+### Build locally
+
 ```bash
 # from repo root
 docker build -t toolport-gateway .


### PR DESCRIPTION
## Summary
- Publish \ghcr.io/tsouth89/toolport-gateway\ from main/tags via GitHub Actions
- PR builds validate the Dockerfile without pushing; main push publishes \:latest\ + \:sha-*\
- Slimmer runtime image (debian:bookworm-slim); docs + compose example updated

## Test plan
- [ ] CI: Publish gateway image job on this PR (build only)
- [ ] After merge: make GHCR package public for anonymous pull
- [ ] \docker pull ghcr.io/tsouth89/toolport-gateway:latest\ smoke

## Notes
One-time: GitHub Packages -> toolport-gateway -> public visibility after first publish.

Made with [Cursor](https://cursor.com)