### PR TITLE
fix(ui): tell users to restart the client after connecting Toolport (SOU-317)

### DIFF
--- a/src/components/ClientDetail.test.tsx
+++ b/src/components/ClientDetail.test.tsx
@@ -1,0 +1,123 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ClientDetail } from "./ClientDetail";
+import type { DetectedClient, Registry } from "@/lib/types";
+
+const installGateway = vi.fn();
+const uninstallGateway = vi.fn();
+const toastSuccess = vi.fn();
+const toastError = vi.fn();
+
+vi.mock("@/lib/api", () => ({
+  installGateway: (...a: unknown[]) => installGateway(...a),
+  uninstallGateway: (...a: unknown[]) => uninstallGateway(...a),
+  migrateClient: vi.fn(),
+  setClientDiscovery: vi.fn(),
+  addServer: vi.fn(),
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: (...a: unknown[]) => toastSuccess(...a),
+    error: vi.fn(),
+    warning: vi.fn(),
+    info: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/toast", () => ({
+  toastError: (...a: unknown[]) => toastError(...a),
+}));
+
+function client(over: Partial<DetectedClient> = {}): DetectedClient {
+  return {
+    id: "claude-desktop",
+    name: "Claude Desktop",
+    usesConnectors: false,
+    configPath: "C:\\Users\\me\\Claude\\claude_desktop_config.json",
+    configExists: true,
+    gatewayInstalled: false,
+    appPresent: true,
+    servers: [],
+    pluginServers: [],
+    error: null,
+    ...over,
+  };
+}
+
+function emptyRegistry(): Registry {
+  return {
+    version: 1,
+    servers: [],
+    profiles: [],
+    activeProfileId: null,
+  };
+}
+
+beforeEach(() => {
+  installGateway.mockReset();
+  uninstallGateway.mockReset();
+  toastSuccess.mockReset();
+  toastError.mockReset();
+});
+
+describe("ClientDetail connect toast (SOU-317)", () => {
+  it("tells the user to restart the client after a successful Connect", async () => {
+    // Without this, the UI says "Connected" while Claude Desktop (and most peers)
+    // still has the old MCP config in memory and Toolport looks broken.
+    installGateway.mockResolvedValue({ backup: false });
+    render(
+      <ClientDetail
+        client={client()}
+        registry={emptyRegistry()}
+        onChanged={() => {}}
+        onRegistryChange={() => {}}
+      />,
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: /connect to toolport/i }));
+
+    await waitFor(() =>
+      expect(installGateway).toHaveBeenCalledWith("claude-desktop", undefined),
+    );
+    expect(toastSuccess).toHaveBeenCalledWith(
+      "Connected Toolport to Claude Desktop",
+      expect.objectContaining({
+        description: "Restart Claude Desktop so it loads Toolport.",
+      }),
+    );
+  });
+
+  it("includes scope detail after the restart nudge when connecting with a profile", async () => {
+    installGateway.mockResolvedValue({ backup: false });
+    // Seed clientScopes so the component's profile state initializes to Work.
+    const reg = emptyRegistry();
+    reg.profiles = [{ id: "p1", name: "Work", enabledServerIds: [] }];
+    reg.clientScopes = { "claude-desktop": "Work" };
+
+    render(
+      <ClientDetail
+        client={client()}
+        registry={reg}
+        onChanged={() => {}}
+        onRegistryChange={() => {}}
+      />,
+    );
+
+    // Already connected would show Disconnect; for connect we need uninstalled.
+    // clientScopes still pre-fills the profile picker for a fresh connect.
+    await userEvent.click(screen.getByRole("button", { name: /connect to toolport/i }));
+
+    await waitFor(() =>
+      expect(installGateway).toHaveBeenCalledWith("claude-desktop", "Work"),
+    );
+    expect(toastSuccess).toHaveBeenCalledWith(
+      "Connected Toolport to Claude Desktop",
+      expect.objectContaining({
+        description:
+          'Restart Claude Desktop so it loads Toolport. Scoped to the "Work" profile.',
+      }),
+    );
+  });
+});

