### PR TITLE
Persist OAuth expiry and refresh proactively

### DIFF
--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -1945,8 +1945,10 @@ fn set_auth_token(
 
 #[tauri::command]
 fn clear_auth_token(state: State<RegistryState>, server_id: String) -> Result<(), String> {
-    secrets::delete_secret(&server_id, secrets::HTTP_AUTH_KEY)?;
+    // Remove refresh metadata first so a second-write failure cannot leave state
+    // that silently recreates the bearer token the user asked to delete.
     remote::clear_oauth_state(&server_id)?;
+    secrets::delete_secret(&server_id, secrets::HTTP_AUTH_KEY)?;
     bump_secrets_generation(state.inner());
     Ok(())
 }

--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -1935,6 +1935,9 @@ fn set_auth_token(
     server_id: String,
     token: String,
 ) -> Result<(), String> {
+    // A manually pasted bearer replaces any prior OAuth session. Keeping stale
+    // refresh metadata could otherwise overwrite the user's token later.
+    remote::clear_oauth_state(&server_id)?;
     secrets::set_secret(&server_id, secrets::HTTP_AUTH_KEY, &token)?;
     bump_secrets_generation(state.inner());
     Ok(())
@@ -1943,6 +1946,7 @@ fn set_auth_token(
 #[tauri::command]
 fn clear_auth_token(state: State<RegistryState>, server_id: String) -> Result<(), String> {
     secrets::delete_secret(&server_id, secrets::HTTP_AUTH_KEY)?;
+    remote::clear_oauth_state(&server_id)?;
     bump_secrets_generation(state.inner());
     Ok(())
 }
@@ -1985,6 +1989,8 @@ async fn authenticate_oauth(
         &res.client_id,
         res.refresh_token,
         Some(resource),
+        res.issued_at,
+        res.expires_at,
     )?;
     bump_secrets_generation(state.inner());
     Ok(())

--- a/src-tauri/src/downstream.rs
+++ b/src-tauri/src/downstream.rs
@@ -1536,8 +1536,8 @@ fn ids_match(got: Option<&Value>, wanted: Option<&Value>) -> bool {
 
 /// A callback that can proactively mint a fresh token before expiry or force a
 /// refresh after a 401/403. `force = false` returns `Ok(None)` when the current
-/// token is still fresh. Errors are surfaced as a per-server authentication
-/// failure instead of sending a request with a token known to be expired.
+/// token is still fresh. A proactive error may fall back to the current token;
+/// a forced error is surfaced as a per-server authentication failure.
 pub type RefreshFn = Box<dyn Fn(bool) -> Result<Option<String>, String> + Send + Sync>;
 
 /// Screen resolved socket addresses against the SSRF policy, fail-closed: returns
@@ -1611,11 +1611,10 @@ pub struct HttpTransport {
     next_id: i64,
     /// Raw bearer token (without the "Bearer " prefix), if the server needs auth.
     auth: Option<String>,
-    /// Called once on a 401/403 to mint a fresh token (an OAuth refresh). Returns
-    /// the new raw token; the request is then retried with it. `None` = no refresh
-    /// available, so an auth failure surfaces as before. This is what lets a long-
-    /// running gateway recover from a short-lived access token expiring mid-session
-    /// instead of 401ing until the server is manually reconnected.
+    /// Called before each POST to refresh a token nearing expiry, and forced once
+    /// after a 401/403 to recover from an already-expired token. A proactive
+    /// `None` or error keeps the current token; a forced refresh must return a new
+    /// raw token or the authentication failure is surfaced.
     refresh: Option<RefreshFn>,
     server_handler: Option<ServerRequestHandler>,
 }
@@ -1680,24 +1679,64 @@ impl HttpTransport {
         Ok(true)
     }
 
+    /// Try to replace a token nearing expiry. Failure here is non-fatal because
+    /// the current token may remain valid throughout the safety window; a real
+    /// 401/403 will force one refresh attempt below.
+    fn refresh_before_send(&mut self) {
+        if let Some(refresh) = &self.refresh {
+            if let Ok(Some(token)) = refresh(false) {
+                self.auth = Some(token);
+            }
+        }
+    }
+
+    fn force_refresh_after_auth_error(&mut self, code: u16) -> Result<(), TransportError> {
+        match self.refresh.as_ref().expect("refresh callback checked")(true) {
+            Ok(Some(token)) => {
+                self.auth = Some(token);
+                Ok(())
+            }
+            Ok(None) => Err(TransportError::Fatal(format!(
+                "HTTP {code} (needs authentication): token refresh returned no token"
+            ))),
+            Err(e) => Err(TransportError::Fatal(format!(
+                "HTTP {code} (needs authentication): token refresh failed: {e}"
+            ))),
+        }
+    }
+
     /// POST JSON-RPC without waiting for a response body (inline replies mid-SSE).
     fn send_post_no_response(&mut self, body: &Value) -> Result<(), TransportError> {
         let payload = body.to_string();
-        let mut req = self
-            .inline_agent
-            .post(&self.url)
-            .set("Content-Type", "application/json")
-            .set("Accept", "application/json, text/event-stream")
-            .set("MCP-Protocol-Version", PROTOCOL_VERSION);
-        if let Some(sid) = &self.session_id {
-            req = req.set("Mcp-Session-Id", sid);
-        }
-        if let Some(token) = &self.auth {
-            req = req.set("Authorization", &bearer_header(token));
-        }
-        let resp = req
-            .send_string(&payload)
-            .map_err(|e| TransportError::Fatal(e.to_string()))?;
+        self.refresh_before_send();
+        let mut refreshed = false;
+        let resp = loop {
+            let mut req = self
+                .inline_agent
+                .post(&self.url)
+                .set("Content-Type", "application/json")
+                .set("Accept", "application/json, text/event-stream")
+                .set("MCP-Protocol-Version", PROTOCOL_VERSION);
+            if let Some(sid) = &self.session_id {
+                req = req.set("Mcp-Session-Id", sid);
+            }
+            if let Some(token) = &self.auth {
+                req = req.set("Authorization", &bearer_header(token));
+            }
+            match req.send_string(&payload) {
+                Ok(resp) => break resp,
+                Err(ureq::Error::Status(code, resp))
+                    if (code == 401 || code == 403)
+                        && !refreshed
+                        && self.refresh.is_some() =>
+                {
+                    let _ = read_capped(resp, 8 * 1024);
+                    refreshed = true;
+                    self.force_refresh_after_auth_error(code)?;
+                }
+                Err(e) => return Err(TransportError::Fatal(e.to_string())),
+            }
+        };
         if let Some(sid) = resp.header("Mcp-Session-Id") {
             self.session_id = Some(sid.to_string());
         }
@@ -1760,17 +1799,7 @@ impl HttpTransport {
         // Refresh shortly before the known expiry, including before initialize.
         // The callback keeps the deadline in memory, so this is a cheap no-op on
         // ordinary calls and only touches vaulted OAuth state when refresh is due.
-        if let Some(refresh) = &self.refresh {
-            match refresh(false) {
-                Ok(Some(token)) => self.auth = Some(token),
-                Ok(None) => {}
-                Err(e) => {
-                    return Err(TransportError::Fatal(format!(
-                        "needs authentication: proactive token refresh failed: {e}"
-                    )))
-                }
-            }
-        }
+        self.refresh_before_send();
 
         // Token refresh is handled internally (it doesn't sleep, so no lock
         // contention). Only 429 and transport-retry signals bubble up as
@@ -1810,22 +1839,8 @@ impl HttpTransport {
                 {
                     let _ = read_capped(r, 8 * 1024);
                     refreshed = true;
-                    match self.refresh.as_ref().expect("refresh callback checked")(true) {
-                        Ok(Some(tok)) => {
-                            self.auth = Some(tok);
-                            continue;
-                        }
-                        Ok(None) => {
-                            return Err(TransportError::Fatal(format!(
-                                "HTTP {code} (needs authentication): token refresh returned no token"
-                            )))
-                        }
-                        Err(e) => {
-                            return Err(TransportError::Fatal(format!(
-                                "HTTP {code} (needs authentication): token refresh failed: {e}"
-                            )))
-                        }
-                    }
+                    self.force_refresh_after_auth_error(code)?;
+                    continue;
                 }
                 Err(ureq::Error::Status(code, r)) => {
                     let detail: String = read_capped(r, 64 * 1024).chars().take(200).collect();
@@ -2269,10 +2284,11 @@ mod tests {
 
     #[test]
     fn http_sse_answers_inline_server_request_before_final_response() {
-        use super::{HttpTransport, ServerRequestHandler, Transport};
+        use super::{HttpTransport, RefreshFn, ServerRequestHandler, Transport};
         use serde_json::Value;
         use std::io::{Read, Write};
         use std::net::TcpListener;
+        use std::sync::atomic::{AtomicUsize, Ordering};
         use std::sync::Arc;
 
         let listener = TcpListener::bind("127.0.0.1:0").unwrap();
@@ -2301,6 +2317,9 @@ mod tests {
 
             let mut inline = listener.accept().unwrap().0;
             let inline_headers = read_http_headers(&mut inline);
+            assert!(String::from_utf8_lossy(&inline_headers)
+                .to_ascii_lowercase()
+                .contains("authorization: bearer fresh"));
             let mut body = String::new();
             if let Some(len) = content_length(&inline_headers) {
                 let mut raw = vec![0u8; len];
@@ -2359,7 +2378,18 @@ mod tests {
             }
         });
         let url = format!("http://127.0.0.1:{port}/");
-        let mut t = HttpTransport::new(&url);
+        let refresh_calls = Arc::new(AtomicUsize::new(0));
+        let calls = Arc::clone(&refresh_calls);
+        let refresh: Option<RefreshFn> = Some(Box::new(move |force| {
+            assert!(!force);
+            if calls.fetch_add(1, Ordering::SeqCst) == 1 {
+                Ok(Some("fresh".to_string()))
+            } else {
+                Ok(None)
+            }
+        }));
+        let mut t =
+            HttpTransport::with_auth_refresh(&url, Some("stale".to_string()), refresh);
         t.set_server_request_handler(handler);
         let result = t
             .post(
@@ -2368,6 +2398,7 @@ mod tests {
             )
             .expect("inline reply should unblock the SSE stream");
         server_handle.join().unwrap();
+        assert_eq!(refresh_calls.load(Ordering::SeqCst), 2);
         assert_eq!(
             result
                 .and_then(|v| v.get("result").cloned())
@@ -2927,6 +2958,104 @@ mod tests {
         assert!(result.is_some());
         assert_eq!(refresh_calls.load(Ordering::SeqCst), 1);
         assert_eq!(*seen_auth.lock().unwrap(), "Bearer fresh");
+    }
+
+    #[test]
+    fn post_uses_current_token_when_proactive_refresh_fails() {
+        use super::{HttpTransport, RefreshFn};
+        use std::sync::{Arc, Mutex};
+
+        let server = tiny_http::Server::http("127.0.0.1:0").unwrap();
+        let port = server.server_addr().to_ip().unwrap().port();
+        let seen_auth = Arc::new(Mutex::new(String::new()));
+        let captured = Arc::clone(&seen_auth);
+        let handle = std::thread::spawn(move || {
+            let req = server.recv().unwrap();
+            *captured.lock().unwrap() = req
+                .headers()
+                .iter()
+                .find(|h| h.field.equiv("Authorization"))
+                .map(|h| h.value.as_str().to_string())
+                .unwrap_or_default();
+            let ct =
+                tiny_http::Header::from_bytes(&b"Content-Type"[..], &b"application/json"[..])
+                    .unwrap();
+            let body = r#"{"jsonrpc":"2.0","id":1,"result":{"ok":true}}"#;
+            let _ = req.respond(tiny_http::Response::from_string(body).with_header(ct));
+        });
+
+        let refresh: Option<RefreshFn> = Some(Box::new(|force| {
+            assert!(!force);
+            Err("temporary OAuth endpoint failure".to_string())
+        }));
+        let url = format!("http://127.0.0.1:{port}/");
+        let mut transport =
+            HttpTransport::with_auth_refresh(&url, Some("still-valid".to_string()), refresh);
+
+        let result = transport.post(
+            &serde_json::json!({ "jsonrpc": "2.0", "id": 1, "method": "ping" }),
+            true,
+        );
+        handle.join().unwrap();
+
+        assert!(result.is_ok());
+        assert_eq!(*seen_auth.lock().unwrap(), "Bearer still-valid");
+    }
+
+    #[test]
+    fn inline_post_refreshes_token_and_retries_on_401() {
+        use super::{HttpTransport, RefreshFn};
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use std::sync::{Arc, Mutex};
+
+        let server = tiny_http::Server::http("127.0.0.1:0").unwrap();
+        let port = server.server_addr().to_ip().unwrap().port();
+        let retry_auth = Arc::new(Mutex::new(String::new()));
+        let hits = Arc::new(AtomicUsize::new(0));
+        let (captured, hit_count) = (Arc::clone(&retry_auth), Arc::clone(&hits));
+        let handle = std::thread::spawn(move || {
+            for _ in 0..2 {
+                let req = server.recv().unwrap();
+                if hit_count.fetch_add(1, Ordering::SeqCst) == 0 {
+                    let _ = req.respond(
+                        tiny_http::Response::from_string("unauthorized").with_status_code(401),
+                    );
+                } else {
+                    *captured.lock().unwrap() = req
+                        .headers()
+                        .iter()
+                        .find(|h| h.field.equiv("Authorization"))
+                        .map(|h| h.value.as_str().to_string())
+                        .unwrap_or_default();
+                    let _ = req.respond(
+                        tiny_http::Response::from_string("{}").with_status_code(202),
+                    );
+                }
+            }
+        });
+
+        let refresh: Option<RefreshFn> = Some(Box::new(|force| {
+            if force {
+                Ok(Some("fresh".to_string()))
+            } else {
+                Ok(None)
+            }
+        }));
+        let url = format!("http://127.0.0.1:{port}/");
+        let mut transport =
+            HttpTransport::with_auth_refresh(&url, Some("stale".to_string()), refresh);
+
+        transport
+            .send_post_no_response(&serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 99,
+                "result": { "roots": [] }
+            }))
+            .expect("inline reply should refresh and retry");
+        handle.join().unwrap();
+
+        assert_eq!(hits.load(Ordering::SeqCst), 2);
+        assert_eq!(*retry_auth.lock().unwrap(), "Bearer fresh");
     }
 
     #[test]

--- a/src-tauri/src/downstream.rs
+++ b/src-tauri/src/downstream.rs
@@ -1534,9 +1534,11 @@ fn ids_match(got: Option<&Value>, wanted: Option<&Value>) -> bool {
     }
 }
 
-/// A callback that mints a fresh token on a 401/403 (e.g. an OAuth refresh), so a
-/// long-running session recovers from an expired access token instead of failing.
-pub type RefreshFn = Box<dyn Fn() -> Option<String> + Send + Sync>;
+/// A callback that can proactively mint a fresh token before expiry or force a
+/// refresh after a 401/403. `force = false` returns `Ok(None)` when the current
+/// token is still fresh. Errors are surfaced as a per-server authentication
+/// failure instead of sending a request with a token known to be expired.
+pub type RefreshFn = Box<dyn Fn(bool) -> Result<Option<String>, String> + Send + Sync>;
 
 /// Screen resolved socket addresses against the SSRF policy, fail-closed: returns
 /// `Err` if ANY address is link-local / cloud-metadata, or - when `block_private` -
@@ -1755,6 +1757,21 @@ impl HttpTransport {
     fn post(&mut self, body: &Value, expect_response: bool) -> Result<Option<Value>, TransportError> {
         let payload = body.to_string();
 
+        // Refresh shortly before the known expiry, including before initialize.
+        // The callback keeps the deadline in memory, so this is a cheap no-op on
+        // ordinary calls and only touches vaulted OAuth state when refresh is due.
+        if let Some(refresh) = &self.refresh {
+            match refresh(false) {
+                Ok(Some(token)) => self.auth = Some(token),
+                Ok(None) => {}
+                Err(e) => {
+                    return Err(TransportError::Fatal(format!(
+                        "needs authentication: proactive token refresh failed: {e}"
+                    )))
+                }
+            }
+        }
+
         // Token refresh is handled internally (it doesn't sleep, so no lock
         // contention). Only 429 and transport-retry signals bubble up as
         // TransportError::Retry so the Router can sleep *outside* the lock.
@@ -1793,14 +1810,19 @@ impl HttpTransport {
                 {
                     let _ = read_capped(r, 8 * 1024);
                     refreshed = true;
-                    match self.refresh.as_ref().and_then(|f| f()) {
-                        Some(tok) => {
+                    match self.refresh.as_ref().expect("refresh callback checked")(true) {
+                        Ok(Some(tok)) => {
                             self.auth = Some(tok);
                             continue;
                         }
-                        None => {
+                        Ok(None) => {
                             return Err(TransportError::Fatal(format!(
-                                "HTTP {code} (needs authentication): token refresh failed"
+                                "HTTP {code} (needs authentication): token refresh returned no token"
+                            )))
+                        }
+                        Err(e) => {
+                            return Err(TransportError::Fatal(format!(
+                                "HTTP {code} (needs authentication): token refresh failed: {e}"
                             )))
                         }
                     }
@@ -2855,6 +2877,59 @@ mod tests {
     }
 
     #[test]
+    fn post_refreshes_proactively_before_sending() {
+        use super::{HttpTransport, RefreshFn};
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use std::sync::{Arc, Mutex};
+        use std::time::Duration;
+
+        let server = tiny_http::Server::http("127.0.0.1:0").unwrap();
+        let port = server.server_addr().to_ip().unwrap().port();
+        let seen_auth = Arc::new(Mutex::new(String::new()));
+        let captured = Arc::clone(&seen_auth);
+        let handle = std::thread::spawn(move || {
+            let req = server
+                .recv_timeout(Duration::from_secs(3))
+                .unwrap()
+                .expect("proactively refreshed request should reach the server");
+            *captured.lock().unwrap() = req
+                .headers()
+                .iter()
+                .find(|h| h.field.equiv("Authorization"))
+                .map(|h| h.value.as_str().to_string())
+                .unwrap_or_default();
+            let ct =
+                tiny_http::Header::from_bytes(&b"Content-Type"[..], &b"application/json"[..])
+                    .unwrap();
+            let body = r#"{"jsonrpc":"2.0","id":1,"result":{"ok":true}}"#;
+            let _ = req.respond(tiny_http::Response::from_string(body).with_header(ct));
+        });
+
+        let refresh_calls = Arc::new(AtomicUsize::new(0));
+        let calls = Arc::clone(&refresh_calls);
+        let refresh: Option<RefreshFn> = Some(Box::new(move |force| {
+            assert!(!force, "successful proactive refresh should avoid a forced retry");
+            calls.fetch_add(1, Ordering::SeqCst);
+            Ok(Some("fresh".to_string()))
+        }));
+        let url = format!("http://127.0.0.1:{port}/");
+        let mut transport =
+            HttpTransport::with_auth_refresh(&url, Some("stale".to_string()), refresh);
+
+        let result = transport
+            .post(
+                &serde_json::json!({ "jsonrpc": "2.0", "id": 1, "method": "ping" }),
+                true,
+            )
+            .expect("post should use the proactively refreshed token");
+        handle.join().unwrap();
+
+        assert!(result.is_some());
+        assert_eq!(refresh_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(*seen_auth.lock().unwrap(), "Bearer fresh");
+    }
+
+    #[test]
     fn post_refreshes_token_and_retries_on_401() {
         use super::{HttpTransport, RefreshFn};
         use std::sync::atomic::{AtomicUsize, Ordering};
@@ -2895,7 +2970,13 @@ mod tests {
         });
 
         let url = format!("http://127.0.0.1:{port}/");
-        let refresh: Option<RefreshFn> = Some(Box::new(|| Some("fresh".to_string())));
+        let refresh: Option<RefreshFn> = Some(Box::new(|force| {
+            if force {
+                Ok(Some("fresh".to_string()))
+            } else {
+                Ok(None)
+            }
+        }));
         let mut t = HttpTransport::with_auth_refresh(&url, Some("stale".to_string()), refresh);
         let res = t
             .post(&serde_json::json!({ "jsonrpc": "2.0", "id": 1, "method": "ping" }), true)

--- a/src-tauri/src/downstream.rs
+++ b/src-tauri/src/downstream.rs
@@ -1691,7 +1691,12 @@ impl HttpTransport {
     }
 
     fn force_refresh_after_auth_error(&mut self, code: u16) -> Result<(), TransportError> {
-        match self.refresh.as_ref().expect("refresh callback checked")(true) {
+        let Some(refresh) = self.refresh.as_ref() else {
+            return Err(TransportError::Fatal(format!(
+                "HTTP {code} (needs authentication): no refresh callback configured"
+            )));
+        };
+        match refresh(true) {
             Ok(Some(token)) => {
                 self.auth = Some(token);
                 Ok(())
@@ -3000,6 +3005,21 @@ mod tests {
 
         assert!(result.is_ok());
         assert_eq!(*seen_auth.lock().unwrap(), "Bearer still-valid");
+    }
+
+    #[test]
+    fn forced_refresh_without_callback_returns_auth_error() {
+        use super::HttpTransport;
+
+        let mut transport = HttpTransport::new("http://127.0.0.1:1/");
+        let error = transport
+            .force_refresh_after_auth_error(401)
+            .expect_err("missing refresh callback should return an authentication error");
+
+        assert_eq!(
+            error.to_string(),
+            "HTTP 401 (needs authentication): no refresh callback configured"
+        );
     }
 
     #[test]

--- a/src-tauri/src/oauth.rs
+++ b/src-tauri/src/oauth.rs
@@ -8,7 +8,7 @@
 
 use std::io::{Read, Write};
 use std::net::TcpListener;
-use std::time::{Duration, Instant};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use base64::Engine;
 use serde::Deserialize;
@@ -17,12 +17,20 @@ use sha2::{Digest, Sha256};
 pub struct Tokens {
     pub access_token: String,
     pub refresh_token: Option<String>,
+    /// Unix timestamp when Toolport received this token response.
+    pub issued_at: u64,
+    /// Unix timestamp when the access token expires, when the server reports a
+    /// lifetime. `None` preserves the reactive-refresh behavior for providers
+    /// that omit `expires_in`.
+    pub expires_at: Option<u64>,
 }
 
 /// Everything needed to use and later refresh a remote server's access.
 pub struct AuthResult {
     pub access_token: String,
     pub refresh_token: Option<String>,
+    pub issued_at: u64,
+    pub expires_at: Option<u64>,
     pub token_endpoint: String,
     pub client_id: String,
 }
@@ -461,10 +469,30 @@ pub fn build_authorize_url(
 struct TokenResponse {
     access_token: String,
     refresh_token: Option<String>,
-    /// Access-token lifetime in seconds, when the server reports it. Logged for
-    /// diagnostics so we can see how often a server expects re-auth.
+    /// Access-token lifetime in seconds, when the server reports it. Converted
+    /// to an absolute expiry so later processes can refresh before the deadline.
     #[serde(default)]
     expires_in: Option<u64>,
+}
+
+impl TokenResponse {
+    fn into_tokens(self, issued_at: u64) -> Tokens {
+        Tokens {
+            access_token: self.access_token,
+            refresh_token: self.refresh_token,
+            issued_at,
+            expires_at: self
+                .expires_in
+                .map(|lifetime| issued_at.saturating_add(lifetime)),
+        }
+    }
+}
+
+fn now_epoch_seconds() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
 }
 
 /// Choose the `scope` to request. The input is the server's advertised
@@ -505,10 +533,7 @@ fn exchange_code(
         resp.refresh_token.is_some(),
         resp.expires_in
     ));
-    Ok(Tokens {
-        access_token: resp.access_token,
-        refresh_token: resp.refresh_token,
-    })
+    Ok(resp.into_tokens(now_epoch_seconds()))
 }
 
 /// Exchange a refresh token for a fresh access token (non-interactive). When a
@@ -540,10 +565,7 @@ pub fn refresh(
         resp.refresh_token.is_some(),
         resp.expires_in
     ));
-    Ok(Tokens {
-        access_token: resp.access_token,
-        refresh_token: resp.refresh_token,
-    })
+    Ok(resp.into_tokens(now_epoch_seconds()))
 }
 
 fn open_browser(url: &str) {
@@ -770,6 +792,8 @@ pub fn authenticate(mcp_url: &str) -> Result<AuthResult, String> {
     Ok(AuthResult {
         access_token: tokens.access_token,
         refresh_token: tokens.refresh_token,
+        issued_at: tokens.issued_at,
+        expires_at: tokens.expires_at,
         token_endpoint: endpoints.token_endpoint,
         client_id,
     })
@@ -941,6 +965,33 @@ mod tests {
         );
         // No advertised scope -> request none.
         assert_eq!(requested_scope(None), None);
+    }
+
+    #[test]
+    fn token_response_keeps_issue_and_expiry_timestamps() {
+        let tokens = TokenResponse {
+            access_token: "access".into(),
+            refresh_token: Some("refresh".into()),
+            expires_in: Some(3_600),
+        }
+        .into_tokens(1_000);
+
+        assert_eq!(tokens.issued_at, 1_000);
+        assert_eq!(tokens.expires_at, Some(4_600));
+        assert_eq!(tokens.refresh_token.as_deref(), Some("refresh"));
+    }
+
+    #[test]
+    fn token_response_without_lifetime_keeps_unknown_expiry() {
+        let tokens = TokenResponse {
+            access_token: "access".into(),
+            refresh_token: None,
+            expires_in: None,
+        }
+        .into_tokens(1_000);
+
+        assert_eq!(tokens.issued_at, 1_000);
+        assert_eq!(tokens.expires_at, None);
     }
 
     #[test]

--- a/src-tauri/src/remote.rs
+++ b/src-tauri/src/remote.rs
@@ -20,6 +20,9 @@ pub const OAUTH_STATE_KEY: &str = STATE_KEY;
 /// Refresh before the exact deadline so the token cannot expire while an MCP
 /// request is in flight.
 const PROACTIVE_REFRESH_SKEW_SECS: u64 = 60;
+/// Avoid hammering a temporarily unavailable OAuth endpoint on every tool call
+/// while still retrying within the pre-expiry safety window.
+const PROACTIVE_REFRESH_RETRY_SECS: u64 = 15;
 
 #[derive(Serialize, Deserialize)]
 struct OAuthState {
@@ -129,8 +132,10 @@ fn refresh_token_with_expiry(server_id: &str) -> Result<RefreshedToken, String> 
         state.resource.as_deref(),
         block_private,
     )?;
-    secrets::set_secret(server_id, secrets::HTTP_AUTH_KEY, &tokens.access_token)?;
-    // Persist a rotated refresh token if the server issued one.
+    // Persist rotated refresh metadata first. If replacing the access token then
+    // fails, the next attempt still has the new refresh token and can recover;
+    // the reverse order could strand a new access token with an invalidated old
+    // refresh token after a second-write failure.
     let new_state = OAuthState {
         token_endpoint: state.token_endpoint,
         client_id: state.client_id,
@@ -141,6 +146,7 @@ fn refresh_token_with_expiry(server_id: &str) -> Result<RefreshedToken, String> 
     };
     let json = serde_json::to_string(&new_state).map_err(|e| e.to_string())?;
     secrets::set_secret(server_id, STATE_KEY, &json)?;
+    secrets::set_secret(server_id, secrets::HTTP_AUTH_KEY, &tokens.access_token)?;
     Ok(RefreshedToken {
         access_token: tokens.access_token,
         expires_at: tokens.expires_at,
@@ -161,9 +167,9 @@ fn refresh_token_if_needed(server_id: &str) -> Result<Option<String>, String> {
     };
     match refresh_decision(&state, now_epoch_seconds()) {
         RefreshDecision::NotNeeded => Ok(None),
-        RefreshDecision::Refresh => refresh_token(server_id)
-            .map(Some)
-            .map_err(|e| format!("OAuth token refresh failed; needs authentication: {e}")),
+        // The token may still be valid throughout the safety window. A transient
+        // refresh failure falls back to it; a real 401/403 forces another refresh.
+        RefreshDecision::Refresh => Ok(refresh_token(server_id).ok()),
         RefreshDecision::Reauthenticate => Err(
             "OAuth access token expires soon and no refresh token is available; needs authentication"
                 .to_string(),
@@ -228,8 +234,20 @@ fn authed_transport(
                 }
             }
 
-            let refreshed = refresh_token_with_expiry(&sid)
-                .map_err(|e| format!("OAuth token refresh failed; needs authentication: {e}"))?;
+            let refreshed = match refresh_token_with_expiry(&sid) {
+                Ok(refreshed) => refreshed,
+                Err(e) => {
+                    if !force {
+                        *next_refresh_at
+                            .lock()
+                            .map_err(|_| "OAuth refresh deadline lock poisoned".to_string())? =
+                            Some(now_epoch_seconds().saturating_add(PROACTIVE_REFRESH_RETRY_SECS));
+                    }
+                    return Err(format!(
+                        "OAuth token refresh failed; needs authentication: {e}"
+                    ));
+                }
+            };
             let deadline = refreshed
                 .expires_at
                 .map(|expires_at| expires_at.saturating_sub(PROACTIVE_REFRESH_SKEW_SECS));

--- a/src-tauri/src/remote.rs
+++ b/src-tauri/src/remote.rs
@@ -6,6 +6,8 @@
 //! access token.
 
 use serde::{Deserialize, Serialize};
+use std::sync::Mutex;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::downstream::{
     DownstreamServer, HttpTransport, RefreshFn, ServerRequestHandler, Transport,
@@ -15,6 +17,9 @@ use crate::{oauth, secrets};
 
 const STATE_KEY: &str = "__oauth_state__";
 pub const OAUTH_STATE_KEY: &str = STATE_KEY;
+/// Refresh before the exact deadline so the token cannot expire while an MCP
+/// request is in flight.
+const PROACTIVE_REFRESH_SKEW_SECS: u64 = 60;
 
 #[derive(Serialize, Deserialize)]
 struct OAuthState {
@@ -25,6 +30,48 @@ struct OAuthState {
     /// to. Optional for back-compat with states vaulted before this existed.
     #[serde(default)]
     resource: Option<String>,
+    /// Unix timestamp when Toolport received the latest token response.
+    /// Optional for states vaulted by older Toolport versions.
+    #[serde(default)]
+    issued_at: Option<u64>,
+    /// Unix access-token expiry derived from the provider's `expires_in`.
+    /// Optional because OAuth providers are allowed to omit the lifetime.
+    #[serde(default)]
+    expires_at: Option<u64>,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum RefreshDecision {
+    NotNeeded,
+    Refresh,
+    Reauthenticate,
+}
+
+struct RefreshedToken {
+    access_token: String,
+    expires_at: Option<u64>,
+}
+
+fn now_epoch_seconds() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+
+fn refresh_decision(state: &OAuthState, now: u64) -> RefreshDecision {
+    let Some(expires_at) = state.expires_at else {
+        // Backward-compatible and provider-compatible: without a known expiry,
+        // retain the existing reactive refresh on 401/403.
+        return RefreshDecision::NotNeeded;
+    };
+    if now.saturating_add(PROACTIVE_REFRESH_SKEW_SECS) < expires_at {
+        RefreshDecision::NotNeeded
+    } else if state.refresh_token.is_some() {
+        RefreshDecision::Refresh
+    } else {
+        RefreshDecision::Reauthenticate
+    }
 }
 
 /// Persist what's needed to refresh this server's token later.
@@ -34,12 +81,16 @@ pub fn store_oauth_state(
     client_id: &str,
     refresh_token: Option<String>,
     resource: Option<String>,
+    issued_at: u64,
+    expires_at: Option<u64>,
 ) -> Result<(), String> {
     let state = OAuthState {
         token_endpoint: token_endpoint.to_string(),
         client_id: client_id.to_string(),
         refresh_token,
         resource,
+        issued_at: Some(issued_at),
+        expires_at,
     };
     let json = serde_json::to_string(&state).map_err(|e| e.to_string())?;
     secrets::set_secret(server_id, STATE_KEY, &json)
@@ -50,9 +101,16 @@ fn load_state(server_id: &str) -> Option<OAuthState> {
         .and_then(|s| serde_json::from_str(&s).ok())
 }
 
+/// Remove refresh metadata when the user clears OAuth or replaces it with a
+/// manually pasted bearer token. Otherwise stale vaulted state could silently
+/// recreate a credential the user explicitly removed.
+pub fn clear_oauth_state(server_id: &str) -> Result<(), String> {
+    secrets::delete_secret(server_id, STATE_KEY)
+}
+
 /// Use the stored refresh token to mint a fresh access token, vault it, and
 /// return it.
-pub fn refresh_token(server_id: &str) -> Result<String, String> {
+fn refresh_token_with_expiry(server_id: &str) -> Result<RefreshedToken, String> {
     let state = load_state(server_id).ok_or("no stored OAuth state to refresh")?;
     let rt = state
         .refresh_token
@@ -78,11 +136,39 @@ pub fn refresh_token(server_id: &str) -> Result<String, String> {
         client_id: state.client_id,
         refresh_token: tokens.refresh_token.or(state.refresh_token),
         resource: state.resource,
+        issued_at: Some(tokens.issued_at),
+        expires_at: tokens.expires_at,
     };
-    if let Ok(json) = serde_json::to_string(&new_state) {
-        let _ = secrets::set_secret(server_id, STATE_KEY, &json);
+    let json = serde_json::to_string(&new_state).map_err(|e| e.to_string())?;
+    secrets::set_secret(server_id, STATE_KEY, &json)?;
+    Ok(RefreshedToken {
+        access_token: tokens.access_token,
+        expires_at: tokens.expires_at,
+    })
+}
+
+pub fn refresh_token(server_id: &str) -> Result<String, String> {
+    refresh_token_with_expiry(server_id).map(|token| token.access_token)
+}
+
+/// Refresh before the known expiry. A legacy/provider state with no expiry is a
+/// no-op and continues to use the 401/403 fallback. If the deadline is close but
+/// no refresh token exists, return an auth-classified error so the existing
+/// per-server "Needs sign-in" UI appears before a failed tool call.
+fn refresh_token_if_needed(server_id: &str) -> Result<Option<String>, String> {
+    let Some(state) = load_state(server_id) else {
+        return Ok(None);
+    };
+    match refresh_decision(&state, now_epoch_seconds()) {
+        RefreshDecision::NotNeeded => Ok(None),
+        RefreshDecision::Refresh => refresh_token(server_id)
+            .map(Some)
+            .map_err(|e| format!("OAuth token refresh failed; needs authentication: {e}")),
+        RefreshDecision::Reauthenticate => Err(
+            "OAuth access token expires soon and no refresh token is available; needs authentication"
+                .to_string(),
+        ),
     }
-    Ok(tokens.access_token)
 }
 
 pub fn is_auth_error(e: &str) -> bool {
@@ -125,7 +211,33 @@ fn authed_transport(
     }
     let refresh: Option<RefreshFn> = if token.is_some() {
         let sid = server_id.to_string();
-        Some(Box::new(move || refresh_token(&sid).ok()))
+        // Keep the proactive deadline in memory. This avoids a keychain read on
+        // every tool call while still updating the deadline after each refresh.
+        let refresh_at = load_state(server_id)
+            .and_then(|state| state.expires_at)
+            .map(|expires_at| expires_at.saturating_sub(PROACTIVE_REFRESH_SKEW_SECS));
+        let next_refresh_at = Mutex::new(refresh_at);
+        Some(Box::new(move |force| {
+            if !force {
+                let deadline = *next_refresh_at
+                    .lock()
+                    .map_err(|_| "OAuth refresh deadline lock poisoned".to_string())?;
+                match deadline {
+                    Some(refresh_at) if now_epoch_seconds() >= refresh_at => {}
+                    _ => return Ok(None),
+                }
+            }
+
+            let refreshed = refresh_token_with_expiry(&sid)
+                .map_err(|e| format!("OAuth token refresh failed; needs authentication: {e}"))?;
+            let deadline = refreshed
+                .expires_at
+                .map(|expires_at| expires_at.saturating_sub(PROACTIVE_REFRESH_SKEW_SECS));
+            *next_refresh_at
+                .lock()
+                .map_err(|_| "OAuth refresh deadline lock poisoned".to_string())? = deadline;
+            Ok(Some(refreshed.access_token))
+        }))
     } else {
         None
     };
@@ -222,8 +334,12 @@ pub fn connect_remote_with_handler(
     // Untrusted-provenance servers also get private/loopback refused at the resolver,
     // matching `guard_connect_target`'s pre-check but closing the DNS-rebind TOCTOU.
     let block_private = is_untrusted_source(server.source.as_deref());
-    let auth = secrets::get_secret(server_id, secrets::HTTP_AUTH_KEY)
+    let stored_auth = secrets::get_secret(server_id, secrets::HTTP_AUTH_KEY)
         .or_else(|| first_vaulted_secret(server));
+    let auth = match refresh_token_if_needed(server_id)? {
+        Some(fresh) => Some(fresh),
+        None => stored_auth,
+    };
     let mut transport = authed_transport(url, auth, server_id, block_private)?;
     if let Some(ref handler) = server_handler {
         transport.set_server_request_handler(handler.clone());
@@ -254,6 +370,57 @@ mod tests {
         assert!(is_auth_error("got 403 Forbidden"));
         assert!(!is_auth_error("HTTP 500: server error"));
         assert!(!is_auth_error("connection refused"));
+    }
+
+    fn oauth_state(expires_at: Option<u64>, refresh_token: Option<&str>) -> OAuthState {
+        OAuthState {
+            token_endpoint: "https://auth.example.com/token".into(),
+            client_id: "client".into(),
+            refresh_token: refresh_token.map(str::to_string),
+            resource: Some("https://mcp.example.com".into()),
+            issued_at: Some(1_000),
+            expires_at,
+        }
+    }
+
+    #[test]
+    fn refresh_decision_uses_expiry_safety_window() {
+        assert_eq!(
+            refresh_decision(&oauth_state(Some(1_061), Some("refresh")), 1_000),
+            RefreshDecision::NotNeeded
+        );
+        assert_eq!(
+            refresh_decision(&oauth_state(Some(1_060), Some("refresh")), 1_000),
+            RefreshDecision::Refresh
+        );
+        assert_eq!(
+            refresh_decision(&oauth_state(Some(999), Some("refresh")), 1_000),
+            RefreshDecision::Refresh
+        );
+    }
+
+    #[test]
+    fn refresh_decision_requests_reauth_without_refresh_token() {
+        assert_eq!(
+            refresh_decision(&oauth_state(Some(1_060), None), 1_000),
+            RefreshDecision::Reauthenticate
+        );
+        assert_eq!(
+            refresh_decision(&oauth_state(None, None), 1_000),
+            RefreshDecision::NotNeeded
+        );
+    }
+
+    #[test]
+    fn oauth_state_from_older_versions_keeps_unknown_expiry() {
+        let state: OAuthState = serde_json::from_str(
+            r#"{"token_endpoint":"https://auth.example.com/token","client_id":"client","refresh_token":"refresh","resource":"https://mcp.example.com"}"#,
+        )
+        .unwrap();
+
+        assert_eq!(state.issued_at, None);
+        assert_eq!(state.expires_at, None);
+        assert_eq!(refresh_decision(&state, 1_000), RefreshDecision::NotNeeded);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- persist OAuth token issue and expiry timestamps derived from `expires_in`
- refresh known-expiring access tokens 60 seconds before the deadline, before an MCP request is sent
- preserve the existing reactive 401/403 refresh path for providers and older vaulted states without expiry metadata
- surface the existing per-server Needs sign-in state when a token is expiring and cannot be refreshed
- clear stale OAuth refresh metadata when a user replaces or removes a bearer token

## Why

Toolport parsed `expires_in` but discarded it, so refresh only happened after a downstream request failed with 401/403. Users received no warning when an OAuth server needed re-authentication, and the first tool call after expiry could fail.

## Impact

OAuth-backed remote servers now refresh before expiration when possible. Servers without a usable refresh token become visibly actionable through the existing authentication UI instead of failing unexpectedly. Existing OAuth state remains backward compatible.

## Validation

- `powershell -NoProfile -ExecutionPolicy Bypass -File scripts/test-rust-windows.ps1`
- 374 library tests passed
- 109 gateway tests passed
- `git diff --check`

Linear: [SOU-160](https://linear.app/southforge-ai/issue/SOU-160/oauth-persist-token-expiry-and-add-proactive-refresh-re-auth-ux)
