### PR TITLE
docs: add consolidated CONDUIT environment variable reference

### DIFF
--- a/docs/headless.md
+++ b/docs/headless.md
@@ -271,10 +271,10 @@ Toolport reads the following environment variables. This is the complete referen
 | `CONDUIT_DATA_DIR` | Override the full path to the Toolport config directory. | OS config root | Everywhere |
 | `CONDUIT_DEBUG` | Enable trace and debug logging. | None | Everywhere |
 | `CONDUIT_DISCOVERY` | Override discovery mode (`lazy`, `grouped`, `full`). | Registry setting | Everywhere |
-| `CONDUIT_EMBED_BLEND` | Semantic search embedding blend weight (float). | Registry setting | Everywhere |
-| `CONDUIT_EMBED_ENDPOINT` | Semantic search embedding endpoint URL. | Registry setting | Everywhere |
-| `CONDUIT_EMBED_KEY` | API key for the semantic search embedding endpoint. | None | Everywhere |
-| `CONDUIT_EMBED_MODEL` | Semantic search embedding model name. | Registry setting | Everywhere |
+| `CONDUIT_EMBED_BLEND` | Semantic search embedding blend weight (float). | Registry setting | Gateway / semantic search |
+| `CONDUIT_EMBED_ENDPOINT` | Semantic search embedding endpoint URL. | Registry setting | Gateway / semantic search |
+| `CONDUIT_EMBED_KEY` | API key for the semantic search embedding endpoint. | None | Gateway / semantic search |
+| `CONDUIT_EMBED_MODEL` | Semantic search embedding model name. | Registry setting | Gateway / semantic search |
 | `CONDUIT_HTTP` | Direct port override or boolean flag to enable HTTP. | None | Gateway |
 | `CONDUIT_HTTP_HOST` | Host IP to bind for the HTTP endpoint. | `127.0.0.1` | Gateway |
 | `CONDUIT_HTTP_PORT` | Port for the HTTP endpoint (when `CONDUIT_HTTP` is a boolean). | `8765` | Gateway |
@@ -284,7 +284,7 @@ Toolport reads the following environment variables. This is the complete referen
 | `CONDUIT_RESULT_BUDGET` | Byte budget before large tool results get shaped/truncated (0 to disable). | `49152` | Everywhere |
 | `CONDUIT_SECRET_<KEY>` | Process env override for a specific scoped secret. | None | Headless |
 | `CONDUIT_SECRET_KEY` | Passphrase to activate the `secrets.enc` file backend. | None | Headless |
-| `CONDUIT_SEMANTIC` | Toggle semantic search (`on` or `off`). | Registry setting | Everywhere |
+| `CONDUIT_SEMANTIC` | Toggle semantic search (`on` or `off`). | Registry setting | Gateway / semantic search |
 | `CONDUIT_TARGET_TRIPLE` | Packaged fallback target architecture (internal use). | None | Desktop |
 
 ## Notes

--- a/docs/headless.md
+++ b/docs/headless.md
@@ -260,6 +260,33 @@ Optional internal pass: re-run the gateway HTTP + MCP integration tests, smoke
 `POST /mcp` initialize → `tools/list` with and without auth, and confirm
 unauthenticated requests to a non-loopback bind are rejected at startup.
 
