### PR TITLE
Release v1.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,32 @@ Entries before the rename below shipped under the project's former name, Conduit
 
 ## [Unreleased]
 
+## [1.9.1] - 2026-07-16
+
+A fast follow-up to v1.9.0: make code mode reachable, correct the activity total, and stop
+the injection scanner from flagging benign shell examples.
+
+### Added
+
+**Turn on code mode from Settings.** Code mode (the `toolport_run_script` meta-tool) was
+gated behind the `CONDUIT_CODE_MODE` env var only, so there was no way to enable it from the
+app. A "Code mode" toggle now lives in Settings under Discovery, off by default. The env var
+still force-enables it for power users. (#346)
+
+### Fixed
+
+**Activity "calls logged" shows your real total.** The summary aggregated only the last 2,000
+audit entries, so the count capped at 2000 and the error rate was taken over that slice. It
+now aggregates the full retained log (still bounded by the log's size cap), so the total,
+error rate, and per-server breakdown are the real numbers. (#347)
+
+**The injection scanner stops flagging benign shell examples.** A tool description that
+documents a hashing pipeline (for example `... | base64 -d | shasum -a 256 | awk ...`) no
+longer trips the "embedded-command" content flag. The scanner now matches a pipe into an
+actual shell or interpreter (`| sh`, `base64 -d | sh`) with word boundaries, so look-alikes
+like `| shasum` and decode-then-hash stay clean while real decode-then-execute still flags.
+(#348)
+
 ## [1.9.0] - 2026-07-16
 
 The orchestration-and-polish release: run whole tool sequences server-side, scope tools by

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "conduit",
   "private": true,
-  "version": "1.9.0",
+  "version": "1.9.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -780,7 +780,7 @@ dependencies = [
 
 [[package]]
 name = "conduit"
-version = "1.9.0"
+version = "1.9.1"
 dependencies = [
  "base64 0.22.1",
  "boa_engine",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conduit"
-version = "1.9.0"
+version = "1.9.1"
 description = "Local MCP gateway: manage all your MCP servers in one place, set up once and shared by every AI client, with ~90% fewer tokens per request"
 authors = ["South Forge AI"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Toolport",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "identifier": "com.tsout.conduit",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
Patch on v1.9.0. Bumps version to 1.9.1 (package.json, tauri.conf.json, Cargo.toml, Cargo.lock) plus the changelog.

- **Added:** Settings toggle for code mode (#346) — was env-only, now reachable from Settings → Discovery.
- **Fixed:** Activity "calls logged" shows the true retained total instead of capping at 2000 (#347).
- **Fixed:** injection scanner no longer flags benign shell examples like `... | base64 -d | shasum ...` in tool descriptions; still flags decode-then-execute into a shell (#348).

Once merged, tagging `v1.9.1` builds the signed Windows/mac/Linux draft. Publishing auto-updates installed gateways, which is what makes all three fixes go live (and enables code mode via the toggle with no env).