### PR TITLE
fix(registry): preserve unknown per-server fields on re-save (#234)

### DIFF
--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -5824,6 +5824,7 @@ mod tests {
                 url: None,
                 source: None,
                 disabled_tools: vec![],
+                unknown_fields: serde_json::Map::new(),
             });
         }
         // alpha is in the active (default) profile; bravo only in a separate one.
@@ -5858,6 +5859,7 @@ mod tests {
                 url: Some(format!("https://mcp.{id}.example/mcp")),
                 source: None,
                 disabled_tools: vec![],
+                unknown_fields: serde_json::Map::new(),
             });
             reg.set_server_enabled("default", id, true).unwrap();
         }
@@ -5891,6 +5893,7 @@ mod tests {
             url: Some("https://mcp.github.example/mcp".into()),
             source: None,
             disabled_tools: vec![],
+            unknown_fields: serde_json::Map::new(),
         });
         reg.set_server_enabled("default", "github", true).unwrap();
         let out = enabled_summary(&reg, &[], None, None);
@@ -6621,6 +6624,7 @@ mod tests {
             url: None,
             source: None,
             disabled_tools: vec![],
+            unknown_fields: serde_json::Map::new(),
         });
         reg.set_server_enabled("default", &id, true).unwrap();
 

--- a/src-tauri/src/clients.rs
+++ b/src-tauri/src/clients.rs
@@ -2430,6 +2430,7 @@ fn gateway_entry(profile: Option<&str>, client_id: &str) -> Result<ServerEntry, 
         url: None,
         source: Some("conduit".to_string()),
         disabled_tools: Vec::new(),
+        unknown_fields: serde_json::Map::new(),
     })
 }
 
@@ -2756,6 +2757,7 @@ mod tests {
             url: None,
             source: None,
             disabled_tools: vec![],
+            unknown_fields: serde_json::Map::new(),
         }
     }
 

--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -414,6 +414,7 @@ fn server_from_detected(server: &clients::McpServer, client_id: &str) -> ServerE
         url: server.url.clone(),
         source: Some(format!("imported:{client_id}")),
         disabled_tools: vec![],
+        unknown_fields: serde_json::Map::new(),
     }
 }
 
@@ -2658,6 +2659,7 @@ mod tests {
             url: None,
             source: None,
             disabled_tools: vec![],
+            unknown_fields: serde_json::Map::new(),
         }
     }
 
@@ -2672,6 +2674,7 @@ mod tests {
             url: None,
             source: None,
             disabled_tools: vec![],
+            unknown_fields: serde_json::Map::new(),
         }
     }
 
@@ -2943,6 +2946,7 @@ mod tests {
             url: None,
             source: None,
             disabled_tools: vec![],
+            unknown_fields: serde_json::Map::new(),
         });
 
         let doc = build_export(&reg, Some("Team setup"), Some("Our shared servers"), None);
@@ -3004,6 +3008,7 @@ mod tests {
             url: Some("https://user:hunter2@mcp.example.com/mcp".into()),
             source: None,
             disabled_tools: vec![],
+            unknown_fields: serde_json::Map::new(),
         });
         let doc = build_export(&reg, None, None, None);
         let serialized = serde_json::to_string(&doc).unwrap();
@@ -3042,6 +3047,7 @@ mod tests {
             url: None,
             source: None,
             disabled_tools: vec![],
+            unknown_fields: serde_json::Map::new(),
         });
         let doc = build_export(&reg, None, None, None);
         let serialized = serde_json::to_string(&doc).unwrap();
@@ -3072,6 +3078,7 @@ mod tests {
             url: None,
             source: None,
             disabled_tools: vec![],
+            unknown_fields: serde_json::Map::new(),
         });
         let json = serde_json::to_string(&build_export(&reg, None, None, None)).unwrap();
         let mut recipient = Registry::default();
