### PR TITLE
Guard semantic embedding requests against SSRF

### DIFF
--- a/src-tauri/src/downstream.rs
+++ b/src-tauri/src/downstream.rs
@@ -1565,15 +1565,19 @@ fn screen_resolved_addrs(
     Ok(())
 }
 
-/// A ureq agent for remote MCP HTTP calls, with the SSRF resolver installed. Because
-/// ureq resolves through this resolver immediately before connecting, screening here
-/// validates the exact address dialed - closing the resolve-then-connect (DNS-rebind)
-/// TOCTOU a separate pre-check has. `block_private` extends the screen to internal
-/// addresses for untrusted-provenance servers.
-fn guarded_agent(block_private: bool) -> ureq::Agent {
+/// A ureq agent with the SSRF resolver installed. Because ureq resolves through this
+/// resolver immediately before connecting, screening here validates the exact address
+/// dialed - closing the resolve-then-connect (DNS-rebind) TOCTOU a separate pre-check
+/// has. `block_private` extends the screen to internal addresses for untrusted inputs.
+/// Redirects stay disabled so a credential-bearing request cannot be replayed to a
+/// different host. Callers choose a timeout appropriate for their operation.
+pub(crate) fn guarded_agent_with_timeout(
+    block_private: bool,
+    timeout: std::time::Duration,
+) -> ureq::Agent {
     use std::net::{SocketAddr, ToSocketAddrs};
     ureq::AgentBuilder::new()
-        .timeout(std::time::Duration::from_secs(30))
+        .timeout(timeout)
         // Never follow redirects. MCP Streamable HTTP doesn't need cross-host
         // redirects, and following one would let a malicious server bounce us to an
         // internal address (SSRF, e.g. cloud metadata) or replay our Authorization
@@ -1585,6 +1589,12 @@ fn guarded_agent(block_private: bool) -> ureq::Agent {
             Ok(addrs)
         })
         .build()
+}
+
+/// The remote MCP transport allows longer-lived calls than short auxiliary HTTP
+/// requests such as semantic embedding lookups.
+fn guarded_agent(block_private: bool) -> ureq::Agent {
+    guarded_agent_with_timeout(block_private, std::time::Duration::from_secs(30))
 }
 
 /// Talks to a remote MCP server over the Streamable HTTP transport: each request

--- a/src-tauri/src/semantic.rs
+++ b/src-tauri/src/semantic.rs
@@ -120,14 +120,15 @@ fn embed_batch(cfg: &SemanticConfig, inputs: &[String]) -> Option<Vec<Vec<f32>>>
     if inputs.is_empty() {
         return Some(Vec::new());
     }
