### PR TITLE
Server-side tool orchestration: code mode (SOU-184)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -39,6 +39,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aligned-vec"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc890384c8602f339876ded803c97ad529f3842aba97f6392b3dba0dd171769b"
+dependencies = [
+ "equator",
+]
+
+[[package]]
 name = "alloc-no-stdlib"
 version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -52,6 +61,12 @@ checksum = "0e76a019e91224d279006ff972f1e984179a6e9feb050adba6ce8274aef23195"
 dependencies = [
  "alloc-no-stdlib",
 ]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "android_system_properties"
@@ -76,6 +91,12 @@ checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 dependencies = [
  "derive_arbitrary",
 ]
+
+[[package]]
+name = "arrayvec"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
 
 [[package]]
 name = "ascii"
@@ -343,6 +364,147 @@ dependencies = [
 ]
 
 [[package]]
+name = "boa_ast"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6339a700715bda376f5ea65c76e8fe8fc880930d8b0638cea68e7f3da6538e0a"
+dependencies = [
+ "bitflags 2.13.0",
+ "boa_interner",
+ "boa_macros",
+ "boa_string",
+ "indexmap 2.14.0",
+ "num-bigint",
+ "rustc-hash",
+]
+
+[[package]]
+name = "boa_engine"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1521be326f8a5c8887e95d4ce7f002917a002a23f7b93b9a6a2bf50ed4157824"
+dependencies = [
+ "aligned-vec",
+ "arrayvec",
+ "bitflags 2.13.0",
+ "boa_ast",
+ "boa_gc",
+ "boa_interner",
+ "boa_macros",
+ "boa_parser",
+ "boa_string",
+ "bytemuck",
+ "cfg-if",
+ "cow-utils",
+ "dashmap",
+ "dynify",
+ "fast-float2",
+ "float16",
+ "futures-channel",
+ "futures-concurrency",
+ "futures-lite",
+ "hashbrown 0.16.1",
+ "icu_normalizer",
+ "indexmap 2.14.0",
+ "intrusive-collections",
+ "itertools",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "num_enum",
+ "paste",
+ "portable-atomic",
+ "rand 0.9.4",
+ "regress",
+ "rustc-hash",
+ "ryu-js",
+ "serde",
+ "serde_json",
+ "small_btree",
+ "static_assertions",
+ "tag_ptr",
+ "tap",
+ "thin-vec",
+ "thiserror 2.0.18",
+ "time",
+ "xsum",
+]
+
+[[package]]
+name = "boa_gc"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17323a98cf2e631afacf1a6d659c1212c48a68bacfa85afab0a66ade80582e51"
+dependencies = [
+ "boa_macros",
+ "boa_string",
+ "hashbrown 0.16.1",
+ "thin-vec",
+]
+
+[[package]]
+name = "boa_interner"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20510b8b02bcde9b0a01cf34c0c308c56156503d1d91cdab4c8cfbd292b747ea"
+dependencies = [
+ "boa_gc",
+ "boa_macros",
+ "hashbrown 0.16.1",
+ "indexmap 2.14.0",
+ "once_cell",
+ "phf",
+ "rustc-hash",
+ "static_assertions",
+]
+
+[[package]]
+name = "boa_macros"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5822cb4f146d243060e588bc5a5f2e709683fdad3d7111f42c48e6b5c921d23d"
+dependencies = [
+ "cfg-if",
+ "cow-utils",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+ "synstructure",
+]
+
+[[package]]
+name = "boa_parser"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd957fa9fa93e3a001a8aba5a5cd40c2bbfde486378be4c4b472fd304aaddb"
+dependencies = [
+ "bitflags 2.13.0",
+ "boa_ast",
+ "boa_interner",
+ "boa_macros",
+ "fast-float2",
+ "icu_properties",
+ "num-bigint",
+ "num-traits",
+ "regress",
+ "rustc-hash",
+]
+
+[[package]]
+name = "boa_string"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca2da1d7f4a76fd9040788a122f0d807910800a7b86f5952e9244848c36511de"
+dependencies = [
+ "fast-float2",
+ "itoa",
+ "paste",
+ "rustc-hash",
+ "ryu-js",
+ "static_assertions",
+]
+
+[[package]]
 name = "brotli"
 version = "8.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -383,6 +545,20 @@ name = "bytemuck"
 version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f65693059b6b9c588b9f62fed1cedbf0a8b805631457ea162d68f0de186f3de5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
 
 [[package]]
 name = "byteorder"
