### PR TITLE
fix(windows): versioned gateway path and stop before update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ Entries before the rename below shipped under the project's former name, Conduit
 
 ## [Unreleased]
 
+### Fixed
+
+- **Windows auto-update with locked gateway** — MCP configs point at a versioned
+  `toolport-gateway-{version}.exe` under `%APPDATA%\\Roaming\\Conduit\\bin` instead of
+  the install-dir copy; before updating, Toolport stops only spawned gateway processes so
+  NSIS can replace locked binaries without closing Cursor or other agents.
+
 ## [1.6.0] - 2026-07-09
 
 **Headless gateway.** Deploy `toolport-gateway` in Docker, speak MCP over HTTP/SSE, pull

--- a/src-tauri/src/clients.rs
+++ b/src-tauri/src/clients.rs
@@ -2274,6 +2274,10 @@ pub fn write_servers(client_id: &str, servers: &[ServerEntry]) -> Result<WriteOu
 // ---------------------------------------------------------------------------
 
 pub(crate) fn resolve_gateway_path() -> Option<PathBuf> {
+    if let Some(p) = crate::gateway_publish::client_gateway_path() {
+        return Some(p);
+    }
+
     let exe = std::env::current_exe().ok()?;
     let dir = exe.parent()?;
     let ext = std::env::consts::EXE_SUFFIX;
@@ -2551,7 +2555,18 @@ fn gateway_command_is_stale(stored: &str, current: &str) -> bool {
     if stored.is_empty() || stored == current {
         return false;
     }
-    stored.to_lowercase().contains("conduit-gateway") || !Path::new(stored).exists()
+    if crate::gateway_publish::is_unversioned_install_gateway_path(stored) {
+        return true;
+    }
+    if stored.to_lowercase().contains("conduit-gateway") || !Path::new(stored).exists() {
+        return true;
+    }
+    // Published bin dir: repoint when the app version bumped the gateway path.
+    let current_norm = current.replace('/', "\\").to_ascii_lowercase();
+    if current_norm.contains("\\conduit\\bin\\toolport-gateway-") {
+        return true;
+    }
+    false
 }
 
 /// Best-effort read of the gateway entry's `CONDUIT_PROFILE` from raw client-config

--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -1848,6 +1848,13 @@ fn http_bridge_alive(bridge: &mut HttpBridge) -> bool {
     alive
 }
 
+/// Stop client-spawned gateway processes before an in-app update (Windows).
+/// MCP clients stay open; only `toolport-gateway` children exit.
+#[tauri::command]
+fn stop_spawned_gateways() -> u32 {
+    crate::gateway_publish::stop_spawned_gateways()
+}
+
 /// Start `toolport-gateway --http <port>` as a supervised child so HTTP/OpenAPI
 /// clients can connect. Idempotent: if it's already running, returns the current
 /// status; otherwise spawns the bundled gateway binary and tracks it.
@@ -2220,6 +2227,7 @@ pub fn run() {
             start_http_bridge,
             stop_http_bridge,
             http_bridge_status,
+            stop_spawned_gateways,
         ])
         // Close-to-tray: the window's X hides it instead of quitting, so the gateway and
         // approval broker keep running (HITL only works while the app is alive). Quit is
