### PR TITLE
feat(gateway): dynamic ${ROOT} working directory from MCP roots (#239)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -633,6 +633,7 @@ dependencies = [
  "tiny_http",
  "toml 0.8.2",
  "ureq",
+ "url",
  "urlencoding",
 ]
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -54,6 +54,9 @@ regex = "1"
 getrandom = "0.2"
 chacha20poly1305 = "0.10"
 urlencoding = "2"
+# file:// URI -> path decoding for the ${ROOT} cwd token (issue #239); already in
+# the tree transitively, promoted to a direct dep for url::Url::to_file_path.
+url = "2"
 # Minimal synchronous HTTP server for the gateway's native HTTP/OpenAPI mode
 # (first-class Open WebUI and any OpenAPI tool client, no external bridge).
 tiny_http = "0.12"

--- a/src-tauri/src/bin/mock-mcp-server.rs
+++ b/src-tauri/src/bin/mock-mcp-server.rs
@@ -26,6 +26,8 @@ fn tool_list(grown: bool) -> Value {
                 "inputSchema": { "type": "object", "properties": {} } }),
         json!({ "name": "die", "description": "Exit the process to simulate a mid-session crash.",
                 "inputSchema": { "type": "object", "properties": {} } }),
+        json!({ "name": "pwd", "description": "Return the process working directory.",
+                "inputSchema": { "type": "object", "properties": {} } }),
     ];
     if grown {
         tools.push(json!({ "name": "greet", "description": "Greet someone by name.",
@@ -103,6 +105,9 @@ fn handle(req: &Value, grown: &mut bool) -> Option<Value> {
                     let who = args.get("name").and_then(|t| t.as_str()).unwrap_or("there");
                     format!("hello {who}")
                 }
+                "pwd" => std::env::current_dir()
+                    .map(|p| p.to_string_lossy().into_owned())
+                    .unwrap_or_default(),
                 other => format!("unknown tool {other}"),
             };
             Some(success(

--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -2592,6 +2592,10 @@ fn build_router(
     http_mode: bool,
     dirty: &Arc<AtomicU8>,
     server_handler: ServerRequestHandler,
+    // The upstream client's project root for the ${ROOT} cwd token (issue #239),
+    // already decoded to a filesystem path. `None` in HTTP mode and before the
+    // client's roots are known; `${ROOT}` servers then fall back to the gateway cwd.
+    root: Option<&str>,
 ) -> Router {
     // In HTTP mode one process serves every registered client, so connect the
     // union of all their profiles (per-request filtering scopes each one down).
@@ -2634,13 +2638,17 @@ fn build_router(
     // Connect concurrently so total time is the slowest server, not the sum. Each
     // thread hands back the server spec + dirty flag alongside the connection so we can
     // build a reconnect factory (used to re-spawn it if it dies mid-session).
+    // Owned copy so each connect thread and each reconnect factory (both 'static)
+    // can carry the root without borrowing.
+    let root_owned = root.map(str::to_owned);
     let handles: Vec<_> = servers
         .into_iter()
         .map(|server| {
             let dirty = Arc::clone(dirty);
             let handler = Arc::clone(&server_handler);
+            let root_t = root_owned.clone();
             std::thread::spawn(move || {
-                let ds = connect_one(&server, &dirty, handler);
+                let ds = connect_one(&server, &dirty, handler, root_t.as_deref());
                 (server, dirty, ds)
             })
         })
@@ -2656,7 +2664,9 @@ fn build_router(
             // factory, so a re-spawn re-injects keychain secrets and re-handshakes
             // exactly like a fresh connect.
             let handler = Arc::clone(&server_handler);
-            let reconnect: Reconnect = Box::new(move || connect_one(&server, &dirty, Arc::clone(&handler)));
+            let root_c = root_owned.clone();
+            let reconnect: Reconnect =
+                Box::new(move || connect_one(&server, &dirty, Arc::clone(&handler), root_c.as_deref()));
             router.add_with_reconnect(ds, Some(reconnect));
         }
     }
@@ -2669,6 +2679,7 @@ fn connect_one(
     server: &ServerEntry,
     dirty: &Arc<AtomicU8>,
     server_handler: ServerRequestHandler,
+    root: Option<&str>,
 ) -> Option<DownstreamServer> {
     let result = if let Some(command) = &server.command {
         let mut env: Vec<(String, String)> = Vec::new();
@@ -2693,11 +2704,18 @@ fn connect_one(
                 }
             }
         }
+        // Resolve the ${ROOT} token against the client's project root (issue #239)
+        // before spawning. `None` (no ${ROOT}, or ${ROOT} with no known root) means
+        // inherit the gateway cwd - the pre-#239 fallback.
+        let resolved_cwd = server
+            .cwd
+            .as_deref()
+            .and_then(|c| downstream::resolve_root_token(c, root));
         match StdioTransport::spawn_watched(
             command,
             &server.args,
             &env,
-            server.cwd.as_deref(),
+            resolved_cwd.as_deref(),
             Arc::clone(dirty),
         ) {
             Ok(mut t) => {
@@ -3025,6 +3043,7 @@ fn watch_registry(
                 http_mode,
                 &downstream_dirty,
                 Arc::clone(&server_handler),
+                None,
             );
             let server_count = new_router.server_count();
             let tools = new_router.aggregated_tools();
@@ -3768,6 +3787,7 @@ fn process_request(
                 state.http,
                 &state.downstream_dirty,
                 Arc::clone(&state.server_handler),
+                None,
             );
             if built.server_count() > 0 {
                 let tools = built.aggregated_tools();
@@ -5080,7 +5100,8 @@ fn main() {
                 .lock()
                 .unwrap_or_else(std::sync::PoisonError::into_inner)
                 .clone();
-            let built = build_router(&reg, p.as_deref(), http_mode, &downstream_dirty, server_handler);
+            let built =
+                build_router(&reg, p.as_deref(), http_mode, &downstream_dirty, server_handler, None);
             let tools = built.aggregated_tools();
             glog(&format!(
                 "background build: {} tools from {} servers",

--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -5216,6 +5216,9 @@ fn main() {
     let mcp_sessions = Arc::new(Mutex::new(HashMap::new()));
     let client_upstream = Arc::new(Mutex::new(ClientUpstreamCaps::default()));
     let client_root = Arc::new(Mutex::new(None::<String>));
+    // Single-flight for every router build/swap (startup, watcher self-heal, and
+    // ${ROOT} rebuilds). Created up front so the startup build can share it.
+    let rebuild_lock = Arc::new(Mutex::new(()));
     let stdio_upstream = Arc::new(StdioUpstream::new(Arc::clone(&stdout)));
     let server_handler = make_server_request_handler(
         Arc::clone(&client_upstream),
@@ -5240,6 +5243,8 @@ fn main() {
         let downstream_dirty = Arc::clone(&downstream_dirty);
         let server_handler = Arc::clone(&server_handler);
         let profile = Arc::clone(&profile);
+        let client_root = Arc::clone(&client_root);
+        let rebuild_lock = Arc::clone(&rebuild_lock);
         std::thread::spawn(move || {
             let reg = registry
                 .lock()
@@ -5249,8 +5254,24 @@ fn main() {
                 .lock()
                 .unwrap_or_else(std::sync::PoisonError::into_inner)
                 .clone();
-            let built =
-                build_router(&reg, p.as_deref(), http_mode, &downstream_dirty, server_handler, None);
+            // Single-flight with the ${ROOT} / self-heal rebuilds, and read the
+            // shared root inside the lock so a late startup swap can't overwrite an
+            // already-resolved ${ROOT} rebuild back to the fallback cwd (issue #239).
+            let _rebuild = rebuild_lock
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            let root = client_root
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .clone();
+            let built = build_router(
+                &reg,
+                p.as_deref(),
+                http_mode,
+                &downstream_dirty,
+                server_handler,
+                root.as_deref(),
+            );
             let tools = built.aggregated_tools();
             glog(&format!(
                 "background build: {} tools from {} servers",
@@ -5312,7 +5333,7 @@ fn main() {
         stdout: Arc::clone(&stdout),
         ready: Arc::clone(&ready),
         downstream_dirty: Arc::clone(&downstream_dirty),
-        rebuild_lock: Arc::new(Mutex::new(())),
+        rebuild_lock,
         lazy,
         profile: Arc::clone(&profile),
         http: http_mode,

--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -2993,6 +2993,9 @@ fn watch_registry(
     http_mode: bool,
     downstream_dirty: Arc<AtomicU8>,
     server_handler: ServerRequestHandler,
+    // Shared ${ROOT} path (issue #239) so a registry-change rebuild keeps placing
+    // ${ROOT} servers in the client's project root instead of resetting to fallback.
+    client_root: Arc<Mutex<Option<String>>>,
 ) {
     eprintln!("toolport: watching registry at {}", path.display());
     let mut last = mtime(&path);
@@ -3037,13 +3040,17 @@ fn watch_registry(
                 prev
             };
             // Build the new router (spawns processes) before taking locks.
+            let root = client_root
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .clone();
             let new_router = build_router(
                 &new_reg,
                 resolved.as_deref(),
                 http_mode,
                 &downstream_dirty,
                 Arc::clone(&server_handler),
-                None,
+                root.as_deref(),
             );
             let server_count = new_router.server_count();
             let tools = new_router.aggregated_tools();
@@ -3181,6 +3188,11 @@ struct GatewayState {
     /// Client-declared upstream capabilities (stdio gateway). Per-session copy on
     /// [`McpSession`] for HTTP MCP clients.
     client_upstream: Arc<Mutex<ClientUpstreamCaps>>,
+    /// The upstream client's project root path for the `${ROOT}` cwd token
+    /// (issue #239), decoded from its first declared root via `file_uri_to_path`.
+    /// `None` until roots are fetched, or if the client declares none; `${ROOT}`
+    /// servers fall back to the gateway cwd until it is set. stdio-only.
+    client_root: Arc<Mutex<Option<String>>>,
     /// Forward server-initiated JSON-RPC to the stdio upstream client.
     stdio_upstream: Arc<StdioUpstream>,
     /// Answers downstream server-initiated RPC (roots, sampling, elicitation).
@@ -3684,9 +3696,140 @@ fn make_server_request_handler(
     })
 }
 
+/// Read the current resolved client project root for the `${ROOT}` cwd token.
+fn current_client_root(state: &GatewayState) -> Option<String> {
+    state
+        .client_root
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .clone()
+}
+
+/// True when the active profile has any enabled server whose cwd uses `${ROOT}`,
+/// so we only rebuild for a roots change when it can actually matter (issue #239).
+fn profile_has_root_server(state: &GatewayState) -> bool {
+    let profile = state
+        .profile
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .clone();
+    let reg = state
+        .registry
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let enabled = match profile.as_deref() {
+        Some(p) => reg.enabled_servers_for(p),
+        None => reg.enabled_servers(),
+    };
+    enabled
+        .into_iter()
+        .any(|s| s.cwd.as_deref().is_some_and(|c| c.contains("${ROOT}")))
+}
+
+/// Rebuild the router with the current `${ROOT}` value and swap it in, mirroring
+/// the registry-watcher rebuild. Guarded by `rebuild_lock` so it single-flights
+/// against the self-heal path. stdio-only (issue #239).
+fn rebuild_router_for_root(state: &GatewayState) {
+    let _rebuild = state
+        .rebuild_lock
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let reg = state
+        .registry
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .clone();
+    let profile = state
+        .profile
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .clone();
+    let root = current_client_root(state);
+    let new_router = build_router(
+        &reg,
+        profile.as_deref(),
+        state.http,
+        &state.downstream_dirty,
+        Arc::clone(&state.server_handler),
+        root.as_deref(),
+    );
+    let tools = new_router.aggregated_tools();
+    *state
+        .router
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner) = Arc::new(new_router);
+    let tools = requarantine_if_needed(&state.registry, &state.router, tools, profile.as_deref());
+    persist_and_emit(&tools, &state.cached_tools, &state.stdout, profile.as_deref());
+    glog(&format!("toolport: ${{ROOT}} rebuild (root={root:?}, {} tools)", tools.len()));
+}
+
+/// Fetch the upstream client's roots over stdio, update the shared `${ROOT}` path,
+/// and rebuild the router when it changed and a `${ROOT}` server exists. Runs on
+/// its own thread so it never blocks the initialize response or the request loop.
+/// No-op in HTTP mode (issue #239 is stdio-only). Called after `initialize` and on
+/// `notifications/roots/list_changed`.
+fn refresh_client_root(state: &GatewayState) {
+    if state.http {
+        return;
+    }
+    let supported = state
+        .client_upstream
+        .lock()
+        .map(|c| c.roots.supported)
+        .unwrap_or(false);
+    let new_root = if supported {
+        match state.stdio_upstream.call("roots/list", json!({})) {
+            Ok(result) => {
+                let roots: Vec<Value> = result
+                    .get("roots")
+                    .and_then(|r| r.as_array())
+                    .cloned()
+                    .unwrap_or_default();
+                // Keep the init-captured field in sync for any downstream consumer.
+                if let Ok(mut caps) = state.client_upstream.lock() {
+                    caps.roots.roots = roots.clone();
+                }
+                roots
+                    .first()
+                    .and_then(|r| r.get("uri"))
+                    .and_then(|u| u.as_str())
+                    .and_then(downstream::file_uri_to_path)
+            }
+            Err(e) => {
+                glog(&format!("toolport: roots/list failed: {e}"));
+                None
+            }
+        }
+    } else {
+        None
+    };
+    let changed = {
+        let mut cur = state
+            .client_root
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if *cur != new_root {
+            *cur = new_root.clone();
+            true
+        } else {
+            false
+        }
+    };
+    // Only respawn when the resolved root actually changed and a ${ROOT} server is
+    // present, so a client that has no root (or no ${ROOT} server) never churns.
+    if changed && profile_has_root_server(state) {
+        rebuild_router_for_root(state);
+    }
+}
+
 fn handle_client_notification(state: &GatewayState, req: &Value) -> bool {
     match req.get("method").and_then(|m| m.as_str()) {
         Some("notifications/roots/list_changed") => {
+            // Re-place ${ROOT} servers if the client's project root changed. Off the
+            // request thread so the roots/list round-trip + rebuild don't block it.
+            let st = state.clone();
+            std::thread::spawn(move || refresh_client_root(&st));
+            // Still tell downstream servers, for ones that consume roots themselves.
             let router = state
                 .router
                 .lock()
@@ -3723,6 +3866,10 @@ fn process_request(
         if let Ok(mut caps) = state.client_upstream.lock() {
             capture_client_upstream_from_init(&mut caps, req.get("params"));
         }
+        // Fetch the client's roots off-thread and place ${ROOT} servers once known,
+        // so the initialize response is never blocked on the round-trip (issue #239).
+        let st = state.clone();
+        std::thread::spawn(move || refresh_client_root(&st));
     }
 
     let wait = match method {
@@ -3781,13 +3928,14 @@ fn process_request(
                 .lock()
                 .unwrap_or_else(std::sync::PoisonError::into_inner)
                 .clone();
+            let root = current_client_root(state);
             let built = build_router(
                 &reg,
                 profile_snapshot.as_deref(),
                 state.http,
                 &state.downstream_dirty,
                 Arc::clone(&state.server_handler),
-                None,
+                root.as_deref(),
             );
             if built.server_count() > 0 {
                 let tools = built.aggregated_tools();
@@ -5067,6 +5215,7 @@ fn main() {
     let downstream_dirty = Arc::new(AtomicU8::new(0));
     let mcp_sessions = Arc::new(Mutex::new(HashMap::new()));
     let client_upstream = Arc::new(Mutex::new(ClientUpstreamCaps::default()));
+    let client_root = Arc::new(Mutex::new(None::<String>));
     let stdio_upstream = Arc::new(StdioUpstream::new(Arc::clone(&stdout)));
     let server_handler = make_server_request_handler(
         Arc::clone(&client_upstream),
@@ -5137,6 +5286,7 @@ fn main() {
         let profile = Arc::clone(&profile);
         let client_id = client_id.clone();
         let env_profile = env_profile.clone();
+        let client_root = Arc::clone(&client_root);
         std::thread::spawn(move || {
             watch_registry(
                 path,
@@ -5150,6 +5300,7 @@ fn main() {
                 http_mode,
                 downstream_dirty,
                 server_handler,
+                client_root,
             )
         });
     }
@@ -5167,6 +5318,7 @@ fn main() {
         http: http_mode,
         mcp_sessions,
         client_upstream,
+        client_root,
         stdio_upstream,
         server_handler,
     };
@@ -5494,6 +5646,7 @@ mod tests {
             http: true,
             mcp_sessions,
             client_upstream,
+            client_root: Arc::new(Mutex::new(None)),
             stdio_upstream,
             server_handler,
         }

--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -15,7 +15,7 @@ use crate::approval;
 use crate::audit;
 use crate::catalog;
 use crate::clients;
-use crate::downstream::{DownstreamServer, StdioTransport};
+use crate::downstream::{resolve_root_token, DownstreamServer, StdioTransport};
 use crate::inspect;
 use crate::integrity;
 use crate::oauth;
@@ -336,7 +336,10 @@ fn connect_server(server: &ServerEntry) -> Result<DownstreamServer, String> {
                 }
             }
         }
-        let t = StdioTransport::spawn(command, &server.args, &env, server.cwd.as_deref())?;
+        // The probe/playground has no upstream client, so ${ROOT} has no root to
+        // resolve against and falls back to the default cwd (issue #239).
+        let cwd = server.cwd.as_deref().and_then(|c| resolve_root_token(c, None));
+        let t = StdioTransport::spawn(command, &server.args, &env, cwd.as_deref())?;
         DownstreamServer::connect(server.id.clone(), Box::new(t))
     } else if server.url.is_some() {
         remote::connect_remote(server)
@@ -522,7 +525,8 @@ fn prewarm_launcher(server: &ServerEntry) {
                     .map(|v| (e.key.clone(), v))
             })
             .collect();
-        if let Ok(t) = StdioTransport::spawn(&command, &server.args, &env, server.cwd.as_deref()) {
+        let cwd = server.cwd.as_deref().and_then(|c| resolve_root_token(c, None));
+        if let Ok(t) = StdioTransport::spawn(&command, &server.args, &env, cwd.as_deref()) {
             // Attempting the handshake keeps the child alive until the download
             // finishes (dropping the transport kills it), and warms it end-to-end
             // when the server actually comes up.

--- a/src-tauri/src/downstream.rs
+++ b/src-tauri/src/downstream.rs
@@ -399,6 +399,46 @@ pub fn expand_cwd(dir: &str) -> std::path::PathBuf {
     std::path::PathBuf::from(out)
 }
 
+/// Resolve the reserved `${ROOT}` token in a per-server working directory
+/// (issue #239). `${ROOT}` stands for the upstream MCP client's current project
+/// directory (its first declared root), resolved here *before* [`expand_cwd`]
+/// runs so `${VAR}` expansion can't mistake it for an env var named `ROOT`.
+///
+/// Returns the cwd string to spawn with, or `None` to inherit the gateway's cwd:
+/// - blank config -> `None` (unset)
+/// - contains `${ROOT}` with a known `root` -> substituted string
+/// - contains `${ROOT}` with no known root (the client declared none, or a
+///   context without one such as the desktop probe) -> `None`, so the server
+///   falls back to the gateway cwd instead of spawning in the wrong place or
+///   being handed a literal `${ROOT}` that would guarantee a spawn failure
+/// - no `${ROOT}` -> the (trimmed) config unchanged
+pub fn resolve_root_token(cwd: &str, root: Option<&str>) -> Option<String> {
+    let trimmed = cwd.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    if trimmed.contains("${ROOT}") {
+        root.map(|r| trimmed.replace("${ROOT}", r))
+    } else {
+        Some(trimmed.to_string())
+    }
+}
+
+/// Decode a `file://` URI (the form MCP roots report) to a filesystem path
+/// string (issue #239). Uses `url::Url::to_file_path`, which handles the local
+/// platform's conventions: POSIX (`file:///home/x`), Windows drive letters
+/// (`file:///C:/x`), UNC hosts (`file://server/share`), and percent-decoding.
+/// Returns `None` for a non-`file` URI or one that can't be converted to a path.
+/// A stdio gateway and its client run on the same machine (this feature is
+/// stdio-only), so decoding on the local platform is always correct.
+pub fn file_uri_to_path(uri: &str) -> Option<String> {
+    let parsed = url::Url::parse(uri).ok()?;
+    if parsed.scheme() != "file" {
+        return None;
+    }
+    parsed.to_file_path().ok().map(|p| p.to_string_lossy().into_owned())
+}
+
 /// macOS GUI apps (and apps they launch, like the client-spawned gateway) inherit
 /// only a minimal PATH, so `npx`/`uvx`/`node` aren't found without this. Computed
 /// once and cached.
@@ -1835,8 +1875,8 @@ fn extract_array(result: &Value, key: &str) -> Vec<Value> {
 #[cfg(test)]
 mod tests {
     use super::{
-        expand_cwd, resolve_command, screen_resolved_addrs, screen_spawn_command, screen_spawn_env,
-        CancelRegistry,
+        expand_cwd, file_uri_to_path, resolve_command, resolve_root_token, screen_resolved_addrs,
+        screen_spawn_command, screen_spawn_env, CancelRegistry,
     };
     use serde_json::json;
 
@@ -1856,6 +1896,49 @@ mod tests {
         if let Some(home) = dirs::home_dir() {
             assert_eq!(expand_cwd("~"), home);
             assert_eq!(expand_cwd("~/proj"), home.join("proj"));
+        }
+    }
+
+    #[test]
+    fn resolve_root_token_substitutes_and_falls_back() {
+        // Blank -> None (inherit the gateway cwd).
+        assert_eq!(resolve_root_token("", Some("/proj")), None);
+        assert_eq!(resolve_root_token("   ", Some("/proj")), None);
+        // ${ROOT} with a known root -> substituted.
+        assert_eq!(resolve_root_token("${ROOT}", Some("/home/u/proj")), Some("/home/u/proj".into()));
+        assert_eq!(
+            resolve_root_token("${ROOT}/sub", Some("/home/u/proj")),
+            Some("/home/u/proj/sub".into())
+        );
+        // ${ROOT} with no known root -> None (fall back, never a literal ${ROOT}).
+        assert_eq!(resolve_root_token("${ROOT}/sub", None), None);
+        // No ${ROOT} -> the trimmed config, regardless of root.
+        assert_eq!(resolve_root_token("/plain", None), Some("/plain".into()));
+        assert_eq!(resolve_root_token("  /plain  ", Some("/proj")), Some("/plain".into()));
+        // Composes with expand_cwd: an un-touched ${VAR} survives for expand_cwd.
+        assert_eq!(resolve_root_token("${ROOT}/${SUB}", Some("/proj")), Some("/proj/${SUB}".into()));
+    }
+
+    #[test]
+    fn file_uri_to_path_decodes_platform_paths() {
+        use std::path::PathBuf;
+        // Non-file / unparseable -> None.
+        assert_eq!(file_uri_to_path("https://example.com/x"), None);
+        assert_eq!(file_uri_to_path("not a uri"), None);
+        // Compare as PathBuf so `/` vs `\` separators don't make the test brittle.
+        let as_path = |u: &str| file_uri_to_path(u).map(PathBuf::from);
+        #[cfg(not(windows))]
+        {
+            assert_eq!(as_path("file:///home/u/proj"), Some(PathBuf::from("/home/u/proj")));
+            assert_eq!(as_path("file:///home/u/my%20proj"), Some(PathBuf::from("/home/u/my proj")));
+        }
+        #[cfg(windows)]
+        {
+            assert_eq!(as_path("file:///C:/Users/u/proj"), Some(PathBuf::from(r"C:\Users\u\proj")));
+            assert_eq!(
+                as_path("file:///C:/Users/u/my%20proj"),
+                Some(PathBuf::from(r"C:\Users\u\my proj"))
+            );
         }
     }
 

--- a/src-tauri/src/registry.rs
+++ b/src-tauri/src/registry.rs
@@ -106,8 +106,11 @@ pub struct ServerEntry {
     /// Working directory for a stdio server. Unset means inherit the gateway's
     /// cwd (the previous behavior). A leading `~` expands to the home dir and
     /// `${VAR}` expands from the environment, so a server that operates on the
-    /// project (e.g. a grep/filesystem tool) can be pinned to it. Only applies to
-    /// stdio servers. See issue #239.
+    /// project (e.g. a grep/filesystem tool) can be pinned to it. The reserved
+    /// token `${ROOT}` expands to the upstream MCP client's current project
+    /// directory (its first declared root); it is resolved only in stdio-gateway
+    /// mode, and falls back to the gateway cwd when no client root is known.
+    /// Only applies to stdio servers. See issue #239.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cwd: Option<String>,
     /// Where this entry came from, e.g. "imported:cursor" or "manual".

--- a/src-tauri/tests/root_cwd.rs
+++ b/src-tauri/tests/root_cwd.rs
@@ -1,0 +1,58 @@
+//! End-to-end check that a stdio server spawns in the resolved `${ROOT}` cwd.
+//!
+//! The `${ROOT}` chain the gateway runs is: a `file://` root URI is decoded to a
+//! path (`file_uri_to_path`), substituted into the server's configured cwd
+//! (`resolve_root_token`), and the child is spawned with the result. The two
+//! parsing halves are unit-tested in `downstream.rs`; this drives the real
+//! `mock-mcp-server` through the actual spawn path and asserts the child process
+//! reports the resolved directory as its cwd, closing the loop for issue #239.
+
+use conduit_lib::downstream::{resolve_root_token, DownstreamServer, StdioTransport};
+use conduit_lib::router::Router;
+use serde_json::json;
+
+/// Spawn the mock server with the given cwd and return what its `pwd` tool reports.
+fn reported_cwd(cwd: Option<&str>) -> String {
+    let mock = env!("CARGO_BIN_EXE_mock-mcp-server");
+    let transport = StdioTransport::spawn(mock, &[], &[], cwd).expect("spawn mock");
+    let server =
+        DownstreamServer::connect("mock".to_string(), Box::new(transport)).expect("connect mock");
+    let mut router = Router::new();
+    router.add(server);
+    let result = router
+        .route_call("mock__pwd", json!({}))
+        .expect("pwd call should route");
+    result["content"][0]["text"]
+        .as_str()
+        .expect("pwd returns text")
+        .to_string()
+}
+
+#[test]
+fn resolved_root_places_the_spawned_server_and_none_falls_back() {
+    // A real directory standing in for the client's project root. Canonicalize so
+    // the comparison is immune to symlinks (macOS /tmp) and path casing.
+    let root_dir = std::fs::canonicalize(std::env::temp_dir()).expect("canonicalize temp dir");
+    let root = root_dir.to_string_lossy().to_string();
+
+    // ${ROOT} with a known root resolves to that path, and the server actually
+    // spawns there.
+    let resolved = resolve_root_token("${ROOT}", Some(&root)).expect("resolve to a path");
+    let reported = reported_cwd(Some(&resolved));
+    assert_eq!(
+        std::fs::canonicalize(&reported).expect("canonicalize reported cwd"),
+        root_dir,
+        "the server should run in the resolved ${{ROOT}} directory"
+    );
+
+    // ${ROOT} with no known root resolves to None, so the server inherits the
+    // default (this test process's) cwd, not the root dir - the fallback path that
+    // keeps a rootless client working.
+    assert!(resolve_root_token("${ROOT}", None).is_none());
+    let reported_default = reported_cwd(None);
+    assert_ne!(
+        std::fs::canonicalize(&reported_default).ok(),
+        Some(root_dir),
+        "with no known root the server must not run in the root directory"
+    );
+}


### PR DESCRIPTION
Implements dynamic `${ROOT}` working directory for stdio MCP servers, resolved from the upstream client's MCP roots. Closes #239.

A server's `cwd` can use the reserved token `${ROOT}`, which expands to the AI client's current project directory, so a filesystem/grep server operates on the project the client has open rather than wherever Toolport sits. This is the dynamic follow-up to the static per-server `cwd` shipped in v1.7 (#262).

## Key decision: stdio-only

`${ROOT}` is resolved **only in stdio-gateway mode**, where the client spawns its own gateway process, so a downstream server is 1:1 with one client and one set of roots. In HTTP/headless mode one process serves every client from a shared router (and the gateway often runs on a different machine than the client), so there is no single correct `${ROOT}`; there it falls back to the gateway cwd. This matches how the codebase already special-cases HTTP.

## Approach

- First declared root, decoded `file://` -> path via `url::Url::to_file_path` (Windows drive letters / UNC / percent-decoding handled by the crate, not by hand).
- A shared `client_root` on `GatewayState`, read by every router-rebuild path (registry watcher, tools/call self-heal, and the roots handler), exactly as the existing shared `profile` is. After `initialize` (stdio, client declared `roots`) an off-thread `roots/list` fetch populates it; it never blocks the initialize response.
- Respawn on `notifications/roots/list_changed`, only when the resolved path actually changed and a `${ROOT}` server exists, so a client with no root (or no `${ROOT}` server) never churns.
- No/empty roots, or a client that doesn't declare `roots`, falls back to the gateway cwd; a literal `${ROOT}` is never passed to a spawn.

### Design note: spawn-then-resolve vs connect-after-roots

I originally planned to *defer* `${ROOT}` servers until roots resolve (never spawn in the wrong dir). Tracing the rebuild sites showed that needs a tri-state resolution value read by four concurrent paths plus a deferral filter, a lot of concurrency surface for a window that's tiny in practice: clients only call tools after `notifications/initialized`, by which point the post-initialize fetch has essentially always resolved, and a stdio gateway is frequently spawned with the project as its cwd anyway. So `${ROOT}` servers spawn with the fallback cwd for the sub-second pre-roots window, then get the real root. Full deferral remains a clean follow-up if we ever want belt-and-suspenders write-safety.

## Progress

- [x] `resolve_root_token` + `file_uri_to_path` helpers (pure, unit-tested)
- [x] Thread the root through `build_router` / `connect_one` + desktop probe sites
- [x] Shared `client_root` + async `roots/list` fetch after `initialize`
- [x] Respawn on `roots/list_changed` (watcher + self-heal read the shared root too)
- [x] Startup build shares `rebuild_lock` + reads the shared root (fixes a swap race CodeRabbit flagged)
- [x] `root_cwd.rs` integration test

## Testing

`cargo test` green on Windows: `resolve_root_token` / `file_uri_to_path` unit tests, the full `downstream::tests` module, the `toolport-gateway` bin suite (86 tests), and the new `root_cwd.rs` integration test (drives the real mock server, asserts it spawns in the resolved `${ROOT}` dir and falls back when there's no root). lib + `toolport-gateway` bin type-check clean.
