### PR TITLE
feat(teams): Team Instructions apply-status receipts — W5 client (SOU-135)

### DIFF
--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -7074,8 +7074,10 @@ mod tests {
             last_version: 42,
             last_etag: Some("\"v42\"".into()),
             usage_reported: usage,
-            team_instructions_hash: None,
+            team_instructions_content: None,
+            team_instructions_version: 0,
             team_instructions_targets: Vec::new(),
+            team_instructions_reported: None,
         });
         assert_eq!(
             router_relevant(&reg),

--- a/src-tauri/src/instructions.rs
+++ b/src-tauri/src/instructions.rs
@@ -46,12 +46,12 @@ pub struct Target {
     pub blocked_if_present: Option<std::path::PathBuf>,
 }
 
-/// The per-client outcome of applying (or skipping) the org instructions. Reported to the
+/// The per-client outcome of applying (or checking) the org instructions. Reported to the
 /// dashboard (spec W5) so an admin can prove which client actually loaded the current rules.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ApplyState {
-    /// Written to disk (or already present and identical).
+    /// The current org content is present on disk for this client.
     Applied,
     /// This client has no supported global-rules location; nothing written.
     Unsupported,
@@ -59,8 +59,30 @@ pub enum ApplyState {
     BlockedOverride,
     /// Content exceeds the client's hard cap and can't be trimmed safely; not written.
     TooLong,
-    /// A filesystem/parse error prevented a safe write; the file was left untouched.
+    /// A filesystem/parse error prevented a safe read/write; the file was left untouched.
     Error,
+    /// The client is installed but the current org content is NOT (yet) on disk — never
+    /// written, drifted, or hand-edited. Distinct from `Applied` so the coverage panel shows a
+    /// truthful "not covered" for a client added after the last write (see [`current_state`]).
+    Stale,
+}
+
+/// One client's reported state, for the apply-status receipt (spec W5).
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct ClientReceipt {
+    pub id: String,
+    pub state: ApplyState,
+}
+
+/// The "effective rules receipt" a member reports so the dashboard can prove per-client
+/// coverage: which version+content the member is on, and each installed client's state.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Receipt {
+    pub version: i64,
+    /// Hash of the org content this receipt is about — proves on-disk == pushed content.
+    pub content_hash: String,
+    pub clients: Vec<ClientReceipt>,
 }
 
 /// Sentinel markers. FROZEN compatibility contract — an older build must still recognize and
@@ -245,6 +267,46 @@ pub fn write_target(t: &Target, team_id: &str, version: i64, content: &str) -> A
     match write_atomic(&t.path, &desired) {
         Ok(()) => ApplyState::Applied,
         Err(_) => ApplyState::Error,
+    }
+}
+
+/// Read-only: what state IS this client's rules file in right now, relative to the current org
+/// `content`+`version`? Used to build the coverage receipt (spec W5) every report cycle, so the
+/// dashboard reflects reality — a client installed after the last write reports `Stale`, a
+/// deleted/hand-edited block reports `Stale`, a shadowed Codex reports `BlockedOverride`, etc.
+/// Never writes.
+pub fn current_state(t: &Target, team_id: &str, version: i64, content: &str) -> ApplyState {
+    if let Some(shadow) = &t.blocked_if_present {
+        if shadow.exists() {
+            return ApplyState::BlockedOverride;
+        }
+    }
+    if content.contains(SENTINEL_START_PREFIX) || content.contains(SENTINEL_END) {
+        return ApplyState::Error;
+    }
+    let existing = match read_existing(&t.path) {
+        Ok(s) => s,
+        Err(_) => return ApplyState::Error,
+    };
+    let (is_current, rendered_len) = match t.strategy {
+        Strategy::OwnedFile => {
+            let desired = render_owned_file(team_id, version, content);
+            (existing == desired, desired.chars().count())
+        }
+        Strategy::SentinelBlock => (
+            block_is_current(&existing, team_id, version, content),
+            upsert_block(&existing, team_id, version, content).chars().count(),
+        ),
+    };
+    if let Some(cap) = t.char_cap {
+        if rendered_len > cap {
+            return ApplyState::TooLong;
+        }
+    }
+    if is_current {
+        ApplyState::Applied
+    } else {
+        ApplyState::Stale
     }
 }
 
