### PR TITLE
feat(gateway): per-server working directory (cwd) for stdio servers (#239)

### DIFF
--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -2693,7 +2693,13 @@ fn connect_one(
                 }
             }
         }
-        match StdioTransport::spawn_watched(command, &server.args, &env, Arc::clone(dirty)) {
+        match StdioTransport::spawn_watched(
+            command,
+            &server.args,
+            &env,
+            server.cwd.as_deref(),
+            Arc::clone(dirty),
+        ) {
             Ok(mut t) => {
                 t.set_server_request_handler(server_handler);
                 DownstreamServer::connect(server.id.clone(), Box::new(t))
@@ -5824,6 +5830,7 @@ mod tests {
                 url: None,
                 source: None,
                 disabled_tools: vec![],
+                cwd: None,
                 unknown_fields: serde_json::Map::new(),
             });
         }
@@ -5859,6 +5866,7 @@ mod tests {
                 url: Some(format!("https://mcp.{id}.example/mcp")),
                 source: None,
                 disabled_tools: vec![],
+                cwd: None,
                 unknown_fields: serde_json::Map::new(),
             });
             reg.set_server_enabled("default", id, true).unwrap();
@@ -5893,6 +5901,7 @@ mod tests {
             url: Some("https://mcp.github.example/mcp".into()),
             source: None,
             disabled_tools: vec![],
+            cwd: None,
             unknown_fields: serde_json::Map::new(),
         });
         reg.set_server_enabled("default", "github", true).unwrap();
@@ -6624,6 +6633,7 @@ mod tests {
             url: None,
             source: None,
             disabled_tools: vec![],
+            cwd: None,
             unknown_fields: serde_json::Map::new(),
         });
         reg.set_server_enabled("default", &id, true).unwrap();

--- a/src-tauri/src/clients.rs
+++ b/src-tauri/src/clients.rs
@@ -2534,6 +2534,7 @@ fn gateway_entry(profile: Option<&str>, client_id: &str) -> Result<ServerEntry, 
         url: None,
         source: Some("conduit".to_string()),
         disabled_tools: Vec::new(),
+        cwd: None,
         unknown_fields: serde_json::Map::new(),
     })
 }
@@ -2861,6 +2862,7 @@ mod tests {
             url: None,
             source: None,
             disabled_tools: vec![],
+            cwd: None,
             unknown_fields: serde_json::Map::new(),
         }
     }

--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -336,7 +336,7 @@ fn connect_server(server: &ServerEntry) -> Result<DownstreamServer, String> {
                 }
             }
         }
-        let t = StdioTransport::spawn(command, &server.args, &env)?;
+        let t = StdioTransport::spawn(command, &server.args, &env, server.cwd.as_deref())?;
         DownstreamServer::connect(server.id.clone(), Box::new(t))
     } else if server.url.is_some() {
         remote::connect_remote(server)
@@ -414,6 +414,7 @@ fn server_from_detected(server: &clients::McpServer, client_id: &str) -> ServerE
         url: server.url.clone(),
         source: Some(format!("imported:{client_id}")),
         disabled_tools: vec![],
+        cwd: None,
         unknown_fields: serde_json::Map::new(),
     }
 }
@@ -521,7 +522,7 @@ fn prewarm_launcher(server: &ServerEntry) {
                     .map(|v| (e.key.clone(), v))
             })
             .collect();
-        if let Ok(t) = StdioTransport::spawn(&command, &server.args, &env) {
+        if let Ok(t) = StdioTransport::spawn(&command, &server.args, &env, server.cwd.as_deref()) {
             // Attempting the handshake keeps the child alive until the download
             // finishes (dropping the transport kills it), and warms it end-to-end
             // when the server actually comes up.
@@ -2659,6 +2660,7 @@ mod tests {
             url: None,
             source: None,
             disabled_tools: vec![],
+            cwd: None,
             unknown_fields: serde_json::Map::new(),
         }
     }
@@ -2674,6 +2676,7 @@ mod tests {
             url: None,
             source: None,
             disabled_tools: vec![],
+            cwd: None,
             unknown_fields: serde_json::Map::new(),
         }
     }