@@ -3178,6 +3185,7 @@ mod tests {
             url: None,
             source: None,
             disabled_tools: vec![],
+            unknown_fields: serde_json::Map::new(),
         });
         reg.add_server(ServerEntry {
             id: "remote".into(),
@@ -3189,6 +3197,7 @@ mod tests {
             url: Some("https://user:hunter2@mcp.example.com/mcp".into()),
             source: None,
             disabled_tools: vec![],
+            unknown_fields: serde_json::Map::new(),
         });
 
         let s = registry_summary(&reg);

--- a/src-tauri/src/registry.rs
+++ b/src-tauri/src/registry.rs
@@ -83,7 +83,11 @@ pub struct EnvVar {
     pub secret: bool,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+// No `Eq`: the `unknown_fields` flatten map (a serde_json::Map) is only `PartialEq`.
+// Dropping `Eq` is what lets an older binary preserve per-server fields it doesn't
+// recognize on re-save, mirroring the same forward-compat protection already on
+// `Registry`. Nothing keys a set/map by `ServerEntry`, so `Eq` was unused.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct ServerEntry {
     #[serde(default)]
@@ -107,6 +111,11 @@ pub struct ServerEntry {
     /// an empty list means every tool the server advertises is exposed.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub disabled_tools: Vec<String>,
+    /// Per-server fields written by a newer build that this binary doesn't know
+    /// about. Captured on load and re-emitted on save so a mixed-version binary
+    /// never strips them (same contract as `Registry::unknown_fields`).
+    #[serde(flatten)]
+    pub unknown_fields: serde_json::Map<String, serde_json::Value>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -1315,6 +1324,7 @@ mod tests {
             url: None,
             source: Some("manual".to_string()),
             disabled_tools: vec![],
+            unknown_fields: serde_json::Map::new(),
         }
     }
 
@@ -1779,6 +1789,48 @@ mod tests {
         assert_eq!(
             round["someFutureFeature"]["level"], 3,
             "unknown fields must round-trip, not be stripped"
+        );
+
+        std::fs::remove_file(&path).ok();
+        std::fs::remove_file(backup_path(&path)).ok();
+    }
+
+    #[test]
+    fn unknown_server_fields_survive_a_round_trip() {
+        // Same forward-compat contract as the top-level test, at the per-SERVER
+        // level: an older binary loading and re-saving a newer build's registry
+        // must not strip a `ServerEntry` field it doesn't understand.
+        let dir = std::env::temp_dir();
+        let path = dir.join(format!("conduit-reg-srv-fwd-{}.json", std::process::id()));
+        std::fs::remove_file(&path).ok();
+        std::fs::remove_file(backup_path(&path)).ok();
+
+        let mut reg = Registry::default();
+        reg.servers.push(ServerEntry {
+            id: "s1".into(),
+            name: "s1".into(),
+            transport: "stdio".into(),
+            command: Some("x".into()),
+            args: vec![],
+            env: vec![],
+            url: None,
+            source: None,
+            disabled_tools: vec![],
+            unknown_fields: serde_json::Map::new(),
+        });
+        // Inject a per-server field this binary's ServerEntry doesn't define.
+        let mut json = serde_json::to_value(&reg).unwrap();
+        json["servers"][0]["futureServerFlag"] = serde_json::json!({ "enabled": true });
+        std::fs::write(&path, serde_json::to_string(&json).unwrap()).unwrap();
+
+        let loaded = load_from(&path).unwrap();
+        save_to(&path, &loaded).unwrap();
+        let round: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        assert_eq!(
+            round["servers"][0]["futureServerFlag"]["enabled"],
+            true,
+            "unknown per-server fields must round-trip, not be stripped"
         );
 
         std::fs::remove_file(&path).ok();

--- a/src-tauri/src/remote.rs
+++ b/src-tauri/src/remote.rs
@@ -304,6 +304,7 @@ mod tests {
             url: Some(url.into()),
             source: source.map(String::from),
             disabled_tools: vec![],
+            unknown_fields: serde_json::Map::new(),
         }
     }
 

--- a/src-tauri/src/teams.rs
+++ b/src-tauri/src/teams.rs
@@ -778,6 +778,7 @@ fn classify_team_server(s: &Value, tag: &str) -> TeamClass {
         url: None,
         source: Some(tag.to_string()),
         disabled_tools: str_array("disabledTools"),
+        unknown_fields: serde_json::Map::new(),
     };
 
     // A server that runs a local command (stdio, or any command-bearing entry) is the RCE
@@ -884,6 +885,7 @@ mod tests {
             url: None,
             source: Some("manual".into()),
             disabled_tools: vec![],
+            unknown_fields: serde_json::Map::new(),
         });
         let active = r.active_profile_id.clone().unwrap();
         r.profiles
@@ -1127,6 +1129,7 @@ mod tests {
             url: None,
             source: Some("manual".into()),
             disabled_tools: vec![],
+            unknown_fields: serde_json::Map::new(),
         });
         // A team-sourced server: excluded too (don't echo the team's own set back).
         r.servers.push(ServerEntry {
@@ -1139,6 +1142,7 @@ mod tests {
             url: Some("https://example.com/mcp".into()),
             source: Some("team:abc".into()),
             disabled_tools: vec![],
+            unknown_fields: serde_json::Map::new(),
         });
         let cfg = team_export(&r);
         let ids: Vec<&str> = cfg["servers"]


### PR DESCRIPTION
## Summary

Closes #234.

`ServerEntry` now carries a `#[serde(flatten)] unknown_fields` map, mirroring the top-level `Registry` protection added in #224. An older binary that loads and re-saves a newer build's registry no longer silently strips per-server fields it doesn't recognize (mixed versions share this file).

This required dropping `Eq` from `ServerEntry` (a `serde_json::Map` is only `PartialEq`). Audited: nothing keys a set/map by `ServerEntry` and `Registry` already lacks `Eq` for the same reason, so `Eq` was unused.

The 21 `ServerEntry { .. }` construction sites each gained an explicit `unknown_fields: serde_json::Map::new()`.

## Scope

`Profile` and `TeamConnection` have the same latent gap (both derive `Eq`). Left as a deliberate follow-up to keep this change focused on the acceptance criterion.

## Test plan

- [x] New `unknown_server_fields_survive_a_round_trip` test (inject an unknown per-server field, load -> save -> reload, assert it survived)
- [x] `cargo test --lib` (333 pass) and `cargo test --bin toolport-gateway --no-default-features` (86 pass)
- [x] Acceptance: a server entry with an unknown field survives load -> save by a binary that doesn't define the field
