### PR TITLE
Protect Teams server updates from stale writes

### DIFF
--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -1875,13 +1875,28 @@ fn team_disconnect(state: State<RegistryState>) -> Result<Registry, String> {
     Ok(fresh)
 }
 
-/// Admin: push the current local server set as the team's shared config (own servers
-/// only, secret values never sent). Returns the new config version.
+/// Admin: replace only the team's shared server list with the current local set (own servers
+/// only, secret values never sent). Remote instructions and policy fields are preserved, and
+/// an optimistic-concurrency conflict is returned rather than overwriting another admin.
 #[tauri::command]
-async fn team_push(state: State<'_, RegistryState>) -> Result<i64, String> {
+async fn team_push_preview(state: State<'_, RegistryState>) -> Result<teams::PushPreview, String> {
     refresh_from_disk(state.inner())?;
-    // push_current does a blocking PUT to the team server; keep it off the main thread.
-    tauri::async_runtime::spawn_blocking(teams::push_current)
+    tauri::async_runtime::spawn_blocking(teams::preview_push_current)
+        .await
+        .map_err(|e| format!("push preview task join failed: {e}"))?
+}
+
+#[tauri::command]
+async fn team_push(
+    state: State<'_, RegistryState>,
+    base_version: i64,
+    local_fingerprint: String,
+) -> Result<i64, String> {
+    refresh_from_disk(state.inner())?;
+    // push_current does a blocking GET + PUT to the team server; keep it off the main thread.
+    tauri::async_runtime::spawn_blocking(move || {
+        teams::push_current(base_version, &local_fingerprint)
+    })
         .await
         .map_err(|e| format!("push task join failed: {e}"))?
 }
@@ -2774,6 +2789,7 @@ pub fn run() {
             team_sync,
             team_sync_wait,
             team_disconnect,
+            team_push_preview,
             team_push,
             set_auth_token,
             clear_auth_token,

--- a/src-tauri/src/teams.rs
+++ b/src-tauri/src/teams.rs
@@ -270,16 +270,173 @@ pub fn fetch_me(server_url: &str, team_id: &str, token: &str) -> Result<Membersh
     }
 }
 
