### PR TITLE
Require authentication for loopback HTTP

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,8 +201,9 @@ Gotcha: when running Toolport from source, build the gateway first with `npm run
 The gateway speaks HTTP/OpenAPI natively, so Open WebUI (and any OpenAPI tool
 client) connects straight to Toolport, no bridge or proxy. Flip on **Settings ->
 Integrations -> Open WebUI / HTTP endpoint** in the app (or run
-`toolport-gateway --http 8765`), then add `http://localhost:8765` as an OpenAPI
-tool server. See [docs/openwebui.md](docs/openwebui.md). The same endpoint serves
+`toolport-gateway --http 8765` after setting `CONDUIT_HTTP_TOKEN`), then add
+`http://localhost:8765` as an OpenAPI tool server. See
+[docs/openwebui.md](docs/openwebui.md). The same endpoint serves
 any HTTP/OpenAPI MCP consumer (n8n, LibreChat, custom agents).
 
 ### Headless / container / MCP over the network
@@ -232,7 +233,9 @@ gateway entry, written for you when you connect a client:
   and `CONDUIT_HTTP_TOKEN` for the required bearer token) - run the gateway in
   HTTP/OpenAPI mode instead of stdio, for Open WebUI and other OpenAPI clients (see
   above). The in-app Settings -> Integrations toggle sets these for you, and the
-  gateway refuses a non-loopback bind without a token.
+  gateway refuses to bind without a token or registered HTTP client. For isolated
+  local development only, `--insecure-loopback` explicitly permits an unauthenticated
+  loopback listener; it never permits an open non-loopback bind.
 
 **Semantic search (optional).** Lazy discovery ranks tools lexically by default. Point it
 at any `/v1/embeddings` endpoint (LM Studio, Ollama, or a cloud provider) to blend in

--- a/docs/headless.md
+++ b/docs/headless.md
@@ -165,8 +165,9 @@ Use this before exposing a headless gateway beyond a trusted host or LAN.
 ### Network and auth
 
 - [ ] **Bearer token set** — `CONDUIT_HTTP_TOKEN` with at least 24 bytes of
-      entropy (`openssl rand -hex 24`). Required when binding anything other than
-      loopback; the process refuses `0.0.0.0` without it.
+      entropy (`openssl rand -hex 24`), or a registered scoped HTTP client. The
+      process refuses any bind without configured authentication unless an operator
+      explicitly passes `--insecure-loopback` for isolated local development.
 - [ ] **Firewall** — only trusted clients can reach the port. Do not publish
       `:8765` to the public internet without a reverse proxy.
 - [ ] **TLS in front** — the gateway speaks plain HTTP. Terminate TLS at nginx,
@@ -258,7 +259,8 @@ a wholly new trust model.
 
 Optional internal pass: re-run the gateway HTTP + MCP integration tests, smoke
 `POST /mcp` initialize → `tools/list` with and without auth, and confirm
-unauthenticated requests to a non-loopback bind are rejected at startup.
+unauthenticated listeners are rejected at startup. Confirm `--insecure-loopback`
+works only on loopback when the local-development escape hatch is required.
 
 ## Environment Variables
 

--- a/docs/headless.md
+++ b/docs/headless.md
@@ -231,9 +231,9 @@ the v1.5.1–1.5.2 audit batch (#203–#207).
 **Known limitations (not bugs, but deploy constraints):**
 
 - No built-in TLS or rate limiting — use a reverse proxy.
-- Loopback without a token warns but still starts: any **local** process (including
-  a malicious web page via browser) can call tools. Set a token even on localhost if
-  browsers run on the same machine.
+- `--insecure-loopback` warns and starts an unauthenticated **local-only** listener:
+  any local process (including a malicious web page via browser) can call tools.
+  Prefer a token even on localhost if browsers run on the same machine.
 - Headless + human approval on = destructive calls blocked, not prompted.
 - MCP HTTP test coverage is thinner than the stdio gateway path (see ROADMAP).
 

--- a/docs/openwebui.md
+++ b/docs/openwebui.md
@@ -13,8 +13,8 @@ Integrations -> "Open WebUI / HTTP endpoint"**, flip it on, and copy the **URL**
 gateway for you and shuts it down when you quit.
 
 > Prefer the command line? `toolport-gateway --http 8765` (or `CONDUIT_HTTP=8765`)
-> does the same thing; set `CONDUIT_HTTP_TOKEN=<your-token>` to require auth (the
-> app does this automatically). It serves an OpenAPI spec at
+> does the same thing when `CONDUIT_HTTP_TOKEN=<your-token>` is set (the app does
+> this automatically). It serves an OpenAPI spec at
 > `http://localhost:8765/openapi.json` and a POST endpoint per tool.
 
 **2. Add it to Open WebUI.** Settings -> Tools -> add an OpenAPI tool server
@@ -44,10 +44,10 @@ That's it. Ask for something one of your servers does ("list my recent emails",
 
 - **Local-only by default.** The gateway binds `127.0.0.1`, so only this machine
   can reach it. If you run Open WebUI in Docker, set `CONDUIT_HTTP_HOST=0.0.0.0`
-  and point the tool server at `http://host.docker.internal:8765`. A loopback bind
-  may run without a token, but a non-loopback bind (`0.0.0.0`) **requires**
-  `CONDUIT_HTTP_TOKEN` (the gateway refuses to bind non-loopback without one); still
-  only expose it on a trusted network.
+  and point the tool server at `http://host.docker.internal:8765`. Every bind requires
+  `CONDUIT_HTTP_TOKEN` or a registered HTTP client. For isolated local development,
+  `--insecure-loopback` explicitly permits an open loopback listener; it never bypasses
+  authentication for `0.0.0.0`. Only expose non-loopback HTTP on a trusted network.
 - **Lazy vs full discovery.** Lazy (default) keeps the model's context tiny and
   is best for capable models. For a weaker local model, `CONDUIT_DISCOVERY=full`
   scoped to a small profile exposes the tools directly (no search step) so the

--- a/scripts/smoke-headless.ps1
+++ b/scripts/smoke-headless.ps1
@@ -134,7 +134,7 @@ try {
     }
 }
 