@@ -456,7 +632,7 @@ checksum = "dd5eb614ed4c27c5d706420e4320fbe3216ab31fa1c33cd8246ac36dae4479ba"
 dependencies = [
  "camino",
  "cargo-platform",
- "semver",
+ "semver 1.0.28",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -607,6 +783,8 @@ name = "conduit"
 version = "1.8.0"
 dependencies = [
  "base64 0.22.1",
+ "boa_engine",
+ "boa_gc",
  "chacha20poly1305",
  "core-foundation 0.10.1",
  "dirs 5.0.1",
@@ -719,6 +897,12 @@ dependencies = [
  "core-foundation 0.10.1",
  "libc",
 ]
+
+[[package]]
+name = "cow-utils"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "417bef24afe1460300965a25ff4a24b8b45ad011948302ec221e8a0a81eb2c79"
 
 [[package]]
 name = "cpufeatures"
@@ -844,6 +1028,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "6.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "dbus"
 version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -909,7 +1107,7 @@ checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
 dependencies = [
  "proc-macro2",
  "quote",
- "rustc_version",
+ "rustc_version 0.4.1",
  "syn 2.0.118",
 ]
 
@@ -1108,6 +1306,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
+name = "dynify"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81acb15628a3e22358bf73de5e7e62360b8a777dbcb5fc9ac7dfa9ae73723747"
+dependencies = [
+ "dynify-macros",
+]
+
+[[package]]
+name = "dynify-macros"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ec431cd708430d5029356535259c5d645d60edd3d39c54e5eea9782d46caa7d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "either"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+
+[[package]]
 name = "embed-resource"
 version = "3.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1115,7 +1339,7 @@ checksum = "c31a88c8d26de40ed18fe748c547845aa39de1db3afd958f8cb91579f3644bcb"
 dependencies = [
  "cc",
  "memchr",
- "rustc_version",
+ "rustc_version 0.4.1",
  "toml 1.1.2+spec-1.1.0",
  "vswhom",
  "winreg 0.55.0",
@@ -1148,6 +1372,26 @@ name = "enumflags2_derive"
 version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "equator"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4711b213838dfee0117e3be6ac926007d7f433d7bbe33595975d4190cb07e6fc"
+dependencies = [
+ "equator-macro",
+]
+
+[[package]]
+name = "equator-macro"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1203,6 +1447,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fast-float2"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8eb564c5c7423d25c886fb561d1e4ee69f72354d16918afa32c08811f6b6a55"
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1224,7 +1474,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38e2275cc4e4fc009b0669731a1e5ab7ebf11f469eaede2bab9309a5b4d6057f"
 dependencies = [
  "memoffset",
- "rustc_version",
+ "rustc_version 0.4.1",
 ]
 
 [[package]]
@@ -1244,6 +1494,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
 name = "flate2"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1251,6 +1507,16 @@ checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+]
+
+[[package]]
+name = "float16"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bffafbd079d520191c7c2779ae9cf757601266cf4167d3f659ff09617ff8483"
+dependencies = [
+ "cfg-if",
+ "rustc_version 0.2.3",
 ]
 
 [[package]]
@@ -1318,6 +1584,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
+]
+
+[[package]]
+name = "futures-concurrency"
+version = "7.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175cd8cca9e1d45b87f18ffa75088f2099e3c4fe5e2f83e42de112560bea8ea6"
+dependencies = [
+ "fixedbitset",
+ "futures-core",
+ "futures-lite",
+ "pin-project",
+ "smallvec",
 ]
 
 [[package]]
@@ -1700,6 +1979,17 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
@@ -1895,13 +2185,12 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.2.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+checksum = "200072f5d0e3614556f94a9930d5dc3e0662a652823904c3a75dc3b0af7fee47"
 dependencies = [
  "displaydoc",
  "potential_utf",
- "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -1915,6 +2204,7 @@ checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
+ "serde",
  "tinystr",
  "writeable",
  "zerovec",
@@ -1922,43 +2212,48 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.2.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+checksum = "8b24a59706036ba941c9476a55cd57b82b77f38a3c667d637ee7cabbc85eaedc"
 dependencies = [
+ "displaydoc",
  "icu_collections",
  "icu_normalizer_data",
  "icu_properties",
  "icu_provider",
  "smallvec",
+ "utf16_iter",
+ "write16",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.2.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+checksum = "00210d6893afc98edb752b664b8890f0ef174c8adbb8d0be9710fa66fbbf72d3"
 
 [[package]]
 name = "icu_properties"
-version = "2.2.0"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+checksum = "f5a97b8ac6235e69506e8dacfb2adf38461d2ce6d3e9bd9c94c4cbc3cd4400a4"
 dependencies = [
+ "displaydoc",
  "icu_collections",
  "icu_locale_core",
  "icu_properties_data",
  "icu_provider",
+ "potential_utf",
  "zerotrie",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_properties_data"
-version = "2.2.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+checksum = "298459143998310acd25ffe6810ed544932242d3f07083eee1084d83a71bd632"
 
 [[package]]
 name = "icu_provider"
@@ -1968,6 +2263,8 @@ checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
+ "serde",
+ "stable_deref_trait",
  "writeable",
  "yoke",
  "zerofrom",
@@ -1994,9 +2291,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.2"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -2058,6 +2355,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "intrusive-collections"
+version = "0.9.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "189d0897e4cbe8c75efedf3502c18c887b05046e59d28404d4d8e46cbc4d1e86"
+dependencies = [
+ "memoffset",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2080,6 +2386,15 @@ checksum = "173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5"
 dependencies = [
  "is-docker",
  "once_cell",
+]
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -2152,7 +2467,7 @@ checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
 dependencies = [
  "proc-macro2",
  "quote",
- "rustc_version",
+ "rustc_version 0.4.1",
  "simd_cesu8",
  "syn 2.0.118",
 ]
@@ -2524,6 +2839,7 @@ checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
  "num-integer",
  "num-traits",
+ "serde",
 ]
 
 [[package]]
@@ -2601,6 +2917,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.118",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -2936,6 +3261,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
 name = "pathdiff"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3044,6 +3375,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "pin-project"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3129,6 +3480,12 @@ dependencies = [
  "opaque-debug",
  "universal-hash",
 ]
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "potential_utf"
@@ -3404,6 +3761,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
+name = "regress"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2057b2325e68a893284d1538021ab90279adac1139957ca2a74426c6f118fb48"
+dependencies = [
+ "hashbrown 0.16.1",
+ "memchr",
+]
+
+[[package]]
 name = "reqwest"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3498,11 +3865,20 @@ checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustc_version"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
+dependencies = [
+ "semver 0.9.0",
+]
+
+[[package]]
+name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
- "semver",
+ "semver 1.0.28",
 ]
 
 [[package]]
@@ -3603,6 +3979,12 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "ryu-js"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04d056b875a9d2e6cb9a61d127afee9ac5999b9f87bcb32079d1318e505be714"
 
 [[package]]
 name = "same-file"
@@ -3755,6 +4137,15 @@ dependencies = [
 
 [[package]]
 name = "semver"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
+dependencies = [
+ "semver-parser",
+]
+
+[[package]]
+name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
@@ -3762,6 +4153,12 @@ dependencies = [
  "serde",
  "serde_core",
 ]
+
+[[package]]
+name = "semver-parser"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
@@ -3984,7 +4381,7 @@ version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
 dependencies = [
- "rustc_version",
+ "rustc_version 0.4.1",
  "simdutf8",
 ]
 
@@ -4005,6 +4402,15 @@ name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "small_btree"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ba60d2df92ba73864714808ca68c059734853e6ab722b40e1cf543ebb3a057a"
+dependencies = [
+ "arrayvec",
+]
 
 [[package]]
 name = "smallvec"
@@ -4184,6 +4590,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "tag_ptr"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0e973b34477b7823833469eb0f5a3a60370fef7a453e02d751b59180d0a5a05"
+
+[[package]]
 name = "tao"
 version = "0.35.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4233,6 +4645,12 @@ dependencies = [
  "quote",
  "syn 2.0.118",
 ]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tar"
@@ -4316,7 +4734,7 @@ dependencies = [
  "heck 0.5.0",
  "json-patch",
  "schemars 0.8.22",
- "semver",
+ "semver 1.0.28",
  "serde",
  "serde_json",
  "tauri-utils",
@@ -4338,7 +4756,7 @@ dependencies = [
  "png 0.17.16",
  "proc-macro2",
  "quote",
- "semver",
+ "semver 1.0.28",
  "serde",
  "serde_json",
  "sha2",
@@ -4543,7 +4961,7 @@ dependencies = [
  "percent-encoding",
  "reqwest",
  "rustls",
- "semver",
+ "semver 1.0.28",
  "serde",
  "serde_json",
  "tar",
@@ -4633,7 +5051,7 @@ dependencies = [
  "quote",
  "regex",
  "schemars 0.8.22",
- "semver",
+ "semver 1.0.28",
  "serde",
  "serde-untagged",
  "serde_json",
@@ -4693,6 +5111,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "thin-vec"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0f7e269b48f0a7dd0146680fa24b50cc67fc0373f086a5b2f99bd084639b482"
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4739,7 +5163,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711a53c2d47bbd818258c498c8dbfe186a2526c631495cfe7e078567f86b8469"
 dependencies = [
  "deranged",
+ "libc",
  "num-conv",
+ "num_threads",
  "powerfmt",
  "serde_core",
  "time-core",
@@ -4790,6 +5216,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
+ "serde_core",
  "zerovec",
 ]
 
@@ -5227,6 +5654,12 @@ name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
+name = "utf16_iter"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
 
 [[package]]
 name = "utf8_iter"
@@ -6070,6 +6503,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
+name = "write16"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
+
+[[package]]
 name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6159,6 +6598,12 @@ dependencies = [
  "libc",
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "xsum"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0637d3a5566a82fa5214bae89087bc8c9fb94cd8e8a3c07feb691bb8d9c632db"
 
 [[package]]
 name = "yoke"
@@ -6370,6 +6815,7 @@ dependencies = [
  "displaydoc",
  "yoke",
  "zerofrom",
+ "zerovec",
 ]
 
 [[package]]
@@ -6378,6 +6824,7 @@ version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
+ "serde",
  "yoke",
  "zerofrom",
  "zerovec-derive",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -50,6 +50,12 @@ dirs = "5"
 ureq = { version = "2", features = ["json"] }
 sha2 = "0.10"
 subtle = "2.6"
+# Pure-Rust JS engine for server-side "code mode" orchestration (SOU-184): run one
+# agent script that calls many downstream tools, so an N-step task costs one round-trip
+# and the intermediate results never enter model context. Chosen over QuickJS to keep the
+# build free of a C toolchain / FFI. `boa_gc` supplies the Trace impls host state needs.
+boa_engine = "0.21"
+boa_gc = "0.21"
 base64 = "0.22"
 regex = "1"
 getrandom = "0.2"

--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -30,6 +30,7 @@ use serde_json::{json, Value};
 
 use conduit_lib::audit;
 use conduit_lib::clients;
+use conduit_lib::codemode;
 use conduit_lib::downstream::{
     self, DownstreamServer, ServerRequestHandler, StdioTransport, Transport, PROTOCOL_VERSION,
 };
@@ -238,6 +239,40 @@ fn confirm_tool_def() -> Value {
     })
 }
 
+/// The `toolport_run_script` "code mode" meta-tool (advertised only when
+/// [`code_mode_enabled`]). One script replaces many round-trips.
+fn run_script_tool_def() -> Value {
+    json!({
+        "name": "toolport_run_script",
+        "description": "Run ONE JavaScript orchestration script server-side instead of making \
+            many separate tool calls. Inside the script, call downstream tools with \
+            `toolport.call(name, args)` (name = the exact tool name from toolport_search_tools, \
+            args = its arguments object); it returns that tool's result as a value. Loop, branch, \
+            and combine results, then `return` a single aggregated value - only the returned value \
+            comes back, so intermediate results never fill your context and a multi-step task \
+            costs one round-trip. Each call still passes the same gates as toolport_call_tool \
+            (scope, human approval). Synchronous: call tools one after another (no await / \
+            Promises). Best when you already know the steps; use toolport_search_tools + \
+            toolport_call_tool while you are still exploring.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "script": {
+                    "type": "string",
+                    "description": "JavaScript body. Call tools with toolport.call(name, args) and `return` the final value. The optional `data` payload below is available as the global `data`."
+                },
+                "data": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "description": "Optional input object exposed to the script as the global `data`."
+                }
+            },
+            "required": ["script"],
+            "additionalProperties": false
+        }
+    })
+}
+
 fn fetch_result_tool_def() -> Value {
     json!({
         "name": "toolport_fetch_result",
@@ -431,6 +466,20 @@ fn grouped_discovery() -> bool {
     discovery_mode() == DiscoveryMode::Grouped
 }
 
+/// Opt-in gate for server-side "code mode" (the `toolport_run_script` meta-tool). Off by
+/// default: code mode runs an agent-supplied JS script that can call many tools in one
+/// round-trip, a powerful capability worth an explicit opt-in even under Toolport's local
+/// trust model. Enable with `CONDUIT_CODE_MODE=1` (or `true`). When off, `run_script` is
+/// neither advertised nor dispatched.
+fn code_mode_enabled() -> bool {
+    std::env::var("CONDUIT_CODE_MODE")
+        .map(|v| {
+            let v = v.trim();
+            v == "1" || v.eq_ignore_ascii_case("true")
+        })
+        .unwrap_or(false)
+}
+
 /// The server prefix of a *namespaced* tool (`server__tool`). `None` for a bare name
 /// (a meta-tool), so those never spawn a spurious `help_<meta>` browse tool. (Guard:
 /// `tool_prefix` returns the whole name when there is no `__`.)
@@ -490,6 +539,9 @@ fn grouped_tool_defs(allow_agent_control: bool, confirm_destructive: bool, catal
         call_tool_def(),
         fetch_result_tool_def(),
     ];
+    if code_mode_enabled() {
+        tools.push(run_script_tool_def());
+    }
     if allow_agent_control {
         tools.push(enable_server_tool_def());
         tools.push(disable_server_tool_def());
@@ -1447,25 +1499,37 @@ fn fmt_tokens(n: u64) -> String {
 fn savings_line() -> String {
     let s = savings::summary();
     let saved = s.get("tokensSaved").and_then(Value::as_u64).unwrap_or(0);
-    if saved == 0 {
+    let round_trips = s.get("roundTripsSaved").and_then(Value::as_u64).unwrap_or(0);
+    if saved == 0 && round_trips == 0 {
         return String::new();
     }
-    let loads = s.get("listLoads").and_then(Value::as_u64).unwrap_or(0);
-    let peak = s.get("peakCatalog").and_then(Value::as_u64).unwrap_or(0);
-    let dollars = (saved as f64 / 1_000_000.0) * 3.0; // Claude Sonnet input $/M
-    let mut line = format!(
-        "\nLazy discovery has kept ~{} tokens of tool definitions out of your agent's \
-         context so far (about ${:.2} at Claude Sonnet input rates) across {loads} \
-         tool-list load(s)",
-        fmt_tokens(saved),
-        dollars
-    );
-    if peak > 4 {
+    let mut line = String::from("\n");
+    if saved > 0 {
+        let loads = s.get("listLoads").and_then(Value::as_u64).unwrap_or(0);
+        let peak = s.get("peakCatalog").and_then(Value::as_u64).unwrap_or(0);
+        let dollars = (saved as f64 / 1_000_000.0) * 3.0; // Claude Sonnet input $/M
         line.push_str(&format!(
-            "; the biggest catalog collapsed {peak} tools down to a handful of meta-tools"
+            "Lazy discovery has kept ~{} tokens of tool definitions out of your agent's \
+             context so far (about ${:.2} at Claude Sonnet input rates) across {loads} \
+             tool-list load(s)",
+            fmt_tokens(saved),
+            dollars
+        ));
+        if peak > 4 {
+            line.push_str(&format!(
+                "; the biggest catalog collapsed {peak} tools down to a handful of meta-tools"
+            ));
+        }
+        line.push_str(".\n");
+    }
+    if round_trips > 0 {
+        // Code mode's second savings headline: round-trips (and their intermediate results)
+        // collapsed into single run_script calls.
+        line.push_str(&format!(
+            "Code mode has collapsed ~{round_trips} downstream tool round-trip(s) into single \
+             run_script call(s), keeping their intermediate results out of context.\n"
         ));
     }
-    line.push_str(".\n");
     line
 }
 
@@ -1870,6 +1934,7 @@ fn is_fixed_meta_tool(name: &str) -> bool {
             | "toolport_fetch_result"
             | "toolport_enable_server"
             | "toolport_disable_server"
+            | "toolport_run_script"
     )
 }
 
@@ -2148,13 +2213,13 @@ fn content_binding_decision(
     }
 }
 
-/// Build the agent-facing envelope for a call the gateway refused to run. Carries a
-/// machine-readable `toolportDecision` + gate `reason` (+ a `retriable` hint) in
-/// `structuredContent` so an agent - or a code-mode script inspecting the result - can pick
+/// Build the agent-facing tool RESULT for a call the gateway refused to run (the inner
+/// `{content, isError, structuredContent}`, which the caller wraps in a JSON-RPC envelope or
+/// hands to a code-mode script as its `toolport.call()` return). Carries a machine-readable
+/// `toolportDecision` + gate `reason` (+ a `retriable` hint) so an agent or script can pick
 /// the right recovery (retry after approval, re-form the call, or abandon) instead of
 /// blind-retrying a flat error string. Every non-approval is fail-closed (`isError: true`).
 fn refused_call_result(
-    id: Value,
     name: &str,
     decision: approval::ApprovalDecision,
     reason_str: &str,
@@ -2190,19 +2255,400 @@ fn refused_call_result(
         approval::ApprovalDecision::Denied => "",
         _ => " Ask the user to approve it in the Toolport app, then retry.",
     };
-    success(
-        id,
-        json!({
-            "content": [{ "type": "text", "text":
-                format!("Toolport: {why}, so it did not run.{guidance}") }],
-            "isError": true,
-            "structuredContent": {
-                "toolportDecision": token,
-                "reason": reason_str,
-                "retriable": retriable,
+    json!({
+        "content": [{ "type": "text", "text":
+            format!("Toolport: {why}, so it did not run.{guidance}") }],
+        "isError": true,
+        "structuredContent": {
+            "toolportDecision": token,
+            "reason": reason_str,
+            "retriable": retriable,
+        }
+    })
+}
+
+/// Execute ONE already-resolved tool call and return the MCP tool RESULT (the inner
+/// `{content, isError, structuredContent}`), NOT a JSON-RPC envelope. This is the single
+/// path both a direct `toolport_call_tool` dispatch and a code-mode script's
+/// `toolport.call()` binding go through, so every gate applies identically to both: the
+/// per-client scope guard, the placeholder guard, the typed human-approval gate with
+/// content-binding, the per-call destructive confirmation, live inspection, result shaping,
+/// and audit. A script therefore never reaches a tool the client couldn't already call, nor
+/// skips a gate a direct call would hit.
+///
+/// `confirm` is `Some` only on the interactive direct path, where a destructive tool can be
+/// held for the agent's `toolport_confirm` token replay. Inside a script that two-step
+/// handshake can't happen, so `confirm` is `None` and such a call fails closed rather than
+/// running unconfirmed. `confirmed` is true only when the call already came back through
+/// `toolport_confirm` (skips the approval + confirm gates so it isn't re-intercepted).
+#[allow(clippy::too_many_arguments)]
+fn execute_call(
+    reg: &Registry,
+    router: &Router,
+    cached: &[Value],
+    client: Option<&str>,
+    allowed: Option<&std::collections::HashSet<String>>,
+    cancel: Option<downstream::CancelContext>,
+    confirm: Option<&ConfirmGuard>,
+    name: &str,
+    arguments: Value,
+    mut confirmed: bool,
+) -> Value {
+    // Resolve the call's real (server, original tool) from the router's route map,
+    // NOT by splitting the exposed name on `__`. A renamed tool (via a tool override)
+    // or a server id containing `__` would otherwise mis-derive the server and
+    // silently weaken the scope guard and the HITL untrusted-provenance check below.
+    let (server_id, tool_name) = router
+        .route_of(name)
+        .map(|(s, t)| (s.to_string(), t.to_string()))
+        .unwrap_or_else(|| (String::new(), name.to_string()));
+    let srv_owned = sanitize_segment(&server_id);
+    let srv = srv_owned.as_str();
+    let tool = tool_name.as_str();
+
+    // Scope guard: a registered HTTP client may only call tools on the
+    // servers its token is allowed to see (a no-op when unscoped). Search
+    // and list are already filtered, but a client could name any tool, so
+    // enforce it on the call path too.
+    if let Some(set) = allowed {
+        if !set.contains(srv) {
+            return json!({
+                "content": [{ "type": "text", "text": format!("Toolport: '{srv}' is not available to this client.") }],
+                "isError": true
+            });
+        }
+    }
+
+    // Pre-call guard: a model that invents an identifier (e.g.
+    // teamId = "your_team_id") would otherwise waste a downstream call
+    // and get a confusing failure. Catch obvious placeholders and point
+    // it at where to source the real value. General across every server.
+    if let Some((param, value)) = find_placeholder_arg(&arguments) {
+        let resource = resource_stem(&param);
+        let hints = source_tool_hints(cached, srv, Some(&resource), 3);
+        let source = if hints.is_empty() {
+            format!("call a list or get tool on the '{srv}' server")
+        } else {
+            format!(
+                "call one of these on the '{srv}' server first: {}",
+                hints.join(", ")
+            )
+        };
+        let msg = format!(
+            "Toolport: \"{value}\" for \"{param}\" looks like a placeholder, not a real \
+             value, and was not sent. Don't invent identifiers. To get a real \"{param}\", \
+             {source}, then call {name} again with the value it returns."
+        );
+        return json!({ "content": [{ "type": "text", "text": msg }], "isError": true });
+    }
+
+    // Human-in-the-loop approval: hold a gated call (destructive, or from an
+    // untrusted-provenance server) until a person approves it in the Toolport app.
+    // Takes precedence over the agent-facing confirm below, and is fail-closed
+    // (no broker / no answer / timeout all deny). Skipped once `confirmed`.
+    if reg.human_approval_effective() && !confirmed {
+        // Resolve destructiveness robustly: cache, then live router, else
+        // fail-closed (an unknown tool must not skip the human gate).
+        let is_dest = tool_is_destructive_fail_closed(name, cached, router);
+        // Untrusted provenance = the same shared/registry signal the SSRF guard
+        // uses. Match on the REAL server id from `route_of` (not the sanitized
+        // prefix): two ids that sanitize alike would otherwise read the wrong
+        // server's trust flag and could skip this gate.
+        let untrusted = reg
+            .servers
+            .iter()
+            .find(|s| s.id == server_id)
+            .map(|s| matches!(s.source.as_deref(), Some("shared") | Some("registry")))
+            .unwrap_or(false);
+        if let Some(reason) = approval::gate_reason(true, is_dest, untrusted) {
+            // The gate reason names WHY a human was asked; shared by the audit record
+            // and the agent-facing envelope on every outcome (approved included).
+            let reason_str = match reason {
+                approval::ApprovalReason::Destructive => "destructive",
+                approval::ApprovalReason::UntrustedSource => "untrusted_source",
+                approval::ApprovalReason::DestructiveAndUntrusted => {
+                    "destructive_and_untrusted"
+                }
+            };
+            // The exact call being approved, content-bound: the bytes that RUN must
+            // hash-match these. Captured before the (blocking) human decision.
+            let approved_args_hash = audit::args_hash(&arguments);
+            let t0 = std::time::Instant::now();
+            let decision = request_human_decision(approval::ApprovalRequest {
+                token: String::new(),
+                id: new_correlation_id(),
+                client: client.map(str::to_string),
+                server: srv.to_string(),
+                tool: tool.to_string(),
+                reason,
+                arguments: arguments.clone(),
+                tool_fingerprint: tool_fingerprint_for(name, cached, router),
+            });
+            let held_ms = t0.elapsed().as_millis() as u64;
+            if !decision.is_approved() {
+                // Governance audit: the gate reason and which non-approval outcome
+                // (denied / no-response / unreachable), plus a content hash of the
+                // exact call - never the raw args. Replaces the flat record_held so
+                // the failure modes are no longer indistinguishable in the log.
+                audit::record_decision(
+                    srv,
+                    tool,
+                    client,
+                    reason_str,
+                    decision_token(decision),
+                    &arguments,
+                    Some(held_ms),
+                );
+                return refused_call_result(name, decision, reason_str);
             }
+            // A human approved. Enforce content-binding before running: if the call
+            // was mutated after approval, reject the stale approval (fail-closed)
+            // rather than run bytes a human never actually saw.
+            if let Some(stale) = content_binding_decision(&approved_args_hash, &arguments) {
+                audit::record_decision(
+                    srv,
+                    tool,
+                    client,
+                    reason_str,
+                    decision_token(stale),
+                    &arguments,
+                    Some(held_ms),
+                );
+                return refused_call_result(name, stale, reason_str);
+            }
+            // Approved calls are audited too, so the trail shows what actually ran,
+            // not only what was blocked.
+            audit::record_decision(
+                srv,
+                tool,
+                client,
+                reason_str,
+                "approved",
+                &arguments,
+                Some(held_ms),
+            );
+            // Skip the agent-confirm step and route the call.
+            confirmed = true;
+        }
+    }
+
+    // Per-call confirmation for destructive tools: intercept the first
+    // call with these arguments, store it, and return a preview. The
+    // agent calls toolport_confirm { token } to replay the stored call.
+    // This runs AFTER the placeholder guard (so a placeholder never
+    // gets a token) and BEFORE the actual route_call (so a destructive
+    // call never reaches the downstream server unconfirmed).
+    // Skip when `confirmed` is true: the call arrived via toolport_confirm
+    // and was already reviewed (prevents re-interception loop).
+    if reg.confirm_destructive && !confirmed {
+        // Resolve destructiveness robustly (cache, then live router, else
+        // fail-closed), so a cold/stale cache can't skip the confirm step for a
+        // destructive tool.
+        let dest = tool_is_destructive_fail_closed(name, cached, router);
+        if dest {
+            match confirm {
+                Some(confirm) => {
+                    let token = confirm.store(name.to_string(), arguments.clone(), client);
+                    let args_pretty =
+                        serde_json::to_string_pretty(&arguments).unwrap_or_default();
+                    let msg = format!(
+                        "⚠️ Destructive action intercepted.\n\nTool: {name}\nArguments:\n{args_pretty}\n\n\
+                         Review the arguments above carefully. If correct, call toolport_confirm \
+                         with token: {token}\n\
+                         The token expires in 60 seconds. The original arguments will be replayed \
+                         exactly."
+                    );
+                    // Held for confirmation, not a failure: record as held (ok), so the
+                    // confirm-destructive feature doesn't inflate the error rate.
+                    audit::record_held(srv, tool, client);
+                    return json!({
+                        "content": [{ "type": "text", "text": msg }],
+                        "isError": true
+                    });
+                }
+                None => {
+                    // Code mode: the agent-token replay handshake can't happen inside a
+                    // script (it needs a second round-trip). Fail closed rather than run
+                    // an unconfirmed destructive call.
+                    audit::record_held(srv, tool, client);
+                    return json!({
+                        "content": [{ "type": "text", "text": format!(
+                            "Toolport: {name} is a destructive tool that requires per-call \
+                             confirmation, which is not available inside a code-mode script. Call \
+                             it directly with toolport_call_tool, or enable human approval so it \
+                             can be approved in the app."
+                        ) }],
+                        "isError": true
+                    });
+                }
+            }
+        }
+    }
+
+    // Live inspection (opt-in, off by default): capture the raw request
+    // args now, only when enabled, so the response can be paired with them
+    // below. When off, nothing is cloned and nothing is ever captured.
+    let inspect_args = if reg.live_inspect {
+        Some(arguments.clone())
+    } else {
+        None
+    };
+
+    let started = Instant::now();
+    match router.route_call_with_cancel(name, arguments, cancel.clone()) {
+        Ok(mut result) => {
+            let ok = !result
+                .get("isError")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false);
+            let ms = started.elapsed().as_millis() as u64;
+            // Capture the failure message (the result's text) before shaping
+            // rewrites the content, so Activity can show why the call failed.
+            let err = if ok {
+                None
+            } else {
+                Some(content_text(&result))
+            };
+            audit::record_timed(srv, tool, ok, Some(ms), err.as_deref(), client);
+            // Live inspection: capture the RAW result here, before content
+            // defense and shaping rewrite it, so the inspector shows exactly
+            // what the server returned. Only runs when live_inspect is on
+            // (inspect_args is Some only then). Attributed to the same client
+            // as the audit line.
+            if let Some(req) = &inspect_args {
+                inspect::record(client, srv, tool, req, &result, ok, ms);
+            }
+            // Content defense: scan this untrusted tool output for injection
+            // and label any flagged text as data before it reaches the agent.
+            if reg.content_defense_effective() {
+                integrity::inspect_result(srv, tool, &mut result);
+            }
+            // Result-shaping: cap an oversized result, cache the full body, and
+            // hand the model a head + a toolport_fetch_result cursor (lossless).
+            // Per-server fidelity policy: a server's `resultBudget` overrides the
+            // global default (Some(0) = never shape, for full-fidelity servers).
+            let budget = reg
+                .result_budgets
+                .get(srv)
+                .map(|&b| b as usize)
+                .unwrap_or_else(shaping::budget);
+            shaping::shape_result(&mut result, budget, client);
+
+            // Recover from a downstream failure: point the model at
+            // sibling list/get tools that can supply a missing/invalid
+            // identifier. Appended after shaping so it's never truncated.
+            if !ok {
+                let hint = recovery_hint(cached, srv);
+                if !hint.is_empty() {
+                    if let Some(arr) = result.get_mut("content").and_then(|c| c.as_array_mut())
+                    {
+                        arr.push(json!({ "type": "text", "text": hint.trim() }));
+                    }
+                }
+            }
+            result
+        }
+        Err(e) => {
+            let ms = started.elapsed().as_millis() as u64;
+            audit::record_timed(srv, tool, false, Some(ms), Some(&e), client);
+            // Live inspection: capture the failed call too, with the error
+            // as the response body. Only when live_inspect is on.
+            if let Some(req) = &inspect_args {
+                inspect::record(client, srv, tool, req, &json!({ "error": e }), false, ms);
+            }
+            let recovery = recovery_hint(cached, srv);
+            json!({
+                "content": [{ "type": "text", "text": format!("Toolport: {e}.{recovery}") }],
+                "isError": true
+            })
+        }
+    }
+}
+
+/// Dispatch a `toolport_run_script` "code mode" call: run the agent's script in the boa
+/// sandbox with a `toolport.call()` binding that re-enters [`execute_call`] for each
+/// downstream call, so every call passes the identical scope + approval gates a direct call
+/// would - a script never widens the client's reach. Returns one aggregated tool result;
+/// the intermediate call results never enter model context. `router_arc` is the shareable
+/// router used to build the `'static` closure the sandbox requires (`None` -> unavailable).
+fn run_script_dispatch(
+    reg: &Registry,
+    router_arc: Option<&Arc<Router>>,
+    cached: &[Value],
+    client: Option<&str>,
+    allowed: Option<&std::collections::HashSet<String>>,
+    cancel: Option<downstream::CancelContext>,
+    arguments: &Value,
+) -> Value {
+    let Some(router_arc) = router_arc else {
+        return json!({
+            "content": [{ "type": "text", "text": "Toolport: code mode is unavailable in this context." }],
+            "isError": true
+        });
+    };
+    let script = match arguments.get("script").and_then(|v| v.as_str()) {
+        Some(s) if !s.trim().is_empty() => s.to_string(),
+        _ => {
+            return json!({
+                "content": [{ "type": "text", "text": "Toolport: run_script requires a non-empty `script` string." }],
+                "isError": true
+            });
+        }
+    };
+    let data = arguments.get("data").cloned().unwrap_or_else(|| json!({}));
+
+    // Owned handles so the sandbox's call binding can be `'static`. Each toolport.call()
+    // re-enters execute_call with these, applying the identical scope + approval gates a
+    // direct call would. `confirm = None` fails closed on the agent-token confirmation path,
+    // which can't complete inside a single script round-trip.
+    let reg_owned = reg.clone();
+    let router_owned = Arc::clone(router_arc);
+    let cached_owned = cached.to_vec();
+    let client_owned = client.map(str::to_string);
+    let allowed_owned = allowed.cloned();
+    let cancel_owned = cancel;
+
+    let call: std::rc::Rc<dyn Fn(&str, Value) -> Value> =
+        std::rc::Rc::new(move |name: &str, args: Value| {
+            execute_call(
+                &reg_owned,
+                &router_owned,
+                &cached_owned,
+                client_owned.as_deref(),
+                allowed_owned.as_ref(),
+                cancel_owned.clone(),
+                None,
+                name,
+                args,
+                false,
+            )
+        });
+
+    let outcome = codemode::run_script(&script, data, call, codemode::Limits::default());
+
+    // Account the round-trips this one call replaced (calls - 1), composing with the
+    // lazy-discovery savings in the same log + counter.
+    if outcome.calls > 1 {
+        savings::record_orchestration((outcome.calls - 1) as u64);
+    }
+
+    match outcome.error {
+        Some(err) => json!({
+            "content": [{ "type": "text", "text": format!("Toolport code mode: the script failed: {err}") }],
+            "isError": true,
+            "structuredContent": { "toolportScript": { "ok": false, "calls": outcome.calls, "error": err } }
         }),
-    )
+        None => {
+            // One aggregated value; the intermediate call results stayed out of context.
+            let text =
+                serde_json::to_string(&outcome.value).unwrap_or_else(|_| "null".to_string());
+            json!({
+                "content": [{ "type": "text", "text": text }],
+                "isError": false,
+                "structuredContent": { "toolportScript": { "ok": true, "calls": outcome.calls }, "result": outcome.value }
+            })
+        }
+    }
 }
 
 #[cfg(test)]
@@ -2223,7 +2669,7 @@ fn handle_request(
     client: Option<&str>,
 ) -> Option<Value> {
     handle_request_with_cancel(
-        req, reg, router, cached, lazy, profile, guard, confirm, allowed, None, client,
+        req, reg, router, cached, lazy, profile, guard, confirm, allowed, None, client, None,
     )
 }
 
@@ -2243,6 +2689,11 @@ fn handle_request_with_cancel(
     // label), threaded in rather than stored on the shared router so concurrent
     // requests can't cross-contaminate and dispatch needn't hold the router lock.
     client: Option<&str>,
+    // The live router as a shareable Arc, used ONLY to build the `'static` call closure a
+    // code-mode script needs (its downstream calls re-enter execute_call). `None` disables
+    // code mode for this request (the test wrapper / any caller without the Arc); the
+    // production dispatch passes `Some(&router)`, the same Arc it already cloned off the lock.
+    router_arc: Option<&Arc<Router>>,
 ) -> Option<Value> {
     let method = req.get("method").and_then(|m| m.as_str()).unwrap_or("");
 
@@ -2282,6 +2733,12 @@ fn handle_request_with_cancel(
                     call_tool_def(),
                     fetch_result_tool_def(),
                 ];
+                // Opt-in code mode: one script that orchestrates many calls in a single
+                // round-trip. Advertised only when enabled, same visibility discipline as
+                // the agent-control tools below.
+                if code_mode_enabled() {
+                    tools.push(run_script_tool_def());
+                }
                 // Opt-in: surface the agent-control tools only when the user has
                 // allowed it, so an agent can't even see them otherwise.
                 if reg.allow_agent_control {
@@ -2357,6 +2814,9 @@ fn handle_request_with_cancel(
                 return Some(success(id, json!({ "tools": tools })));
             }
             let mut tools = vec![status_tool_def(), fetch_result_tool_def()];
+            if code_mode_enabled() {
+                tools.push(run_script_tool_def());
+            }
             // The confirm tool is advertised only while confirmation is on.
             if reg.confirm_destructive {
                 tools.push(confirm_tool_def());
@@ -2769,277 +3229,49 @@ fn handle_request_with_cancel(
                 ));
             }
 
+            // toolport_run_script: server-side "code mode". Run one agent script that calls
+            // many downstream tools via toolport.call(), collapsing an N-step task into one
+            // round-trip; intermediate results never enter model context. Opt-in, and needs
+            // the shareable router (router_arc) to build the script's call binding.
+            if name == "toolport_run_script" {
+                if !code_mode_enabled() {
+                    return Some(success(
+                        id,
+                        json!({
+                            "content": [{ "type": "text", "text": "Toolport: code mode is disabled. Set CONDUIT_CODE_MODE=1 to enable toolport_run_script." }],
+                            "isError": true
+                        }),
+                    ));
+                }
+                return Some(success(
+                    id,
+                    run_script_dispatch(reg, router_arc, cached, client, allowed, cancel, &arguments),
+                ));
+            }
+
             // toolport_call_tool dispatches a discovered tool: unwrap to its real
-            // name + arguments and fall through to the normal routing below.
+            // name + arguments, then run it through the shared execute path (scope,
+            // approval, confirm, shaping) that a code-mode toolport.call() also uses.
             let (name, arguments) = if name == "toolport_call_tool" {
                 unwrap_call_tool(&arguments)
             } else {
                 (name, arguments)
             };
-            let name = name.as_str();
-
-            // Resolve the call's real (server, original tool) from the router's route map,
-            // NOT by splitting the exposed name on `__`. A renamed tool (via a tool override)
-            // or a server id containing `__` would otherwise mis-derive the server and
-            // silently weaken the scope guard and the HITL untrusted-provenance check below.
-            let (server_id, tool_name) = router
-                .route_of(name)
-                .map(|(s, t)| (s.to_string(), t.to_string()))
-                .unwrap_or_else(|| (String::new(), name.to_string()));
-            let srv_owned = sanitize_segment(&server_id);
-            let srv = srv_owned.as_str();
-            let tool = tool_name.as_str();
-
-            // Scope guard: a registered HTTP client may only call tools on the
-            // servers its token is allowed to see (a no-op when unscoped). Search
-            // and list are already filtered, but a client could name any tool, so
-            // enforce it on the call path too.
-            if let Some(set) = allowed {
-                if !set.contains(srv) {
-                    return Some(success(
-                        id,
-                        json!({
-                            "content": [{ "type": "text", "text": format!("Toolport: '{srv}' is not available to this client.") }],
-                            "isError": true
-                        }),
-                    ));
-                }
-            }
-
-            // Pre-call guard: a model that invents an identifier (e.g.
-            // teamId = "your_team_id") would otherwise waste a downstream call
-            // and get a confusing failure. Catch obvious placeholders and point
-            // it at where to source the real value. General across every server.
-            if let Some((param, value)) = find_placeholder_arg(&arguments) {
-                let resource = resource_stem(&param);
-                let hints = source_tool_hints(cached, srv, Some(&resource), 3);
-                let source = if hints.is_empty() {
-                    format!("call a list or get tool on the '{srv}' server")
-                } else {
-                    format!(
-                        "call one of these on the '{srv}' server first: {}",
-                        hints.join(", ")
-                    )
-                };
-                let msg = format!(
-                    "Toolport: \"{value}\" for \"{param}\" looks like a placeholder, not a real \
-                     value, and was not sent. Don't invent identifiers. To get a real \"{param}\", \
-                     {source}, then call {name} again with the value it returns."
-                );
-                return Some(success(
-                    id,
-                    json!({ "content": [{ "type": "text", "text": msg }], "isError": true }),
-                ));
-            }
-
-            // Human-in-the-loop approval: hold a gated call (destructive, or from an
-            // untrusted-provenance server) until a person approves it in the Toolport app.
-            // Takes precedence over the agent-facing confirm below, and is fail-closed
-            // (no broker / no answer / timeout all deny). Skipped once `confirmed`.
-            if reg.human_approval_effective() && !confirmed {
-                // Resolve destructiveness robustly: cache, then live router, else
-                // fail-closed (an unknown tool must not skip the human gate).
-                let is_dest = tool_is_destructive_fail_closed(name, cached, router);
-                // Untrusted provenance = the same shared/registry signal the SSRF guard
-                // uses. Match on the REAL server id from `route_of` (not the sanitized
-                // prefix): two ids that sanitize alike would otherwise read the wrong
-                // server's trust flag and could skip this gate.
-                let untrusted = reg
-                    .servers
-                    .iter()
-                    .find(|s| s.id == server_id)
-                    .map(|s| matches!(s.source.as_deref(), Some("shared") | Some("registry")))
-                    .unwrap_or(false);
-                if let Some(reason) = approval::gate_reason(true, is_dest, untrusted) {
-                    // The gate reason names WHY a human was asked; shared by the audit record
-                    // and the agent-facing envelope on every outcome (approved included).
-                    let reason_str = match reason {
-                        approval::ApprovalReason::Destructive => "destructive",
-                        approval::ApprovalReason::UntrustedSource => "untrusted_source",
-                        approval::ApprovalReason::DestructiveAndUntrusted => {
-                            "destructive_and_untrusted"
-                        }
-                    };
-                    // The exact call being approved, content-bound: the bytes that RUN must
-                    // hash-match these. Captured before the (blocking) human decision.
-                    let approved_args_hash = audit::args_hash(&arguments);
-                    let t0 = std::time::Instant::now();
-                    let decision = request_human_decision(approval::ApprovalRequest {
-                        token: String::new(),
-                        id: new_correlation_id(),
-                        client: client.map(str::to_string),
-                        server: srv.to_string(),
-                        tool: tool.to_string(),
-                        reason,
-                        arguments: arguments.clone(),
-                        tool_fingerprint: tool_fingerprint_for(name, cached, router),
-                    });
-                    let held_ms = t0.elapsed().as_millis() as u64;
-                    if !decision.is_approved() {
-                        // Governance audit: the gate reason and which non-approval outcome
-                        // (denied / no-response / unreachable), plus a content hash of the
-                        // exact call - never the raw args. Replaces the flat record_held so
-                        // the failure modes are no longer indistinguishable in the log.
-                        audit::record_decision(
-                            srv,
-                            tool,
-                            client,
-                            reason_str,
-                            decision_token(decision),
-                            &arguments,
-                            Some(held_ms),
-                        );
-                        return Some(refused_call_result(id, name, decision, reason_str));
-                    }
-                    // A human approved. Enforce content-binding before running: if the call
-                    // was mutated after approval, reject the stale approval (fail-closed)
-                    // rather than run bytes a human never actually saw.
-                    if let Some(stale) = content_binding_decision(&approved_args_hash, &arguments) {
-                        audit::record_decision(
-                            srv,
-                            tool,
-                            client,
-                            reason_str,
-                            decision_token(stale),
-                            &arguments,
-                            Some(held_ms),
-                        );
-                        return Some(refused_call_result(id, name, stale, reason_str));
-                    }
-                    // Approved calls are audited too, so the trail shows what actually ran,
-                    // not only what was blocked.
-                    audit::record_decision(
-                        srv,
-                        tool,
-                        client,
-                        reason_str,
-                        "approved",
-                        &arguments,
-                        Some(held_ms),
-                    );
-                    // Skip the agent-confirm step and route the call.
-                    confirmed = true;
-                }
-            }
-
-            // Per-call confirmation for destructive tools: intercept the first
-            // call with these arguments, store it, and return a preview. The
-            // agent calls toolport_confirm { token } to replay the stored call.
-            // This runs AFTER the placeholder guard (so a placeholder never
-            // gets a token) and BEFORE the actual route_call (so a destructive
-            // call never reaches the downstream server unconfirmed).
-            // Skip when `confirmed` is true: the call arrived via toolport_confirm
-            // and was already reviewed (prevents re-interception loop).
-            if reg.confirm_destructive && !confirmed {
-                // Resolve destructiveness robustly (cache, then live router, else
-                // fail-closed), so a cold/stale cache can't skip the confirm step for a
-                // destructive tool.
-                let dest = tool_is_destructive_fail_closed(name, cached, router);
-                if dest {
-                    let token = confirm.store(name.to_string(), arguments.clone(), client);
-                    let args_pretty = serde_json::to_string_pretty(&arguments).unwrap_or_default();
-                    let msg = format!(
-                        "⚠️ Destructive action intercepted.\n\nTool: {name}\nArguments:\n{args_pretty}\n\n\
-                         Review the arguments above carefully. If correct, call toolport_confirm \
-                         with token: {token}\n\
-                         The token expires in 60 seconds. The original arguments will be replayed \
-                         exactly."
-                    );
-                    // Held for confirmation, not a failure: record as held (ok), so the
-                    // confirm-destructive feature doesn't inflate the error rate.
-                    audit::record_held(srv, tool, client);
-                    return Some(success(
-                        id,
-                        json!({
-                            "content": [{ "type": "text", "text": msg }],
-                            "isError": true
-                        }),
-                    ));
-                }
-            }
-
-            // Live inspection (opt-in, off by default): capture the raw request
-            // args now, only when enabled, so the response can be paired with them
-            // below. When off, nothing is cloned and nothing is ever captured.
-            let inspect_args = if reg.live_inspect {
-                Some(arguments.clone())
-            } else {
-                None
-            };
-
-            let started = Instant::now();
-            match router.route_call_with_cancel(name, arguments, cancel.clone()) {
-                Ok(mut result) => {
-                    let ok = !result
-                        .get("isError")
-                        .and_then(|v| v.as_bool())
-                        .unwrap_or(false);
-                    let ms = started.elapsed().as_millis() as u64;
-                    // Capture the failure message (the result's text) before shaping
-                    // rewrites the content, so Activity can show why the call failed.
-                    let err = if ok {
-                        None
-                    } else {
-                        Some(content_text(&result))
-                    };
-                    audit::record_timed(srv, tool, ok, Some(ms), err.as_deref(), client);
-                    // Live inspection: capture the RAW result here, before content
-                    // defense and shaping rewrite it, so the inspector shows exactly
-                    // what the server returned. Only runs when live_inspect is on
-                    // (inspect_args is Some only then). Attributed to the same client
-                    // as the audit line.
-                    if let Some(req) = &inspect_args {
-                        inspect::record(client, srv, tool, req, &result, ok, ms);
-                    }
-                    // Content defense: scan this untrusted tool output for injection
-                    // and label any flagged text as data before it reaches the agent.
-                    if reg.content_defense_effective() {
-                        integrity::inspect_result(srv, tool, &mut result);
-                    }
-                    // Result-shaping: cap an oversized result, cache the full body, and
-                    // hand the model a head + a toolport_fetch_result cursor (lossless).
-                    // Per-server fidelity policy: a server's `resultBudget` overrides the
-                    // global default (Some(0) = never shape, for full-fidelity servers).
-                    let budget = reg
-                        .result_budgets
-                        .get(srv)
-                        .map(|&b| b as usize)
-                        .unwrap_or_else(shaping::budget);
-                    shaping::shape_result(&mut result, budget, client);
-
-                    // Recover from a downstream failure: point the model at
-                    // sibling list/get tools that can supply a missing/invalid
-                    // identifier. Appended after shaping so it's never truncated.
-                    if !ok {
-                        let hint = recovery_hint(cached, srv);
-                        if !hint.is_empty() {
-                            if let Some(arr) =
-                                result.get_mut("content").and_then(|c| c.as_array_mut())
-                            {
-                                arr.push(json!({ "type": "text", "text": hint.trim() }));
-                            }
-                        }
-                    }
-                    Some(success(id, result))
-                }
-                Err(e) => {
-                    let ms = started.elapsed().as_millis() as u64;
-                    audit::record_timed(srv, tool, false, Some(ms), Some(&e), client);
-                    // Live inspection: capture the failed call too, with the error
-                    // as the response body. Only when live_inspect is on.
-                    if let Some(req) = &inspect_args {
-                        inspect::record(client, srv, tool, req, &json!({ "error": e }), false, ms);
-                    }
-                    let recovery = recovery_hint(cached, srv);
-                    Some(success(
-                        id,
-                        json!({
-                            "content": [{ "type": "text", "text": format!("Toolport: {e}.{recovery}") }],
-                            "isError": true
-                        }),
-                    ))
-                }
-            }
+            Some(success(
+                id,
+                execute_call(
+                    reg,
+                    router,
+                    cached,
+                    client,
+                    allowed,
+                    cancel,
+                    Some(confirm),
+                    name.as_str(),
+                    arguments,
+                    confirmed,
+                ),
+            ))
         }
         "resources/list" => {
             let mut resources = router.aggregated_resources();
@@ -4639,6 +4871,9 @@ fn process_request(
         allowed,
         cancel,
         client,
+        // The same live Arc<Router> just cloned off the lock, so a code-mode script's
+        // downstream calls run against this request's consistent catalog snapshot.
+        Some(&router),
     )
 }
 
@@ -4775,6 +5010,9 @@ fn http_tool_defs(
             call_tool_def(),
             fetch_result_tool_def(),
         ];
+        if code_mode_enabled() {
+            tools.push(run_script_tool_def());
+        }
         if allow_agent {
             tools.push(enable_server_tool_def());
             tools.push(disable_server_tool_def());
@@ -4798,6 +5036,9 @@ fn http_tool_defs(
         grouped_tool_defs(allow_agent, confirm_destructive, &scoped)
     } else {
         let mut tools = vec![status_tool_def(), fetch_result_tool_def()];
+        if code_mode_enabled() {
+            tools.push(run_script_tool_def());
+        }
         tools.extend(catalog());
         tools
     }
@@ -6950,8 +7191,8 @@ mod tests {
             (approval::ApprovalDecision::StaleState, "stale_state", true),
         ];
         for (decision, token, retriable) in cases {
-            let v = refused_call_result(json!(1), "db__drop", decision, "destructive");
-            let result = &v["result"];
+            // Now returns the inner tool result directly (the caller wraps it).
+            let result = refused_call_result("db__drop", decision, "destructive");
             assert_eq!(result["isError"].as_bool(), Some(true), "{token} must fail closed");
             let sc = &result["structuredContent"];
             assert_eq!(sc["toolportDecision"].as_str(), Some(token));
@@ -6960,6 +7201,145 @@ mod tests {
             // The human-readable text still names the tool so a person reading a log sees it.
             assert!(result["content"][0]["text"].as_str().unwrap().contains("db__drop"));
         }
+    }
+
+    /// Code mode: a script that calls a downstream tool twice through `toolport.call()`
+    /// aggregates both results and returns ONE value; only that value comes back, and the
+    /// call count is reported for savings accounting.
+    #[test]
+    fn run_script_aggregates_downstream_calls() {
+        let reg = Registry::default();
+        let router = Arc::new(paging_router("hello".to_string()));
+        let args = json!({
+            "script": "var a = toolport.call('s__big', {}); \
+                       var b = toolport.call('s__big', {}); \
+                       return { name: a.structuredContent.user.name, \
+                                sum: a.structuredContent.user.age + b.structuredContent.user.age };"
+        });
+        let result = run_script_dispatch(&reg, Some(&router), &[], None, None, None, &args);
+        assert_eq!(result["isError"].as_bool(), Some(false));
+        assert_eq!(result["structuredContent"]["toolportScript"]["ok"], true);
+        assert_eq!(result["structuredContent"]["toolportScript"]["calls"], 2);
+        // The aggregate the script returned, not two intermediate tool results.
+        assert_eq!(result["structuredContent"]["result"]["name"], "Alice");
+        assert_eq!(result["structuredContent"]["result"]["sum"], 60);
+    }
+
+    /// The per-client scope guard applies to a call made INSIDE a script exactly as it does
+    /// to a direct call: a script can't reach a server the client isn't scoped to. This is
+    /// the security-critical property of routing script calls through `execute_call`.
+    #[test]
+    fn run_script_call_respects_client_scope() {
+        let reg = Registry::default();
+        let router = Arc::new(paging_router("hi".to_string()));
+        let mut allowed = std::collections::HashSet::new();
+        allowed.insert("other".to_string()); // NOT "s"
+        let args = json!({ "script": "return toolport.call('s__big', {});" });
+        let result =
+            run_script_dispatch(&reg, Some(&router), &[], Some("scoped"), Some(&allowed), None, &args);
+        // The script itself ran; the value it returned is the scope-denied tool result.
+        assert_eq!(result["structuredContent"]["toolportScript"]["ok"], true);
+        let call_result = &result["structuredContent"]["result"];
+        assert_eq!(call_result["isError"].as_bool(), Some(true));
+        assert!(call_result["content"][0]["text"]
+            .as_str()
+            .unwrap()
+            .contains("not available to this client"));
+    }
+
+    /// Safety: a destructive tool called INSIDE a script fails closed when per-call
+    /// confirmation is on but human approval isn't. The agent-token replay handshake can't
+    /// complete in a single script round-trip, so rather than run an unconfirmed destructive
+    /// call, the call is refused - nothing destructive executes.
+    #[test]
+    fn run_script_destructive_call_fails_closed_without_confirmation() {
+        let mut reg = Registry::default();
+        reg.confirm_destructive = true;
+        let router = Arc::new(paging_router("x".to_string()));
+        // Mark the tool destructive via the cached catalog the fail-closed resolver checks.
+        let cached = vec![json!({ "name": "s__big", "annotations": { "destructiveHint": true } })];
+        let args = json!({ "script": "return toolport.call('s__big', {});" });
+        let result = run_script_dispatch(&reg, Some(&router), &cached, None, None, None, &args);
+        assert_eq!(result["structuredContent"]["toolportScript"]["ok"], true);
+        let call_result = &result["structuredContent"]["result"];
+        assert_eq!(call_result["isError"].as_bool(), Some(true));
+        assert!(call_result["content"][0]["text"]
+            .as_str()
+            .unwrap()
+            .contains("per-call confirmation"));
+    }
+
+    /// An empty/whitespace script is rejected before the engine runs.
+    #[test]
+    fn run_script_rejects_empty_script() {
+        let reg = Registry::default();
+        let router = Arc::new(paging_router("x".to_string()));
+        let result =
+            run_script_dispatch(&reg, Some(&router), &[], None, None, None, &json!({ "script": "   " }));
+        assert_eq!(result["isError"].as_bool(), Some(true));
+        assert!(result["content"][0]["text"]
+            .as_str()
+            .unwrap()
+            .contains("non-empty"));
+    }
+
+    /// Without a shareable router (no code-mode-capable context), the dispatch is unavailable
+    /// rather than running against a missing catalog.
+    #[test]
+    fn run_script_without_router_is_unavailable() {
+        let reg = Registry::default();
+        let result =
+            run_script_dispatch(&reg, None, &[], None, None, None, &json!({ "script": "return 1;" }));
+        assert_eq!(result["isError"].as_bool(), Some(true));
+        assert!(result["content"][0]["text"]
+            .as_str()
+            .unwrap()
+            .contains("unavailable"));
+    }
+
+    /// A syntactically broken script fails closed with an error result, never a panic, and
+    /// reports how many calls it managed before failing.
+    #[test]
+    fn run_script_reports_script_errors() {
+        let reg = Registry::default();
+        let router = Arc::new(paging_router("x".to_string()));
+        let args = json!({ "script": "this is not valid javascript )(" });
+        let result = run_script_dispatch(&reg, Some(&router), &[], None, None, None, &args);
+        assert_eq!(result["isError"].as_bool(), Some(true));
+        assert_eq!(result["structuredContent"]["toolportScript"]["ok"], false);
+    }
+
+    /// With `CONDUIT_CODE_MODE` unset (the default), the dispatch refuses `toolport_run_script`
+    /// so the capability is opt-in. (`handle_request` also passes no router Arc, a second
+    /// fail-closed.)
+    #[test]
+    fn run_script_is_refused_when_code_mode_disabled() {
+        let reg = Registry::default();
+        let router = routed_router("s", "tool");
+        let req = json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": { "name": "toolport_run_script", "arguments": { "script": "return 1;" } }
+        });
+        let resp = handle_request(
+            &req,
+            &reg,
+            &router,
+            &[],
+            true,
+            None,
+            &SearchGuard::default(),
+            &ConfirmGuard::new(),
+            None,
+            None,
+        )
+        .unwrap();
+        assert_eq!(resp["result"]["isError"].as_bool(), Some(true));
+        assert!(resp["result"]["content"][0]["text"]
+            .as_str()
+            .unwrap()
+            .contains("code mode is disabled"));
     }
 
     fn router() -> Router {

--- a/src-tauri/src/codemode.rs
+++ b/src-tauri/src/codemode.rs
@@ -1,0 +1,312 @@
+//! Server-side tool orchestration ("code mode"): run ONE agent-submitted script that
+//! calls multiple downstream tools, loops, and branches, and returns a single aggregated
+//! value. This is the results-layer twin of lazy discovery: lazy discovery collapses N
+//! tool *definitions* to a handful of meta-tools; code mode collapses N tool *calls +
+//! results* to one `run_script` round-trip, so the intermediate results never land in the
+//! model's context.
+//!
+//! The engine is [`boa_engine`], a pure-Rust JS interpreter, so this adds no C toolchain
+//! or FFI to the build. Because Toolport is single-user and local, the agent is already
+//! trusted and the servers already run on the host: the sandbox's job is round-trip and
+//! token reduction, NOT a security boundary. It still fails closed on resource limits so a
+//! runaway or buggy script can't wedge the gateway.
+//!
+//! The one capability a script gets is `toolport.call(name, args)`, a synchronous binding
+//! that routes a single downstream call through the caller-supplied closure — which the
+//! gateway wires to the SAME path a direct `toolport_call_tool` takes (per-client scope,
+//! human approval, result shaping), so a script never widens what the client could already
+//! reach. Limits: a cap on the number of downstream calls, a wall-clock deadline (checked
+//! at each call), and boa's own loop-iteration / recursion caps for pure-JS runaway.
+
+use std::cell::Cell;
+use std::rc::Rc;
+use std::time::{Duration, Instant};
+
+use boa_engine::{
+    js_string, Context, JsError, JsNativeError, JsValue, NativeFunction, Source,
+};
+use boa_engine::property::Attribute;
+use boa_gc::{Finalize, Trace};
+use serde_json::{json, Value};
+
+/// Resource limits for one script run. All are fail-closed: exceeding any of them aborts
+/// the script with an error result the agent can read and recover from.
+#[derive(Debug, Clone, Copy)]
+pub struct Limits {
+    /// Max number of `toolport.call()` invocations. Bounds fan-out and downstream load.
+    pub max_calls: usize,
+    /// Wall-clock budget for the whole run, checked at each `toolport.call()`.
+    pub wall_clock: Duration,
+    /// Max total loop iterations across the script (boa runtime limit); bounds a pure-JS
+    /// `while(true){}` that never calls a tool.
+    pub loop_iteration_limit: u64,
+    /// Max recursion depth (boa runtime limit).
+    pub recursion_limit: usize,
+}
+
+impl Default for Limits {
+    fn default() -> Self {
+        Limits {
+            max_calls: 64,
+            wall_clock: Duration::from_secs(60),
+            loop_iteration_limit: 10_000_000,
+            recursion_limit: 400,
+        }
+    }
+}
+
+/// The outcome of running a script.
+#[derive(Debug, Clone)]
+pub struct ScriptOutcome {
+    /// The script's return value as JSON (`null` if it returned nothing). Meaningful only
+    /// when `error` is `None`.
+    pub value: Value,
+    /// How many `toolport.call()` invocations the script actually made — used to account
+    /// round-trips saved (calls - 1) and to report fan-out.
+    pub calls: usize,
+    /// `Some(message)` if the script threw, hit a limit, or failed to compile. Fail-closed:
+    /// the caller surfaces this to the agent as an error result.
+    pub error: Option<String>,
+}
+
+/// Host state shared with the `__toolport_call` native function. Holds no JS/GC references,
+/// so its `Trace` impl is empty (sound: nothing here points into the boa heap).
+struct HostState {
+    /// The downstream call binding: `(tool_name, arguments) -> result`. Boxed so the caller
+    /// can supply any closure; `Rc<RefCell>` because boa native functions are `Fn`, not
+    /// `FnMut`, and the closure is single-threaded (boa `Context` is `!Send`).
+    call: Rc<dyn Fn(&str, Value) -> Value>,
+    /// Shared with the run so the count survives after the closure is moved into boa.
+    calls_made: Rc<Cell<usize>>,
+    max_calls: usize,
+    deadline: Instant,
+}
+
+impl Finalize for HostState {}
+// SAFETY: HostState holds only Rust-owned data (an `Rc<dyn Fn>`, counters, an `Instant`),
+// never a boa `Gc`/`JsValue`, so there is nothing for the collector to trace: every method
+// is a sound no-op.
+unsafe impl Trace for HostState {
+    unsafe fn trace(&self, _tracer: &mut boa_gc::Tracer) {}
+    unsafe fn trace_non_roots(&self) {}
+    fn run_finalizer(&self) {}
+}
+
+/// The JS prelude installed before the user script. Wraps the raw `__toolport_call` host
+/// binding (which speaks JSON strings) in an ergonomic `toolport.call(name, args)` that
+/// takes/returns real JS values, and exposes the injected `data` payload.
+const PRELUDE: &str = r#"
+globalThis.toolport = {
+    call: function (name, args) {
+        var payload = (args === undefined || args === null) ? {} : args;
+        return JSON.parse(__toolport_call(String(name), JSON.stringify(payload)));
+    },
+};
+"#;
+
+/// Run `script` with `data` available as a global `data` object, giving it `toolport.call`
+/// bound to `call`. Returns one aggregated [`ScriptOutcome`]; intermediate call results are
+/// never surfaced. Synchronous: `await`/Promises are not driven in v1 (a script that needs
+/// concurrency is a follow-up), so scripts should call tools sequentially.
+///
+/// `call` must be `'static` (the gateway builds it from `Arc`-cloned handles). It is invoked
+/// once per `toolport.call()`; whatever it returns becomes that call's JS result.
+pub fn run_script(
+    script: &str,
+    data: Value,
+    call: Rc<dyn Fn(&str, Value) -> Value>,
+    limits: Limits,
+) -> ScriptOutcome {
+    let calls_made = Rc::new(Cell::new(0usize));
+    let mut context = Context::default();
+
+    // Pure-JS runaway guards (a script that loops/recurses forever without calling a tool).
+    context
+        .runtime_limits_mut()
+        .set_loop_iteration_limit(limits.loop_iteration_limit);
+    context
+        .runtime_limits_mut()
+        .set_recursion_limit(limits.recursion_limit);
+
+    let state = HostState {
+        call,
+        calls_made: calls_made.clone(),
+        max_calls: limits.max_calls,
+        deadline: Instant::now() + limits.wall_clock,
+    };
+
+    // The raw host binding: (nameString, argsJsonString) -> resultJsonString. Enforces the
+    // call budget and wall-clock deadline before every downstream call, fail-closed.
+    let native = NativeFunction::from_copy_closure_with_captures(
+        |_this: &JsValue, args: &[JsValue], state: &HostState, _ctx: &mut Context| {
+            if state.calls_made.get() >= state.max_calls {
+                return Err(JsError::from_native(JsNativeError::error().with_message(
+                    format!("toolport.call budget exceeded ({} calls)", state.max_calls),
+                )));
+            }
+            if Instant::now() >= state.deadline {
+                return Err(JsError::from_native(
+                    JsNativeError::error().with_message("toolport script wall-clock deadline exceeded"),
+                ));
+            }
+            let name = args
+                .first()
+                .and_then(JsValue::as_string)
+                .map(|s| s.to_std_string_escaped())
+                .unwrap_or_default();
+            let args_json = args
+                .get(1)
+                .and_then(JsValue::as_string)
+                .map(|s| s.to_std_string_escaped())
+                .unwrap_or_else(|| "{}".to_string());
+            let parsed: Value = serde_json::from_str(&args_json).unwrap_or(Value::Null);
+
+            state.calls_made.set(state.calls_made.get() + 1);
+            let result = (state.call)(&name, parsed);
+
+            let result_str = serde_json::to_string(&result).unwrap_or_else(|_| "null".to_string());
+            Ok(JsValue::from(js_string!(result_str)))
+        },
+        state,
+    );
+
+    if let Err(e) = context.register_global_callable(js_string!("__toolport_call"), 2, native) {
+        return fail(&mut context, calls_made.get(), e);
+    }
+
+    // Inject `data` as a global before the prelude/script run.
+    match JsValue::from_json(&data, &mut context) {
+        Ok(v) => {
+            if let Err(e) =
+                context.register_global_property(js_string!("data"), v, Attribute::all())
+            {
+                return fail(&mut context, calls_made.get(), e);
+            }
+        }
+        Err(e) => return fail(&mut context, calls_made.get(), e),
+    }
+
+    if let Err(e) = context.eval(Source::from_bytes(PRELUDE)) {
+        return fail(&mut context, calls_made.get(), e);
+    }
+
+    // Wrap the user script in an IIFE so a top-level `return` works and the whole thing is
+    // one expression whose value is the script's result.
+    let wrapped = format!("(function () {{\n{script}\n}})()");
+    match context.eval(Source::from_bytes(wrapped.as_bytes())) {
+        Ok(v) => {
+            let value = v.to_json(&mut context).ok().flatten().unwrap_or(Value::Null);
+            ScriptOutcome {
+                value,
+                calls: calls_made.get(),
+                error: None,
+            }
+        }
+        Err(e) => fail(&mut context, calls_made.get(), e),
+    }
+}
+
+/// Build a fail-closed outcome from a boa error, rendering it to a readable message.
+/// Uses the error's `Display` rather than `to_opaque` on purpose: boa's uncatchable
+/// runtime-limit errors (loop/recursion caps) panic when converted to an opaque JS value,
+/// and `Display` yields a usable message (`Uncaught Error: ...`, `RuntimeLimit: ...`) for
+/// every error kind.
+fn fail(_context: &mut Context, calls: usize, err: JsError) -> ScriptOutcome {
+    ScriptOutcome {
+        value: json!(null),
+        calls,
+        error: Some(err.to_string()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::RefCell;
+
+    /// A call binding that records the calls it saw and echoes a canned reply per tool.
+    fn recording_call(
+        log: Rc<RefCell<Vec<(String, Value)>>>,
+    ) -> Rc<dyn Fn(&str, Value) -> Value> {
+        Rc::new(move |name: &str, args: Value| {
+            log.borrow_mut().push((name.to_string(), args.clone()));
+            json!({ "echo": name, "args": args })
+        })
+    }
+
+    #[test]
+    fn runs_a_plain_script_and_returns_its_value() {
+        let call = Rc::new(|_: &str, _: Value| Value::Null);
+        let out = run_script("return 1 + 2;", json!({}), call, Limits::default());
+        assert_eq!(out.error, None);
+        assert_eq!(out.value, json!(3));
+        assert_eq!(out.calls, 0);
+    }
+
+    #[test]
+    fn toolport_call_reaches_the_binding_and_data_is_injected() {
+        let log = Rc::new(RefCell::new(Vec::new()));
+        let call = recording_call(log.clone());
+        let script = r#"
+            var out = [];
+            for (var i = 0; i < data.ids.length; i++) {
+                var r = toolport.call("lookup", { id: data.ids[i] });
+                out.push(r.args.id);
+            }
+            return out;
+        "#;
+        let out = run_script(script, json!({ "ids": [10, 20, 30] }), call, Limits::default());
+        assert_eq!(out.error, None, "unexpected error: {:?}", out.error);
+        assert_eq!(out.value, json!([10, 20, 30]));
+        assert_eq!(out.calls, 3);
+        assert_eq!(log.borrow().len(), 3);
+        assert_eq!(log.borrow()[0].0, "lookup");
+        assert_eq!(log.borrow()[1].1, json!({ "id": 20 }));
+    }
+
+    #[test]
+    fn call_budget_is_enforced() {
+        let call = Rc::new(|_: &str, _: Value| json!({}));
+        let limits = Limits {
+            max_calls: 2,
+            ..Limits::default()
+        };
+        let out = run_script(
+            "for (var i = 0; i < 10; i++) { toolport.call('t', {}); } return 'done';",
+            json!({}),
+            call,
+            limits,
+        );
+        // Fail-closed: it made exactly the budgeted calls, then errored instead of finishing.
+        assert_eq!(out.calls, 2);
+        assert_ne!(out.error, None);
+        assert!(out.error.unwrap().contains("budget"));
+    }
+
+    #[test]
+    fn loop_limit_stops_pure_js_runaway() {
+        let call = Rc::new(|_: &str, _: Value| Value::Null);
+        let limits = Limits {
+            loop_iteration_limit: 1000,
+            ..Limits::default()
+        };
+        let out = run_script("while (true) {} return 1;", json!({}), call, limits);
+        assert_ne!(out.error, None, "an infinite loop must be stopped");
+        assert_eq!(out.calls, 0);
+    }
+
+    #[test]
+    fn a_thrown_error_is_reported_not_panicked() {
+        let call = Rc::new(|_: &str, _: Value| Value::Null);
+        let out = run_script("throw new Error('boom');", json!({}), call, Limits::default());
+        assert!(out.error.unwrap().contains("boom"));
+    }
+
+    #[test]
+    fn syntax_error_fails_closed() {
+        let call = Rc::new(|_: &str, _: Value| Value::Null);
+        let out = run_script("this is not valid )(", json!({}), call, Limits::default());
+        assert_ne!(out.error, None);
+        assert_eq!(out.calls, 0);
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -6,6 +6,7 @@ mod desktop;
 pub mod audit;
 pub mod catalog;
 pub mod clients;
+pub mod codemode;
 pub mod downstream;
 pub mod gateway_publish;
 pub mod inspect;

--- a/src-tauri/src/savings.rs
+++ b/src-tauri/src/savings.rs
@@ -95,6 +95,31 @@ pub fn record(full_tokens: u64, meta_tokens: u64, catalog_tools: u64, by_server:
     if !by_server.is_empty() {
         entry["byServer"] = json!(by_server);
     }
+    append_line(&entry);
+}
+
+/// Record one code-mode script run: the downstream round-trips it collapsed into a single
+/// `run_script` call (`round_trips_saved` = calls - 1). Written to the SAME log + counter as
+/// lazy-discovery savings, tagged `kind:"orchestration"` and carrying `roundTripsSaved` so
+/// the reader totals round-trips-saved separately from tokens-saved. `loads:0` keeps it out
+/// of the list-serve count (a script run is not a `tools/list`). No-op when nothing was saved.
+pub fn record_orchestration(round_trips_saved: u64) {
+    if round_trips_saved == 0 {
+        return;
+    }
+    append_line(&json!({
+        "ts": epoch_millis() as u64,
+        "kind": "orchestration",
+        "roundTripsSaved": round_trips_saved,
+        "loads": 0,
+    }));
+}
+
+/// Append one JSON entry as a single line. Every connected client spawns its own gateway
+/// process, so this is `O_APPEND` with one `write_all` (not `writeln!`) per line: concurrent
+/// writers can't interleave bytes into a corrupt JSON line, and a read-modify-write counter
+/// would race. Best-effort; rotates the log when it grows past the cap.
+fn append_line(entry: &Value) {
     if let Some(path) = savings_path() {
         if let Some(parent) = path.parent() {
             let _ = std::fs::create_dir_all(parent);
@@ -104,8 +129,6 @@ pub fn record(full_tokens: u64, meta_tokens: u64, catalog_tools: u64, by_server:
             .append(true)
             .open(&path)
         {
-            // Single write_all (not writeln!) so concurrent client-spawned gateways
-            // can't interleave bytes into corrupt JSON lines.
             let _ = file.write_all(format!("{entry}\n").as_bytes());
         }
         rotate_if_large(&path);
@@ -150,16 +173,22 @@ fn fold(entries: &[Value]) -> Value {
     let mut loads = 0u64;
     let mut peak = 0u64;
     let mut since = 0u64;
+    let mut round_trips = 0u64;
     for e in entries {
         saved = saved.saturating_add(e.get("saved").and_then(Value::as_u64).unwrap_or(0));
+        // A normal list-serve line has no `loads` and counts as one; a carry line and an
+        // orchestration line carry an explicit `loads` (the latter is 0), so neither a
+        // rotation nor a code-mode run inflates the list-load count.
         loads = loads.saturating_add(e.get("loads").and_then(Value::as_u64).unwrap_or(1));
         peak = peak.max(e.get("tools").and_then(Value::as_u64).unwrap_or(0));
+        round_trips = round_trips
+            .saturating_add(e.get("roundTripsSaved").and_then(Value::as_u64).unwrap_or(0));
         let ts = e.get("ts").and_then(Value::as_u64).unwrap_or(0);
         if ts > 0 && (since == 0 || ts < since) {
             since = ts;
         }
     }
-    json!({ "ts": since, "saved": saved, "tools": peak, "loads": loads })
+    json!({ "ts": since, "saved": saved, "tools": peak, "loads": loads, "roundTripsSaved": round_trips })
 }
 
 /// Every savings line on disk, oldest first (bounded by rotation). Shared by the
@@ -189,6 +218,7 @@ fn aggregate(entries: &[Value]) -> Value {
         "listLoads": folded.get("loads").and_then(Value::as_u64).unwrap_or(0),
         "peakCatalog": folded.get("tools").and_then(Value::as_u64).unwrap_or(0),
         "sinceTs": folded.get("ts").and_then(Value::as_u64).unwrap_or(0),
+        "roundTripsSaved": folded.get("roundTripsSaved").and_then(Value::as_u64).unwrap_or(0),
     })
 }
 
@@ -242,5 +272,37 @@ mod tests {
         assert_eq!(s["tokensSaved"], 0);
         assert_eq!(s["listLoads"], 0);
         assert_eq!(s["sinceTs"], 0);
+        assert_eq!(s["roundTripsSaved"], 0);
+    }
+
+    #[test]
+    fn orchestration_lines_total_round_trips_without_inflating_loads() {
+        // Code-mode runs live in the same log; they add round-trips-saved but are NOT
+        // list serves, so they must not count toward listLoads or tokensSaved.
+        let entries = vec![
+            json!({ "ts": 100, "saved": 60, "tools": 80 }), // one lazy list serve
+            json!({ "ts": 200, "kind": "orchestration", "roundTripsSaved": 5, "loads": 0 }),
+            json!({ "ts": 300, "kind": "orchestration", "roundTripsSaved": 3, "loads": 0 }),
+        ];
+        let s = aggregate(&entries);
+        assert_eq!(s["tokensSaved"], 60);
+        assert_eq!(s["listLoads"], 1); // only the list serve
+        assert_eq!(s["roundTripsSaved"], 8); // 5 + 3
+        assert_eq!(s["peakCatalog"], 80);
+    }
+
+    #[test]
+    fn carry_line_preserves_round_trips_after_rotation() {
+        // Folding a mix (list serve + orchestration) into a carry line and re-aggregating
+        // yields the same totals, so rotation never loses round-trips-saved.
+        let detail = [
+            json!({ "ts": 10, "saved": 100, "tools": 40 }),
+            json!({ "ts": 20, "kind": "orchestration", "roundTripsSaved": 7, "loads": 0 }),
+        ];
+        let carry = fold(&detail);
+        let s = aggregate(&[carry]);
+        assert_eq!(s["tokensSaved"], 100);
+        assert_eq!(s["listLoads"], 1);
+        assert_eq!(s["roundTripsSaved"], 7);
     }
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -234,6 +234,9 @@ export interface SavingsSummary {
   listLoads: number;
   peakCatalog: number;
   sinceTs: number;
+  /** Downstream tool round-trips collapsed into single code-mode run_script calls.
+   * Absent in older savings logs written before code mode. */
+  roundTripsSaved?: number;
 }
 
 export interface AuthInfo {


### PR DESCRIPTION
Server-side **code mode** (SOU-184): one agent-submitted JS script calls many downstream tools via `toolport.call()` and returns a single aggregated value, so an N-step task costs one round-trip and the intermediate results never enter model context. This is the results-layer twin of lazy discovery (which collapses tool *definitions*); here we collapse tool *calls + results*.

## Executor extraction (no behavior change on the direct path)
Pulled the whole tool-call sequence — route resolution, per-client scope guard, placeholder guard, typed human-approval + content-binding, destructive confirmation, live inspection, result shaping, audit — out of the inline `tools/call` handler into one reusable `execute_call()` returning the tool RESULT. `toolport_call_tool` now goes through it. **Every existing approval/scope/confirm/shaping test still passes**, proving no gate changed.

## Code mode
- A script's `toolport.call()` takes the SAME `execute_call()` path, so it can never reach a tool the client couldn't call, nor skip a gate. The confirm-token replay can't complete mid-script, so a destructive call there **fails closed** rather than running unconfirmed.
- `run_script_dispatch` builds a `'static` call closure from an Arc-cloned `Router` + a `Registry` snapshot and runs it in a pure-Rust **boa** sandbox (`codemode.rs`) — no C toolchain / FFI.
- Fail-closed limits: call-count budget, wall-clock deadline (per call), boa loop/recursion caps. Thrown/syntax/limit errors return a readable error, never panic.
- **Opt-in** via `CONDUIT_CODE_MODE=1` (a JS-execution surface deserves an explicit gate); advertised in lazy/grouped/full tool-lists only when enabled, and the dispatch refuses it when off.

## Accounting
`savings::record_orchestration` logs round-trips-saved (`calls - 1`) as `kind:"orchestration"` in the same log/counter, without inflating token or list-load counts; `toolport_status` surfaces it as a second headline.

## Deferred (documented in code)
- `parallel()` / async (v1 is synchronous; sequential calls already deliver the win).
- The script's returned aggregate isn't itself shaped (individual tool results are).
- Composite tools (declarative DAG) — the issue's second half, a likely Teams follow-up.

## Tests
`codemode.rs` sandbox (6); gateway integration: script aggregates real downstream calls, scope guard applies inside a script, destructive-in-script fails closed, empty-script / missing-router / disabled all fail closed, script errors reported not panicked; savings orchestration totals + carry-line preservation. Rust lib + bins green locally (392 + 122). Refs SOU-184.
