### PR TITLE
perf(gateway): index local tool search

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,6 +71,7 @@ dist-ssr
 .smoke-test/
 /benchmark/capable/
 /benchmark/local-*/
+/benchmark/local-compare*.json
 /benchmark/groq/
 /benchmark/gemini/
 # Local ground-truth for grading (your real account items) - never commit

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -54,7 +54,7 @@ searchable, lazy `tools/list`, search, and routed-call overhead versus calling t
 same server directly.
 
 ```bash
-cargo build --manifest-path src-tauri/Cargo.toml --bins
+cargo build --release --manifest-path src-tauri/Cargo.toml --bins
 node benchmark/latency.mjs 200
 node benchmark/latency.mjs 200 --json
 node benchmark/latency.mjs 200 --check
@@ -63,6 +63,44 @@ node benchmark/latency.mjs 200 --check
 `--json` is intended for storing and comparing results across commits and competing
 local gateways. `--check` enforces the deliberately generous regression ceilings in
 `latency-budget.json`; tighten them only with evidence from multiple machines.
+
+## Side-by-side local gateway comparison (`compare-local.mjs`)
+
+This is the competitive harness. It generates one deterministic MCP catalog, launches
+the same dependency-free fixture server behind each gateway, and drives both products
+through their public stdio MCP interfaces. It compares:
+
+- cold start until a known capability is searchable;
+- the count and estimated token cost of always-exposed gateway tools plus MCP
+  initialization instructions;
+- search median/p95, returned-payload size, recall@K, and mean reciprocal rank
+  over shared queries;
+- routed-call median/p95 overhead against calling the fixture directly.
+
+Ratel Local is pinned in `compare-local.config.json` and installed into the operating
+system's temporary directory, not this repository:
+
+```bash
+cargo build --release --manifest-path src-tauri/Cargo.toml --bins
+npm run bench:compare -- --install-ratel
+
+# Subsequent offline/cached runs
+npm run bench:compare
+npm run bench:compare -- --sizes=25,100,500 --iterations=200
+npm run bench:compare -- --settle-ms=1000
+npm run bench:compare -- --json --out=benchmark/local-compare.json
+
+# Toolport-only regression run
+npm run bench:compare -- --products=toolport
+```
+
+The comparison prefers Toolport's release binary and records the selected path and
+build profile in JSON. A debug binary is accepted for development smoke tests, but
+do not publish performance numbers from a debug-vs-release run.
+
+The report deliberately separates deterministic gateway mechanics from model-graded
+agent accuracy. Use `bench-sweep.mjs` for end-to-end model tasks; do not present this
+synthetic retrieval fixture as an agent-accuracy benchmark.
 
 ## What it reports
 

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -46,6 +46,24 @@ MODEL="qwen2.5-7b-instruct" node benchmark/bench.js
 LLM_URL="http://localhost:11434/v1/chat/completions" MODEL="qwen2.5:7b" node benchmark/bench.js
 ```
 
