### PR TITLE
fix(ui): label active-profile client scope (#446)

### DIFF
--- a/src/components/ClientDetail.tsx
+++ b/src/components/ClientDetail.tsx
@@ -85,7 +85,7 @@ export function ClientDetail({ client, registry, onChanged, onRegistryChange }: 
   // Snapshotted at dialog-open time so a registry-changed event mid-review can't
   // reshuffle `toImport` out from under the indices the user already confirmed.
   const [bulkImportServers, setBulkImportServers] = useState<McpServer[] | null>(null);
-  // "" = expose all enabled servers (follow active profile); else scope to one.
+  // "" = follow the active profile; else scope to one.
   const [profile, setProfile] = useState("");
   const [migrateOpen, setMigrateOpen] = useState(false);
   const installed = client.gatewayInstalled;
@@ -166,7 +166,7 @@ export function ClientDetail({ client, registry, onChanged, onRegistryChange }: 
       toast.success(
         profile
           ? `${client.name} scoped to "${profile}".`
-          : `${client.name} now uses all enabled servers.`,
+          : `${client.name} now follows the active profile.`,
       );
       onChanged();
     } catch (e) {
@@ -343,7 +343,7 @@ export function ClientDetail({ client, registry, onChanged, onRegistryChange }: 
             <p className="mt-1 text-xs text-muted-foreground">
               Sees{" "}
               <span className="font-medium text-foreground">
-                {currentScope ? `the "${currentScope}" profile` : "all enabled servers"}
+                {currentScope ? `the "${currentScope}" profile` : "the active profile"}
               </span>{" "}
               · {scopeServerCount(currentScope)} server
               {scopeServerCount(currentScope) === 1 ? "" : "s"}
@@ -366,7 +366,7 @@ export function ClientDetail({ client, registry, onChanged, onRegistryChange }: 
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
-                <SelectItem value="__all__">All enabled servers</SelectItem>
+                <SelectItem value="__all__">Follow active profile</SelectItem>
                 {profiles.map((p) => (
                   <SelectItem key={p.id} value={p.name}>
                     Only: {p.name}
@@ -655,7 +655,7 @@ export function ClientDetail({ client, registry, onChanged, onRegistryChange }: 
                     <SelectValue />
                   </SelectTrigger>
                   <SelectContent>
-                    <SelectItem value="__all__">All enabled servers</SelectItem>
+                    <SelectItem value="__all__">Follow active profile</SelectItem>
                     {profiles.map((p) => (
                       <SelectItem key={p.id} value={p.name}>
                         Only: {p.name}


### PR DESCRIPTION
## Summary

Same change as #446 (contributor nightcityblade / fixes #443): rename unscoped client scope copy from "All enabled servers" to "Follow active profile".

## Why a second PR

#446 is from a fork and conflicted with main after SOU-317 (restart toast description on applyScope). Conflict resolved to keep both:
- new active-profile wording
- `clientRestartHint` description on rescope toast

## Tracking

- Fixes #443
- Supersedes #446 (cannot push merge resolution to the fork)
- Linear SOU-335