@@ -543,6 +605,53 @@ mod tests {
         assert_eq!(write_target(&t, TEAM, 1, "tiny"), ApplyState::TooLong);
         // The user's file must be left exactly as it was.
         assert_eq!(std::fs::read_to_string(&path).unwrap(), "x".repeat(40));
+    }
+
+    #[test]
+    fn current_state_reports_applied_stale_and_blocked() {
+        let s = Scratch::new();
+        // Owned file: absent -> Stale; after write -> Applied; hand-edited -> Stale.
+        let owned = owned_target(s.path("rules.md"));
+        assert_eq!(current_state(&owned, TEAM, 1, "c"), ApplyState::Stale);
+        write_target(&owned, TEAM, 1, "c");
+        assert_eq!(current_state(&owned, TEAM, 1, "c"), ApplyState::Applied);
+        // A newer version the writer hasn't applied yet reads as Stale.
+        assert_eq!(current_state(&owned, TEAM, 2, "c"), ApplyState::Stale);
+        std::fs::write(&owned.path, "user clobbered it").unwrap();
+        assert_eq!(current_state(&owned, TEAM, 1, "c"), ApplyState::Stale);
+
+        // Sentinel block in a shared file.
+        let path = s.path("AGENTS.md");
+        std::fs::write(&path, "# user\n").unwrap();
+        let block = block_target(path.clone());
+        assert_eq!(current_state(&block, TEAM, 1, "c"), ApplyState::Stale);
+        write_target(&block, TEAM, 1, "c");
+        assert_eq!(current_state(&block, TEAM, 1, "c"), ApplyState::Applied);
+
+        // Codex-style shadow file -> BlockedOverride regardless of the target's contents.
+        let shadow = s.path("AGENTS.override.md");
+        std::fs::write(&shadow, "opt out").unwrap();
+        let shadowed = Target {
+            path: s.path("codex-AGENTS.md"),
+            strategy: Strategy::SentinelBlock,
+            char_cap: None,
+            blocked_if_present: Some(shadow),
+        };
+        assert_eq!(current_state(&shadowed, TEAM, 1, "c"), ApplyState::BlockedOverride);
+    }
+
+    #[test]
+    fn current_state_reports_too_long() {
+        let s = Scratch::new();
+        let path = s.path("global_rules.md");
+        std::fs::write(&path, "x".repeat(40)).unwrap();
+        let t = Target {
+            path,
+            strategy: Strategy::SentinelBlock,
+            char_cap: Some(50),
+            blocked_if_present: None,
+        };
+        assert_eq!(current_state(&t, TEAM, 1, "tiny"), ApplyState::TooLong);
     }
 
     #[test]

--- a/src-tauri/src/registry.rs
+++ b/src-tauri/src/registry.rs
@@ -452,17 +452,26 @@ pub struct TeamConnection {
     /// the report window (today + yesterday) on every successful report.
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub usage_reported: HashMap<String, HashMap<String, [u64; 2]>>,
-    /// Hash of the org instructions content last written to disk (see [`crate::instructions`]).
-    /// A sync whose pulled content hashes to this value skips the client-file writes entirely,
-    /// so the ~25s sync loop only touches rules files when the org content actually changed.
-    /// `None` = nothing written yet (or the config carries no instructions).
+    /// The org instructions content last applied to disk (see [`crate::instructions`]). Persisted
+    /// so a steady-state sync (a 304, with no config in hand) can still recompute each client's
+    /// coverage for the apply-status receipt, and so the writer skips the client-file writes when
+    /// the content is unchanged. `None` = no instructions active (absent/disabled/blank).
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub team_instructions_hash: Option<String>,
+    pub team_instructions_content: Option<String>,
+    /// The config version at which `team_instructions_content` was last written — the version the
+    /// on-disk block markers carry, and the one the coverage receipt reports. Advances only when
+    /// the content changes, so a server-only config edit doesn't make the marker look stale.
+    #[serde(default)]
+    pub team_instructions_version: i64,
     /// Absolute paths of the client rules files this member's app actually wrote. Cleanup on
     /// team-leave iterates THIS recorded list rather than re-resolving clients, so a file
     /// survives cleanup even if the client was later uninstalled or its detection changed.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub team_instructions_targets: Vec<String>,
+    /// Hash of the apply-status receipt last successfully sent to the server, so an unchanged
+    /// receipt isn't re-POSTed every ~25s sync. `None` = nothing reported yet.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub team_instructions_reported: Option<String>,
 }
 
 /// Settings for embedding-based search re-ranking. The embedding API key, if the

