### PR TITLE
fix(ui): label active-profile client scope

### DIFF
--- a/src/components/ClientDetail.tsx
+++ b/src/components/ClientDetail.tsx
@@ -85,7 +85,7 @@ export function ClientDetail({ client, registry, onChanged, onRegistryChange }: 
   // Snapshotted at dialog-open time so a registry-changed event mid-review can't
   // reshuffle `toImport` out from under the indices the user already confirmed.
   const [bulkImportServers, setBulkImportServers] = useState<McpServer[] | null>(null);
-  // "" = expose all enabled servers (follow active profile); else scope to one.
+  // "" = follow the active profile; else scope to one.
   const [profile, setProfile] = useState("");
   const [migrateOpen, setMigrateOpen] = useState(false);
   const installed = client.gatewayInstalled;
@@ -166,7 +166,7 @@ export function ClientDetail({ client, registry, onChanged, onRegistryChange }: 
       toast.success(
         profile
           ? `${client.name} scoped to "${profile}".`
-          : `${client.name} now uses all enabled servers.`,
+          : `${client.name} now follows the active profile.`,
       );
       onChanged();
     } catch (e) {
@@ -343,7 +343,7 @@ export function ClientDetail({ client, registry, onChanged, onRegistryChange }: 
             <p className="mt-1 text-xs text-muted-foreground">
               Sees{" "}
               <span className="font-medium text-foreground">
-                {currentScope ? `the "${currentScope}" profile` : "all enabled servers"}
+                {currentScope ? `the "${currentScope}" profile` : "the active profile"}
               </span>{" "}
               · {scopeServerCount(currentScope)} server
               {scopeServerCount(currentScope) === 1 ? "" : "s"}
@@ -366,7 +366,7 @@ export function ClientDetail({ client, registry, onChanged, onRegistryChange }: 
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
-                <SelectItem value="__all__">All enabled servers</SelectItem>
+                <SelectItem value="__all__">Follow active profile</SelectItem>
                 {profiles.map((p) => (
                   <SelectItem key={p.id} value={p.name}>
                     Only: {p.name}
@@ -655,7 +655,7 @@ export function ClientDetail({ client, registry, onChanged, onRegistryChange }: 
                     <SelectValue />
                   </SelectTrigger>
                   <SelectContent>
-                    <SelectItem value="__all__">All enabled servers</SelectItem>
+                    <SelectItem value="__all__">Follow active profile</SelectItem>
                     {profiles.map((p) => (
                       <SelectItem key={p.id} value={p.name}>
                         Only: {p.name}


### PR DESCRIPTION
<!-- Thanks for contributing to Toolport. Keep PRs focused and small where you can. -->

## What and why

Fixes #443.

Unscoped clients follow the active profile, but ClientDetail described that state as using every enabled server. This updates both scope pickers, the summary, and the success toast to describe the actual active-profile behavior consistently.

## Testing

- [x] `npm run build` passes
- [x] `npm run test` passes (15 files, 120 tests)
- [x] `npm run audit:prod` passes (0 vulnerabilities)
- [ ] `npm run test:rust` passes (`npm run test:rust:windows` on Windows if the debug gateway binary is locked) — N/A: this copy-only change does not touch Rust code
- [ ] Ran the app (`npm run tauri dev`) and checked the change by hand — not run; the issue explicitly does not require a test or snapshot for this copy-only change

Also verified:

- `npm run lint` (0 errors; existing repository warnings remain)
- `npm run format:check`

## Notes

N/A — no screenshot is included for this copy-only change. The diff contains no secrets, keys, or personal paths.
