### PR TITLE
fix(import): keep same-package servers with distinct names in bulk import

### DIFF
--- a/src-tauri/src/clients.rs
+++ b/src-tauri/src/clients.rs
@@ -1114,15 +1114,19 @@ fn name_from_invocation(command: &str, args: &[String]) -> String {
     command_stem(command)
 }
 
-/// Key an imported server by its full package spec when it is launched through
-/// a package runner. The display name intentionally drops a package scope, so
-/// using it alone would collapse `@acme/mcp-weather` and
-/// `@other/mcp-weather` during bulk import. Other servers retain the existing
-/// case-insensitive name-based dedupe behavior.
+/// Key an imported server for bulk-import dedupe. The friendly display name
+/// intentionally drops a package scope, so keying on it alone collapses
+/// `@acme/mcp-weather` and `@other/mcp-weather` (both name "weather") during
+/// import (#257). Fold the launched package spec into the key so those stay
+/// distinct, but keep the name as a tiebreaker so two entries for the SAME
+/// package under different names (e.g. `github-personal` and `github-work`,
+/// one token each) both survive instead of silently collapsing to one. Servers
+/// without a recognizable runner package key on name alone, as before.
 pub fn import_dedupe_key(name: &str, command: Option<&str>, args: &[String]) -> String {
+    let name = name.to_ascii_lowercase();
     match command.and_then(|command| launcher_package_arg(command, args)) {
-        Some(package) => format!("package:{}", package.to_ascii_lowercase()),
-        None => format!("name:{}", name.to_ascii_lowercase()),
+        Some(package) => format!("package:{}|name:{}", package.to_ascii_lowercase(), name),
+        None => format!("name:{}", name),
     }
 }
 

--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -2916,6 +2916,27 @@ mod tests {
     }
 
     #[test]
+    fn servers_to_import_keeps_same_package_under_distinct_names() {
+        // A multi-account setup runs the SAME package twice under different
+        // names (e.g. a personal and a work token). Keying on the package alone
+        // would collapse them and silently drop one; the name tiebreaker keeps
+        // both while still distinguishing different packages (see the test above).
+        let mut client = detected_client("claude", vec![], vec![]);
+        client.servers = vec![
+            detected_mcp_server_with_args("github-personal", "npx", &["-y", "@mcp/server-github"]),
+            detected_mcp_server_with_args("github-work", "npx", &["-y", "@mcp/server-github"]),
+        ];
+        let picked = servers_to_import(&[client], &Registry::default());
+        assert_eq!(picked.len(), 2);
+        let names: std::collections::HashSet<_> =
+            picked.iter().map(|server| server.name.as_str()).collect();
+        assert_eq!(
+            names,
+            std::collections::HashSet::from(["github-personal", "github-work"])
+        );
+    }
+
+    #[test]
     fn servers_to_import_skips_existing_and_own_gateway_entry() {
         let detected = vec![detected_client(
             "cursor",


### PR DESCRIPTION
## What

Follow-up to #280. That change keyed bulk-import dedupe on the launcher package spec alone so two different scoped packages sharing a friendly display name (e.g. `@acme/mcp-weather` and `@other/mcp-weather`, both named "weather") stop collapsing (#257).

It over-corrected in the other direction: a multi-account setup that runs the **same** package twice under different names (e.g. `github-personal` and `github-work`, one token each) now collapses to a single entry, **silently dropping the second server** on import. That is exactly the "silently under-imports relative to what was promised" failure the comment above `servers_to_import` warns against.

## Fix

Fold the display name into the package key as a tiebreaker:

```rust
// before
Some(package) => format!("package:{}", package.to_ascii_lowercase()),
// after
Some(package) => format!("package:{}|name:{}", package.to_ascii_lowercase(), name),
```

Both directions now hold:
- Different packages, same friendly name (#257) → different keys → both kept.
- Same package, distinct names (multi-account) → different keys → both kept.

The key stays an opaque string round-tripped through `preview_import_servers` → `import_servers`, so no frontend change is needed.

## Tests

- Added `servers_to_import_keeps_same_package_under_distinct_names` reproducing the multi-account collapse.
- `cargo test --lib --bins`: 346 + 86 pass, including the existing #257 distinct-packages test and the cross-client name-collapse test.