### PR TITLE
Folder/project-scoped auto-routing (SOU-188)

### DIFF
--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -3535,6 +3535,22 @@ fn resolve_live_profile(
     }
 }
 
+/// The profile that actually governs a client's scope right now: a folder-scoped override
+/// when the client's reported project root matches a `folder_profiles` mapping (SOU-188),
+/// otherwise the client's configured profile from [`resolve_live_profile`]. Folder routing
+/// auto-scopes by working directory with no manual profile switch; an unmatched or unknown
+/// root leaves the configured behavior exactly as before. stdio-only for now (the root comes
+/// from the single upstream client's MCP `roots`); the HTTP bridge always passes `root: None`.
+fn effective_profile(
+    reg: &Registry,
+    client_id: Option<&str>,
+    env_profile: &Option<String>,
+    root: Option<&str>,
+) -> Option<String> {
+    root.and_then(|r| reg.profile_for_root(r))
+        .or_else(|| resolve_live_profile(reg, client_id, env_profile))
+}
+
 /// The registry as a JSON value with the `team` block removed. The gateway builds the
 /// router ONLY from servers/profiles/policy flags and never reads the `team` block (its
 /// sync version/etag, role, member name, and per-day usage watermarks). The desktop team
@@ -3628,7 +3644,17 @@ fn watch_registry(
                 continue;
             }
             last_relevant = new_relevant;
-            let resolved = resolve_live_profile(&new_reg, client_id.as_deref(), &env_profile);
+            // The client's reported project root, read first so folder routing (SOU-188) can
+            // fold into the profile resolution below AND place ${ROOT} servers in the rebuild.
+            let root = client_root
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .clone();
+            // Effective profile = a folder-scoped override for the current root, else the
+            // client's configured profile. So editing folder_profiles (a registry change)
+            // re-applies routing live for a client already sitting in a mapped folder.
+            let resolved =
+                effective_profile(&new_reg, client_id.as_deref(), &env_profile, root.as_deref());
             // Capture the profile we were serving before this reload so the log can
             // show the transition - the single most useful line when diagnosing
             // "why can't this client see server X": it pins down which profile is
@@ -3642,10 +3668,6 @@ fn watch_registry(
                 prev
             };
             // Build the new router (spawns processes) before taking locks.
-            let root = client_root
-                .lock()
-                .unwrap_or_else(std::sync::PoisonError::into_inner)
-                .clone();
             let new_router = build_router(
                 &new_reg,
                 resolved.as_deref(),
@@ -3799,6 +3821,11 @@ struct GatewayState {
     stdio_upstream: Arc<StdioUpstream>,
     /// Answers downstream server-initiated RPC (roots, sampling, elicitation).
     server_handler: ServerRequestHandler,
+    /// This stdio gateway's single client id + boot `CONDUIT_PROFILE`, kept so the
+    /// root-change handler can recompute the effective (folder-scoped) profile off the
+    /// request thread without re-reading env. Process constants; unused in HTTP mode.
+    client_id: Option<String>,
+    env_profile: Option<String>,
 }
 
 /// Client capabilities the upstream MCP client declared at `initialize`.
@@ -4456,9 +4483,41 @@ fn refresh_client_root(state: &GatewayState) {
             false
         }
     };
-    // Only respawn when the resolved root actually changed and a ${ROOT} server is
-    // present, so a client that has no root (or no ${ROOT} server) never churns.
-    if changed && profile_has_root_server(state) {
+    if !changed {
+        return;
+    }
+    // Folder routing (SOU-188): the new project root may map to a different profile. Recompute
+    // the effective profile (folder override for this root, else the configured one) and swap
+    // state.profile before the rebuild so the new server scope takes effect. No mapping match
+    // leaves the configured profile untouched, exactly as before.
+    let new_effective = {
+        let reg = state
+            .registry
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        effective_profile(
+            &reg,
+            state.client_id.as_deref(),
+            &state.env_profile,
+            new_root.as_deref(),
+        )
+    };
+    let profile_switched = {
+        let mut cur = state
+            .profile
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if *cur != new_effective {
+            *cur = new_effective;
+            true
+        } else {
+            false
+        }
+    };
+    // Rebuild when folder routing switched the profile (new server scope) OR a ${ROOT} server
+    // must be re-placed at the new path. rebuild_router_for_root reads the now-updated
+    // state.profile and emits tools/list_changed; skip the churn when neither applies.
+    if profile_switched || profile_has_root_server(state) {
         rebuild_router_for_root(state);
     }
 }
