### PR TITLE
fix(connect): give npx-style launchers time to install on first connect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ Entries before the rename below shipped under the project's former name, Conduit
 
 ## [Unreleased]
 
+### Fixed
+
+- **npx-based servers no longer show a false "Error" on their first connect.** `npx -y`,
+  `uvx`, `pnpm dlx`, and similar download-then-run launchers can take 15-60s to fetch
+  their package on a cold cache, but the connect handshake only waited 10s, so a
+  freshly added (or cache-wiped) server timed out into an Error badge and then
+  "mysteriously" worked on the next refresh. Launcher commands now get a 120s
+  first-`initialize` budget (everything else keeps the tight 10s so hung servers still
+  fail fast), the app shows "Installing…" instead of an anonymous stall while the
+  download runs, a timeout that does hit explains the package is still downloading,
+  and adding an npx-style server pre-warms the download in the background so the first
+  real connect is instant.
+
 ## [1.5.3] - 2026-07-08
 
 Teams reliability and activation batch, ahead of the Teams launch.

--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -242,7 +242,45 @@ fn add_server(state: State<RegistryState>, entry: ServerEntry) -> Result<Registr
     let mut reg = state.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
     reg.add_server(entry);
     registry::save(&reg)?;
+    // add_server appends, so the saved entry (with its assigned id) is the last one.
+    if let Some(saved) = reg.servers.last() {
+        prewarm_launcher(saved);
+    }
     Ok(reg.clone())
+}
+
+/// Fire-and-forget spawn of a just-added download-then-run server (npx, uvx, ...)
+/// so the launcher fetches its package now, in the background, instead of on the
+/// first health probe or gateway connect. Lenient about env: missing secrets are
+/// skipped rather than fatal - the child may exit complaining about them, but by
+/// then the package is already in the launcher's cache, which is the whole point.
+/// The connect result is deliberately ignored; the real probe reports health.
+fn prewarm_launcher(server: &ServerEntry) {
+    let Some(command) = server.command.clone() else {
+        return;
+    };
+    if !crate::downstream::is_download_launcher(&command, &server.args) {
+        return;
+    }
+    let server = server.clone();
+    std::thread::spawn(move || {
+        let env: Vec<(String, String)> = server
+            .env
+            .iter()
+            .filter_map(|e| {
+                e.value
+                    .clone()
+                    .or_else(|| secrets::get_secret(&server.id, &e.key))
+                    .map(|v| (e.key.clone(), v))
+            })
+            .collect();
+        if let Ok(t) = StdioTransport::spawn(&command, &server.args, &env) {
+            // Attempting the handshake keeps the child alive until the download
+            // finishes (dropping the transport kills it), and warms it end-to-end
+            // when the server actually comes up.
+            let _ = DownstreamServer::connect(server.id.clone(), Box::new(t));
+        }
+    });
 }
 
 #[tauri::command]

--- a/src-tauri/src/downstream.rs
+++ b/src-tauri/src/downstream.rs
@@ -28,6 +28,16 @@ const STDIO_READ_TIMEOUT: Duration = Duration::from_secs(30);
 /// so one hung server should fail in seconds, not stall everything for the full
 /// live-call timeout. Restored to STDIO_READ_TIMEOUT once connected.
 const STDIO_CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+/// First-`initialize` budget for download-then-run launchers (npx, uvx, pnpm dlx,
+/// ...). On a cold cache these resolve and download the server package before the
+/// process can answer anything - easily 15-60s, far past the normal handshake
+/// budget - so the tight timeout misreports a healthy-but-installing server as
+/// broken (it then works on the next refresh, once the cache is warm). Being
+/// alive-but-quiet is expected during the download; a child that actually dies
+/// still fails immediately because its stdout closing ends the wait. Batch
+/// connects run one thread per server, so several cold launchers install in
+/// parallel and a batch waits out this budget at most once, not per server.
+const LAUNCHER_CONNECT_TIMEOUT: Duration = Duration::from_secs(120);
 /// Keep at most this many bytes of a child's stderr tail for error reporting.
 const STDERR_TAIL_CAP: usize = 4096;
 
