### PR TITLE
feat(quarantine): annotation detail on card + notify on new entries (SOU-305)

### DIFF
--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -1635,9 +1635,81 @@ fn set_quarantine_on_drift(state: State<RegistryState>, on: bool) -> Result<Regi
 }
 
 /// Tools currently quarantined (blocked after a high-risk drift), across all profiles.
+///
+/// Also fires an OS notification when a **new** entry appears after the first baseline
+/// poll (SOU-305 option 1). Quarantine is decided in the gateway process; the app only
+/// learns by polling, so this is the cheapest "notify when it happens while the app is
+/// running" path. First call only seeds the seen-set so restarting the app with an
+/// already-quarantined tool does not re-notify.
 #[tauri::command]
-fn list_quarantined() -> Vec<serde_json::Value> {
-    integrity::all_quarantined()
+fn list_quarantined(app: AppHandle) -> Vec<serde_json::Value> {
+    let list = integrity::all_quarantined();
+    notify_new_quarantines(&app, &list);
+    list
+}
+
+/// Keys of quarantine entries we have already observed this process. `None` = not
+/// baselined yet (first poll seeds without notifying).
+static QUARANTINE_SEEN: Mutex<Option<std::collections::HashSet<String>>> = Mutex::new(None);
+
+fn quarantine_entry_key(rec: &serde_json::Value) -> String {
+    let profile = rec.get("profile").and_then(|v| v.as_str()).unwrap_or("");
+    let tool = rec.get("tool").and_then(|v| v.as_str()).unwrap_or("?");
+    let ts = rec.get("ts").and_then(|v| v.as_u64()).unwrap_or(0);
+    format!("{profile}\0{tool}@{ts}")
+}
+
+fn notify_new_quarantines(app: &AppHandle, list: &[serde_json::Value]) {
+    let keys: std::collections::HashSet<String> =
+        list.iter().map(quarantine_entry_key).collect();
+    let mut guard = QUARANTINE_SEEN
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    match guard.as_mut() {
+        None => {
+            // First poll: baseline only.
+            *guard = Some(keys);
+        }
+        Some(seen) => {
+            let mut newcomers: Vec<&serde_json::Value> = list
+                .iter()
+                .filter(|rec| !seen.contains(&quarantine_entry_key(rec)))
+                .collect();
+            if !newcomers.is_empty() {
+                // Newest first for the body when several land in one poll.
+                newcomers.sort_by_key(|r| std::cmp::Reverse(r.get("ts").and_then(|v| v.as_u64()).unwrap_or(0)));
+                let title = if newcomers.len() == 1 {
+                    "Toolport: tool quarantined".to_string()
+                } else {
+                    format!("Toolport: {} tools quarantined", newcomers.len())
+                };
+                let body = newcomers
+                    .iter()
+                    .take(3)
+                    .map(|r| {
+                        let tool = r.get("tool").and_then(|v| v.as_str()).unwrap_or("?");
+                        let detail = r
+                            .get("detail")
+                            .and_then(|v| v.as_str())
+                            .or_else(|| r.get("reason").and_then(|v| v.as_str()))
+                            .unwrap_or("high-risk change");
+                        format!("{tool}: {detail}")
+                    })
+                    .collect::<Vec<_>>()
+                    .join("\n");
+                let _ = app
+                    .notification()
+                    .builder()
+                    .title(title)
+                    .body(body)
+                    .show();
+                if let Some(win) = app.get_webview_window("main") {
+                    let _ = win.request_user_attention(Some(tauri::UserAttentionType::Informational));
+                }
+            }
+            *seen = keys;
+        }
+    }
 }
 
 /// Re-approve a quarantined tool so the gateway re-exposes it. Re-saving the registry

--- a/src-tauri/src/integrity.rs
+++ b/src-tauri/src/integrity.rs
@@ -411,7 +411,11 @@ fn check_inner(profile: Option<&str>, current: &[Value]) -> Vec<Value> {
                 // tool's, so re-baseline quietly (no event, no re-scan).
                 Some(old) if old.fp != pin.fp && fp_version(&old.fp) == fp_version(&pin.fp) => {
                     let sev = drift_severity(t, annotation_downgrade(old, t));
-                    events.push(event(server, name, "changed", sev));
+                    // Capture prior annotation flags on the event *before* re-baseline
+                    // overwrites the pin (SOU-305). apply_quarantine stores them on the
+                    // quarantine record so the UI can say "readOnlyHint: true → false"
+                    // rather than only "a safety annotation dropped".
+                    events.push(changed_event(server, name, sev, old, &pin));
                     scan = true;
                 }
                 None => {
@@ -851,16 +855,24 @@ fn apply_quarantine_inner(profile: Option<&str>, current: &[Value], events: &[Va
         };
         if !q.contains_key(tool) {
             let server = e.get("server").and_then(Value::as_str).unwrap_or("?");
-            q.insert(
-                tool.to_string(),
-                json!({
-                    "ts": epoch_millis(),
-                    "server": server,
-                    "tool": tool,
-                    "reason": reason,
-                    "change": change,
-                }),
-            );
+            let mut rec = json!({
+                "ts": epoch_millis(),
+                "server": server,
+                "tool": tool,
+                "reason": reason,
+                "change": change,
+            });
+            // Concrete annotation prior→new (SOU-305). Optional: older events / poison
+            // rows omit these; the UI falls back to `reason` alone.
+            for key in ["prev_ro", "new_ro", "prev_dh", "new_dh"] {
+                if let Some(v) = e.get(key) {
+                    rec[key] = v.clone();
+                }
+            }
+            if let Some(detail) = annotation_change_detail(e) {
+                rec["detail"] = json!(detail);
+            }
+            q.insert(tool.to_string(), rec);
             added = true;
         }
     }
@@ -1476,6 +1488,55 @@ fn event(server: &str, tool: &str, change: &str, severity: &str) -> Value {
         "change": change,
         "severity": severity,
     })
+}
+
+/// `changed` drift with prior/new safety annotations for the quarantine card (SOU-305).
+fn changed_event(server: &str, tool: &str, severity: &str, old: &Pin, new: &Pin) -> Value {
+    let mut e = event(server, tool, "changed", severity);
+    e["prev_ro"] = json!(old.ro);
+    e["new_ro"] = json!(new.ro);
+    e["prev_dh"] = json!(old.dh);
+    e["new_dh"] = json!(new.dh);
+    e
+}
+
+/// Human-readable annotation delta for the quarantine card, e.g.
+/// `readOnlyHint: true → false`. Empty when no annotation fields moved.
+fn annotation_change_detail(e: &Value) -> Option<String> {
+    let mut parts = Vec::new();
+    for (label, prev_k, new_k) in [
+        ("readOnlyHint", "prev_ro", "new_ro"),
+        ("destructiveHint", "prev_dh", "new_dh"),
+    ] {
+        let prev = e.get(prev_k);
+        let next = e.get(new_k);
+        if prev == next {
+            continue;
+        }
+        // Only emit when at least one side is present on the event.
+        if prev.is_none() && next.is_none() {
+            continue;
+        }
+        parts.push(format!(
+            "{label}: {} → {}",
+            fmt_opt_hint(prev),
+            fmt_opt_hint(next)
+        ));
+    }
+    if parts.is_empty() {
+        None
+    } else {
+        Some(parts.join("; "))
+    }
+}
+
+fn fmt_opt_hint(v: Option<&Value>) -> String {
+    match v {
+        None => "absent".into(),
+        Some(Value::Null) => "absent".into(),
+        Some(Value::Bool(b)) => b.to_string(),
+        Some(other) => other.to_string(),
+    }
 }
 
 pub fn security_path() -> Option<PathBuf> {
@@ -2427,9 +2488,29 @@ mod tests {
         // is not marked destructive.
         let current = vec![json!({ "name": "db__query", "description": "Query.",
             "inputSchema": {"type":"object"}, "annotations": { "readOnlyHint": false } })];
-        let events = vec![event("db", "db__query", "changed", SEV_HIGH)];
+        let old = Pin {
+            fp: "v1:old".into(),
+            ro: Some(true),
+            dh: None,
+            first_seen: 1,
+            last_changed: 1,
+        };
+        let new = pin_of(&current[0]);
+        let events = vec![changed_event("db", "db__query", SEV_HIGH, &old, &new)];
         assert!(apply_quarantine(profile, &current, &events));
         assert!(quarantined(profile).contains("db__query"));
+        // SOU-305: quarantine record carries a concrete prior→new annotation detail.
+        let rec = quarantine_list(profile)
+            .into_iter()
+            .find(|r| r.get("tool").and_then(Value::as_str) == Some("db__query"))
+            .expect("quarantine record for db__query");
+        assert_eq!(rec["prev_ro"], true);
+        assert_eq!(rec["new_ro"], false);
+        assert_eq!(
+            rec["detail"].as_str(),
+            Some("readOnlyHint: true → false"),
+            "card detail must name the annotation flip"
+        );
 
         // A benign (info) change to the same tool would NOT quarantine.
         assert!(release(profile, "db__query"));
@@ -2439,6 +2520,20 @@ mod tests {
         if let Some(p) = quarantine_path(profile) {
             let _ = std::fs::remove_file(p);
         }
+    }
+
+    #[test]
+    fn annotation_change_detail_formats_absent_and_skips_unchanged() {
+        let e = json!({
+            "prev_ro": true, "new_ro": null,
+            "prev_dh": false, "new_dh": false,
+        });
+        assert_eq!(
+            annotation_change_detail(&e).as_deref(),
+            Some("readOnlyHint: true → absent")
+        );
+        let unchanged = json!({ "prev_ro": true, "new_ro": true });
+        assert_eq!(annotation_change_detail(&unchanged), None);
     }
 
     #[test]
@@ -2510,7 +2605,7 @@ mod tests {
             match pins.get(name) {
                 Some(old) if old.fp != new.fp && fp_version(&old.fp) == fp_version(&new.fp) => {
                     let sev = drift_severity(t, annotation_downgrade(old, t));
-                    drifts.push(event(server_of(name), name, "changed", sev))
+                    drifts.push(changed_event(server_of(name), name, sev, old, new))
                 }
                 None => drifts.push(event(server_of(name), name, "added", drift_severity(t, false))),
                 _ => {}

--- a/src-tauri/src/integrity.rs
+++ b/src-tauri/src/integrity.rs
@@ -16,10 +16,31 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::io::Write;
 use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+use std::time::SystemTime;
 
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use sha2::{Digest, Sha256};
+
+/// Last successful parse of a quarantine store, keyed by path + `(mtime, len)`.
+/// The gateway reconciles quarantine on a 1s watcher tick (SOU-303); without this
+/// pre-filter every tick re-reads and re-parses even when the file is unchanged.
+/// The stamp is only a skip gate — callers still diff the **set** to decide whether
+/// the live router needs to change (mtime alone would fire on this process's own
+/// `apply_quarantine` writes).
+struct QuarantineReadCache {
+    path: PathBuf,
+    mtime: SystemTime,
+    len: u64,
+    set: BTreeSet<String>,
+}
+
+static QUARANTINE_READ_CACHE: Mutex<Option<QuarantineReadCache>> = Mutex::new(None);
+
+#[cfg(test)]
+static QUARANTINE_READ_COUNT: std::sync::atomic::AtomicUsize =
+    std::sync::atomic::AtomicUsize::new(0);
 
 /// Pins map: namespaced tool name (`server__tool`) -> pinned baseline.
 type Pins = BTreeMap<String, Pin>;
@@ -644,22 +665,86 @@ pub fn quarantined_checked(profile: Option<&str>) -> Result<BTreeSet<String>, St
         // place, so an empty set is the truth here rather than a failure.
         return Ok(BTreeSet::new());
     };
-    let raw = match std::fs::read_to_string(&path) {
-        Ok(s) => s,
+    quarantined_checked_at(&path)
+}
+
+/// Path-level read used by [`quarantined_checked`]. Separated so the mtime/len
+/// pre-filter (SOU-303) and fail-closed parse sit in one place.
+fn quarantined_checked_at(path: &Path) -> Result<BTreeSet<String>, String> {
+    let meta = match std::fs::metadata(path) {
+        Ok(m) => m,
         // Missing is the normal first-run state: nothing quarantined yet.
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(BTreeSet::new()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            // Drop a stale hit for this path so a later recreate is re-parsed.
+            clear_quarantine_read_cache_for(path);
+            return Ok(BTreeSet::new());
+        }
         Err(e) => return Err(format!("quarantine store at {path:?} is unreadable: {e}")),
     };
-    if raw.trim().is_empty() {
-        return Ok(BTreeSet::new());
+    let mtime = match meta.modified() {
+        Ok(t) => t,
+        Err(e) => {
+            return Err(format!(
+                "quarantine store at {path:?} has unreadable mtime: {e}"
+            ))
+        }
+    };
+    let len = meta.len();
+
+    {
+        let cache = QUARANTINE_READ_CACHE
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if let Some(c) = cache.as_ref() {
+            if c.path == path && c.mtime == mtime && c.len == len {
+                return Ok(c.set.clone());
+            }
+        }
     }
-    match serde_json::from_str::<Quarantine>(&raw) {
-        Ok(q) => Ok(q
-            .into_iter()
-            .filter(|(_, v)| !is_legacy_added(v))
-            .map(|(k, _)| k)
-            .collect()),
-        Err(e) => Err(format!("quarantine store at {path:?} is corrupt: {e}")),
+
+    #[cfg(test)]
+    QUARANTINE_READ_COUNT.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+
+    let raw = match std::fs::read_to_string(path) {
+        Ok(s) => s,
+        // Race: file vanished between metadata and open — treat as empty.
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            clear_quarantine_read_cache_for(path);
+            return Ok(BTreeSet::new());
+        }
+        Err(e) => return Err(format!("quarantine store at {path:?} is unreadable: {e}")),
+    };
+    let set = if raw.trim().is_empty() {
+        BTreeSet::new()
+    } else {
+        match serde_json::from_str::<Quarantine>(&raw) {
+            Ok(q) => q
+                .into_iter()
+                .filter(|(_, v)| !is_legacy_added(v))
+                .map(|(k, _)| k)
+                .collect(),
+            // Fail closed: do not cache a corrupt parse, do not return empty.
+            Err(e) => return Err(format!("quarantine store at {path:?} is corrupt: {e}")),
+        }
+    };
+
+    *QUARANTINE_READ_CACHE
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(QuarantineReadCache {
+        path: path.to_path_buf(),
+        mtime,
+        len,
+        set: set.clone(),
+    });
+    Ok(set)
+}
+
+fn clear_quarantine_read_cache_for(path: &Path) {
+    let mut cache = QUARANTINE_READ_CACHE
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    if cache.as_ref().is_some_and(|c| c.path == path) {
+        *cache = None;
     }
 }
 
@@ -1586,6 +1671,57 @@ mod tests {
         if let Some(p) = quarantine_path(profile) {
             let _ = std::fs::remove_file(p);
         }
+    }
+
+    #[test]
+    fn quarantined_checked_skips_reread_when_mtime_and_len_unchanged() {
+        // SOU-303: watcher ticks call this every second; an unchanged store must not
+        // re-open and re-parse the file. A real change (new mtime/len) must re-read.
+        let _data_dir_lock = crate::registry::data_dir_test_lock();
+        let _data_dir = TestDataDir::new("q-cache");
+        let profile = Some("sou303-cache");
+        let path = quarantine_path(profile).expect("data dir resolves under TestDataDir");
+
+        let current = vec![destructive_tool("srv__wipe", "Wipe everything.")];
+        let events = vec![event("srv", "srv__wipe", "changed", SEV_HIGH)];
+        assert!(apply_quarantine(profile, &current, &events));
+
+        QUARANTINE_READ_COUNT.store(0, std::sync::atomic::Ordering::SeqCst);
+        let first = quarantined_checked(profile).expect("readable store");
+        assert!(first.contains("srv__wipe"));
+        assert_eq!(
+            QUARANTINE_READ_COUNT.load(std::sync::atomic::Ordering::SeqCst),
+            1,
+            "first load parses the file"
+        );
+
+        let second = quarantined_checked(profile).expect("cache hit");
+        assert_eq!(second, first);
+        assert_eq!(
+            QUARANTINE_READ_COUNT.load(std::sync::atomic::Ordering::SeqCst),
+            1,
+            "unchanged mtime+len must skip the re-read"
+        );
+
+        assert!(release(profile, "srv__wipe"));
+        let third = quarantined_checked(profile).expect("release rewrites the store");
+        assert!(third.is_empty());
+        assert_eq!(
+            QUARANTINE_READ_COUNT.load(std::sync::atomic::Ordering::SeqCst),
+            2,
+            "a rewrite (new mtime/len) must re-parse"
+        );
+
+        // Corrupt parse must fail closed and must not poison the cache with empty.
+        std::fs::write(&path, "{ not json").unwrap();
+        assert!(
+            quarantined_checked(profile).is_err(),
+            "corrupt store is an error, not empty"
+        );
+        // Stamp changed so we re-attempted the read.
+        assert!(QUARANTINE_READ_COUNT.load(std::sync::atomic::Ordering::SeqCst) >= 3);
+
+        let _ = std::fs::remove_file(path);
     }
 
     #[test]

--- a/src/components/QuarantineAlert.test.tsx
+++ b/src/components/QuarantineAlert.test.tsx
@@ -52,6 +52,21 @@ describe("QuarantineAlert", () => {
     ).toBeInTheDocument();
   });
 
+  it("prefers the concrete annotation detail when present (SOU-305)", async () => {
+    listQuarantined.mockResolvedValue([
+      tool({
+        reason: "a tool dropped a readOnly/destructive safety annotation",
+        detail: "readOnlyHint: true → false",
+      }),
+    ]);
+    render(<QuarantineAlert />);
+    expect(await screen.findByText("readOnlyHint: true → false")).toBeInTheDocument();
+    // Generic reason stays as secondary context under the concrete delta.
+    expect(
+      screen.getByText("a tool dropped a readOnly/destructive safety annotation"),
+    ).toBeInTheDocument();
+  });
+
   it("re-approves through the profile-scoped API and re-reads the list", async () => {
     // Empty profile is the no-profile store; the backend maps it to None. Passing the
     // wrong profile would silently release nothing.

--- a/src/components/QuarantineAlert.tsx
+++ b/src/components/QuarantineAlert.tsx
@@ -141,9 +141,15 @@ export function QuarantineAlert({ onReview }: { onReview?: () => void }) {
               <li key={k} className="flex items-start gap-3 px-4 py-2.5">
                 <div className="min-w-0 flex-1">
                   <p className="truncate font-mono text-xs">{q.tool}</p>
-                  {/* The reason is the point of the card, so it stays prominent: it is
-                      what makes re-approving an informed decision instead of a reflex. */}
-                  <p className="mt-0.5 text-xs text-warning">{q.reason}</p>
+                  {/* The reason / detail is the point of the card, so it stays prominent:
+                      it is what makes re-approving an informed decision instead of a
+                      reflex. Prefer the concrete annotation delta when present (SOU-305). */}
+                  <p className="mt-0.5 text-xs text-warning">
+                    {q.detail ? q.detail : q.reason}
+                  </p>
+                  {q.detail ? (
+                    <p className="mt-0.5 text-[11px] text-muted-foreground">{q.reason}</p>
+                  ) : null}
                   <p className="mt-0.5 text-[11px] text-muted-foreground">
                     {q.server}
                     {q.profile ? ` · ${q.profile}` : ""} · {whenLabel(q.ts)}

--- a/src/components/SettingsView.tsx
+++ b/src/components/SettingsView.tsx
@@ -936,7 +936,7 @@ export function SettingsView({ registry, onRegistryChange }: Props) {
                   <span className="min-w-0 truncate font-mono">{q.tool}</span>
                   <span
                     className="min-w-0 truncate text-muted-foreground"
-                    title={q.reason}
+                    title={q.detail || q.reason}
                   >
                     {q.detail ? q.detail : q.reason}
                   </span>

--- a/src/components/SettingsView.tsx
+++ b/src/components/SettingsView.tsx
@@ -934,7 +934,12 @@ export function SettingsView({ registry, onRegistryChange }: Props) {
                   className="flex items-center gap-2 text-xs"
                 >
                   <span className="min-w-0 truncate font-mono">{q.tool}</span>
-                  <span className="shrink-0 text-muted-foreground">{q.reason}</span>
+                  <span
+                    className="min-w-0 truncate text-muted-foreground"
+                    title={q.reason}
+                  >
+                    {q.detail ? q.detail : q.reason}
+                  </span>
                   <button
                     type="button"
                     onClick={() => reapprove(q)}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -290,6 +290,12 @@ export interface QuarantinedTool {
   reason: string;
   ts: number;
   profile: string;
+  /** Concrete annotation delta when known, e.g. `readOnlyHint: true → false` (SOU-305). */
+  detail?: string | null;
+  prev_ro?: boolean | null;
+  new_ro?: boolean | null;
+  prev_dh?: boolean | null;
+  new_dh?: boolean | null;
 }
 
 /** Tools currently quarantined (blocked after a high-risk drift), across profiles. */


### PR DESCRIPTION
## Summary
- Record prior/new `readOnlyHint` / `destructiveHint` on quarantine records (SOU-305 cheapest useful version).
- QuarantineAlert + Settings show the concrete delta when present.
- App poll fires an OS notification for newly appeared quarantine entries after the first baseline (option 1; gateway-to-app signal still future work).

## Tracking
- Linear: SOU-305
- GitHub: #438

## Test plan
- [x] cargo test --lib annotation_
- [x] vitest QuarantineAlert.test.tsx