### PR TITLE
fix(gateway): serialize oauth callback flow across clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ Entries before the rename below shipped under the project's former name, Conduit
 
 ### Fixed
 
+- **OAuth callback port collision across clients** — concurrent gateway processes now
+  serialize browser OAuth for the same remote server with a short-lived filesystem
+  lock, so only one callback listener/browser flow runs and waiters reuse the
+  vaulted auth state when it completes. (#228)
+
 - **Gateway stale secrets** — `secrets_generation` in the registry bumps on vault
   changes so running gateways reload credentials without a manual restart. (#226)
 

--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -38,12 +38,12 @@ const OAUTH_LOCK_POLL_MS: u64 = 250;
 
 struct OAuthFlowLock {
     path: std::path::PathBuf,
-    nonce: String,
+    attempt_id: String,
 }
 
 impl Drop for OAuthFlowLock {
     fn drop(&mut self) {
-        let completion = oauth_completion_path(&self.path, &self.nonce);
+        let completion = oauth_completion_path(&self.path, &self.attempt_id);
         let _ = std::fs::write(
             completion,
             format!("done={} pid={}
@@ -57,7 +57,7 @@ impl Drop for OAuthFlowLock {
 struct OAuthLockSnapshot {
     modified: SystemTime,
     content: String,
-    nonce: Option<String>,
+    attempt_id: Option<String>,
 }
 
 impl OAuthLockSnapshot {
@@ -78,7 +78,7 @@ fn now_unix_secs() -> u64 {
         .as_secs()
 }
 
-fn oauth_attempt_nonce() -> String {
+fn oauth_attempt_id() -> String {
     let nanos = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .unwrap_or_default()
@@ -86,17 +86,17 @@ fn oauth_attempt_nonce() -> String {
     format!("{}-{nanos}", std::process::id())
 }
 
-fn oauth_completion_path(path: &std::path::Path, nonce: &str) -> std::path::PathBuf {
+fn oauth_completion_path(path: &std::path::Path, attempt_id: &str) -> std::path::PathBuf {
     let name = path
         .file_name()
         .and_then(|v| v.to_str())
         .unwrap_or("oauth.lock");
-    path.with_file_name(format!("{name}.{nonce}.done"))
+    path.with_file_name(format!("{name}.{attempt_id}.done"))
 }
 
-fn oauth_lock_contents(nonce: &str) -> String {
+fn oauth_lock_contents(attempt_id: &str) -> String {
     format!(
-        "nonce={nonce}
+        "nonce={attempt_id}
 pid={}
 started={}
 lease_secs={}
@@ -107,7 +107,7 @@ lease_secs={}
     )
 }
 
-fn parse_lock_nonce(content: &str) -> Option<String> {
+fn parse_lock_attempt_id(content: &str) -> Option<String> {
     content
         .lines()
         .find_map(|line| line.strip_prefix("nonce=").map(ToOwned::to_owned))
@@ -124,11 +124,11 @@ fn read_oauth_lock_snapshot(path: &std::path::Path) -> Result<Option<OAuthLockSn
         .map_err(|e| format!("could not read oauth lock timestamp: {e}"))?;
     let content = std::fs::read_to_string(path)
         .map_err(|e| format!("could not read oauth lock file: {e}"))?;
-    let nonce = parse_lock_nonce(&content);
+    let attempt_id = parse_lock_attempt_id(&content);
     Ok(Some(OAuthLockSnapshot {
         modified,
         content,
-        nonce,
+        attempt_id,
     }))
 }
 
@@ -139,15 +139,15 @@ fn lock_snapshot_is_expired(snapshot: &OAuthLockSnapshot) -> bool {
     elapsed.as_secs() >= OAUTH_LOCK_LEASE_SECS
 }
 
-fn completion_exists(path: &std::path::Path, nonce: &str) -> bool {
-    oauth_completion_path(path, nonce).exists()
+fn completion_exists(path: &std::path::Path, attempt_id: &str) -> bool {
+    oauth_completion_path(path, attempt_id).exists()
 }
 
 fn try_replace_stale_lock(
     path: &std::path::Path,
     observed: &OAuthLockSnapshot,
     contender_contents: &str,
-    contender_nonce: &str,
+    contender_attempt_id: &str,
 ) -> Result<bool, String> {
     let Some(current) = read_oauth_lock_snapshot(path)? else {
         return Ok(false);
@@ -155,7 +155,7 @@ fn try_replace_stale_lock(
     if current.instance_key() != observed.instance_key() {
         return Ok(false);
     }
-    let _ = std::fs::remove_file(oauth_completion_path(path, contender_nonce));
+    let _ = std::fs::remove_file(oauth_completion_path(path, contender_attempt_id));
     let mut file = std::fs::OpenOptions::new()
         .write(true)
         .truncate(true)
@@ -186,9 +186,9 @@ fn oauth_lock_path(server_id: &str, url: &str) -> Result<std::path::PathBuf, Str
 }
 
 fn try_acquire_oauth_lock(path: &std::path::Path) -> Result<Option<OAuthFlowLock>, String> {
-    let nonce = oauth_attempt_nonce();
-    let contents = oauth_lock_contents(&nonce);
-    let _ = std::fs::remove_file(oauth_completion_path(path, &nonce));
+    let attempt_id = oauth_attempt_id();
+    let contents = oauth_lock_contents(&attempt_id);
+    let _ = std::fs::remove_file(oauth_completion_path(path, &attempt_id));
     match std::fs::OpenOptions::new().write(true).create_new(true).open(path) {
         Ok(mut f) => {
             use std::io::Write;
@@ -196,7 +196,7 @@ fn try_acquire_oauth_lock(path: &std::path::Path) -> Result<Option<OAuthFlowLock
                 .map_err(|e| format!("could not write oauth lock file: {e}"))?;
             Ok(Some(OAuthFlowLock {
                 path: path.to_path_buf(),
-                nonce,
+                attempt_id,
             }))
         }
         Err(e) if e.kind() == ErrorKind::AlreadyExists => {
@@ -204,11 +204,11 @@ fn try_acquire_oauth_lock(path: &std::path::Path) -> Result<Option<OAuthFlowLock
                 return Ok(None);
             };
             if lock_snapshot_is_expired(&observed)
-                && try_replace_stale_lock(path, &observed, &contents, &nonce)?
+                && try_replace_stale_lock(path, &observed, &contents, &attempt_id)?
             {
                 return Ok(Some(OAuthFlowLock {
                     path: path.to_path_buf(),
-                    nonce,
+                    attempt_id,
                 }));
             }
             Ok(None)
@@ -219,12 +219,12 @@ fn try_acquire_oauth_lock(path: &std::path::Path) -> Result<Option<OAuthFlowLock
 
 fn acquire_or_wait_oauth_lock(_server_id: &str, url: &str) -> Result<Option<OAuthFlowLock>, String> {
     let path = oauth_lock_path(_server_id, url)?;
-    let mut observed_nonce: Option<String> = None;
+    let mut observed_attempt_id: Option<String> = None;
     let deadline = std::time::Instant::now() + Duration::from_secs(OAUTH_LOCK_WAIT_SECS);
     loop {
         if let Some(lock) = try_acquire_oauth_lock(&path)? {
-            if let Some(nonce) = &observed_nonce {
-                if completion_exists(&path, nonce) {
+            if let Some(attempt_id) = &observed_attempt_id {
+                if completion_exists(&path, attempt_id) {
                     drop(lock);
                     return Ok(None);
                 }
@@ -232,12 +232,12 @@ fn acquire_or_wait_oauth_lock(_server_id: &str, url: &str) -> Result<Option<OAut
             return Ok(Some(lock));
         }
         if let Some(snapshot) = read_oauth_lock_snapshot(&path)? {
-            if let Some(nonce) = snapshot.nonce {
-                observed_nonce = Some(nonce);
+            if let Some(attempt_id) = snapshot.attempt_id {
+                observed_attempt_id = Some(attempt_id);
             }
         }
-        if let Some(nonce) = &observed_nonce {
-            if completion_exists(&path, nonce) {
+        if let Some(attempt_id) = &observed_attempt_id {
+            if completion_exists(&path, attempt_id) {
                 return Ok(None);
             }
         }
@@ -2675,7 +2675,7 @@ mod tests {
 
 
     #[test]
-    fn oauth_waiter_uses_attempt_completion_nonce() {
+    fn oauth_waiter_uses_attempt_completion_id() {
         let unique = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .unwrap_or_default()
@@ -2685,23 +2685,24 @@ mod tests {
         let lock = try_acquire_oauth_lock(&path)
             .expect("lock acquisition should not fail")
             .expect("lock should be acquired");
-        let nonce = lock.nonce.clone();
+        let attempt_id = lock.attempt_id.clone();
 
-        let stale_done = oauth_completion_path(&path, "old-attempt");
+        let stale_attempt = format!("old-attempt-{unique}");
+        let stale_done = oauth_completion_path(&path, &stale_attempt);
         std::fs::write(&stale_done, "done=1").expect("stale completion should be writable");
         assert!(
-            !completion_exists(&path, &nonce),
+            !completion_exists(&path, &attempt_id),
             "completion from a prior attempt must not satisfy current waiter"
         );
 
         drop(lock);
         assert!(
-            completion_exists(&path, &nonce),
+            completion_exists(&path, &attempt_id),
             "lock drop should mark the specific attempt complete"
         );
 
         let _ = std::fs::remove_file(stale_done);
-        let _ = std::fs::remove_file(oauth_completion_path(&path, &nonce));
+        let _ = std::fs::remove_file(oauth_completion_path(&path, &attempt_id));
         let _ = std::fs::remove_file(path);
     }
 
@@ -2713,20 +2714,24 @@ mod tests {
             .as_nanos();
         let path = std::env::temp_dir().join(format!("conduit-oauth-lock-{unique}.lock"));
 
-        std::fs::write(&path, oauth_lock_contents("observed")).expect("initial lock write should work");
+        let observed_id = format!("observed-{unique}");
+        let fresh_id = format!("fresh-owner-{unique}");
+        let contender_id = format!("contender-{unique}");
+        std::fs::write(&path, oauth_lock_contents(&observed_id))
+            .expect("initial lock write should work");
         let observed = read_oauth_lock_snapshot(&path)
             .expect("snapshot read should work")
             .expect("snapshot should exist");
 
         std::thread::sleep(Duration::from_millis(5));
-        std::fs::write(&path, oauth_lock_contents("fresh-owner"))
+        std::fs::write(&path, oauth_lock_contents(&fresh_id))
             .expect("fresh lock write should work");
 
         let replaced = try_replace_stale_lock(
             &path,
             &observed,
-            &oauth_lock_contents("contender"),
-            "contender",
+            &oauth_lock_contents(&contender_id),
+            &contender_id,
         )
         .expect("replace check should not error");
         assert!(
@@ -2736,7 +2741,7 @@ mod tests {
 
         let current = std::fs::read_to_string(&path).expect("current lock should be readable");
         assert!(
-            current.contains("nonce=fresh-owner"),
+            current.contains(&format!("nonce={fresh_id}")),
             "fresh lock instance must remain intact"
         );
         let _ = std::fs::remove_file(path);

--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -96,7 +96,7 @@ fn oauth_completion_path(path: &std::path::Path, attempt_id: &str) -> std::path:
 
 fn oauth_lock_contents(attempt_id: &str) -> String {
     format!(
-        "nonce={attempt_id}
+        "attempt_id={attempt_id}
 pid={}
 started={}
 lease_secs={}
@@ -110,7 +110,7 @@ lease_secs={}
 fn parse_lock_attempt_id(content: &str) -> Option<String> {
     content
         .lines()
-        .find_map(|line| line.strip_prefix("nonce=").map(ToOwned::to_owned))
+        .find_map(|line| line.strip_prefix("attempt_id=").or_else(|| line.strip_prefix("nonce=")).map(ToOwned::to_owned))
 }
 
 fn read_oauth_lock_snapshot(path: &std::path::Path) -> Result<Option<OAuthLockSnapshot>, String> {
@@ -2741,7 +2741,7 @@ mod tests {
 
         let current = std::fs::read_to_string(&path).expect("current lock should be readable");
         assert!(
-            current.contains(&format!("nonce={fresh_id}")),
+            current.contains(&format!("attempt_id={fresh_id}")),
             "fresh lock instance must remain intact"
         );
         let _ = std::fs::remove_file(path);

--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -38,12 +38,135 @@ const OAUTH_LOCK_POLL_MS: u64 = 250;
 
 struct OAuthFlowLock {
     path: std::path::PathBuf,
+    nonce: String,
 }
 
 impl Drop for OAuthFlowLock {
     fn drop(&mut self) {
+        let completion = oauth_completion_path(&self.path, &self.nonce);
+        let _ = std::fs::write(
+            completion,
+            format!("done={} pid={}
+", now_unix_secs(), std::process::id()),
+        );
         let _ = std::fs::remove_file(&self.path);
     }
+}
+
+#[derive(Clone)]
+struct OAuthLockSnapshot {
+    modified: SystemTime,
+    content: String,
+    nonce: Option<String>,
+}
+
+impl OAuthLockSnapshot {
+    fn instance_key(&self) -> String {
+        let modified = self
+            .modified
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos();
+        format!("{modified}:{}", self.content)
+    }
+}
+
+fn now_unix_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+
+fn oauth_attempt_nonce() -> String {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    format!("{}-{nanos}", std::process::id())
+}
+
+fn oauth_completion_path(path: &std::path::Path, nonce: &str) -> std::path::PathBuf {
+    let name = path
+        .file_name()
+        .and_then(|v| v.to_str())
+        .unwrap_or("oauth.lock");
+    path.with_file_name(format!("{name}.{nonce}.done"))
+}
+
+fn oauth_lock_contents(nonce: &str) -> String {
+    format!(
+        "nonce={nonce}
+pid={}
+started={}
+lease_secs={}
+",
+        std::process::id(),
+        now_unix_secs(),
+        OAUTH_LOCK_LEASE_SECS
+    )
+}
+
+fn parse_lock_nonce(content: &str) -> Option<String> {
+    content
+        .lines()
+        .find_map(|line| line.strip_prefix("nonce=").map(ToOwned::to_owned))
+}
+
+fn read_oauth_lock_snapshot(path: &std::path::Path) -> Result<Option<OAuthLockSnapshot>, String> {
+    let meta = match std::fs::metadata(path) {
+        Ok(meta) => meta,
+        Err(e) if e.kind() == ErrorKind::NotFound => return Ok(None),
+        Err(e) => return Err(format!("could not stat oauth lock file: {e}")),
+    };
+    let modified = meta
+        .modified()
+        .map_err(|e| format!("could not read oauth lock timestamp: {e}"))?;
+    let content = std::fs::read_to_string(path)
+        .map_err(|e| format!("could not read oauth lock file: {e}"))?;
+    let nonce = parse_lock_nonce(&content);
+    Ok(Some(OAuthLockSnapshot {
+        modified,
+        content,
+        nonce,
+    }))
+}
+
+fn lock_snapshot_is_expired(snapshot: &OAuthLockSnapshot) -> bool {
+    let Ok(elapsed) = snapshot.modified.elapsed() else {
+        return false;
+    };
+    elapsed.as_secs() >= OAUTH_LOCK_LEASE_SECS
+}
+
+fn completion_exists(path: &std::path::Path, nonce: &str) -> bool {
+    oauth_completion_path(path, nonce).exists()
+}
+
+fn try_replace_stale_lock(
+    path: &std::path::Path,
+    observed: &OAuthLockSnapshot,
+    contender_contents: &str,
+    contender_nonce: &str,
+) -> Result<bool, String> {
+    let Some(current) = read_oauth_lock_snapshot(path)? else {
+        return Ok(false);
+    };
+    if current.instance_key() != observed.instance_key() {
+        return Ok(false);
+    }
+    let _ = std::fs::remove_file(oauth_completion_path(path, contender_nonce));
+    let mut file = std::fs::OpenOptions::new()
+        .write(true)
+        .truncate(true)
+        .open(path)
+        .map_err(|e| format!("could not rewrite stale oauth lock file: {e}"))?;
+    use std::io::Write;
+    file.write_all(contender_contents.as_bytes())
+        .map_err(|e| format!("could not write oauth lock file: {e}"))?;
+    file.flush()
+        .map_err(|e| format!("could not flush oauth lock file: {e}"))?;
+    Ok(true)
 }
 
 fn oauth_lock_key(server_id: &str, url: &str) -> String {
@@ -62,42 +185,31 @@ fn oauth_lock_path(server_id: &str, url: &str) -> Result<std::path::PathBuf, Str
     Ok(locks.join(format!("{}.lock", oauth_lock_key(server_id, url))))
 }
 
-fn lock_is_expired(path: &std::path::Path) -> bool {
-    let Ok(meta) = std::fs::metadata(path) else {
-        return true;
-    };
-    let Ok(modified) = meta.modified() else {
-        return false;
-    };
-    let Ok(elapsed) = modified.elapsed() else {
-        return false;
-    };
-    elapsed.as_secs() >= OAUTH_LOCK_LEASE_SECS
-}
-
 fn try_acquire_oauth_lock(path: &std::path::Path) -> Result<Option<OAuthFlowLock>, String> {
+    let nonce = oauth_attempt_nonce();
+    let contents = oauth_lock_contents(&nonce);
+    let _ = std::fs::remove_file(oauth_completion_path(path, &nonce));
     match std::fs::OpenOptions::new().write(true).create_new(true).open(path) {
         Ok(mut f) => {
             use std::io::Write;
-            let now = SystemTime::now()
-                .duration_since(UNIX_EPOCH)
-                .unwrap_or_default()
-                .as_secs();
-            let _ = writeln!(
-                f,
-                "pid={} started={} lease_secs={}",
-                std::process::id(),
-                now,
-                OAUTH_LOCK_LEASE_SECS
-            );
+            f.write_all(contents.as_bytes())
+                .map_err(|e| format!("could not write oauth lock file: {e}"))?;
             Ok(Some(OAuthFlowLock {
                 path: path.to_path_buf(),
+                nonce,
             }))
         }
         Err(e) if e.kind() == ErrorKind::AlreadyExists => {
-            if lock_is_expired(path) {
-                let _ = std::fs::remove_file(path);
-                return try_acquire_oauth_lock(path);
+            let Some(observed) = read_oauth_lock_snapshot(path)? else {
+                return Ok(None);
+            };
+            if lock_snapshot_is_expired(&observed)
+                && try_replace_stale_lock(path, &observed, &contents, &nonce)?
+            {
+                return Ok(Some(OAuthFlowLock {
+                    path: path.to_path_buf(),
+                    nonce,
+                }));
             }
             Ok(None)
         }
@@ -105,20 +217,29 @@ fn try_acquire_oauth_lock(path: &std::path::Path) -> Result<Option<OAuthFlowLock
     }
 }
 
-fn oauth_auth_complete(server_id: &str) -> bool {
-    secrets::get_secret(server_id, secrets::HTTP_AUTH_KEY).is_some()
-        && secrets::get_secret(server_id, remote::OAUTH_STATE_KEY).is_some()
-}
-
-fn acquire_or_wait_oauth_lock(server_id: &str, url: &str) -> Result<Option<OAuthFlowLock>, String> {
-    let path = oauth_lock_path(server_id, url)?;
+fn acquire_or_wait_oauth_lock(_server_id: &str, url: &str) -> Result<Option<OAuthFlowLock>, String> {
+    let path = oauth_lock_path(_server_id, url)?;
+    let mut observed_nonce: Option<String> = None;
     let deadline = std::time::Instant::now() + Duration::from_secs(OAUTH_LOCK_WAIT_SECS);
     loop {
         if let Some(lock) = try_acquire_oauth_lock(&path)? {
+            if let Some(nonce) = &observed_nonce {
+                if completion_exists(&path, nonce) {
+                    drop(lock);
+                    return Ok(None);
+                }
+            }
             return Ok(Some(lock));
         }
-        if oauth_auth_complete(server_id) {
-            return Ok(None);
+        if let Some(snapshot) = read_oauth_lock_snapshot(&path)? {
+            if let Some(nonce) = snapshot.nonce {
+                observed_nonce = Some(nonce);
+            }
+        }
+        if let Some(nonce) = &observed_nonce {
+            if completion_exists(&path, nonce) {
+                return Ok(None);
+            }
         }
         if std::time::Instant::now() >= deadline {
             return Err(
@@ -2550,6 +2671,75 @@ mod tests {
         let c = oauth_lock_key("srv-2", "https://mcp.example.com");
         assert_eq!(a, b, "same server identity must map to same lock key");
         assert_ne!(a, c, "different server identity must map to different lock keys");
+    }
+
+
+    #[test]
+    fn oauth_waiter_uses_attempt_completion_nonce() {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!("conduit-oauth-lock-{unique}.lock"));
+
+        let lock = try_acquire_oauth_lock(&path)
+            .expect("lock acquisition should not fail")
+            .expect("lock should be acquired");
+        let nonce = lock.nonce.clone();
+
+        let stale_done = oauth_completion_path(&path, "old-attempt");
+        std::fs::write(&stale_done, "done=1").expect("stale completion should be writable");
+        assert!(
+            !completion_exists(&path, &nonce),
+            "completion from a prior attempt must not satisfy current waiter"
+        );
+
+        drop(lock);
+        assert!(
+            completion_exists(&path, &nonce),
+            "lock drop should mark the specific attempt complete"
+        );
+
+        let _ = std::fs::remove_file(stale_done);
+        let _ = std::fs::remove_file(oauth_completion_path(&path, &nonce));
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn stale_lock_replace_requires_same_observed_instance() {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!("conduit-oauth-lock-{unique}.lock"));
+
+        std::fs::write(&path, oauth_lock_contents("observed")).expect("initial lock write should work");
+        let observed = read_oauth_lock_snapshot(&path)
+            .expect("snapshot read should work")
+            .expect("snapshot should exist");
+
+        std::thread::sleep(Duration::from_millis(5));
+        std::fs::write(&path, oauth_lock_contents("fresh-owner"))
+            .expect("fresh lock write should work");
+
+        let replaced = try_replace_stale_lock(
+            &path,
+            &observed,
+            &oauth_lock_contents("contender"),
+            "contender",
+        )
+        .expect("replace check should not error");
+        assert!(
+            !replaced,
+            "stale cleanup must not clobber a newly replaced lock"
+        );
+
+        let current = std::fs::read_to_string(&path).expect("current lock should be readable");
+        assert!(
+            current.contains("nonce=fresh-owner"),
+            "fresh lock instance must remain intact"
+        );
+        let _ = std::fs::remove_file(path);
     }
 
     #[test]

--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -1,11 +1,14 @@
 //! Tauri desktop shell: tray, webview IPC commands, approval broker, HTTP bridge.
 
+use std::io::ErrorKind;
 use std::sync::Mutex;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use tauri::menu::{Menu, MenuItem, PredefinedMenuItem};
 use tauri::tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent};
 use tauri::{AppHandle, Emitter, Listener, Manager, State};
 use tauri_plugin_notification::NotificationExt;
+use sha2::{Digest, Sha256};
 
 use crate::approval_broker;
 use crate::approval;
@@ -28,6 +31,104 @@ use crate::usage_report;
 use crate::vendors;
 
 type RegistryState = Mutex<Registry>;
+
+const OAUTH_LOCK_LEASE_SECS: u64 = 180;
+const OAUTH_LOCK_WAIT_SECS: u64 = 30;
+const OAUTH_LOCK_POLL_MS: u64 = 250;
+
+struct OAuthFlowLock {
+    path: std::path::PathBuf,
+}
+
+impl Drop for OAuthFlowLock {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.path);
+    }
+}
+
+fn oauth_lock_key(server_id: &str, url: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(server_id.as_bytes());
+    hasher.update(b"\n");
+    hasher.update(url.as_bytes());
+    format!("{:x}", hasher.finalize())
+}
+
+fn oauth_lock_path(server_id: &str, url: &str) -> Result<std::path::PathBuf, String> {
+    let dir = registry::conduit_dir().ok_or("could not resolve the data directory")?;
+    let locks = dir.join("oauth-locks");
+    std::fs::create_dir_all(&locks)
+        .map_err(|e| format!("could not create oauth lock directory: {e}"))?;
+    Ok(locks.join(format!("{}.lock", oauth_lock_key(server_id, url))))
+}
+
+fn lock_is_expired(path: &std::path::Path) -> bool {
+    let Ok(meta) = std::fs::metadata(path) else {
+        return true;
+    };
+    let Ok(modified) = meta.modified() else {
+        return false;
+    };
+    let Ok(elapsed) = modified.elapsed() else {
+        return false;
+    };
+    elapsed.as_secs() >= OAUTH_LOCK_LEASE_SECS
+}
+
+fn try_acquire_oauth_lock(path: &std::path::Path) -> Result<Option<OAuthFlowLock>, String> {
+    match std::fs::OpenOptions::new().write(true).create_new(true).open(path) {
+        Ok(mut f) => {
+            use std::io::Write;
+            let now = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_secs();
+            let _ = writeln!(
+                f,
+                "pid={} started={} lease_secs={}",
+                std::process::id(),
+                now,
+                OAUTH_LOCK_LEASE_SECS
+            );
+            Ok(Some(OAuthFlowLock {
+                path: path.to_path_buf(),
+            }))
+        }
+        Err(e) if e.kind() == ErrorKind::AlreadyExists => {
+            if lock_is_expired(path) {
+                let _ = std::fs::remove_file(path);
+                return try_acquire_oauth_lock(path);
+            }
+            Ok(None)
+        }
+        Err(e) => Err(format!("could not create oauth lock file: {e}")),
+    }
+}
+
+fn oauth_auth_complete(server_id: &str) -> bool {
+    secrets::get_secret(server_id, secrets::HTTP_AUTH_KEY).is_some()
+        && secrets::get_secret(server_id, remote::OAUTH_STATE_KEY).is_some()
+}
+
+fn acquire_or_wait_oauth_lock(server_id: &str, url: &str) -> Result<Option<OAuthFlowLock>, String> {
+    let path = oauth_lock_path(server_id, url)?;
+    let deadline = std::time::Instant::now() + Duration::from_secs(OAUTH_LOCK_WAIT_SECS);
+    loop {
+        if let Some(lock) = try_acquire_oauth_lock(&path)? {
+            return Ok(Some(lock));
+        }
+        if oauth_auth_complete(server_id) {
+            return Ok(None);
+        }
+        if std::time::Instant::now() >= deadline {
+            return Err(
+                "another Toolport process is already running OAuth for this server; timed out waiting for it to finish"
+                    .to_string(),
+            );
+        }
+        std::thread::sleep(Duration::from_millis(OAUTH_LOCK_POLL_MS));
+    }
+}
 
 /// Tracks the optional `toolport-gateway --http` child the app supervises so
 /// HTTP/OpenAPI clients (Open WebUI and the like) can connect with one click,
@@ -1438,6 +1539,10 @@ async fn authenticate_oauth(
     server_id: String,
     url: String,
 ) -> Result<(), String> {
+    let Some(_lock) = acquire_or_wait_oauth_lock(&server_id, &url)? else {
+        // Another process completed the OAuth flow for this same server while we waited.
+        return Ok(());
+    };
     let resource = url.clone();
     let res = tauri::async_runtime::spawn_blocking(move || oauth::authenticate(&url))
         .await
@@ -2412,6 +2517,39 @@ mod tests {
             source: None,
             disabled_tools: vec![],
         }
+    }
+
+    #[test]
+    fn oauth_lock_serializes_concurrent_attempts() {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!("conduit-oauth-lock-{unique}.lock"));
+        let lock1 = try_acquire_oauth_lock(&path)
+            .expect("first lock should not fail")
+            .expect("first lock should be acquired");
+        assert!(
+            try_acquire_oauth_lock(&path)
+                .expect("second lock should not fail")
+                .is_none(),
+            "second concurrent lock must wait"
+        );
+        drop(lock1);
+        let lock2 = try_acquire_oauth_lock(&path)
+            .expect("third lock should not fail")
+            .expect("lock should be available after release");
+        drop(lock2);
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn oauth_lock_key_is_stable_and_scoped() {
+        let a = oauth_lock_key("srv-1", "https://mcp.example.com");
+        let b = oauth_lock_key("srv-1", "https://mcp.example.com");
+        let c = oauth_lock_key("srv-2", "https://mcp.example.com");
+        assert_eq!(a, b, "same server identity must map to same lock key");
+        assert_ne!(a, c, "different server identity must map to different lock keys");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add a cross-process OAuth lease lock in `conduit_dir/oauth-locks` keyed by server identity (`server_id + url`) to serialize interactive browser callback flows.
- Make waiting processes poll briefly and return success if vaulted access token + OAuth state appear, avoiding duplicate callback listeners and browser spawns.
- Add focused desktop unit tests for lock serialization/key stability and document the fix in Unreleased changelog.

Closes #228

## Test plan
- [x] `cargo test --manifest-path src-tauri/Cargo.toml --lib oauth_lock_ -- --nocapture`
- [x] Verified lock tests pass (`desktop::tests::oauth_lock_serializes_concurrent_attempts`, `desktop::tests::oauth_lock_key_is_stable_and_scoped`)
- [ ] Manual multi-client OAuth smoke test (recommended in QA)