### PR TITLE
Activity: show the true retained call total (SOU-196)

### DIFF
--- a/src-tauri/src/audit.rs
+++ b/src-tauri/src/audit.rs
@@ -352,11 +352,30 @@ fn latency(durs: &mut [u64]) -> (Option<u64>, Option<u64>) {
     (Some(avg), Some(durs[idx]))
 }
 
-/// Aggregate the last `window` calls into per-server stats plus global totals.
-/// This is the data behind the observability dashboard: call volume, error
-/// rate, and latency per server, computed locally from the audit log.
-pub fn stats(window: usize) -> Value {
-    aggregate(&read_recent(window))
+/// Every retained entry, newest first. The log is size-capped (see `MAX_AUDIT_BYTES`), so
+/// this stays bounded no matter how long Toolport has been running.
+pub fn read_all() -> Vec<Value> {
+    let path = match audit_path() {
+        Some(p) => p,
+        None => return Vec::new(),
+    };
+    let content = match std::fs::read_to_string(&path) {
+        Ok(c) => c,
+        Err(_) => return Vec::new(),
+    };
+    content
+        .lines()
+        .rev()
+        .filter_map(|line| serde_json::from_str(line).ok())
+        .collect()
+}
+
+/// Aggregate the FULL retained log into per-server stats plus global totals: call volume,
+/// error rate, and latency per server, computed locally. Totals are the real count of what's
+/// retained (the byte cap bounds it), not a fixed window, so the error rate stays consistent
+/// with the call count instead of being taken over an arbitrary slice.
+pub fn stats() -> Value {
+    aggregate(&read_all())
 }
 
 /// Pure aggregation of audit entries into per-server + global stats. Split from

--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -892,11 +892,11 @@ fn get_audit_log(limit: usize) -> Vec<serde_json::Value> {
     audit::read_recent(limit)
 }
 
-/// Aggregate the recent audit log into per-server call/error/latency stats for
-/// the observability dashboard.
+/// Aggregate the full retained audit log into per-server call/error/latency stats for
+/// the observability dashboard. Bounded by the log's byte cap, so totals are real.
 #[tauri::command]
-fn audit_stats(window: usize) -> serde_json::Value {
-    audit::stats(window)
+fn audit_stats() -> serde_json::Value {
+    audit::stats()
 }
 
 /// Recent tool-definition integrity events (newest first): a previously-approved

--- a/src/components/ActivityView.tsx
+++ b/src/components/ActivityView.tsx
@@ -1429,7 +1429,7 @@ export function ActivityView({
         setEntries([]);
         setLoadError(true);
       });
-    getAuditStats(2000)
+    getAuditStats()
       .then((s) => alive && setStats(s))
       .catch(() => alive && setStats(null));
     getSavingsSummary()

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -47,8 +47,8 @@ export function getAuditLog(limit = 200): Promise<AuditEntry[]> {
 }
 
 /** Aggregated per-server stats (calls, error rate, latency) from the audit log. */
-export function getAuditStats(window = 2000): Promise<AuditStats> {
-  return invoke<AuditStats>("audit_stats", { window });
+export function getAuditStats(): Promise<AuditStats> {
+  return invoke<AuditStats>("audit_stats", {});
 }
 
 /** A tool-definition integrity event: a previously-approved tool changed


### PR DESCRIPTION
The Activity summary called `getAuditStats(2000)`, and `audit::stats(window)` aggregated only the last `window` entries, so "calls logged" capped at 2000 and read as a total when it was really a window (and the error rate was taken over that same slice).

The audit log is already byte-capped (`MAX_AUDIT_BYTES` = 4 MB), so aggregating over the whole retained log is bounded. This changes `stats()` to aggregate over all retained entries (new `read_all`), so the total, error rate, and per-server breakdown are the real retained numbers and stay consistent with each other. The recent-calls list stays windowed. Dropped the now-meaningless `window` param from `audit_stats` / `getAuditStats`.

Part of the v1.9.1 follow-up patch (with #346).

tsc + eslint clean; desktop feature compiles; 12 audit tests pass.