### PR TITLE
Add structured-result projection to toolport_fetch_result (SOU-162)

### DIFF
--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -8115,7 +8115,7 @@ mod tests {
                     "arguments": {
                         "cursor": cursor,
                         "offset": offset,
-                        "len": body.len() - offset,
+                        "len":  usize::MAX,
                     }
                 }
             });
@@ -8140,6 +8140,7 @@ mod tests {
                 .unwrap();
 
             assert!(fetched.starts_with(&body[offset..]));
+            
             assert!(fetched.contains("[Toolport: end of result"));
         }
 

--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -163,12 +163,10 @@ fn fetch_result_tool_def() -> Value {
             "type": "object",
             "properties": {
                 "cursor": { "type": "string", "description": "The cursor from the marker." },
-                "offset": { "type": "integer", "minimum": 0, "description": "Character offset to read from (shown in the marker)." },
-                "projection": { "type": "string", "description": "Optional dot-separated path into structuredContent (for example: data.items.0.name)."
-             },
+                "offset": { "type": "integer", "minimum": 0, "description": "Character offset to read from (shown in the marker). Ignored when `projection` is set." },
+                "projection": { "type": "string", "description": "Optional dot-separated path into structuredContent (for example: data.items.0.name). When set, returns just that field instead of a text page." }
             },
-          
-            "required": ["cursor", "offset"],
+            "required": ["cursor"],
             "additionalProperties": false
         }
     })

--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -163,12 +163,11 @@ fn fetch_result_tool_def() -> Value {
             "type": "object",
             "properties": {
                 "cursor": { "type": "string", "description": "The cursor from the marker." },
-                "offset": { "type": "integer", "minimum": 0, "description": "Character offset to read from (shown in the marker)." }
+                "offset": { "type": "integer", "minimum": 0, "description": "Character offset to read from (shown in the marker)." },
+                "projection": { "type": "string", "description": "Optional dot-separated path into structuredContent (for example: data.items.0.name)."
+             },
             },
-            "projection": {
-                "type": "string",
-                "description": "Optional dot-separated path into structuredContent (for example: data.items.0.name)."
-            },
+          
             "required": ["cursor", "offset"],
             "additionalProperties": false
         }
@@ -2457,7 +2456,6 @@ fn handle_request_with_cancel(
                         .map(|&b| b as usize)
                         .unwrap_or_else(shaping::budget);
                     shaping::shape_result(&mut result, budget, client);
-                    let text = result["content"][0]["text"].as_str().unwrap();
 
                     // Recover from a downstream failure: point the model at
                     // sibling list/get tools that can supply a missing/invalid
@@ -5736,6 +5734,12 @@ mod tests {
                         "type": "text",
                         "text" : self.body.clone()
                     }],
+                    "structuredContent": {
+                        "user": {
+                            "name": "Alice",
+                            "age": 30
+                        }
+                    },
                     "isError": false
                 })),
                 other => Err(conduit_lib::downstream::TransportError::Fatal(
@@ -8138,4 +8142,82 @@ mod tests {
             assert!(fetched.starts_with(&body[offset..]));
             assert!(fetched.contains("[Toolport: end of result"));
         }
+
+        #[test]
+    fn fetch_result_projection_dispatch_returns_requested_field() {
+        let body = "A".repeat(50_000);
+
+        let reg = Registry::default();
+        let router = paging_router(body);
+
+        let req = json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {
+                "name": "s__big",
+                "arguments": {}
+            }
+        });
+
+        let resp = handle_request(
+            &req,
+            &reg,
+            &router,
+            &[],
+            true,
+            None,
+            &SearchGuard::default(),
+            &ConfirmGuard::new(),
+            None,
+            None,
+        )
+        .unwrap();
+
+        let text = resp["result"]["content"][0]["text"]
+            .as_str()
+            .unwrap();
+
+        let cursor = text
+            .split("\"cursor\":\"")
+            .nth(1)
+            .unwrap()
+            .split('"')
+            .next()
+            .unwrap();
+
+        let fetch_req = json!({
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/call",
+            "params": {
+                "name": "toolport_fetch_result",
+                "arguments": {
+                    "cursor": cursor,
+                    "projection": "user.age"
+                }
+            }
+        });
+
+        let fetch_resp = handle_request(
+            &fetch_req,
+            &reg,
+            &router,
+            &[],
+            true,
+            None,
+            &SearchGuard::default(),
+            &ConfirmGuard::new(),
+            None,
+            None,
+        )
+        .unwrap();
+
+        assert!(!fetch_resp["result"]["isError"].as_bool().unwrap());
+
+        assert_eq!(
+            fetch_resp["result"]["content"][0]["text"].as_str().unwrap(),
+            "30"
+        );
+    }
     }

