### PR TITLE
fix(app): stop flashing console windows when Toolport launches

### DIFF
--- a/src-tauri/src/gateway_publish.rs
+++ b/src-tauri/src/gateway_publish.rs
@@ -151,6 +151,18 @@ pub fn client_gateway_path() -> Option<PathBuf> {
     publish_bundled_gateway()
 }
 
+/// Suppress the console window Windows would otherwise flash for a CLI child.
+///
+/// These run at app launch, so without it the user sees black CMD windows pop up every
+/// time Toolport starts - which reads as something being wrong, especially to a
+/// non-technical user. `tasklist` in particular now runs on EVERY launch (SOU-306 made the
+/// stale-gateway check ungated), so an occasional flash became a guaranteed one.
+#[cfg(windows)]
+fn no_console(cmd: &mut std::process::Command) {
+    use std::os::windows::process::CommandExt;
+    cmd.creation_flags(0x0800_0000); // CREATE_NO_WINDOW
+}
+
 /// Terminate client-spawned gateway processes so the installer can replace locked binaries
 /// and so clients respawn the just-installed version instead of keeping the old one until the
 /// user relaunches them. Does not touch parent apps (Cursor, Codex, etc.). Returns how many
@@ -164,11 +176,12 @@ pub fn client_gateway_path() -> Option<PathBuf> {
 pub fn stop_spawned_gateways() -> u32 {
     let mut stopped = 0u32;
     for image in ["toolport-gateway*.exe", "conduit-gateway*.exe"] {
-        let status = std::process::Command::new("taskkill")
-            .args(["/F", "/IM", image])
+        let mut cmd = std::process::Command::new("taskkill");
+        cmd.args(["/F", "/IM", image])
             .stdout(std::process::Stdio::null())
-            .stderr(std::process::Stdio::null())
-            .status();
+            .stderr(std::process::Stdio::null());
+        no_console(&mut cmd);
+        let status = cmd.status();
         if status.map(|s| s.success()).unwrap_or(false) {
             stopped += 1;
         }
@@ -202,13 +215,12 @@ pub fn stop_stale_gateways() -> Vec<String> {
     let images = running_gateway_images();
     let mut killed = Vec::new();
     for image in stale_gateway_images(&images, env!("CARGO_PKG_VERSION")) {
-        let ok = std::process::Command::new("taskkill")
-            .args(["/F", "/IM", &image])
+        let mut cmd = std::process::Command::new("taskkill");
+        cmd.args(["/F", "/IM", &image])
             .stdout(std::process::Stdio::null())
-            .stderr(std::process::Stdio::null())
-            .status()
-            .map(|s| s.success())
-            .unwrap_or(false);
+            .stderr(std::process::Stdio::null());
+        no_console(&mut cmd);
+        let ok = cmd.status().map(|s| s.success()).unwrap_or(false);
         if ok {
             killed.push(image);
         }
@@ -245,10 +257,10 @@ fn stale_gateway_images(images: &[String], current: &str) -> Vec<String> {
 /// clients actually run is versioned; nothing else on the system uses that shape.
 #[cfg(windows)]
 fn running_gateway_images() -> Vec<String> {
-    let Ok(out) = std::process::Command::new("tasklist")
-        .args(["/FO", "CSV", "/NH"])
-        .output()
-    else {
+    let mut cmd = std::process::Command::new("tasklist");
+    cmd.args(["/FO", "CSV", "/NH"]);
+    no_console(&mut cmd);
+    let Ok(out) = cmd.output() else {
         return Vec::new();
     };
     let text = String::from_utf8_lossy(&out.stdout);


### PR DESCRIPTION
Two black CMD windows appear for several seconds when Toolport launches. It reads as something being wrong, and would make a non-technical user wary of an app whose whole pitch is that it's safe to run.

## Cause

Three CLI children in `gateway_publish.rs` spawn without `CREATE_NO_WINDOW`, so Windows gives each one a console:

- `taskkill` in `stop_spawned_gateways` (two invocations, one per image pattern)
- `taskkill` in `stop_stale_gateways`
- `tasklist` in `running_gateway_images`

Everywhere else in the codebase already handles this — the HTTP bridge (`desktop.rs`) and every stdio MCP server (`downstream.rs`) both set the flag, the latter with a comment describing this exact symptom. These were the only launch-time spawns that missed it.

## I made this worse in #404

Before that change, `taskkill` only ran when a repoint had just happened, which is rare. Making the stale-gateway check ungated means `tasklist` now runs on **every launch** — turning an occasional flash into a guaranteed one. That regression is in the v1.9.4 draft as it currently stands.

## Ruled out

- `open_data_dir` spawns `explorer`, but it's user-triggered, not launch-time.
- The login-shell PATH probe in `downstream.rs` would be a good candidate for a multi-second window, but it's `#[cfg(not(windows))]`.

## Verification

- [x] All three spawns now go through a `no_console` helper
- [x] 436 lib + 129 gateway tests pass
- [x] `cargo check --all-targets` clean

Not directly unit-testable — whether Windows draws a console is an OS behaviour, not a return value. The check that matters is visual: launch the app and confirm no windows appear.
