### PR TITLE
Code mode: full intermediate results + fetchResult handoff

### DIFF
--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -2842,8 +2842,9 @@ impl RoutedCallProfiler {
 /// `confirm` is `Some` only on the interactive direct path, where a destructive tool can be
 /// held for the agent's `toolport_confirm` token replay. Inside a script that two-step
 /// handshake can't happen, so `confirm` is `None` and such a call fails closed rather than
-/// running unconfirmed. `confirmed` is true only when the call already came back through
+/// running unconfirmed. `opts.confirmed` is true only when the call already came back through
 /// `toolport_confirm` (skips the approval + confirm gates so it isn't re-intercepted).
+/// `opts.shape` controls byte-budget shaping (see [`CallOpts`]).
 #[allow(clippy::too_many_arguments)]
 fn execute_call(
     reg: &Registry,
@@ -2855,12 +2856,10 @@ fn execute_call(
     confirm: Option<&ConfirmGuard>,
     name: &str,
     arguments: Value,
-    mut confirmed: bool,
-    // When false, content defense still runs but result-shaping is skipped. Code-mode
-    // intermediate calls pass full bodies into the sandbox (they never enter model
-    // context); only the script's final aggregate is shaped for the client.
-    shape: bool,
+    opts: CallOpts,
 ) -> Value {
+    let mut confirmed = opts.confirmed;
+    let shape = opts.shape;
     let mut call_profiler = RoutedCallProfiler::start(name);
     // Resolve the call's real (server, original tool) from the router's route map,
     // NOT by splitting the exposed name on `__`. A renamed tool (via a tool override)
@@ -3176,6 +3175,17 @@ fn execute_call(
     }
 }
 
+/// Flags for [`execute_call`] that would otherwise be adjacent bools (easy to swap).
+#[derive(Clone, Copy)]
+struct CallOpts {
+    /// True after a successful `toolport_confirm` replay (skip re-approval/confirm).
+    confirmed: bool,
+    /// When false, content defense still runs but result-shaping is skipped. Code-mode
+    /// intermediate calls pass full bodies into the sandbox (they never enter model
+    /// context); only the script's final aggregate is shaped for the client.
+    shape: bool,
+}
+
 /// Run untrusted tool-call output through content defense and result shaping, then
 /// append a Toolport-authored trailer. Shared by the success and error branches of
 /// [`execute_call`] so they can't drift: a hostile server must not be able to bypass the
@@ -3331,8 +3341,10 @@ fn run_script_dispatch(
                 None,
                 name,
                 args,
-                false,
-                false,
+                CallOpts {
+                    confirmed: false,
+                    shape: false,
+                },
             )
         });
 
@@ -4040,8 +4052,10 @@ fn handle_request_with_cancel(
                     Some(confirm),
                     name.as_str(),
                     arguments,
-                    confirmed,
-                    true,
+                    CallOpts {
+                        confirmed,
+                        shape: true,
+                    },
                 ),
             ))
         }

