### PR TITLE
security(integrity): cross-process lock on the pins/quarantine stores (SOU-165)

### DIFF
--- a/src-tauri/src/integrity.rs
+++ b/src-tauri/src/integrity.rs
@@ -317,11 +317,34 @@ fn save_pins(profile: Option<&str>, pins: &Pins) {
     }
 }
 
+/// Run a load-modify-save of an on-disk integrity store while holding the cross-process lock
+/// that guards `path` (its sibling `<path>.lock`), so two Toolport gateways detecting drift at
+/// the same moment serialize instead of read-modify-writing over each other. Without it a stale
+/// writer can clobber a peer's quarantine set and silently un-block a just-quarantined tool, or
+/// lose a peer's pin re-baseline (SOU-165). Best-effort: if the lock can't be acquired (a peer
+/// held it past the deadline) we log and run anyway, so this never regresses below today's
+/// atomic-but-unlocked write.
+fn with_store_lock<T>(path: &Path, f: impl FnOnce() -> T) -> T {
+    let _lock = crate::registry::lock_at(path)
+        .map_err(|e| eprintln!("conduit: proceeding without the integrity lock on {path:?}: {e}"))
+        .ok();
+    f()
+}
+
 /// Diff `current` tools against the pinned baseline for `profile` and record a
 /// security event for each drift. Returns the drift events (also written to
 /// `security.jsonl`). A tool whose server has never been pinned is treated as a
 /// fresh baseline (no drift); only servers we've already seen can "drift".
 pub fn check(profile: Option<&str>, current: &[Value]) -> Vec<Value> {
+    // Serialize the pin baseline's load-modify-save so a concurrent gateway's re-baseline can't
+    // clobber this one (SOU-165). No pins path (no config dir) = nothing to persist, run direct.
+    match pins_path(profile) {
+        Some(path) => with_store_lock(&path, || check_inner(profile, current)),
+        None => check_inner(profile, current),
+    }
+}
+
+fn check_inner(profile: Option<&str>, current: &[Value]) -> Vec<Value> {
     let mut events: Vec<Value> = Vec::new();
     let pins = match load_pins(profile) {
         PinsLoad::Loaded(p) => p,
@@ -642,12 +665,17 @@ pub fn all_quarantined() -> Vec<Value> {
 /// rebuild. `check` has already re-baselined the current definition, so a re-approved
 /// tool won't immediately re-flag. Returns whether the tool was actually quarantined.
 pub fn release(profile: Option<&str>, tool: &str) -> bool {
-    let mut q = load_quarantine(profile);
-    if q.remove(tool).is_some() {
-        save_quarantine(profile, &q);
-        return true;
-    }
-    false
+    let Some(path) = quarantine_path(profile) else { return false };
+    // Under the cross-process lock so a concurrent gateway's quarantine write can't clobber this
+    // release (or vice versa) via a stale read-modify-write (SOU-165).
+    with_store_lock(&path, || {
+        let mut q = load_quarantine(profile);
+        if q.remove(tool).is_some() {
+            save_quarantine(profile, &q);
+            return true;
+        }
+        false
+    })
 }
 
 /// From `check`'s drift `events` and the `current` tool list, quarantine the HIGH-RISK
@@ -657,6 +685,13 @@ pub fn release(profile: Option<&str>, tool: &str) -> bool {
 /// blocked. (High-risk-by-auth — a drift on a credential-bearing server — is a later
 /// pass; it needs server-secret context the integrity layer doesn't hold here.)
 pub fn apply_quarantine(profile: Option<&str>, current: &[Value], events: &[Value]) -> bool {
+    let Some(path) = quarantine_path(profile) else { return false };
+    // Under the cross-process lock so two gateways quarantining a drift at the same moment
+    // serialize instead of one clobbering the other's set (SOU-165).
+    with_store_lock(&path, || apply_quarantine_inner(profile, current, events))
+}
+
+fn apply_quarantine_inner(profile: Option<&str>, current: &[Value], events: &[Value]) -> bool {
     let mut q = load_quarantine(profile);
     let mut added = false;
     for e in events {

--- a/src-tauri/src/registry.rs
+++ b/src-tauri/src/registry.rs
@@ -1534,14 +1534,15 @@ pub fn save(registry: &Registry) -> Result<(), String> {
     save_to(&path, registry)
 }
 
-/// A held cross-process exclusive lock over the registry, released on drop (and by the OS
-/// if the holding process exits). Serializes the registry read-modify-write section across
+/// A held cross-process exclusive lock over a file's sibling `<path>.lock`, released on drop
+/// (and by the OS if the holding process exits). Serializes a read-modify-write section across
 /// the desktop app, the gateway binary, and the team-sync worker, so no writer's save can
-/// revert another process's concurrent change (SOU-23). Advisory: it only excludes other
-/// holders of THIS lock, which every registry writer takes via `update` / `update_at`.
-pub struct RegistryLock(std::fs::File);
+/// revert another process's concurrent change (SOU-23). Used for the registry (via `update` /
+/// `update_at` / `lock_at`) and the integrity pins/quarantine stores (SOU-165). Advisory: it
+/// only excludes other holders of THIS lock, which every writer of the guarded file takes.
+pub struct FileLock(std::fs::File);
 
-impl Drop for RegistryLock {
+impl Drop for FileLock {
     fn drop(&mut self) {
         // Also released when the File closes / the process exits; explicit for clarity.
         let _ = self.0.unlock();
@@ -1560,7 +1561,7 @@ fn lock_path(path: &Path) -> PathBuf {
 /// Acquire the exclusive registry lock, retrying briefly under contention. Registry writes
 /// are sub-millisecond, so a real conflict clears at once; a holder stuck past the deadline
 /// surfaces as an error rather than hanging the caller indefinitely.
-fn lock_for(path: &Path) -> Result<RegistryLock, String> {
+fn lock_for(path: &Path) -> Result<FileLock, String> {
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
     }
@@ -1572,7 +1573,7 @@ fn lock_for(path: &Path) -> Result<RegistryLock, String> {
     let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
     loop {
         match file.try_lock_exclusive() {
-            Ok(()) => return Ok(RegistryLock(file)),
+            Ok(()) => return Ok(FileLock(file)),
             // Contended. The error KIND for "already locked" differs by platform (`WouldBlock`
             // on Unix, a lock-violation OS error on Windows), so do NOT gate the retry on it:
             // the lock file already opened above, so any try-lock failure here is contention.
@@ -1603,11 +1604,11 @@ pub fn update<T>(f: impl FnOnce(&mut Registry) -> Result<T, String>) -> Result<(
     Ok((reg, out))
 }
 
-/// Acquire the cross-process registry lock for an explicit path, for a caller that runs its
-/// own load-modify-save (the gateway's agent toggle, which interleaves audit + early
-/// returns) rather than using [`update_at`]. Hold the returned guard across the entire
-/// read-decide-write.
-pub fn lock_at(path: &Path) -> Result<RegistryLock, String> {
+/// Acquire the cross-process lock guarding an explicit path (its sibling `<path>.lock`), for a
+/// caller that runs its own load-modify-save rather than using [`update_at`]: the gateway's
+/// agent toggle (which interleaves audit + early returns), and the integrity pins/quarantine
+/// stores (SOU-165). Hold the returned guard across the entire read-decide-write.
+pub fn lock_at(path: &Path) -> Result<FileLock, String> {
     lock_for(path)
 }
 
@@ -2290,6 +2291,33 @@ mod tests {
             .any(|e| e.file_name().to_string_lossy().starts_with(&prefix));
         assert!(!leftover, "temp file left behind after a successful write");
         std::fs::remove_file(&path).ok();
+    }
+
+    #[test]
+    fn file_lock_excludes_a_second_holder_and_releases_on_drop() {
+        let dir = std::env::temp_dir();
+        let path = dir.join(format!("conduit-lock-{}.json", std::process::id()));
+        std::fs::remove_file(lock_path(&path)).ok();
+        let guard = lock_at(&path).expect("first lock acquires");
+        // A second, independent handle on the same sibling .lock must NOT acquire while held -
+        // this is what serializes two Toolport processes' read-modify-write (SOU-23 / SOU-165).
+        let second = std::fs::OpenOptions::new()
+            .create(true)
+            .write(true)
+            .open(lock_path(&path))
+            .unwrap();
+        assert!(
+            second.try_lock_exclusive().is_err(),
+            "a second holder acquired the lock while it was still held"
+        );
+        drop(guard);
+        // Once the guard drops the OS releases the advisory lock, so the same handle can take it.
+        assert!(
+            second.try_lock_exclusive().is_ok(),
+            "lock was not released after the guard dropped"
+        );
+        let _ = second.unlock();
+        std::fs::remove_file(lock_path(&path)).ok();
     }
 
     #[cfg(unix)]


### PR DESCRIPTION
Part of SOU-165 (the **integrity-file locking** sub-item).

## Problem
`tool-pins.json` and `quarantine.json` are atomic-write but **unlocked**. Each individual write is atomic (temp + fsync + rename), but the surrounding **read-modify-write** is not serialized across processes. So two gateways detecting drift at the same moment can each `load → modify → save`, and the loser's stale write clobbers the winner's change.

The dangerous case: gateway A quarantines a poisoned/destructive tool while gateway B, holding a stale read, saves a set that doesn't include it — **silently un-blocking a tool that was just quarantined**, a fail-open of the supply-chain defense. Running multiple gateways on one box is common (each MCP client gets its own), so this race is real, not theoretical.

## Fix
Wrap every integrity load-modify-save in the same cross-process advisory lock SOU-23 already uses for the registry:
- `apply_quarantine`, `release` — the quarantine RMW (the security-critical one).
- the pin re-baseline in `check` — the pins RMW.

Mechanically, the registry's `RegistryLock` guard is generalized to a shared `FileLock` (it was already a plain `<path>.lock` sibling-file lock over `fs2`), and integrity acquires it via the existing `registry::lock_at`. Best-effort: if the lock can't be taken within the deadline (a peer held it), we log and proceed unlocked, so behavior never regresses below today's atomic-but-unlocked write.

## Tests
- `file_lock_excludes_a_second_holder_and_releases_on_drop` — a second handle can't take the lock while a guard is held, and can once it drops (fast, no wait).
- Existing quarantine/integrity suites (32 integrity + 7 quarantine tests) now exercise the locked path and pass.

Build clean, all touched-module tests green (registry 45, integrity 32, quarantine 7).

## Scope note
This closes the integrity-locking sub-item of SOU-165. The other two sub-items stay open: the **Unix** half of orphaned-process cleanup (Windows already shipped in #330; can't be verified from Windows), and deterministic tool-collision suffixes (carved to #356, assigned to a contributor).