### PR TITLE
fix(app): refresh servers incrementally so one slow probe doesn't stall the grid (#252)

### DIFF
--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -947,9 +947,39 @@ fn last_lines(text: &str, n: usize) -> String {
     tail
 }
 
-/// Connect to each enabled server in the active profile and report health + tool count.
+/// How long to wait for one server's probe before giving up on it. Generous
+/// enough for an `npx` first-run package install, but bounded so a single hung
+/// server can't leave its row "checking" forever. Issue #252.
+const PROBE_TIMEOUT: Duration = Duration::from_secs(90);
+
+/// Probe one server, never blocking longer than `PROBE_TIMEOUT`. On timeout the
+/// underlying probe thread is left to finish or die on its own; we return a
+/// timed-out result so the row resolves instead of spinning indefinitely.
+fn probe_one_bounded(server: &ServerEntry) -> ProbeResult {
+    let (tx, rx) = std::sync::mpsc::channel();
+    let s = server.clone();
+    std::thread::spawn(move || {
+        let _ = tx.send(probe_one(&s));
+    });
+    rx.recv_timeout(PROBE_TIMEOUT).unwrap_or_else(|_| ProbeResult {
+        server_id: server.id.clone(),
+        ok: false,
+        tool_count: 0,
+        error: Some(format!("timed out after {}s", PROBE_TIMEOUT.as_secs())),
+        auth_required: false,
+    })
+}
+
+/// Connect to each enabled server in the active profile and report health + tool
+/// count. Emits a `server-probed` event per server the moment it finishes, so the
+/// UI resolves each row independently instead of waiting for the slowest - a cold
+/// `npx` install used to leave the whole grid "checking" for 30-60s. Still returns
+/// the full batch for callers that want it. Issue #252.
 #[tauri::command]
-async fn probe_servers(state: State<'_, RegistryState>) -> Result<Vec<ProbeResult>, String> {
+async fn probe_servers(
+    app: tauri::AppHandle,
+    state: State<'_, RegistryState>,
+) -> Result<Vec<ProbeResult>, String> {
     // Snapshot which servers to probe, then drop the lock before any I/O.
     let servers: Vec<ServerEntry> = {
         let reg = state.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
@@ -959,11 +989,19 @@ async fn probe_servers(state: State<'_, RegistryState>) -> Result<Vec<ProbeResul
             .cloned()
             .collect()
     };
-    // Probe concurrently on worker threads so the UI thread never blocks.
+    // One worker thread per server. Each emits its result as soon as it's ready
+    // (the UI listens for `server-probed`), then contributes to the returned batch.
     tauri::async_runtime::spawn_blocking(move || {
         let handles: Vec<_> = servers
             .into_iter()
-            .map(|s| std::thread::spawn(move || probe_one(&s)))
+            .map(|s| {
+                let app = app.clone();
+                std::thread::spawn(move || {
+                    let result = probe_one_bounded(&s);
+                    let _ = app.emit("server-probed", &result);
+                    result
+                })
+            })
             .collect();
         handles.into_iter().filter_map(|h| h.join().ok()).collect()
     })
@@ -2663,6 +2701,23 @@ mod tests {
             cwd: None,
             unknown_fields: serde_json::Map::new(),
         }
+    }
+
+    #[test]
+    fn probe_one_bounded_passes_through_a_fast_failure_well_under_the_timeout() {
+        // A bogus command fails to spawn immediately, so the bounded wrapper must
+        // return that result promptly (nowhere near PROBE_TIMEOUT) and carry the
+        // server id - it only times out for a genuinely hung probe.
+        let mut server = plain_server("bogus", "Bogus");
+        server.command = Some("toolport-no-such-binary-xyz".into());
+        let start = std::time::Instant::now();
+        let r = probe_one_bounded(&server);
+        assert!(
+            start.elapsed() < Duration::from_secs(10),
+            "a fast failure must not wait on the timeout"
+        );
+        assert!(!r.ok);
+        assert_eq!(r.server_id, "bogus");
     }
 
     fn plain_server(id: &str, name: &str) -> ServerEntry {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -264,6 +264,20 @@ function App() {
     };
   }, []);
 
+  // A refresh emits one `server-probed` event per server as its probe finishes, so
+  // each row resolves the moment its own result is in - a slow npx cold-start no
+  // longer holds the whole grid in "checking" until the slowest server returns
+  // (issue #252). The batched probeServers() return still reconciles at the end.
+  useEffect(() => {
+    const unlisten = listen<ProbeResult>("server-probed", (e) => {
+      setHealth((h) => ({ ...h, [e.payload.serverId]: e.payload }));
+      setBackendReachable(true);
+    });
+    return () => {
+      void unlisten.then((f) => f());
+    };
+  }, []);
+
   // Keep a team member's shared server set AND security policy current even if they never
   // open the Teams tab: an admin tightening a force-quarantine / approval policy must reach
   // every member near-instantly, not just those who happen to click "Sync now". This runs a


### PR DESCRIPTION
## Summary

Closes #252.

`probe_servers` probed every server in parallel but **joined all of them before returning a single `Vec`**, so the UI updated only when the *slowest* probe finished — a cold `npx` package install (the "Installing…" rows) left the whole grid stuck on "Checking…" for 30-60s and read as broken.

Now each server is probed on its own thread and **emits a `server-probed` event the moment it finishes**; `App.tsx` listens and merges each result into `health` so every row resolves independently. Fast servers show connected/failed within a second or two even while a slow install is still running. A **90s per-probe timeout** backstops a genuinely hung server so its row can't spin forever (it resolves to a timed-out error instead). The batched `probeServers()` return is kept for callers that want it (onboarding), and reconciles at the end.

## Test plan

- [x] `probe_one_bounded_passes_through_a_fast_failure_well_under_the_timeout` — a bogus command returns promptly (nowhere near the 90s timeout) with the right server id
- [x] `cargo test --lib` (340) + `cargo test --bin toolport-gateway --no-default-features` (86)
- [x] Frontend `tsc` clean, `eslint` 0 errors, `vitest` 69 pass

## Note

Not browser-previewable (Tauri app + needs real servers to probe), so verified via the type-check/lint/build and the timeout unit test rather than a live screenshot. The event wiring mirrors the app's existing `listen()` patterns (team-removed, approval-pending).