--- a/src-tauri/src/teams.rs
+++ b/src-tauri/src/teams.rs
@@ -453,13 +453,20 @@ fn post_usage_day(
     token: &str,
     day: &str,
     rows: Vec<Value>,
+    instructions_status: Option<&Value>,
 ) -> Result<bool, String> {
     require_secure_team_url(server_url)?;
     let url = format!("{}/teams/{}/usage", base(server_url), team_id);
+    let mut body = json!({ "day": day, "rows": rows });
+    // The apply-status receipt rides the usage POST (spec W5). An older server ignores the extra
+    // key; a client without instructions omits it entirely.
+    if let Some(status) = instructions_status {
+        body["instructionsStatus"] = status.clone();
+    }
     match agent()
         .post(&url)
         .set("authorization", &format!("Bearer {token}"))
-        .send_json(json!({ "day": day, "rows": rows }))
+        .send_json(body)
     {
         Ok(_) => Ok(true),
         Err(ureq::Error::Status(404 | 405, _)) => Ok(false),
@@ -521,8 +528,10 @@ fn finish_connect(server_url: &str, member_name: Option<&str>, joined: Joined) -
         last_version: 0,
         last_etag: None,
         usage_reported: HashMap::new(),
-        team_instructions_hash: None,
+        team_instructions_content: None,
+        team_instructions_version: 0,
         team_instructions_targets: Vec::new(),
+        team_instructions_reported: None,
     };
     // Pull BEFORE loading the registry, then load a FRESH copy AFTER the (possibly
     // multi-second) network round trip and apply onto that — mirroring `sync_inner`.
@@ -667,6 +676,10 @@ fn sync_inner(wait_secs: u64) -> Result<SyncResult, String> {
     // usage rollup to the team server. Any failure here must never affect the sync
     // result — the member's config is already applied and saved.
     report_usage(&conn, &token);
+    // Report each installed client's instructions coverage (spec W5), every cycle, deduped so an
+    // unchanged receipt isn't re-sent. Independent of the config change above, so a client
+    // installed after the last edit is reflected as soon as it appears.
+    report_instructions_status(&conn, &token);
     Ok(SyncResult::Ok {
         role,
         role_changed,
@@ -750,7 +763,7 @@ fn report_usage(conn: &TeamConnection, token: &str) {
                 })
             })
             .collect();
-        match post_usage_day(&conn.server_url, &conn.team_id, token, &day, rows) {
+        match post_usage_day(&conn.server_url, &conn.team_id, token, &day, rows, None) {
             Ok(true) => {
                 new_state.insert(day, merged);
                 changed = true;
@@ -802,19 +815,19 @@ fn desired_instructions(cfg: &serde_json::Value) -> Option<String> {
 fn apply_instructions(team_id: &str, version: i64, desired: Option<&str>) {
     use crate::instructions::{self, ApplyState};
     // Prior state: only act if still connected to THIS team.
-    let (prev_hash, prev_targets) = match crate::registry::load() {
+    let (prev_content, prev_targets) = match crate::registry::load() {
         Ok(reg) => match reg.team.as_ref() {
             Some(t) if t.team_id == team_id => (
-                t.team_instructions_hash.clone(),
+                t.team_instructions_content.clone(),
                 t.team_instructions_targets.clone(),
             ),
             _ => return,
         },
         Err(_) => return,
     };
-    let new_hash = desired.map(instructions::content_hash);
-    if new_hash == prev_hash {
-        return; // unchanged — nothing to write or clean up
+    if desired == prev_content.as_deref() {
+        return; // content unchanged — nothing to write or clean up (coverage is re-checked and
+                // reported every cycle by `report_instructions_status`, independent of this)
     }
 
     let mut written: Vec<String> = Vec::new();
@@ -848,14 +861,17 @@ fn apply_instructions(team_id: &str, version: i64, desired: Option<&str>) {
         }
     }
 
-    // Persist the new hash + written set so the next sync can skip and `disconnect` can clean up.
-    // The compare-and-set returns false if the team changed or was cleared while we were writing
-    // (a race with `disconnect`/team-switch): in that case our just-written files have no record
-    // to clean them by, so roll them back here rather than orphan them on disk.
+    // Persist the content+version we just applied and the written set, so a steady-state cycle can
+    // recompute coverage and `disconnect` can clean up. The compare-and-set returns false if the
+    // team changed/cleared while we were writing (a race with `disconnect`/team-switch): our
+    // just-written files then have no record to clean them by, so roll them back rather than
+    // orphan them.
+    let new_content = desired.map(str::to_string);
     let recorded = crate::registry::update(|reg| {
         if let Some(t) = reg.team.as_mut() {
             if t.team_id == team_id {
-                t.team_instructions_hash = new_hash.clone();
+                t.team_instructions_content = new_content.clone();
+                t.team_instructions_version = version;
                 t.team_instructions_targets = written.clone();
                 return Ok(true);
             }
@@ -866,6 +882,89 @@ fn apply_instructions(team_id: &str, version: i64, desired: Option<&str>) {
         for path in &written {
             instructions::remove_recorded(std::path::Path::new(path));
         }
+    }
+}
+
+/// Build the apply-status receipt (spec W5): for each INSTALLED client, the current on-disk state
+/// of the org rules. Read-only — reflects reality every cycle, so a client added after the last
+/// write shows `Stale`, not silently missing. Includes unsupported installed clients (Cursor /
+/// Warp) so the admin sees they need a manual copy.
+fn build_instructions_receipt(
+    team_id: &str,
+    version: i64,
+    content: &str,
+) -> crate::instructions::Receipt {
+    use crate::instructions::{self, ApplyState, ClientReceipt};
+    let clients = crate::clients::detect_clients()
+        .into_iter()
+        .filter(|c| c.app_present)
+        .map(|c| {
+            let state = match crate::clients::client_rules_target(&c.id) {
+                Some(target) => instructions::current_state(&target, team_id, version, content),
+                None => ApplyState::Unsupported,
+            };
+            ClientReceipt { id: c.id, state }
+        })
+        .collect();
+    instructions::Receipt {
+        version,
+        content_hash: instructions::content_hash(content),
+        clients,
+    }
+}
+
+/// Report this member's instructions coverage to the team server, once per sync cycle. Sends only
+/// when the receipt CHANGED since the last successful send (dedup by hash), so an unchanged
+/// coverage state costs the server nothing. Best-effort; a failure just retries next cycle. No-op
+/// when the team has no active instructions.
+fn report_instructions_status(conn: &TeamConnection, token: &str) {
+    use crate::instructions;
+    let (content, version, reported) = {
+        let Ok(reg) = crate::registry::load() else {
+            return;
+        };
+        match reg.team.as_ref() {
+            Some(t) if t.team_id == conn.team_id => (
+                t.team_instructions_content.clone(),
+                t.team_instructions_version,
+                t.team_instructions_reported.clone(),
+            ),
+            _ => return,
+        }
+    };
+    let Some(content) = content else {
+        return; // no instructions active for this team
+    };
+    let receipt = build_instructions_receipt(&conn.team_id, version, &content);
+    let Ok(receipt_json) = serde_json::to_value(&receipt) else {
+        return;
+    };
+    let fingerprint = instructions::content_hash(&receipt_json.to_string());
+    if reported.as_deref() == Some(fingerprint.as_str()) {
+        return; // unchanged since the last successful send
+    }
+    let day = usage_report::utc_day_back(0);
+    match post_usage_day(
+        &conn.server_url,
+        &conn.team_id,
+        token,
+        &day,
+        Vec::new(),
+        Some(&receipt_json),
+    ) {
+        Ok(true) => {
+            let _ = crate::registry::update(|reg| {
+                if let Some(t) = reg.team.as_mut() {
+                    if t.team_id == conn.team_id {
+                        t.team_instructions_reported = Some(fingerprint.clone());
+                    }
+                }
+                Ok(())
+            });
+        }
+        // Old server without the endpoint, or a transient failure: leave `reported` unset so we
+        // retry on a later cycle.
+        _ => {}
     }
 }
 


### PR DESCRIPTION
## What

The client half of W5 (apply-status receipts) for Team Instructions. W2 writes org rules to each client's rules file; this makes the member **report which client actually loaded them**, so the coming dashboard coverage panel can prove per-member, per-client coverage.

Ships dark alongside W2 — a member only sends a receipt when the team actually has instructions active.

## How

- **`instructions::current_state`** (read-only) computes each client's `ApplyState` by *inspecting disk* against the current org content+version. Truthful by construction: a client installed **after** the last write reports `Stale`, not silently missing — the accuracy gap a naive apply-time snapshot would've had (flagged in the W2 audit).
- New **`ApplyState::Stale`** + **`Receipt`/`ClientReceipt`** wire types (`contentHash` camelCase, snake_case states).
- **`report_instructions_status`** runs every sync cycle (incl. 304s), builds the receipt over installed clients (including unsupported ones like Cursor/Warp so the admin knows they need a manual copy), and POSTs it on the existing `/teams/{id}/usage` endpoint as `instructionsStatus`. Deduped by a stored fingerprint so an unchanged receipt is never re-sent; best-effort, retries next cycle.
- **Registry**: `TeamConnection` now persists the applied content + its version (so a 304 cycle can recompute coverage without the config in hand) and the last-reported fingerprint — replacing the write-only content hash.

## Compatibility
- An older server ignores the extra `instructionsStatus` POST field (no `deny_unknown_fields`).
- Pairs with the server intake + dashboard coverage panel (toolport-teams PR, next). Merge order: server first, then this — though both are inert until `TEAMS_INSTRUCTIONS` is on.

## Verification
- +2 tests (`current_state` applied/stale/blocked/too-long). Full suite green: **430 lib + 122 bin**. `cargo build` + `clippy` clean.