+## Deterministic latency and startup report (`latency.mjs`)
+
+This offline benchmark uses the bundled mock MCP server to isolate Toolport's own
+cost. It measures the gateway handshake, time until the downstream catalog is
+searchable, lazy `tools/list`, search, and routed-call overhead versus calling the
+same server directly.
+
+```bash
+cargo build --manifest-path src-tauri/Cargo.toml --bins
+node benchmark/latency.mjs 200
+node benchmark/latency.mjs 200 --json
+node benchmark/latency.mjs 200 --check
+```
+
+`--json` is intended for storing and comparing results across commits and competing
+local gateways. `--check` enforces the deliberately generous regression ceilings in
+`latency-budget.json`; tighten them only with evidence from multiple machines.
+
 ## What it reports
 
 Per task and as totals, for each mode:

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -94,9 +94,10 @@ npm run bench:compare -- --json --out=benchmark/local-compare.json
 npm run bench:compare -- --products=toolport
 ```
 
-The comparison prefers Toolport's release binary and records the selected path and
-build profile in JSON. A debug binary is accepted for development smoke tests, but
-do not publish performance numbers from a debug-vs-release run.
+The comparison prefers Toolport's release binary and records the selected path,
+SHA-256, build profile, Git revision, and dirty-worktree state in JSON. A debug
+binary is accepted for development smoke tests, but do not publish performance
+numbers from a debug-vs-release run.
 
 The report deliberately separates deterministic gateway mechanics from model-graded
 agent accuracy. Use `bench-sweep.mjs` for end-to-end model tasks; do not present this

--- a/benchmark/compare-local.config.json
+++ b/benchmark/compare-local.config.json
@@ -1,0 +1,12 @@
+{
+  "ratel": {
+    "package": "@ratel-ai/ratel-local",
+    "version": "0.5.0"
+  },
+  "defaults": {
+    "catalogSizes": [25, 100, 500],
+    "iterations": 100,
+    "settleMilliseconds": 500,
+    "topK": 5
+  }
+}

--- a/benchmark/compare-local.mjs
+++ b/benchmark/compare-local.mjs
@@ -10,6 +10,7 @@
 //   node benchmark/compare-local.mjs --json --out=benchmark/local-compare.json
 
 import { spawn, spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
 import {
   existsSync,
   mkdtempSync,
@@ -635,6 +636,19 @@ function gitRevision() {
   return result.status === 0 ? result.stdout.trim() : null;
 }
 
+function gitDirty() {
+  const result = spawnSync("git", ["status", "--porcelain", "--untracked-files=no"], {
+    cwd: ROOT,
+    encoding: "utf8",
+    windowsHide: true,
+  });
+  return result.status === 0 ? result.stdout.trim().length > 0 : null;
+}
+
+function fileSha256(path) {
+  return createHash("sha256").update(readFileSync(path)).digest("hex");
+}
+
 function markdown(result) {
   const lines = [
     "# Local MCP gateway comparison",
@@ -681,7 +695,9 @@ async function main() {
     },
     versions: {
       toolportRevision: gitRevision(),
+      toolportDirty: gitDirty(),
       toolportBinary: TOOLPORT_GATEWAY,
+      toolportBinarySha256: fileSha256(TOOLPORT_GATEWAY),
       toolportBuildProfile: TOOLPORT_GATEWAY === RELEASE_GATEWAY ? "release" : "debug",
       ratelPackage: ratelBin ? `${CONFIG.ratel.package}@${CONFIG.ratel.version}` : null,
     },

--- a/benchmark/compare-local.mjs
+++ b/benchmark/compare-local.mjs
@@ -1,0 +1,744 @@
+#!/usr/bin/env node
+// Vendor-neutral local MCP gateway benchmark.
+//
+// Both products ingest the same generated MCP catalog from fixture-mcp.mjs and
+// are driven through their public stdio MCP surfaces. No model, network service,
+// account, or API key participates in the measured workload.
+//
+//   npm run bench:compare -- --install-ratel
+//   node benchmark/compare-local.mjs --products=toolport --sizes=25,100
+//   node benchmark/compare-local.mjs --json --out=benchmark/local-compare.json
+
+import { spawn, spawnSync } from "node:child_process";
+import {
+  existsSync,
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { createInterface } from "node:readline";
+import { fileURLToPath } from "node:url";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(HERE, "..");
+const CONFIG = JSON.parse(readFileSync(join(HERE, "compare-local.config.json"), "utf8"));
+const FIXTURE = join(HERE, "fixture-mcp.mjs");
+const DEBUG = join(ROOT, "src-tauri", "target", "debug");
+const RELEASE = join(ROOT, "src-tauri", "target", "release");
+const RELEASE_GATEWAY = executable(RELEASE, "toolport-gateway");
+const DEBUG_GATEWAY = executable(DEBUG, "toolport-gateway");
+const TOOLPORT_GATEWAY =
+  process.env.TOOLPORT_GATEWAY ||
+  (existsSync(RELEASE_GATEWAY) ? RELEASE_GATEWAY : DEBUG_GATEWAY);
+const argv = process.argv.slice(2);
+
+const options = {
+  products: valueArg("products", "toolport,ratel")
+    .split(",")
+    .map((value) => value.trim())
+    .filter(Boolean),
+  sizes: valueArg("sizes", CONFIG.defaults.catalogSizes.join(","))
+    .split(",")
+    .map(Number)
+    .filter((value) => Number.isInteger(value) && value > 0),
+  iterations: Math.max(20, Number(valueArg("iterations", CONFIG.defaults.iterations))),
+  settleMilliseconds: Math.max(
+    0,
+    Number(valueArg("settle-ms", CONFIG.defaults.settleMilliseconds)),
+  ),
+  topK: Math.max(1, Number(valueArg("top-k", CONFIG.defaults.topK))),
+  json: argv.includes("--json"),
+  installRatel: argv.includes("--install-ratel"),
+  out: optionalValueArg("out"),
+};
+
+for (const product of options.products) {
+  if (!["toolport", "ratel"].includes(product)) {
+    fail(`unknown product "${product}" (expected toolport and/or ratel)`);
+  }
+}
+if (options.sizes.length === 0) fail("at least one positive catalog size is required");
+
+const SIGNAL_TOOLS = [
+  {
+    name: "github_create_pull_request",
+    description: "Open a new GitHub pull request from a branch with a title and body.",
+    query: "open a pull request for my branch",
+  },
+  {
+    name: "postgres_run_query",
+    description: "Execute a SQL query against a PostgreSQL database and return rows.",
+    query: "run a SQL query against my database",
+  },
+  {
+    name: "stripe_refund_payment",
+    description: "Refund a Stripe payment or charge to the customer.",
+    query: "refund a customer payment",
+  },
+  {
+    name: "resend_send_email",
+    description: "Send a transactional email message to a recipient.",
+    query: "send a welcome email to a new signup",
+  },
+  {
+    name: "filesystem_read_file",
+    description: "Read text content from a file on the local filesystem.",
+    query: "read a local file from disk",
+  },
+  {
+    name: "vercel_list_projects",
+    description: "List the projects deployed in a Vercel account or team.",
+    query: "show my deployed Vercel projects",
+  },
+  {
+    name: "sentry_list_issues",
+    description: "List recent application errors and unresolved issues from Sentry.",
+    query: "find recent production application errors",
+  },
+  {
+    name: "cloudflare_purge_cache",
+    description: "Purge cached assets for a Cloudflare zone.",
+    query: "clear the CDN cache for my website",
+  },
+  {
+    name: "calendar_create_event",
+    description: "Create a calendar event with attendees, start time, and end time.",
+    query: "schedule a meeting with the team",
+  },
+  {
+    name: "slack_post_message",
+    description: "Post a message to a Slack channel.",
+    query: "send an update to our Slack channel",
+  },
+];
+
+const INIT = {
+  protocolVersion: "2025-06-18",
+  capabilities: {},
+  clientInfo: { name: "toolport-local-comparison", version: "1" },
+};
+
+function valueArg(name, fallback) {
+  return optionalValueArg(name) ?? fallback;
+}
+
+function optionalValueArg(name) {
+  const prefix = `--${name}=`;
+  const inline = argv.find((arg) => arg.startsWith(prefix));
+  if (inline) return inline.slice(prefix.length);
+  const index = argv.indexOf(`--${name}`);
+  if (index >= 0) return argv[index + 1];
+  return undefined;
+}
+
+function executable(dir, name) {
+  return join(dir, process.platform === "win32" ? `${name}.exe` : name);
+}
+
+function fail(message) {
+  console.error(message);
+  process.exit(2);
+}
+
+function now() {
+  return Number(process.hrtime.bigint()) / 1e6;
+}
+
+function sleep(milliseconds) {
+  return new Promise((resolvePromise) => setTimeout(resolvePromise, milliseconds));
+}
+
+function stats(values) {
+  const sorted = [...values].sort((a, b) => a - b);
+  const quantile = (q) =>
+    sorted[Math.min(sorted.length - 1, Math.ceil(sorted.length * q) - 1)];
+  return {
+    median: quantile(0.5),
+    p95: quantile(0.95),
+    min: sorted[0],
+    max: sorted.at(-1),
+  };
+}
+
+async function measure(fn, iterations) {
+  const values = [];
+  for (let i = 0; i < iterations; i++) {
+    const started = now();
+    await fn(i);
+    values.push(now() - started);
+  }
+  return stats(values);
+}
+
+function makeCatalog(size) {
+  const selectedSignals = SIGNAL_TOOLS.slice(0, Math.min(size, SIGNAL_TOOLS.length));
+  const tools = selectedSignals.map(({ name, description }) =>
+    toolDefinition(name, description),
+  );
+  const domains = [
+    "inventory",
+    "analytics",
+    "billing",
+    "deployment",
+    "monitoring",
+    "documents",
+    "support",
+    "identity",
+  ];
+  for (let i = tools.length; i < size; i++) {
+    const domain = domains[i % domains.length];
+    tools.push(
+      toolDefinition(
+        `service_${String(i).padStart(4, "0")}_${domain}_operation`,
+        `Perform operation ${i} for the ${domain} service using its resource identifier.`,
+      ),
+    );
+  }
+  return { tools };
+}
+
+function toolDefinition(name, description) {
+  return {
+    name,
+    description,
+    inputSchema: {
+      type: "object",
+      properties: {
+        resourceId: { type: "string", description: "Target resource identifier." },
+        options: {
+          type: "object",
+          description: "Optional operation settings.",
+          additionalProperties: true,
+        },
+      },
+      required: ["resourceId"],
+    },
+  };
+}
+
+class McpProcess {
+  constructor(command, args, spawnOptions = {}) {
+    this.stderr = "";
+    this.pending = new Map();
+    this.nextId = 0;
+    this.proc = spawn(command, args, {
+      ...spawnOptions,
+      stdio: ["pipe", "pipe", "pipe"],
+      windowsHide: true,
+    });
+    this.proc.stderr.on("data", (chunk) => {
+      this.stderr = `${this.stderr}${chunk}`.slice(-12_000);
+    });
+    const lines = createInterface({ input: this.proc.stdout, crlfDelay: Infinity });
+    lines.on("line", (line) => {
+      let message;
+      try {
+        message = JSON.parse(line);
+      } catch {
+        return;
+      }
+      const pending = this.pending.get(message.id);
+      if (!pending) return;
+      clearTimeout(pending.timer);
+      this.pending.delete(message.id);
+      pending.resolve(message);
+    });
+    this.proc.on("error", (error) => this.rejectAll(error));
+    this.proc.on("exit", (code) => {
+      if (this.pending.size > 0) {
+        this.rejectAll(
+          new Error(`process exited with code ${code}\n${this.stderr.trim()}`),
+        );
+      }
+    });
+  }
+
+  call(method, params = {}, timeoutMs = 20_000) {
+    return new Promise((resolvePromise, reject) => {
+      const id = ++this.nextId;
+      const timer = setTimeout(() => {
+        this.pending.delete(id);
+        reject(
+          new Error(`${method} timed out after ${timeoutMs} ms\n${this.stderr.trim()}`),
+        );
+      }, timeoutMs);
+      this.pending.set(id, { resolve: resolvePromise, reject, timer });
+      this.proc.stdin.write(
+        `${JSON.stringify({ jsonrpc: "2.0", id, method, params })}\n`,
+      );
+    });
+  }
+
+  notify(method, params = {}) {
+    this.proc.stdin.write(`${JSON.stringify({ jsonrpc: "2.0", method, params })}\n`);
+  }
+
+  rejectAll(error) {
+    for (const pending of this.pending.values()) {
+      clearTimeout(pending.timer);
+      pending.reject(error);
+    }
+    this.pending.clear();
+  }
+
+  stop() {
+    try {
+      this.proc.stdin.end();
+      this.proc.kill();
+    } catch {
+      // Best-effort cleanup of an already-exited benchmark child.
+    }
+  }
+}
+
+function fixtureArgs(catalogPath) {
+  return [FIXTURE, catalogPath];
+}
+
+function toolportAdapter(registryPath) {
+  if (!existsSync(TOOLPORT_GATEWAY)) {
+    fail(
+      `missing Toolport gateway at ${TOOLPORT_GATEWAY}\n` +
+        "Build it with: cargo build --manifest-path src-tauri/Cargo.toml --bins",
+    );
+  }
+  return {
+    name: "toolport",
+    command: TOOLPORT_GATEWAY,
+    args: [],
+    env: {
+      ...process.env,
+      TOOLPORT_REGISTRY: registryPath,
+      TOOLPORT_PROFILE: "benchmark",
+      TOOLPORT_DISCOVERY: "lazy",
+    },
+    searchTool: "toolport_search_tools",
+    invokeTool: "toolport_call_tool",
+    searchArgs: (query, topK) => ({ query, limit: topK }),
+    invokeArgs: (toolId, args) => ({ name: toolId, arguments: args }),
+    parseSearch: parseToolportSearch,
+  };
+}
+
+function ratelAdapter(configPath, ratelBin, benchmarkHome) {
+  return {
+    name: "ratel",
+    command: process.execPath,
+    args: [ratelBin, "serve", configPath],
+    env: {
+      ...process.env,
+      HOME: benchmarkHome,
+      USERPROFILE: benchmarkHome,
+      RATEL_TELEMETRY: "off",
+    },
+    searchTool: "search_capabilities",
+    invokeTool: "invoke_tool",
+    searchArgs: (query, topK) => ({ query, topKTools: topK, topKSkills: 1 }),
+    invokeArgs: (toolId, args) => ({ toolId, args }),
+    parseSearch: parseRatelSearch,
+  };
+}
+
+function parseToolportSearch(response) {
+  const text = response.result?.content?.map((item) => item.text ?? "").join("\n") ?? "";
+  return [...text.matchAll(/"name"\s*:\s*"([^"]+)"/g)].map((match) => match[1]);
+}
+
+function parseRatelSearch(response) {
+  let payload = response.result?.structuredContent;
+  if (!payload) {
+    const text = response.result?.content?.[0]?.text;
+    try {
+      payload = JSON.parse(text);
+    } catch {
+      payload = {};
+    }
+  }
+  return (payload.tools?.groups ?? []).flatMap((group) =>
+    (group.hits ?? []).map((hit) => hit.toolId),
+  );
+}
+
+async function waitForCatalog(client, adapter, expectedToolId, readinessQuery) {
+  const started = now();
+  let lastNames = [];
+  while (now() - started < 20_000) {
+    const response = await client.call(
+      "tools/call",
+      {
+        name: adapter.searchTool,
+        arguments: adapter.searchArgs(readinessQuery, options.topK),
+      },
+      20_000,
+    );
+    lastNames = adapter.parseSearch(response);
+    if (lastNames.includes(expectedToolId)) return;
+    await sleep(25);
+  }
+  throw new Error(
+    `${adapter.name} catalog never surfaced ${expectedToolId}; last results: ${lastNames.join(", ")}`,
+  );
+}
+
+async function benchmarkDirect(catalogPath, toolName) {
+  const client = new McpProcess(process.execPath, fixtureArgs(catalogPath));
+  try {
+    await client.call("initialize", INIT);
+    client.notify("notifications/initialized");
+    for (let i = 0; i < 10; i++) {
+      await client.call("tools/call", {
+        name: toolName,
+        arguments: { resourceId: "benchmark" },
+      });
+    }
+    return await measure(
+      () =>
+        client.call("tools/call", {
+          name: toolName,
+          arguments: { resourceId: "benchmark" },
+        }),
+      options.iterations,
+    );
+  } finally {
+    client.stop();
+  }
+}
+
+async function benchmarkProduct(adapter, direct, expectedToolId, retrievalCases) {
+  const processStarted = now();
+  const client = new McpProcess(adapter.command, adapter.args, {
+    env: adapter.env,
+    cwd: ROOT,
+  });
+  try {
+    const handshakeStarted = now();
+    const initialized = await client.call("initialize", INIT);
+    const handshake = now() - handshakeStarted;
+    if (initialized.error) throw new Error(JSON.stringify(initialized.error));
+    client.notify("notifications/initialized");
+    await waitForCatalog(client, adapter, expectedToolId, retrievalCases[0].query);
+    const catalogReady = now() - processStarted;
+    // Toolport makes its catalog searchable before all background integrity/cache
+    // work has necessarily gone quiet, while Ratel completes ingestion during its
+    // initialize handshake. Give both the same unmeasured quiet period so the
+    // steady-state operation timings do not accidentally score startup work.
+    await sleep(options.settleMilliseconds);
+
+    const listed = await client.call("tools/list", {});
+    const exposedTools = listed.result?.tools ?? [];
+    const toolDefinitionBytes = Buffer.byteLength(JSON.stringify(exposedTools));
+    const instructions = initialized.result?.instructions ?? "";
+    const instructionBytes = Buffer.byteLength(instructions);
+    const alwaysOnBytes = toolDefinitionBytes + instructionBytes;
+
+    // Measure dispatch before the search workload so index construction, trace
+    // writes, and CPU/cache churn from repeated searches cannot contaminate it.
+    for (let i = 0; i < 10; i++) {
+      await client.call("tools/call", {
+        name: adapter.invokeTool,
+        arguments: adapter.invokeArgs(expectedToolId, { resourceId: "benchmark" }),
+      });
+    }
+    const routedCall = await measure(
+      () =>
+        client.call("tools/call", {
+          name: adapter.invokeTool,
+          arguments: adapter.invokeArgs(expectedToolId, { resourceId: "benchmark" }),
+        }),
+      options.iterations,
+    );
+
+    for (let i = 0; i < 10; i++) {
+      await client.call("tools/call", {
+        name: adapter.searchTool,
+        arguments: adapter.searchArgs(
+          retrievalCases[i % retrievalCases.length].query,
+          options.topK,
+        ),
+      });
+    }
+    const searchPayloadBytes = [];
+    const search = await measure(async (i) => {
+      const response = await client.call("tools/call", {
+        name: adapter.searchTool,
+        arguments: adapter.searchArgs(
+          retrievalCases[i % retrievalCases.length].query,
+          options.topK,
+        ),
+      });
+      searchPayloadBytes.push(Buffer.byteLength(JSON.stringify(response.result ?? {})));
+    }, options.iterations);
+
+    const cases = [];
+    for (const testCase of retrievalCases) {
+      const response = await client.call("tools/call", {
+        name: adapter.searchTool,
+        arguments: adapter.searchArgs(testCase.query, options.topK),
+      });
+      const names = adapter.parseSearch(response);
+      const wanted = `fixture__${testCase.name}`;
+      const index = names.indexOf(wanted);
+      cases.push({
+        query: testCase.query,
+        expected: wanted,
+        rank: index >= 0 ? index + 1 : null,
+        topK: names,
+      });
+    }
+
+    const hits = cases.filter((item) => item.rank !== null);
+    const reciprocalRank =
+      cases.reduce((sum, item) => sum + (item.rank ? 1 / item.rank : 0), 0) /
+      cases.length;
+    return {
+      handshake,
+      catalogReady,
+      exposedSurface: {
+        toolCount: exposedTools.length,
+        toolDefinitionBytes,
+        instructionBytes,
+        alwaysOnBytes,
+        estimatedTokens: Math.ceil(alwaysOnBytes / 4),
+        names: exposedTools.map((tool) => tool.name).sort(),
+      },
+      search,
+      searchPayload: {
+        bytes: stats(searchPayloadBytes),
+        estimatedTokens: stats(searchPayloadBytes.map((bytes) => Math.ceil(bytes / 4))),
+      },
+      retrieval: {
+        cases: cases.length,
+        hitsAtK: hits.length,
+        recallAtK: hits.length / cases.length,
+        meanReciprocalRank: reciprocalRank,
+        details: cases,
+      },
+      routedCall,
+      directCall: direct,
+      gatewayOverhead: {
+        median: routedCall.median - direct.median,
+        p95: routedCall.p95 - direct.p95,
+      },
+    };
+  } finally {
+    client.stop();
+  }
+}
+
+function writeConfigs(dir, catalogPath) {
+  const registryPath = join(dir, "toolport-registry.json");
+  writeFileSync(
+    registryPath,
+    JSON.stringify({
+      version: 1,
+      servers: [
+        {
+          id: "fixture",
+          name: "Fixture",
+          transport: "stdio",
+          command: process.execPath,
+          args: fixtureArgs(catalogPath),
+          env: [],
+        },
+      ],
+      profiles: [
+        {
+          id: "benchmark",
+          name: "Benchmark",
+          enabledServerIds: ["fixture"],
+        },
+      ],
+      activeProfileId: "benchmark",
+      lazyDiscovery: true,
+    }),
+  );
+
+  const ratelPath = join(dir, "ratel-config.json");
+  writeFileSync(
+    ratelPath,
+    JSON.stringify({
+      mcpServers: {
+        fixture: {
+          type: "stdio",
+          command: process.execPath,
+          args: fixtureArgs(catalogPath),
+        },
+      },
+    }),
+  );
+  return { registryPath, ratelPath };
+}
+
+function resolveRatelBinary() {
+  if (process.env.RATEL_LOCAL_BIN) return resolve(process.env.RATEL_LOCAL_BIN);
+  const vendorRoot = join(
+    tmpdir(),
+    "toolport-competitive-bench",
+    `ratel-local-${CONFIG.ratel.version}`,
+  );
+  const packageRoot = join(
+    vendorRoot,
+    "node_modules",
+    ...CONFIG.ratel.package.split("/"),
+  );
+  const binary = join(packageRoot, "dist", "bin.js");
+  if (!existsSync(binary) && options.installRatel) {
+    mkdirSync(vendorRoot, { recursive: true });
+    const bundledNpm = join(
+      dirname(process.execPath),
+      "node_modules",
+      "npm",
+      "bin",
+      "npm-cli.js",
+    );
+    const npmCommand = existsSync(bundledNpm) ? process.execPath : "npm";
+    const npmArgs = existsSync(bundledNpm) ? [bundledNpm] : [];
+    const installed = spawnSync(
+      npmCommand,
+      [
+        ...npmArgs,
+        "install",
+        "--prefix",
+        vendorRoot,
+        "--no-audit",
+        "--no-fund",
+        `${CONFIG.ratel.package}@${CONFIG.ratel.version}`,
+      ],
+      { encoding: "utf8", windowsHide: true },
+    );
+    if (installed.status !== 0) {
+      fail(
+        `could not install Ratel Local:\n` +
+          `${installed.error?.message ?? ""}\n${installed.stdout ?? ""}\n${installed.stderr ?? ""}`,
+      );
+    }
+  }
+  if (!existsSync(binary)) {
+    fail(
+      `Ratel Local ${CONFIG.ratel.version} is not prepared.\n` +
+        "Run once with --install-ratel, or set RATEL_LOCAL_BIN to dist/bin.js.",
+    );
+  }
+  return binary;
+}
+
+function gitRevision() {
+  const result = spawnSync("git", ["rev-parse", "HEAD"], {
+    cwd: ROOT,
+    encoding: "utf8",
+    windowsHide: true,
+  });
+  return result.status === 0 ? result.stdout.trim() : null;
+}
+
+function markdown(result) {
+  const lines = [
+    "# Local MCP gateway comparison",
+    "",
+    `Same generated MCP server, ${result.runtime.iterations} measured iterations per operation.`,
+    "Token counts below estimate the always-exposed MCP tool-definition payload as JSON bytes / 4.",
+    "",
+    `| Catalog | Product | Ready ms | Exposed tools | Always-on est. tokens | Search result est. tokens | Search p50 / p95 ms | Recall@${result.runtime.topK} | MRR | Call overhead p50 / p95 ms |`,
+    "| ---: | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |",
+  ];
+  for (const run of result.runs) {
+    for (const [product, metrics] of Object.entries(run.products)) {
+      lines.push(
+        `| ${run.catalogSize} | ${product} | ${metrics.catalogReady.toFixed(2)} | ` +
+          `${metrics.exposedSurface.toolCount} | ${metrics.exposedSurface.estimatedTokens} | ` +
+          `${metrics.searchPayload.estimatedTokens.median.toFixed(0)} | ` +
+          `${metrics.search.median.toFixed(2)} / ${metrics.search.p95.toFixed(2)} | ` +
+          `${(metrics.retrieval.recallAtK * 100).toFixed(0)}% | ` +
+          `${metrics.retrieval.meanReciprocalRank.toFixed(3)} | ` +
+          `${metrics.gatewayOverhead.median.toFixed(2)} / ${metrics.gatewayOverhead.p95.toFixed(2)} |`,
+      );
+    }
+  }
+  lines.push(
+    "",
+    "Interpretation: this measures local gateway mechanics and lexical retrieval over a shared fixture.",
+    "It does not claim end-to-end agent accuracy; model-graded task runs remain a separate benchmark.",
+  );
+  return `${lines.join("\n")}\n`;
+}
+
+async function main() {
+  const ratelBin = options.products.includes("ratel") ? resolveRatelBinary() : null;
+  const result = {
+    schemaVersion: 1,
+    generatedAt: new Date().toISOString(),
+    fairness: {
+      sameUpstreamProcess: true,
+      sameCatalog: true,
+      sameQueries: true,
+      sameIterations: true,
+      networkRequiredDuringMeasurement: false,
+      tokenEstimate: "serialized MCP tools/list JSON bytes divided by four",
+    },
+    versions: {
+      toolportRevision: gitRevision(),
+      toolportBinary: TOOLPORT_GATEWAY,
+      toolportBuildProfile: TOOLPORT_GATEWAY === RELEASE_GATEWAY ? "release" : "debug",
+      ratelPackage: ratelBin ? `${CONFIG.ratel.package}@${CONFIG.ratel.version}` : null,
+    },
+    runtime: {
+      platform: process.platform,
+      arch: process.arch,
+      node: process.version,
+      iterations: options.iterations,
+      settleMilliseconds: options.settleMilliseconds,
+      topK: options.topK,
+    },
+    runs: [],
+  };
+
+  for (const catalogSize of options.sizes) {
+    const dir = mkdtempSync(join(tmpdir(), `toolport-local-compare-${catalogSize}-`));
+    try {
+      const catalogPath = join(dir, "catalog.json");
+      writeFileSync(catalogPath, JSON.stringify(makeCatalog(catalogSize)));
+      const { registryPath, ratelPath } = writeConfigs(dir, catalogPath);
+      const retrievalCases = SIGNAL_TOOLS.slice(
+        0,
+        Math.min(catalogSize, SIGNAL_TOOLS.length),
+      );
+      const expectedToolId = `fixture__${retrievalCases[0].name}`;
+      const direct = await benchmarkDirect(catalogPath, retrievalCases[0].name);
+      const products = {};
+      for (const product of options.products) {
+        const adapter =
+          product === "toolport"
+            ? toolportAdapter(registryPath)
+            : ratelAdapter(ratelPath, ratelBin, dir);
+        products[product] = await benchmarkProduct(
+          adapter,
+          direct,
+          expectedToolId,
+          retrievalCases,
+        );
+      }
+      result.runs.push({ catalogSize, products });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }
+
+  const rendered = options.json
+    ? `${JSON.stringify(result, null, 2)}\n`
+    : markdown(result);
+  if (options.out) {
+    const outputPath = resolve(options.out);
+    writeFileSync(outputPath, rendered);
+    if (!options.json) console.log(`Wrote ${outputPath}`);
+  }
+  process.stdout.write(rendered);
+}
+
+main().catch((error) => {
+  console.error(error.stack || error.message || error);
+  process.exit(1);
+});

--- a/benchmark/fixture-mcp.mjs
+++ b/benchmark/fixture-mcp.mjs
@@ -1,0 +1,84 @@
+#!/usr/bin/env node
+// Deterministic MCP server shared by the local-gateway comparison harness.
+// It intentionally has no package dependencies: both products launch this exact
+// process and ingest the exact same generated catalog.
+
+import { readFileSync } from "node:fs";
+import { createInterface } from "node:readline";
+
+const catalogPath = process.argv[2];
+if (!catalogPath) {
+  console.error("usage: node fixture-mcp.mjs <catalog.json>");
+  process.exit(2);
+}
+
+const tools = JSON.parse(readFileSync(catalogPath, "utf8")).tools;
+if (!Array.isArray(tools)) {
+  console.error("catalog must contain a tools array");
+  process.exit(2);
+}
+
+const byName = new Map(tools.map((tool) => [tool.name, tool]));
+const rl = createInterface({ input: process.stdin, crlfDelay: Infinity });
+
+function write(message) {
+  process.stdout.write(`${JSON.stringify(message)}\n`);
+}
+
+function result(id, value) {
+  write({ jsonrpc: "2.0", id, result: value });
+}
+
+function error(id, code, message) {
+  write({ jsonrpc: "2.0", id, error: { code, message } });
+}
+
+rl.on("line", (line) => {
+  if (!line.trim()) return;
+  let request;
+  try {
+    request = JSON.parse(line);
+  } catch {
+    return;
+  }
+  if (request.id == null) return;
+
+  switch (request.method) {
+    case "initialize":
+      result(request.id, {
+        protocolVersion: "2025-06-18",
+        capabilities: { tools: {} },
+        serverInfo: { name: "toolport-benchmark-fixture", version: "1" },
+      });
+      break;
+    case "ping":
+      result(request.id, {});
+      break;
+    case "tools/list":
+      result(request.id, { tools });
+      break;
+    case "tools/call": {
+      const name = request.params?.name;
+      if (!byName.has(name)) {
+        error(request.id, -32602, `unknown fixture tool: ${name}`);
+        break;
+      }
+      result(request.id, {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify({
+              ok: true,
+              tool: name,
+              arguments: request.params?.arguments ?? {},
+            }),
+          },
+        ],
+        isError: false,
+      });
+      break;
+    }
+    default:
+      error(request.id, -32601, `method not found: ${request.method}`);
+  }
+});

--- a/benchmark/latency-budget.json
+++ b/benchmark/latency-budget.json
@@ -1,0 +1,9 @@
+{
+  "maximumMilliseconds": {
+    "handshake": 100,
+    "catalogReady": 1000,
+    "toolsList.p95": 5,
+    "search.p95": 10,
+    "gatewayOverhead.p95": 10
+  }
+}

--- a/benchmark/latency.mjs
+++ b/benchmark/latency.mjs
@@ -7,13 +7,15 @@
 // the mock directly, so the difference on the tool-call path is purely what Toolport
 // adds. Deterministic and offline: no model, no network, no API keys.
 //
-//   node benchmark/latency.mjs [iterations]      (default 200)
+//   node benchmark/latency.mjs [iterations]              (default 200)
+//   node benchmark/latency.mjs 200 --json                (machine-readable)
+//   node benchmark/latency.mjs 200 --check               (enforce latency-budget.json)
 //
 // Needs a debug build first:
 //   cargo build --manifest-path src-tauri/Cargo.toml --bins
 
 import { spawn } from "node:child_process";
-import { mkdtempSync, writeFileSync, rmSync, existsSync } from "node:fs";
+import { mkdtempSync, writeFileSync, rmSync, existsSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
@@ -23,7 +25,11 @@ const DEBUG = join(__dirname, "..", "src-tauri", "target", "debug");
 const exe = (n) => join(DEBUG, process.platform === "win32" ? `${n}.exe` : n);
 const GATEWAY = exe("toolport-gateway");
 const MOCK = exe("mock-mcp-server");
-const N = Math.max(20, Number(process.argv[2] || 200));
+const args = process.argv.slice(2);
+const N = Math.max(20, Number(args.find((arg) => /^\d+$/.test(arg)) || 200));
+const JSON_OUTPUT = args.includes("--json");
+const CHECK_BUDGET = args.includes("--check");
+const BUDGET_PATH = join(__dirname, "latency-budget.json");
 
 for (const [label, p] of [
   ["gateway", GATEWAY],
@@ -94,6 +100,15 @@ const loop = async (fn, n) => {
   return stats(xs);
 };
 
+async function waitUntil(fn, timeoutMs = 10_000) {
+  const started = now();
+  while (now() - started < timeoutMs) {
+    if (await fn()) return now() - started;
+    await sleep(25);
+  }
+  throw new Error(`gateway catalog was not ready after ${timeoutMs} ms`);
+}
+
 const INIT = {
   protocolVersion: "2025-06-18",
   capabilities: {},
@@ -139,6 +154,7 @@ async function main() {
   const direct = await loop(() => m.call("tools/call", { name: bare, arguments: {} }), N);
 
   // 2) Through the gateway.
+  const gatewayStarted = now();
   const gw = spawn(GATEWAY, [], {
     env: {
       ...process.env,
@@ -151,7 +167,14 @@ async function main() {
   const g = client(gw);
   const handshake = await timed(() => g.call("initialize", INIT));
   g.notify("notifications/initialized");
-  await sleep(1200); // let the mock connect so the catalog is populated
+  await waitUntil(async () => {
+    const response = await g.call("tools/call", {
+      name: "toolport_search_tools",
+      arguments: { query: bare, limit: 25 },
+    });
+    return JSON.stringify(response).includes(`mock__${bare}`);
+  });
+  const catalogReady = now() - gatewayStarted;
 
   for (let k = 0; k < 15; k++) await g.call("tools/list", {}); // warm up
   const list = await loop(() => g.call("tools/list", {}), N);
@@ -178,19 +201,69 @@ async function main() {
   gw.kill();
   rmSync(dir, { recursive: true, force: true });
 
+  const overhead = {
+    median: gwCall.median - direct.median,
+    p95: gwCall.p95 - direct.p95,
+  };
+  const result = {
+    schemaVersion: 1,
+    runtime: {
+      platform: process.platform,
+      arch: process.arch,
+      node: process.version,
+      iterations: N,
+    },
+    milliseconds: {
+      handshake,
+      catalogReady,
+      toolsList: list,
+      search,
+      routedCall: gwCall,
+      directCall: direct,
+      gatewayOverhead: overhead,
+    },
+  };
+
+  if (CHECK_BUDGET) {
+    if (!existsSync(BUDGET_PATH)) {
+      throw new Error(`missing latency budget: ${BUDGET_PATH}`);
+    }
+    const budget = JSON.parse(readFileSync(BUDGET_PATH, "utf8"));
+    const failures = [];
+    for (const [metric, limit] of Object.entries(budget.maximumMilliseconds || {})) {
+      const actual = metric
+        .split(".")
+        .reduce((value, key) => value?.[key], result.milliseconds);
+      if (typeof actual !== "number") {
+        failures.push(`${metric}: unknown metric`);
+      } else if (actual > limit) {
+        failures.push(`${metric}: ${actual.toFixed(2)} ms > ${limit} ms`);
+      }
+    }
+    result.budget = { path: BUDGET_PATH, passed: failures.length === 0, failures };
+    if (failures.length) process.exitCode = 1;
+  }
+
+  if (JSON_OUTPUT) {
+    console.log(JSON.stringify(result, null, 2));
+    return;
+  }
+
   const row = (label, x) =>
     `  ${label.padEnd(28)}${x.median.toFixed(2).padStart(6)} ms   (p95 ${x.p95.toFixed(2)})`;
   console.log(`\nToolport gateway latency  (mock downstream, ${N} iterations, median)\n`);
   console.log(
     `  ${"handshake (one-time)".padEnd(28)}${handshake.toFixed(2).padStart(6)} ms`,
   );
+  console.log(
+    `  ${"catalog ready (cold start)".padEnd(28)}${catalogReady.toFixed(2).padStart(6)} ms`,
+  );
   console.log(row("tools/list (lazy, 4 core tools)", list));
   console.log(row("toolport_search_tools", search));
   console.log(row("toolport_call_tool -> mock", gwCall));
   console.log(row("mock tool call (direct)", direct));
-  const overhead = gwCall.median - direct.median;
   console.log(
-    `\n  => Toolport adds ~${overhead.toFixed(2)} ms per tool call vs calling the server directly.`,
+    `\n  => Toolport adds ~${overhead.median.toFixed(2)} ms per tool call vs calling the server directly.`,
   );
   console.log(
     `     Real servers take tens to hundreds of ms each, so that overhead is noise,`,
@@ -198,6 +271,13 @@ async function main() {
   console.log(
     `     and it buys ~90% fewer tokens. See BENCHMARK.md for the token numbers.\n`,
   );
+  if (result.budget) {
+    console.log(
+      result.budget.passed
+        ? "  Latency budget: PASS\n"
+        : `  Latency budget: FAIL\n    ${result.budget.failures.join("\n    ")}\n`,
+    );
+  }
 }
 
 main().catch((e) => {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "test:rust:windows": "powershell -ExecutionPolicy Bypass -File scripts/test-rust-windows.ps1",
     "bench:latency": "node benchmark/latency.mjs",
     "bench:latency:check": "node benchmark/latency.mjs --check",
+    "bench:compare": "node benchmark/compare-local.mjs",
     "audit:prod": "npm audit --omit=dev",
     "prepare": "husky"
   },

--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
     "test:watch": "vitest",
     "test:rust": "cargo test --manifest-path src-tauri/Cargo.toml --lib --bins --tests",
     "test:rust:windows": "powershell -ExecutionPolicy Bypass -File scripts/test-rust-windows.ps1",
+    "bench:latency": "node benchmark/latency.mjs",
+    "bench:latency:check": "node benchmark/latency.mjs --check",
     "audit:prod": "npm audit --omit=dev",
     "prepare": "husky"
   },

--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -1019,6 +1019,7 @@ fn synonym_group(token: &str) -> &'static [&'static str] {
         &["project", "repo", "repository"],
         &["user", "account", "member", "customer"],
         &["team", "org", "organization", "workspace"],
+        &["schedule", "calendar", "meeting", "appointment"],
         &["dispute", "chargeback"],
         &["token", "tokenize"],
     ];
@@ -1028,6 +1029,115 @@ fn synonym_group(token: &str) -> &'static [&'static str] {
         .copied()
         .unwrap_or(&[])
 }
+
+#[derive(Debug)]
+struct SearchDocument {
+    name_tokens: HashSet<String>,
+    description_tokens: HashSet<String>,
+    server_prefix: String,
+}
+
+/// Immutable lexical index paired with one immutable catalog snapshot.
+///
+/// Tool definitions change only when the downstream catalog is rebuilt, so doing
+/// this work in the request path wastes time and creates latency proportional to
+/// catalog size. The index stores only normalized search fields and document
+/// frequencies; schemas remain in the catalog and are projected only for selected
+/// results.
+#[derive(Debug, Default)]
+struct CatalogSearchIndex {
+    documents: Vec<SearchDocument>,
+    document_frequency: HashMap<String, usize>,
+    catalog_address: usize,
+}
+
+impl CatalogSearchIndex {
+    fn build(tools: &[Value]) -> Self {
+        let mut documents = Vec::with_capacity(tools.len());
+        let mut document_frequency = HashMap::new();
+
+        for tool in tools {
+            let name = tool.get("name").and_then(Value::as_str).unwrap_or("");
+            let description = tool
+                .get("description")
+                .and_then(Value::as_str)
+                .unwrap_or("");
+            let name_tokens: HashSet<String> = search_tokens(name).into_iter().collect();
+            let description_tokens: HashSet<String> =
+                index_tokens(description).into_iter().collect();
+
+            let mut seen = HashSet::with_capacity(name_tokens.len() + description_tokens.len());
+            seen.extend(name_tokens.iter().map(String::as_str));
+            seen.extend(description_tokens.iter().map(String::as_str));
+            for token in seen {
+                *document_frequency.entry(token.to_string()).or_insert(0) += 1;
+            }
+
+            documents.push(SearchDocument {
+                name_tokens,
+                description_tokens,
+                server_prefix: tool_prefix(tool),
+            });
+        }
+
+        Self {
+            documents,
+            document_frequency,
+            catalog_address: tools.as_ptr() as usize,
+        }
+    }
+
+    fn matches_catalog(&self, tools: &[Value]) -> bool {
+        self.documents.len() == tools.len() && self.catalog_address == tools.as_ptr() as usize
+    }
+
+    /// Conservative auxiliary-memory estimate for regression tests and diagnostics.
+    /// This is deliberately not presented as process RSS.
+    fn estimated_auxiliary_bytes(&self) -> usize {
+        let document_bytes = self.documents.iter().map(|doc| {
+            let token_bytes: usize = doc
+                .name_tokens
+                .iter()
+                .chain(&doc.description_tokens)
+                .map(|token| token.capacity())
+                .sum();
+            std::mem::size_of::<SearchDocument>()
+                + doc.server_prefix.capacity()
+                + token_bytes
+                + (doc.name_tokens.capacity() + doc.description_tokens.capacity())
+                    * std::mem::size_of::<String>()
+                    * 2
+        });
+        let df_bytes = self.document_frequency.keys().map(|token| {
+            token.capacity()
+                + std::mem::size_of::<String>()
+                + std::mem::size_of::<usize>()
+                + 2 * std::mem::size_of::<usize>()
+        });
+        document_bytes.sum::<usize>() + df_bytes.sum::<usize>()
+    }
+}
+
+#[derive(Debug)]
+struct CatalogSnapshot {
+    tools: Vec<Value>,
+    search: CatalogSearchIndex,
+}
+
+impl CatalogSnapshot {
+    fn new(tools: Vec<Value>) -> Self {
+        let search = CatalogSearchIndex::build(&tools);
+        Self { tools, search }
+    }
+}
+
+impl Default for CatalogSnapshot {
+    fn default() -> Self {
+        Self::new(Vec::new())
+    }
+}
+
+type SharedCatalog = Arc<Mutex<Arc<CatalogSnapshot>>>;
 
 /// Rank the cached catalog against a query, optionally scoped to one server.
 /// Ranking is lexical with IDF weighting: query and tools are tokenized (camelCase
@@ -1055,6 +1165,7 @@ fn search_catalog(
 /// As `search_catalog`, with optional semantic re-ranking. When `sem` is None or
 /// inactive, or embeddings are unavailable, ranking is pure lexical and byte-for-byte
 /// identical to before, semantic only ever adds, never degrades.
+#[cfg(test)]
 fn search_catalog_with(
     cached: &[Value],
     query: &str,
@@ -1062,7 +1173,28 @@ fn search_catalog_with(
     limit: usize,
     sem: Option<&semantic::SemanticConfig>,
 ) -> SearchOutcome {
-    use std::collections::HashMap;
+    search_catalog_indexed(cached, query, server, limit, sem, None)
+}
+
+/// Indexed search entry point used by the live gateway. Tests and cold/live
+/// fallbacks may omit `index`; in that case a temporary index is built so behavior
+/// remains identical and there is only one ranking implementation.
+fn search_catalog_indexed(
+    cached: &[Value],
+    query: &str,
+    server: Option<&str>,
+    limit: usize,
+    sem: Option<&semantic::SemanticConfig>,
+    index: Option<&CatalogSearchIndex>,
+) -> SearchOutcome {
+    let fallback_index;
+    let index = match index.filter(|candidate| candidate.matches_catalog(cached)) {
+        Some(index) => index,
+        None => {
+            fallback_index = CatalogSearchIndex::build(cached);
+            &fallback_index
+        }
+    };
     let q = query.to_lowercase();
     let terms: Vec<&str> = q.split_whitespace().filter(|t| !t.is_empty()).collect();
     let server_filter = server
@@ -1070,54 +1202,59 @@ fn search_catalog_with(
         .filter(|s| !s.is_empty());
 
     // Optionally restrict to one server (its prefix contains the filter text).
-    let pool: Vec<&Value> = cached
+    let pool: Vec<usize> = index
+        .documents
         .iter()
-        .filter(|t| match &server_filter {
-            Some(sf) => tool_prefix(t).contains(sf.as_str()),
+        .enumerate()
+        .filter(|(_, doc)| match &server_filter {
+            Some(sf) => doc.server_prefix.contains(sf.as_str()),
             None => true,
         })
+        .map(|(position, _)| position)
         .collect();
 
     // Select an ordered set of tool refs (ranking happens here; projection below).
     let (selected, total, low_confidence, broadened, direct_returned) = if terms.is_empty() {
         // Empty query: list the pool. With `server` set this enumerates that server.
         let total = pool.len();
-        let selected: Vec<&Value> = pool.iter().take(limit).copied().collect();
+        let selected: Vec<&Value> = pool
+            .iter()
+            .take(limit)
+            .filter_map(|position| cached.get(*position))
+            .collect();
         let direct_returned = selected.len();
         (selected, total, false, 0, direct_returned)
     } else {
-        // Tokenize each tool and compute document frequencies, so IDF can weight a
-        // rare token (e.g. "products", "teams") far above a common one (e.g. "list",
-        // "get"). That makes "list products" rank the products tool over the many
-        // generic "list" tools - the keyword-only wandering we hit with Stripe.
-        use std::collections::HashSet;
-        let docs: Vec<(&Value, HashSet<String>, HashSet<String>)> = pool
-            .iter()
-            .map(|t| {
-                let name = t.get("name").and_then(|v| v.as_str()).unwrap_or("");
-                let desc = t.get("description").and_then(|v| v.as_str()).unwrap_or("");
-                (
-                    *t,
-                    search_tokens(name).into_iter().collect(),
-                    index_tokens(desc).into_iter().collect(),
-                )
-            })
-            .collect();
-        let n = docs.len().max(1) as f64;
-        let mut df: HashMap<&str, usize> = HashMap::new();
-        for (_, name_set, desc_set) in &docs {
-            for tok in name_set.union(desc_set) {
-                *df.entry(tok.as_str()).or_insert(0) += 1;
+        // The normal local path reuses the precomputed global document frequencies.
+        // A substring server filter can select more than one server, so preserve its
+        // historical ranking by deriving DF over that already-tokenized subset.
+        let scoped_df;
+        let df = if server_filter.is_none() {
+            &index.document_frequency
+        } else {
+            let mut frequencies = HashMap::new();
+            for position in &pool {
+                let doc = &index.documents[*position];
+                for token in doc.name_tokens.union(&doc.description_tokens) {
+                    *frequencies.entry(token.clone()).or_insert(0) += 1;
+                }
             }
-        }
-        let idf = |tok: &str| ((n + 1.0) / (*df.get(tok).unwrap_or(&0) as f64 + 1.0)).ln() + 1.0;
+            scoped_df = frequencies;
+            &scoped_df
+        };
+        let n = pool.len().max(1) as f64;
+        let idf = |tok: &str| {
+            ((n + 1.0) / (*df.get(tok).unwrap_or(&0) as f64 + 1.0)).ln() + 1.0
+        };
 
         let q_tokens = index_tokens(query);
         // Lexical score for EVERY doc (0 if no hit), kept so optional semantic
         // re-ranking can also surface tools the keywords missed entirely.
-        let lex: Vec<(f64, &Value)> = docs
+        let lex: Vec<(f64, &Value)> = pool
             .iter()
-            .map(|(t, name_set, desc_set)| {
+            .filter_map(|position| {
+                let doc = index.documents.get(*position)?;
+                let tool = cached.get(*position)?;
                 let mut score = 0.0_f64;
                 for qt in &q_tokens {
                     // Best field hit across the query token and its synonyms; name
@@ -1126,15 +1263,19 @@ fn search_catalog_with(
                     let cands =
                         std::iter::once(qt.as_str()).chain(synonym_group(qt).iter().copied());
                     for c in cands {
-                        if name_set.contains(c) {
+                        if doc.name_tokens.contains(c) {
                             best = best.max(NAME_W * idf(c));
-                        } else if desc_set.contains(c) {
+                        } else if doc.description_tokens.contains(c) {
                             best = best.max(DESC_W * idf(c));
                         }
                     }
                     // Prefix fallback for partial words ("proj" -> "project").
                     if best == 0.0 && qt.len() >= 3 {
-                        if let Some(tok) = name_set.iter().find(|t| t.starts_with(qt.as_str())) {
+                        if let Some(tok) = doc
+                            .name_tokens
+                            .iter()
+                            .find(|t| t.starts_with(qt.as_str()))
+                        {
                             best = 0.6 * NAME_W * idf(tok);
                         }
                     }
@@ -1147,8 +1288,9 @@ fn search_catalog_with(
                 // since both name-match every query token. Multiplicative so it only
                 // separates near-ties, never overrides a stronger IDF signal; skipped on
                 // a zero score so non-matches stay out.
-                if score > 0.0 && !name_set.is_empty() {
-                    let explained = name_set
+                if score > 0.0 && !doc.name_tokens.is_empty() {
+                    let explained = doc
+                        .name_tokens
                         .iter()
                         .filter(|nt| {
                             q_tokens
@@ -1156,10 +1298,10 @@ fn search_catalog_with(
                                 .any(|qt| qt == *nt || synonym_group(qt).contains(&nt.as_str()))
                         })
                         .count();
-                    let coverage = explained as f64 / name_set.len() as f64;
+                    let coverage = explained as f64 / doc.name_tokens.len() as f64;
                     score *= 1.0 + NAME_SPECIFICITY_W * coverage;
                 }
-                (score, *t)
+                Some((score, tool))
             })
             .collect();
 
@@ -1188,7 +1330,7 @@ fn search_catalog_with(
                     .map(|qt| {
                         let matched_idf = std::iter::once(qt.as_str())
                             .chain(synonym_group(qt).iter().copied())
-                            .filter(|candidate| df.contains_key(candidate))
+                            .filter(|candidate| df.contains_key(*candidate))
                             .map(idf)
                             .fold(0.0_f64, f64::max);
                         if matched_idf > 0.0 {
@@ -1237,7 +1379,7 @@ fn search_catalog_with(
                 .collect();
             let visible_servers = pool
                 .iter()
-                .map(|tool| tool_prefix(tool))
+                .map(|position| index.documents[*position].server_prefix.as_str())
                 .collect::<std::collections::HashSet<_>>()
                 .len()
                 .max(1);
@@ -1246,10 +1388,13 @@ fn search_catalog_with(
             for tool in &selected {
                 *per.entry(tool_prefix(tool)).or_insert(0) += 1;
             }
-            for tool in &pool {
+            for position in &pool {
                 if selected.len() >= target {
                     break;
                 }
+                let Some(tool) = cached.get(*position) else {
+                    continue;
+                };
                 let name = tool.get("name").and_then(Value::as_str).unwrap_or("");
                 if !seen.insert(name.to_string()) {
                     continue;
@@ -1261,7 +1406,7 @@ fn search_catalog_with(
                     }
                     *count += 1;
                 }
-                selected.push(*tool);
+                selected.push(tool);
             }
         }
         let broadened = selected.len().saturating_sub(direct_returned);
@@ -2779,8 +2924,10 @@ fn handle_request(
     // requests can't cross-contaminate and dispatch needn't hold the router lock.
     client: Option<&str>,
 ) -> Option<Value> {
+    let search_index = CatalogSearchIndex::build(cached);
     handle_request_with_cancel(
-        req, reg, router, cached, lazy, profile, guard, confirm, allowed, None, client, None,
+        req, reg, router, cached, lazy, profile, guard, confirm, allowed, None, client,
+        Some(&search_index), None,
     )
 }
 
@@ -2800,6 +2947,10 @@ fn handle_request_with_cancel(
     // label), threaded in rather than stored on the shared router so concurrent
     // requests can't cross-contaminate and dispatch needn't hold the router lock.
     client: Option<&str>,
+    // Immutable index built from the same catalog snapshot as `cached`. Scoped
+    // HTTP clients and cold live-router fallbacks rebuild from their filtered
+    // source rather than risk indexing a tool they cannot see.
+    search_index: Option<&CatalogSearchIndex>,
     // The live router as a shareable Arc, used ONLY to build the `'static` call closure a
     // code-mode script needs (its downstream calls re-enter execute_call). `None` disables
     // code mode for this request (the test wrapper / any caller without the Arc); the
