### PR TITLE
feat(gateway): live per-client profile scoping, diagnostics, and import fix

### DIFF
--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -1117,7 +1117,7 @@ fn enabled_summary(
     }
 
     let mut out = format!("{header} has {} enabled server(s):\n", servers.len());
-    for s in servers {
+    for s in &servers {
         let target = match (&s.command, &s.url) {
             (Some(cmd), _) => format!("{} {}", cmd, s.args.join(" ")),
             (None, Some(url)) => url.clone(),
@@ -1142,10 +1142,33 @@ fn enabled_summary(
                 *counts.entry(prefix).or_insert(0) += 1;
             }
         }
+        // Only surface the "0 tools" hint once the catalog has actually populated
+        // (at least one server produced tools). Before that, every server reads as
+        // zero simply because downstream connections are still coming up, which
+        // would be pure noise rather than a signal.
         if !counts.is_empty() {
             out.push_str("\nTools by server (pass the prefix as `server` to list them all):\n");
-            for (p, c) in counts {
+            for (p, c) in &counts {
                 out.push_str(&format!("- {p}: {c} tool(s)\n"));
+            }
+            // An enabled server contributing no tools to a populated catalog is the
+            // classic symptom of an auth-gated server that hasn't been signed into
+            // yet (e.g. Atlassian's OAuth), or one that failed to connect. Call it
+            // out so the agent (and user) can self-diagnose instead of assuming the
+            // server is simply missing.
+            let silent: Vec<&str> = servers
+                .iter()
+                .filter(|s| !counts.contains_key(&sanitize_segment(&s.id)))
+                .map(|s| s.name.as_str())
+                .collect();
+            if !silent.is_empty() {
+                out.push_str(
+                    "\nEnabled but exposing 0 tools (may still be connecting, or may need \
+                     authentication - e.g. an OAuth sign-in in Conduit):\n",
+                );
+                for name in silent {
+                    out.push_str(&format!("- {name}\n"));
+                }
             }
         }
     }
@@ -2906,6 +2929,31 @@ fn save_tool_cache(tools: &[Value], profile: Option<&str>) {
     }
 }
 
+/// Resolve this client's live profile from `registry.client_scopes[client_id]`
+/// (kept current by `watch_registry` on every reload). Three cases:
+/// - a non-empty entry: this client is scoped to that named profile;
+/// - an empty-string entry: this client is *explicitly* unscoped (follow the
+///   active profile now), so return `None` and do NOT fall back to the boot env
+///   var - that's what makes a live re-scope to "all servers" take effect
+///   without restarting the client (see `Registry::set_client_unscoped`);
+/// - no entry at all: fall back to the `CONDUIT_PROFILE` this process started
+///   with (e.g. an install from before `CONDUIT_CLIENT_ID` existed).
+/// Callers with no `client_id` at all (the HTTP bridge, or a pre-CLIENT_ID
+/// install) always fall through to `env_profile` unchanged. Note current
+/// installs - scoped or unscoped - always write `CONDUIT_CLIENT_ID`, so an
+/// unscoped one lands in the empty-string case above, not here.
+fn resolve_live_profile(
+    reg: &Registry,
+    client_id: Option<&str>,
+    env_profile: &Option<String>,
+) -> Option<String> {
+    match client_id.and_then(|id| reg.client_scopes.get(id)) {
+        Some(p) if p.trim().is_empty() => None,
+        Some(p) => Some(p.clone()),
+        None => env_profile.clone(),
+    }
+}
+
 /// Poll the registry file; on change, reload, rebuild the router, and tell the
 /// client its tool list changed. This is what makes a toggle apply live.
 #[allow(clippy::too_many_arguments)]
@@ -2915,7 +2963,9 @@ fn watch_registry(
     router: Arc<Mutex<Arc<Router>>>,
     stdout: Arc<Mutex<std::io::Stdout>>,
     cached_tools: Arc<Mutex<Vec<Value>>>,
-    profile: Option<String>,
+    profile: Arc<Mutex<Option<String>>>,
+    client_id: Option<String>,
+    env_profile: Option<String>,
     http_mode: bool,
     downstream_dirty: Arc<AtomicU8>,
     server_handler: ServerRequestHandler,
@@ -2949,14 +2999,28 @@ fn watch_registry(
                 }
             };
             last = current;
+            let resolved = resolve_live_profile(&new_reg, client_id.as_deref(), &env_profile);
+            // Capture the profile we were serving before this reload so the log can
+            // show the transition - the single most useful line when diagnosing
+            // "why can't this client see server X": it pins down which profile is
+            // actually in effect and how many servers it resolved to.
+            let previous = {
+                let mut guard = profile
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner);
+                let prev = guard.clone();
+                *guard = resolved.clone();
+                prev
+            };
             // Build the new router (spawns processes) before taking locks.
             let new_router = build_router(
                 &new_reg,
-                profile.as_deref(),
+                resolved.as_deref(),
                 http_mode,
                 &downstream_dirty,
                 Arc::clone(&server_handler),
             );
+            let server_count = new_router.server_count();
             let tools = new_router.aggregated_tools();
             *registry
                 .lock()
