### PR TITLE
feat(gateway): opt-in Prometheus /metrics (SOU-347)

### DIFF
--- a/docs/headless.md
+++ b/docs/headless.md
@@ -43,6 +43,19 @@ toolport-gateway --http 8765
 Point Open WebUI at `http://host:8765` with the bearer token as the API key.
 Point an MCP client at `http://host:8765/mcp` (streamable-HTTP).
 
+### Prometheus metrics (opt-in)
+
+Off by default. Set `CONDUIT_METRICS=1` on the gateway process, then scrape:
+
+```bash
+curl -s -H "Authorization: Bearer $CONDUIT_HTTP_TOKEN" \
+  http://127.0.0.1:8765/metrics
+```
+
+Emits counters for tool calls (`server`, `tool`, `client`, `ok`), held
+destructive calls, duration sum/count, lazy-discovery tokens saved, and a
+quarantine gauge. Labels are ids only (never arguments). Same auth as OpenAPI.
+
 ### MCP handshake (curl)
 
 ```bash
@@ -284,6 +297,7 @@ Toolport reads the following environment variables. This is the complete referen
 | `CONDUIT_HTTP_HOST`             | Host IP to bind for the HTTP endpoint.                                                             | `127.0.0.1`      | Gateway                   |
 | `CONDUIT_HTTP_PORT`             | Port for the HTTP endpoint (when `CONDUIT_HTTP` is a boolean).                                     | `8765`           | Gateway                   |
 | `CONDUIT_HTTP_TOKEN`            | Bearer token for HTTP authentication.                                                              | None             | Gateway                   |
+| `CONDUIT_METRICS`               | Opt-in Prometheus `GET /metrics` (`1` / `true` / `yes`). Off by default.                           | Off              | Gateway (HTTP mode)       |
 | `CONDUIT_PROFILE`               | Initial profile value for a scoped client install; live scope is resolved via `CONDUIT_CLIENT_ID`. | None             | Clients                   |
 | `CONDUIT_REGISTRY`              | Override the path to `registry.json`.                                                              | Config root      | Everywhere                |
 | `CONDUIT_RESULT_BUDGET`         | Byte budget before large tool results get shaped/truncated (0 to disable).                         | `49152`          | Everywhere                |

--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -6004,15 +6004,37 @@ fn handle_http(
             "application/json",
             openapi_spec(state, allowed).to_string(),
         ),
-        ("GET", "/") | ("GET", "/docs") => HttpOut::new(
-            200,
-            "text/plain; charset=utf-8",
-            "Toolport gateway (HTTP mode).\n\
-             OpenAPI: GET /openapi.json, POST /{tool_name} with a JSON body.\n\
-             MCP streamable-HTTP: POST /mcp with JSON-RPC; GET /mcp for server→client SSE.\n\
-             Auth: Authorization: Bearer <CONDUIT_HTTP_TOKEN>."
-                .to_string(),
-        ),
+        ("GET", "/") | ("GET", "/docs") => {
+            let metrics_line = if conduit_lib::metrics::metrics_enabled() {
+                "Metrics: GET /metrics (Prometheus text; set CONDUIT_METRICS=1).\n"
+            } else {
+                "Metrics: off (set CONDUIT_METRICS=1 to enable GET /metrics).\n"
+            };
+            HttpOut::new(
+                200,
+                "text/plain; charset=utf-8",
+                format!(
+                    "Toolport gateway (HTTP mode).\n\
+                     OpenAPI: GET /openapi.json, POST /{{tool_name}} with a JSON body.\n\
+                     MCP streamable-HTTP: POST /mcp with JSON-RPC; GET /mcp for server→client SSE.\n\
+                     {metrics_line}\
+                     Auth: Authorization: Bearer <CONDUIT_HTTP_TOKEN>."
+                ),
+            )
+        }
+        ("GET", "/metrics") => {
+            if !conduit_lib::metrics::metrics_enabled() {
+                return HttpOut::json_err(
+                    404,
+                    "metrics disabled; set CONDUIT_METRICS=1 on the gateway to enable",
+                );
+            }
+            HttpOut::new(
+                200,
+                "text/plain; version=0.0.4; charset=utf-8",
+                conduit_lib::metrics::render(),
+            )
+        }
         ("POST", p) => {
             let name = p.trim_start_matches('/');
             if name.is_empty() {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -12,6 +12,7 @@ pub mod gateway_publish;
 pub mod inspect;
 pub mod instructions;
 pub mod integrity;
+pub mod metrics;
 pub mod oauth;
 pub mod rate_limits;
 pub mod registry;

--- a/src-tauri/src/metrics.rs
+++ b/src-tauri/src/metrics.rs
@@ -1,0 +1,190 @@
+//! Opt-in Prometheus `/metrics` for the HTTP gateway (SOU-347).
+//!
+//! Off by default (`CONDUIT_METRICS=1` / `true` / `yes` to enable). Scrapes the
+//! same local audit + savings + quarantine files the desktop dashboards use.
+//! Labels are bounded to ids only (server / tool / client / ok), never args.
+
+use std::collections::BTreeMap;
+
+use serde_json::Value;
+
+/// Whether `GET /metrics` is served. Default off.
+pub fn metrics_enabled() -> bool {
+    match std::env::var("CONDUIT_METRICS") {
+        Ok(v) => {
+            let t = v.trim();
+            t == "1" || t.eq_ignore_ascii_case("true") || t.eq_ignore_ascii_case("yes")
+        }
+        Err(_) => false,
+    }
+}
+
+/// Prometheus text exposition of current local stats.
+pub fn render() -> String {
+    let entries = crate::audit::read_all();
+    let tokens_saved = crate::savings::summary()
+        .get("tokensSaved")
+        .and_then(Value::as_u64)
+        .unwrap_or(0);
+    let quarantined = crate::integrity::all_quarantined().len() as u64;
+    render_from_parts(&entries, tokens_saved, quarantined)
+}
+
+/// Pure renderer for tests (no disk).
+pub fn render_from_parts(entries: &[Value], tokens_saved: u64, quarantined_tools: u64) -> String {
+    // key: (server, tool, client, ok) -> (calls, error_count_if_not_ok is redundant with ok label)
+    let mut calls: BTreeMap<(String, String, String, bool), u64> = BTreeMap::new();
+    let mut held: BTreeMap<(String, String, String), u64> = BTreeMap::new();
+    let mut dur_sum: BTreeMap<(String, String), u64> = BTreeMap::new();
+    let mut dur_count: BTreeMap<(String, String), u64> = BTreeMap::new();
+
+    for e in entries {
+        let server = e
+            .get("server")
+            .and_then(Value::as_str)
+            .unwrap_or("unknown")
+            .to_string();
+        let tool = e
+            .get("tool")
+            .and_then(Value::as_str)
+            .unwrap_or("unknown")
+            .to_string();
+        let client = e
+            .get("client")
+            .and_then(Value::as_str)
+            .filter(|c| !c.is_empty())
+            .unwrap_or("")
+            .to_string();
+        let ok = e.get("ok").and_then(Value::as_bool).unwrap_or(true);
+        *calls
+            .entry((server.clone(), tool.clone(), client.clone(), ok))
+            .or_insert(0) += 1;
+        if e.get("held").and_then(Value::as_bool) == Some(true) {
+            *held
+                .entry((server.clone(), tool.clone(), client.clone()))
+                .or_insert(0) += 1;
+        }
+        if let Some(ms) = e.get("durationMs").and_then(Value::as_u64) {
+            *dur_sum.entry((server.clone(), tool.clone())).or_insert(0) += ms;
+            *dur_count.entry((server, tool)).or_insert(0) += 1;
+        }
+    }
+
+    let mut out = String::with_capacity(2048);
+    out.push_str("# HELP toolport_tool_calls_total Tool calls in the retained local audit log\n");
+    out.push_str("# TYPE toolport_tool_calls_total counter\n");
+    for ((server, tool, client, ok), n) in &calls {
+        out.push_str(&format!(
+            "toolport_tool_calls_total{{server=\"{}\",tool=\"{}\",client=\"{}\",ok=\"{}\"}} {}\n",
+            esc_label(server),
+            esc_label(tool),
+            esc_label(client),
+            if *ok { "true" } else { "false" },
+            n
+        ));
+    }
+
+    out.push_str(
+        "# HELP toolport_held_calls_total Destructive calls held for confirmation (retained log)\n",
+    );
+    out.push_str("# TYPE toolport_held_calls_total counter\n");
+    for ((server, tool, client), n) in &held {
+        out.push_str(&format!(
+            "toolport_held_calls_total{{server=\"{}\",tool=\"{}\",client=\"{}\"}} {}\n",
+            esc_label(server),
+            esc_label(tool),
+            esc_label(client),
+            n
+        ));
+    }
+
+    out.push_str(
+        "# HELP toolport_tool_call_duration_milliseconds_sum Sum of recorded call durations (ms)\n",
+    );
+    out.push_str("# TYPE toolport_tool_call_duration_milliseconds_sum counter\n");
+    for ((server, tool), sum) in &dur_sum {
+        out.push_str(&format!(
+            "toolport_tool_call_duration_milliseconds_sum{{server=\"{}\",tool=\"{}\"}} {}\n",
+            esc_label(server),
+            esc_label(tool),
+            sum
+        ));
+    }
+    out.push_str(
+        "# HELP toolport_tool_call_duration_milliseconds_count Timed tool calls in the retained log\n",
+    );
+    out.push_str("# TYPE toolport_tool_call_duration_milliseconds_count counter\n");
+    for ((server, tool), n) in &dur_count {
+        out.push_str(&format!(
+            "toolport_tool_call_duration_milliseconds_count{{server=\"{}\",tool=\"{}\"}} {}\n",
+            esc_label(server),
+            esc_label(tool),
+            n
+        ));
+    }
+
+    out.push_str(
+        "# HELP toolport_tokens_saved_total Estimated tool-definition tokens saved by lazy discovery\n",
+    );
+    out.push_str("# TYPE toolport_tokens_saved_total counter\n");
+    out.push_str(&format!("toolport_tokens_saved_total {}\n", tokens_saved));
+
+    out.push_str("# HELP toolport_quarantined_tools Tools currently quarantined after high-risk drift\n");
+    out.push_str("# TYPE toolport_quarantined_tools gauge\n");
+    out.push_str(&format!("toolport_quarantined_tools {}\n", quarantined_tools));
+
+    out
+}
+
+/// Escape a Prometheus label value (backslash, newline, double-quote).
+fn esc_label(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        match c {
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '"' => out.push_str("\\\""),
+            _ => out.push(c),
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn metrics_enabled_parses_truthy() {
+        // Unit path: pure parser via env is process-global; just lock the pure bits here.
+        assert_eq!(esc_label(r#"a"b\c"#), r#"a\"b\\c"#);
+        assert_eq!(esc_label("x\ny"), r#"x\ny"#);
+    }
+
+    #[test]
+    fn render_groups_calls_and_held() {
+        let entries = vec![
+            json!({"server":"s1","tool":"echo","ok":true,"durationMs":10,"client":"web"}),
+            json!({"server":"s1","tool":"echo","ok":false,"durationMs":20,"client":"web"}),
+            json!({"server":"s1","tool":"wipe","ok":true,"held":true}),
+        ];
+        let text = render_from_parts(&entries, 42, 1);
+        assert!(text.contains("toolport_tool_calls_total{server=\"s1\",tool=\"echo\",client=\"web\",ok=\"true\"} 1"));
+        assert!(text.contains("toolport_tool_calls_total{server=\"s1\",tool=\"echo\",client=\"web\",ok=\"false\"} 1"));
+        assert!(text.contains("toolport_held_calls_total{server=\"s1\",tool=\"wipe\",client=\"\"} 1"));
+        assert!(text.contains("toolport_tool_call_duration_milliseconds_sum{server=\"s1\",tool=\"echo\"} 30"));
+        assert!(text.contains("toolport_tool_call_duration_milliseconds_count{server=\"s1\",tool=\"echo\"} 2"));
+        assert!(text.contains("toolport_tokens_saved_total 42"));
+        assert!(text.contains("toolport_quarantined_tools 1"));
+        assert!(text.contains("# TYPE toolport_tool_calls_total counter"));
+    }
+
+    #[test]
+    fn empty_log_still_emits_gauges() {
+        let text = render_from_parts(&[], 0, 0);
+        assert!(text.contains("toolport_tokens_saved_total 0"));
+        assert!(text.contains("toolport_quarantined_tools 0"));
+        assert!(!text.contains("toolport_tool_calls_total{"));
+    }
+}


### PR DESCRIPTION
## Summary
**SOU-347** (first P2 after CF comparison page): opt-in Prometheus exporter.

- Off by default (`CONDUIT_METRICS=1` / `true` / `yes`)
- `GET /metrics` on HTTP gateway, same bearer auth as OpenAPI
- Metrics: `toolport_tool_calls_total`, `toolport_held_calls_total`, duration sum/count, `toolport_tokens_saved_total`, `toolport_quarantined_tools`
- Labels bounded to ids (server/tool/client/ok), never args
- `docs/headless.md` scrape example + env table

OTLP push left for a follow-up (issue phase 2).

## Test plan
- [x] `cargo test metrics` (3 unit tests)
- [ ] Manual: `CONDUIT_METRICS=1 CONDUIT_HTTP=8765` + bearer curl `/metrics`