### PR TITLE
fix: clear new profile name on close

### DIFF
--- a/src/components/ProfileBar.test.tsx
+++ b/src/components/ProfileBar.test.tsx
@@ -1,0 +1,45 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ProfileBar } from "./ProfileBar";
+import type { Registry } from "@/lib/types";
+
+vi.mock("sonner", () => ({ toast: { success: vi.fn() } }));
+vi.mock("@/lib/toast", () => ({ toastError: vi.fn() }));
+vi.mock("@/lib/api", () => ({
+  createProfile: vi.fn(),
+  deleteProfile: vi.fn(),
+  setActiveProfile: vi.fn(),
+}));
+
+const registry: Registry = {
+  version: 1,
+  servers: [],
+  profiles: [{ id: "default", name: "Default", enabledServerIds: [] }],
+  activeProfileId: "default",
+};
+
+async function openDialog() {
+  await userEvent.click(screen.getByRole("button", { name: /new profile/i }));
+  return screen.getByLabelText(/name/i);
+}
+
+describe("ProfileBar", () => {
+  it("clears the new profile name after cancelling the dialog", async () => {
+    render(<ProfileBar registry={registry} onChange={vi.fn()} />);
+
+    await userEvent.type(await openDialog(), "Work");
+    await userEvent.click(screen.getByRole("button", { name: /cancel/i }));
+
+    expect(await openDialog()).toHaveValue("");
+  });
+
+  it("clears the new profile name when the dialog closes via Escape", async () => {
+    render(<ProfileBar registry={registry} onChange={vi.fn()} />);
+
+    await userEvent.type(await openDialog(), "Personal");
+    await userEvent.keyboard("{Escape}");
+
+    expect(await openDialog()).toHaveValue("");
+  });
+});

--- a/src/components/ProfileBar.tsx
+++ b/src/components/ProfileBar.tsx
@@ -63,6 +63,13 @@ export function ProfileBar({ registry, onChange }: Props) {
     }
   }
 
+  function handleOpenChange(nextOpen: boolean) {
+    setOpen(nextOpen);
+    if (!nextOpen) {
+      setName("");
+    }
+  }
+
   return (
     <div className="flex items-center gap-1.5">
       <Select value={activeId} onValueChange={handleSwitch}>
@@ -108,7 +115,7 @@ export function ProfileBar({ registry, onChange }: Props) {
         />
       )}
 
-      <Dialog open={open} onOpenChange={setOpen}>
+      <Dialog open={open} onOpenChange={handleOpenChange}>
         <DialogContent className="sm:max-w-sm">
           <DialogHeader>
             <DialogTitle>New profile</DialogTitle>
@@ -132,7 +139,7 @@ export function ProfileBar({ registry, onChange }: Props) {
             />
           </div>
           <DialogFooter>
-            <Button variant="outline" onClick={() => setOpen(false)}>
+            <Button variant="outline" onClick={() => handleOpenChange(false)}>
               Cancel
             </Button>
             <Button onClick={handleCreate} disabled={!name.trim()}>


### PR DESCRIPTION
## Summary
- reset the new-profile name whenever the dialog closes
- route Cancel through the same close handler as Escape and overlay dismissal
- add component coverage for Cancel and Escape close paths

Fixes #380

## Validation
- npm test -- src/components/ProfileBar.test.tsx
- npm run format:check
- npm run lint
- npm test
- npm run build
- git diff --check