### PR TITLE
Release 1.7.1: end the team-sync RAM storm (gateway skip-rebuild + no-op save)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,20 @@ Entries before the rename below shipped under the project's former name, Conduit
 
 ## [Unreleased]
 
-## [1.7.0] - 2026-07-09
+## [1.7.1] - 2026-07-10
+
+A focused patch that makes Toolport Teams safe to use: joining a team no longer
+destabilizes the app.
+
+### Fixed
+
+**Joining a team could exhaust system memory and hang the app.** Once connected to a team,
+the background sync rewrote the local registry every cycle even when nothing had changed, and
+each rewrite made every running gateway rebuild and re-spawn every configured MCP server. The
+orphaned server processes piled up until the machine ran out of RAM and the app stopped
+opening. Two changes fix it: a no-op sync no longer rewrites the registry at all, and the
+gateway no longer rebuilds when only team-sync metadata (usage stats, sync version) changed.
+A routine sync now costs nothing and never re-spawns your servers. (#286)
 
 This release leads with a security fix and clears a batch of rough edges around running
 servers and living in the app day to day.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "conduit",
   "private": true,
-  "version": "1.7.0",
+  "version": "1.7.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -604,7 +604,7 @@ dependencies = [
 
 [[package]]
 name = "conduit"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "base64 0.22.1",
  "chacha20poly1305",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conduit"
-version = "1.7.0"
+version = "1.7.1"
 description = "Local MCP gateway: manage all your MCP servers in one place, set up once and shared by every AI client, with ~90% fewer tokens per request"
 authors = ["South Forge AI"]
 edition = "2021"

--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -2978,6 +2978,22 @@ fn resolve_live_profile(
     }
 }
 
+/// The registry as a JSON value with the `team` block removed. The gateway builds the
+/// router ONLY from servers/profiles/policy flags and never reads the `team` block (its
+/// sync version/etag, role, member name, and per-day usage watermarks). The desktop team
+/// sync loop rewrites those fields on a timer, so keying a rebuild off the raw file made
+/// every routine sync re-spawn every stdio server — the process leak that exhausted a
+/// user's RAM. Comparing this slice lets the watcher rebuild only when something the router
+/// actually depends on changed. Returned as a serde_json::Value and compared with `==`
+/// (order-independent) so HashMap key-order jitter across a load can't look like a change.
+fn router_relevant(reg: &Registry) -> Value {
+    let mut v = serde_json::to_value(reg).unwrap_or(Value::Null);
+    if let Some(obj) = v.as_object_mut() {
+        obj.remove("team");
+    }
+    v
+}
+
 /// Poll the registry file; on change, reload, rebuild the router, and tell the
 /// client its tool list changed. This is what makes a toggle apply live.
 #[allow(clippy::too_many_arguments)]
@@ -2999,6 +3015,13 @@ fn watch_registry(
 ) {
     eprintln!("toolport: watching registry at {}", path.display());
     let mut last = mtime(&path);
+    // Router-relevant slice (everything except the `team` block) as of the initial build,
+    // so a team-metadata-only rewrite from the desktop sync loop doesn't force a rebuild.
+    let mut last_relevant = router_relevant(
+        &registry
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner),
+    );
     loop {
         std::thread::sleep(Duration::from_millis(1000));
         // A live downstream server that changed its own tool set (sent
@@ -3026,6 +3049,20 @@ fn watch_registry(
                 }
             };
             last = current;
+            // A team-metadata-only rewrite (usage watermark, sync version/etag, role) from
+            // the desktop sync loop changes nothing the router depends on. Update the stored
+            // copy but skip the rebuild, so a routine sync never re-spawns every stdio server
+            // (the leak that exhausted a user's RAM). Still rebuild when a downstream server
+            // also signaled a change, so that path is never dropped.
+            let new_relevant = router_relevant(&new_reg);
+            if downstream_changed == 0 && new_relevant == last_relevant {
+                *registry
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner) = new_reg;
+                eprintln!("toolport: registry changed (team metadata only); skipped rebuild");
+                continue;
+            }
+            last_relevant = new_relevant;
             let resolved = resolve_live_profile(&new_reg, client_id.as_deref(), &env_profile);
             // Capture the profile we were serving before this reload so the log can
             // show the transition - the single most useful line when diagnosing
