### PR TITLE
feat(import): review bulk imports before applying

### DIFF
--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -460,15 +460,40 @@ fn servers_to_import(detected: &[clients::DetectedClient], existing: &Registry) 
     picked
 }
 
-/// Pull servers from every detected client into the registry, skipping any whose
-/// name already exists.
+fn selected_servers_to_import(
+    detected: &[clients::DetectedClient],
+    existing: &Registry,
+    selected: Option<&std::collections::HashSet<String>>,
+) -> Vec<ServerEntry> {
+    servers_to_import(detected, existing)
+        .into_iter()
+        .filter(|server| {
+            selected.map_or(true, |keys| {
+                keys.contains(&clients::import_dedupe_key(
+                    &server.name,
+                    server.command.as_deref(),
+                    &server.args,
+                ))
+            })
+        })
+        .collect()
+}
+
+/// Pull selected servers from every detected client into the registry. Omitting
+/// `selected` preserves the legacy import-all behavior; callers that preview
+/// first pass the opaque import keys they explicitly confirmed.
 #[tauri::command]
-async fn import_servers(state: State<'_, RegistryState>) -> Result<Registry, String> {
+async fn import_servers(
+    state: State<'_, RegistryState>,
+    selected: Option<Vec<String>>,
+) -> Result<Registry, String> {
     let detected = tauri::async_runtime::spawn_blocking(clients::detect_clients)
         .await
         .map_err(|e| e.to_string())?;
     let mut reg = state.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
-    for server in servers_to_import(&detected, &reg) {
+    let selected: Option<std::collections::HashSet<String>> =
+        selected.map(|keys| keys.into_iter().collect());
+    for server in selected_servers_to_import(&detected, &reg, selected.as_ref()) {
         reg.add_server(server);
     }
     registry::save(&reg)?;
@@ -2000,6 +2025,10 @@ fn read_setup_file(path: String) -> Result<String, String> {
 #[derive(serde::Serialize)]
 #[serde(rename_all = "camelCase")]
 struct ImportItem {
+    /// Stable only for the current detected-import preview. Shared setup previews
+    /// have no key because they are confirmed as one complete document.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    key: Option<String>,
     name: String,
     transport: String,
     command: Option<String>,
@@ -2007,6 +2036,32 @@ struct ImportItem {
     url: Option<String>,
     /// False if a server with this name already exists (the import would skip it).
     is_new: bool,
+}
+
+/// Show exactly what the bulk client import would add without changing the
+/// registry. The same import key is accepted by `import_servers` after review.
+#[tauri::command]
+async fn preview_import_servers(state: State<'_, RegistryState>) -> Result<Vec<ImportItem>, String> {
+    let detected = tauri::async_runtime::spawn_blocking(clients::detect_clients)
+        .await
+        .map_err(|e| e.to_string())?;
+    let reg = state.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+    Ok(servers_to_import(&detected, &reg)
+        .into_iter()
+        .map(|server| ImportItem {
+            key: Some(clients::import_dedupe_key(
+                &server.name,
+                server.command.as_deref(),
+                &server.args,
+            )),
+            name: server.name,
+            transport: server.transport,
+            command: server.command,
+            args: server.args,
+            url: server.url,
+            is_new: true,
+        })
+        .collect())
 }
 
 /// Parse a shared setup and report what it WOULD add, without importing anything.
@@ -2028,6 +2083,7 @@ fn preview_import(state: State<RegistryState>, json: String) -> Result<Vec<Impor
                 .iter()
                 .any(|e| e.name.eq_ignore_ascii_case(&s.name));
             ImportItem {
+                key: None,
                 name: s.name,
                 transport: s.transport,
                 command: s.command,
@@ -2471,6 +2527,7 @@ pub fn run() {
             get_registry,
             take_registry_recovery_notice,
             import_servers,
+            preview_import_servers,
             parse_server_snippet,
             add_server,
             update_server,
@@ -2820,6 +2877,19 @@ mod tests {
         let picked = servers_to_import(&detected, &reg);
         assert_eq!(picked.len(), 1);
         assert_eq!(picked[0].name.to_lowercase(), "linear");
+    }
+
+    #[test]
+    fn selected_servers_to_import_respects_the_reviewed_keys() {
+        let detected = vec![detected_client(
+            "cursor",
+            vec!["linear", "github"],
+            vec![],
+        )];
+        let selected = std::collections::HashSet::from(["name:github".to_string()]);
+        let picked = selected_servers_to_import(&detected, &Registry::default(), Some(&selected));
+        assert_eq!(picked.len(), 1);
+        assert_eq!(picked[0].name, "github");
     }
 
     #[test]

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,6 +27,7 @@ import {
   getRegistry,
   takeRegistryRecoveryNotice,
   importServers,
+  previewImportServers,
   probeServers,
   removeServer,
   setAllEnabled,
@@ -38,6 +39,7 @@ import {
   isEnabled,
   isGatewayServer,
   type DetectedClient,
+  type ImportItem,
   type ProbeResult,
   type Registry,
   type ServerEntry,
@@ -53,6 +55,7 @@ import { AppSidebar } from "@/components/AppSidebar";
 import { PendingApprovals } from "@/components/PendingApprovals";
 import { RegistryServerRow } from "@/components/RegistryServerRow";
 import { ServerDialog } from "@/components/ServerDialog";
+import { ImportReviewDialog } from "@/components/ImportReviewDialog";
 
 // Secondary destinations are code-split so the initial bundle only carries the
 // default Servers view and the app chrome. Each mounts behind a Suspense
@@ -93,6 +96,8 @@ const BULK_DISABLE_CONFIRM_MIN = 3;
 function App() {
   const [registry, setRegistry] = useState<Registry | null>(null);
   const [clients, setClients] = useState<DetectedClient[]>([]);
+  const [importPreview, setImportPreview] = useState<ImportItem[] | null>(null);
+  const [importing, setImporting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   const [busyId, setBusyId] = useState<string | null>(null);
@@ -464,9 +469,26 @@ function App() {
   }
 
   async function handleImport() {
+    setImporting(true);
+    try {
+      const preview = await previewImportServers();
+      if (preview.length === 0) {
+        toast.success("Nothing new to import");
+        return;
+      }
+      setImportPreview(preview);
+    } catch (e) {
+      toastError(`Couldn't prepare import: ${e}`);
+    } finally {
+      setImporting(false);
+    }
+  }
+
+  async function confirmImport(selected: string[]) {
+    setImporting(true);
     try {
       const before = registry?.servers.length ?? 0;
-      const next = await importServers();
+      const next = await importServers(selected);
       setRegistry(next);
       const added = next.servers.length - before;
       toast.success(
@@ -474,8 +496,11 @@ function App() {
           ? `Imported ${added} server${added === 1 ? "" : "s"}`
           : "Nothing new to import",
       );
+      setImportPreview(null);
     } catch (e) {
       toastError(`Import failed: ${e}`);
+    } finally {
+      setImporting(false);
     }
   }
 
@@ -739,6 +764,15 @@ function App() {
           </ScrollArea>
         </main>
       </div>
+      <ImportReviewDialog
+        open={importPreview !== null}
+        items={importPreview ?? []}
+        busy={importing}
+        onOpenChange={(open) => {
+          if (!open && !importing) setImportPreview(null);
+        }}
+        onConfirm={confirmImport}
+      />
       {showOnboarding && registry && (
         <Suspense fallback={null}>
           <Onboarding

--- a/src/components/ClientDetail.tsx
+++ b/src/components/ClientDetail.tsx
@@ -18,6 +18,7 @@ import {
   importableServers,
   isGatewayServer,
   type DetectedClient,
+  type ImportItem,
   type McpServer,
   type Registry,
   type ServerEntry,
@@ -40,6 +41,7 @@ import {
 } from "@/components/ui/select";
 import { TransportPill } from "@/components/TransportPill";
 import { ConfirmDialog } from "@/components/ConfirmDialog";
+import { ImportReviewDialog } from "@/components/ImportReviewDialog";
 
 interface Props {
   client: DetectedClient;
@@ -50,6 +52,7 @@ interface Props {
 
 export function ClientDetail({ client, registry, onChanged, onRegistryChange }: Props) {
   const [busy, setBusy] = useState(false);
+  const [bulkImportPreview, setBulkImportPreview] = useState<ImportItem[] | null>(null);
   // "" = expose all enabled servers (follow active profile); else scope to one.
   const [profile, setProfile] = useState("");
   const [migrateOpen, setMigrateOpen] = useState(false);
@@ -151,6 +154,15 @@ export function ClientDetail({ client, registry, onChanged, onRegistryChange }: 
   }
   const allServers = [...byName.values()];
   const toImport = importableServers(client, registry);
+  const bulkImportCandidates = toImport.map((server, index) => ({
+    key: String(index),
+    name: server.name,
+    transport: server.transport,
+    command: server.command,
+    args: server.args,
+    url: server.url,
+    isNew: true,
+  }));
 
   async function importOne(server: McpServer) {
     const isPlugin = pluginNames.has(server.name.toLowerCase());
@@ -184,10 +196,16 @@ export function ClientDetail({ client, registry, onChanged, onRegistryChange }: 
   }
 
   async function handleImportAll() {
+    setBulkImportPreview(bulkImportCandidates);
+  }
+
+  async function confirmImportAll(selected: string[]) {
     setBusy(true);
     let ok = 0;
     const failed: string[] = [];
-    for (const s of toImport) {
+    for (const key of selected) {
+      const s = toImport[Number(key)];
+      if (!s) continue;
       try {
         await importOne(s);
         ok += 1;
@@ -198,6 +216,7 @@ export function ClientDetail({ client, registry, onChanged, onRegistryChange }: 
     setBusy(false);
     if (failed.length === 0) {
       toast.success(`Imported ${ok} server${ok === 1 ? "" : "s"} into Toolport`);
+      setBulkImportPreview(null);
     } else if (ok > 0) {
       toast.warning(`Imported ${ok}, couldn't import ${failed.join(", ")}`);
     } else {
@@ -550,6 +569,16 @@ export function ClientDetail({ client, registry, onChanged, onRegistryChange }: 
           </DialogFooter>
         </DialogContent>
       </Dialog>
+      <ImportReviewDialog
+        open={bulkImportPreview !== null}
+        items={bulkImportPreview ?? []}
+        busy={busy}
+        title={`Review ${client.name} servers`}
+        onOpenChange={(open) => {
+          if (!open && !busy) setBulkImportPreview(null);
+        }}
+        onConfirm={confirmImportAll}
+      />
     </div>
   );
 }

--- a/src/components/ImportReviewDialog.tsx
+++ b/src/components/ImportReviewDialog.tsx
@@ -1,0 +1,188 @@
+import { useState } from "react";
+import { Check, ShieldAlert } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { TransportPill } from "@/components/TransportPill";
+import type { ImportItem } from "@/lib/types";
+
+interface Props {
+  open: boolean;
+  items: ImportItem[];
+  busy?: boolean;
+  title?: string;
+  onOpenChange: (open: boolean) => void;
+  onConfirm: (keys: string[]) => void;
+}
+
+/** Review and choose detected client servers before adding them to Toolport. */
+export function ImportReviewDialog({
+  open,
+  items,
+  busy = false,
+  title = "Review servers to import",
+  onOpenChange,
+  onConfirm,
+}: Props) {
+  if (!open) return null;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-lg">
+        <ImportReviewContent
+          items={items}
+          busy={busy}
+          title={title}
+          onOpenChange={onOpenChange}
+          onConfirm={onConfirm}
+        />
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function ImportReviewContent({
+  items,
+  busy = false,
+  title = "Review servers to import",
+  onOpenChange,
+  onConfirm,
+}: Omit<Props, "open">) {
+  const keyedItems = items.map((item, index) => ({
+    item,
+    key: item.key ?? `${item.name}-${index}`,
+  }));
+  const [selected, setSelected] = useState<Set<string>>(
+    () => new Set(keyedItems.map(({ key }) => key)),
+  );
+
+  const selectedCount = selected.size;
+  return (
+    <>
+      <DialogHeader>
+        <DialogTitle>{title}</DialogTitle>
+      </DialogHeader>
+      <div className="flex flex-col gap-4 py-1">
+        <p className="text-xs text-muted-foreground">
+          Review the commands and URLs before adding them. You can leave any server
+          unchecked and import only the ones you want.
+        </p>
+        <div className="flex max-h-72 flex-col gap-2 overflow-y-auto">
+          {keyedItems.map(({ item, key }) => {
+            const isSelected = selected.has(key);
+            return (
+              <button
+                key={key}
+                type="button"
+                className={`rounded-md text-left transition-colors ${
+                  isSelected ? "ring-1 ring-success/60" : "opacity-60"
+                }`}
+                onClick={() =>
+                  setSelected((previous) => {
+                    const next = new Set(previous);
+                    if (isSelected) next.delete(key);
+                    else next.add(key);
+                    return next;
+                  })
+                }
+              >
+                <ImportRow item={item} selected={isSelected} />
+              </button>
+            );
+          })}
+        </div>
+        <div className="flex items-center justify-between gap-2 border-t pt-3">
+          <Button variant="ghost" onClick={() => onOpenChange(false)} disabled={busy}>
+            Cancel
+          </Button>
+          <Button
+            onClick={() => onConfirm(Array.from(selected))}
+            disabled={busy || selectedCount === 0}
+          >
+            <Check className="size-4" />
+            {selectedCount === 0
+              ? "Select a server"
+              : `Import ${selectedCount} server${selectedCount === 1 ? "" : "s"}`}
+          </Button>
+        </div>
+      </div>
+    </>
+  );
+}
+
+/** One reviewable server: name, what it runs, and the relevant safety flags. */
+export function ImportRow({ item, selected }: { item: ImportItem; selected?: boolean }) {
+  const runs =
+    item.command != null ? [item.command, ...item.args].join(" ") : (item.url ?? "");
+  const shell = runsShell(item.command);
+  const privateHost = isPrivateHostUrl(item.url);
+  return (
+    <div className="rounded-md border px-3 py-2">
+      <div className="flex items-center gap-2">
+        {selected !== undefined && (
+          <span
+            aria-hidden="true"
+            className={`size-3 rounded-sm border ${
+              selected ? "border-success bg-success" : "border-muted-foreground"
+            }`}
+          />
+        )}
+        <span className="truncate text-sm font-medium">{item.name}</span>
+        <TransportPill transport={item.transport} />
+        {!item.isNew && (
+          <span className="ml-auto shrink-0 text-xs text-muted-foreground">
+            already added
+          </span>
+        )}
+      </div>
+      {runs && (
+        <p className="mt-1 font-mono text-xs break-all text-muted-foreground">{runs}</p>
+      )}
+      {shell && (
+        <p className="mt-1.5 flex items-center gap-1.5 text-xs text-warning">
+          <ShieldAlert className="size-3.5 shrink-0" />
+          Runs a shell command. Only import setups you trust.
+        </p>
+      )}
+      {privateHost && (
+        <p className="mt-1.5 flex items-center gap-1.5 text-xs text-warning">
+          <ShieldAlert className="size-3.5 shrink-0" />
+          Connects to a private or internal address. Only import setups you trust.
+        </p>
+      )}
+    </div>
+  );
+}
+
+function runsShell(command: string | null): boolean {
+  if (!command) return false;
+  const base = command
+    .replace(/\\/g, "/")
+    .split("/")
+    .pop()!
+    .toLowerCase()
+    .replace(/\.exe$/, "");
+  return ["cmd", "sh", "bash", "zsh", "powershell", "pwsh"].includes(base);
+}
+
+function isPrivateHostUrl(url: string | null | undefined): boolean {
+  if (!url) return false;
+  let host: string;
+  try {
+    host = new URL(url).hostname.toLowerCase().replace(/^\[|\]$/g, "");
+  } catch {
+    return false;
+  }
+  if (host === "localhost" || host.endsWith(".localhost") || host === "::1") return true;
+  const match = host.match(/^(\d{1,3})\.(\d{1,3})\.\d{1,3}\.\d{1,3}$/);
+  if (!match) return false;
+  const first = Number(match[1]);
+  const second = Number(match[2]);
+  return (
+    first === 127 ||
+    first === 10 ||
+    first === 0 ||
+    (first === 192 && second === 168) ||
+    (first === 172 && second >= 16 && second <= 31) ||
+    (first === 169 && second === 254)
+  );
+}

--- a/src/components/Onboarding.tsx
+++ b/src/components/Onboarding.tsx
@@ -22,6 +22,7 @@ import {
   importServers,
   installGateway,
   listStacks,
+  previewImportServers,
   teamConnect,
 } from "@/lib/api";
 import { teamUrlError } from "@/lib/teamUrl";
@@ -30,6 +31,7 @@ import {
   importableServers,
   isGatewayServer,
   type DetectedClient,
+  type ImportItem,
   type ProbeResult,
   type Registry,
   type Stack,
@@ -37,6 +39,7 @@ import {
 import { openExternal } from "@/lib/openUrl";
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent } from "@/components/ui/dialog";
+import { ImportReviewDialog } from "@/components/ImportReviewDialog";
 
 interface Props {
   /** Step to open at (0 = Welcome). Used to resume mid-flow. */
@@ -420,6 +423,7 @@ function AddServers({
   onNext: () => void;
 }) {
   const [busy, setBusy] = useState(false);
+  const [importPreview, setImportPreview] = useState<ImportItem[] | null>(null);
   const [imported, setImported] = useState<number | null>(null);
   const [stacks, setStacks] = useState<Stack[]>([]);
   const [selected, setSelected] = useState<string | null>(null);
@@ -439,11 +443,28 @@ function AddServers({
   async function doImport() {
     setBusy(true);
     try {
-      const next = await importServers();
+      const preview = await previewImportServers();
+      if (preview.length === 0) {
+        toast.success("No new servers found in your clients");
+        return;
+      }
+      setImportPreview(preview);
+    } catch (e) {
+      toastError(`Couldn't prepare import: ${e}`);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function confirmImport(selected: string[]) {
+    setBusy(true);
+    try {
+      const next = await importServers(selected);
       onImport(next);
       setImported(next.servers.filter((s) => !isGatewayServer(s)).length);
       setTouched(true);
       toast.success("Imported servers from your clients");
+      setImportPreview(null);
     } catch (e) {
       toastError(`Import failed: ${e}`);
     } finally {
@@ -583,6 +604,15 @@ function AddServers({
         {touched ? "Next" : "I'll add servers later"}
         <ArrowRight className="size-4" />
       </Button>
+      <ImportReviewDialog
+        open={importPreview !== null}
+        items={importPreview ?? []}
+        busy={busy}
+        onOpenChange={(open) => {
+          if (!open && !busy) setImportPreview(null);
+        }}
+        onConfirm={confirmImport}
+      />
     </>
   );
 }

--- a/src/components/ShareDialog.tsx
+++ b/src/components/ShareDialog.tsx
@@ -7,7 +7,6 @@ import {
   FileUp,
   Link2,
   Loader2,
-  ShieldAlert,
   Upload,
 } from "lucide-react";
 import { toast } from "sonner";
@@ -36,8 +35,8 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
-import { TransportPill } from "@/components/TransportPill";
 import { Label } from "@/components/ui/label";
+import { ImportRow } from "@/components/ImportReviewDialog";
 
 interface Props {
   trigger: ReactNode;
@@ -487,79 +486,6 @@ export function ShareDialog({ trigger, onImported }: Props) {
       </DialogContent>
     </Dialog>
   );
-}
-
-/** One reviewable server: name, what it runs, and a flag if it spawns a shell. */
-function ImportRow({ item }: { item: ImportItem }) {
-  const runs =
-    item.command != null ? [item.command, ...item.args].join(" ") : (item.url ?? "");
-  const shell = runsShell(item.command);
-  const privateHost = isPrivateHostUrl(item.url);
-  return (
-    <div className="rounded-md border px-3 py-2">
-      <div className="flex items-center gap-2">
-        <span className="truncate text-sm font-medium">{item.name}</span>
-        <TransportPill transport={item.transport} />
-        {!item.isNew && (
-          <span className="ml-auto shrink-0 text-xs text-muted-foreground">
-            already added
-          </span>
-        )}
-      </div>
-      {runs && (
-        <p className="mt-1 font-mono text-xs break-all text-muted-foreground">{runs}</p>
-      )}
-      {shell && (
-        <p className="mt-1.5 flex items-center gap-1.5 text-xs text-warning">
-          <ShieldAlert className="size-3.5 shrink-0" />
-          Runs a shell command. Only import setups you trust.
-        </p>
-      )}
-      {privateHost && (
-        <p className="mt-1.5 flex items-center gap-1.5 text-xs text-warning">
-          <ShieldAlert className="size-3.5 shrink-0" />
-          Connects to a private or internal address. Only import setups you trust.
-        </p>
-      )}
-    </div>
-  );
-}
-
-/** True if the command spawns a shell interpreter (extra scrutiny on import). */
-function runsShell(command: string | null): boolean {
-  if (!command) return false;
-  const base = command
-    .replace(/\\/g, "/")
-    .split("/")
-    .pop()!
-    .toLowerCase()
-    .replace(/\.exe$/, "");
-  return ["cmd", "sh", "bash", "zsh", "powershell", "pwsh"].includes(base);
-}
-
-/** True if the URL targets a loopback, private-network, or cloud-metadata host -
- * a server that would read from inside your own machine or LAN. Mirrors the
- * backend host-privacy guard so an imported setup pointing inward is flagged. */
-function isPrivateHostUrl(url: string | null | undefined): boolean {
-  if (!url) return false;
-  let host: string;
-  try {
-    host = new URL(url).hostname.toLowerCase().replace(/^\[|\]$/g, "");
-  } catch {
-    return false;
-  }
-  if (host === "localhost" || host.endsWith(".localhost")) return true;
-  if (host === "::1") return true; // IPv6 loopback
-  const m = host.match(/^(\d{1,3})\.(\d{1,3})\.\d{1,3}\.\d{1,3}$/);
-  if (m) {
-    const a = Number(m[1]);
-    const b = Number(m[2]);
-    if (a === 127 || a === 10 || a === 0) return true; // loopback, private, this-host
-    if (a === 192 && b === 168) return true; // private
-    if (a === 172 && b >= 16 && b <= 31) return true; // private
-    if (a === 169 && b === 254) return true; // link-local + cloud metadata (169.254.169.254)
-  }
-  return false;
 }
 
 /** A filesystem-safe slug for the default filename. */

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -531,9 +531,14 @@ export function takeRegistryRecoveryNotice(): Promise<RegistryRecoveryNotice | n
   return invoke<RegistryRecoveryNotice | null>("take_registry_recovery_notice");
 }
 
-/** Pull servers from every detected client into the registry. */
-export function importServers(): Promise<Registry> {
-  return invoke<Registry>("import_servers");
+/** Pull reviewed servers from every detected client into the registry. */
+export function importServers(selected?: string[]): Promise<Registry> {
+  return invoke<Registry>("import_servers", { selected });
+}
+
+/** Preview every detected-client server the bulk import would add. */
+export function previewImportServers(): Promise<ImportItem[]> {
+  return invoke<ImportItem[]>("preview_import_servers");
 }
 
 /** Parse a pasted config snippet (JSON/TOML/YAML/CLI), auto-detecting format. */

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -238,6 +238,8 @@ export interface AuthInfo {
 
 /** One server a shared setup would add, shown for review before importing. */
 export interface ImportItem {
+  /** Opaque key used to confirm a detected-client import. Absent for shared setups. */
+  key?: string;
   name: string;
   transport: Transport;
   command: string | null;


### PR DESCRIPTION
## What changed

- Adds a reusable review dialog that lists each detected server, its command or URL, and existing safety flags.
- Lets people deselect individual servers before bulk import.
- Adds a non-mutating backend preview and only imports the reviewed keys.
- Uses the same review presentation for main import, onboarding, client details, and shared setup previews.

## Why

Bulk import previously added every detected server immediately. A review step lets people check what will run or connect before changing their registry.

Closes #274.

## Validation

- `npm run build`
- `npm run test` (74 passing)
- `npm run lint` (passes with 19 pre-existing warnings)
- `cargo test --manifest-path src-tauri/Cargo.toml --lib selected_servers_to_import`
- `scripts/test-rust-windows.ps1` (345 library tests and 86 gateway tests)