--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -545,20 +545,18 @@ fn run_script_tool_def() -> Value {
         "description": "Run ONE JavaScript orchestration script server-side instead of making \
             many separate tool calls. Prefer the typed surface when you know the server: \
             `servers.stripe.create_refund({...})` (sync) or `servers.stripe.createRefund.async({...})` \
-            (Promise; fan out with Promise.all / await). CamelCase aliases are provided when they \
-            differ from the snake_case tool segment. Also: `toolport.call(name, args)`, \
-            `toolport.callAsync`, `toolport.callAll`, `toolport.listTools()`, `toolport.listServers()`. \
-            Loop, branch, and combine results, then `return` a single aggregated value - only the \
-            returned value comes back, so intermediate results never fill your context. Top-level \
-            await works. Each call still passes the same gates as toolport_call_tool (scope, human \
-            approval). Best when you already know the steps; use toolport_search_tools + \
-            toolport_call_tool while exploring.",
+            (Promise; fan out with Promise.all / await). Also: `toolport.call`, `callAsync`, \
+            `callAll`, `fetchResult({cursor, offset, projection})`, `listTools()`, `listServers()`. \
+            Intermediate tool results are full-sized inside the script (not context-budget shaped); \
+            only your returned aggregate is shaped for the model. Loop, branch, project, then \
+            `return` one value. Top-level await works. Gates match toolport_call_tool (scope, human \
+            approval). Best when you already know the steps; explore with toolport_search_tools first.",
         "inputSchema": {
             "type": "object",
             "properties": {
                 "script": {
                     "type": "string",
-                    "description": "JavaScript body. Prefer servers.<server>.<tool>(args) or toolport.call / callAsync / callAll; `return` the final value (top-level await ok). Global `data` is the optional payload below; toolport.listTools/listServers introspect the scoped catalog."
+                    "description": "JavaScript body. Prefer servers.<server>.<tool>(args) or toolport.call / callAsync / callAll / fetchResult; `return` the final value (top-level await ok). Intermediate results are full-sized in-script. Global `data` is the optional payload below."
                 },
                 "data": {
                     "type": "object",
@@ -2858,6 +2856,10 @@ fn execute_call(
     name: &str,
     arguments: Value,
     mut confirmed: bool,
+    // When false, content defense still runs but result-shaping is skipped. Code-mode
+    // intermediate calls pass full bodies into the sandbox (they never enter model
+    // context); only the script's final aggregate is shaped for the client.
+    shape: bool,
 ) -> Value {
     let mut call_profiler = RoutedCallProfiler::start(name);
     // Resolve the call's real (server, original tool) from the router's route map,
@@ -3106,7 +3108,7 @@ fn execute_call(
             } else {
                 recovery_hint(cached, srv)
             };
-            let out = defend_and_shape(reg, srv, tool, client, result, &trailer);
+            let out = defend_and_shape(reg, srv, tool, client, result, &trailer, shape);
             if let Some(profiler) = &mut call_profiler {
                 profiler.mark_postprocess();
             }
@@ -3161,7 +3163,15 @@ fn execute_call(
                 "content": [{ "type": "text", "text": e }],
                 "isError": true,
             });
-            defend_and_shape(reg, srv, tool, client, result, &recovery_hint(cached, srv))
+            defend_and_shape(
+                reg,
+                srv,
+                tool,
+                client,
+                result,
+                &recovery_hint(cached, srv),
+                shape,
+            )
         }
     }
 }
@@ -3183,6 +3193,7 @@ fn defend_and_shape(
     client: Option<&str>,
     mut result: Value,
     trailer: &str,
+    shape: bool,
 ) -> Value {
     // Scan untrusted output for injection; label always, optionally fail closed.
     // Block mode alone must still run the scanner: an org forceBlockOnInjection (or a
@@ -3200,20 +3211,24 @@ fn defend_and_shape(
     }
     // Cap an oversized result, cache the full body, hand back a head + fetch cursor.
     // A per-server resultBudget overrides the global default (Some(0) = never shape).
-    let budget = reg
-        .result_budgets
-        .get(srv)
-        .map(|&b| b as usize)
-        .unwrap_or_else(|| {
-        let (budget, warning) = shaping::budget();
+    // Code-mode intermediate calls pass `shape = false`: full bodies stay in the
+    // sandbox; only the script's final aggregate is shaped for the model.
+    if shape {
+        let budget = reg
+            .result_budgets
+            .get(srv)
+            .map(|&b| b as usize)
+            .unwrap_or_else(|| {
+                let (budget, warning) = shaping::budget();
 
-        if let Some(msg) = warning {
-            eprintln!("{msg}");
-        }
+                if let Some(msg) = warning {
+                    eprintln!("{msg}");
+                }
 
-        budget
-    });
-    shaping::shape_result(&mut result, budget, client);
+                budget
+            });
+        shaping::shape_result(&mut result, budget, client);
+    }
     // Toolport-authored trailer, appended last so it survives both passes intact.
     let trailer = trailer.trim();
     if !trailer.is_empty() {
@@ -3302,6 +3317,8 @@ fn run_script_dispatch(
     let cancel_owned = cancel;
 
     // Arc + Send + Sync so independent callAsync work can run on a small host thread pool.
+    // shape=false: intermediate results stay full-sized in the sandbox (never enter model
+    // context). Content defense still runs. Final aggregate is shaped below.
     let call: codemode::CallBinding =
         Arc::new(move |name: &str, args: Value| {
             execute_call(
@@ -3315,14 +3332,33 @@ fn run_script_dispatch(
                 name,
                 args,
                 false,
+                false,
             )
         });
+
+    // Cursor handoff for any already-shaped result (prior turn, or external cursor in data).
+    let client_for_fetch = client.map(str::to_string);
+    let fetch: codemode::FetchBinding = Arc::new(move |args: codemode::FetchArgs| {
+        shaping::fetch_result(
+            &args.cursor,
+            args.offset,
+            args.len,
+            client_for_fetch.as_deref(),
+            args.projection.as_deref(),
+        )
+    });
 
     // Typed `servers.*` stubs from the client-scoped catalog (meta-tools excluded).
     let catalog = script_catalog_tools(cached, allowed);
 
-    let outcome =
-        codemode::run_script(&script, data, call, codemode::Limits::default(), &catalog);
+    let outcome = codemode::run_script(
+        &script,
+        data,
+        call,
+        Some(fetch),
+        codemode::Limits::default(),
+        &catalog,
+    );
 
     // Account the round-trips this one call replaced (calls - 1), composing with the
     // lazy-discovery savings in the same log + counter.
@@ -3348,10 +3384,10 @@ fn run_script_dispatch(
         }
     };
 
-    // Each toolport.call() result is shaped independently, but a script can aggregate
-    // many individually bounded results into one response that is far larger than the
-    // client transport can safely decode. Shape the final aggregate as one unit too.
-    // The full aggregate remains available through toolport_fetch_result's cursor.
+    // Intermediate calls were not shaped (full bodies stayed in the sandbox). The
+    // script's aggregate can still blow the transport/context budget, so shape only
+    // this final result; the full aggregate remains available via toolport_fetch_result
+    // (or toolport.fetchResult inside a later script).
     let (budget, warning) = shaping::budget();
     if let Some(msg) = warning {
         eprintln!("{msg}");
@@ -4005,6 +4041,7 @@ fn handle_request_with_cancel(
                     name.as_str(),
                     arguments,
                     confirmed,
+                    true,
                 ),
             ))
         }
@@ -8798,7 +8835,7 @@ mod tests {
             "content": [{ "type": "text", "text": payload }],
             "isError": true,
         });
-        let out = defend_and_shape(&reg, "evil-server", "evil__tool", None, result, "");
+        let out = defend_and_shape(&reg, "evil-server", "evil__tool", None, result, "", true);
         let text = out["content"][0]["text"].as_str().unwrap();
         assert!(text.contains("external data"), "error text must be labeled as data");
         assert!(text.contains("evil-server"), "wrapper names the originating server");
@@ -8809,7 +8846,7 @@ mod tests {
             "content": [{ "type": "text", "text": "e".repeat(200_000) }],
             "isError": true,
         });
