### PR TITLE
fix: format activity error rates consistently

### DIFF
--- a/src/components/ActivityView.tsx
+++ b/src/components/ActivityView.tsx
@@ -18,7 +18,7 @@ import {
   XCircle,
 } from "lucide-react";
 import { toast } from "sonner";
-import { fmtTokens } from "@/lib/utils";
+import { fmtPercent, fmtTokens } from "@/lib/utils";
 import { toastError } from "@/lib/toast";
 import { save } from "@tauri-apps/plugin-dialog";
 import { Input } from "@/components/ui/input";
@@ -531,7 +531,7 @@ function SavingsBanner({ savings }: { savings: SavingsSummary }) {
 }
 
 function errCell(errors: number, errorRate: number) {
-  return errors > 0 ? `${(errorRate * 100).toFixed(0)}%` : "0";
+  return fmtPercent(errorRate, { floorNonZero: errors > 0 });
 }
 
 /** One server row that expands to reveal its per-tool breakdown. */
@@ -700,7 +700,7 @@ function StatsPanel({ stats }: { stats: AuditStats }) {
   // below the security lane. It's one tap when you actually want the breakdown.
   const [tableOpen, setTableOpen] = useState(false);
   if (stats.total === 0) return null;
-  const errPct = (stats.errorRate * 100).toFixed(stats.errorRate < 0.1 ? 1 : 0);
+  const errPct = fmtPercent(stats.errorRate, { floorNonZero: stats.errors > 0 });
   // Surface how many servers have errors on the collapsed toggle: the aggregate error % can
   // dilute a single fully-broken server among many healthy ones, so a per-server signal has
   // to be visible without expanding the table.
@@ -720,7 +720,7 @@ function StatsPanel({ stats }: { stats: AuditStats }) {
           >
             {stats.errors}
           </div>
-          <div className="text-xs text-muted-foreground">errors ({errPct}%)</div>
+          <div className="text-xs text-muted-foreground">errors ({errPct})</div>
         </div>
         <div className="rounded-lg border p-3">
           <div className="text-2xl font-semibold tabular-nums">

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { fmtTokens } from "./utils";
+import { fmtPercent, fmtTokens } from "./utils";
 
 describe("fmtTokens", () => {
   it("renders small numbers as-is", () => {
@@ -35,5 +35,25 @@ describe("fmtTokens", () => {
     expect(fmtTokens(0)).toBe("0");
     expect(fmtTokens(-1)).toBe("-1");
     expect(fmtTokens(-12345)).toBe("-12345");
+  });
+});
+
+describe("fmtPercent", () => {
+  it("always includes the percent suffix for zero values", () => {
+    expect(fmtPercent(0)).toBe("0%");
+  });
+
+  it("uses adaptive precision below ten percent", () => {
+    expect(fmtPercent(0.002)).toBe("0.2%");
+    expect(fmtPercent(0.099)).toBe("9.9%");
+    expect(fmtPercent(0.1)).toBe("10%");
+  });
+
+  it("floors tiny nonzero values instead of rounding them to zero", () => {
+    expect(fmtPercent(0.0004, { floorNonZero: true })).toBe("<0.1%");
+  });
+
+  it("can use the nonzero floor when the count is nonzero but the rate rounded away", () => {
+    expect(fmtPercent(0, { floorNonZero: true })).toBe("<0.1%");
   });
 });

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -18,3 +18,18 @@ export function fmtTokens(n: number): string {
   if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`;
   return `${n}`;
 }
+
+/**
+ * Format a ratio as a percent with the same adaptive precision everywhere.
+ * When `floorNonZero` is true, tiny positive rates render as "<0.1%" instead
+ * of rounding down to a misleading "0%".
+ */
+export function fmtPercent(
+  rate: number,
+  options: { floorNonZero?: boolean } = {},
+): string {
+  const percent = rate * 100;
+  if (options.floorNonZero && percent > 0 && percent < 0.1) return "<0.1%";
+  if (options.floorNonZero && percent === 0) return "<0.1%";
+  return `${percent.toFixed(percent > 0 && percent < 10 ? 1 : 0)}%`;
+}


### PR DESCRIPTION
## Summary
- add a shared percent formatter with adaptive precision and a nonzero floor
- use it for both Activity summary and per-server/per-tool error rate cells
- cover zero, adaptive precision, and <0.1% floor behavior in utils tests

Fixes #378

## Validation
- npm test -- src/lib/utils.test.ts
- npm run format:check
- npm run lint
- npm test
- npm run build
- git diff --check