### PR TITLE
fix: show tool fetch failures in profile scope panel

### DIFF
--- a/src/components/SettingsView.test.tsx
+++ b/src/components/SettingsView.test.tsx
@@ -1,0 +1,132 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { ThemeProvider } from "@/lib/theme";
+import { SettingsView } from "./SettingsView";
+import { listServerTools } from "@/lib/api";
+import type { Registry } from "@/lib/types";
+
+vi.mock("@/lib/api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/api")>();
+
+  return {
+    ...actual,
+    listServerTools: vi.fn(),
+  };
+});
+
+const mockedListServerTools = vi.mocked(listServerTools);
+
+const registry: Registry = {
+  version: 1,
+  servers: [
+    {
+      id: "github",
+      name: "GitHub",
+      transport: "stdio",
+      command: null,
+      args: [],
+      env: [],
+      url: null,
+      source: null,
+    },
+    {
+      id: "slack",
+      name: "Slack",
+      transport: "stdio",
+      command: null,
+      args: [],
+      env: [],
+      url: null,
+      source: null,
+    },
+  ],
+  profiles: [
+    {
+      id: "default",
+      name: "Default",
+      enabledServerIds: ["github", "slack"],
+    },
+  ],
+  activeProfileId: "default",
+};
+
+function renderSettings() {
+  render(
+    <ThemeProvider>
+      <SettingsView registry={registry} onRegistryChange={vi.fn()} />
+    </ThemeProvider>,
+  );
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+
+  return {
+    promise,
+    resolve,
+  };
+}
+
+describe("SettingsView tool loading", () => {
+  it("keeps loading state scoped to each server", async () => {
+    const user = userEvent.setup();
+
+    const githubRequest = deferred<{ name: string }[]>();
+    const slackRequest = deferred<{ name: string }[]>();
+
+    mockedListServerTools
+      .mockReturnValueOnce(githubRequest.promise)
+      .mockReturnValueOnce(slackRequest.promise);
+
+    renderSettings();
+
+    // Open the profile.
+    await user.click(
+      screen.getByRole("button", {
+        name: /default active 2 servers/i,
+      }),
+    );
+
+    // Expand GitHub (request A starts).
+    await user.click(
+      screen.getByRole("button", {
+        name: /github/i,
+      }),
+    );
+
+    expect(screen.getByText("Loading tools…")).toBeInTheDocument();
+
+    // Expand Slack while GitHub is still pending (request B starts).
+    await user.click(
+      screen.getByRole("button", {
+        name: /slack/i,
+      }),
+    );
+
+    // Slack is now the visible expanded server.
+    expect(screen.getByText("Loading tools…")).toBeInTheDocument();
+
+    // Resolve GitHub first.
+    githubRequest.resolve([{ name: "repo-search" }]);
+
+    // Slack should still be loading because loading is tracked per server.
+    await waitFor(() => {
+      expect(screen.getByText("Loading tools…")).toBeInTheDocument();
+    });
+
+    // Resolve Slack afterwards.
+    slackRequest.resolve([{ name: "send-message" }]);
+
+    expect(await screen.findByText("send-message")).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(screen.queryByText("Loading tools…")).not.toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/SettingsView.tsx
+++ b/src/components/SettingsView.tsx
@@ -31,6 +31,7 @@ import {
 } from "@tauri-apps/plugin-autostart";
 import { open as openFolderDialog } from "@tauri-apps/plugin-dialog";
 import { toastError } from "@/lib/toast";
+import { Button } from "@/components/ui/button";
 import {
   addHttpClient,
   clearInspectLog,
@@ -375,9 +376,28 @@ function ProfileToolScope({
   }, [registry.servers]);
   const [expanded, setExpanded] = useState<string | null>(null);
   const [toolsByServer, setToolsByServer] = useState<Record<string, string[]>>({});
+  const [errorByServer, setErrorByServer] = useState<Record<string, boolean>>({});
   const [loading, setLoading] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
   const scope = profile.toolScope ?? {};
+
+  async function loadTools(serverId: string) {
+    setLoading(serverId);
+    try {
+      const tools = await listServerTools(serverId);
+      setToolsByServer((m) => ({ ...m, [serverId]: tools.map((t) => t.name) }));
+      setErrorByServer((m) => {
+        const next = { ...m };
+        delete next[serverId];
+        return next;
+      });
+    } catch (e) {
+      toastError(`Couldn't load ${serverName.get(serverId) ?? serverId} tools: ${e}`);
+      setErrorByServer((m) => ({ ...m, [serverId]: true }));
+    } finally {
+      setLoading(null);
+    }
+  }
 
   async function expand(serverId: string) {
     if (expanded === serverId) {
@@ -386,15 +406,7 @@ function ProfileToolScope({
     }
     setExpanded(serverId);
     if (!toolsByServer[serverId]) {
-      setLoading(serverId);
-      try {
-        const tools = await listServerTools(serverId);
-        setToolsByServer((m) => ({ ...m, [serverId]: tools.map((t) => t.name) }));
-      } catch (e) {
-        toastError(`Couldn't load ${serverName.get(serverId) ?? serverId} tools: ${e}`);
-      } finally {
-        setLoading(null);
-      }
+      await loadTools(serverId);
     }
   }
 
@@ -453,6 +465,22 @@ function ProfileToolScope({
               <div className="border-t border-border/40 px-2 py-1.5">
                 {loading === serverId ? (
                   <p className="text-xs text-muted-foreground">Loading tools…</p>
+                ) : errorByServer[serverId] ? (
+                  <div
+                    role="status"
+                    aria-live="polite"
+                    className="flex flex-col gap-2 rounded-md border border-border p-3"
+                  >
+                    <p className="text-xs text-muted-foreground">Couldn't load tools</p>
+                    <Button
+                      variant="outline"
+                      size="xs"
+                      className="w-fit"
+                      onClick={() => loadTools(serverId)}
+                    >
+                      Retry
+                    </Button>
+                  </div>
                 ) : allTools && allTools.length > 0 ? (
                   <div className="flex flex-col gap-1">
                     {allTools.map((tool) => (
@@ -470,7 +498,7 @@ function ProfileToolScope({
                   </div>
                 ) : (
                   <p className="text-xs text-muted-foreground">
-                    No tools, or the server isn&apos;t reachable right now.
+                    This server exposes no tools.
                   </p>
                 )}
               </div>

--- a/src/components/SettingsView.tsx
+++ b/src/components/SettingsView.tsx
@@ -401,6 +401,10 @@ function ProfileToolScope({
         return next;
       });
     } catch (e) {
+      // Ignore stale failures (a newer load for this server is in flight or done).
+      if (requestIdByServer.current[serverId] !== requestId) {
+        return;
+      }
       toastError(`Couldn't load ${serverName.get(serverId) ?? serverId} tools: ${e}`);
       setErrorByServer((m) => ({ ...m, [serverId]: true }));
     } finally {

--- a/src/components/SettingsView.tsx
+++ b/src/components/SettingsView.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState, useRef } from "react";
 import {
   Activity,
   Bot,
@@ -377,14 +377,23 @@ function ProfileToolScope({
   const [expanded, setExpanded] = useState<string | null>(null);
   const [toolsByServer, setToolsByServer] = useState<Record<string, string[]>>({});
   const [errorByServer, setErrorByServer] = useState<Record<string, boolean>>({});
-  const [loading, setLoading] = useState<string | null>(null);
+  const [loadingByServer, setLoadingByServer] = useState<Record<string, boolean>>({});
+  const requestIdByServer = useRef<Record<string, number>>({});
   const [busy, setBusy] = useState(false);
   const scope = profile.toolScope ?? {};
 
   async function loadTools(serverId: string) {
-    setLoading(serverId);
+    const requestId = (requestIdByServer.current[serverId] ?? 0) + 1;
+    requestIdByServer.current[serverId] = requestId;
+    setLoadingByServer((m) => ({
+      ...m,
+      [serverId]: true,
+    }));
     try {
       const tools = await listServerTools(serverId);
+      if (requestIdByServer.current[serverId] !== requestId) {
+        return;
+      }
       setToolsByServer((m) => ({ ...m, [serverId]: tools.map((t) => t.name) }));
       setErrorByServer((m) => {
         const next = { ...m };
@@ -395,7 +404,12 @@ function ProfileToolScope({
       toastError(`Couldn't load ${serverName.get(serverId) ?? serverId} tools: ${e}`);
       setErrorByServer((m) => ({ ...m, [serverId]: true }));
     } finally {
-      setLoading(null);
+      if (requestIdByServer.current[serverId] === requestId) {
+        setLoadingByServer((m) => ({
+          ...m,
+          [serverId]: false,
+        }));
+      }
     }
   }
 
@@ -463,7 +477,7 @@ function ProfileToolScope({
             </button>
             {open && (
               <div className="border-t border-border/40 px-2 py-1.5">
-                {loading === serverId ? (
+                {loadingByServer[serverId] ? (
                   <p className="text-xs text-muted-foreground">Loading tools…</p>
                 ) : errorByServer[serverId] ? (
                   <div

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -27,3 +27,16 @@ for (const method of [
     elemProto[method] = () => {};
   }
 }
+
+if (typeof window.matchMedia === "undefined") {
+  window.matchMedia = ((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => false,
+  })) as typeof window.matchMedia;
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Toolport. Keep PRs focused and small where you can. -->

## What and why

Fixed an issue where failed tool fetches in the profile scope panel were indistinguishable from servers that genuinely expose no tools.

Previously, when `listServerTools(serverId)` failed, the error was only shown through a toast. After the toast disappeared, the UI would fall back to:

> No tools, or the server isn't reachable right now.

This made it unclear whether:
- the server had no available tools, or
- the tool fetch failed due to a transient error.

Changes made:
- Added `errorByServer` state to track failed tool fetches per server.
- Extracted tool fetching logic into a reusable `loadTools` function.
- Added an inline error state with a retry action in the profile scope panel.
- Retry now re-runs the tool fetch without collapsing the expanded server view.
- Successful fetches clear any previous error state for that server.
- Updated the empty state handling so fetch failures are separated from servers with no tools.

Closes #381 

## Testing

<!-- How did you verify this? -->

- [x] `npm run build` passes
- [x] `npm run test` passes
- [ ] `npm run audit:prod` passes
- [ ] `npm run test:rust` passes (`npm run test:rust:windows` on Windows if the debug gateway binary is locked)
- [x] Ran the app (`npm run tauri dev`) and checked the change by hand

## Notes

<!-- Screenshots for UI changes, follow-ups, or anything a reviewer should know.
     Confirm no secrets, keys, or personal paths are included in the diff. -->

- Verified failed tool fetches now show an inline error with a retry option.
- Verified retry triggers the same tool loading flow used during initial expansion.
- No secrets, keys, or personal paths are included in the diff.