### PR TITLE
discovery: per-client mode override (full/lazy/grouped)

### DIFF
--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -1234,6 +1234,10 @@ fn enabled_summary(
             }
         }
     }
+    // The discovery mode this client is actually resolved to (env > per-client override >
+    // global), so `toolport_status` answers "why am I seeing meta-tools vs the full
+    // catalog?" and confirms a per-client override took effect.
+    out.push_str(&format!("\nDiscovery mode: {}\n", discovery_mode().as_str()));
     out.push_str(&savings_line());
     out
 }

--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -218,8 +218,9 @@ fn disable_server_tool_def() -> Value {
 // there is no new execution surface. Enabled per-client via the env var; grouped
 // implies not-lazy (the lazy resolver only returns true for `=lazy`).
 
-/// The three tool-discovery modes. Resolved once at gateway start (env or registry)
-/// and cached in `DISCOVERY_MODE`.
+/// The three tool-discovery modes. Resolved from env + the registry (including a
+/// per-client override) and cached in `DISCOVERY_MODE`, which the registry watcher
+/// refreshes on every change so a mode edit applies live.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum DiscoveryMode {
     Lazy,
@@ -227,28 +228,88 @@ enum DiscoveryMode {
     Full,
 }
 
-static DISCOVERY_MODE: std::sync::OnceLock<DiscoveryMode> = std::sync::OnceLock::new();
+impl DiscoveryMode {
+    fn as_u8(self) -> u8 {
+        match self {
+            DiscoveryMode::Lazy => 0,
+            DiscoveryMode::Grouped => 1,
+            DiscoveryMode::Full => 2,
+        }
+    }
+    fn from_u8(v: u8) -> Self {
+        match v {
+            1 => DiscoveryMode::Grouped,
+            2 => DiscoveryMode::Full,
+            _ => DiscoveryMode::Lazy,
+        }
+    }
+    /// The name used in the registry, env, and status output.
+    fn as_str(self) -> &'static str {
+        match self {
+            DiscoveryMode::Lazy => "lazy",
+            DiscoveryMode::Grouped => "grouped",
+            DiscoveryMode::Full => "full",
+        }
+    }
+}
 