@@ -447,6 +457,13 @@ pub trait Transport: Send {
     /// connect handshake fast. Default no-op: transports with their own fixed
     /// request timeout (e.g. HTTP) ignore it.
     fn set_read_timeout(&mut self, _timeout: Duration) {}
+    /// Budget for the connect handshake's `initialize`. Stdio invocations that
+    /// download their package before running (npx and friends) report the long
+    /// launcher budget; everything else keeps the tight default so one hung
+    /// server can't stall a batch probe.
+    fn connect_timeout(&self) -> Duration {
+        STDIO_CONNECT_TIMEOUT
+    }
     /// Start reacting to the server's own `notifications/tools/list_changed`.
     /// Called once the connect handshake is done, so a server that announces its
     /// tools during startup doesn't trigger a needless rebuild. Default no-op:
@@ -854,6 +871,10 @@ pub struct StdioTransport {
     /// once this is set, so tool-list changes announced during startup are
     /// ignored. Flipped on by `arm_tools_watch` after the handshake.
     armed: Arc<AtomicBool>,
+    /// The command is a download-then-run launcher (npx, uvx, ...): its first
+    /// `initialize` gets the long connect budget, and a connect timeout is
+    /// reported as "still installing" rather than a dead server.
+    launcher: bool,
     /// Answers server-initiated JSON-RPC (e.g. `roots/list`) by forwarding to the
     /// upstream MCP client. Set by the gateway before the connect handshake.
     server_handler: Option<ServerRequestHandler>,
@@ -876,6 +897,46 @@ pub fn normalize_invocation(command: &str, args: &[String]) -> (String, Vec<Stri
         }
     }
     (command.to_string(), args.to_vec())
+}
+
+/// True when the invocation is a download-then-run launcher: the command may have
+/// to resolve and download the actual server package before it can respond (npx /
+/// bunx from the npm registry, uvx / pipx from PyPI, and the package managers'
+/// dlx/exec forms). Matches the executable's basename so absolute paths and
+/// Windows shims (`npx.cmd`, `npx.exe`) count too.
+pub fn is_download_launcher(command: &str, args: &[String]) -> bool {
+    let (command, args) = normalize_invocation(command, args);
+    let base = Path::new(&command)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or(&command)
+        .to_ascii_lowercase();
+    let base = base
+        .strip_suffix(".exe")
+        .or_else(|| base.strip_suffix(".cmd"))
+        .or_else(|| base.strip_suffix(".ps1"))
+        .unwrap_or(&base);
+    let first = args.first().map(String::as_str);
+    match base {
+        "npx" | "uvx" | "bunx" => true,
+        // These only download via their run-a-package subcommand; `pnpm start`
+        // and friends run what's already there.
+        "pnpm" | "yarn" => first == Some("dlx"),
+        "npm" => matches!(first, Some("exec") | Some("x")),
+        "pipx" => first == Some("run"),
+        _ => false,
+    }
+}
+
+/// The connect-handshake read timeout policy for a stdio invocation: launchers
+/// that may be downloading their package on first run get the long budget,
+/// everything else the tight one (so a hung server still fails fast).
+pub fn stdio_connect_timeout(command: &str, args: &[String]) -> Duration {
+    if is_download_launcher(command, args) {
+        LAUNCHER_CONNECT_TIMEOUT
+    } else {
+        STDIO_CONNECT_TIMEOUT
+    }
 }
 
 impl StdioTransport {
@@ -1007,6 +1068,7 @@ impl StdioTransport {
             next_id: 1,
             read_timeout: STDIO_READ_TIMEOUT,
             armed,
+            launcher: is_download_launcher(command, args),
             server_handler: None,
         })
     }
