### PR TITLE
security: correct SECURITY.md accuracy + add clear-activity control (SOU-41)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,7 +1,8 @@
 # Security
 
 Toolport is a local-first MCP gateway and manager. This document describes how it
-handles secrets and trust, and how to report a vulnerability.
+handles secrets, network boundaries, and trust across each way it runs, what it
+records locally, and how to report a vulnerability.
 
 ## Reporting a vulnerability
 
@@ -20,31 +21,127 @@ credit reporters who want it.
 Toolport ships fixes on the latest release only. Always run the newest version
 from the [Releases](https://github.com/tsouth89/toolport/releases) page.
 
-## Security design
+## How Toolport runs, and where the boundaries are
 
-- **Local-first.** Toolport's core gateway runs on your machine. The desktop app
-  is a manager; the gateway is a local process each AI client spawns over stdio.
-  There is no telemetry. Routine tool traffic is between the gateway and the
-  upstream MCP servers _you_ configure. Optional hosted features make explicit
-  user-initiated requests: shared setup links use `toolport.app`, and Teams uses
-  the team server URL you choose.
-- **Secrets in the OS keychain.** API keys and OAuth tokens are stored in the
-  platform keychain (macOS Keychain, Windows Credential Manager, Linux Secret
-  Service), never in plaintext config files and never written to logs.
-- **OAuth 2.1, done conservatively.** Dynamic client registration, PKCE (S256),
-  a CSRF `state` check, a loopback (`127.0.0.1`) redirect, RFC 8707 resource
-  binding, and `offline_access` refresh tokens. Discovered authorization, token,
-  and registration endpoints must be `https://` (loopback `http` is allowed only
-  for local development).
-- **Minimal attack surface.** The gateway communicates over stdio and opens no
-  listening network port. The only socket it ever binds is a transient
-  `127.0.0.1` loopback listener during an OAuth callback, which closes as soon as
-  the flow completes.
-- **Diagnostics off by default.** Debug logging is gated behind the
-  `CONDUIT_DEBUG` environment variable and never records tokens or full
-  authorization URLs.
-- **Tool governance.** Per-tool enable/disable and a destructive-tool deny-list
-  let you block dangerous tools before a client can ever call them.
+Toolport's core is a local gateway that AI clients reach; the desktop app is a
+manager around it. What network surface exists depends on the mode you run:
+
+- **Desktop app + stdio gateway (the default).** Each AI client spawns the
+  gateway as a local child process and talks to it over stdio (standard
+  input/output). In this mode the gateway binds **no listening network port** at
+  all. The only socket it ever opens is a transient `127.0.0.1` loopback listener
+  during an OAuth callback, which closes as soon as that flow completes.
+- **Local HTTP / OpenAPI bridge (`CONDUIT_HTTP`).** For clients that speak HTTP
+  or OpenAPI instead of stdio, the gateway can bind a listener. It defaults to
+  `127.0.0.1:8765` (loopback only), configurable with `CONDUIT_HTTP_HOST` and the
+  port. When the desktop app starts this bridge it auto-generates a bearer token
+  (`CONDUIT_HTTP_TOKEN`); a request without a valid token gets `401`, and any
+  cross-site browser request is rejected with `403` regardless of token. A gateway
+  you launch by hand on loopback **without** a token binds anyway and is reachable
+  by any local process, so set a token if other local users or processes are not
+  trusted.
+- **Headless / Docker.** The published image runs the HTTP bridge and sets
+  `CONDUIT_HTTP_HOST=0.0.0.0` so it is reachable off-host. Binding to a
+  non-loopback address **requires** `CONDUIT_HTTP_TOKEN`: without one the gateway
+  refuses to start. Put it behind your own TLS/ingress; the gateway serves plain
+  HTTP and expects the operator to terminate TLS.
+- **Sharing and Teams (opt-in, hosted).** These make explicit, user-initiated
+  requests to hosted services and are covered under
+  [Telemetry and hosted services](#telemetry-and-hosted-services) below.
+
+## Secrets
+
+API keys and OAuth tokens are never written to plaintext config files and never
+written to logs. Where they live depends on the backend, selected by environment:
+
+- **OS keychain (desktop default).** With no secret-related env var set, secrets
+  go to the platform keychain: the macOS data-protection keychain (under a
+  team-scoped access group shared with the signed gateway), Windows Credential
+  Manager, or the Linux Secret Service.
+- **Encrypted file backend (`CONDUIT_SECRET_KEY`).** Setting this env var switches
+  storage to an encrypted `secrets.enc` file (XChaCha20-Poly1305) in Toolport's
+  data directory, keyed from the passphrase. This is the backend for headless and
+  containerized deployments where no OS keychain is available. The passphrase is
+  the whole key: choose a high-entropy value and keep it out of shell history and
+  image layers. If `secrets.enc` leaks together with a weak passphrase, the
+  secrets are recoverable, so treat the file as sensitive.
+- **Environment injection (headless).** A secret can also be supplied directly as
+  `CONDUIT_SECRET_<KEY>`, or as a bare `<KEY>` only when
+  `CONDUIT_ALLOW_BARE_SECRET_ENV` is set. These are read from the process
+  environment in cleartext, so they are only as protected as the environment that
+  holds them.
+
+## Authentication and OAuth 2.1
+
+Downstream OAuth is done conservatively: dynamic client registration, PKCE
+(S256), a CSRF `state` check, a loopback (`127.0.0.1`) redirect, RFC 8707 resource
+binding, and `offline_access` refresh tokens. Discovered authorization, token, and
+registration endpoints must be `https://` (loopback `http` is allowed only for
+local development).
+
+## Tool governance and enforcement
+
+Toolport is detection-first by default, but it is not detection-only: several
+controls actively gate or block a call before it reaches an upstream server.
+
+- **Destructive-tool policy.** With the destructive-tool deny policy on, tools
+  judged destructive (by their `destructiveHint`, or a write-verb name heuristic)
+  are hidden from the catalog and blocked before a client can call them.
+- **Confirm-before-destructive.** A softer mode intercepts the first call to a
+  destructive tool, returns a preview, and only routes it after an explicit
+  `toolport_confirm`.
+- **Quarantine on drift.** When an already-approved tool changes in a high-risk
+  way (poisoned description, or a destructive/annotation downgrade), it is
+  quarantined and blocked until you re-approve it.
+- **Human-in-the-loop approval.** When enabled, destructive tools and tools from
+  untrusted-provenance servers (shared/registry sources) require an explicit human
+  approval. This gate is fail-closed: a denied, timed-out, or unreachable decision
+  blocks the call, which returns an error and never routes.
+- **Content provenance labeling.** Flagged tool results and resource reads are
+  wrapped with a provenance marker telling the model the block is external data,
+  not instructions. This labels and fences the content; by design it does not drop
+  or block it, so the model still receives it, clearly marked.
+
+Which of these are active depends on your settings and, for Teams, your org
+policy. Debug logging is off by default, gated behind `CONDUIT_DEBUG`, and never
+records tokens or full authorization URLs.
+
+## Telemetry and hosted services
+
+In local use, Toolport sends **no telemetry**. Routine tool traffic is only
+between the gateway and the upstream MCP servers _you_ configure. Data leaves your
+machine only through features you explicitly turn on:
+
+- **Teams usage reporting (opt-in, only when joined to a team).** When connected
+  to a Toolport Teams organization, a periodic sync reports **aggregate** usage
+  for team-provided servers to the team server URL you joined: per-server row of
+  call count, tokens saved, and estimated cost. It never sends tool names,
+  arguments, results, or anything about your personal (non-team) servers.
+- **Shared setup links.** Creating a share link POSTs a secret-stripped server
+  setup to `https://toolport.app/api/share`, and only when you take that action.
+  Importing a shared link fetches it from the same endpoint.
+- **Team server URL.** You provide the Teams server address when you join; there
+  is no hardcoded default, and non-loopback team URLs must be `https://`.
+
+## What Toolport records locally, and how to clear it
+
+Everything below stays in Toolport's local data directory (`%APPDATA%\Conduit` on
+Windows, the platform config dir elsewhere; override with `CONDUIT_DATA_DIR`) and
+never leaves your device on its own. Each log is capped and trims oldest-first:
+
+| Local record           | File                 | Retained                                | Contains                                                      |
+| ---------------------- | -------------------- | --------------------------------------- | ------------------------------------------------------------- |
+| Audit log              | `audit.jsonl`        | last ~5,000 entries (or 4 MB)           | tool calls and approval/policy decisions                      |
+| Discovery search trace | `search-trace.jsonl` | last ~500                               | lazy-discovery searches the agent ran                         |
+| Live inspector         | `inspect.jsonl`      | last ~50 (opt-in, off by default)       | captured call arguments and results                           |
+| Savings log            | `savings.jsonl`      | last ~2,000, plus a carry-forward total | token-savings tallies (a running aggregate survives trimming) |
+
+Registry config, secrets, tool catalogs, and these logs never leave the device
+except through the opt-in hosted features above.
+
+Clear controls: the Activity view has a confirmed **Clear retained activity**
+action that deletes all four logs; the live inspector also clears itself when you
+turn live inspection off. Both are local, irreversible deletes.
 
 ## Trust model and your responsibilities
 
@@ -52,7 +149,13 @@ Toolport proxies to whatever MCP servers **you** add. It does not vet the behavi
 of third-party servers: an upstream server you configure runs as a local process
 (for stdio servers) and/or receives the credentials you give it. **Only add
 servers you trust.** Lazy discovery reduces how much surface is exposed to the
-agent, but a tool you approve still executes upstream.
+agent, and the governance controls above can gate a call, but a tool you approve
+still executes upstream.
+
+When you run Toolport outside the desktop app, some safety defaults become your
+responsibility: set `CONDUIT_HTTP_TOKEN` (required for any non-loopback bind),
+choose a high-entropy `CONDUIT_SECRET_KEY` for the encrypted file backend, and put
+the HTTP bridge behind your own TLS.
 
 ## Known issues
 

--- a/src-tauri/src/audit.rs
+++ b/src-tauri/src/audit.rs
@@ -24,11 +24,18 @@ pub fn audit_path() -> Option<PathBuf> {
     Some(crate::registry::conduit_dir()?.join("audit.jsonl"))
 }
 
-/// Delete the audit log (called when the user clears retained activity). Local,
-/// irreversible; the next call re-creates the file.
-pub fn clear() {
-    if let Some(path) = audit_path() {
-        let _ = std::fs::remove_file(path);
+/// Delete the audit log (called when the user clears retained activity). Returns
+/// `Err` only on a real removal failure; a missing file (nothing to clear) is
+/// success, so the caller can honestly confirm the log is gone rather than report a
+/// false "cleared". Local and irreversible; the next call re-creates the file.
+pub fn try_clear() -> std::io::Result<()> {
+    let Some(path) = audit_path() else {
+        return Ok(());
+    };
+    match std::fs::remove_file(&path) {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(e),
     }
 }
 

--- a/src-tauri/src/audit.rs
+++ b/src-tauri/src/audit.rs
@@ -24,6 +24,14 @@ pub fn audit_path() -> Option<PathBuf> {
     Some(crate::registry::conduit_dir()?.join("audit.jsonl"))
 }
 
+/// Delete the audit log (called when the user clears retained activity). Local,
+/// irreversible; the next call re-creates the file.
+pub fn clear() {
+    if let Some(path) = audit_path() {
+        let _ = std::fs::remove_file(path);
+    }
+}
+
 fn epoch_millis() -> u128 {
     std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)

--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -1234,6 +1234,10 @@ fn enabled_summary(
             }
         }
     }
+    // The discovery mode this client is actually resolved to (env > per-client override >
+    // global), so `toolport_status` answers "why am I seeing meta-tools vs the full
+    // catalog?" and confirms a per-client override took effect.
+    out.push_str(&format!("\nDiscovery mode: {}\n", discovery_mode().as_str()));
     out.push_str(&savings_line());
     out
 }

