### PR TITLE
Activity savings banner: B/T units + honest dollar hedge

### DIFF
--- a/src/components/ActivityView.tsx
+++ b/src/components/ActivityView.tsx
@@ -483,10 +483,13 @@ function SavingsBanner({ savings }: { savings: SavingsSummary }) {
           ≈ {fmtTokens(savings.tokensSaved)}{" "}
           <span className="text-base font-normal text-muted-foreground">tokens</span>
         </span>
-        <span className="text-xl font-semibold tabular-nums text-muted-foreground">
-          ≈ {fmtDollars(dollars)}
+        <span
+          className="text-xl font-semibold tabular-nums text-muted-foreground"
+          title="A ceiling at list input prices. Tool definitions live in the cacheable prompt prefix, so with prompt caching the real figure is lower; actual spend depends on your model mix and cache-hit rate."
+        >
+          up to {fmtDollars(dollars)}
           <span className="ml-1 text-xs font-normal text-muted-foreground/70">
-            illustrative
+            list prices, before caching
           </span>
         </span>
       </div>

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -19,6 +19,12 @@ describe("fmtTokens", () => {
     expect(fmtTokens(1_234_567)).toBe("1.2M");
   });
 
+  it("rolls over to B and T instead of thousands of M", () => {
+    expect(fmtTokens(1_000_000_000)).toBe("1.0B");
+    expect(fmtTokens(2_110_000_000)).toBe("2.1B");
+    expect(fmtTokens(1_500_000_000_000)).toBe("1.5T");
+  });
+
   it("handles the boundary at 999999 (rounds up to 1000.0k, not 1.0M)", () => {
     // 999999 is just below the 1_000_000 threshold, so it takes the "k" branch:
     // (999999 / 1000).toFixed(1) === "1000.0", giving "1000.0k" rather than "1.0M".

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -6,11 +6,14 @@ export function cn(...inputs: ClassValue[]) {
 }
 
 /**
- * Format a token count compactly: 1_234_567 -> "1.2M", 12_345 -> "12.3k".
- * Single source of truth so every surface (Activity, Sidebar, ...) shows the
- * same rounded figure for the same number.
+ * Format a token count compactly: 1_234_567 -> "1.2M", 2_110_000_000 -> "2.1B",
+ * 12_345 -> "12.3k". Rolls over at each 1000x so a large catalog reads as "2.1B"
+ * rather than "2110.0M". Single source of truth so every surface (Activity,
+ * Sidebar, share text, ...) shows the same rounded figure for the same number.
  */
 export function fmtTokens(n: number): string {
+  if (n >= 1_000_000_000_000) return `${(n / 1_000_000_000_000).toFixed(1)}T`;
+  if (n >= 1_000_000_000) return `${(n / 1_000_000_000).toFixed(1)}B`;
   if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
   if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`;
   return `${n}`;


### PR DESCRIPTION
Two small fixes to the Activity "tokens kept out of context" banner.

## 1. Token units roll over past millions
`fmtTokens` topped out at `M`, so a large catalog rendered as **"2110.0M"**. It now rolls over at each 1000x → **"2.1B"** (and `T` beyond). Shared util, so Activity, the Sidebar, and the share text all benefit. New tests cover the B/T tiers; existing `.0`/boundary behavior is unchanged.

## 2. Honest framing for the dollar figure
The dollar estimate is `tokensSaved / 1M × list price`, which ignores **prompt caching**: tool definitions live in the cacheable prompt prefix, so in real multi-turn use the repeated tokens cost ~10% of list price, not 100%. Multiplying the whole delta by full input price is really an upper bound.

Rather than build a caching-accurate calculator (not worth it for a secondary metric), this reframes the number honestly so a technical evaluator can't knock it over:
- `illustrative` → **"up to $X · list prices, before caching"**
- a tooltip explaining tool defs sit in the cacheable prefix, so the real figure is lower and depends on model mix + cache-hit rate.

The **token count stays the defensible hero**; the dollar figure now reads as "we know what this is" rather than a claim a skeptic dismisses. (Aligns with the standing "lead with context/usage, dollars last" positioning.)

## Testing
- `fmtTokens` unit tests (B/T + existing) pass; full vitest green (95).
- tsc + prettier clean.
- Tauri-backed screen, so verified via the pure `fmtTokens` function + typecheck rather than the browser preview.