-# --- Test 4: HITL fail-closed (unit test) ---
+# --- Test 6: HITL fail-closed (unit test) ---
 Write-Host "Running approval_broker_fails_closed unit test..."
 Push-Location $repoRoot
 cargo test --manifest-path src-tauri/Cargo.toml --no-default-features --bin toolport-gateway approval_broker_fails_closed 2>&1 | Out-Null

--- a/scripts/smoke-headless.ps1
+++ b/scripts/smoke-headless.ps1
@@ -34,6 +34,18 @@ $failed = 0
 
 function Pass($msg) { Write-Host "[PASS] $msg" -ForegroundColor Green }
 function Fail($msg) { Write-Host "[FAIL] $msg" -ForegroundColor Red; $script:failed++ }
+function Wait-HttpCode($url, $expected, $headers = @(), $timeoutSeconds = 10) {
+    $deadline = [DateTime]::UtcNow.AddSeconds($timeoutSeconds)
+    $code = ""
+    do {
+        $curlArgs = @("-s", "--connect-timeout", "1", "--max-time", "2", "-o", "NUL", "-w", "%{http_code}")
+        foreach ($header in $headers) { $curlArgs += @("-H", $header) }
+        $code = & curl.exe @curlArgs $url
+        if ($LASTEXITCODE -eq 0 -and $code -eq $expected) { return $code }
+        Start-Sleep -Milliseconds 100
+    } while ([DateTime]::UtcNow -lt $deadline)
+    return $code
+}
 
 Write-Host "Using gateway: $bin"
 
@@ -42,8 +54,8 @@ $env:CONDUIT_REGISTRY = $registry
 $env:CONDUIT_HTTP_HOST = "0.0.0.0"
 Remove-Item Env:CONDUIT_HTTP_TOKEN -ErrorAction SilentlyContinue
 $p1 = Start-Process -FilePath $bin -ArgumentList "--http", "18765" -PassThru -WindowStyle Hidden -RedirectStandardError (Join-Path $smokeDir "t1.err")
