### PR TITLE
Settings: add a Code mode toggle (SOU-195)

### DIFF
--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -383,6 +383,15 @@ fn set_discovery_mode(mode: DiscoveryMode) {
     DISCOVERY_MODE.store(mode.as_u8(), std::sync::atomic::Ordering::Relaxed);
 }
 
+/// The live "code mode" flag, synced from the registry's `code_mode` on startup and by the
+/// registry watcher (like [`DISCOVERY_MODE`]). Read lock-free by [`code_mode_enabled`], so the
+/// six advertise/dispatch sites don't need a `Registry` threaded through them.
+static CODE_MODE: AtomicBool = AtomicBool::new(false);
+
+fn set_code_mode_flag(enabled: bool) {
+    CODE_MODE.store(enabled, Ordering::Relaxed);
+}
+
 /// Parse a registry / per-client override mode string; `None` for empty, `inherit`, or an
 /// unrecognized value (so it falls through to the next precedence level).
 fn parse_mode(s: &str) -> Option<DiscoveryMode> {
@@ -469,15 +478,17 @@ fn grouped_discovery() -> bool {
 /// Opt-in gate for server-side "code mode" (the `toolport_run_script` meta-tool). Off by
 /// default: code mode runs an agent-supplied JS script that can call many tools in one
 /// round-trip, a powerful capability worth an explicit opt-in even under Toolport's local
-/// trust model. Enable with `CONDUIT_CODE_MODE=1` (or `true`). When off, `run_script` is
-/// neither advertised nor dispatched.
+/// trust model. Enabled by the registry's `code_mode` toggle (the Settings switch, synced
+/// into [`CODE_MODE`]); `CONDUIT_CODE_MODE=1` (or `true`) still force-enables regardless, for
+/// power users and tests. When off, `run_script` is neither advertised nor dispatched.
 fn code_mode_enabled() -> bool {
-    std::env::var("CONDUIT_CODE_MODE")
+    let env_forced = std::env::var("CONDUIT_CODE_MODE")
         .map(|v| {
             let v = v.trim();
             v == "1" || v.eq_ignore_ascii_case("true")
         })
-        .unwrap_or(false)
+        .unwrap_or(false);
+    env_forced || CODE_MODE.load(Ordering::Relaxed)
 }
 
 /// The server prefix of a *namespaced* tool (`server__tool`). `None` for a bare name
@@ -3879,6 +3890,9 @@ fn watch_registry(
                 eprintln!("toolport: discovery mode -> {}", new_mode.as_str());
             }
             set_discovery_mode(new_mode);
+            // Refresh code mode from the freshly-loaded registry so a Settings toggle takes
+            // effect without restarting the client (same live-refresh path as discovery mode).
+            set_code_mode_flag(new_reg.code_mode);
             // A team-metadata-only rewrite (usage watermark, sync version/etag, role) from
             // the desktop sync loop changes nothing the router depends on. Update the stored
             // copy but skip the rebuild, so a routine sync never re-spawns every stdio server
@@ -6779,6 +6793,9 @@ fn main() {
             registry::Registry::default()
         }
     };
+    // Seed code mode from the registry so it's live from the first request, before the
+    // watcher's first tick (an env override still force-enables inside code_mode_enabled).
+    set_code_mode_flag(loaded.code_mode);
     inspect::clear();
     // Resolve the live profile immediately from what's already on disk, rather than
     // waiting for the watcher's first tick: a scoped client re-launched after being

--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -1674,6 +1674,18 @@ fn set_lazy_discovery(state: State<RegistryState>, lazy: bool) -> Result<Registr
     Ok(reg)
 }
 
+/// Enable or disable server-side "code mode" (the `toolport_run_script` meta-tool). The
+/// gateway reads this from the registry and refreshes it live on the next watcher tick, so
+/// it applies to every client without forwarding an env var. Off by default.
+#[tauri::command]
+fn set_code_mode(state: State<RegistryState>, enabled: bool) -> Result<Registry, String> {
+    let (reg, _) = write_registry(state.inner(), |reg| {
+        reg.code_mode = enabled;
+        Ok(())
+    })?;
+    Ok(reg)
+}
+
 /// Opt into agent control: lets an agent enable or disable servers through the
 /// gateway's `conduit_enable_server` / `conduit_disable_server` tools. Off by
 /// default; the destructive-tool safety switch stays user-only regardless of this.
