### PR TITLE
test(clients): cover Continue YAML write safety

### DIFF
--- a/src-tauri/src/clients.rs
+++ b/src-tauri/src/clients.rs
@@ -605,7 +605,7 @@ fn hermes_path() -> Option<PathBuf> {
 }
 
 fn continue_path() -> Option<PathBuf> {
-    Some(home()?.join(".continue").join("config.yaml"))
+    client_config_path("continue")
 }
 
 /// Witsy keeps MCP servers in a top-level `mcpServers` object inside its main
@@ -4310,6 +4310,70 @@ command = "npx"
     }
 
     #[test]
+    fn continue_yaml_round_trip_preserves_config() {
+        let path = temp_path("continue.yaml");
+        std::fs::write(
+            &path,
+            "models:\n  - title: GPT-4o\n    provider: openai\n    model: gpt-4o\nrules:\n  - Keep responses concise\nmcpServers:\n  - name: old-server\n    command: old-command\n",
+        )
+        .unwrap();
+
+        let servers = vec![stdio("filesystem"), stdio("github")];
+        write_continue_yaml_servers(&path, &servers).unwrap();
+
+        let content = std::fs::read_to_string(&path).unwrap();
+        let parsed = parse_continue_yaml_servers(&content).unwrap();
+        assert_eq!(parsed.len(), 2);
+        assert_eq!(parsed[0].name, "filesystem");
+        assert_eq!(parsed[0].command.as_deref(), Some("npx"));
+        assert_eq!(
+            parsed[0].args,
+            vec!["-y", "@modelcontextprotocol/server-filesystem"]
+        );
+        assert_eq!(parsed[0].env_keys, vec!["TOKEN".to_string()]);
+        assert_eq!(parsed[1].name, "github");
+
+        let root: serde_yaml::Value = serde_yaml::from_str(&content).unwrap();
+        assert_eq!(
+            root.get("models")
+                .and_then(|models| models.as_sequence())
+                .and_then(|models| models.first())
+                .and_then(|model| model.get("title"))
+                .and_then(|title| title.as_str()),
+            Some("GPT-4o")
+        );
+        assert_eq!(
+            root.get("rules")
+                .and_then(|rules| rules.as_sequence())
+                .and_then(|rules| rules.first())
+                .and_then(|rule| rule.as_str()),
+            Some("Keep responses concise")
+        );
+        assert!(content.contains("plain-value"));
+
+        std::fs::remove_file(&path).ok();
+    }
+
+    #[test]
+    fn continue_yaml_write_never_wipes_unparseable() {
+        let path = temp_path("continue-bad.yaml");
+        let garbage = "models:\n  - title: GPT-4o\nmcpServers: [unbalanced\n";
+        std::fs::write(&path, garbage).unwrap();
+
+        assert!(write_continue_yaml_servers(&path, &[stdio("github")]).is_err());
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), garbage);
+
+        std::fs::remove_file(&path).ok();
+    }
+
+    #[test]
+    fn continue_is_registered_as_yaml_mcp_servers_list() {
+        let d = defs().into_iter().find(|d| d.id == "continue").unwrap();
+        assert!(matches!(d.format, Format::YamlMcpServersList));
+        assert!((d.path)().is_some());
+    }
+
+    #[test]
     fn hermes_yaml_round_trip_preserves_config() {
         let path = temp_path("hermes.yaml");
         // A real config.yaml has model settings AND mcp_servers; touch neither but ours.
@@ -4525,6 +4589,9 @@ command = "npx"
             ("cursor", |home, _| home.join(".cursor").join("mcp.json")),
             ("opencode", |home, _| {
                 home.join(".config").join("opencode").join("opencode.json")
+            }),
+            ("continue", |home, _| {
+                home.join(".continue").join("config.yaml")
             }),
             ("pi", |home, _| {
                 home.join(".pi").join("agent").join("mcp.json")


### PR DESCRIPTION
## What and why

Continue stores models, rules, and MCP servers in the same
`~/.continue/config.yaml` file. Its writer had no direct round-trip or
never-wipe coverage, so a regression could silently remove unrelated settings
or replace a malformed user config.

This adds tests that:

- write and read back multiple Continue MCP servers
- verify model and rule settings survive the write
- assert malformed non-empty YAML remains byte-for-byte untouched
- lock in Continue's client registration and cross-platform config path

`continue_path()` now uses the shared client config resolver so the runtime path
and the platform path table cannot drift apart.

Closes #376.

## Testing

- [x] `npm run build`
- [x] `npm run test` - 115 passed
- [x] `npm run audit:prod` - 0 vulnerabilities
- [x] `npm run test:rust` - 447 library tests passed, 4 ignored; 129 gateway tests passed
- [x] `npm run lint` - 0 errors; 20 existing warnings
- [x] `npm run format:check`
- [x] focused Continue tests - 5 passed
- [x] `git diff --check`

## Notes

- No secrets, secret values, or personal config contents are included.
- I did not run the desktop app because this change is test coverage plus a
  behavior-neutral path resolver cleanup.
