### PR TITLE
fix(activity): stable row keys so the 3s live refresh keeps expanded rows open

### DIFF
--- a/src/components/ActivityView.test.tsx
+++ b/src/components/ActivityView.test.tsx
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, act } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ActivityView } from "./ActivityView";
+import type { AuditEntry } from "@/lib/types";
+
+const getAuditLog = vi.fn();
+
+vi.mock("@/lib/api", () => ({
+  clearActivityLogs: vi.fn(),
+  exportAuditToPath: vi.fn(),
+  getAuditLog: (...a: unknown[]) => getAuditLog(...a),
+  getAuditStats: vi.fn(() => Promise.resolve(null)),
+  getInspectLog: vi.fn(() => Promise.resolve([])),
+  getSavingsSummary: vi.fn(() => Promise.resolve(null)),
+  getSearchTraces: vi.fn(() => Promise.resolve([])),
+  getSecurityEvents: vi.fn(() => Promise.resolve([])),
+  getToolIdentities: vi.fn(() => Promise.resolve([])),
+}));
+
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn(), warning: vi.fn(), info: vi.fn() },
+}));
+
+vi.mock("@/lib/toast", () => ({ toastError: vi.fn() }));
+
+vi.mock("@tauri-apps/plugin-dialog", () => ({ save: vi.fn() }));
+
+function entry(over: Partial<AuditEntry> = {}): AuditEntry {
+  return {
+    ts: 1700000000000,
+    server: "github",
+    tool: "create_issue",
+    ok: true,
+    durationMs: 120,
+    ...over,
+  };
+}
+
+const failed = entry({
+  ts: 1700000001000,
+  tool: "merge_pr",
+  ok: false,
+  error: "403: token lacks repo scope",
+});
+const initialLog = [failed, entry()];
+// Same list with a fresh call prepended, as the 3s live tick would refetch it.
+const refreshedLog = [entry({ ts: 1700000002000, tool: "list_issues" }), ...initialLog];
+
+beforeEach(() => {
+  vi.useFakeTimers({ shouldAdvanceTime: true });
+  getAuditLog.mockResolvedValue(initialLog);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.clearAllMocks();
+});
+
+describe("ActivityView recent calls", () => {
+  it("keeps an expanded error row open across a live-poll refetch", async () => {
+    const user = userEvent.setup({
+      advanceTimers: (ms) => vi.advanceTimersByTime(ms),
+    });
+    render(<ActivityView refreshKey={0} registry={null} />);
+
+    await act(async () => {});
+    await user.click(screen.getByRole("button", { name: /recent calls/i }));
+
+    // Expand the failed call's error detail.
+    await user.click(screen.getByText("merge_pr"));
+    expect(screen.getByText("403: token lacks repo scope")).toBeInTheDocument();
+
+    // Next poll returns the same entries with a new call prepended.
+    getAuditLog.mockResolvedValue(refreshedLog);
+    await act(async () => {
+      vi.advanceTimersByTime(3000);
+    });
+
+    expect(screen.getByText("list_issues")).toBeInTheDocument();
+    expect(screen.getByText("403: token lacks repo scope")).toBeInTheDocument();
+  });
+});

--- a/src/components/ActivityView.tsx
+++ b/src/components/ActivityView.tsx
@@ -18,7 +18,7 @@ import {
   XCircle,
 } from "lucide-react";
 import { toast } from "sonner";
-import { fmtPercent, fmtTokens, fmtTs } from "@/lib/utils";
+import { fmtPercent, fmtTokens, fmtTs, stableListKeys } from "@/lib/utils";
 import { toastError } from "@/lib/toast";
 import { save } from "@tauri-apps/plugin-dialog";
 import { Input } from "@/components/ui/input";
