### PR TITLE
teams: treat a 404 config pull as 'no config yet', not a hard error

### DIFF
--- a/src-tauri/src/teams.rs
+++ b/src-tauri/src/teams.rs
@@ -162,6 +162,14 @@ pub fn pull_config(
             Ok(Some((version, config, new_etag)))
         }
         Err(ureq::Error::Status(304, _)) => Ok(None),
+        // A team that has never had a config pushed yet returns 404 (no config row on the
+        // server). That is "nothing to sync," not a failure: without this, the first
+        // pull_config in `connect` errors out and rolls the just-saved member token back, so
+        // joining any brand-new team fails outright. The current server serves an empty
+        // `{servers:[]}` 200 for this case; this keeps a new client working against an older
+        // self-hosted server that still 404s. Mirrors `fetch_me`/`post_usage_day` below,
+        // which likewise treat a 404 as "resource/endpoint absent, degrade gracefully."
+        Err(ureq::Error::Status(404, _)) => Ok(None),
         Err(e) => Err(stringify(e)),
     }
 }


### PR DESCRIPTION
## Problem

Joining a **brand-new team** (one with no config pushed yet) fails outright. `teams::connect` runs an initial `pull_config` right after `join`, and against a team with no config the server returns `GET /teams/{id}/config -> 404`. `pull_config` surfaced any non-304 status as an error, so that first pull failed and the just-saved member token was rolled back — the connection never stuck.

## Fix

Treat a `404` from the config pull like the existing `304` arm — `Ok(None)`, i.e. "nothing to sync yet" — instead of a hard error:

```rust
Err(ureq::Error::Status(304, _)) => Ok(None),
Err(ureq::Error::Status(404, _)) => Ok(None),   // no config pushed yet
Err(e) => Err(stringify(e)),
```

This mirrors `fetch_me` and `post_usage_day` in the same file, which already degrade gracefully on a 404 ("resource/endpoint absent").

## Relationship to the server fix

The primary fix is server-side (toolport-teams `fix/teams-empty-config-404`): the server now serves an empty `{servers:[]}` 200 for a not-yet-pushed team, which resolves this for every current app install on redeploy with no desktop release needed.

This client change is **defense-in-depth**: it keeps a new client working against an **older self-hosted** Teams server that still returns 404, and encodes the correct principle that "no config yet" is not a failure.

## Testing

- `cargo check` clean.
- `cargo test teams::` — 16 passed.
