### PR TITLE
Code mode on by default with Settings kill switch (SOU-397)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ Entries before the rename below shipped under the project's former name, Conduit
 
 ## [Unreleased]
 
+### Discovery
+
+**Code mode on by default.** `toolport_run_script` is advertised unless you turn **Code
+mode** off in Settings (or set `"code_mode": false` in the registry). Each in-script call
+still hits the same scope and approval gates as `toolport_call_tool`. Code mode is not a
+security boundary (agent-supplied JS). `TOOLPORT_CODE_MODE=1` still force-enables.
+Existing registries that already store `"code_mode": false` stay off. (SOU-397)
+
 ## [1.9.5] - 2026-07-25
 
 Finishes the Conduit → Toolport rename for what users and configs see, keeps

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,10 @@ Entries before the rename below shipped under the project's former name, Conduit
 ### Discovery
 
 **Code mode on by default.** `toolport_run_script` is advertised unless you turn **Code
-mode** off in Settings (or set `"code_mode": false` in the registry). Each in-script call
+mode** off in Settings (or set `"codeMode": false` in the registry). Each in-script call
 still hits the same scope and approval gates as `toolport_call_tool`. Code mode is not a
 security boundary (agent-supplied JS). `TOOLPORT_CODE_MODE=1` still force-enables.
-Existing registries that already store `"code_mode": false` stay off. (SOU-397)
+Existing registries that already store `"codeMode": false` stay off. (SOU-397)
 
 ## [1.9.5] - 2026-07-25
 

--- a/README.md
+++ b/README.md
@@ -247,7 +247,10 @@ gateway entry, written for you when you connect a client:
   loopback listener; it never permits an open non-loopback bind.
 - `TOOLPORT_METRICS=1` - opt-in Prometheus `GET /metrics` on the HTTP surface.
 - `TOOLPORT_DEBUG=1` - per-request gateway trace logging.
-- `TOOLPORT_CODE_MODE=1` - force-enable code mode (`toolport_run_script`); Settings can also toggle this.
+- `TOOLPORT_CODE_MODE=1` - force-enable code mode (`toolport_run_script`) even if Settings
+  has it off. Code mode is **on by default** (Settings kill switch turns it off). Each
+  in-script tool call still respects profile scope and human approval; code mode is not a
+  security boundary.
 
 Every `TOOLPORT_*` name still accepts the pre-rename `CONDUIT_*` alias (for example
 `CONDUIT_HTTP_TOKEN` continues to work). Prefer `TOOLPORT_*` in new configs.

--- a/docs/headless.md
+++ b/docs/headless.md
@@ -319,8 +319,8 @@ headless and Docker configs do not break on upgrade.
   app or a one-time manual URL in the client config — which is what sandboxed
   setups usually want anyway.
 - **Code mode** (`toolport_run_script`) is **on by default** in the registry
-  (Settings kill switch / `"code_mode": false`). It is not a security boundary:
+  (Settings kill switch / `"codeMode": false`). It is not a security boundary:
   agents supply JS that can call many tools in one round-trip; each call still
   hits the same scope and approval gates. Shared multi-tenant gateways that do
-  not want the surface should set `"code_mode": false` in the registry.
+  not want the surface should set `"codeMode": false` in the registry.
 - Open WebUI details: [openwebui.md](./openwebui.md).

--- a/docs/headless.md
+++ b/docs/headless.md
@@ -292,6 +292,7 @@ headless and Docker configs do not break on upgrade.
 | `TOOLPORT_CLIENT_ID`             | Identifies the client to the gateway for live profile resolution.                                   | None             | Clients                   |
 | `TOOLPORT_DATA_DIR`              | Override the full path to the Toolport config directory.                                            | OS config root   | Everywhere                |
 | `TOOLPORT_DEBUG`                 | Enable trace and debug logging.                                                                     | None             | Everywhere                |
