### PR TITLE
fix(teams): pause team-sync off a Rust window-visibility signal, not document.hidden (SOU-256)

### DIFF
--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -2608,7 +2608,23 @@ fn show_main_window(app: &AppHandle) {
         let _ = w.show();
         let _ = w.unminimize();
         let _ = w.set_focus();
+        // Tell the frontend the window is visible again so the team-sync loop resumes and does
+        // an immediate catch-up poll. The webview's Page Visibility API doesn't report Tauri
+        // tray show/hide on Windows, so this event is the authoritative signal (see the
+        // team-sync effect in App.tsx and `main_window_visible`).
+        let _ = app.emit("team-window-visible", true);
     }
+}
+
+/// Whether the main window is currently shown (vs hidden to the tray). Seeds the frontend
+/// team-sync loop's visibility gate on mount - live changes come via the `team-window-visible`
+/// event emitted from show/hide. Defaults to visible if the window is missing or the platform
+/// query fails, so sync never wedges off on an unexpected error.
+#[tauri::command]
+fn main_window_visible(app: AppHandle) -> bool {
+    app.get_webview_window("main")
+        .and_then(|w| w.is_visible().ok())
+        .unwrap_or(true)
 }
 
 /// Reflect the pending-approval count on the tray tooltip, so a glance at the tray
