### PR TITLE
settings: nest Pinned prerequisites under Lazy discovery (SOU-223)

### DIFF
--- a/src/components/SettingsView.tsx
+++ b/src/components/SettingsView.tsx
@@ -832,8 +832,18 @@ export function SettingsView({ registry, onRegistryChange }: Props) {
           "Expose 4 meta-tools, not the full catalog (all clients)",
           apply(setLazyDiscovery),
         )}
+        {/* Pinned prerequisites is a refinement of lazy discovery (the tools it must never
+            hide), not a peer feature, so nest it under the Lazy discovery toggle with an
+            indent + left rail. It has no meaning when lazy discovery is off, so it collapses
+            away entirely then. Code mode below is an independent capability and stays a
+            full-width sibling. */}
         {lazyDiscovery ? (
-          <PinnedPrerequisites registry={registry} onRegistryChange={onRegistryChange} />
+          <div className="ml-4 border-l-2 border-border/50 pl-3">
+            <PinnedPrerequisites
+              registry={registry}
+              onRegistryChange={onRegistryChange}
+            />
+          </div>
         ) : null}
         {toggle(
           Braces,


### PR DESCRIPTION
Closes SOU-223.

## Why
The Discovery section rendered Lazy discovery, Pinned prerequisites, and Code mode as three flat sibling cards. But **Pinned prerequisites is a refinement of Lazy discovery** — it's the set of tools lazy discovery must never hide, so it has no meaning when lazy discovery is off. **Code mode** (`toolport_run_script`) is orthogonal and works regardless of discovery mode. Presenting all three as peers hid that parent/child relationship.

## Change
Nest `PinnedPrerequisites` under the Lazy discovery toggle with an indent + left rail so it visibly hangs off it, and keep Code mode as a full-width sibling below. Layout only — the ordering (Lazy → Pinned → Code) and the collapse-when-lazy-is-off behavior were already in place; this makes the hierarchy visible.

```
Lazy discovery            [toggle]
 └ Pinned prerequisites   (indented, left rail; collapses when lazy is off)
Code mode                 [toggle]
```

## Verification
No behavior change (a wrapper `<div>` around the existing conditional render). `tsc --noEmit` clean, eslint clean, pre-commit prettier/eslint passed.