### PR TITLE
Route remaining hand-formatted timestamps through fmtTs

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -94,6 +94,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { Toaster } from "@/components/ui/sonner";
 import { useTheme } from "@/lib/theme";
+import { fmtTs } from "@/lib/utils";
 
 /** Above this many servers, "Disable all" asks for confirmation first. */
 const BULK_DISABLE_CONFIRM_MIN = 3;
@@ -197,7 +198,7 @@ function App() {
         setRegistry(reg);
         setClients(dc);
         if (recovery) {
-          const when = new Date(recovery.recoveredAtMs).toLocaleString();
+          const when = fmtTs(recovery.recoveredAtMs);
           const detail =
             recovery.reason === "corrupt"
               ? `The registry file was damaged. Restored from backup (${when}).`

--- a/src/components/QuarantineAlert.tsx
+++ b/src/components/QuarantineAlert.tsx
@@ -3,6 +3,7 @@ import { ShieldAlert } from "lucide-react";
 import { listQuarantined, releaseQuarantine, type QuarantinedTool } from "@/lib/api";
 import { toastError } from "@/lib/toast";
 import { Button } from "@/components/ui/button";
+import { fmtTs } from "@/lib/utils";
 
 /** Matches the PendingApprovals cadence so the two attention surfaces feel equally live. */
 const POLL_MS = 2000;
@@ -34,7 +35,7 @@ function whenLabel(ts: number): string {
   if (mins < 60) return `${mins}m ago`;
   const hrs = Math.floor(mins / 60);
   if (hrs < 24) return `${hrs}h ago`;
-  return new Date(ts).toLocaleDateString();
+  return fmtTs(ts, "date");
 }
 
 /**


### PR DESCRIPTION
## What and why

Fixes #419

Routes the two timestamps left hand-formatted outside the Activity view through the shared `fmtTs` helper from `src/lib/utils.ts`:

- `QuarantineAlert.tsx` `whenLabel`: `new Date(ts).toLocaleDateString()` -> `fmtTs(ts, "date")` (pure de-duplication, no visible change).
- `App.tsx` profile-recovery notice: `new Date(recovery.recoveredAtMs).toLocaleString()` -> `fmtTs(recovery.recoveredAtMs)` (default short month/day/hour/minute shape, matching Activity rows).

## Testing

- [x] `npm run build` passes
- [x] `npm run test` passes (124 tests, 17 files)
- [ ] `npm run audit:prod`
- [ ] `npm run test:rust` (Rust untouched by this change)
- [ ] Ran the app (`npm run tauri dev`) and checked the change by hand

`npm run lint` passes (0 errors).

## Notes

Call-site swaps only; `fmtTs` is already covered by `src/lib/utils.test.ts`. No secrets or personal paths in the diff.