### PR TITLE
release: 1.7.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,38 @@ Entries before the rename below shipped under the project's former name, Conduit
 
 ## [Unreleased]
 
+## [1.7.3] - 2026-07-11
+
+Security hardening for the spawn supply-chain guard, plus update and team-join fixes.
+
+### Security
+
+**Spawned servers no longer inherit Toolport's own control secrets.** A downstream MCP
+server ran with the gateway's full environment, which in the self-host and `--http` bridge
+deployments carries the vault master key (`CONDUIT_SECRET_KEY`) and the local tool-bridge
+token (`CONDUIT_HTTP_TOKEN`). The gateway now strips its `CONDUIT_*` control vars from every
+spawned server, so an untrusted server package can't read them. (#298)
+
+**Closed several spawn-screener bypasses.** The supply-chain guard now catches getopt
+flag-clustering (`sh -ec`, `python -Ec`, `ruby`/`perl -we`, `node -pe`), deno/bun remote
+subcommands hidden behind a value flag, `data:` source URLs, versioned interpreter names
+(`python3.10`), and more launcher wrappers (nsenter, strace, bwrap, and friends). (#299)
+
+### Fixed
+
+**Clients pick up an updated gateway without a relaunch.** After an update (auto or manual)
+the old client-spawned gateway kept running, so the client kept talking to the previous
+binary; versioned gateway images are now matched and stopped so each client respawns the
+freshly-installed one on its next request. (#289)
+
+**Joining a brand-new team works against an older self-hosted server.** A `404` from the
+first config pull is treated as "no config yet" rather than a hard error. (#285)
+
+### Thanks
+
+Test coverage from first-time contributors: @glasses-and-hat (`fmtTokens`) and @tapheret2
+(`openExternal` URL guard). (#277, #300)
+
 ## [1.7.2] - 2026-07-11
 
 The Teams stability release: two separate freezes when joining a team, plus import,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "conduit",
   "private": true,
-  "version": "1.7.2",
+  "version": "1.7.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -604,7 +604,7 @@ dependencies = [
 
 [[package]]
 name = "conduit"
-version = "1.7.2"
+version = "1.7.3"
 dependencies = [
  "base64 0.22.1",
  "chacha20poly1305",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conduit"
-version = "1.7.2"
+version = "1.7.3"
 description = "Local MCP gateway: manage all your MCP servers in one place, set up once and shared by every AI client, with ~90% fewer tokens per request"
 authors = ["South Forge AI"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Toolport",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "identifier": "com.tsout.conduit",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
Cuts **1.7.3** with the accumulated post-1.7.2 fixes.

**Security**
- #298 — strip the gateway's `CONDUIT_*` control env (vault key, bridge token) from every spawned server.
- #299 — close spawn-screener parser bypasses (flag-clustering, deno/bun remote subcommands, `data:` URLs, versioned interpreter names, more wrappers).

**Fixed**
- #289 — clients pick up an updated gateway without a relaunch.
- #285 — joining a brand-new team works against an older self-hosted server.

Version bumped in `package.json`, `src-tauri/Cargo.toml`, `src-tauri/tauri.conf.json` (+ `Cargo.lock`); CHANGELOG entry added. `package-lock.json` is left as-is (its root version has been out of sync since before 1.7.2 and CI doesn't enforce it, so not churning it here).

After merge, tag `v1.7.3` to build the draft release.