### PR TITLE
Improve local search efficiency and benchmark coverage

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -74,7 +74,10 @@ through their public stdio MCP interfaces. It compares:
 - the count and estimated token cost of always-exposed gateway tools plus MCP
   initialization instructions;
 - search median/p95, returned-payload size, recall@K, and mean reciprocal rank
-  over shared queries;
+  over shared queries with plausible near-match distractors;
+- schema-ready@K plus the total response tokens and round trips needed to obtain
+  the exact input schema and make a discovered result ready to invoke (so a
+  smaller first response is not rewarded when it forces another lookup);
 - routed-call median/p95 overhead against calling the fixture directly.
 
 Ratel Local is pinned in `compare-local.config.json` and installed into the operating
@@ -87,6 +90,7 @@ npm run bench:compare -- --install-ratel
 # Subsequent offline/cached runs
 npm run bench:compare
 npm run bench:compare -- --sizes=25,100,500 --iterations=200
+npm run bench:compare -- --products=toolport --check
 npm run bench:compare -- --settle-ms=1000
 npm run bench:compare -- --json --out=benchmark/local-compare.json
 
@@ -97,7 +101,11 @@ npm run bench:compare -- --products=toolport
 The comparison prefers Toolport's release binary and records the selected path,
 SHA-256, build profile, Git revision, and dirty-worktree state in JSON. A debug
 binary is accepted for development smoke tests, but do not publish performance
-numbers from a debug-vs-release run.
+numbers from a debug-vs-release run. Each catalog size also gets a disposable
+Toolport data directory, so existing audit logs, traces, caches, and result
+cursors cannot influence the timings. `--check` enforces the cross-machine
+regression ceilings in `compare-local.config.json`; it checks Toolport only,
+even when a competitor is included in the report.
 
 The report deliberately separates deterministic gateway mechanics from model-graded
 agent accuracy. Use `bench-sweep.mjs` for end-to-end model tasks; do not present this

--- a/benchmark/compare-local.config.json
+++ b/benchmark/compare-local.config.json
@@ -8,5 +8,16 @@
     "iterations": 100,
     "settleMilliseconds": 500,
     "topK": 5
+  },
+  "toolportBudgets": {
+    "maxCatalogReadyMilliseconds": 1500,
+    "maxAlwaysOnEstimatedTokens": 1050,
+    "maxSearchMedianMilliseconds": 10,
+    "maxSearchP95Milliseconds": 25,
+    "maxSearchMedianEstimatedTokens": 450,
+    "maxSearchP95EstimatedTokens": 550,
+    "minRecallAtK": 1,
+    "minSchemaReadyAtK": 1,
+    "maxCallOverheadP95Milliseconds": 5
   }
 }

