### PR TITLE
Fixes #384: Fix vendor detection matching keywords in URL path instead of host

### DIFF
--- a/src-tauri/src/vendors.rs
+++ b/src-tauri/src/vendors.rs
@@ -131,8 +131,8 @@ fn vendors() -> &'static [Vendor] {
 }
 
 fn match_vendor(url: &str) -> Option<&'static Vendor> {
-    let lower = url.to_lowercase();
-    vendors().iter().find(|v| lower.contains(v.needle))
+    let host = url::Url::parse(url).ok()?.host_str()?.to_lowercase();
+    vendors().iter().find(|v| host.contains(v.needle))
 }
 
 /// Decide what a server needs: try connecting with no auth; if it works it needs
@@ -169,12 +169,26 @@ mod tests {
 
     #[test]
     fn matches_known_vendors() {
-        assert_eq!(match_vendor("https://mcp.stripe.com").unwrap().name, "Stripe");
+        assert_eq!(
+            match_vendor("https://mcp.stripe.com").unwrap().name,
+            "Stripe"
+        );
         assert_eq!(
             match_vendor("https://mcp.revenuecat.ai/mcp").unwrap().name,
             "RevenueCat"
         );
         assert!(match_vendor("https://unknown.example.com").is_none());
+
+        assert!(match_vendor("https://mcp.composio.dev/github").is_none());
+
+        assert_eq!(
+            match_vendor("https://api.githubcopilot.com/mcp")
+                .unwrap()
+                .name,
+            "GitHub"
+        );
+
+        assert!(match_vendor("https://mcp.composio.dev/clerk").is_none());
     }
 
     #[test]


### PR DESCRIPTION
 Fixes #384

## Problem
`match_vendor` in `src-tauri/src/vendors.rs` matched vendor keywords against the entire URL, including the path and query — not just the host. Since several needles are bare words (`clerk`, `github`, `notion`, `supabase`, `vercel`, `inngest`, `revenuecat`, `cloudflare`), path-based MCP gateways like Composio or Pipedream (e.g. `https://mcp.composio.dev/github`) were misclassified as the vendor named in the path.

The Clerk case was the most serious: Clerk carries `force_kind: Some("none")`, which short-circuits the live auth probe. A path like `https://mcp.composio.dev/clerk` was telling users "Clerk connects without a token," when the server might require one — leading to a runtime failure with no useful guidance.

## Fix
`match_vendor` now parses the URL and matches vendor needles against the host only, using `url::Url::parse().host_str()`. No new dependency needed — `url` is already used in this codebase (`downstream.rs:435`).

If the URL doesn't parse, the function returns `None` rather than falling back to whole-string matching, since a wrong vendor hint is worse than no hint.

The bare/loose needles (e.g. `github`, `revenuecat`) are intentionally left as-is, not tightened into full domains — host-only matching already prevents the false positives, and loosely-matched needles are load-bearing for real vendor domains that don't match their brand name exactly (e.g. RevenueCat's server is on `.ai`, not `.com`; GitHub's official Copilot endpoint is `api.githubcopilot.com`, not `github.com`).

## Tests
Extended `matches_known_vendors` in `vendors.rs` with:
- `https://mcp.composio.dev/github` → `None`
- `https://mcp.composio.dev/clerk` → `None`
- `https://mcp.stripe.com` and `https://mcp.revenuecat.ai` still match correctly (regression check)
- `https://api.githubcopilot.com/mcp/` → matches GitHub (locks in multi-domain matching)

## Note on test suite
Two unrelated pre-existing tests failed locally on my machine and appear to be flaky/environment-sensitive, not related to this change:
- `desktop::tests::probe_one_bounded_passes_through_a_fast_failure_well_under_the_timeout` — a timing-sensitive assertion
- `registry::tests::update_at_serializes_concurrent_writers_with_no_lost_updates` — fails due to a file lock contention error, likely WSL-specific

All three `vendors::` tests pass cleanly, including the new/updated `matches_known_vendors`.