@@ -2825,6 +2837,7 @@ pub fn run() {
             list_quarantined,
             release_quarantine,
             set_lazy_discovery,
+            set_code_mode,
             set_allow_agent_control,
             set_client_discovery,
             team_connect,

--- a/src-tauri/src/registry.rs
+++ b/src-tauri/src/registry.rs
@@ -336,6 +336,13 @@ pub struct Registry {
     /// browse per-server instead of searching - instead of setting a per-client env var.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub discovery_mode: Option<String>,
+    /// Opt-in server-side "code mode": advertise the `toolport_run_script` meta-tool so an
+    /// agent can orchestrate many downstream tool calls in one sandboxed JS script (a single
+    /// round-trip). Off by default, since agent-supplied server-side JS is a powerful surface.
+    /// The gateway reads this from the registry, so it applies to every client; an explicit
+    /// `CONDUIT_CODE_MODE=1` still force-enables regardless.
+    #[serde(default)]
+    pub code_mode: bool,
     /// Opt-in agent control: when true, an agent may turn servers on or off via
     /// the gateway's `conduit_enable_server` / `conduit_disable_server` tools.
     /// Off by default. The `deny_destructive` safety switch is never agent-
@@ -503,6 +510,7 @@ impl Default for Registry {
             quarantine_on_drift: false,
             lazy_discovery: true,
             discovery_mode: None,
+            code_mode: false,
             allow_agent_control: false,
             integrity_check: true,
             content_defense: true,

--- a/src/components/SettingsView.tsx
+++ b/src/components/SettingsView.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import {
   Activity,
   Bot,
+  Braces,
   Check,
   ChevronRight,
   Copy,
@@ -44,6 +45,7 @@ import {
   setAllowAgentControl,
   setConfirmDestructive,
   setDenyDestructive,
+  setCodeMode,
   setHumanApproval,
   setLazyDiscovery,
   setFolderProfiles,
@@ -485,6 +487,7 @@ function ProfileToolScope({
 export function SettingsView({ registry, onRegistryChange }: Props) {
   const { theme, setTheme } = useTheme();
   const lazyDiscovery = registry?.lazyDiscovery ?? true;
+  const codeMode = registry?.codeMode ?? false;
   const denyDestructive = registry?.denyDestructive ?? false;
   const confirmDestructive = registry?.confirmDestructive ?? false;
   const humanApproval = registry?.humanApproval ?? false;
@@ -832,6 +835,14 @@ export function SettingsView({ registry, onRegistryChange }: Props) {
         {lazyDiscovery ? (
           <PinnedPrerequisites registry={registry} onRegistryChange={onRegistryChange} />
         ) : null}
+        {toggle(
+          Braces,
+          codeMode,
+          "text-info",
+          "Code mode",
+          "Let agents run one server-side script that calls many tools in a single round-trip (sandboxed; each call still respects profile scope and human approval)",
+          apply(setCodeMode),
+        )}
       </section>
       <section className="flex flex-col gap-2">
         <h2 className="text-xs font-medium tracking-wide text-muted-foreground uppercase">

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -306,6 +306,11 @@ export function setLazyDiscovery(lazy: boolean): Promise<Registry> {
   return invoke<Registry>("set_lazy_discovery", { lazy });
 }
 
+/** Toggle server-side code mode (the toolport_run_script meta-tool) for all clients. */
+export function setCodeMode(enabled: boolean): Promise<Registry> {
+  return invoke<Registry>("set_code_mode", { enabled });
+}
+
 /** Override one client's discovery mode ("full" | "lazy" | "grouped"), or clear it
  * (`null`) so the client inherits the global mode. Applies live via the gateway's
  * per-client resolution, no reconnect needed. */

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -431,6 +431,9 @@ export interface Registry {
   /** Global discovery mode ("full" | "lazy" | "grouped"). Takes precedence over
    * `lazyDiscovery`; absent = fall back to the `lazyDiscovery` bool. */
   discoveryMode?: string | null;
+  /** Opt-in "code mode": advertise the `toolport_run_script` meta-tool so agents can
+   * orchestrate many tool calls in one server-side script. Off by default. */
+  codeMode?: boolean;
   /** Per-client discovery-mode override, keyed by client id (e.g. "cursor" ->
    * "grouped"). Absent = that client inherits the global mode. */
   clientDiscovery?: Record<string, string>;


### PR DESCRIPTION
Code mode (`toolport_run_script`, SOU-184) was gated behind the `CONDUIT_CODE_MODE` env var only, so there was no way to enable it from the app. This adds a Settings toggle.

**Backend**
- New `code_mode: bool` on the registry (default off, `#[serde(default)]`).
- The gateway syncs it into a `CODE_MODE` AtomicBool on startup and on every registry-watcher tick, mirroring how `DISCOVERY_MODE` is synced. `code_mode_enabled()` now returns `env-override OR registry flag`, so none of the six advertise/dispatch call sites needed a `Registry` threaded through them (one is `grouped_tool_defs`, which has none in scope).
- `CONDUIT_CODE_MODE=1` still force-enables, for power users and tests.
- New `set_code_mode` Tauri command.
- Takes effect live on the next watcher tick, no client restart needed.

**Frontend**
- `codeMode` on the Registry type, `setCodeMode` in api.ts.
- A "Code mode" toggle in Settings → Discovery, off by default, with copy noting it's sandboxed and still respects profile scope + human approval.

tsc + eslint clean; both cargo feature paths (`--features desktop`, gateway bin `--no-default-features`) compile; all 44 registry tests pass.