--- a/src/components/ClientDetail.tsx
+++ b/src/components/ClientDetail.tsx
@@ -48,6 +48,7 @@ import {
 import { TransportPill } from "@/components/TransportPill";
 import { ConfirmDialog } from "@/components/ConfirmDialog";
 import { ImportReviewDialog } from "@/components/ImportReviewDialog";
+import { clientRestartHint, connectSuccessDescription } from "@/lib/clientConnect";
 
 interface Props {
   client: DetectedClient;
@@ -163,10 +164,13 @@ export function ClientDetail({ client, registry, onChanged, onRegistryChange }: 
     setBusy(true);
     try {
       await installGateway(client.id, profile || undefined);
+      // Rescope rewrites the client's MCP config the same way Connect does; without a
+      // restart hint the change is invisible until the next cold start (SOU-317).
       toast.success(
         profile
           ? `${client.name} scoped to "${profile}".`
           : `${client.name} now uses all enabled servers.`,
+        { description: clientRestartHint(client.name) },
       );
       onChanged();
     } catch (e) {
@@ -301,12 +305,13 @@ export function ClientDetail({ client, registry, onChanged, onRegistryChange }: 
         toast.success(`Disconnected Toolport from ${client.name}`);
       } else {
         const outcome = await installGateway(client.id, profile || undefined);
+        // Restart is the load-bearing line (SOU-317): MCP clients typically do not
+        // pick up a new gateway entry until relaunch. Scope/backup are secondary.
         toast.success(`Connected Toolport to ${client.name}`, {
-          description: profile
-            ? `Scoped to the "${profile}" profile.`
-            : outcome.backup
-              ? "Previous config backed up."
-              : undefined,
+          description: connectSuccessDescription(client.name, [
+            profile ? `Scoped to the "${profile}" profile.` : null,
+            !profile && outcome.backup ? "Previous config backed up." : null,
+          ]),
         });
       }
       onChanged();

--- a/src/components/Onboarding.tsx
+++ b/src/components/Onboarding.tsx
@@ -29,6 +29,7 @@ import {
   teamJoinPoll,
 } from "@/lib/api";
 import { ClientLogo } from "@/components/ClientLogo";
+import { clientRestartHint } from "@/lib/clientConnect";
 import { teamUrlError } from "@/lib/teamUrl";
 import { Input } from "@/components/ui/input";
 import {
@@ -710,7 +711,12 @@ function ConnectClients({
       await installGateway(client.id);
       setDone((prev) => new Set(prev).add(client.id));
       onConnected();
-      toast.success(`Connected Toolport to ${client.name}`);
+      // Same trap as ClientDetail (SOU-317): config is written now, but the client
+      // usually only loads it on restart. Verify step also says this; put it on the
+      // success toast so it is not delayed until that step.
+      toast.success(`Connected Toolport to ${client.name}`, {
+        description: clientRestartHint(client.name),
+      });
     } catch (e) {
       toastError(`Couldn't connect: ${e}`);
     } finally {

--- a/src/lib/clientConnect.test.ts
+++ b/src/lib/clientConnect.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from "vitest";
+import { clientRestartHint, connectSuccessDescription } from "./clientConnect";
+
+describe("clientRestartHint / connectSuccessDescription (SOU-317)", () => {
+  it("puts the restart line first and keeps optional scope/backup notes", () => {
+    expect(clientRestartHint("Claude Desktop")).toBe(
+      "Restart Claude Desktop so it loads Toolport.",
+    );
+    expect(
+      connectSuccessDescription("Claude Desktop", [
+        'Scoped to the "Work" profile.',
+        false,
+        null,
+      ]),
+    ).toBe('Restart Claude Desktop so it loads Toolport. Scoped to the "Work" profile.');
+    expect(connectSuccessDescription("Claude Desktop")).toBe(
+      "Restart Claude Desktop so it loads Toolport.",
+    );
+  });
+});

--- a/src/lib/clientConnect.ts
+++ b/src/lib/clientConnect.ts
@@ -1,0 +1,17 @@
+/**
+ * Most MCP clients only read their config at startup (Claude Desktop especially).
+ * After Toolport writes a gateway entry, a success toast that only says "Connected"
+ * leaves the user thinking the product is broken until they happen to restart
+ * (SOU-317). Universal wording: a restart never hurts clients that hot-reload.
+ */
+export function clientRestartHint(clientName: string): string {
+  return `Restart ${clientName} so it loads Toolport.`;
+}
+
+/** Connect/rescope toast body: restart first, then optional scope/backup notes. */
+export function connectSuccessDescription(
+  clientName: string,
+  extras: Array<string | undefined | null | false> = [],
+): string {
+  return [clientRestartHint(clientName), ...extras.filter(Boolean)].join(" ");
+}


### PR DESCRIPTION
## Summary

Connecting a client outside onboarding only toasted "Connected Toolport to {client}". Most MCP clients (Claude Desktop especially) load MCP config at startup, so Toolport looked broken until a restart.

- Lead connect success toasts with `Restart {client} so it loads Toolport.`
- Same nudge on rescope and Onboarding connect
- Shared helpers in `src/lib/clientConnect.ts` (keeps Onboarding from importing the lazy ClientDetail chunk)

## Tracking

- Linear: SOU-317

## Test plan

- [x] `vitest` ClientDetail connect toast asserts restart copy
- [x] `vitest` connectSuccessDescription helper
- [ ] Manual: Clients → Connect to Toolport → toast shows restart line
