### PR TITLE
test(integrity): isolate data-directory tests

### DIFF
--- a/src-tauri/src/inspect.rs
+++ b/src-tauri/src/inspect.rs
@@ -165,12 +165,6 @@ pub fn clear() {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::Mutex;
-
-    // The inspect file path is process-global (one file per machine), so these
-    // tests can't run concurrently against it. Serialize them, and reset the file
-    // at the start of each so they don't see each other's writes.
-    static TEST_LOCK: Mutex<()> = Mutex::new(());
 
     fn reset() {
         clear();
@@ -178,7 +172,7 @@ mod tests {
 
     #[test]
     fn record_then_read_recent_returns_it() {
-        let _g = TEST_LOCK.lock().unwrap();
+        let _data_dir = crate::registry::data_dir_test_lock();
         reset();
         record(
             Some("cursor"),
@@ -204,7 +198,7 @@ mod tests {
 
     #[test]
     fn ring_caps_at_fifty() {
-        let _g = TEST_LOCK.lock().unwrap();
+        let _data_dir = crate::registry::data_dir_test_lock();
         reset();
         for i in 0..60 {
             record(
@@ -228,7 +222,7 @@ mod tests {
 
     #[test]
     fn oversized_request_is_truncated_not_stored() {
-        let _g = TEST_LOCK.lock().unwrap();
+        let _data_dir = crate::registry::data_dir_test_lock();
         reset();
         // A request whose serialized JSON is well over the 4 KB cap.
         let big = "x".repeat(8 * 1024);

--- a/src-tauri/src/integrity.rs
+++ b/src-tauri/src/integrity.rs
@@ -1480,6 +1480,36 @@ pub fn read_recent(limit: usize) -> Vec<Value> {
 mod tests {
     use super::*;
 
+    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    struct TestDataDir {
+        guard: Option<crate::registry::DataDirOverride>,
+        path: PathBuf,
+    }
+
+    impl TestDataDir {
+        fn new(label: &str) -> Self {
+            let path = std::env::temp_dir().join(format!(
+                "toolport-integrity-{label}-{}",
+                std::process::id()
+            ));
+            let _ = std::fs::remove_dir_all(&path);
+            std::fs::create_dir_all(&path).expect("create temporary data directory");
+            let guard = crate::registry::DataDirOverride::set(&path);
+            Self {
+                guard: Some(guard),
+                path,
+            }
+        }
+    }
+
+    impl Drop for TestDataDir {
+        fn drop(&mut self) {
+            self.guard.take();
+            let _ = std::fs::remove_dir_all(&self.path);
+        }
+    }
+
     fn tool(name: &str, desc: &str) -> Value {
         json!({ "name": name, "description": desc, "inputSchema": { "type": "object" } })
     }
@@ -1491,6 +1521,8 @@ mod tests {
 
     #[test]
     fn quarantine_blocks_poison_and_destructive_drift_then_releases() {
+        let _env = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _data_dir = TestDataDir::new("quarantine");
         let profile = Some("quarantine-unit");
         if let Some(p) = quarantine_path(profile) {
             let _ = std::fs::remove_file(p);
@@ -1528,6 +1560,8 @@ mod tests {
 
     #[test]
     fn added_destructive_tool_is_not_quarantined_and_legacy_added_clears() {
+        let _env = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _data_dir = TestDataDir::new("added");
         let profile = Some("quarantine-added-unit");
         if let Some(p) = quarantine_path(profile) {
             let _ = std::fs::remove_file(p);
@@ -1611,6 +1645,8 @@ mod tests {
 
     #[test]
     fn baseline_tracks_first_seen_and_last_changed() {
+        let _env = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _data_dir = TestDataDir::new("timestamps");
         let profile = Some("identity-ts-unit");
         if let Some(p) = pins_path(profile) {
             let _ = std::fs::remove_file(p);
@@ -1646,6 +1682,8 @@ mod tests {
 
     #[test]
     fn empty_pins_file_is_corrupt_not_a_silent_wipe() {
+        let _env = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _data_dir = TestDataDir::new("empty-pins");
         // atomic_write never leaves an empty pins file, so an empty one means the baseline
         // was truncated (a crash mid foreign write, or an attacker wiping it to reset drift
         // detection). It must trip the LOUD path, never a silent re-baseline: returning Fresh
@@ -2168,6 +2206,8 @@ mod tests {
 
     #[test]
     fn annotation_downgrade_quarantines_non_destructive_tool() {
+        let _env = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _data_dir = TestDataDir::new("downgrade");
         let profile = Some("integrity-downgrade-unit");
         if let Some(p) = quarantine_path(profile) {
             let _ = std::fs::remove_file(p);

--- a/src-tauri/src/integrity.rs
+++ b/src-tauri/src/integrity.rs
@@ -1480,24 +1480,25 @@ pub fn read_recent(limit: usize) -> Vec<Value> {
 mod tests {
     use super::*;
 
-    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    static TEST_DIR_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
 
     struct TestDataDir {
-        guard: Option<crate::registry::DataDirOverride>,
+        _guard: crate::registry::DataDirOverride,
         path: PathBuf,
     }
 
     impl TestDataDir {
         fn new(label: &str) -> Self {
+            let seq = TEST_DIR_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
             let path = std::env::temp_dir().join(format!(
-                "toolport-integrity-{label}-{}",
-                std::process::id()
+                "toolport-integrity-{label}-{}-{seq}",
+                std::process::id(),
             ));
             let _ = std::fs::remove_dir_all(&path);
             std::fs::create_dir_all(&path).expect("create temporary data directory");
             let guard = crate::registry::DataDirOverride::set(&path);
             Self {
-                guard: Some(guard),
+                _guard: guard,
                 path,
             }
         }
@@ -1505,7 +1506,6 @@ mod tests {
 
     impl Drop for TestDataDir {
         fn drop(&mut self) {
-            self.guard.take();
             let _ = std::fs::remove_dir_all(&self.path);
         }
     }
@@ -1521,7 +1521,7 @@ mod tests {
 
     #[test]
     fn quarantine_blocks_poison_and_destructive_drift_then_releases() {
-        let _env = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _data_dir_lock = crate::registry::data_dir_test_lock();
         let _data_dir = TestDataDir::new("quarantine");
         let profile = Some("quarantine-unit");
         if let Some(p) = quarantine_path(profile) {
@@ -1560,7 +1560,7 @@ mod tests {
 
     #[test]
     fn added_destructive_tool_is_not_quarantined_and_legacy_added_clears() {
-        let _env = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _data_dir_lock = crate::registry::data_dir_test_lock();
         let _data_dir = TestDataDir::new("added");
         let profile = Some("quarantine-added-unit");
         if let Some(p) = quarantine_path(profile) {
@@ -1645,7 +1645,7 @@ mod tests {
 
     #[test]
     fn baseline_tracks_first_seen_and_last_changed() {
-        let _env = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _data_dir_lock = crate::registry::data_dir_test_lock();
         let _data_dir = TestDataDir::new("timestamps");
         let profile = Some("identity-ts-unit");
         if let Some(p) = pins_path(profile) {
@@ -1682,7 +1682,7 @@ mod tests {
 
     #[test]
     fn empty_pins_file_is_corrupt_not_a_silent_wipe() {
-        let _env = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _data_dir_lock = crate::registry::data_dir_test_lock();
         let _data_dir = TestDataDir::new("empty-pins");
         // atomic_write never leaves an empty pins file, so an empty one means the baseline
         // was truncated (a crash mid foreign write, or an attacker wiping it to reset drift
@@ -2206,7 +2206,7 @@ mod tests {
 
     #[test]
     fn annotation_downgrade_quarantines_non_destructive_tool() {
-        let _env = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _data_dir_lock = crate::registry::data_dir_test_lock();
         let _data_dir = TestDataDir::new("downgrade");
         let profile = Some("integrity-downgrade-unit");
         if let Some(p) = quarantine_path(profile) {

--- a/src-tauri/src/registry.rs
+++ b/src-tauri/src/registry.rs
@@ -1160,6 +1160,20 @@ pub fn conduit_dir_resolution() -> DirResolution {
 static DATA_DIR_OVERRIDE_ACTIVE: std::sync::atomic::AtomicBool =
     std::sync::atomic::AtomicBool::new(false);
 static DATA_DIR_OVERRIDE: std::sync::RwLock<Option<PathBuf>> = std::sync::RwLock::new(None);
+#[cfg(test)]
+static DATA_DIR_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+/// Serialize tests that resolve [`conduit_dir`] with tests that override it.
+///
+/// The override is process-global, so this lock is required even for tests that only
+/// read the normal data directory; otherwise they can observe another test's scratch
+/// directory while that test holds a [`DataDirOverride`].
+#[cfg(test)]
+pub(crate) fn data_dir_test_lock() -> std::sync::MutexGuard<'static, ()> {
+    DATA_DIR_TEST_LOCK
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+}
 
 /// Points [`conduit_dir`] at a scratch directory until the guard drops. **Tests only.**
 ///
@@ -1173,8 +1187,9 @@ static DATA_DIR_OVERRIDE: std::sync::RwLock<Option<PathBuf>> = std::sync::RwLock
 /// compiled WITHOUT `cfg(test)`, so a cfg-gated hook would be invisible in exactly the
 /// place that needs it.
 ///
-/// The override is process-global, so tests that use it must serialize against each
-/// other (the gateway tests hold a shared `ENV_LOCK` for this).
+/// The override is process-global. Every test in the same test binary that resolves
+/// [`conduit_dir`] directly or indirectly must hold `data_dir_test_lock`, whether
+/// or not that test installs an override itself.
 #[doc(hidden)]
 #[must_use = "the override is reverted when the guard drops, so it must be bound"]
 pub struct DataDirOverride(());
@@ -2347,6 +2362,7 @@ mod tests {
     #[cfg(windows)]
     #[test]
     fn conduit_dir_is_direct_outside_a_container() {
+        let _data_dir = data_dir_test_lock();
         assert_eq!(conduit_dir_resolution(), DirResolution::Direct);
         let dir = conduit_dir().expect("home dir resolves");
         assert!(dir.ends_with(format!("AppData\\Roaming\\{}", data_dir_leaf_name())));

--- a/src-tauri/src/searchtrace.rs
+++ b/src-tauri/src/searchtrace.rs
@@ -182,14 +182,10 @@ pub fn clear() {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::Mutex;
-
-    // One file per machine, so these can't run concurrently. Serialize + reset.
-    static TEST_LOCK: Mutex<()> = Mutex::new(());
 
     #[test]
     fn record_then_read_returns_newest_first() {
-        let _g = TEST_LOCK.lock().unwrap();
+        let _data_dir = crate::registry::data_dir_test_lock();
         clear();
         record(
             Some("cursor"),
@@ -235,7 +231,7 @@ mod tests {
 
     #[test]
     fn ranking_and_mode_are_recorded_and_capped() {
-        let _g = TEST_LOCK.lock().unwrap();
+        let _data_dir = crate::registry::data_dir_test_lock();
         clear();
         // Ranking with more than MAX_NAMES entries; only MAX_NAMES are stored.
         let ranking: Vec<Value> = (0..40)
@@ -291,7 +287,7 @@ mod tests {
 
     #[test]
     fn query_is_capped_and_names_are_limited() {
-        let _g = TEST_LOCK.lock().unwrap();
+        let _data_dir = crate::registry::data_dir_test_lock();
         clear();
         let long_q = "x".repeat(500);
         let many: Vec<String> = (0..40).map(|i| format!("srv__t{i}")).collect();
@@ -320,7 +316,7 @@ mod tests {
 
     #[test]
     fn no_match_search_is_still_recorded() {
-        let _g = TEST_LOCK.lock().unwrap();
+        let _data_dir = crate::registry::data_dir_test_lock();
         clear();
         record(
             None,


### PR DESCRIPTION
## What and why

Adds a scoped temporary data-directory override to integrity tests that touch disk. Each test now gets an isolated directory and cleanup restores the prior override before deleting it.

Closes #400

## Testing

- cargo test integrity::tests -- 32 passed

The repository-wide Rust suite still reaches the unrelated process-state-sensitive inspect::tests::ring_caps_at_fifty failure (24/27 observed events versus the fixed expectation of 50).

## Notes

The production integrity path is unchanged. The helper is test-only, and both Toolport commits include DCO sign-off.

- [x] No secrets, keys, or personal paths are included in the diff