### PR TITLE
teams: run all team network commands off the main thread (fix UI freeze on join) — 1.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,18 @@ Entries before the rename below shipped under the project's former name, Conduit
 
 ## [Unreleased]
 
-## [1.7.1] - 2026-07-10
+## [1.7.2] - 2026-07-11
+
+### Fixed
+
+**Joining a team no longer freezes the app.** The commands that talk to the team server -
+joining, the background config sync, and the admin config push - were synchronous, so their
+blocking network calls ran on the app's UI thread. Joining kicked off a background sync that
+holds a ~30-second long-poll open continuously, so the moment you connected to a team the UI
+thread was blocked and the window went "Not Responding" (the app hung, though the machine was
+otherwise fine). Without a team those commands never run, which is why the app was flawless
+until you joined one. They now run off the main thread, so joining, syncing, and pushing stay
+responsive. Separate from the 1.7.1 memory-storm fix; this was a pure UI-thread hang. (#288)
 
 A focused patch that makes Toolport Teams safe to use: joining a team no longer
 destabilizes the app.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "conduit",
   "private": true,
-  "version": "1.7.1",
+  "version": "1.7.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -604,7 +604,7 @@ dependencies = [
 
 [[package]]
 name = "conduit"
-version = "1.7.1"
+version = "1.7.2"
 dependencies = [
  "base64 0.22.1",
  "chacha20poly1305",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conduit"
-version = "1.7.1"
+version = "1.7.2"
 description = "Local MCP gateway: manage all your MCP servers in one place, set up once and shared by every AI client, with ~90% fewer tokens per request"
 authors = ["South Forge AI"]
 edition = "2021"

--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -1623,24 +1623,39 @@ fn team_connect(
 }
 
 /// Pull the latest team config and re-merge it. A no-op when nothing changed.
+///
+/// `async` + `spawn_blocking` is load-bearing, not stylistic: a synchronous Tauri command
+/// runs on the main (UI) thread, and the config pull is a blocking network call. The
+/// long-poll variant below blocks for up to 30s per cycle, and the member's background loop
+/// re-invokes it continuously, so as a sync command it froze the whole app ("Not Responding")
+/// for anyone connected to a team and starved every other command (probe_servers, etc.).
+/// Running the blocking pull on a worker thread keeps the event loop free.
 #[tauri::command]
-fn team_sync(app: tauri::AppHandle, state: State<RegistryState>) -> Result<Registry, String> {
+async fn team_sync(app: tauri::AppHandle, state: State<'_, RegistryState>) -> Result<Registry, String> {
     flush_to_disk(state.inner())?;
-    finish_sync(&app, state.inner(), teams::sync_now()?)
+    let result = tauri::async_runtime::spawn_blocking(teams::sync_now)
+        .await
+        .map_err(|e| format!("sync task join failed: {e}"))??;
+    finish_sync(&app, state.inner(), result)
 }
 
 /// Long-polling sync for the member's background loop: the config pull parks on the server
 /// for up to `wait_secs` (clamped) and returns the instant the team config view changes, so
 /// a dashboard policy edit enforces in ~1s instead of at the next interval. Otherwise
-/// identical to [`team_sync`]; the frontend re-invokes it in a loop.
+/// identical to [`team_sync`]; the frontend re-invokes it in a loop. See [`team_sync`] for
+/// why the blocking pull must run off the main thread.
 #[tauri::command]
-fn team_sync_wait(
+async fn team_sync_wait(
     app: tauri::AppHandle,
-    state: State<RegistryState>,
+    state: State<'_, RegistryState>,
     wait_secs: u64,
 ) -> Result<Registry, String> {
     flush_to_disk(state.inner())?;
-    finish_sync(&app, state.inner(), teams::sync_wait(wait_secs.min(30))?)
+    let wait = wait_secs.min(30);
+    let result = tauri::async_runtime::spawn_blocking(move || teams::sync_wait(wait))
+        .await
+        .map_err(|e| format!("sync task join failed: {e}"))??;
+    finish_sync(&app, state.inner(), result)
 }
 
 /// Apply a sync result to the shared registry state and tell the UI what happened. Shared by

--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -1605,15 +1605,22 @@ fn reload_into_state(state: &RegistryState) -> Result<Registry, String> {
 /// keychain, pulls the team's server set, and merges it into the local registry
 /// non-destructively (team servers are tagged and enabled in the active profile).
 #[tauri::command]
-fn team_connect(
+async fn team_connect(
     app: tauri::AppHandle,
-    state: State<RegistryState>,
+    state: State<'_, RegistryState>,
     server_url: String,
     invite_code: String,
     member_name: Option<String>,
 ) -> Result<Registry, String> {
     flush_to_disk(state.inner())?;
-    let outcome = teams::connect(&server_url, &invite_code, member_name.as_deref())?;
+    // Same reason as team_sync: a synchronous command runs on Tauri's main (UI) thread, and
+    // teams::connect does a blocking network join + first config pull. Run it off-thread so
+    // clicking "Connect" to join a team doesn't freeze the whole app until the join returns.
+    let outcome = tauri::async_runtime::spawn_blocking(move || {
+        teams::connect(&server_url, &invite_code, member_name.as_deref())
+    })
+    .await
+    .map_err(|e| format!("connect task join failed: {e}"))??;
     let fresh = reload_into_state(state.inner())?;
     nudge_gateway(state.inner());
     // Team config adds local/stdio + LAN servers OFF (the member reviews + enables them)
@@ -1710,9 +1717,12 @@ fn team_disconnect(state: State<RegistryState>) -> Result<Registry, String> {
 /// Admin: push the current local server set as the team's shared config (own servers
 /// only, secret values never sent). Returns the new config version.
 #[tauri::command]
-fn team_push(state: State<RegistryState>) -> Result<i64, String> {
+async fn team_push(state: State<'_, RegistryState>) -> Result<i64, String> {
     flush_to_disk(state.inner())?;
-    teams::push_current()
+    // push_current does a blocking PUT to the team server; keep it off the main thread.
+    tauri::async_runtime::spawn_blocking(teams::push_current)
+        .await
+        .map_err(|e| format!("push task join failed: {e}"))?
 }
 
 /// Re-save the registry to bump its mtime. The running gateway watches that file

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Toolport",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "identifier": "com.tsout.conduit",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## Symptom
The desktop app goes **"Not Responding"** the moment you join a team (and stays hung while connected). Only with a team; opening/closing with the same servers and no team is flawless. RAM/CPU flat — a pure **UI-thread hang**, distinct from the registry RAM-storm fixed in 1.7.1.

## Root cause
The commands that talk to the team server — `team_connect` (join), `team_sync` / `team_sync_wait` (background config sync), and `team_push` (admin config push) — were **synchronous** `#[tauri::command]`s. Tauri runs synchronous commands on the **main (UI) thread**, and these do **blocking network calls**:
- `team_connect`: `POST /join` + first config pull
- `team_sync_wait`: a **~30s config long-poll**, re-invoked continuously by the member's background loop
- `team_push`: `PUT /config`

So joining a team blocked the UI thread on the network, and the background sync loop kept it blocked essentially forever. Latent until the team-join fix let anyone actually reach these paths.

## Fix
Make all four network-bound commands `async` and run the blocking call on a worker via `tauri::async_runtime::spawn_blocking`, keeping the event loop free. `team_disconnect` stays sync (local only: clears registry + keychain, no network). No frontend change — `invoke()` awaits a promise either way.

## Verification (done)
Built a dev binary and ran it against a real team registry:
- Background sync ran **many full cycles** (`flush → sync_wait → finish_sync`) with the window **Responding=True** throughout.
- **Joining a team via the Connect button no longer freezes** (confirmed live by the maintainer).

Full suite green (**347 + 87**). Ships as **1.7.2**.