+| `TOOLPORT_CODE_MODE`             | Force-enable code mode (`toolport_run_script`) even if Settings/registry has it off.                | Off (force)      | Gateway                   |
 | `TOOLPORT_DISCOVERY`             | Override discovery mode (`lazy`, `grouped`, `full`).                                                | Registry setting | Everywhere                |
 | `TOOLPORT_EMBED_BLEND`           | Semantic search embedding blend weight (float).                                                     | Registry setting | Gateway / semantic search |
 | `TOOLPORT_EMBED_ENDPOINT`        | Semantic search embedding endpoint URL.                                                             | Registry setting | Gateway / semantic search |
@@ -317,4 +318,9 @@ headless and Docker configs do not break on upgrade.
 - **Client config writers** (Cursor/Claude local JSON) still need the desktop
   app or a one-time manual URL in the client config — which is what sandboxed
   setups usually want anyway.
+- **Code mode** (`toolport_run_script`) is **on by default** in the registry
+  (Settings kill switch / `"code_mode": false`). It is not a security boundary:
+  agents supply JS that can call many tools in one round-trip; each call still
+  hits the same scope and approval gates. Shared multi-tenant gateways that do
+  not want the surface should set `"code_mode": false` in the registry.
 - Open WebUI details: [openwebui.md](./openwebui.md).

--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -803,13 +803,14 @@ fn grouped_discovery() -> bool {
     discovery_mode() == DiscoveryMode::Grouped
 }
 