-Start-Sleep -Seconds 2
-if ($p1.HasExited -and $p1.ExitCode -ne 0) {
+$p1Exited = $p1.WaitForExit(5000)
+if ($p1Exited -and $p1.ExitCode -ne 0) {
     $err = Get-Content (Join-Path $smokeDir "t1.err") -Raw -ErrorAction SilentlyContinue
     if ($err -match "refusing to bind.*without HTTP authentication") {
         Pass "non-loopback without token refuses start (exit $($p1.ExitCode))"
@@ -51,15 +63,18 @@ if ($p1.HasExited -and $p1.ExitCode -ne 0) {
         Fail "non-loopback without token exited $($p1.ExitCode) but message unexpected: $err"
     }
 } else {
-    if (-not $p1.HasExited) { Stop-Process -Id $p1.Id -Force -ErrorAction SilentlyContinue }
+    if (-not $p1Exited) {
+        Stop-Process -Id $p1.Id -Force -ErrorAction SilentlyContinue
+        [void]$p1.WaitForExit(5000)
+    }
     Fail "non-loopback without token should refuse start"
 }
 
 # --- Test 2: loopback without auth also refuses start ---
 $env:CONDUIT_HTTP_HOST = "127.0.0.1"
 $p2 = Start-Process -FilePath $bin -ArgumentList "--http", "18764" -PassThru -WindowStyle Hidden -RedirectStandardError (Join-Path $smokeDir "t2.err")
-Start-Sleep -Seconds 2
-if ($p2.HasExited -and $p2.ExitCode -ne 0) {
+$p2Exited = $p2.WaitForExit(5000)
+if ($p2Exited -and $p2.ExitCode -ne 0) {
     $err = Get-Content (Join-Path $smokeDir "t2.err") -Raw -ErrorAction SilentlyContinue
     if ($err -match "refusing to bind.*without HTTP authentication") {
         Pass "loopback without auth refuses start (exit $($p2.ExitCode))"
@@ -67,20 +82,23 @@ if ($p2.HasExited -and $p2.ExitCode -ne 0) {
         Fail "loopback without auth exited $($p2.ExitCode) but message unexpected: $err"
     }
 } else {
-    if (-not $p2.HasExited) { Stop-Process -Id $p2.Id -Force -ErrorAction SilentlyContinue }
+    if (-not $p2Exited) {
+        Stop-Process -Id $p2.Id -Force -ErrorAction SilentlyContinue
+        [void]$p2.WaitForExit(5000)
+    }
     Fail "loopback without auth should refuse start"
 }
 
 # --- Test 3: explicit insecure loopback escape hatch works locally ---
 $p3 = Start-Process -FilePath $bin -ArgumentList "--http", "18764", "--insecure-loopback" -PassThru -WindowStyle Hidden -RedirectStandardError (Join-Path $smokeDir "t3.err")
-Start-Sleep -Seconds 2
+$code = Wait-HttpCode "http://127.0.0.1:18764/" "200"
 if ($p3.HasExited) {
     $err = Get-Content (Join-Path $smokeDir "t3.err") -Raw -ErrorAction SilentlyContinue
     Fail "explicit insecure loopback exited unexpectedly: $err"
 } else {
-    $code = curl.exe -s -o NUL -w "%{http_code}" "http://127.0.0.1:18764/"
     if ($code -eq "200") { Pass "explicit insecure loopback starts locally" } else { Fail "explicit insecure loopback returned $code" }
     Stop-Process -Id $p3.Id -Force -ErrorAction SilentlyContinue
+    [void]$p3.WaitForExit(5000)
 }
 
 # --- Start authenticated gateway for tests 4-5 ---
@@ -89,14 +107,13 @@ $env:CONDUIT_HTTP_TOKEN = $token
 $gw = Start-Process -FilePath $bin -ArgumentList "--http", "$port" -PassThru -WindowStyle Hidden
 $gatewayPid = $gw.Id
 Set-Content -Path (Join-Path $smokeDir "gateway.pid") -Value $gatewayPid
-Start-Sleep -Seconds 2
 
 try {
     # --- Test 4: auth ---
-    $codeNoAuth = curl.exe -s -o NUL -w "%{http_code}" "http://127.0.0.1:${port}/"
+    $codeNoAuth = Wait-HttpCode "http://127.0.0.1:${port}/" "401"
     if ($codeNoAuth -eq "401") { Pass "GET / without auth returns 401" } else { Fail "GET / without auth returned $codeNoAuth (expected 401)" }
 
-    $codeAuth = curl.exe -s -o NUL -w "%{http_code}" -H "Authorization: Bearer $token" "http://127.0.0.1:${port}/"
+    $codeAuth = curl.exe -s --connect-timeout 2 --max-time 5 -o NUL -w "%{http_code}" -H "Authorization: Bearer $token" "http://127.0.0.1:${port}/"
     if ($codeAuth -eq "200") { Pass "GET / with bearer returns 200" } else { Fail "GET / with bearer returned $codeAuth (expected 200)" }
 
     # --- Test 5: MCP handshake ---
@@ -106,7 +123,7 @@ try {
 
     $initHdr = Join-Path $smokeDir "init.hdr"
     $initBody = Join-Path $smokeDir "init.json"
-    curl.exe -sD $initHdr -o $initBody -X POST "http://127.0.0.1:${port}/mcp" `
+    curl.exe -s --connect-timeout 2 --max-time 5 -D $initHdr -o $initBody -X POST "http://127.0.0.1:${port}/mcp" `
         -H "Authorization: Bearer $token" -H "Content-Type: application/json" -H "Accept: application/json" `
         --data-binary "@$initReq" | Out-Null
 
@@ -120,7 +137,7 @@ try {
         $listReq = Join-Path $smokeDir "list-req.json"
         [System.IO.File]::WriteAllText($listReq, '{"jsonrpc":"2.0","id":2,"method":"tools/list"}')
         $listOut = Join-Path $smokeDir "list.json"
-        curl.exe -s -o $listOut -X POST "http://127.0.0.1:${port}/mcp" `
+        curl.exe -s --connect-timeout 2 --max-time 5 -o $listOut -X POST "http://127.0.0.1:${port}/mcp" `
             -H "Authorization: Bearer $token" -H "Content-Type: application/json" `
             -H "Mcp-Session-Id: $sid" --data-binary "@$listReq" | Out-Null
         $listJson = Get-Content $listOut -Raw | ConvertFrom-Json
@@ -130,6 +147,7 @@ try {
 } finally {
     if ($gatewayPid) {
         Stop-Process -Id $gatewayPid -Force -ErrorAction SilentlyContinue
+        [void]$gw.WaitForExit(5000)
         Remove-Item (Join-Path $smokeDir "gateway.pid") -ErrorAction SilentlyContinue
     }
 }

--- a/scripts/smoke-headless.ps1
+++ b/scripts/smoke-headless.ps1
@@ -45,7 +45,7 @@ $p1 = Start-Process -FilePath $bin -ArgumentList "--http", "18765" -PassThru -Wi
 Start-Sleep -Seconds 2
 if ($p1.HasExited -and $p1.ExitCode -ne 0) {
     $err = Get-Content (Join-Path $smokeDir "t1.err") -Raw -ErrorAction SilentlyContinue
-    if ($err -match "refusing to bind.*without CONDUIT_HTTP_TOKEN") {
+    if ($err -match "refusing to bind.*without HTTP authentication") {
         Pass "non-loopback without token refuses start (exit $($p1.ExitCode))"
     } else {
         Fail "non-loopback without token exited $($p1.ExitCode) but message unexpected: $err"
@@ -55,7 +55,35 @@ if ($p1.HasExited -and $p1.ExitCode -ne 0) {
     Fail "non-loopback without token should refuse start"
 }
 
-# --- Start gateway for tests 2-3 ---
+# --- Test 2: loopback without auth also refuses start ---
+$env:CONDUIT_HTTP_HOST = "127.0.0.1"
+$p2 = Start-Process -FilePath $bin -ArgumentList "--http", "18764" -PassThru -WindowStyle Hidden -RedirectStandardError (Join-Path $smokeDir "t2.err")
+Start-Sleep -Seconds 2
+if ($p2.HasExited -and $p2.ExitCode -ne 0) {
+    $err = Get-Content (Join-Path $smokeDir "t2.err") -Raw -ErrorAction SilentlyContinue
+    if ($err -match "refusing to bind.*without HTTP authentication") {
+        Pass "loopback without auth refuses start (exit $($p2.ExitCode))"
+    } else {
+        Fail "loopback without auth exited $($p2.ExitCode) but message unexpected: $err"
+    }
+} else {
+    if (-not $p2.HasExited) { Stop-Process -Id $p2.Id -Force -ErrorAction SilentlyContinue }
+    Fail "loopback without auth should refuse start"
+}
+
+# --- Test 3: explicit insecure loopback escape hatch works locally ---
+$p3 = Start-Process -FilePath $bin -ArgumentList "--http", "18764", "--insecure-loopback" -PassThru -WindowStyle Hidden -RedirectStandardError (Join-Path $smokeDir "t3.err")
+Start-Sleep -Seconds 2
+if ($p3.HasExited) {
+    $err = Get-Content (Join-Path $smokeDir "t3.err") -Raw -ErrorAction SilentlyContinue
+    Fail "explicit insecure loopback exited unexpectedly: $err"
+} else {
+    $code = curl.exe -s -o NUL -w "%{http_code}" "http://127.0.0.1:18764/"
+    if ($code -eq "200") { Pass "explicit insecure loopback starts locally" } else { Fail "explicit insecure loopback returned $code" }
+    Stop-Process -Id $p3.Id -Force -ErrorAction SilentlyContinue
+}
+
+# --- Start authenticated gateway for tests 4-5 ---
 $env:CONDUIT_HTTP_HOST = "127.0.0.1"
 $env:CONDUIT_HTTP_TOKEN = $token
 $gw = Start-Process -FilePath $bin -ArgumentList "--http", "$port" -PassThru -WindowStyle Hidden
@@ -64,14 +92,14 @@ Set-Content -Path (Join-Path $smokeDir "gateway.pid") -Value $gatewayPid
 Start-Sleep -Seconds 2
 
 try {
-    # --- Test 2: auth ---
+    # --- Test 4: auth ---
     $codeNoAuth = curl.exe -s -o NUL -w "%{http_code}" "http://127.0.0.1:${port}/"
     if ($codeNoAuth -eq "401") { Pass "GET / without auth returns 401" } else { Fail "GET / without auth returned $codeNoAuth (expected 401)" }
 
     $codeAuth = curl.exe -s -o NUL -w "%{http_code}" -H "Authorization: Bearer $token" "http://127.0.0.1:${port}/"
     if ($codeAuth -eq "200") { Pass "GET / with bearer returns 200" } else { Fail "GET / with bearer returned $codeAuth (expected 200)" }
 
-    # --- Test 3: MCP handshake ---
+    # --- Test 5: MCP handshake ---
     $initReq = Join-Path $smokeDir "init-req.json"
     $initJson = '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"smoke","version":"0"}}}'
     [System.IO.File]::WriteAllText($initReq, $initJson)

--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -5168,7 +5168,16 @@ fn insecure_loopback_requested(args: &[String]) -> bool {
 
 /// Startup admission policy. The escape hatch is never valid for a non-loopback bind.
 fn http_bind_is_authorized(loopback: bool, auth_configured: bool, insecure_loopback: bool) -> bool {
-    auth_configured || (loopback && insecure_loopback)
+    auth_configured || http_allows_insecure_open(loopback, auth_configured, insecure_loopback)
+}
+
+/// Activate the open-listener fallback only when the escape hatch was required at startup.
+fn http_allows_insecure_open(
+    loopback: bool,
+    auth_configured: bool,
+    insecure_loopback: bool,
+) -> bool {
+    loopback && insecure_loopback && !auth_configured
 }
 
 fn serve_http(state: GatewayState, port: u16) {
@@ -5193,6 +5202,8 @@ fn serve_http(state: GatewayState, port: u16) {
     let auth_configured = token.is_some() || registered_clients;
     let args: Vec<String> = std::env::args().collect();
     let insecure_loopback = insecure_loopback_requested(&args);
+    let allow_insecure_open =
+        http_allows_insecure_open(loopback, auth_configured, insecure_loopback);
 
     if !http_bind_is_authorized(loopback, auth_configured, insecure_loopback) {
         if loopback {
@@ -5210,7 +5221,7 @@ fn serve_http(state: GatewayState, port: u16) {
         }
         std::process::exit(1);
     }
-    if !auth_configured {
+    if allow_insecure_open {
         eprintln!(
             "toolport-gateway: WARNING - {INSECURE_LOOPBACK_FLAG} enabled; any local process \
              (including a web page open in your browser) can call your tools."
@@ -5243,7 +5254,7 @@ fn serve_http(state: GatewayState, port: u16) {
                     token6,
                     search6,
                     confirm6,
-                    insecure_loopback,
+                    allow_insecure_open,
                 )
             });
             glog(&format!(
@@ -5272,7 +5283,7 @@ fn serve_http(state: GatewayState, port: u16) {
         token,
         search,
         confirm,
-        loopback && insecure_loopback,
+        allow_insecure_open,
     );
 }
 
@@ -6599,6 +6610,9 @@ mod tests {
         assert!(!http_bind_is_authorized(true, false, false));
         assert!(!http_bind_is_authorized(false, false, false));
         assert!(!http_bind_is_authorized(false, false, true));
+        assert!(http_allows_insecure_open(true, false, true));
+        assert!(!http_allows_insecure_open(true, true, true));
+        assert!(!http_allows_insecure_open(false, false, true));
     }
 
     #[test]
@@ -6745,9 +6759,14 @@ mod tests {
         // Removing the last registered client while the gateway is live must not
         // turn an authenticated listener into an open one. Only immutable startup
         // policy from `--insecure-loopback` enables the fallback.
+        let authenticated_startup_allows_open = http_allows_insecure_open(true, true, true);
         reg.http_clients.clear();
-        assert!(resolve_http_scope(&reg, None, None, false).is_none());
-        assert_eq!(resolve_http_scope(&reg, None, None, true), Some(None));
+        assert!(resolve_http_scope(&reg, None, None, authenticated_startup_allows_open).is_none());
+        let explicit_open_startup = http_allows_insecure_open(true, false, true);
+        assert_eq!(
+            resolve_http_scope(&reg, None, None, explicit_open_startup),
+            Some(None)
+        );
     }
 
     #[test]

--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -1792,6 +1792,7 @@ fn resolve_http_caller(
     reg: &Registry,
     env_token: Option<&str>,
     provided: Option<&str>,
+    allow_insecure_open: bool,
 ) -> Option<(Option<std::collections::HashSet<String>>, HttpCaller)> {
     let owner_scope = |allowed: &Option<std::collections::HashSet<String>>| {
         allowed.as_ref().map(|set| {
@@ -1848,8 +1849,9 @@ fn resolve_http_caller(
         ));
     }
 
-    // No auth configured at all: open, preserving the loopback default.
-    if env_token.is_none() && reg.http_clients.is_empty() {
+    // No auth configured at all: reachable only when startup explicitly allowed
+    // `--insecure-loopback`; keep the request resolver usable for that escape hatch.
+    if allow_insecure_open && env_token.is_none() && reg.http_clients.is_empty() {
         return Some((
             None,
             HttpCaller {
@@ -1871,13 +1873,14 @@ fn resolve_http_scope(
     reg: &Registry,
     env_token: Option<&str>,
     provided: Option<&str>,
+    allow_insecure_open: bool,
 ) -> Option<Option<std::collections::HashSet<String>>> {
-    resolve_http_caller(reg, env_token, provided).map(|(allowed, _)| allowed)
+    resolve_http_caller(reg, env_token, provided, allow_insecure_open).map(|(allowed, _)| allowed)
 }
 
 /// The audit label for a registered HTTP client's bearer: its `label`, or its `id`
 /// when the label is blank. `None` when the token isn't a registered client (legacy
-/// single-token, open loopback, or the local stdio app), so those calls stay
+/// single-token, explicitly insecure loopback, or the local stdio app), so those calls stay
 /// unattributed in the audit log rather than mislabeled. Pure, so it's unit-testable.
 #[cfg(test)]
 fn http_client_label(reg: &Registry, provided: Option<&str>) -> Option<String> {
@@ -5105,8 +5108,8 @@ fn handle_http(
 }
 
 /// Run the blocking HTTP/OpenAPI server. Binds 127.0.0.1 by default (local
-/// only); set `CONDUIT_HTTP_HOST=0.0.0.0` to expose it (unauthenticated, so
-/// only on a trusted network).
+/// only); set `CONDUIT_HTTP_HOST=0.0.0.0` to expose it. Every bind requires a
+/// bearer token unless loopback is explicitly started with `--insecure-loopback`.
 /// Cap on an inbound HTTP request body. Tool arguments are tiny; this just stops
 /// an unauthenticated caller from forcing the gateway to buffer a huge body.
 const MAX_HTTP_BODY: u64 = 4 * 1024 * 1024;
@@ -5156,6 +5159,18 @@ fn ct_eq(a: &[u8], b: &[u8]) -> bool {
     diff == 0
 }
 
+const INSECURE_LOOPBACK_FLAG: &str = "--insecure-loopback";
+
+/// Whether the operator explicitly requested the local unauthenticated escape hatch.
+fn insecure_loopback_requested(args: &[String]) -> bool {
+    args.iter().any(|arg| arg == INSECURE_LOOPBACK_FLAG)
+}
+
+/// Startup admission policy. The escape hatch is never valid for a non-loopback bind.
+fn http_bind_is_authorized(loopback: bool, auth_configured: bool, insecure_loopback: bool) -> bool {
+    auth_configured || (loopback && insecure_loopback)
+}
+
 fn serve_http(state: GatewayState, port: u16) {
     let host = std::env::var("CONDUIT_HTTP_HOST")
         .ok()
@@ -5170,19 +5185,35 @@ fn serve_http(state: GatewayState, port: u16) {
         .filter(|t| !t.is_empty());
 
     let loopback = matches!(host.as_str(), "127.0.0.1" | "::1" | "localhost");
-    // Fail closed: a non-loopback endpoint runs the user's credentials for
-    // anyone who can reach the port, so refuse to bind one without a token.
-    if !loopback && token.is_none() {
-        eprintln!(
-            "toolport-gateway: refusing to bind {host}:{port} without CONDUIT_HTTP_TOKEN. \
-             A non-loopback HTTP endpoint would be unauthenticated. Set a token, or bind 127.0.0.1."
-        );
+    let registered_clients = state
+        .registry
+        .lock()
+        .map(|reg| !reg.http_clients.is_empty())
+        .unwrap_or(false);
+    let auth_configured = token.is_some() || registered_clients;
+    let args: Vec<String> = std::env::args().collect();
+    let insecure_loopback = insecure_loopback_requested(&args);
+
+    if !http_bind_is_authorized(loopback, auth_configured, insecure_loopback) {
+        if loopback {
+            eprintln!(
+                "toolport-gateway: refusing to bind {host}:{port} without HTTP authentication. \
+                 Set CONDUIT_HTTP_TOKEN, configure a registered HTTP client, or explicitly pass \
+                 {INSECURE_LOOPBACK_FLAG} to accept unauthenticated local access."
+            );
+        } else {
+            eprintln!(
+                "toolport-gateway: refusing to bind {host}:{port} without HTTP authentication. \
+                 Set CONDUIT_HTTP_TOKEN or configure a registered HTTP client. \
+                 {INSECURE_LOOPBACK_FLAG} is valid only for loopback binds."
+            );
+        }
         std::process::exit(1);
     }
-    if token.is_none() {
+    if !auth_configured {
         eprintln!(
-            "toolport-gateway: WARNING - HTTP endpoint has no token; any local process (including a \
-             web page open in your browser) can call your tools. Set CONDUIT_HTTP_TOKEN to require auth."
+            "toolport-gateway: WARNING - {INSECURE_LOOPBACK_FLAG} enabled; any local process \
+             (including a web page open in your browser) can call your tools."
         );
     }
 
@@ -5199,9 +5230,22 @@ fn serve_http(state: GatewayState, port: u16) {
     // listener makes `http://localhost:<port>` fail even though 127.0.0.1 works.
     if host == "127.0.0.1" {
         if let Ok(server6) = tiny_http::Server::http(("::1", port)) {
-            let (state6, token6, search6, confirm6) =
-                (state.clone(), token.clone(), search.clone(), confirm.clone());
-            std::thread::spawn(move || serve_http_loop(server6, state6, token6, search6, confirm6));
+            let (state6, token6, search6, confirm6) = (
+                state.clone(),
+                token.clone(),
+                search.clone(),
+                confirm.clone(),
+            );
+            std::thread::spawn(move || {
+                serve_http_loop(
+                    server6,
+                    state6,
+                    token6,
+                    search6,
+                    confirm6,
+                    insecure_loopback,
+                )
+            });
             glog(&format!(
                 "HTTP/OpenAPI also listening on http://[::1]:{port}"
             ));
@@ -5217,12 +5261,19 @@ fn serve_http(state: GatewayState, port: u16) {
     };
     glog(&format!(
         "HTTP mode on http://{host}:{port} (OpenAPI + MCP /mcp, auth={})",
-        token.is_some()
+        auth_configured
     ));
     eprintln!(
         "toolport-gateway: HTTP on http://localhost:{port}  (OpenAPI /openapi.json, MCP POST /mcp)"
     );
-    serve_http_loop(server, state, token, search, confirm);
+    serve_http_loop(
+        server,
+        state,
+        token,
+        search,
+        confirm,
+        loopback && insecure_loopback,
+    );
 }
 
 /// The accept loop for one listener. Each accepted request is handed to its own
@@ -5340,6 +5391,7 @@ fn serve_http_loop(
     token: Option<String>,
     search: Arc<SearchGuard>,
     confirm: Arc<ConfirmGuard>,
+    allow_insecure_open: bool,
 ) {
     serve_http_loop_with_inflight(
         server,
@@ -5347,6 +5399,7 @@ fn serve_http_loop(
         token,
         search,
         confirm,
+        allow_insecure_open,
         Arc::new(AtomicUsize::new(0)),
     );
 }
@@ -5357,6 +5410,7 @@ fn serve_http_loop_with_inflight(
     token: Option<String>,
     search: Arc<SearchGuard>,
     confirm: Arc<ConfirmGuard>,
+    allow_insecure_open: bool,
     inflight: Arc<AtomicUsize>,
 ) {
     for request in server.incoming_requests() {
@@ -5372,7 +5426,14 @@ fn serve_http_loop_with_inflight(
         );
         std::thread::spawn(move || {
             let _permit = guard;
-            handle_connection(request, &state, &token, &search, &confirm);
+            handle_connection(
+                request,
+                &state,
+                &token,
+                &search,
+                &confirm,
+                allow_insecure_open,
+            );
         });
     }
 }
@@ -5401,6 +5462,7 @@ fn handle_connection(
     token: &Option<String>,
     search: &SearchGuard,
     confirm: &ConfirmGuard,
+    allow_insecure_open: bool,
 ) {
         let method = request.method().to_string().to_uppercase();
         let url = request.url().to_string();
@@ -5448,7 +5510,8 @@ fn handle_connection(
         // Auth + scope gate: resolve the bearer to (authorized, allowed-servers).
         // OPTIONS is the data-less preflight, always allowed and unscoped. Else the
         // registry decides: the legacy env token (full connected set), a registered
-        // HTTP client (its profile's servers), or open when no auth is configured.
+        // HTTP client (its profile's servers), or open only when startup explicitly
+        // accepted `--insecure-loopback`.
         // A bad/missing token is rejected before we read the body or route.
         let provided = request
             .headers()
@@ -5466,7 +5529,12 @@ fn handle_connection(
                 .unwrap_or_else(std::sync::PoisonError::into_inner);
             // Resolve authorization, routing scope, audit attribution, and MCP
             // session ownership from one token lookup and one effective allow-set.
-            match resolve_http_caller(&reg, token.as_deref(), provided_tok) {
+            match resolve_http_caller(
+                &reg,
+                token.as_deref(),
+                provided_tok,
+                allow_insecure_open,
+            ) {
                 Some((allowed, resolved_caller)) => {
                     caller = Some(resolved_caller);
                     Some(allowed)
@@ -6265,7 +6333,7 @@ mod tests {
         let port = server.server_addr().to_ip().unwrap().port();
         let search = Arc::new(SearchGuard::default());
         let confirm = Arc::new(ConfirmGuard::new());
-        std::thread::spawn(move || serve_http_loop(server, state, None, search, confirm));
+        std::thread::spawn(move || serve_http_loop(server, state, None, search, confirm, true));
         std::thread::sleep(Duration::from_millis(50)); // let the listener come up
 
         // Kick off the slow (blocking) call on its own thread, then let it get parked
@@ -6344,6 +6412,7 @@ mod tests {
                 None,
                 search,
                 confirm,
+                true,
                 listener_inflight,
             )
         });
@@ -6508,6 +6577,31 @@ mod tests {
     }
 
     #[test]
+    fn insecure_loopback_requires_the_exact_cli_flag() {
+        let args = vec![
+            "toolport-gateway".to_string(),
+            "--http".to_string(),
+            "8765".to_string(),
+            INSECURE_LOOPBACK_FLAG.to_string(),
+        ];
+        assert!(insecure_loopback_requested(&args));
+        assert!(!insecure_loopback_requested(&[
+            "toolport-gateway".to_string(),
+            "--insecure".to_string(),
+        ]));
+    }
+
+    #[test]
+    fn http_bind_requires_auth_except_for_explicit_loopback_escape_hatch() {
+        assert!(http_bind_is_authorized(true, true, false));
+        assert!(http_bind_is_authorized(false, true, false));
+        assert!(http_bind_is_authorized(true, false, true));
+        assert!(!http_bind_is_authorized(true, false, false));
+        assert!(!http_bind_is_authorized(false, false, false));
+        assert!(!http_bind_is_authorized(false, false, true));
+    }
+
+    #[test]
     fn server_of_tool_extracts_prefix() {
         assert_eq!(server_of_tool("vercel__deploy"), "vercel");
         assert_eq!(server_of_tool("resend__send_email"), "resend");
@@ -6611,14 +6705,15 @@ mod tests {
     #[test]
     fn resolve_http_scope_auth_and_scope_policy() {
         let mut reg = Registry::default();
-        // No auth configured at all -> open, unscoped.
-        assert_eq!(resolve_http_scope(&reg, None, None), Some(None));
+        // No auth configured at all -> open only under the explicit escape hatch.
+        assert_eq!(resolve_http_scope(&reg, None, None, true), Some(None));
+        assert_eq!(resolve_http_scope(&reg, None, None, false), None);
         // Legacy env token: exact match -> unscoped; mismatch -> rejected.
         assert_eq!(
-            resolve_http_scope(&reg, Some("envtok"), Some("envtok")),
+            resolve_http_scope(&reg, Some("envtok"), Some("envtok"), false),
             Some(None)
         );
-        assert!(resolve_http_scope(&reg, Some("envtok"), Some("nope")).is_none());
+        assert!(resolve_http_scope(&reg, Some("envtok"), Some("nope"), false).is_none());
         // A registered client with an empty profile is authorized but unscoped.
         reg.http_clients.push(registry::HttpClient {
             id: "c1".into(),
@@ -6626,11 +6721,14 @@ mod tests {
             token_sha256: registry::sha256_hex("fulltok"),
             profile: String::new(),
         });
-        assert_eq!(resolve_http_scope(&reg, None, Some("fulltok")), Some(None));
+        assert_eq!(
+            resolve_http_scope(&reg, None, Some("fulltok"), false),
+            Some(None)
+        );
         // Once any client is registered, an unknown/absent bearer is rejected
         // (the open default no longer applies).
-        assert!(resolve_http_scope(&reg, None, Some("unknown")).is_none());
-        assert!(resolve_http_scope(&reg, None, None).is_none());
+        assert!(resolve_http_scope(&reg, None, Some("unknown"), false).is_none());
+        assert!(resolve_http_scope(&reg, None, None, false).is_none());
         // A client scoped to a non-empty profile resolves to a (possibly empty)
         // allow-set; exact membership is covered by enabled_servers_for tests.
         reg.http_clients.push(registry::HttpClient {
@@ -6640,9 +6738,16 @@ mod tests {
             profile: "Default".into(),
         });
         assert!(matches!(
-            resolve_http_scope(&reg, None, Some("scopedtok")),
+            resolve_http_scope(&reg, None, Some("scopedtok"), false),
             Some(Some(_))
         ));
+
+        // Removing the last registered client while the gateway is live must not
+        // turn an authenticated listener into an open one. Only immutable startup
+        // policy from `--insecure-loopback` enables the fallback.
+        reg.http_clients.clear();
+        assert!(resolve_http_scope(&reg, None, None, false).is_none());
+        assert_eq!(resolve_http_scope(&reg, None, None, true), Some(None));
     }
 
     #[test]
@@ -6689,8 +6794,8 @@ mod tests {
             profile: String::new(),
         });
 
-        let (_, first) = resolve_http_caller(&reg, None, Some("tok1")).unwrap();
-        let (_, second) = resolve_http_caller(&reg, None, Some("tok2")).unwrap();
+        let (_, first) = resolve_http_caller(&reg, None, Some("tok1"), false).unwrap();
+        let (_, second) = resolve_http_caller(&reg, None, Some("tok2"), false).unwrap();
         assert_eq!(first.audit_label.as_deref(), Some("Open WebUI"));
         assert_eq!(second.audit_label.as_deref(), Some("Open WebUI"));
         assert_ne!(


### PR DESCRIPTION
## Summary

- require HTTP authentication on loopback as well as non-loopback binds
- allow unauthenticated local development only with the explicit `--insecure-loopback` flag
- keep that startup policy immutable so removing registered clients cannot make a live listener fail open
- update headless/Open WebUI docs and smoke coverage

## Impact

The desktop integration already supplies `CONDUIT_HTTP_TOKEN`, so normal app users are unaffected. Manual HTTP startup now needs a token, a registered HTTP client, or the explicit loopback-only escape hatch.

## Validation

- `scripts/test-rust-windows.ps1` (364 library + 99 gateway tests)
- `scripts/smoke-headless.ps1` (startup refusal, insecure-loopback escape hatch, bearer auth, MCP handshake, approval broker fail-closed)
- focused loopback/auth policy tests
- targeted Prettier check and PowerShell parser check

Linear: SOU-25