@@ -3089,12 +3240,19 @@ fn handle_request_with_cancel(
                 } else {
                     cached
                 };
-                // Scope the searchable catalog to the client's allowed servers
-                // (a no-op when unscoped), so search can't surface out-of-scope tools.
-                let scoped = scope_tools(base, allowed, |n| {
-                    router.route_of(n).map(|(s, _)| s.to_string())
-                });
-                let source: &[Value] = &scoped;
+                // Avoid cloning the entire catalog for the normal local/unscoped path.
+                // Scoped HTTP callers still get a fail-closed filtered copy and a
+                // temporary index built only from that visible subset.
+                let scoped;
+                let (source, source_index): (&[Value], Option<&CatalogSearchIndex>) =
+                    if allowed.is_none() {
+                        (base, search_index.filter(|index| index.matches_catalog(base)))
+                    } else {
+                        scoped = scope_tools(base, allowed, |n| {
+                            router.route_of(n).map(|(s, _)| s.to_string())
+                        });
+                        (&scoped, None)
+                    };
                 // Semantic re-ranking if the user has configured it (off by default;
                 // falls back to lexical on any failure).
                 let s = &reg.semantic_search;
@@ -3104,7 +3262,14 @@ fn handle_request_with_cancel(
                     s.model.clone(),
                     s.blend,
                 );