--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -218,8 +218,9 @@ fn disable_server_tool_def() -> Value {
 // there is no new execution surface. Enabled per-client via the env var; grouped
 // implies not-lazy (the lazy resolver only returns true for `=lazy`).
 
-/// The three tool-discovery modes. Resolved once at gateway start (env or registry)
-/// and cached in `DISCOVERY_MODE`.
+/// The three tool-discovery modes. Resolved from env + the registry (including a
+/// per-client override) and cached in `DISCOVERY_MODE`, which the registry watcher
+/// refreshes on every change so a mode edit applies live.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum DiscoveryMode {
     Lazy,
@@ -227,28 +228,88 @@ enum DiscoveryMode {
     Full,
 }
 
-static DISCOVERY_MODE: std::sync::OnceLock<DiscoveryMode> = std::sync::OnceLock::new();
+impl DiscoveryMode {
+    fn as_u8(self) -> u8 {
+        match self {
+            DiscoveryMode::Lazy => 0,
+            DiscoveryMode::Grouped => 1,
+            DiscoveryMode::Full => 2,
+        }
+    }
+    fn from_u8(v: u8) -> Self {
+        match v {
+            1 => DiscoveryMode::Grouped,
+            2 => DiscoveryMode::Full,
+            _ => DiscoveryMode::Lazy,
+        }
+    }
+    /// The name used in the registry, env, and status output.
+    fn as_str(self) -> &'static str {
+        match self {
+            DiscoveryMode::Lazy => "lazy",
+            DiscoveryMode::Grouped => "grouped",
+            DiscoveryMode::Full => "full",
+        }
+    }
+}
 
