### PR TITLE
feat(teams): Team Instructions client writer — W2, ships dark (SOU-135)

### DIFF
--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -7074,6 +7074,8 @@ mod tests {
             last_version: 42,
             last_etag: Some("\"v42\"".into()),
             usage_reported: usage,
+            team_instructions_hash: None,
+            team_instructions_targets: Vec::new(),
         });
         assert_eq!(
             router_relevant(&reg),

--- a/src-tauri/src/clients.rs
+++ b/src-tauri/src/clients.rs
@@ -365,7 +365,10 @@ fn resolve_rules_target(
     };
     let target = match client_id {
         // Strategy A — Toolport owns a whole file in the client's rules DIRECTORY.
-        "claude-code" => owned(
+        // Claude Code's `~/.claude/rules/` is also read by VS Code Copilot (Claude-compat
+        // paths), so both map here; path-dedup writes it once when both are installed and a
+        // standalone VS Code install is still covered.
+        "claude-code" | "vscode" => owned(
             home.join(".claude")
                 .join("rules")
                 .join("toolport-team-rules.md"),
@@ -390,8 +393,10 @@ fn resolve_rules_target(
             // AGENTS.override.md, if present, makes Codex ignore AGENTS.md entirely.
             blocked_if_present: Some(home.join(".codex").join("AGENTS.override.md")),
         },
-        // Shared with Antigravity — one write to GEMINI.md covers both.
-        "gemini-cli" => block(home.join(".gemini").join("GEMINI.md")),
+        // Gemini CLI and Antigravity share `~/.gemini/GEMINI.md`; both resolve to it so a
+        // standalone install of EITHER is covered, and `apply_instructions`' path-dedup writes
+        // it once when both are present.
+        "gemini-cli" | "antigravity" => block(home.join(".gemini").join("GEMINI.md")),
         "windsurf" => Target {
             path: home
                 .join(".codeium")
@@ -3863,14 +3868,12 @@ command = "npx"
     }
 
     #[test]
-    fn rules_target_unsupported_and_transitive_clients_return_none() {
-        // Cursor/Warp store globals in UI/cloud; Antigravity + VS Code Copilot are covered by
-        // Gemini's / Claude Code's file; Continue is deferred; chat apps have no rules file.
+    fn rules_target_unsupported_clients_return_none() {
+        // Cursor/Warp store globals in UI/cloud; Continue is deferred; chat/identity apps have
+        // no global rules file we manage.
         for id in [
             "cursor",
             "warp",
-            "antigravity",
-            "vscode",
             "continue",
             "claude-desktop",
             "lm-studio",
@@ -3882,6 +3885,25 @@ command = "npx"
                 "{id} should have no managed rules target"
             );
         }
+    }
+
+    #[test]
+    fn rules_target_transitive_clients_share_the_covering_file() {
+        // A standalone Antigravity / VS Code install must still be covered: each resolves to the
+        // same file as the client whose format it reads, and `apply_instructions` de-dupes the
+        // shared path so it's written once when both are installed.
+        let home = mock_home(Platform::MacOs);
+        let p = Platform::MacOs;
+        assert_eq!(
+            resolve_rules_target("antigravity", &home, p),
+            resolve_rules_target("gemini-cli", &home, p),
+            "Antigravity shares Gemini's GEMINI.md"
+        );
+        assert_eq!(
+            resolve_rules_target("vscode", &home, p),
+            resolve_rules_target("claude-code", &home, p),
+            "VS Code Copilot shares Claude Code's rules file"
+        );
     }
 
     /// Serializes tests that read or mutate the process-global XDG env vars. Rust

--- a/src-tauri/src/clients.rs
+++ b/src-tauri/src/clients.rs
@@ -335,6 +335,93 @@ fn resolve_client_config_path_linux(client_id: &str, home: &std::path::Path) -> 
     Some(path)
 }
 
+/// Resolve where a client reads its GLOBAL agent-rules file (Team Instructions, spec "W2").
+/// This is DISTINCT from the client's MCP-config path — e.g. Claude Code's config is
+/// `~/.claude.json` but its rules live under `~/.claude/rules/`. `None` means the client has
+/// no global-rules location we write: either its globals are UI/cloud-stored (Cursor, Warp),
+/// or it's covered transitively by another client's file (Antigravity reads Gemini's
+/// `GEMINI.md`; VS Code Copilot reads Claude Code's `~/.claude` rules). Unlike the config
+/// resolver these paths are all home-anchored (or literal `~/.config`), so one cross-platform
+/// resolver covers Linux too — no XDG/data-dir or MSIX handling needed. See the spec's adapter
+/// table for citations.
+fn resolve_rules_target(
+    client_id: &str,
+    home: &std::path::Path,
+    platform: Platform,
+) -> Option<crate::instructions::Target> {
+    use crate::instructions::{Strategy, Target};
+    let config = roaming_config_dir(home, platform);
+    let owned = |path: PathBuf| Target {
+        path,
+        strategy: Strategy::OwnedFile,
+        char_cap: None,
+        blocked_if_present: None,
+    };
+    let block = |path: PathBuf| Target {
+        path,
+        strategy: Strategy::SentinelBlock,
+        char_cap: None,
+        blocked_if_present: None,
+    };
+    let target = match client_id {
+        // Strategy A — Toolport owns a whole file in the client's rules DIRECTORY.
+        "claude-code" => owned(
+            home.join(".claude")
+                .join("rules")
+                .join("toolport-team-rules.md"),
+        ),
+        "kiro" => owned(
+            home.join(".kiro")
+                .join("steering")
+                .join("toolport-team-rules.md"),
+        ),
+        "roo-code" => owned(home.join(".roo").join("rules").join("toolport-team-rules.md")),
+        "cline" => owned(
+            home.join("Documents")
+                .join("Cline")
+                .join("Rules")
+                .join("toolport-team-rules.md"),
+        ),
+        // Strategy B — Toolport owns only the sentinel span in a shared global file.
+        "codex" => Target {
+            path: home.join(".codex").join("AGENTS.md"),
+            strategy: Strategy::SentinelBlock,
+            char_cap: None,
+            // AGENTS.override.md, if present, makes Codex ignore AGENTS.md entirely.
+            blocked_if_present: Some(home.join(".codex").join("AGENTS.override.md")),
+        },
+        // Shared with Antigravity — one write to GEMINI.md covers both.
+        "gemini-cli" => block(home.join(".gemini").join("GEMINI.md")),
+        "windsurf" => Target {
+            path: home
+                .join(".codeium")
+                .join("windsurf")
+                .join("memories")
+                .join("global_rules.md"),
+            strategy: Strategy::SentinelBlock,
+            char_cap: Some(6000), // Windsurf hard-caps the global rules file.
+            blocked_if_present: None,
+        },
+        "goose" => block(home.join(".config").join("goose").join(".goosehints")),
+        "pi" => block(home.join(".pi").join("agent").join("AGENTS.md")),
+        "zed" => match platform {
+            Platform::Windows => block(config.join("Zed").join("AGENTS.md")),
+            Platform::MacOs | Platform::Linux => {
+                block(home.join(".config").join("zed").join("AGENTS.md"))
+            }
+        },
+        _ => return None,
+    };
+    Some(target)
+}
+
+/// The rules-file target for a client on the current machine, or `None` if unsupported /
+/// transitively covered. Mirrors [`client_config_path`].
+pub fn client_rules_target(client_id: &str) -> Option<crate::instructions::Target> {
+    let home = home()?;
+    resolve_rules_target(client_id, &home, Platform::current())
+}
+
 fn claude_desktop_path() -> Option<PathBuf> {
     // Claude Desktop is MSIX-packaged, so its Roaming config can live at the real
     // %APPDATA% and/or inside the package's virtualized LocalCache. Prefer the
@@ -3726,6 +3813,74 @@ command = "npx"
             Platform::Windows => PathBuf::from(r"C:\Users\alice"),
             Platform::MacOs => PathBuf::from("/Users/alice"),
             Platform::Linux => PathBuf::from("/home/alice"),
+        }
+    }
+
+    #[test]
+    fn rules_target_claude_code_is_owned_file_all_platforms() {
+        use crate::instructions::Strategy;
+        for p in [Platform::Windows, Platform::MacOs, Platform::Linux] {
+            let t = resolve_rules_target("claude-code", &mock_home(p), p).expect("supported");
+            assert_eq!(t.strategy, Strategy::OwnedFile);
+            assert!(
+                t.path.ends_with(PathBuf::from("rules").join("toolport-team-rules.md")),
+                "unexpected claude-code rules path on {p:?}: {:?}",
+                t.path
+            );
+            assert!(t.path.to_string_lossy().contains(".claude"));
+        }
+    }
+
+    #[test]
+    fn rules_target_codex_is_sentinel_and_flags_override() {
+        use crate::instructions::Strategy;
+        let home = mock_home(Platform::MacOs);
+        let t = resolve_rules_target("codex", &home, Platform::MacOs).expect("supported");
+        assert_eq!(t.strategy, Strategy::SentinelBlock);
+        assert!(t.path.ends_with(PathBuf::from(".codex").join("AGENTS.md")));
+        assert_eq!(
+            t.blocked_if_present,
+            Some(home.join(".codex").join("AGENTS.override.md")),
+            "Codex AGENTS.override.md must shadow AGENTS.md"
+        );
+    }
+
+    #[test]
+    fn rules_target_windsurf_carries_hard_cap() {
+        let t = resolve_rules_target("windsurf", &mock_home(Platform::Linux), Platform::Linux)
+            .expect("supported");
+        assert_eq!(t.char_cap, Some(6000));
+    }
+
+    #[test]
+    fn rules_target_zed_is_platform_specific() {
+        let win = resolve_rules_target("zed", &mock_home(Platform::Windows), Platform::Windows)
+            .expect("supported");
+        assert!(win.path.to_string_lossy().contains("Zed"));
+        let mac = resolve_rules_target("zed", &mock_home(Platform::MacOs), Platform::MacOs)
+            .expect("supported");
+        assert!(mac.path.ends_with(PathBuf::from(".config").join("zed").join("AGENTS.md")));
+    }
+
+    #[test]
+    fn rules_target_unsupported_and_transitive_clients_return_none() {
+        // Cursor/Warp store globals in UI/cloud; Antigravity + VS Code Copilot are covered by
+        // Gemini's / Claude Code's file; Continue is deferred; chat apps have no rules file.
+        for id in [
+            "cursor",
+            "warp",
+            "antigravity",
+            "vscode",
+            "continue",
+            "claude-desktop",
+            "lm-studio",
+            "jan",
+            "hermes",
+        ] {
+            assert!(
+                resolve_rules_target(id, &mock_home(Platform::MacOs), Platform::MacOs).is_none(),
+                "{id} should have no managed rules target"
+            );
         }
     }
 

--- a/src-tauri/src/instructions.rs
+++ b/src-tauri/src/instructions.rs
@@ -1,0 +1,511 @@
+//! Team Instructions — write org-managed agent rules to each AI client's rules file.
+//!
+//! An admin authors the team's agent instructions once in the Teams dashboard; the server
+//! carries them in the team config under the top-level `instructions` key (see the
+//! `team-instructions` spec). This module is the client half (spec "W2"): it turns that
+//! content into files on disk next to — never over — the member's own instructions, and
+//! removes them cleanly when the member leaves the team.
+//!
+//! Two write strategies, both non-destructive:
+//!
+//!   * [`Strategy::OwnedFile`] — Toolport owns a whole file in a client's rules *directory*
+//!     (e.g. `~/.claude/rules/toolport-team-rules.md`). We create/replace/delete the entire
+//!     file; there are no user bytes in it to protect.
+//!   * [`Strategy::SentinelBlock`] — the client reads a single shared global rules file that
+//!     the user may also edit, so we own only the span between two HTML-comment markers and
+//!     leave every byte outside them untouched.
+//!
+//! The invariant the tests pin: an upsert changes only the managed span (or appends one), and
+//! a remove takes the managed span back out, so a full join→edit→leave cycle returns the
+//! user's own content unchanged.
+
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+
+/// How a client's rules file is written.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Strategy {
+    /// Toolport owns the whole file (a dedicated file in a rules directory).
+    OwnedFile,
+    /// Toolport owns only the span between the sentinel markers in a shared file.
+    SentinelBlock,
+}
+
+/// A resolved place to write one client's copy of the org instructions.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Target {
+    /// Absolute path of the file to write.
+    pub path: std::path::PathBuf,
+    pub strategy: Strategy,
+    /// Hard character cap for clients that truncate/ignore an over-long global file
+    /// (e.g. Windsurf's 6,000-char global rules). `None` = no client-imposed cap.
+    pub char_cap: Option<usize>,
+    /// A user opt-out file whose mere existence makes the client ignore `path` (Codex's
+    /// `AGENTS.override.md` shadows `AGENTS.md`). When it exists, applying reports
+    /// [`ApplyState::BlockedOverride`] and writes nothing.
+    pub blocked_if_present: Option<std::path::PathBuf>,
+}
+
+/// The per-client outcome of applying (or skipping) the org instructions. Reported to the
+/// dashboard (spec W5) so an admin can prove which client actually loaded the current rules.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ApplyState {
+    /// Written to disk (or already present and identical).
+    Applied,
+    /// This client has no supported global-rules location; nothing written.
+    Unsupported,
+    /// A user opt-out file shadows the target (e.g. Codex `AGENTS.override.md`); not written.
+    BlockedOverride,
+    /// Content exceeds the client's hard cap and can't be trimmed safely; not written.
+    TooLong,
+    /// A filesystem/parse error prevented a safe write; the file was left untouched.
+    Error,
+}
+
+/// Sentinel markers. FROZEN compatibility contract — an older build must still recognize and
+/// replace/remove a block a newer build wrote, so these strings never change. The team id and
+/// version live in the START marker for provenance and cheap change display; only the START
+/// *prefix* is matched, so the id/version can vary without breaking recognition.
+pub const SENTINEL_START_PREFIX: &str = "<!-- toolport:team-instructions:start";
+pub const SENTINEL_END: &str = "<!-- toolport:team-instructions:end -->";
+
+/// FROZEN prefix of the header stamped on an [`Strategy::OwnedFile`] file. Cleanup on
+/// team-leave identifies our owned files by this prefix (so it only ever deletes files we
+/// wrote), which must stay recognizable across versions.
+pub const OWNED_HEADER_PREFIX: &str = "<!-- Managed by Toolport";
+
+/// The one-line header stamped at the top of an [`Strategy::OwnedFile`] file so a member who
+/// opens it understands it is managed and will be overwritten.
+fn owned_header(team_id: &str, version: i64) -> String {
+    format!("{OWNED_HEADER_PREFIX} — team {team_id}, v{version}. Edits are overwritten on sync; leave the team to remove. -->")
+}
+
+fn start_marker(team_id: &str, version: i64) -> String {
+    format!("{SENTINEL_START_PREFIX} team={team_id} v={version} -->")
+}
+
+/// Stable content hash reported to the server as the "effective rules receipt": it identifies
+/// exactly the org content a client wrote to disk. Not cryptographic — only needs to detect
+/// change and let the dashboard prove on-disk == the pushed version.
+pub fn content_hash(content: &str) -> String {
+    let mut h = DefaultHasher::new();
+    content.hash(&mut h);
+    format!("{:016x}", h.finish())
+}
+
+/// Render the full body of an [`Strategy::OwnedFile`] file (header + a blank line + content).
+/// Always newline-terminated.
+pub fn render_owned_file(team_id: &str, version: i64, content: &str) -> String {
+    let body = content.trim_end_matches('\n');
+    format!("{}\n\n{}\n", owned_header(team_id, version), body)
+}
+
+/// The managed block text for the sentinel strategy: START marker, content, END marker.
+fn render_block(team_id: &str, version: i64, content: &str) -> String {
+    let body = content.trim_end_matches('\n');
+    format!("{}\n{}\n{}", start_marker(team_id, version), body, SENTINEL_END)
+}
+
+/// Byte range `[start, end)` of an existing managed block in `existing`, or `None`. `start` is
+/// the offset of the START marker; `end` is just past the END marker (not its trailing
+/// newline). Matches on the frozen START prefix + END, so a block from any version is found.
+fn find_block(existing: &str) -> Option<(usize, usize)> {
+    let start = existing.find(SENTINEL_START_PREFIX)?;
+    // The END marker that closes THIS block is the first one at or after START.
+    let end_rel = existing[start..].find(SENTINEL_END)?;
+    let end = start + end_rel + SENTINEL_END.len();
+    Some((start, end))
+}
+
+/// Insert or replace the managed block in a shared file, leaving every byte outside the block
+/// untouched.
+///
+///   * If a block already exists, its span (START..END) is replaced in place — the surrounding
+///     user text, including whatever separated it, is byte-identical afterwards.
+///   * Otherwise the block is appended after the user's content with a single blank-line
+///     separator, so a later [`remove_block`] can take exactly those bytes back out.
+///
+/// Idempotent: re-running with the same team/version/content yields byte-identical output.
+pub fn upsert_block(existing: &str, team_id: &str, version: i64, content: &str) -> String {
+    let block = render_block(team_id, version, content);
+    if let Some((start, end)) = find_block(existing) {
+        let mut out = String::with_capacity(existing.len() + block.len());
+        out.push_str(&existing[..start]);
+        out.push_str(&block);
+        out.push_str(&existing[end..]);
+        return out;
+    }
+    if existing.is_empty() {
+        return format!("{block}\n");
+    }
+    // Append after the user's content. Guarantee the block starts at column 0 with exactly one
+    // blank line of separation, without rewriting any existing byte: only newlines are added.
+    let sep = if existing.ends_with('\n') { "\n" } else { "\n\n" };
+    format!("{existing}{sep}{block}\n")
+}
+
+/// Remove the managed block (and the single blank-line separator [`upsert_block`] adds when it
+/// appends) from a shared file. Returns `None` if there is no block. The result restores the
+/// user's own content, normalized to end with a newline: a file that had no trailing newline
+/// before we appended gets one back, because the newline we must insert to put the block on its
+/// own line is indistinguishable on the way out from a newline the user typed — an unavoidable
+/// ambiguity, and a cosmetically irrelevant one for a rules file. A block the user relocated
+/// mid-file is removed in place, leaving at most one blank line where it sat.
+pub fn remove_block(existing: &str) -> Option<String> {
+    let (start, end) = find_block(existing)?;
+    // Consume the block's own trailing newline if present.
+    let mut cut_end = end;
+    if existing[cut_end..].starts_with('\n') {
+        cut_end += 1;
+    }
+    // Consume exactly one blank-line separator immediately before the block — the one we add on
+    // append. Only a lone leading "\n" (the separator) is eaten; the newline that terminates the
+    // user's real previous line is preserved.
+    let mut cut_start = start;
+    if existing[..cut_start].ends_with('\n') {
+        let without_last = &existing[..cut_start - 1];
+        if without_last.is_empty() || without_last.ends_with('\n') {
+            cut_start -= 1;
+        }
+    }
+    let mut out = String::with_capacity(existing.len());
+    out.push_str(&existing[..cut_start]);
+    out.push_str(&existing[cut_end..]);
+    Some(out)
+}
+
+/// True when `existing` already carries a managed block for the exact `team_id`+`version`+
+/// `content` (so a re-sync with no change can skip the write entirely).
+pub fn block_is_current(existing: &str, team_id: &str, version: i64, content: &str) -> bool {
+    match find_block(existing) {
+        Some((start, end)) => existing[start..end] == render_block(team_id, version, content),
+        None => false,
+    }
+}
+
+/// Read a target file, treating "not found" as empty (a first write). An existing-but-unreadable
+/// file is an error so the caller reports it rather than clobbering.
+fn read_existing(path: &std::path::Path) -> Result<String, String> {
+    match std::fs::read_to_string(path) {
+        Ok(s) => Ok(s),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(String::new()),
+        Err(e) => Err(e.to_string()),
+    }
+}
+
+/// Create parent dirs then write atomically (temp + rename, 0600), reusing the registry's
+/// hardened primitive so a crash mid-write can't leave a torn rules file.
+fn write_atomic(path: &std::path::Path, contents: &str) -> Result<(), String> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
+    }
+    crate::registry::atomic_write(path, contents)
+}
+
+/// Apply the org instructions to ONE client target. Atomic and non-destructive: it never
+/// partially writes, never overwrites a shared file it couldn't read, and skips (reporting why)
+/// when a client shadow-file or hard cap makes the write pointless.
+pub fn write_target(t: &Target, team_id: &str, version: i64, content: &str) -> ApplyState {
+    // Codex-style shadow file: the client ignores our target entirely, so writing it would be
+    // invisible and confusing. Report it instead.
+    if let Some(shadow) = &t.blocked_if_present {
+        if shadow.exists() {
+            return ApplyState::BlockedOverride;
+        }
+    }
+    // Hard client cap on the global rules file (Windsurf): don't write something it will drop.
+    if let Some(cap) = t.char_cap {
+        if content.chars().count() > cap {
+            return ApplyState::TooLong;
+        }
+    }
+    let desired = match t.strategy {
+        Strategy::OwnedFile => render_owned_file(team_id, version, content),
+        Strategy::SentinelBlock => {
+            let existing = match read_existing(&t.path) {
+                Ok(s) => s,
+                Err(_) => return ApplyState::Error,
+            };
+            if block_is_current(&existing, team_id, version, content) {
+                return ApplyState::Applied; // already up to date; skip the write
+            }
+            upsert_block(&existing, team_id, version, content)
+        }
+    };
+    match write_atomic(&t.path, &desired) {
+        Ok(()) => ApplyState::Applied,
+        Err(_) => ApplyState::Error,
+    }
+}
+
+/// Remove a previously-written managed artifact, identifying its kind by content so cleanup
+/// survives a client that was uninstalled or whose detection changed. An owned file (our header)
+/// is deleted whole; a shared file has only our sentinel block stripped, and is deleted if
+/// nothing but whitespace remains. A file that is neither (already cleaned, or user-replaced) is
+/// left untouched. Best-effort: unreadable/missing paths are a no-op.
+pub fn remove_recorded(path: &std::path::Path) {
+    let existing = match std::fs::read_to_string(path) {
+        Ok(s) => s,
+        Err(_) => return,
+    };
+    if existing.contains(SENTINEL_START_PREFIX) {
+        if let Some(stripped) = remove_block(&existing) {
+            if stripped.trim().is_empty() {
+                let _ = std::fs::remove_file(path);
+            } else {
+                let _ = write_atomic(path, &stripped);
+            }
+        }
+    } else if existing.starts_with(OWNED_HEADER_PREFIX) {
+        let _ = std::fs::remove_file(path);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const TEAM: &str = "team_abc";
+
+    #[test]
+    fn owned_file_has_header_and_content_and_trailing_newline() {
+        let f = render_owned_file(TEAM, 3, "Never commit secrets.");
+        assert!(f.starts_with("<!-- Managed by Toolport"));
+        assert!(f.contains("team team_abc, v3"));
+        assert!(f.contains("Never commit secrets."));
+        assert!(f.ends_with('\n'));
+        // Idempotent render.
+        assert_eq!(f, render_owned_file(TEAM, 3, "Never commit secrets.\n"));
+    }
+
+    #[test]
+    fn upsert_into_empty_file() {
+        let out = upsert_block("", TEAM, 1, "Rule one");
+        assert!(out.contains(SENTINEL_START_PREFIX));
+        assert!(out.contains("Rule one"));
+        assert!(out.trim_end().ends_with(SENTINEL_END));
+    }
+
+    #[test]
+    fn upsert_appends_and_preserves_user_bytes() {
+        let user = "# My personal rules\nAlways run tests.\n";
+        let out = upsert_block(user, TEAM, 1, "Org rule");
+        // Every user byte is preserved as a prefix.
+        assert!(out.starts_with(user), "user content must be byte-preserved");
+        assert!(out.contains("Org rule"));
+    }
+
+    #[test]
+    fn upsert_appends_when_user_file_lacks_trailing_newline() {
+        let user = "no trailing newline";
+        let out = upsert_block(user, TEAM, 1, "Org rule");
+        assert!(out.starts_with(user));
+        // Block sits on its own line after a blank separator.
+        assert!(out.contains("\n\n<!-- toolport:team-instructions:start"));
+    }
+
+    #[test]
+    fn upsert_replaces_in_place_leaving_outside_bytes_identical() {
+        let user_pre = "# Top\n\n";
+        let user_post = "\n# Bottom\n";
+        let v1 = format!("{user_pre}{}{user_post}", render_block(TEAM, 1, "old"));
+        let v2 = upsert_block(&v1, TEAM, 2, "new");
+        // Text outside the managed block is byte-for-byte unchanged.
+        assert!(v2.starts_with(user_pre), "prefix must be untouched");
+        assert!(v2.ends_with(user_post), "suffix must be untouched");
+        assert!(v2.contains("new") && !v2.contains(">old<"));
+        assert!(v2.contains("v=2"));
+    }
+
+    #[test]
+    fn upsert_is_idempotent() {
+        let user = "# Rules\nkeep me\n";
+        let once = upsert_block(user, TEAM, 5, "org content");
+        let twice = upsert_block(&once, TEAM, 5, "org content");
+        assert_eq!(once, twice, "re-applying the same version is a no-op");
+    }
+
+    #[test]
+    fn remove_after_append_restores_user_content() {
+        // Full join -> apply -> leave cycle: the user's content comes back, normalized only by
+        // a guaranteed trailing newline (see `remove_block` docs). Files that already end in a
+        // newline round-trip byte-for-byte.
+        for user in [
+            "# My personal rules\nAlways run tests.\n",
+            "single line, no newline",
+            "trailing spaces   \nand more\n",
+            "",
+        ] {
+            let with = upsert_block(user, TEAM, 1, "Org rule");
+            let back = remove_block(&with).expect("a block was inserted");
+            let normalized = if user.is_empty() || user.ends_with('\n') {
+                user.to_string()
+            } else {
+                format!("{user}\n")
+            };
+            assert_eq!(back, normalized, "full cycle must restore user content for {user:?}");
+        }
+    }
+
+    #[test]
+    fn remove_returns_none_without_a_block() {
+        assert_eq!(remove_block("# just user rules\n"), None);
+    }
+
+    #[test]
+    fn remove_in_place_block_leaves_surrounding_text() {
+        let user_pre = "# Top\ntext\n\n";
+        let user_post = "\n# Bottom\nmore\n";
+        let full = format!("{user_pre}{}{user_post}", render_block(TEAM, 1, "org"));
+        let back = remove_block(&full).expect("block present");
+        assert!(!back.contains(SENTINEL_START_PREFIX));
+        assert!(!back.contains(SENTINEL_END));
+        assert!(back.contains("# Top"));
+        assert!(back.contains("# Bottom"));
+    }
+
+    #[test]
+    fn block_is_current_detects_matching_and_stale() {
+        let f = upsert_block("user\n", TEAM, 7, "content");
+        assert!(block_is_current(&f, TEAM, 7, "content"));
+        assert!(!block_is_current(&f, TEAM, 8, "content"), "version change");
+        assert!(!block_is_current(&f, TEAM, 7, "different"), "content change");
+        assert!(!block_is_current("user\n", TEAM, 7, "content"), "no block");
+    }
+
+    #[test]
+    fn content_hash_is_stable_and_distinguishes() {
+        assert_eq!(content_hash("abc"), content_hash("abc"));
+        assert_ne!(content_hash("abc"), content_hash("abd"));
+    }
+
+    #[test]
+    fn upsert_survives_content_with_marker_lookalikes() {
+        // User text that mentions the marker words must not confuse find/replace.
+        let user = "I documented the toolport:team-instructions format once.\n";
+        let out = upsert_block(user, TEAM, 1, "real org rule");
+        assert!(out.starts_with(user));
+        let back = remove_block(&out).expect("block present");
+        assert_eq!(back, user);
+    }
+
+    // ---- filesystem-level apply/remove ----
+
+    use std::path::PathBuf;
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    /// A unique scratch dir per test (no `tempfile` dep needed); best-effort cleanup on drop.
+    struct Scratch(PathBuf);
+    impl Scratch {
+        fn new() -> Self {
+            static N: AtomicU32 = AtomicU32::new(0);
+            let dir = std::env::temp_dir().join(format!(
+                "toolport-instr-{}-{}",
+                std::process::id(),
+                N.fetch_add(1, Ordering::Relaxed)
+            ));
+            std::fs::create_dir_all(&dir).unwrap();
+            Scratch(dir)
+        }
+        fn path(&self, name: &str) -> PathBuf {
+            self.0.join(name)
+        }
+    }
+    impl Drop for Scratch {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
+
+    fn owned_target(path: PathBuf) -> Target {
+        Target { path, strategy: Strategy::OwnedFile, char_cap: None, blocked_if_present: None }
+    }
+    fn block_target(path: PathBuf) -> Target {
+        Target { path, strategy: Strategy::SentinelBlock, char_cap: None, blocked_if_present: None }
+    }
+
+    #[test]
+    fn owned_file_apply_creates_then_remove_deletes() {
+        let s = Scratch::new();
+        // Parent dirs are created on demand.
+        let t = owned_target(s.path("rules").join("toolport-team-rules.md"));
+        assert_eq!(write_target(&t, TEAM, 2, "Org rule"), ApplyState::Applied);
+        let on_disk = std::fs::read_to_string(&t.path).unwrap();
+        assert!(on_disk.starts_with(OWNED_HEADER_PREFIX));
+        assert!(on_disk.contains("Org rule"));
+        remove_recorded(&t.path);
+        assert!(!t.path.exists(), "owned file should be deleted on leave");
+    }
+
+    #[test]
+    fn sentinel_apply_preserves_user_file_and_remove_restores_it() {
+        let s = Scratch::new();
+        let path = s.path("AGENTS.md");
+        let user = "# My rules\nAlways run tests.\n";
+        std::fs::write(&path, user).unwrap();
+        let t = block_target(path.clone());
+        assert_eq!(write_target(&t, TEAM, 1, "Org rule"), ApplyState::Applied);
+        let after = std::fs::read_to_string(&path).unwrap();
+        assert!(after.starts_with(user), "user bytes preserved");
+        assert!(after.contains("Org rule"));
+        // Idempotent re-apply doesn't churn the file.
+        assert_eq!(write_target(&t, TEAM, 1, "Org rule"), ApplyState::Applied);
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), after);
+        // Leaving strips only our block; the user's file survives with their content.
+        remove_recorded(&path);
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), user);
+    }
+
+    #[test]
+    fn sentinel_into_absent_file_then_remove_deletes_empty_file() {
+        let s = Scratch::new();
+        let path = s.path("GEMINI.md"); // does not exist yet
+        let t = block_target(path.clone());
+        assert_eq!(write_target(&t, TEAM, 1, "Only org content"), ApplyState::Applied);
+        assert!(path.exists());
+        // The whole file was ours -> stripping the block leaves nothing -> delete.
+        remove_recorded(&path);
+        assert!(!path.exists(), "a file that held only our block should be removed");
+    }
+
+    #[test]
+    fn blocked_override_skips_write() {
+        let s = Scratch::new();
+        let shadow = s.path("AGENTS.override.md");
+        std::fs::write(&shadow, "user opt-out").unwrap();
+        let target_path = s.path("AGENTS.md");
+        let t = Target {
+            path: target_path.clone(),
+            strategy: Strategy::SentinelBlock,
+            char_cap: None,
+            blocked_if_present: Some(shadow),
+        };
+        assert_eq!(write_target(&t, TEAM, 1, "Org rule"), ApplyState::BlockedOverride);
+        assert!(!target_path.exists(), "must not write when shadowed");
+    }
+
+    #[test]
+    fn too_long_content_skips_write() {
+        let s = Scratch::new();
+        let path = s.path("global_rules.md");
+        let t = Target {
+            path: path.clone(),
+            strategy: Strategy::SentinelBlock,
+            char_cap: Some(10),
+            blocked_if_present: None,
+        };
+        assert_eq!(write_target(&t, TEAM, 1, "way over the tiny cap"), ApplyState::TooLong);
+        assert!(!path.exists());
+    }
+
+    #[test]
+    fn remove_recorded_leaves_a_foreign_file_untouched() {
+        let s = Scratch::new();
+        let path = s.path("someones.md");
+        let foreign = "# not ours\njust user content\n";
+        std::fs::write(&path, foreign).unwrap();
+        remove_recorded(&path);
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), foreign);
+    }
+}

