### PR TITLE
docs: describe config_is_whole_app_state accurately

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -301,8 +301,12 @@ Follow the existing conventions — at minimum:
   also update `client_config_paths_honor_xdg_dirs_on_linux`.
 
 - If the config file stores broader app settings instead of only MCP servers,
-  add the client to `config_is_whole_app_state()` so reads and writes use the
-  lenient whole-file path.
+  add the client to `config_is_whole_app_state()`. This records that the file is
+  whole-app state and is threaded through the write paths as the `lenient` flag.
+  It is a declaration of intent rather than a behavior switch today: the
+  never-wipe protection (a non-empty file that won't parse is always an error,
+  never silently replaced) already applies to every client regardless. See the
+  comment on `read_existing_json` for the history.
 
 - A round-trip test if you added a new `Format` variant: write servers → read
   them back → verify they match. See `json_mcpservers_round_trips` for the


### PR DESCRIPTION
Follow-up to #385.

That PR added a useful line telling contributors to register whole-app-state clients in `config_is_whole_app_state()`, but described the effect as making "reads and writes use the lenient whole-file path". That overstates what the flag does today.

The flag is still threaded from `write_servers` / `install_or_remove` into `read_existing_json` as `lenient`, but it no longer changes that path. Per the comment on `read_existing_json`, the never-wipe protection was deliberately extended to **every** config after single-purpose `mcpServers` files were found to silently wipe a user's other servers on a parse failure while reporting success.

So registering a client is still the right thing to do (it records intent, and it's where any future whole-app-state-specific behavior would hang off), it just isn't a behavior switch right now. Reworded to say that, with a pointer to the `read_existing_json` comment for the history.

Docs only, no code change.