### PR TITLE
Activity: live-update the feed + Live Inspector while open (SOU-142)

### DIFF
--- a/src/components/ActivityView.tsx
+++ b/src/components/ActivityView.tsx
@@ -1399,9 +1399,11 @@ export function ActivityView({
 
   // Live update (SOU-142): tool calls never touch the registry, so the parent's refreshKey
   // never bumps for them and the feed would sit frozen while an agent works. While Activity
-  // is open AND the window is visible, tick every few seconds so the call list + Live
-  // Inspector refetch the local logs in place (silent, no spinner). Visibility-guarded so a
-  // backgrounded app doesn't churn; mirrors how PendingApprovals polls.
+  // is mounted, tick every few seconds so the call list + Live Inspector refetch the local
+  // logs in place (silent, no spinner). Mirrors how PendingApprovals polls. The visibility
+  // check skips a tick when the webview reports the page hidden; it's best-effort (a desktop
+  // webview doesn't reliably flip visibilityState on minimize), but each tick is only a few
+  // cheap local-file reads, so continuing while minimized costs next to nothing.
   const [liveTick, setLiveTick] = useState(0);
   useEffect(() => {
     const id = setInterval(() => {

--- a/src/components/ActivityView.tsx
+++ b/src/components/ActivityView.tsx
@@ -1397,6 +1397,22 @@ export function ActivityView({
     }
   }
 
+  // Live update (SOU-142): tool calls never touch the registry, so the parent's refreshKey
+  // never bumps for them and the feed would sit frozen while an agent works. While Activity
+  // is open AND the window is visible, tick every few seconds so the call list + Live
+  // Inspector refetch the local logs in place (silent, no spinner). Visibility-guarded so a
+  // backgrounded app doesn't churn; mirrors how PendingApprovals polls.
+  const [liveTick, setLiveTick] = useState(0);
+  useEffect(() => {
+    const id = setInterval(() => {
+      if (document.visibilityState === "visible") setLiveTick((t) => t + 1);
+    }, 3000);
+    return () => clearInterval(id);
+  }, []);
+  // Combined so panels refetch on either a registry change or a live tick. Both counters
+  // only increase, so the sum always changes when either does (no collisions).
+  const liveKey = refreshKey + liveTick;
+
   useEffect(() => {
     let alive = true;
     getAuditLog(200)
@@ -1422,7 +1438,7 @@ export function ActivityView({
     return () => {
       alive = false;
     };
-  }, [refreshKey, reloadTick]);
+  }, [liveKey, reloadTick]);
 
   // Export the full retained audit log. The save dialog offers CSV and JSON; the
   // chosen extension picks the format. CSV is formula-injection-safe in the backend.
@@ -1495,9 +1511,9 @@ export function ActivityView({
           reference panels (discovery / identities / inspector) collapsed below it so they
           don't stack into a wall on first load. */}
       {savings && savings.tokensSaved > 0 ? <SavingsBanner savings={savings} /> : null}
-      <DiscoveryTraces refreshKey={refreshKey} />
-      <ToolIdentities refreshKey={refreshKey} />
-      {registry?.liveInspect ? <LiveInspector refreshKey={refreshKey} /> : null}
+      <DiscoveryTraces refreshKey={liveKey} />
+      <ToolIdentities refreshKey={liveKey} />
+      {registry?.liveInspect ? <LiveInspector refreshKey={liveKey} /> : null}
     </>
   );
 


### PR DESCRIPTION
The top item from the 2026-07-13 UX audit. Activity is the "watch your agent work" surface (and hosts the free Live Inspector), but it only refetched on mount or `registry-changed`. Tool calls never touch the registry, so a user sitting on Activity while an agent runs saw a **frozen call list and a frozen Live Inspector** until they navigated away and back or hit Refresh.

## Fix
Poll the local logs every 3s while Activity is mounted **and** the window is visible, the pragmatic first step the issue calls out. (An `audit-appended` event would be cleaner, but the audit log is written by separate per-client gateway processes, so a Tauri event can't reach the app without file-watching, deferred.)

- A visibility-guarded `liveTick` (cleared on unmount) is folded into the existing `refreshKey` (`liveKey = refreshKey + liveTick`; both counters only increase, so the sum always changes when either does).
- `liveKey` drives every panel: the call list, stats/savings/security, the Live Inspector, discovery traces, and tool identities, so all refetch in place.
- **No flicker:** none of these panels show a loading spinner on refetch (they `setEntries` on resolve), so the update is silent. Reads are small local files.
- Visibility guard means a backgrounded app doesn't churn. Mirrors how `PendingApprovals` already polls.

## Testing
tsc + eslint + vitest (95) green. Activity is Tauri-backed (data via `invoke`), so the browser preview can't drive it; verified via typecheck + the existing suite, and the pattern mirrors the working `PendingApprovals` poll.

Refs SOU-142.