### PR TITLE
feat(teams): member-facing Team Instructions status — W4 (SOU-135)

### DIFF
--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -1912,10 +1912,14 @@ fn emit_team_review(app: &tauri::AppHandle, outcome: teams::MergeOutcome) {
 
 /// Member-facing Team Instructions status (spec W4): the org content on this machine, its
 /// version, and each installed client's on-disk state. `None` when the team has no active
-/// instructions. Read-only.
+/// instructions. Read-only. Async + `spawn_blocking` because it scans every installed client's
+/// rules file, which must not run on the UI thread.
 #[tauri::command]
-fn team_instructions_status() -> Option<teams::InstructionsStatusView> {
-    teams::instructions_status()
+async fn team_instructions_status() -> Option<teams::InstructionsStatusView> {
+    tauri::async_runtime::spawn_blocking(teams::instructions_status)
+        .await
+        .ok()
+        .flatten()
 }
 
 /// Leave the team: remove its merged servers, clear the connection and the token.

--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -1910,6 +1910,14 @@ fn emit_team_review(app: &tauri::AppHandle, outcome: teams::MergeOutcome) {
     }
 }
 
+/// Member-facing Team Instructions status (spec W4): the org content on this machine, its
+/// version, and each installed client's on-disk state. `None` when the team has no active
+/// instructions. Read-only.
+#[tauri::command]
+fn team_instructions_status() -> Option<teams::InstructionsStatusView> {
+    teams::instructions_status()
+}
+
 /// Leave the team: remove its merged servers, clear the connection and the token.
 #[tauri::command]
 fn team_disconnect(state: State<RegistryState>) -> Result<Registry, String> {
@@ -2861,6 +2869,7 @@ pub fn run() {
             team_sync,
             team_sync_wait,
             main_window_visible,
+            team_instructions_status,
             team_disconnect,
             team_push_preview,
             team_push,

--- a/src-tauri/src/teams.rs
+++ b/src-tauri/src/teams.rs
@@ -913,6 +913,57 @@ fn build_instructions_receipt(
     }
 }
 
+/// One client's row in the member-facing instructions status view (spec W4).
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct InstructionsClientStatus {
+    pub id: String,
+    pub name: String,
+    pub state: crate::instructions::ApplyState,
+}
+
+/// The member-facing view of the org instructions on THIS machine (spec W4): the exact content
+/// the org pushed, its version, and each installed client's current on-disk state. `None` when
+/// the team has no active instructions. Read-only; drives the Teams-tab status row.
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct InstructionsStatusView {
+    pub content: String,
+    pub version: i64,
+    pub clients: Vec<InstructionsClientStatus>,
+}
+
+/// Build the member-facing instructions status for the currently-connected team, or `None` if
+/// there's no connection or no active instructions. Reuses the same read-only per-client check
+/// as the coverage receipt, so what the member sees matches what the admin's coverage panel sees.
+pub fn instructions_status() -> Option<InstructionsStatusView> {
+    use crate::instructions::{self, ApplyState};
+    let reg = crate::registry::load().ok()?;
+    let team = reg.team.as_ref()?;
+    let content = team.team_instructions_content.clone()?;
+    let version = team.team_instructions_version;
+    let team_id = team.team_id.clone();
+    let clients = crate::clients::detect_clients()
+        .into_iter()
+        .filter(|c| c.app_present)
+        .map(|c| {
+            let state = match crate::clients::client_rules_target(&c.id) {
+                Some(target) => instructions::current_state(&target, &team_id, version, &content),
+                None => ApplyState::Unsupported,
+            };
+            InstructionsClientStatus {
+                id: c.id,
+                name: c.name,
+                state,
+            }
+        })
+        .collect();
+    Some(InstructionsStatusView {
+        content,
+        version,
+        clients,
+    })
+}
+
 /// Report this member's instructions coverage to the team server, once per sync cycle. Sends only
 /// when the receipt CHANGED since the last successful send (dedup by hash), so an unchanged
 /// coverage state costs the server nothing. Best-effort; a failure just retries next cycle. No-op

--- a/src/components/TeamsView.test.tsx
+++ b/src/components/TeamsView.test.tsx
@@ -10,6 +10,7 @@ const api = vi.hoisted(() => ({
   teamDisconnect: vi.fn(),
   teamPushPreview: vi.fn(),
   teamPush: vi.fn(),
+  teamInstructionsStatus: vi.fn().mockResolvedValue(null),
   setServerEnabled: vi.fn(),
 }));
 

--- a/src/components/TeamsView.tsx
+++ b/src/components/TeamsView.tsx
@@ -7,6 +7,11 @@ import {
   Users,
   Server,
   AlertTriangle,
+  Check,
+  Clock,
+  Ban,
+  Minus,
+  FileText,
 } from "lucide-react";
 import { listen } from "@tauri-apps/api/event";
 import { Badge } from "@/components/ui/badge";
@@ -22,12 +27,42 @@ import {
   teamDisconnect,
   teamPushPreview,
   teamPush,
+  teamInstructionsStatus,
   setServerEnabled,
 } from "@/lib/api";
 import { teamUrlError } from "@/lib/teamUrl";
 import { isEnabled, activeProfile } from "@/lib/types";
 import type { TeamPushPreview } from "@/lib/api";
-import type { Registry } from "@/lib/types";
+import type {
+  Registry,
+  InstructionsStatusView,
+  InstructionsApplyState,
+} from "@/lib/types";
+
+/** How each per-client instructions state renders in the member's Teams tab (spec W4). */
+const INSTR_STATE_META: Record<
+  InstructionsApplyState,
+  { label: string; className: string; Icon: typeof Check }
+> = {
+  applied: { label: "Applied", className: "text-success", Icon: Check },
+  stale: { label: "Not applied yet", className: "text-warning", Icon: Clock },
+  blocked_override: {
+    label: "Blocked by a local override",
+    className: "text-warning",
+    Icon: Ban,
+  },
+  too_long: {
+    label: "Too long for this client",
+    className: "text-warning",
+    Icon: AlertTriangle,
+  },
+  unsupported: {
+    label: "Copy manually",
+    className: "text-muted-foreground",
+    Icon: Minus,
+  },
+  error: { label: "Write error", className: "text-destructive", Icon: AlertTriangle },
+};
 
 /** The hosted Toolport Teams instance, prefilled as the default. Self-hosters replace
  * it with their own server URL. */
@@ -60,6 +95,25 @@ export function TeamsView({
   const [notice, setNotice] = useState<string | null>(null);
   const [skipNote, setSkipNote] = useState<string | null>(null);
   const [pushPreview, setPushPreview] = useState<TeamPushPreview | null>(null);
+  // The member-facing Team Instructions status on this machine (spec W4): what the org pushed
+  // and how each installed AI client currently holds it. Refetched on connect and whenever a sync
+  // bumps the config version, so it tracks the files the writer just wrote.
+  const [instr, setInstr] = useState<InstructionsStatusView | null>(null);
+  useEffect(() => {
+    // The command returns null when there's no team (or no active instructions), so there's no
+    // synchronous clear here — the result always lands via the async resolution.
+    let cancelled = false;
+    teamInstructionsStatus()
+      .then((s) => {
+        if (!cancelled) setInstr(s);
+      })
+      .catch(() => {
+        if (!cancelled) setInstr(null);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [team?.teamId, team?.lastVersion]);
   // Set while an approval-gated join waits for an admin. Holds the connect inputs so a poll
   // uses the values from when the request was made, not whatever the fields say later.
   const [pending, setPending] = useState<{
@@ -559,6 +613,49 @@ export function TeamsView({
               </>
             )}
           </div>
+
+          {instr && (
+            <div className="rounded-xl border bg-card p-5">
+              <div className="mb-1 flex items-center gap-2">
+                <FileText className="size-4 text-muted-foreground" />
+                <h3 className="text-sm font-medium">Team instructions</h3>
+                <span className="text-xs text-muted-foreground">v{instr.version}</span>
+              </div>
+              <p className="mb-3 text-xs text-muted-foreground">
+                Org-managed agent rules, written to your AI clients alongside — never over
+                — your own instructions. Leaving the team removes them.
+              </p>
+              <pre className="mb-3 max-h-40 overflow-auto whitespace-pre-wrap rounded-lg border bg-muted/20 p-3 font-mono text-xs text-foreground">
+                {instr.content}
+              </pre>
+              {instr.clients.length === 0 ? (
+                <p className="text-xs text-muted-foreground">
+                  No supported AI clients detected on this machine.
+                </p>
+              ) : (
+                <ul className="grid gap-1.5">
+                  {instr.clients.map((c) => {
+                    const meta = INSTR_STATE_META[c.state];
+                    const Icon = meta.Icon;
+                    return (
+                      <li
+                        key={c.id}
+                        className="flex items-center justify-between gap-3 text-sm"
+                      >
+                        <span className="truncate">{c.name}</span>
+                        <span
+                          className={`flex shrink-0 items-center gap-1 text-xs ${meta.className}`}
+                        >
+                          <Icon className="size-3.5" />
+                          {meta.label}
+                        </span>
+                      </li>
+                    );
+                  })}
+                </ul>
+              )}
+            </div>
+          )}
         </div>
       )}
     </div>

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -8,6 +8,7 @@ import type {
   FolderProfile,
   ImportItem,
   InspectEntry,
+  InstructionsStatusView,
   McpPrompt,
   McpResource,
   McpTool,
@@ -413,6 +414,14 @@ export function teamSyncWait(waitSecs: number): Promise<Registry> {
  */
 export function mainWindowVisible(): Promise<boolean> {
   return invoke<boolean>("main_window_visible");
+}
+
+/**
+ * The member-facing Team Instructions status on this machine: the org content, its version, and
+ * each installed client's on-disk state. `null` when the team has no active instructions.
+ */
+export function teamInstructionsStatus(): Promise<InstructionsStatusView | null> {
+  return invoke<InstructionsStatusView | null>("team_instructions_status");
 }
 
 /** Leave the team: remove its merged servers and clear the saved token. */

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -474,6 +474,23 @@ export interface TeamConnection {
   lastVersion?: number;
 }
 
+/** Per-client on-disk state of the org Team Instructions (spec W4/W5). */
+export type InstructionsApplyState =
+  "applied" | "stale" | "blocked_override" | "too_long" | "unsupported" | "error";
+
+export interface InstructionsClientStatus {
+  id: string;
+  name: string;
+  state: InstructionsApplyState;
+}
+
+/** The member-facing view of the org instructions on this machine (`team_instructions_status`). */
+export interface InstructionsStatusView {
+  content: string;
+  version: number;
+  clients: InstructionsClientStatus[];
+}
+
 export function activeProfile(registry: Registry): Profile | undefined {
   return (
     registry.profiles.find((p) => p.id === registry.activeProfileId) ??


### PR DESCRIPTION
## What

The last code piece of Team Instructions. The admin can already see coverage (W5); this lets a **member see their own** status. The Teams tab shows a "Team instructions" card when the team has active instructions: the org content the member received, its version, and each installed AI client's current on-disk state.

Per-client states: **applied** ✓ / **not applied yet** / **blocked by a local override** / **too long for this client** / **copy manually** (unsupported clients like Cursor/Warp) / **write error**.

Ships dark with the rest — the card only appears once a team actually has instructions and the app has synced them.

## How

- **Rust**: `teams::instructions_status()` builds the view from the registry-persisted content + version using the **same read-only `current_state`** per client as the W5 receipt, so the member's view matches the admin's coverage panel exactly. Exposed via the `team_instructions_status` Tauri command.
- **Frontend**: a status card in `TeamsView`, refetched on connect and whenever a sync bumps the config version (so it tracks the files the writer just wrote). Read-only — a member can't edit org rules; leaving the team removes them.

## Verification
- Full suite green: **430 lib + 122 bin** (Rust), **98 vitest** (incl. the updated `TeamsView` test mock). `tsc` + `eslint` clean.
- The card's live rendering is exercised at the pre-flag E2E (needs a real connected team with pushed instructions); logic is unit-covered via the shared `current_state`.

Completes SOU-135's implementation. Remaining before `TEAMS_INSTRUCTIONS` flips on: the on-machine E2E (join → files appear → edit → ~1s update → member card + admin coverage → leave → gone) on Windows + Mac.