### PR TITLE
Native MCP resource subscriptions and updated fanout (SOU-394)

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -81,6 +81,18 @@ MCP defines no separate templates list-change notification. Incomplete
 downstream pagination keeps the previous complete snapshot (covered in Rust
 unit tests and documented here).
 
+### Resource subscriptions (SOU-394)
+
+Toolport always advertises `resources.subscribe` and proxies
+`resources/subscribe` / `resources/unsubscribe` through the same first-writer
+ownership path as `resources/read` (concrete URI, then template expansion),
+with the same HTTP scope rules. Downstream subscribe is reference-counted per
+URI; `notifications/resources/updated` is forwarded only to subscribed
+upstream clients (stdio + HTTP SSE), and is kept distinct from
+`resources/list_changed`. Unknown or out-of-scope URIs fail closed. The fixture
+exposes `emit_resource_updated` so the harness can trigger a real downstream
+update after subscribe.
+
 ```bash
 npm run build:gateway
 npm run bench:mcp-native

--- a/benchmark/fixture-mcp.mjs
+++ b/benchmark/fixture-mcp.mjs
@@ -44,6 +44,8 @@ const pageCounters = {
   resourceTemplates: 0,
   prompts: 0,
 };
+/** URIs this fixture session has accepted via resources/subscribe (SOU-394). */
+const resourceSubscriptions = new Set();
 const rl = createInterface({ input: process.stdin, crlfDelay: Infinity });
 
 function write(message) {
@@ -173,7 +175,7 @@ rl.on("line", (line) => {
         capabilities: {
           tools: {},
           ...(resources.length > 0 || resourceTemplates.length > 0
-            ? { resources: {} }
+            ? { resources: { subscribe: true } }
             : {}),
           ...(prompts.length > 0 ? { prompts: {} } : {}),
           ...(prompts.length > 0 || resourceTemplates.length > 0
@@ -206,6 +208,29 @@ rl.on("line", (line) => {
       const name = request.params?.name;
       if (!byName.has(name)) {
         error(request.id, -32602, `unknown fixture tool: ${name}`);
+        break;
+      }
+      // Control plane for SOU-394: emit resources/updated for a subscribed URI
+      // so the gateway fanout path can be exercised end-to-end.
+      if (name === "emit_resource_updated") {
+        const uri = request.params?.arguments?.uri;
+        if (typeof uri !== "string" || !uri) {
+          error(request.id, -32602, "emit_resource_updated requires arguments.uri");
+          break;
+        }
+        if (!resourceSubscriptions.has(uri)) {
+          error(request.id, -32602, `emit_resource_updated: uri not subscribed: ${uri}`);
+          break;
+        }
+        write({
+          jsonrpc: "2.0",
+          method: "notifications/resources/updated",
+          params: { uri },
+        });
+        result(request.id, {
+          content: [{ type: "text", text: JSON.stringify({ ok: true, uri }) }],
+          isError: false,
+        });
         break;
       }
       result(request.id, {
@@ -291,6 +316,35 @@ rl.on("line", (line) => {
           },
         ],
       });
+      break;
+    }
+    case "resources/subscribe": {
+      const uri = request.params?.uri;
+      if (!uri || typeof uri !== "string") {
+        error(request.id, -32602, "resources/subscribe requires params.uri");
+        break;
+      }
+      let known = resourcesByUri.has(uri);
+      if (!known) {
+        known = resourceTemplates.some((t) => templateMatches(uri, t.uriTemplate));
+      }
+      if (!known) {
+        error(request.id, -32602, `unknown fixture resource: ${uri}`);
+        break;
+      }
+      resourceSubscriptions.add(uri);
+      result(request.id, {});
+      break;
+    }
+    case "resources/unsubscribe": {
+      const uri = request.params?.uri;
+      if (!uri || typeof uri !== "string") {
+        error(request.id, -32602, "resources/unsubscribe requires params.uri");
+        break;
+      }
+      resourceSubscriptions.delete(uri);
+      // Idempotent success even when the URI was not subscribed.
+      result(request.id, {});
       break;
     }
     case "prompts/list": {

--- a/benchmark/mcp-native.mjs
+++ b/benchmark/mcp-native.mjs
@@ -37,6 +37,8 @@ class McpProcess {
     this.stderr = "";
     this.pending = new Map();
     this.nextId = 0;
+    this.notifications = [];
+    this.notificationWaiters = [];
     this.proc = spawn(command, args, {
       ...options,
       stdio: ["pipe", "pipe", "pipe"],
@@ -51,6 +53,23 @@ class McpProcess {
       try {
         message = JSON.parse(line);
       } catch {
+        return;
+      }
+      // Server→client notifications (no id): collect for waitForNotification.
+      if (message.id === undefined || message.id === null) {
+        if (typeof message.method === "string") {
+          this.notifications.push(message);
+          const still = [];
+          for (const waiter of this.notificationWaiters) {
+            if (waiter.method && message.method !== waiter.method) {
+              still.push(waiter);
+              continue;
+            }
+            clearTimeout(waiter.timer);
+            waiter.resolve(message);
+          }
+          this.notificationWaiters = still;
+        }
         return;
       }
       const pending = this.pending.get(message.id);
@@ -87,12 +106,38 @@ class McpProcess {
     this.proc.stdin.write(`${JSON.stringify({ jsonrpc: "2.0", method, params })}\n`);
   }
 
+  /** Wait for a server notification (optionally filtered by method). */
+  waitForNotification(method, timeoutMs = 10_000) {
+    const existing = this.notifications.find((n) => !method || n.method === method);
+    if (existing) {
+      this.notifications = this.notifications.filter((n) => n !== existing);
+      return Promise.resolve(existing);
+    }
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.notificationWaiters = this.notificationWaiters.filter((w) => w !== waiter);
+        reject(
+          new Error(
+            `waitForNotification(${method ?? "*"}) timed out\n${this.stderr.trim()}`,
+          ),
+        );
+      }, timeoutMs);
+      const waiter = { method, resolve, reject, timer };
+      this.notificationWaiters.push(waiter);
+    });
+  }
+
   rejectAll(error) {
     for (const pending of this.pending.values()) {
       clearTimeout(pending.timer);
       pending.reject(error);
     }
     this.pending.clear();
+    for (const waiter of this.notificationWaiters) {
+      clearTimeout(waiter.timer);
+      waiter.reject(error);
+    }
+    this.notificationWaiters = [];
   }
 
   stop() {
@@ -109,6 +154,19 @@ function definitions(kind, count) {
   return Array.from({ length: count }, (_, index) => {
     const suffix = String(index).padStart(2, "0");
     if (kind === "tools") {
+      // First tool doubles as the SOU-394 control plane for emitting
+      // notifications/resources/updated after a successful subscribe.
+      if (index === 0) {
+        return {
+          name: "emit_resource_updated",
+          description: "Emit resources/updated for a subscribed URI",
+          inputSchema: {
+            type: "object",
+            properties: { uri: { type: "string" } },
+            required: ["uri"],
+          },
+        };
+      }
       return {
         name: `tool_${suffix}`,
         description: `Fixture tool ${suffix}`,
@@ -322,6 +380,7 @@ async function main() {
 
       checks.advertisesNativeCapabilities =
         initialized.capabilities?.resources?.listChanged === true &&
+        initialized.capabilities?.resources?.subscribe === true &&
         initialized.capabilities?.prompts?.listChanged === true &&
         initialized.capabilities?.completions !== undefined;
       checks.allToolsDiscovered = tools.length === count;
@@ -349,6 +408,64 @@ async function main() {
         resourcesResult.nextCursor === undefined &&
         templatesResult.nextCursor === undefined &&
         promptsResult.nextCursor === undefined;
+
+      // --- Resource subscriptions + resources/updated fanout (SOU-394) ---
+      const subUri = lastResource;
+      assertNoRpcError(
+        await client.call("resources/subscribe", { uri: subUri }),
+        "resources/subscribe",
+      );
+      // Unknown URI fails closed (no owner).
+      const unknownSub = await client.call("resources/subscribe", {
+        uri: "fixture://does-not-exist",
+      });
+      checks.subscribeUnknownUriFailsClosed = Boolean(unknownSub.error);
+
+      // Trigger a downstream resources/updated via the fixture control tool.
+      // Drain any list_changed noise from ready so we wait for the real update.
+      client.notifications = client.notifications.filter(
+        (n) => n.method !== "notifications/tools/list_changed",
+      );
+      const waitUpdated = client.waitForNotification(
+        "notifications/resources/updated",
+        15_000,
+      );
+      assertNoRpcError(
+        await client.call("tools/call", {
+          name: "fixture__emit_resource_updated",
+          arguments: { uri: subUri },
+        }),
+        "tools/call emit_resource_updated",
+      );
+      const updated = await waitUpdated;
+      checks.resourceUpdatedForwardedToSubscriber = updated?.params?.uri === subUri;
+
+      assertNoRpcError(
+        await client.call("resources/unsubscribe", { uri: subUri }),
+        "resources/unsubscribe",
+      );
+      // After unsubscribe, a second emit should not reach this client.
+      // Fixture refuses emit when not subscribed (tool-level isError; gateway
+      // surfaces that as a successful JSON-RPC with isError:true).
+      const afterUnsub = await client.call("tools/call", {
+        name: "fixture__emit_resource_updated",
+        arguments: { uri: subUri },
+      });
+      checks.unsubscribeStopsDownstreamEmit =
+        afterUnsub.result?.isError === true ||
+        String(afterUnsub.result?.content?.[0]?.text ?? "").includes("not subscribed");
+
+      // Expanded template URI can be subscribed via template ownership.
+      const templateUri = expandedLater;
+      assertNoRpcError(
+        await client.call("resources/subscribe", { uri: templateUri }),
+        "resources/subscribe template expansion",
+      );
+      assertNoRpcError(
+        await client.call("resources/unsubscribe", { uri: templateUri }),
+        "resources/unsubscribe template expansion",
+      );
+      checks.subscribeTemplateExpandedUri = true;
     });
 
     // --- Cross-server template/URI collisions: first writer wins ---
@@ -490,7 +607,9 @@ async function main() {
     if (jsonOutput) {
       console.log(JSON.stringify(report, null, 2));
     } else {
-      console.log("# Toolport native MCP pagination + templates + completions");
+      console.log(
+        "# Toolport native MCP pagination + templates + completions + subscriptions",
+      );
       console.log("");
       console.log(
         `Fixture: ${count} tools/resources/templates/prompts; 2 items per downstream page.`,

--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -32,7 +32,8 @@ use conduit_lib::audit;
 use conduit_lib::clients;
 use conduit_lib::codemode;
 use conduit_lib::downstream::{
-    self, DownstreamServer, ServerRequestHandler, StdioTransport, Transport, PROTOCOL_VERSION,
+    self, DownstreamServer, ResourceUpdatedSink, ServerRequestHandler, StdioTransport, Transport,
+    PROTOCOL_VERSION,
 };
 use conduit_lib::inspect;
 use conduit_lib::integrity;
@@ -57,6 +58,131 @@ fn error(id: Value, code: i64, message: &str) -> Value {
 const MAX_SEARCH_QUERY_CHARS: usize = 512;
 const MAX_SEARCH_QUERY_TOKENS: usize = 64;
 const MAX_STDIO_LINE_BYTES: usize = 16 * 1024 * 1024;
+
+/// Session key for the single stdio MCP client (HTTP uses real `Mcp-Session-Id`).
+const RESOURCE_SUB_STDIO: &str = "stdio";
+/// Per-client cap on concurrent resource subscriptions (SOU-394).
+const MAX_RESOURCE_SUBS_PER_SESSION: usize = 256;
+/// Process-wide cap on concurrent resource subscriptions (SOU-394).
+const MAX_RESOURCE_SUBS_TOTAL: usize = 4096;
+
+/// Per-session / per-URI resource subscription tracking for SOU-394.
+///
+/// Policy: always-on proxy. The gateway advertises `resources.subscribe` and
+/// fails closed when no owner can subscribe (unknown URI, out of scope, or
+/// downstream reject). Downstream subscribe is reference-counted: first
+/// upstream session for a URI opens the downstream sub; last close drops it.
+#[derive(Default)]
+struct ResourceSubscriptionTable {
+    /// session_id -> subscribed URIs
+    by_session: HashMap<String, HashSet<String>>,
+    /// uri -> sessions interested in updates
+    by_uri: HashMap<String, HashSet<String>>,
+    /// uri -> owning downstream server id (set when the first session subscribes)
+    uri_owner: HashMap<String, String>,
+}
+
+impl ResourceSubscriptionTable {
+    fn total_count(&self) -> usize {
+        self.by_uri.values().map(|s| s.len()).sum()
+    }
+
+    /// Register local interest. `Ok(true)` when this is the first session for
+    /// `uri` (caller must open the downstream subscription). `Ok(false)` when
+    /// the session was already subscribed or another session already holds it.
+    fn add(&mut self, session: &str, uri: &str, owner: &str) -> Result<bool, String> {
+        if self
+            .by_session
+            .get(session)
+            .is_some_and(|s| s.contains(uri))
+        {
+            // Idempotent re-subscribe for the same session.
+            return Ok(false);
+        }
+        let session_count = self.by_session.get(session).map(|s| s.len()).unwrap_or(0);
+        if session_count >= MAX_RESOURCE_SUBS_PER_SESSION {
+            return Err(format!(
+                "subscription limit ({MAX_RESOURCE_SUBS_PER_SESSION}) reached for this session"
+            ));
+        }
+        if self.total_count() >= MAX_RESOURCE_SUBS_TOTAL {
+            return Err(format!(
+                "global subscription limit ({MAX_RESOURCE_SUBS_TOTAL}) reached"
+            ));
+        }
+        let first_global = self
+            .by_uri
+            .get(uri)
+            .map(|s| s.is_empty())
+            .unwrap_or(true);
+        self.by_session
+            .entry(session.to_string())
+            .or_default()
+            .insert(uri.to_string());
+        self.by_uri
+            .entry(uri.to_string())
+            .or_default()
+            .insert(session.to_string());
+        if first_global {
+            self.uri_owner
+                .insert(uri.to_string(), owner.to_string());
+        }
+        Ok(first_global)
+    }
+
+    /// Remove one subscription. Returns the owner when this was the last session
+    /// for the URI (caller should drop the downstream subscription).
+    fn remove(&mut self, session: &str, uri: &str) -> Option<String> {
+        let had = self
+            .by_session
+            .get_mut(session)
+            .is_some_and(|s| s.remove(uri));
+        if !had {
+            return None;
+        }
+        if let Some(set) = self.by_session.get(session) {
+            if set.is_empty() {
+                self.by_session.remove(session);
+            }
+        }
+        if let Some(sessions) = self.by_uri.get_mut(uri) {
+            sessions.remove(session);
+            if sessions.is_empty() {
+                self.by_uri.remove(uri);
+                return self.uri_owner.remove(uri);
+            }
+        }
+        None
+    }
+
+    /// Drop every subscription for a disconnected session. Returns `(uri, owner)`
+    /// pairs that need a downstream unsubscribe.
+    fn drop_session(&mut self, session: &str) -> Vec<(String, String)> {
+        let Some(uris) = self.by_session.remove(session) else {
+            return Vec::new();
+        };
+        let mut need_unsub = Vec::new();
+        for uri in uris {
+            if let Some(sessions) = self.by_uri.get_mut(&uri) {
+                sessions.remove(session);
+                if sessions.is_empty() {
+                    self.by_uri.remove(&uri);
+                    if let Some(owner) = self.uri_owner.remove(&uri) {
+                        need_unsub.push((uri, owner));
+                    }
+                }
+            }
+        }
+        need_unsub
+    }
+
+    fn sessions_for_uri(&self, uri: &str) -> Vec<String> {
+        self.by_uri
+            .get(uri)
+            .map(|s| s.iter().cloned().collect())
+            .unwrap_or_default()
+    }
+}
 
 #[derive(Debug, PartialEq, Eq)]
 enum BoundedLine {
@@ -3097,7 +3223,9 @@ fn handle_request_with_cancel(
                     "protocolVersion": proto,
                     "capabilities": {
                         "tools": { "listChanged": true },
-                        "resources": { "listChanged": true },
+                        // Always-on proxy for resource subscriptions (SOU-394):
+                        // advertise subscribe, fail closed when no owner can.
+                        "resources": { "listChanged": true, "subscribe": true },
                         "prompts": { "listChanged": true },
                         "completions": {}
                     },
@@ -3903,6 +4031,8 @@ fn build_router(
     // already decoded to a filesystem path. `None` in HTTP mode and before the
     // client's roots are known; `${ROOT}` servers then fall back to the gateway cwd.
     root: Option<&str>,
+    // Optional sink for downstream `notifications/resources/updated` (SOU-394).
+    resource_updated: Option<ResourceUpdatedSink>,
 ) -> Router {
     // In HTTP mode one process serves every registered client, so connect the
     // union of all their profiles (per-request filtering scopes each one down).
@@ -3988,9 +4118,16 @@ fn build_router(
             let dirty = Arc::clone(dirty);
             let handler = Arc::clone(&server_handler);
             let root_t = root_owned.clone();
+            let resource_updated = resource_updated.clone();
             std::thread::spawn(move || {
-                let ds = connect_one(&server, &dirty, handler, root_t.as_deref());
-                (server, dirty, ds)
+                let ds = connect_one(
+                    &server,
+                    &dirty,
+                    handler,
+                    root_t.as_deref(),
+                    resource_updated.clone(),
+                );
+                (server, dirty, resource_updated, ds)
             })
         })
         .collect();
@@ -4000,14 +4137,21 @@ fn build_router(
     // since they're applied as each server's tools are added.
     router.set_overrides(reg.tool_overrides.clone());
     for handle in handles {
-        if let Ok((server, dirty, Some(ds))) = handle.join() {
+        if let Ok((server, dirty, resource_updated, Some(ds))) = handle.join() {
             // The same `connect_one` used for the initial spawn is the reconnect
             // factory, so a re-spawn re-injects keychain secrets and re-handshakes
             // exactly like a fresh connect.
             let handler = Arc::clone(&server_handler);
             let root_c = root_owned.clone();
-            let reconnect: Reconnect =
-                Box::new(move || connect_one(&server, &dirty, Arc::clone(&handler), root_c.as_deref()));
+            let reconnect: Reconnect = Box::new(move || {
+                connect_one(
+                    &server,
+                    &dirty,
+                    Arc::clone(&handler),
+                    root_c.as_deref(),
+                    resource_updated.clone(),
+                )
+            });
             router.add_with_reconnect(ds, Some(reconnect));
         }
     }
@@ -4021,6 +4165,7 @@ fn connect_one(
     dirty: &Arc<AtomicU8>,
     server_handler: ServerRequestHandler,
     root: Option<&str>,
+    resource_updated: Option<ResourceUpdatedSink>,
 ) -> Option<DownstreamServer> {
     let result = if let Some(command) = &server.command {
         let mut env: Vec<(String, String)> = Vec::new();
@@ -4058,6 +4203,7 @@ fn connect_one(
             &env,
             resolved_cwd.as_deref(),
             Arc::clone(dirty),
+            resource_updated,
         ) {
             Ok(mut t) => {
                 t.set_server_request_handler(server_handler);
@@ -4140,6 +4286,210 @@ fn fanout_mcp_notification(
         }
         if !session.push_message(json.clone(), request_id_key(msg)) {
             eprintln!("toolport: MCP session outbound queue full; list_changed dropped");
+        }
+    }
+}
+
+/// Deliver `notifications/resources/updated` only to sessions that subscribed
+/// to `uri` (stdio + HTTP SSE). Distinct from list_changed fanout (SOU-394).
+fn deliver_resource_updated(
+    stdout: &Arc<Mutex<std::io::Stdout>>,
+    mcp_sessions: &Arc<Mutex<HashMap<String, Arc<McpSession>>>>,
+    subs: &Arc<Mutex<ResourceSubscriptionTable>>,
+    uri: &str,
+) {
+    let targets = {
+        let table = subs
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        table.sessions_for_uri(uri)
+    };
+    if targets.is_empty() {
+        return;
+    }
+    let msg = json!({
+        "jsonrpc": "2.0",
+        "method": "notifications/resources/updated",
+        "params": { "uri": uri }
+    });
+    let Ok(json) = serde_json::to_string(&msg) else {
+        return;
+    };
+    let mut need_stdio = false;
+    let mut http_ids: Vec<String> = Vec::new();
+    for sid in targets {
+        if sid == RESOURCE_SUB_STDIO {
+            need_stdio = true;
+        } else {
+            http_ids.push(sid);
+        }
+    }
+    if need_stdio {
+        let mut out = stdout
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let _ = write_json_line(&mut *out, &msg);
+    }
+    if !http_ids.is_empty() {
+        let sessions = mcp_sessions
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        for sid in http_ids {
+            let Some(session) = sessions.get(&sid) else {
+                continue;
+            };
+            if session.is_expired() || session.closed.load(Ordering::SeqCst) {
+                continue;
+            }
+            if !session.push_message(json.clone(), None) {
+                eprintln!(
+                    "toolport: MCP session outbound queue full; resources/updated dropped"
+                );
+            }
+        }
+    }
+}
+
+/// Build the drain-thread sink that fans resource-updated notifications to
+/// subscribed upstream clients only (SOU-394).
+fn make_resource_updated_sink(
+    stdout: Arc<Mutex<std::io::Stdout>>,
+    mcp_sessions: Arc<Mutex<HashMap<String, Arc<McpSession>>>>,
+    subs: Arc<Mutex<ResourceSubscriptionTable>>,
+) -> ResourceUpdatedSink {
+    Arc::new(move |uri: String| {
+        deliver_resource_updated(&stdout, &mcp_sessions, &subs, &uri);
+    })
+}
+
+/// Active MCP session key for resource subscription bookkeeping: real HTTP
+/// session id when set, otherwise the stdio sentinel.
+fn active_resource_session_id() -> String {
+    ACTIVE_MCP_SESSION.with(|cell| {
+        cell.borrow()
+            .clone()
+            .unwrap_or_else(|| RESOURCE_SUB_STDIO.to_string())
+    })
+}
+
+/// Handle `resources/subscribe` / `resources/unsubscribe` with ownership routing,
+/// HTTP scope, and fail-closed downstream proxying (SOU-394).
+fn handle_resource_subscription(
+    state: &GatewayState,
+    router: &Router,
+    req: &Value,
+    allowed: Option<&std::collections::HashSet<String>>,
+    method: &str,
+) -> Option<Value> {
+    let id = match req.get("id") {
+        Some(id) if !id.is_null() => id.clone(),
+        _ => return None,
+    };
+    let uri = req
+        .get("params")
+        .and_then(|p| p.get("uri"))
+        .and_then(|u| u.as_str())
+        .unwrap_or("");
+    if uri.is_empty() {
+        return Some(error(id, -32602, "Toolport: resources subscription requires params.uri"));
+    }
+    // Same ownership + scope rules as resources/read (fail closed / not-found).
+    let Some(owner) = router.resource_server(uri).map(str::to_string) else {
+        return Some(error(
+            id,
+            -32602,
+            &format!("Toolport: no server owns resource '{uri}'"),
+        ));
+    };
+    if let Some(set) = allowed {
+        if !server_in_allowed_scope(&owner, set) {
+            return Some(error(
+                id,
+                -32602,
+                &format!("Toolport: no server owns resource '{uri}'"),
+            ));
+        }
+    }
+    let session = active_resource_session_id();
+    match method {
+        "resources/subscribe" => {
+            let first = {
+                let mut table = state
+                    .resource_subs
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner);
+                match table.add(&session, uri, &owner) {
+                    Ok(first) => first,
+                    Err(e) => return Some(error(id, -32602, &format!("Toolport: {e}"))),
+                }
+            };
+            if first {
+                if let Err(e) = router.subscribe_resource(uri) {
+                    // Fail closed: roll back local tracking when the owner cannot
+                    // open a real subscription.
+                    let mut table = state
+                        .resource_subs
+                        .lock()
+                        .unwrap_or_else(std::sync::PoisonError::into_inner);
+                    let _ = table.remove(&session, uri);
+                    return Some(error(
+                        id,
+                        -32602,
+                        &format!(
+                            "Toolport: {}",
+                            integrity::defend_error_text(uri, &e)
+                        ),
+                    ));
+                }
+            }
+            Some(success(id, json!({})))
+        }
+        "resources/unsubscribe" => {
+            let last_owner = {
+                let mut table = state
+                    .resource_subs
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner);
+                table.remove(&session, uri)
+            };
+            if let Some(_owner) = last_owner {
+                // Best-effort: local bookkeeping already dropped; a downstream
+                // unsubscribe failure must not leave the client stuck subscribed.
+                if let Err(e) = router.unsubscribe_resource(uri) {
+                    eprintln!(
+                        "toolport: downstream resources/unsubscribe failed for '{uri}': {e}"
+                    );
+                }
+            }
+            // Idempotent success when the session was not subscribed.
+            Some(success(id, json!({})))
+        }
+        _ => Some(error(id, -32601, &format!("Method not found: {method}"))),
+    }
+}
+
+/// Best-effort downstream unsubscribes after a session disconnect (SOU-394).
+fn cleanup_resource_subs_for_session(state: &GatewayState, session: &str) {
+    let need_unsub = {
+        let mut table = state
+            .resource_subs
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        table.drop_session(session)
+    };
+    if need_unsub.is_empty() {
+        return;
+    }
+    let router = state
+        .router
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .clone();
+    for (uri, _owner) in need_unsub {
+        if let Err(e) = router.unsubscribe_resource(&uri) {
+            eprintln!(
+                "toolport: cleanup resources/unsubscribe failed for '{uri}': {e}"
+            );
         }
     }
 }
@@ -4562,6 +4912,8 @@ fn watch_registry(
     // Live HTTP MCP sessions so list_changed notifications also fan out over SSE
     // (SOU-328). Empty in pure-stdio mode; same Arc as GatewayState.
     mcp_sessions: Arc<Mutex<HashMap<String, Arc<McpSession>>>>,
+    // Resource-updated sink re-wired into rebuilds after registry reload (SOU-394).
+    resource_updated: Option<ResourceUpdatedSink>,
 ) {
     eprintln!("toolport: watching registry at {}", path.display());
     let mut state = WatchLoopState {
@@ -4590,6 +4942,7 @@ fn watch_registry(
             &server_handler,
             &client_root,
             Some(&mcp_sessions),
+            resource_updated.as_ref(),
             &mut state,
         );
     }
@@ -4616,6 +4969,7 @@ fn watch_tick(
     server_handler: &ServerRequestHandler,
     client_root: &Arc<Mutex<Option<String>>>,
     mcp_sessions: Option<&Arc<Mutex<HashMap<String, Arc<McpSession>>>>>,
+    resource_updated: Option<&ResourceUpdatedSink>,
     state: &mut WatchLoopState,
 ) -> TickOutcome {
     // Re-approving a tool rewrites quarantine.json, which is NOT the registry file
@@ -4719,6 +5073,7 @@ fn watch_tick(
             downstream_dirty,
             Arc::clone(server_handler),
             root.as_deref(),
+            resource_updated.cloned(),
         );
         let server_count = new_router.server_count();
         let tools = new_router.aggregated_tools();
@@ -4890,6 +5245,11 @@ struct GatewayState {
     /// request thread without re-reading env. Process constants; unused in HTTP mode.
     client_id: Option<String>,
     env_profile: Option<String>,
+    /// Upstream resource subscriptions (session → URI) for SOU-394 fanout.
+    resource_subs: Arc<Mutex<ResourceSubscriptionTable>>,
+    /// Drain-thread sink that delivers `notifications/resources/updated` to
+    /// subscribed clients. Shared with every stdio downstream spawn/reconnect.
+    resource_updated_sink: Option<ResourceUpdatedSink>,
 }
 
 /// Client capabilities the upstream MCP client declared at `initialize`.
@@ -5495,6 +5855,7 @@ fn rebuild_router_for_root(state: &GatewayState) {
         &state.downstream_dirty,
         Arc::clone(&state.server_handler),
         root.as_deref(),
+        state.resource_updated_sink.clone(),
     );
     let tools = new_router.aggregated_tools();
     *state
@@ -5664,6 +6025,8 @@ fn process_request(
         | "resources/list"
         | "resources/templates/list"
         | "resources/read"
+        | "resources/subscribe"
+        | "resources/unsubscribe"
         | "prompts/list"
         | "prompts/get"
         | "completion/complete" => true,
@@ -5724,6 +6087,7 @@ fn process_request(
                 &state.downstream_dirty,
                 Arc::clone(&state.server_handler),
                 root.as_deref(),
+                state.resource_updated_sink.clone(),
             );
             if built.server_count() > 0 {
                 let tools = built.aggregated_tools();
@@ -5775,6 +6139,11 @@ fn process_request(
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner)
         .clone();
+    // Resource subscriptions need the live GatewayState (session table + sink)
+    // and the same ownership/scope path as resources/read (SOU-394).
+    if method == "resources/subscribe" || method == "resources/unsubscribe" {
+        return handle_resource_subscription(state, &router, req, allowed, method);
+    }
     handle_request_with_cancel(
         req,
         &reg,
@@ -6210,7 +6579,25 @@ fn mcp_require_session(
         .mcp_sessions
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner);
-    sessions.retain(|_, s| !s.is_expired() && !s.closed.load(Ordering::SeqCst));
+    // Drop expired/closed sessions and release any last-holder resource subs
+    // they held (SOU-394). Collect first so we do not hold the sessions lock
+    // across cleanup that may call the router.
+    let stale: Vec<String> = sessions
+        .iter()
+        .filter(|(_, s)| s.is_expired() || s.closed.load(Ordering::SeqCst))
+        .map(|(id, _)| id.clone())
+        .collect();
+    for id in &stale {
+        sessions.remove(id);
+    }
+    drop(sessions);
+    for id in &stale {
+        cleanup_resource_subs_for_session(state, id);
+    }
+    let sessions = state
+        .mcp_sessions
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
     match sessions.get(sid).filter(|session| session.owner.as_ref() == owner) {
         Some(sess) => {
             sess.touch();
@@ -6320,6 +6707,9 @@ fn handle_mcp_http(
                     .lock()
                     .unwrap_or_else(std::sync::PoisonError::into_inner)
                     .remove(&sid);
+                // Drop resource subscriptions for this HTTP session and release
+                // any last-holder downstream subs (SOU-394).
+                cleanup_resource_subs_for_session(state, &sid);
                 HttpOut::new(204, "text/plain", String::new())
             }
             Err(e) => e,
@@ -7735,6 +8125,13 @@ fn main() {
     let mcp_sessions = Arc::new(Mutex::new(HashMap::new()));
     let client_upstream = Arc::new(Mutex::new(ClientUpstreamCaps::default()));
     let client_root = Arc::new(Mutex::new(None::<String>));
+    // Resource subscription tracking + drain-thread sink (SOU-394).
+    let resource_subs = Arc::new(Mutex::new(ResourceSubscriptionTable::default()));
+    let resource_updated_sink = Some(make_resource_updated_sink(
+        Arc::clone(&stdout),
+        Arc::clone(&mcp_sessions),
+        Arc::clone(&resource_subs),
+    ));
     // Single-flight for every router build/swap (startup, watcher self-heal, and
     // ${ROOT} rebuilds). Created up front so the startup build can share it.
     let rebuild_lock = Arc::new(Mutex::new(()));
@@ -7766,6 +8163,7 @@ fn main() {
         let client_root = Arc::clone(&client_root);
         let rebuild_lock = Arc::clone(&rebuild_lock);
         let mcp_sessions = Arc::clone(&mcp_sessions);
+        let resource_updated = resource_updated_sink.clone();
         std::thread::spawn(move || {
             let reg = registry
                 .lock()
@@ -7792,6 +8190,7 @@ fn main() {
                 &downstream_dirty,
                 server_handler,
                 root.as_deref(),
+                resource_updated,
             );
             let tools = built.aggregated_tools();
             glog(&format!(
@@ -7831,6 +8230,7 @@ fn main() {
         let env_profile = env_profile.clone();
         let client_root = Arc::clone(&client_root);
         let mcp_sessions = Arc::clone(&mcp_sessions);
+        let resource_updated = resource_updated_sink.clone();
         std::thread::spawn(move || {
             watch_registry(
                 path,
@@ -7846,6 +8246,7 @@ fn main() {
                 server_handler,
                 client_root,
                 mcp_sessions,
+                resource_updated,
             )
         });
     }
@@ -7868,6 +8269,8 @@ fn main() {
         server_handler,
         client_id: client_id.clone(),
         env_profile: env_profile.clone(),
+        resource_subs,
+        resource_updated_sink,
     };
 
     // Native HTTP/OpenAPI transport: a first-class path for HTTP tool clients
@@ -8744,6 +9147,12 @@ mod tests {
             Arc::clone(&mcp_sessions),
             true,
         );
+        let resource_subs = Arc::new(Mutex::new(ResourceSubscriptionTable::default()));
+        let resource_updated_sink = Some(make_resource_updated_sink(
+            Arc::clone(&stdout),
+            Arc::clone(&mcp_sessions),
+            Arc::clone(&resource_subs),
+        ));
         GatewayState {
             registry: Arc::new(Mutex::new(Registry::default())),
             router: Arc::new(Mutex::new(Arc::new(Router::new()))),
@@ -8762,6 +9171,8 @@ mod tests {
             server_handler,
             client_id: None,
             env_profile: None,
+            resource_subs,
+            resource_updated_sink,
         }
     }
 
@@ -10565,6 +10976,66 @@ mod tests {
         assert_eq!(resp["id"], 1);
         assert_eq!(resp["result"]["protocolVersion"], "2025-06-18");
         assert_eq!(resp["result"]["capabilities"]["tools"]["listChanged"], true);
+        // Always-on proxy policy for resource subscriptions (SOU-394).
+        assert_eq!(resp["result"]["capabilities"]["resources"]["subscribe"], true);
+        assert_eq!(resp["result"]["capabilities"]["resources"]["listChanged"], true);
+    }
+
+    #[test]
+    fn resource_subscription_table_tracks_refcount_and_session_drop() {
+        let mut table = ResourceSubscriptionTable::default();
+        assert!(table.add("s1", "file://a", "alpha").unwrap());
+        assert!(!table.add("s1", "file://a", "alpha").unwrap()); // idempotent
+        assert!(!table.add("s2", "file://a", "alpha").unwrap()); // second session
+        assert_eq!(table.sessions_for_uri("file://a").len(), 2);
+        assert!(table.remove("s1", "file://a").is_none()); // still held by s2
+        assert_eq!(table.remove("s2", "file://a").as_deref(), Some("alpha"));
+        assert!(table.sessions_for_uri("file://a").is_empty());
+
+        assert!(table.add("http-1", "file://b", "beta").unwrap());
+        assert!(table.add("http-1", "file://c", "beta").unwrap());
+        let dropped = table.drop_session("http-1");
+        assert_eq!(dropped.len(), 2);
+        assert!(table.sessions_for_uri("file://b").is_empty());
+    }
+
+    #[test]
+    fn deliver_resource_updated_reaches_only_subscribed_http_sessions() {
+        let state = http_state(false);
+        let s1 = match mint_mcp_session(&state, None) {
+            Ok(s) => s,
+            Err(_) => panic!("mint s1 failed"),
+        };
+        let s2 = match mint_mcp_session(&state, None) {
+            Ok(s) => s,
+            Err(_) => panic!("mint s2 failed"),
+        };
+        {
+            let mut table = state.resource_subs.lock().unwrap();
+            table.add(&s1, "fixture://only-s1", "srv").unwrap();
+        }
+        deliver_resource_updated(
+            &state.stdout,
+            &state.mcp_sessions,
+            &state.resource_subs,
+            "fixture://only-s1",
+        );
+        let sessions = state.mcp_sessions.lock().unwrap();
+        let chunk1 = {
+            let sess = sessions.get(&s1).unwrap();
+            let mut out = sess.outbound.lock().unwrap();
+            out.pop_front().map(|m| m.json).unwrap_or_default()
+        };
+        let chunk2 = {
+            let sess = sessions.get(&s2).unwrap();
+            let mut out = sess.outbound.lock().unwrap();
+            out.pop_front().map(|m| m.json)
+        };
+        assert!(
+            chunk1.contains("resources/updated") && chunk1.contains("fixture://only-s1"),
+            "subscribed session missing update: {chunk1}"
+        );
+        assert!(chunk2.is_none(), "unsubscribed session must not receive update");
     }
 
     #[test]
@@ -11022,6 +11493,7 @@ mod tests {
             &server_handler,
             &client_root,
             None,
+            None,
             &mut state,
         );
         assert!(
@@ -11049,6 +11521,7 @@ mod tests {
             &server_handler,
             &client_root,
             None,
+            None,
             &mut state,
         );
         assert!(steady.idle_after_quarantine);
@@ -11069,6 +11542,7 @@ mod tests {
             &downstream_dirty,
             &server_handler,
             &client_root,
+            None,
             None,
             &mut state,
         );

--- a/src-tauri/src/downstream.rs
+++ b/src-tauri/src/downstream.rs
@@ -15,6 +15,11 @@ use std::sync::mpsc::{Receiver, RecvTimeoutError, Sender};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
+/// Called from a downstream stdout drain when an armed server emits
+/// `notifications/resources/updated` (SOU-394). The gateway fans the URI out to
+/// subscribed upstream clients only.
+pub type ResourceUpdatedSink = Arc<dyn Fn(String) + Send + Sync>;
+
 use serde_json::{json, Value};
 
 pub const PROTOCOL_VERSION: &str = "2025-06-18";
@@ -648,20 +653,47 @@ fn is_list_changed(line: &str) -> bool {
     list_changed_kind(line) == change::TOOLS
 }
 
+/// Extract the resource URI from a `notifications/resources/updated` line, or
+/// `None` when the line is not that notification. Distinct from list_changed
+/// (SOU-394): resource content changed, not the catalog membership.
+fn resource_updated_uri(line: &str) -> Option<String> {
+    // Cheap gate: skip JSON parse for ordinary request/response lines.
+    if !line.contains("resources/updated") {
+        return None;
+    }
+    let v: Value = serde_json::from_str(line.trim()).ok()?;
+    if v.get("method").and_then(|m| m.as_str()) != Some("notifications/resources/updated") {
+        return None;
+    }
+    v.get("params")
+        .and_then(|p| p.get("uri"))
+        .and_then(|u| u.as_str())
+        .filter(|u| !u.is_empty())
+        .map(str::to_string)
+}
+
 /// Forward one drained stdout line to the request loop, first flagging `dirty` if
-/// the server (once `armed`) announced a tool-list change. Returns false when the
-/// receiver is gone (transport closed) so the drain loop can stop.
+/// the server (once `armed`) announced a tool-list change, and invoking the
+/// resource-updated sink for `notifications/resources/updated` (SOU-394).
+/// Returns false when the receiver is gone (transport closed) so the drain loop
+/// can stop.
 fn forward_line(
     line: String,
     tx: &Sender<String>,
     dirty: &Option<Arc<AtomicU8>>,
     armed: &Arc<AtomicBool>,
+    resource_updated: &Option<ResourceUpdatedSink>,
 ) -> bool {
-    if let Some(flag) = dirty {
-        if armed.load(Ordering::SeqCst) {
+    if armed.load(Ordering::SeqCst) {
+        if let Some(flag) = dirty {
             let kind = list_changed_kind(&line);
             if kind != 0 {
                 flag.fetch_or(kind, Ordering::SeqCst);
+            }
+        }
+        if let Some(sink) = resource_updated {
+            if let Some(uri) = resource_updated_uri(&line) {
+                sink(uri);
             }
         }
     }
@@ -1424,7 +1456,7 @@ impl StdioTransport {
         env: &[(String, String)],
         cwd: Option<&str>,
     ) -> Result<Self, String> {
-        Self::spawn_inner(command, args, env, cwd, None)
+        Self::spawn_inner(command, args, env, cwd, None, None)
     }
 
     /// Like [`spawn`], but sets a [`change`] bit in `dirty` whenever the downstream
@@ -1432,14 +1464,19 @@ impl StdioTransport {
     /// (after `arm_tools_watch`). The gateway watches that flag and re-queries the
     /// affected list, so a server changing its own catalog mid-session reaches the
     /// client instead of being silently dropped.
+    ///
+    /// When `resource_updated` is set, armed `notifications/resources/updated`
+    /// lines invoke that sink with the resource URI (SOU-394) so the gateway can
+    /// fan out only to subscribed upstream clients.
     pub fn spawn_watched(
         command: &str,
         args: &[String],
         env: &[(String, String)],
         cwd: Option<&str>,
         dirty: Arc<AtomicU8>,
+        resource_updated: Option<ResourceUpdatedSink>,
     ) -> Result<Self, String> {
-        Self::spawn_inner(command, args, env, cwd, Some(dirty))
+        Self::spawn_inner(command, args, env, cwd, Some(dirty), resource_updated)
     }
 
     fn spawn_inner(
@@ -1448,6 +1485,7 @@ impl StdioTransport {
         env: &[(String, String)],
         cwd: Option<&str>,
         dirty: Option<Arc<AtomicU8>>,
+        resource_updated: Option<ResourceUpdatedSink>,
     ) -> Result<Self, String> {
         // Split a command that packed its args into the `command` string, so a
         // mis-shaped config spawns correctly instead of erroring cryptically.
@@ -1539,7 +1577,7 @@ impl StdioTransport {
                             );
                             break;
                         }
-                        if !forward_line(line, &tx, &dirty, &drain_armed) {
+                        if !forward_line(line, &tx, &dirty, &drain_armed, &resource_updated) {
                             break;
                         }
                     }
@@ -2457,6 +2495,20 @@ impl DownstreamServer {
     ) -> Result<Value, TransportError> {
         self.transport
             .request_with_cancel("resources/read", json!({ "uri": uri }), cancel)
+    }
+
+    /// Subscribe to `notifications/resources/updated` for one resource URI on
+    /// this downstream (SOU-394). The gateway only calls this when at least one
+    /// upstream client is subscribed to the same URI.
+    pub fn subscribe_resource(&mut self, uri: &str) -> Result<Value, TransportError> {
+        self.transport
+            .request("resources/subscribe", json!({ "uri": uri }))
+    }
+
+    /// Drop a previously established downstream resource subscription.
+    pub fn unsubscribe_resource(&mut self, uri: &str) -> Result<Value, TransportError> {
+        self.transport
+            .request("resources/unsubscribe", json!({ "uri": uri }))
     }
 
     /// Get one prompt by its (original, downstream) name.
@@ -3817,23 +3869,24 @@ mod tests {
         let dirty = Some(Arc::new(AtomicU8::new(0)));
         let armed = Arc::new(AtomicBool::new(false));
         let (tx, rx) = std::sync::mpsc::channel();
+        let no_sink = None;
 
         // Unarmed (still in the handshake window): the line is forwarded but the
         // change is not acted on.
-        assert!(forward_line(notif.to_string(), &tx, &dirty, &armed));
+        assert!(forward_line(notif.to_string(), &tx, &dirty, &armed, &no_sink));
         assert_eq!(dirty.as_ref().unwrap().load(Ordering::SeqCst), 0);
         assert_eq!(rx.recv().unwrap(), notif);
 
         // Armed: the same notification now sets the TOOLS bit.
         armed.store(true, Ordering::SeqCst);
-        assert!(forward_line(notif.to_string(), &tx, &dirty, &armed));
+        assert!(forward_line(notif.to_string(), &tx, &dirty, &armed, &no_sink));
         assert_eq!(dirty.as_ref().unwrap().load(Ordering::SeqCst), change::TOOLS);
         assert_eq!(rx.recv().unwrap(), notif);
 
         // A resources/list_changed sets the RESOURCES bit alongside it (OR, not
         // overwrite), so distinct changes between watcher ticks aren't lost.
         let res_notif = r#"{"jsonrpc":"2.0","method":"notifications/resources/list_changed"}"#;
-        assert!(forward_line(res_notif.to_string(), &tx, &dirty, &armed));
+        assert!(forward_line(res_notif.to_string(), &tx, &dirty, &armed, &no_sink));
         assert_eq!(
             dirty.as_ref().unwrap().load(Ordering::SeqCst),
             change::TOOLS | change::RESOURCES
@@ -3843,13 +3896,64 @@ mod tests {
         // An ordinary line is always forwarded and never flags a change.
         let resp = r#"{"jsonrpc":"2.0","id":1,"result":{}}"#;
         let dirty2 = Some(Arc::new(AtomicU8::new(0)));
-        assert!(forward_line(resp.to_string(), &tx, &dirty2, &armed));
+        assert!(forward_line(resp.to_string(), &tx, &dirty2, &armed, &no_sink));
         assert_eq!(dirty2.as_ref().unwrap().load(Ordering::SeqCst), 0);
         assert_eq!(rx.recv().unwrap(), resp);
 
         // A closed receiver makes forward_line report "stop".
         drop(rx);
-        assert!(!forward_line(notif.to_string(), &tx, &dirty, &armed));
+        assert!(!forward_line(notif.to_string(), &tx, &dirty, &armed, &no_sink));
+    }
+
+    #[test]
+    fn resource_updated_uri_parses_only_updated_notifications() {
+        use super::resource_updated_uri;
+        assert_eq!(
+            resource_updated_uri(
+                r#"{"jsonrpc":"2.0","method":"notifications/resources/updated","params":{"uri":"file://a"}}"#
+            )
+            .as_deref(),
+            Some("file://a")
+        );
+        // list_changed must not be treated as an updated notification.
+        assert_eq!(
+            resource_updated_uri(
+                r#"{"jsonrpc":"2.0","method":"notifications/resources/list_changed"}"#
+            ),
+            None
+        );
+        assert_eq!(resource_updated_uri(r#"{"jsonrpc":"2.0","id":1,"result":{}}"#), None);
+        assert_eq!(resource_updated_uri("not json"), None);
+    }
+
+    #[test]
+    fn forward_line_invokes_resource_updated_sink_when_armed() {
+        use super::{forward_line, ResourceUpdatedSink};
+        use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
+        use std::sync::{Arc, Mutex};
+
+        let seen: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+        let sink_seen = Arc::clone(&seen);
+        let sink: ResourceUpdatedSink = Arc::new(move |uri| {
+            sink_seen.lock().unwrap().push(uri);
+        });
+        let dirty = Some(Arc::new(AtomicU8::new(0)));
+        let armed = Arc::new(AtomicBool::new(false));
+        let (tx, rx) = std::sync::mpsc::channel();
+        let sink_opt = Some(sink);
+        let line = r#"{"jsonrpc":"2.0","method":"notifications/resources/updated","params":{"uri":"fixture://r"}}"#;
+
+        // Unarmed: no sink call.
+        assert!(forward_line(line.to_string(), &tx, &dirty, &armed, &sink_opt));
+        assert!(seen.lock().unwrap().is_empty());
+        assert_eq!(rx.recv().unwrap(), line);
+
+        // Armed: sink receives the URI; dirty bits stay clear (not a list change).
+        armed.store(true, Ordering::SeqCst);
+        assert!(forward_line(line.to_string(), &tx, &dirty, &armed, &sink_opt));
+        assert_eq!(seen.lock().unwrap().as_slice(), &["fixture://r".to_string()]);
+        assert_eq!(dirty.as_ref().unwrap().load(Ordering::SeqCst), 0);
+        assert_eq!(rx.recv().unwrap(), line);
     }
 
     #[test]

--- a/src-tauri/src/router.rs
+++ b/src-tauri/src/router.rs
@@ -1106,6 +1106,28 @@ impl Router {
         })
     }
 
+    /// Subscribe to resource-updated notifications on the owning downstream
+    /// (concrete first-writer, then template expansion — same as
+    /// [`read_resource`]). SOU-394.
+    pub fn subscribe_resource(&self, uri: &str) -> Result<Value, String> {
+        let server_id = self
+            .resource_server(uri)
+            .ok_or_else(|| format!("no server owns resource '{uri}'"))?
+            .to_string();
+        let slot = self.slot_for(&server_id)?;
+        self.call_with_retry(&slot, |server| server.subscribe_resource(uri))
+    }
+
+    /// Unsubscribe from resource-updated notifications on the owning downstream.
+    pub fn unsubscribe_resource(&self, uri: &str) -> Result<Value, String> {
+        let server_id = self
+            .resource_server(uri)
+            .ok_or_else(|| format!("no server owns resource '{uri}'"))?
+            .to_string();
+        let slot = self.slot_for(&server_id)?;
+        self.call_with_retry(&slot, |server| server.unsubscribe_resource(uri))
+    }
+
     /// Get a prompt by its exposed name, forwarding the server's real name.
     /// `&self`: locks only the owning server (see `route_call`).
     pub fn get_prompt(&self, exposed_name: &str, arguments: Value) -> Result<Value, String> {
@@ -1311,6 +1333,10 @@ mod tests {
                 "resources/read" => {
                     let uri = params.get("uri").and_then(|u| u.as_str()).unwrap_or("");
                     Ok(json!({ "contents": [{ "uri": uri, "text": format!("{}-body", self.label) }] }))
+                }
+                "resources/subscribe" | "resources/unsubscribe" => {
+                    let uri = params.get("uri").and_then(|u| u.as_str()).unwrap_or("");
+                    Ok(json!({ "uri": uri, "via": self.label }))
                 }
                 "prompts/list" => Ok(json!({
                     "prompts": [{ "name": "greet", "description": "greeting" }]
@@ -1908,6 +1934,11 @@ mod tests {
         );
         let result = router.read_resource("postgres://item/42").unwrap();
         assert_eq!(result["contents"][0]["text"], "postgres-body");
+        // Subscribe/unsubscribe use the same ownership path as read (SOU-394).
+        let sub = router.subscribe_resource("postgres://item/42").unwrap();
+        assert_eq!(sub["via"], "postgres");
+        let unsub = router.unsubscribe_resource("postgres://item/42").unwrap();
+        assert_eq!(unsub["via"], "postgres");
     }
 
     #[test]
@@ -1939,6 +1970,9 @@ mod tests {
                         Ok(json!({
                             "contents": [{ "uri": uri, "text": format!("{}-body", self.label) }]
                         }))
+                    }
+                    "resources/subscribe" | "resources/unsubscribe" => {
+                        Ok(json!({ "via": self.label }))
                     }
                     other => Err(TransportError::Fatal(format!("unexpected method {other}"))),
                 }

--- a/src-tauri/tests/circuit_breaker.rs
+++ b/src-tauri/tests/circuit_breaker.rs
@@ -17,7 +17,8 @@ use serde_json::json;
 fn circuit_opens_after_a_server_dies_and_fast_fails() {
     let mock = env!("CARGO_BIN_EXE_mock-mcp-server");
     let dirty = Arc::new(AtomicU8::new(0));
-    let transport = StdioTransport::spawn_watched(mock, &[], &[], None, dirty).expect("spawn mock");
+    let transport =
+        StdioTransport::spawn_watched(mock, &[], &[], None, dirty, None).expect("spawn mock");
     let server =
         DownstreamServer::connect("mock".to_string(), Box::new(transport)).expect("connect mock");
     let mut router = Router::new();

--- a/src-tauri/tests/list_changed.rs
+++ b/src-tauri/tests/list_changed.rs
@@ -45,7 +45,8 @@ fn live_tool_change_surfaces_via_refresh_without_respawn() {
     let mock = env!("CARGO_BIN_EXE_mock-mcp-server");
     let dirty = Arc::new(AtomicU8::new(0));
     let transport =
-        StdioTransport::spawn_watched(mock, &[], &[], None, Arc::clone(&dirty)).expect("spawn mock");
+        StdioTransport::spawn_watched(mock, &[], &[], None, Arc::clone(&dirty), None)
+            .expect("spawn mock");
     let mut server =
         DownstreamServer::connect("mock".to_string(), Box::new(transport)).expect("connect mock");
     // connect() only loads tools; pull the baseline resources/prompts so the


### PR DESCRIPTION
## Summary
- Advertise `resources.subscribe` as an always-on proxy (fail closed when no owner / out of scope / downstream rejects)
- Handle `resources/subscribe` + `resources/unsubscribe` via first-writer URI ownership (concrete then template expansion) and the same sanitized HTTP scope as `resources/read`
- Per-session subscription tracking with bounds, refcounted downstream subs, and cleanup on HTTP session disconnect/expiry
- Forward `notifications/resources/updated` only to subscribed clients (stdio + HTTP SSE), kept distinct from `resources/list_changed`
- Extend `fixture-mcp.mjs` + `mcp-native.mjs` for subscribe/unsubscribe/updated/unknown URI/template expansion

## Test plan
- [x] `scripts/test-rust-windows.ps1` (lib + gateway + integration tests)
- [x] `npm test -- --run`
- [x] `npm run build`
- [x] `npm run lint` (warnings only, pre-existing)
- [x] `npm run bench:mcp-native` (all PASS including SOU-394 checks)
- [x] `npm run bench:compare -- --products=toolport --sizes=25 --iterations=20 --check`

Closes SOU-394
Parent: SOU-381