### PR TITLE
test(gateway): extract watch_tick so quarantine reconcile call-site is covered (SOU-304)

### DIFF
--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -3975,6 +3975,25 @@ fn router_relevant(reg: &Registry) -> Value {
     v
 }
 
+/// Mutable loop state for [`watch_registry`] / [`watch_tick`].
+struct WatchLoopState {
+    /// Last observed registry-file mtime (None if missing).
+    last_mtime: Option<SystemTime>,
+    /// Router-relevant slice of the last applied registry (excludes team metadata).
+    last_relevant: Value,
+}
+
+/// What one watcher iteration did. Extracted so tests can drive a tick without the
+/// infinite sleep loop (SOU-304).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct TickOutcome {
+    /// Live quarantine set was re-filtered (and `list_changed` may have been sent).
+    quarantine_changed: bool,
+    /// No registry reload and no downstream refresh — only the quarantine pass ran
+    /// before the early-continue. A release must still land on this path (SOU-292).
+    idle_after_quarantine: bool,
+}
+
 /// Poll the registry file; on change, reload, rebuild the router, and tell the
 /// client its tool list changed. This is what makes a toggle apply live.
 #[allow(clippy::too_many_arguments)]
@@ -3995,200 +4014,253 @@ fn watch_registry(
     client_root: Arc<Mutex<Option<String>>>,
 ) {
     eprintln!("toolport: watching registry at {}", path.display());
-    let mut last = mtime(&path);
-    // Router-relevant slice (everything except the `team` block) as of the initial build,
-    // so a team-metadata-only rewrite from the desktop sync loop doesn't force a rebuild.
-    let mut last_relevant = router_relevant(
-        &registry
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner),
-    );
+    let mut state = WatchLoopState {
+        last_mtime: mtime(&path),
+        // Router-relevant slice (everything except the `team` block) as of the initial build,
+        // so a team-metadata-only rewrite from the desktop sync loop doesn't force a rebuild.
+        last_relevant: router_relevant(
+            &registry
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner),
+        ),
+    };
     loop {
         std::thread::sleep(Duration::from_millis(1000));
-        // Re-approving a tool rewrites quarantine.json, which is NOT the registry file
-        // this loop watches, so it has to be reconciled on its own. Deliberately ahead of
-        // the early-continue below: a release changes neither the registry mtime nor the
-        // downstream flag, so gating it on either would skip it entirely (SOU-292).
-        {
-            let p = profile
-                .lock()
-                .unwrap_or_else(std::sync::PoisonError::into_inner)
-                .clone();
-            reconcile_quarantine(&registry, &router, &stdout, p.as_deref());
-        }
-        // A live downstream server that changed its own tool set (sent
-        // tools/list_changed) sets this. Swap before acting so a notification
-        // arriving mid-refresh is caught on the next tick rather than lost.
-        let downstream_changed = downstream_dirty.swap(0, Ordering::SeqCst);
-        let current = mtime(&path);
-        let file_changed = current != last;
-        if !file_changed && downstream_changed == 0 {
-            continue;
-        }
+        let _ = watch_tick(
+            &path,
+            &registry,
+            &router,
+            &stdout,
+            &cached_tools,
+            &profile,
+            client_id.as_deref(),
+            env_profile.as_deref(),
+            http_mode,
+            &downstream_dirty,
+            &server_handler,
+            &client_root,
+            &mut state,
+        );
+    }
+}
 