@@ -1022,8 +1022,8 @@ function DiscoveryTraces({ refreshKey }: { refreshKey: number }) {
             Local and bounded: tool names only, never arguments or results.
           </p>
           <div className="flex flex-col gap-1">
-            {entries.map((t, i) => (
-              <DiscoveryRow key={`${t.ts}-${i}`} t={t} />
+            {stableListKeys(entries, (t) => `${t.ts}-${t.query}`).map((key, i) => (
+              <DiscoveryRow key={key} t={entries[i]} />
             ))}
           </div>
         </>
@@ -1331,9 +1331,11 @@ function LiveInspector({ refreshKey }: { refreshKey: number }) {
             </p>
           ) : (
             <div className="flex flex-col gap-1">
-              {entries.map((e, i) => (
-                <InspectRow key={`${e.ts}-${e.server}-${e.tool}-${i}`} e={e} />
-              ))}
+              {stableListKeys(entries, (e) => `${e.ts}-${e.server}-${e.tool}`).map(
+                (key, i) => (
+                  <InspectRow key={key} e={entries[i]} />
+                ),
+              )}
             </div>
           )}
         </>
@@ -1660,9 +1662,9 @@ export function ActivityView({
                 )}
               </div>
             ) : (
-              visible.map((e, i) => (
-                <CallRow key={`${e.ts}-${e.server}-${e.tool}-${i}`} e={e} />
-              ))
+              stableListKeys(visible, (e) => `${e.ts}-${e.server}-${e.tool}`).map(
+                (key, i) => <CallRow key={key} e={visible[i]} />,
+              )
             )}
           </div>
         </>

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -17,6 +17,18 @@ describe("stableListKeys", () => {
     const after = stableListKeys(["new", "x", "y", "x"], (s) => s);
     expect(after.slice(1)).toEqual(before);
   });
+
+  it("never collides a generated suffix with a real identity containing #", () => {
+    const keys = stableListKeys(["a#1", "a", "a"], (s) => s);
+    expect(new Set(keys).size).toBe(keys.length);
+  });
+
+  it("keeps keys stable and unique when #-containing identities are prepended", () => {
+    const before = stableListKeys(["a", "a"], (s) => s);
+    const after = stableListKeys(["a#1", "a", "a"], (s) => s);
+    expect(after.slice(1)).toEqual(before);
+    expect(new Set(after).size).toBe(after.length);
+  });
 });
 
 describe("fmtTokens", () => {

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -1,5 +1,23 @@
 import { describe, it, expect } from "vitest";
-import { fmtPercent, fmtTokens, fmtTs } from "./utils";
+import { fmtPercent, fmtTokens, fmtTs, stableListKeys } from "./utils";
+
+describe("stableListKeys", () => {
+  it("uses the bare identity when there are no collisions", () => {
+    expect(stableListKeys(["a", "b", "c"], (s) => s)).toEqual(["a", "b", "c"]);
+  });
+
+  it("disambiguates colliding identities deterministically", () => {
+    const keys = stableListKeys(["a", "a", "b", "a"], (s) => s);
+    expect(keys).toEqual(["a#2", "a#1", "b", "a"]);
+    expect(new Set(keys).size).toBe(keys.length);
+  });
+
+  it("keeps existing keys stable when new entries are prepended", () => {
+    const before = stableListKeys(["x", "y", "x"], (s) => s);
+    const after = stableListKeys(["new", "x", "y", "x"], (s) => s);
+    expect(after.slice(1)).toEqual(before);
+  });
+});
 
 describe("fmtTokens", () => {
   it("renders small numbers as-is", () => {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -20,6 +20,27 @@ export function fmtTokens(n: number): string {
 }
 
 /**
+ * Stable React keys for a newest-first list whose entries have no unique id.
+ * Each key is the item's identity plus, on collision, an occurrence counter
+ * counted from the END of the array, so prepending new entries never changes
+ * the key of an existing row (an index-based suffix shifts on every prepend
+ * and remounts each row, resetting its expand/collapse state). Identities can
+ * collide (e.g. two calls to the same tool in the same millisecond), so the
+ * counter keeps keys unique deterministically.
+ */
+export function stableListKeys<T>(items: T[], identity: (item: T) => string): string[] {
+  const seen = new Map<string, number>();
+  const keys = new Array<string>(items.length);
+  for (let i = items.length - 1; i >= 0; i--) {
+    const id = identity(items[i]);
+    const n = seen.get(id) ?? 0;
+    seen.set(id, n + 1);
+    keys[i] = n === 0 ? id : `${id}#${n}`;
+  }
+  return keys;
+}
+
+/**
  * Format a ratio as a percent with the same adaptive precision everywhere.
  * When `floorNonZero` is true, tiny positive rates render as "<0.1%" instead
  * of rounding down to a misleading "0%".

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -26,7 +26,10 @@ export function fmtTokens(n: number): string {
  * the key of an existing row (an index-based suffix shifts on every prepend
  * and remounts each row, resetting its expand/collapse state). Identities can
  * collide (e.g. two calls to the same tool in the same millisecond), so the
- * counter keeps keys unique deterministically.
+ * counter keeps keys unique deterministically. "#" inside identities is
+ * escaped to "##" so a generated "#n" suffix can never equal another
+ * identity that happens to end in "#n" (the escaped form only contains "#"
+ * in even-length runs, while the suffix adds a lone "#").
  */
 export function stableListKeys<T>(items: T[], identity: (item: T) => string): string[] {
   const seen = new Map<string, number>();
@@ -35,7 +38,8 @@ export function stableListKeys<T>(items: T[], identity: (item: T) => string): st
     const id = identity(items[i]);
     const n = seen.get(id) ?? 0;
     seen.set(id, n + 1);
-    keys[i] = n === 0 ? id : `${id}#${n}`;
+    const escaped = id.replace(/#/g, "##");
+    keys[i] = n === 0 ? escaped : `${escaped}#${n}`;
   }
   return keys;
 }


### PR DESCRIPTION
## Summary
Fixes #428

Activity rows were keyed with the array index appended (`${e.ts}-${e.server}-${e.tool}-${i}`). The audit log is newest-first, so each new call prepended by the 3s live tick shifted every index, changed every key, and React remounted each row — resetting `useState(false)` and collapsing any expanded error detail / inspector JSON / discovery trace.

Fix: new `stableListKeys(items, identity)` helper in `src/lib/utils.ts` that keys rows by identity (`ts-server-tool`, or `ts-query` for discovery traces) and disambiguates identity collisions (e.g. two calls in the same millisecond) with an occurrence counter counted from the **end** of the array, so prepends never change existing keys:

```ts
stableListKeys(["new", "x", "y", "x"], id) // ["new", "x#1", "y", "x"] — old keys unchanged
```

Applied to `CallRow`, `InspectRow`, and `DiscoveryRow` in `ActivityView.tsx`.

Tests: unit tests for `stableListKeys`, plus a component test (as sketched in the issue) that expands a failed `CallRow`, advances the 3s fake-timer tick with a new entry prepended to the mocked `getAuditLog`, and asserts the error text stays visible — it fails on the old keys and passes with this change.
