### PR TITLE
Teams: handle approval-gated join links in the desktop app

### DIFF
--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -1601,9 +1601,23 @@ fn reload_into_state(state: &RegistryState) -> Result<Registry, String> {
     Ok(fresh)
 }
 
-/// Join a Toolport Teams server with an invite code. Vaults the member token in the OS
-/// keychain, pulls the team's server set, and merges it into the local registry
-/// non-destructively (team servers are tagged and enabled in the active profile).
+/// Result of a connect (or a pending-join poll). `status` is "connected" (joined; `registry`
+/// is the fresh merged state), "pending" (an approval-gated link — poll `request_token` via
+/// `team_join_poll`), "denied", or "unknown". The frontend switches on `status`.
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct TeamConnectResult {
+    status: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    registry: Option<Registry>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    request_token: Option<String>,
+}
+
+/// Join a Toolport Teams server with an invite or join-link code. A normal code vaults the
+/// member token in the OS keychain, pulls the team's server set, and merges it into the local
+/// registry non-destructively. An approval-gated link instead returns `status: "pending"` with
+/// a `request_token` the frontend polls (nothing is stored locally until an admin approves).
 #[tauri::command]
 async fn team_connect(
     app: tauri::AppHandle,
@@ -1611,7 +1625,7 @@ async fn team_connect(
     server_url: String,
     invite_code: String,
     member_name: Option<String>,
-) -> Result<Registry, String> {
+) -> Result<TeamConnectResult, String> {
     flush_to_disk(state.inner())?;
     // Same reason as team_sync: a synchronous command runs on Tauri's main (UI) thread, and
     // teams::connect does a blocking network join + first config pull. Run it off-thread so
@@ -1621,12 +1635,57 @@ async fn team_connect(
     })
     .await
     .map_err(|e| format!("connect task join failed: {e}"))??;
-    let fresh = reload_into_state(state.inner())?;
-    nudge_gateway(state.inner());
-    // Team config adds local/stdio + LAN servers OFF (the member reviews + enables them)
-    // and refuses link-local/metadata URLs. Surface both so the state is never a mystery.
-    emit_team_review(&app, outcome);
-    Ok(fresh)
+    match outcome {
+        teams::ConnectOutcome::Connected(review) => {
+            let fresh = reload_into_state(state.inner())?;
+            nudge_gateway(state.inner());
+            // Team config adds local/stdio + LAN servers OFF (the member reviews + enables them)
+            // and refuses link-local/metadata URLs. Surface both so the state is never a mystery.
+            emit_team_review(&app, review);
+            Ok(TeamConnectResult { status: "connected", registry: Some(fresh), request_token: None })
+        }
+        teams::ConnectOutcome::Pending { request_token } => Ok(TeamConnectResult {
+            status: "pending",
+            registry: None,
+            request_token: Some(request_token),
+        }),
+    }
+}
+
+/// Poll a pending, approval-gated join. The frontend calls this on an interval after
+/// `team_connect` returned `status: "pending"`, handing back the `request_token` (and the same
+/// `member_name`). On approval it finalizes exactly like a direct connect and returns the fresh
+/// registry; otherwise it reports still-pending, denied, or unknown (expired/invalid).
+#[tauri::command]
+async fn team_join_poll(
+    app: tauri::AppHandle,
+    state: State<'_, RegistryState>,
+    server_url: String,
+    request_token: String,
+    member_name: Option<String>,
+) -> Result<TeamConnectResult, String> {
+    let poll = tauri::async_runtime::spawn_blocking(move || {
+        teams::poll_join(&server_url, &request_token, member_name.as_deref())
+    })
+    .await
+    .map_err(|e| format!("poll task join failed: {e}"))??;
+    match poll {
+        teams::JoinPoll::Connected(review) => {
+            let fresh = reload_into_state(state.inner())?;
+            nudge_gateway(state.inner());
+            emit_team_review(&app, review);
+            Ok(TeamConnectResult { status: "connected", registry: Some(fresh), request_token: None })
+        }
+        teams::JoinPoll::Pending => {
+            Ok(TeamConnectResult { status: "pending", registry: None, request_token: None })
+        }
+        teams::JoinPoll::Denied => {
+            Ok(TeamConnectResult { status: "denied", registry: None, request_token: None })
+        }
+        teams::JoinPoll::Unknown => {
+            Ok(TeamConnectResult { status: "unknown", registry: None, request_token: None })
+        }
+    }
 }
 
 /// Pull the latest team config and re-merge it. A no-op when nothing changed.