-/// Admin push of the team config. Returns the new version.
-pub fn push_config(server_url: &str, team_id: &str, token: &str, config: &Value) -> Result<i64, String> {
+/// A dashboard edit that lands between the preflight GET and PUT must never be overwritten.
+/// Keep this message stable and actionable: it is surfaced directly in the Teams UI.
+const STALE_PUSH_MESSAGE: &str =
+    "The team config changed before this update could be saved. Sync to review the latest settings, then try again; nothing was overwritten.";
+
+/// Fetch the complete current config before an admin replaces its server list. Unlike the
+/// sync pull, this request is intentionally unconditional: the caller needs the full object so
+/// instructions, policies, and future top-level fields can be round-tripped unchanged.
+fn fetch_config_for_update(
+    server_url: &str,
+    team_id: &str,
+    token: &str,
+) -> Result<(i64, Value), String> {
     require_secure_team_url(server_url)?;
     let url = format!("{}/teams/{}/config", base(server_url), team_id);
-    let body = serde_json::json!({ "config": config });
-    let resp = agent()
+    match agent()
+        .get(&url)
+        .set("authorization", &format!("Bearer {token}"))
+        .call()
+    {
+        Ok(resp) => {
+            let v: Value = resp.into_json().map_err(|e| e.to_string())?;
+            let version = v["version"]
+                .as_i64()
+                .ok_or("team server returned a config without a version")?;
+            let config = v.get("config").cloned().unwrap_or(Value::Null);
+            if !config.is_object()
+                || !config.get("servers").map(Value::is_array).unwrap_or(false)
+            {
+                return Err("team server returned a config without a server list".into());
+            }
+            Ok((version, config))
+        }
+        // Older self-hosted servers can have no config row until the first push. Version zero
+        // is the optimistic-concurrency baseline used by current servers for that empty state.
+        Err(ureq::Error::Status(404, _)) => Ok((0, json!({ "servers": [] }))),
+        Err(e) => Err(stringify(e)),
+    }
+}
+
+/// Replace only `servers` in a fetched config, preserving every other current and future field.
+fn replace_server_set(mut config: Value, servers: Value) -> Result<Value, String> {
+    if !servers.is_array() {
+        return Err("local team export did not contain a server list".into());
+    }
+    let object = config
+        .as_object_mut()
+        .ok_or("team server returned a config that was not an object")?;
+    object.insert("servers".to_string(), servers);
+    Ok(config)
+}
+
+fn push_body(config: &Value, base_version: i64) -> Value {
+    json!({ "config": config, "base_version": base_version })
+}
+
+fn push_status_message(status: u16) -> Option<&'static str> {
+    (status == 409).then_some(STALE_PUSH_MESSAGE)
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PushPreview {
+    pub base_version: i64,
+    pub local_fingerprint: String,
+    pub added: Vec<String>,
+    pub changed: Vec<String>,
+    pub removed: Vec<String>,
+}
+
+fn server_index(servers: &Value) -> Result<BTreeMap<String, &Value>, String> {
+    let list = servers
+        .as_array()
+        .ok_or("team server list was not an array")?;
+    let mut indexed = BTreeMap::new();
+    for server in list {
+        let id = server
+            .get("id")
+            .and_then(Value::as_str)
+            .filter(|id| !id.trim().is_empty())
+            .ok_or("team server entry had no id")?
+            .to_string();
+        if indexed.insert(id.clone(), server).is_some() {
+            return Err(format!("team server list contained duplicate id '{id}'"));
+        }
+    }
+    Ok(indexed)
+}
+
+fn preview_name(server: &Value, id: &str) -> String {
+    server
+        .get("name")
+        .and_then(Value::as_str)
+        .filter(|name| !name.trim().is_empty())
+        .unwrap_or(id)
+        .to_string()
+}
+
+fn sort_preview_names(names: &mut [String]) {
+    names.sort_by(|a, b| {
+        a.to_ascii_lowercase()
+            .cmp(&b.to_ascii_lowercase())
+            .then_with(|| a.cmp(b))
+    });
+}
+
+fn build_push_preview(
+    base_version: i64,
+    remote_servers: &Value,
+    local_servers: &Value,
+) -> Result<PushPreview, String> {
+    let remote = server_index(remote_servers)?;
+    let local = server_index(local_servers)?;
+    let mut added = Vec::new();
+    let mut changed = Vec::new();
+    let mut removed = Vec::new();
+
+    for (id, server) in &local {
+        match remote.get(id) {
+            None => added.push(preview_name(server, id)),
+            Some(previous) if *previous != *server => changed.push(preview_name(server, id)),
+            Some(_) => {}
+        }
+    }
+    for (id, server) in &remote {
+        if !local.contains_key(id) {
+            removed.push(preview_name(server, id));
+        }
+    }
+    sort_preview_names(&mut added);
+    sort_preview_names(&mut changed);
+    sort_preview_names(&mut removed);
+
+    Ok(PushPreview {
+        base_version,
+        local_fingerprint: crate::audit::args_hash(local_servers),
+        added,
+        changed,
+        removed,
+    })
+}
+
+/// Admin push of a servers-only config update. Returns the new version.
+pub fn push_config(
+    server_url: &str,
+    team_id: &str,
+    token: &str,
+    config: &Value,
+    base_version: i64,
+) -> Result<i64, String> {
+    require_secure_team_url(server_url)?;
+    let url = format!("{}/teams/{}/config", base(server_url), team_id);
+    let body = push_body(config, base_version);
+    let resp = match agent()
         .put(&url)
         .set("authorization", &format!("Bearer {token}"))
         .send_json(body)
-        .map_err(stringify)?;
+    {
+        Ok(resp) => resp,
+        Err(e @ ureq::Error::Status(status, _)) => {
+            if let Some(message) = push_status_message(status) {
+                return Err(message.into());
+            }
+            return Err(stringify(e));
+        }
+        Err(e) => return Err(stringify(e)),
+    };
     let v: Value = resp.into_json().map_err(|e| e.to_string())?;
     v["version"]
         .as_i64()
@@ -619,23 +776,60 @@ pub fn disconnect() -> Result<(), String> {
     Ok(())
 }
 
-/// Admin: push the current local server set as the team config. The user's own servers
-/// only (team-sourced ones are excluded), secret values never sent. Returns the version.
-pub fn push_current() -> Result<i64, String> {
+/// Admin: preview replacing the remote config's server list with the current local server set.
+/// The returned version and fingerprint bind the later confirmation to exactly what was shown.
+pub fn preview_push_current() -> Result<PushPreview, String> {
     let reg = crate::registry::load()?;
     let conn = reg.team.clone().ok_or("not connected to a team")?;
     if conn.role != "admin" {
         return Err("only a team admin can push the shared config".into());
     }
     let token = load_token().ok_or("team token is missing from the keychain")?;
-    let cfg = team_export(&reg);
-    push_config(&conn.server_url, &conn.team_id, &token, &cfg)
+    let local_servers = team_server_export(&reg);
+    let (base_version, remote_config) =
+        fetch_config_for_update(&conn.server_url, &conn.team_id, &token)?;
+    build_push_preview(
+        base_version,
+        remote_config
+            .get("servers")
+            .ok_or("team server returned a config without a server list")?,
+        &local_servers,
+    )
 }
 
-/// Build the config an admin pushes: the user's own servers (not team-sourced), with
-/// env keys but no secret values, plus the destructive-tool policy flag and the
-/// org screening policy.
-fn team_export(reg: &Registry) -> Value {
+/// Admin: replace only the remote config's server list with the current local server set.
+/// The user's own servers only (team-sourced ones are excluded), secret values never sent.
+/// Every other remote field is retained and the fetched version protects against stale writes.
+pub fn push_current(
+    expected_base_version: i64,
+    expected_local_fingerprint: &str,
+) -> Result<i64, String> {
+    let reg = crate::registry::load()?;
+    let conn = reg.team.clone().ok_or("not connected to a team")?;
+    if conn.role != "admin" {
+        return Err("only a team admin can push the shared config".into());
+    }
+    let token = load_token().ok_or("team token is missing from the keychain")?;
+    let servers = team_server_export(&reg);
+    if crate::audit::args_hash(&servers) != expected_local_fingerprint {
+        return Err(
+            "Your local server set changed after the preview. Review the update again before saving."
+                .into(),
+        );
+    }
+    let (base_version, remote_config) =
+        fetch_config_for_update(&conn.server_url, &conn.team_id, &token)?;
+    if base_version != expected_base_version {
+        return Err(STALE_PUSH_MESSAGE.into());
+    }
+    let cfg = replace_server_set(remote_config, servers)?;
+    push_config(&conn.server_url, &conn.team_id, &token, &cfg, base_version)
+}
+
+/// Build the server list an admin pushes: the user's own servers (not team-sourced), with
+/// env keys but no secret values. Governance lives on the server and is retained from the
+/// preflight GET rather than inferred from one admin's local safety preferences.
+fn team_server_export(reg: &Registry) -> Value {
     let servers: Vec<Value> = reg
         .servers
         .iter()
@@ -676,20 +870,7 @@ fn team_export(reg: &Registry) -> Value {
             })
         })
         .collect();
-    serde_json::json!({
-        "servers": servers,
-        "denyDestructive": reg.deny_destructive,
-        // Org screening policy. Emitted on every push so a desktop push never silently
-        // wipes a dashboard-set policy. Each flag is tighten-only on the member side:
-        // `true` forces the corresponding local safety toggle on, `false`/absent is a
-        // no-op that can never turn a member's toggle off. Shape is intentionally
-        // extensible (e.g. a future `sensitivity` field) without a breaking change.
-        "screeningPolicy": {
-            "forceContentDefense": reg.content_defense,
-            "forceQuarantineOnDrift": reg.quarantine_on_drift,
-            "forceHumanApproval": reg.human_approval,
-        },
-    })
+    Value::Array(servers)
 }
 
 // --- merge (pure, testable) ---
@@ -1317,22 +1498,85 @@ mod tests {
     }
 
     #[test]
-    fn team_export_round_trips_screening_policy() {
-        // The pushed config must carry the policy so a desktop push never wipes it, and
-        // it must reflect the admin's own toggles.
-        let mut r = base_registry();
-        r.content_defense = true;
-        r.quarantine_on_drift = true;
-        r.human_approval = true;
-        let cfg = team_export(&r);
-        let sp = cfg.get("screeningPolicy").expect("policy is emitted");
-        assert_eq!(sp.get("forceContentDefense").and_then(Value::as_bool), Some(true));
-        assert_eq!(sp.get("forceQuarantineOnDrift").and_then(Value::as_bool), Some(true));
-        assert_eq!(sp.get("forceHumanApproval").and_then(Value::as_bool), Some(true));
+    fn replacing_servers_preserves_instructions_policies_and_unknown_fields() {
+        let remote = json!({
+            "servers": [{ "id": "old" }],
+            "instructions": "Use the approved issue workflow.",
+            "denyDestructive": true,
+            "screeningPolicy": { "forceHumanApproval": true },
+            "futureControl": { "mode": "strict", "revision": 7 }
+        });
+        let new_servers = json!([{ "id": "new" }]);
+
+        let updated = replace_server_set(remote.clone(), new_servers.clone()).unwrap();
+
+        assert_eq!(updated["servers"], new_servers);
+        for key in [
+            "instructions",
+            "denyDestructive",
+            "screeningPolicy",
+            "futureControl",
+        ] {
+            assert_eq!(
+                updated[key], remote[key],
+                "{key} must be round-tripped unchanged"
+            );
+        }
     }
 
     #[test]
-    fn team_export_excludes_gateway_and_team_servers() {
+    fn push_payload_binds_the_fetched_base_version() {
+        let config = json!({ "servers": [], "instructions": "keep me" });
+        let body = push_body(&config, 42);
+        assert_eq!(body["base_version"], 42);
+        assert_eq!(body["config"], config);
+    }
+
+    #[test]
+    fn push_preview_reports_sorted_added_changed_and_removed_names() {
+        let remote = json!([
+            { "id": "remove-z", "name": "Zulu", "transport": "http" },
+            { "id": "same", "name": "Same", "transport": "http" },
+            { "id": "change", "name": "Old label", "transport": "http" }
+        ]);
+        let local = json!([
+            { "id": "new-b", "name": "beta", "transport": "http" },
+            { "id": "change", "name": "Changed", "transport": "stdio" },
+            { "id": "same", "name": "Same", "transport": "http" },
+            { "id": "new-a", "name": "Alpha", "transport": "http" }
+        ]);
+
+        let preview = build_push_preview(7, &remote, &local).unwrap();
+
+        assert_eq!(preview.base_version, 7);
+        assert_eq!(preview.added, vec!["Alpha", "beta"]);
+        assert_eq!(preview.changed, vec!["Changed"]);
+        assert_eq!(preview.removed, vec!["Zulu"]);
+        assert_eq!(preview.local_fingerprint, crate::audit::args_hash(&local));
+    }
+
+    #[test]
+    fn push_preview_rejects_ambiguous_duplicate_ids() {
+        let duplicated = json!([
+            { "id": "same", "name": "One" },
+            { "id": "same", "name": "Two" }
+        ]);
+        let err = build_push_preview(1, &json!([]), &duplicated).unwrap_err();
+        assert!(err.contains("duplicate id 'same'"));
+    }
+
+    #[test]
+    fn stale_push_status_is_actionable_and_other_errors_fall_through() {
+        let message = push_status_message(409).expect("409 must be recognized as stale");
+        assert!(message.contains("changed"));
+        assert!(message.contains("Sync"));
+        assert!(message.contains("nothing was overwritten"));
+        assert_eq!(push_status_message(401), None);
+        assert_eq!(push_status_message(500), None);
+    }
+
+    #[test]
+    fn team_server_export_excludes_gateway_and_team_servers() {
         let mut r = base_registry(); // has "mine" (manual)
         // Toolport's own gateway entry: infra, must never be pushed to the team.
         r.servers.push(ServerEntry {
@@ -1362,8 +1606,8 @@ mod tests {
             cwd: None,
             unknown_fields: serde_json::Map::new(),
         });
-        let cfg = team_export(&r);
-        let ids: Vec<&str> = cfg["servers"]
+        let servers = team_server_export(&r);
+        let ids: Vec<&str> = servers
             .as_array()
             .unwrap()
             .iter()

--- a/src/components/TeamsView.test.tsx
+++ b/src/components/TeamsView.test.tsx
@@ -1,0 +1,97 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { Registry } from "@/lib/types";
+
+const api = vi.hoisted(() => ({
+  teamConnect: vi.fn(),
+  teamJoinPoll: vi.fn(),
+  teamSync: vi.fn(),
+  teamDisconnect: vi.fn(),
+  teamPushPreview: vi.fn(),
+  teamPush: vi.fn(),
+  setServerEnabled: vi.fn(),
+}));
+
+vi.mock("@/lib/api", () => api);
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: vi.fn().mockResolvedValue(vi.fn()),
+}));
+
+import { TeamsView } from "./TeamsView";
+
+const registry: Registry = {
+  version: 1,
+  servers: [],
+  profiles: [{ id: "default", name: "Default", enabledServerIds: [] }],
+  activeProfileId: "default",
+  team: {
+    serverUrl: "https://teams.toolport.app",
+    teamId: "team-1",
+    role: "admin",
+    lastVersion: 6,
+  },
+};
+
+describe("TeamsView shared-server update", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows a deterministic diff and does not push until the admin confirms", async () => {
+    const preview = {
+      baseVersion: 7,
+      localFingerprint: "preview-fingerprint",
+      added: ["Alpha", "beta"],
+      changed: ["GitHub"],
+      removed: ["Legacy"],
+    };
+    api.teamPushPreview.mockResolvedValue(preview);
+    api.teamPush.mockResolvedValue(8);
+
+    render(<TeamsView registry={registry} onRegistryChange={vi.fn()} />);
+    await userEvent.click(screen.getByRole("button", { name: "Update shared servers" }));
+
+    expect(await screen.findByText("Added (2)")).toBeInTheDocument();
+    expect(screen.getByText("Changed (1)")).toBeInTheDocument();
+    expect(screen.getByText("Removed (1)")).toBeInTheDocument();
+    for (const name of ["Alpha", "beta", "GitHub", "Legacy"]) {
+      expect(screen.getByText(name)).toBeInTheDocument();
+    }
+    expect(api.teamPush).not.toHaveBeenCalled();
+
+    await userEvent.click(screen.getByRole("button", { name: "Replace shared servers" }));
+    await waitFor(() => expect(api.teamPush).toHaveBeenCalledWith(preview));
+    expect(await screen.findByText(/now version 8/i)).toBeInTheDocument();
+  });
+
+  it("discards a stale confirmation and requires a fresh preview", async () => {
+    const preview = {
+      baseVersion: 7,
+      localFingerprint: "preview-fingerprint",
+      added: [],
+      changed: ["GitHub"],
+      removed: [],
+    };
+    api.teamPushPreview.mockResolvedValue(preview);
+    api.teamPush.mockRejectedValue(
+      new Error("The team config changed; nothing was overwritten."),
+    );
+
+    render(<TeamsView registry={registry} onRegistryChange={vi.fn()} />);
+    await userEvent.click(screen.getByRole("button", { name: "Update shared servers" }));
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Replace shared servers" }),
+    );
+
+    expect(
+      await screen.findByText(/team config changed; nothing was overwritten/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Replace shared servers" }),
+    ).not.toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: "Update shared servers" }));
+    await waitFor(() => expect(api.teamPushPreview).toHaveBeenCalledTimes(2));
+  });
+});