@@ -6616,6 +6675,8 @@ fn main() {
         client_root,
         stdio_upstream,
         server_handler,
+        client_id: client_id.clone(),
+        env_profile: env_profile.clone(),
     };
 
     // Native HTTP/OpenAPI transport: a first-class path for HTTP tool clients
@@ -6962,6 +7023,40 @@ mod tests {
         }
     }
 
+    /// Folder routing (SOU-188): a reported root that matches a `folder_profiles` mapping
+    /// overrides the client's configured profile; an unmatched or absent root falls back to
+    /// the configured profile (client_scopes, then env), so unmapped clients are unchanged.
+    #[test]
+    fn effective_profile_prefers_folder_override_then_configured() {
+        let mut reg = Registry::default();
+        reg.folder_profiles = vec![registry::FolderProfile {
+            path: "/proj/work".into(),
+            profile: "Work".into(),
+        }];
+        reg.client_scopes.insert("cursor".into(), "Billing".into());
+        let env = Some("Env".to_string());
+        // Root under a mapping -> folder override wins over the configured profile.
+        assert_eq!(
+            effective_profile(&reg, Some("cursor"), &env, Some("/proj/work/repo")),
+            Some("Work".into())
+        );
+        // Root outside any mapping -> the client's configured profile (client_scopes).
+        assert_eq!(
+            effective_profile(&reg, Some("cursor"), &env, Some("/elsewhere")),
+            Some("Billing".into())
+        );
+        // No root reported -> configured profile, unchanged.
+        assert_eq!(
+            effective_profile(&reg, Some("cursor"), &env, None),
+            Some("Billing".into())
+        );
+        // No client scope + no folder match -> env fallback (legacy behavior).
+        assert_eq!(
+            effective_profile(&reg, None, &env, Some("/elsewhere")),
+            Some("Env".into())
+        );
+    }
+
     fn router() -> Router {
         Router::new()
     }
@@ -7093,6 +7188,8 @@ mod tests {
             client_root: Arc::new(Mutex::new(None)),
             stdio_upstream,
             server_handler,
+            client_id: None,
+            env_profile: None,
         }
     }
 

--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -19,7 +19,9 @@ use crate::downstream::{resolve_root_token, DownstreamServer, StdioTransport};
 use crate::inspect;
 use crate::integrity;
 use crate::oauth;
-use crate::registry::{self, arg_looks_secret, redact_url_userinfo, Profile, Registry, ServerEntry};
+use crate::registry::{
+    self, arg_looks_secret, redact_url_userinfo, FolderProfile, Profile, Registry, ServerEntry,
+};
 use crate::remote;
 use crate::router;
 use crate::savings;
@@ -615,6 +617,21 @@ fn delete_profile(state: State<RegistryState>, id: String) -> Result<Registry, S
 #[tauri::command]
 fn set_active_profile(state: State<RegistryState>, id: String) -> Result<Registry, String> {
     let (reg, _) = write_registry(state.inner(), |reg| reg.set_active_profile(&id))?;
+    Ok(reg)
+}
+
+/// Replace the folder -> profile auto-routing mappings (SOU-188). A gateway serving a client
+/// whose reported project root is under a mapped path auto-scopes to that profile. Returns
+/// the saved registry so the UI reflects the persisted list.
+#[tauri::command]
+fn set_folder_profiles(
+    state: State<RegistryState>,
+    mappings: Vec<FolderProfile>,
+) -> Result<Registry, String> {
+    let (reg, _) = write_registry(state.inner(), |reg| {
+        reg.set_folder_profiles(mappings);
+        Ok(())
+    })?;
     Ok(reg)
 }
 
