### PR TITLE
fix(app): stop stale gateways by version, not by whether a repoint just happened

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,13 @@ approved, so a re-approved tool works on the very next call. (#395)
 are blocked couldn't be read, it was treated as "nothing is blocked", quietly dropping the
 protection. It now keeps enforcing what it already knows and says so. (#399)
 
+**Updating now actually replaces the gateway your AI clients are using.** Toolport runs a
+small gateway process for each connected client, and that's where most fixes live - including
+the re-approve fix above. After an update those clients could keep running the _old_ gateway
+until you restarted them, so you'd install a fix, watch the problem persist, and reasonably
+conclude the update hadn't worked. Toolport now retires out-of-date gateways when it starts,
+and each client picks up the new one on its next request. (#404)
+
 **Downstream servers run in their own process group on macOS and Linux**, so a server
 starting up can't disturb the display of a terminal-based AI client. Thanks to
 @bradhallett. (#364)

--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -3748,6 +3748,11 @@ fn reconcile_to(
     };
     // Notify outside the router lock so a slow client write can't stall a request.
     if changed {
+        // To the gateway log, not just stderr: MCP clients swallow a gateway's stderr, so a
+        // user reporting "re-approve didn't work" would send diagnostics with no trace of
+        // whether the reconcile ever ran. The failure path already logs here; this keeps the
+        // success path visible too.
+        glog("quarantine set changed on disk; re-filtering exposed tools");
         eprintln!("toolport: quarantine set changed on disk; re-filtering exposed tools");
         notify_tools_changed(stdout);
     }

--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -2966,15 +2966,27 @@ pub fn run() {
                         repointed.len(),
                         repointed.join(", ")
                     );
-                    // A repoint means the gateway binary path changed (a version bump), so the
-                    // clients' currently-running gateways are the OLD version. Stop them so each
-                    // client respawns the freshly-installed gateway on its next request, instead
-                    // of the user having to relaunch the client to pick it up. Covers MANUAL
-                    // updates (running the installer), which never go through the in-app updater
-                    // that already calls stop_spawned_gateways. Only fires when something was
-                    // actually repointed, so a normal launch never kills a healthy gateway.
-                    let stopped = crate::gateway_publish::stop_spawned_gateways();
-                    eprintln!("toolport: stopped {stopped} stale gateway image(s) after re-point");
+                }
+                // Stop any gateway running a version other than this one, so each client
+                // respawns the freshly-installed gateway on its next request rather than the
+                // user having to relaunch the client. Covers MANUAL updates (running the
+                // installer), which never go through the in-app updater that already calls
+                // stop_spawned_gateways.
+                //
+                // Deliberately NOT gated on `repointed` (SOU-306). That call is idempotent, so
+                // once configs point at the new binary it returns empty forever and the cleanup
+                // became one-shot: it was a proxy for "is a running gateway on an old version?"
+                // and the two come apart precisely after a manual install, or on any launch
+                // after the first. Checking versions directly makes this self-correcting, so a
+                // later launch still cleans up what an earlier one missed. Current-version
+                // gateways are left alone, so a normal launch kills nothing.
+                let stale = crate::gateway_publish::stop_stale_gateways();
+                if !stale.is_empty() {
+                    eprintln!(
+                        "toolport: stopped {} stale gateway process image(s): {}",
+                        stale.len(),
+                        stale.join(", ")
+                    );
                 }
             });
 

--- a/src-tauri/src/gateway_publish.rs
+++ b/src-tauri/src/gateway_publish.rs
@@ -181,6 +181,99 @@ pub fn stop_spawned_gateways() -> u32 {
     0
 }
 
+/// Terminate only gateway processes running a version OTHER than the installed one, and
+/// report the image names killed. Unlike [`stop_spawned_gateways`] this leaves current
+/// gateways alone, so it is safe to run on every launch.
+///
+/// Why this exists (SOU-306): the launch-time cleanup used to be gated on
+/// `repoint_stale_gateways()` returning a non-empty list. That call is idempotent, so once
+/// client configs point at the new binary it returns empty forever and the cleanup never
+/// runs again. The gate was a proxy for "is a running gateway on an old version?", and the
+/// two come apart exactly when the repoint already happened - after a manual install, or on
+/// any launch after the first. Six 1.9.3 gateways survived a 1.9.4 update that way, two of
+/// them across an app restart.
+///
+/// This matters because the gateway is where fixes like SOU-292 live: a user who updates to
+/// get one, while their client keeps an old gateway alive, still has the bug and reasonably
+/// concludes the update did nothing. Clients respawn the gateway on their next request, so
+/// killing is enough; nothing needs relaunching here.
+#[cfg(windows)]
+pub fn stop_stale_gateways() -> Vec<String> {
+    let images = running_gateway_images();
+    let mut killed = Vec::new();
+    for image in stale_gateway_images(&images, env!("CARGO_PKG_VERSION")) {
+        let ok = std::process::Command::new("taskkill")
+            .args(["/F", "/IM", &image])
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false);
+        if ok {
+            killed.push(image);
+        }
+    }
+    killed
+}
+
+/// Which of `images` are gateways running a version other than `current`.
+///
+/// Split from the process enumeration and the killing so the decision is testable without
+/// spawning anything: getting this wrong is expensive in both directions - too eager and a
+/// launch kills the gateway it just published, too shy and the stale one survives and the
+/// user silently keeps running old code.
+fn stale_gateway_images(images: &[String], current: &str) -> Vec<String> {
+    // Names the current install may legitimately be running under. The unversioned forms are
+    // kept because a dev/unpackaged run uses them and carries no version to compare, so
+    // killing them would take out a running `tauri dev` gateway. `conduit-gateway` is the
+    // pre-rename form, kept so an in-place upgrade from an old install can't self-kill.
+    let keep = [
+        format!("toolport-gateway-{current}.exe"),
+        format!("conduit-gateway-{current}.exe"),
+        "toolport-gateway.exe".to_string(),
+        "conduit-gateway.exe".to_string(),
+    ];
+    images
+        .iter()
+        .filter(|image| !keep.iter().any(|k| k.eq_ignore_ascii_case(image)))
+        .cloned()
+        .collect()
+}
+
+/// Distinct image names of running gateway processes, e.g. `toolport-gateway-1.9.3.exe`.
+/// Matched on the `*-gateway*` shape rather than an exact name because the published binary
+/// clients actually run is versioned; nothing else on the system uses that shape.
+#[cfg(windows)]
+fn running_gateway_images() -> Vec<String> {
+    let Ok(out) = std::process::Command::new("tasklist")
+        .args(["/FO", "CSV", "/NH"])
+        .output()
+    else {
+        return Vec::new();
+    };
+    let text = String::from_utf8_lossy(&out.stdout);
+    let mut names: Vec<String> = Vec::new();
+    for line in text.lines() {
+        // CSV rows look like: "image.exe","1234","Console","1","12,345 K"
+        let Some(name) = line.trim().strip_prefix('"').and_then(|r| r.split('"').next())
+        else {
+            continue;
+        };
+        let lower = name.to_ascii_lowercase();
+        let ours = (lower.starts_with("toolport-gateway") || lower.starts_with("conduit-gateway"))
+            && lower.ends_with(".exe");
+        if ours && !names.iter().any(|n: &String| n.eq_ignore_ascii_case(name)) {
+            names.push(name.to_string());
+        }
+    }
+    names
+}
+
+#[cfg(not(windows))]
+pub fn stop_stale_gateways() -> Vec<String> {
+    Vec::new()
+}
+
 /// Last path segment, regardless of OS path separator (client configs store Windows paths).
 fn path_basename(stored: &str) -> &str {
     stored.rsplit(['\\', '/']).next().unwrap_or(stored)
@@ -215,6 +308,51 @@ mod tests {
         assert!(is_unversioned_install_gateway_path(
             "/Applications/Toolport.app/Contents/MacOS/conduit-gateway"
         ));
+    }
+
+    #[test]
+    fn stale_gateway_images_keeps_current_and_kills_older() {
+        // Regression for SOU-306. A 1.9.4 update left six 1.9.3 gateways running because the
+        // cleanup was gated on a repoint that had already happened, so users kept running old
+        // gateway code and did not receive the fix they had just updated for.
+        let running = vec![
+            "toolport-gateway-1.9.3.exe".to_string(),
+            "toolport-gateway-1.9.4.exe".to_string(),
+            "toolport-gateway-1.8.0.exe".to_string(),
+            "conduit-gateway-1.7.2.exe".to_string(),
+        ];
+        let stale = stale_gateway_images(&running, "1.9.4");
+
+        assert!(
+            !stale.contains(&"toolport-gateway-1.9.4.exe".to_string()),
+            "must never kill the version it just published"
+        );
+        assert!(stale.contains(&"toolport-gateway-1.9.3.exe".to_string()));
+        assert!(stale.contains(&"toolport-gateway-1.8.0.exe".to_string()));
+        assert!(
+            stale.contains(&"conduit-gateway-1.7.2.exe".to_string()),
+            "the pre-rename image is still stale when its version differs"
+        );
+        assert_eq!(stale.len(), 3);
+    }
+
+    #[test]
+    fn stale_gateway_images_spares_unversioned_and_a_clean_launch() {
+        // Unversioned images are dev/unpackaged runs with no version to compare; killing them
+        // would take out a running `tauri dev` gateway.
+        let dev = vec![
+            "toolport-gateway.exe".to_string(),
+            "conduit-gateway.exe".to_string(),
+        ];
+        assert!(stale_gateway_images(&dev, "1.9.4").is_empty());
+
+        // The common case: nothing stale, so a normal launch kills nothing.
+        let current = vec!["toolport-gateway-1.9.4.exe".to_string()];
+        assert!(stale_gateway_images(&current, "1.9.4").is_empty());
+
+        // And the pre-rename image at the current version is the same install, not a leftover.
+        let renamed = vec!["conduit-gateway-1.9.4.exe".to_string()];
+        assert!(stale_gateway_images(&renamed, "1.9.4").is_empty());
     }
 
     #[test]


### PR DESCRIPTION
Fixes SOU-306. Found while smoke-testing the v1.9.4 draft.

## What happened

After updating to 1.9.4, **six `toolport-gateway-1.9.3.exe` processes were still running**, all with start times predating the update. Two survived a subsequent app restart.

The install itself was fine: the new binary was published and client configs were repointed to it. Only the stale-process cleanup never ran.

## Why it matters more than it looks

The gateway is where fixes like SOU-292 live. A user who updates specifically to get one, while their MCP client keeps an old gateway alive, **still has the bug** and reasonably concludes the update did nothing.

Confirmed live, in both directions:

- With a **1.9.3** gateway, a quarantine written to disk was ignored entirely — the tool kept working while the app showed it as blocked.
- After restarting the client so a **1.9.4** gateway spawned, the same quarantine was enforced, and re-approving unblocked it within a second with no restart.

## Root cause

```rust
let repointed = clients::repoint_stale_gateways();
if !repointed.is_empty() {
    let stopped = crate::gateway_publish::stop_spawned_gateways();
}
```

`repoint_stale_gateways()` is **idempotent**. Once configs point at the new binary it returns empty forever, so the cleanup was effectively one-shot.

The gate was a proxy for *"is a running gateway on an old version?"* — and the two come apart precisely when the repoint already happened: after a manual install, or on any launch after the first.

The in-app updater path was never affected; `updater.ts` calls `stop_spawned_gateways` directly before installing. This only hit manual installs.

## The fix

Check the actual condition. Enumerate running gateway images and stop the ones whose version differs from this build, **ungated**. Self-correcting: a later launch cleans up what an earlier one missed.

Spared deliberately:
- **The current version** — killing what you just published would be the damaging failure.
- **Unversioned images** (`toolport-gateway.exe`) — those are dev/unpackaged runs with no version to compare; killing them would take out a running `tauri dev` gateway.
- **The pre-rename `conduit-gateway` form at the current version** — same install, not a leftover.

A normal launch with nothing stale still kills nothing.

## Tests

The keep/kill decision is split into a pure `stale_gateway_images()` so it's testable without spawning processes — same lesson as #399, where testing the I/O wrapper instead of the decision left the real logic uncovered.

**Mutation-checked:** removing the keep list fails both tests, including the assertion that it never kills the version it just published.

435 lib + 129 gateway tests pass.

## Also in here

The quarantine reconciler now logs to the **gateway log**, not only stderr. MCP clients swallow gateway stderr, so a user reporting "re-approve didn't work" would have sent diagnostics containing no trace of whether the reconcile ran. The failure path already logged there; this makes the success path match. Found while verifying the fix above — the successful reconcile left no evidence.

## Note for the release

This does **not** retroactively fix already-running gateways for someone on 1.9.4. It takes effect from the next version. So the v1.9.4 notes should still tell people to restart their AI clients after updating.
