### PR TITLE
ci(release): cache npm downloads across the release matrix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,6 +65,11 @@ jobs:
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 20
+          # Cache the npm download cache (~/.npm), keyed on package-lock.json, so `npm ci`
+          # below doesn't re-fetch the whole frontend dep tree on every release across all
+          # four matrix jobs. ci.yml already does this; a cache miss just falls back to a
+          # normal `npm ci`, so it never affects the built artifact.
+          cache: npm
 
       - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
 


### PR DESCRIPTION
## What
Add `cache: npm` to `setup-node` in the release workflow.

## Why
The release workflow's `setup-node` had no npm cache, so `npm ci` re-fetched the entire frontend dependency tree on **every release, across all four matrix jobs** (Windows, both macOS arches, Linux). `ci.yml` already caches npm — this just brings the release path to parity.

## Safety
- Caches only the npm download cache (`~/.npm`), keyed on `package-lock.json`.
- A cache miss falls back to a normal `npm ci`, so it **cannot affect the built artifact** — it's a pure speedup.
- Same one-liner `ci.yml` already relies on, so the pattern is proven in this repo.

Workflow-only change; takes effect on the next tagged release.

## Not included
Deliberately left out the **mold linker** idea for the Linux job. That changes how the shipped Linux binary is linked and can't be verified without a real tagged release build, so it needs a test release first rather than going in blind.