### PR TITLE
chore(release): 1.6.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,7 @@ license-signing.keycd
 /docs/SITE-MESSAGING.md
 /docs/specs/
 /docs/drafts/
+
+# Agent/session scratch (never commit)
+_poll_pr.py
+_cr*.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,18 +6,50 @@ Entries before the rename below shipped under the project's former name, Conduit
 
 ## [Unreleased]
 
+## [1.6.0] - 2026-07-09
+
+Headless gateway release: deploy Toolport as a container, speak MCP over HTTP/SSE,
+and ship a prebuilt GHCR image. Plus MCP server-initiated RPC passthrough, Teams
+usage reporting, and a fix for npx cold-start false errors.
+
+### Added
+
+- **Headless / container gateway.** Run `toolport-gateway` without the desktop app:
+  `POST /mcp` streamable-HTTP, env-file secrets (`CONDUIT_SECRET_KEY`), Docker +
+  `docker-compose.example.yml`, and docs in `docs/headless.md`. (#214)
+- **MCP listen stream.** `GET /mcp` opens a long-lived SSE stream for server→client
+  JSON-RPC (keepalive when idle). (#216)
+- **MCP server-initiated RPC passthrough (#167).** When the upstream client declares
+  `roots`, `sampling`, or `elicitation` at `initialize`, downstream servers can call
+  `roots/list`, `sampling/createMessage`, and `elicitation/create`; the gateway
+  forwards to the client over stdio or HTTP MCP. HTTP downstream answers inline
+  during SSE `POST` responses. (#217, #218, #219)
+- **Prebuilt gateway image on GHCR.** `ghcr.io/tsouth89/toolport-gateway:latest`
+  published from `main` (CI-built binary + slim runtime image). (#222, #223)
+- **AnythingLLM client support.** Connect AnythingLLM to Toolport from the Clients
+  view. (#213)
+- **Teams per-server usage rollups.** Members report per-server tool-call counts to
+  the team server for dashboard rollups. (#221)
+
 ### Fixed
 
 - **npx-based servers no longer show a false "Error" on their first connect.** `npx -y`,
-  `uvx`, `pnpm dlx`, and similar download-then-run launchers can take 15-60s to fetch
+  `uvx`, `pnpm dlx`, and similar download-then-run launchers can take 15–60s to fetch
   their package on a cold cache, but the connect handshake only waited 10s, so a
-  freshly added (or cache-wiped) server timed out into an Error badge and then
-  "mysteriously" worked on the next refresh. Launcher commands now get a 120s
-  first-`initialize` budget (everything else keeps the tight 10s so hung servers still
-  fail fast), the app shows "Installing…" instead of an anonymous stall while the
-  download runs, a timeout that does hit explains the package is still downloading,
-  and adding an npx-style server pre-warms the download in the background so the first
-  real connect is instant.
+  freshly added server timed out into an Error badge and then worked on retry. Launcher
+  commands now get a 120s first-`initialize` budget (everything else keeps 10s), the
+  app shows **"Installing…"** while the download runs, and adding an npx-style server
+  pre-warms the download in the background. (#237)
+- **SSE streaming for inline server-initiated RPC.** HTTP downstream no longer buffers
+  the full SSE body before forwarding inline JSON-RPC to the upstream client. (#220)
+- **Registry data preserved on read failure.** A transient or permission error reading
+  `registry.json` no longer wipes the file to an empty default. (#224)
+
+### Changed
+
+- **Gateway-only compile path.** `cargo build --no-default-features --bin toolport-gateway`
+  skips the Tauri desktop shell and WebKit; CI/docker builds use this (~3 min vs ~8 min).
+  Default `desktop` feature unchanged for the app. (#225)
 
 ## [1.5.3] - 2026-07-08
 
@@ -1154,7 +1186,9 @@ driven by the agent on your terms, and supports two more clients.
 - First public release: local MCP gateway and manager with lazy discovery,
   per-agent profiles, the catalog, the tool playground, and the activity log.
 
-[Unreleased]: https://github.com/tsouth89/conduit/compare/v0.3.16...HEAD
+[Unreleased]: https://github.com/tsouth89/toolport/compare/v1.6.0...HEAD
+[1.6.0]: https://github.com/tsouth89/toolport/releases/tag/v1.6.0
+[1.5.3]: https://github.com/tsouth89/toolport/releases/tag/v1.5.3
 [0.3.16]: https://github.com/tsouth89/conduit/releases/tag/v0.3.16
 [0.3.15]: https://github.com/tsouth89/conduit/releases/tag/v0.3.15
 [0.3.14]: https://github.com/tsouth89/conduit/releases/tag/v0.3.14

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,6 +15,7 @@ Requires Node 20+ and the Rust toolchain.
 ```bash
 npm install
 npm run build:gateway   # build the gateway binary (clients spawn it; needed when running from source)
+                       # uses --no-default-features to skip Tauri/WebKit for a fast compile
 npm run tauri dev       # run the desktop app
 ```
 
@@ -34,7 +35,7 @@ The gateway is a separate binary that AI clients spawn as a subprocess. Packaged
 releases bundle it, but when running from source you must build it manually:
 
 ```bash
-npm run build:gateway   # one-time, or after gateway code changes
+npm run build:gateway   # one-time, or after gateway code changes (--no-default-features)
 ```
 
 If a client reports the gateway "was not found," you forgot this step.

--- a/README.md
+++ b/README.md
@@ -315,9 +315,14 @@ The frontend is typechecked with `npx tsc --noEmit`.
   attempt keeps the callback port reserved for a few minutes and can cause a
   "state mismatch" on the next try.
 - **A client reports the gateway "was not found" (running from source).** Build
-  the gateway binary once: `cd src-tauri && cargo build --bin toolport-gateway`.
+  the gateway binary once: `npm run build:gateway` (or
+  `cargo build --no-default-features --bin toolport-gateway --manifest-path src-tauri/Cargo.toml`).
   `npm run tauri dev` builds the app but not this separate binary; packaged
   releases bundle it, so installed users never hit this.
+- **An npx/uvx server shows "Error" then works on retry.** On a cold npm/PyPI cache
+  the first connect can take up to ~2 minutes while the package downloads. v1.6.0+
+  shows **"Installing…"** during that wait and pre-warms downloads when you add the
+  server. If it still fails, check network access and try **Re-check** after a minute.
 - **Repeated macOS keychain prompts / "could not read secret from the keychain"
   in dev.** An unsigned dev build gets an unstable code-signing identity, so the
   keychain re-prompts or denies reads. Signed release builds (v0.9.3+) don't: they
@@ -350,8 +355,9 @@ Toolport is in active development. Working end to end: the
 gateway, lazy discovery, per-agent scoping, OAuth/key auth with live propagation,
 the catalog, client import/migrate, per-tool and destructive-tool governance, the
 human approval queue, a global Settings view, tool-integrity and content-defense
-detection, an audit log with latency/error stats, resources + prompts proxying, and
-a tool playground. See
+detection, an audit log with latency/error stats, resources + prompts proxying, a
+tool playground, and a **headless/container gateway** (MCP over HTTP/SSE, Docker,
+GHCR image — see [docs/headless.md](docs/headless.md)). See
 [docs/ROADMAP.md](docs/ROADMAP.md) for what is done and planned.
 
 ## Known issues

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -6,20 +6,28 @@ Releases are built by CI on a version tag (`.github/workflows/release.yml`).
    - `src-tauri/tauri.conf.json` (`version`), drives the installer filename
    - `src-tauri/Cargo.toml` (`version`)
    - `package.json` (`version`)
-   - `src-tauri/Cargo.lock` (run `cargo check` after bumping `Cargo.toml` to refresh it)
+   - `package-lock.json` (root `version` fields)
+   - `src-tauri/Cargo.lock` (the `conduit` package `version` entry)
+   - `CHANGELOG.md` — move `[Unreleased]` entries into a dated section
    - `server.json` only when publishing a matching standalone `@tsouth89/conduit-gateway` package
-2. Commit the bump.
-3. Tag and push:
+2. Draft user-facing notes in `docs/release-notes/vX.Y.Z.md` (paste into the GitHub
+   release body when publishing the draft CI creates).
+3. Commit the bump (e.g. `chore(release): 1.6.0`).
+4. Merge to `main`, then tag and push:
 
    ```bash
-   git tag v0.2.0
-   git push origin v0.2.0
+   git checkout main && git pull
+   git tag v1.6.0
+   git push origin v1.6.0
    ```
 
 CI builds installers for **Windows** (NSIS), **macOS** (dmg), and **Linux**
 (deb + AppImage), each with the gateway bundled, and attaches them to a **draft**
-release with auto-generated notes. Review it on the Releases page and click
-**Publish**.
+release with auto-generated notes. Replace or augment the body with
+`docs/release-notes/vX.Y.Z.md`, then click **Publish**.
+
+The **gateway container image** (`ghcr.io/tsouth89/toolport-gateway`) publishes
+separately on every push to `main` via `docker-publish.yml` — no tag required.
 
 ## Manual fallback
 
@@ -27,9 +35,10 @@ If you'd rather build locally:
 
 ```bash
 npm run tauri:bundle
-gh release create v0.2.0 \
-  "src-tauri/target/release/bundle/nsis/Toolport_0.2.0_x64-setup.exe" \
-  --title "Toolport v0.2.0" --generate-notes
+gh release create v1.6.0 \
+  "src-tauri/target/release/bundle/nsis/Toolport_1.6.0_x64-setup.exe" \
+  --title "Toolport v1.6.0" \
+  --notes-file docs/release-notes/v1.6.0.md
 ```
 
 ## Signing

--- a/docs/release-notes/v1.6.0.md
+++ b/docs/release-notes/v1.6.0.md
@@ -1,0 +1,75 @@
+# Toolport v1.6.0
+
+**Headless gateway, MCP over the network, and a much smoother first connect for npx servers.**
+
+This release is a big step if you've been running Toolport only as a desktop app. The same
+`toolport-gateway` binary now deploys in Docker, speaks MCP streamable-HTTP, and publishes
+to GHCR — while the desktop app picks up reliability fixes that matter day to day.
+
+---
+
+## Headless / container gateway
+
+Run Toolport without the UI for sandboxes, agents, and Open WebUI:
+
+| Endpoint                             | Use                                                                  |
+| ------------------------------------ | -------------------------------------------------------------------- |
+| `POST /mcp`                          | MCP clients over streamable-HTTP (Claude Code remote, Cursor, Pi, …) |
+| `GET /mcp`                           | Long-lived SSE listen stream for server→client JSON-RPC              |
+| `GET /openapi.json` + `POST /{tool}` | Open WebUI, n8n, LibreChat                                           |
+
+```bash
+docker pull ghcr.io/tsouth89/toolport-gateway:latest
+```
+
+See [docs/headless.md](../headless.md) for compose, env-file secrets, and handshake examples.
+
+---
+
+## MCP server-initiated RPC (#167)
+
+When your MCP client declares `roots`, `sampling`, or `elicitation` at `initialize`,
+downstream servers can call back through the gateway:
+
+- `roots/list`
+- `sampling/createMessage`
+- `elicitation/create`
+
+Works over stdio and HTTP MCP (inline during SSE `POST` responses).
+
+---
+
+## npx / uvx first connect
+
+`npx -y`, `uvx`, `pnpm dlx`, and similar launchers often need 15–60 seconds to download on
+a cold cache. Toolport used to show a false **Error** after 10 seconds, then succeed on
+retry.
+
+**Now:**
+
+- 120s first-connect budget for download launchers (10s for everything else)
+- **"Installing…"** badge while the package downloads
+- Background pre-warm when you add an npx-style server
+
+---
+
+## Also in this release
+
+- **AnythingLLM** — connect from the Clients view (#213)
+- **Teams usage rollups** — per-server tool-call counts reported to the team dashboard (#221)
+- **Registry safety** — a read failure no longer wipes your config (#224)
+- **Faster gateway builds** — CI/docker skip Tauri/WebKit (`--no-default-features`) (#225)
+
+---
+
+## Upgrade
+
+**Desktop:** Settings → About → Check for updates (v0.3.3+), or download the installer
+from [Releases](https://github.com/tsouth89/toolport/releases).
+
+**Docker:** `docker pull ghcr.io/tsouth89/toolport-gateway:latest` and restart your
+container.
+
+**From source:** `git pull`, `npm install`, `npm run build:gateway`, `npm run tauri dev`.
+
+Full changelog: [CHANGELOG.md](../../CHANGELOG.md#160---2026-07-09).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "conduit",
-  "version": "1.5.1",
+  "version": "1.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "conduit",
-      "version": "1.5.1",
+      "version": "1.6.0",
       "dependencies": {
         "@fontsource-variable/geist": "^5.2.9",
         "@tailwindcss/vite": "^4.3.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "conduit",
   "private": true,
-  "version": "1.5.3",
+  "version": "1.6.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -604,7 +604,7 @@ dependencies = [
 
 [[package]]
 name = "conduit"
-version = "1.5.3"
+version = "1.6.0"
 dependencies = [
  "base64 0.22.1",
  "chacha20poly1305",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conduit"
-version = "1.5.3"
+version = "1.6.0"
 description = "Local MCP gateway: manage all your MCP servers in one place, set up once and shared by every AI client, with ~90% fewer tokens per request"
 authors = ["South Forge AI"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Toolport",
-  "version": "1.5.3",
+  "version": "1.6.0",
   "identifier": "com.tsout.conduit",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## Summary
Release prep for **1.6.0** — everything merged since 1.5.3 is documented and version-bumped.

### Highlights since 1.5.3
- Headless/container gateway (MCP HTTP/SSE, Docker, env secrets)
- GHCR `toolport-gateway` image + fast CI builds
- MCP server-initiated RPC passthrough (roots, sampling, elicitation)
- npx/uvx cold-start fix ("Installing…" UI, 120s budget)
- Teams per-server usage rollups, AnythingLLM client
- Registry read-failure safety, gateway-only compile

## After merge
Tag `v1.6.0` on main to trigger the release workflow (draft installers + updater manifest).

## Test plan
- [x] Changelog reviewed against merged PRs #213–#225, #237
- [ ] CI green on version bump only

