### PR TITLE
Preserve paginated MCP catalogs

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -64,6 +64,20 @@ node benchmark/latency.mjs 200 --check
 local gateways. `--check` enforces the deliberately generous regression ceilings in
 `latency-budget.json`; tighten them only with evidence from multiple machines.
 
+## Native MCP pagination regression (`mcp-native.mjs`)
+
+This end-to-end harness launches Toolport over stdio with a deterministic MCP
+fixture that paginates tools, resources, and prompts at two items per page. It
+verifies that Toolport discovers every downstream page, exposes the complete
+aggregated lists without forcing existing clients to paginate, and can invoke,
+read, and fetch entries that appeared only on the final page.
+
+```bash
+npm run build:gateway
+npm run bench:mcp-native
+npm run bench:mcp-native -- --json
+```
+
 ## Side-by-side local gateway comparison (`compare-local.mjs`)
 
 This is the competitive harness. It generates one deterministic MCP catalog, launches

--- a/benchmark/fixture-mcp.mjs
+++ b/benchmark/fixture-mcp.mjs
@@ -12,13 +12,22 @@ if (!catalogPath) {
   process.exit(2);
 }
 
-const tools = JSON.parse(readFileSync(catalogPath, "utf8")).tools;
+const catalog = JSON.parse(readFileSync(catalogPath, "utf8"));
+const tools = catalog.tools;
 if (!Array.isArray(tools)) {
   console.error("catalog must contain a tools array");
   process.exit(2);
 }
+const resources = Array.isArray(catalog.resources) ? catalog.resources : [];
+const prompts = Array.isArray(catalog.prompts) ? catalog.prompts : [];
+const pageSize =
+  Number.isInteger(catalog.pageSize) && catalog.pageSize > 0
+    ? catalog.pageSize
+    : Number.POSITIVE_INFINITY;
 
 const byName = new Map(tools.map((tool) => [tool.name, tool]));
