### PR TITLE
Reduce routed-call audit overhead

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -91,6 +91,7 @@ npm run bench:compare -- --install-ratel
 npm run bench:compare
 npm run bench:compare -- --sizes=25,100,500 --iterations=200
 npm run bench:compare -- --products=toolport --check
+npm run bench:compare -- --products=toolport --profile-calls
 npm run bench:compare -- --settle-ms=1000
 npm run bench:compare -- --json --out=benchmark/local-compare.json
 
@@ -106,6 +107,13 @@ Toolport data directory, so existing audit logs, traces, caches, and result
 cursors cannot influence the timings. `--check` enforces the cross-machine
 regression ceilings in `compare-local.config.json`; it checks Toolport only,
 even when a competitor is included in the report.
+
+`--profile-calls` enables Toolport's opt-in routed-call stage timer and adds
+preflight, downstream, post-processing, audit, and total p50/p95 timings for
+successful routed calls to the report. The gateway writes those diagnostics to
+stderr, never the MCP protocol stream, and includes no arguments or result data.
+Keep it off for headline latency comparisons because emitting one diagnostic
+line per call adds its own measurement overhead.
 
 The report deliberately separates deterministic gateway mechanics from model-graded
 agent accuracy. Use `bench-sweep.mjs` for end-to-end model tasks; do not present this

--- a/benchmark/compare-local.config.json
+++ b/benchmark/compare-local.config.json
@@ -18,6 +18,6 @@
     "maxSearchP95EstimatedTokens": 550,
     "minRecallAtK": 1,
     "minSchemaReadyAtK": 1,
-    "maxCallOverheadP95Milliseconds": 5
+    "maxCallOverheadP95Milliseconds": 3
   }
 }

--- a/benchmark/compare-local.mjs
+++ b/benchmark/compare-local.mjs
@@ -58,6 +58,7 @@ const options = {
   topK: Math.max(1, Number(valueArg("top-k", CONFIG.defaults.topK))),
   json: argv.includes("--json"),
   check: argv.includes("--check"),
+  profileCalls: argv.includes("--profile-calls"),
   installRatel: argv.includes("--install-ratel"),
   out: optionalValueArg("out"),
 };