--- a/benchmark/compare-local.mjs
+++ b/benchmark/compare-local.mjs
@@ -782,6 +782,10 @@ function toolportBudgetViolations(result) {
   if (!budget) return [];
   const violations = [];
   const maximum = (label, actual, limit, catalogSize) => {
+    if (typeof actual !== "number" || typeof limit !== "number") {
+      violations.push(`${catalogSize} tools: ${label} has no numeric metric or budget`);
+      return;
+    }
     if (actual > limit) {
       violations.push(
         `${catalogSize} tools: ${label} ${actual.toFixed(2)} exceeded ${limit}`,
@@ -789,6 +793,10 @@ function toolportBudgetViolations(result) {
     }
   };
   const minimum = (label, actual, limit, catalogSize) => {
+    if (typeof actual !== "number" || typeof limit !== "number") {
+      violations.push(`${catalogSize} tools: ${label} has no numeric metric or budget`);
+      return;
+    }
     if (actual < limit) {
       violations.push(
         `${catalogSize} tools: ${label} ${actual.toFixed(3)} fell below ${limit}`,

--- a/benchmark/compare-local.mjs
+++ b/benchmark/compare-local.mjs
@@ -23,13 +23,17 @@ import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { createInterface } from "node:readline";
 import { fileURLToPath } from "node:url";
+import { isDeepStrictEqual } from "node:util";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const ROOT = resolve(HERE, "..");
 const CONFIG = JSON.parse(readFileSync(join(HERE, "compare-local.config.json"), "utf8"));
 const FIXTURE = join(HERE, "fixture-mcp.mjs");
-const DEBUG = join(ROOT, "src-tauri", "target", "debug");
-const RELEASE = join(ROOT, "src-tauri", "target", "release");
+const TARGET = process.env.CARGO_TARGET_DIR
+  ? resolve(process.env.CARGO_TARGET_DIR)
+  : join(ROOT, "src-tauri", "target");
+const DEBUG = join(TARGET, "debug");
+const RELEASE = join(TARGET, "release");
 const RELEASE_GATEWAY = executable(RELEASE, "toolport-gateway");
 const DEBUG_GATEWAY = executable(DEBUG, "toolport-gateway");
 const TOOLPORT_GATEWAY =
@@ -53,6 +57,7 @@ const options = {
   ),
   topK: Math.max(1, Number(valueArg("top-k", CONFIG.defaults.topK))),
   json: argv.includes("--json"),
+  check: argv.includes("--check"),
   installRatel: argv.includes("--install-ratel"),
   out: optionalValueArg("out"),
 };
@@ -114,6 +119,53 @@ const SIGNAL_TOOLS = [
     name: "slack_post_message",
     description: "Post a message to a Slack channel.",
     query: "send an update to our Slack channel",
+  },
+];
+
+// Plausible near-matches make the retrieval fixture test intent, not merely
+// keyword presence. They are deliberately useful tools rather than nonsense
+// distractors, so ranking the requested action first requires the verb and
+// surrounding context to matter.
+const DECOY_TOOLS = [
+  {
+    name: "github_list_pull_requests",
+    description: "List existing open GitHub pull requests and their branches.",
+  },
+  {
+    name: "postgres_explain_query",
+    description: "Explain the execution plan for a PostgreSQL query without running it.",
+  },
+  {
+    name: "stripe_list_refunds",
+    description: "List previous Stripe payment refunds for a customer.",
+  },
+  {
+    name: "resend_list_emails",
+    description: "List transactional email messages previously sent through Resend.",
+  },
+  {
+    name: "filesystem_search_files",
+    description: "Search local file names and paths without reading file content.",
+  },
+  {
+    name: "vercel_get_project",
+    description: "Get configuration for one known Vercel project.",
+  },
+  {
+    name: "sentry_get_issue",
+    description: "Get details for one known Sentry issue identifier.",
+  },
+  {
+    name: "cloudflare_get_cache_rules",
+    description: "Read the configured Cloudflare CDN cache rules for a zone.",
+  },
+  {
+    name: "calendar_list_events",
+    description: "List existing calendar events in a time range.",
+  },
+  {
+    name: "slack_list_messages",
+    description: "List recent messages from a Slack channel.",
   },
 ];
 
@@ -180,6 +232,10 @@ function makeCatalog(size) {
   const tools = selectedSignals.map(({ name, description }) =>
     toolDefinition(name, description),
   );
+  for (const { name, description } of DECOY_TOOLS) {
+    if (tools.length >= size) break;
+    tools.push(toolDefinition(name, description));
+  }
   const domains = [
     "inventory",
     "analytics",
@@ -314,6 +370,10 @@ function toolportAdapter(registryPath) {
     env: {
       ...process.env,
       TOOLPORT_REGISTRY: registryPath,
+      // Keep audit/search traces, result cursors, and cache files inside this
+      // disposable run. Otherwise prior local Toolport activity can change I/O
+      // cost and make repeated benchmark runs drift.
+      TOOLPORT_DATA_DIR: dirname(registryPath),
       TOOLPORT_PROFILE: "benchmark",
       TOOLPORT_DISCOVERY: "lazy",
     },
@@ -322,6 +382,7 @@ function toolportAdapter(registryPath) {
     searchArgs: (query, topK) => ({ query, limit: topK }),
     invokeArgs: (toolId, args) => ({ name: toolId, arguments: args }),
     parseSearch: parseToolportSearch,
+    parseHits: parseToolportHits,
   };
 }
 
@@ -341,15 +402,34 @@ function ratelAdapter(configPath, ratelBin, benchmarkHome) {
     searchArgs: (query, topK) => ({ query, topKTools: topK, topKSkills: 1 }),
     invokeArgs: (toolId, args) => ({ toolId, args }),
     parseSearch: parseRatelSearch,
+    parseHits: parseRatelHits,
   };
 }
 
 function parseToolportSearch(response) {
-  const text = response.result?.content?.map((item) => item.text ?? "").join("\n") ?? "";
-  return [...text.matchAll(/"name"\s*:\s*"([^"]+)"/g)].map((match) => match[1]);
+  return parseToolportHits(response).map((hit) => hit.toolId);
 }
 
 function parseRatelSearch(response) {
+  return parseRatelHits(response).map((hit) => hit.toolId);
+}
+
+function parseToolportHits(response) {
+  const text = response.result?.content?.map((item) => item.text ?? "").join("\n") ?? "";
+  const marker = text.lastIndexOf("\n\n[");
+  if (marker < 0) return [];
+  try {
+    const tools = JSON.parse(text.slice(marker + 2));
+    if (!Array.isArray(tools)) return [];
+    return tools
+      .filter((tool) => tool && typeof tool.name === "string")
+      .map((tool) => ({ toolId: tool.name, inputSchema: tool.inputSchema }));
+  } catch {
+    return [];
+  }
+}
+
+function parseRatelHits(response) {
   let payload = response.result?.structuredContent;
   if (!payload) {
     const text = response.result?.content?.[0]?.text;
@@ -360,7 +440,9 @@ function parseRatelSearch(response) {
     }
   }
   return (payload.tools?.groups ?? []).flatMap((group) =>
-    (group.hits ?? []).map((hit) => hit.toolId),
+    (group.hits ?? [])
+      .filter((hit) => typeof hit?.toolId === "string")
+      .map((hit) => ({ toolId: hit.toolId, inputSchema: hit.inputSchema })),
   );
 }
 
@@ -409,7 +491,13 @@ async function benchmarkDirect(catalogPath, toolName) {
   }
 }
 
-async function benchmarkProduct(adapter, direct, expectedToolId, retrievalCases) {
+async function benchmarkProduct(
+  adapter,
+  direct,
+  expectedToolId,
+  retrievalCases,
+  catalogTools,
+) {
   const processStarted = now();
   const client = new McpProcess(adapter.command, adapter.args, {
     env: adapter.env,
@@ -474,24 +562,61 @@ async function benchmarkProduct(adapter, direct, expectedToolId, retrievalCases)
       searchPayloadBytes.push(Buffer.byteLength(JSON.stringify(response.result ?? {})));
     }, options.iterations);
 
+    const expectedSchemas = new Map(
+      catalogTools.map((tool) => [`fixture__${tool.name}`, tool.inputSchema ?? {}]),
+    );
     const cases = [];
     for (const testCase of retrievalCases) {
       const response = await client.call("tools/call", {
         name: adapter.searchTool,
         arguments: adapter.searchArgs(testCase.query, options.topK),
       });
-      const names = adapter.parseSearch(response);
+      const hits = adapter.parseHits(response);
+      const names = hits.map((hit) => hit.toolId);
       const wanted = `fixture__${testCase.name}`;
       const index = names.indexOf(wanted);
+      const firstResponseBytes = Buffer.byteLength(JSON.stringify(response.result ?? {}));
+      let readyResponseBytes = firstResponseBytes;
+      let readyRoundTrips = 1;
+      let schemaMatches =
+        index >= 0 &&
+        isDeepStrictEqual(hits[index]?.inputSchema ?? null, expectedSchemas.get(wanted));
+
+      // A result without the exact schema is discoverable but not yet actionable.
+      // Measure the real recovery cost instead of rewarding a smaller first response
+      // that forces the agent to search again before it can invoke the tool.
+      if (index >= 0 && !schemaMatches) {
+        const schemaResponse = await client.call("tools/call", {
+          name: adapter.searchTool,
+          arguments: adapter.searchArgs(wanted, options.topK),
+        });
+        readyRoundTrips += 1;
+        readyResponseBytes += Buffer.byteLength(
+          JSON.stringify(schemaResponse.result ?? {}),
+        );
+        const schemaHit = adapter
+          .parseHits(schemaResponse)
+          .find((hit) => hit.toolId === wanted);
+        schemaMatches = isDeepStrictEqual(
+          schemaHit?.inputSchema ?? null,
+          expectedSchemas.get(wanted),
+        );
+      }
       cases.push({
         query: testCase.query,
         expected: wanted,
         rank: index >= 0 ? index + 1 : null,
         topK: names,
+        schemaMatches,
+        readyToInvoke: index >= 0 && schemaMatches,
+        readyRoundTrips,
+        readyResponseBytes,
+        readyEstimatedTokens: Math.ceil(readyResponseBytes / 4),
       });
     }
 
     const hits = cases.filter((item) => item.rank !== null);
+    const ready = cases.filter((item) => item.readyToInvoke);
     const reciprocalRank =
       cases.reduce((sum, item) => sum + (item.rank ? 1 / item.rank : 0), 0) /
       cases.length;
@@ -516,6 +641,9 @@ async function benchmarkProduct(adapter, direct, expectedToolId, retrievalCases)
         hitsAtK: hits.length,
         recallAtK: hits.length / cases.length,
         meanReciprocalRank: reciprocalRank,
+        readyAtK: ready.length / cases.length,
+        readyResponseTokens: stats(cases.map((item) => item.readyEstimatedTokens)),
+        readyRoundTrips: stats(cases.map((item) => item.readyRoundTrips)),
         details: cases,
       },
       routedCall,
@@ -649,6 +777,86 @@ function fileSha256(path) {
   return createHash("sha256").update(readFileSync(path)).digest("hex");
 }
 
+function toolportBudgetViolations(result) {
+  const budget = CONFIG.toolportBudgets;
+  if (!budget) return [];
+  const violations = [];
+  const maximum = (label, actual, limit, catalogSize) => {
+    if (actual > limit) {
+      violations.push(
+        `${catalogSize} tools: ${label} ${actual.toFixed(2)} exceeded ${limit}`,
+      );
+    }
+  };
+  const minimum = (label, actual, limit, catalogSize) => {
+    if (actual < limit) {
+      violations.push(
+        `${catalogSize} tools: ${label} ${actual.toFixed(3)} fell below ${limit}`,
+      );
+    }
+  };
+
+  for (const run of result.runs) {
+    const metrics = run.products.toolport;
+    if (!metrics) continue;
+    maximum(
+      "catalog-ready ms",
+      metrics.catalogReady,
+      budget.maxCatalogReadyMilliseconds,
+      run.catalogSize,
+    );
+    maximum(
+      "always-on estimated tokens",
+      metrics.exposedSurface.estimatedTokens,
+      budget.maxAlwaysOnEstimatedTokens,
+      run.catalogSize,
+    );
+    maximum(
+      "search median ms",
+      metrics.search.median,
+      budget.maxSearchMedianMilliseconds,
+      run.catalogSize,
+    );
+    maximum(
+      "search p95 ms",
+      metrics.search.p95,
+      budget.maxSearchP95Milliseconds,
+      run.catalogSize,
+    );
+    maximum(
+      "search median estimated tokens",
+      metrics.searchPayload.estimatedTokens.median,
+      budget.maxSearchMedianEstimatedTokens,
+      run.catalogSize,
+    );
+    maximum(
+      "search p95 estimated tokens",
+      metrics.searchPayload.estimatedTokens.p95,
+      budget.maxSearchP95EstimatedTokens,
+      run.catalogSize,
+    );
+    minimum(
+      `recall@${result.runtime.topK}`,
+      metrics.retrieval.recallAtK,
+      budget.minRecallAtK,
+      run.catalogSize,
+    );
+    minimum(
+      `schema-ready@${result.runtime.topK}`,
+      metrics.retrieval.readyAtK,
+      budget.minSchemaReadyAtK,
+      run.catalogSize,
+    );
+    maximum(
+      "call overhead p95 ms",
+      metrics.gatewayOverhead.p95,
+      budget.maxCallOverheadP95Milliseconds,
+      run.catalogSize,
+    );
+  }
+  return violations;
+}
+
 function markdown(result) {
   const lines = [
     "# Local MCP gateway comparison",
@@ -656,17 +864,19 @@ function markdown(result) {
     `Same generated MCP server, ${result.runtime.iterations} measured iterations per operation.`,
     "Token counts below estimate the always-exposed MCP tool-definition payload as JSON bytes / 4.",
     "",
-    `| Catalog | Product | Ready ms | Exposed tools | Always-on est. tokens | Search result est. tokens | Search p50 / p95 ms | Recall@${result.runtime.topK} | MRR | Call overhead p50 / p95 ms |`,
-    "| ---: | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |",
+    `| Catalog | Product | Ready ms | Exposed tools | Always-on est. tokens | Search tokens p50 / p95 | Search p50 / p95 ms | Recall@${result.runtime.topK} | Schema-ready@${result.runtime.topK} | Ready tokens / trips p50 | MRR | Call overhead p50 / p95 ms |`,
+    "| ---: | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |",
   ];
   for (const run of result.runs) {
     for (const [product, metrics] of Object.entries(run.products)) {
       lines.push(
         `| ${run.catalogSize} | ${product} | ${metrics.catalogReady.toFixed(2)} | ` +
           `${metrics.exposedSurface.toolCount} | ${metrics.exposedSurface.estimatedTokens} | ` +
-          `${metrics.searchPayload.estimatedTokens.median.toFixed(0)} | ` +
+          `${metrics.searchPayload.estimatedTokens.median.toFixed(0)} / ${metrics.searchPayload.estimatedTokens.p95.toFixed(0)} | ` +
           `${metrics.search.median.toFixed(2)} / ${metrics.search.p95.toFixed(2)} | ` +
           `${(metrics.retrieval.recallAtK * 100).toFixed(0)}% | ` +
+          `${(metrics.retrieval.readyAtK * 100).toFixed(0)}% | ` +
+          `${metrics.retrieval.readyResponseTokens.median.toFixed(0)} / ${metrics.retrieval.readyRoundTrips.median.toFixed(0)} | ` +
           `${metrics.retrieval.meanReciprocalRank.toFixed(3)} | ` +
           `${metrics.gatewayOverhead.median.toFixed(2)} / ${metrics.gatewayOverhead.p95.toFixed(2)} |`,
       );
@@ -716,7 +926,8 @@ async function main() {
     const dir = mkdtempSync(join(tmpdir(), `toolport-local-compare-${catalogSize}-`));
     try {
       const catalogPath = join(dir, "catalog.json");
-      writeFileSync(catalogPath, JSON.stringify(makeCatalog(catalogSize)));
+      const catalog = makeCatalog(catalogSize);
+      writeFileSync(catalogPath, JSON.stringify(catalog));
       const { registryPath, ratelPath } = writeConfigs(dir, catalogPath);
       const retrievalCases = SIGNAL_TOOLS.slice(
         0,
@@ -735,6 +946,7 @@ async function main() {
           direct,
           expectedToolId,
           retrievalCases,
+          catalog.tools,
         );
       }
       result.runs.push({ catalogSize, products });
@@ -743,6 +955,14 @@ async function main() {
     }
   }
 
+  const budgetViolations = options.check ? toolportBudgetViolations(result) : [];
+  if (options.check) {
+    result.toolportBudgetCheck = {
+      passed: budgetViolations.length === 0,
+      budgets: CONFIG.toolportBudgets,
+      violations: budgetViolations,
+    };
+  }
   const rendered = options.json
     ? `${JSON.stringify(result, null, 2)}\n`
     : markdown(result);
@@ -752,6 +972,9 @@ async function main() {
     if (!options.json) console.log(`Wrote ${outputPath}`);
   }
   process.stdout.write(rendered);
+  if (budgetViolations.length > 0) {
+    fail(`Toolport regression budget failed:\n- ${budgetViolations.join("\n- ")}`);
+  }
 }
 
 main().catch((error) => {

--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -1319,39 +1319,59 @@ fn search_catalog_indexed(
         // pure lexical (positive scores only, highest first), identical to before.
         let semantic_ranked = semantic_rerank(sem, query, &lex);
         let used_semantic = semantic_ranked.is_some();
-        let ranked: Vec<(f64, &Value)> = semantic_ranked.unwrap_or_else(|| {
+        let mut ranked: Vec<(f64, &Value)> = semantic_ranked.unwrap_or_else(|| {
             let mut s: Vec<(f64, &Value)> =
                 lex.iter().filter(|(sc, _)| *sc > 0.0).cloned().collect();
             s.sort_by(|a, b| b.0.partial_cmp(&a.0).unwrap_or(std::cmp::Ordering::Equal));
             s
         });
+        // An agent follows schemaOmitted recovery by searching the exact exposed
+        // name it was given. Make that contract deterministic: an exact name must
+        // lead even when another tool happens to score higher on shared tokens.
+        // This also guarantees project_budgeted keeps the requested tool's schema.
+        let exact_position = ranked.iter().position(|(_, tool)| {
+            tool.get("name")
+                .and_then(Value::as_str)
+                .map(|name| name.eq_ignore_ascii_case(query.trim()))
+                .unwrap_or(false)
+        });
+        if let Some(position) = exact_position.filter(|position| *position > 0) {
+            let exact = ranked.remove(position);
+            ranked.insert(0, exact);
+        }
         let total = ranked.len();
 
-        let low_confidence = match ranked.first() {
-            None => true,
-            Some((top_score, _)) if used_semantic => *top_score < LOW_CONFIDENCE_HYBRID_SCORE,
-            Some((top_score, _)) => {
-                // Normalize the raw lexical score against an ideal result where
-                // every meaningful query token hits a tool name. Missing query
-                // terms still contribute to the denominator, which is exactly the
-                // weak-evidence case that should broaden.
-                let ideal_idf: f64 = q_tokens
-                    .iter()
-                    .map(|qt| {
-                        let matched_idf = std::iter::once(qt.as_str())
-                            .chain(synonym_group(qt).iter().copied())
-                            .filter(|candidate| df.contains_key(*candidate))
-                            .map(idf)
-                            .fold(0.0_f64, f64::max);
-                        if matched_idf > 0.0 {
-                            matched_idf
-                        } else {
-                            idf(qt)
-                        }
-                    })
-                    .sum();
-                let ideal = NAME_W * ideal_idf * (1.0 + NAME_SPECIFICITY_W);
-                ideal <= f64::EPSILON || *top_score / ideal < LOW_CONFIDENCE_LEXICAL_RATIO
+        let low_confidence = if exact_position.is_some() {
+            false
+        } else {
+            match ranked.first() {
+                None => true,
+                Some((top_score, _)) if used_semantic => {
+                    *top_score < LOW_CONFIDENCE_HYBRID_SCORE
+                }
+                Some((top_score, _)) => {
+                    // Normalize the raw lexical score against an ideal result where
+                    // every meaningful query token hits a tool name. Missing query
+                    // terms still contribute to the denominator, which is exactly the
+                    // weak-evidence case that should broaden.
+                    let ideal_idf: f64 = q_tokens
+                        .iter()
+                        .map(|qt| {
+                            let matched_idf = std::iter::once(qt.as_str())
+                                .chain(synonym_group(qt).iter().copied())
+                                .filter(|candidate| df.contains_key(*candidate))
+                                .map(idf)
+                                .fold(0.0_f64, f64::max);
+                            if matched_idf > 0.0 {
+                                matched_idf
+                            } else {
+                                idf(qt)
+                            }
+                        })
+                        .sum();
+                    let ideal = NAME_W * ideal_idf * (1.0 + NAME_SPECIFICITY_W);
+                    ideal <= f64::EPSILON || *top_score / ideal < LOW_CONFIDENCE_LEXICAL_RATIO
+                }
             }
         };
 
@@ -2479,13 +2499,9 @@ fn execute_call(
     // NOT by splitting the exposed name on `__`. A renamed tool (via a tool override)
     // or a server id containing `__` would otherwise mis-derive the server and
     // silently weaken the scope guard and the HITL untrusted-provenance check below.
-    let (server_id, tool_name) = router
-        .route_of(name)
-        .map(|(s, t)| (s.to_string(), t.to_string()))
-        .unwrap_or_else(|| (String::new(), name.to_string()));
-    let srv_owned = sanitize_segment(&server_id);
+    let (server_id, tool) = router.route_of(name).unwrap_or(("", name));
+    let srv_owned = sanitize_segment(server_id);
     let srv = srv_owned.as_str();
-    let tool = tool_name.as_str();
 
     // Scope guard: a registered HTTP client may only call tools on the
     // servers its token is allowed to see (a no-op when unscoped). Search
@@ -2529,7 +2545,7 @@ fn execute_call(
     if let Some(team) = reg.team.as_ref() {
         if !team.rate_limits.is_empty() {
             if let Err(msg) =
-                conduit_lib::rate_limits::check_and_count(&team.rate_limits, &server_id, tool)
+                conduit_lib::rate_limits::check_and_count(&team.rate_limits, server_id, tool)
             {
                 // Count as a failed call with a clear reason so Activity / export show the block.
                 audit::record_timed(srv, tool, false, None, Some("rate_limit"), client);
@@ -3446,14 +3462,17 @@ fn handle_request_with_cancel(
                     // commits instead of re-searching (the v0.3.6 keep-searching nudges
                     // overcorrected and made compliant models thrash).
                     format!(
-                        "Found {total} matching tool(s){scope}. Top match: `{top}` - its full input \
-                         schema is included below, so call it now with toolport_call_tool (name: \
-                         \"{top}\") if it fits. Only search again if none of these match.{pin_note}{more}{schema_note}"
+                        "Found {total} matching tool(s){scope}. Top match: `{top}`. Its complete \
+                         schema is below; if it fits, call it with toolport_call_tool using name \
+                         \"{top}\". Only search again if none match.{pin_note}{more}{schema_note}"
                     )
                 };
                 let text = format!(
                     "{lead}\n\n{}",
-                    serde_json::to_string_pretty(&matches).unwrap_or_default()
+                    // This JSON is model input, not a human-facing log. Compact encoding
+                    // preserves every field and the complete top schema while avoiding
+                    // spending tokens on indentation and line breaks on every search.
+                    serde_json::to_string(&matches).unwrap_or_default()
                 );
                 // Record the trace: the ground-truth cost of what THIS search returned
                 // vs. what advertising the whole (scoped) catalog would cost per turn.
@@ -11192,6 +11211,26 @@ mod tests {
     }
 
     #[test]
+    fn exact_exposed_name_promotes_tool_and_restores_schema() {
+        let cat = vec![
+            json!({
+                "name": "filesystem__search_files",
+                "description": "Search local file names and paths.",
+                "inputSchema": { "type": "object", "properties": { "query": { "type": "string" } } }
+            }),
+            json!({
+                "name": "filesystem__read_file",
+                "description": "Read one local file.",
+                "inputSchema": { "type": "object", "properties": { "path": { "type": "string" } } }
+            }),
+        ];
+        let (hits, _) = search_catalog(&cat, "filesystem__read_file", None, 5);
+        assert_eq!(hits[0]["name"], "filesystem__read_file");
+        assert_eq!(hits[0]["inputSchema"]["properties"]["path"]["type"], "string");
+        assert!(hits[0].get("schemaOmitted").is_none());
+    }
+
+    #[test]
     fn search_diversifies_across_servers_when_unscoped() {
         // One server with many matching tools shouldn't crowd the others out.
         let mut cat = catalog();
@@ -11320,6 +11359,18 @@ mod tests {
         assert!(
             text.to_lowercase().contains("only search again"),
             "should signal not to keep searching"
+        );
+        let (_, payload) = text
+            .split_once("\n\n")
+            .expect("guidance and compact JSON payload");
+        assert!(
+            !payload.contains('\n'),
+            "search JSON should not spend context on pretty-print whitespace"
+        );
+        let tools: Value = serde_json::from_str(payload).expect("valid search result JSON");
+        assert!(
+            tools[0]["inputSchema"].is_object(),
+            "the top match must remain ready to invoke with its complete schema"
         );
     }
 

--- a/src-tauri/src/router.rs
+++ b/src-tauri/src/router.rs
@@ -783,11 +783,10 @@ impl Router {
         let (server_id, tool) = self
             .routes
             .get(exposed_name)
-            .cloned()
             .ok_or_else(|| format!("no route for tool '{exposed_name}'"))?;
-        let slot = self.slot_for(&server_id)?;
+        let slot = self.slot_for(server_id)?;
         self.call_with_retry(&slot, |server| {
-            server.call_with_cancel(&tool, arguments.clone(), cancel.clone())
+            server.call_with_cancel(tool, arguments.clone(), cancel.clone())
         })
     }
 


### PR DESCRIPTION
## What changed

- compact lazy-search result JSON while preserving every field and the complete top-result schema
- make exact exposed-name searches deterministically promote the requested tool, so schemaOmitted recovery always returns an invocation-ready schema
- remove duplicate route-string allocations from the local call path without bypassing scope, policy, approval, audit, or result shaping
- extend the local gateway harness with plausible near-match tools, schema-ready@K, ready-to-invoke token/round-trip cost, and p50/p95 payload reporting
- isolate benchmark state in disposable data directories and honor CARGO_TARGET_DIR in worktrees
- add --check with Toolport regression budgets for startup, context cost, payload size, search latency, recall, schema readiness, and routed-call overhead

## Why

The previous payload comparison rewarded a smaller first response even when it did not contain the exact schema needed to invoke the discovered tool. The benchmark now measures the complete discovery-to-ready path and catches failures in the documented exact-name schema recovery flow.

## Impact

The four-tool lazy MCP surface and existing request schemas remain unchanged. On the 25/100/500-tool regression suite, Toolport now holds 100% Recall@5 and 100% schema-ready@5 in one search, with roughly 401-402 estimated median search-response tokens and a 441-token p95.

## Validation

- Rust: 499 library tests, 144 gateway tests, and 4 integration tests passed
- Frontend: 18 files / 133 tests passed
- ESLint: 0 errors (existing warnings only)
- Production frontend build passed
- node --check benchmark/compare-local.mjs
- npm run bench:compare -- --products=toolport --iterations=100 --check
- 200-iteration release comparison across 25, 100, and 500 tools