--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -165,6 +165,10 @@ fn fetch_result_tool_def() -> Value {
                 "cursor": { "type": "string", "description": "The cursor from the marker." },
                 "offset": { "type": "integer", "minimum": 0, "description": "Character offset to read from (shown in the marker)." }
             },
+            "projection": {
+                "type": "string",
+                "description": "Optional dot-separated path into structuredContent (for example: data.items.0.name)."
+            },
             "required": ["cursor", "offset"],
             "additionalProperties": false
         }
@@ -1947,9 +1951,12 @@ fn handle_request_with_cancel(
                     .and_then(|v| v.as_u64())
                     .unwrap_or(0) as usize;
                 let len = arguments.get("len").and_then(|v| v.as_u64()).unwrap_or(0) as usize;
+                let projection = arguments
+                    .get("projection")
+                    .and_then(|v| v.as_str());
                 // Pass the calling client so a client can only fetch results it stashed
                 // (the stash is process-global in HTTP mode).
-                return Some(success(id, shaping::fetch_result(cursor, offset, len, client)));
+                return Some(success(id, shaping::fetch_result(cursor, offset, len, client, projection)));
             }
 
             // toolport_confirm: replay a previously-intercepted destructive call.
@@ -2450,6 +2457,8 @@ fn handle_request_with_cancel(
                         .map(|&b| b as usize)
                         .unwrap_or_else(shaping::budget);
                     shaping::shape_result(&mut result, budget, client);
+                    let text = result["content"][0]["text"].as_str().unwrap();
+
                     // Recover from a downstream failure: point the model at
                     // sibling list/get tools that can supply a missing/invalid
                     // identifier. Appended after shaping so it's never truncated.
@@ -5702,6 +5711,44 @@ mod tests {
             Ok(())
         }
     }
+    struct PagingRoute {
+    body: String,
+    }
+
+    impl conduit_lib::downstream::Transport for PagingRoute {
+        fn request(
+            &mut self,
+            method: &str,
+            _params: Value,
+        ) -> Result<Value, conduit_lib::downstream::TransportError> {
+             match method {
+                "initialize" => Ok(json!({
+                    "protocolVersion": "2025-06-18"
+                })),
+                "tools/list" => Ok(json!({
+                    "tools": [{
+                        "name": "big",
+                        "description": "",
+                    }]
+                })),
+                "tools/call" => Ok(json!({
+                    "content": [{
+                        "type": "text",
+                        "text" : self.body.clone()
+                    }],
+                    "isError": false
+                })),
+                other => Err(conduit_lib::downstream::TransportError::Fatal(
+                    format!("unexpected {other}")
+                )),
+             }
+        }
+
+        fn notify(&mut self, _method: &str, _params: Value) -> Result<(), conduit_lib::downstream::TransportError> {
+            Ok(())
+        }
+    }
+
 
     /// A router with one server `id` exposing one tool `tool` (so `id__tool` routes).
     fn routed_router(id: &str, tool: &str) -> Router {
@@ -5712,6 +5759,19 @@ mod tests {
             }),
         )
         .unwrap();
+        let mut r = Router::new();
+        r.add(ds);
+        r
+    }
+
+
+    fn paging_router(body: String) -> Router {
+        let ds = DownstreamServer::connect(
+            "s".to_string(),
+            Box::new(PagingRoute {body}),
+        )
+        .unwrap();
+       
         let mut r = Router::new();
         r.add(ds);
         r
@@ -7977,4 +8037,105 @@ mod tests {
             "confirmed call must not be re-intercepted (would loop). Got: {text2}"
         );
     }
