### PR TITLE
feat: add transport helper text in server dialog

### DIFF
--- a/src/components/ServerDialog.tsx
+++ b/src/components/ServerDialog.tsx
@@ -351,6 +351,10 @@ export function ServerDialog({
                 <SelectItem value="sse">sse (remote)</SelectItem>
               </SelectContent>
             </Select>
+
+            <p className="text-xs text-muted-foreground">
+              Use stdio for a local command, or http/sse for a remote URL.
+            </p>
           </div>
 
           {isStdio ? (


### PR DESCRIPTION

## What and why

- Adds helper text below the Transport selector in the Add/Edit Server dialog.
- Previously, users had to open the transport dropdown to understand the difference between `stdio`, `http`, and `sse`. This change adds a short inline hint explaining that `stdio` is used for local commands while `http/sse` are used for remote URLs.

Closes #267

## Testing

<!-- How did you verify this? -->

- [x] `npm run build` passes
- [x] `npm run test` passes
- [ ] `npm run audit:prod` passes
- [ ] `npm run test:rust` passes (`npm run test:rust:windows` on Windows if the debug gateway binary is locked)
- [x] Ran the app (`npm run tauri dev`) and checked the change by hand

Verified the helper text appears correctly in both Add Server and Edit Server dialogs and does not affect the existing layout.

## Notes

<!-- Screenshots for UI changes, follow-ups, or anything a reviewer should know.
     Confirm no secrets, keys, or personal paths are included in the diff. -->

No functional behavior was changed. This only adds explanatory helper text below the Transport selector.

No secrets, keys, or personal paths are included in the diff.