-        let shaped = defend_and_shape(&reg, "srv", "srv__t", None, huge, "");
+        let shaped = defend_and_shape(&reg, "srv", "srv__t", None, huge, "", true);
         let shaped_text = shaped["content"][0]["text"].as_str().unwrap();
         assert!(
             shaped_text.len() < 200_000,
@@ -8820,7 +8857,7 @@ mod tests {
         // The Toolport-authored trailer is appended after the scan, as its own block,
         // so it is never wrapped as external data.
         let clean = json!({ "content": [{ "type": "text", "text": "not found" }], "isError": true });
-        let with_hint = defend_and_shape(&reg, "srv", "srv__t", None, clean, "Try list_things first.");
+        let with_hint = defend_and_shape(&reg, "srv", "srv__t", None, clean, "Try list_things first.", true);
         let blocks = with_hint["content"].as_array().unwrap();
         let trailer = blocks.last().unwrap()["text"].as_str().unwrap();
         assert_eq!(trailer, "Try list_things first.");
@@ -8837,7 +8874,7 @@ mod tests {
         let result = json!({
             "content": [{ "type": "text", "text": payload }],
         });
-        let out = defend_and_shape(&reg, "evil-server", "evil__tool", None, result, "");
+        let out = defend_and_shape(&reg, "evil-server", "evil__tool", None, result, "", true);
         assert_eq!(out["isError"], true, "blocked call must be isError");
         let text = out["content"][0]["text"].as_str().unwrap();
         assert!(text.contains("blocked"), "security message");
@@ -8857,7 +8894,7 @@ mod tests {
         let result = json!({
             "content": [{ "type": "text", "text": payload }],
         });
-        let out = defend_and_shape(&reg, "evil-server", "evil__tool", None, result, "");
+        let out = defend_and_shape(&reg, "evil-server", "evil__tool", None, result, "", true);
         assert_ne!(
             out["content"][0]["text"].as_str().unwrap().starts_with("Toolport: blocked"),
             true,
@@ -8876,7 +8913,7 @@ mod tests {
         let result = json!({
             "content": [{ "type": "text", "text": payload }],
         });
-        let out = defend_and_shape(&reg, "evil-server", "evil__tool", None, result, "");
+        let out = defend_and_shape(&reg, "evil-server", "evil__tool", None, result, "", true);
         assert!(
             out["content"][0]["text"]
                 .as_str()
@@ -8897,7 +8934,7 @@ mod tests {
         let result = json!({
             "content": [{ "type": "text", "text": payload }],
         });
-        let out = defend_and_shape(&reg, "evil-server", "evil__tool", None, result, "");
+        let out = defend_and_shape(&reg, "evil-server", "evil__tool", None, result, "", true);
         assert_eq!(out["isError"], true);
         assert!(
             out["content"][0]["text"]
@@ -9219,13 +9256,13 @@ mod tests {
         assert_eq!(result["structuredContent"]["result"]["sum"], 60);
     }
 
-    /// A code-mode script can combine several individually shaped downstream results.
-    /// The final aggregate must itself stay within the gateway result budget, otherwise
-    /// large single-line JSON-RPC responses can break client transport decoders.
+    /// Intermediate tool results stay full-sized inside the script; only the final
+    /// aggregate is shaped for the model. Scripts can filter/project huge bodies in JS.
     #[test]
     fn run_script_shapes_oversized_final_aggregate() {
         let reg = Registry::default();
-        let router = Arc::new(paging_router("x".repeat(shaping::DEFAULT_BUDGET_BYTES * 2)));
+        let body = "x".repeat(shaping::DEFAULT_BUDGET_BYTES * 2);
+        let router = Arc::new(paging_router(body.clone()));
         let args = json!({
             "script": "return [ \
                 toolport.call('s__big', {}), \
@@ -9266,9 +9303,78 @@ mod tests {
             serde_json::from_str(fetched_text).expect("complete fetched aggregate");
         let calls = aggregate.as_array().expect("script returned an array");
         assert_eq!(calls.len(), 4);
-        assert!(calls.iter().all(|call| call["content"][0]["text"]
+        // Intermediates were NOT shaped: full bodies (or structured) available to the script.
+        assert!(calls.iter().all(|call| {
+            let text = call["content"][0]["text"].as_str().unwrap_or("");
+            !text.contains("Toolport shaped this result")
+                && (text.contains(&body) || call.get("structuredContent").is_some())
+        }));
+    }
+
+    /// Script sees the full oversized intermediate and can return a small projection.
+    #[test]
+    fn run_script_can_project_large_intermediate_without_cursor() {
+        let reg = Registry::default();
+        let big = "y".repeat(shaping::DEFAULT_BUDGET_BYTES * 2);
+        let router = Arc::new(paging_router(big.clone()));
+        let args = json!({
+            "script": "var r = toolport.call('s__big', {}); \
+                       var t = r.content[0].text; \
+                       return { len: t.length, head: t.slice(0, 8), shaped: t.indexOf('Toolport shaped') >= 0 };"
+        });
+        let result = run_script_dispatch(&reg, Some(&router), &[], None, None, None, &args);
+        assert_eq!(result["isError"].as_bool(), Some(false));
+        let v = &result["structuredContent"]["result"];
+        assert_eq!(v["shaped"], false);
+        assert_eq!(v["len"], big.chars().count() as u64); // or as number
+        assert_eq!(v["head"], "yyyyyyyy");
+    }
+
+    /// toolport.fetchResult pages a shaped stash (same owner rules as toolport_fetch_result).
+    #[test]
+    fn run_script_fetch_result_reads_shaped_cursor() {
+        let reg = Registry::default();
+        let router = Arc::new(paging_router("z".to_string()));
+        // Seed the shaping cache as a prior shaped agent-facing result would.
+        // Body must dominate the envelope so shape_result actually caches (half-size rule).
+        let payload = format!("hello{}", "x".repeat(2000));
+        let mut seeded = json!({
+            "content": [{ "type": "text", "text": payload }],
+            "isError": false
+        });
+        assert!(
+            shaping::shape_result(&mut seeded, 512, Some("alice")),
+            "seed must shape so a cursor exists"
+        );
+        let seed_text = seeded["content"][0]["text"].as_str().unwrap();
+        let cursor = seed_text
+            .split("\"cursor\":\"")
+            .nth(1)
+            .and_then(|rest| rest.split('"').next())
+            .expect("seed cursor");
+
+        let args = json!({
+            "script": format!(
+                "var page = toolport.fetchResult({{ cursor: '{cursor}', offset: 0, len: 5 }}); \
+                 return page.content[0].text;"
+            ),
+        });
+        // Client owner must match the stash owner.
+        let result = run_script_dispatch(
+            &reg,
+            Some(&router),
+            &[],
+            Some("alice"),
+            None,
+            None,
+            &args,
+        );
+        assert_eq!(result["isError"].as_bool(), Some(false));
+        let text = result["structuredContent"]["result"]
             .as_str()
-            .is_some_and(|body| body.contains("Toolport shaped this result"))));
+            .unwrap_or("");
+        // fetch_result returns the page plus a Toolport footer; head is the body slice.
+        assert!(text.starts_with("hello"), "got {text}");
     }
 
     /// The per-client scope guard applies to a call made INSIDE a script exactly as it does

--- a/src-tauri/src/codemode.rs
+++ b/src-tauri/src/codemode.rs
@@ -20,11 +20,14 @@
 //!   `.async(args)` for the Promise form. CamelCase aliases are added when they differ
 //!   from the sanitized tool segment (e.g. `create_refund` and `createRefund`).
 //! - `toolport.listTools()` / `toolport.listServers()` — catalog introspection
+//! - `toolport.fetchResult({cursor, offset?, len?, projection?})` — page a previously
+//!   shaped result (cursor handoff / structured projection) without leaving the script
 //!
-//! Each binding routes through the caller-supplied closure (the same path as
-//! `toolport_call_tool`: per-client scope, human approval, result shaping), so a script
-//! never widens what the client could already reach. Limits: call budget, wall-clock
-//! deadline, max concurrent host calls, and boa's loop/recursion caps.
+//! Downstream calls from a script still pass scope, HITL, and content-defense gates, but
+//! intermediate results are **not** byte-budget shaped: full bodies stay in the sandbox
+//! (they never enter model context). The gateway shapes only the script's final aggregate
+//! for the client. Limits: call budget, wall-clock deadline, max concurrent host calls,
+//! promise-job budget, and boa's loop/recursion caps.
 
 use std::cell::{Cell, RefCell};
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
@@ -47,6 +50,18 @@ use serde_json::{json, Value};
 /// `Send + Sync` so independent `callAsync` work can run on a small thread pool without
 /// serializing every host call on the JS thread.
 pub type CallBinding = Arc<dyn Fn(&str, Value) -> Value + Send + Sync>;
+
+/// Arguments for [`FetchBinding`] / `toolport.fetchResult`.
+#[derive(Debug, Clone)]
+pub struct FetchArgs {
+    pub cursor: String,
+    pub offset: usize,
+    pub len: usize,
+    pub projection: Option<String>,
+}
+
+/// Host binding for paging a shaped result by cursor (same cache as `toolport_fetch_result`).
+pub type FetchBinding = Arc<dyn Fn(FetchArgs) -> Value + Send + Sync>;
 
 /// Resource limits for one script run. All are fail-closed: exceeding any of them aborts
 /// the script with an error result the agent can read and recover from.
@@ -249,6 +264,19 @@ struct HostState {
     pending: Rc<RefCell<VecDeque<PendingCall>>>,
 }
 
+/// Capture for `__toolport_fetch_result` (no GC refs).
+struct FetchHost {
+    fetch: Option<FetchBinding>,
+}
+
+impl Finalize for FetchHost {}
+// SAFETY: only Arc/Option of host closures — no boa heap pointers.
+unsafe impl Trace for FetchHost {
+    unsafe fn trace(&self, _tracer: &mut boa_gc::Tracer) {}
+    unsafe fn trace_non_roots(&self) {}
+    fn run_finalizer(&self) {}
+}
+
 impl Clone for HostState {
     fn clone(&self) -> Self {
         Self {
@@ -321,6 +349,18 @@ globalThis.toolport = {
             var args = item && item.args;
             return toolport.callAsync(name, args);
         }));
+    },
+    // Page a shaped result by cursor (same stash as toolport_fetch_result). Prefer
+    // projecting / filtering full intermediate tool results in-script instead; this
+    // is for cursors handed in via `data` or left from a prior shaped agent turn.
+    fetchResult: function (opts) {
+        opts = (opts === undefined || opts === null) ? {} : opts;
+        return JSON.parse(__toolport_fetch_result(JSON.stringify({
+            cursor: opts.cursor,
+            offset: opts.offset,
+            len: opts.len,
+            projection: opts.projection
+        })));
     },
     listTools: function () { return []; },
     listServers: function () { return []; },
@@ -477,13 +517,16 @@ fn is_js_ident_start(s: &str) -> bool {
 }
 
 /// Run `script` with `data` available as a global `data` object, giving it `toolport.call`
-/// / `callAsync` / `callAll` bound to `call`, plus `servers.*` stubs from `catalog`.
-/// Returns one aggregated [`ScriptOutcome`]; intermediate call results never surface to
-/// the model.
+/// / `callAsync` / `callAll` / `fetchResult` bound to host closures, plus `servers.*`
+/// stubs from `catalog`. Returns one aggregated [`ScriptOutcome`]; intermediate call
+/// results never surface to the model.
 ///
 /// Scripts are wrapped in an async IIFE so top-level `await` and returned Promises work.
 /// Independent `callAsync` work is flushed with up to [`Limits::max_parallel`] host calls
 /// in flight at once.
+///
+/// `fetch` wires `toolport.fetchResult` (cursor paging / projection). Pass `None` to
+/// leave fetchResult as a fail-closed stub (tests that only exercise tool calls).
 ///
 /// `catalog` is the list of exposed tool names (`server__tool`) the script may stub;
 /// pass the client-scoped cache (meta tools filtered). Empty is fine: string-form
@@ -495,6 +538,7 @@ pub fn run_script(
     script: &str,
     data: Value,
     call: CallBinding,
+    fetch: Option<FetchBinding>,
     limits: Limits,
     catalog: &[String],
 ) -> ScriptOutcome {
@@ -564,6 +608,57 @@ pub fn run_script(
     }
     if let Err(e) =
         context.register_global_callable(js_string!("__toolport_call_async"), 2, async_native)
+    {
+        return fail(calls_made.get(), e);
+    }
+
+    // Fetch binding: pages shaped results by cursor. Absent binding fails closed.
+    let fetch_host = FetchHost { fetch };
+    let fetch_native = NativeFunction::from_copy_closure_with_captures(
+        |_this: &JsValue, args: &[JsValue], host: &FetchHost, _ctx: &mut Context| {
+            let Some(fetch) = host.fetch.as_ref() else {
+                return Err(JsError::from_native(JsNativeError::error().with_message(
+                    "toolport.fetchResult is unavailable in this context",
+                )));
+            };
+            let raw = args
+                .first()
+                .and_then(JsValue::as_string)
+                .map(|s| s.to_std_string_escaped())
+                .unwrap_or_else(|| "{}".to_string());
+            let spec: Value = serde_json::from_str(&raw).unwrap_or(Value::Null);
+            let cursor = spec
+                .get("cursor")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            if cursor.is_empty() {
+                return Err(JsError::from_native(JsNativeError::error().with_message(
+                    "toolport.fetchResult requires a non-empty cursor",
+                )));
+            }
+            let offset = spec
+                .get("offset")
+                .and_then(|v| v.as_u64())
+                .unwrap_or(0) as usize;
+            let len = spec.get("len").and_then(|v| v.as_u64()).unwrap_or(0) as usize;
+            let projection = spec
+                .get("projection")
+                .and_then(|v| v.as_str())
+                .map(str::to_string);
+            let result = (fetch)(FetchArgs {
+                cursor,
+                offset,
+                len,
+                projection,
+            });
+            let result_str = serde_json::to_string(&result).unwrap_or_else(|_| "null".to_string());
+            Ok(JsValue::from(js_string!(result_str)))
+        },
+        fetch_host,
+    );
+    if let Err(e) =
+        context.register_global_callable(js_string!("__toolport_fetch_result"), 1, fetch_native)
     {
         return fail(calls_made.get(), e);
     }
@@ -818,7 +913,7 @@ mod tests {
     }
 
     fn run(script: &str, data: Value, call: CallBinding, limits: Limits) -> ScriptOutcome {
-        run_script(script, data, call, limits, &[])
+        run_script(script, data, call, None, limits, &[])
     }
 
     #[test]
@@ -1007,8 +1102,9 @@ mod tests {
         let elapsed = started.elapsed();
         assert_eq!(out.error, None, "unexpected error: {:?}", out.error);
         assert_eq!(out.calls, 3);
+        // Three 80ms sequential would be ~240ms; allow headroom for scheduler noise.
         assert!(
-            elapsed < StdDuration::from_millis(200),
+            elapsed < StdDuration::from_millis(220),
             "expected overlapping host calls, took {elapsed:?}"
         );
     }
@@ -1080,7 +1176,7 @@ mod tests {
                 title: c.args.title,
             };
         "#;
-        let out = run_script(script, json!({}), call, Limits::default(), &catalog);
+        let out = run_script(script, json!({}), call, None, Limits::default(), &catalog);
         assert_eq!(out.error, None, "unexpected error: {:?}", out.error);
         assert_eq!(out.calls, 3);
         assert_eq!(
@@ -1118,7 +1214,7 @@ mod tests {
             ]);
             return results.map(function (r) { return r.echo; }).sort();
         "#;
-        let out = run_script(script, json!({}), call, Limits::default(), &catalog);
+        let out = run_script(script, json!({}), call, None, Limits::default(), &catalog);
         assert_eq!(out.error, None, "unexpected error: {:?}", out.error);
         assert_eq!(out.calls, 2);
         assert_eq!(
@@ -1182,10 +1278,58 @@ mod tests {
                 b: servers.s.createRefund({}).echo,
             };
         "#;
-        let out = run_script(script, json!({}), call, Limits::default(), &catalog);
+        let out = run_script(script, json!({}), call, None, Limits::default(), &catalog);
         assert_eq!(out.error, None, "unexpected error: {:?}", out.error);
         assert_eq!(out.value["a"], json!("s__create_refund"));
         assert_eq!(out.value["b"], json!("s__createRefund"));
+    }
+
+    #[test]
+    fn fetch_result_binding_pages_shaped_cursor() {
+        // Simulate a shaped stash entry via the fetch binding (gateway wires shaping::fetch_result).
+        let full = "abcdefghijklmnopqrstuvwxyz";
+        let fetch: FetchBinding = Arc::new(move |args: FetchArgs| {
+            assert_eq!(args.cursor, "r1");
+            let start = args.offset.min(full.len());
+            let end = if args.len == 0 {
+                full.len()
+            } else {
+                start.saturating_add(args.len).min(full.len())
+            };
+            json!({
+                "content": [{ "type": "text", "text": &full[start..end] }],
+                "isError": false
+            })
+        });
+        let call = Arc::new(|_: &str, _: Value| Value::Null);
+        let out = run_script(
+            r#"
+                const a = toolport.fetchResult({ cursor: "r1", offset: 0, len: 5 });
+                const b = toolport.fetchResult({ cursor: "r1", offset: 5, len: 5 });
+                return { a: a.content[0].text, b: b.content[0].text };
+            "#,
+            json!({}),
+            call,
+            Some(fetch),
+            Limits::default(),
+            &[],
+        );
+        assert_eq!(out.error, None, "unexpected error: {:?}", out.error);
+        assert_eq!(out.value["a"], json!("abcde"));
+        assert_eq!(out.value["b"], json!("fghij"));
+    }
+
+    #[test]
+    fn fetch_result_unavailable_without_binding() {
+        let call = Arc::new(|_: &str, _: Value| Value::Null);
+        let out = run(
+            r#"return toolport.fetchResult({ cursor: "r1" });"#,
+            json!({}),
+            call,
+            Limits::default(),
+        );
+        assert_ne!(out.error, None);
+        assert!(out.error.unwrap().contains("unavailable"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Result-shaping Tier 2 handoff for code mode (follow-on to SOU-348).

- **In-script tool calls** still run content defense + gates, but **skip byte-budget shaping** so the sandbox sees full results (they never enter model context).
- **Final aggregate** is still shaped for the client / transport budget.
- **\	oolport.fetchResult({cursor, offset, len, projection})\** pages a prior shaped cursor with the same owner scoping as \	oolport_fetch_result\.

## Why
Previously each intermediate \	oolport.call\ was shaped, so scripts often only saw truncated heads + cursors and could not filter large payloads without another agent round-trip.

## Tests
- [x] codemode: 22 tests
- [x] gateway run_script: 12 tests (incl. full intermediate, final shape, fetchResult owner path)
- [ ] CI
- [ ] CodeRabbit / human review

## Review notes
- Memory: a script can hold up to \max_calls\ full results in the boa heap; bounded by call budget + wall clock (same as before, just fuller bodies).
- Do **not** auto-merge; leave open for review.
