### PR TITLE
feat(clients): add Oh My Pi (omp) client support

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ and refreshes too.
 
 ## Supported clients
 
-Toolport auto-detects these **22 AI clients**, installs the gateway into each with one
+Toolport auto-detects these **23 AI clients**, installs the gateway into each with one
 click, and can import a client's existing servers. It writes the config file shown
 below for you, so you never have to edit these by hand.
 
@@ -179,6 +179,7 @@ below for you, so you never have to edit these by hand.
 | Jan            | `<data>/Jan/data/mcp_config.json`                                                          | JSON (`mcpServers`)      |
 | BoltAI         | `~/.boltai/mcp.json`                                                                       | JSON (`mcpServers`)      |
 | Pi             | `~/.pi/agent/mcp.json`                                                                     | JSON (`mcpServers`)      |
+| Oh My Pi       | `~/.omp/agent/mcp.json`                                                                    | JSON (`mcpServers`)      |
 | Goose          | `~/.config/goose/config.yaml`                                                              | YAML (`extensions`)      |
 | Hermes         | `~/.hermes/config.yaml`                                                                    | YAML (`mcp_servers`)     |
 | AnythingLLM    | `<config>/anythingllm-desktop/storage/plugins/anythingllm_mcp_servers.json`                | JSON (`mcpServers`)      |

--- a/src-tauri/src/clients.rs
+++ b/src-tauri/src/clients.rs
@@ -198,6 +198,7 @@ fn resolve_client_config_path(
         "cursor" => home.join(".cursor").join("mcp.json"),
         "boltai" => home.join(".boltai").join("mcp.json"),
         "pi" => home.join(".pi").join("agent").join("mcp.json"),
+        "omp" => home.join(".omp").join("agent").join("mcp.json"),
         "vscode" => config.join("Code").join("User").join("mcp.json"),
         "windsurf" => home
             .join(".codeium")
@@ -292,6 +293,7 @@ fn resolve_client_config_path_linux(client_id: &str, home: &std::path::Path) -> 
         "cursor" => home.join(".cursor").join("mcp.json"),
         "boltai" => home.join(".boltai").join("mcp.json"),
         "pi" => home.join(".pi").join("agent").join("mcp.json"),
+        "omp" => home.join(".omp").join("agent").join("mcp.json"),
         "vscode" => config.join("Code").join("User").join("mcp.json"),
         "windsurf" => home
             .join(".codeium")
@@ -409,6 +411,7 @@ fn resolve_rules_target(
         },
         "goose" => block(home.join(".config").join("goose").join(".goosehints")),
         "pi" => block(home.join(".pi").join("agent").join("AGENTS.md")),
+        "omp" => block(home.join(".omp").join("agent").join("AGENTS.md")),
         "zed" => match platform {
             Platform::Windows => block(config.join("Zed").join("AGENTS.md")),
             Platform::MacOs | Platform::Linux => {
@@ -477,6 +480,12 @@ fn boltai_path() -> Option<PathBuf> {
 /// left unset so it uses its defaults). Home-anchored, identical on every OS.
 fn pi_path() -> Option<PathBuf> {
     client_config_path("pi")
+}
+
+/// Oh My Pi (omp) is a fork of Pi with its own config directory (~/.omp).
+/// Same `mcpServers` JSON format as Pi; home-anchored, identical on every OS.
+fn omp_path() -> Option<PathBuf> {
+    client_config_path("omp")
 }
 
 fn vscode_path() -> Option<PathBuf> {
@@ -829,6 +838,14 @@ fn defs() -> Vec<ClientDef> {
             format: Format::JsonMcpServers,
             uses_connectors: false,
             path: pi_path,
+            plugin_scan: None,
+        },
+        ClientDef {
+            id: "omp",
+            name: "Oh My Pi",
+            format: Format::JsonMcpServers,
+            uses_connectors: false,
+            path: omp_path,
             plugin_scan: None,
         },
         ClientDef {
@@ -3699,6 +3716,13 @@ command = "npx"
     fn goose_is_registered_as_yaml_extensions() {
         let d = defs().into_iter().find(|d| d.id == "goose").unwrap();
         assert!(matches!(d.format, Format::YamlExtensions));
+        assert!((d.path)().is_some());
+    }
+
+    #[test]
+    fn omp_is_registered_as_json_mcp_servers() {
+        let d = defs().into_iter().find(|d| d.id == "omp").unwrap();
+        assert!(matches!(d.format, Format::JsonMcpServers));
         assert!((d.path)().is_some());
     }
 


### PR DESCRIPTION
## What and why

[Oh My Pi (omp)](https://github.com/can1357/oh-my-pi) is a popular fork of Pi (18.5k stars) that uses `~/.omp` as its config directory instead of `~/.pi`. The MCP config format is identical — JSON `mcpServers` at `~/.omp/agent/mcp.json` — so omp is added as a distinct client entry alongside Pi, with its own path and ID. This keeps existing Pi users unaffected while giving omp its own first-class entry in the Clients sidebar.

## Changes

Adds omp in 6 places, following the exact pattern established by the existing Pi entry:

- `resolve_client_config_path` + `resolve_client_config_path_linux`: `~/.omp/agent/mcp.json`
- `block_if_present`: `~/.omp/agent/AGENTS.md` (omp reads AGENTS.md like Pi)
- `omp_path()` resolver function
- `defs()` `ClientDef` registration (id: `"omp"`, name: `"Oh My Pi"`, format: `JsonMcpServers`)
- README supported clients table (22 → 23)
- Registration test: `omp_is_registered_as_json_mcp_servers`

## Testing

- [x] `npm run build` passes
- [x] `npm run test:rust` passes — 555/555 tests (including new registration test)
- [x] `npm run audit:prod` passes — 0 vulnerabilities
- [ ] `npm run test` — N/A (minimal frontend impact: one more client in the sidebar)
- [ ] Ran the app — not yet (Rust-only change, but worth confirming omp shows in the sidebar)

## Notes

No secrets, keys, or personal paths in the diff. omp honors `PI_CONFIG_DIR` / `PI_CODING_AGENT_DIR` env overrides, but the default path is `~/.omp/agent/mcp.json` on all platforms.

**Reference PR:** [#18 (BoltAI client)](https://github.com/tsouth89/toolport/pull/18) — same pattern: a path resolver, one `ClientDef`, and a registration test.

Signed-off-by: Brad Hallett <bradhallett@users.noreply.github.com>