### PR TITLE
Debounce ShareDialog exportConfig calls

### DIFF
--- a/src/components/ShareDialog.tsx
+++ b/src/components/ShareDialog.tsx
@@ -55,6 +55,8 @@ export function ShareDialog({ trigger, onImported }: Props) {
   const [name, setName] = useState("");
   const [description, setDescription] = useState("");
   const [exported, setExported] = useState("");
+  const [debouncedName, setDebouncedName] = useState(name);
+  const [debouncedDescription, setDebouncedDescription] = useState(description);
   const [paste, setPaste] = useState("");
   const [copied, setCopied] = useState(false);
   const [busyAction, setBusyAction] = useState<
@@ -91,6 +93,15 @@ export function ShareDialog({ trigger, onImported }: Props) {
     servers.length === 0 || allSelected ? undefined : Array.from(selected);
 
   useEffect(() => {
+    const timer = setTimeout(() => {
+      setDebouncedName(name);
+      setDebouncedDescription(description);
+    }, 250);
+
+    return () => clearTimeout(timer);
+  }, [name, description]);
+
+  useEffect(() => {
     if (!open) return;
     setShareLink(""); // the export changed, so any prior link is stale
     // Guard against out-of-order responses: this effect re-fires on every keystroke
@@ -98,7 +109,7 @@ export function ShareDialog({ trigger, onImported }: Props) {
     // order. Without this, a slower earlier response could overwrite the preview with
     // stale content. Only the latest effect run is allowed to commit its result.
     let cancelled = false;
-    exportConfig(name, description, shareFilter)
+    exportConfig(debouncedName, debouncedDescription, shareFilter)
       .then((v) => {
         if (!cancelled) setExported(v);
       })
@@ -109,7 +120,7 @@ export function ShareDialog({ trigger, onImported }: Props) {
       cancelled = true;
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [open, name, description, selected, servers]);
+  }, [open, debouncedName, debouncedDescription, selected, servers]);
 
   function onOpenChange(next: boolean) {
     setOpen(next);


### PR DESCRIPTION
<!-- Thanks for contributing to Toolport. Keep PRs focused and small where you can. -->

## What and why

- Debounce Share dialog exports while editing the setup name and description.
- Previously, every keystroke in the Name and Description fields triggered a new `exportConfig` IPC call. Although the existing race guard prevented stale results from overwriting newer ones, it still performed unnecessary exports while typing.
- This change debounces updates to the Name and Description fields by approximately 250 ms before triggering the export, reducing redundant IPC calls without changing the exported output.


Closes #294 

## Testing

<!-- How did you verify this? -->

- [x] `npm run build` passes
- [x] `npm run test` passes
- [ ] `npm run audit:prod` passes
- [ ] `npm run test:rust` passes (`npm run test:rust:windows` on Windows if the debug gateway binary is locked)
- [x] Ran the app (`npm run tauri dev`) and checked the change by hand
  
## Notes

- Verified rapid typing in the Name and Description fields triggers a single export after approximately 250 ms of inactivity.
- Verified pausing while typing triggers one export after each pause.
- Verified the exported configuration remains unchanged.