### PR TITLE
fix(activity): label tool-less security notices

### DIFF
--- a/src/components/ActivityView.tsx
+++ b/src/components/ActivityView.tsx
@@ -303,7 +303,9 @@ function SecurityNotices({
                     <span className={`rounded px-1.5 py-0.5 font-medium ${badge.cls}`}>
                       {badge.label}
                     </span>
-                    <code className="font-mono text-foreground">{e.tool}</code>
+                    <code className="font-mono text-foreground">
+                      {e.tool || e.server || "integrity baseline"}
+                    </code>
                     {e.signatures && e.signatures.length > 0 && (
                       <span className="text-muted-foreground">
                         ({e.signatures.join(", ")})


### PR DESCRIPTION
## What and why

High-severity security notices currently render the optional `tool` field directly. Events such as `pins_load_failed` do not carry a tool, leaving an empty code chip in the Activity view.

This change keeps existing tool labels unchanged, falls back to the server name when available, and otherwise shows `integrity baseline`.

Closes #293.

## Testing

- [x] `npm.cmd run build`
- [x] `npm.cmd run test` — 6 files, 76 tests
- [x] `npm.cmd run lint` — 0 errors; 19 pre-existing warnings
- [x] `npm.cmd run audit:prod` — 0 vulnerabilities
- [x] `npx.cmd prettier --check src/components/ActivityView.tsx`
- [ ] `npm run test:rust` — frontend-only change; Rust toolchain is not installed locally
- [ ] Manual Tauri app check — not run locally

## Notes

- The diff is limited to the affected JSX rendering boundary.
- No secrets, keys, personal paths, or unrelated formatting are included.
- This contribution was prepared and verified by an AI-assisted automation agent operating the `sapunyangkut` account. It has not received independent human code review.
