### PR TITLE
chore(coderabbit): skip reviews on docs-only and no-logic PRs

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -18,13 +18,30 @@ reviews:
     drafts: false
     # Review once when the PR opens, not again on each subsequent commit.
     auto_incremental_review: false
+    # Don't spend review quota on PRs that carry no production logic. Matching is
+    # case-insensitive substring against the PR title, and the repo uses
+    # conventional-commit prefixes, so "docs:", "chore:", "style:" and friends are
+    # caught. Deliberately NOT skipped: "ci"/"build"/"deps", where a workflow or
+    # dependency change can be security-relevant and is worth a look.
+    ignore_title_keywords:
+      - docs
+      - chore
+      - style
+      - typo
+      - release
+      - WIP
   # Skip generated / vendored / build output so reviews stay signal-heavy.
+  # Prose is excluded too, so a docs-only PR has nothing left to review even if
+  # its title doesn't match the keywords above.
   path_filters:
     - "!**/package-lock.json"
     - "!**/*.lock"
     - "!dist/**"
     - "!src-tauri/target/**"
     - "!**/*.min.*"
+    - "!**/*.md"
+    - "!**/*.mdx"
+    - "!**/LICENSE"
   path_instructions:
     - path: "src/**/*.{ts,tsx}"
       instructions: >-


### PR DESCRIPTION
## What and why

CodeRabbit review quota was being spent on PRs that contain no production logic. Two changes, both verified against the v2 schema:

1. **`auto_review.ignore_title_keywords`** skips a PR whose title contains `docs`, `chore`, `style`, `typo`, `release`, or `WIP`. Matching is case-insensitive substring, and the repo uses conventional-commit prefixes, so `docs: ...` and `chore: ...` are caught.

2. **`path_filters`** now also exclude prose (`**/*.md`, `**/*.mdx`, `**/LICENSE`), so a docs-only PR has nothing reviewable left even when its title doesn't match a keyword. This is the belt-and-braces half, since a docs PR titled `fix: ...` would slip past the keyword check.

## Deliberately NOT skipped

`ci`, `build`, and `deps` are left in. A workflow change or a dependency bump can be security-relevant (pinned actions, supply chain), and those are exactly the PRs worth a second pair of eyes.

## Risk

Low. `ignore_title_keywords` is substring-based, so a PR like `fix: update docs link in error message` would also be skipped. That is an acceptable false-skip: CodeRabbit is advisory only here (`request_changes_workflow: false`), so a missed review never blocks a merge, and a human review is still the gate.

## Verification

- [x] YAML parses cleanly (`js-yaml`)
- [x] `ignore_title_keywords` and `path_filters` confirmed present in https://coderabbit.ai/integrations/schema.v2.json
- [x] No change to `profile: chill`, `request_changes_workflow: false`, or the existing path_instructions