-        if file_changed {
-            // The registry changed: servers may have been added, removed, or
-            // reconfigured, so reload and rebuild from scratch. This re-connects
-            // everything, which also subsumes any pending downstream change.
-            eprintln!("toolport: registry file changed on disk");
-            // Don't advance `last` until a successful load, so a half-written file
-            // (caught mid-save) is retried on the next tick instead of skipped.
-            let new_reg = match registry::load_from(&path) {
-                Ok(r) => r,
-                Err(e) => {
-                    eprintln!("toolport: reload failed (will retry): {e}");
-                    continue;
-                }
-            };
-            last = current;
-            // Refresh the live discovery mode from the freshly-loaded registry: a per-client
-            // override edit (`client_discovery`) may be the only change, and it isn't
-            // router-relevant, so resolve it here before the rebuild fast-path can `continue`.
-            let new_mode = discovery_mode_for(&new_reg, client_id.as_deref());
-            if new_mode != discovery_mode() {
-                eprintln!("toolport: discovery mode -> {}", new_mode.as_str());
+/// One iteration of the registry watcher (no sleep).
+///
+/// Quarantine reconciliation runs **before** the early-continue on
+/// "registry unchanged && no downstream dirty". A release rewrites only
+/// `quarantine.json`, so gating reconcile on the registry mtime would reintroduce
+/// SOU-292. Tests call this directly (SOU-304).
+#[allow(clippy::too_many_arguments)]
+fn watch_tick(
+    path: &Path,
+    registry: &Arc<Mutex<Registry>>,
+    router: &Arc<Mutex<Arc<Router>>>,
+    stdout: &Arc<Mutex<std::io::Stdout>>,
+    cached_tools: &Arc<Mutex<Vec<Value>>>,
+    profile: &Arc<Mutex<Option<String>>>,
+    client_id: Option<&str>,
+    env_profile: Option<&str>,
+    http_mode: bool,
+    downstream_dirty: &Arc<AtomicU8>,
+    server_handler: &ServerRequestHandler,
+    client_root: &Arc<Mutex<Option<String>>>,
+    state: &mut WatchLoopState,
+) -> TickOutcome {
+    // Re-approving a tool rewrites quarantine.json, which is NOT the registry file
+    // this loop watches, so it has to be reconciled on its own. Deliberately ahead of
+    // the early-continue below: a release changes neither the registry mtime nor the
+    // downstream flag, so gating it on either would skip it entirely (SOU-292).
+    let quarantine_changed = {
+        let p = profile
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .clone();
+        reconcile_quarantine(registry, router, stdout, p.as_deref())
+    };
+    // A live downstream server that changed its own tool set (sent
+    // tools/list_changed) sets this. Swap before acting so a notification
+    // arriving mid-refresh is caught on the next tick rather than lost.
+    let downstream_changed = downstream_dirty.swap(0, Ordering::SeqCst);
+    let current = mtime(path);
+    let file_changed = current != state.last_mtime;
+    if !file_changed && downstream_changed == 0 {
+        return TickOutcome {
+            quarantine_changed,
+            idle_after_quarantine: true,
+        };
+    }
+
+    if file_changed {
+        // The registry changed: servers may have been added, removed, or
+        // reconfigured, so reload and rebuild from scratch. This re-connects
+        // everything, which also subsumes any pending downstream change.
+        eprintln!("toolport: registry file changed on disk");
+        // Don't advance `last_mtime` until a successful load, so a half-written file
+        // (caught mid-save) is retried on the next tick instead of skipped.
+        let new_reg = match registry::load_from(path) {
+            Ok(r) => r,
+            Err(e) => {
+                eprintln!("toolport: reload failed (will retry): {e}");
+                return TickOutcome {
+                    quarantine_changed,
+                    idle_after_quarantine: false,
+                };
             }
-            set_discovery_mode(new_mode);
-            // Refresh code mode from the freshly-loaded registry so a Settings toggle takes
-            // effect without restarting the client (same live-refresh path as discovery mode).
-            set_code_mode_flag(new_reg.code_mode);
-            // A team-metadata-only rewrite (usage watermark, sync version/etag, role) from
-            // the desktop sync loop changes nothing the router depends on. Update the stored
-            // copy but skip the rebuild, so a routine sync never re-spawns every stdio server
-            // (the leak that exhausted a user's RAM). Still rebuild when a downstream server
-            // also signaled a change, so that path is never dropped.
-            let new_relevant = router_relevant(&new_reg);
-            if downstream_changed == 0 && new_relevant == last_relevant {
-                *registry
-                    .lock()
-                    .unwrap_or_else(std::sync::PoisonError::into_inner) = new_reg;
-                eprintln!("toolport: registry changed (team metadata only); skipped rebuild");
-                continue;
-            }
-            last_relevant = new_relevant;
-            // The client's reported project root, read first so folder routing (SOU-188) can
-            // fold into the profile resolution below AND place ${ROOT} servers in the rebuild.
-            let root = client_root
-                .lock()
-                .unwrap_or_else(std::sync::PoisonError::into_inner)
-                .clone();
-            // Effective profile = a folder-scoped override for the current root, else the
-            // client's configured profile. So editing folder_profiles (a registry change)
-            // re-applies routing live for a client already sitting in a mapped folder.
-            let resolved =
-                effective_profile(&new_reg, client_id.as_deref(), &env_profile, root.as_deref());
-            // Capture the profile we were serving before this reload so the log can
-            // show the transition - the single most useful line when diagnosing
-            // "why can't this client see server X": it pins down which profile is
-            // actually in effect and how many servers it resolved to.
-            let previous = {
-                let mut guard = profile
-                    .lock()
-                    .unwrap_or_else(std::sync::PoisonError::into_inner);
-                let prev = guard.clone();
-                *guard = resolved.clone();
-                prev
-            };
-            // Build the new router (spawns processes) before taking locks.
-            let new_router = build_router(
-                &new_reg,
-                resolved.as_deref(),
-                http_mode,
-                &downstream_dirty,
-                Arc::clone(&server_handler),
-                root.as_deref(),
-            );
-            let server_count = new_router.server_count();
-            let tools = new_router.aggregated_tools();
+        };
+        state.last_mtime = current;
+        // Refresh the live discovery mode from the freshly-loaded registry: a per-client
+        // override edit (`client_discovery`) may be the only change, and it isn't
+        // router-relevant, so resolve it here before the rebuild fast-path can return.
+        let new_mode = discovery_mode_for(&new_reg, client_id);
+        if new_mode != discovery_mode() {
+            eprintln!("toolport: discovery mode -> {}", new_mode.as_str());
+        }
+        set_discovery_mode(new_mode);
+        // Refresh code mode from the freshly-loaded registry so a Settings toggle takes
+        // effect without restarting the client (same live-refresh path as discovery mode).
+        set_code_mode_flag(new_reg.code_mode);
+        // A team-metadata-only rewrite (usage watermark, sync version/etag, role) from
+        // the desktop sync loop changes nothing the router depends on. Update the stored
+        // copy but skip the rebuild, so a routine sync never re-spawns every stdio server
+        // (the leak that exhausted a user's RAM). Still rebuild when a downstream server
+        // also signaled a change, so that path is never dropped.
+        let new_relevant = router_relevant(&new_reg);
+        if downstream_changed == 0 && new_relevant == state.last_relevant {
             *registry
                 .lock()
                 .unwrap_or_else(std::sync::PoisonError::into_inner) = new_reg;
+            eprintln!("toolport: registry changed (team metadata only); skipped rebuild");
+            return TickOutcome {
+                quarantine_changed,
+                idle_after_quarantine: false,
+            };
+        }
+        state.last_relevant = new_relevant;
+        // The client's reported project root, read first so folder routing (SOU-188) can
+        // fold into the profile resolution below AND place ${ROOT} servers in the rebuild.
+        let root = client_root
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .clone();
+        // Effective profile = a folder-scoped override for the current root, else the
+        // client's configured profile. So editing folder_profiles (a registry change)
+        // re-applies routing live for a client already sitting in a mapped folder.
+        let env_owned = env_profile.map(|s| s.to_string());
+        let resolved = effective_profile(&new_reg, client_id, &env_owned, root.as_deref());
+        // Capture the profile we were serving before this reload so the log can
+        // show the transition - the single most useful line when diagnosing
+        // "why can't this client see server X": it pins down which profile is
+        // actually in effect and how many servers it resolved to.
+        let previous = {
+            let mut guard = profile
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            let prev = guard.clone();
+            *guard = resolved.clone();
+            prev
+        };
+        // Build the new router (spawns processes) before taking locks.
+        let new_router = build_router(
+            &new_reg,
+            resolved.as_deref(),
+            http_mode,
+            downstream_dirty,
+            Arc::clone(server_handler),
+            root.as_deref(),
+        );
+        let server_count = new_router.server_count();
+        let tools = new_router.aggregated_tools();
+        *registry
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = new_reg;
+        *router
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = Arc::new(new_router);
+        let tools = requarantine_if_needed(registry, router, tools, resolved.as_deref());
+        persist_and_emit(&tools, cached_tools, stdout, resolved.as_deref());
+        let fmt_profile = |p: &Option<String>| match p {
+            Some(name) => format!("'{name}'"),
+            None => "(active profile / unscoped)".to_string(),
+        };
+        eprintln!(
+            "toolport: registry changed{} -> profile {} (was {}); {} server(s), {} tools; sent tools/list_changed",
+            client_id
+                .map(|c| format!(" [client={c}]"))
+                .unwrap_or_default(),
+            fmt_profile(&resolved),
+            fmt_profile(&previous),
+            server_count,
+            tools.len(),
+        );
+    } else {
+        let resolved = profile
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .clone();
+        // One or more live servers announced a list change. Re-query only the
+        // affected list(s) in place rather than re-spawning: a runtime or
+        // session-scoped change (the usual reason a server sends this) would be
+        // lost by a fresh process that never saw it. Each kind forwards its own
+        // notification so the client re-fetches exactly what changed. (make_mut
+        // forks the router only if a request still holds the prior Arc, keeping
+        // live connections.)
+        // Re-query the affected list(s) WITHOUT holding the top-level router lock
+        // across the blocking downstream `list` call. Each refresh_* iterates the
+        // servers doing synchronous tools/list I/O bounded by the connect timeout;
+        // holding the router lock across it (as the old make_mut path did) wedges
+        // every concurrent request - in HTTP-bridge mode, every client - for up to
+        // num_servers x connect-timeout while one slow downstream answers. Instead
+        // clone the router off-lock (the Vec<Arc<ServerSlot>> shares the same live
+        // connections, so only the cached metadata is copied), refresh the clone,
+        // then swap it in under a brief lock. Mirrors the full-rebuild branch above.
+        if downstream_changed & downstream::change::TOOLS != 0 {
+            let mut next = {
+                let guard = router
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner);
+                (**guard).clone()
+            };
+            next.refresh_tools();
+            let tools = next.aggregated_tools();
             *router
                 .lock()
-                .unwrap_or_else(std::sync::PoisonError::into_inner) = Arc::new(new_router);
-            let tools = requarantine_if_needed(&registry, &router, tools, resolved.as_deref());
-            persist_and_emit(&tools, &cached_tools, &stdout, resolved.as_deref());
-            let fmt_profile = |p: &Option<String>| match p {
-                Some(name) => format!("'{name}'"),
-                None => "(active profile / unscoped)".to_string(),
-            };
-            eprintln!(
-                "toolport: registry changed{} -> profile {} (was {}); {} server(s), {} tools; sent tools/list_changed",
-                client_id
-                    .as_deref()
-                    .map(|c| format!(" [client={c}]"))
-                    .unwrap_or_default(),
-                fmt_profile(&resolved),
-                fmt_profile(&previous),
-                server_count,
-                tools.len(),
-            );
-        } else {
-            let resolved = profile
-                .lock()
-                .unwrap_or_else(std::sync::PoisonError::into_inner)
-                .clone();
-            // One or more live servers announced a list change. Re-query only the
-            // affected list(s) in place rather than re-spawning: a runtime or
-            // session-scoped change (the usual reason a server sends this) would be
-            // lost by a fresh process that never saw it. Each kind forwards its own
-            // notification so the client re-fetches exactly what changed. (make_mut
-            // forks the router only if a request still holds the prior Arc, keeping
-            // live connections.)
-            // Re-query the affected list(s) WITHOUT holding the top-level router lock
-            // across the blocking downstream `list` call. Each refresh_* iterates the
-            // servers doing synchronous tools/list I/O bounded by the connect timeout;
-            // holding the router lock across it (as the old make_mut path did) wedges
-            // every concurrent request - in HTTP-bridge mode, every client - for up to
-            // num_servers x connect-timeout while one slow downstream answers. Instead
-            // clone the router off-lock (the Vec<Arc<ServerSlot>> shares the same live
-            // connections, so only the cached metadata is copied), refresh the clone,
-            // then swap it in under a brief lock. Mirrors the full-rebuild branch above.
-            if downstream_changed & downstream::change::TOOLS != 0 {
-                let mut next = {
-                    let guard = router
-                        .lock()
-                        .unwrap_or_else(std::sync::PoisonError::into_inner);
-                    (**guard).clone()
-                };
-                next.refresh_tools();
-                let tools = next.aggregated_tools();
-                *router
-                    .lock()
-                    .unwrap_or_else(std::sync::PoisonError::into_inner) = Arc::new(next);
-                let tools = requarantine_if_needed(&registry, &router, tools, resolved.as_deref());
-                persist_and_emit(&tools, &cached_tools, &stdout, resolved.as_deref());
-                eprintln!("toolport: downstream tools/list_changed, refreshed + sent");
-            }
-            if downstream_changed & downstream::change::RESOURCES != 0 {
-                let mut next = {
-                    let guard = router
-                        .lock()
-                        .unwrap_or_else(std::sync::PoisonError::into_inner);
-                    (**guard).clone()
-                };
-                next.refresh_resources();
-                *router
-                    .lock()
-                    .unwrap_or_else(std::sync::PoisonError::into_inner) = Arc::new(next);
-                notify_list_changed(&stdout, "notifications/resources/list_changed");
-                eprintln!("toolport: downstream resources/list_changed, refreshed + sent");
-            }
-            if downstream_changed & downstream::change::PROMPTS != 0 {
-                let mut next = {
-                    let guard = router
-                        .lock()
-                        .unwrap_or_else(std::sync::PoisonError::into_inner);
-                    (**guard).clone()
-                };
-                next.refresh_prompts();
-                *router
-                    .lock()
-                    .unwrap_or_else(std::sync::PoisonError::into_inner) = Arc::new(next);
-                notify_list_changed(&stdout, "notifications/prompts/list_changed");
-                eprintln!("toolport: downstream prompts/list_changed, refreshed + sent");
-            }
+                .unwrap_or_else(std::sync::PoisonError::into_inner) = Arc::new(next);
+            let tools = requarantine_if_needed(registry, router, tools, resolved.as_deref());
+            persist_and_emit(&tools, cached_tools, stdout, resolved.as_deref());
+            eprintln!("toolport: downstream tools/list_changed, refreshed + sent");
         }
+        if downstream_changed & downstream::change::RESOURCES != 0 {
+            let mut next = {
+                let guard = router
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner);
+                (**guard).clone()
+            };
+            next.refresh_resources();
+            *router
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner) = Arc::new(next);
+            notify_list_changed(stdout, "notifications/resources/list_changed");
+            eprintln!("toolport: downstream resources/list_changed, refreshed + sent");
+        }
+        if downstream_changed & downstream::change::PROMPTS != 0 {
+            let mut next = {
+                let guard = router
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner);
+                (**guard).clone()
+            };
+            next.refresh_prompts();
+            *router
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner) = Arc::new(next);
+            notify_list_changed(stdout, "notifications/prompts/list_changed");
+            eprintln!("toolport: downstream prompts/list_changed, refreshed + sent");
+        }
+    }
+    TickOutcome {
+        quarantine_changed,
+        idle_after_quarantine: false,
     }
 }
 
