### PR TITLE
fix(ui): copy-error button + keyboard/label a11y (#254, #260)

### DIFF
--- a/src/components/ActivityView.tsx
+++ b/src/components/ActivityView.tsx
@@ -788,6 +788,12 @@ function InspectRow({ e }: { e: InspectEntry }) {
       <div
         className="flex cursor-pointer items-center gap-3 px-3 py-2 hover:bg-muted/30"
         onClick={() => setOpen((o) => !o)}
+        onKeyDown={(event) => {
+          if (event.key === "Enter" || event.key === " ") {
+            event.preventDefault();
+            setOpen((o) => !o);
+          }
+        }}
         role="button"
         aria-expanded={open}
         tabIndex={0}
@@ -850,6 +856,12 @@ function DiscoveryRow({ t }: { t: SearchTrace }) {
       <div
         className="flex cursor-pointer items-center gap-3 px-3 py-2 hover:bg-muted/30"
         onClick={() => setOpen((o) => !o)}
+        onKeyDown={(event) => {
+          if (event.key === "Enter" || event.key === " ") {
+            event.preventDefault();
+            setOpen((o) => !o);
+          }
+        }}
         role="button"
         aria-expanded={open}
         tabIndex={0}
@@ -1032,6 +1044,12 @@ function ToolIdentityRow({ t }: { t: ToolIdentity }) {
       <div
         className="flex cursor-pointer items-center gap-3 px-3 py-2 hover:bg-muted/30"
         onClick={() => setOpen((o) => !o)}
+        onKeyDown={(event) => {
+          if (event.key === "Enter" || event.key === " ") {
+            event.preventDefault();
+            setOpen((o) => !o);
+          }
+        }}
         role="button"
         aria-expanded={open}
         tabIndex={0}

--- a/src/components/RegistryServerRow.tsx
+++ b/src/components/RegistryServerRow.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { ChevronDown, Copy, KeyRound, LogIn, Pencil, Trash2, Users } from "lucide-react";
 import { isDownloadLauncher } from "@/lib/launcher";
 import { errorHeadline, shortenUrls } from "@/lib/errors";
+import { toast } from "sonner";
 import type { ProbeResult, Registry, ServerEntry } from "@/lib/types";
 import { Switch } from "@/components/ui/switch";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
@@ -228,9 +229,24 @@ export function RegistryServerRow({
                   EADDRINUSE, a 401) isn't buried under a stack trace + a giant
                   OAuth URL; the full output stays below, bounded and scrollable
                   with long URLs shortened. */}
-              <p className="text-xs font-medium text-warning">
-                {errorHeadline(health.error)}
-              </p>
+              <div className="flex items-start justify-between gap-2">
+                <p className="text-xs font-medium text-warning">
+                  {errorHeadline(health.error)}
+                </p>
+                <button
+                  type="button"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    void navigator.clipboard.writeText(health?.error ?? "");
+                    toast.success("Error copied");
+                  }}
+                  title="Copy the full error"
+                  className="inline-flex shrink-0 items-center gap-1 rounded px-1.5 py-0.5 text-[11px] text-muted-foreground transition-colors hover:bg-accent hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                >
+                  <Copy className="size-3" />
+                  Copy
+                </button>
+              </div>
               <p className="max-h-32 overflow-y-auto font-mono text-[11px] break-words whitespace-pre-wrap text-muted-foreground">
                 {shortenUrls(health.error)}
               </p>

--- a/src/components/ServerDialog.tsx
+++ b/src/components/ServerDialog.tsx
@@ -342,7 +342,7 @@ export function ServerDialog({
               value={form.transport}
               onValueChange={(v) => set("transport", v as Transport)}
             >
-              <SelectTrigger>
+              <SelectTrigger aria-label="Transport">
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>


### PR DESCRIPTION
## Summary

Two small UI-polish fixes from the audit.

- **#254** — a **Copy** button on the expanded server-row error that copies the full raw output to the clipboard (the box already shows a headline + scrollable/URL-shortened full text; this makes grabbing the whole thing one click).
- **#260** — a11y:
  - **Enter/Space keyboard activation** for the Activity rows that were `role="button" tabIndex={0}` with no `onKeyDown` (they were focusable and announced as buttons but not keyboard-activatable). Mirrors the handler an already-correct row uses.
  - an **`aria-label="Transport"`** on the Add-Server transport `SelectTrigger` so it has an accessible name.

Closes #254. Closes #260.

## Test plan

- [x] `tsc` clean, `eslint` 0 errors on the changed files, `vitest` 69 pass
- [x] Keyboard handler landed on the 3 previously-bare `role="button"` Activity rows (4 total incl. the pre-existing one)

Not browser-previewable (Tauri app), so verified via type-check/lint/tests rather than a live screenshot.