--- a/src-tauri/src/instructions.rs
+++ b/src-tauri/src/instructions.rs
@@ -214,11 +214,12 @@ pub fn write_target(t: &Target, team_id: &str, version: i64, content: &str) -> A
             return ApplyState::BlockedOverride;
         }
     }
-    // Hard client cap on the global rules file (Windsurf): don't write something it will drop.
-    if let Some(cap) = t.char_cap {
-        if content.chars().count() > cap {
-            return ApplyState::TooLong;
-        }
+    // Org content that contains our own frozen markers would corrupt everything downstream: an
+    // embedded END would fool `find_block` into terminating the managed span early, and an
+    // embedded START would make `remove_recorded` misclassify an owned file as a sentinel one.
+    // Refuse rather than write something we can't later find and cleanly remove.
+    if content.contains(SENTINEL_START_PREFIX) || content.contains(SENTINEL_END) {
+        return ApplyState::Error;
     }
     let desired = match t.strategy {
         Strategy::OwnedFile => render_owned_file(team_id, version, content),
@@ -233,6 +234,14 @@ pub fn write_target(t: &Target, team_id: &str, version: i64, content: &str) -> A
             upsert_block(&existing, team_id, version, content)
         }
     };
+    // Hard client cap (Windsurf) applies to the WHOLE global-rules file we're about to write —
+    // the member's existing rules plus our block and markers — not just the org content. Check
+    // the fully rendered result so we never write a file the client will silently truncate.
+    if let Some(cap) = t.char_cap {
+        if desired.chars().count() > cap {
+            return ApplyState::TooLong;
+        }
+    }
     match write_atomic(&t.path, &desired) {
         Ok(()) => ApplyState::Applied,
         Err(_) => ApplyState::Error,
@@ -497,6 +506,43 @@ mod tests {
         };
         assert_eq!(write_target(&t, TEAM, 1, "way over the tiny cap"), ApplyState::TooLong);
         assert!(!path.exists());
+    }
+
+    #[test]
+    fn content_carrying_our_markers_is_refused() {
+        let s = Scratch::new();
+        // A START marker in owned content would make cleanup misclassify the file; an END marker
+        // in sentinel content would truncate the block. Both must be refused, nothing written.
+        let owned = owned_target(s.path("owned.md"));
+        assert_eq!(
+            write_target(&owned, TEAM, 1, &format!("evil {SENTINEL_START_PREFIX} x -->")),
+            ApplyState::Error
+        );
+        assert!(!owned.path.exists());
+        let block = block_target(s.path("block.md"));
+        assert_eq!(
+            write_target(&block, TEAM, 1, &format!("evil {SENTINEL_END} tail")),
+            ApplyState::Error
+        );
+        assert!(!block.path.exists());
+    }
+
+    #[test]
+    fn cap_counts_the_whole_rendered_file_not_just_content() {
+        let s = Scratch::new();
+        let path = s.path("global_rules.md");
+        // Pre-existing user rules already near the cap; a small org block tips the FILE over even
+        // though the org content alone is tiny.
+        std::fs::write(&path, "x".repeat(40)).unwrap();
+        let t = Target {
+            path: path.clone(),
+            strategy: Strategy::SentinelBlock,
+            char_cap: Some(50),
+            blocked_if_present: None,
+        };
+        assert_eq!(write_target(&t, TEAM, 1, "tiny"), ApplyState::TooLong);
+        // The user's file must be left exactly as it was.
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), "x".repeat(40));
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -10,6 +10,7 @@ pub mod codemode;
 pub mod downstream;
 pub mod gateway_publish;
 pub mod inspect;
