### PR TITLE
Clarify 'Move config in' UI copy

### DIFF
--- a/src/components/ClientDetail.tsx
+++ b/src/components/ClientDetail.tsx
@@ -547,7 +547,7 @@ export function ClientDetail({ client, registry, onChanged, onRegistryChange }: 
                   disabled={busy}
                 >
                   <Shuffle className="size-3" />
-                  Import into gateway ({movable.length})
+                  Move into gateway ({movable.length})
                 </Button>
               )}
             </div>
@@ -563,7 +563,7 @@ export function ClientDetail({ client, registry, onChanged, onRegistryChange }: 
               </li>
               {movable.length > 0 && (
                 <li>
-                  <span className="font-medium text-foreground">Import into gateway</span>{" "}
+                  <span className="font-medium text-foreground">Move into gateway</span>{" "}
                   copies it, then removes it from {client.name}'s config so the gateway is
                   the only source (plugin servers stay). The cutover that actually saves
                   context.
@@ -577,8 +577,8 @@ export function ClientDetail({ client, registry, onChanged, onRegistryChange }: 
               <span>
                 {client.name} is already connected to Toolport. Import on its own leaves a
                 copy here too, so these tools load twice, once directly and once through
-                the gateway. Use <span className="font-medium">Import into gateway</span>{" "}
-                to avoid that.
+                the gateway. Use <span className="font-medium">Move into gateway</span> to
+                avoid that.
               </span>
             </p>
           )}

--- a/src/components/ClientDetail.tsx
+++ b/src/components/ClientDetail.tsx
@@ -547,7 +547,7 @@ export function ClientDetail({ client, registry, onChanged, onRegistryChange }: 
                   disabled={busy}
                 >
                   <Shuffle className="size-3" />
-                  Move config in ({movable.length})
+                  Import into gateway ({movable.length})
                 </Button>
               )}
             </div>
@@ -563,7 +563,7 @@ export function ClientDetail({ client, registry, onChanged, onRegistryChange }: 
               </li>
               {movable.length > 0 && (
                 <li>
-                  <span className="font-medium text-foreground">Move config in</span>{" "}
+                  <span className="font-medium text-foreground">Import into gateway</span>{" "}
                   copies it, then removes it from {client.name}'s config so the gateway is
                   the only source (plugin servers stay). The cutover that actually saves
                   context.
@@ -577,8 +577,8 @@ export function ClientDetail({ client, registry, onChanged, onRegistryChange }: 
               <span>
                 {client.name} is already connected to Toolport. Import on its own leaves a
                 copy here too, so these tools load twice, once directly and once through
-                the gateway. Use <span className="font-medium">Move config in</span> to
-                avoid that.
+                the gateway. Use <span className="font-medium">Import into gateway</span>{" "}
+                to avoid that.
               </span>
             </p>
           )}


### PR DESCRIPTION
<!-- Thanks for contributing to Toolport. Keep PRs focused and small where you can. -->

## What and why

Clarify the "Move config in" copy in the Client Details view.

- This replaces the "Move config in" label with the clearer phrase "Import into gateway" across the three user-facing occurrences in `ClientDetail.tsx`. The updated wording makes the action easier for new users to understand while leaving the underlying behavior unchanged.

Closes #268 

## Testing

<!-- How did you verify this? -->

- [x] `npm run build` passes
- [x] `npm run test` passes
- [ ] `npm run audit:prod` passes
- [ ] `npm run test:rust` passes (`npm run test:rust:windows` on Windows if the debug gateway binary is locked)
- [x] Ran the app (`npm run tauri dev`) and checked the change by hand

