### PR TITLE
registry: cross-process write lock to prevent lost updates

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -610,6 +610,7 @@ dependencies = [
  "chacha20poly1305",
  "core-foundation 0.10.1",
  "dirs 5.0.1",
+ "fs2",
  "getrandom 0.2.17",
  "json5",
  "keyring",
@@ -1296,6 +1297,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -52,6 +52,10 @@ sha2 = "0.10"
 base64 = "0.22"
 regex = "1"
 getrandom = "0.2"
+# OS advisory file locking (flock / LockFileEx) for the cross-process registry write
+# lock, so the app, the gateway binary, and the team-sync worker can't revert each
+# other's registry.json edits. Auto-released by the OS if a holder crashes.
+fs2 = "0.4"
 chacha20poly1305 = "0.10"
 urlencoding = "2"
 # file:// URI -> path decoding for the ${ROOT} cwd token (issue #239); already in

--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -457,8 +457,11 @@ fn set_server_enabled_via_agent(
         .or_else(|| reg.active_profile_id.clone())
         .ok_or_else(|| "Toolport: no active profile to change.".to_string())?;
 
-    // Load fresh so a concurrent edit in the app isn't clobbered, and re-check the
-    // opt-in on that fresh copy (the user may have just turned it off).
+    // Hold the cross-process registry lock across the whole load-modify-save so a concurrent
+    // app or team-sync write can't land between our read and our save and be reverted
+    // (SOU-23). Held until this function returns. Also re-check the opt-in on the fresh copy
+    // (the user may have just turned it off).
+    let _lock = registry::lock_at(path).map_err(|e| format!("Toolport: {e}"))?;
     let mut fresh = registry::load_from(path)
         .map_err(|e| format!("Toolport: could not read the registry ({e})."))?;
     if !fresh.allow_agent_control {

--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -490,14 +490,15 @@ async fn import_servers(
     let detected = tauri::async_runtime::spawn_blocking(clients::detect_clients)
         .await
         .map_err(|e| e.to_string())?;
-    let mut reg = state.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
     let selected: Option<std::collections::HashSet<String>> =
         selected.map(|keys| keys.into_iter().collect());
-    for server in selected_servers_to_import(&detected, &reg, selected.as_ref()) {
-        reg.add_server(server);
-    }
-    registry::save(&reg)?;
-    Ok(reg.clone())
+    let (reg, _) = write_registry(state.inner(), |reg| {
+        for server in selected_servers_to_import(&detected, reg, selected.as_ref()) {
+            reg.add_server(server);
+        }
+        Ok(())
+    })?;
+    Ok(reg)
 }
 
 /// Parse a pasted config snippet and return the detected server(s) with
@@ -517,14 +518,13 @@ fn parse_server_snippet(text: String) -> Result<Vec<clients::ParsedSnippetServer
 
 #[tauri::command]
 fn add_server(state: State<RegistryState>, entry: ServerEntry) -> Result<Registry, String> {
-    let mut reg = state.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
-    reg.add_server(entry);
-    registry::save(&reg)?;
-    // add_server appends, so the saved entry (with its assigned id) is the last one.
-    if let Some(saved) = reg.servers.last() {
+    let (reg, id) = write_registry(state.inner(), |reg| Ok(reg.add_server(entry)))?;
+    // Warm the launcher for the entry we just added, found by its assigned id (a concurrent
+    // add under the lock could otherwise make `last` a different server).
+    if let Some(saved) = reg.servers.iter().find(|s| s.id == id) {
         prewarm_launcher(saved);
     }
-    Ok(reg.clone())
+    Ok(reg)
 }
 
 /// Fire-and-forget spawn of a just-added download-then-run server (npx, uvx, ...)
@@ -564,18 +564,14 @@ fn prewarm_launcher(server: &ServerEntry) {
 
 #[tauri::command]
 fn update_server(state: State<RegistryState>, entry: ServerEntry) -> Result<Registry, String> {
-    let mut reg = state.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
-    reg.update_server(entry)?;
-    registry::save(&reg)?;
-    Ok(reg.clone())
+    let (reg, _) = write_registry(state.inner(), |reg| reg.update_server(entry))?;
+    Ok(reg)
 }
 
 #[tauri::command]
 fn remove_server(state: State<RegistryState>, id: String) -> Result<Registry, String> {
-    let mut reg = state.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
-    reg.remove_server(&id)?;
-    registry::save(&reg)?;
-    Ok(reg.clone())
+    let (reg, _) = write_registry(state.inner(), |reg| reg.remove_server(&id))?;
+    Ok(reg)
 }
 
 #[tauri::command]
@@ -585,10 +581,10 @@ fn set_server_enabled(
     server_id: String,
     enabled: bool,
 ) -> Result<Registry, String> {
-    let mut reg = state.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
-    reg.set_server_enabled(&profile_id, &server_id, enabled)?;
-    registry::save(&reg)?;
-    Ok(reg.clone())
+    let (reg, _) = write_registry(state.inner(), |reg| {
+        reg.set_server_enabled(&profile_id, &server_id, enabled)
+    })?;
+    Ok(reg)
 }
 
 #[tauri::command]
@@ -597,34 +593,29 @@ fn set_all_enabled(
     profile_id: String,
     enabled: bool,
 ) -> Result<Registry, String> {
-    let mut reg = state.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
-    reg.set_all_enabled(&profile_id, enabled)?;
-    registry::save(&reg)?;
-    Ok(reg.clone())
+    let (reg, _) = write_registry(state.inner(), |reg| reg.set_all_enabled(&profile_id, enabled))?;
+    Ok(reg)
 }
 
 #[tauri::command]
 fn create_profile(state: State<RegistryState>, name: String) -> Result<Registry, String> {
-    let mut reg = state.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
-    reg.add_profile(&name);
-    registry::save(&reg)?;
-    Ok(reg.clone())
+    let (reg, _) = write_registry(state.inner(), |reg| {
+        reg.add_profile(&name);
+        Ok(())
+    })?;
+    Ok(reg)
 }
 
 #[tauri::command]
 fn delete_profile(state: State<RegistryState>, id: String) -> Result<Registry, String> {
-    let mut reg = state.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
-    reg.remove_profile(&id)?;
-    registry::save(&reg)?;
-    Ok(reg.clone())
+    let (reg, _) = write_registry(state.inner(), |reg| reg.remove_profile(&id))?;
+    Ok(reg)
 }
 
 #[tauri::command]
 fn set_active_profile(state: State<RegistryState>, id: String) -> Result<Registry, String> {
-    let mut reg = state.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
-    reg.set_active_profile(&id)?;
-    registry::save(&reg)?;
-    Ok(reg.clone())
+    let (reg, _) = write_registry(state.inner(), |reg| reg.set_active_profile(&id))?;
+    Ok(reg)
 }
 
 /// Write a server set into a client's config (backs up first). Not yet called by
@@ -650,13 +641,21 @@ fn install_gateway(
     // and re-apply this client's effective scope without re-reading the config.
     // A concrete profile is stored by name; "no profile" is recorded as an
     // explicit-unscoped marker (not a removal) so a running gateway drops its old
-    // scope live instead of falling back to its boot-time CONDUIT_PROFILE.
-    let mut reg = state.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
-    match profile.as_deref().map(str::trim).filter(|p| !p.is_empty()) {
-        Some(p) => reg.set_client_scope(&client_id, Some(p)),
-        None => reg.set_client_unscoped(&client_id),
-    }
-    registry::save(&reg)?;
+    // scope live instead of falling back to its boot-time CONDUIT_PROFILE. The client
+    // config was already written above (outside the lock); only the registry record
+    // goes through the locked load-modify-save.
+    let scope: Option<String> = profile
+        .as_deref()
+        .map(str::trim)
+        .filter(|p| !p.is_empty())
+        .map(str::to_string);
+    write_registry(state.inner(), |reg| {
+        match scope.as_deref() {
+            Some(p) => reg.set_client_scope(&client_id, Some(p)),
+            None => reg.set_client_unscoped(&client_id),
+        }
+        Ok(())
+    })?;
     Ok(outcome)
 }
 
@@ -667,9 +666,10 @@ fn uninstall_gateway(
     client_id: String,
 ) -> Result<clients::WriteOutcome, String> {
     let outcome = clients::uninstall_gateway(&client_id)?;
-    let mut reg = state.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
-    reg.set_client_scope(&client_id, None);
-    registry::save(&reg)?;
+    write_registry(state.inner(), |reg| {
+        reg.set_client_scope(&client_id, None);
+        Ok(())
+    })?;
     Ok(outcome)
 }
 
@@ -700,16 +700,17 @@ fn add_http_client(
 ) -> Result<AddedHttpClient, String> {
     let token = random_hex()?;
     let id = random_hex()?;
-    let mut reg = state.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
-    reg.http_clients.push(registry::HttpClient {
-        id,
-        label: label.trim().to_string(),
-        token_sha256: registry::sha256_hex(&token),
-        profile: profile.unwrap_or_default().trim().to_string(),
-    });
-    registry::save(&reg)?;
+    let (reg, _) = write_registry(state.inner(), |reg| {
+        reg.http_clients.push(registry::HttpClient {
+            id,
+            label: label.trim().to_string(),
+            token_sha256: registry::sha256_hex(&token),
+            profile: profile.unwrap_or_default().trim().to_string(),
+        });
+        Ok(())
+    })?;
     Ok(AddedHttpClient {
-        registry: reg.clone(),
+        registry: reg,
         token,
     })
 }
@@ -717,10 +718,11 @@ fn add_http_client(
 /// Remove a registered HTTP-bridge client (revokes its token).
 #[tauri::command]
 fn remove_http_client(state: State<RegistryState>, id: String) -> Result<Registry, String> {
-    let mut reg = state.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
-    reg.http_clients.retain(|c| c.id != id);
-    registry::save(&reg)?;
-    Ok(reg.clone())
+    let (reg, _) = write_registry(state.inner(), |reg| {
+        reg.http_clients.retain(|c| c.id != id);
+        Ok(())
+    })?;
+    Ok(reg)
 }
 
 #[derive(serde::Serialize)]
@@ -753,8 +755,8 @@ async fn migrate_client(
         .find(|c| c.id == client_id)
         .ok_or_else(|| format!("Unknown client '{client_id}'"))?;
 
-    let (imported, moved) = {
-        let mut reg = state.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+    // Import the client's servers under the lock (a fresh load-modify-save).
+    let (_, (imported, moved)) = write_registry(state.inner(), |reg| {
         let mut imported = 0;
         let mut moved = Vec::new();
         for server in &client.servers {
@@ -771,25 +773,28 @@ async fn migrate_client(
                 imported += 1;
             }
         }
-        registry::save(&reg)?;
-        (imported, moved)
-    };
+        Ok((imported, moved))
+    })?;
 
-    // Rewrite the client to only the gateway (backs up first).
+    // Rewrite the client to only the gateway (backs up first). External to the registry, so
+    // it stays outside the lock; the scope record below is a separate locked write.
     clients::migrate_to_gateway(&client_id, profile.as_deref())?;
 
     // Record the scope now that the client config was rewritten to the gateway.
     // "No profile" becomes an explicit-unscoped marker (not a removal) so a live
     // re-scope to "all servers" applies without restarting the client.
-    let registry = {
-        let mut reg = state.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
-        match profile.as_deref().map(str::trim).filter(|p| !p.is_empty()) {
+    let scope: Option<String> = profile
+        .as_deref()
+        .map(str::trim)
+        .filter(|p| !p.is_empty())
+        .map(str::to_string);
+    let (registry, _) = write_registry(state.inner(), |reg| {
+        match scope.as_deref() {
             Some(p) => reg.set_client_scope(&client_id, Some(p)),
             None => reg.set_client_unscoped(&client_id),
         }
-        registry::save(&reg)?;
-        reg.clone()
-    };
+        Ok(())
+    })?;
 
     Ok(MigrateResult {
         registry,
@@ -807,24 +812,27 @@ fn set_secret(
     key: String,
     value: String,
 ) -> Result<Registry, String> {
+    // Keychain write first (external to the registry, so outside the lock), then record
+    // that the secret exists + bump the generation on the FRESH value under the lock.
     secrets::set_secret(&server_id, &key, &value)?;
-    let mut reg = state.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
-    if let Some(server) = reg.servers.iter_mut().find(|s| s.id == server_id) {
-        match server.env.iter_mut().find(|e| e.key == key) {
-            Some(ev) => {
-                ev.secret = true;
-                ev.value = None;
+    let (reg, _) = write_registry(state.inner(), |reg| {
+        if let Some(server) = reg.servers.iter_mut().find(|s| s.id == server_id) {
+            match server.env.iter_mut().find(|e| e.key == key) {
+                Some(ev) => {
+                    ev.secret = true;
+                    ev.value = None;
+                }
+                None => server.env.push(registry::EnvVar {
+                    key,
+                    value: None,
+                    secret: true,
+                }),
             }
-            None => server.env.push(registry::EnvVar {
-                key,
-                value: None,
-                secret: true,
-            }),
         }
-    }
-    reg.secrets_generation = reg.secrets_generation.wrapping_add(1);
-    registry::save(&reg)?;
-    Ok(reg.clone())
+        reg.secrets_generation = reg.secrets_generation.wrapping_add(1);
+        Ok(())
+    })?;
+    Ok(reg)
 }
 
 /// Remove a secret from the keychain and drop the env var from the server entry.
@@ -835,13 +843,14 @@ fn delete_secret(
     key: String,
 ) -> Result<Registry, String> {
     secrets::delete_secret(&server_id, &key)?;
-    let mut reg = state.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
-    if let Some(server) = reg.servers.iter_mut().find(|s| s.id == server_id) {
-        server.env.retain(|e| e.key != key);
-    }
-    reg.secrets_generation = reg.secrets_generation.wrapping_add(1);
-    registry::save(&reg)?;
-    Ok(reg.clone())
+    let (reg, _) = write_registry(state.inner(), |reg| {
+        if let Some(server) = reg.servers.iter_mut().find(|s| s.id == server_id) {
+            server.env.retain(|e| e.key != key);
+        }
+        reg.secrets_generation = reg.secrets_generation.wrapping_add(1);
+        Ok(())
+    })?;
+    Ok(reg)
 }
 
 /// The most recent tool-call audit entries (newest first).
@@ -1181,10 +1190,10 @@ fn set_tool_enabled(
     tool: String,
     enabled: bool,
 ) -> Result<Registry, String> {
-    let mut reg = state.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
-    reg.set_tool_enabled(&server_id, &tool, enabled)?;
-    registry::save(&reg)?;
-    Ok(reg.clone())
+    let (reg, _) = write_registry(state.inner(), |reg| {
+        reg.set_tool_enabled(&server_id, &tool, enabled)
+    })?;
+    Ok(reg)
 }
 
 /// Pin (or unpin) a tool as a lazy-discovery prerequisite: search always surfaces a
@@ -1197,20 +1206,22 @@ fn set_tool_pinned(
     tool: String,
     pinned: bool,
 ) -> Result<Registry, String> {
-    let mut reg = state.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
-    reg.set_tool_pinned(&server_id, &tool, pinned);
-    registry::save(&reg)?;
-    Ok(reg.clone())
+    let (reg, _) = write_registry(state.inner(), |reg| {
+        reg.set_tool_pinned(&server_id, &tool, pinned);
+        Ok(())
+    })?;
+    Ok(reg)
 }
 
 /// Flip the global destructive-tool deny switch. When on, the gateway hides and
 /// blocks every tool annotated `destructiveHint: true` across all servers.
 #[tauri::command]
 fn set_deny_destructive(state: State<RegistryState>, deny: bool) -> Result<Registry, String> {
-    let mut reg = state.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
-    reg.set_deny_destructive(deny);
-    registry::save(&reg)?;
-    Ok(reg.clone())
+    let (reg, _) = write_registry(state.inner(), |reg| {
+        reg.set_deny_destructive(deny);
+        Ok(())
+    })?;
+    Ok(reg)
 }
 
 /// Toggle per-call confirmation for destructive tools. When enabled, the gateway
@@ -1219,10 +1230,11 @@ fn set_deny_destructive(state: State<RegistryState>, deny: bool) -> Result<Regis
 /// `deny_destructive` (confirm turns deny off).
 #[tauri::command]
 fn set_confirm_destructive(state: State<RegistryState>, confirm: bool) -> Result<Registry, String> {
-    let mut reg = state.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
-    reg.set_confirm_destructive(confirm);
-    registry::save(&reg)?;
-    Ok(reg.clone())
+    let (reg, _) = write_registry(state.inner(), |reg| {
+        reg.set_confirm_destructive(confirm);
+        Ok(())
+    })?;
+    Ok(reg)
 }
 
 /// Toggle human-in-the-loop approval. When on, a gated tool call (destructive, or from an
@@ -1230,10 +1242,11 @@ fn set_confirm_destructive(state: State<RegistryState>, confirm: bool) -> Result
 /// via the approval broker. Distinct from confirm-destructive (which the agent re-confirms).
 #[tauri::command]
 fn set_human_approval(state: State<RegistryState>, on: bool) -> Result<Registry, String> {
-    let mut reg = state.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
-    reg.set_human_approval(on);
-    registry::save(&reg)?;
-    Ok(reg.clone())
+    let (reg, _) = write_registry(state.inner(), |reg| {
+        reg.set_human_approval(on);
+        Ok(())
+    })?;
+    Ok(reg)
 }
 
 /// The tool calls currently held awaiting a human decision (for the Pending Approvals UI).
@@ -1268,9 +1281,10 @@ fn decide_approval(
             let key = approval::fingerprint_allow_key(&view.server, &view.tool, fp);
             broker.add_session_allow(key.clone());
             if scope == "always" {
-                let mut reg = state.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
-                reg.allow_tool(key);
-                registry::save(&reg)?;
+                write_registry(state.inner(), |reg| {
+                    reg.allow_tool(key);
+                    Ok(())
+                })?;
             }
         }
     }
@@ -1334,11 +1348,10 @@ fn revoke_allowed_tool(
     broker: State<approval_broker::ApprovalBroker>,
     key: String,
 ) -> Result<(), String> {
-    {
-        let mut reg = state.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+    write_registry(state.inner(), |reg| {
         reg.revoke_tool(&key);
-        registry::save(&reg)?;
-    }
+        Ok(())
+    })?;
     broker.remove_session_allow(&key);
     Ok(())
 }
@@ -1357,14 +1370,15 @@ fn set_tool_override(
     description: Option<String>,
 ) -> Result<Registry, String> {
     let norm = |s: Option<String>| s.map(|v| v.trim().to_string()).filter(|v| !v.is_empty());
-    let mut reg = state.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
-    reg.set_tool_override(
-        server,
-        tool,
-        registry::ToolOverride { name: norm(name), description: norm(description) },
-    );
-    registry::save(&reg)?;
-    Ok(reg.clone())
+    let (reg, _) = write_registry(state.inner(), |reg| {
+        reg.set_tool_override(
+            server,
+            tool,
+            registry::ToolOverride { name: norm(name), description: norm(description) },
+        );
+        Ok(())
+    })?;
+    Ok(reg)
 }
 
 /// Remove a tool's exposure override, restoring the server's own name and description.
@@ -1374,10 +1388,11 @@ fn clear_tool_override(
     server: String,
     tool: String,
 ) -> Result<Registry, String> {
-    let mut reg = state.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
-    reg.clear_tool_override(&server, &tool);
-    registry::save(&reg)?;
-    Ok(reg.clone())
+    let (reg, _) = write_registry(state.inner(), |reg| {
+        reg.clear_tool_override(&server, &tool);
+        Ok(())
+    })?;
+    Ok(reg)
 }
 
 /// Toggle live request/response inspection. When enabled, the gateway captures each
@@ -1387,10 +1402,11 @@ fn clear_tool_override(
 /// it off in the UI should also clear the ring (see `clear_inspect_log`).
 #[tauri::command]
 fn set_live_inspect(state: State<RegistryState>, enabled: bool) -> Result<Registry, String> {
-    let mut reg = state.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
-    reg.set_live_inspect(enabled);
-    registry::save(&reg)?;
-    Ok(reg.clone())
+    let (reg, _) = write_registry(state.inner(), |reg| {
+        reg.set_live_inspect(enabled);
+        Ok(())
+    })?;
+    Ok(reg)
 }
 
 /// The most recent live-inspection captures (newest first): each tool call's args and
@@ -1534,10 +1550,11 @@ fn list_tool_identities(state: State<RegistryState>) -> Vec<ToolIdentity> {
 /// that drifts from its pinned baseline, until the user re-approves it.
 #[tauri::command]
 fn set_quarantine_on_drift(state: State<RegistryState>, on: bool) -> Result<Registry, String> {
-    let mut reg = state.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
-    reg.quarantine_on_drift = on;
-    registry::save(&reg)?;
-    Ok(reg.clone())
+    let (reg, _) = write_registry(state.inner(), |reg| {
+        reg.quarantine_on_drift = on;
+        Ok(())
+    })?;
+    Ok(reg)
 }
 
 /// Tools currently quarantined (blocked after a high-risk drift), across all profiles.
@@ -1560,8 +1577,11 @@ fn release_quarantine(
         Some(profile.as_str())
     };
     integrity::release(prof, &tool);
-    let reg = state.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
-    registry::save(&reg)?;
+    // The quarantine release lives in the separate tool-pins file; the former blind re-save
+    // here was only a gateway mtime-nudge (which the no-op guard usually swallowed anyway)
+    // and it could revert a concurrent gateway/team write (SOU-23). Refresh the cache
+    // instead of blind-writing the possibly-stale snapshot.
+    reload_into_state(state.inner())?;
     Ok(())
 }
 
@@ -1570,10 +1590,11 @@ fn release_quarantine(
 /// Clients pick it up the next time they (re)spawn the gateway.
 #[tauri::command]
 fn set_lazy_discovery(state: State<RegistryState>, lazy: bool) -> Result<Registry, String> {
-    let mut reg = state.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
-    reg.set_lazy_discovery(lazy);
-    registry::save(&reg)?;
-    Ok(reg.clone())
+    let (reg, _) = write_registry(state.inner(), |reg| {
+        reg.set_lazy_discovery(lazy);
+        Ok(())
+    })?;
+    Ok(reg)
 }
 
 /// Opt into agent control: lets an agent enable or disable servers through the
@@ -1581,18 +1602,38 @@ fn set_lazy_discovery(state: State<RegistryState>, lazy: bool) -> Result<Registr
 /// default; the destructive-tool safety switch stays user-only regardless of this.
 #[tauri::command]
 fn set_allow_agent_control(state: State<RegistryState>, allow: bool) -> Result<Registry, String> {
-    let mut reg = state.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
-    reg.allow_agent_control = allow;
-    registry::save(&reg)?;
-    Ok(reg.clone())
+    let (reg, _) = write_registry(state.inner(), |reg| {
+        reg.allow_agent_control = allow;
+        Ok(())
+    })?;
+    Ok(reg)
 }
 
 /// Flush the in-memory registry to disk so the teams module (which reads the registry
 /// file) operates on the current state, then refresh the in-memory state from disk
 /// after the team operation merged into it.
-fn flush_to_disk(state: &RegistryState) -> Result<(), String> {
-    let reg = state.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
-    registry::save(&reg)
+/// Load-modify-save the registry under the cross-process lock (mutating a FRESH on-disk
+/// copy), then sync the in-memory cache to the persisted result. The in-process mutex is
+/// held across the whole op so app threads serialize on it before the file lock; together
+/// with `registry::update` this stops any app command from reverting a concurrent gateway
+/// or team-sync write (SOU-23). Returns the new registry and `f`'s value.
+fn write_registry<T>(
+    state: &RegistryState,
+    f: impl FnOnce(&mut Registry) -> Result<T, String>,
+) -> Result<(Registry, T), String> {
+    let mut guard = state.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+    let (reg, out) = registry::update(f)?;
+    *guard = reg.clone();
+    Ok((reg, out))
+}
+
+/// Refresh the in-memory cache from disk. Formerly `flush_to_disk`, which PUSHED the
+/// in-memory snapshot to disk; that blind write could revert a concurrent gateway/team
+/// change (SOU-23), and it is now unnecessary because every mutation persists immediately
+/// via `write_registry`, so the in-memory copy never holds unsaved changes. Pulling instead
+/// keeps the cache current for the team flows without ever clobbering the file.
+fn refresh_from_disk(state: &RegistryState) -> Result<(), String> {
+    reload_into_state(state).map(|_| ())
 }
 
 fn reload_into_state(state: &RegistryState) -> Result<Registry, String> {
@@ -1626,7 +1667,7 @@ async fn team_connect(
     invite_code: String,
     member_name: Option<String>,
 ) -> Result<TeamConnectResult, String> {
-    flush_to_disk(state.inner())?;
+    refresh_from_disk(state.inner())?;
     // Same reason as team_sync: a synchronous command runs on Tauri's main (UI) thread, and
     // teams::connect does a blocking network join + first config pull. Run it off-thread so
     // clicking "Connect" to join a team doesn't freeze the whole app until the join returns.
@@ -1698,7 +1739,7 @@ async fn team_join_poll(
 /// Running the blocking pull on a worker thread keeps the event loop free.
 #[tauri::command]
 async fn team_sync(app: tauri::AppHandle, state: State<'_, RegistryState>) -> Result<Registry, String> {
-    flush_to_disk(state.inner())?;
+    refresh_from_disk(state.inner())?;
     let result = tauri::async_runtime::spawn_blocking(teams::sync_now)
         .await
         .map_err(|e| format!("sync task join failed: {e}"))??;
@@ -1716,7 +1757,7 @@ async fn team_sync_wait(
     state: State<'_, RegistryState>,
     wait_secs: u64,
 ) -> Result<Registry, String> {
-    flush_to_disk(state.inner())?;
+    refresh_from_disk(state.inner())?;
     let wait = wait_secs.min(30);
     let result = tauri::async_runtime::spawn_blocking(move || teams::sync_wait(wait))
         .await
@@ -1766,7 +1807,7 @@ fn emit_team_review(app: &tauri::AppHandle, outcome: teams::MergeOutcome) {
 /// Leave the team: remove its merged servers, clear the connection and the token.
 #[tauri::command]
 fn team_disconnect(state: State<RegistryState>) -> Result<Registry, String> {
-    flush_to_disk(state.inner())?;
+    refresh_from_disk(state.inner())?;
     teams::disconnect()?;
     let fresh = reload_into_state(state.inner())?;
     nudge_gateway(state.inner());
@@ -1777,7 +1818,7 @@ fn team_disconnect(state: State<RegistryState>) -> Result<Registry, String> {
 /// only, secret values never sent). Returns the new config version.
 #[tauri::command]
 async fn team_push(state: State<'_, RegistryState>) -> Result<i64, String> {
-    flush_to_disk(state.inner())?;
+    refresh_from_disk(state.inner())?;
     // push_current does a blocking PUT to the team server; keep it off the main thread.
     tauri::async_runtime::spawn_blocking(teams::push_current)
         .await
@@ -1787,20 +1828,23 @@ async fn team_push(state: State<'_, RegistryState>) -> Result<i64, String> {
 /// Re-save the registry to bump its mtime. The running gateway watches that file
 /// and rebuilds on change, so freshly-vaulted credentials take effect (and the
 /// server's tools flow to connected clients) without a manual restart.
+/// Refresh the in-memory cache from disk. Formerly a blind re-save meant to bump the
+/// registry mtime so the gateway would reload; that reverted concurrent gateway/team writes
+/// (SOU-23) and, because the no-op guard skips a same-content save, rarely bumped the mtime
+/// anyway. A real change (e.g. `bump_secrets_generation`) advances the file under the lock
+/// and triggers the gateway reload on its own.
 fn nudge_gateway(state: &RegistryState) {
-    // Recover from a poisoned lock like every other command does; otherwise a
-    // poisoned mutex would skip this re-save and freshly-vaulted credentials would
-    // silently never propagate to the running gateway.
-    let reg = state.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
-    let _ = registry::save(&reg);
+    let _ = reload_into_state(state);
 }
 
-/// Bump [`Registry::secrets_generation`] and save so gateways reload even when
-/// only the keychain changed.
+/// Bump [`Registry::secrets_generation`] and save under the lock so gateways reload even
+/// when only the keychain changed. Increments the FRESH on-disk value (not a stale `+1`) so
+/// a concurrent bump from another writer isn't lost.
 fn bump_secrets_generation(state: &RegistryState) {
-    let mut reg = state.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
-    reg.secrets_generation = reg.secrets_generation.wrapping_add(1);
-    let _ = registry::save(&reg);
+    let _ = write_registry(state, |reg| {
+        reg.secrets_generation = reg.secrets_generation.wrapping_add(1);
+        Ok(())
+    });
 }
 
 #[tauri::command]
@@ -2083,10 +2127,8 @@ fn deliver_shared_import(handle: &tauri::AppHandle, id: String) {
 /// values are never included, so each new server is left for the user to vault.
 #[tauri::command]
 fn import_config(state: State<RegistryState>, json: String) -> Result<Registry, String> {
-    let mut reg = state.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
-    apply_import(&mut reg, &json)?;
-    registry::save(&reg)?;
-    Ok(reg.clone())
+    let (reg, _) = write_registry(state.inner(), |reg| apply_import(reg, &json))?;
+    Ok(reg)
 }
 
 /// Read a shared-setup file from disk (path from an open dialog), capped so a

--- a/src-tauri/src/registry.rs
+++ b/src-tauri/src/registry.rs
@@ -1397,15 +1397,18 @@ fn lock_for(path: &Path) -> Result<RegistryLock, String> {
     loop {
         match file.try_lock_exclusive() {
             Ok(()) => return Ok(RegistryLock(file)),
-            Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+            // Contended. The error KIND for "already locked" differs by platform (`WouldBlock`
+            // on Unix, a lock-violation OS error on Windows), so do NOT gate the retry on it:
+            // the lock file already opened above, so any try-lock failure here is contention.
+            // Retry briefly, then surface it rather than hang the caller indefinitely.
+            Err(e) => {
                 if std::time::Instant::now() >= deadline {
-                    return Err(
-                        "The registry is locked by another Toolport process; try again.".into(),
-                    );
+                    return Err(format!(
+                        "The registry is locked by another Toolport process ({e}); try again."
+                    ));
                 }
                 std::thread::sleep(std::time::Duration::from_millis(20));
             }
-            Err(e) => return Err(format!("Could not lock the registry: {e}")),
         }
     }
 }
@@ -1561,6 +1564,47 @@ mod tests {
         let reloaded = load_from(&path).unwrap();
         assert!(reloaded.deny_destructive && reloaded.allow_agent_control);
 
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn update_at_serializes_concurrent_writers_with_no_lost_updates() {
+        // The definitive lock check: many threads each read-increment-write via update_at.
+        // Because each increment is a load-modify-save under the exclusive lock, none are
+        // lost, so the final count equals the total number of writes. Without the lock, the
+        // interleaved read-modify-write would drop increments. This exercises the same file
+        // lock used cross-process: each update_at opens its own handle and contends on it.
+        let dir = std::env::temp_dir().join(format!("conduit-sou23-conc-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("registry.json");
+        save_to(&path, &Registry::default()).unwrap(); // secrets_generation starts at 0
+
+        const THREADS: u64 = 4;
+        const PER: u64 = 30;
+        let handles: Vec<_> = (0..THREADS)
+            .map(|_| {
+                let p = path.clone();
+                std::thread::spawn(move || {
+                    for _ in 0..PER {
+                        update_at(&p, |r| {
+                            r.secrets_generation += 1;
+                            Ok(())
+                        })
+                        .unwrap();
+                    }
+                })
+            })
+            .collect();
+        for h in handles {
+            h.join().unwrap();
+        }
+
+        let final_reg = load_from(&path).unwrap();
+        assert_eq!(
+            final_reg.secrets_generation,
+            THREADS * PER,
+            "every increment persisted; the lock prevented lost updates"
+        );
         std::fs::remove_dir_all(&dir).ok();
     }
 

--- a/src-tauri/src/registry.rs
+++ b/src-tauri/src/registry.rs
@@ -12,6 +12,7 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 
+use fs2::FileExt;
 use serde::{Deserialize, Serialize};
 
 const REGISTRY_VERSION: u32 = 1;
@@ -1357,6 +1358,93 @@ pub fn save(registry: &Registry) -> Result<(), String> {
     save_to(&path, registry)
 }
 
+/// A held cross-process exclusive lock over the registry, released on drop (and by the OS
+/// if the holding process exits). Serializes the registry read-modify-write section across
+/// the desktop app, the gateway binary, and the team-sync worker, so no writer's save can
+/// revert another process's concurrent change (SOU-23). Advisory: it only excludes other
+/// holders of THIS lock, which every registry writer takes via `update` / `update_at`.
+pub struct RegistryLock(std::fs::File);
+
+impl Drop for RegistryLock {
+    fn drop(&mut self) {
+        // Also released when the File closes / the process exits; explicit for clarity.
+        let _ = self.0.unlock();
+    }
+}
+
+/// The sibling lock file for the registry at `path` (`<registry>.lock`). A dedicated file,
+/// not registry.json itself, so locking never races the atomic temp+rename that swaps the
+/// registry inode on every save.
+fn lock_path(path: &Path) -> PathBuf {
+    let mut s = path.as_os_str().to_os_string();
+    s.push(".lock");
+    PathBuf::from(s)
+}
+
+/// Acquire the exclusive registry lock, retrying briefly under contention. Registry writes
+/// are sub-millisecond, so a real conflict clears at once; a holder stuck past the deadline
+/// surfaces as an error rather than hanging the caller indefinitely.
+fn lock_for(path: &Path) -> Result<RegistryLock, String> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
+    }
+    let file = std::fs::OpenOptions::new()
+        .create(true)
+        .write(true)
+        .open(lock_path(path))
+        .map_err(|e| format!("Could not open the registry lock: {e}"))?;
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+    loop {
+        match file.try_lock_exclusive() {
+            Ok(()) => return Ok(RegistryLock(file)),
+            Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                if std::time::Instant::now() >= deadline {
+                    return Err(
+                        "The registry is locked by another Toolport process; try again.".into(),
+                    );
+                }
+                std::thread::sleep(std::time::Duration::from_millis(20));
+            }
+            Err(e) => return Err(format!("Could not lock the registry: {e}")),
+        }
+    }
+}
+
+/// Load-modify-save the resolved registry while holding the cross-process lock, so the
+/// write reflects (and can't clobber) any change another process made since this one last
+/// read. `f` mutates a FRESH on-disk copy; the persisted registry and `f`'s value are
+/// returned. Every registry writer (app commands, the gateway toggle, team sync) goes
+/// through this or [`update_at`] — that is what makes the lock effective.
+pub fn update<T>(f: impl FnOnce(&mut Registry) -> Result<T, String>) -> Result<(Registry, T), String> {
+    let path = resolved_path().ok_or("Could not resolve registry path")?;
+    let _lock = lock_for(&path)?;
+    let mut reg = load()?;
+    let out = f(&mut reg)?;
+    save(&reg)?;
+    Ok((reg, out))
+}
+
+/// Acquire the cross-process registry lock for an explicit path, for a caller that runs its
+/// own load-modify-save (the gateway's agent toggle, which interleaves audit + early
+/// returns) rather than using [`update_at`]. Hold the returned guard across the entire
+/// read-decide-write.
+pub fn lock_at(path: &Path) -> Result<RegistryLock, String> {
+    lock_for(path)
+}
+
+/// Like [`update`] but for a caller that already resolved an explicit path (the gateway
+/// binary), locking the same sibling lock file so it serializes with the app's `update`.
+pub fn update_at<T>(
+    path: &Path,
+    f: impl FnOnce(&mut Registry) -> Result<T, String>,
+) -> Result<(Registry, T), String> {
+    let _lock = lock_for(path)?;
+    let mut reg = load_from(path)?;
+    let out = f(&mut reg)?;
+    save_to(path, &reg)?;
+    Ok((reg, out))
+}
+
 /// The path the registry actually resolves to, honoring `CONDUIT_REGISTRY`.
 pub fn resolved_path() -> Option<PathBuf> {
     if let Ok(path) = std::env::var("CONDUIT_REGISTRY") {
@@ -1443,6 +1531,37 @@ mod tests {
         assert_eq!(r.profiles.len(), 1);
         assert_eq!(r.active_profile_id(), DEFAULT_PROFILE_ID);
         assert!(r.enabled_servers().is_empty());
+    }
+
+    #[test]
+    fn update_at_loads_fresh_and_preserves_a_concurrent_write() {
+        // The core SOU-23 property: because `update_at` load-modify-saves a FRESH on-disk
+        // copy (under the cross-process lock), a write another process made to a DIFFERENT
+        // field between this process's reads is preserved, not reverted. Uses an explicit
+        // path (no CONDUIT_REGISTRY env), so it's independent of other tests.
+        let dir = std::env::temp_dir().join(format!("conduit-sou23-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("registry.json");
+        save_to(&path, &Registry::default()).unwrap();
+
+        // Simulate a concurrent external writer flipping `allow_agent_control` on disk.
+        let mut disk = load_from(&path).unwrap();
+        disk.allow_agent_control = true;
+        save_to(&path, &disk).unwrap();
+
+        // Our update touches a different field. Loading fresh must keep the concurrent change.
+        let (out, ()) = update_at(&path, |r| {
+            r.deny_destructive = true;
+            Ok(())
+        })
+        .unwrap();
+        assert!(out.deny_destructive, "our change applied");
+        assert!(out.allow_agent_control, "the concurrent write was NOT reverted");
+
+        let reloaded = load_from(&path).unwrap();
+        assert!(reloaded.deny_destructive && reloaded.allow_agent_control);
+
+        std::fs::remove_dir_all(&dir).ok();
     }
 
     #[test]

--- a/src-tauri/src/teams.rs
+++ b/src-tauri/src/teams.rs
@@ -370,17 +370,20 @@ fn finish_connect(server_url: &str, member_name: Option<&str>, joined: Joined) -
     // Loading first and saving here would clobber any change another command made to the
     // registry while we were waiting on the join window's pull.
     let pulled = pull_config(&base(server_url), &joined.team_id, &joined.member_token, 0, None, 0)?;
-    let mut reg = crate::registry::load()?;
-    reg.team = Some(conn);
-    let mut outcome = MergeOutcome::default();
-    if let Some((version, cfg, etag)) = pulled {
-        outcome = apply_team_config(&mut reg, &joined.team_id, &cfg);
-        if let Some(t) = reg.team.as_mut() {
-            t.last_version = version;
-            t.last_etag = etag;
+    // Load-modify-save the fresh registry under the cross-process lock, so a concurrent write
+    // during the join window's pull isn't reverted (SOU-23).
+    let (reg, outcome) = crate::registry::update(|reg| {
+        reg.team = Some(conn);
+        let mut outcome = MergeOutcome::default();
+        if let Some((version, cfg, etag)) = pulled {
+            outcome = apply_team_config(reg, &joined.team_id, &cfg);
+            if let Some(t) = reg.team.as_mut() {
+                t.last_version = version;
+                t.last_etag = etag;
+            }
         }
-    }
-    crate::registry::save(&reg)?;
+        Ok(outcome)
+    })?;
     let conn = reg.team.clone().ok_or_else(|| "team connection lost after save".to_string())?;
     Ok((conn, outcome))
 }
@@ -450,33 +453,39 @@ fn sync_inner(wait_secs: u64) -> Result<SyncResult, String> {
     // Re-load a FRESH registry now, AFTER the (possibly multi-second) network round
     // trips, and apply the deltas to it. Loading at the top and saving here would clobber
     // any change another command made to the registry while we were on the network.
-    let mut reg = crate::registry::load()?;
-    match reg.team.as_ref() {
-        // The user disconnected or switched teams mid-sync: don't apply stale results.
-        None => return Ok(SyncResult::Ok { role, role_changed, applied: None }),
-        Some(t) if t.team_id != conn.team_id => {
-            return Ok(SyncResult::Ok { role, role_changed, applied: None })
+    // Apply the deltas onto a FRESH registry under the cross-process lock, so a concurrent
+    // app or gateway write between our network round trip and our save isn't reverted
+    // (SOU-23). The closure returns `None` when the user disconnected / switched teams
+    // mid-sync (nothing applied); `Some(applied)` otherwise.
+    let (_, result) = crate::registry::update(|reg| {
+        match reg.team.as_ref() {
+            None => return Ok(None),
+            Some(t) if t.team_id != conn.team_id => return Ok(None),
+            _ => {}
         }
-        _ => {}
-    }
-
-    let applied = match pulled {
-        None => None,
-        Some((version, cfg, etag)) => {
-            let outcome = apply_team_config(&mut reg, &conn.team_id, &cfg);
-            if let Some(t) = reg.team.as_mut() {
-                t.last_version = version;
-                t.last_etag = etag;
+        let applied = match pulled {
+            None => None,
+            Some((version, cfg, etag)) => {
+                let outcome = apply_team_config(reg, &conn.team_id, &cfg);
+                if let Some(t) = reg.team.as_mut() {
+                    t.last_version = version;
+                    t.last_etag = etag;
+                }
+                Some((version, outcome))
             }
-            Some((version, outcome))
+        };
+        // Persist the refreshed role alongside any applied config, so admin-only UI tracks
+        // the member's real, current role on every sync.
+        if let Some(t) = reg.team.as_mut() {
+            t.role = role.clone();
         }
+        Ok(Some(applied))
+    })?;
+    let applied = match result {
+        // Skipped (disconnected / switched teams mid-sync): don't report usage for it.
+        None => return Ok(SyncResult::Ok { role, role_changed, applied: None }),
+        Some(applied) => applied,
     };
-    // Persist the refreshed role alongside any applied config, so admin-only UI tracks
-    // the member's real, current role on every sync.
-    if let Some(t) = reg.team.as_mut() {
-        t.role = role.clone();
-    }
-    crate::registry::save(&reg)?;
     // Best-effort showback after the config work: report today's/yesterday's per-server
     // usage rollup to the team server. Any failure here must never affect the sync
     // result — the member's config is already applied and saved.
@@ -587,23 +596,25 @@ fn report_usage(conn: &TeamConnection, token: &str) {
     // Persist the watermarks on a FRESH registry (same clobber-avoidance as sync_inner:
     // the POSTs above are network round trips another command may have raced past).
     // `new_state` only ever holds today + yesterday, so old days prune themselves.
-    let Ok(mut reg) = crate::registry::load() else { return };
-    if let Some(t) = reg.team.as_mut() {
-        if t.team_id == conn.team_id {
-            t.usage_reported = new_state;
-            let _ = crate::registry::save(&reg);
+    let _ = crate::registry::update(|reg| {
+        if let Some(t) = reg.team.as_mut() {
+            if t.team_id == conn.team_id {
+                t.usage_reported = new_state;
+            }
         }
-    }
+        Ok(())
+    });
 }
 
 /// Leave the team: remove its merged servers, clear the connection and the token.
 pub fn disconnect() -> Result<(), String> {
-    let mut reg = crate::registry::load()?;
-    if let Some(conn) = reg.team.clone() {
-        remove_team(&mut reg, &conn.team_id);
-    }
-    reg.team = None;
-    crate::registry::save(&reg)?;
+    crate::registry::update(|reg| {
+        if let Some(conn) = reg.team.clone() {
+            remove_team(reg, &conn.team_id);
+        }
+        reg.team = None;
+        Ok(())
+    })?;
     let _ = clear_token();
     Ok(())
 }


### PR DESCRIPTION
## What & why

**SOU-23** — the desktop app, the gateway binary, and the team-sync worker all read-modify-write `registry.json` with no cross-process coordination. Each writes the whole file, so a blind save from one process could revert a concurrent field change from another (a lost update; individual writes stay atomic, so no corruption). Realistic when an agent toggles a server through the gateway (`allow_agent_control`, off by default) or a team op runs while the user edits in the app.

## The fix

- **Cross-process advisory lock** (`fs2` OS flock / LockFileEx, auto-released on process exit) + `registry::update` / `update_at` / `lock_at`: load-modify-save a **fresh** on-disk copy while holding the lock, so a write reflects and can't clobber a concurrent change.
- **App (`desktop.rs`)**: every mutating command now goes through a `write_registry` helper (locked load-modify-save + in-memory cache sync) instead of blind-saving the possibly-stale in-memory snapshot. Commands with an external side effect keep it outside the lock:
  - client-config writes (`install` / `uninstall` / `migrate_client`) — external write first, registry record in the lock;
  - keychain (`set` / `delete_secret`, auth tokens) — keychain first, then the record + a fresh `secrets_generation` bump;
  - the approval broker (`decide_approval`) — the irreversible release stays outside.
- `flush_to_disk` → `refresh_from_disk`, and the `nudge_gateway` / `release_quarantine` blind re-saves now **pull** from disk instead of pushing a stale snapshot (they were redundant — every mutation persists immediately — and could clobber a concurrent write).
- **Gateway** (`set_server_enabled_via_agent`) and **all four team-sync writers** take the same lock across their load-modify-save; the network round trips stay outside it.

## Verification

- New test `update_at_loads_fresh_and_preserves_a_concurrent_write` (fails without the fresh reload).
- lib **356** tests + gateway-bin **89** pass; clippy clean on changed files; rustfmt-clean on the change.
- No deadlock: the in-process mutex is always taken before the file lock, team-sync/gateway take only the file lock, and no locked closure re-enters the lock.

## Note

Adds one dependency, `fs2` (tiny, OS advisory locking). The in-memory `RegistryState` is now a cache kept in sync by `write_registry` and the mtime poll; disk is the source of truth.