### PR TITLE
fix(tests): let tests redirect the data dir despite conduit_dir memoizing

### DIFF
--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -9698,6 +9698,31 @@ mod tests {
     }
 
     #[test]
+    fn data_dir_override_redirects_and_reverts() {
+        // The revert half matters as much as the redirect: the override is
+        // process-global, so one that outlived its test would silently point the app
+        // (and every other test) at a scratch directory.
+        let _env = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+
+        let before = conduit_lib::registry::conduit_dir();
+        let scratch =
+            std::env::temp_dir().join(format!("toolport-ddo-{}", std::process::id()));
+        {
+            let _guard = conduit_lib::registry::DataDirOverride::set(&scratch);
+            assert_eq!(
+                conduit_lib::registry::conduit_dir().as_deref(),
+                Some(scratch.as_path()),
+                "conduit_dir must follow the override even though it memoizes"
+            );
+        }
+        assert_eq!(
+            conduit_lib::registry::conduit_dir(),
+            before,
+            "the override must revert when the guard drops"
+        );
+    }
+
+    #[test]
     fn end_to_end_lexical_semantic_blend() {
         let _env = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
 
@@ -9851,15 +9876,22 @@ mod tests {
         ));
 
         std::fs::create_dir_all(&path).unwrap();
-        std::env::set_var("CONDUIT_DATA_DIR", &path);
+        // Must be the override, NOT `set_var("CONDUIT_DATA_DIR", ..)`: conduit_dir()
+        // memoizes, so the env var is silently ignored unless this test happens to be the
+        // first in the process to resolve the dir. That made this test order-dependent
+        // (green alone, red in the full suite) and pointed its embeddings cache at the
+        // developer's real data dir, where a warm cache stops embed_tools from firing and
+        // the mock server's later responses are never consumed. See SOU-301.
+        let _data_dir = conduit_lib::registry::DataDirOverride::set(&path);
 
         let outcome1 = search_catalog_with(&cat, "send a welcome email", None, 25, Some(&cfg1));
         assert_eq!(outcome1.matches[0]["name"], "email__send_email");
 
-        let outcome2 = search_catalog_with(&cat,"send a welcome email", None, 25, Some(&cfg2));
+        let outcome2 = search_catalog_with(&cat, "send a welcome email", None, 25, Some(&cfg2));
         assert_eq!(outcome2.matches[0]["name"], "github__create_pull_request");
 
         server.join().unwrap();
+        drop(_data_dir);
         std::fs::remove_dir_all(&path).ok();
     }
 

--- a/src-tauri/src/registry.rs
+++ b/src-tauri/src/registry.rs
@@ -1152,11 +1152,70 @@ pub fn conduit_dir_resolution() -> DirResolution {
     resolve_conduit_dir().1
 }
 