--- a/src/components/TeamsView.tsx
+++ b/src/components/TeamsView.tsx
@@ -20,11 +20,13 @@ import {
   teamJoinPoll,
   teamSync,
   teamDisconnect,
+  teamPushPreview,
   teamPush,
   setServerEnabled,
 } from "@/lib/api";
 import { teamUrlError } from "@/lib/teamUrl";
 import { isEnabled, activeProfile } from "@/lib/types";
+import type { TeamPushPreview } from "@/lib/api";
 import type { Registry } from "@/lib/types";
 
 /** The hosted Toolport Teams instance, prefilled as the default. Self-hosters replace
@@ -57,6 +59,7 @@ export function TeamsView({
   const [error, setError] = useState<string | null>(null);
   const [notice, setNotice] = useState<string | null>(null);
   const [skipNote, setSkipNote] = useState<string | null>(null);
+  const [pushPreview, setPushPreview] = useState<TeamPushPreview | null>(null);
   // Set while an approval-gated join waits for an admin. Holds the connect inputs so a poll
   // uses the values from when the request was made, not whatever the fields say later.
   const [pending, setPending] = useState<{
@@ -180,10 +183,17 @@ export function TeamsView({
       setNotice("Left the team. Its servers were removed; your own are untouched.");
     });
 
+  const onPreviewPush = () =>
+    run("preview-push", async () => {
+      setPushPreview(await teamPushPreview());
+    });
+
   const onPush = () =>
     run("push", async () => {
-      const v = await teamPush();
-      setNotice(`Pushed your server set to the team (now version ${v}).`);
+      if (!pushPreview) throw new Error("Review the shared-server update before saving.");
+      const v = await teamPush(pushPreview);
+      setPushPreview(null);
+      setNotice(`Updated the team's shared servers (now version ${v}).`);
     });
 
   // Member consent: enable a review server (local command / LAN URL) into the active
@@ -435,14 +445,61 @@ export function TeamsView({
                     <ShieldCheck className="size-3.5 text-success" /> Admin
                   </div>
                   <p className="text-xs text-muted-foreground">
-                    Push your current server set to the team. Secret values are never
+                    Replace the team's shared servers with your current server set. Team
+                    instructions and security policies are preserved; secrets are never
                     sent.
                   </p>
                 </div>
-                <Button size="sm" onClick={onPush} disabled={busy !== null}>
+                <Button size="sm" onClick={onPreviewPush} disabled={busy !== null}>
                   <Upload className="size-3.5" />
-                  {busy === "push" ? "Pushing…" : "Push my setup"}
+                  {busy === "preview-push" ? "Comparing…" : "Update shared servers"}
                 </Button>
+                <ConfirmDialog
+                  open={pushPreview !== null}
+                  onOpenChange={(open) => {
+                    if (!open) setPushPreview(null);
+                  }}
+                  title="Replace the team's shared servers?"
+                  description={
+                    pushPreview && (
+                      <div className="grid gap-3 text-left">
+                        <p>
+                          Only the shared server list changes. Team instructions, security
+                          policies, and other settings stay unchanged.
+                        </p>
+                        {(
+                          [
+                            ["Added", pushPreview.added],
+                            ["Changed", pushPreview.changed],
+                            ["Removed", pushPreview.removed],
+                          ] as const
+                        ).map(([label, names]) => (
+                          <div key={label}>
+                            <div className="font-medium text-foreground">
+                              {label} ({names.length})
+                            </div>
+                            {names.length > 0 ? (
+                              <ul className="mt-1 max-h-24 list-disc overflow-y-auto pl-5">
+                                {names.map((name, index) => (
+                                  <li key={`${label}-${name}-${index}`}>{name}</li>
+                                ))}
+                              </ul>
+                            ) : (
+                              <div className="mt-1">None</div>
+                            )}
+                          </div>
+                        ))}
+                        <p>
+                          If the team or your local servers change before saving, Toolport
+                          will stop and ask you to review again instead of overwriting
+                          anything.
+                        </p>
+                      </div>
+                    )
+                  }
+                  confirmLabel="Replace shared servers"
+                  onConfirm={onPush}
+                />
               </div>
             )}
           </div>

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -404,9 +404,25 @@ export function teamDisconnect(): Promise<Registry> {
   return invoke<Registry>("team_disconnect");
 }
 
-/** Admin: push the current local server set as the team's shared config; returns version. */
-export function teamPush(): Promise<number> {
-  return invoke<number>("team_push");
+export interface TeamPushPreview {
+  baseVersion: number;
+  localFingerprint: string;
+  added: string[];
+  changed: string[];
+  removed: string[];
+}
+
+/** Admin: compare the local server export with the team's current shared server list. */
+export function teamPushPreview(): Promise<TeamPushPreview> {
+  return invoke<TeamPushPreview>("team_push_preview");
+}
+
+/** Admin: apply an explicitly previewed shared-server replacement; returns version. */
+export function teamPush(preview: TeamPushPreview): Promise<number> {
+  return invoke<number>("team_push", {
+    baseVersion: preview.baseVersion,
+    localFingerprint: preview.localFingerprint,
+  });
 }
 
 /** Probe every supported MCP client and read its current server configuration. */


### PR DESCRIPTION
## Summary

- replace only the shared server list so dashboard instructions, policies, and future config fields are preserved
- bind confirmation to the reviewed remote version and exact local server export
- reject concurrent remote or local changes and require a fresh preview
- show admins deterministic added, changed, and removed server lists before saving

Linear: SOU-129

## Validation

- `npm test` (94 passed)
- `npm run build`
- `npm run lint` (0 errors; existing warnings only)
- `scripts/test-rust-windows.ps1` (368 library + 104 gateway tests passed)
- `cargo clippy --manifest-path src-tauri/Cargo.toml --lib --tests` (existing warnings only)
- `git diff --check`