### PR TITLE
update: stop versioned + manual-update gateways so clients pick up the new version

### DIFF
--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -2695,6 +2695,15 @@ pub fn run() {
                         repointed.len(),
                         repointed.join(", ")
                     );
+                    // A repoint means the gateway binary path changed (a version bump), so the
+                    // clients' currently-running gateways are the OLD version. Stop them so each
+                    // client respawns the freshly-installed gateway on its next request, instead
+                    // of the user having to relaunch the client to pick it up. Covers MANUAL
+                    // updates (running the installer), which never go through the in-app updater
+                    // that already calls stop_spawned_gateways. Only fires when something was
+                    // actually repointed, so a normal launch never kills a healthy gateway.
+                    let stopped = crate::gateway_publish::stop_spawned_gateways();
+                    eprintln!("toolport: stopped {stopped} stale gateway image(s) after re-point");
                 }
             });
 

--- a/src-tauri/src/gateway_publish.rs
+++ b/src-tauri/src/gateway_publish.rs
@@ -151,12 +151,19 @@ pub fn client_gateway_path() -> Option<PathBuf> {
     publish_bundled_gateway()
 }
 
-/// Terminate client-spawned gateway processes so the installer can replace locked binaries.
-/// Does not touch parent apps (Cursor, Codex, etc.). Returns how many images were targeted.
+/// Terminate client-spawned gateway processes so the installer can replace locked binaries
+/// and so clients respawn the just-installed version instead of keeping the old one until the
+/// user relaunches them. Does not touch parent apps (Cursor, Codex, etc.). Returns how many
+/// image patterns `taskkill` reported killing.
+///
+/// The `*` globs are load-bearing: the published gateway clients actually run is VERSIONED
+/// (`toolport-gateway-1.7.2.exe`), so matching only the bare `toolport-gateway.exe` (the old
+/// behavior) killed nothing on a real update. `taskkill /IM` accepts a wildcard on the image
+/// name; nothing else on the system is named `*-gateway*`, so the match stays scoped to ours.
 #[cfg(windows)]
 pub fn stop_spawned_gateways() -> u32 {
     let mut stopped = 0u32;
-    for image in ["toolport-gateway.exe", "conduit-gateway.exe"] {
+    for image in ["toolport-gateway*.exe", "conduit-gateway*.exe"] {
         let status = std::process::Command::new("taskkill")
             .args(["/F", "/IM", image])
             .stdout(std::process::Stdio::null())


### PR DESCRIPTION
## Problem
After updating between versions, the old client-spawned gateway kept running until the user relaunched their AI client (Cursor/Codex/etc.), so the client kept talking to the **old** gateway binary.

Two gaps:
1. **`stop_spawned_gateways` only killed the bare image names** (`toolport-gateway.exe` / `conduit-gateway.exe`). The published gateway clients actually run is **versioned** (`toolport-gateway-1.7.2.exe`), so on a real update it killed nothing. The in-app updater *did* call it — it just matched no processes.
2. **The manual-update path** (downloading + running the installer) never calls `stop_spawned_gateways` at all — on launch the app only repoints client configs.

## Fix
1. Match with a `*` glob (`toolport-gateway*.exe`, `conduit-gateway*.exe`) — `taskkill /IM` supports wildcards — so versioned binaries are actually killed.
2. On launch, when `repoint_stale_gateways` reports it moved a client onto a new gateway path (i.e. a version changed), also stop the now-stale gateways. Guarded on a **non-empty repoint**, so a normal launch never touches a healthy gateway. This covers manual updates, which skip the in-app updater.

Net: after any update (auto or manual), each client respawns the freshly-installed gateway on its next request instead of the user having to relaunch the client.

## Notes / testing
- `cargo check` clean; `cargo test gateway_publish` passes.
- The `taskkill /IM` wildcard is documented Windows behavior; I did **not** run it against the live gateway to avoid disrupting a working setup — it takes effect on the next real update.
- Clients that don't auto-reconnect a dropped stdio server will still show a brief disconnect until their next request, but they no longer silently run stale code.