-}
+            
+        #[test]
+        fn oversized_tool_call_can_be_fetched() {
+            let body = format!("{}THE_END", "A".repeat(50_000));
+
+            let reg = Registry::default();
+            let router = paging_router(body.clone());
+
+            // First call: invoke the downstream tool.
+            let req = json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "tools/call",
+                "params": {
+                    "name": "s__big",
+                    "arguments": {}
+                }
+            });
+
+            let resp = handle_request(
+                &req,
+                &reg,
+                &router,
+                &[],
+                true,
+                None,
+                &SearchGuard::default(),
+                &ConfirmGuard::new(),
+                None,
+                None,
+            )
+            .unwrap();
+
+            let text = resp["result"]["content"][0]["text"]
+                .as_str()
+                .unwrap();
+
+
+            // Oversized results should be shaped into a preview.
+            assert!(text.len() < body.len());
+            assert!(text.contains("Toolport shaped"));
+            assert!(text.contains("\"cursor\""));
+
+            // Extract cursor.
+            let cursor = text
+                .split("\"cursor\":\"")
+                .nth(1)
+                .unwrap()
+                .split('"')
+                .next()
+                .unwrap();
+
+            // Extract offset.
+            let offset: usize = text
+                .split("\"offset\":")
+                .nth(1)
+                .unwrap()
+                .split(|c| c == ',' || c == '}')
+                .next()
+                .unwrap()
+                .parse()
+                .unwrap();
+
+
+            // Fetch the remainder through the public tool API.
+            let fetch_req = json!({
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "tools/call",
+                "params": {
+                    "name": "toolport_fetch_result",
+                    "arguments": {
+                        "cursor": cursor,
+                        "offset": offset,
+                        "len": body.len() - offset,
+                    }
+                }
+            });
+
+            let fetch_resp = handle_request(
+                &fetch_req,
+                &reg,
+                &router,
+                &[],
+                true,
+                None,
+                &SearchGuard::default(),
+                &ConfirmGuard::new(),
+                None,
+                None,
+            )
+            .unwrap();
+
+
+            let fetched = fetch_resp["result"]["content"][0]["text"]
+                .as_str()
+                .unwrap();
+
+            assert!(fetched.starts_with(&body[offset..]));
+            assert!(fetched.contains("[Toolport: end of result"));
+        }
+    }

