### PR TITLE
feat(clients): add Grok Build (xAI terminal coding agent)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -236,7 +236,7 @@ Check the client's config file and match it to a `Format` variant:
 | `JsonServers`        | `{"servers": {...}}`                               | VS Code                          |
 | `JsonOpenCodeMcp`    | `{"mcp": {"name": {"command": [...]}}}`            | OpenCode                         |
 | `JsonContextServers` | `{"context_servers": {...}}` (JSONC)               | Zed                              |
-| `TomlMcpServers`     | `[mcp_servers.name]`                               | Codex                            |
+| `TomlMcpServers`     | `[mcp_servers.name]`                               | Codex, Grok Build                |
 | `YamlExtensions`     | `extensions:` map (Goose shape: `cmd`/`envs`)      | Goose                            |
 | `YamlMcpServers`     | `mcp_servers:` map (Hermes shape: `command`/`env`) | Hermes                           |
 | `YamlMcpServersList` | `mcpServers:` list                                 | Continue                         |

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ and refreshes too.
 
 ## Supported clients
 
-Toolport auto-detects these **26 AI clients**, installs the gateway into each with one
+Toolport auto-detects these **27 AI clients**, installs the gateway into each with one
 click, and can import a client's existing servers. It writes the config file shown
 below for you, so you never have to edit these by hand.
 
@@ -167,6 +167,7 @@ below for you, so you never have to edit these by hand.
 | Windsurf       | `~/.codeium/windsurf/mcp_config.json`                                                      | JSON (`mcpServers`)      |
 | OpenCode       | `~/.config/opencode/opencode.json`                                                         | JSON (`mcp`)             |
 | Codex          | `~/.codex/config.toml`                                                                     | TOML (`mcp_servers`)     |
+| Grok Build     | `~/.grok/config.toml`                                                                      | TOML (`mcp_servers`)     |
 | Continue       | `~/.continue/config.yaml`                                                                  | YAML (`mcpServers`)      |
 | Antigravity    | `~/.gemini/config/mcp_config.json`                                                         | JSON (`mcpServers`)      |
 | Gemini CLI     | `~/.gemini/settings.json`                                                                  | JSON (`mcpServers`)      |