@@ -2269,6 +2277,12 @@ pub fn run() {
             // that path no longer exists). Surgical + backed up; a no-op once every
             // client is on the current path.
             std::thread::spawn(|| {
+                if let Some(published) = crate::gateway_publish::publish_bundled_gateway() {
+                    eprintln!(
+                        "toolport: published client gateway at {}",
+                        published.display()
+                    );
+                }
                 let repointed = clients::repoint_stale_gateways();
                 if !repointed.is_empty() {
                     eprintln!(

--- a/src-tauri/src/gateway_publish.rs
+++ b/src-tauri/src/gateway_publish.rs
@@ -174,22 +174,23 @@ pub fn stop_spawned_gateways() -> u32 {
     0
 }
 
+/// Last path segment, regardless of OS path separator (client configs store Windows paths).
+fn path_basename(stored: &str) -> &str {
+    stored.rsplit(['\\', '/']).next().unwrap_or(stored)
+}
+
 /// Whether a stored client config still points at an install-dir (unversioned) gateway.
 pub fn is_unversioned_install_gateway_path(stored: &str) -> bool {
     let lower = stored.to_ascii_lowercase();
     if lower.contains("conduit-gateway") {
         return true;
     }
-    let path = Path::new(stored);
-    let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
-        return false;
-    };
-    let name_lower = name.to_ascii_lowercase();
+    let name_lower = path_basename(stored).to_ascii_lowercase();
     if name_lower != "toolport-gateway.exe" && name_lower != "conduit-gateway.exe" {
         return false;
     }
     // Unversioned basename outside Conduit/bin → install dir or other stale layout.
-    !lower.contains("\\conduit\\bin\\")
+    !(lower.contains("\\conduit\\bin\\") || lower.contains("/conduit/bin/"))
 }
 
 #[cfg(test)]

--- a/src-tauri/src/gateway_publish.rs
+++ b/src-tauri/src/gateway_publish.rs
@@ -1,0 +1,223 @@
+//! Versioned gateway publishing for Windows packaged installs.
+//!
+//! Client MCP configs point at `%APPDATA%\Roaming\Conduit\bin\toolport-gateway-{version}.exe`
+//! instead of the install-dir copy NSIS must overwrite on update. Publishing copies the
+//! bundled gateway to a new versioned filename (never fighting a lock on the old file),
+//! records the path in `gateway-manifest.json`, and lets `repoint_stale_gateways` migrate
+//! client configs.
+
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+const MANIFEST_FILE: &str = "gateway-manifest.json";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct GatewayManifest {
+    pub version: String,
+    pub path: String,
+    pub size: u64,
+}
+
+/// True on Windows packaged builds (not `cargo run` from `target/`).
+pub fn should_publish_client_gateway() -> bool {
+    #[cfg(windows)]
+    {
+        if let Ok(exe) = std::env::current_exe() {
+            let lower = exe.to_string_lossy().to_ascii_lowercase();
+            return !lower.contains("\\target\\");
+        }
+    }
+    #[cfg(not(windows))]
+    let _ = ();
+    false
+}
+
+fn gateway_bin_dir() -> Option<PathBuf> {
+    Some(crate::registry::conduit_dir()?.join("bin"))
+}
+
+fn manifest_path() -> Option<PathBuf> {
+    Some(gateway_bin_dir()?.join(MANIFEST_FILE))
+}
+
+fn versioned_dest(version: &str) -> Option<PathBuf> {
+    let ext = std::env::consts::EXE_SUFFIX;
+    Some(
+        gateway_bin_dir()?.join(format!("toolport-gateway-{version}{ext}")),
+    )
+}
+
+/// Gateway binary bundled next to the running app (install dir).
+pub fn bundled_gateway_source() -> Option<PathBuf> {
+    let exe = std::env::current_exe().ok()?;
+    let dir = exe.parent()?;
+    let ext = std::env::consts::EXE_SUFFIX;
+    let version = env!("CARGO_PKG_VERSION");
+
+    let versioned = dir.join(format!("toolport-gateway-{version}{ext}"));
+    if versioned.is_file() {
+        return Some(versioned);
+    }
+
+    let plain = dir.join(format!("toolport-gateway{ext}"));
+    if plain.is_file() {
+        return Some(plain);
+    }
+
+    let legacy = dir.join(format!("conduit-gateway{ext}"));
+    if legacy.is_file() {
+        return Some(legacy);
+    }
+
+    if let Some(triple) = option_env!("CONDUIT_TARGET_TRIPLE").filter(|t| !t.is_empty()) {
+        for name in ["toolport-gateway", "conduit-gateway"] {
+            let suffixed = dir.join(format!("{name}-{triple}{ext}"));
+            if suffixed.is_file() {
+                return Some(suffixed);
+            }
+        }
+    }
+
+    None
+}
+
+fn file_size(path: &Path) -> Option<u64> {
+    std::fs::metadata(path).ok().map(|m| m.len())
+}
+
+/// Copy the install-dir gateway into `Conduit/bin` when needed and write the manifest.
+pub fn publish_bundled_gateway() -> Option<PathBuf> {
+    if !should_publish_client_gateway() {
+        return None;
+    }
+    let src = bundled_gateway_source()?;
+    let version = env!("CARGO_PKG_VERSION").to_string();
+    let dest = versioned_dest(&version)?;
+    let src_size = file_size(&src)?;
+
+    let needs_copy = match file_size(&dest) {
+        Some(dest_size) => dest_size != src_size,
+        None => true,
+    };
+    if needs_copy {
+        if let Some(parent) = dest.parent() {
+            std::fs::create_dir_all(parent).ok()?;
+        }
+        std::fs::copy(&src, &dest).ok()?;
+    }
+
+    let manifest = GatewayManifest {
+        version: version.clone(),
+        path: dest.to_string_lossy().into_owned(),
+        size: file_size(&dest).unwrap_or(src_size),
+    };
+    if let Some(path) = manifest_path() {
+        if let Ok(json) = serde_json::to_string_pretty(&manifest) {
+            let _ = crate::registry::atomic_write(&path, &json);
+        }
+    }
+
+    Some(dest)
+}
+
+/// Published client gateway path from the manifest, when it matches this build.
+pub fn published_gateway_path() -> Option<PathBuf> {
+    if !should_publish_client_gateway() {
+        return None;
+    }
+    let path = manifest_path()?;
+    let raw = std::fs::read_to_string(&path).ok()?;
+    let manifest: GatewayManifest = serde_json::from_str(&raw).ok()?;
+    if manifest.version != env!("CARGO_PKG_VERSION") {
+        return None;
+    }
+    let p = PathBuf::from(&manifest.path);
+    if p.is_file() {
+        Some(p)
+    } else {
+        None
+    }
+}
+
+/// Resolve the path MCP clients should spawn: publish if needed, else read manifest.
+pub fn client_gateway_path() -> Option<PathBuf> {
+    if !should_publish_client_gateway() {
+        return None;
+    }
+    if let Some(p) = published_gateway_path() {
+        return Some(p);
+    }
+    publish_bundled_gateway()
+}
+
+/// Terminate client-spawned gateway processes so the installer can replace locked binaries.
+/// Does not touch parent apps (Cursor, Codex, etc.). Returns how many images were targeted.
+#[cfg(windows)]
+pub fn stop_spawned_gateways() -> u32 {
+    let mut stopped = 0u32;
+    for image in ["toolport-gateway.exe", "conduit-gateway.exe"] {
+        let status = std::process::Command::new("taskkill")
+            .args(["/F", "/IM", image])
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status();
+        if status.map(|s| s.success()).unwrap_or(false) {
+            stopped += 1;
+        }
+    }
+    stopped
+}
+
+#[cfg(not(windows))]
+pub fn stop_spawned_gateways() -> u32 {
+    0
+}
+
+/// Whether a stored client config still points at an install-dir (unversioned) gateway.
+pub fn is_unversioned_install_gateway_path(stored: &str) -> bool {
+    let lower = stored.to_ascii_lowercase();
+    if lower.contains("conduit-gateway") {
+        return true;
+    }
+    let path = Path::new(stored);
+    let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+        return false;
+    };
+    let name_lower = name.to_ascii_lowercase();
+    if name_lower != "toolport-gateway.exe" && name_lower != "conduit-gateway.exe" {
+        return false;
+    }
+    // Unversioned basename outside Conduit/bin → install dir or other stale layout.
+    !lower.contains("\\conduit\\bin\\")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unversioned_install_path_detected() {
+        assert!(is_unversioned_install_gateway_path(
+            r"C:\Users\me\AppData\Local\Toolport\toolport-gateway.exe"
+        ));
+        assert!(!is_unversioned_install_gateway_path(
+            r"C:\Users\me\AppData\Roaming\Conduit\bin\toolport-gateway-1.6.0.exe"
+        ));
+        assert!(is_unversioned_install_gateway_path(
+            "/Applications/Toolport.app/Contents/MacOS/conduit-gateway"
+        ));
+    }
+
+    #[test]
+    fn manifest_roundtrip_fields() {
+        let m = GatewayManifest {
+            version: "1.6.0".into(),
+            path: r"C:\x\toolport-gateway-1.6.0.exe".into(),
+            size: 42,
+        };
+        let json = serde_json::to_string(&m).unwrap();
+        let back: GatewayManifest = serde_json::from_str(&json).unwrap();
+        assert_eq!(m, back);
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -7,6 +7,7 @@ pub mod audit;
 pub mod catalog;
 pub mod clients;
 pub mod downstream;
+pub mod gateway_publish;
 pub mod inspect;
 pub mod integrity;
 pub mod oauth;

--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -105,7 +105,8 @@ function VersionFooter({
     if (!update) return;
     setInstalling(true);
     toast.info(`Updating to v${update.version}…`, {
-      description: "Toolport will restart when it's done.",
+      description:
+        "Stopping gateway processes so the installer can replace files. MCP clients may disconnect briefly; your editors can stay open.",
     });
     try {
       await installUpdate(update);

--- a/src/lib/updater.ts
+++ b/src/lib/updater.ts
@@ -1,3 +1,4 @@
+import { invoke } from "@tauri-apps/api/core";
 import { check, type Update } from "@tauri-apps/plugin-updater";
 import { relaunch } from "@tauri-apps/plugin-process";
 
@@ -21,6 +22,7 @@ export async function checkForUpdate(): Promise<UpdateCheck> {
 
 /** Download + install the update, then relaunch into the new version. */
 export async function installUpdate(update: Update): Promise<void> {
+  await invoke<number>("stop_spawned_gateways");
   await update.downloadAndInstall();
   await relaunch();
 }


### PR DESCRIPTION
## Summary
- Publish `toolport-gateway-{version}.exe` to `%APPDATA%\Roaming\Conduit\bin` on Windows packaged installs and record it in `gateway-manifest.json`.
- On startup, publish the bundled gateway then `repoint_stale_gateways` so MCP client configs stop pointing at the install-dir copy NSIS must overwrite.
- Before in-app update install, `stop_spawned_gateways` terminates only `toolport-gateway.exe` / `conduit-gateway.exe` children so locked binaries can be replaced without closing Cursor or other agents.

## Test plan
- [ ] `cargo test --lib` passes
- [ ] Windows packaged install: client configs repoint to versioned bin path after launch
- [ ] In-app update succeeds when gateway was previously locked
- [ ] MCP clients reconnect after update (editors stay open)