@@ -2746,6 +2763,7 @@ pub fn run() {
             create_profile,
             delete_profile,
             set_active_profile,
+            set_folder_profiles,
             write_to_client,
             install_gateway,
             uninstall_gateway,

--- a/src-tauri/src/registry.rs
+++ b/src-tauri/src/registry.rs
@@ -138,6 +138,18 @@ pub struct Profile {
     pub enabled_server_ids: Vec<String>,
 }
 
+/// Maps a project folder to a profile, so the gateway can auto-scope a client to the right
+/// server set based on the working directory (MCP `root`) it reports, instead of a manual
+/// profile switch. A client whose reported root is `path` or a descendant of it resolves to
+/// `profile`; the longest matching `path` wins. `profile` is a profile id OR name (resolved
+/// the same way as `client_scopes`, via `resolve_profile_id`).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct FolderProfile {
+    pub path: String,
+    pub profile: String,
+}
+
 /// A consumer registered to reach the gateway over the HTTP/OpenAPI bridge with
 /// its own bearer token and scope. Lets one bridge process serve several clients
 /// (e.g. Open WebUI) with different server sets, resolved per request from the
@@ -177,6 +189,35 @@ fn ct_eq(a: &str, b: &str) -> bool {
         diff |= x ^ y;
     }
     diff == 0
+}
+
+/// Normalize a filesystem path for prefix comparison WITHOUT touching disk: unify separators
+/// to `/`, trim a trailing separator, and lowercase on Windows (its paths are
+/// case-insensitive). String-only so it works for a path that doesn't exist on this machine
+/// (the client reported it). Not canonicalization, just enough to compare two reported paths.
+fn normalize_path(p: &str) -> String {
+    let mut s = p.trim().replace('\\', "/");
+    while s.len() > 1 && s.ends_with('/') {
+        s.pop();
+    }
+    if cfg!(windows) {
+        s = s.to_ascii_lowercase();
+    }
+    s
+}
+
+/// True when `root` is `base` itself or a descendant of it, matched on a path BOUNDARY so
+/// base `/a/proj` matches `/a/proj` and `/a/proj/src` but never `/a/project`. Both must
+/// already be [`normalize_path`]-ed. An empty `base` matches nothing (an unset mapping path
+/// must not swallow every root).
+fn path_is_within(base: &str, root: &str) -> bool {
+    if base.is_empty() {
+        return false;
+    }
+    if root == base {
+        return true;
+    }
+    root.starts_with(base) && root.as_bytes().get(base.len()) == Some(&b'/')
 }
 
 /// A user override for how one tool is exposed to clients, keyed in the registry by the
