### PR TITLE
Typed HITL decisions + content-binding on approvals (SOU-163)

### DIFF
--- a/src-tauri/src/approval.rs
+++ b/src-tauri/src/approval.rs
@@ -90,6 +90,14 @@ pub enum ApprovalDecision {
     /// in time". Still fail-closed - it never lets the call proceed. The broker never sends
     /// this; it is only ever produced gateway-side.
     Unreachable,
+    /// A human approved a *specific* call, but the arguments about to execute no longer match
+    /// the ones that were approved (their canonical [`crate::audit::args_hash`] differs). The
+    /// stale approval is rejected rather than run on mutated content - approval binds to
+    /// CONTENT, not just intent. Like [`Unreachable`], the broker never sends this; it is
+    /// only ever produced gateway-side, at execute time, and is still fail-closed. This is
+    /// the seam a decoupled approval (session re-use, or a code-mode script that approves
+    /// then replays) must clear before its effect runs.
+    StaleState,
 }
 
 impl ApprovalDecision {
@@ -167,6 +175,20 @@ mod tests {
         assert!(!ApprovalDecision::Timeout.is_approved());
         // Unreachable is fail-closed exactly like the other non-approvals.
         assert!(!ApprovalDecision::Unreachable.is_approved());
+        // StaleState (approved-then-mutated) is fail-closed too: content no longer matches.
+        assert!(!ApprovalDecision::StaleState.is_approved());
+    }
+
+    #[test]
+    fn stale_state_is_a_distinct_serde_variant() {
+        // Round-trips to snake_case and is distinct from the other non-approvals so a
+        // caller can tell "the approved content changed" apart from a deny/timeout.
+        let s = serde_json::to_string(&ApprovalDecision::StaleState).unwrap();
+        assert_eq!(s, "\"stale_state\"");
+        let back: ApprovalDecision = serde_json::from_str(&s).unwrap();
+        assert_eq!(back, ApprovalDecision::StaleState);
+        assert_ne!(ApprovalDecision::StaleState, ApprovalDecision::Denied);
+        assert_ne!(ApprovalDecision::StaleState, ApprovalDecision::Unreachable);
     }
 
     #[test]

--- a/src-tauri/src/audit.rs
+++ b/src-tauri/src/audit.rs
@@ -121,7 +121,7 @@ fn decision_entry(
     reason: &str,
     decision: &str,
     args_hash: &str,
-    duration_ms: Option<u64>,
+    held_ms: Option<u64>,
 ) -> Value {
     // `held` = the call was gated and did NOT run. An `approved` decision ran, so it is not
     // held (it must not inflate the held count); every non-approval was blocked, so it is.
@@ -137,8 +137,10 @@ fn decision_entry(
         "decision": decision,
         "argsHash": args_hash,
     });
-    if let Some(ms) = duration_ms {
-        entry["durationMs"] = json!(ms);
+    // The approval wait, recorded as `heldMs` (not `durationMs`) so a governance view can
+    // tell how long a human was asked apart from a call's downstream execution duration.
+    if let Some(ms) = held_ms {
+        entry["heldMs"] = json!(ms);
     }
     if let Some(c) = client.filter(|c| !c.is_empty()) {
         entry["client"] = json!(c);
@@ -156,7 +158,7 @@ pub fn record_decision(
     reason: &str,
     decision: &str,
     args: &Value,
-    duration_ms: Option<u64>,
+    held_ms: Option<u64>,
 ) {
     write_line(&decision_entry(
         server,
@@ -165,7 +167,7 @@ pub fn record_decision(
         reason,
         decision,
         &args_hash(args),
-        duration_ms,
+        held_ms,
     ));
 }
 
@@ -481,6 +483,7 @@ const CSV_COLUMNS: &[&str] = &[
     "decision",
     "argsHash",
     "durationMs",
+    "heldMs",
     "action",
     "error",
 ];
@@ -532,7 +535,7 @@ mod tests {
         })];
         let csv = to_csv(&entries);
         assert!(csv.starts_with(
-            "ts,server,tool,client,ok,held,kind,reason,decision,argsHash,durationMs,action,error\r\n"
+            "ts,server,tool,client,ok,held,kind,reason,decision,argsHash,durationMs,heldMs,action,error\r\n"
         ));
         assert!(csv.contains("\"gh\""));
         assert!(csv.contains("\"search\""));
@@ -679,7 +682,9 @@ mod tests {
         assert_eq!(e["reason"], "destructive");
         assert_eq!(e["decision"], "unreachable");
         assert_eq!(e["argsHash"], "deadbeef");
-        assert_eq!(e["durationMs"], 1234);
+        // The wait is `heldMs` (approval wait), not `durationMs` (downstream exec time).
+        assert_eq!(e["heldMs"], 1234);
+        assert!(e.get("durationMs").is_none());
         assert_eq!(e["client"], "claude");
         // Held (didn't run) but ok:true so it stays out of the error rate.
         assert_eq!(e["held"], true);
@@ -693,8 +698,8 @@ mod tests {
         assert_eq!(denied["reason"], "untrusted_source");
         // Unattributed call omits the client field entirely.
         assert!(denied.get("client").is_none());
-        // durationMs is optional.
-        assert!(denied.get("durationMs").is_none());
+        // heldMs is optional.
+        assert!(denied.get("heldMs").is_none());
 
         // An approved call RAN, so it is audited but not counted as held (still ok:true).
         let approved = decision_entry("s", "t", None, "destructive", "approved", "h", None);

--- a/src-tauri/src/audit.rs
+++ b/src-tauri/src/audit.rs
@@ -103,14 +103,17 @@ pub fn record_held(server: &str, tool: &str, client: Option<&str>) {
 }
 
 /// Build the audit entry for a gated HITL decision. Pure (no I/O) so it's unit-testable.
-/// Kept `ok:true` + `held:true` so it stays out of the error rate and the existing
-/// held-row UI renders it unchanged; the added fields (`kind`, `reason`, `decision`,
+/// `ok:true` keeps governance outcomes out of the error rate; `held` is true for every
+/// blocked outcome and false for `approved` (which ran), so the held-row UI stays honest;
+/// the added fields (`kind`, `reason`, `decision`,
 /// `argsHash`) let a governance / Approvals view tell *why* a call was gated and *which*
-/// way it resolved (denied vs no-response vs unreachable) apart - which the old flat
-/// `record_held` collapsed into one indistinguishable record. `reason` is the snake_case
-/// [`crate::approval::ApprovalReason`]; `decision` is `approved` | `denied` | `no_response`
-/// | `unreachable`. The RAW arguments are never stored - only `argsHash` - so the log
-/// proves which exact call was decided without persisting secrets/PII from arguments.
+/// way it resolved (approved vs denied vs no-response vs unreachable vs stale-state) apart -
+/// which the old flat `record_held` collapsed into one indistinguishable record. `reason`
+/// is the snake_case [`crate::approval::ApprovalReason`]; `decision` is `approved` |
+/// `denied` | `no_response` | `unreachable` | `stale_state` (the last: a human approved but
+/// the arguments were mutated before execute, so the stale approval was rejected). The RAW
+/// arguments are never stored - only `argsHash` - so the log proves which exact call was
+/// decided without persisting secrets/PII from arguments.
 fn decision_entry(
     server: &str,
     tool: &str,
@@ -120,12 +123,15 @@ fn decision_entry(
     args_hash: &str,
     duration_ms: Option<u64>,
 ) -> Value {
+    // `held` = the call was gated and did NOT run. An `approved` decision ran, so it is not
+    // held (it must not inflate the held count); every non-approval was blocked, so it is.
+    // `ok:true` throughout keeps governance outcomes (a deny, a timeout) out of the error rate.
     let mut entry = json!({
         "ts": epoch_millis() as u64,
         "server": server,
         "tool": tool,
         "ok": true,
-        "held": true,
+        "held": decision != "approved",
         "kind": "approval",
         "reason": reason,
         "decision": decision,
@@ -689,6 +695,12 @@ mod tests {
         assert!(denied.get("client").is_none());
         // durationMs is optional.
         assert!(denied.get("durationMs").is_none());
+
+        // An approved call RAN, so it is audited but not counted as held (still ok:true).
+        let approved = decision_entry("s", "t", None, "destructive", "approved", "h", None);
+        assert_eq!(approved["decision"], "approved");
+        assert_eq!(approved["held"], false);
+        assert_eq!(approved["ok"], true);
     }
 
     #[test]

--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -2115,6 +2115,95 @@ fn request_human_decision(mut req: approval::ApprovalRequest) -> approval::Appro
     }
 }
 
+/// The stable machine token for a HITL decision, shared by the audit record and the
+/// agent-facing envelope so both name the outcome the same way. `Approved` is included for
+/// the audit path (approved calls are logged too); the refusal envelope never sees it.
+fn decision_token(decision: approval::ApprovalDecision) -> &'static str {
+    match decision {
+        approval::ApprovalDecision::Approved => "approved",
+        approval::ApprovalDecision::Denied => "denied",
+        approval::ApprovalDecision::Unreachable => "unreachable",
+        approval::ApprovalDecision::StaleState => "stale_state",
+        // A human was asked but didn't answer in the fail-closed window.
+        approval::ApprovalDecision::Timeout => "no_response",
+    }
+}
+
+/// Content-binding gate: after a human approves a *specific* call, the bytes that RUN must
+/// equal the bytes APPROVED. Returns `StaleState` when the canonical `argsHash` of `current`
+/// differs from `approved_hash` (the call was mutated after approval), else `None` so the
+/// call may proceed. In today's synchronous path the approved and executed arguments are the
+/// same value, so this is a defense-in-depth invariant; it is also the enforcement seam a
+/// decoupled approval (session re-use, or a code-mode script that approves then replays with
+/// different arguments) must clear before its effect runs. Fail-closed: any mismatch blocks.
+fn content_binding_decision(
+    approved_hash: &str,
+    current: &Value,
+) -> Option<approval::ApprovalDecision> {
+    if audit::args_hash(current) == approved_hash {
+        None
+    } else {
+        Some(approval::ApprovalDecision::StaleState)
+    }
+}
+
+/// Build the agent-facing envelope for a call the gateway refused to run. Carries a
+/// machine-readable `toolportDecision` + gate `reason` (+ a `retriable` hint) in
+/// `structuredContent` so an agent - or a code-mode script inspecting the result - can pick
+/// the right recovery (retry after approval, re-form the call, or abandon) instead of
+/// blind-retrying a flat error string. Every non-approval is fail-closed (`isError: true`).
+fn refused_call_result(
+    id: Value,
+    name: &str,
+    decision: approval::ApprovalDecision,
+    reason_str: &str,
+) -> Value {
+    let token = decision_token(decision);
+    let (retriable, why) = match decision {
+        approval::ApprovalDecision::Denied => {
+            (false, format!("the call to {name} was denied by a human reviewer"))
+        }
+        approval::ApprovalDecision::Unreachable => (
+            true,
+            format!(
+                "the call to {name} could not be approved because the Toolport approval service \
+                 was unreachable (is the Toolport app running?)"
+            ),
+        ),
+        approval::ApprovalDecision::StaleState => (
+            true,
+            format!(
+                "the call to {name} changed after it was approved, so the stale approval was \
+                 rejected"
+            ),
+        ),
+        _ => (
+            true,
+            format!("the call to {name} was not approved in time (the Toolport app may be closed)"),
+        ),
+    };
+    let guidance = match decision {
+        approval::ApprovalDecision::StaleState => {
+            " Re-form the exact call and get it approved again, then retry."
+        }
+        approval::ApprovalDecision::Denied => "",
+        _ => " Ask the user to approve it in the Toolport app, then retry.",
+    };
+    success(
+        id,
+        json!({
+            "content": [{ "type": "text", "text":
+                format!("Toolport: {why}, so it did not run.{guidance}") }],
+            "isError": true,
+            "structuredContent": {
+                "toolportDecision": token,
+                "reason": reason_str,
+                "retriable": retriable,
+            }
+        }),
+    )
+}
+
 #[cfg(test)]
 #[allow(clippy::too_many_arguments)]
 fn handle_request(
@@ -2758,6 +2847,18 @@ fn handle_request_with_cancel(
                     .map(|s| matches!(s.source.as_deref(), Some("shared") | Some("registry")))
                     .unwrap_or(false);
                 if let Some(reason) = approval::gate_reason(true, is_dest, untrusted) {
+                    // The gate reason names WHY a human was asked; shared by the audit record
+                    // and the agent-facing envelope on every outcome (approved included).
+                    let reason_str = match reason {
+                        approval::ApprovalReason::Destructive => "destructive",
+                        approval::ApprovalReason::UntrustedSource => "untrusted_source",
+                        approval::ApprovalReason::DestructiveAndUntrusted => {
+                            "destructive_and_untrusted"
+                        }
+                    };
+                    // The exact call being approved, content-bound: the bytes that RUN must
+                    // hash-match these. Captured before the (blocking) human decision.
+                    let approved_args_hash = audit::args_hash(&arguments);
                     let t0 = std::time::Instant::now();
                     let decision = request_human_decision(approval::ApprovalRequest {
                         token: String::new(),
@@ -2771,45 +2872,48 @@ fn handle_request_with_cancel(
                     });
                     let held_ms = t0.elapsed().as_millis() as u64;
                     if !decision.is_approved() {
-                        let why = match decision {
-                            approval::ApprovalDecision::Denied => "was denied by a human reviewer",
-                            approval::ApprovalDecision::Unreachable => {
-                                "could not be approved because the Toolport approval service was \
-                                 unreachable (is the Toolport app running?)"
-                            }
-                            _ => "was not approved in time (the Toolport app may be closed)",
-                        };
                         // Governance audit: the gate reason and which non-approval outcome
                         // (denied / no-response / unreachable), plus a content hash of the
                         // exact call - never the raw args. Replaces the flat record_held so
-                        // the three failure modes are no longer indistinguishable in the log.
-                        let reason_str = match reason {
-                            approval::ApprovalReason::Destructive => "destructive",
-                            approval::ApprovalReason::UntrustedSource => "untrusted_source",
-                            approval::ApprovalReason::DestructiveAndUntrusted => {
-                                "destructive_and_untrusted"
-                            }
-                        };
-                        let decision_str = match decision {
-                            approval::ApprovalDecision::Denied => "denied",
-                            approval::ApprovalDecision::Unreachable => "unreachable",
-                            _ => "no_response",
-                        };
+                        // the failure modes are no longer indistinguishable in the log.
                         audit::record_decision(
-                            srv, tool, client, reason_str, decision_str, &arguments, Some(held_ms),
+                            srv,
+                            tool,
+                            client,
+                            reason_str,
+                            decision_token(decision),
+                            &arguments,
+                            Some(held_ms),
                         );
-                        return Some(success(
-                            id,
-                            json!({
-                                "content": [{ "type": "text", "text": format!(
-                                    "Toolport: the call to {name} {why}, so it did not run. \
-                                     Ask the user to approve it in the Toolport app, then retry."
-                                ) }],
-                                "isError": true
-                            }),
-                        ));
+                        return Some(refused_call_result(id, name, decision, reason_str));
                     }
-                    // A human approved: skip the agent-confirm step and route the call.
+                    // A human approved. Enforce content-binding before running: if the call
+                    // was mutated after approval, reject the stale approval (fail-closed)
+                    // rather than run bytes a human never actually saw.
+                    if let Some(stale) = content_binding_decision(&approved_args_hash, &arguments) {
+                        audit::record_decision(
+                            srv,
+                            tool,
+                            client,
+                            reason_str,
+                            decision_token(stale),
+                            &arguments,
+                            Some(held_ms),
+                        );
+                        return Some(refused_call_result(id, name, stale, reason_str));
+                    }
+                    // Approved calls are audited too, so the trail shows what actually ran,
+                    // not only what was blocked.
+                    audit::record_decision(
+                        srv,
+                        tool,
+                        client,
+                        reason_str,
+                        "approved",
+                        &arguments,
+                        Some(held_ms),
+                    );
+                    // Skip the agent-confirm step and route the call.
                     confirmed = true;
                 }
             }
@@ -6801,6 +6905,56 @@ mod tests {
         let d = decide_via_broker(bad, &mut r);
         assert!(!d.is_approved());
         assert_eq!(d, approval::ApprovalDecision::Unreachable);
+    }
+
+    /// The audit record and the agent-facing envelope must name every outcome the same way,
+    /// so a governance view and a recovering agent never disagree about what happened.
+    #[test]
+    fn decision_token_names_every_outcome() {
+        assert_eq!(decision_token(approval::ApprovalDecision::Approved), "approved");
+        assert_eq!(decision_token(approval::ApprovalDecision::Denied), "denied");
+        assert_eq!(decision_token(approval::ApprovalDecision::Timeout), "no_response");
+        assert_eq!(decision_token(approval::ApprovalDecision::Unreachable), "unreachable");
+        assert_eq!(decision_token(approval::ApprovalDecision::StaleState), "stale_state");
+    }
+
+    /// Content-binding: identical arguments pass (the approved call runs); any change to the
+    /// arguments after approval yields StaleState, so the stale approval never runs.
+    #[test]
+    fn content_binding_matches_only_identical_args() {
+        let approved = audit::args_hash(&json!({ "table": "users", "hard": true }));
+        // Same content, different key order -> canonical hash matches -> allowed.
+        assert!(content_binding_decision(&approved, &json!({ "hard": true, "table": "users" }))
+            .is_none());
+        // Mutated after approval (different value) -> StaleState, fail-closed.
+        assert_eq!(
+            content_binding_decision(&approved, &json!({ "table": "orders", "hard": true })),
+            Some(approval::ApprovalDecision::StaleState)
+        );
+    }
+
+    /// The refusal envelope is machine-readable: a code-mode script (or any agent) can read
+    /// `structuredContent.toolportDecision` + `retriable` to pick a recovery instead of
+    /// blind-retrying a flat error string. Every non-approval stays `isError: true`.
+    #[test]
+    fn refused_call_result_carries_typed_decision() {
+        let cases = [
+            (approval::ApprovalDecision::Denied, "denied", false),
+            (approval::ApprovalDecision::Timeout, "no_response", true),
+            (approval::ApprovalDecision::Unreachable, "unreachable", true),
+            (approval::ApprovalDecision::StaleState, "stale_state", true),
+        ];
+        for (decision, token, retriable) in cases {
+            let v = refused_call_result(json!(1), "db__drop", decision, "destructive");
+            let result = &v["result"];
+            assert_eq!(result["isError"].as_bool(), Some(true), "{token} must fail closed");
+            let sc = &result["structuredContent"];
+            assert_eq!(sc["toolportDecision"].as_str(), Some(token));
+            assert_eq!(sc["reason"].as_str(), Some("destructive"));
+            assert_eq!(sc["retriable"].as_bool(), Some(retriable));
+            // The human-readable text still names the tool so a person reading a log sees it.
+            assert!(result["content"][0]["text"].as_str().unwrap().contains("db__drop"));
+        }
     }
 
     fn router() -> Router {

--- a/src/components/ActivityView.tsx
+++ b/src/components/ActivityView.tsx
@@ -673,7 +673,7 @@ function CallRow({ e }: { e: AuditEntry }) {
           </span>
         )}
         <span className="ml-auto shrink-0 text-xs tabular-nums text-muted-foreground">
-          {fmtMs(e.durationMs ?? null)}
+          {fmtMs(e.durationMs ?? e.heldMs ?? null)}
         </span>
         <span className="shrink-0 text-xs text-muted-foreground">
           {new Date(e.ts).toLocaleString()}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -58,6 +58,9 @@ export interface AuditEntry {
   ok: boolean;
   /** How long the call took, ms. Absent for records logged before timing. */
   durationMs?: number;
+  /** How long a gated call waited for a human approval decision, ms. Present on
+   * `kind:"approval"` records instead of durationMs (which is downstream exec time). */
+  heldMs?: number;
   /** Short failure message for a failed call (never args or result data). */
   error?: string;
   /** A destructive call held for confirmation (not a success and not an error). */


### PR DESCRIPTION
Makes the human-in-the-loop approval path **legible** and **content-bound**, so an agent (and, next, a code-mode script per SOU-184) can recover from a held call instead of collapsing every non-approval into "tool failed".

## What changed

**Typed decision surfaced to the agent.** Every refused call now returns a machine-readable envelope instead of a flat `isError` string:

```json
{ "isError": true,
  "structuredContent": { "toolportDecision": "unreachable", "reason": "destructive", "retriable": true } }
```

`toolportDecision` ∈ `denied | no_response | unreachable | stale_state`, with a `retriable` hint so the model picks the right next step (retry after approval, re-form the call, or abandon). One `decision_token` maps the outcome so the audit record and the agent envelope always agree.

**Approved calls are audited too.** `record_decision` previously fired only on the non-approval branch; now an `approved` record is written (with `heldMs` + `argsHash`) so the trail shows what *ran*, not just what was blocked. `held` now reflects reality (`false` for `approved`, which ran) so the held count stays honest; `ok:true` keeps governance outcomes out of the error rate.

**Content-binding enforced at execute.** `ApprovalDecision::StaleState` (gateway-produced, fail-closed, never sent by the broker) means "a human approved this call but its arguments changed before execute". The gate captures the approved call's canonical `argsHash` and rejects a stale approval if the bytes about to run no longer match — approval binds to *content*, not just intent. In today's synchronous path this is a defense-in-depth invariant; it's also the seam a decoupled/replayed approval (session re-use, or a SOU-184 code-mode script) must clear before its effect runs.

## Deferred (still on SOU-163)

- Execution-phase variants `downstream_timeout` / `target_error` — need a downstream-error classifier (separate effort).
- `policy_blocked` — needs a policy deny-list.
- The Activity **Approvals** tab (filter `kind == "approval"`, distinct iconography for `unreachable` vs `denied`) — follow-up frontend work; the data + CSV columns already flow through.

## Tests

- `approval.rs`: `StaleState` serde round-trip + `is_approved() == false`.
- `audit.rs`: `approved` → `held:false, ok:true`; raw args never stored.
- gateway: `decision_token` names every outcome; content-binding passes identical args (key-order-independent) and rejects mutated args as `StaleState`; the refusal envelope carries the typed decision + `retriable` and stays `isError:true`.

Rust lib + bin suites green locally (378 + 112). Refs SOU-163.