-    // A bounded agent, so a hung/slow embeddings endpoint (a wedged local Ollama/LM
-    // Studio, a black-holed cloud host) can't stall the interactive tool search
-    // indefinitely: on timeout `send_json` errors and the caller falls back to the
-    // pure-lexical ranker. Without this, the bare `ureq::post` inherits ureq's default
-    // of no read timeout and a hang here blocks the whole `search_tools` response.
-    let agent = ureq::AgentBuilder::new()
-        .timeout(std::time::Duration::from_secs(10))
-        .build();
+    // Reuse the gateway's connect-time SSRF resolver so DNS rebinding or a redirect
+    // cannot send the tool catalog (or CONDUIT_EMBED_KEY) to cloud metadata. Private
+    // and loopback addresses remain allowed because local Ollama/LM Studio endpoints
+    // are a supported configuration. Keep the short timeout so any failure falls back
+    // promptly to the pure-lexical ranker.
+    let agent = crate::downstream::guarded_agent_with_timeout(
+        false,
+        std::time::Duration::from_secs(10),
+    );
     let mut req = agent.post(&cfg.endpoint).set("Content-Type", "application/json");
     if let Ok(key) = std::env::var("CONDUIT_EMBED_KEY") {
         if !key.is_empty() {
@@ -206,6 +207,15 @@ pub fn embed_tools(cfg: &SemanticConfig, tools: &[&Value]) -> HashMap<String, Ve
 mod tests {
     use super::*;
 
+    fn embedding_config(endpoint: String) -> SemanticConfig {
+        SemanticConfig {
+            enabled: true,
+            endpoint,
+            model: "test-model".into(),
+            blend: 0.5,
+        }
+    }
+
     #[test]
     fn cosine_basic() {
         assert!((cosine(&[1.0, 0.0], &[1.0, 0.0]) - 1.0).abs() < 1e-6);
@@ -245,5 +255,60 @@ mod tests {
         assert!(!SemanticConfig { enabled: false, ..base.clone() }.is_active());
         assert!(!SemanticConfig { endpoint: "".into(), ..base.clone() }.is_active());
         assert!(!SemanticConfig { model: "".into(), ..base }.is_active());
+    }
+
+    #[test]
+    fn embedding_agent_allows_local_endpoints() {
+        let listener = tiny_http::Server::http("127.0.0.1:0").unwrap();
+        let port = listener.server_addr().to_ip().unwrap().port();
+        let endpoint = format!("http://127.0.0.1:{port}/v1/embeddings");
+        let server = std::thread::spawn(move || {
+            let request = listener.recv().unwrap();
+            let body = r#"{"data":[{"embedding":[1.0,2.0]}]}"#;
+            let content_type = tiny_http::Header::from_bytes(
+                &b"Content-Type"[..],
+                &b"application/json"[..],
+            )
+            .unwrap();
+            request
+                .respond(tiny_http::Response::from_string(body).with_header(content_type))
+                .unwrap();
+        });
+
+        assert_eq!(
+            embed_query(&embedding_config(endpoint), "hello"),
+            Some(vec![1.0, 2.0])
+        );
+        server.join().unwrap();
+    }
+
+    #[test]
+    fn embedding_agent_does_not_follow_redirects() {
+        use std::net::TcpListener;
+
+        let redirect_target = TcpListener::bind("127.0.0.1:0").unwrap();
+        redirect_target.set_nonblocking(true).unwrap();
+        let target_url = format!("http://{}/stolen", redirect_target.local_addr().unwrap());
+
+        let redirector = tiny_http::Server::http("127.0.0.1:0").unwrap();
+        let port = redirector.server_addr().to_ip().unwrap().port();
+        let endpoint = format!("http://127.0.0.1:{port}/v1/embeddings");
+        let server = std::thread::spawn(move || {
+            let request = redirector.recv().unwrap();
+            let location = tiny_http::Header::from_bytes(&b"Location"[..], target_url.as_bytes())
+                .unwrap();
+            request
+                .respond(
+                    tiny_http::Response::empty(302).with_header(location),
+                )
+                .unwrap();
+        });
+
+        assert!(embed_query(&embedding_config(endpoint), "hello").is_none());
+        server.join().unwrap();
+        assert!(matches!(
+            redirect_target.accept(),
+            Err(error) if error.kind() == std::io::ErrorKind::WouldBlock
+        ));
     }
 }


### PR DESCRIPTION
## What
- route semantic embedding requests through Toolport's connect-time SSRF resolver
- keep localhost and private-network endpoints available for Ollama and LM Studio
- disable redirects while preserving the existing 10-second lexical fallback
- cover local endpoint access and redirect refusal with regression tests

## Why
The configured embeddings endpoint receives the tool catalog and may receive `CONDUIT_EMBED_KEY`. Reusing the guarded resolver prevents DNS rebinding to link-local/cloud metadata, while refusing redirects prevents replaying that request to another host.

## Validation
- `cargo test --manifest-path src-tauri/Cargo.toml --lib semantic::tests -- --nocapture` (6 passed)
- `scripts/test-rust-windows.ps1` (361 library + 92 gateway tests passed)
- `git diff --check`

Linear: SOU-25