### PR TITLE
Speed up the release build: deps-only Rust cache + cached signing tool (SOU-198)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,20 +92,30 @@ jobs:
         if: matrix.target
         run: rustup target add ${{ matrix.target }}
 
-      # No Rust build cache on releases. A restored target/ kept serving a stale
-      # workspace compilation that cargo trusted (the crate compiled 0 times), so
-      # v0.3.12 and v0.3.13 shipped binaries missing the newly added savings_summary
-      # command. Building from scratch guarantees the binary matches the tagged
-      # source. Releases are infrequent, so the extra compile time is worth it.
+      # Cache DEPENDENCY build artifacts only, never the workspace's own crates.
+      # History: a naive actions/cache of all of `src-tauri/target` (still used by ci.yml)
+      # once served a stale local-crate compile that cargo trusted (the crate recompiled 0
+      # times), so v0.3.12/v0.3.13 shipped signed binaries missing a command. Swatinem/
+      # rust-cache is different in the way that matters here: before saving it evicts the
+      # workspace members (the `conduit` lib + its bins) from the cache, so they ALWAYS
+      # recompile from the tagged source, while the third-party deps (the bulk of the
+      # compile) are restored. That is the from-scratch guarantee for OUR code plus the
+      # speedup for everyone else's. Do NOT replace this with a plain actions/cache of
+      # `target/`. Keyed per matrix leg so the two macOS targets don't share a cache.
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          workspaces: src-tauri
+          key: ${{ matrix.target || matrix.bundles }}
+
       - name: Install dependencies
         run: npm ci
 
-      - name: Give the Linux runner headroom (no cache means a from-scratch build)
+      - name: Give the Linux runner headroom (the app crate still links from scratch)
         if: matrix.os == 'ubuntu-22.04'
         run: |
-          # v0.3.14's Linux job was killed mid-build with no error output: removing
-          # the cache means a full from-scratch compile, and the WebKitGTK link step
-          # exhausts the runner. Free disk and add swap so it can't OOM/run out.
+          # v0.3.14's Linux job was killed mid-build with no error output: even with the
+          # dependency cache, the `conduit` crate always recompiles and its WebKitGTK link
+          # step exhausts the runner. Free disk and add swap so it can't OOM/run out.
           # Best-effort so a transient hiccup here never fails the release.
           sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /usr/share/swift 2>/dev/null || true
           sudo fallocate -l 10G /mnt/conduit-swap && sudo chmod 600 /mnt/conduit-swap \
@@ -122,12 +132,26 @@ jobs:
       # signature, so auto-update keeps working (a post-build sign would invalidate
       # the .sig). Endpoint/account default to this project's values; the cert
       # profile name must be set as the AZURE_SIGNING_PROFILE repo variable.
+      # trusted-signing-cli is built from source (cargo install) on the Windows job. Cache
+      # the compiled binary so a release only rebuilds it when the key is bumped. Bump the
+      # `-v1` suffix to force a fresh install (e.g. to pick up a new version of the tool).
+      - name: Cache trusted-signing-cli
+        if: matrix.os == 'windows-latest' && env.AZURE_CLIENT_ID != ''
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: ~/.cargo/bin/trusted-signing-cli.exe
+          key: trusted-signing-cli-${{ runner.os }}-v1
+
       - name: Set up Windows code signing (Azure Trusted Signing)
         id: winsign
         if: matrix.os == 'windows-latest' && env.AZURE_CLIENT_ID != ''
         shell: pwsh
         run: |
-          cargo install trusted-signing-cli --locked
+          if (-not (Test-Path "$env:USERPROFILE\.cargo\bin\trusted-signing-cli.exe")) {
+            cargo install trusted-signing-cli --locked
+          } else {
+            Write-Host "trusted-signing-cli restored from cache"
+          }
           $endpoint = "${{ vars.AZURE_SIGNING_ENDPOINT }}"; if (-not $endpoint) { $endpoint = "https://eus.codesigning.azure.net" }
           $account  = "${{ vars.AZURE_SIGNING_ACCOUNT }}";  if (-not $account)  { $account  = "southforgesigning" }
           $certProfile = "${{ vars.AZURE_SIGNING_PROFILE }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,11 +101,17 @@ jobs:
       # recompile from the tagged source, while the third-party deps (the bulk of the
       # compile) are restored. That is the from-scratch guarantee for OUR code plus the
       # speedup for everyone else's. Do NOT replace this with a plain actions/cache of
-      # `target/`. Keyed per matrix leg so the two macOS targets don't share a cache.
+      # `target/`. `key` distinguishes the two macOS targets (same runner OS); rust-cache
+      # already keys on the OS, so windows/linux (empty target) stay separate on their own.
+      # cache-bin: false keeps ~/.cargo/bin (which rust-cache caches by default) OUT of this
+      # cache: the Windows signer `trusted-signing-cli` lives there and is cached explicitly
+      # below, and a cache-restored signing binary would both defeat that step's version key
+      # and widen the poisoning surface for a tool that runs with the signing secrets.
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           workspaces: src-tauri
-          key: ${{ matrix.target || matrix.bundles }}
+          key: ${{ matrix.target }}
+          cache-bin: "false"
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
Cuts release build time without reintroducing the stale-binary bug the workflow was deliberately avoiding.

## Background
The Release workflow built all 4 platforms with no Rust cache, on purpose: a naive `actions/cache` of the whole `src-tauri/target` (the approach ci.yml still uses) once served a stale local-crate compile that cargo trusted, and v0.3.12/v0.3.13 shipped signed binaries missing a command.

## What changed
1. **`Swatinem/rust-cache` (deps-only).** This is a different mechanism from a plain `target/` cache: before saving, rust-cache evicts the workspace members (`conduit` lib + its bins) from the cache, so **our code always recompiles from the tagged source** while third-party deps (most of the compile) are restored. Keyed per matrix leg so the two macOS targets don't share a cache. Pinned to a commit SHA per repo convention.
2. **Cache `trusted-signing-cli`.** The Windows job built it from source (`cargo install`) every release; now it's cached and only reinstalls on a key miss.

## Safety
- This does **not** reintroduce a naive `target/` cache. The comment block spells out why rust-cache is safe where that was not, so the next person doesn't undo it.
- No app-code change; the guarantee that the shipped binary matches the tag is preserved (workspace crates always rebuild).
- Effect only shows on the **next** release build; expect the biggest win on patch releases where deps are unchanged.

Holding for review since it's the signed pipeline.