+pub mod instructions;
 pub mod integrity;
 pub mod oauth;
 pub mod registry;

--- a/src-tauri/src/registry.rs
+++ b/src-tauri/src/registry.rs
@@ -452,6 +452,17 @@ pub struct TeamConnection {
     /// the report window (today + yesterday) on every successful report.
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub usage_reported: HashMap<String, HashMap<String, [u64; 2]>>,
+    /// Hash of the org instructions content last written to disk (see [`crate::instructions`]).
+    /// A sync whose pulled content hashes to this value skips the client-file writes entirely,
+    /// so the ~25s sync loop only touches rules files when the org content actually changed.
+    /// `None` = nothing written yet (or the config carries no instructions).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub team_instructions_hash: Option<String>,
+    /// Absolute paths of the client rules files this member's app actually wrote. Cleanup on
+    /// team-leave iterates THIS recorded list rather than re-resolving clients, so a file
+    /// survives cleanup even if the client was later uninstalled or its detection changed.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub team_instructions_targets: Vec<String>,
 }
 
 /// Settings for embedding-based search re-ranking. The embedding API key, if the

--- a/src-tauri/src/teams.rs
+++ b/src-tauri/src/teams.rs
@@ -521,12 +521,19 @@ fn finish_connect(server_url: &str, member_name: Option<&str>, joined: Joined) -
         last_version: 0,
         last_etag: None,
         usage_reported: HashMap::new(),
