### PR TITLE
fix(app): extract a readable headline from downstream errors (#229)

### DIFF
--- a/src/components/RegistryServerRow.tsx
+++ b/src/components/RegistryServerRow.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { ChevronDown, Copy, KeyRound, LogIn, Pencil, Trash2, Users } from "lucide-react";
 import { isDownloadLauncher } from "@/lib/launcher";
+import { errorHeadline, shortenUrls } from "@/lib/errors";
 import type { ProbeResult, Registry, ServerEntry } from "@/lib/types";
 import { Switch } from "@/components/ui/switch";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
@@ -222,9 +223,18 @@ export function RegistryServerRow({
             </code>
           )}
           {status === "error" && health?.error && (
-            <p className="max-h-32 overflow-y-auto text-xs break-words whitespace-pre-wrap text-warning">
-              {health.error}
-            </p>
+            <div className="flex flex-col gap-1">
+              {/* Lead with a readable headline so the useful signal (exit status,
+                  EADDRINUSE, a 401) isn't buried under a stack trace + a giant
+                  OAuth URL; the full output stays below, bounded and scrollable
+                  with long URLs shortened. */}
+              <p className="text-xs font-medium text-warning">
+                {errorHeadline(health.error)}
+              </p>
+              <p className="max-h-32 overflow-y-auto font-mono text-[11px] break-words whitespace-pre-wrap text-muted-foreground">
+                {shortenUrls(health.error)}
+              </p>
+            </div>
           )}
 
           <div className="flex flex-wrap items-center gap-1">
@@ -319,7 +329,7 @@ function StatusLabel({
       <Tooltip>
         <TooltipTrigger asChild>{text}</TooltipTrigger>
         <TooltipContent side="top" className="max-w-xs">
-          <p className="text-xs text-warning">{error}</p>
+          <p className="text-xs text-warning">{errorHeadline(error)}</p>
         </TooltipContent>
       </Tooltip>
     );

--- a/src/lib/errors.test.ts
+++ b/src/lib/errors.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from "vitest";
+import { errorHeadline, truncateMiddle, shortenUrls } from "./errors";
+
+describe("errorHeadline", () => {
+  it("surfaces EADDRINUSE with the address, past a stack trace", () => {
+    const raw = [
+      "Error: listen EADDRINUSE: address already in use 127.0.0.1:39541",
+      "    at Server.setupListenHandle [as _listen2] (node:net:1817:16)",
+      "    at listenInCluster (node:net:1865:12)",
+    ].join("\n");
+    expect(errorHeadline(raw)).toBe("Port already in use (127.0.0.1:39541)");
+  });
+
+  it("recognizes ENOENT, ECONNREFUSED, timeout, 401, 403", () => {
+    expect(errorHeadline("spawn npx ENOENT")).toBe("Command or file not found (ENOENT)");
+    expect(errorHeadline("connect ECONNREFUSED 127.0.0.1:8080")).toBe(
+      "Connection refused",
+    );
+    expect(errorHeadline("timed out waiting for initialize")).toBe(
+      "Timed out waiting for the server",
+    );
+    expect(errorHeadline("Request failed: 401 Unauthorized")).toBe(
+      "Authentication required (401)",
+    );
+    expect(errorHeadline("HTTP 403 Forbidden")).toBe("Access forbidden (403)");
+  });
+
+  it("does not treat a giant OAuth authorize URL as an auth headline by itself", () => {
+    // A ~2KB authorize URL with no 401/unauthorized text should fall to the last
+    // line, with the URL middle-truncated, not blow up the message.
+    const url = "https://auth.example.com/authorize?" + "scope=".repeat(300) + "x";
+    const raw = `Failed to start mcp-remote\nOpen this URL to continue: ${url}`;
+    const head = errorHeadline(raw);
+    expect(head).not.toContain("Authentication required");
+    expect(head).toContain("…");
+    expect(head.length).toBeLessThanOrEqual(160);
+  });
+
+  it("falls back to exit status, then the last meaningful line", () => {
+    expect(errorHeadline("child process exited with status 1")).toBe(
+      "Exited with status 1",
+    );
+    expect(errorHeadline("line one\n\n   the real problem   \n")).toBe(
+      "the real problem",
+    );
+  });
+
+  it("never throws on empty/nullish input", () => {
+    expect(errorHeadline("")).toBe("Unknown error");
+    expect(errorHeadline(null)).toBe("Unknown error");
+    expect(errorHeadline(undefined)).toBe("Unknown error");
+  });
+});
+
+describe("truncateMiddle / shortenUrls", () => {
+  it("middle-truncates only past the cap", () => {
+    expect(truncateMiddle("short", 100)).toBe("short");
+    const out = truncateMiddle("a".repeat(200), 21);
+    expect(out).toHaveLength(21);
+    expect(out).toContain("…");
+  });
+
+  it("shortens long URLs but leaves short ones", () => {
+    expect(shortenUrls("see http://x.io/ok", 80)).toBe("see http://x.io/ok");
+    expect(shortenUrls("go " + "http://x.io/" + "q".repeat(200), 40)).toContain("…");
+  });
+});

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -1,0 +1,69 @@
+/**
+ * Turn a raw downstream/probe error into a short, human-readable headline.
+ *
+ * A failed stdio spawn or remote connect can surface a multi-KB dump: a full
+ * Node stack trace plus a giant OAuth authorize URL with dozens of scopes. Shown
+ * verbatim in a status tooltip or row, that buries the one useful line
+ * (`exited status 1`, `EADDRINUSE 127.0.0.1:39541`) and reads as broken. These
+ * helpers pull out the signal and keep the noise available but out of the way.
+ */
+
+// Recognized signals, checked in order; first match wins. Each returns a short
+// headline. Kept deliberately small: these are the failures users actually hit.
+const PATTERNS: Array<[RegExp, (m: RegExpMatchArray) => string]> = [
+  [
+    /EADDRINUSE[^\n]*?(\d{1,3}(?:\.\d{1,3}){3}:\d+|:\d+)/i,
+    (m) => `Port already in use (${m[1]})`,
+  ],
+  [/EADDRINUSE/i, () => "Port already in use"],
+  [/ENOENT/i, () => "Command or file not found (ENOENT)"],
+  [/ECONNREFUSED/i, () => "Connection refused"],
+  [
+    /timed out waiting for initialize|timed? ?out/i,
+    () => "Timed out waiting for the server",
+  ],
+  [/\b401\b|unauthorized/i, () => "Authentication required (401)"],
+  [/\b403\b|forbidden/i, () => "Access forbidden (403)"],
+];
+
+/**
+ * Middle-truncate a long run of non-space characters (e.g. a giant OAuth URL) so
+ * it stays on one readable line instead of dominating the message.
+ */
+export function truncateMiddle(s: string, max = 100): string {
+  if (s.length <= max) return s;
+  const head = Math.ceil((max - 1) / 2);
+  const tail = Math.floor((max - 1) / 2);
+  return `${s.slice(0, head)}…${s.slice(s.length - tail)}`;
+}
+
+/** Replace any long URL in `s` with a middle-truncated version. */
+export function shortenUrls(s: string, max = 80): string {
+  return s.replace(/https?:\/\/\S+/g, (u) => truncateMiddle(u, max));
+}
+
+/**
+ * A one-line headline for an error. Prefers a recognized pattern, then an
+ * `exited status N` line, then the last non-empty line, capped in length with any
+ * long URL middle-truncated. Never throws; returns "Unknown error" for empty input.
+ */
+export function errorHeadline(raw: string | null | undefined): string {
+  const text = (raw ?? "").trim();
+  if (!text) return "Unknown error";
+
+  for (const [re, fmt] of PATTERNS) {
+    const m = text.match(re);
+    if (m) return fmt(m);
+  }
+
+  const exit = text.match(/exit(?:ed)?\s+(?:with\s+)?(?:status|code)\s+(\d+)/i);
+  if (exit) return `Exited with status ${exit[1]}`;
+
+  const lastLine =
+    text
+      .split(/\r?\n/)
+      .map((l) => l.trim())
+      .filter(Boolean)
+      .pop() ?? text;
+  return truncateMiddle(shortenUrls(lastLine, 60), 160);
+}


### PR DESCRIPTION
## Summary

Closes #229.

A failed probe or spawn could dump a Node stack trace plus a multi-KB OAuth authorize URL into the server row's status tooltip and expanded view, burying the one useful line (`exited status 1`, `EADDRINUSE 127.0.0.1:39541`) and reading as broken.

- **`src/lib/errors.ts`** — `errorHeadline()` pulls a one-line headline from a raw error: recognized patterns first (EADDRINUSE with address, ENOENT, ECONNREFUSED, timeout, 401/403), then an `exited status N` line, then the last meaningful line, with long URLs middle-truncated. `shortenUrls()` / `truncateMiddle()` tidy the full text. Pure, never throws.
- **`RegistryServerRow`** — the status tooltip now shows the headline instead of the raw wall; the expanded view leads with the headline and keeps the full output below, bounded/scrollable/monospace with URLs shortened.

Notably, a giant OAuth authorize URL on its own no longer reads as "Authentication required" — the headline only says that on an actual `401`/`unauthorized`.

## Already in place (not part of this change)

- The bounded scrollable error container (`max-h-32 overflow-y-auto`).
- The auth-badge inference (`remote::is_auth_error`) is already specific to `401`/`403`/`unauthorized`/`needs authentication`, not any OAuth-ish string.

## Deferred (optional follow-up)

- A "copy full output" button on the expanded error (the full text is already scrollable/accessible).

## Test plan

- [x] `src/lib/errors.test.ts` — 7 cases: EADDRINUSE-past-a-stack-trace, ENOENT/ECONNREFUSED/timeout/401/403, giant-OAuth-URL-is-not-an-auth-headline, exit-status/last-line fallback, empty/null
- [x] `tsc --noEmit` clean, `eslint` clean, full `vitest` 69 pass