@@ -2606,6 +2665,7 @@ pub fn run() {
             set_lazy_discovery,
             set_allow_agent_control,
             team_connect,
+            team_join_poll,
             team_sync,
             team_sync_wait,
             team_disconnect,

--- a/src-tauri/src/teams.rs
+++ b/src-tauri/src/teams.rs
@@ -89,13 +89,18 @@ pub struct Joined {
     pub role: String,
 }
 
-/// Redeem an invite code, returning the member token, team id, and role.
-pub fn join(server_url: &str, invite_code: &str, member_name: Option<&str>) -> Result<Joined, String> {
-    require_secure_team_url(server_url)?;
-    let url = format!("{}/join", base(server_url));
-    let body = serde_json::json!({ "invite_code": invite_code, "member_name": member_name });
-    let resp = agent().post(&url).send_json(body).map_err(stringify)?;
-    let v: Value = resp.into_json().map_err(|e| e.to_string())?;
+/// Outcome of redeeming a code at `/join`.
+pub enum JoinResult {
+    /// Joined immediately: the token/role are ready to finalize.
+    Joined(Joined),
+    /// The link requires admin approval. No member/token exists yet; poll `request_token` via
+    /// [`poll_join`] until an admin approves or denies.
+    Pending { request_token: String },
+}
+
+/// Parse a `Joined` from a `/join` (or `/join/status`) response body. Both endpoints return the
+/// same `team_id` / `member_token` / `role` shape on success.
+fn joined_from(v: &Value) -> Result<Joined, String> {
     let token = v["member_token"].as_str().unwrap_or_default().to_string();
     if token.is_empty() {
         return Err("server did not return a member token".into());
@@ -105,6 +110,57 @@ pub fn join(server_url: &str, invite_code: &str, member_name: Option<&str>) -> R
         member_token: token,
         role: v["role"].as_str().unwrap_or("member").to_string(),
     })
+}
+
+/// Redeem an invite or join-link code. A normal code joins immediately; an approval-gated link
+/// returns `Pending` with a token to poll.
+pub fn join(server_url: &str, invite_code: &str, member_name: Option<&str>) -> Result<JoinResult, String> {
+    require_secure_team_url(server_url)?;
+    let url = format!("{}/join", base(server_url));
+    let body = serde_json::json!({ "invite_code": invite_code, "member_name": member_name });
+    let resp = agent().post(&url).send_json(body).map_err(stringify)?;
+    let v: Value = resp.into_json().map_err(|e| e.to_string())?;
+    // An approval-gated link hands back a request token instead of a member token.
+    if v["pending"].as_bool().unwrap_or(false) {
+        let request_token = v["request_token"].as_str().unwrap_or_default().to_string();
+        if request_token.is_empty() {
+            return Err("the server marked the join pending but returned no request token".into());
+        }
+        return Ok(JoinResult::Pending { request_token });
+    }
+    Ok(JoinResult::Joined(joined_from(&v)?))
+}
+
+/// Result of polling a pending join request at `/join/status`.
+pub enum JoinPoll {
+    /// Still waiting on an admin.
+    Pending,
+    /// Approved and fully finalized locally (token vaulted, config pulled + merged).
+    Connected(MergeOutcome),
+    /// An admin denied the request.
+    Denied,
+    /// The request is gone (expired or the token is wrong); the user should start over.
+    Unknown,
+}
+
+/// Poll a pending join request. On approval, finalizes the join exactly like a direct connect
+/// (vaults the fresh token, pulls + merges the team config) and returns `Connected`.
+pub fn poll_join(
+    server_url: &str,
+    request_token: &str,
+    member_name: Option<&str>,
+) -> Result<JoinPoll, String> {
+    require_secure_team_url(server_url)?;
+    let url = format!("{}/join/status", base(server_url));
+    let body = serde_json::json!({ "request_token": request_token });
+    let resp = agent().post(&url).send_json(body).map_err(stringify)?;
+    let v: Value = resp.into_json().map_err(|e| e.to_string())?;
+    match v["status"].as_str().unwrap_or("") {
+        "approved" => complete_join(server_url, member_name, joined_from(&v)?).map(JoinPoll::Connected),
+        "denied" => Ok(JoinPoll::Denied),
+        "pending" => Ok(JoinPoll::Pending),
+        _ => Ok(JoinPoll::Unknown),
+    }
 }
 
 /// Pull the team's current config. `Ok(None)` means unchanged since `last_version`
@@ -258,10 +314,29 @@ fn stringify(e: ureq::Error) -> String {
 
 // --- orchestration (HTTP + merge + persist) ---
 
-/// Join a team: redeem the invite, vault the token, record the connection, and do the
-/// first pull + merge. Returns the stored connection.
-pub fn connect(server_url: &str, invite_code: &str, member_name: Option<&str>) -> Result<MergeOutcome, String> {
-    let joined = join(server_url, invite_code, member_name)?;
+/// Outcome of a connect attempt: either fully joined, or held pending admin approval.
+pub enum ConnectOutcome {
+    /// Joined and merged; carries the config-merge result for the review prompt.
+    Connected(MergeOutcome),
+    /// The link requires approval. Nothing was stored locally (no token, no connection); the
+    /// caller polls `request_token` via [`poll_join`] until an admin acts.
+    Pending { request_token: String },
+}
+
+/// Join a team: redeem the code, and for a normal join vault the token, record the connection,
+/// and do the first pull + merge. An approval-gated link returns `Pending` and stores nothing.
+pub fn connect(server_url: &str, invite_code: &str, member_name: Option<&str>) -> Result<ConnectOutcome, String> {
+    match join(server_url, invite_code, member_name)? {
+        JoinResult::Joined(joined) => {
+            complete_join(server_url, member_name, joined).map(ConnectOutcome::Connected)
+        }
+        JoinResult::Pending { request_token } => Ok(ConnectOutcome::Pending { request_token }),
+    }
+}
+
+/// Finalize an approved join: vault the token, record the connection, and do the first
+/// pull + merge. Shared by the direct-connect and approval-poll paths.
+fn complete_join(server_url: &str, member_name: Option<&str>, joined: Joined) -> Result<MergeOutcome, String> {
     save_token(&joined.member_token)?;
     // The token is now in the keychain. Any failure past this point must clear it,
     // or we'd orphan a live bearer token with no local record of the connection.

--- a/src/components/Onboarding.tsx
+++ b/src/components/Onboarding.tsx
@@ -24,6 +24,7 @@ import {
   listStacks,
   previewImportServers,
   teamConnect,
+  teamJoinPoll,
 } from "@/lib/api";
 import { teamUrlError } from "@/lib/teamUrl";
 import { Input } from "@/components/ui/input";
@@ -290,6 +291,50 @@ function JoinTeam({
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [joined, setJoined] = useState(false);
+  // Set while an approval-gated join waits for an admin; holds the values used to request it.
+  const [pending, setPending] = useState<{
+    serverUrl: string;
+    requestToken: string;
+    name?: string;
+  } | null>(null);
+
+  // Poll a pending, approval-gated join until an admin acts. A transient network error keeps
+  // the wait alive; an explicit deny/expiry ends it with a message.
+  useEffect(() => {
+    if (!pending) return;
+    let cancelled = false;
+    const tick = async () => {
+      try {
+        const r = await teamJoinPoll(
+          pending.serverUrl,
+          pending.requestToken,
+          pending.name,
+        );
+        if (cancelled) return;
+        if (r.status === "connected" && r.registry) {
+          setPending(null);
+          onRegistryChange(r.registry);
+          onClientsRefresh();
+          setJoined(true);
+        } else if (r.status === "denied") {
+          setPending(null);
+          setError("An admin declined your request to join this team.");
+        } else if (r.status === "unknown") {
+          setPending(null);
+          setError("This join request expired. Ask for the link again and reconnect.");
+        }
+      } catch {
+        // Transient: the next tick retries.
+      }
+    };
+    void tick();
+    const id = setInterval(tick, 4000);
+    return () => {
+      cancelled = true;
+      clearInterval(id);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pending]);
 
   const join = async () => {
     setError(null);
@@ -304,14 +349,19 @@ function JoinTeam({
     }
     setBusy(true);
     try {
-      const r = await teamConnect(
-        serverUrl.trim(),
-        code.trim(),
-        name.trim() || undefined,
-      );
-      onRegistryChange(r);
-      onClientsRefresh();
-      setJoined(true);
+      const su = serverUrl.trim();
+      const mn = name.trim() || undefined;
+      const r = await teamConnect(su, code.trim(), mn);
+      if (r.status === "pending" && r.requestToken) {
+        // Approval-gated link: hold and poll (effect above) until an admin approves.
+        setPending({ serverUrl: su, requestToken: r.requestToken, name: mn });
+      } else if (r.status === "connected" && r.registry) {
+        onRegistryChange(r.registry);
+        onClientsRefresh();
+        setJoined(true);
+      } else {
+        setError("The server returned an unexpected connect response.");
+      }
     } catch (e) {
       setError(String(e));
     } finally {
@@ -396,14 +446,30 @@ function JoinTeam({
           <ArrowLeft className="size-3.5" />
           Back
         </button>
-        <Button onClick={join} disabled={busy}>
-          {busy ? (
-            <Loader2 className="size-4 animate-spin" />
-          ) : (
-            <Users className="size-4" />
-          )}
-          Join team
-        </Button>
+        {pending ? (
+          <div className="flex items-center gap-2.5 rounded-lg border border-primary/40 bg-primary/5 px-3 py-2 text-sm">
+            <Loader2 className="size-4 shrink-0 animate-spin text-primary" />
+            <span className="text-muted-foreground">
+              Waiting for an admin to approve you…
+            </span>
+            <button
+              type="button"
+              onClick={() => setPending(null)}
+              className="ml-1 text-xs text-muted-foreground underline transition hover:text-foreground"
+            >
+              Cancel
+            </button>
+          </div>
+        ) : (
+          <Button onClick={join} disabled={busy}>
+            {busy ? (
+              <Loader2 className="size-4 animate-spin" />
+            ) : (
+              <Users className="size-4" />
+            )}
+            Join team
+          </Button>
+        )}
       </div>
     </>
   );

--- a/src/components/TeamsView.tsx
+++ b/src/components/TeamsView.tsx
@@ -17,6 +17,7 @@ import { TransportPill } from "@/components/TransportPill";
 import { Input } from "@/components/ui/input";
 import {
   teamConnect,
+  teamJoinPoll,
   teamSync,
   teamDisconnect,
   teamPush,
@@ -56,6 +57,13 @@ export function TeamsView({
   const [error, setError] = useState<string | null>(null);
   const [notice, setNotice] = useState<string | null>(null);
   const [skipNote, setSkipNote] = useState<string | null>(null);
+  // Set while an approval-gated join waits for an admin. Holds the connect inputs so a poll
+  // uses the values from when the request was made, not whatever the fields say later.
+  const [pending, setPending] = useState<{
+    serverUrl: string;
+    requestToken: string;
+    memberName?: string;
+  } | null>(null);
 
   // Team servers that run a local command or hit a LAN address arrive OFF (the member
   // reviews + enables them below); link-local/metadata URLs are blocked outright. The
@@ -102,15 +110,63 @@ export function TeamsView({
       if (!inviteCode.trim()) {
         throw new Error("An invite or connect code is required.");
       }
-      const r = await teamConnect(
-        serverUrl.trim(),
-        inviteCode.trim(),
-        memberName.trim() || undefined,
-      );
-      onRegistryChange(r);
-      setInviteCode("");
-      setNotice("Connected. The team's servers were added to your active profile.");
+      const su = serverUrl.trim();
+      const mn = memberName.trim() || undefined;
+      const r = await teamConnect(su, inviteCode.trim(), mn);
+      if (r.status === "pending" && r.requestToken) {
+        // An approval-gated link: nothing is joined yet. Hold here and poll (below) until an
+        // admin approves or denies; the fields stay as-is so the request context is preserved.
+        setPending({ serverUrl: su, requestToken: r.requestToken, memberName: mn });
+        setNotice("Request sent. Waiting for an admin to approve you.");
+        return;
+      }
+      if (r.status === "connected" && r.registry) {
+        onRegistryChange(r.registry);
+        setInviteCode("");
+        setNotice("Connected. The team's servers were added to your active profile.");
+        return;
+      }
+      throw new Error("The server returned an unexpected connect response.");
     });
+
+  // While a join is pending admin approval, poll for the verdict. A transient network error
+  // keeps the wait alive (a blip shouldn't cancel it); an explicit deny/expiry ends it.
+  useEffect(() => {
+    if (!pending) return;
+    let cancelled = false;
+    const tick = async () => {
+      try {
+        const r = await teamJoinPoll(
+          pending.serverUrl,
+          pending.requestToken,
+          pending.memberName,
+        );
+        if (cancelled) return;
+        if (r.status === "connected" && r.registry) {
+          setPending(null);
+          onRegistryChange(r.registry);
+          setInviteCode("");
+          setNotice("Approved. The team's servers were added to your active profile.");
+        } else if (r.status === "denied") {
+          setPending(null);
+          setError("An admin declined your request to join this team.");
+        } else if (r.status === "unknown") {
+          setPending(null);
+          setError("This join request expired. Ask for the link again and reconnect.");
+        }
+        // "pending" → keep waiting.
+      } catch {
+        // Transient: leave `pending` set so the next tick retries.
+      }
+    };
+    void tick();
+    const id = setInterval(tick, 4000);
+    return () => {
+      cancelled = true;
+      clearInterval(id);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pending]);
 
   const onSync = () =>
     run("sync", async () => {
@@ -299,9 +355,30 @@ export function TeamsView({
               />
             </label>
             <div>
-              <Button onClick={onConnect} disabled={busy !== null}>
-                {busy === "connect" ? "Connecting…" : "Connect"}
-              </Button>
+              {pending ? (
+                <div className="flex items-center gap-3 rounded-lg border border-primary/40 bg-primary/5 p-3 text-sm">
+                  <RefreshCw className="size-4 shrink-0 animate-spin text-primary" />
+                  <span className="text-muted-foreground">
+                    Waiting for an admin to approve your request. Leave this open, it
+                    finishes on its own once they approve.
+                  </span>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="ml-auto shrink-0"
+                    onClick={() => {
+                      setPending(null);
+                      setNotice(null);
+                    }}
+                  >
+                    Cancel
+                  </Button>
+                </div>
+              ) : (
+                <Button onClick={onConnect} disabled={busy !== null}>
+                  {busy === "connect" ? "Connecting…" : "Connect"}
+                </Button>
+              )}
             </div>
           </div>
         </div>

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -325,15 +325,45 @@ export function httpBridgeStatus(): Promise<HttpBridgeStatus> {
   return invoke<HttpBridgeStatus>("http_bridge_status");
 }
 
-/** Join a Toolport Teams server with an invite code; merges the team's servers in. */
+/**
+ * Result of {@link teamConnect} / {@link teamJoinPoll}. `status` is:
+ * - `connected` — joined; `registry` is the fresh merged state.
+ * - `pending` — the link requires admin approval; poll `requestToken` via {@link teamJoinPoll}.
+ * - `denied` — an admin declined the request.
+ * - `unknown` — the request expired or is invalid; start over.
+ */
+export interface TeamConnectResult {
+  status: "connected" | "pending" | "denied" | "unknown";
+  registry?: Registry;
+  requestToken?: string;
+}
+
+/** Join a Toolport Teams server with an invite or join-link code; merges the team's servers in. */
 export function teamConnect(
   serverUrl: string,
   inviteCode: string,
   memberName?: string,
-): Promise<Registry> {
-  return invoke<Registry>("team_connect", {
+): Promise<TeamConnectResult> {
+  return invoke<TeamConnectResult>("team_connect", {
     serverUrl,
     inviteCode,
+    memberName: memberName ?? null,
+  });
+}
+
+/**
+ * Poll a pending, approval-gated join. Call on an interval after {@link teamConnect} returns
+ * `status: "pending"`, passing back the `requestToken` and the same `memberName`. Resolves to
+ * `connected` once an admin approves, or `pending` / `denied` / `unknown`.
+ */
+export function teamJoinPoll(
+  serverUrl: string,
+  requestToken: string,
+  memberName?: string,
+): Promise<TeamConnectResult> {
+  return invoke<TeamConnectResult>("team_join_poll", {
+    serverUrl,
+    requestToken,
     memberName: memberName ?? null,
   });
 }


### PR DESCRIPTION
## What & why

A reusable team join link can now require admin approval (the server + web dashboard for this shipped in the toolport-teams repo). Redeeming such a link no longer joins immediately: the server returns a **pending request**, an admin approves or denies it, and only then does the app finish joining. This teaches the desktop client that flow. Normal invite/connect codes are unchanged.

## `teams.rs`
- `join()` returns `JoinResult::{ Joined, Pending { request_token } }` — an approval link hands back a request token instead of a member token.
- `poll_join()` calls `POST /join/status` and, on approval, finalizes exactly like a direct connect (vaults the fresh token, pulls + merges the team config).
- `connect()` returns `ConnectOutcome::{ Connected, Pending }`; the finalize tail is factored into `complete_join()` so both the direct and approval paths share it.

## `desktop.rs`
- `team_connect` now returns `{ status, registry?, requestToken? }` where `status` is `"connected"` or `"pending"`.
- New `team_join_poll` command polls a pending request → `"connected"` (finalized), `"pending"`, `"denied"`, or `"unknown"`.

## Frontend (TeamsView + Onboarding)
- On a `"pending"` connect, the UI shows "waiting for an admin to approve" and polls every 4s. Approval completes the join; a deny or expiry surfaces a clear message; a transient network error keeps the wait alive rather than dropping it. Cancel stops the wait.

## Notes
- Backward compatible: a normal join returns `status: "connected"` and behaves exactly as before.
- No usable token is delivered until approval; the poll mints a fresh member token server-side, so a dropped poll response just re-mints on the next tick.
- Rust compiles and the 16 teams-module tests pass; `tsc --noEmit` and `eslint` are clean.

Pairs with the teams-server approval feature; ships in the next desktop build (no standalone release needed).