@@ -2844,6 +2860,7 @@ pub fn run() {
             team_join_poll,
             team_sync,
             team_sync_wait,
+            main_window_visible,
             team_disconnect,
             team_push_preview,
             team_push,
@@ -2881,6 +2898,10 @@ pub fn run() {
                     let _ = window.hide();
                     // Hidden to the tray => menu-bar only, so drop the Dock icon (macOS).
                     set_dock_icon_visible(window.app_handle(), false);
+                    // Tell the frontend the window is hidden so the team-sync loop parks and
+                    // stops polling the team server (each poll would otherwise keep a
+                    // scale-to-zero Postgres awake). Resumes via show_main_window's emit.
+                    let _ = window.app_handle().emit("team-window-visible", false);
                     maybe_show_tray_hint(window.app_handle());
                 }
             }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,6 +27,7 @@ import {
   getRegistry,
   takeRegistryRecoveryNotice,
   importServers,
+  mainWindowVisible,
   previewImportServers,
   probeServers,
   removeServer,
@@ -295,12 +296,19 @@ function App() {
   // ~1s while staying cheap when idle. Not tied to the Teams view. Keyed on the team id so it
   // starts on connect and tears down on disconnect/removal.
   //
-  // While the app is backgrounded (minimized / hidden to the tray) the loop PAUSES entirely:
-  // a connected-but-idle client otherwise re-polls every ~25s forever, and each poll touches
-  // the team server's database, which pins a scale-to-zero Postgres (Neon) awake 24/7 and
-  // burns compute even when nobody is using Toolport (SOU-256). We resume the instant the
-  // window is shown again with an immediate poll, so a policy change that landed while we were
-  // hidden is picked up the moment the user comes back.
+  // While the app is hidden to the tray the loop PAUSES entirely (zero requests): a
+  // connected-but-idle client otherwise re-polls every ~25s forever, and each poll hits the
+  // team server's database, which pins a scale-to-zero Postgres (Neon) awake around the clock
+  // and burns compute even when nobody is using Toolport (SOU-256). We resume with an immediate
+  // catch-up poll the instant the window is shown, so a policy change that landed while hidden
+  // is picked up the moment the user comes back.
+  //
+  // The visibility signal comes from the Rust side: the `team-window-visible` event emitted on
+  // show/hide, seeded by an initial `mainWindowVisible()` pull for a straight-to-tray launch.
+  // The webview's own Page Visibility API is NOT reliable here - on Windows, hiding a Tauri
+  // window to the tray does not flip `document.hidden`, so a purely web-based gate kept polling
+  // from the tray. We still fold in `document.hidden` as a secondary signal for the platforms
+  // where it does fire (e.g. a real minimize).
   const teamId = registry?.team?.teamId;
   useEffect(() => {
     if (!teamId) return;
@@ -313,19 +321,36 @@ function App() {
     const FLOOR_MS = 3000;
     const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
-    // Resolve when the window becomes visible again, so a backgrounded loop parks here (issuing
-    // zero requests) instead of hammering the server, and wakes on show or on teardown.
+    // Window visibility, source of truth = Rust; `hidden()` also folds in the webview signal.
+    // A backgrounded loop parks in `waitUntilVisible` (issuing zero requests) and wakes on show
+    // or on teardown.
+    let windowVisible = true;
+    const hidden = () => !windowVisible || document.hidden;
     let wake: (() => void) | null = null;
-    const onVisible = () => {
-      if (!document.hidden && wake) {
+    const maybeWake = () => {
+      if (!hidden() && wake) {
         wake();
         wake = null;
       }
     };
-    document.addEventListener("visibilitychange", onVisible);
+    const setWindowVisible = (v: boolean) => {
+      windowVisible = v;
+      maybeWake();
+    };
+    document.addEventListener("visibilitychange", maybeWake);
+    // Seed initial state (covers a launch that goes straight to the tray via --hidden), then
+    // track live show/hide from the Rust side.
+    void mainWindowVisible()
+      .then((v) => {
+        if (!cancelled) setWindowVisible(v);
+      })
+      .catch(() => {});
+    const unlisten = listen<boolean>("team-window-visible", (e) => {
+      if (!cancelled) setWindowVisible(e.payload);
+    });
     const waitUntilVisible = () =>
       new Promise<void>((resolve) => {
-        if (!document.hidden || cancelled) {
+        if (!hidden() || cancelled) {
           resolve();
           return;
         }
@@ -334,7 +359,7 @@ function App() {
 
     const loop = async () => {
       while (!cancelled) {
-        if (document.hidden) {
+        if (hidden()) {
           await waitUntilVisible();
           if (cancelled) break;
           // Fall straight through to a poll so we resync immediately on show.
@@ -361,7 +386,8 @@ function App() {
     void loop();
     return () => {
       cancelled = true;
-      document.removeEventListener("visibilitychange", onVisible);
+      document.removeEventListener("visibilitychange", maybeWake);
+      void unlisten.then((f) => f());
       // Unblock a loop parked in waitUntilVisible so its cancelled check runs and it exits.
       if (wake) {
         wake();

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -405,6 +405,16 @@ export function teamSyncWait(waitSecs: number): Promise<Registry> {
   return invoke<Registry>("team_sync_wait", { waitSecs });
 }
 
+/**
+ * Whether the main window is currently shown (vs hidden to the tray). Used to seed the
+ * team-sync loop's visibility gate on mount, for the case where the app launched straight to
+ * the tray; live changes arrive via the `team-window-visible` event. Defaults to visible on
+ * any error so sync never wedges off.
+ */
+export function mainWindowVisible(): Promise<boolean> {
+  return invoke<boolean>("main_window_visible");
+}
+
 /** Leave the team: remove its merged servers and clear the saved token. */
 export function teamDisconnect(): Promise<Registry> {
   return invoke<Registry>("team_disconnect");


### PR DESCRIPTION
## Why

v1.9.2 paused the team-sync long-poll using the Page Visibility API (`document.hidden`). Verified live against prod that this **does not work for the reported case**: on Windows, hiding a Tauri window to the tray does not flip `document.hidden`, so a tray'd app kept polling every ~25s. Neon's `last_active` advanced from `05:07` to `05:17` with the app sitting in the tray, compute stayed `active`. Each poll's auth + `current_version` reads keep the scale-to-zero Postgres awake around the clock, which is the pin SOU-256 is about.

## What

Drive the pause off the authoritative signal the Rust side already owns:

- `show_main_window` and the close-to-tray `CloseRequested` handler now emit a `team-window-visible` (bool) event.
- New `main_window_visible` command seeds the frontend's initial gate (covers a straight-to-tray `--hidden` launch, before any event fires).
- The App.tsx team-sync loop gates on that signal; `document.hidden` stays folded in as a secondary signal for platforms where it does fire (e.g. a real minimize).

While hidden the loop makes **zero** requests, so Neon can autosuspend; on show it resumes with an immediate catch-up poll so a policy change that landed while hidden is applied the moment the user returns.

### Tradeoff

While the app is in the tray, an admin's policy change (force-quarantine / approval tightening) isn't pulled until the window is opened. The last-synced policy stays enforced by the gateway; only updates wait. This is the intended behavior for "the app isn't in front."

Note: plain minimize-to-taskbar (the `-` button, not close-to-tray) isn't explicitly covered here beyond the `document.hidden` fallback; the reported and dominant background state is the tray.

## Verification

- `cargo build` clean
- `tsc --noEmit` + `eslint` clean (0 errors)
- `vitest run` — 98 passed

Follows the server-side write throttle (#186, deployed) and supersedes the v1.9.2 `document.hidden` approach (#359).