### PR TITLE
Fix stale tool-count messaging

### DIFF
--- a/benchmark/latency.mjs
+++ b/benchmark/latency.mjs
@@ -184,7 +184,7 @@ async function main() {
   console.log(
     `  ${"handshake (one-time)".padEnd(28)}${handshake.toFixed(2).padStart(6)} ms`,
   );
-  console.log(row("tools/list (lazy, 3 tools)", list));
+  console.log(row("tools/list (lazy, 4 core tools)", list));
   console.log(row("toolport_search_tools", search));
   console.log(row("toolport_call_tool -> mock", gwCall));
   console.log(row("mock tool call (direct)", direct));

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -314,8 +314,8 @@ flips every weakness:
 
 - **~90% fewer tokens.** In lazy-discovery mode the gateway advertises 4 meta-tools
   instead of every server's full tool list, so the agent's context stays flat no
-  matter how many servers you connect. Measured: 97% less tool overhead per request
-  (see [BENCHMARK.md](../BENCHMARK.md)).
+  matter how many servers you connect. Measured: 99.5% less tool-definition overhead
+  per request on a 415-tool catalog (see [BENCHMARK.md](../BENCHMARK.md)).
 - **Hot toggle, no restart.** Enable/disable a server, the gateway re-emits its
   tool list via the MCP `notifications/tools/list_changed`; supporting clients
   update live. The client's own config never changed, so nothing reloads.
@@ -405,7 +405,7 @@ Phase 2 - Client integration
 
 Phase 3 - Scaling & UX
 
-- [x] Lazy discovery: `CONDUIT_DISCOVERY=lazy` exposes 4 meta-tools (search/call)
+- [x] Lazy discovery: `CONDUIT_DISCOVERY=lazy` exposes 4 core meta-tools (status/search/call/fetch)
 - [x] Per-agent scoping: `CONDUIT_PROFILE` + per-client profile picker, per-profile cache
 - [x] Catalog: curated popular set + live official MCP Registry search, type-ahead
 - [x] Catalog as a left-nav destination; status grouping; non-blocking UI commands

--- a/docs/demo.ass
+++ b/docs/demo.ass
@@ -15,5 +15,5 @@ Dialogue: 0,0:00:00.30,0:00:04.80,Cap,,0,0,0,,{\c&H99D334&}One local gateway{\c&
 Dialogue: 0,0:00:05.20,0:00:10.40,Cap,,0,0,0,,Add a server from the {\c&H99D334&}catalog{\c&HFFFFFF&}
 Dialogue: 0,0:00:10.80,0:00:15.80,Cap,,0,0,0,,Set up {\c&H99D334&}once{\c&HFFFFFF&}. Keys stay in your OS keychain.
 Dialogue: 0,0:00:16.30,0:00:22.80,Cap,,0,0,0,,Connect it to {\c&H99D334&}every AI tool{\c&HFFFFFF&}
-Dialogue: 0,0:00:23.30,0:00:28.80,Cap,,0,0,0,,Your agent loads {\c&H99D334&}3 tools{\c&HFFFFFF&}, not hundreds
+Dialogue: 0,0:00:23.30,0:00:28.80,Cap,,0,0,0,,Your agent loads {\c&H99D334&}a handful{\c&HFFFFFF&}, not hundreds
 Dialogue: 0,0:00:29.20,0:00:35.90,Cap,,0,0,0,,Then it {\c&H99D334&}just works{\c&HFFFFFF&}, in every client

--- a/docs/demo.srt
+++ b/docs/demo.srt
@@ -16,7 +16,7 @@ Connect it to every AI tool
 
 5
 00:00:23,300 --> 00:00:28,800
-Your agent loads 3 tools, not hundreds
+Your agent loads a handful, not hundreds
 
 6
 00:00:29,200 --> 00:00:35,900

--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -60,10 +60,11 @@ fn status_tool_def() -> Value {
     })
 }
 
-/// The two meta-tools that power lazy discovery: search then call. In lazy mode
-/// these (plus toolport_status) are the ONLY tools advertised, so the client's
-/// context holds a handful of tool defs instead of hundreds - the model discovers
-/// the real tool on demand and dispatches through `toolport_call_tool`.
+/// The core meta-tools that power lazy discovery. In lazy mode the gateway advertises
+/// status, search, call, and fetch-result, plus only the optional controls the user has
+/// enabled. The client's context holds a handful of tool defs instead of hundreds -
+/// the model discovers the real tool on demand and dispatches through
+/// `toolport_call_tool`.
 ///
 /// The description leads with a directive plus GENERIC capability examples (email,
 /// payments, deployments, ...) so the model treats Toolport as the front door for any

--- a/src/components/Onboarding.tsx
+++ b/src/components/Onboarding.tsx
@@ -832,9 +832,10 @@ function Done({
             Toolport now manages {serverCount} server
             {serverCount === 1 ? "" : "s"} across {connectedCount} connected tool
             {connectedCount === 1 ? "" : "s"}. Toggle one on or off and your clients
-            update live, no restart. Each client loads 3 search tools instead of every
-            tool, up to 91% fewer tokens at the same task success. And Toolport watches
-            every server for tampering and prompt injection, see Activity.
+            update live, no restart. Each client loads a handful of Toolport meta-tools
+            instead of every downstream tool, up to 91% fewer tokens at the same task
+            success. And Toolport watches every server for tampering and prompt injection,
+            see Activity.
           </>
         ) : (
           <>


### PR DESCRIPTION
## What changed

- replaces the stale three-tool onboarding claim with accurate, evergreen wording
- updates demo captions and benchmark output labels
- corrects the gateway's lazy-discovery documentation
- aligns roadmap measurements with the current four-tool, 886-token baseline

## Why

Toolport originally exposed three lazy-discovery tools. It now exposes four core tools by default, plus only the optional controls a user enables.

## Validation

- `npm run build`
- repository-wide scan for stale three-tool claims