--- a/src-tauri/src/clients.rs
+++ b/src-tauri/src/clients.rs
@@ -213,6 +213,7 @@ fn resolve_client_config_path(
             .join("windsurf")
             .join("mcp_config.json"),
         "opencode" => home.join(".config").join("opencode").join("opencode.json"),
+        "grok" => home.join(".grok").join("config.toml"),
         "codex" => home.join(".codex").join("config.toml"),
         "claude-code" => home.join(".claude.json"),
         "gemini-cli" => home.join(".gemini").join("settings.json"),
@@ -313,6 +314,7 @@ fn resolve_client_config_path_linux(client_id: &str, home: &std::path::Path) -> 
         // OpenCode documents this literal home-relative path on every platform;
         // unlike most Linux clients it does not follow XDG_CONFIG_HOME here.
         "opencode" => home.join(".config").join("opencode").join("opencode.json"),
+        "grok" => home.join(".grok").join("config.toml"),
         "codex" => home.join(".codex").join("config.toml"),
         "claude-code" => home.join(".claude.json"),
         "gemini-cli" => home.join(".gemini").join("settings.json"),
@@ -514,6 +516,16 @@ fn windsurf_path() -> Option<PathBuf> {
 
 fn codex_path() -> Option<PathBuf> {
     client_config_path("codex")
+}
+
+/// Grok Build (xAI's terminal coding agent) stores MCP servers in
+/// `~/.grok/config.toml` under `[mcp_servers.<name>]` - the same TOML shape as
+/// Codex, so it shares the `TomlMcpServers` format. It also reads Claude Code's
+/// config as a fallback, but writing our own explicit entry is what makes the
+/// gateway reliably visible (`grok mcp list` doesn't surface the Claude-config
+/// pickup).
+fn grok_path() -> Option<PathBuf> {
+    client_config_path("grok")
 }
 
 fn claude_code_path() -> Option<PathBuf> {
@@ -772,6 +784,16 @@ fn defs() -> Vec<ClientDef> {
             format: Format::JsonOpenCodeMcp,
             uses_connectors: false,
             path: opencode_path,
+            plugin_scan: None,
+        },
+        ClientDef {
+            // Grok Build (xAI's terminal coding agent): ~/.grok/config.toml,
+            // [mcp_servers.<name>] - same TOML shape as Codex.
+            id: "grok",
+            name: "Grok Build",
+            format: Format::TomlMcpServers,
+            uses_connectors: false,
+            path: grok_path,
             plugin_scan: None,
         },
         ClientDef {
@@ -4282,6 +4304,15 @@ command = "npx"
     }
 
     #[test]
+    fn grok_build_is_registered_as_toml_mcp_servers() {
+        // Grok Build shares Codex's TOML `[mcp_servers.<name>]` shape, so it reuses the
+        // TomlMcpServers format and just points at ~/.grok/config.toml.
+        let definition = defs().into_iter().find(|d| d.id == "grok").unwrap();
+        assert!(matches!(definition.format, Format::TomlMcpServers));
+        assert!((definition.path)().is_some());
+    }
+
+    #[test]
     fn opencode_round_trip_preserves_other_settings() {
         let path = temp_path("opencode.json");
         std::fs::write(
@@ -4875,6 +4906,7 @@ command = "npx"
     fn client_config_paths_are_stable_across_platforms() {
         let cases: &[(&str, fn(&Path, Platform) -> PathBuf)] = &[
             ("cursor", |home, _| home.join(".cursor").join("mcp.json")),
+            ("grok", |home, _| home.join(".grok").join("config.toml")),
             ("opencode", |home, _| {
                 home.join(".config").join("opencode").join("opencode.json")
             }),


### PR DESCRIPTION
Adds Grok Build (xAI's terminal coding agent) as a first-class client. Takes the supported-client count to 27.

## Why it's nearly free

Grok Build stores MCP servers in `~/.grok/config.toml` under `[mcp_servers.<name>]` with `command`/`args`/`env` — the **exact TOML shape Codex uses**. So this reuses the existing `TomlMcpServers` format with no new parse/write/edit code; it's a path resolver + a `ClientDef`.

## Why first-class rather than relying on Claude-compat

Grok also auto-reads `~/.claude.json` / `.mcp.json`, so in theory a Toolport-in-Claude setup carries over. In practice it's unreliable: on a machine with the gateway configured only in `~/.claude.json`, `grok mcp list` reports **"No MCP servers configured."** Writing our own explicit entry into `~/.grok/config.toml` is the dependable path, and it's what first-class support gives — detection, one-click install, and import of existing servers.

## Validated on the real CLI

Ran grok's own `grok mcp add` and read back exactly what it writes:

```toml
[mcp_servers.toolport-selftest]
command = "npx"
args = ["-y", "@modelcontextprotocol/server-filesystem"]
enabled = true
```

That's precisely what our `TomlMcpServers` writer emits. grok defaults `enabled` to `true` when omitted, so a Toolport-written entry (which doesn't set `enabled`) is enabled by default. No format changes needed.

Fail-closed behavior comes for free with the TOML path: `edit_toml_gateway` errors on an unparseable file and leaves the user's whole `~/.grok/config.toml` intact rather than rewriting it down to just the gateway entry (that config also holds `[cli]`/`[ui]`/`[marketplace]` settings).

## Tests

- `grok_build_is_registered_as_toml_mcp_servers` — asserts the def uses `TomlMcpServers` and resolves a path.
- Added to `client_config_paths_are_stable_across_platforms`.
- Full client suite green (100 tests); the shared TOML round-trip / never-wipe tests already cover the format behavior.

## Out of scope (possible follow-ups)

- Grok also supports `AGENTS.md` project rules; wiring it into the rules-sync (team instructions) target is a separate, optional add.
- Grok's Claude-compatible plugin marketplace (`.claude-plugin` / `.mcp.json`) is unrelated to gateway install.