@@ -1093,9 +1155,23 @@ impl Transport for StdioTransport {
             let line = match self.rx.recv_timeout(remaining) {
                 Ok(l) => l,
                 Err(RecvTimeoutError::Timeout) => {
+                    // A launcher child that is alive but never answered `initialize`
+                    // even after the long budget is almost certainly still installing
+                    // its package (cold npm/PyPI cache, slow network). Say so: a bare
+                    // timeout reads as a broken server when it isn't. A dead child
+                    // never reaches here (its stdout closing ends the wait below).
+                    let alive = self.child.try_wait().map(|s| s.is_none()).unwrap_or(false);
+                    if self.launcher && alive && method == "initialize" {
+                        return Err(TransportError::Unavailable(
+                            "timed out waiting for 'initialize'; the launcher is likely \
+                             still downloading the server package (first run on a cold \
+                             cache). It usually connects on the next refresh."
+                                .to_string(),
+                        ));
+                    }
                     return Err(TransportError::Unavailable(format!(
                         "timed out waiting for '{method}' response"
-                    )))
+                    )));
                 }
                 Err(RecvTimeoutError::Disconnected) => {
                     return Err(TransportError::Unavailable(self.closed_error()))
@@ -1147,6 +1223,14 @@ impl Transport for StdioTransport {
 
     fn set_read_timeout(&mut self, timeout: Duration) {
         self.read_timeout = timeout;
+    }
+
+    fn connect_timeout(&self) -> Duration {
+        if self.launcher {
+            LAUNCHER_CONNECT_TIMEOUT
+        } else {
+            STDIO_CONNECT_TIMEOUT
+        }
     }
 
     fn arm_tools_watch(&mut self) {
@@ -1538,8 +1622,12 @@ impl DownstreamServer {
     /// endpoint. The gateway calls `load_resources_prompts` to populate them.
     pub fn connect(id: String, mut transport: Box<dyn Transport>) -> Result<Self, String> {
         // Fail the handshake fast so one unresponsive server can't stall the whole
-        // batch probe / router rebuild for the full live-call timeout.
-        transport.set_read_timeout(STDIO_CONNECT_TIMEOUT);
+        // batch probe / router rebuild for the full live-call timeout. The transport
+        // picks the budget: download-then-run launchers (npx, uvx, ...) get a long
+        // first-`initialize` window because a cold cache means the package downloads
+        // before the server can answer at all.
+        let handshake_timeout = transport.connect_timeout();
+        transport.set_read_timeout(handshake_timeout);
         let init = transport.request(
             "initialize",
             json!({
@@ -1553,6 +1641,10 @@ impl DownstreamServer {
         let caps_prompts = caps.and_then(|c| c.get("prompts")).is_some();
         transport.notify("notifications/initialized", json!({})).map_err(|e| e.to_string())?;
 
+        // `initialize` answered, so any launcher download is done: the rest of the
+        // handshake goes back to the tight budget - a server that comes up but then
+        // hangs on `tools/list` should still fail in seconds.
+        transport.set_read_timeout(STDIO_CONNECT_TIMEOUT);
         let result = transport.request("tools/list", json!({})).map_err(|e| e.to_string())?;
         let tools = extract_array(&result, "tools");
 
@@ -1700,6 +1792,74 @@ mod tests {
         CancelRegistry,
     };
     use serde_json::json;
+
+    #[test]
+    fn download_launchers_get_the_long_connect_budget() {
+        use super::{stdio_connect_timeout, LAUNCHER_CONNECT_TIMEOUT};
+        let a = |v: &[&str]| v.iter().map(|s| s.to_string()).collect::<Vec<_>>();
+        // Bare launchers, wherever they live and however Windows shims them.
+        for cmd in [
+            "npx",
+            "uvx",
+            "bunx",
+            "/usr/local/bin/npx",
+            r"C:\Program Files\nodejs\npx.cmd",
+            "NPX.EXE",
+            "uvx.exe",
+        ] {
+            assert_eq!(
+                stdio_connect_timeout(cmd, &a(&["-y", "@scope/pkg"])),
+                LAUNCHER_CONNECT_TIMEOUT,
+                "{cmd} should get the launcher budget"
+            );
+        }
+        // Package managers count only in their download-then-run form.
+        for (cmd, args) in [
+            ("pnpm", vec!["dlx", "some-mcp"]),
+            ("yarn", vec!["dlx", "some-mcp"]),
+            ("npm", vec!["exec", "some-mcp"]),
+            ("npm", vec!["x", "some-mcp"]),
+            ("pipx", vec!["run", "some-mcp"]),
+        ] {
+            assert_eq!(
+                stdio_connect_timeout(cmd, &a(&args)),
+                LAUNCHER_CONNECT_TIMEOUT,
+                "{cmd} {args:?} should get the launcher budget"
+            );
+        }
+        // A config that packed the whole invocation into `command` is normalized
+        // the same way the spawn path does before matching.
+        assert_eq!(
+            stdio_connect_timeout("npx -y @scope/pkg", &[]),
+            LAUNCHER_CONNECT_TIMEOUT
+        );
+    }
+
+    #[test]
+    fn ordinary_commands_keep_the_tight_connect_budget() {
+        use super::{stdio_connect_timeout, STDIO_CONNECT_TIMEOUT};
+        let a = |v: &[&str]| v.iter().map(|s| s.to_string()).collect::<Vec<_>>();
+        for (cmd, args) in [
+            // Already-installed runtimes: nothing to download, fail fast.
+            ("node", vec!["server.js"]),
+            ("python", vec!["-m", "some_mcp"]),
+            ("docker", vec!["run", "npx"]), // launcher name in args is not a launcher
+            (r"C:\tools\my-server.exe", vec![]),
+            // Package managers running an existing project, not fetching one.
+            ("pnpm", vec!["run", "start"]),
+            ("yarn", vec!["start"]),
+            ("npm", vec!["start"]),
+            ("pipx", vec![]),
+            // A path that merely contains a launcher-ish segment.
+            ("/opt/npx-tools/server", vec![]),
+        ] {
+            assert_eq!(
+                stdio_connect_timeout(cmd, &a(&args)),
+                STDIO_CONNECT_TIMEOUT,
+                "{cmd} {args:?} should keep the tight budget"
+            );
+        }
+    }
 
     #[test]
     fn is_server_initiated_request_detects_downstream_rpc() {

--- a/src/components/RegistryServerRow.tsx
+++ b/src/components/RegistryServerRow.tsx
@@ -1,5 +1,6 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { ChevronDown, Copy, KeyRound, LogIn, Pencil, Trash2, Users } from "lucide-react";
+import { isDownloadLauncher } from "@/lib/launcher";
 import type { ProbeResult, Registry, ServerEntry } from "@/lib/types";
 import { Switch } from "@/components/ui/switch";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
@@ -88,6 +89,20 @@ export function RegistryServerRow({
       : (server.url ?? "");
   const secretCount = server.env.filter((e) => e.secret).length;
   const status = statusOf(enabled, health);
+  // For npx/uvx-style servers, a first probe that sits in "checking" past a few
+  // seconds is almost certainly the launcher downloading the package (a warm start
+  // answers in ~1s). Name that wait "Installing…" so a slow first connect reads as
+  // progress, not a stall. Resets whenever the row leaves "checking".
+  const launcher = isDownloadLauncher(server.command, server.args);
+  const [installing, setInstalling] = useState(false);
+  // Reset during render (not in the effect) so a later re-check starts back at
+  // "Checking…" instead of flashing a stale "Installing…".
+  if (installing && (status !== "checking" || !launcher)) setInstalling(false);
+  useEffect(() => {
+    if (status !== "checking" || !launcher) return;
+    const t = setTimeout(() => setInstalling(true), 4000);
+    return () => clearTimeout(t);
+  }, [status, launcher]);
   // Team-synced servers are tagged `team:<id>`. An admin manages them centrally, so a
   // member sees a Team badge and can't edit/remove them locally (a local change would
   // just re-sync away), but still authenticates them (keys stay on their own machine).
@@ -99,7 +114,9 @@ export function RegistryServerRow({
       : status === "error"
         ? "Error"
         : status === "checking"
-          ? "Checking…"
+          ? installing
+            ? "Installing…"
+            : "Checking…"
           : "Disabled";
 
   // Next free "Name (N)" for the duplicate-for-another-account action.
@@ -136,7 +153,9 @@ export function RegistryServerRow({
 
         <span
           className={`size-2 shrink-0 rounded-full ${DOT[status]}`}
-          aria-label={statusAriaLabel(status, label)}
+          aria-label={
+            installing ? "Installing the server package" : statusAriaLabel(status, label)
+          }
           role="status"
         />
 

--- a/src/lib/launcher.test.ts
+++ b/src/lib/launcher.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "vitest";
+import { isDownloadLauncher } from "./launcher";
+
+describe("isDownloadLauncher", () => {
+  it("matches the bare launchers", () => {
+    for (const cmd of ["npx", "uvx", "bunx"]) {
+      expect(isDownloadLauncher(cmd, ["-y", "@scope/pkg"]), cmd).toBe(true);
+    }
+  });
+
+  it("matches launchers behind absolute paths and Windows shims", () => {
+    expect(isDownloadLauncher("/usr/local/bin/npx", ["-y", "pkg"])).toBe(true);
+    expect(isDownloadLauncher("C:\\Program Files\\nodejs\\npx.cmd", ["pkg"])).toBe(true);
+    expect(isDownloadLauncher("NPX.EXE", ["pkg"])).toBe(true);
+  });
+
+  it("matches package managers only in their download-then-run form", () => {
+    expect(isDownloadLauncher("pnpm", ["dlx", "some-mcp"])).toBe(true);
+    expect(isDownloadLauncher("yarn", ["dlx", "some-mcp"])).toBe(true);
+    expect(isDownloadLauncher("npm", ["exec", "some-mcp"])).toBe(true);
+    expect(isDownloadLauncher("npm", ["x", "some-mcp"])).toBe(true);
+    expect(isDownloadLauncher("pipx", ["run", "some-mcp"])).toBe(true);
+
+    expect(isDownloadLauncher("pnpm", ["run", "start"])).toBe(false);
+    expect(isDownloadLauncher("yarn", ["start"])).toBe(false);
+    expect(isDownloadLauncher("npm", ["start"])).toBe(false);
+    expect(isDownloadLauncher("pipx", [])).toBe(false);
+  });
+
+  it("normalizes a packed command string like the backend spawn path", () => {
+    expect(isDownloadLauncher("npx -y @scope/pkg", [])).toBe(true);
+    expect(isDownloadLauncher("pnpm dlx some-mcp", [])).toBe(true);
+    // A real path with spaces is not split, so it stays a non-launcher.
+    expect(isDownloadLauncher("/opt/my tools/server --stdio", [])).toBe(false);
+  });
+
+  it("leaves ordinary commands alone", () => {
+    expect(isDownloadLauncher(null, [])).toBe(false);
+    expect(isDownloadLauncher("node", ["server.js"])).toBe(false);
+    expect(isDownloadLauncher("python", ["-m", "some_mcp"])).toBe(false);
+    expect(isDownloadLauncher("docker", ["run", "npx"])).toBe(false);
+    expect(isDownloadLauncher("/opt/npx-tools/server", [])).toBe(false);
+  });
+});

--- a/src/lib/launcher.ts
+++ b/src/lib/launcher.ts
@@ -1,0 +1,31 @@
+/** Download-then-run launchers (npx, uvx, pnpm dlx, ...): the first spawn may have
+ * to download the server package before it can answer, so a health probe can sit
+ * in "checking" for a while on a cold cache. The UI uses this to name that wait
+ * "Installing…" instead of letting it read as a stall. Mirrors the backend policy
+ * in src-tauri/src/downstream.rs (`is_download_launcher`), including its
+ * normalization of a config that packed the whole invocation into `command`.
+ */
+export function isDownloadLauncher(command: string | null, args: string[]): boolean {
+  if (!command) return false;
+  let cmd = command;
+  let argv = args;
+  // Backend `normalize_invocation`: a packed `"npx -y @scope/pkg"` with empty args
+  // is split, but only when the first token is a bare program name (no path).
+  if (args.length === 0) {
+    const parts = command.split(/\s+/).filter(Boolean);
+    const first = parts[0] ?? "";
+    if (parts.length > 1 && !first.includes("/") && !first.includes("\\")) {
+      cmd = first;
+      argv = parts.slice(1);
+    }
+  }
+  const base = (cmd.split(/[\\/]/).pop() ?? cmd)
+    .toLowerCase()
+    .replace(/\.(exe|cmd|ps1)$/, "");
+  if (base === "npx" || base === "uvx" || base === "bunx") return true;
+  const sub = argv[0];
+  if ((base === "pnpm" || base === "yarn") && sub === "dlx") return true;
+  if (base === "npm" && (sub === "exec" || sub === "x")) return true;
+  if (base === "pipx" && sub === "run") return true;
+  return false;
+}


### PR DESCRIPTION
Stacked on #225 (edits desktop.rs, which that PR introduces). Retarget to main after it merges, or merge this into it.

## Problem

npx -y / uvx / pnpm dlx download the server package before the process can answer anything. On a cold cache that's 15-60s, but the stdio connect handshake gives every server 10s. Result: a freshly added or cache-wiped server fails with "timed out waiting for 'initialize' response", shows an Error badge, then works on the next refresh. The 2026-07-08 registry restore hit this on six servers at once after an npm cache wipe.

## Fix

Three parts:

1. **Launcher-aware handshake budget** (downstream.rs). `is_download_launcher()` matches npx/uvx/bunx by basename (absolute paths and Windows .cmd/.exe/.ps1 shims included, packed "npx -y pkg" commands normalized like the spawn path), plus pnpm/yarn dlx, npm exec|x, pipx run. `Transport::connect_timeout()` gives those 120s for the first initialize. Once initialize answers, tools/list drops back to the tight 10s, and non-launcher servers keep 10s everywhere so a hung server still fails fast. A child that dies mid-download still fails immediately via its closed stdout. Batch connects already run one thread per server, so a cold batch pays the wait once, not per server.

2. **Honest UI while installing** (RegistryServerRow.tsx, lib/launcher.ts). After 4s in "Checking..." on a launcher server the label flips to "Installing..." (warm starts answer in ~1s, so a longer wait is the download). If the 120s still isn't enough, the timeout error now says the package is likely still downloading instead of reading like a dead server.

3. **Pre-warm on add** (desktop.rs). add_server kicks off the launcher download on a background thread at save time, lenient about missing secrets (the child may exit complaining, but the package is cached by then). First real connect is then usually instant.

## Tests

- downstream.rs: two policy tests covering launchers behind paths/shims/case, the packed-command form, and the non-matches (pnpm run, npm start, docker run npx, paths that merely contain "npx").
- launcher.test.ts: mirrored frontend suite.
- Full suites green: 321 rust lib + 78 bin, 66 vitest.

## Notes for review

- Team-synced servers and update_server don't pre-warm; their first probe or gateway connect covers it with the 120s budget.
- A gateway router rebuild joins on the slowest connect, so a rebuild catching a cold launcher can block tool calls up to ~2min once. Intentional trade vs dropping those servers to Error.