### PR TITLE
test: cover the openExternal URL guard (#266)

### DIFF
--- a/src/lib/openUrl.test.ts
+++ b/src/lib/openUrl.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { openUrl } = vi.hoisted(() => ({ openUrl: vi.fn() }));
+
+vi.mock("@tauri-apps/plugin-opener", () => ({ openUrl }));
+
+// Import after mock so the module binds to the mock.
+const { openExternal } = await import("./openUrl");
+
+describe("openExternal", () => {
+  beforeEach(() => {
+    openUrl.mockClear();
+  });
+
+  it("allows http and https URLs through to the opener", async () => {
+    await openExternal("https://example.com/docs");
+    await openExternal("http://localhost:3000");
+    expect(openUrl).toHaveBeenCalledWith("https://example.com/docs");
+    expect(openUrl).toHaveBeenCalledWith("http://localhost:3000");
+    expect(openUrl).toHaveBeenCalledTimes(2);
+  });
+
+  it("refuses file:, javascript:, malformed, and empty inputs", async () => {
+    await openExternal("file:///etc/passwd");
+    await openExternal("javascript:alert(1)");
+    await openExternal("not a url");
+    await openExternal("");
+    await openExternal(null);
+    await openExternal(undefined);
+    await openExternal(42 as unknown as string);
+    expect(openUrl).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
Vitest coverage for the `openExternal` URL guard (`src/lib/openUrl.ts`): `http`/`https` are forwarded to the OS opener; `file:`, `javascript:`, malformed, empty, and non-string inputs are refused (no-op).

Closes #266.

## Credit
This is @tapheret2's work from #276, finished and landed here so it doesn't stay stuck: rebased onto current `main`, the opener mock switched to a hoisted `vi.fn()` to satisfy `no-unused-vars`, and the duplicate `fmtTokens` tests dropped (already covered by #277). Credited via `Co-authored-by`.

## Testing
`npx vitest run src/lib/openUrl.test.ts` — 2 passing; eslint clean.