### PR TITLE
ci: run Rust integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,9 +73,8 @@ jobs:
       - name: Frontend tests
         run: npm run test
 
-      # The Rust unit tests: the library AND the standalone gateway binary's own
-      # tests (dispatch, scoping, HITL, HTTP). `--bins` runs the binary targets'
-      # tests too; checking only that the binary compiled let a gateway test fail
-      # silently, so run them.
-      - name: Rust tests (lib + binaries)
+      # Run the library, standalone binary, and integration targets explicitly.
+      # Keeping all three flags prevents any test class from silently dropping
+      # out of CI when the command is updated.
+      - name: Rust tests (lib + binaries + integration)
         run: npm run test:rust

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,8 +48,8 @@ If a client reports the gateway "was not found," you forgot this step.
 ### Running tests
 
 ```bash
-# Backend (Rust)
-cargo test --manifest-path src-tauri/Cargo.toml
+# Backend (Rust: library, binaries, and integration tests)
+npm run test:rust
 
 # Headless gateway smoke (Windows; build gateway first)
 powershell -ExecutionPolicy Bypass -File scripts/smoke-headless.ps1
@@ -62,10 +62,10 @@ npx tsc --noEmit && npm run build
 ```
 
 The Rust suite includes unit tests in each module (`clients`, `catalog`,
-`registry`, `router`, `oauth`, etc.) and an integration test
-(`tests/list_changed.rs`) that exercises the gateway's live tool-change
-notification path. Frontend tests use [Vitest](https://vitest.dev) and live
-alongside the code as `*.test.ts` files inside `src/`.
+`registry`, `router`, `oauth`, etc.), binary-target tests, and integration tests
+in `src-tauri/tests/`. Use the npm script above so your local target selection
+matches CI. Frontend tests use [Vitest](https://vitest.dev) and live alongside
+the code as `*.test.ts` files inside `src/`.
 
 ### Formatting
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "lint:fix": "eslint src/ --fix",
     "test": "vitest run",
     "test:watch": "vitest",
-    "test:rust": "cargo test --manifest-path src-tauri/Cargo.toml --lib --bins",
+    "test:rust": "cargo test --manifest-path src-tauri/Cargo.toml --lib --bins --tests",
     "test:rust:windows": "powershell -ExecutionPolicy Bypass -File scripts/test-rust-windows.ps1",
     "audit:prod": "npm audit --omit=dev",
     "prepare": "husky"

--- a/scripts/test-rust-windows.ps1
+++ b/scripts/test-rust-windows.ps1
@@ -13,4 +13,4 @@ if ($resolvedGateway) {
     }
 }
 
-cargo test --manifest-path (Join-Path $repoRoot "src-tauri\Cargo.toml") --lib --bins
+cargo test --manifest-path (Join-Path $repoRoot "src-tauri\Cargo.toml") --lib --bins --tests


### PR DESCRIPTION
## What and why

Adds Cargo `--tests` coverage to the cross-platform Rust test scripts so the four integration-test targets under `src-tauri/tests/` are compiled and run in CI. Updates the CI label and contributor documentation to match.

Closes #426.

## Testing

- [x] `npm run build` passes
- [x] `npm run test` passes (17 files, 124 tests)
- [ ] `npm run audit:prod` passes — the unchanged lockfile currently reports the pre-existing PostCSS advisory GHSA-r28c-9q8g-f849
- [ ] `npm run test:rust` passes — all targets compile, then the lib suite reaches a pre-existing unsigned-macOS keychain failure (472 passed, 1 failed, 4 ignored) before Cargo advances to integration targets
- [ ] Ran the app (`npm run tauri dev`) and checked the change by hand — not applicable to this CI/docs-only change

Additional verification:

- `npm run format:check`
- `npm run lint` (0 errors; 20 existing warnings)
- `cargo test --manifest-path src-tauri/Cargo.toml --test circuit_breaker --test list_changed --test root_cwd --test security_doc` (4/4 pass)
- Negative control: `cargo test --lib --bins --no-run` lists no integration executables; adding `--tests` lists all four integration targets
- `git diff --check`

## Notes

The Windows PowerShell path receives the identical flag change and was statically reviewed; it was not executed on macOS. No secrets, keys, or personal paths are included in the diff.