### PR TITLE
Tool-granular profiles / FeatureSets (SOU-189)

### DIFF
--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -3412,8 +3412,25 @@ fn build_router(
             disabled.insert(s.id.clone(), s.disabled_tools.iter().cloned().collect());
         }
     }
+    // Tool-granular profile scope (SOU-189): the active profile's per-server tool allow-list.
+    // Baked into this per-profile router so tools/list, search, and the call guard all honor
+    // it with no per-request threading. Applies to the stdio (per-profile) router only; the
+    // shared HTTP-bridge router serves many profiles, so its tool-scope is a per-request
+    // follow-up (stdio-first, same line as folder routing).
+    let mut allow = std::collections::HashMap::new();
+    if !http_mode {
+        let pid = profile
+            .map(|p| reg.resolve_profile_id(p))
+            .unwrap_or_else(|| reg.active_profile_id());
+        if let Some(prof) = reg.profiles.iter().find(|p| p.id == pid) {
+            for (server_id, tools) in &prof.tool_scope {
+                allow.insert(server_id.clone(), tools.iter().cloned().collect());
+            }
+        }
+    }
     let policy = ToolPolicy {
         disabled,
+        allow,
         deny_destructive: reg.deny_destructive_effective(),
         // Hide already-quarantined tools from the first build (the set persists across
         // restarts); newly detected drift is added during the integrity check below.

--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -635,6 +635,22 @@ fn set_folder_profiles(
     Ok(reg)
 }
 
+/// Set (or clear) a profile's tool-granular scope for one server (SOU-189). `tools = Some(list)`
+/// narrows that server to exactly those original tool names within the profile; `None` (or an
+/// empty list) clears it, restoring all tools on that server. Returns the saved registry.
+#[tauri::command]
+fn set_profile_server_tools(
+    state: State<RegistryState>,
+    profile_id: String,
+    server_id: String,
+    tools: Option<Vec<String>>,
+) -> Result<Registry, String> {
+    let (reg, _) = write_registry(state.inner(), |reg| {
+        reg.set_profile_server_tools(&profile_id, &server_id, tools)
+    })?;
+    Ok(reg)
+}
+
 /// Write a server set into a client's config (backs up first). Not yet called by
 /// the UI; reserved for bulk operations.
 #[tauri::command]
@@ -2764,6 +2780,7 @@ pub fn run() {
             delete_profile,
             set_active_profile,
             set_folder_profiles,
+            set_profile_server_tools,
             write_to_client,
             install_gateway,
             uninstall_gateway,
@@ -3324,6 +3341,7 @@ mod tests {
             id: "default".into(),
             name: "Default".into(),
             enabled_server_ids: vec!["gh".into()],
+            tool_scope: Default::default(),
         }];
         let mut baselines = BTreeMap::new();
         let bl = |fp: &str, fs: u64, lc: u64| integrity::ToolBaseline {

--- a/src-tauri/src/registry.rs
+++ b/src-tauri/src/registry.rs
@@ -690,11 +690,12 @@ impl Registry {
         }
     }
 
-    /// Set or clear a profile's tool allow-list for one server. `Some(non-empty list)` narrows
-    /// that server to exactly those ORIGINAL tool names; `None` or an empty list removes the
-    /// entry, restoring "all tools on that server". Idempotent. The UI sends the full desired
-    /// list, and sends `None` when every tool is selected so an unnarrowed profile stays empty
-    /// (backward compatible: no `tool_scope` written).
+    /// Set or clear a profile's tool allow-list for one server. `Some(list)` narrows that
+    /// server to exactly those ORIGINAL tool names (an EMPTY list is a real state: expose NO
+    /// tools on that server, enforced as block-all). `None` removes the entry, restoring "all
+    /// tools on that server". Idempotent. The UI sends `None` only when every tool is selected,
+    /// so an unnarrowed profile keeps an empty `tool_scope` (backward compatible), and sends
+    /// `Some(subset)` otherwise, distinguishing "all" (None) from "none" (empty list).
     pub fn set_profile_server_tools(
         &mut self,
         profile_id: &str,
@@ -707,10 +708,10 @@ impl Registry {
             .find(|p| p.id == profile_id)
             .ok_or_else(|| format!("No profile with id '{profile_id}'"))?;
         match tools {
-            Some(list) if !list.is_empty() => {
+            Some(list) => {
                 profile.tool_scope.insert(server_id.to_string(), list);
             }
-            _ => {
+            None => {
                 profile.tool_scope.remove(server_id);
             }
         }
@@ -1879,6 +1880,21 @@ mod tests {
         // Clearing restores all-allowed and leaves the map empty (backward compatible).
         r.set_profile_server_tools("default", &gh, None).unwrap();
         assert!(r.profile_allows_tool("default", &gh, "create_issue"));
+        assert!(r.profiles[0].tool_scope.is_empty());
+    }
+
+    #[test]
+    fn empty_allow_list_exposes_no_tools_distinct_from_clear() {
+        let mut r = Registry::default();
+        let gh = r.add_server(sample_server("github"));
+        // Some(empty) = expose NO tools on this server (not the same as "all tools").
+        r.set_profile_server_tools("default", &gh, Some(vec![])).unwrap();
+        assert!(!r.profile_allows_tool("default", &gh, "search"));
+        assert!(!r.profile_allows_tool("default", &gh, "anything"));
+        assert!(r.profiles[0].tool_scope.contains_key(&gh));
+        // None = clear the narrowing, back to all tools.
+        r.set_profile_server_tools("default", &gh, None).unwrap();
+        assert!(r.profile_allows_tool("default", &gh, "search"));
         assert!(r.profiles[0].tool_scope.is_empty());
     }
 

--- a/src-tauri/src/registry.rs
+++ b/src-tauri/src/registry.rs
@@ -136,6 +136,15 @@ pub struct Profile {
     pub name: String,
     #[serde(default)]
     pub enabled_server_ids: Vec<String>,
+    /// Optional tool-granular scoping (the "FeatureSet" layer): a per-server allow-list of
+    /// the ORIGINAL tool names this profile exposes. A server present here exposes ONLY the
+    /// listed tools; a server ABSENT exposes all of its tools, exactly as before. An empty
+    /// map means the profile is server-granular only, so this is fully backward compatible.
+    /// Keyed by server id -> original tool names (like `pinned_tools`), so a `tool_override`
+    /// rename can't slip a tool past the scope. Enforced everywhere the server scope is:
+    /// tools/list, search, and the call guard.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub tool_scope: HashMap<String, Vec<String>>,
 }
 
 /// Maps a project folder to a profile, so the gateway can auto-scope a client to the right
@@ -478,6 +487,7 @@ impl Default for Registry {
                 id: DEFAULT_PROFILE_ID.to_string(),
                 name: "Default".to_string(),
                 enabled_server_ids: Vec::new(),
+                tool_scope: HashMap::new(),
             }],
             active_profile_id: Some(DEFAULT_PROFILE_ID.to_string()),
             deny_destructive: false,
@@ -575,6 +585,8 @@ impl Registry {
         }
         for profile in &mut self.profiles {
             profile.enabled_server_ids.retain(|sid| sid != id);
+            // Drop any tool-scope allow-list for the removed server so it can't orphan.
+            profile.tool_scope.remove(id);
         }
         Ok(())
     }
@@ -659,6 +671,50 @@ impl Registry {
             .find(|s| s.id == server_id)
             .map(|s| !s.disabled_tools.iter().any(|t| t == tool))
             .unwrap_or(true)
+    }
+
+    /// Whether a profile exposes a given tool (tool-granular scoping / "FeatureSet"). Default-
+    /// allow: if the profile has no `tool_scope` allow-list for `server_id`, every tool on
+    /// that server is exposed (server-granular behavior, unchanged). If it does, ONLY the
+    /// listed tools are. Layered UNDER the server scope, so it only narrows within a profile's
+    /// enabled servers. `tool` is the ORIGINAL tool name (as `route_of` yields it). An unknown
+    /// profile ref imposes no extra tool restriction here (the server scope already blocks it).
+    pub fn profile_allows_tool(&self, profile_ref: &str, server_id: &str, tool: &str) -> bool {
+        let id = self.resolve_profile_id(profile_ref);
+        match self.profiles.iter().find(|p| p.id == id) {
+            Some(p) => match p.tool_scope.get(server_id) {
+                Some(allowed) => allowed.iter().any(|t| t == tool),
+                None => true,
+            },
+            None => true,
+        }
+    }
+
+    /// Set or clear a profile's tool allow-list for one server. `Some(non-empty list)` narrows
+    /// that server to exactly those ORIGINAL tool names; `None` or an empty list removes the
+    /// entry, restoring "all tools on that server". Idempotent. The UI sends the full desired
+    /// list, and sends `None` when every tool is selected so an unnarrowed profile stays empty
+    /// (backward compatible: no `tool_scope` written).
+    pub fn set_profile_server_tools(
+        &mut self,
+        profile_id: &str,
+        server_id: &str,
+        tools: Option<Vec<String>>,
+    ) -> Result<(), String> {
+        let profile = self
+            .profiles
+            .iter_mut()
+            .find(|p| p.id == profile_id)
+            .ok_or_else(|| format!("No profile with id '{profile_id}'"))?;
+        match tools {
+            Some(list) if !list.is_empty() => {
+                profile.tool_scope.insert(server_id.to_string(), list);
+            }
+            _ => {
+                profile.tool_scope.remove(server_id);
+            }
+        }
+        Ok(())
     }
 
     /// Pin or unpin a tool as a lazy-discovery prerequisite (by ORIGINAL tool name).
@@ -807,6 +863,7 @@ impl Registry {
             id: id.clone(),
             name: name.to_string(),
             enabled_server_ids: Vec::new(),
+            tool_scope: HashMap::new(),
         });
         id
     }
@@ -1799,6 +1856,59 @@ mod tests {
         assert_eq!(r.profile_for_root("/home/me/workspace"), None);
         // Empty root never matches.
         assert_eq!(r.profile_for_root(""), None);
+    }
+
+    #[test]
+    fn tool_scope_narrows_a_profile_to_specific_tools() {
+        let mut r = Registry::default();
+        let gh = r.add_server(sample_server("github"));
+        let db = r.add_server(sample_server("postgres"));
+        // Default-allow: no scope -> every tool exposed on every server.
+        assert!(r.profile_allows_tool("default", &gh, "search"));
+        assert!(r.profile_allows_tool("default", &db, "query"));
+
+        // Narrow github to only `search`; postgres untouched.
+        r.set_profile_server_tools("default", &gh, Some(vec!["search".into()]))
+            .unwrap();
+        assert!(r.profile_allows_tool("default", &gh, "search"));
+        assert!(!r.profile_allows_tool("default", &gh, "create_issue")); // not allow-listed
+        assert!(r.profile_allows_tool("default", &db, "query")); // no scope on db -> all allowed
+        // Resolves by profile NAME too, like the other scope lookups.
+        assert!(!r.profile_allows_tool("Default", &gh, "create_issue"));
+
+        // Clearing restores all-allowed and leaves the map empty (backward compatible).
+        r.set_profile_server_tools("default", &gh, None).unwrap();
+        assert!(r.profile_allows_tool("default", &gh, "create_issue"));
+        assert!(r.profiles[0].tool_scope.is_empty());
+    }
+
+    #[test]
+    fn removing_a_server_drops_its_tool_scope() {
+        let mut r = Registry::default();
+        let gh = r.add_server(sample_server("github"));
+        r.set_profile_server_tools("default", &gh, Some(vec!["search".into()]))
+            .unwrap();
+        assert!(!r.profiles[0].tool_scope.is_empty());
+        r.remove_server(&gh).unwrap();
+        assert!(
+            r.profiles[0].tool_scope.is_empty(),
+            "tool_scope must not orphan a removed server"
+        );
+    }
+
+    #[test]
+    fn tool_scope_omitted_from_json_when_empty() {
+        // Back-compat: a profile with no tool scope serializes without the field.
+        let r = Registry::default();
+        assert!(!serde_json::to_string(&r).unwrap().contains("toolScope"));
+    }
+
+    #[test]
+    fn unknown_profile_ref_imposes_no_extra_tool_restriction() {
+        // The server scope already fails an unknown profile closed; this must not add a
+        // second, confusing block, so it is default-allow for an unresolved profile.
+        let r = Registry::default();
+        assert!(r.profile_allows_tool("nope", "github", "anything"));
     }
 
     #[test]

--- a/src-tauri/src/router.rs
+++ b/src-tauri/src/router.rs
@@ -190,6 +190,11 @@ fn split_camel_lower(word: &str) -> Vec<String> {
 pub struct ToolPolicy {
     /// server id -> original tool names the user switched off.
     pub disabled: HashMap<String, HashSet<String>>,
+    /// server id -> the ONLY original tool names the active profile exposes (tool-granular
+    /// scoping / "FeatureSet"). A server present here allow-lists: every other tool on it is
+    /// hidden and blocked. A server ABSENT exposes all of its tools. Empty = no tool-granular
+    /// scoping, so this is fully backward compatible.
+    pub allow: HashMap<String, HashSet<String>>,
     /// Hide and block any tool annotated `destructiveHint: true`.
     pub deny_destructive: bool,
     /// Exposed (namespaced) tool names quarantined after a high-risk drift; hidden
@@ -213,6 +218,15 @@ impl ToolPolicy {
             .is_some_and(|set| set.contains(orig))
         {
             return Some("disabled");
+        }
+        // Tool-granular profile scope: if this server is narrowed to an allow-list, a tool
+        // not on it is outside the active profile's scope (hidden + blocked, same as disabled).
+        if self
+            .allow
+            .get(server_id)
+            .is_some_and(|set| !set.contains(orig))
+        {
+            return Some("outside the active profile's tool scope");
         }
         if self.deny_destructive && is_destructive(tool) {
             return Some("blocked by the destructive-tool policy");
@@ -1391,6 +1405,32 @@ mod tests {
         assert_eq!(names, vec!["db__list_tables"]);
         let err = router.route_call("db__drop_table", json!({})).unwrap_err();
         assert!(err.contains("destructive"), "unexpected: {err}");
+    }
+
+    #[test]
+    fn tool_scope_allow_list_hides_and_blocks_non_listed_tools() {
+        // A profile's per-server allow-list ("FeatureSet"): the server exposes ONLY the
+        // listed tool; the rest are both hidden from the catalog and blocked on a direct call.
+        let mut allow = HashMap::new();
+        allow.insert("db".to_string(), HashSet::from(["echo".to_string()]));
+        let policy = ToolPolicy {
+            allow,
+            ..Default::default()
+        };
+        let mut router = Router::with_policy(policy);
+        router.add(mock_server("db"));
+
+        let names: Vec<String> = router
+            .aggregated_tools()
+            .iter()
+            .filter_map(|t| t.get("name").and_then(|n| n.as_str()).map(String::from))
+            .collect();
+        assert_eq!(names, vec!["db__echo"], "only the allow-listed tool is exposed");
+
+        // Hidden, and also blocked on a direct call (not merely invisible).
+        let err = router.route_call("db__add", json!({})).unwrap_err();
+        assert!(err.contains("tool scope"), "unexpected: {err}");
+        assert!(router.route_call("db__echo", json!({})).is_ok());
     }
 
     #[test]

--- a/src-tauri/src/teams.rs
+++ b/src-tauri/src/teams.rs
@@ -1266,6 +1266,7 @@ mod tests {
             id: "p2".into(),
             name: "Second".into(),
             enabled_server_ids: Vec::new(),
+            tool_scope: Default::default(),
         });
         let cfg = json!({ "servers": [
             { "id": "review1", "name": "Review1", "transport": "stdio", "command": "run-me" }

--- a/src/components/SettingsView.tsx
+++ b/src/components/SettingsView.tsx
@@ -680,7 +680,9 @@ export function SettingsView({ registry, onRegistryChange }: Props) {
           <p className="text-xs text-muted-foreground">
             A profile is a named set of servers you can scope a client to. Expand a server
             to narrow it to specific tools (a "FeatureSet"); leaving every tool checked
-            exposes the whole server.
+            exposes the whole server. Tool narrowing applies to stdio clients (Claude
+            Desktop, Cursor, VS Code, and the like); HTTP-bridge clients still see the
+            whole server for now.
           </p>
           <div className="flex flex-col divide-y rounded-lg border">
             {profiles.map((p) => {

--- a/src/components/SettingsView.tsx
+++ b/src/components/SettingsView.tsx
@@ -3,6 +3,7 @@ import {
   Activity,
   Bot,
   Check,
+  ChevronRight,
   Copy,
   Eye,
   EyeOff,
@@ -30,6 +31,8 @@ import {
   httpBridgeStatus,
   listAllowedTools,
   listQuarantined,
+  listServerTools,
+  setProfileServerTools,
   releaseQuarantine,
   revokeAllowedTool,
   removeHttpClient,
@@ -47,7 +50,7 @@ import {
   type HttpBridgeStatus,
   type QuarantinedTool,
 } from "@/lib/api";
-import type { AllowedTool, FolderProfile, Registry } from "@/lib/types";
+import type { AllowedTool, FolderProfile, Profile, Registry } from "@/lib/types";
 import { Switch } from "@/components/ui/switch";
 import {
   Select,
@@ -318,6 +321,130 @@ function PostureSummary({
   );
 }
 
+/** Tool-granular scope for one profile (SOU-189): per enabled server, expand to pick exactly
+ * which tools the profile exposes. All-checked = the whole server (no narrowing); unchecking
+ * writes an allow-list that tools/list, search, and the call guard all honor. Tools load
+ * lazily on expand. stdio clients (the per-profile router); the HTTP bridge is a follow-up. */
+function ProfileToolScope({
+  profile,
+  registry,
+  onRegistryChange,
+}: {
+  profile: Profile;
+  registry: Registry;
+  onRegistryChange: (r: Registry) => void;
+}) {
+  const serverName = useMemo(() => {
+    const m = new Map<string, string>();
+    for (const s of registry.servers) m.set(s.id, s.name);
+    return m;
+  }, [registry.servers]);
+  const [expanded, setExpanded] = useState<string | null>(null);
+  const [toolsByServer, setToolsByServer] = useState<Record<string, string[]>>({});
+  const [loading, setLoading] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  const scope = profile.toolScope ?? {};
+
+  async function expand(serverId: string) {
+    if (expanded === serverId) {
+      setExpanded(null);
+      return;
+    }
+    setExpanded(serverId);
+    if (!toolsByServer[serverId]) {
+      setLoading(serverId);
+      try {
+        const tools = await listServerTools(serverId);
+        setToolsByServer((m) => ({ ...m, [serverId]: tools.map((t) => t.name) }));
+      } catch (e) {
+        toastError(`Couldn't load ${serverName.get(serverId) ?? serverId} tools: ${e}`);
+      } finally {
+        setLoading(null);
+      }
+    }
+  }
+
+  async function toggleTool(serverId: string, tool: string, allTools: string[]) {
+    // Current in-scope set is the allow-list if present, else every tool.
+    const current = new Set(scope[serverId] ?? allTools);
+    if (current.has(tool)) current.delete(tool);
+    else current.add(tool);
+    // All selected -> clear the scope (whole server); otherwise persist the subset.
+    const next =
+      current.size >= allTools.length ? null : allTools.filter((t) => current.has(t));
+    setBusy(true);
+    try {
+      onRegistryChange(await setProfileServerTools(profile.id, serverId, next));
+    } catch (e) {
+      toastError(`Couldn't update tool scope: ${e}`);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  const servers = profile.enabledServerIds.filter((id) => serverName.has(id));
+  if (servers.length === 0) return null;
+
+  return (
+    <div className="mt-1.5 flex flex-col gap-1">
+      {servers.map((serverId) => {
+        const allTools = toolsByServer[serverId];
+        const scoped = scope[serverId];
+        const badge = scoped
+          ? allTools
+            ? `${scoped.length} of ${allTools.length} tools`
+            : `${scoped.length} tools`
+          : "all tools";
+        const open = expanded === serverId;
+        return (
+          <div key={serverId} className="rounded border border-border/50 bg-muted/10">
+            <button
+              onClick={() => expand(serverId)}
+              className="flex w-full items-center gap-2 px-2 py-1.5 text-xs hover:bg-muted/30"
+            >
+              <ChevronRight
+                className={`size-3.5 shrink-0 transition-transform ${open ? "rotate-90" : ""}`}
+              />
+              <span className="font-medium">{serverName.get(serverId)}</span>
+              <span
+                className={`ml-auto ${scoped ? "text-info" : "text-muted-foreground"}`}
+              >
+                {badge}
+              </span>
+            </button>
+            {open && (
+              <div className="border-t border-border/40 px-2 py-1.5">
+                {loading === serverId ? (
+                  <p className="text-xs text-muted-foreground">Loading tools…</p>
+                ) : allTools && allTools.length > 0 ? (
+                  <div className="flex flex-col gap-1">
+                    {allTools.map((tool) => (
+                      <label key={tool} className="flex items-center gap-2 text-xs">
+                        <input
+                          type="checkbox"
+                          checked={scoped ? scoped.includes(tool) : true}
+                          disabled={busy}
+                          onChange={() => toggleTool(serverId, tool, allTools)}
+                          className="size-3.5"
+                        />
+                        <code className="font-mono text-foreground/90">{tool}</code>
+                      </label>
+                    ))}
+                  </div>
+                ) : (
+                  <p className="text-xs text-muted-foreground">
+                    No tools, or the server isn&apos;t reachable right now.
+                  </p>
+                )}
+              </div>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
 /** Global discovery + security policy. These apply to every client uniformly, so
  * they live here rather than in the per-server Playground. */
 export function SettingsView({ registry, onRegistryChange }: Props) {
@@ -548,8 +675,9 @@ export function SettingsView({ registry, onRegistryChange }: Props) {
             Profiles
           </h2>
           <p className="text-xs text-muted-foreground">
-            A profile is a named subset of servers you can scope a client to. Here's what
-            each one exposes.
+            A profile is a named set of servers you can scope a client to. Expand a server
+            to narrow it to specific tools (a "FeatureSet"); leaving every tool checked
+            exposes the whole server.
           </p>
           <div className="flex flex-col divide-y rounded-lg border">
             {profiles.map((p) => {
@@ -577,6 +705,13 @@ export function SettingsView({ registry, onRegistryChange }: Props) {
                     <p className="text-xs text-muted-foreground italic">
                       No servers in this profile.
                     </p>
+                  )}
+                  {registry && (
+                    <ProfileToolScope
+                      profile={p}
+                      registry={registry}
+                      onRegistryChange={onRegistryChange}
+                    />
                   )}
                 </div>
               );

--- a/src/components/SettingsView.tsx
+++ b/src/components/SettingsView.tsx
@@ -369,9 +369,12 @@ function ProfileToolScope({
     const current = new Set(scope[serverId] ?? allTools);
     if (current.has(tool)) current.delete(tool);
     else current.add(tool);
-    // All selected -> clear the scope (whole server); otherwise persist the subset.
-    const next =
-      current.size >= allTools.length ? null : allTools.filter((t) => current.has(t));
+    // Every real tool selected -> clear the scope (whole server). Otherwise persist the
+    // checked subset (which may be empty = expose no tools). `.every` (not a size compare)
+    // so a stale entry from a since-removed tool can't fake an "all selected" state.
+    const next = allTools.every((t) => current.has(t))
+      ? null
+      : allTools.filter((t) => current.has(t));
     setBusy(true);
     try {
       onRegistryChange(await setProfileServerTools(profile.id, serverId, next));

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -657,6 +657,20 @@ export function setActiveProfile(id: string): Promise<Registry> {
   return invoke<Registry>("set_active_profile", { id });
 }
 
+/** Set (or clear with `null`) a profile's tool-granular scope for one server (SOU-189):
+ * the only original tool names that profile exposes on that server. `null`/empty = all. */
+export function setProfileServerTools(
+  profileId: string,
+  serverId: string,
+  tools: string[] | null,
+): Promise<Registry> {
+  return invoke<Registry>("set_profile_server_tools", {
+    profileId,
+    serverId,
+    tools,
+  });
+}
+
 /** Replace the folder -> profile auto-routing mappings (SOU-188). */
 export function setFolderProfiles(mappings: FolderProfile[]): Promise<Registry> {
   return invoke<Registry>("set_folder_profiles", { mappings });

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -359,6 +359,10 @@ export interface Profile {
   id: string;
   name: string;
   enabledServerIds: string[];
+  /** Tool-granular scope ("FeatureSet"): server id -> the only tool names this profile
+   * exposes on that server. A server absent = all its tools; empty/absent = server-granular
+   * only. Enforced in tools/list, search, and the call guard. */
+  toolScope?: Record<string, string[]>;
 }
 
 /** A folder -> profile auto-routing mapping (SOU-188): a client whose reported project


### PR DESCRIPTION
Extends profiles from **server-granular** to optionally **tool-granular**, so a context can expose exactly which tools it wants, not just which servers.

## Design note: why not a separate "bundle" entity
The issue framed this as named "bundles" layered on profiles. On reflection that leaves two overlapping scoping concepts (profiles = servers, bundles = tools) that a user must both configure. Modeling it as a **tool-granular profile** is the cleaner long-term foundation: one concept, **no new binding** (`client_scopes` and folder routing already select a profile), backward compatible, and it grows straight into org-published Teams FeatureSets. The genuinely-orthogonal case (same servers, different tool exposure per context) is a Teams/org-policy need, deferred there rather than paid for now.

## What changed
- **registry**: `Profile.tool_scope` (server id → allow-list of original tool names; a server *absent* = all its tools; empty map = server-granular, unchanged). `profile_allows_tool` resolver + `set_profile_server_tools` setter; `remove_server` purges scope so it can't orphan. Omitted from JSON when empty, so existing `registry.json` round-trips.
- **router**: `ToolPolicy` gains a per-server `allow` list, enforced in `blocked_reason` — an out-of-scope tool is hidden from `tools/list` **and** blocked on a direct call (not merely invisible).
- **gateway**: `build_router` bakes the active profile's `tool_scope` into the per-profile (stdio) router, so `tools/list`, search, and the call guard all honor it with **zero per-request threading**. The shared HTTP-bridge router serves many profiles, so its tool-scope is a per-request follow-up (stdio-first, same line as folder routing).
- **desktop**: `set_profile_server_tools` command.
- **UI**: the Settings "Profiles" section becomes an editor — expand a server to check exactly which tools the profile exposes (lazy-loaded); all-checked clears the scope (whole server).

## Safety / scope
- Fully backward compatible: a profile with no `tool_scope` behaves exactly as before.
- Enforced at the same three points as server scope (list, search, call), so a hidden tool can't be reached by naming it directly.
- **Deferred**: HTTP-bridge per-request tool-scope; agent-composable bundles + Teams org-published FeatureSets (the issue's optional extras).

## Tests
registry (narrow / clear / default-allow / name-resolution / server-removal cleanup / back-compat serialization) and router (allow-list hides + blocks). Rust **397 lib + 122 bin** green; tsc + prettier + vitest (95) green. Settings is Tauri-backed, so verified via the pure resolver/router tests + typecheck rather than the browser preview.

Refs SOU-189.