### PR TITLE
chore(coderabbit): stop skipping chore-titled PRs

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -20,12 +20,17 @@ reviews:
     auto_incremental_review: false
     # Don't spend review quota on PRs that carry no production logic. Matching is
     # case-insensitive substring against the PR title, and the repo uses
-    # conventional-commit prefixes, so "docs:", "chore:", "style:" and friends are
-    # caught. Deliberately NOT skipped: "ci"/"build"/"deps", where a workflow or
-    # dependency change can be security-relevant and is worth a look.
+    # conventional-commit prefixes, so "docs:", "style:" and friends are caught.
+    #
+    # Deliberately NOT skipped:
+    #   ci / build / deps - a workflow or dependency change can be
+    #     security-relevant and is worth a look.
+    #   chore - was skipped initially and removed after PR #391 ("chore: add jsx
+    #     a11y linting") went unreviewed and shipped a TS compile error. "chore:"
+    #     is the prefix most likely to sit on a PR that actually changes lint
+    #     config, tooling, or source, so it's the wrong thing to skip.
     ignore_title_keywords:
       - docs
-      - chore
       - style
       - typo
       - release


### PR DESCRIPTION
Removes `chore` from `reviews.auto_review.ignore_title_keywords`.

## Why

`chore` was in the skip list from the start. That meant #391 (`chore: add jsx a11y linting`) received **no AI review** despite touching `eslint.config.mjs`, `package.json`, `package-lock.json` and `src/components/ActivityView.tsx`. It shipped a TypeScript compile error (`TS2783`, duplicate JSX props) that CI caught rather than review.

Of the conventional-commit prefixes, `chore:` is the one most likely to sit on a PR that genuinely changes tooling, lint config, or source. It's the wrong thing to skip.

## What stays

`docs`, `style`, `typo`, `release`, `WIP` remain, and the prose `path_filters` (`**/*.md`, `**/*.mdx`, `**/LICENSE`) are untouched, so a genuinely doc-only PR still costs no review quota. `ci` / `build` / `deps` were never skipped.

## Note

This PR's own title starts with `chore:`, so with the updated config on this branch it should be reviewed rather than skipped. That doubles as a live check that the change works.