### PR TITLE
fix(ui): show client detection errors in detail view

### DIFF
--- a/src/components/ClientDetail.test.tsx
+++ b/src/components/ClientDetail.test.tsx
@@ -62,6 +62,24 @@ beforeEach(() => {
   toastError.mockReset();
 });
 
+describe("ClientDetail detection errors", () => {
+  it("shows the client error in the main panel", () => {
+    render(
+      <ClientDetail
+        client={client({ error: "Couldn't parse config: unexpected token" })}
+        registry={emptyRegistry()}
+        onChanged={() => {}}
+        onRegistryChange={() => {}}
+      />,
+    );
+
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "Couldn't parse config: unexpected token",
+    );
+    expect(screen.getByRole("button", { name: /connect to toolport/i })).toBeEnabled();
+  });
+});
+
 describe("ClientDetail connect toast (SOU-317)", () => {
   it("tells the user to restart the client after a successful Connect", async () => {
     // Without this, the UI says "Connected" while Claude Desktop (and most peers)

--- a/src/components/ClientDetail.tsx
+++ b/src/components/ClientDetail.tsx
@@ -415,6 +415,19 @@ export function ClientDetail({ client, registry, onChanged, onRegistryChange }: 
         </div>
       </div>
 
+      {client.error && (
+        <div
+          role="alert"
+          className="flex items-start gap-2 rounded-lg border border-warning/30 bg-warning/10 px-3 py-2 text-sm text-warning"
+        >
+          <TriangleAlert className="mt-0.5 size-4 shrink-0" />
+          <div className="min-w-0">
+            <p className="font-medium">Couldn't read this client's configuration</p>
+            <p className="mt-0.5 break-words text-xs">{client.error}</p>
+          </div>
+        </div>
+      )}
+
       {installed && (
         <div className="flex items-center justify-between gap-3 rounded-lg border border-border/60 bg-muted/20 px-3 py-2">
           <div className="min-w-0">


### PR DESCRIPTION
## What and why

I added a persistent warning banner to ClientDetail whenever client detection reports an error. The detail panel now shows the exact configuration read/parse failure without requiring the sidebar tooltip, while keeping the Connect action available as allowed by the issue acceptance criteria.

Fixes #444

## Testing

- [x] `npm run build` passes
- [x] `npm run test` passes (131 tests)
- [x] `npm run audit:prod` passes
- [ ] `npm run test:rust` passes (`npm run test:rust:windows` on Windows if the debug gateway binary is locked)
- [ ] Ran the app (`npm run tauri dev`) and checked the change by hand

Additional checks:

- `npm run test -- src/components/ClientDetail.test.tsx`
- `npm run lint` (passes with existing warnings)
- `npx prettier --check src/components/ClientDetail.tsx src/components/ClientDetail.test.tsx`
- `git diff --check origin/main...HEAD`

## Notes

This is a frontend-only change. I did not run the Rust suite or the desktop app locally; the full repository CI remains the integration check.
