### PR TITLE
test: add unit tests for the fmtTokens token formatter

### DIFF
--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "vitest";
+import { fmtTokens } from "./utils";
+
+describe("fmtTokens", () => {
+  it("renders small numbers as-is", () => {
+    expect(fmtTokens(0)).toBe("0");
+    expect(fmtTokens(1)).toBe("1");
+    expect(fmtTokens(999)).toBe("999");
+  });
+
+  it("renders thousands with a k suffix", () => {
+    expect(fmtTokens(1000)).toBe("1.0k");
+    expect(fmtTokens(12345)).toBe("12.3k");
+    expect(fmtTokens(999499)).toBe("999.5k");
+  });
+
+  it("renders millions with an M suffix", () => {
+    expect(fmtTokens(1_000_000)).toBe("1.0M");
+    expect(fmtTokens(1_234_567)).toBe("1.2M");
+  });
+
+  it("handles the boundary at 999999 (rounds up to 1000.0k, not 1.0M)", () => {
+    // 999999 is just below the 1_000_000 threshold, so it takes the "k" branch:
+    // (999999 / 1000).toFixed(1) === "1000.0", giving "1000.0k" rather than "1.0M".
+    expect(fmtTokens(999999)).toBe("1000.0k");
+  });
+
+  it("passes 0 and negative inputs through unformatted", () => {
+    expect(fmtTokens(0)).toBe("0");
+    expect(fmtTokens(-1)).toBe("-1");
+    expect(fmtTokens(-12345)).toBe("-12345");
+  });
+});


### PR DESCRIPTION
## Summary
Adds unit test coverage for `fmtTokens` in `src/lib/utils.ts`, which had none.

- Small numbers (< 1000) render as-is
- Thousands render with a `k` suffix
- Millions render with an `M` suffix
- The `999999` boundary renders `"1000.0k"`, not `"1.0M"` (asserts the actual current behavior, per the issue notes)
- `0` and negative inputs

## Test plan
- [x] `npm test` — 74/74 passing (5 new)
- [x] `npm run lint` — no new errors/warnings from this file
- [x] `npx prettier --check` — clean

Closes #265