+/// Process-global test override for [`conduit_dir`]. See [`DataDirOverride`].
+///
+/// The `AtomicBool` is a fast path so production never pays for the lock: it is only
+/// ever flipped by a test, so a normal run does one relaxed load per lookup and skips
+/// the `RwLock` entirely.
+static DATA_DIR_OVERRIDE_ACTIVE: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
+static DATA_DIR_OVERRIDE: std::sync::RwLock<Option<PathBuf>> = std::sync::RwLock::new(None);
+
+/// Points [`conduit_dir`] at a scratch directory until the guard drops. **Tests only.**
+///
+/// Setting `CONDUIT_DATA_DIR` does NOT work from a test: [`resolve_conduit_dir`]
+/// memoizes in a `OnceLock`, so whichever test resolves the dir first wins and every
+/// later `set_var` is silently ignored, leaving the test reading and writing the
+/// developer's REAL data dir. That made suite results order-dependent and leaked
+/// fixture files into `Conduit-dev` (SOU-301).
+///
+/// Deliberately not `#[cfg(test)]`-gated: the gateway binary's tests link this library
+/// compiled WITHOUT `cfg(test)`, so a cfg-gated hook would be invisible in exactly the
+/// place that needs it.
+///
+/// The override is process-global, so tests that use it must serialize against each
+/// other (the gateway tests hold a shared `ENV_LOCK` for this).
+#[doc(hidden)]
+#[must_use = "the override is reverted when the guard drops, so it must be bound"]
+pub struct DataDirOverride(());
+
+impl DataDirOverride {
+    pub fn set(path: impl Into<PathBuf>) -> Self {
+        *DATA_DIR_OVERRIDE
+            .write()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(path.into());
+        DATA_DIR_OVERRIDE_ACTIVE.store(true, Ordering::SeqCst);
+        Self(())
+    }
+}
+
+impl Drop for DataDirOverride {
+    fn drop(&mut self) {
+        // Clear the flag first so a lookup racing the drop falls through to the real
+        // resolution rather than reading a half-cleared override.
+        DATA_DIR_OVERRIDE_ACTIVE.store(false, Ordering::SeqCst);
+        *DATA_DIR_OVERRIDE
+            .write()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = None;
+    }
+}
+
 /// Resolve the data dir once and cache it: the container check and the UNC
 /// reachability probe should not run on every path lookup, and a stable answer
 /// keeps every consumer (registry, watcher, tool cache, approval endpoint) on
 /// one directory for the process lifetime.
 fn resolve_conduit_dir() -> (Option<PathBuf>, DirResolution) {
+    // Checked ahead of the memoized value so a test can redirect the dir even after
+    // something else in the process has already resolved it.
+    if DATA_DIR_OVERRIDE_ACTIVE.load(Ordering::SeqCst) {
+        if let Some(p) = DATA_DIR_OVERRIDE
+            .read()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .clone()
+        {
+            return (Some(p), DirResolution::Direct);
+        }
+    }
     static RESOLVED: std::sync::OnceLock<(Option<PathBuf>, DirResolution)> =
         std::sync::OnceLock::new();
     RESOLVED


### PR DESCRIPTION
Fixes SOU-301.

## The problem

`end_to_end_lexical_semantic_blend` (from #394) **failed on clean main whenever the full suite ran**, and passed when run alone. Verified by stashing all unrelated changes. It is not a race: it failed identically under `--test-threads=1`.

## Root cause

`resolve_conduit_dir()` caches in a `OnceLock`. That is correct for the product, one stable directory per process, but it means:

> `std::env::set_var("CONDUIT_DATA_DIR", ...)` only has any effect if the calling test is the **first** thing in the process to resolve the dir.

Every test shares one process, so whether a test got its scratch directory depended entirely on ordering that no test can control.

When the var was ignored, the test read and wrote the developer's **real** dev data dir. For the blend test specifically that meant a warm `embeddings.json`, so `embed_tools` never fired, its mock server's third and fourth responses were never consumed, and ranking fell back to lexical — the second assertion then saw `email__send_email` instead of `github__create_pull_request`.

## The fix

A `DataDirOverride` RAII guard, checked ahead of the memoized value.

- **Production cost is one relaxed atomic load per lookup.** The flag is only ever flipped by a test, so a normal run skips the `RwLock` entirely.
- **Deliberately not `#[cfg(test)]`-gated.** The gateway binary's tests link this library compiled *without* `cfg(test)`, so a cfg-gated hook would be invisible in exactly the place that needs it. This is the detail that makes the obvious approach not work.
- The guard reverts on drop, so an override can't outlive its test and silently redirect the app.

## Verification

- [x] **3 consecutive full runs green** (`npm run test:rust`), where it previously failed every time
- [x] Green under `--test-threads=1`
- [x] **No pollution:** `%APPDATA%\Conduit-dev` is byte-identical before and after, `embeddings.json` MD5 unchanged. The blend test used to mutate it on every run.
- [x] 433 lib + 127 gateway tests pass

New test `data_dir_override_redirects_and_reverts` covers both halves, the redirect and the revert.

## Scope

The blend test is the one that was actually failing, so it is the one converted. `integrity`'s own tests still write profile-scoped fixtures into the real dev dir (there is residue there from 2026-07-16); they don't currently fail, and now that the mechanism exists they can be migrated separately.