@@ -2964,10 +3028,28 @@ fn watch_registry(
             *router
                 .lock()
                 .unwrap_or_else(std::sync::PoisonError::into_inner) = Arc::new(new_router);
-            let tools = requarantine_if_needed(&registry, &router, tools, profile.as_deref());
-            persist_and_emit(&tools, &cached_tools, &stdout, profile.as_deref());
-            eprintln!("toolport: registry changed, sent tools/list_changed");
+            let tools = requarantine_if_needed(&registry, &router, tools, resolved.as_deref());
+            persist_and_emit(&tools, &cached_tools, &stdout, resolved.as_deref());
+            let fmt_profile = |p: &Option<String>| match p {
+                Some(name) => format!("'{name}'"),
+                None => "(active profile / unscoped)".to_string(),
+            };
+            eprintln!(
+                "toolport: registry changed{} -> profile {} (was {}); {} server(s), {} tools; sent tools/list_changed",
+                client_id
+                    .as_deref()
+                    .map(|c| format!(" [client={c}]"))
+                    .unwrap_or_default(),
+                fmt_profile(&resolved),
+                fmt_profile(&previous),
+                server_count,
+                tools.len(),
+            );
         } else {
+            let resolved = profile
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .clone();
             // One or more live servers announced a list change. Re-query only the
             // affected list(s) in place rather than re-spawning: a runtime or
             // session-scoped change (the usual reason a server sends this) would be
@@ -2996,8 +3078,8 @@ fn watch_registry(
                 *router
                     .lock()
                     .unwrap_or_else(std::sync::PoisonError::into_inner) = Arc::new(next);
-                let tools = requarantine_if_needed(&registry, &router, tools, profile.as_deref());
-                persist_and_emit(&tools, &cached_tools, &stdout, profile.as_deref());
+                let tools = requarantine_if_needed(&registry, &router, tools, resolved.as_deref());
+                persist_and_emit(&tools, &cached_tools, &stdout, resolved.as_deref());
                 eprintln!("toolport: downstream tools/list_changed, refreshed + sent");
             }
             if downstream_changed & downstream::change::RESOURCES != 0 {
@@ -3061,7 +3143,10 @@ struct GatewayState {
     /// server_count under the router lock and skip.
     rebuild_lock: Arc<Mutex<()>>,
     lazy: bool,
-    profile: Option<String>,
+    /// Live-updated: the registry watcher keeps this in sync with
+    /// `registry.client_scopes` for a scoped client, so a profile switch reaches
+    /// every reader here without a gateway restart.
+    profile: Arc<Mutex<Option<String>>>,
     /// True when this process is the HTTP/OpenAPI bridge (vs a stdio client's
     /// gateway). The bridge connects the union of all registered clients' servers.
     http: bool,
@@ -3631,6 +3716,14 @@ fn process_request(
         }
     }
 
+    // Snapshot the live-updated profile once: the watcher may swap it mid-request,
+    // but a single request should see one consistent value throughout.
+    let profile_snapshot = state
+        .profile
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .clone();
+
     // Self-heal: a call with no live downstream servers means the startup read
     // found none (transient) or a server was authed after we built. Reload and
     // rebuild once so the call can route instead of failing.
@@ -3665,7 +3758,7 @@ fn process_request(
                 .clone();
             let built = build_router(
                 &reg,
-                state.profile.as_deref(),
+                profile_snapshot.as_deref(),
                 state.http,
                 &state.downstream_dirty,
                 Arc::clone(&state.server_handler),
@@ -3681,7 +3774,7 @@ fn process_request(
                         .cached_tools
                         .lock()
                         .unwrap_or_else(std::sync::PoisonError::into_inner) = tools.clone();
-                    save_tool_cache(&tools, state.profile.as_deref());
+                    save_tool_cache(&tools, profile_snapshot.as_deref());
                 }
                 glog(&format!(
                     "self-heal: rebuilt router ({} servers, {} tools)",
@@ -3725,7 +3818,7 @@ fn process_request(
         &router,
         &cache_snapshot,
         state.lazy,
-        state.profile.as_deref(),
+        profile_snapshot.as_deref(),
         guard,
         confirm,
         allowed,
@@ -4859,7 +4952,18 @@ fn main() {
     let _ = DISCOVERY_MODE.set(mode);
     let lazy = matches!(mode, DiscoveryMode::Lazy);
     // Per-client scoping: this gateway exposes only the named profile's servers.
-    let profile = std::env::var("CONDUIT_PROFILE")
+    // This is only the bootstrap value - once the registry loads below, the live
+    // value (kept in sync with registry.client_scopes on every watcher tick) wins.
+    let env_profile = std::env::var("CONDUIT_PROFILE")
+        .ok()
+        .filter(|s| !s.trim().is_empty());
+    // Identifies this client for a live profile lookup in registry.client_scopes,
+    // so any re-scope (scoped->scoped, scoped->unscoped, unscoped->scoped)
+    // propagates without restarting the client. Every install now writes this,
+    // scoped or not; only a client installed before this env var existed lacks it
+    // (until its next reinstall) and falls back to CONDUIT_PROFILE - see
+    // docs/drafts/profile-switch-live-reload-plan.md.
+    let client_id = std::env::var("CONDUIT_CLIENT_ID")
         .ok()
         .filter(|s| !s.trim().is_empty());
     // HTTP/OpenAPI bridge mode: one process serves every registered client, so the
@@ -4868,7 +4972,7 @@ fn main() {
     let http_mode = http_port_opt.is_some();
     glog("=== gateway start ===");
     glog(&format!(
-        "cwd={:?} CONDUIT_REGISTRY={:?} registry_path={:?} dir_resolution={:?} lazy={lazy} profile={profile:?}",
+        "cwd={:?} CONDUIT_REGISTRY={:?} registry_path={:?} dir_resolution={:?} lazy={lazy} profile={env_profile:?} client_id={client_id:?}",
         std::env::current_dir().ok(),
         std::env::var("CONDUIT_REGISTRY").ok(),
         registry::resolved_path(),
@@ -4911,6 +5015,10 @@ fn main() {
         }
     };
     inspect::clear();
+    // Resolve the live profile immediately from what's already on disk, rather than
+    // waiting for the watcher's first tick: a scoped client re-launched after being
+    // re-scoped should see the new profile from its very first request.
+    let resolved_profile = resolve_live_profile(&loaded, client_id.as_deref(), &env_profile);
     let registry = Arc::new(Mutex::new(loaded));
     // Empty router + cached catalog: the handshake and tools/list answer instantly
     // (from cache), while downstream servers connect in the background for the
@@ -4920,7 +5028,11 @@ fn main() {
     // request loop, the watcher, and the self-heal path all follow this, so there's
     // no deadlock; keep new code consistent with it.
     let router = Arc::new(Mutex::new(Arc::new(Router::new())));
-    let cached_tools = Arc::new(Mutex::new(load_tool_cache(profile.as_deref())));
+    let cached_tools = Arc::new(Mutex::new(load_tool_cache(resolved_profile.as_deref())));
+    // Shared, live-updated: the watcher re-resolves this from registry.client_scopes
+    // on every reload (falling back to `env_profile` if this client has no scope
+    // entry), so a profile switch reaches every reader below without a restart.
+    let profile = Arc::new(Mutex::new(resolved_profile));
     let stdout = Arc::new(Mutex::new(std::io::stdout()));
     let ready = Arc::new(AtomicBool::new(false));
     // Flipped by any downstream transport that emits notifications/tools/list_changed.
@@ -4952,19 +5064,17 @@ fn main() {
         let cached_tools = Arc::clone(&cached_tools);
         let downstream_dirty = Arc::clone(&downstream_dirty);
         let server_handler = Arc::clone(&server_handler);
-        let profile = profile.clone();
+        let profile = Arc::clone(&profile);
         std::thread::spawn(move || {
             let reg = registry
                 .lock()
                 .unwrap_or_else(std::sync::PoisonError::into_inner)
                 .clone();
-            let built = build_router(
-                &reg,
-                profile.as_deref(),
-                http_mode,
-                &downstream_dirty,
-                server_handler,
-            );
+            let p = profile
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .clone();
+            let built = build_router(&reg, p.as_deref(), http_mode, &downstream_dirty, server_handler);
             let tools = built.aggregated_tools();
             glog(&format!(
                 "background build: {} tools from {} servers",
@@ -4981,7 +5091,7 @@ fn main() {
                 *cached_tools
                     .lock()
                     .unwrap_or_else(std::sync::PoisonError::into_inner) = tools.clone();
-                save_tool_cache(&tools, profile.as_deref());
+                save_tool_cache(&tools, p.as_deref());
             } else {
                 glog("background build was empty; keeping previous tool cache");
             }
@@ -4997,7 +5107,9 @@ fn main() {
         let cached_tools = Arc::clone(&cached_tools);
         let downstream_dirty = Arc::clone(&downstream_dirty);
         let server_handler = Arc::clone(&server_handler);
-        let profile = profile.clone();
+        let profile = Arc::clone(&profile);
+        let client_id = client_id.clone();
+        let env_profile = env_profile.clone();
         std::thread::spawn(move || {
             watch_registry(
                 path,
@@ -5006,6 +5118,8 @@ fn main() {
                 stdout,
                 cached_tools,
                 profile,
+                client_id,
+                env_profile,
                 http_mode,
                 downstream_dirty,
                 server_handler,
@@ -5022,7 +5136,7 @@ fn main() {
         downstream_dirty: Arc::clone(&downstream_dirty),
         rebuild_lock: Arc::new(Mutex::new(())),
         lazy,
-        profile: profile.clone(),
+        profile: Arc::clone(&profile),
         http: http_mode,
         mcp_sessions,
         client_upstream,
@@ -5123,6 +5237,84 @@ fn main() {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn resolve_live_profile_prefers_client_scope_over_frozen_env_var() {
+        // The bug: a scoped client's profile used to be frozen at CONDUIT_PROFILE
+        // for the process lifetime. Once client_scopes has an entry for this
+        // client, it must win - that's what makes a profile switch apply without
+        // restarting the client.
+        let mut reg = Registry::default();
+        reg.set_client_scope("cursor", Some("Billing"));
+        let env_profile = Some("Default".to_string());
+        assert_eq!(
+            resolve_live_profile(&reg, Some("cursor"), &env_profile),
+            Some("Billing".to_string())
+        );
+    }
+
+    #[test]
+    fn resolve_live_profile_falls_back_to_env_var_when_scope_unset() {
+        // A client_id with no client_scopes entry yet (e.g. installed before
+        // CONDUIT_CLIENT_ID existed, or never re-scoped) keeps the bootstrap value.
+        let reg = Registry::default();
+        let env_profile = Some("Default".to_string());
+        assert_eq!(
+            resolve_live_profile(&reg, Some("cursor"), &env_profile),
+            Some("Default".to_string())
+        );
+    }
+
+    #[test]
+    fn resolve_live_profile_explicit_unscope_overrides_frozen_env_var() {
+        // Re-scoping a client to "all servers" records an explicit-unscoped marker
+        // (empty string), which must resolve to None (follow the active profile)
+        // rather than falling back to the CONDUIT_PROFILE this process booted with.
+        // Without this, switching from a named profile to unscoped wouldn't apply
+        // until the client restarted.
+        let mut reg = Registry::default();
+        reg.set_client_unscoped("cursor");
+        let env_profile = Some("Billing".to_string());
+        assert_eq!(resolve_live_profile(&reg, Some("cursor"), &env_profile), None);
+    }
+
+    #[test]
+    fn resolve_live_profile_ignores_other_clients_scopes() {
+        let mut reg = Registry::default();
+        reg.set_client_scope("windsurf", Some("Billing"));
+        let env_profile = Some("Default".to_string());
+        assert_eq!(
+            resolve_live_profile(&reg, Some("cursor"), &env_profile),
+            Some("Default".to_string())
+        );
+    }
+
+    #[test]
+    fn resolve_live_profile_unscoped_client_always_uses_env_profile() {
+        // No client_id at all (unscoped install): never consult client_scopes.
+        // This path already resolves the active profile live elsewhere, via
+        // Registry::enabled_servers().
+        let mut reg = Registry::default();
+        reg.set_client_scope("cursor", Some("Billing"));
+        assert_eq!(resolve_live_profile(&reg, None, &None), None);
+    }
+
+    #[test]
+    fn resolve_live_profile_switch_takes_effect_on_next_resolution() {
+        // Simulates a profile switch mid-session: same client_id, registry
+        // mutated in place (as the watcher would see across two poll ticks).
+        let mut reg = Registry::default();
+        reg.set_client_scope("cursor", Some("Billing"));
+        assert_eq!(
+            resolve_live_profile(&reg, Some("cursor"), &None),
+            Some("Billing".to_string())
+        );
+        reg.set_client_scope("cursor", Some("Engineering"));
+        assert_eq!(
+            resolve_live_profile(&reg, Some("cursor"), &None),
+            Some("Engineering".to_string())
+        );
+    }
 
     #[test]
     fn capture_client_upstream_records_roots_sampling_and_elicitation() {
@@ -5271,7 +5463,7 @@ mod tests {
             downstream_dirty: Arc::new(AtomicU8::new(0)),
             rebuild_lock: Arc::new(Mutex::new(())),
             lazy,
-            profile: None,
+            profile: Arc::new(Mutex::new(None)),
             http: true,
             mcp_sessions,
             client_upstream,
@@ -5650,6 +5842,59 @@ mod tests {
         assert!(scoped.contains("bravo"));
         assert!(!scoped.contains("alpha"));
         assert!(!scoped.contains("alpha-cmd"));
+    }
+
+    #[test]
+    fn status_flags_enabled_servers_that_expose_no_tools() {
+        let mut reg = Registry::default();
+        for id in ["github", "atlassian"] {
+            reg.servers.push(ServerEntry {
+                id: id.into(),
+                name: id.into(),
+                transport: "http".into(),
+                command: None,
+                args: vec![],
+                env: vec![],
+                url: Some(format!("https://mcp.{id}.example/mcp")),
+                source: None,
+                disabled_tools: vec![],
+            });
+            reg.set_server_enabled("default", id, true).unwrap();
+        }
+        // Catalog has loaded (github contributed tools) but atlassian is silent -
+        // the classic "connected but unauthed" case (e.g. OAuth not completed).
+        let cached = vec![
+            json!({ "name": "github__list_repos" }),
+            json!({ "name": "github__create_issue" }),
+        ];
+        let out = enabled_summary(&reg, &cached, None, None);
+        assert!(out.contains("github: 2 tool(s)"));
+        assert!(out.contains("Enabled but exposing 0 tools"));
+        // The silent server is named under the hint; the one with tools is not.
+        let hint = out.split("Enabled but exposing 0 tools").nth(1).unwrap();
+        assert!(hint.contains("atlassian"));
+        assert!(!hint.contains("github"));
+    }
+
+    #[test]
+    fn status_omits_zero_tool_hint_before_catalog_populates() {
+        // Before any server has produced tools (empty catalog = still connecting),
+        // the hint must stay silent - otherwise every server reads as "0 tools".
+        let mut reg = Registry::default();
+        reg.servers.push(ServerEntry {
+            id: "github".into(),
+            name: "github".into(),
+            transport: "http".into(),
+            command: None,
+            args: vec![],
+            env: vec![],
+            url: Some("https://mcp.github.example/mcp".into()),
+            source: None,
+            disabled_tools: vec![],
+        });
+        reg.set_server_enabled("default", "github", true).unwrap();
+        let out = enabled_summary(&reg, &[], None, None);
+        assert!(!out.contains("Enabled but exposing 0 tools"));
     }
 
     #[test]

--- a/src-tauri/src/clients.rs
+++ b/src-tauri/src/clients.rs
@@ -1883,12 +1883,17 @@ fn write_yaml_extensions(path: &Path, servers: &[ServerEntry]) -> Result<(), Str
     atomic_write(path, &out)
 }
 
-fn edit_yaml_gateway(path: &Path, install: bool, profile: Option<&str>) -> Result<(), String> {
+fn edit_yaml_gateway(
+    path: &Path,
+    install: bool,
+    profile: Option<&str>,
+    client_id: &str,
+) -> Result<(), String> {
     let mut root = read_existing_yaml(path)?;
     let exts = yaml_extensions_mut(&mut root);
     let key = serde_yaml::Value::String(GATEWAY_ENTRY_NAME.into());
     if install {
-        exts.insert(key, entry_to_goose_yaml(&gateway_entry(profile)?));
+        exts.insert(key, entry_to_goose_yaml(&gateway_entry(profile, client_id)?));
     } else {
         exts.remove(&key);
     }
@@ -2039,6 +2044,7 @@ fn edit_continue_yaml_gateway(
     path: &Path,
     install: bool,
     profile: Option<&str>,
+    client_id: &str,
 ) -> Result<(), String> {
     let mut root = read_existing_yaml(path)?;
 
@@ -2053,7 +2059,7 @@ fn edit_continue_yaml_gateway(
     });
 
     if install {
-        servers.push(entry_to_continue_yaml(&gateway_entry(profile)?));
+        servers.push(entry_to_continue_yaml(&gateway_entry(profile, client_id)?));
     }
 
     let out = serde_yaml::to_string(&root).map_err(|e| e.to_string())?;
@@ -2229,12 +2235,16 @@ fn edit_hermes_yaml_gateway(
     path: &Path,
     install: bool,
     profile: Option<&str>,
+    client_id: &str,
 ) -> Result<(), String> {
     let mut root = read_existing_hermes_yaml(path)?;
     let mcp_servers = hermes_mcp_servers_mut(&mut root);
     let key = serde_yaml::Value::String(GATEWAY_ENTRY_NAME.into());
     if install {
-        mcp_servers.insert(key, entry_to_hermes_yaml(&gateway_entry(profile)?));
+        mcp_servers.insert(
+            key,
+            entry_to_hermes_yaml(&gateway_entry(profile, client_id)?),
+        );
     } else {
         mcp_servers.remove(&key);
     }
@@ -2381,7 +2391,7 @@ fn stable_gateway_copy(src: &std::path::Path) -> Option<PathBuf> {
     Some(dest)
 }
 
-fn gateway_entry(profile: Option<&str>) -> Result<ServerEntry, String> {
+fn gateway_entry(profile: Option<&str>, client_id: &str) -> Result<ServerEntry, String> {
     let path = resolve_gateway_path().ok_or("Could not locate the toolport-gateway binary")?;
     let env_var = |k: &str, v: &str| crate::registry::EnvVar {
         key: k.to_string(),
@@ -2394,8 +2404,19 @@ fn gateway_entry(profile: Option<&str>) -> Result<ServerEntry, String> {
     // gateway (e.g. Antigravity), where a config env would never take effect.
     // Only per-client profile scoping needs an env var.
     let mut env: Vec<crate::registry::EnvVar> = Vec::new();
-    // Optionally scope this client to one profile, so it only ever sees that
-    // slice of servers (no cross-domain tool ambiguity).
+    // Always identify the client. The gateway re-resolves this client's live
+    // profile from registry.client_scopes[CONDUIT_CLIENT_ID] on every reload, so
+    // every re-scope applies without restarting the client - scoped->scoped,
+    // scoped->unscoped, AND unscoped->scoped (an unscoped install still carries
+    // its id, and its empty-string scope marker just resolves to "follow the
+    // active profile" until it's given a named one). A client installed before
+    // this env var existed simply has no CONDUIT_CLIENT_ID until its next
+    // reinstall and falls back to CONDUIT_PROFILE meanwhile. See
+    // docs/drafts/profile-switch-live-reload-plan.md.
+    env.push(env_var("CONDUIT_CLIENT_ID", client_id));
+    // CONDUIT_PROFILE is only the *initial* value for a scoped install; once the
+    // registry loads, the live client_scopes entry wins. Unscoped installs omit
+    // it (and record an empty-string scope marker via set_client_unscoped).
     if let Some(p) = profile.map(str::trim).filter(|p| !p.is_empty()) {
         env.push(env_var("CONDUIT_PROFILE", p));
     }
@@ -2418,6 +2439,7 @@ fn edit_json_gateway(
     install: bool,
     profile: Option<&str>,
     lenient: bool,
+    client_id: &str,
 ) -> Result<(), String> {
     let mut root = if path.exists() {
         let content = read_config_file(path)?;
@@ -2439,7 +2461,7 @@ fn edit_json_gateway(
     if install {
         servers.insert(
             GATEWAY_ENTRY_NAME.to_string(),
-            entry_to_json(&gateway_entry(profile)?),
+            entry_to_json(&gateway_entry(profile, client_id)?),
         );
     } else {
         servers.remove(GATEWAY_ENTRY_NAME);
@@ -2449,7 +2471,12 @@ fn edit_json_gateway(
     atomic_write(path, &out)
 }
 
-fn edit_toml_gateway(path: &Path, install: bool, profile: Option<&str>) -> Result<(), String> {
+fn edit_toml_gateway(
+    path: &Path,
+    install: bool,
+    profile: Option<&str>,
+    client_id: &str,
+) -> Result<(), String> {
     let mut root = if path.exists() {
         let content = read_config_file(path)?;
         read_existing_toml(&content)?
@@ -2478,7 +2505,7 @@ fn edit_toml_gateway(path: &Path, install: bool, profile: Option<&str>) -> Resul
     if install {
         servers.insert(
             GATEWAY_ENTRY_NAME.to_string(),
-            entry_to_toml(&gateway_entry(profile)?),
+            entry_to_toml(&gateway_entry(profile, client_id)?),
         );
     } else {
         servers.remove(GATEWAY_ENTRY_NAME);
@@ -2512,16 +2539,20 @@ fn install_or_remove(
     let lenient = config_is_whole_app_state(client_id);
     match def.format {
         Format::JsonMcpServers => {
-            edit_json_gateway(&path, "mcpServers", install, profile, lenient)?
+            edit_json_gateway(&path, "mcpServers", install, profile, lenient, client_id)?
         }
-        Format::JsonServers => edit_json_gateway(&path, "servers", install, profile, lenient)?,
+        Format::JsonServers => {
+            edit_json_gateway(&path, "servers", install, profile, lenient, client_id)?
+        }
         Format::JsonContextServers => {
-            edit_json_gateway(&path, "context_servers", install, profile, true)?
+            edit_json_gateway(&path, "context_servers", install, profile, true, client_id)?
         }
-        Format::TomlMcpServers => edit_toml_gateway(&path, install, profile)?,
-        Format::YamlExtensions => edit_yaml_gateway(&path, install, profile)?,
-        Format::YamlMcpServers => edit_hermes_yaml_gateway(&path, install, profile)?,
-        Format::YamlMcpServersList => edit_continue_yaml_gateway(&path, install, profile)?,
+        Format::TomlMcpServers => edit_toml_gateway(&path, install, profile, client_id)?,
+        Format::YamlExtensions => edit_yaml_gateway(&path, install, profile, client_id)?,
+        Format::YamlMcpServers => edit_hermes_yaml_gateway(&path, install, profile, client_id)?,
+        Format::YamlMcpServersList => {
+            edit_continue_yaml_gateway(&path, install, profile, client_id)?
+        }
     }
     Ok(WriteOutcome {
         path: path.display().to_string(),
@@ -2545,7 +2576,7 @@ pub fn uninstall_gateway(client_id: &str) -> Result<WriteOutcome, String> {
 /// the client talking only to the gateway. Backs up first; unrelated config keys
 /// are preserved. Caller is responsible for importing first so nothing is lost.
 pub fn migrate_to_gateway(client_id: &str, profile: Option<&str>) -> Result<WriteOutcome, String> {
-    write_servers(client_id, &[gateway_entry(profile)?])
+    write_servers(client_id, &[gateway_entry(profile, client_id)?])
 }
 
 /// Whether a client's stored gateway command should be re-pointed: it names the
@@ -2920,7 +2951,7 @@ bad = "not-a-table"
         )
         .unwrap();
 
-        edit_json_gateway(&path, "mcpServers", true, Some("Billing"), false).unwrap();
+        edit_json_gateway(&path, "mcpServers", true, Some("Billing"), false, "claude-code").unwrap();
         let root: serde_json::Value =
             serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
         let servers = root["mcpServers"].as_object().unwrap();
@@ -2934,13 +2965,40 @@ bad = "not-a-table"
         assert_eq!(root["theme"], "dark");
         assert_eq!(servers["existing"]["env"]["SECRET"], "keepme");
 
-        edit_json_gateway(&path, "mcpServers", false, None, false).unwrap();
+        edit_json_gateway(&path, "mcpServers", false, None, false, "claude-code").unwrap();
         let root2: serde_json::Value =
             serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
         let servers2 = root2["mcpServers"].as_object().unwrap();
         assert!(!servers2.contains_key("conduit"));
         assert!(servers2.contains_key("existing"));
         std::fs::remove_file(&path).ok();
+    }
+
+    #[test]
+    fn scoped_install_writes_client_id_for_live_profile_resolution() {
+        // A scoped install must carry CONDUIT_CLIENT_ID alongside CONDUIT_PROFILE,
+        // so the running gateway can re-resolve this client's profile live from
+        // registry.client_scopes instead of trusting a frozen env var forever.
+        let entry = gateway_entry(Some("Billing"), "cursor").unwrap();
+        let env: std::collections::HashMap<_, _> = entry
+            .env
+            .iter()
+            .map(|e| (e.key.clone(), e.value.clone()))
+            .collect();
+        assert_eq!(env.get("CONDUIT_PROFILE").unwrap().as_deref(), Some("Billing"));
+        assert_eq!(env.get("CONDUIT_CLIENT_ID").unwrap().as_deref(), Some("cursor"));
+
+        // Unscoped installs still carry CONDUIT_CLIENT_ID (so the client can be
+        // re-scoped to a named profile live later, without a restart) but omit
+        // CONDUIT_PROFILE - the gateway resolves the active profile live for them.
+        let unscoped = gateway_entry(None, "cursor").unwrap();
+        let uenv: std::collections::HashMap<_, _> = unscoped
+            .env
+            .iter()
+            .map(|e| (e.key.clone(), e.value.clone()))
+            .collect();
+        assert_eq!(uenv.get("CONDUIT_CLIENT_ID").unwrap().as_deref(), Some("cursor"));
+        assert!(uenv.get("CONDUIT_PROFILE").is_none());
     }
 
     // Informational (no assert): prints what the Cursor plugin scanner finds on
@@ -3071,7 +3129,7 @@ bad = "not-a-table"
         assert_eq!(parsed[0].name, "existing");
 
         // Installing preserves the unrelated key and the existing server.
-        edit_json_gateway(&path, "context_servers", true, None, true).unwrap();
+        edit_json_gateway(&path, "context_servers", true, None, true, "zed").unwrap();
         let root: serde_json::Value =
             serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
         assert_eq!(root["ui_font_size"], 16);
@@ -3087,7 +3145,7 @@ bad = "not-a-table"
         let garbage = "this is not json or json5 at all {{{";
         std::fs::write(&path, garbage).unwrap();
         // A lenient edit must ERROR, never replace the file with an empty object.
-        assert!(edit_json_gateway(&path, "context_servers", true, None, true).is_err());
+        assert!(edit_json_gateway(&path, "context_servers", true, None, true, "zed").is_err());
         assert_eq!(std::fs::read_to_string(&path).unwrap(), garbage);
         std::fs::remove_file(&path).ok();
     }
@@ -3108,7 +3166,7 @@ bad = "not-a-table"
         let path = std::env::temp_dir().join(format!("conduit-claude-{}.json", std::process::id()));
         let garbage = "{ \"projects\": {}, \"oauthAccount\": broken not json";
         std::fs::write(&path, garbage).unwrap();
-        assert!(edit_json_gateway(&path, "mcpServers", true, None, true).is_err());
+        assert!(edit_json_gateway(&path, "mcpServers", true, None, true, "claude-code").is_err());
         assert_eq!(std::fs::read_to_string(&path).unwrap(), garbage);
         std::fs::remove_file(&path).ok();
     }
@@ -3121,7 +3179,7 @@ bad = "not-a-table"
         let path = std::env::temp_dir().join(format!("conduit-bad-{}.toml", std::process::id()));
         let garbage = "model = \"o3\"\n[[[ this is not valid toml";
         std::fs::write(&path, garbage).unwrap();
-        assert!(edit_toml_gateway(&path, true, None).is_err());
+        assert!(edit_toml_gateway(&path, true, None, "codex").is_err());
         assert_eq!(std::fs::read_to_string(&path).unwrap(), garbage);
         std::fs::remove_file(&path).ok();
     }
@@ -3135,7 +3193,7 @@ bad = "not-a-table"
             "model = \"o3\"\napproval_policy = \"on-request\"\n\n[profiles.work]\nmodel = \"gpt-5\"\n",
         )
         .unwrap();
-        edit_toml_gateway(&path, true, None).unwrap();
+        edit_toml_gateway(&path, true, None, "codex").unwrap();
         let v: toml::Value = toml::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
         assert_eq!(v.get("model").and_then(|x| x.as_str()), Some("o3"));
         assert_eq!(
@@ -3200,7 +3258,7 @@ bad = "not-a-table"
         assert_eq!(parsed[0].transport, "stdio");
 
         // Installing the gateway preserves the model key and the existing extension.
-        edit_yaml_gateway(&path, true, None).unwrap();
+        edit_yaml_gateway(&path, true, None, "goose").unwrap();
         let v: serde_yaml::Value =
             serde_yaml::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
         assert_eq!(
@@ -3215,7 +3273,7 @@ bad = "not-a-table"
         assert!(conduit.get("cmd").and_then(|x| x.as_str()).is_some());
 
         // Uninstall removes only conduit.
-        edit_yaml_gateway(&path, false, None).unwrap();
+        edit_yaml_gateway(&path, false, None, "goose").unwrap();
         let after: serde_yaml::Value =
             serde_yaml::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
         let exts2 = after
@@ -3233,7 +3291,7 @@ bad = "not-a-table"
         let garbage = "key: value\n  - [unbalanced flow sequence\n:::not valid";
         std::fs::write(&path, garbage).unwrap();
         // A parse failure must error, never replace config.yaml (it holds model config).
-        assert!(edit_yaml_gateway(&path, true, None).is_err());
+        assert!(edit_yaml_gateway(&path, true, None, "goose").is_err());
         assert_eq!(std::fs::read_to_string(&path).unwrap(), garbage);
         std::fs::remove_file(&path).ok();
     }
@@ -3294,7 +3352,7 @@ bad = "not-a-table"
         assert_eq!(parsed[0].env_keys, vec!["Authorization".to_string()]);
 
         // Installing the gateway preserves the model key and the existing server.
-        edit_hermes_yaml_gateway(&path, true, None).unwrap();
+        edit_hermes_yaml_gateway(&path, true, None, "hermes").unwrap();
         let v: serde_yaml::Value =
             serde_yaml::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
         assert_eq!(
@@ -3309,7 +3367,7 @@ bad = "not-a-table"
         assert!(conduit.get("command").and_then(|x| x.as_str()).is_some());
 
         // Uninstall removes only conduit.
-        edit_hermes_yaml_gateway(&path, false, None).unwrap();
+        edit_hermes_yaml_gateway(&path, false, None, "hermes").unwrap();
         let after: serde_yaml::Value =
             serde_yaml::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
         let servers2 = after
@@ -3327,7 +3385,7 @@ bad = "not-a-table"
         let garbage = "key: value\n  - [unbalanced flow sequence\n:::not valid";
         std::fs::write(&path, garbage).unwrap();
         // A parse failure must error, never replace config.yaml (it holds model config).
-        assert!(edit_hermes_yaml_gateway(&path, true, None).is_err());
+        assert!(edit_hermes_yaml_gateway(&path, true, None, "hermes").is_err());
         assert_eq!(std::fs::read_to_string(&path).unwrap(), garbage);
         std::fs::remove_file(&path).ok();
     }

--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -417,6 +417,42 @@ fn server_from_detected(server: &clients::McpServer, client_id: &str) -> ServerE
     }
 }
 
+/// Servers to add to the registry from a set of detected clients: both a
+/// client's main config servers and its plugin-detected ones (e.g. Cursor/Roo
+/// project-level scans), skipping the gateway's own entry and anything whose
+/// name already exists (checked against `existing` plus whatever this same
+/// call has already picked, so duplicate names across clients collapse to one).
+/// The onboarding banner promises a count across both server sources (see
+/// `importableServers` in `src/lib/types.ts`), so this must actually cover
+/// both or it silently under-imports relative to what was promised.
+fn servers_to_import(detected: &[clients::DetectedClient], existing: &Registry) -> Vec<ServerEntry> {
+    let mut picked: Vec<ServerEntry> = Vec::new();
+    let mut names: std::collections::HashSet<String> = existing
+        .servers
+        .iter()
+        .map(|s| s.name.to_lowercase())
+        .collect();
+    for client in detected {
+        for server in client.servers.iter().chain(client.plugin_servers.iter()) {
+            let entry = server_from_detected(server, &client.id);
+            // Recognize the gateway by command path too, not just the "conduit"
+            // name: an entry registered under any other name (a leftover from
+            // before the rename, a manual add, whatever) still points straight
+            // at our own binary, and importing it risks the gateway proxying
+            // itself. See is_gateway_server's doc comment - this is the exact
+            // contract it promises but this call site wasn't honoring.
+            if clients::is_gateway_server(&entry) {
+                continue;
+            }
+            let key = entry.name.to_lowercase();
+            if names.insert(key) {
+                picked.push(entry);
+            }
+        }
+    }
+    picked
+}
+
 /// Pull servers from every detected client into the registry, skipping any whose
 /// name already exists.
 #[tauri::command]
@@ -425,20 +461,8 @@ async fn import_servers(state: State<'_, RegistryState>) -> Result<Registry, Str
         .await
         .map_err(|e| e.to_string())?;
     let mut reg = state.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
-    for client in &detected {
-        for server in &client.servers {
-            // Never import our own gateway entry (it would recurse).
-            if server.name.eq_ignore_ascii_case(clients::GATEWAY_ENTRY_NAME) {
-                continue;
-            }
-            let exists = reg
-                .servers
-                .iter()
-                .any(|e| e.name.eq_ignore_ascii_case(&server.name));
-            if !exists {
-                reg.add_server(server_from_detected(server, &client.id));
-            }
-        }
+    for server in servers_to_import(&detected, &reg) {
+        reg.add_server(server);
     }
     registry::save(&reg)?;
     Ok(reg.clone())
@@ -591,8 +615,14 @@ fn install_gateway(
     let outcome = clients::install_gateway(&client_id, profile.as_deref())?;
     // Record the scope we just wrote into the client's config, so the UI can show
     // and re-apply this client's effective scope without re-reading the config.
+    // A concrete profile is stored by name; "no profile" is recorded as an
+    // explicit-unscoped marker (not a removal) so a running gateway drops its old
+    // scope live instead of falling back to its boot-time CONDUIT_PROFILE.
     let mut reg = state.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
-    reg.set_client_scope(&client_id, profile.as_deref());
+    match profile.as_deref().map(str::trim).filter(|p| !p.is_empty()) {
+        Some(p) => reg.set_client_scope(&client_id, Some(p)),
+        None => reg.set_client_unscoped(&client_id),
+    }
     registry::save(&reg)?;
     Ok(outcome)
 }
@@ -716,9 +746,14 @@ async fn migrate_client(
     clients::migrate_to_gateway(&client_id, profile.as_deref())?;
 
     // Record the scope now that the client config was rewritten to the gateway.
+    // "No profile" becomes an explicit-unscoped marker (not a removal) so a live
+    // re-scope to "all servers" applies without restarting the client.
     let registry = {
         let mut reg = state.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
-        reg.set_client_scope(&client_id, profile.as_deref());
+        match profile.as_deref().map(str::trim).filter(|p| !p.is_empty()) {
+            Some(p) => reg.set_client_scope(&client_id, Some(p)),
+            None => reg.set_client_unscoped(&client_id),
+        }
         registry::save(&reg)?;
         reg.clone()
     };
@@ -2638,6 +2673,106 @@ mod tests {
             source: None,
             disabled_tools: vec![],
         }
+    }
+
+    fn detected_mcp_server(name: &str) -> clients::McpServer {
+        clients::McpServer {
+            name: name.into(),
+            transport: "stdio".into(),
+            command: Some("x".into()),
+            args: vec![],
+            env_keys: vec![],
+            url: None,
+        }
+    }
+
+    fn detected_mcp_server_with_command(name: &str, command: &str) -> clients::McpServer {
+        clients::McpServer {
+            command: Some(command.into()),
+            ..detected_mcp_server(name)
+        }
+    }
+
+    fn detected_client(id: &str, servers: Vec<&str>, plugin_servers: Vec<&str>) -> clients::DetectedClient {
+        clients::DetectedClient {
+            id: id.into(),
+            name: id.into(),
+            uses_connectors: false,
+            config_path: String::new(),
+            config_exists: true,
+            app_present: true,
+            servers: servers.into_iter().map(detected_mcp_server).collect(),
+            plugin_servers: plugin_servers.into_iter().map(detected_mcp_server).collect(),
+            gateway_installed: false,
+            error: None,
+        }
+    }
+
+    #[test]
+    fn servers_to_import_includes_plugin_detected_servers() {
+        // The onboarding banner promises a count across BOTH client.servers and
+        // client.plugin_servers (see importableServers in src/lib/types.ts); the
+        // import used to only walk client.servers, silently dropping every
+        // plugin-detected one (e.g. Cursor/Roo project-level scans) and leaving
+        // the actual import far short of the promised count.
+        let detected = vec![detected_client(
+            "cursor",
+            vec!["node_repl"],
+            vec!["linear", "github", "figma"],
+        )];
+        let reg = Registry::default();
+        let picked = servers_to_import(&detected, &reg);
+        let names: std::collections::HashSet<_> =
+            picked.iter().map(|s| s.name.to_lowercase()).collect();
+        assert_eq!(names.len(), 4);
+        assert!(names.contains("node_repl"));
+        assert!(names.contains("linear"));
+        assert!(names.contains("github"));
+        assert!(names.contains("figma"));
+    }
+
+    #[test]
+    fn servers_to_import_dedupes_by_name_across_clients_and_sources() {
+        let detected = vec![
+            detected_client("cursor", vec!["Linear"], vec!["linear"]),
+            detected_client("claude-code", vec!["linear"], vec![]),
+        ];
+        let reg = Registry::default();
+        let picked = servers_to_import(&detected, &reg);
+        assert_eq!(picked.len(), 1);
+        assert_eq!(picked[0].name.to_lowercase(), "linear");
+    }
+
+    #[test]
+    fn servers_to_import_skips_existing_and_own_gateway_entry() {
+        let detected = vec![detected_client(
+            "cursor",
+            vec!["already-here", clients::GATEWAY_ENTRY_NAME],
+            vec!["new-one"],
+        )];
+        let mut reg = Registry::default();
+        reg.add_server(plain_server("x", "already-here"));
+        let picked = servers_to_import(&detected, &reg);
+        assert_eq!(picked.len(), 1);
+        assert_eq!(picked[0].name, "new-one");
+    }
+
+    #[test]
+    fn servers_to_import_skips_gateway_registered_under_a_different_name() {
+        // Regression: a real config had the gateway entry named "toolport"
+        // (not "conduit"), pointing at toolport-gateway.exe - a leftover from
+        // before the rename or a manual add. The name-only check let it through
+        // and imported the gateway as if it were a normal downstream server,
+        // which risks the gateway proxying itself if ever enabled.
+        let mut client = detected_client("claude-code", vec!["linear"], vec![]);
+        client.servers.push(detected_mcp_server_with_command(
+            "toolport",
+            r"C:\Users\x\AppData\Local\Toolport\toolport-gateway.exe",
+        ));
+        let reg = Registry::default();
+        let picked = servers_to_import(&[client], &reg);
+        assert_eq!(picked.len(), 1);
+        assert_eq!(picked[0].name.to_lowercase(), "linear");
     }
 
     #[test]

--- a/src-tauri/src/registry.rs
+++ b/src-tauri/src/registry.rs
@@ -839,6 +839,22 @@ impl Registry {
         }
     }
 
+    /// Record that a client is *explicitly* unscoped: it follows the active
+    /// profile (the full connected set), and we want that to apply live. This is
+    /// deliberately distinct from having no entry at all: an empty-string marker
+    /// means "follow the active profile now", so a running gateway can drop its
+    /// previous scope on the next reload; a missing entry means "no recorded
+    /// scope, fall back to the CONDUIT_PROFILE this process booted with" (e.g. an
+    /// install from before CONDUIT_CLIENT_ID existed). Without this distinction,
+    /// re-scoping a client from a named profile to "all servers" wouldn't take
+    /// effect until the client restarted. The frontend already reads a missing
+    /// or empty scope identically (`clientScopes?.[id] ?? ""`), so this needs no
+    /// UI change.
+    pub fn set_client_unscoped(&mut self, client_id: &str) {
+        self.client_scopes
+            .insert(client_id.to_string(), String::new());
+    }
+
     /// Find the registered HTTP client whose stored hash matches `token`'s
     /// SHA-256, if any. The bridge uses this to resolve a bearer to its scope.
     pub fn http_client_for_token(&self, token: &str) -> Option<&HttpClient> {
@@ -1375,6 +1391,22 @@ mod tests {
         r.set_client_scope("claude", Some("Work"));
         r.set_client_scope("claude", None);
         assert!(!r.client_scopes.contains_key("claude"));
+    }
+
+    #[test]
+    fn explicit_unscoped_is_distinct_from_no_entry() {
+        let mut r = Registry::default();
+        // Explicit-unscoped is recorded as an empty-string entry, NOT a removal, so
+        // the gateway can tell "follow the active profile now" (present, empty)
+        // apart from "no recorded scope, fall back to boot env" (absent).
+        r.set_client_unscoped("cursor");
+        assert_eq!(r.client_scopes.get("cursor").map(String::as_str), Some(""));
+        assert!(r.client_scopes.contains_key("cursor"));
+        // Re-scoping to a named profile replaces the marker; uninstall clears it.
+        r.set_client_scope("cursor", Some("Billing"));
+        assert_eq!(r.client_scopes.get("cursor").map(String::as_str), Some("Billing"));
+        r.set_client_scope("cursor", None);
+        assert!(!r.client_scopes.contains_key("cursor"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Three related improvements to the per-client gateway, from a session that started as a "why can't this client see server X" investigation.

**Live per-client profile scoping.** The gateway re-resolves each client's profile from `registry.client_scopes` on every reload (keyed by `CONDUIT_CLIENT_ID`, now written for every install), so re-scoping a client applies live, without a restart: scoped->scoped, scoped->unscoped, and unscoped->scoped. Adds `Registry::set_client_unscoped` to record an explicit-unscoped marker distinct from "no recorded scope".

**Diagnostics.** The registry watcher logs each profile transition with server and tool counts (the single most useful line when diagnosing which profile a client is actually on). `toolport_status` now flags enabled servers that expose 0 tools (the classic connected-but-unauthenticated case, e.g. an OAuth server not yet signed into), guarded so it stays quiet while the catalog is still populating.

**Import fix.** `servers_to_import` now also imports plugin-detected servers (Cursor/Roo project-level scans) and recognizes the gateway by command path, not just by name, so a renamed leftover gateway entry can't be imported and proxy itself.

## Test plan

- [x] `cargo test --lib` (332 pass) and `cargo test --bin toolport-gateway` (86 pass)
- [x] Release gateway build: `cargo build --release --bin toolport-gateway --no-default-features`
- [x] Verified live: switching a client to a scoped profile applied without a restart (only the scoped server appeared)
- [x] Deadlock review: the new `profile` mutex is a leaf lock, never held across `build_router` or the registry/router locks