@@ -2946,6 +2949,7 @@ mod tests {
             url: None,
             source: None,
             disabled_tools: vec![],
+            cwd: None,
             unknown_fields: serde_json::Map::new(),
         });
 
@@ -3008,6 +3012,7 @@ mod tests {
             url: Some("https://user:hunter2@mcp.example.com/mcp".into()),
             source: None,
             disabled_tools: vec![],
+            cwd: None,
             unknown_fields: serde_json::Map::new(),
         });
         let doc = build_export(&reg, None, None, None);
@@ -3047,6 +3052,7 @@ mod tests {
             url: None,
             source: None,
             disabled_tools: vec![],
+            cwd: None,
             unknown_fields: serde_json::Map::new(),
         });
         let doc = build_export(&reg, None, None, None);
@@ -3078,6 +3084,7 @@ mod tests {
             url: None,
             source: None,
             disabled_tools: vec![],
+            cwd: None,
             unknown_fields: serde_json::Map::new(),
         });
         let json = serde_json::to_string(&build_export(&reg, None, None, None)).unwrap();
@@ -3185,6 +3192,7 @@ mod tests {
             url: None,
             source: None,
             disabled_tools: vec![],
+            cwd: None,
             unknown_fields: serde_json::Map::new(),
         });
         reg.add_server(ServerEntry {
@@ -3197,6 +3205,7 @@ mod tests {
             url: Some("https://user:hunter2@mcp.example.com/mcp".into()),
             source: None,
             disabled_tools: vec![],
+            cwd: None,
             unknown_fields: serde_json::Map::new(),
         });
 

--- a/src-tauri/src/downstream.rs
+++ b/src-tauri/src/downstream.rs
@@ -368,6 +368,37 @@ pub fn resolve_command(command: &str) -> String {
 }
 
 /// A PATH that includes the user's real shell PATH plus common install dirs.
+/// Expand a per-server working directory string (issue #239): a leading `~`
+/// (or `~/`) becomes the home dir, and `${VAR}` is replaced with the environment
+/// value (unset vars expand to empty). Returns the expanded path; the caller sets
+/// it as the child's cwd, and the OS reports a clear error if it doesn't exist.
+pub fn expand_cwd(dir: &str) -> std::path::PathBuf {
+    // Env vars first, so `~` inside an expanded value is still honored below.
+    let mut out = String::with_capacity(dir.len());
+    let bytes = dir.as_bytes();
+    let mut i = 0;
+    while i < dir.len() {
+        if bytes[i] == b'$' && dir[i..].starts_with("${") {
+            if let Some(end) = dir[i + 2..].find('}') {
+                let name = &dir[i + 2..i + 2 + end];
+                out.push_str(&std::env::var(name).unwrap_or_default());
+                i += 2 + end + 1;
+                continue;
+            }
+        }
+        out.push(dir[i..].chars().next().unwrap());
+        i += dir[i..].chars().next().unwrap().len_utf8();
+    }
+    // Leading `~` -> home dir.
+    if out == "~" || out.starts_with("~/") || out.starts_with("~\\") {
+        if let Some(home) = dirs::home_dir() {
+            let rest = out[1..].trim_start_matches(['/', '\\']);
+            return if rest.is_empty() { home } else { home.join(rest) };
+        }
+    }
+    std::path::PathBuf::from(out)
+}
+
 /// macOS GUI apps (and apps they launch, like the client-spawned gateway) inherit
 /// only a minimal PATH, so `npx`/`uvx`/`node` aren't found without this. Computed
 /// once and cached.
@@ -945,8 +976,13 @@ impl StdioTransport {
     /// Spawn a downstream server without watching for its tool-list changes.
     /// Used by one-shot callers (the app's health probe and playground) that
     /// don't keep the connection around to react to live notifications.
-    pub fn spawn(command: &str, args: &[String], env: &[(String, String)]) -> Result<Self, String> {
-        Self::spawn_inner(command, args, env, None)
+    pub fn spawn(
+        command: &str,
+        args: &[String],
+        env: &[(String, String)],
+        cwd: Option<&str>,
+    ) -> Result<Self, String> {
+        Self::spawn_inner(command, args, env, cwd, None)
     }
 
     /// Like [`spawn`], but sets a [`change`] bit in `dirty` whenever the downstream
@@ -958,15 +994,17 @@ impl StdioTransport {
         command: &str,
         args: &[String],
         env: &[(String, String)],
+        cwd: Option<&str>,
         dirty: Arc<AtomicU8>,
     ) -> Result<Self, String> {
-        Self::spawn_inner(command, args, env, Some(dirty))
+        Self::spawn_inner(command, args, env, cwd, Some(dirty))
     }
 
     fn spawn_inner(
         command: &str,
         args: &[String],
         env: &[(String, String)],
+        cwd: Option<&str>,
         dirty: Option<Arc<AtomicU8>>,
     ) -> Result<Self, String> {
         // Split a command that packed its args into the `command` string, so a
@@ -987,6 +1025,13 @@ impl StdioTransport {
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped());
+        // Optional per-server working directory (issue #239). Unset (or blank)
+        // means inherit the gateway's cwd, the previous behavior. `~` and `${VAR}`
+        // are expanded so a config can pin a server to a project dir. If the dir
+        // doesn't exist the spawn fails with a clear error, surfaced by the probe.
+        if let Some(dir) = cwd.map(str::trim).filter(|d| !d.is_empty()) {
+            cmd.current_dir(expand_cwd(dir));
+        }
         // Give the child the augmented PATH too, so e.g. `npx` can find `node`.
         #[cfg(not(windows))]
         cmd.env("PATH", augmented_path());
@@ -1790,10 +1835,29 @@ fn extract_array(result: &Value, key: &str) -> Vec<Value> {
 #[cfg(test)]
 mod tests {
     use super::{
-        resolve_command, screen_resolved_addrs, screen_spawn_command, screen_spawn_env,
+        expand_cwd, resolve_command, screen_resolved_addrs, screen_spawn_command, screen_spawn_env,
         CancelRegistry,
     };
     use serde_json::json;
+
+    #[test]
+    fn expand_cwd_handles_tilde_and_env() {
+        use std::path::PathBuf;
+        // A unique var name so the process-wide set_var can't collide with a
+        // parallel test.
+        let var = format!("TP_TEST_CWD_{}", std::process::id());
+        std::env::set_var(&var, "abc");
+        assert_eq!(expand_cwd(&format!("/x/${{{var}}}/y")), PathBuf::from("/x/abc/y"));
+        std::env::remove_var(&var);
+        // An unset var expands to empty; a literal path is unchanged.
+        assert_eq!(expand_cwd("/x/${TP_UNSET_ZZZ}/y"), PathBuf::from("/x//y"));
+        assert_eq!(expand_cwd("/plain/path"), PathBuf::from("/plain/path"));
+        // A leading `~` becomes the home dir.
+        if let Some(home) = dirs::home_dir() {
+            assert_eq!(expand_cwd("~"), home);
+            assert_eq!(expand_cwd("~/proj"), home.join("proj"));
+        }
+    }
 
     #[test]
     fn download_launchers_get_the_long_connect_budget() {

--- a/src-tauri/src/registry.rs
+++ b/src-tauri/src/registry.rs
@@ -103,6 +103,13 @@ pub struct ServerEntry {
     pub env: Vec<EnvVar>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub url: Option<String>,
+    /// Working directory for a stdio server. Unset means inherit the gateway's
+    /// cwd (the previous behavior). A leading `~` expands to the home dir and
+    /// `${VAR}` expands from the environment, so a server that operates on the
+    /// project (e.g. a grep/filesystem tool) can be pinned to it. Only applies to
+    /// stdio servers. See issue #239.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cwd: Option<String>,
     /// Where this entry came from, e.g. "imported:cursor" or "manual".
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub source: Option<String>,
@@ -1406,6 +1413,7 @@ mod tests {
             url: None,
             source: Some("manual".to_string()),
             disabled_tools: vec![],
+            cwd: None,
             unknown_fields: serde_json::Map::new(),
         }
     }
@@ -1919,6 +1927,7 @@ mod tests {
             url: None,
             source: None,
             disabled_tools: vec![],
+            cwd: None,
             unknown_fields: serde_json::Map::new(),
         });
         // Inject a per-server field this binary's ServerEntry doesn't define.

--- a/src-tauri/src/remote.rs
+++ b/src-tauri/src/remote.rs
@@ -304,6 +304,7 @@ mod tests {
             url: Some(url.into()),
             source: source.map(String::from),
             disabled_tools: vec![],
+            cwd: None,
             unknown_fields: serde_json::Map::new(),
         }
     }

--- a/src-tauri/src/teams.rs
+++ b/src-tauri/src/teams.rs
@@ -778,6 +778,7 @@ fn classify_team_server(s: &Value, tag: &str) -> TeamClass {
         url: None,
         source: Some(tag.to_string()),
         disabled_tools: str_array("disabledTools"),
+        cwd: None,
         unknown_fields: serde_json::Map::new(),
     };
 
@@ -885,6 +886,7 @@ mod tests {
             url: None,
             source: Some("manual".into()),
             disabled_tools: vec![],
+            cwd: None,
             unknown_fields: serde_json::Map::new(),
         });
         let active = r.active_profile_id.clone().unwrap();
@@ -1129,6 +1131,7 @@ mod tests {
             url: None,
             source: Some("manual".into()),
             disabled_tools: vec![],
+            cwd: None,
             unknown_fields: serde_json::Map::new(),
         });
         // A team-sourced server: excluded too (don't echo the team's own set back).
@@ -1142,6 +1145,7 @@ mod tests {
             url: Some("https://example.com/mcp".into()),
             source: Some("team:abc".into()),
             disabled_tools: vec![],
+            cwd: None,
             unknown_fields: serde_json::Map::new(),
         });
         let cfg = team_export(&r);

--- a/src-tauri/tests/circuit_breaker.rs
+++ b/src-tauri/tests/circuit_breaker.rs
@@ -17,7 +17,7 @@ use serde_json::json;
 fn circuit_opens_after_a_server_dies_and_fast_fails() {
     let mock = env!("CARGO_BIN_EXE_mock-mcp-server");
     let dirty = Arc::new(AtomicU8::new(0));
-    let transport = StdioTransport::spawn_watched(mock, &[], &[], dirty).expect("spawn mock");
+    let transport = StdioTransport::spawn_watched(mock, &[], &[], None, dirty).expect("spawn mock");
     let server =
         DownstreamServer::connect("mock".to_string(), Box::new(transport)).expect("connect mock");
     let mut router = Router::new();

--- a/src-tauri/tests/list_changed.rs
+++ b/src-tauri/tests/list_changed.rs
@@ -45,7 +45,7 @@ fn live_tool_change_surfaces_via_refresh_without_respawn() {
     let mock = env!("CARGO_BIN_EXE_mock-mcp-server");
     let dirty = Arc::new(AtomicU8::new(0));
     let transport =
-        StdioTransport::spawn_watched(mock, &[], &[], Arc::clone(&dirty)).expect("spawn mock");
+        StdioTransport::spawn_watched(mock, &[], &[], None, Arc::clone(&dirty)).expect("spawn mock");
     let mut server =
         DownstreamServer::connect("mock".to_string(), Box::new(transport)).expect("connect mock");
     // connect() only loads tools; pull the baseline resources/prompts so the

--- a/src/components/ServerDialog.tsx
+++ b/src/components/ServerDialog.tsx
@@ -75,6 +75,7 @@ export function ServerDialog({
     command: initial?.command ?? "",
     args: formatArgs(initial?.args ?? []),
     url: initial?.url ?? "",
+    cwd: initial?.cwd ?? "",
   });
   // Env vars (API keys etc.). Values are vaulted in the OS keychain, never stored
   // in the registry, so existing secrets show as declared keys with empty values.
@@ -114,6 +115,7 @@ export function ServerDialog({
         command: initial?.command ?? "",
         args: formatArgs(initial?.args ?? []),
         url: initial?.url ?? "",
+        cwd: initial?.cwd ?? "",
       });
       setEnvRows(initial?.env.map((e) => ({ key: e.key, value: "" })) ?? []);
       setTest({ status: "idle", message: "" });
@@ -157,6 +159,7 @@ export function ServerDialog({
         command: s.command ?? "",
         args: formatArgs(s.args),
         url: s.url ?? "",
+        cwd: "",
       });
       setEnvRows(
         s.env.map((e) => ({
@@ -199,6 +202,7 @@ export function ServerDialog({
       })),
       url: isStdio ? null : form.url.trim() || null,
       source: initial?.source ?? "manual",
+      cwd: isStdio ? form.cwd.trim() || null : null,
     };
   }
 
@@ -370,6 +374,21 @@ export function ServerDialog({
                   value={form.args}
                   onChange={(e) => set("args", e.target.value)}
                 />
+              </div>
+              <div className="flex flex-col gap-2">
+                <Label htmlFor="srv-cwd">Working directory (optional)</Label>
+                <Input
+                  id="srv-cwd"
+                  placeholder="~/projects/my-app"
+                  value={form.cwd}
+                  onChange={(e) => set("cwd", e.target.value)}
+                />
+                <p className="text-xs text-muted-foreground">
+                  Where this server runs. Leave blank to inherit Toolport's directory.
+                  Useful for tools that work on a project (a filesystem or code-search
+                  server). <code className="font-mono">~</code> and{" "}
+                  <code className="font-mono">{"${VAR}"}</code> are expanded.
+                </p>
               </div>
             </>
           ) : (

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -338,6 +338,9 @@ export interface ServerEntry {
   source: string | null;
   /** Original tool names switched off; hidden from clients by the gateway. */
   disabledTools?: string[];
+  /** Working directory for a stdio server. Unset = inherit the gateway's cwd.
+   * `~` and `${VAR}` are expanded. Lets a server run in a project dir (#239). */
+  cwd?: string | null;
 }
 
 export interface Profile {


### PR DESCRIPTION
## Summary

Part of #239. Adds an optional **working directory (`cwd`) per stdio server**.

Previously downstream stdio servers inherited the gateway's own cwd (often not the project, and fixed for the HTTP bridge), with no way to override — so a server that operates on the project (a grep/filesystem tool like grepai) ran in the wrong place. Now:

- **`ServerEntry.cwd`** — when set, the gateway *and* the app's probe/playground spawn the server with that working directory. Unset (or blank) = inherit the gateway's cwd (unchanged behavior, no regression).
- **Expansion** — a leading `~` becomes the home dir and `${VAR}` expands from the environment (`expand_cwd`), so you can write `~/projects/app` or `${MY_PROJECT}`.
- Threaded through `spawn` / `spawn_watched` / `spawn_inner` → `Command::current_dir`, and passed at every spawn site (gateway `build_router`, desktop `connect_server`, prewarm).
- **UI** — a "Working directory (optional)" field in the add/edit dialog.

### Scope / follow-up

This is the static/pinned mechanism. The **dynamic `${ROOT}` variant** (resolve the cwd to the AI client's currently-open project via the MCP roots Toolport already forwards, and respawn on `roots/list_changed`) is a separate, heavier lifecycle change — planned as a follow-up rather than half-built here. Note: MCP roots already pass through, so roots-aware servers already get the client's workspace; this `cwd` work is specifically for servers that use the process working directory instead.

## Test plan

- [x] `expand_cwd_handles_tilde_and_env` — `${VAR}`, unset var → empty, literal path unchanged, `~`/`~/x` → home
- [x] `cargo test --lib` (339) + `cargo test --bin toolport-gateway --no-default-features` (86)
- [x] Integration tests updated for the new spawn signature (`list_changed`, `circuit_breaker`) and passing
- [x] Frontend: `tsc` clean, `eslint` clean, `vitest` 69 pass