+        team_instructions_hash: None,
+        team_instructions_targets: Vec::new(),
     };
     // Pull BEFORE loading the registry, then load a FRESH copy AFTER the (possibly
     // multi-second) network round trip and apply onto that — mirroring `sync_inner`.
     // Loading first and saving here would clobber any change another command made to the
     // registry while we were waiting on the join window's pull.
     let pulled = pull_config(&base(server_url), &joined.team_id, &joined.member_token, 0, None, 0)?;
+    // Capture the org instructions before the closure consumes `pulled`; applied to disk after
+    // the save (outside the lock).
+    let desired_instr = pulled
+        .as_ref()
+        .map(|(version, cfg, _)| (*version, desired_instructions(cfg)));
     // Load-modify-save the fresh registry under the cross-process lock, so a concurrent write
     // during the join window's pull isn't reverted (SOU-23).
     let (reg, outcome) = crate::registry::update(|reg| {
@@ -541,6 +548,9 @@ fn finish_connect(server_url: &str, member_name: Option<&str>, joined: Joined) -
         }
         Ok(outcome)
     })?;
+    if let Some((version, desired)) = desired_instr {
+        apply_instructions(&joined.team_id, version, desired.as_deref());
+    }
     let conn = reg.team.clone().ok_or_else(|| "team connection lost after save".to_string())?;
     Ok((conn, outcome))
 }
