### PR TITLE
style(docs): format environment variable reference

### DIFF
--- a/docs/headless.md
+++ b/docs/headless.md
@@ -264,28 +264,28 @@ unauthenticated requests to a non-loopback bind are rejected at startup.
 
 Toolport reads the following environment variables. This is the complete reference across all components.
 
-| Name | Purpose | Default | Where it applies |
-| ---- | ------- | ------- | ---------------- |
-| `CONDUIT_ALLOW_BARE_SECRET_ENV` | Opt-in to read bare secret keys (e.g. `STRIPE_KEY`) from the environment. | None | Headless |
-| `CONDUIT_CLIENT_ID` | Identifies the client to the gateway for live profile resolution. | None | Clients |
-| `CONDUIT_DATA_DIR` | Override the full path to the Toolport config directory. | OS config root | Everywhere |
-| `CONDUIT_DEBUG` | Enable trace and debug logging. | None | Everywhere |
-| `CONDUIT_DISCOVERY` | Override discovery mode (`lazy`, `grouped`, `full`). | Registry setting | Everywhere |
-| `CONDUIT_EMBED_BLEND` | Semantic search embedding blend weight (float). | Registry setting | Gateway / semantic search |
-| `CONDUIT_EMBED_ENDPOINT` | Semantic search embedding endpoint URL. | Registry setting | Gateway / semantic search |
-| `CONDUIT_EMBED_KEY` | API key for the semantic search embedding endpoint. | None | Gateway / semantic search |
-| `CONDUIT_EMBED_MODEL` | Semantic search embedding model name. | Registry setting | Gateway / semantic search |
-| `CONDUIT_HTTP` | Direct port override or boolean flag to enable HTTP. | None | Gateway |
-| `CONDUIT_HTTP_HOST` | Host IP to bind for the HTTP endpoint. | `127.0.0.1` | Gateway |
-| `CONDUIT_HTTP_PORT` | Port for the HTTP endpoint (when `CONDUIT_HTTP` is a boolean). | `8765` | Gateway |
-| `CONDUIT_HTTP_TOKEN` | Bearer token for HTTP authentication. | None | Gateway |
-| `CONDUIT_PROFILE` | Initial profile value for a scoped client install; live scope is resolved via `CONDUIT_CLIENT_ID`. | None | Clients |
-| `CONDUIT_REGISTRY` | Override the path to `registry.json`. | Config root | Everywhere |
-| `CONDUIT_RESULT_BUDGET` | Byte budget before large tool results get shaped/truncated (0 to disable). | `49152` | Everywhere |
-| `CONDUIT_SECRET_<KEY>` | Process env override for a specific scoped secret. | None | Headless |
-| `CONDUIT_SECRET_KEY` | Passphrase to activate the `secrets.enc` file backend. | None | Headless |
-| `CONDUIT_SEMANTIC` | Toggle semantic search (`on` or `off`). | Registry setting | Gateway / semantic search |
-| `CONDUIT_TARGET_TRIPLE` | Packaged fallback target architecture (internal use). | None | Desktop |
+| Name                            | Purpose                                                                                            | Default          | Where it applies          |
+| ------------------------------- | -------------------------------------------------------------------------------------------------- | ---------------- | ------------------------- |
+| `CONDUIT_ALLOW_BARE_SECRET_ENV` | Opt-in to read bare secret keys (e.g. `STRIPE_KEY`) from the environment.                          | None             | Headless                  |
+| `CONDUIT_CLIENT_ID`             | Identifies the client to the gateway for live profile resolution.                                  | None             | Clients                   |
+| `CONDUIT_DATA_DIR`              | Override the full path to the Toolport config directory.                                           | OS config root   | Everywhere                |
+| `CONDUIT_DEBUG`                 | Enable trace and debug logging.                                                                    | None             | Everywhere                |
+| `CONDUIT_DISCOVERY`             | Override discovery mode (`lazy`, `grouped`, `full`).                                               | Registry setting | Everywhere                |
+| `CONDUIT_EMBED_BLEND`           | Semantic search embedding blend weight (float).                                                    | Registry setting | Gateway / semantic search |
+| `CONDUIT_EMBED_ENDPOINT`        | Semantic search embedding endpoint URL.                                                            | Registry setting | Gateway / semantic search |
+| `CONDUIT_EMBED_KEY`             | API key for the semantic search embedding endpoint.                                                | None             | Gateway / semantic search |
+| `CONDUIT_EMBED_MODEL`           | Semantic search embedding model name.                                                              | Registry setting | Gateway / semantic search |
+| `CONDUIT_HTTP`                  | Direct port override or boolean flag to enable HTTP.                                               | None             | Gateway                   |
+| `CONDUIT_HTTP_HOST`             | Host IP to bind for the HTTP endpoint.                                                             | `127.0.0.1`      | Gateway                   |
+| `CONDUIT_HTTP_PORT`             | Port for the HTTP endpoint (when `CONDUIT_HTTP` is a boolean).                                     | `8765`           | Gateway                   |
+| `CONDUIT_HTTP_TOKEN`            | Bearer token for HTTP authentication.                                                              | None             | Gateway                   |
+| `CONDUIT_PROFILE`               | Initial profile value for a scoped client install; live scope is resolved via `CONDUIT_CLIENT_ID`. | None             | Clients                   |
+| `CONDUIT_REGISTRY`              | Override the path to `registry.json`.                                                              | Config root      | Everywhere                |
+| `CONDUIT_RESULT_BUDGET`         | Byte budget before large tool results get shaped/truncated (0 to disable).                         | `49152`          | Everywhere                |
+| `CONDUIT_SECRET_<KEY>`          | Process env override for a specific scoped secret.                                                 | None             | Headless                  |
+| `CONDUIT_SECRET_KEY`            | Passphrase to activate the `secrets.enc` file backend.                                             | None             | Headless                  |
+| `CONDUIT_SEMANTIC`              | Toggle semantic search (`on` or `off`).                                                            | Registry setting | Gateway / semantic search |
+| `CONDUIT_TARGET_TRIPLE`         | Packaged fallback target architecture (internal use).                                              | None             | Desktop                   |
 
 ## Notes
 


### PR DESCRIPTION
## What changed

Formats the environment-variables table in `docs/headless.md` with the repository's checked-in Prettier configuration.

## Why

Main CI #546 failed at `npm run format:check` after the documentation table merged. The security code in the same mainline snapshot was not the cause.

## Validation

- `npx prettier --check docs/headless.md`
- `git diff --check`

Restores the formatting gate on `main` once merged.
