### PR TITLE
release(macos): bounded notarization waits so an Apple queue stall can't hang a release (SOU-199)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -199,6 +199,10 @@ jobs:
       # script fails fast with a clear message if any required secret is missing.
       - name: Sign + notarize + package (macOS)
         if: startsWith(matrix.os, 'macos')
+        # Backstop for SOU-199: even with the script's bounded notarization waits, cap the whole
+        # macOS sign/notarize/package step so a stuck Apple Notary queue fails the job in ~1h
+        # instead of burning toward the 6h job cap.
+        timeout-minutes: 60
         run: bash scripts/macos-package-ci.sh
         env:
           APP: src-tauri/target/${{ matrix.target }}/release/bundle/macos/Toolport.app

--- a/scripts/macos-package-ci.sh
+++ b/scripts/macos-package-ci.sh
@@ -114,13 +114,45 @@ APP="$APP" IDENTITY="$APPLE_SIGNING_IDENTITY" APP_PROFILE="$APP_PROFILE" GW_PROF
 # 4. Notarize + staple the app.
 #    Gatekeeper requires the .app be notarized and stapled. notarytool wants a
 #    zip; ditto --keepParent preserves the .app structure.
+#
+#    Notarization uses a BOUNDED wait (SOU-199). Apple's Developer ID Notary
+#    Service has recurring "In Progress" queue stalls, and a plain `submit
+#    --wait` blocks until Apple answers, which hung v1.9.1's mac job ~2h until
+#    the 6h job cap. notarize() submits, then waits with a hard timeout, and on
+#    a timeout or rejection dumps the notarization log and fails fast so the
+#    release can simply be re-run once Apple's queue recovers. release.yml also
+#    caps this whole step with timeout-minutes as a backstop.
 # ---------------------------------------------------------------------------
+NOTARIZE_TIMEOUT="${NOTARIZE_TIMEOUT:-30m}"
+notarize() {
+  local artifact="$1" kind="$2" id status
+  log "Submitting the $kind for notarization"
+  id="$(xcrun notarytool submit "$artifact" \
+    --apple-id "$APPLE_ID" --password "$APPLE_PASSWORD" --team-id "$APPLE_TEAM_ID" \
+    --output-format json |
+    python3 -c 'import sys,json; print(json.load(sys.stdin).get("id",""))')" ||
+    die "notarytool submit failed for the $kind"
+  [[ -n "$id" ]] || die "notarytool submit returned no submission id for the $kind"
+  log "Waiting on notarization $id (timeout $NOTARIZE_TIMEOUT)"
+  # Bounded wait; on timeout notarytool exits non-zero and prints no final JSON, so `status`
+  # comes back empty and trips the not-Accepted branch below (a rejection yields "Invalid").
+  status="$(xcrun notarytool wait "$id" \
+    --apple-id "$APPLE_ID" --password "$APPLE_PASSWORD" --team-id "$APPLE_TEAM_ID" \
+    --timeout "$NOTARIZE_TIMEOUT" --output-format json 2>/dev/null |
+    python3 -c 'import sys,json; print(json.load(sys.stdin).get("status",""))' 2>/dev/null || true)"
+  if [[ "$status" != "Accepted" ]]; then
+    printf '::error::Notarization of the %s (%s) did not succeed (status: %s); Apple queue stall or rejection. Log follows:\n' \
+      "$kind" "$id" "${status:-timeout}" >&2
+    xcrun notarytool log "$id" \
+      --apple-id "$APPLE_ID" --password "$APPLE_PASSWORD" --team-id "$APPLE_TEAM_ID" >&2 || true
+    die "notarization did not succeed for the $kind; re-run the release once Apple's Notary queue recovers"
+  fi
+}
+
 log "Notarizing the app"
 APP_ZIP="$WORK/Toolport-notarize.zip"
 ditto -c -k --keepParent "$APP" "$APP_ZIP"