@@ -607,6 +617,11 @@ fn sync_inner(wait_secs: u64) -> Result<SyncResult, String> {
         wait_secs,
     )?;
 
+    // Capture the org instructions before the closure consumes `pulled`; applied to disk after
+    // the save (outside the lock). `None` on a 304 (config unchanged) — nothing to reconcile.
+    let desired_instr = pulled
+        .as_ref()
+        .map(|(version, cfg, _)| (*version, desired_instructions(cfg)));
     // Re-load a FRESH registry now, AFTER the (possibly multi-second) network round
     // trips, and apply the deltas to it. Loading at the top and saving here would clobber
     // any change another command made to the registry while we were on the network.
@@ -643,6 +658,11 @@ fn sync_inner(wait_secs: u64) -> Result<SyncResult, String> {
         None => return Ok(SyncResult::Ok { role, role_changed, applied: None }),
         Some(applied) => applied,
     };
+    // Write/refresh the org instructions to each installed client's rules file (skips unless the
+    // content actually changed). Outside the lock, best-effort, never fails the sync.
+    if let Some((version, desired)) = desired_instr {
+        apply_instructions(&conn.team_id, version, desired.as_deref());
+    }
     // Best-effort showback after the config work: report today's/yesterday's per-server
     // usage rollup to the team server. Any failure here must never affect the sync
     // result — the member's config is already applied and saved.