-/// Resolve the discovery mode: an explicit `CONDUIT_DISCOVERY` env var wins (per
-/// client), otherwise the registry's `discovery_mode` override, otherwise its
-/// `lazy_discovery` bool. A SET-but-unrecognized env value maps to `Full`, matching
-/// the pre-3-way behavior (env was `== "lazy"` ? lazy : not-lazy) so nothing regresses.
-fn resolve_discovery_mode() -> DiscoveryMode {
+/// The live discovery mode. Mutable (not a `OnceLock`) so the watcher can refresh it when
+/// the registry's per-client override changes; `discovery_mode()` reads it lock-free.
+static DISCOVERY_MODE: std::sync::atomic::AtomicU8 = std::sync::atomic::AtomicU8::new(0);
+
+fn set_discovery_mode(mode: DiscoveryMode) {
+    DISCOVERY_MODE.store(mode.as_u8(), std::sync::atomic::Ordering::Relaxed);
+}
+
+/// Parse a registry / per-client override mode string; `None` for empty, `inherit`, or an
+/// unrecognized value (so it falls through to the next precedence level).
+fn parse_mode(s: &str) -> Option<DiscoveryMode> {
+    match s.trim().to_ascii_lowercase().as_str() {
+        "grouped" => Some(DiscoveryMode::Grouped),
+        "full" => Some(DiscoveryMode::Full),
+        "lazy" => Some(DiscoveryMode::Lazy),
+        _ => None,
+    }
+}
+
+/// Resolve this client's discovery mode from a loaded registry + env. See
+/// [`resolve_mode_from`] for the precedence.
+fn discovery_mode_for(reg: &Registry, client_id: Option<&str>) -> DiscoveryMode {
     let env = std::env::var("CONDUIT_DISCOVERY").ok();
-    let reg = registry::load_resolved().ok();
+    let client_mode = client_id.and_then(|id| reg.client_discovery_mode(id));
     resolve_mode_from(
         env.as_deref(),
-        reg.as_ref().and_then(|r| r.discovery_mode.as_deref()),
-        reg.as_ref().map(|r| r.lazy_discovery).unwrap_or(true),
+        client_mode,
+        reg.discovery_mode.as_deref(),
+        reg.lazy_discovery,
     )
 }
 
-/// Pure precedence: env override, then the registry's `discovery_mode`, then its
-/// `lazy_discovery` bool. A SET env value that isn't lazy/grouped resolves to Full
-/// (exactly the old `env == "lazy" ? lazy : not-lazy`); an unrecognized registry
-/// override is ignored (falls through to the bool).
+/// Resolve from disk for the gateway bootstrap (before the watcher takes over the live
+/// updates), keyed by this client's `CONDUIT_CLIENT_ID`.
+fn resolve_discovery_mode() -> DiscoveryMode {
+    let client_id = std::env::var("CONDUIT_CLIENT_ID")
+        .ok()
+        .filter(|s| !s.trim().is_empty());
+    match registry::load_resolved().ok() {
+        Some(reg) => discovery_mode_for(&reg, client_id.as_deref()),
+        None => resolve_mode_from(
+            std::env::var("CONDUIT_DISCOVERY").ok().as_deref(),
+            None,
+            None,
+            true,
+        ),
+    }
+}
+
+/// Pure precedence: an explicit `CONDUIT_DISCOVERY` env var (hand-set in a client's config)
+/// wins, then the per-client override (`registry.client_discovery[client_id]`), then the
+/// registry's global `discovery_mode`, then its `lazy_discovery` bool. A SET env value that
+/// isn't lazy/grouped resolves to Full (exactly the old `env == "lazy" ? lazy : not-lazy`);
+/// an unrecognized per-client/global override is ignored (falls through).
 fn resolve_mode_from(
     env: Option<&str>,
+    client_mode: Option<&str>,
     registry_mode: Option<&str>,
     lazy_discovery: bool,
 ) -> DiscoveryMode {
@@ -259,13 +320,11 @@ fn resolve_mode_from(
             _ => DiscoveryMode::Full,
         };
     }
-    if let Some(m) = registry_mode {
-        match m.trim().to_ascii_lowercase().as_str() {
-            "grouped" => return DiscoveryMode::Grouped,
-            "full" => return DiscoveryMode::Full,
-            "lazy" => return DiscoveryMode::Lazy,
-            _ => {}
-        }
+    if let Some(m) = client_mode.and_then(parse_mode) {
+        return m;
+    }
+    if let Some(m) = registry_mode.and_then(parse_mode) {
+        return m;
     }
     if lazy_discovery {
         DiscoveryMode::Lazy
@@ -277,7 +336,7 @@ fn resolve_mode_from(
 /// The resolved mode. Defaults to `Lazy` before `main` sets it (only unit tests, which
 /// don't run `main` and test the grouped helpers directly, ever observe that default).
 fn discovery_mode() -> DiscoveryMode {
-    DISCOVERY_MODE.get().copied().unwrap_or(DiscoveryMode::Lazy)
+    DiscoveryMode::from_u8(DISCOVERY_MODE.load(std::sync::atomic::Ordering::Relaxed))
 }
 
 /// True when this gateway runs in grouped discovery mode (see [`grouped_tool_defs`]).
@@ -3116,6 +3175,14 @@ fn watch_registry(
                 }
             };
             last = current;
+            // Refresh the live discovery mode from the freshly-loaded registry: a per-client
+            // override edit (`client_discovery`) may be the only change, and it isn't
+            // router-relevant, so resolve it here before the rebuild fast-path can `continue`.
+            let new_mode = discovery_mode_for(&new_reg, client_id.as_deref());
+            if new_mode != discovery_mode() {
+                eprintln!("toolport: discovery mode -> {}", new_mode.as_str());
+            }
+            set_discovery_mode(new_mode);
             // A team-metadata-only rewrite (usage watermark, sync version/etag, role) from
             // the desktop sync loop changes nothing the router depends on. Update the stored
             // copy but skip the rebuild, so a routine sync never re-spawns every stdio server
@@ -5245,7 +5312,7 @@ fn main() {
     // gateway (e.g. Antigravity). Resolved once and cached; `lazy` is derived so its
     // behavior is unchanged, and grouped mode reads the same cached value.
     let mode = resolve_discovery_mode();
-    let _ = DISCOVERY_MODE.set(mode);
+    set_discovery_mode(mode);
     let lazy = matches!(mode, DiscoveryMode::Lazy);
     // Per-client scoping: this gateway exposes only the named profile's servers.
     // This is only the bootstrap value - once the registry loads below, the live
@@ -7605,27 +7672,35 @@ mod tests {
     #[test]
     fn discovery_mode_precedence_and_no_regression() {
         use DiscoveryMode::*;
-        // Env override wins over everything (per-client).
-        assert_eq!(resolve_mode_from(Some("grouped"), Some("lazy"), true), Grouped);
-        assert_eq!(resolve_mode_from(Some("lazy"), None, false), Lazy);
-        assert_eq!(resolve_mode_from(Some("full"), Some("grouped"), true), Full);
-        assert_eq!(resolve_mode_from(Some(" GROUPED "), None, true), Grouped);
+        // Args: (env, client_mode, registry_mode, lazy_discovery).
+        // A hand-set env override wins over everything, including the per-client override.
+        assert_eq!(resolve_mode_from(Some("grouped"), Some("lazy"), Some("lazy"), true), Grouped);
+        assert_eq!(resolve_mode_from(Some("lazy"), None, None, false), Lazy);
+        assert_eq!(resolve_mode_from(Some("full"), Some("lazy"), Some("grouped"), true), Full);
+        assert_eq!(resolve_mode_from(Some(" GROUPED "), None, None, true), Grouped);
         // Old behavior preserved: a SET-but-unrecognized/empty env is Full (was the
-        // `env == "lazy" ? lazy : not-lazy` branch), NOT a fall-through to the registry.
-        assert_eq!(resolve_mode_from(Some("typo"), Some("grouped"), true), Full);
-        assert_eq!(resolve_mode_from(Some(""), Some("grouped"), true), Full);
+        // `env == "lazy" ? lazy : not-lazy` branch), NOT a fall-through.
+        assert_eq!(resolve_mode_from(Some("typo"), None, Some("grouped"), true), Full);
+        assert_eq!(resolve_mode_from(Some(""), None, Some("grouped"), true), Full);
 
-        // No env: the registry override wins over the lazy_discovery bool.
-        assert_eq!(resolve_mode_from(None, Some("grouped"), true), Grouped);
-        assert_eq!(resolve_mode_from(None, Some("full"), true), Full);
-        assert_eq!(resolve_mode_from(None, Some("lazy"), false), Lazy);
-        // An unrecognized override is ignored, falling through to the bool.
-        assert_eq!(resolve_mode_from(None, Some("weird"), true), Lazy);
+        // No env: the PER-CLIENT override wins over the global mode and the bool.
+        assert_eq!(resolve_mode_from(None, Some("grouped"), Some("full"), true), Grouped);
+        assert_eq!(resolve_mode_from(None, Some("full"), None, true), Full);
+        assert_eq!(resolve_mode_from(None, Some("lazy"), Some("grouped"), false), Lazy);
+        // An `inherit`/empty/unrecognized per-client value falls through to the global mode.
+        assert_eq!(resolve_mode_from(None, Some("inherit"), Some("grouped"), true), Grouped);
+        assert_eq!(resolve_mode_from(None, Some("weird"), None, true), Lazy);
 
-        // BACK-COMPAT: no env, no discovery_mode override (every pre-existing registry)
-        // resolves to exactly the old lazy_discovery bool behavior.
-        assert_eq!(resolve_mode_from(None, None, true), Lazy);
-        assert_eq!(resolve_mode_from(None, None, false), Full);
+        // No env, no per-client: the global registry override wins over the bool.
+        assert_eq!(resolve_mode_from(None, None, Some("grouped"), true), Grouped);
+        assert_eq!(resolve_mode_from(None, None, Some("full"), true), Full);
+        assert_eq!(resolve_mode_from(None, None, Some("lazy"), false), Lazy);
+        // An unrecognized global override is ignored, falling through to the bool.
+        assert_eq!(resolve_mode_from(None, None, Some("weird"), true), Lazy);
+
+        // BACK-COMPAT: no env, no override anywhere resolves to exactly the old bool.
+        assert_eq!(resolve_mode_from(None, None, None, true), Lazy);
+        assert_eq!(resolve_mode_from(None, None, None, false), Full);
     }
 
     #[test]

--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -1432,11 +1432,11 @@ fn get_inspect_log(limit: usize) -> Vec<serde_json::Value> {
 }
 
 /// Clear the live-inspection ring (delete `inspect.jsonl`), so no captured args/results
-/// linger. Called when the user turns live inspection off.
+/// linger. Called when the user turns live inspection off. Surfaces a real removal
+/// failure so the UI never confirms a delete that did not happen.
 #[tauri::command]
 fn clear_inspect_log() -> Result<(), String> {
-    inspect::clear();
-    Ok(())
+    inspect::try_clear().map_err(|e| format!("Couldn't clear the inspector log: {e}"))
 }
 
 /// Recent lazy-discovery search traces (newest first): what the model searched for,
@@ -1451,21 +1451,37 @@ fn get_search_traces(limit: usize) -> Vec<serde_json::Value> {
 /// Clear the search-trace log (delete `search-trace.jsonl`).
 #[tauri::command]
 fn clear_search_traces() -> Result<(), String> {
-    searchtrace::clear();
-    Ok(())
+    searchtrace::try_clear().map_err(|e| format!("Couldn't clear the search traces: {e}"))
 }
 
 /// Clear all retained local activity in one confirmed action: the audit log, discovery
 /// search traces, live-inspection captures, and the savings tally (including its
 /// carry-forward total). Each is a local, irreversible delete; the logs re-create
 /// themselves on the next event. Backs the Activity view's "Clear retained activity".
+///
+/// Attempts every log even if one fails (so a single locked file doesn't leave the
+/// rest un-cleared), then reports exactly which could not be removed. Never confirms a
+/// delete that did not happen: a leftover sensitive log must not read as "cleared".
 #[tauri::command]
 fn clear_activity_logs() -> Result<(), String> {
-    audit::clear();
-    searchtrace::clear();
-    inspect::clear();
-    savings::clear();
-    Ok(())
+    let mut failed = Vec::new();
+    if audit::try_clear().is_err() {
+        failed.push("audit log");
+    }
+    if searchtrace::try_clear().is_err() {
+        failed.push("search traces");
+    }
+    if inspect::try_clear().is_err() {
+        failed.push("inspector captures");
+    }
+    if savings::try_clear().is_err() {
+        failed.push("savings");
+    }
+    if failed.is_empty() {
+        Ok(())
+    } else {
+        Err(format!("Couldn't clear: {}", failed.join(", ")))
+    }
 }
 
 /// One exposed tool's verifiable identity: the model-visible alias joined back to its

--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -1455,6 +1455,19 @@ fn clear_search_traces() -> Result<(), String> {
     Ok(())
 }
 
+/// Clear all retained local activity in one confirmed action: the audit log, discovery
+/// search traces, live-inspection captures, and the savings tally (including its
+/// carry-forward total). Each is a local, irreversible delete; the logs re-create
+/// themselves on the next event. Backs the Activity view's "Clear retained activity".
+#[tauri::command]
+fn clear_activity_logs() -> Result<(), String> {
+    audit::clear();
+    searchtrace::clear();
+    inspect::clear();
+    savings::clear();
+    Ok(())
+}
+
 /// One exposed tool's verifiable identity: the model-visible alias joined back to its
 /// source server + the profiles that enable it, plus the integrity fingerprint and
 /// when the definition was first seen / last changed. This is the "capability
@@ -2732,6 +2745,7 @@ pub fn run() {
             clear_inspect_log,
             get_search_traces,
             clear_search_traces,
+            clear_activity_logs,
             list_tool_identities,
             set_quarantine_on_drift,
             list_quarantined,

--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -1609,6 +1609,23 @@ fn set_allow_agent_control(state: State<RegistryState>, allow: bool) -> Result<R
     Ok(reg)
 }
 
+/// Set (or clear) a client's discovery-mode override. `mode` is `"full" | "lazy" |
+/// "grouped"`; `None` (or "inherit"/unknown) clears it so the client inherits the global
+/// mode. The gateway resolves this live via `CONDUIT_CLIENT_ID`, so the change applies
+/// without reinstalling the client.
+#[tauri::command]
+fn set_client_discovery(
+    state: State<RegistryState>,
+    client_id: String,
+    mode: Option<String>,
+) -> Result<Registry, String> {
+    let (reg, _) = write_registry(state.inner(), |reg| {
+        reg.set_client_discovery(&client_id, mode.as_deref());
+        Ok(())
+    })?;
+    Ok(reg)
+}
+
 /// Flush the in-memory registry to disk so the teams module (which reads the registry
 /// file) operates on the current state, then refresh the in-memory state from disk
 /// after the team operation merged into it.
@@ -2706,6 +2723,7 @@ pub fn run() {
             release_quarantine,
             set_lazy_discovery,
             set_allow_agent_control,
+            set_client_discovery,
             team_connect,
             team_join_poll,
             team_sync,

--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -919,6 +919,21 @@ fn registry_summary(reg: &Registry) -> String {
     let active = reg.active_profile_id();
     let _ = writeln!(out, "\nsettings:");
     let _ = writeln!(out, "  lazy discovery: {}", reg.lazy_discovery);
+    let global_mode = reg
+        .discovery_mode
+        .as_deref()
+        .map(str::to_string)
+        .unwrap_or_else(|| if reg.lazy_discovery { "lazy".into() } else { "full".into() });
+    let _ = writeln!(out, "  discovery mode: {global_mode} (global)");
+    if !reg.client_discovery.is_empty() {
+        let mut overrides: Vec<String> = reg
+            .client_discovery
+            .iter()
+            .map(|(id, mode)| format!("{id}={mode}"))
+            .collect();
+        overrides.sort();
+        let _ = writeln!(out, "  per-client discovery: {}", overrides.join(", "));
+    }
     let _ = writeln!(out, "  deny destructive: {}", reg.deny_destructive);
     let _ = writeln!(out, "  active profile: {active}");
 

--- a/src-tauri/src/inspect.rs
+++ b/src-tauri/src/inspect.rs
@@ -142,12 +142,24 @@ pub fn read_recent(limit: usize) -> Vec<Value> {
     entries
 }
 
-/// Clear the inspect ring (delete the file). Called when the user turns live
-/// inspection off, so no captured args/results linger.
-pub fn clear() {
-    if let Some(path) = inspect_path() {
-        let _ = std::fs::remove_file(&path);
+/// Delete the inspect ring. Returns `Err` only on a real removal failure; a missing
+/// file (nothing to clear) is success, so a caller can honestly confirm the captured
+/// args/results are gone.
+pub fn try_clear() -> std::io::Result<()> {
+    let Some(path) = inspect_path() else {
+        return Ok(());
+    };
+    match std::fs::remove_file(&path) {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(e),
     }
+}
+
+/// Fire-and-forget clear, for callers that clear best-effort (turning live inspection
+/// off) and don't surface the outcome.
+pub fn clear() {
+    let _ = try_clear();
 }
 
 #[cfg(test)]

--- a/src-tauri/src/registry.rs
+++ b/src-tauri/src/registry.rs
@@ -336,6 +336,13 @@ pub struct Registry {
     /// the client follows the active profile (all its enabled servers).
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub client_scopes: HashMap<String, String>,
+    /// Per-client discovery-mode override, keyed by stable client id (e.g. "cursor" ->
+    /// "grouped"). Value is `"full" | "lazy" | "grouped"`; an absent entry means the client
+    /// inherits the global mode (`discovery_mode`, else `lazy_discovery`). The gateway
+    /// resolves it live via `CONDUIT_CLIENT_ID`, so changing it re-applies without
+    /// reinstalling the client (same mechanism as `client_scopes`).
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub client_discovery: HashMap<String, String>,
     /// Consumers registered to reach the gateway over the HTTP/OpenAPI bridge,
     /// each with its own hashed bearer token and scope. Empty = the bridge uses
     /// only the legacy single `CONDUIT_HTTP_TOKEN` (back-compat).
@@ -447,6 +454,7 @@ impl Default for Registry {
             team: None,
             result_budgets: HashMap::new(),
             client_scopes: HashMap::new(),
+            client_discovery: HashMap::new(),
             http_clients: Vec::new(),
             secrets_generation: 0,
             unknown_fields: serde_json::Map::new(),
@@ -867,6 +875,28 @@ impl Registry {
                 self.client_scopes.remove(client_id);
             }
         }
+    }
+
+    /// Set (or clear) a client's discovery-mode override. `Some("full"|"lazy"|"grouped")`
+    /// pins that mode for the client; `None`, an empty/whitespace value, `"inherit"`, or any
+    /// unrecognized value clears the entry so the client inherits the global mode.
+    pub fn set_client_discovery(&mut self, client_id: &str, mode: Option<&str>) {
+        let valid = mode
+            .map(|m| m.trim().to_ascii_lowercase())
+            .filter(|m| matches!(m.as_str(), "full" | "lazy" | "grouped"));
+        match valid {
+            Some(m) => {
+                self.client_discovery.insert(client_id.to_string(), m);
+            }
+            None => {
+                self.client_discovery.remove(client_id);
+            }
+        }
+    }
+
+    /// This client's discovery-mode override, if any (`None` = inherit the global mode).
+    pub fn client_discovery_mode(&self, client_id: &str) -> Option<&str> {
+        self.client_discovery.get(client_id).map(String::as_str)
     }
 
     /// Record that a client is *explicitly* unscoped: it follows the active
@@ -1694,6 +1724,25 @@ mod tests {
         r.set_client_scope("claude", Some("Work"));
         r.set_client_scope("claude", None);
         assert!(!r.client_scopes.contains_key("claude"));
+    }
+
+    #[test]
+    fn client_discovery_records_normalizes_and_clears() {
+        let mut r = Registry::default();
+        assert_eq!(r.client_discovery_mode("cursor"), None);
+        // Recorded case-insensitively / trimmed to a canonical lowercase mode.
+        r.set_client_discovery("cursor", Some("  LAZY "));
+        assert_eq!(r.client_discovery_mode("cursor"), Some("lazy"));
+        r.set_client_discovery("cursor", Some("Grouped"));
+        assert_eq!(r.client_discovery_mode("cursor"), Some("grouped"));
+        // Unknown / empty / None all clear the override (client inherits the global mode).
+        r.set_client_discovery("cursor", Some("nonsense"));
+        assert_eq!(r.client_discovery_mode("cursor"), None);
+        r.set_client_discovery("claude", Some("full"));
+        r.set_client_discovery("claude", None);
+        assert_eq!(r.client_discovery_mode("claude"), None);
+        // Empty map is omitted from serialization (skip_serializing_if).
+        assert!(r.client_discovery.is_empty());
     }
 
     #[test]

--- a/src-tauri/src/savings.rs
+++ b/src-tauri/src/savings.rs
@@ -28,6 +28,15 @@ fn savings_path() -> Option<PathBuf> {
     Some(crate::registry::conduit_dir()?.join("savings.jsonl"))
 }
 
+/// Delete the savings log, including the carry-forward aggregate (called when the
+/// user clears retained activity). Local, irreversible; the running total resets to
+/// zero and the next serve starts a fresh file.
+pub fn clear() {
+    if let Some(path) = savings_path() {
+        let _ = std::fs::remove_file(path);
+    }
+}
+
 fn epoch_millis() -> u128 {
     std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)

--- a/src-tauri/src/savings.rs
+++ b/src-tauri/src/savings.rs
@@ -29,11 +29,17 @@ fn savings_path() -> Option<PathBuf> {
 }
 
 /// Delete the savings log, including the carry-forward aggregate (called when the
-/// user clears retained activity). Local, irreversible; the running total resets to
-/// zero and the next serve starts a fresh file.
-pub fn clear() {
-    if let Some(path) = savings_path() {
-        let _ = std::fs::remove_file(path);
+/// user clears retained activity). Returns `Err` only on a real removal failure; a
+/// missing file (nothing to clear) is success. Local and irreversible; the running
+/// total resets to zero and the next serve starts a fresh file.
+pub fn try_clear() -> std::io::Result<()> {
+    let Some(path) = savings_path() else {
+        return Ok(());
+    };
+    match std::fs::remove_file(&path) {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(e),
     }
 }
 

--- a/src-tauri/src/searchtrace.rs
+++ b/src-tauri/src/searchtrace.rs
@@ -157,11 +157,23 @@ pub fn read_recent(limit: usize) -> Vec<Value> {
         .collect()
 }
 
-/// Delete the trace log (called when the user clears it from Activity).
-pub fn clear() {
-    if let Some(path) = trace_path() {
-        let _ = std::fs::remove_file(path);
+/// Delete the trace log. Returns `Err` only on a real removal failure; a missing file
+/// (nothing to clear) is success, so a caller can honestly confirm it is gone.
+pub fn try_clear() -> std::io::Result<()> {
+    let Some(path) = trace_path() else {
+        return Ok(());
+    };
+    match std::fs::remove_file(&path) {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(e),
     }
+}
+
+/// Fire-and-forget clear (called when the user clears it from Activity, and from the
+/// test resets that don't surface the outcome).
+pub fn clear() {
+    let _ = try_clear();
 }
 
 #[cfg(test)]

--- a/src-tauri/tests/security_doc.rs
+++ b/src-tauri/tests/security_doc.rs
@@ -1,0 +1,22 @@
+//! Regression guard for SECURITY.md accuracy (SOU-41).
+//!
+//! SECURITY.md used to carry two materially false absolute claims: that the gateway
+//! "opens no listening network port" (false in HTTP / Docker mode, which binds a
+//! persistent listener, `0.0.0.0:8765` by default in the image) and that "There is no
+//! telemetry" (Teams reports per-server aggregate usage to the team server). If you
+//! reword the doc, keep every such statement mode-aware, not absolute, so the two
+//! claims can never silently return.
+
+#[test]
+fn security_md_has_no_stale_absolute_claims() {
+    let path = concat!(env!("CARGO_MANIFEST_DIR"), "/../SECURITY.md");
+    let text = std::fs::read_to_string(path).unwrap_or_else(|e| panic!("read {path}: {e}"));
+    for banned in ["opens no listening network port", "There is no telemetry"] {
+        assert!(
+            !text.contains(banned),
+            "SECURITY.md re-introduced a false absolute claim: {banned:?}. Keep the \
+             wording mode-aware (see SOU-41): the gateway binds a listener in HTTP/Docker \
+             mode, and Teams reports aggregate usage."
+        );
+    }
+}

--- a/src/components/ActivityView.tsx
+++ b/src/components/ActivityView.tsx
@@ -13,6 +13,7 @@ import {
   ShieldAlert,
   ShieldCheck,
   Sparkles,
+  Trash2,
   X,
   XCircle,
 } from "lucide-react";
@@ -21,7 +22,9 @@ import { fmtTokens } from "@/lib/utils";
 import { toastError } from "@/lib/toast";
 import { save } from "@tauri-apps/plugin-dialog";
 import { Input } from "@/components/ui/input";
+import { ConfirmDialog } from "@/components/ConfirmDialog";
 import {
+  clearActivityLogs,
   exportAuditToPath,
   getAuditLog,
   getAuditStats,
@@ -1368,6 +1371,20 @@ export function ActivityView({
   // this, a first-run backend failure renders the friendly "No tool calls yet" state
   // and hides that anything is wrong.
   const [loadError, setLoadError] = useState(false);
+  // Local reload trigger: bumped after a "Clear retained activity" so the panels
+  // refetch (they'd otherwise keep showing the just-deleted rows until the parent's
+  // refreshKey next changes).
+  const [reloadTick, setReloadTick] = useState(0);
+
+  async function clearActivity() {
+    try {
+      await clearActivityLogs();
+      toast.success("Cleared retained activity");
+      setReloadTick((t) => t + 1);
+    } catch (e) {
+      toastError(`Couldn't clear activity: ${e}`);
+    }
+  }
 
   useEffect(() => {
     let alive = true;
@@ -1394,7 +1411,7 @@ export function ActivityView({
     return () => {
       alive = false;
     };
-  }, [refreshKey]);
+  }, [refreshKey, reloadTick]);
 
   // Export the full retained audit log. The save dialog offers CSV and JSON; the
   // chosen extension picks the format. CSV is formula-injection-safe in the backend.
@@ -1556,6 +1573,22 @@ export function ActivityView({
           <Download className="size-3.5" aria-hidden="true" />
           Export
         </button>
+        <ConfirmDialog
+          trigger={
+            <button
+              title="Delete all retained activity kept on this device"
+              className="flex shrink-0 items-center gap-1.5 rounded-md border px-2.5 py-1 text-xs text-muted-foreground transition-colors hover:bg-destructive/10 hover:text-destructive focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none"
+            >
+              <Trash2 className="size-3.5" aria-hidden="true" />
+              Clear
+            </button>
+          }
+          title="Clear retained activity?"
+          description="Permanently deletes everything Toolport keeps on this device: the audit log, discovery search traces, live-inspection captures, and the savings tally (including its running total). Nothing is sent anywhere; each log starts fresh on the next event. This can't be undone."
+          confirmLabel="Clear activity"
+          destructive
+          onConfirm={clearActivity}
+        />
       </div>
 
       {logOpen && (

--- a/src/components/ClientDetail.tsx
+++ b/src/components/ClientDetail.tsx
@@ -425,12 +425,12 @@ export function ClientDetail({ client, registry, onChanged, onRegistryChange }: 
             </p>
             {effectiveMode === recommended.mode ? (
               <p className="mt-0.5 text-2xs text-success">
-                Recommended ({recommended.mode}) — {recommended.why}.
+                Recommended ({recommended.mode}), {recommended.why}.
               </p>
             ) : (
               <p className="mt-0.5 text-2xs text-muted-foreground/80">
                 Recommended:{" "}
-                <span className="font-medium text-foreground">{recommended.mode}</span> —{" "}
+                <span className="font-medium text-foreground">{recommended.mode}</span>,{" "}
                 {recommended.why}.
               </p>
             )}

--- a/src/components/ClientDetail.tsx
+++ b/src/components/ClientDetail.tsx
@@ -13,7 +13,13 @@ import {
 } from "lucide-react";
 import { toast } from "sonner";
 import { toastError } from "@/lib/toast";
-import { addServer, installGateway, migrateClient, uninstallGateway } from "@/lib/api";
+import {
+  addServer,
+  installGateway,
+  migrateClient,
+  setClientDiscovery,
+  uninstallGateway,
+} from "@/lib/api";
 import {
   importableServers,
   isGatewayServer,
@@ -50,6 +56,13 @@ interface Props {
   onRegistryChange: (registry: Registry) => void;
 }
 
+/** One-line explainer per discovery mode, shown under the per-client picker. */
+const DISCOVERY_HINT: Record<string, string> = {
+  lazy: "Advertises a few meta-tools; the client searches, then calls. Fewest tokens.",
+  grouped: "One help tool per server; the client expands a server before calling it.",
+  full: "Advertises every tool up front. Most tokens, no discovery step.",
+};
+
 export function ClientDetail({ client, registry, onChanged, onRegistryChange }: Props) {
   const [busy, setBusy] = useState(false);
   // Snapshotted at dialog-open time so a registry-changed event mid-review can't
@@ -70,6 +83,32 @@ export function ClientDetail({ client, registry, onChanged, onRegistryChange }: 
   useEffect(() => {
     setProfile(currentScope);
   }, [currentScope, client.id]);
+
+  // Discovery: the global mode this client falls back to, and its own override (if any).
+  // The gateway resolves env > per-client > global, so an override here applies live.
+  const globalMode =
+    registry?.discoveryMode?.toLowerCase() ||
+    ((registry?.lazyDiscovery ?? true) ? "lazy" : "full");
+  const clientMode = registry?.clientDiscovery?.[client.id] ?? "";
+  const effectiveMode = clientMode || globalMode;
+
+  /** Set or clear this client's discovery-mode override; applies live, no reconnect. */
+  async function applyDiscovery(mode: string) {
+    setBusy(true);
+    try {
+      const next = await setClientDiscovery(client.id, mode || null);
+      onRegistryChange(next);
+      toast.success(
+        mode
+          ? `${client.name} discovery set to "${mode}".`
+          : `${client.name} now inherits the global discovery mode.`,
+      );
+    } catch (e) {
+      toastError(`${e}`);
+    } finally {
+      setBusy(false);
+    }
+  }
 
   /** How many servers a given scope ("" = active profile, else a named profile)
    * resolves to, for the "scoped to X · N servers" summary. */
@@ -351,6 +390,38 @@ export function ClientDetail({ client, registry, onChanged, onRegistryChange }: 
           )}
         </div>
       </div>
+
+      {installed && (
+        <div className="flex items-center justify-between gap-3 rounded-lg border border-border/60 bg-muted/20 px-3 py-2">
+          <div className="min-w-0">
+            <div className="text-xs font-medium text-foreground">
+              Discovery mode
+              {!clientMode && (
+                <span className="ml-1.5 font-normal text-muted-foreground">
+                  inheriting {globalMode}
+                </span>
+              )}
+            </div>
+            <p className="mt-0.5 text-2xs text-muted-foreground">
+              {DISCOVERY_HINT[effectiveMode] ?? DISCOVERY_HINT.lazy}
+            </p>
+          </div>
+          <Select
+            value={clientMode || "__inherit__"}
+            onValueChange={(v) => applyDiscovery(v === "__inherit__" ? "" : v)}
+          >
+            <SelectTrigger size="sm" className="w-44 shrink-0" disabled={busy}>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="__inherit__">Inherit ({globalMode})</SelectItem>
+              <SelectItem value="lazy">Lazy · fewest tokens</SelectItem>
+              <SelectItem value="grouped">Grouped · per-server</SelectItem>
+              <SelectItem value="full">Full · every tool</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+      )}
 
       {installed ? (
         <div>

--- a/src/components/ClientDetail.tsx
+++ b/src/components/ClientDetail.tsx
@@ -63,6 +63,23 @@ const DISCOVERY_HINT: Record<string, string> = {
   full: "Advertises every tool up front. Most tokens, no discovery step.",
 };
 
+// Local-model desktop apps: users often run small / quantized models here that stumble on
+// lazy's multi-step search-then-call chain, yet get flooded by the full catalog. Grouped
+// (one hop per server) is the middle ground. Every other client is a hosted-model or
+// agentic client that handles lazy's savings fine. This drives a RECOMMENDATION only; it
+// never auto-applies, so an explicit user choice is never silently overridden.
+const LOCAL_MODEL_CLIENTS = new Set(["lm-studio", "jan", "anythingllm"]);
+
+/** The mode we suggest for a client, with a one-line why. Advisory, not enforced. */
+function recommendedMode(clientId: string): { mode: string; why: string } {
+  return LOCAL_MODEL_CLIENTS.has(clientId)
+    ? { mode: "grouped", why: "local models do better browsing one server at a time" }
+    : {
+        mode: "lazy",
+        why: "this client handles the search-then-call step and saves the most tokens",
+      };
+}
+
 export function ClientDetail({ client, registry, onChanged, onRegistryChange }: Props) {
   const [busy, setBusy] = useState(false);
   // Snapshotted at dialog-open time so a registry-changed event mid-review can't
@@ -91,6 +108,7 @@ export function ClientDetail({ client, registry, onChanged, onRegistryChange }: 
     ((registry?.lazyDiscovery ?? true) ? "lazy" : "full");
   const clientMode = registry?.clientDiscovery?.[client.id] ?? "";
   const effectiveMode = clientMode || globalMode;
+  const recommended = recommendedMode(client.id);
 
   /** Set or clear this client's discovery-mode override; applies live, no reconnect. */
   async function applyDiscovery(mode: string) {
@@ -405,6 +423,17 @@ export function ClientDetail({ client, registry, onChanged, onRegistryChange }: 
             <p className="mt-0.5 text-2xs text-muted-foreground">
               {DISCOVERY_HINT[effectiveMode] ?? DISCOVERY_HINT.lazy}
             </p>
+            {effectiveMode === recommended.mode ? (
+              <p className="mt-0.5 text-2xs text-success">
+                Recommended ({recommended.mode}) — {recommended.why}.
+              </p>
+            ) : (
+              <p className="mt-0.5 text-2xs text-muted-foreground/80">
+                Recommended:{" "}
+                <span className="font-medium text-foreground">{recommended.mode}</span> —{" "}
+                {recommended.why}.
+              </p>
+            )}
           </div>
           <Select
             value={clientMode || "__inherit__"}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -263,6 +263,13 @@ export function clearSearchTraces(): Promise<void> {
   return invoke<void>("clear_search_traces");
 }
 
+/** Clear all retained local activity at once: audit log, discovery traces,
+ * live-inspection captures, and the savings tally (incl. its carry-forward total).
+ * Local, irreversible deletes; each log re-creates itself on the next event. */
+export function clearActivityLogs(): Promise<void> {
+  return invoke<void>("clear_activity_logs");
+}
+
 /** Every pinned tool's verifiable identity (alias -> server/profiles + fingerprint +
  * first-seen/last-changed) for the active profile. Empty until a baseline is pinned. */
 export function getToolIdentities(): Promise<ToolIdentity[]> {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -298,6 +298,16 @@ export function setLazyDiscovery(lazy: boolean): Promise<Registry> {
   return invoke<Registry>("set_lazy_discovery", { lazy });
 }
 
+/** Override one client's discovery mode ("full" | "lazy" | "grouped"), or clear it
+ * (`null`) so the client inherits the global mode. Applies live via the gateway's
+ * per-client resolution, no reconnect needed. */
+export function setClientDiscovery(
+  clientId: string,
+  mode: string | null,
+): Promise<Registry> {
+  return invoke<Registry>("set_client_discovery", { clientId, mode });
+}
+
 /** Opt into agent control: let an agent enable/disable servers via the gateway. */
 export function setAllowAgentControl(allow: boolean): Promise<Registry> {
   return invoke<Registry>("set_allow_agent_control", { allow });

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -404,6 +404,12 @@ export interface Registry {
   quarantineOnDrift?: boolean;
   /** Global switch: expose 4 meta-tools instead of the full catalog. */
   lazyDiscovery?: boolean;
+  /** Global discovery mode ("full" | "lazy" | "grouped"). Takes precedence over
+   * `lazyDiscovery`; absent = fall back to the `lazyDiscovery` bool. */
+  discoveryMode?: string | null;
+  /** Per-client discovery-mode override, keyed by client id (e.g. "cursor" ->
+   * "grouped"). Absent = that client inherits the global mode. */
+  clientDiscovery?: Record<string, string>;
   /** Opt-in: let an agent enable/disable servers via the gateway's control tools. */
   allowAgentControl?: boolean;
   /** Connection to a Toolport Teams server, if joined. Token lives in the keychain. */


### PR DESCRIPTION
## Why

SECURITY.md made materially false absolute claims that undercut trust in a security product. Every correction below is verified against the code.

| Old claim | Reality |
|---|---|
| "opens no listening network port" | Only true for stdio mode. HTTP/OpenAPI and Docker bind a persistent listener (`0.0.0.0:8765` in the image; token required). |
| "Secrets in the OS keychain" | Desktop default only. Headless also supports the encrypted `secrets.enc` backend (`CONDUIT_SECRET_KEY`) and env injection. |
| "There is no telemetry" | When joined to a team, Teams sync reports **per-server aggregate** call counts / tokens-saved to the team server (never tool names, args, or personal servers). |
| Governance understated | The product hides/blocks destructive tools, quarantines drifted tools, requires HITL approval, and labels flagged results. |

## What

**Docs (`SECURITY.md`) rewrite** — mode-aware throughout:
- Network boundaries per run mode: desktop stdio (no port), local HTTP bridge (`127.0.0.1:8765` default, auto-token on desktop, `403` on cross-site), headless Docker (`0.0.0.0`, token required or it refuses to start).
- Each secret backend (keychain / `secrets.enc` / env injection) and how it's selected.
- Real enforcement modes, with the honest note that content-provenance labeling *wraps* rather than blocks.
- Telemetry section that keeps the local-first promise but carves out opt-in Teams aggregate reporting and share links.
- A plain-language data inventory with retention limits (audit ~5,000, discovery trace ~500, inspector ~50, savings ~2,000 + carry-forward) and where each lives.
- Operator responsibilities for headless (token, high-entropy `CONDUIT_SECRET_KEY`, TLS).

**Clear-activity control** (the audit's missing "clear retained state"):
- `audit::clear()` and `savings::clear()` (inspector + discovery trace already had clear). A single `clear_activity_logs` command wipes all four local logs.
- Activity view: a confirmed, destructive **Clear** button beside Export, with a scope explanation; panels refetch after clearing.

**Sync guard**: `tests/security_doc.rs` fails if either false absolute phrase ("opens no listening network port", "There is no telemetry") returns to SECURITY.md.

## Scope notes

- README/CHANGELOG "never blocks" mentions are feature-scoped to content-defense labeling (which genuinely wraps, not blocks) and remain accurate; left as-is.
- Website privacy/security pages were corrected separately in [toolport-site #29](https://github.com/tsouth89/toolport-site/pull/29).

## Tests

358 lib tests + the new doc guard pass; `cargo check --lib` clean; `tsc --noEmit` and eslint clean. The `clear()` one-liners mirror the shipping `inspect::clear` / `searchtrace::clear`; the audit/savings test modules test pure functions only, so no filesystem-global test was added (consistent with those modules).

Closes SOU-41.