### PR TITLE
perf(docker): fast gateway image via CI-built binary

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -25,6 +25,6 @@ benchmark/
 *.md
 !src-tauri/**/*.md
 
-toolport-gateway-bin
+# OS / IDE
 .DS_Store
 Thumbs.db

--- a/.dockerignore
+++ b/.dockerignore
@@ -25,6 +25,6 @@ benchmark/
 *.md
 !src-tauri/**/*.md
 
-# OS / IDE
+toolport-gateway-bin
 .DS_Store
 Thumbs.db

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,9 +1,7 @@
 name: Publish gateway image
 
-# Builds the headless toolport-gateway Docker image and pushes to GHCR on main/tags.
-# Self-hosters can `docker pull ghcr.io/tsouth89/toolport-gateway:latest` without
-# compiling locally. After the first run, make the package public in GitHub
-# (Package settings -> Change visibility -> Public) for anonymous pulls.
+# Builds toolport-gateway with cached Rust on the host, then packages a slim
+# runtime image to GHCR. Avoids compiling Tauri/WebKit inside Docker (~9 min).
 
 on:
   push:
@@ -22,17 +20,67 @@ permissions:
   packages: write
 
 env:
-  # Pinned name (not ${{ github.repository }}) so repo renames don't break pulls.
   IMAGE: ghcr.io/tsouth89/toolport-gateway
 
 jobs:
