### PR TITLE
ci: pin workflow actions to commit SHAs + tighten Docker permissions

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -28,10 +28,12 @@ jobs:
   audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
       - name: Install cargo-audit
-        run: cargo install cargo-audit --locked
+        run: cargo install cargo-audit --version 0.22.2 --locked
       - name: Audit dependencies
         working-directory: src-tauri
         run: cargo audit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,14 +19,16 @@ jobs:
     name: Build + test
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 20
           cache: npm
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
 
       - name: Install Linux build dependencies
         run: |
@@ -41,7 +43,7 @@ jobs:
           sudo fallocate -l 8G /mnt/ci-swap && sudo chmod 600 /mnt/ci-swap && sudo mkswap /mnt/ci-swap && sudo swapon /mnt/ci-swap || true
 
       - name: Cache cargo + target
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: |
             ~/.cargo/registry

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -15,9 +15,11 @@ concurrency:
   group: docker-gateway-${{ github.ref }}
   cancel-in-progress: true
 
+# Least privilege at the top level: read-only. Only the publish job below is
+# granted packages:write (GHCR push); the build-gateway job just compiles and
+# uploads an artifact, so it needs no write scope.
 permissions:
   contents: read
-  packages: write
 
 env:
   IMAGE: ghcr.io/tsouth89/toolport-gateway
@@ -27,11 +29,11 @@ jobs:
     name: build gateway binary
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
 
       - name: Install Linux build dependencies
         run: |
@@ -39,7 +41,7 @@ jobs:
           sudo apt-get install -y build-essential libssl-dev pkg-config libdbus-1-dev
 
       - name: Cache cargo + target
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: |
             ~/.cargo/registry
@@ -54,7 +56,7 @@ jobs:
       - name: Test toolport-gateway
         run: cargo test --release --bin toolport-gateway --manifest-path src-tauri/Cargo.toml --no-default-features
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: toolport-gateway-bin
           path: src-tauri/target/release/toolport-gateway
@@ -64,12 +66,15 @@ jobs:
     name: build + push image
     needs: build-gateway
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      packages: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: toolport-gateway-bin
           path: artifact
@@ -77,11 +82,11 @@ jobs:
       - name: Stage binary for Dockerfile
         run: cp artifact/toolport-gateway toolport-gateway-bin && chmod 755 toolport-gateway-bin
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Log in to GHCR
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -89,7 +94,7 @@ jobs:
 
       - name: Image tags + labels
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
           images: ${{ env.IMAGE }}
           tags: |
@@ -98,7 +103,7 @@ jobs:
             type=sha,format=short
 
       - name: Build + push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           file: Dockerfile


### PR DESCRIPTION
## What & why

Supply-chain hardening (**SOU-39**). `ci.yml`, `audit.yml`, and `docker-publish.yml` referenced third-party actions by mutable tag (`@v4`, `@stable`, …); only `release.yml` was SHA-pinned. A compromised or force-repushed tag on any of those actions could run arbitrary code in CI — including the `docker-publish` job that pushes `ghcr.io/tsouth89/toolport-gateway`.

## Changes

- **Pin every third-party action to a full commit SHA** (10 refs across the 3 workflows), version in a trailing comment. Each SHA is the current target of that action's existing tag, so **action versions are unchanged**; reused `release.yml`'s already-vetted checkout / setup-node / rust-toolchain pins.
- **`persist-credentials: false`** on the `ci.yml` and `audit.yml` checkouts (`docker-publish.yml` already had it).
- **Docker permission split**: the top level is now `contents: read`; `packages: write` is granted only to the `publish` job. `build-gateway` (compile + upload artifact) inherits read-only.
- **Pin `cargo-audit`** to `0.22.2` in `audit.yml`.

## Verification

All three workflows run on this PR — `ci` on every PR, `docker-publish` on PRs to `main`, and `audit` because the PR edits `.github/workflows/audit.yml` (in its path filter) — so every pinned SHA is exercised end-to-end; a bad pin fails the run. YAML parses clean and no mutable action refs remain.

## Deferred (kept on SOU-39)

Larger, separate follow-ups, not in this PR: `Dockerfile`/`Dockerfile.source` base-image digest pinning, SBOM + signed provenance/attestation for the GHCR image, and Dependabot/Renovate for controlled action/base-image updates.