@@ -280,6 +281,7 @@ function toolDefinition(name, description) {
 class McpProcess {
   constructor(command, args, spawnOptions = {}) {
     this.stderr = "";
+    this.callProfiles = [];
     this.pending = new Map();
     this.nextId = 0;
     this.proc = spawn(command, args, {
@@ -287,8 +289,26 @@ class McpProcess {
       stdio: ["pipe", "pipe", "pipe"],
       windowsHide: true,
     });
-    this.proc.stderr.on("data", (chunk) => {
-      this.stderr = `${this.stderr}${chunk}`.slice(-12_000);
+    const stderrLines = createInterface({ input: this.proc.stderr, crlfDelay: Infinity });
+    stderrLines.on("line", (line) => {
+      this.stderr = `${this.stderr}${line}\n`.slice(-12_000);
+      const prefix = "toolport-call-profile ";
+      if (!line.startsWith(prefix)) return;
+      try {
+        const profile = JSON.parse(line.slice(prefix.length));
+        const timingFields = [
+          "preflightUs",
+          "downstreamUs",
+          "postprocessUs",
+          "auditUs",
+          "totalUs",
+        ];
+        if (timingFields.every((field) => Number.isFinite(profile[field]))) {
+          this.callProfiles.push(profile);
+        }
+      } catch {
+        // A diagnostic line must never affect the benchmark transport.
+      }
     });
     const lines = createInterface({ input: this.proc.stdout, crlfDelay: Infinity });
     lines.on("line", (line) => {
@@ -376,6 +396,7 @@ function toolportAdapter(registryPath) {
       TOOLPORT_DATA_DIR: dirname(registryPath),
       TOOLPORT_PROFILE: "benchmark",
       TOOLPORT_DISCOVERY: "lazy",
+      ...(options.profileCalls ? { TOOLPORT_PROFILE_CALLS: "1" } : {}),
     },
     searchTool: "toolport_search_tools",
     invokeTool: "toolport_call_tool",
@@ -532,6 +553,7 @@ async function benchmarkProduct(
         arguments: adapter.invokeArgs(expectedToolId, { resourceId: "benchmark" }),
       });
     }
+    client.callProfiles.length = 0;
     const routedCall = await measure(
       () =>
         client.call("tools/call", {
@@ -540,6 +562,7 @@ async function benchmarkProduct(
         }),
       options.iterations,
     );
+    const callProfiles = client.callProfiles.splice(0);
 
     for (let i = 0; i < 10; i++) {
       await client.call("tools/call", {
@@ -652,6 +675,18 @@ async function benchmarkProduct(
         median: routedCall.median - direct.median,
         p95: routedCall.p95 - direct.p95,
       },
+      ...(callProfiles.length > 0
+        ? {
+            callStagesMicroseconds: Object.fromEntries(
+              ["preflight", "downstream", "postprocess", "audit", "total"].map(
+                (stage) => [
+                  stage,
+                  stats(callProfiles.map((profile) => profile[`${stage}Us`])),
+                ],
+              ),
+            ),
+          }
+        : {}),
     };
   } finally {
     client.stop();
@@ -895,6 +930,29 @@ function markdown(result) {
     "Interpretation: this measures local gateway mechanics and lexical retrieval over a shared fixture.",
     "It does not claim end-to-end agent accuracy; model-graded task runs remain a separate benchmark.",
   );
+  const profiled = result.runs.filter(
+    (run) => run.products.toolport?.callStagesMicroseconds,
+  );
+  if (profiled.length > 0) {
+    lines.push(
+      "",
+      "## Toolport routed-call stages",
+      "",
+      "Opt-in gateway stage timings in microseconds. Profiling output is emitted after the measured total.",
+      "",
+      "| Catalog | Stage | p50 / p95 µs |",
+      "| ---: | --- | ---: |",
+    );
+    for (const run of profiled) {
+      for (const [stage, values] of Object.entries(
+        run.products.toolport.callStagesMicroseconds,
+      )) {
+        lines.push(
+          `| ${run.catalogSize} | ${stage} | ${values.median.toFixed(0)} / ${values.p95.toFixed(0)} |`,
+        );
+      }
+    }
+  }
   return `${lines.join("\n")}\n`;
 }
 
@@ -926,6 +984,7 @@ async function main() {
       iterations: options.iterations,
       settleMilliseconds: options.settleMilliseconds,
       topK: options.topK,
+      profileCalls: options.profileCalls,
     },
     runs: [],
   };

--- a/src-tauri/src/audit.rs
+++ b/src-tauri/src/audit.rs
@@ -195,36 +195,76 @@ pub fn record_decision(
 pub fn args_hash(value: &Value) -> String {
     use sha2::{Digest, Sha256};
     let mut hasher = Sha256::new();
-    hasher.update(canonical_json(value).as_bytes());
-    hasher.finalize().iter().map(|b| format!("{b:02x}")).collect()
+    {
+        let mut writer = DigestWriter(&mut hasher);
+        write_canonical_json(&mut writer, value);
+    }
+    let digest = hasher.finalize();
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut out = String::with_capacity(digest.len() * 2);
+    for byte in digest {
+        out.push(HEX[(byte >> 4) as usize] as char);
+        out.push(HEX[(byte & 0x0f) as usize] as char);
+    }
+    out
 }
 
-/// Serialize `value` to canonical JSON: object keys sorted recursively so the string (and
-/// therefore its hash) is independent of key insertion order. Scalars defer to serde's
-/// stringification; only object key ordering is normalized.
-fn canonical_json(value: &Value) -> String {
+struct DigestWriter<'a>(&'a mut sha2::Sha256);
+
+impl std::io::Write for DigestWriter<'_> {
+    fn write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {
+        use sha2::Digest;
+        self.0.update(bytes);
+        Ok(bytes.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+/// Stream canonical JSON into a writer instead of recursively allocating a
+/// `String` for every object, array, and scalar. Object keys remain sorted,
+/// preserving the exact stable hash contract used by approvals and audit export.
+fn write_canonical_json(writer: &mut impl std::io::Write, value: &Value) {
     match value {
         Value::Object(map) => {
+            let _ = writer.write_all(b"{");
             let mut keys: Vec<&String> = map.keys().collect();
             keys.sort();
-            let inner: Vec<String> = keys
-                .into_iter()
-                .map(|k| {
-                    format!(
-                        "{}:{}",
-                        serde_json::to_string(k).unwrap_or_default(),
-                        canonical_json(&map[k])
-                    )
-                })
-                .collect();
-            format!("{{{}}}", inner.join(","))
+            for (index, key) in keys.into_iter().enumerate() {
+                if index > 0 {
+                    let _ = writer.write_all(b",");
+                }
+                write_json_scalar(writer, key);
+                let _ = writer.write_all(b":");
+                write_canonical_json(writer, &map[key]);
+            }
+            let _ = writer.write_all(b"}");
         }
         Value::Array(arr) => {
-            let inner: Vec<String> = arr.iter().map(canonical_json).collect();
-            format!("[{}]", inner.join(","))
+            let _ = writer.write_all(b"[");
+            for (index, item) in arr.iter().enumerate() {
+                if index > 0 {
+                    let _ = writer.write_all(b",");
+                }
+                write_canonical_json(writer, item);
+            }
+            let _ = writer.write_all(b"]");
         }
-        other => other.to_string(),
+        scalar => write_json_scalar(writer, scalar),
     }
+}
+
+fn write_json_scalar<T: serde::Serialize>(writer: &mut impl std::io::Write, value: &T) {
+    let _ = serde_json::to_writer(&mut *writer, value);
+}
+
+#[cfg(test)]
+fn canonical_json(value: &Value) -> String {
+    let mut bytes = Vec::new();
+    write_canonical_json(&mut bytes, value);
+    String::from_utf8(bytes).unwrap_or_default()
 }
 
 /// Build the audit entry for an agent-control server toggle. Pure (no I/O) so the
@@ -292,24 +332,48 @@ fn write_line(entry: &Value) {
     let Some(path) = audit_path() else {
         return;
     };
-    if let Some(parent) = path.parent() {
-        let _ = std::fs::create_dir_all(parent);
+    write_line_at(&path, entry);
+}
+
+fn write_line_at(path: &Path, entry: &Value) {
+    let open = || {
+        std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&path)
+    };
+    // The registry normally created this directory before any call. Avoid a
+    // redundant create-directory syscall on every append, but retain the
+    // standalone/first-writer behavior by creating it and retrying on NotFound.
+    let mut file = match open() {
+        Ok(file) => file,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            if let Some(parent) = path.parent() {
+                let _ = std::fs::create_dir_all(parent);
+            }
+            match open() {
+                Ok(file) => file,
+                Err(_) => return,
+            }
+        }
+        Err(_) => return,
+    };
+    let line = format!("{entry}\n");
+    if file.write_all(line.as_bytes()).is_err() {
+        return;
     }
-    if let Ok(mut file) = std::fs::OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(&path)
-    {
-        let _ = file.write_all(format!("{entry}\n").as_bytes());
-    }
-    rotate_if_large(&path);
+    // Query size through the handle we already opened instead of reopening the
+    // path for metadata. Drop it before rotation so Windows can atomically
+    // replace the log when the cap is crossed.
+    let size = file.metadata().map(|metadata| metadata.len()).unwrap_or(0);
+    drop(file);
+    rotate_if_large(&path, size);
 }
 
 /// Trim the audit log to its most recent `KEEP_LINES` lines once it exceeds the
 /// size cap, so it stays bounded over months of use. Best-effort: a failure here
 /// never affects the call being logged.
-fn rotate_if_large(path: &Path) {
-    let size = std::fs::metadata(path).map(|m| m.len()).unwrap_or(0);
+fn rotate_if_large(path: &Path, size: u64) {
     if size <= MAX_AUDIT_BYTES {
         return;
     }
@@ -704,6 +768,23 @@ mod tests {
     }
 
     #[test]
+    fn audit_append_creates_missing_parent_and_writes_one_json_line() {
+        let root = std::env::temp_dir().join(format!(
+            "toolport-audit-append-{}-{}",
+            std::process::id(),
+            epoch_millis()
+        ));
+        let path = root.join("nested").join("audit.jsonl");
+        write_line_at(&path, &json!({"server":"fixture","ok":true}));
+        let content = std::fs::read_to_string(&path).expect("audit line");
+        assert!(content.ends_with('\n'));
+        assert_eq!(content.lines().count(), 1);
+        let entry: Value = serde_json::from_str(content.trim()).expect("valid JSON");
+        assert_eq!(entry["server"], "fixture");
+        std::fs::remove_dir_all(root).ok();
+    }
+
+    #[test]
     fn decision_entry_records_outcome_and_never_stores_raw_args() {
         let e = decision_entry(
             "neon",
@@ -767,9 +848,13 @@ mod tests {
 
     #[test]
     fn canonical_json_sorts_object_keys_recursively() {
+        let value = json!({ "b": 1, "a": { "d": 4, "c": 3 } });
+        assert_eq!(canonical_json(&value), r#"{"a":{"c":3,"d":4},"b":1}"#);
+        // Regression guard: the streaming implementation must remain byte-for-byte
+        // compatible with hashes persisted by previous Toolport versions.
         assert_eq!(
-            canonical_json(&json!({ "b": 1, "a": { "d": 4, "c": 3 } })),
-            r#"{"a":{"c":3,"d":4},"b":1}"#,
+            args_hash(&value),
+            "943d56ce0b02b80a8afcd12d849426226b68f2d8cd2840af8f6f93067f14c360"
         );
     }
 }

--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -2468,6 +2468,76 @@ fn refused_call_result(
     })
 }
 
+/// Opt-in stage timer for diagnosing Toolport's own routed-call overhead. Disabled
+/// by default and cached once per process; the normal call path pays only an
+/// `Option` branch. Timings go to stderr (never the MCP protocol stream) and contain
+/// no arguments or result data.
+struct RoutedCallProfiler {
+    tool: String,
+    started: Instant,
+    checkpoint: Instant,
+    preflight_us: u64,
+    downstream_us: u64,
+    postprocess_us: u64,
+}
+
+impl RoutedCallProfiler {
+    fn start(tool: &str) -> Option<Self> {
+        static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+        let enabled = *ENABLED.get_or_init(|| {
+            conduit_lib::brand::env_var("TOOLPORT_PROFILE_CALLS", "CONDUIT_PROFILE_CALLS")
+                .map(|value| matches!(value.trim().to_ascii_lowercase().as_str(), "1" | "true"))
+                .unwrap_or(false)
+        });
+        enabled.then(|| {
+            let now = Instant::now();
+            Self {
+                tool: tool.to_string(),
+                started: now,
+                checkpoint: now,
+                preflight_us: 0,
+                downstream_us: 0,
+                postprocess_us: 0,
+            }
+        })
+    }
+
+    fn elapsed_since_checkpoint(&mut self) -> u64 {
+        let now = Instant::now();
+        let elapsed = now.duration_since(self.checkpoint).as_micros() as u64;
+        self.checkpoint = now;
+        elapsed
+    }
+
+    fn mark_preflight(&mut self) {
+        self.preflight_us = self.elapsed_since_checkpoint();
+    }
+
+    fn mark_downstream(&mut self) {
+        self.downstream_us = self.elapsed_since_checkpoint();
+    }
+
+    fn mark_postprocess(&mut self) {
+        self.postprocess_us = self.elapsed_since_checkpoint();
+    }
+
+    fn finish(mut self) {
+        let audit_us = self.elapsed_since_checkpoint();
+        let total_us = self.started.elapsed().as_micros() as u64;
+        eprintln!(
+            "toolport-call-profile {}",
+            json!({
+                "tool": self.tool,
+                "preflightUs": self.preflight_us,
+                "downstreamUs": self.downstream_us,
+                "postprocessUs": self.postprocess_us,
+                "auditUs": audit_us,
+                "totalUs": total_us,
+            })
+        );
+    }
+}
+
 /// Execute ONE already-resolved tool call and return the MCP tool RESULT (the inner
 /// `{content, isError, structuredContent}`), NOT a JSON-RPC envelope. This is the single
 /// path both a direct `toolport_call_tool` dispatch and a code-mode script's
@@ -2495,6 +2565,7 @@ fn execute_call(
     arguments: Value,
     mut confirmed: bool,
 ) -> Value {
+    let mut call_profiler = RoutedCallProfiler::start(name);
     // Resolve the call's real (server, original tool) from the router's route map,
     // NOT by splitting the exposed name on `__`. A renamed tool (via a tool override)
     // or a server id containing `__` would otherwise mis-derive the server and
@@ -2710,10 +2781,16 @@ fn execute_call(
     };
     // Hash args for the audit line (and SOU-171 org export) without storing them.
     let call_args_hash = audit::args_hash(&arguments);
+    if let Some(profiler) = &mut call_profiler {
+        profiler.mark_preflight();
+    }
 
     let started = Instant::now();
     match router.route_call_with_cancel(name, arguments, cancel.clone()) {
         Ok(result) => {
+            if let Some(profiler) = &mut call_profiler {
+                profiler.mark_downstream();
+            }
             let ms = started.elapsed().as_millis() as u64;
             // Downstream success flag (before content defense may flip isError on a
             // high-confidence injection block — SOU-345). Live inspect keeps the RAW
@@ -2736,6 +2813,9 @@ fn execute_call(
                 recovery_hint(cached, srv)
             };
             let out = defend_and_shape(reg, srv, tool, client, result, &trailer);
+            if let Some(profiler) = &mut call_profiler {
+                profiler.mark_postprocess();
+            }
             // Audit the agent-facing outcome: a content-defense block is a failed call
             // for governance / SOU-171 export even when the downstream returned ok.
             let ok = !out
@@ -2756,6 +2836,9 @@ fn execute_call(
                 client,
                 Some(&call_args_hash),
             );
+            if let Some(profiler) = call_profiler {
+                profiler.finish();
+            }
             out
         }
         Err(e) => {


### PR DESCRIPTION
## What changed

- add an opt-in routed-call stage profiler to the local comparison harness and gateway
- stream canonical call arguments directly into SHA-256 instead of building recursive JSON strings
- remove redundant audit-directory and metadata filesystem operations while preserving synchronous append and rotation
- tighten the routed-call p95 regression ceiling from 5 ms to 3 ms

## Why

Stage profiling showed synchronous audit persistence was the largest part of Toolport's local routed-call overhead. The hot path was allocating canonical JSON and performing avoidable filesystem work for every successful call.

## Impact

The optimized path keeps Toolport's existing content binding, synchronous audit append, bounded log rotation, content defense, shaping, and MCP behavior intact. In a 300-iteration local comparison, routed-call overhead measured about 0.53–0.59 ms median and 0.71–0.83 ms p95 across 25, 100, and 500-tool catalogs. Opt-in profiling showed the audit stage falling from roughly 0.52–0.88 ms median to 0.27–0.34 ms median, depending on catalog size.

## Validation

- complete Windows Rust suite: 648 tests passed
- frontend tests: 18 files, 133 tests passed
- production frontend build
- ESLint: 0 errors (20 existing warnings)
- `npm run bench:compare -- --products=toolport --iterations=150 --check`
- Prettier, Node syntax, and `git diff --check`