@@ -336,6 +377,12 @@ pub struct Registry {
     /// the client follows the active profile (all its enabled servers).
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub client_scopes: HashMap<String, String>,
+    /// Folder -> profile mappings for project-scoped auto-routing: when a client reports a
+    /// working directory (MCP `root`), the gateway picks the profile whose mapped path is the
+    /// longest prefix of that root, instead of the client's manually-set profile. Empty = no
+    /// folder routing (every client follows its configured/active profile as before).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub folder_profiles: Vec<FolderProfile>,
     /// Per-client discovery-mode override, keyed by stable client id (e.g. "cursor" ->
     /// "grouped"). Value is `"full" | "lazy" | "grouped"`; an absent entry means the client
     /// inherits the global mode (`discovery_mode`, else `lazy_discovery`). The gateway
@@ -454,6 +501,7 @@ impl Default for Registry {
             team: None,
             result_budgets: HashMap::new(),
             client_scopes: HashMap::new(),
+            folder_profiles: Vec::new(),
             client_discovery: HashMap::new(),
             http_clients: Vec::new(),
             secrets_generation: 0,
@@ -824,6 +872,38 @@ impl Registry {
             .iter()
             .filter(|s| self.is_enabled(&id, &s.id))
             .collect()
+    }
+
+    /// Resolve the folder-scoped profile for a client's reported root path, if any
+    /// [`folder_profiles`](Self::folder_profiles) mapping matches. The longest matching
+    /// mapped path wins (so a nested mapping overrides its parent). Returns the mapped
+    /// profile string (id or name, resolved like `client_scopes`), or `None` to fall back to
+    /// the client's configured/active profile. Path-only string matching, never touches disk:
+    /// canonicalizing would fail for a root that doesn't exist on THIS machine, and the point
+    /// is to match what the client reported.
+    pub fn profile_for_root(&self, root: &str) -> Option<String> {
+        let root = normalize_path(root);
+        if root.is_empty() {
+            return None;
+        }
+        self.folder_profiles
+            .iter()
+            .filter_map(|fp| {
+                let base = normalize_path(&fp.path);
+                path_is_within(&base, &root).then_some((base.len(), fp.profile.clone()))
+            })
+            .max_by_key(|(len, _)| *len)
+            .map(|(_, profile)| profile)
+    }
+
+    /// Replace the folder -> profile routing mappings (the UI edits the list wholesale). Drops
+    /// entries with a blank path or profile; stores paths verbatim (normalized only at match
+    /// time in [`profile_for_root`]).
+    pub fn set_folder_profiles(&mut self, mappings: Vec<FolderProfile>) {
+        self.folder_profiles = mappings
+            .into_iter()
+            .filter(|m| !m.path.trim().is_empty() && !m.profile.trim().is_empty())
+            .collect();
     }
 
     /// Servers the multi-tenant HTTP bridge must connect: the union of the base
@@ -1694,6 +1774,62 @@ mod tests {
             r.enabled_servers_for("nope").is_empty(),
             "unknown profile must fail closed, not fall back to active"
         );
+    }
+
+    #[test]
+    fn profile_for_root_longest_prefix_wins_on_a_path_boundary() {
+        let mut r = Registry::default();
+        r.folder_profiles = vec![
+            FolderProfile { path: "/home/me/work".into(), profile: "Work".into() },
+            FolderProfile { path: "/home/me/work/client-a".into(), profile: "ClientA".into() },
+            FolderProfile { path: "/home/me/personal".into(), profile: "Personal".into() },
+        ];
+        // Exact match, and a descendant picks the parent mapping.
+        assert_eq!(r.profile_for_root("/home/me/work"), Some("Work".into()));
+        assert_eq!(r.profile_for_root("/home/me/work/src"), Some("Work".into()));
+        // A more specific nested mapping wins over its parent.
+        assert_eq!(
+            r.profile_for_root("/home/me/work/client-a/repo"),
+            Some("ClientA".into())
+        );
+        assert_eq!(r.profile_for_root("/home/me/personal/notes"), Some("Personal".into()));
+        // No mapping -> None (caller falls back to the configured profile).
+        assert_eq!(r.profile_for_root("/tmp/other"), None);
+        // Boundary: a sibling sharing a NAME prefix must not match ("work" vs "workspace").
+        assert_eq!(r.profile_for_root("/home/me/workspace"), None);
+        // Empty root never matches.
+        assert_eq!(r.profile_for_root(""), None);
+    }
+
+    #[test]
+    fn set_folder_profiles_drops_blank_entries() {
+        let mut r = Registry::default();
+        r.set_folder_profiles(vec![
+            FolderProfile { path: "/a".into(), profile: "P".into() },
+            FolderProfile { path: "  ".into(), profile: "P".into() }, // blank path
+            FolderProfile { path: "/b".into(), profile: " ".into() },  // blank profile
+        ]);
+        assert_eq!(r.folder_profiles.len(), 1);
+        assert_eq!(r.folder_profiles[0].path, "/a");
+    }
+
+    #[test]
+    fn profile_for_root_normalizes_separators_and_trailing_slash() {
+        let mut r = Registry::default();
+        r.folder_profiles =
+            vec![FolderProfile { path: "/home/me/work/".into(), profile: "Work".into() }];
+        // A trailing slash on the mapping and backslash separators in the root both normalize.
+        assert_eq!(r.profile_for_root("/home/me/work"), Some("Work".into()));
+        assert_eq!(r.profile_for_root(r"\home\me\work\sub"), Some("Work".into()));
+    }
+
+    #[test]
+    fn folder_profiles_omitted_from_json_when_empty() {
+        // Back-compat: a registry with no folder routing serializes without the field, so
+        // existing registry.json files round-trip unchanged.
+        let r = Registry::default();
+        let json = serde_json::to_string(&r).unwrap();
+        assert!(!json.contains("folderProfiles"));
     }
 
     #[test]

--- a/src/components/SettingsView.tsx
+++ b/src/components/SettingsView.tsx
@@ -6,6 +6,7 @@ import {
   Copy,
   Eye,
   EyeOff,
+  FolderTree,
   Globe,
   Layers,
   Pin,
@@ -37,6 +38,7 @@ import {
   setDenyDestructive,
   setHumanApproval,
   setLazyDiscovery,
+  setFolderProfiles,
   setLiveInspect,
   setQuarantineOnDrift,
   setToolPinned,
@@ -45,7 +47,7 @@ import {
   type HttpBridgeStatus,
   type QuarantinedTool,
 } from "@/lib/api";
-import type { AllowedTool, Registry } from "@/lib/types";
+import type { AllowedTool, FolderProfile, Registry } from "@/lib/types";
 import { Switch } from "@/components/ui/switch";
 import {
   Select,
@@ -134,6 +136,120 @@ function PinnedPrerequisites({
             </li>
           ))}
         </ul>
+      )}
+    </div>
+  );
+}
+
+/** Folder -> profile auto-routing (SOU-188): map a project folder to a profile so a client
+ * opened in that folder auto-scopes to it, no manual profile switch. Reads/writes
+ * `registry.folderProfiles`; the longest matching path wins at match time. stdio clients. */
+function FolderRouting({
+  registry,
+  onRegistryChange,
+}: {
+  registry: Registry | null;
+  onRegistryChange: (registry: Registry) => void;
+}) {
+  const mappings = registry?.folderProfiles ?? [];
+  const profiles = registry?.profiles ?? [];
+  const [path, setPath] = useState("");
+  const [profile, setProfile] = useState("");
+  const [busy, setBusy] = useState(false);
+
+  async function save(next: FolderProfile[]) {
+    setBusy(true);
+    try {
+      onRegistryChange(await setFolderProfiles(next));
+    } catch (e) {
+      toastError(`Couldn't save folder routing: ${e}`);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function add() {
+    const p = path.trim();
+    if (!p || !profile) return;
+    // Replace any existing mapping for the same path rather than duplicating it.
+    const next = [...mappings.filter((m) => m.path.trim() !== p), { path: p, profile }];
+    await save(next);
+    setPath("");
+    setProfile("");
+  }
+
+  // A mapping's profile is stored as an id or name; show the profile's display name.
+  const label = (ref: string) =>
+    profiles.find((p) => p.id === ref || p.name === ref)?.name ?? ref;
+
+  return (
+    <div className="rounded-lg border border-border/60 bg-muted/20 p-3">
+      <div className="flex items-center gap-2 text-xs">
+        <FolderTree className="size-3.5 shrink-0 text-info" />
+        <span className="font-medium">Project folder routing</span>
+        <span className="rounded-full bg-muted px-1.5 py-0.5 text-muted-foreground">
+          {mappings.length}
+        </span>
+        <span className="ml-auto text-muted-foreground">
+          auto-scope a client by the folder it opens in
+        </span>
+      </div>
+      {mappings.length > 0 && (
+        <ul className="mt-2 space-y-1">
+          {mappings.map((m) => (
+            <li key={m.path} className="flex items-center gap-2 text-xs">
+              <code className="truncate rounded bg-muted px-1.5 py-0.5 font-mono text-foreground/90">
+                {m.path}
+              </code>
+              <span className="shrink-0 text-muted-foreground">&rarr;</span>
+              <span className="shrink-0 text-foreground/90">{label(m.profile)}</span>
+              <button
+                onClick={() => save(mappings.filter((x) => x.path !== m.path))}
+                disabled={busy}
+                aria-label={`Remove routing for ${m.path}`}
+                className="ml-auto rounded p-0.5 text-muted-foreground/60 transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-border disabled:opacity-50"
+              >
+                <X className="size-3.5" />
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+      {profiles.length === 0 ? (
+        <p className="mt-2 text-xs text-muted-foreground">
+          Create a profile first, then map a folder to it here.
+        </p>
+      ) : (
+        <div className="mt-2 flex items-center gap-2">
+          <input
+            value={path}
+            onChange={(e) => setPath(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") void add();
+            }}
+            placeholder="/path/to/project"
+            className="min-w-0 flex-1 rounded border bg-background px-2 py-1 font-mono text-xs focus-visible:ring-1 focus-visible:ring-border focus-visible:outline-none"
+          />
+          <Select value={profile} onValueChange={setProfile}>
+            <SelectTrigger className="h-7 w-32 text-xs">
+              <SelectValue placeholder="Profile" />
+            </SelectTrigger>
+            <SelectContent>
+              {profiles.map((p) => (
+                <SelectItem key={p.id} value={p.id}>
+                  {p.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <button
+            onClick={() => void add()}
+            disabled={busy || !path.trim() || !profile}
+            className="shrink-0 rounded border px-2 py-1 text-xs font-medium hover:bg-muted disabled:opacity-50"
+          >
+            Add
+          </button>
+        </div>
       )}
     </div>
   );
@@ -466,6 +582,7 @@ export function SettingsView({ registry, onRegistryChange }: Props) {
               );
             })}
           </div>
+          <FolderRouting registry={registry} onRegistryChange={onRegistryChange} />
         </section>
       )}
       <section className="flex flex-col gap-2">

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -5,6 +5,7 @@ import type {
   AuthInfo,
   CatalogEntry,
   DetectedClient,
+  FolderProfile,
   ImportItem,
   InspectEntry,
   McpPrompt,
@@ -654,4 +655,9 @@ export function deleteProfile(id: string): Promise<Registry> {
 
 export function setActiveProfile(id: string): Promise<Registry> {
   return invoke<Registry>("set_active_profile", { id });
+}
+
+/** Replace the folder -> profile auto-routing mappings (SOU-188). */
+export function setFolderProfiles(mappings: FolderProfile[]): Promise<Registry> {
+  return invoke<Registry>("set_folder_profiles", { mappings });
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -358,6 +358,14 @@ export interface Profile {
   enabledServerIds: string[];
 }
 
+/** A folder -> profile auto-routing mapping (SOU-188): a client whose reported project
+ * root is `path` or a descendant auto-scopes to `profile` (a profile id or name), the
+ * longest matching path wins. Empty list = no folder routing. */
+export interface FolderProfile {
+  path: string;
+  profile: string;
+}
+
 /** A tool call held awaiting a human decision (the HITL approval queue). */
 export interface PendingApproval {
   id: string;
@@ -393,6 +401,8 @@ export interface Registry {
   servers: ServerEntry[];
   profiles: Profile[];
   activeProfileId: string | null;
+  /** Folder -> profile auto-routing mappings. Absent/empty = no folder routing. */
+  folderProfiles?: FolderProfile[];
   /** Per-tool exposure overrides (rename / re-describe), keyed by server id then original tool name. */
   toolOverrides?: Record<string, Record<string, ToolOverride>>;
   /** Tools pinned as lazy-discovery prerequisites, keyed by server id -> original tool names. */


### PR DESCRIPTION
Folder/project-scoped auto-routing (**SOU-188**): auto-scope a client to the right profile by the project folder it opens in (its reported MCP `root`), instead of a manual profile switch. Competitive parity with MCPMux's folder-based resolution (see the MCPMux competitive review).

Open your `work/` repo and get the work servers; open `personal/` and get the personal ones, no switch, and cross-project credential leakage is prevented automatically.

## How it works
- **`registry.rs`**: `FolderProfile { path, profile }` + a `folder_profiles` field (omitted from JSON when empty, so existing `registry.json` round-trips unchanged). `profile_for_root()` resolves a reported root to a profile by longest matching path, path-boundary-safe (`/a/proj` never matches `/a/project`), separator/trailing-slash/Windows-case normalized, string-only (never touches disk). `set_folder_profiles()` setter (drops blank entries).
- **`toolport-gateway.rs`**: `effective_profile(reg, client_id, env_profile, root)` = a folder override when the reported root matches a mapping, else the client's configured profile (`resolve_live_profile`). Applied at both recompute points:
  - the **registry watcher** (so editing mappings re-applies routing live for a client already in a mapped folder), and
  - **`refresh_client_root`** (so a project-root change re-scopes, rebuilds the router, and emits `tools/list_changed`).
  `GatewayState` carries `client_id`/`env_profile` for the off-thread recompute.
- **`desktop.rs`**: `set_folder_profiles` Tauri command.
- **UI**: `FolderProfile` type + `folderProfiles` on `Registry`, a `setFolderProfiles` binding, and a **"Project folder routing"** section in Settings (list of `path → profile` with add/remove).

## Safety / scope
- **Unmapped clients and HTTP mode are byte-for-byte unchanged** — empty `folder_profiles` → `None` → the existing profile path; `refresh_client_root` early-returns in HTTP mode.
- **stdio-only for now** (Claude Desktop, Cursor, VS Code, …). HTTP-bridge per-session folder routing is a documented follow-up.
- No two-writer conflict: both recompute points derive the effective profile from the same inputs.

## Tests
`profile_for_root` (longest-prefix / path-boundary / normalization), `set_folder_profiles` filtering, `effective_profile` precedence. Rust lib + bins green (384 + 115), tsc + prettier + vitest (94) green.

Refs SOU-188. Independent of the code-mode PR (SOU-184).