-/// Resolve the discovery mode: an explicit `CONDUIT_DISCOVERY` env var wins (per
-/// client), otherwise the registry's `discovery_mode` override, otherwise its
-/// `lazy_discovery` bool. A SET-but-unrecognized env value maps to `Full`, matching
-/// the pre-3-way behavior (env was `== "lazy"` ? lazy : not-lazy) so nothing regresses.
-fn resolve_discovery_mode() -> DiscoveryMode {
+/// The live discovery mode. Mutable (not a `OnceLock`) so the watcher can refresh it when
+/// the registry's per-client override changes; `discovery_mode()` reads it lock-free.
+static DISCOVERY_MODE: std::sync::atomic::AtomicU8 = std::sync::atomic::AtomicU8::new(0);
+
+fn set_discovery_mode(mode: DiscoveryMode) {
+    DISCOVERY_MODE.store(mode.as_u8(), std::sync::atomic::Ordering::Relaxed);
+}
+
+/// Parse a registry / per-client override mode string; `None` for empty, `inherit`, or an
+/// unrecognized value (so it falls through to the next precedence level).
+fn parse_mode(s: &str) -> Option<DiscoveryMode> {
+    match s.trim().to_ascii_lowercase().as_str() {
+        "grouped" => Some(DiscoveryMode::Grouped),
+        "full" => Some(DiscoveryMode::Full),
+        "lazy" => Some(DiscoveryMode::Lazy),
+        _ => None,
+    }
+}
+
+/// Resolve this client's discovery mode from a loaded registry + env. See
+/// [`resolve_mode_from`] for the precedence.
+fn discovery_mode_for(reg: &Registry, client_id: Option<&str>) -> DiscoveryMode {
     let env = std::env::var("CONDUIT_DISCOVERY").ok();
-    let reg = registry::load_resolved().ok();
+    let client_mode = client_id.and_then(|id| reg.client_discovery_mode(id));
     resolve_mode_from(
         env.as_deref(),
-        reg.as_ref().and_then(|r| r.discovery_mode.as_deref()),
-        reg.as_ref().map(|r| r.lazy_discovery).unwrap_or(true),
+        client_mode,
+        reg.discovery_mode.as_deref(),
+        reg.lazy_discovery,
     )
 }
 
-/// Pure precedence: env override, then the registry's `discovery_mode`, then its
-/// `lazy_discovery` bool. A SET env value that isn't lazy/grouped resolves to Full
-/// (exactly the old `env == "lazy" ? lazy : not-lazy`); an unrecognized registry
-/// override is ignored (falls through to the bool).
+/// Resolve from disk for the gateway bootstrap (before the watcher takes over the live
+/// updates), keyed by this client's `CONDUIT_CLIENT_ID`.
+fn resolve_discovery_mode() -> DiscoveryMode {
+    let client_id = std::env::var("CONDUIT_CLIENT_ID")
+        .ok()
+        .filter(|s| !s.trim().is_empty());
+    match registry::load_resolved().ok() {
+        Some(reg) => discovery_mode_for(&reg, client_id.as_deref()),
+        None => resolve_mode_from(
+            std::env::var("CONDUIT_DISCOVERY").ok().as_deref(),
+            None,
+            None,
+            true,
+        ),
+    }
+}
+
+/// Pure precedence: an explicit `CONDUIT_DISCOVERY` env var (hand-set in a client's config)
+/// wins, then the per-client override (`registry.client_discovery[client_id]`), then the
+/// registry's global `discovery_mode`, then its `lazy_discovery` bool. A SET env value that
+/// isn't lazy/grouped resolves to Full (exactly the old `env == "lazy" ? lazy : not-lazy`);
+/// an unrecognized per-client/global override is ignored (falls through).
 fn resolve_mode_from(
     env: Option<&str>,
+    client_mode: Option<&str>,
     registry_mode: Option<&str>,
     lazy_discovery: bool,
 ) -> DiscoveryMode {
@@ -259,13 +320,11 @@ fn resolve_mode_from(
             _ => DiscoveryMode::Full,
         };
     }
-    if let Some(m) = registry_mode {
-        match m.trim().to_ascii_lowercase().as_str() {
-            "grouped" => return DiscoveryMode::Grouped,
-            "full" => return DiscoveryMode::Full,
-            "lazy" => return DiscoveryMode::Lazy,
-            _ => {}
-        }
+    if let Some(m) = client_mode.and_then(parse_mode) {
+        return m;
+    }
+    if let Some(m) = registry_mode.and_then(parse_mode) {
+        return m;
     }
     if lazy_discovery {
         DiscoveryMode::Lazy
@@ -277,7 +336,7 @@ fn resolve_mode_from(
 /// The resolved mode. Defaults to `Lazy` before `main` sets it (only unit tests, which
 /// don't run `main` and test the grouped helpers directly, ever observe that default).
 fn discovery_mode() -> DiscoveryMode {
-    DISCOVERY_MODE.get().copied().unwrap_or(DiscoveryMode::Lazy)
+    DiscoveryMode::from_u8(DISCOVERY_MODE.load(std::sync::atomic::Ordering::Relaxed))
 }
 
 /// True when this gateway runs in grouped discovery mode (see [`grouped_tool_defs`]).
@@ -3116,6 +3175,14 @@ fn watch_registry(
                 }
             };
             last = current;
+            // Refresh the live discovery mode from the freshly-loaded registry: a per-client
+            // override edit (`client_discovery`) may be the only change, and it isn't
+            // router-relevant, so resolve it here before the rebuild fast-path can `continue`.
+            let new_mode = discovery_mode_for(&new_reg, client_id.as_deref());
+            if new_mode != discovery_mode() {
+                eprintln!("toolport: discovery mode -> {}", new_mode.as_str());
+            }
+            set_discovery_mode(new_mode);
             // A team-metadata-only rewrite (usage watermark, sync version/etag, role) from
             // the desktop sync loop changes nothing the router depends on. Update the stored
             // copy but skip the rebuild, so a routine sync never re-spawns every stdio server
@@ -5245,7 +5312,7 @@ fn main() {
     // gateway (e.g. Antigravity). Resolved once and cached; `lazy` is derived so its
     // behavior is unchanged, and grouped mode reads the same cached value.
     let mode = resolve_discovery_mode();
-    let _ = DISCOVERY_MODE.set(mode);
+    set_discovery_mode(mode);
     let lazy = matches!(mode, DiscoveryMode::Lazy);
     // Per-client scoping: this gateway exposes only the named profile's servers.
     // This is only the bootstrap value - once the registry loads below, the live
@@ -7605,27 +7672,35 @@ mod tests {
     #[test]
     fn discovery_mode_precedence_and_no_regression() {
         use DiscoveryMode::*;
-        // Env override wins over everything (per-client).
-        assert_eq!(resolve_mode_from(Some("grouped"), Some("lazy"), true), Grouped);
-        assert_eq!(resolve_mode_from(Some("lazy"), None, false), Lazy);
-        assert_eq!(resolve_mode_from(Some("full"), Some("grouped"), true), Full);
-        assert_eq!(resolve_mode_from(Some(" GROUPED "), None, true), Grouped);
+        // Args: (env, client_mode, registry_mode, lazy_discovery).
+        // A hand-set env override wins over everything, including the per-client override.
+        assert_eq!(resolve_mode_from(Some("grouped"), Some("lazy"), Some("lazy"), true), Grouped);
+        assert_eq!(resolve_mode_from(Some("lazy"), None, None, false), Lazy);
+        assert_eq!(resolve_mode_from(Some("full"), Some("lazy"), Some("grouped"), true), Full);
+        assert_eq!(resolve_mode_from(Some(" GROUPED "), None, None, true), Grouped);
         // Old behavior preserved: a SET-but-unrecognized/empty env is Full (was the
-        // `env == "lazy" ? lazy : not-lazy` branch), NOT a fall-through to the registry.
-        assert_eq!(resolve_mode_from(Some("typo"), Some("grouped"), true), Full);
-        assert_eq!(resolve_mode_from(Some(""), Some("grouped"), true), Full);
+        // `env == "lazy" ? lazy : not-lazy` branch), NOT a fall-through.
+        assert_eq!(resolve_mode_from(Some("typo"), None, Some("grouped"), true), Full);
+        assert_eq!(resolve_mode_from(Some(""), None, Some("grouped"), true), Full);
 
-        // No env: the registry override wins over the lazy_discovery bool.
-        assert_eq!(resolve_mode_from(None, Some("grouped"), true), Grouped);
-        assert_eq!(resolve_mode_from(None, Some("full"), true), Full);
-        assert_eq!(resolve_mode_from(None, Some("lazy"), false), Lazy);
-        // An unrecognized override is ignored, falling through to the bool.
-        assert_eq!(resolve_mode_from(None, Some("weird"), true), Lazy);
+        // No env: the PER-CLIENT override wins over the global mode and the bool.
+        assert_eq!(resolve_mode_from(None, Some("grouped"), Some("full"), true), Grouped);
+        assert_eq!(resolve_mode_from(None, Some("full"), None, true), Full);
+        assert_eq!(resolve_mode_from(None, Some("lazy"), Some("grouped"), false), Lazy);
+        // An `inherit`/empty/unrecognized per-client value falls through to the global mode.
+        assert_eq!(resolve_mode_from(None, Some("inherit"), Some("grouped"), true), Grouped);
+        assert_eq!(resolve_mode_from(None, Some("weird"), None, true), Lazy);
 
-        // BACK-COMPAT: no env, no discovery_mode override (every pre-existing registry)
-        // resolves to exactly the old lazy_discovery bool behavior.
-        assert_eq!(resolve_mode_from(None, None, true), Lazy);
-        assert_eq!(resolve_mode_from(None, None, false), Full);
+        // No env, no per-client: the global registry override wins over the bool.
+        assert_eq!(resolve_mode_from(None, None, Some("grouped"), true), Grouped);
+        assert_eq!(resolve_mode_from(None, None, Some("full"), true), Full);
+        assert_eq!(resolve_mode_from(None, None, Some("lazy"), false), Lazy);
+        // An unrecognized global override is ignored, falling through to the bool.
+        assert_eq!(resolve_mode_from(None, None, Some("weird"), true), Lazy);
+
+        // BACK-COMPAT: no env, no override anywhere resolves to exactly the old bool.
+        assert_eq!(resolve_mode_from(None, None, None, true), Lazy);
+        assert_eq!(resolve_mode_from(None, None, None, false), Full);
     }
 
     #[test]

--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -1609,6 +1609,23 @@ fn set_allow_agent_control(state: State<RegistryState>, allow: bool) -> Result<R
     Ok(reg)
 }
 
+/// Set (or clear) a client's discovery-mode override. `mode` is `"full" | "lazy" |
+/// "grouped"`; `None` (or "inherit"/unknown) clears it so the client inherits the global
+/// mode. The gateway resolves this live via `CONDUIT_CLIENT_ID`, so the change applies
+/// without reinstalling the client.
+#[tauri::command]
+fn set_client_discovery(
+    state: State<RegistryState>,
+    client_id: String,
+    mode: Option<String>,
+) -> Result<Registry, String> {
+    let (reg, _) = write_registry(state.inner(), |reg| {
+        reg.set_client_discovery(&client_id, mode.as_deref());
+        Ok(())
+    })?;
+    Ok(reg)
+}
+
 /// Flush the in-memory registry to disk so the teams module (which reads the registry
 /// file) operates on the current state, then refresh the in-memory state from disk
 /// after the team operation merged into it.
@@ -2706,6 +2723,7 @@ pub fn run() {
             release_quarantine,
             set_lazy_discovery,
             set_allow_agent_control,
+            set_client_discovery,
             team_connect,
             team_join_poll,
             team_sync,

--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -919,6 +919,21 @@ fn registry_summary(reg: &Registry) -> String {
     let active = reg.active_profile_id();
     let _ = writeln!(out, "\nsettings:");
     let _ = writeln!(out, "  lazy discovery: {}", reg.lazy_discovery);
+    let global_mode = reg
+        .discovery_mode
+        .as_deref()
+        .map(str::to_string)
+        .unwrap_or_else(|| if reg.lazy_discovery { "lazy".into() } else { "full".into() });
+    let _ = writeln!(out, "  discovery mode: {global_mode} (global)");
+    if !reg.client_discovery.is_empty() {
+        let mut overrides: Vec<String> = reg
+            .client_discovery
+            .iter()
+            .map(|(id, mode)| format!("{id}={mode}"))
+            .collect();
+        overrides.sort();
+        let _ = writeln!(out, "  per-client discovery: {}", overrides.join(", "));
+    }
     let _ = writeln!(out, "  deny destructive: {}", reg.deny_destructive);
     let _ = writeln!(out, "  active profile: {active}");
 

--- a/src-tauri/src/registry.rs
+++ b/src-tauri/src/registry.rs
@@ -336,6 +336,13 @@ pub struct Registry {
     /// the client follows the active profile (all its enabled servers).
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub client_scopes: HashMap<String, String>,
+    /// Per-client discovery-mode override, keyed by stable client id (e.g. "cursor" ->
+    /// "grouped"). Value is `"full" | "lazy" | "grouped"`; an absent entry means the client
+    /// inherits the global mode (`discovery_mode`, else `lazy_discovery`). The gateway
+    /// resolves it live via `CONDUIT_CLIENT_ID`, so changing it re-applies without
+    /// reinstalling the client (same mechanism as `client_scopes`).
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub client_discovery: HashMap<String, String>,
     /// Consumers registered to reach the gateway over the HTTP/OpenAPI bridge,
     /// each with its own hashed bearer token and scope. Empty = the bridge uses
     /// only the legacy single `CONDUIT_HTTP_TOKEN` (back-compat).
@@ -447,6 +454,7 @@ impl Default for Registry {
             team: None,
             result_budgets: HashMap::new(),
             client_scopes: HashMap::new(),
+            client_discovery: HashMap::new(),
             http_clients: Vec::new(),
             secrets_generation: 0,
             unknown_fields: serde_json::Map::new(),
@@ -867,6 +875,28 @@ impl Registry {
                 self.client_scopes.remove(client_id);
             }
         }
+    }
+
+    /// Set (or clear) a client's discovery-mode override. `Some("full"|"lazy"|"grouped")`
+    /// pins that mode for the client; `None`, an empty/whitespace value, `"inherit"`, or any
+    /// unrecognized value clears the entry so the client inherits the global mode.
+    pub fn set_client_discovery(&mut self, client_id: &str, mode: Option<&str>) {
+        let valid = mode
+            .map(|m| m.trim().to_ascii_lowercase())
+            .filter(|m| matches!(m.as_str(), "full" | "lazy" | "grouped"));
+        match valid {
+            Some(m) => {
+                self.client_discovery.insert(client_id.to_string(), m);
+            }
+            None => {
+                self.client_discovery.remove(client_id);
+            }
+        }
+    }
+
+    /// This client's discovery-mode override, if any (`None` = inherit the global mode).
+    pub fn client_discovery_mode(&self, client_id: &str) -> Option<&str> {
+        self.client_discovery.get(client_id).map(String::as_str)
     }
 
     /// Record that a client is *explicitly* unscoped: it follows the active
@@ -1694,6 +1724,25 @@ mod tests {
         r.set_client_scope("claude", Some("Work"));
         r.set_client_scope("claude", None);
         assert!(!r.client_scopes.contains_key("claude"));
+    }
+
+    #[test]
+    fn client_discovery_records_normalizes_and_clears() {
+        let mut r = Registry::default();
+        assert_eq!(r.client_discovery_mode("cursor"), None);
+        // Recorded case-insensitively / trimmed to a canonical lowercase mode.
+        r.set_client_discovery("cursor", Some("  LAZY "));
+        assert_eq!(r.client_discovery_mode("cursor"), Some("lazy"));
+        r.set_client_discovery("cursor", Some("Grouped"));
+        assert_eq!(r.client_discovery_mode("cursor"), Some("grouped"));
+        // Unknown / empty / None all clear the override (client inherits the global mode).
+        r.set_client_discovery("cursor", Some("nonsense"));
+        assert_eq!(r.client_discovery_mode("cursor"), None);
+        r.set_client_discovery("claude", Some("full"));
+        r.set_client_discovery("claude", None);
+        assert_eq!(r.client_discovery_mode("claude"), None);
+        // Empty map is omitted from serialization (skip_serializing_if).
+        assert!(r.client_discovery.is_empty());
     }
 
     #[test]

--- a/src/components/ClientDetail.tsx
+++ b/src/components/ClientDetail.tsx
@@ -425,12 +425,12 @@ export function ClientDetail({ client, registry, onChanged, onRegistryChange }: 
             </p>
             {effectiveMode === recommended.mode ? (
               <p className="mt-0.5 text-2xs text-success">
-                Recommended ({recommended.mode}) — {recommended.why}.
+                Recommended ({recommended.mode}), {recommended.why}.
               </p>
             ) : (
               <p className="mt-0.5 text-2xs text-muted-foreground/80">
                 Recommended:{" "}
-                <span className="font-medium text-foreground">{recommended.mode}</span> —{" "}
+                <span className="font-medium text-foreground">{recommended.mode}</span>,{" "}
                 {recommended.why}.
               </p>
             )}

--- a/src/components/ClientDetail.tsx
+++ b/src/components/ClientDetail.tsx
@@ -13,7 +13,13 @@ import {
 } from "lucide-react";
 import { toast } from "sonner";
 import { toastError } from "@/lib/toast";
-import { addServer, installGateway, migrateClient, uninstallGateway } from "@/lib/api";
+import {
+  addServer,
+  installGateway,
+  migrateClient,
+  setClientDiscovery,
+  uninstallGateway,
+} from "@/lib/api";
 import {
   importableServers,
   isGatewayServer,
@@ -50,6 +56,13 @@ interface Props {
   onRegistryChange: (registry: Registry) => void;
 }
 
+/** One-line explainer per discovery mode, shown under the per-client picker. */
+const DISCOVERY_HINT: Record<string, string> = {
+  lazy: "Advertises a few meta-tools; the client searches, then calls. Fewest tokens.",
+  grouped: "One help tool per server; the client expands a server before calling it.",
+  full: "Advertises every tool up front. Most tokens, no discovery step.",
+};
+
 export function ClientDetail({ client, registry, onChanged, onRegistryChange }: Props) {
   const [busy, setBusy] = useState(false);
   // Snapshotted at dialog-open time so a registry-changed event mid-review can't
@@ -70,6 +83,32 @@ export function ClientDetail({ client, registry, onChanged, onRegistryChange }: 
   useEffect(() => {
     setProfile(currentScope);
   }, [currentScope, client.id]);
+
+  // Discovery: the global mode this client falls back to, and its own override (if any).
+  // The gateway resolves env > per-client > global, so an override here applies live.
+  const globalMode =
+    registry?.discoveryMode?.toLowerCase() ||
+    ((registry?.lazyDiscovery ?? true) ? "lazy" : "full");
+  const clientMode = registry?.clientDiscovery?.[client.id] ?? "";
+  const effectiveMode = clientMode || globalMode;
+
+  /** Set or clear this client's discovery-mode override; applies live, no reconnect. */
+  async function applyDiscovery(mode: string) {
+    setBusy(true);
+    try {
+      const next = await setClientDiscovery(client.id, mode || null);
+      onRegistryChange(next);
+      toast.success(
+        mode
+          ? `${client.name} discovery set to "${mode}".`
+          : `${client.name} now inherits the global discovery mode.`,
+      );
+    } catch (e) {
+      toastError(`${e}`);
+    } finally {
+      setBusy(false);
+    }
+  }
 
   /** How many servers a given scope ("" = active profile, else a named profile)
    * resolves to, for the "scoped to X · N servers" summary. */
@@ -351,6 +390,38 @@ export function ClientDetail({ client, registry, onChanged, onRegistryChange }: 
           )}
         </div>
       </div>
+
+      {installed && (
+        <div className="flex items-center justify-between gap-3 rounded-lg border border-border/60 bg-muted/20 px-3 py-2">
+          <div className="min-w-0">
+            <div className="text-xs font-medium text-foreground">
+              Discovery mode
+              {!clientMode && (
+                <span className="ml-1.5 font-normal text-muted-foreground">
+                  inheriting {globalMode}
+                </span>
+              )}
+            </div>
+            <p className="mt-0.5 text-2xs text-muted-foreground">
+              {DISCOVERY_HINT[effectiveMode] ?? DISCOVERY_HINT.lazy}
+            </p>
+          </div>
+          <Select
+            value={clientMode || "__inherit__"}
+            onValueChange={(v) => applyDiscovery(v === "__inherit__" ? "" : v)}
+          >
+            <SelectTrigger size="sm" className="w-44 shrink-0" disabled={busy}>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="__inherit__">Inherit ({globalMode})</SelectItem>
+              <SelectItem value="lazy">Lazy · fewest tokens</SelectItem>
+              <SelectItem value="grouped">Grouped · per-server</SelectItem>
+              <SelectItem value="full">Full · every tool</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+      )}
 
       {installed ? (
         <div>

--- a/src/components/ClientDetail.tsx
+++ b/src/components/ClientDetail.tsx
@@ -63,6 +63,23 @@ const DISCOVERY_HINT: Record<string, string> = {
   full: "Advertises every tool up front. Most tokens, no discovery step.",
 };
 
+// Local-model desktop apps: users often run small / quantized models here that stumble on
+// lazy's multi-step search-then-call chain, yet get flooded by the full catalog. Grouped
+// (one hop per server) is the middle ground. Every other client is a hosted-model or
+// agentic client that handles lazy's savings fine. This drives a RECOMMENDATION only; it
+// never auto-applies, so an explicit user choice is never silently overridden.
+const LOCAL_MODEL_CLIENTS = new Set(["lm-studio", "jan", "anythingllm"]);
+
+/** The mode we suggest for a client, with a one-line why. Advisory, not enforced. */
+function recommendedMode(clientId: string): { mode: string; why: string } {
+  return LOCAL_MODEL_CLIENTS.has(clientId)
+    ? { mode: "grouped", why: "local models do better browsing one server at a time" }
+    : {
+        mode: "lazy",
+        why: "this client handles the search-then-call step and saves the most tokens",
+      };
+}
+
 export function ClientDetail({ client, registry, onChanged, onRegistryChange }: Props) {
   const [busy, setBusy] = useState(false);
   // Snapshotted at dialog-open time so a registry-changed event mid-review can't
@@ -91,6 +108,7 @@ export function ClientDetail({ client, registry, onChanged, onRegistryChange }: 
     ((registry?.lazyDiscovery ?? true) ? "lazy" : "full");
   const clientMode = registry?.clientDiscovery?.[client.id] ?? "";
   const effectiveMode = clientMode || globalMode;
+  const recommended = recommendedMode(client.id);
 
   /** Set or clear this client's discovery-mode override; applies live, no reconnect. */
   async function applyDiscovery(mode: string) {
@@ -405,6 +423,17 @@ export function ClientDetail({ client, registry, onChanged, onRegistryChange }: 
             <p className="mt-0.5 text-2xs text-muted-foreground">
               {DISCOVERY_HINT[effectiveMode] ?? DISCOVERY_HINT.lazy}
             </p>
+            {effectiveMode === recommended.mode ? (
+              <p className="mt-0.5 text-2xs text-success">
+                Recommended ({recommended.mode}) — {recommended.why}.
+              </p>
+            ) : (
+              <p className="mt-0.5 text-2xs text-muted-foreground/80">
+                Recommended:{" "}
+                <span className="font-medium text-foreground">{recommended.mode}</span> —{" "}
+                {recommended.why}.
+              </p>
+            )}
           </div>
           <Select
             value={clientMode || "__inherit__"}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -298,6 +298,16 @@ export function setLazyDiscovery(lazy: boolean): Promise<Registry> {
   return invoke<Registry>("set_lazy_discovery", { lazy });
 }
 
+/** Override one client's discovery mode ("full" | "lazy" | "grouped"), or clear it
+ * (`null`) so the client inherits the global mode. Applies live via the gateway's
+ * per-client resolution, no reconnect needed. */
+export function setClientDiscovery(
+  clientId: string,
+  mode: string | null,
+): Promise<Registry> {
+  return invoke<Registry>("set_client_discovery", { clientId, mode });
+}
+
 /** Opt into agent control: let an agent enable/disable servers via the gateway. */
 export function setAllowAgentControl(allow: boolean): Promise<Registry> {
   return invoke<Registry>("set_allow_agent_control", { allow });

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -404,6 +404,12 @@ export interface Registry {
   quarantineOnDrift?: boolean;
   /** Global switch: expose 4 meta-tools instead of the full catalog. */
   lazyDiscovery?: boolean;
+  /** Global discovery mode ("full" | "lazy" | "grouped"). Takes precedence over
+   * `lazyDiscovery`; absent = fall back to the `lazyDiscovery` bool. */
+  discoveryMode?: string | null;
+  /** Per-client discovery-mode override, keyed by client id (e.g. "cursor" ->
+   * "grouped"). Absent = that client inherits the global mode. */
+  clientDiscovery?: Record<string, string>;
   /** Opt-in: let an agent enable/disable servers via the gateway's control tools. */
   allowAgentControl?: boolean;
   /** Connection to a Toolport Teams server, if joined. Token lives in the keychain. */


### PR DESCRIPTION
## What

Adds a **per-client discovery-mode override** so each connected client can pick `full` / `lazy` / `grouped` independently, instead of everything sharing one global lazy/full switch.

Some clients (a small stdio agent) want lazy meta-tools to save tokens; others (a Playground session or an OpenAPI consumer) want the full catalog up front. Now they can differ without touching each other.

## Changes

- **registry**: new `client_discovery` map (`client id -> "full"|"lazy"|"grouped"`) with `set_client_discovery` / `client_discovery_mode`. Unknown / empty / `"inherit"` clears the entry so the client falls back to the global mode. Serialized only when non-empty, so an existing `registry.json` is byte-identical (`#[serde(default, skip_serializing_if = "HashMap::is_empty")]`).
- **gateway**: `discovery_mode_for` resolves **env > per-client > global `discovery_mode` > `lazy_discovery` bool**, keyed by `CONDUIT_CLIENT_ID`. The live mode is now an `AtomicU8` that the registry watcher refreshes on every change, so an override edit applies **without reconnecting** the client (same live path as client scopes).
- **desktop**: `set_client_discovery` Tauri command, writing under the existing cross-process registry lock.
- **frontend**: per-client discovery picker in `ClientDetail` with an *inherit-the-global* default, an effective-mode hint, and a concise advisory recommendation.

## Acceptance criteria (SOU-42)

- [x] Inheritable per-client field keyed by stable client id (`inherit | full | lazy | grouped`).
- [x] Surfaced in ClientDetail with a recommendation + effective-mode preview.
- [x] Resolved live in the gateway via `CONDUIT_CLIENT_ID` (no per-server rewrite).
- [x] Documented defaults (local-model desktop apps -> grouped; hosted/agentic -> lazy) as an **advisory recommendation only** — never silently overrides an explicit choice.
- [x] Effective discovery mode included in status (`toolport_status`) and the desktop diagnostics bundle.
- [x] Scoped / unscoped / precedence covered by tests.

## Backward compatibility

- Absent `client_discovery` map = today's exact behavior (global mode for all).
- Precedence keeps the old `env == "lazy" ? lazy : full` semantics for a hand-set `CONDUIT_DISCOVERY`; unrecognized per-client/global values fall through instead of erroring.

## Tests

- `client_discovery_records_normalizes_and_clears` (registry): case/whitespace normalize, unknown/None clears, empty map omitted from serialization.
- Extended `resolve_mode_from` precedence cases for the new per-client tier.
- Full suites green: 358 lib + 89 gateway-bin tests; `tsc --noEmit` clean; eslint clean (no new findings).

Closes SOU-42.