--- a/src-tauri/src/shaping.rs
+++ b/src-tauri/src/shaping.rs
@@ -46,6 +46,10 @@ pub fn budget() -> usize {
 struct Cached {
     body: String,
     structured: Option<Value>,
+    /// The entry's total serialized size (`body` + structured JSON), computed once at
+    /// insert. The eviction loop sums this across entries on every oversized call, so
+    /// caching it avoids re-serializing every structured payload on each iteration.
+    size: usize,
     at: Instant,
     /// The client the result belongs to (a registered HTTP client's label), or None
     /// for the single-tenant stdio process. Only this client may fetch it back.
@@ -182,11 +186,7 @@ pub fn shape_result(result: &mut Value, budget: usize, owner: Option<&str>) -> b
         .unwrap_or(false);
 
     let cursor = next_cursor();
-    let new_entry_size = body.len()
-        + structured
-            .as_ref()
-            .map(value_size)
-            .unwrap_or(0);
+    let new_entry_size = body.len() + structured.as_ref().map(value_size).unwrap_or(0);
 
     {
         let mut map = cache().lock().unwrap_or_else(|e| e.into_inner());
@@ -194,21 +194,11 @@ pub fn shape_result(result: &mut Value, budget: usize, owner: Option<&str>) -> b
 
         // Bound memory: evict oldest until the entry count and total bytes leave
         // room for this cached result (or the cache empties, keeping one over-cap
-        // result).
+        // result). Each entry's `size` is precomputed, so this sum is O(n) adds, not
+        // O(n) JSON re-serializations, on every iteration.
         while !map.is_empty()
             && (map.len() >= MAX_CACHE_ENTRIES
-                || map
-                    .values()
-                    .map(|c| {
-                        c.body.len()
-                            + c.structured
-                                .as_ref()
-                                .map(value_size)
-                                .unwrap_or(0)
-                    })
-                    .sum::<usize>()
-                    + new_entry_size
-                    > MAX_CACHE_BYTES)
+                || map.values().map(|c| c.size).sum::<usize>() + new_entry_size > MAX_CACHE_BYTES)
         {
             let Some(oldest) = map.iter().min_by_key(|(_, c)| c.at).map(|(k, _)| k.clone()) else {
                 break;
@@ -221,6 +211,7 @@ pub fn shape_result(result: &mut Value, budget: usize, owner: Option<&str>) -> b
             Cached {
                 body,
                 structured,
+                size: new_entry_size,
                 at: Instant::now(),
                 owner: owner.map(str::to_string),
             },

--- a/src-tauri/src/shaping.rs
+++ b/src-tauri/src/shaping.rs
@@ -90,6 +90,10 @@ fn extract_body(result: &Value) -> String {
     out
 }
 
+fn value_size(value: &Value) -> usize { 
+    serde_json::to_string(value) .map(|s| s.len()) .unwrap_or(0) 
+}
+
 fn text_result(text: String, is_error: bool) -> Value {
     json!({ "content": [{ "type": "text", "text": text }], "isError": is_error })
 }
@@ -161,10 +165,10 @@ pub fn shape_result(result: &mut Value, budget: usize, owner: Option<&str>) -> b
     // projection captures under half the bytes), shaping would drop data and its
     // "nothing was lost" claim would be false. Pass those through untouched.
     let body = extract_body(result);
-    let structured = result.get("structuredContent").cloned();
     if !is_text_representable(result) || body.len() < size / 2 {
         return false;
     }
+    let structured = result.get("structuredContent").cloned();
 
     let total = body.chars().count();
     // Reserve room for the marker, then show as much of the body head as fits the
@@ -178,20 +182,40 @@ pub fn shape_result(result: &mut Value, budget: usize, owner: Option<&str>) -> b
         .unwrap_or(false);
 
     let cursor = next_cursor();
+    let new_entry_size = body.len()
+        + structured
+            .as_ref()
+            .map(value_size)
+            .unwrap_or(0);
+
     {
         let mut map = cache().lock().unwrap_or_else(|e| e.into_inner());
         sweep(&mut map);
+
         // Bound memory: evict oldest until the entry count and total bytes leave
-        // room for this body (or the cache empties, keeping one over-cap body).
+        // room for this cached result (or the cache empties, keeping one over-cap
+        // result).
         while !map.is_empty()
             && (map.len() >= MAX_CACHE_ENTRIES
-                || map.values().map(|c| c.body.len()).sum::<usize>() + body.len() > MAX_CACHE_BYTES)
+                || map
+                    .values()
+                    .map(|c| {
+                        c.body.len()
+                            + c.structured
+                                .as_ref()
+                                .map(value_size)
+                                .unwrap_or(0)
+                    })
+                    .sum::<usize>()
+                    + new_entry_size
+                    > MAX_CACHE_BYTES)
         {
             let Some(oldest) = map.iter().min_by_key(|(_, c)| c.at).map(|(k, _)| k.clone()) else {
                 break;
             };
             map.remove(&oldest);
         }
+
         map.insert(
             cursor.clone(),
             Cached {
@@ -202,7 +226,6 @@ pub fn shape_result(result: &mut Value, budget: usize, owner: Option<&str>) -> b
             },
         );
     }
-
     let marker = format!(
         "\n\n[Toolport shaped this result: it was ~{} KB, larger than the {} KB context \
          budget. Showing the first {} of {} characters. The rest is held temporarily, call \

--- a/src-tauri/src/shaping.rs
+++ b/src-tauri/src/shaping.rs
@@ -45,6 +45,7 @@ pub fn budget() -> usize {
 
 struct Cached {
     body: String,
+    structured: Option<Value>,
     at: Instant,
     /// The client the result belongs to (a registered HTTP client's label), or None
     /// for the single-tenant stdio process. Only this client may fetch it back.
@@ -91,6 +92,23 @@ fn extract_body(result: &Value) -> String {
 
 fn text_result(text: String, is_error: bool) -> Value {
     json!({ "content": [{ "type": "text", "text": text }], "isError": is_error })
+}
+
+fn project<'a>(value: &'a Value, path: &str) -> Option<&'a Value> {
+    let mut current = value;
+
+    for segment in path.split('.') {
+        if let Some(object) = current.as_object() {
+            current = object.get(segment)?;
+        } else if let Some(array) = current.as_array() {
+            let index = segment.parse::<usize>().ok()?;
+            current = array.get(index)?;
+        } else {
+            return None;
+        }
+    }
+
+    Some(current)
 }
 
 /// The longest char-boundary prefix of `s` whose UTF-8 length is at most
@@ -143,6 +161,7 @@ pub fn shape_result(result: &mut Value, budget: usize, owner: Option<&str>) -> b
     // projection captures under half the bytes), shaping would drop data and its
     // "nothing was lost" claim would be false. Pass those through untouched.
     let body = extract_body(result);
+    let structured = result.get("structuredContent").cloned();
     if !is_text_representable(result) || body.len() < size / 2 {
         return false;
     }
@@ -177,6 +196,7 @@ pub fn shape_result(result: &mut Value, budget: usize, owner: Option<&str>) -> b
             cursor.clone(),
             Cached {
                 body,
+                structured,
                 at: Instant::now(),
                 owner: owner.map(str::to_string),
             },
@@ -201,7 +221,7 @@ pub fn shape_result(result: &mut Value, budget: usize, owner: Option<&str>) -> b
 
 /// Return the next slice of a cached shaped result, by cursor + character offset.
 /// `len` of 0 means "use the current budget".
-pub fn fetch_result(cursor: &str, offset: usize, len: usize, requester: Option<&str>) -> Value {
+pub fn fetch_result(cursor: &str, offset: usize, len: usize, requester: Option<&str>, projection: Option<&str>,) -> Value {
     let mut map = cache().lock().unwrap_or_else(|e| e.into_inner());
     sweep(&mut map);
     // Scope: a cached result is readable only by the client that stashed it. A mismatch
@@ -222,6 +242,32 @@ pub fn fetch_result(cursor: &str, offset: usize, len: usize, requester: Option<&
             );
         }
     };
+    if let Some(path) = projection {
+    let structured = match &c.structured {
+        Some(value) => value,
+        None => {
+            return text_result(
+                "[Toolport: this cached result has no structuredContent.]".to_string(),
+                true,
+            );
+        }
+    };
+
+    let value = match project(structured, path) {
+        Some(value) => value,
+        None => {
+            return text_result(
+                format!("[Toolport: projection \"{path}\" not found.]"),
+                true,
+            );
+        }
+    };
+
+    return text_result(
+        serde_json::to_string(value).unwrap_or_default(),
+        false,
+    );
+}
     let total = c.body.chars().count();
     if offset >= total {
         return text_result(
@@ -311,14 +357,14 @@ mod tests {
             .and_then(|s| s.split('"').next())
             .unwrap()
             .to_string();
-        let more = fetch_result(&cursor, 1500, 500, None);
+        let more = fetch_result(&cursor, 1500, 500, None, None);
         let mt = more["content"][0]["text"].as_str().unwrap();
         assert!(mt.contains("of 10000"));
     }
 
     #[test]
     fn fetch_unknown_cursor_is_an_error() {
-        let v = fetch_result("nope", 0, 100, None);
+        let v = fetch_result("nope", 0, 100, None, None);
         assert_eq!(v["isError"].as_bool(), Some(true));
     }
 
@@ -344,16 +390,16 @@ mod tests {
         // cursors exist. The stash is process-global, so in HTTP mode this is the only
         // thing stopping one client from reading another's result by guessing r{n}.
         assert_eq!(
-            fetch_result(&cursor, 0, 100, Some("mallory"))["isError"].as_bool(),
+            fetch_result(&cursor, 0, 100, Some("mallory"),None)["isError"].as_bool(),
             Some(true)
         );
         assert_eq!(
-            fetch_result(&cursor, 0, 100, None)["isError"].as_bool(),
+            fetch_result(&cursor, 0, 100, None, None)["isError"].as_bool(),
             Some(true)
         );
         // The owner still reads it.
         assert_ne!(
-            fetch_result(&cursor, 0, 100, Some("alice"))["isError"].as_bool(),
+            fetch_result(&cursor, 0, 100, Some("alice"), None)["isError"].as_bool(),
             Some(true)
         );
     }
@@ -365,7 +411,7 @@ mod tests {
         let cursor = cursor_of(&r);
         // offset + len must saturate, not overflow into a start > end byte slice
         // (which panics, and on the stdio transport takes down the whole gateway).
-        let v = fetch_result(&cursor, 5, usize::MAX, None);
+        let v = fetch_result(&cursor, 5, usize::MAX, None, None);
         assert_ne!(v["isError"].as_bool(), Some(true));
         assert!(v["content"][0]["text"]
             .as_str()
@@ -408,7 +454,7 @@ mod tests {
             .unwrap()
             .to_string();
         // Read 100 chars starting at char 1000 (byte 3000): all euros, none split.
-        let page = fetch_result(&cursor, 1000, 100, None);
+        let page = fetch_result(&cursor, 1000, 100, None, None);
         let pt = page["content"][0]["text"].as_str().unwrap();
         let body = pt.split("\n\n[Toolport:").next().unwrap();
         assert_eq!(body.chars().filter(|&c| c == '€').count(), 100);
@@ -426,7 +472,7 @@ mod tests {
             .and_then(|s| s.split('"').next())
             .unwrap()
             .to_string();
-        let past = fetch_result(&cursor, 999_999, 100, None);
+        let past = fetch_result(&cursor, 999_999, 100, None, None);
         let pt = past["content"][0]["text"].as_str().unwrap();
         assert!(pt.contains("past the end"));
         assert_eq!(past["isError"].as_bool(), Some(false));
@@ -469,5 +515,58 @@ mod tests {
             "cache grew to {} entries",
             map.len()
         );
+    }
+
+    #[test]
+    fn fetch_result_projection_returns_nested_field() {
+        let mut r = json!({
+            "content": [{
+                "type": "text",
+                "text": "x".repeat(4096)
+            }],
+            "structuredContent": {
+                "data": {
+                    "users": [
+                        {
+                            "profile": {
+                                "name": "Alice",
+                                "age": 30
+                            }
+                        },
+                        {
+                            "profile": {
+                                "name": "Bob",
+                                "age": 40
+                            }
+                        }
+                    ]
+                }
+            },
+            "isError": false
+        });
+
+        // Force shaping so the result is cached.
+        assert!(shape_result(&mut r, 2048, None));
+
+        let text = r["content"][0]["text"].as_str().unwrap();
+        let cursor = text
+            .split("\"cursor\":\"")
+            .nth(1)
+            .and_then(|s| s.split('"').next())
+            .unwrap()
+            .to_string();
+
+        let projected = fetch_result(
+            &cursor,
+            0,
+            0,
+            None,
+            Some("data.users.1.profile.age"),
+        );
+
+        assert!(!projected["isError"].as_bool().unwrap());
+
+        let text = projected["content"][0]["text"].as_str().unwrap();
+        assert_eq!(text, "40");
     }
 }


### PR DESCRIPTION
> **Credit:** original implementation by @BharadwajKanneveti (tsouth89/toolport#313). This PR is their branch plus minor review fixes.

Implements the field-projection half of [SBS-162](https://linear.app/southforge-ai/issue/SBS-162/result-shaping-always-on-lossless-output-compression-per-tool-field) (result shaping): let an agent pull one nested field out of a large held result instead of paging the whole body back into context.

## What changed

* `shaping.rs`: cache a result's `structuredContent` alongside the shaped text body when a result is shaped. Cache-eviction sizing now counts the structured bytes too, so the memory bound stays honest.
* `toolport_fetch_result` gains an optional `projection` argument: a dot-separated path into the cached `structuredContent` (e.g. `data.users.1.profile.age`). It walks objects by key and arrays by index, returns the projected value as text, and returns a typed `isError` result when there's no `structuredContent` or the path misses.
* Gateway wires the new `projection` param through `handle_request` to `shaping::fetch_result`.

## Why

This is the per-tool field-projection lever from [SBS-162](https://linear.app/southforge-ai/issue/SBS-162/result-shaping-always-on-lossless-output-compression-per-tool-field)'s results-layer token thesis: shaping already truncates over-budget results to a head + paging cursor; projection lets the agent fetch exactly the field it needs from the held remainder rather than streaming it back.

## Tests

* `shaping.rs`: projection returns a nested field; existing paging/owner-scope tests updated for the new `fetch_result` signature.
* gateway: end-to-end `oversized_tool_call_can_be_fetched` (shape → cursor → fetch remainder) and `fetch_result_projection_dispatch_returns_requested_field` (shape → projection through the public tool API).

Relates to [SBS-162](https://linear.app/southforge-ai/issue/SBS-162/result-shaping-always-on-lossless-output-compression-per-tool-field). Follow-on results-layer work (always-on minification, `kind:"output"` accounting in `savings.rs`) stays open on that issue.