### PR TITLE
fix(gateway): fail closed on an unreadable quarantine store, and cover the wired path

### DIFF
--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -3651,19 +3651,48 @@ fn requarantine_if_needed(
 /// The quarantine set the router SHOULD be enforcing right now, mirroring how the
 /// initial build gates on the feature flag: when quarantine-on-drift is off, nothing is
 /// blocked even though the persisted set survives on disk for when it's turned back on.
-fn effective_quarantine(registry: &Arc<Mutex<Registry>>, profile: Option<&str>) -> BTreeSet<String> {
+fn effective_quarantine(
+    registry: &Arc<Mutex<Registry>>,
+    profile: Option<&str>,
+) -> Option<BTreeSet<String>> {
     let on = {
         let r = registry
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
         r.quarantine_on_drift_effective()
     };
-    if on {
-        integrity::quarantined(profile)
-    } else {
-        BTreeSet::new()
+    if !on {
+        return Some(BTreeSet::new());
+    }
+    match integrity::quarantined_checked(profile) {
+        Ok(set) => {
+            // Recovered: let a future failure warn again.
+            QUARANTINE_READ_FAILED.store(false, Ordering::SeqCst);
+            Some(set)
+        }
+        // Fail CLOSED. An unreadable store is indistinguishable from an empty one, so
+        // treating it as empty would silently un-block every quarantined tool. Returning
+        // None keeps the router enforcing whatever it already has until the store is
+        // readable again.
+        Err(e) => {
+            // Warn once per failure streak: this runs on a 1s watcher tick, so logging
+            // unconditionally would bury the gateway log.
+            if !QUARANTINE_READ_FAILED.swap(true, Ordering::SeqCst) {
+                glog(&format!(
+                    "SECURITY: {e}; keeping the current quarantine set rather than \
+                     un-blocking. Re-approve tools once the store is readable."
+                ));
+                eprintln!("toolport: {e}; keeping the current quarantine set");
+            }
+            None
+        }
     }
 }
+
+/// Whether the last quarantine-store read failed, so the 1s watcher tick warns on the
+/// transition into failure rather than on every tick.
+static QUARANTINE_READ_FAILED: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
 
 /// Reconcile the router's live quarantine set against what's persisted, and re-filter if
 /// they diverged. Returns whether anything changed.
@@ -3687,7 +3716,11 @@ fn reconcile_quarantine(
     stdout: &Arc<Mutex<std::io::Stdout>>,
     profile: Option<&str>,
 ) -> bool {
-    reconcile_to(router, stdout, effective_quarantine(registry, profile))
+    match effective_quarantine(registry, profile) {
+        Some(want) => reconcile_to(router, stdout, want),
+        // Store unreadable: keep enforcing the current set rather than weakening it.
+        None => false,
+    }
 }
 
 /// Apply a target quarantine set to the live router, re-filtering (and telling the client)
@@ -9694,7 +9727,71 @@ mod tests {
             "fixture must have the feature off"
         );
         let registry = Arc::new(Mutex::new(reg));
-        assert!(effective_quarantine(&registry, Some("unused-profile")).is_empty());
+        assert_eq!(
+            effective_quarantine(&registry, Some("unused-profile")),
+            Some(BTreeSet::new()),
+            "feature off is a known-empty set, not an unknown one"
+        );
+    }
+
+    #[test]
+    fn a_corrupt_quarantine_store_keeps_the_current_set_instead_of_un_blocking() {
+        // `load_quarantine` reports a corrupt store as an EMPTY set (and moves the file
+        // aside). At startup that is the only answer available, but reconciling a LIVE set
+        // against it is a fail-OPEN: empty is indistinguishable from "the user re-approved
+        // everything", so a corrupt file would silently un-block every quarantined tool,
+        // and the rename would make the next tick read a legitimately-empty store and keep
+        // it that way. Reconciling must fail CLOSED.
+        let _env = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let dir =
+            std::env::temp_dir().join(format!("toolport-corrupt-q-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let _data_dir = conduit_lib::registry::DataDirOverride::set(&dir);
+
+        let profile = Some("corrupt-q");
+        let current = vec![json!({ "name": "srv__wipe", "description": "x", "inputSchema": {} })];
+        let events = vec![json!({
+            "server": "srv", "tool": "srv__wipe", "change": "poison", "severity": "high"
+        })];
+        assert!(conduit_lib::integrity::apply_quarantine(
+            profile, &current, &events
+        ));
+
+        let mut reg = Registry::default();
+        reg.quarantine_on_drift = true;
+        let registry = Arc::new(Mutex::new(reg));
+        let router = Arc::new(Mutex::new(Arc::new(Router::new())));
+        let stdout = Arc::new(Mutex::new(std::io::stdout()));
+
+        assert!(reconcile_quarantine(&registry, &router, &stdout, profile));
+        assert!(router.lock().unwrap().quarantined().contains("srv__wipe"));
+
+        // Corrupt the store underneath the running gateway.
+        let path = dir.join("quarantine-corrupt-q.json");
+        assert!(path.exists(), "fixture wrote where expected: {path:?}");
+        std::fs::write(&path, "{ not json at all").unwrap();
+
+        assert_eq!(
+            effective_quarantine(&registry, profile),
+            None,
+            "an unreadable store must be reported as unknown, not as empty"
+        );
+        assert!(
+            !reconcile_quarantine(&registry, &router, &stdout, profile),
+            "a corrupt store must not trigger a re-filter"
+        );
+        assert!(
+            router.lock().unwrap().quarantined().contains("srv__wipe"),
+            "the tool must STAY blocked while the store is unreadable"
+        );
+
+        // And it must recover once the store is readable again.
+        std::fs::write(&path, "{}").unwrap();
+        assert!(reconcile_quarantine(&registry, &router, &stdout, profile));
+        assert!(router.lock().unwrap().quarantined().is_empty());
+
+        drop(_data_dir);
+        std::fs::remove_dir_all(&dir).ok();
     }
 
     #[test]

--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -9698,6 +9698,57 @@ mod tests {
     }
 
     #[test]
+    fn reconcile_quarantine_reads_the_persisted_set_and_clears_a_release() {
+        // Covers `reconcile_quarantine` itself, the function the watcher actually calls.
+        // The other tests exercise `reconcile_to`, its pure half, which leaves the
+        // composition with `effective_quarantine` (and that function's ON branch, the one
+        // that touches disk) unverified. Given SOU-292 was a correct function nothing
+        // invoked, the composition is worth asserting directly.
+        //
+        // Only writable because SOU-301 landed DataDirOverride: `set_var` cannot redirect
+        // conduit_dir() once anything has resolved it, so this would otherwise read and
+        // write the developer's real data dir and be order-dependent.
+        let _env = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let dir = std::env::temp_dir().join(format!("toolport-sou292-e2e-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let _data_dir = conduit_lib::registry::DataDirOverride::set(&dir);
+
+        let profile = Some("sou292-e2e");
+        let current = vec![json!({ "name": "srv__wipe", "description": "x", "inputSchema": {} })];
+        let events = vec![json!({
+            "server": "srv", "tool": "srv__wipe", "change": "poison", "severity": "high"
+        })];
+        assert!(
+            conduit_lib::integrity::apply_quarantine(profile, &current, &events),
+            "fixture should have quarantined the tool"
+        );
+
+        let mut reg = Registry::default();
+        reg.quarantine_on_drift = true;
+        let registry = Arc::new(Mutex::new(reg));
+        let router = Arc::new(Mutex::new(Arc::new(Router::new())));
+        let stdout = Arc::new(Mutex::new(std::io::stdout()));
+
+        // Picks the persisted set up off disk (effective_quarantine's ON branch).
+        assert!(reconcile_quarantine(&registry, &router, &stdout, profile));
+        assert!(router.lock().unwrap().quarantined().contains("srv__wipe"));
+
+        // Steady state: no churn while nothing changes.
+        assert!(!reconcile_quarantine(&registry, &router, &stdout, profile));
+
+        // The user re-approves. This is the SOU-292 regression, end to end.
+        assert!(conduit_lib::integrity::release(profile, "srv__wipe"));
+        assert!(reconcile_quarantine(&registry, &router, &stdout, profile));
+        assert!(
+            router.lock().unwrap().quarantined().is_empty(),
+            "a released tool must stop being enforced"
+        );
+
+        drop(_data_dir);
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
     fn data_dir_override_redirects_and_reverts() {
         // The revert half matters as much as the redirect: the override is
         // process-global, so one that outlived its test would silently point the app

--- a/src-tauri/src/integrity.rs
+++ b/src-tauri/src/integrity.rs
@@ -619,6 +619,44 @@ pub fn quarantined(profile: Option<&str>) -> BTreeSet<String> {
     load_quarantine(profile).into_keys().collect()
 }
 
+/// Like [`quarantined`], but reports an unreadable or unparseable store as an ERROR
+/// instead of as "nothing is quarantined", and never renames anything.
+///
+/// [`load_quarantine`] treats a corrupt file as empty (and moves it aside). That is
+/// tolerable at startup, where there is no prior state to preserve and empty is the only
+/// answer available. It is NOT safe for a caller that reconciles a LIVE quarantine set:
+/// reading a failed load as an empty set is indistinguishable from "the user re-approved
+/// everything", so it would silently un-block every quarantined tool. Callers that can
+/// keep enforcing their current set should use this and fail closed on `Err`.
+///
+/// Deliberately non-destructive. `load_quarantine` renames a corrupt file to `.corrupt`,
+/// which would turn the very next read into a legitimate-looking empty set and re-open
+/// the same hole one tick later.
+pub fn quarantined_checked(profile: Option<&str>) -> Result<BTreeSet<String>, String> {
+    let Some(path) = quarantine_path(profile) else {
+        // No resolvable data dir means nothing can have been persisted in the first
+        // place, so an empty set is the truth here rather than a failure.
+        return Ok(BTreeSet::new());
+    };
+    let raw = match std::fs::read_to_string(&path) {
+        Ok(s) => s,
+        // Missing is the normal first-run state: nothing quarantined yet.
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(BTreeSet::new()),
+        Err(e) => return Err(format!("quarantine store at {path:?} is unreadable: {e}")),
+    };
+    if raw.trim().is_empty() {
+        return Ok(BTreeSet::new());
+    }
+    match serde_json::from_str::<Quarantine>(&raw) {
+        Ok(q) => Ok(q
+            .into_iter()
+            .filter(|(_, v)| !is_legacy_added(v))
+            .map(|(k, _)| k)
+            .collect()),
+        Err(e) => Err(format!("quarantine store at {path:?} is corrupt: {e}")),
+    }
+}
+
 /// Full quarantine records for `profile` (server, tool, reason, ts) for the UI.
 pub fn quarantine_list(profile: Option<&str>) -> Vec<Value> {
     load_quarantine(profile).into_values().collect()


### PR DESCRIPTION
Two findings from a self-review pass over the SOU-292 fix, since CodeRabbit was rate-limited on all of tonight's PRs.

## 1. Fail-open on an unreadable quarantine store (behaviour fix)

`load_quarantine` reports a corrupt store as an **empty set** and renames the file aside. At startup that's the only answer available: there's no prior state to preserve.

But the reconciler diffs that against a **live** set, and empty is indistinguishable from *"the user re-approved everything"* — so a corrupt file would silently un-block every quarantined tool. The rename made it worse: the next tick would read a legitimately-missing store and keep the set cleared for good.

That turned a startup-only fail-open into a **continuous** one, within a second, on a security feature. The comment in `load_quarantine` even says *"do NOT silently return empty ... a fail-OPEN of the supply-chain defense"*, so intent and implementation had already drifted apart.

**Fix:** `integrity::quarantined_checked` surfaces an unreadable or unparseable store as an error, and never renames (renaming would re-open the same hole one tick later). `effective_quarantine` now returns `Option`; `None` means *unknown*, and the reconciler keeps enforcing whatever the router already has. Warned once per failure streak, since this runs on a 1s tick.

`quarantined()` is untouched, so the startup path and the UI keep their existing behaviour. Blast radius is the reconciler only.

## 2. The wired entry point had no test coverage

The SOU-292 tests exercised `reconcile_to`, its **pure half**. Nothing asserted the composition in `reconcile_quarantine` — the function the watcher actually calls — or `effective_quarantine`'s **ON** branch, which reads the persisted set off disk.

`reconcile_quarantine` appeared exactly twice in the tree: its definition and its single call site. Deleting the call would have kept every test green. That's the same bug class SOU-292 *was*: a correct function nothing invoked.

Both new tests are only writable because #398 landed `DataDirOverride`. `set_var` can't redirect `conduit_dir()` once anything has resolved it, so before that they'd have written the developer's real dev data dir and been order-dependent.

## Verification

- [x] **Both mutation-checked.** Restoring the old fail-open makes the corrupt-store test fail; breaking `effective_quarantine`'s ON branch makes the coverage test fail.
- [x] Full suite: 433 lib + 129 gateway
- [x] `%APPDATA%\Conduit-dev` left with no fixture residue

## Residual gap, not covered

Nothing asserts the call site sits *before* the watcher loop's early `continue`. Moving it below would silently reintroduce SOU-292 for the release path with all tests green. `watch_registry` is an infinite loop with sleeps, so that needs restructuring rather than a unit test — flagging it rather than pretending it's covered.
