### PR TITLE
fix: force toaster theme to dark

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -808,7 +808,7 @@ function App() {
         destructive
         onConfirm={handleToggleAll}
       />
-      <Toaster position="bottom-right" />
+      <Toaster theme="dark" position="bottom-right" />
     </TooltipProvider>
   );
 }

--- a/src/components/ui/sonner.tsx
+++ b/src/components/ui/sonner.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useTheme } from "next-themes";
 import { Toaster as Sonner, type ToasterProps } from "sonner";
 import {
   CircleCheckIcon,
@@ -11,11 +10,8 @@ import {
 } from "lucide-react";
 
 const Toaster = ({ ...props }: ToasterProps) => {
-  const { theme = "system" } = useTheme();
-
   return (
     <Sonner
-      theme={theme as ToasterProps["theme"]}
       className="toaster group"
       icons={{
         success: <CircleCheckIcon className="size-4" />,


### PR DESCRIPTION
## What and why

- Fixes the toaster following the system theme on a dark-only app.
- The app always uses dark mode, but the Sonner toaster was using `next-themes` and resolving the theme as `system`, which allowed OS appearance settings to influence toast styling.
- This change removes the system theme dependency from the toaster wrapper and explicitly passes `theme="dark"` when rendering the toaster, ensuring toasts remain dark regardless of the OS theme.

Closes #292 

## Testing

- [x] `npm run build` passes
- [x] `npm run test` passes
- [ ] `npm run audit:prod` passes
- [ ] `npm run test:rust` passes (`npm run test:rust:windows` on Windows if the debug gateway binary is locked)
- [x] Ran the app (`npm run tauri dev`) and checked the change by hand

Verified the toaster receives `theme="dark"` and renders correctly with both light and dark OS appearance settings.

## Notes

No UI behavior was changed other than forcing toast styling to remain dark.

No secrets, keys, or personal paths are included in the diff.