-                let outcome = search_catalog_with(source, query, server, limit, Some(&sem_cfg));
+                let outcome = search_catalog_indexed(
+                    source,
+                    query,
+                    server,
+                    limit,
+                    Some(&sem_cfg),
+                    source_index,
+                );
                 let mut matches = outcome.matches;
                 let total = outcome.total;
                 let low_confidence = outcome.low_confidence;
@@ -3939,14 +4104,23 @@ fn reconcile_to(
 
 fn persist_and_emit(
     tools: &[Value],
-    cached_tools: &Arc<Mutex<Vec<Value>>>,
+    cached_tools: &SharedCatalog,
     stdout: &Arc<Mutex<std::io::Stdout>>,
     profile: Option<&str>,
 ) {
     if !tools.is_empty() {
+        let started = Instant::now();
+        let next = Arc::new(CatalogSnapshot::new(tools.to_vec()));
+        let index_bytes = next.search.estimated_auxiliary_bytes();
         *cached_tools
             .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner) = tools.to_vec();
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = next;
+        gtrace(&format!(
+            "search index rebuilt: {} tools, ~{} KiB auxiliary, {:.2} ms",
+            tools.len(),
+            index_bytes.div_ceil(1024),
+            started.elapsed().as_secs_f64() * 1000.0
+        ));
         save_tool_cache(tools, profile);
     }
     notify_tools_changed(stdout);
@@ -4144,7 +4318,7 @@ fn watch_registry(
     registry: Arc<Mutex<Registry>>,
     router: Arc<Mutex<Arc<Router>>>,
     stdout: Arc<Mutex<std::io::Stdout>>,
-    cached_tools: Arc<Mutex<Vec<Value>>>,
+    cached_tools: SharedCatalog,
     profile: Arc<Mutex<Option<String>>>,
     client_id: Option<String>,
     env_profile: Option<String>,
@@ -4198,7 +4372,7 @@ fn watch_tick(
     registry: &Arc<Mutex<Registry>>,
     router: &Arc<Mutex<Arc<Router>>>,
     stdout: &Arc<Mutex<std::io::Stdout>>,
-    cached_tools: &Arc<Mutex<Vec<Value>>>,
+    cached_tools: &SharedCatalog,
     profile: &Arc<Mutex<Option<String>>>,
     client_id: Option<&str>,
     env_profile: Option<&str>,
@@ -4425,7 +4599,7 @@ struct GatewayState {
     // behind an in-flight request. Rebuilds swap in a new Arc; refresh/requarantine fork
     // via Arc::make_mut.
     router: Arc<Mutex<Arc<Router>>>,
-    cached_tools: Arc<Mutex<Vec<Value>>>,
+    cached_tools: SharedCatalog,
     stdout: Arc<Mutex<std::io::Stdout>>,
     ready: Arc<AtomicBool>,
     downstream_dirty: Arc<AtomicU8>,
@@ -5226,6 +5400,7 @@ fn process_request(
             .cached_tools
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .tools
             .is_empty(),
         "tools/call" | "resources/list" | "resources/read" | "prompts/list" | "prompts/get" => true,
         _ => false,
@@ -5296,7 +5471,8 @@ fn process_request(
                     *state
                         .cached_tools
                         .lock()
-                        .unwrap_or_else(std::sync::PoisonError::into_inner) = tools.clone();
+                        .unwrap_or_else(std::sync::PoisonError::into_inner) =
+                        Arc::new(CatalogSnapshot::new(tools.clone()));
                     save_tool_cache(&tools, profile_snapshot.as_deref());
                 }
                 glog(&format!(
@@ -5339,7 +5515,7 @@ fn process_request(
         req,
         &reg,
         &router,
-        &cache_snapshot,
+        &cache_snapshot.tools,
         state.lazy,
         profile_snapshot.as_deref(),
         guard,
@@ -5347,6 +5523,7 @@ fn process_request(
         allowed,
         cancel,
         client,
+        Some(&cache_snapshot.search),
         // The same live Arc<Router> just cloned off the lock, so a code-mode script's
         // downstream calls run against this request's consistent catalog snapshot.
         Some(&router),
@@ -5500,14 +5677,14 @@ fn http_tool_defs(
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
             .clone();
-        if cached.is_empty() {
+        if cached.tools.is_empty() {
             state
                 .router
                 .lock()
                 .unwrap_or_else(std::sync::PoisonError::into_inner)
                 .aggregated_tools()
         } else {
-            cached
+            cached.tools.clone()
         }
     };
     if state.lazy {
@@ -7278,7 +7455,9 @@ fn main() {
     // request loop, the watcher, and the self-heal path all follow this, so there's
     // no deadlock; keep new code consistent with it.
     let router = Arc::new(Mutex::new(Arc::new(Router::new())));
-    let cached_tools = Arc::new(Mutex::new(load_tool_cache(resolved_profile.as_deref())));
+    let cached_tools = Arc::new(Mutex::new(Arc::new(CatalogSnapshot::new(load_tool_cache(
+        resolved_profile.as_deref(),
+    )))));
     // Shared, live-updated: the watcher re-resolves this from registry.client_scopes
     // on every reload (falling back to `env_profile` if this client has no scope
     // entry), so a profile switch reaches every reader below without a restart.
@@ -7307,6 +7486,7 @@ fn main() {
         cached_tools
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .tools
             .len()
     ));
 
@@ -7363,7 +7543,8 @@ fn main() {
             if !tools.is_empty() {
                 *cached_tools
                     .lock()
-                    .unwrap_or_else(std::sync::PoisonError::into_inner) = tools.clone();
+                    .unwrap_or_else(std::sync::PoisonError::into_inner) =
+                    Arc::new(CatalogSnapshot::new(tools.clone()));
                 save_tool_cache(&tools, p.as_deref());
             } else {
                 glog("background build was empty; keeping previous tool cache");
@@ -8247,7 +8428,7 @@ mod tests {
         GatewayState {
             registry: Arc::new(Mutex::new(Registry::default())),
             router: Arc::new(Mutex::new(Arc::new(Router::new()))),
-            cached_tools: Arc::new(Mutex::new(Vec::new())),
+            cached_tools: Arc::new(Mutex::new(Arc::new(CatalogSnapshot::default()))),
             stdout,
             ready: Arc::new(AtomicBool::new(true)),
             downstream_dirty: Arc::new(AtomicU8::new(0)),
@@ -10418,7 +10599,7 @@ mod tests {
         let registry = Arc::new(Mutex::new(reg));
         let router = Arc::new(Mutex::new(Arc::new(Router::new())));
         let stdout = Arc::new(Mutex::new(std::io::stdout()));
-        let cached_tools = Arc::new(Mutex::new(Vec::new()));
+        let cached_tools = Arc::new(Mutex::new(Arc::new(CatalogSnapshot::default())));
         let profile_slot = Arc::new(Mutex::new(Some(profile_name.to_string())));
         let downstream_dirty = Arc::new(AtomicU8::new(0));
         let client_root = Arc::new(Mutex::new(None));
@@ -11420,6 +11601,7 @@ mod tests {
             json!({ "name": "gh__listPullRequests", "description": "List PRs", "inputSchema": {} }),
             json!({ "name": "stripe__list_disputes", "description": "List disputes", "inputSchema": {} }),
             json!({ "name": "stripe__create_token", "description": "Create a token", "inputSchema": {} }),
+            json!({ "name": "calendar__create_event", "description": "Create a calendar event", "inputSchema": {} }),
         ];
         // Synonym: "mail" finds the email tool even though it never says "mail".
         let (hits, _) = search_catalog(&cat, "mail", None, 10);
@@ -11439,6 +11621,10 @@ mod tests {
         assert_eq!(hits[0]["name"], "stripe__list_disputes");
         let (hits, _) = search_catalog(&cat, "tokenize", None, 10);
         assert_eq!(hits[0]["name"], "stripe__create_token");
+
+        // Calendar vocabulary varies heavily between users and MCP servers.
+        let (hits, _) = search_catalog(&cat, "schedule a meeting", None, 10);
+        assert_eq!(hits[0]["name"], "calendar__create_event");
     }
 
     #[test]
@@ -11462,6 +11648,103 @@ mod tests {
         ];
         let (hits, _) = search_catalog(&cat, "what are the invoices for this account", None, 10);
         assert_eq!(hits[0]["name"], "billing__list_invoices");
+    }
+
+    #[test]
+    fn indexed_search_preserves_unindexed_results_and_scoping() {
+        let catalog = vec![
+            json!({ "name": "calendar__create_event", "description": "Create a calendar event", "inputSchema": {} }),
+            json!({ "name": "calendar__list_events", "description": "List upcoming calendar entries", "inputSchema": {} }),
+            json!({ "name": "github__create_issue", "description": "Create a repository issue", "inputSchema": {} }),
+            json!({ "name": "mail__send_email", "description": "Send an email message", "inputSchema": {} }),
+        ];
+        let index = CatalogSearchIndex::build(&catalog);
+
+        for (query, server, limit) in [
+            ("create", None, 25),
+            ("schedule a meeting", None, 3),
+            ("list", Some("calendar"), 25),
+            ("", Some("calendar"), 1),
+            ("no lexical match", None, 12),
+        ] {
+            let rebuilt = search_catalog_with(&catalog, query, server, limit, None);
+            let indexed =
+                search_catalog_indexed(&catalog, query, server, limit, None, Some(&index));
+            assert_eq!(
+                indexed.matches, rebuilt.matches,
+                "indexed result mismatch for query {query:?}, server {server:?}"
+            );
+            assert_eq!(indexed.total, rebuilt.total);
+            assert_eq!(indexed.low_confidence, rebuilt.low_confidence);
+            assert_eq!(indexed.broadened, rebuilt.broadened);
+            assert_eq!(indexed.direct_returned, rebuilt.direct_returned);
+        }
+    }
+
+    #[test]
+    fn catalog_snapshot_keeps_tools_and_index_on_the_same_generation() {
+        let old = CatalogSnapshot::new(vec![json!({
+            "name": "old__find_invoice", "description": "Find an invoice", "inputSchema": {}
+        })]);
+        let next = CatalogSnapshot::new(vec![json!({
+            "name": "new__schedule_meeting", "description": "Schedule a meeting", "inputSchema": {}
+        })]);
+
+        assert!(old.search.matches_catalog(&old.tools));
+        assert!(next.search.matches_catalog(&next.tools));
+        assert!(
+            !next.search.matches_catalog(&old.tools),
+            "same-sized catalog generations must never share an index"
+        );
+
+        let old_result =
+            search_catalog_indexed(&old.tools, "invoice", None, 5, None, Some(&old.search));
+        let next_result =
+            search_catalog_indexed(&next.tools, "meeting", None, 5, None, Some(&next.search));
+        assert_eq!(old_result.matches[0]["name"], "old__find_invoice");
+        assert_eq!(next_result.matches[0]["name"], "new__schedule_meeting");
+    }
+
+    #[test]
+    fn search_index_scales_to_ten_thousand_tools_with_bounded_memory() {
+        let catalog: Vec<Value> = (0..10_000)
+            .map(|i| {
+                json!({
+                    "name": format!("server{}__lookup_customer_record_{i}", i % 50),
+                    "description": format!("Look up customer record {i} in account group {}", i % 100),
+                    "inputSchema": { "type": "object", "properties": { "id": { "type": "string" } } }
+                })
+            })
+            .collect();
+        let started = Instant::now();
+        let index = CatalogSearchIndex::build(&catalog);
+        let elapsed = started.elapsed();
+        let estimated = index.estimated_auxiliary_bytes();
+
+        assert_eq!(index.documents.len(), 10_000);
+        assert_eq!(index.document_frequency.get("customer"), Some(&10_000));
+        assert!(
+            estimated < 64 * 1024 * 1024,
+            "auxiliary index estimate unexpectedly large: {estimated} bytes"
+        );
+
+        let outcome = search_catalog_indexed(
+            &catalog,
+            "customer record 9876",
+            None,
+            5,
+            None,
+            Some(&index),
+        );
+        assert_eq!(
+            outcome.matches[0]["name"],
+            "server26__lookup_customer_record_9876"
+        );
+        eprintln!(
+            "10k-tool search index: {:.2} ms build, {:.2} MiB estimated auxiliary memory",
+            elapsed.as_secs_f64() * 1000.0,
+            estimated as f64 / (1024.0 * 1024.0)
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What and why

Toolport's local gateway previously cloned the complete JSON tool catalog, tokenized every tool, and rebuilt document frequencies for every search. That kept behavior correct but made search latency scale unnecessarily with catalog size.

This moves that work to catalog refresh time and adds a vendor-neutral benchmark harness so future performance and retrieval claims are reproducible.

## Changes

- Pair each immutable tool catalog with a precomputed lexical search index.
- Atomically replace the catalog and index during live refreshes.
- Reuse normalized name/description tokens and document frequencies.
- Avoid cloning the full catalog for normal unscoped local searches.
- Preserve fail-closed filtering for scoped HTTP callers.
- Add calendar/schedule/meeting vocabulary coverage for a shared retrieval miss.
- Add correctness, generation-coherence, and 10,000-tool scale tests.
- Extend the deterministic latency benchmark with JSON output and regression budgets.
- Add a pinned Toolport-versus-Ratel Local comparison harness.
- Record Git revision, dirty state, build profile, binary path, and SHA-256 in benchmark output.

## Compatibility and safety

Public MCP tool names, request schemas, response shapes, routing, auditing, content defense, result shaping, and optional semantic fallback remain unchanged. No model download, external API, embedding dependency, or new Rust crate is required.

## Release benchmark

Windows x64 release builds, shared generated MCP fixture:

| Catalog | Product | Search median / p95 | Recall@5 | Always-on context |
| ---: | --- | ---: | ---: | ---: |
| 500 | Toolport | 1.31 / 1.63 ms | 100% | ~1,000 tokens |
| 500 | Ratel Local 0.5.0 | 10.68 / 12.66 ms | 90% | ~1,240 tokens |
| 10,000 | Toolport | 11.08 / 12.76 ms | 100% | ~1,000 tokens |
| 10,000 | Ratel Local 0.5.0 | 318.06 / 391.49 ms | 90% | ~1,241 tokens |

These are deterministic gateway/retrieval measurements, not claims about end-to-end agent accuracy.

## Validation

- `cargo test --manifest-path src-tauri/Cargo.toml --bin toolport-gateway`
- 141 gateway tests passed.
- `npx prettier --check benchmark/fixture-mcp.mjs benchmark/compare-local.mjs benchmark/compare-local.config.json benchmark/README.md package.json`
- `node --check benchmark/compare-local.mjs`
- `node --check benchmark/fixture-mcp.mjs`
- `git diff --check origin/main...HEAD`