-xcrun notarytool submit "$APP_ZIP" \
-  --apple-id "$APPLE_ID" --password "$APPLE_PASSWORD" --team-id "$APPLE_TEAM_ID" \
-  --wait
+notarize "$APP_ZIP" "app"
 xcrun stapler staple "$APP"
 xcrun stapler validate "$APP" || die "stapler validate failed on the app"
 
@@ -136,9 +168,7 @@ DMG="$DMG_DIR/Toolport_${TARGET}.dmg"
 rm -f "$DMG"
 hdiutil create -volname "Toolport" -srcfolder "$APP" -ov -format UDZO "$DMG"
 codesign --force --timestamp -s "$APPLE_SIGNING_IDENTITY" "$DMG"
-xcrun notarytool submit "$DMG" \
-  --apple-id "$APPLE_ID" --password "$APPLE_PASSWORD" --team-id "$APPLE_TEAM_ID" \
-  --wait
+notarize "$DMG" "dmg"
 xcrun stapler staple "$DMG"
 
 # ---------------------------------------------------------------------------

--- a/scripts/macos-package-ci.sh
+++ b/scripts/macos-package-ci.sh
@@ -123,7 +123,11 @@ APP="$APP" IDENTITY="$APPLE_SIGNING_IDENTITY" APP_PROFILE="$APP_PROFILE" GW_PROF
 #    release can simply be re-run once Apple's queue recovers. release.yml also
 #    caps this whole step with timeout-minutes as a backstop.
 # ---------------------------------------------------------------------------
-NOTARIZE_TIMEOUT="${NOTARIZE_TIMEOUT:-30m}"
+# 20m per artifact (not 30m): the two sequential waits plus signing, stapling, dmg creation,
+# the updater re-sign, and the failure-log dump must all finish under release.yml's 60m step
+# cap, so the helper's own fast-fail + `notarytool log` diagnostics always beat the blunt step
+# timeout (2x20m waits + overhead leaves ~15m of headroom).
+NOTARIZE_TIMEOUT="${NOTARIZE_TIMEOUT:-20m}"
 notarize() {
   local artifact="$1" kind="$2" id status
   log "Submitting the $kind for notarization"


### PR DESCRIPTION
Closes SOU-199.

## Problem
v1.9.1's macOS arm64 job hung ~2h. `scripts/macos-package-ci.sh` ran `xcrun notarytool submit --wait` twice (.app then .dmg), and Apple's Developer ID Notary Service had a stuck "In Progress" queue episode (a recurring Apple issue). `--wait` blocks until Apple answers, so one bad Apple day stalls the whole release toward the 6h job cap. We cleared it manually with cancel + `gh run rerun` once the queue recovered.

## Fix (Option A + step backstop)
- **Bounded-wait `notarize()` helper**: submit → capture the submission id → `notarytool wait <id> --timeout` (default **30m**, override via `NOTARIZE_TIMEOUT`). On a timeout or non-`Accepted` status it prints a GitHub `::error::` line, dumps `notarytool log <id>` for the reason, and fails fast — so a stalled Apple queue is a quick, **retryable** failure, not a multi-hour hang.
- **Step backstop**: `timeout-minutes: 60` on the "Sign + notarize + package (macOS)" step, so even an unforeseen hang fails the job in ~1h instead of ~6h.

Both the app and the dmg go through the helper. Order is unchanged (notarize+staple app → build dmg from the stapled app → notarize+staple dmg), so **Option B (concurrent submit) was deliberately not used** — it would put an un-stapled app inside the dmg.

## Verification
`bash -n` clean, `release.yml` parses as valid YAML, no live `--wait` remains. The notarization path itself needs a macOS runner + Apple credentials, so it can't be exercised from CI here (same constraint as SOU-221); it'll be proven on the next release cut. Logic is a drop-in around the existing submit calls with no change to signing/stapling/updater steps.