@@ -5437,6 +5474,43 @@ fn main() {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn router_relevant_ignores_team_metadata_but_tracks_real_changes() {
+        // A team-metadata-only rewrite (what the desktop sync loop does every ~25s, even on
+        // a no-op 304 or a usage-watermark bump) must NOT register as a change, or the
+        // gateway respawns every stdio server on every sync - the process leak that
+        // exhausted a user's RAM. A change OUTSIDE the team block must still be detected.
+        let mut reg = Registry::default();
+        let base = router_relevant(&reg);
+
+        // Connecting to a team + bumping usage/version/etag/role lives entirely in the
+        // `team` block, which the gateway never reads.
+        let mut usage = std::collections::HashMap::new();
+        usage.insert("2026-07-10".to_string(), std::collections::HashMap::new());
+        reg.team = Some(registry::TeamConnection {
+            server_url: "https://teams.toolport.app".into(),
+            team_id: "t1".into(),
+            role: "admin".into(),
+            member_name: Some("Tyler".into()),
+            last_version: 42,
+            last_etag: Some("\"v42\"".into()),
+            usage_reported: usage,
+        });
+        assert_eq!(
+            router_relevant(&reg),
+            base,
+            "team-block churn (usage/version/etag/role) must not count as a router change"
+        );
+
+        // A policy flag lives OUTSIDE the team block: a real change the router must rebuild for.
+        reg.deny_destructive = !reg.deny_destructive;
+        assert_ne!(
+            router_relevant(&reg),
+            base,
+            "a non-team change must still be detected so a real toggle rebuilds"
+        );
+    }
 
     #[test]
     fn resolve_live_profile_prefers_client_scope_over_frozen_env_var() {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Toolport",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "identifier": "com.tsout.conduit",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
Patch release **1.7.1**. Makes Toolport Teams safe to use by ending the team-sync RAM storm from both sides. Ships together with #286 (already merged to main).

## What was wrong

Once a machine joined a team, the desktop **team sync loop** rewrote `registry.json` every ~25s — even on a no-op (304) pull — and the **gateway's `watch_registry` rebuilt on any mtime change**, re-spawning every stdio MCP server. The orphaned `npx`/`cmd`/`node`/`uvx` children piled up unbounded (observed: 150+ processes, ~7 GB and climbing toward a 32 GB freeze; the app hung on launch). Latent until the recent join fix let anyone actually reach the sync loop.

## Fixes (both sides)

- **#286 (merged):** `registry::save` is now a no-op when the serialized registry is unchanged — a 304 sync no longer touches the file at all.
- **This PR (gateway):** `watch_registry` compares `router_relevant(&reg)` — the registry minus the `team` block — and **skips the rebuild when only team metadata changed** (sync version/etag, role, per-day usage watermarks). The gateway never reads the `team` block, so this is safe; a real server/profile/policy change still rebuilds, and a concurrent downstream `list_changed` still forces the rebuild path.

Net: a routine sync costs nothing and never re-spawns your servers.

## Release contents

- `router_relevant()` + `watch_registry` guard in the gateway, with a unit test (`router_relevant_ignores_team_metadata_but_tracks_real_changes`).
- Version bump 1.7.0 → 1.7.1 (`package.json`, `tauri.conf.json`, `Cargo.toml`, `Cargo.lock`).
- CHANGELOG entry.

## Testing

- Full suite green: **347 + 87 passing**, 0 failures.
- Merging this and tagging `v1.7.1` triggers the signed release build + auto-update manifest; installed 1.7.0 apps update themselves.

## Not included (follow-ups)

- #285 (client `pull_config` 404 tolerance) — defense-in-depth for old self-hosted servers; separate.
- Tree-killing stdio child groups on teardown — now rarely triggered (rebuilds only happen on real server changes), so deferred.