-/// Opt-in gate for server-side "code mode" (the `toolport_run_script` meta-tool). Off by
-/// default: code mode runs an agent-supplied JS script that can call many tools in one
-/// round-trip, a powerful capability worth an explicit opt-in even under Toolport's local
-/// trust model. Enabled by the registry's `code_mode` toggle (the Settings switch, synced
-/// into [`CODE_MODE`]); `TOOLPORT_CODE_MODE=1` (or legacy `CONDUIT_CODE_MODE`) still
-/// force-enables regardless, for power users and tests. When off, `run_script` is
-/// neither advertised nor dispatched.
+/// Gate for server-side "code mode" (the `toolport_run_script` meta-tool).
+///
+/// Policy (SOU-397): **on by default** via the registry's `code_mode` field (Settings
+/// switch, synced into [`CODE_MODE`]). Kill switch: turn Settings off. Code mode runs
+/// agent-supplied JS and is not a security boundary; each host call still passes the same
+/// scope / human-approval gates as `toolport_call_tool`. `TOOLPORT_CODE_MODE=1` (or legacy
+/// `CONDUIT_CODE_MODE`) still force-enables for power users and tests. When off, `run_script`
+/// is neither advertised nor dispatched.
 fn code_mode_enabled() -> bool {
     let env_forced = conduit_lib::brand::env_flag("TOOLPORT_CODE_MODE", "CONDUIT_CODE_MODE");
     env_forced || CODE_MODE.load(Ordering::Relaxed)
@@ -3511,9 +3512,8 @@ fn handle_request_with_cancel(
                     call_tool_def(),
                     fetch_result_tool_def(),
                 ];
-                // Opt-in code mode: one script that orchestrates many calls in a single
-                // round-trip. Advertised only when enabled, same visibility discipline as
-                // the agent-control tools below.
+                // Code mode (on by default, Settings kill switch): one script that
+                // orchestrates many calls in a single round-trip.
                 if code_mode_enabled() {
                     tools.push(run_script_tool_def());
                 }
@@ -9605,12 +9605,15 @@ mod tests {
         assert_eq!(result["structuredContent"]["toolportScript"]["ok"], false);
     }
 
-    /// With `CONDUIT_CODE_MODE` unset (the default), the dispatch refuses `toolport_run_script`
-    /// so the capability is opt-in. (`handle_request` also passes no router Arc, a second
-    /// fail-closed.)
+    /// Kill switch path: when the live flag is off (test default atomic + no env),
+    /// dispatch refuses `toolport_run_script`. Production seeds the flag from the
+    /// registry at boot (now default true); this covers the Settings-off path.
     #[test]
     fn run_script_is_refused_when_code_mode_disabled() {
-        let reg = Registry::default();
+        // Do not flip the global CODE_MODE atomic here: tests run in parallel.
+        // Atomic defaults false; env must be unset for this assertion.
+        let mut reg = Registry::default();
+        reg.code_mode = false;
         let router = routed_router("s", "tool");
         let req = json!({
             "jsonrpc": "2.0",
@@ -9636,6 +9639,20 @@ mod tests {
             .as_str()
             .unwrap()
             .contains("code mode is disabled"));
+    }
+
+    #[test]
+    fn code_mode_defaults_on_in_registry() {
+        // SOU-397: new registries and missing serde field default on. Explicit
+        // false remains the kill switch (camelCase field name in JSON).
+        assert!(Registry::default().code_mode);
+        let minimal = r#"{"version":1,"servers":[],"profiles":[]}"#;
+        let parsed: Registry = serde_json::from_str(minimal).unwrap();
+        assert!(parsed.code_mode, "missing codeMode field should default true");
+        let explicit_off: Registry =
+            serde_json::from_str(r#"{"version":1,"servers":[],"profiles":[],"codeMode":false}"#)
+                .unwrap();
+        assert!(!explicit_off.code_mode);
     }
 
     fn router() -> Router {

--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -1761,7 +1761,8 @@ fn set_lazy_discovery(state: State<RegistryState>, lazy: bool) -> Result<Registr
 
 /// Enable or disable server-side "code mode" (the `toolport_run_script` meta-tool). The
 /// gateway reads this from the registry and refreshes it live on the next watcher tick, so
-/// it applies to every client without forwarding an env var. Off by default.
+/// it applies to every client without forwarding an env var. On by default (SOU-397);
+/// pass `enabled: false` as the kill switch.
 #[tauri::command]
 fn set_code_mode(state: State<RegistryState>, enabled: bool) -> Result<Registry, String> {
     let (reg, _) = write_registry(state.inner(), |reg| {

--- a/src-tauri/src/registry.rs
+++ b/src-tauri/src/registry.rs
@@ -343,8 +343,8 @@ pub struct Registry {
     /// round-trip). **On by default** (SOU-397): each in-script call still hits the same
     /// scope / approval gates as `toolport_call_tool`, and Settings is the kill switch.
     /// Code mode is not a security boundary (agent-supplied JS). Shared/HTTP multi-tenant
-    /// operators who do not want the surface can turn it off in Settings or omit it from
-    /// the registry with an explicit `false`. `TOOLPORT_CODE_MODE=1` (legacy
+    /// operators who do not want the surface can turn it off in Settings or set
+    /// `"codeMode": false` in the registry. `TOOLPORT_CODE_MODE=1` (legacy
     /// `CONDUIT_CODE_MODE`) still force-enables regardless of the toggle.
     #[serde(default = "default_true")]
     pub code_mode: bool,

--- a/src-tauri/src/registry.rs
+++ b/src-tauri/src/registry.rs
@@ -338,12 +338,15 @@ pub struct Registry {
     /// browse per-server instead of searching - instead of setting a per-client env var.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub discovery_mode: Option<String>,
-    /// Opt-in server-side "code mode": advertise the `toolport_run_script` meta-tool so an
+    /// Server-side "code mode": advertise the `toolport_run_script` meta-tool so an
     /// agent can orchestrate many downstream tool calls in one sandboxed JS script (a single
-    /// round-trip). Off by default, since agent-supplied server-side JS is a powerful surface.
-    /// The gateway reads this from the registry, so it applies to every client; an explicit
-    /// `CONDUIT_CODE_MODE=1` still force-enables regardless.
-    #[serde(default)]
+    /// round-trip). **On by default** (SOU-397): each in-script call still hits the same
+    /// scope / approval gates as `toolport_call_tool`, and Settings is the kill switch.
+    /// Code mode is not a security boundary (agent-supplied JS). Shared/HTTP multi-tenant
+    /// operators who do not want the surface can turn it off in Settings or omit it from
+    /// the registry with an explicit `false`. `TOOLPORT_CODE_MODE=1` (legacy
+    /// `CONDUIT_CODE_MODE`) still force-enables regardless of the toggle.
+    #[serde(default = "default_true")]
     pub code_mode: bool,
     /// Opt-in agent control: when true, an agent may turn servers on or off via
     /// the gateway's `conduit_enable_server` / `conduit_disable_server` tools.
@@ -568,7 +571,7 @@ impl Default for Registry {
             quarantine_on_drift: false,
             lazy_discovery: true,
             discovery_mode: None,
-            code_mode: false,
+            code_mode: true,
             allow_agent_control: false,
             integrity_check: true,
             content_defense: true,

--- a/src/components/SettingsView.tsx
+++ b/src/components/SettingsView.tsx
@@ -857,7 +857,7 @@ export function SettingsView({ registry, onRegistryChange }: Props) {
           codeMode,
           "text-info",
           "Code mode",
-          "On by default: agents can run one server-side script that calls many tools in a single round-trip. Sandboxed JS; each call still respects profile scope and human approval. Not a security boundary — turn off to hide toolport_run_script.",
+          "On by default: agents can run one server-side script that calls many tools in a single round-trip. Sandboxed JS; each call still respects profile scope and human approval. Not a security boundary; turn off to hide toolport_run_script.",
           apply(setCodeMode),
         )}
       </section>

--- a/src/components/SettingsView.tsx
+++ b/src/components/SettingsView.tsx
@@ -491,7 +491,9 @@ function ProfileToolScope({
 export function SettingsView({ registry, onRegistryChange }: Props) {
   const { theme, setTheme } = useTheme();
   const lazyDiscovery = registry?.lazyDiscovery ?? true;
-  const codeMode = registry?.codeMode ?? false;
+  // On by default (SOU-397); only treat explicit false as off when the field is missing
+  // during a partial load, match the registry serde default.
+  const codeMode = registry?.codeMode ?? true;
   const denyDestructive = registry?.denyDestructive ?? false;
   const confirmDestructive = registry?.confirmDestructive ?? false;
   const humanApproval = registry?.humanApproval ?? false;
@@ -855,7 +857,7 @@ export function SettingsView({ registry, onRegistryChange }: Props) {
           codeMode,
           "text-info",
           "Code mode",
-          "Let agents run one server-side script that calls many tools in a single round-trip (sandboxed; each call still respects profile scope and human approval)",
+          "On by default: agents can run one server-side script that calls many tools in a single round-trip. Sandboxed JS; each call still respects profile scope and human approval. Not a security boundary — turn off to hide toolport_run_script.",
           apply(setCodeMode),
         )}
       </section>

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -435,8 +435,8 @@ export interface Registry {
   /** Global discovery mode ("full" | "lazy" | "grouped"). Takes precedence over
    * `lazyDiscovery`; absent = fall back to the `lazyDiscovery` bool. */
   discoveryMode?: string | null;
-  /** Opt-in "code mode": advertise the `toolport_run_script` meta-tool so agents can
-   * orchestrate many tool calls in one server-side script. Off by default. */
+  /** Code mode: advertise `toolport_run_script` so agents can orchestrate many tool
+   * calls in one server-side script. On by default (SOU-397); Settings is the kill switch. */
   codeMode?: boolean;
   /** Per-client discovery-mode override, keyed by client id (e.g. "cursor" ->
    * "grouped"). Absent = that client inherits the global mode. */


### PR DESCRIPTION
## Summary

- **Policy (SOU-397):** code mode is **on by default** so capable clients get `toolport_run_script` without a hidden opt-in.
- Settings remains a clear **kill switch** (`code_mode: false` / toggle off).
- Not a security boundary: agent-supplied JS; each host call still uses the same scope / approval gates as `toolport_call_tool`.
- Docs: README, headless notes, CHANGELOG Unreleased; Settings copy updated.
- Upgrade note: registries missing the field flip on via serde `default_true`; explicit "codeMode": false` stays off.

Closes last SOU-348 residual on default-on.

## Test plan

- [x] `cargo test --bin toolport-gateway code_mode`
- [x] `cargo test --bin toolport-gateway run_script_is_refused`
- [x] `cargo test -p conduit --lib registry`
- [ ] CI green
- [ ] CodeRabbit review

Linear: https://linear.app/southforge-ai/issue/SOU-397