@@ -9876,6 +9948,128 @@ mod tests {
         std::fs::write(&path, "{}").unwrap();
         assert!(reconcile_quarantine(&registry, &router, &stdout, profile));
         assert!(router.lock().unwrap().quarantined().is_empty());
+
+        drop(_data_dir);
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn watch_tick_reconciles_a_release_without_registry_or_downstream_change() {
+        // SOU-304: the infinite watch_registry loop used to be untestable, so moving
+        // reconcile_quarantine below the early-continue would reintroduce SOU-292 with
+        // every existing test still green. Drive a single tick and assert a release is
+        // applied when neither the registry mtime nor the downstream flag moves.
+        let _env = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let dir = std::env::temp_dir().join(format!(
+            "toolport-sou304-tick-{}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let _data_dir = conduit_lib::registry::DataDirOverride::set(&dir);
+
+        let profile_name = "sou304-tick";
+        let profile = Some(profile_name);
+        let current = vec![json!({ "name": "srv__wipe", "description": "x", "inputSchema": {} })];
+        let events = vec![json!({
+            "server": "srv", "tool": "srv__wipe", "change": "poison", "severity": "high"
+        })];
+        assert!(conduit_lib::integrity::apply_quarantine(
+            profile, &current, &events
+        ));
+
+        let mut reg = Registry::default();
+        reg.quarantine_on_drift = true;
+        let registry = Arc::new(Mutex::new(reg));
+        let router = Arc::new(Mutex::new(Arc::new(Router::new())));
+        let stdout = Arc::new(Mutex::new(std::io::stdout()));
+        let cached_tools = Arc::new(Mutex::new(Vec::new()));
+        let profile_slot = Arc::new(Mutex::new(Some(profile_name.to_string())));
+        let downstream_dirty = Arc::new(AtomicU8::new(0));
+        let client_root = Arc::new(Mutex::new(None));
+        let server_handler: ServerRequestHandler = Arc::new(|_| None);
+
+        // Stable "registry" path that does not change across ticks.
+        let reg_path = dir.join("registry.json");
+        std::fs::write(&reg_path, "{}").unwrap();
+        let mut state = WatchLoopState {
+            last_mtime: mtime(&reg_path),
+            last_relevant: router_relevant(&registry.lock().unwrap()),
+        };
+
+        // First tick: pick up the quarantined tool from disk.
+        let load = watch_tick(
+            &reg_path,
+            &registry,
+            &router,
+            &stdout,
+            &cached_tools,
+            &profile_slot,
+            None,
+            None,
+            false,
+            &downstream_dirty,
+            &server_handler,
+            &client_root,
+            &mut state,
+        );
+        assert!(
+            load.idle_after_quarantine,
+            "no registry/downstream work on a quiet tick"
+        );
+        assert!(
+            load.quarantine_changed,
+            "first tick must load the persisted quarantine set"
+        );
+        assert!(router.lock().unwrap().quarantined().contains("srv__wipe"));
+
+        // Steady state: still idle, no re-filter.
+        let steady = watch_tick(
+            &reg_path,
+            &registry,
+            &router,
+            &stdout,
+            &cached_tools,
+            &profile_slot,
+            None,
+            None,
+            false,
+            &downstream_dirty,
+            &server_handler,
+            &client_root,
+            &mut state,
+        );
+        assert!(steady.idle_after_quarantine);
+        assert!(!steady.quarantine_changed);
+
+        // Release on disk only (registry mtime + downstream flag untouched).
+        assert!(conduit_lib::integrity::release(profile, "srv__wipe"));
+        let after = watch_tick(
+            &reg_path,
+            &registry,
+            &router,
+            &stdout,
+            &cached_tools,
+            &profile_slot,
+            None,
+            None,
+            false,
+            &downstream_dirty,
+            &server_handler,
+            &client_root,
+            &mut state,
+        );
+        assert!(
+            after.idle_after_quarantine,
+            "release must still land on the early-continue path"
+        );
+        assert!(
+            after.quarantine_changed,
+            "tick must reconcile the release without a registry change"
+        );
+        assert!(
+            router.lock().unwrap().quarantined().is_empty(),
+            "released tool must stop being enforced"
+        );
 
         drop(_data_dir);
         std::fs::remove_dir_all(&dir).ok();


### PR DESCRIPTION
## Summary
- Extract registry watcher iteration into `watch_tick` (no sleep).
- Assert a quarantine release is applied on the idle path (no registry/downstream change) so SOU-292 cannot regress silently.

## Tracking
- Linear: SOU-304
- GitHub: #436

## Test plan
- [x] cargo test --bin toolport-gateway watch_tick_reconciles