-  publish:
-    name: build + push image
+  build-gateway:
+    name: build gateway binary
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Install Linux build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libsoup-3.0-dev build-essential curl wget file libxdo-dev libssl-dev libayatana-appindicator3-dev librsvg2-dev patchelf pkg-config libdbus-1-dev
+
+      - name: Cache cargo + target
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            src-tauri/target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('src-tauri/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-
+
+      - run: npm ci
+      - run: npm run build
+
+      - name: Build toolport-gateway
+        run: cargo build --release --bin toolport-gateway --manifest-path src-tauri/Cargo.toml
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: toolport-gateway-bin
+          path: src-tauri/target/release/toolport-gateway
+          retention-days: 1
+
+  publish:
+    name: build + push image
+    needs: build-gateway
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: toolport-gateway-bin
+          path: artifact
+
+      - name: Stage binary for Dockerfile
+        run: cp artifact/toolport-gateway toolport-gateway-bin && chmod 755 toolport-gateway-bin
 
       - uses: docker/setup-buildx-action@v3
 
@@ -58,8 +106,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
+          file: Dockerfile
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,41 +1,16 @@
-# Headless Toolport gateway image (OpenAPI + MCP streamable-HTTP).
-# Build from the repo root:
-#   docker build -t toolport-gateway .
-# Published to ghcr.io/tsouth89/toolport-gateway on push to main (see
-# .github/workflows/docker-publish.yml).
-
-FROM rust:1-slim-bookworm AS build
-WORKDIR /src
-RUN apt-get update && apt-get install -y --no-install-recommends \
-        pkg-config libssl-dev libdbus-1-dev libglib2.0-dev libgtk-3-dev libwebkit2gtk-4.1-dev libjavascriptcoregtk-4.1-dev \
-    && rm -rf /var/lib/apt/lists/*
-
-# Cache dependency compilation: copy manifests + icons (tauri-build needs them),
-# stub the sources, build once, then rebuild with the real tree.
-COPY src-tauri/Cargo.toml src-tauri/Cargo.lock src-tauri/build.rs src-tauri/tauri.conf.json ./src-tauri/
-COPY src-tauri/icons ./src-tauri/icons
-COPY src-tauri/capabilities ./src-tauri/capabilities
-WORKDIR /src/src-tauri
-RUN mkdir -p src/bin && \
-    printf '%s\n' \
-      '#[cfg(test)] mod tests {}' \
-      'pub fn _docker_dep_stub() {}' > src/lib.rs && \
-    printf 'fn main() {}\n' > src/main.rs && \
-    printf 'fn main() {}\n' > src/bin/toolport-gateway.rs && \
-    printf 'fn main() {}\n' > src/bin/mock-mcp-server.rs && \
-    cargo build --release --bin toolport-gateway
-
-COPY src-tauri/src ./src
-RUN touch src/lib.rs src/main.rs src/bin/toolport-gateway.rs src/bin/mock-mcp-server.rs && \
-    cargo build --release --bin toolport-gateway
+# Runtime-only headless Toolport gateway image.
+# CI builds `toolport-gateway` with cached Rust (see docker-publish.yml) and
+# copies the binary in as `toolport-gateway-bin` before `docker build`.
+# For a from-source local build, use: docker build -f Dockerfile.source .
 
 FROM debian:bookworm-slim
 RUN apt-get update && apt-get install -y --no-install-recommends \
         ca-certificates libssl3 libdbus-1-3 curl \
     && rm -rf /var/lib/apt/lists/*
 WORKDIR /data
-COPY --from=build /src/src-tauri/target/release/toolport-gateway /usr/local/bin/toolport-gateway
-RUN useradd --system --uid 10001 --home-dir /data toolport \
+COPY toolport-gateway-bin /usr/local/bin/toolport-gateway
+RUN chmod 755 /usr/local/bin/toolport-gateway \
+    && useradd --system --uid 10001 --home-dir /data toolport \
     && chown toolport:toolport /data
 
 USER toolport
@@ -45,5 +20,4 @@ ENV CONDUIT_REGISTRY=/data/registry.json
 EXPOSE 8765
 VOLUME ["/data"]
 
-# CONDUIT_HTTP_TOKEN is required for non-loopback binds (enforced by the binary).
 ENTRYPOINT ["toolport-gateway", "--http", "8765"]

--- a/Dockerfile.source
+++ b/Dockerfile.source
@@ -1,0 +1,46 @@
+# From-source headless Toolport gateway image (local dev when you don't have Rust).
+# Slow: compiles Tauri/WebKit inside Docker. CI uses Dockerfile (runtime-only) +
+# a cached host build instead.
+#
+#   docker build -f Dockerfile.source -t toolport-gateway .
+
+FROM rust:1-slim-bookworm AS build
+WORKDIR /src
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        pkg-config libssl-dev libdbus-1-dev libglib2.0-dev libgtk-3-dev libwebkit2gtk-4.1-dev libjavascriptcoregtk-4.1-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY src-tauri/Cargo.toml src-tauri/Cargo.lock src-tauri/build.rs src-tauri/tauri.conf.json ./src-tauri/
+COPY src-tauri/icons ./src-tauri/icons
+COPY src-tauri/capabilities ./src-tauri/capabilities
+WORKDIR /src/src-tauri
+RUN mkdir -p src/bin && \
+    printf '%s\n' \
+      '#[cfg(test)] mod tests {}' \
+      'pub fn _docker_dep_stub() {}' > src/lib.rs && \
+    printf 'fn main() {}\n' > src/main.rs && \
+    printf 'fn main() {}\n' > src/bin/toolport-gateway.rs && \
+    printf 'fn main() {}\n' > src/bin/mock-mcp-server.rs && \
+    cargo build --release --bin toolport-gateway
+
+COPY src-tauri/src ./src
+RUN touch src/lib.rs src/main.rs src/bin/toolport-gateway.rs src/bin/mock-mcp-server.rs && \
+    cargo build --release --bin toolport-gateway
+
+FROM debian:bookworm-slim
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates libssl3 libdbus-1-3 curl \
+    && rm -rf /var/lib/apt/lists/*
+WORKDIR /data
+COPY --from=build /src/src-tauri/target/release/toolport-gateway /usr/local/bin/toolport-gateway
+RUN useradd --system --uid 10001 --home-dir /data toolport \
+    && chown toolport:toolport /data
+
+USER toolport
+ENV CONDUIT_HTTP=8765
+ENV CONDUIT_HTTP_HOST=0.0.0.0
+ENV CONDUIT_REGISTRY=/data/registry.json
+EXPOSE 8765
+VOLUME ["/data"]
+
+ENTRYPOINT ["toolport-gateway", "--http", "8765"]

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -87,7 +87,8 @@ low real exposure since the gateway only writes when `allow_agent_control` is on
 - [~] **Streamable-HTTP upstream transport** — `POST /mcp` and `GET /mcp` listen stream ship
   (session ids, JSON-RPC, selective SSE responses; see `docs/headless.md` +
   `docker-compose.example.yml`). OpenAPI HTTP mode already shipped for Open WebUI.
-  **GHCR:** `ghcr.io/tsouth89/toolport-gateway` published from `main`. Optional
+  **GHCR:** `ghcr.io/tsouth89/toolport-gateway` published from `main` (host-built
+  binary + slim runtime image; see `Dockerfile` + `docker-publish.yml`). Optional
   follow-up: long-lived `GET /mcp` listen on HTTP downstream for servers that push
   RPC outside SSE POST responses. (S)
 

--- a/docs/headless.md
+++ b/docs/headless.md
@@ -74,15 +74,18 @@ docker compose up -d
 
 ### Build locally
 
+From source (slow — compiles inside Docker):
+
 ```bash
-# from repo root
+docker build -f Dockerfile.source -t toolport-gateway .
+```
+
+Or use the runtime Dockerfile after building the binary on the host:
+
+```bash
+cargo build --release --bin toolport-gateway --manifest-path src-tauri/Cargo.toml
+cp src-tauri/target/release/toolport-gateway toolport-gateway-bin
 docker build -t toolport-gateway .
-mkdir -p data
-cp data/registry.json.example data/registry.json
-# edit data/registry.json for your servers, then:
-cp docker-compose.example.yml docker-compose.yml
-# create .env with at least CONDUIT_HTTP_TOKEN=...
-docker compose up --build
 ```
 
 Image defaults:


### PR DESCRIPTION
## Summary
- Split Docker: CI compiles `toolport-gateway` with shared cargo cache; Dockerfile is runtime-only (~1 min image job vs ~9 min in-Docker compile)
- Keep `Dockerfile.source` for local from-source builds
- Update headless docs

## Test plan
- [ ] CI build-gateway job passes (shares cache key with main CI)
- [ ] publish job builds slim image on PR (no push)
- [ ] After merge: verify GHCR image still runs

## Safety
No gateway logic changes — packaging only.

Made with [Cursor](https://cursor.com)