### PR TITLE
fix(deps): patch the two open Dependabot alerts in the shadcn subtree

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1367,11 +1367,13 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.14",
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.11.tgz",
+      "integrity": "sha512-bjD221KPLoJTWUwso1J6fGKiTXEUFedG/s0visavY4zakFPkeGURMRNly+FhBHs7T8Dz4qHaZIMX9ZoJHSJtKA==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=18.14.1"
+        "node": ">=20"
       },
       "peerDependencies": {
         "hono": "^4"
@@ -6589,7 +6591,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -71,6 +71,8 @@
   },
   "overrides": {
     "esbuild": "^0.28.1",
+    "fast-uri": "^3.1.4",
+    "@hono/node-server": "^2.0.5",
     "eslint-plugin-jsx-a11y": {
       "eslint": "$eslint"
     }


### PR DESCRIPTION
Closes both open Dependabot alerts. Both are **dev-scope**, reaching us only through `shadcn` → `@modelcontextprotocol/sdk`.

| Package | Severity | Advisory |
|---|---|---|
| `fast-uri` | High | [GHSA-4c8g-83qw-93j6](https://github.com/advisories/GHSA-4c8g-83qw-93j6) — host confusion via failed IDN canonicalization |
| `@hono/node-server` | Moderate | [GHSA-frvp-7c67-39w9](https://github.com/advisories/GHSA-frvp-7c67-39w9) — `serve-static` path traversal on Windows |

## Why overrides, and why they differ

**`fast-uri` has an in-range patch.** `ajv` pins `^3.0.1`, and 3.1.4 is patched, so the override stays inside the existing constraint. Low risk.

**`@hono/node-server` has none.** 1.19.14 is the last 1.x release; the fix only lands in 2.0.5. So this one is a deliberate **major** override of a transitive dependency, not a routine bump. I verified it resolves without `ERESOLVE` and that the shadcn CLI still loads and runs (`--version` and `--help` both exit 0).

**Caveat, stated plainly:** shadcn has an `mcp` subcommand that would actually exercise `@hono/node-server`, and the checks above do **not** exercise that path. Nothing in this project's workflow runs it, but if you ever use `shadcn mcp`, that's the thing to watch.

## What I tried first and rejected

Removing `shadcn` outright. It presents as a dev-only codegen CLI, so dropping it should have removed the whole subtree and both alerts permanently.

It **breaks the build**: `src/index.css` line 3 does `@import "shadcn/tailwind.css"`, so the Tailwind plugin fails to resolve. Caught by running the build, not by inspection.

That also corrects something I wrote on #396: "nothing under `src/` imports it" was wrong — I grepped for JS/TS imports and missed the CSS one. Moving it to `devDependencies` there was still correct, since the build runs with dev deps installed.

## Follow-up worth considering

shadcn ships an `eject` command that inlines `shadcn/tailwind.css` and removes the dependency. That would drop this entire subtree permanently rather than chasing its advisories one at a time. Bigger change than I'd want to make at release time, but it's the durable answer.

## Verification

- [x] `npm audit` clean at **every** scope (was 1 high + 1 moderate)
- [x] `npm ci` (strict) passes
- [x] `tsc`, `lint`, `build` clean
- [x] 108 frontend tests
- [x] shadcn CLI still functional
