### PR TITLE
refactor(activity): centralize timestamp formatting

### DIFF
--- a/src/components/ActivityView.tsx
+++ b/src/components/ActivityView.tsx
@@ -18,7 +18,7 @@ import {
   XCircle,
 } from "lucide-react";
 import { toast } from "sonner";
-import { fmtPercent, fmtTokens } from "@/lib/utils";
+import { fmtPercent, fmtTokens, fmtTs } from "@/lib/utils";
 import { toastError } from "@/lib/toast";
 import { save } from "@tauri-apps/plugin-dialog";
 import { Input } from "@/components/ui/input";
@@ -325,12 +325,7 @@ function SecurityNotices({
                     )}
                     <span className="ml-auto text-muted-foreground">
                       {count > 1 ? "last " : ""}
-                      {new Date(e.ts).toLocaleString(undefined, {
-                        month: "short",
-                        day: "numeric",
-                        hour: "2-digit",
-                        minute: "2-digit",
-                      })}
+                      {fmtTs(e.ts)}
                     </span>
                     <button
                       onClick={() => onDismiss(e)}
@@ -414,14 +409,7 @@ function QuietDriftHistory({
                   {e.change === "added" ? "new tool" : "changed"}
                 </span>
                 <code className="font-mono text-muted-foreground">{e.tool}</code>
-                <span className="ml-auto text-muted-foreground/70">
-                  {new Date(e.ts).toLocaleString(undefined, {
-                    month: "short",
-                    day: "numeric",
-                    hour: "2-digit",
-                    minute: "2-digit",
-                  })}
-                </span>
+                <span className="ml-auto text-muted-foreground/70">{fmtTs(e.ts)}</span>
                 <button
                   onClick={() => onDismiss(e)}
                   aria-label="Dismiss this change"
@@ -681,9 +669,7 @@ function CallRow({ e }: { e: AuditEntry }) {
         <span className="ml-auto shrink-0 text-xs tabular-nums text-muted-foreground">
           {fmtMs(e.durationMs ?? e.heldMs ?? null)}
         </span>
-        <span className="shrink-0 text-xs text-muted-foreground">
-          {new Date(e.ts).toLocaleString()}
-        </span>
+        <span className="shrink-0 text-xs text-muted-foreground">{fmtTs(e.ts)}</span>
       </div>
       {open && e.error && (
         <div className="border-t border-border/50 bg-destructive/5 px-3 py-2 pl-9">
@@ -832,7 +818,7 @@ function InspectRow({ e }: { e: InspectEntry }) {
           {fmtMs(e.durationMs ?? null)}
         </span>
         <span className="shrink-0 text-xs text-muted-foreground">
-          {new Date(e.ts).toLocaleTimeString()}
+          {fmtTs(e.ts, "time")}
         </span>
       </div>
       {open && (
@@ -911,7 +897,7 @@ function DiscoveryRow({ t }: { t: SearchTrace }) {
           {resultSummary}
         </span>
         <span className="shrink-0 text-xs text-muted-foreground">
-          {new Date(t.ts).toLocaleTimeString()}
+          {fmtTs(t.ts, "time")}
         </span>
       </div>
       {open && (
@@ -1057,7 +1043,7 @@ function DiscoveryTraces({ refreshKey }: { refreshKey: number }) {
 function ToolIdentityRow({ t }: { t: ToolIdentity }) {
   const [open, setOpen] = useState(false);
   const fpShort = t.fingerprint.replace(/^v\d+:/, "").slice(0, 12) || "-";
-  const fmtDate = (ms: number) => (ms > 0 ? new Date(ms).toLocaleDateString() : "-");
+  const fmtDate = (ms: number) => (ms > 0 ? fmtTs(ms, "date") : "-");
   return (
     <div className="rounded-md border border-border/50 text-sm">
       <div

--- a/src/components/ActivityView.tsx
+++ b/src/components/ActivityView.tsx
@@ -432,13 +432,7 @@ function SavingsBanner({ savings }: { savings: SavingsSummary }) {
   const [modelLabel, setModelLabel] = useState("Claude Sonnet");
   const price = SAVINGS_MODEL_PRICE.get(modelLabel) ?? 3;
   const dollars = (savings.tokensSaved / 1_000_000) * price;
-  const since =
-    savings.sinceTs > 0
-      ? new Date(savings.sinceTs).toLocaleDateString(undefined, {
-          month: "short",
-          day: "numeric",
-        })
-      : null;
+  const since = savings.sinceTs > 0 ? fmtTs(savings.sinceTs, "monthDay") : null;
   const details = [
     `across ${savings.listLoads.toLocaleString()} tool-list load${savings.listLoads === 1 ? "" : "s"}`,
     savings.peakCatalog > 4

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -79,4 +79,13 @@ describe("fmtTs", () => {
   it("formats date-only timestamps", () => {
     expect(fmtTs(timestamp, "date")).toBe(new Date(timestamp).toLocaleDateString());
   });
+
+  it("formats month-and-day timestamps without a year", () => {
+    expect(fmtTs(timestamp, "monthDay")).toBe(
+      new Date(timestamp).toLocaleDateString(undefined, {
+        month: "short",
+        day: "numeric",
+      }),
+    );
+  });
 });

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { fmtPercent, fmtTokens } from "./utils";
+import { fmtPercent, fmtTokens, fmtTs } from "./utils";
 
 describe("fmtTokens", () => {
   it("renders small numbers as-is", () => {
@@ -55,5 +55,28 @@ describe("fmtPercent", () => {
 
   it("can use the nonzero floor when the count is nonzero but the rate rounded away", () => {
     expect(fmtPercent(0, { floorNonZero: true })).toBe("<0.1%");
+  });
+});
+
+describe("fmtTs", () => {
+  const timestamp = new Date("2026-07-22T19:30:00").getTime();
+
+  it("formats timestamps with the default date and time format", () => {
+    expect(fmtTs(timestamp)).toBe(
+      new Date(timestamp).toLocaleString(undefined, {
+        month: "short",
+        day: "numeric",
+        hour: "2-digit",
+        minute: "2-digit",
+      }),
+    );
+  });
+
+  it("formats time-only timestamps", () => {
+    expect(fmtTs(timestamp, "time")).toBe(new Date(timestamp).toLocaleTimeString());
+  });
+
+  it("formats date-only timestamps", () => {
+    expect(fmtTs(timestamp, "date")).toBe(new Date(timestamp).toLocaleDateString());
   });
 });

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -33,3 +33,18 @@ export function fmtPercent(
   if (options.floorNonZero && percent === 0) return "<0.1%";
   return `${percent.toFixed(percent > 0 && percent < 10 ? 1 : 0)}%`;
 }
+
+export function fmtTs(timestamp: number, format?: "time" | "date"): string {
+  if (format === "time") {
+    return new Date(timestamp).toLocaleTimeString();
+  } else if (format === "date") {
+    return new Date(timestamp).toLocaleDateString();
+  } else {
+    return new Date(timestamp).toLocaleString(undefined, {
+      month: "short",
+      day: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+    });
+  }
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -34,11 +34,22 @@ export function fmtPercent(
   return `${percent.toFixed(percent > 0 && percent < 10 ? 1 : 0)}%`;
 }
 
-export function fmtTs(timestamp: number, format?: "time" | "date"): string {
+/**
+ * Format an epoch-ms timestamp for display. The default is the short
+ * date-and-time shape used by most Activity rows; `"time"` and `"date"` are the
+ * locale defaults for a single component, and `"monthDay"` is the compact
+ * month-and-day used where the year would be noise (the savings banner).
+ */
+export function fmtTs(timestamp: number, format?: "time" | "date" | "monthDay"): string {
   if (format === "time") {
     return new Date(timestamp).toLocaleTimeString();
   } else if (format === "date") {
     return new Date(timestamp).toLocaleDateString();
+  } else if (format === "monthDay") {
+    return new Date(timestamp).toLocaleDateString(undefined, {
+      month: "short",
+      day: "numeric",
+    });
   } else {
     return new Date(timestamp).toLocaleString(undefined, {
       month: "short",


### PR DESCRIPTION
<!-- Thanks for contributing to Toolport. Keep PRs focused and small where you can. -->

## What and why

Added a shared `fmtTs` timestamp formatter and updated the Activity view to use a consistent timestamp format across different sections.

Previously, Activity view timestamps were formatted in multiple ways:
- Custom `toLocaleString` options in some sections
- Bare `toLocaleString()` in audit rows
- `toLocaleTimeString()` in live activity streams
- `toLocaleDateString()` in tool identity details

This caused inconsistent timestamp presentation across the UI.

Closes #379 

This change:
- Introduces `fmtTs` as the single source of truth for timestamp formatting.
- Supports explicit formatting variants:
  - Default: date + time format for normal activity entries.
  - `time`: time-only format for live activity streams.
  - `date`: date-only format for identity metadata.
- Replaces direct timestamp formatting calls in `ActivityView.tsx`.
- Adds unit tests covering default, time-only, and date-only timestamp formats.

## Testing

- [ ] `npm run build` passes
- [x] `npm run test` passes
- [ ] `npm run audit:prod` passes
- [ ] `npm run test:rust` passes (`npm run test:rust:windows` on Windows if the debug gateway binary is locked)
- [x] Ran the app (`npm run tauri dev`) and checked the change by hand

## Notes

Verified that timestamp rendering is now consistent across Activity view sections while preserving time-only formatting for live activity streams.