@@ -763,8 +783,93 @@ fn report_usage(conn: &TeamConnection, token: &str) {
     });
 }
 
+/// The org instructions the pulled config wants applied: the `content` string when the block
+/// is present, enabled, and non-empty; `None` (meaning "remove any managed files") when the key
+/// is absent, disabled, or blank. A Free/lapsed team never receives the key (the server
+/// soft-drops it), so those members degrade to clean removal here automatically.
+fn desired_instructions(cfg: &serde_json::Value) -> Option<String> {
+    let i = cfg.get("instructions")?;
+    let enabled = i.get("enabled").and_then(|v| v.as_bool()).unwrap_or(true);
+    let content = i.get("content").and_then(|v| v.as_str()).unwrap_or("");
+    (enabled && !content.trim().is_empty()).then(|| content.to_string())
+}
+
+/// Write (or remove) the org Team Instructions across every installed client's rules file after
+/// a config change (spec "W2"). Best-effort and run OUTSIDE the registry lock — a failure here
+/// must never affect the already-applied, already-saved server config. Skips entirely when the
+/// org content is unchanged since the last write (hash match), so the ~25s sync loop only ever
+/// touches rules files when an admin actually edits the instructions.
+fn apply_instructions(team_id: &str, version: i64, desired: Option<&str>) {
+    use crate::instructions::{self, ApplyState};
+    // Prior state: only act if still connected to THIS team.
+    let (prev_hash, prev_targets) = match crate::registry::load() {
+        Ok(reg) => match reg.team.as_ref() {
+            Some(t) if t.team_id == team_id => (
+                t.team_instructions_hash.clone(),
+                t.team_instructions_targets.clone(),
+            ),
+            _ => return,
+        },
+        Err(_) => return,
+    };
+    let new_hash = desired.map(instructions::content_hash);
+    if new_hash == prev_hash {
+        return; // unchanged — nothing to write or clean up
+    }
+
+    let mut written: Vec<String> = Vec::new();
+    if let Some(content) = desired {
+        let mut seen_paths = std::collections::HashSet::new();
+        for client in crate::clients::detect_clients() {
+            // Only write into clients that are actually installed, so we never scatter rules
+            // files into an absent client's home.
+            if !client.app_present {
+                continue;
+            }
+            let Some(target) = crate::clients::client_rules_target(&client.id) else {
+                continue; // unsupported or covered transitively (Antigravity/Copilot)
+            };
+            let key = target.path.to_string_lossy().to_string();
+            if !seen_paths.insert(key.clone()) {
+                continue; // a shared file (e.g. Gemini/Antigravity) already handled this round
+            }
+            if instructions::write_target(&target, team_id, version, content) == ApplyState::Applied
+            {
+                written.push(key);
+            }
+        }
+    }
+    // Remove any file we wrote before but did NOT (re)write now: instructions were removed or
+    // disabled, a client was uninstalled, or a target path changed. Iterating the RECORDED list
+    // (not a fresh client scan) means cleanup survives a client that has since disappeared.
+    for old in &prev_targets {
+        if !written.iter().any(|w| w == old) {
+            instructions::remove_recorded(std::path::Path::new(old));
+        }
+    }
+
+    // Persist the new hash + written set so the next sync can skip and `disconnect` can clean up.
+    let _ = crate::registry::update(|reg| {
+        if let Some(t) = reg.team.as_mut() {
+            if t.team_id == team_id {
+                t.team_instructions_hash = new_hash.clone();
+                t.team_instructions_targets = written.clone();
+            }
+        }
+        Ok(())
+    });
+}
+
 /// Leave the team: remove its merged servers, clear the connection and the token.
 pub fn disconnect() -> Result<(), String> {
+    // Capture the recorded instructions files before clearing the connection, so we can delete
+    // them AFTER the registry lock releases (FS side-effects on external client files don't
+    // belong inside the lock — same discipline as the writer and `report_usage`).
+    let instr_targets = crate::registry::load()
+        .ok()
+        .and_then(|r| r.team)
+        .map(|t| t.team_instructions_targets)
+        .unwrap_or_default();
     crate::registry::update(|reg| {
         if let Some(conn) = reg.team.clone() {
             remove_team(reg, &conn.team_id);
@@ -772,6 +877,9 @@ pub fn disconnect() -> Result<(), String> {
         reg.team = None;
         Ok(())
     })?;
+    for path in &instr_targets {
+        crate::instructions::remove_recorded(std::path::Path::new(path));
+    }
     let _ = clear_token();
     Ok(())
 }
@@ -1145,6 +1253,27 @@ pub fn remove_team(reg: &mut Registry, team_id: &str) {
 mod tests {
     use super::*;
     use serde_json::json;
+
+    #[test]
+    fn desired_instructions_reads_enabled_nonempty_content() {
+        let cfg = json!({ "instructions": { "enabled": true, "content": "Rule one" } });
+        assert_eq!(desired_instructions(&cfg).as_deref(), Some("Rule one"));
+        // `enabled` defaults to true when omitted.
+        let cfg = json!({ "instructions": { "content": "Implied on" } });
+        assert_eq!(desired_instructions(&cfg).as_deref(), Some("Implied on"));
+    }
+
+    #[test]
+    fn desired_instructions_treats_disabled_blank_or_absent_as_removal() {
+        for cfg in [
+            json!({ "instructions": { "enabled": false, "content": "hidden" } }),
+            json!({ "instructions": { "enabled": true, "content": "   \n  " } }),
+            json!({ "instructions": { "enabled": true } }),
+            json!({ "servers": [] }), // key absent (e.g. Free/lapsed team, soft-dropped)
+        ] {
+            assert_eq!(desired_instructions(&cfg), None, "should mean removal: {cfg}");
+        }
+    }
 
     #[test]
     fn merge_reported_takes_the_max_per_counter() {

--- a/src-tauri/src/teams.rs
+++ b/src-tauri/src/teams.rs
@@ -849,15 +849,24 @@ fn apply_instructions(team_id: &str, version: i64, desired: Option<&str>) {
     }
 
     // Persist the new hash + written set so the next sync can skip and `disconnect` can clean up.
-    let _ = crate::registry::update(|reg| {
+    // The compare-and-set returns false if the team changed or was cleared while we were writing
+    // (a race with `disconnect`/team-switch): in that case our just-written files have no record
+    // to clean them by, so roll them back here rather than orphan them on disk.
+    let recorded = crate::registry::update(|reg| {
         if let Some(t) = reg.team.as_mut() {
             if t.team_id == team_id {
                 t.team_instructions_hash = new_hash.clone();
                 t.team_instructions_targets = written.clone();
+                return Ok(true);
             }
         }
-        Ok(())
+        Ok(false)
     });
+    if !matches!(recorded, Ok((_, true))) {
+        for path in &written {
+            instructions::remove_recorded(std::path::Path::new(path));
+        }
+    }
 }
 
 /// Leave the team: remove its merged servers, clear the connection and the token.


### PR DESCRIPTION
## What

Implements the **client writer** for Team Instructions (SOU-135, spec `docs/specs/team-instructions.md` "W2"). The server already accepts/stores/tier-gates a team `instructions` block (W1) and the dashboard editor exists (W3) — both behind `TEAMS_INSTRUCTIONS=1` — but nothing on the desktop side consumed it. Now, on config sync, the app writes the org rules into each installed AI client's global rules file, **next to — never over —** the member's own instructions, and removes them cleanly when the member leaves the team.

**Ships dark:** inert until a team config actually carries `instructions`, so this can merge and ride the next release train without turning anything on. W4 (member-facing status UI) and W5 (apply-status receipts → dashboard coverage) are the follow-up passes.

## How

**`src-tauri/src/instructions.rs`** (new) — the correctness-critical core, front-loaded and heavily tested:
- Two non-destructive strategies. `OwnedFile` owns a whole file in a rules *directory*; `SentinelBlock` owns only the span between frozen `<!-- toolport:team-instructions:start … -->` / `…:end -->` markers in a shared file.
- `upsert_block` changes **only** the managed span or appends one — property-tested byte-identical outside the markers, idempotent on re-sync, and safe against user text that mentions the marker words.
- `remove_block` restores the user's content on leave. One property test surfaced a genuine ambiguity — a file with no trailing newline can't round-trip bit-exact because putting the block on its own line requires a newline indistinguishable from a user's — so the honest contract is "content preserved up to a trailing newline," documented and tested. Newline-terminated files round-trip exactly.
- Atomic writes via the registry's hardened primitive; unreadable shared files are skipped, never clobbered. `content_hash` (the "effective rules receipt") and the `ApplyState` model for W4/W5.

**`src-tauri/src/clients.rs`** — a rules-file resolver *distinct from* the MCP-config path (Claude Code's config is `~/.claude.json` but its rules live under `~/.claude/rules/`). MVP adapters: Claude Code / Kiro / Roo / Cline (owned file), Codex / Gemini / Windsurf / Goose / Pi / Zed (sentinel), with Codex `AGENTS.override.md` shadow detection and Windsurf's 6,000-char cap. Antigravity + VS Code Copilot are covered transitively; Cursor/Warp are unsupported (UI/cloud-stored globals).

**`src-tauri/src/teams.rs`** — applied after the registry save at **both** sync sites (join + steady-state), **outside** the lock, best-effort (never fails a sync); skipped unless the org-content hash changed. `TeamConnection` records the hash + written paths so cleanup on leave iterates the recorded list and survives an uninstalled client.

### Design corrections vs the spec
- The write hook is *after* `registry::update()` returns (two call sites), not "after `apply_team_config` saves" — that fn is pure/in-memory and the save happens in the caller, so the disk write runs post-lock like `report_usage`.
- Registry state lives on `TeamConnection` (cleared naturally on disconnect), not as top-level fields.

## Tradeoffs / scope
- Only writes into **installed** clients (`app_present`) so we never scatter files into an absent client's home.
- v1 is a single `content` field (no per-group/per-concern blocks yet — P2). No member-facing status UI yet (W4).

## Verification
- 25 new tests (write strategies incl. FS-level temp-file round-trips, per-OS resolver table, config parser). Full suite green: **425 lib + 122 bin**. `cargo build` + `clippy` clean.
- Manual E2E (join → files appear → edit → ~1s update → leave → artifacts gone, user bytes intact) will run before the `TEAMS_INSTRUCTIONS` flag is enabled in prod, per the spec's gating.