+## Environment Variables
+
+Toolport reads the following environment variables. This is the complete reference across all components.
+
+| Name | Purpose | Default | Where it applies |
+| ---- | ------- | ------- | ---------------- |
+| `CONDUIT_ALLOW_BARE_SECRET_ENV` | Opt-in to read bare secret keys (e.g. `STRIPE_KEY`) from the environment. | None | Headless |
+| `CONDUIT_CLIENT_ID` | Identifies the client to the gateway for live profile resolution. | None | Clients |
+| `CONDUIT_DATA_DIR` | Override the full path to the Toolport config directory. | OS config root | Everywhere |
+| `CONDUIT_DEBUG` | Enable trace and debug logging. | None | Everywhere |
+| `CONDUIT_DISCOVERY` | Override discovery mode (`lazy`, `grouped`, `full`). | Registry setting | Everywhere |
+| `CONDUIT_EMBED_BLEND` | Semantic search embedding blend weight (float). | Registry setting | Everywhere |
+| `CONDUIT_EMBED_ENDPOINT` | Semantic search embedding endpoint URL. | Registry setting | Everywhere |
+| `CONDUIT_EMBED_KEY` | API key for the semantic search embedding endpoint. | None | Everywhere |
+| `CONDUIT_EMBED_MODEL` | Semantic search embedding model name. | Registry setting | Everywhere |
+| `CONDUIT_HTTP` | Direct port override or boolean flag to enable HTTP. | None | Gateway |
+| `CONDUIT_HTTP_HOST` | Host IP to bind for the HTTP endpoint. | `127.0.0.1` | Gateway |
+| `CONDUIT_HTTP_PORT` | Port for the HTTP endpoint (when `CONDUIT_HTTP` is a boolean). | `8765` | Gateway |
+| `CONDUIT_HTTP_TOKEN` | Bearer token for HTTP authentication. | None | Gateway |
+| `CONDUIT_PROFILE` | The client's effective scope or profile. | None | Clients |
+| `CONDUIT_REGISTRY` | Override the path to `registry.json`. | Config root | Everywhere |
+| `CONDUIT_RESULT_BUDGET` | Byte budget before large tool results get shaped/truncated (0 to disable). | `49152` | Everywhere |
+| `CONDUIT_SECRET_<KEY>` | Process env override for a specific scoped secret. | None | Headless |
+| `CONDUIT_SECRET_KEY` | Passphrase to activate the `secrets.enc` file backend. | None | Headless |
+| `CONDUIT_SEMANTIC` | Toggle semantic search (`on` or `off`). | Registry setting | Everywhere |
+| `CONDUIT_TARGET_TRIPLE` | Packaged fallback target architecture (internal use). | None | Desktop |
+
 ## Notes
 
 - **HITL approvals** need the desktop app’s approval broker. Leave human

--- a/docs/headless.md
+++ b/docs/headless.md
@@ -279,7 +279,7 @@ Toolport reads the following environment variables. This is the complete referen
 | `CONDUIT_HTTP_HOST` | Host IP to bind for the HTTP endpoint. | `127.0.0.1` | Gateway |
 | `CONDUIT_HTTP_PORT` | Port for the HTTP endpoint (when `CONDUIT_HTTP` is a boolean). | `8765` | Gateway |
 | `CONDUIT_HTTP_TOKEN` | Bearer token for HTTP authentication. | None | Gateway |
-| `CONDUIT_PROFILE` | The client's effective scope or profile. | None | Clients |
+| `CONDUIT_PROFILE` | Initial profile value for a scoped client install; live scope is resolved via `CONDUIT_CLIENT_ID`. | None | Clients |
 | `CONDUIT_REGISTRY` | Override the path to `registry.json`. | Config root | Everywhere |
 | `CONDUIT_RESULT_BUDGET` | Byte budget before large tool results get shaped/truncated (0 to disable). | `49152` | Everywhere |
 | `CONDUIT_SECRET_<KEY>` | Process env override for a specific scoped secret. | None | Headless |


### PR DESCRIPTION
<!-- Thanks for contributing to Toolport. Keep PRs focused and small where you can. -->

Add a consolidated environment-variables reference to the docs #269
## What and why

Toolport reads ~20 `CONDUIT_*` environment variables scattered across the `src-tauri/src` codebase, but previously only a subset of them were documented in `docs/headless.md`. 

This PR adds a comprehensive reference table to `docs/headless.md` that enumerates all `CONDUIT_*` variables. The table lists each variable's name, purpose, default value, and where it applies, providing a single source of truth for users and contributors without duplicating existing sections.

## Testing

- [x] `npm run build` passes
- [x] `npm run test` passes
- [x] `npm run audit:prod` passes
- [x] `npm run test:rust` passes (`npm run test:rust:windows` on Windows if the debug gateway binary is locked)
- [x] Ran the app (`npm run tauri dev`) and checked the change by hand

*(Note: This is a documentation-only change, so no code behavior is affected. Verified formatting visually in markdown.)*

## Notes

- Checked that no secret values or keys were included in the table's default values column.
- This PR only touches `docs/headless.md`; there are no code changes.

Closes #269