### PR TITLE
chore: remove dead next-themes dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,6 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "2.1.1",
         "lucide-react": "^1.21.0",
-        "next-themes": "^0.4.6",
         "radix-ui": "^1.6.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
@@ -7424,14 +7423,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/next-themes": {
-      "version": "0.4.6",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
       }
     },
     "node_modules/node-domexception": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "2.1.1",
     "lucide-react": "^1.21.0",
-    "next-themes": "^0.4.6",
     "radix-ui": "^1.6.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",


### PR DESCRIPTION
Follow-up housekeeping to #333.

`src/components/ui/sonner.tsx` was the only consumer of `next-themes` in the tree, and #333 removed that import when it hardcoded the toaster to `theme="dark"`. So the dependency is now dead — this drops it from `package.json` and the lockfile.

No code or behavior change; pure dependency prune.

## Testing
- `npm run build` (tsc + vite) passes
- `npm run test` (vitest 94) passes
- `npm run audit:prod` passes (0 vulnerabilities)
- `grep -rn next-themes src/` returns nothing

If the planned light/system theme toggle (SOU-145) lands, it can re-add a theme provider then; keeping a dead dep in the meantime isn't worth it.