+const resourcesByUri = new Map(resources.map((resource) => [resource.uri, resource]));
+const promptsByName = new Map(prompts.map((prompt) => [prompt.name, prompt]));
 const rl = createInterface({ input: process.stdin, crlfDelay: Infinity });
 
 function write(message) {
@@ -31,6 +40,21 @@ function result(id, value) {
 
 function error(id, code, message) {
   write({ jsonrpc: "2.0", id, error: { code, message } });
+}
+
+function page(items, cursor) {
+  let offset = 0;
+  if (cursor !== undefined) {
+    const match = /^fixture:(\d+)$/.exec(cursor);
+    if (!match) return null;
+    offset = Number(match[1]);
+  }
+  const selected = items.slice(offset, offset + pageSize);
+  const next = offset + selected.length;
+  return {
+    items: selected,
+    ...(next < items.length ? { nextCursor: `fixture:${next}` } : {}),
+  };
 }
 
 rl.on("line", (line) => {
@@ -47,16 +71,29 @@ rl.on("line", (line) => {
     case "initialize":
       result(request.id, {
         protocolVersion: "2025-06-18",
-        capabilities: { tools: {} },
+        capabilities: {
+          tools: {},
+          ...(resources.length > 0 ? { resources: {} } : {}),
+          ...(prompts.length > 0 ? { prompts: {} } : {}),
+        },
         serverInfo: { name: "toolport-benchmark-fixture", version: "1" },
       });
       break;
     case "ping":
       result(request.id, {});
       break;
-    case "tools/list":
-      result(request.id, { tools });
+    case "tools/list": {
+      const listed = page(tools, request.params?.cursor);
+      if (!listed) {
+        error(request.id, -32602, "invalid fixture cursor");
+        break;
+      }
+      result(request.id, {
+        tools: listed.items,
+        ...(listed.nextCursor ? { nextCursor: listed.nextCursor } : {}),
+      });
       break;
+    }
     case "tools/call": {
       const name = request.params?.name;
       if (!byName.has(name)) {
@@ -75,6 +112,67 @@ rl.on("line", (line) => {
           },
         ],
         isError: false,
+      });
+      break;
+    }
+    case "resources/list": {
+      const listed = page(resources, request.params?.cursor);
+      if (!listed) {
+        error(request.id, -32602, "invalid fixture cursor");
+        break;
+      }
+      result(request.id, {
+        resources: listed.items,
+        ...(listed.nextCursor ? { nextCursor: listed.nextCursor } : {}),
+      });
+      break;
+    }
+    case "resources/read": {
+      const resource = resourcesByUri.get(request.params?.uri);
+      if (!resource) {
+        error(request.id, -32602, `unknown fixture resource: ${request.params?.uri}`);
+        break;
+      }
+      result(request.id, {
+        contents: [
+          {
+            uri: resource.uri,
+            mimeType: resource.mimeType ?? "text/plain",
+            text: `fixture content for ${resource.name}`,
+          },
+        ],
+      });
+      break;
+    }
+    case "prompts/list": {
+      const listed = page(prompts, request.params?.cursor);
+      if (!listed) {
+        error(request.id, -32602, "invalid fixture cursor");
+        break;
+      }
+      result(request.id, {
+        prompts: listed.items,
+        ...(listed.nextCursor ? { nextCursor: listed.nextCursor } : {}),
+      });
+      break;
+    }
+    case "prompts/get": {
+      const prompt = promptsByName.get(request.params?.name);
+      if (!prompt) {
+        error(request.id, -32602, `unknown fixture prompt: ${request.params?.name}`);
+        break;
+      }
+      result(request.id, {
+        description: prompt.description,
+        messages: [
+          {
+            role: "user",
+            content: {
+              type: "text",
+              text: `fixture prompt ${prompt.name}`,
+            },
+          },
+        ],
       });
       break;
     }

--- a/benchmark/mcp-native.mjs
+++ b/benchmark/mcp-native.mjs
@@ -1,0 +1,304 @@
+#!/usr/bin/env node
+// End-to-end regression harness for Toolport's native MCP aggregation.
+// The fixture paginates every primitive; the checks prove later pages remain
+// discoverable and routable through Toolport's public stdio MCP interface.
+
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { createInterface } from "node:readline";
+import { spawn } from "node:child_process";
+import { tmpdir } from "node:os";
+import { fileURLToPath } from "node:url";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(HERE, "..");
+const FIXTURE = join(HERE, "fixture-mcp.mjs");
+const TARGET = process.env.CARGO_TARGET_DIR
+  ? resolve(process.env.CARGO_TARGET_DIR)
+  : join(ROOT, "src-tauri", "target");
+const profile = process.env.TOOLPORT_GATEWAY_PROFILE === "release" ? "release" : "debug";
+const gateway =
+  process.env.TOOLPORT_GATEWAY ||
+  join(
+    TARGET,
+    profile,
+    process.platform === "win32" ? "toolport-gateway.exe" : "toolport-gateway",
+  );
+const jsonOutput = process.argv.includes("--json");
+
+function fail(message) {
+  console.error(message);
+  process.exitCode = 1;
+}
+
+class McpProcess {
+  constructor(command, args, options) {
+    this.stderr = "";
+    this.pending = new Map();
+    this.nextId = 0;
+    this.proc = spawn(command, args, {
+      ...options,
+      stdio: ["pipe", "pipe", "pipe"],
+      windowsHide: true,
+    });
+    this.proc.stderr.on("data", (chunk) => {
+      this.stderr = `${this.stderr}${chunk}`.slice(-12_000);
+    });
+    const lines = createInterface({ input: this.proc.stdout, crlfDelay: Infinity });
+    lines.on("line", (line) => {
+      let message;
+      try {
+        message = JSON.parse(line);
+      } catch {
+        return;
+      }
+      const pending = this.pending.get(message.id);
+      if (!pending) return;
+      clearTimeout(pending.timer);
+      this.pending.delete(message.id);
+      pending.resolve(message);
+    });
+    this.proc.on("error", (error) => this.rejectAll(error));
+    this.proc.on("exit", (code) => {
+      if (this.pending.size > 0) {
+        this.rejectAll(
+          new Error(`gateway exited with code ${code}\n${this.stderr.trim()}`),
+        );
+      }
+    });
+  }
+
+  call(method, params = {}, timeoutMs = 20_000) {
+    return new Promise((resolvePromise, reject) => {
+      const id = ++this.nextId;
+      const timer = setTimeout(() => {
+        this.pending.delete(id);
+        reject(new Error(`${method} timed out\n${this.stderr.trim()}`));
+      }, timeoutMs);
+      this.pending.set(id, { resolve: resolvePromise, reject, timer });
+      this.proc.stdin.write(
+        `${JSON.stringify({ jsonrpc: "2.0", id, method, params })}\n`,
+      );
+    });
+  }
+
+  notify(method, params = {}) {
+    this.proc.stdin.write(`${JSON.stringify({ jsonrpc: "2.0", method, params })}\n`);
+  }
+
+  rejectAll(error) {
+    for (const pending of this.pending.values()) {
+      clearTimeout(pending.timer);
+      pending.reject(error);
+    }
+    this.pending.clear();
+  }
+
+  stop() {
+    try {
+      this.proc.stdin.end();
+      this.proc.kill();
+    } catch {
+      // Best-effort cleanup of an already-exited process.
+    }
+  }
+}
+
+function definitions(kind, count) {
+  return Array.from({ length: count }, (_, index) => {
+    const suffix = String(index).padStart(2, "0");
+    if (kind === "tools") {
+      return {
+        name: `tool_${suffix}`,
+        description: `Fixture tool ${suffix}`,
+        inputSchema: {
+          type: "object",
+          properties: { value: { type: "string" } },
+        },
+      };
+    }
+    if (kind === "resources") {
+      return {
+        uri: `fixture://resource/${suffix}`,
+        name: `resource_${suffix}`,
+        description: `Fixture resource ${suffix}`,
+        mimeType: "text/plain",
+      };
+    }
+    return {
+      name: `prompt_${suffix}`,
+      description: `Fixture prompt ${suffix}`,
+      arguments: [{ name: "topic", required: false }],
+    };
+  });
+}
+
+function assertNoRpcError(response, label) {
+  if (response.error) {
+    throw new Error(`${label}: ${JSON.stringify(response.error)}`);
+  }
+  return response.result;
+}
+
+async function main() {
+  if (!existsSync(gateway)) {
+    throw new Error(
+      `missing Toolport gateway at ${gateway}\n` + "Build it with: npm run build:gateway",
+    );
+  }
+
+  const count = 7;
+  const dir = mkdtempSync(join(tmpdir(), "toolport-mcp-native-"));
+  const catalogPath = join(dir, "catalog.json");
+  const registryPath = join(dir, "registry.json");
+  writeFileSync(
+    catalogPath,
+    JSON.stringify({
+      pageSize: 2,
+      tools: definitions("tools", count),
+      resources: definitions("resources", count),
+      prompts: definitions("prompts", count),
+    }),
+  );
+  writeFileSync(
+    registryPath,
+    JSON.stringify({
+      version: 1,
+      servers: [
+        {
+          id: "fixture",
+          name: "Fixture",
+          transport: "stdio",
+          command: process.execPath,
+          args: [FIXTURE, catalogPath],
+          env: [],
+        },
+      ],
+      profiles: [
+        {
+          id: "benchmark",
+          name: "Benchmark",
+          enabledServerIds: ["fixture"],
+        },
+      ],
+      activeProfileId: "benchmark",
+      lazyDiscovery: false,
+    }),
+  );
+
+  const started = performance.now();
+  const client = new McpProcess(gateway, [], {
+    cwd: ROOT,
+    env: {
+      ...process.env,
+      TOOLPORT_REGISTRY: registryPath,
+      TOOLPORT_DATA_DIR: dir,
+      TOOLPORT_PROFILE: "benchmark",
+      TOOLPORT_DISCOVERY: "full",
+    },
+  });
+  try {
+    const initialized = assertNoRpcError(
+      await client.call("initialize", {
+        protocolVersion: "2025-06-18",
+        capabilities: {},
+        clientInfo: { name: "mcp-native-harness", version: "1" },
+      }),
+      "initialize",
+    );
+    client.notify("notifications/initialized");
+
+    const toolsResult = assertNoRpcError(await client.call("tools/list"), "tools/list");
+    const resourcesResult = assertNoRpcError(
+      await client.call("resources/list"),
+      "resources/list",
+    );
+    const promptsResult = assertNoRpcError(
+      await client.call("prompts/list"),
+      "prompts/list",
+    );
+    const tools = toolsResult.tools.filter((tool) => tool.name.startsWith("fixture__"));
+    const resources = resourcesResult.resources;
+    const prompts = promptsResult.prompts;
+    const lastTool = `fixture__tool_${String(count - 1).padStart(2, "0")}`;
+    const lastResource = `fixture://resource/${String(count - 1).padStart(2, "0")}`;
+    const lastPrompt = `fixture__prompt_${String(count - 1).padStart(2, "0")}`;
+
+    const called = assertNoRpcError(
+      await client.call("tools/call", {
+        name: lastTool,
+        arguments: { value: "later-page" },
+      }),
+      "tools/call",
+    );
+    const read = assertNoRpcError(
+      await client.call("resources/read", { uri: lastResource }),
+      "resources/read",
+    );
+    const prompted = assertNoRpcError(
+      await client.call("prompts/get", {
+        name: lastPrompt,
+        arguments: { topic: "later-page" },
+      }),
+      "prompts/get",
+    );
+
+    const checks = {
+      advertisesNativeCapabilities:
+        initialized.capabilities?.resources?.listChanged === true &&
+        initialized.capabilities?.prompts?.listChanged === true,
+      allToolsDiscovered: tools.length === count,
+      allResourcesDiscovered: resources.length === count,
+      allPromptsDiscovered: prompts.length === count,
+      laterPageToolRouted:
+        called.content?.[0]?.text?.includes(`"tool":"tool_06"`) === true,
+      laterPageResourceRead:
+        read.contents?.[0]?.text === "fixture content for resource_06",
+      laterPagePromptFetched:
+        prompted.messages?.[0]?.content?.text === "fixture prompt prompt_06",
+      aggregatedListsRemainBackwardCompatible:
+        toolsResult.nextCursor === undefined &&
+        resourcesResult.nextCursor === undefined &&
+        promptsResult.nextCursor === undefined,
+    };
+    const report = {
+      gateway,
+      readyMilliseconds: performance.now() - started,
+      pageSize: 2,
+      expectedPerPrimitive: count,
+      discovered: {
+        tools: tools.length,
+        resources: resources.length,
+        prompts: prompts.length,
+      },
+      checks,
+    };
+
+    if (jsonOutput) {
+      console.log(JSON.stringify(report, null, 2));
+    } else {
+      console.log("# Toolport native MCP pagination");
+      console.log("");
+      console.log(
+        `Fixture: ${count} tools, ${count} resources, ${count} prompts; 2 items per downstream page.`,
+      );
+      console.log(`Gateway ready + checks: ${report.readyMilliseconds.toFixed(2)} ms`);
+      console.log("");
+      for (const [name, passed] of Object.entries(checks)) {
+        console.log(`- ${passed ? "PASS" : "FAIL"} ${name}`);
+      }
+    }
+
+    const failed = Object.entries(checks).filter(([, passed]) => !passed);
+    if (failed.length > 0) {
+      fail(`native MCP checks failed: ${failed.map(([name]) => name).join(", ")}`);
+    }
+  } finally {
+    client.stop();
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+main().catch((error) => {
+  fail(error.stack ?? error.message);
+});

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "bench:latency": "node benchmark/latency.mjs",
     "bench:latency:check": "node benchmark/latency.mjs --check",
     "bench:compare": "node benchmark/compare-local.mjs",
+    "bench:mcp-native": "node benchmark/mcp-native.mjs",
     "audit:prod": "npm audit --omit=dev",
     "prepare": "husky"
   },

--- a/src-tauri/src/downstream.rs
+++ b/src-tauri/src/downstream.rs
@@ -45,6 +45,11 @@ const STDERR_TAIL_CAP: usize = 4096;
 /// or broken server can't stream gigabytes to exhaust gateway memory. Generous: real
 /// MCP responses are tiny.
 const MAX_RESPONSE_BYTES: u64 = 16 * 1024 * 1024;
+/// Bound paginated MCP catalog traversal so a malicious server cannot keep the
+/// gateway in an infinite cursor chain or grow its in-memory catalog without limit.
+const MAX_LIST_PAGES: usize = 1_000;
+const MAX_LIST_ITEMS: usize = 100_000;
+const MAX_LIST_DURATION: Duration = Duration::from_secs(30);
 
 /// Retry budget for transient HTTP failures that are SAFE to repeat: a connection
 /// that never reached the server, or an explicit 429 rate-limit. We deliberately
@@ -2253,8 +2258,12 @@ impl DownstreamServer {
         // handshake goes back to the tight budget - a server that comes up but then
         // hangs on `tools/list` should still fail in seconds.
         transport.set_read_timeout(STDIO_CONNECT_TIMEOUT);
-        let result = transport.request("tools/list", json!({})).map_err(|e| e.to_string())?;
-        let tools = extract_array(&result, "tools");
+        let listed = fetch_paginated_list(&mut *transport, "tools/list", "tools")
+            .map_err(|e| e.to_string())?;
+        if let Some(warning) = &listed.warning {
+            eprintln!("toolport: server '{id}' returned a partial tool catalog: {warning}");
+        }
+        let tools = listed.items;
 
         // Restore the longer timeout: actual tool calls can legitimately be slow.
         transport.set_read_timeout(STDIO_READ_TIMEOUT);
@@ -2278,8 +2287,17 @@ impl DownstreamServer {
     /// hung server can't stall the refresh; on error the previous list is kept.
     pub fn refresh_tools(&mut self) {
         self.transport.set_read_timeout(STDIO_CONNECT_TIMEOUT);
-        if let Ok(result) = self.transport.request("tools/list", json!({})) {
-            self.tools = extract_array(&result, "tools");
+        match fetch_paginated_list(&mut *self.transport, "tools/list", "tools") {
+            Ok(listed) if listed.warning.is_none() => self.tools = listed.items,
+            Ok(listed) => eprintln!(
+                "toolport: keeping server '{}' previous tool catalog after an incomplete refresh: {}",
+                self.id,
+                listed.warning.unwrap_or_default()
+            ),
+            Err(error) => eprintln!(
+                "toolport: keeping server '{}' previous tool catalog after refresh failed: {error}",
+                self.id
+            ),
         }
         self.transport.set_read_timeout(STDIO_READ_TIMEOUT);
     }
@@ -2293,8 +2311,17 @@ impl DownstreamServer {
             return;
         }
         self.transport.set_read_timeout(STDIO_CONNECT_TIMEOUT);
-        if let Ok(r) = self.transport.request("resources/list", json!({})) {
-            self.resources = extract_array(&r, "resources");
+        match fetch_paginated_list(&mut *self.transport, "resources/list", "resources") {
+            Ok(listed) if listed.warning.is_none() => self.resources = listed.items,
+            Ok(listed) => eprintln!(
+                "toolport: keeping server '{}' previous resource catalog after an incomplete refresh: {}",
+                self.id,
+                listed.warning.unwrap_or_default()
+            ),
+            Err(error) => eprintln!(
+                "toolport: keeping server '{}' previous resource catalog after refresh failed: {error}",
+                self.id
+            ),
         }
         self.transport.set_read_timeout(STDIO_READ_TIMEOUT);
     }
@@ -2307,8 +2334,17 @@ impl DownstreamServer {
             return;
         }
         self.transport.set_read_timeout(STDIO_CONNECT_TIMEOUT);
-        if let Ok(r) = self.transport.request("prompts/list", json!({})) {
-            self.prompts = extract_array(&r, "prompts");
+        match fetch_paginated_list(&mut *self.transport, "prompts/list", "prompts") {
+            Ok(listed) if listed.warning.is_none() => self.prompts = listed.items,
+            Ok(listed) => eprintln!(
+                "toolport: keeping server '{}' previous prompt catalog after an incomplete refresh: {}",
+                self.id,
+                listed.warning.unwrap_or_default()
+            ),
+            Err(error) => eprintln!(
+                "toolport: keeping server '{}' previous prompt catalog after refresh failed: {error}",
+                self.id
+            ),
         }
         self.transport.set_read_timeout(STDIO_READ_TIMEOUT);
     }
@@ -2318,13 +2354,29 @@ impl DownstreamServer {
     /// so only the gateway (which actually proxies these) pays the cost.
     pub fn load_resources_prompts(&mut self) {
         if self.caps_resources {
-            if let Ok(r) = self.transport.request("resources/list", json!({})) {
-                self.resources = extract_array(&r, "resources");
+            if let Ok(listed) =
+                fetch_paginated_list(&mut *self.transport, "resources/list", "resources")
+            {
+                if let Some(warning) = &listed.warning {
+                    eprintln!(
+                        "toolport: server '{}' returned a partial resource catalog: {warning}",
+                        self.id
+                    );
+                }
+                self.resources = listed.items;
             }
         }
         if self.caps_prompts {
-            if let Ok(r) = self.transport.request("prompts/list", json!({})) {
-                self.prompts = extract_array(&r, "prompts");
+            if let Ok(listed) =
+                fetch_paginated_list(&mut *self.transport, "prompts/list", "prompts")
+            {
+                if let Some(warning) = &listed.warning {
+                    eprintln!(
+                        "toolport: server '{}' returned a partial prompt catalog: {warning}",
+                        self.id
+                    );
+                }
+                self.prompts = listed.items;
             }
         }
     }
@@ -2393,15 +2445,207 @@ fn extract_array(result: &Value, key: &str) -> Vec<Value> {
         .unwrap_or_default()
 }
 
+struct PaginatedList {
+    items: Vec<Value>,
+    /// Present when at least one page succeeded but traversal could not finish.
+    /// Initial discovery may expose that useful prefix; refreshes keep the prior
+    /// complete snapshot instead of replacing it with a partial catalog.
+    warning: Option<String>,
+}
+
+/// Traverse one MCP list operation using its opaque `nextCursor`. The first page
+/// remains mandatory. Once at least one page has succeeded, a later failure is
+/// returned as a partial result so a server stays usable during initial discovery.
+/// Cursor loops and excessive page/item counts are bounded defensively.
+fn fetch_paginated_list(
+    transport: &mut dyn Transport,
+    method: &str,
+    key: &str,
+) -> Result<PaginatedList, TransportError> {
+    let mut items = Vec::new();
+    let mut cursor: Option<String> = None;
+    let mut seen_cursors = HashSet::new();
+    let started = Instant::now();
+
+    for page_index in 0..MAX_LIST_PAGES {
+        if page_index > 0 && started.elapsed() >= MAX_LIST_DURATION {
+            return Ok(PaginatedList {
+                items,
+                warning: Some(format!(
+                    "catalog traversal exceeded the {}-second safety cap",
+                    MAX_LIST_DURATION.as_secs()
+                )),
+            });
+        }
+        let params = cursor
+            .as_ref()
+            .map_or_else(|| json!({}), |value| json!({ "cursor": value }));
+        let result = match transport.request(method, params) {
+            Ok(result) => result,
+            Err(error) if page_index > 0 => {
+                return Ok(PaginatedList {
+                    items,
+                    warning: Some(format!("page {} failed: {error}", page_index + 1)),
+                });
+            }
+            Err(error) => return Err(error),
+        };
+
+        let page = extract_array(&result, key);
+        let remaining = MAX_LIST_ITEMS.saturating_sub(items.len());
+        if page.len() > remaining {
+            items.extend(page.into_iter().take(remaining));
+            return Ok(PaginatedList {
+                items,
+                warning: Some(format!("catalog exceeded the {MAX_LIST_ITEMS}-item safety cap")),
+            });
+        }
+        items.extend(page);
+
+        let Some(next_cursor) = result
+            .get("nextCursor")
+            .and_then(Value::as_str)
+            .map(str::to_string)
+        else {
+            return Ok(PaginatedList {
+                items,
+                warning: None,
+            });
+        };
+        if !seen_cursors.insert(next_cursor.clone()) {
+            return Ok(PaginatedList {
+                items,
+                warning: Some("server repeated a pagination cursor".to_string()),
+            });
+        }
+        cursor = Some(next_cursor);
+    }
+
+    Ok(PaginatedList {
+        items,
+        warning: Some(format!("catalog exceeded the {MAX_LIST_PAGES}-page safety cap")),
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
         cwd_validation_error, empty_cwd_variables, expand_cwd, file_uri_to_path, resolve_command,
         resolve_root_token, screen_resolved_addrs, screen_spawn_command, screen_spawn_env,
-        validate_cwd, CancelRegistry,
+        validate_cwd, CancelRegistry, DownstreamServer, Transport, TransportError,
+        fetch_paginated_list,
     };
-    use serde_json::json;
+    use serde_json::{json, Value};
+    use std::collections::VecDeque;
     use std::path::Path;
+
+    struct PaginationTransport {
+        responses: VecDeque<Result<Value, TransportError>>,
+        params: Vec<Value>,
+    }
+
+    impl PaginationTransport {
+        fn new(responses: Vec<Result<Value, TransportError>>) -> Self {
+            Self {
+                responses: responses.into(),
+                params: Vec::new(),
+            }
+        }
+    }
+
+    impl Transport for PaginationTransport {
+        fn request(&mut self, _method: &str, params: Value) -> Result<Value, TransportError> {
+            self.params.push(params);
+            self.responses
+                .pop_front()
+                .expect("pagination test supplied a response")
+        }
+
+        fn notify(&mut self, _method: &str, _params: Value) -> Result<(), TransportError> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn paginated_list_collects_every_page_and_treats_empty_cursor_as_opaque() {
+        let mut transport = PaginationTransport::new(vec![
+            Ok(json!({"tools":[{"name":"a"}],"nextCursor":""})),
+            Ok(json!({"tools":[{"name":"b"}],"nextCursor":"page-3"})),
+            Ok(json!({"tools":[{"name":"c"}]})),
+        ]);
+        let listed = fetch_paginated_list(&mut transport, "tools/list", "tools").unwrap();
+        assert!(listed.warning.is_none());
+        assert_eq!(
+            listed
+                .items
+                .iter()
+                .filter_map(|item| item["name"].as_str())
+                .collect::<Vec<_>>(),
+            vec!["a", "b", "c"]
+        );
+        assert_eq!(
+            transport.params,
+            vec![json!({}), json!({"cursor":""}), json!({"cursor":"page-3"})]
+        );
+    }
+
+    #[test]
+    fn paginated_list_stops_on_a_repeated_cursor() {
+        let mut transport = PaginationTransport::new(vec![
+            Ok(json!({"resources":[{"uri":"one:"}],"nextCursor":"same"})),
+            Ok(json!({"resources":[{"uri":"two:"}],"nextCursor":"same"})),
+        ]);
+        let listed =
+            fetch_paginated_list(&mut transport, "resources/list", "resources").unwrap();
+        assert_eq!(listed.items.len(), 2);
+        assert_eq!(
+            listed.warning.as_deref(),
+            Some("server repeated a pagination cursor")
+        );
+    }
+
+    #[test]
+    fn downstream_server_loads_all_tool_resource_and_prompt_pages() {
+        let transport = PaginationTransport::new(vec![
+            Ok(json!({
+                "capabilities": { "resources": {}, "prompts": {} }
+            })),
+            Ok(json!({"tools":[{"name":"one"}],"nextCursor":"tools-2"})),
+            Ok(json!({"tools":[{"name":"two"}]})),
+            Ok(json!({"resources":[{"uri":"one:"}],"nextCursor":"resources-2"})),
+            Ok(json!({"resources":[{"uri":"two:"}]})),
+            Ok(json!({"prompts":[{"name":"one"}],"nextCursor":"prompts-2"})),
+            Ok(json!({"prompts":[{"name":"two"}]})),
+        ]);
+        let mut server =
+            DownstreamServer::connect("fixture".to_string(), Box::new(transport)).unwrap();
+        server.load_resources_prompts();
+        assert_eq!(server.tools.len(), 2);
+        assert_eq!(server.resources.len(), 2);
+        assert_eq!(server.prompts.len(), 2);
+        assert_eq!(server.tools[1]["name"], "two");
+        assert_eq!(server.resources[1]["uri"], "two:");
+        assert_eq!(server.prompts[1]["name"], "two");
+    }
+
+    #[test]
+    fn incomplete_refresh_keeps_the_previous_complete_catalog() {
+        let transport = PaginationTransport::new(vec![
+            Ok(json!({"tools":[{"name":"partial"}],"nextCursor":"two"})),
+            Err(TransportError::Unavailable("page two timed out".to_string())),
+        ]);
+        let mut server = DownstreamServer {
+            id: "fixture".to_string(),
+            transport: Box::new(transport),
+            tools: vec![json!({"name":"stable"})],
+            resources: Vec::new(),
+            prompts: Vec::new(),
+            caps_resources: false,
+            caps_prompts: false,
+        };
+        server.refresh_tools();
+        assert_eq!(server.tools, vec![json!({"name":"stable"})]);
+    }
 
     /// Minimal FFI for getpgrp (test-only, avoids adding libc as a dependency).
     #[cfg(unix)]


### PR DESCRIPTION
## What changed

- traverse opaque `nextCursor` chains for downstream `tools/list`, `resources/list`, and `prompts/list`
- bound catalog traversal by page count, item count, elapsed time, and repeated-cursor detection
- keep the last complete catalog when a live refresh fails on a later page
- extend the deterministic MCP fixture with paginated resources and prompts
- add an end-to-end native MCP regression harness that proves final-page entries remain discoverable and routable

## Why

Toolport previously requested only the first page from each downstream MCP list operation. Standards-compliant servers that paginate therefore had later tools, resources, and prompts silently disappear behind the gateway.

## Impact

Toolport now aggregates complete paginated downstream catalogs while preserving its existing upstream behavior: clients still receive complete lists and are not newly required to paginate. Later-page tools can be invoked, resources can be read, and prompts can be fetched normally. Malformed or unbounded cursor chains fail safely, and an incomplete refresh cannot replace a previously complete live catalog.

## Validation

- complete Windows Rust suite: 652 tests passed
- frontend tests: 18 files, 133 tests passed
- production frontend build
- ESLint: 0 errors (20 existing warnings)
- `npm run bench:mcp-native`
- `npm run bench:compare -- --products=toolport --sizes=25 --iterations=20 --check`
- Prettier, Node syntax, and `git diff --check`
