### PR TITLE
fix(clients): never revert a user-customized gateway entry (SOU-405)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,26 @@ still hits the same scope and approval gates as `toolport_call_tool`. Code mode 
 security boundary (agent-supplied JS). `TOOLPORT_CODE_MODE=1` still force-enables.
 Existing registries that already store `"codeMode": false` stay off. (SOU-397)
 
+### Fixed
+
+**A hand-edited gateway entry is no longer reverted on every app launch.** The
+launch-time re-point recognized its own entry by _name_, so an entry still called
+`toolport` but pointed at something else — an `mcp-remote` bridge against the HTTP
+endpoint, a container, a wrapper script — was treated as a stale install and rewritten
+back to the default stdio command every time the app started. Re-pointing now requires
+the stored command to actually name a Toolport gateway binary; anything else is treated
+as user-managed and left exactly as written (and the skip is logged). Genuine
+migrations — an older version, the pre-rename `conduit-gateway`, the pre-rename data
+directory, an unversioned install path — are unaffected. (#487)
+
+**A machine-wide `TOOLPORT_HTTP` / `CONDUIT_HTTP` no longer hijacks client-spawned
+gateways.** HTTP mode replaces the stdio transport, so an inherited value left every
+MCP client with a gateway that never answered its pipe, and every gateway after the
+first colliding on the shared port (`WSAEADDRINUSE`) — which some clients treat as
+fatal. The env forms are now ignored, with a warning, when stdin is a pipe. The
+desktop app, the Docker images, and the documented headless setup all pass `--http`
+explicitly and are unaffected; use the flag in scripts and services too. (#487)
+
 ## [1.9.5] - 2026-07-25
 
 Finishes the Conduit → Toolport rename for what users and configs see, keeps

--- a/Dockerfile.source
+++ b/Dockerfile.source
@@ -35,7 +35,10 @@ RUN useradd --system --uid 10001 --home-dir /data toolport \
     && chown toolport:toolport /data
 
 USER toolport
-ENV CONDUIT_HTTP=8765
+# HTTP mode comes from the `--http` flag on the ENTRYPOINT below, not from the
+# environment: the gateway ignores TOOLPORT_HTTP/CONDUIT_HTTP when its stdin is a
+# pipe, so an inherited value can never turn a client-spawned gateway into a second
+# HTTP server racing for this port (issue #487).
 ENV CONDUIT_HTTP_HOST=0.0.0.0
 ENV CONDUIT_REGISTRY=/data/registry.json
 EXPOSE 8765

--- a/docs/openwebui.md
+++ b/docs/openwebui.md
@@ -12,10 +12,16 @@ Integrations -> "Open WebUI / HTTP endpoint"**, flip it on, and copy the **URL**
 (`http://localhost:8765`) and the **token** it shows. The app supervises the
 gateway for you and shuts it down when you quit.
 
-> Prefer the command line? `toolport-gateway --http 8765` (or `TOOLPORT_HTTP=8765`)
-> does the same thing when `TOOLPORT_HTTP_TOKEN=<your-token>` is set (the app does
-> this automatically). It serves an OpenAPI spec at
-> `http://localhost:8765/openapi.json` and a POST endpoint per tool.
+> Prefer the command line? `toolport-gateway --http 8765` does the same thing when
+> `TOOLPORT_HTTP_TOKEN=<your-token>` is set (the app does this automatically). It
+> serves an OpenAPI spec at `http://localhost:8765/openapi.json` and a POST endpoint
+> per tool.
+>
+> `TOOLPORT_HTTP=8765` also works from an interactive shell, but **use the `--http`
+> flag in scripts, services, and containers**. HTTP mode replaces the stdio
+> transport, so the gateway deliberately ignores the environment variable when its
+> stdin is a pipe — otherwise a machine-wide `TOOLPORT_HTTP` would turn the gateway
+> every MCP client spawns into another HTTP server fighting over this port.
 
 **2. Add it to Open WebUI.** Settings -> Tools -> add an OpenAPI tool server
 pointing at `http://localhost:8765`, and paste the **token** as its API key

--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -6671,10 +6671,13 @@ fn handle_stdio_request(
     }
 }
 
+/// `stdio_peer` is true when stdin is a pipe rather than a terminal, i.e. an MCP
+/// client spawned this process and is waiting to speak JSON-RPC on it.
 fn resolve_http_port(
     cli_port: Option<u16>,
     http: Option<&str>,
     http_port: Option<&str>,
+    stdio_peer: bool,
 ) -> (Option<u16>, Option<String>) {
     // CLI flag has highest priority.
     if let Some(port) = cli_port {
@@ -6686,6 +6689,27 @@ fn resolve_http_port(
     let v = v.trim();
     if v.is_empty() {
         return (None, None);
+    }
+    // Ambient env + a client on the other end of stdin: ignore the env (issue #487).
+    // HTTP mode REPLACES the stdio loop rather than running beside it, so honoring a
+    // machine-wide TOOLPORT_HTTP here hands the client a gateway that never answers
+    // its pipe - and every client that starts after the first also collides on the
+    // shared port (WSAEADDRINUSE / os error 10048), which some clients treat as fatal.
+    // The env var is a global, so one stray `setx` breaks every client at once.
+    //
+    // The desktop app starts its bridge with an explicit `--http`, handled above and
+    // unaffected. A human running the gateway by hand has a terminal on stdin and
+    // still gets the env form. Anything else - a service, or a detached run with stdin
+    // redirected from null - now has to say `--http` out loud, which the warning says.
+    if stdio_peer {
+        return (
+            None,
+            Some(format!(
+                "toolport: ignoring TOOLPORT_HTTP/CONDUIT_HTTP='{v}' from the environment - this \
+                 gateway was spawned by a client on stdio, and HTTP mode would replace the stdio \
+                 transport that client is waiting on. Pass --http explicitly to run the HTTP bridge."
+            )),
+        );
     }
     if let Ok(port) = v.parse::<u16>() {
         if port > 0 {
@@ -6713,7 +6737,12 @@ fn resolve_http_port(
 /// Resolve the HTTP port. `--http [port]` on the command line wins; otherwise
 /// `CONDUIT_HTTP=<port>` is the direct env form, and a truthy `CONDUIT_HTTP`
 /// falls back to `CONDUIT_HTTP_PORT` or 8765. Absent everywhere -> stdio mode.
+///
+/// The env forms are ignored (with a warning) when a client spawned us on stdio, so a
+/// machine-wide `TOOLPORT_HTTP` can't silently turn every client's gateway into a
+/// racing HTTP server - see [`resolve_http_port`] and issue #487.
 fn http_port() -> (Option<u16>, Option<String>) {
+    use std::io::IsTerminal;
     // CLI flag: `toolport-gateway --http` (default 8765) or `--http 9000`.
     let args: Vec<String> = std::env::args().collect();
     let cli_port = args
@@ -6729,11 +6758,9 @@ fn http_port() -> (Option<u16>, Option<String>) {
         });
     let http = conduit_lib::brand::env_var("TOOLPORT_HTTP", "CONDUIT_HTTP");
     let http_port = conduit_lib::brand::env_var("TOOLPORT_HTTP_PORT", "CONDUIT_HTTP_PORT");
-    resolve_http_port(
-        cli_port,
-        http.as_deref(),
-        http_port.as_deref(),
-    )
+    // A client that spawns us over stdio gives us a pipe; a human gets a terminal.
+    let stdio_peer = !std::io::stdin().is_terminal();
+    resolve_http_port(cli_port, http.as_deref(), http_port.as_deref(), stdio_peer)
 }
 
 /// The tools the HTTP surface exposes, mirroring `tools/list`: the meta-tools
@@ -13267,17 +13294,29 @@ mod tests {
     #[test]
     fn resolve_http_port_cases() {
         // CLI port wins over everything.
-        assert_eq!(resolve_http_port(Some(9000), Some("8000"), Some("7000")), (Some(9000), None));
+        assert_eq!(
+            resolve_http_port(Some(9000), Some("8000"), Some("7000"), false),
+            (Some(9000), None)
+        );
         // Direct port form: CONDUIT_HTTP=9000.
-        assert_eq!(resolve_http_port(None, Some("9000"), None), (Some(9000), None));
+        assert_eq!(
+            resolve_http_port(None, Some("9000"), None, false),
+            (Some(9000), None)
+        );
         // Truthy CONDUIT_HTTP uses CONDUIT_HTTP_PORT.
-        assert_eq!(resolve_http_port(None, Some("true"), Some("9001")), (Some(9001), None));
+        assert_eq!(
+            resolve_http_port(None, Some("true"), Some("9001"), false),
+            (Some(9001), None)
+        );
         // Truthy CONDUIT_HTTP without a port falls back to default.
-        assert_eq!(resolve_http_port(None, Some("yes"), None), (Some(8765), None));
+        assert_eq!(
+            resolve_http_port(None, Some("yes"), None, false),
+            (Some(8765), None)
+        );
         // No HTTP configuration means stdio mode.
-        assert_eq!(resolve_http_port(None, None, None), (None, None));
+        assert_eq!(resolve_http_port(None, None, None, false), (None, None));
         // Invalid value returns no port and warning.
-        let (port, warning) = resolve_http_port(None, Some("invalid"), None);
+        let (port, warning) = resolve_http_port(None, Some("invalid"), None, false);
         assert_eq!(port, None);
         assert_eq!(
             warning.as_deref(),
@@ -13285,6 +13324,40 @@ mod tests {
                 "toolport: unrecognized TOOLPORT_HTTP/CONDUIT_HTTP value 'invalid', HTTP bridge disabled"
             )
         );
+    }
+
+    #[test]
+    fn ambient_http_env_is_ignored_when_a_client_spawned_us() {
+        // Regression for issue #487. A machine-wide TOOLPORT_HTTP/CONDUIT_HTTP is
+        // inherited by every client, and every gateway those clients spawn. HTTP mode
+        // REPLACES the stdio loop, so honoring it here would leave each client with a
+        // gateway that never answers its pipe, and every gateway after the first
+        // colliding on the shared port (WSAEADDRINUSE) - which some clients treat as
+        // fatal. Ignore the env and serve stdio, loudly.
+        for value in ["1", "true", "on", "yes", "9000", "invalid"] {
+            let (port, warning) = resolve_http_port(None, Some(value), Some("9001"), true);
+            assert_eq!(
+                port, None,
+                "env value {value:?} must not enable HTTP on a stdio spawn"
+            );
+            let warning = warning.expect("ignoring the env must be reported, not silent");
+            assert!(
+                warning.contains("spawned by a client on stdio") && warning.contains("--http"),
+                "warning should name the cause and the fix, got: {warning}"
+            );
+        }
+
+        // The desktop app's own bridge passes --http explicitly and is unaffected,
+        // even though it is itself spawned with piped stdio.
+        assert_eq!(
+            resolve_http_port(Some(8765), Some("1"), None, true),
+            (Some(8765), None)
+        );
+
+        // No HTTP configuration at all stays a silent stdio start - a client spawn is
+        // the normal case and must not warn.
+        assert_eq!(resolve_http_port(None, None, None, true), (None, None));
+        assert_eq!(resolve_http_port(None, Some(""), None, true), (None, None));
     }
 
     #[test]

--- a/src-tauri/src/clients.rs
+++ b/src-tauri/src/clients.rs
@@ -3488,9 +3488,43 @@ pub fn migrate_to_gateway(client_id: &str, profile: Option<&str>) -> Result<Writ
     write_servers(client_id, &[gateway_entry(profile, client_id)?])
 }
 
+/// Whether a stored client-config command is recognizably one of *our* gateway
+/// binaries. This is the provenance test that separates an entry Toolport wrote
+/// from one the user has taken over.
+///
+/// [`gateway_identity_matches`] deliberately matches on the entry NAME alone, so a
+/// hand-edited entry still called `toolport` is found (we must not leave a duplicate
+/// behind, and the UI must still show it as our slot). But "we recognize this slot"
+/// is not "we own this command". A user who repoints the entry at an HTTP bridge
+/// (`npx -y mcp-remote http://localhost:8765/mcp ...`), a container, or their own
+/// wrapper script has taken it over, and rewriting it destroys a deliberate
+/// customization on every launch (issue #487).
+///
+/// Matched on the command's BASENAME rather than a substring of the whole path, so a
+/// wrapper that merely *lives* in a directory containing `toolport-gateway` is not
+/// mistaken for the binary itself. Version suffixes (`toolport-gateway-1.9.5.exe`)
+/// and the pre-rename name (`conduit-gateway`) both count as ours.
+fn command_is_gateway_binary(stored: &str) -> bool {
+    let basename = stored
+        .trim()
+        .trim_matches('"')
+        .rsplit(['\\', '/'])
+        .next()
+        .unwrap_or("")
+        .to_ascii_lowercase();
+    let stem = basename.strip_suffix(".exe").unwrap_or(&basename);
+    stem.starts_with("toolport-gateway") || stem.starts_with("conduit-gateway")
+}
+
 /// Whether a client's stored gateway command should be re-pointed: it names the
 /// pre-rename binary (`conduit-gateway`), or its path no longer exists on disk, and
 /// it isn't already the current path.
+///
+/// Presumes the command is already known to be ours; the caller
+/// ([`gateway_entry_needs_rewrite`]) establishes that with
+/// [`command_is_gateway_binary`] first. These heuristics cannot make that call
+/// themselves - they read "not our current path" as "our binary moved", which is only
+/// true once provenance is settled.
 fn gateway_command_is_stale(stored: &str, current: &str) -> bool {
     if stored.is_empty() || stored == current {
         return false;
@@ -3527,6 +3561,22 @@ fn gateway_entry_needs_rewrite(
     current: &str,
     config_text: Option<&str>,
 ) -> bool {
+    // Provenance gate (issue #487), deliberately FIRST. Every rewrite below is a
+    // migration of an entry we wrote - a moved binary, the pre-rename entry name, the
+    // pre-rename env keys. None of them apply to an entry whose command isn't one of
+    // our gateway binaries: that entry belongs to the user, and rewriting it silently
+    // reverts a deliberate customization on every app launch.
+    //
+    // The heuristics below cannot make this call on their own. A bare `npx` fails
+    // `gateway_command_is_stale`'s `Path::exists` test, and on a normal install its
+    // published-bin branch treats anything not byte-identical to the current path as
+    // stale - so without this gate every custom command is "stale" by construction.
+    //
+    // An entry with no command at all (a user-written http/sse entry under our name)
+    // is likewise not ours, and falls out here on the empty basename.
+    if !command_is_gateway_binary(stored_command) {
+        return false;
+    }
     if gateway_command_is_stale(stored_command, current)
         || entry_name.eq_ignore_ascii_case(LEGACY_GATEWAY_ENTRY_NAME)
     {
@@ -3601,6 +3651,11 @@ fn read_gateway_profile(client_id: &str) -> Option<String> {
 /// up first), and profile-preserving (the profile is read from raw config text,
 /// independent of the entry name). Guarded so it never writes a path that doesn't
 /// exist. Returns the ids of clients it rewrote.
+///
+/// Only entries whose command is one of our own gateway binaries are ever rewritten
+/// (see [`command_is_gateway_binary`]). An entry under our name pointing at anything
+/// else - an HTTP bridge, a container, a wrapper script - is the user's, and is left
+/// exactly as they wrote it (issue #487).
 pub fn repoint_stale_gateways() -> Vec<String> {
     let Some(current) = resolve_gateway_path().map(|p| p.to_string_lossy().into_owned()) else {
         return Vec::new();
@@ -3628,6 +3683,19 @@ pub fn repoint_stale_gateways() -> Vec<String> {
             .and_then(|def| (def.path)())
             .and_then(|path| read_config_file(&path).ok());
         if !gateway_entry_needs_rewrite(entry_name, stored, &current, config_text.as_deref()) {
+            // Say so when we're standing down because the entry is the user's, rather
+            // than because it was already current. Both are no-ops here, but they mean
+            // very different things, and a silent skip is what made issue #487's
+            // opposite (a silent rewrite) so hard to diagnose.
+            if entry.is_some() && !command_is_gateway_binary(stored) {
+                eprintln!(
+                    "toolport: leaving {}'s '{}' entry alone - its command ({}) is not a Toolport \
+                     gateway binary, so the entry is treated as user-managed",
+                    client.id,
+                    entry_name,
+                    if stored.is_empty() { "none" } else { stored },
+                );
+            }
             continue;
         }
         let profile = config_text
@@ -4100,6 +4168,96 @@ bad = "not-a-table"
         assert!(!servers2.contains_key(GATEWAY_ENTRY_NAME));
         assert!(servers2.contains_key("existing"));
         std::fs::remove_file(&path).ok();
+    }
+
+    #[test]
+    fn customized_gateway_entry_is_never_repointed() {
+        // Regression for issue #487. A user repointed Claude Desktop's `toolport` entry
+        // at the documented HTTP endpoint via an mcp-remote bridge; every launch of the
+        // app reverted it to the default stdio command and left another backup behind.
+        //
+        // The entry is still ours by NAME (that's what keeps it visible and dedup'd),
+        // but not by command, so the launch re-point must stand down.
+        let current = r"C:\Users\me\AppData\Roaming\Toolport\bin\toolport-gateway-1.9.5.exe";
+
+        // The reported command, as Claude Desktop stores it. Note it would fail every
+        // staleness heuristic: `npx` is not a path that exists, and the published-bin
+        // branch calls anything that isn't byte-identical to `current` stale.
+        assert!(!gateway_entry_needs_rewrite(
+            GATEWAY_ENTRY_NAME,
+            "npx",
+            current,
+            Some(
+                r#"{"mcpServers":{"toolport":{"command":"npx","args":["-y","mcp-remote","http://localhost:8765/mcp"]}}}"#
+            )
+        ));
+
+        // Other shapes a user reasonably reaches for, all left alone.
+        for command in [
+            "npx",
+            "cmd",
+            "docker",
+            "node",
+            "uvx",
+            r"C:\Users\me\bin\my-toolport-wrapper.cmd",
+            // Lives in a dir named for the gateway, but is not the gateway. Basename
+            // matching is what keeps this from being mistaken for ours.
+            r"C:\tools\toolport-gateway\wrapper.exe",
+            // A user-written http/sse entry has no command at all.
+            "",
+        ] {
+            assert!(
+                !gateway_entry_needs_rewrite(GATEWAY_ENTRY_NAME, command, current, None),
+                "custom command {command:?} must be treated as user-managed"
+            );
+        }
+
+        // The legacy-name and legacy-env branches must not sneak past the gate either:
+        // a customized entry the user happened to leave named `conduit`, in a config
+        // that still mentions CONDUIT_* elsewhere, is still theirs.
+        assert!(!gateway_entry_needs_rewrite(
+            LEGACY_GATEWAY_ENTRY_NAME,
+            "npx",
+            current,
+            Some(r#"{"env":{"CONDUIT_CLIENT_ID":"claude-desktop"}}"#)
+        ));
+
+        // ...while real migrations still happen. These are the cases the re-point
+        // exists for, and each names one of our binaries.
+        for stale in [
+            r"C:\Users\me\AppData\Local\Toolport\toolport-gateway.exe", // unversioned install dir
+            r"C:\Users\me\AppData\Roaming\Toolport\bin\toolport-gateway-1.9.4.exe", // older version
+            r"C:\Users\me\AppData\Roaming\Conduit\bin\toolport-gateway-1.9.5.exe", // pre-rename data dir
+            "/Applications/Toolport.app/Contents/MacOS/conduit-gateway", // pre-rename binary
+        ] {
+            assert!(
+                gateway_entry_needs_rewrite(GATEWAY_ENTRY_NAME, stale, current, None),
+                "{stale:?} is one of ours and must still be re-pointed"
+            );
+        }
+    }
+
+    #[test]
+    fn gateway_binary_provenance_matches_basename_only() {
+        assert!(command_is_gateway_binary("toolport-gateway"));
+        assert!(command_is_gateway_binary("conduit-gateway"));
+        assert!(command_is_gateway_binary(
+            r"C:\Users\me\AppData\Roaming\Toolport\bin\toolport-gateway-1.9.5.exe"
+        ));
+        // Case and quoting as they turn up in real client configs.
+        assert!(command_is_gateway_binary(r#""C:\X\Toolport-Gateway.EXE""#));
+        assert!(command_is_gateway_binary("/opt/toolport/toolport-gateway"));
+
+        assert!(!command_is_gateway_binary(""));
+        assert!(!command_is_gateway_binary("npx"));
+        assert!(!command_is_gateway_binary("cmd"));
+        // A substring match on the full path would wrongly claim these.
+        assert!(!command_is_gateway_binary(
+            r"C:\tools\toolport-gateway\wrapper.exe"
+        ));
+        assert!(!command_is_gateway_binary(
+            "/usr/local/bin/my-toolport-gateway-shim"
+        ));
     }
 
     #[test]


### PR DESCRIPTION
Fixes #487.

## The reported bug

A user repointed Claude Desktop's `toolport` entry from the default gateway command at an `mcp-remote` bridge against Toolport's own documented HTTP endpoint. Every launch of `conduit.exe` reverted it to the default stdio command and left another snapshot in `backups\claude-desktop\`.

`repoint_stale_gateways()` locates "our" entry with `gateway_identity_matches`, which matches on the **entry name alone** — an entry named `toolport` is ours regardless of its command. `gateway_command_is_stale` then rewrites it, and it could not have done otherwise:

- `stored = "npx"` is not empty and not equal to current, so it falls through to `!Path::new("npx").exists()` → stale. Any command that isn't a filesystem path is unconditionally stale.
- Even an absolute path to a real binary wouldn't survive: the published-bin branch returns true whenever the *current* gateway path is under `\Toolport\bin\toolport-gateway-`, which it always is on a normal install.

The predicate was effectively "anything not byte-identical to our current path". The root defect is that there was **no notion of provenance** — "this entry is ours" was inferred from its name, and a heuristic written for *our binary having moved* was applied to commands that were never our binary. A deliberate customization and a broken install were indistinguishable.

## A — provenance gate

New `command_is_gateway_binary` matches the command's **basename** against our own binaries (`toolport-gateway*` / `conduit-gateway*`, version suffixes and `.exe` allowed). `gateway_entry_needs_rewrite` consults it first, so it gates all three rewrite triggers — stale command, legacy entry name, legacy `CONDUIT_*` env — not just the one that fired here. An entry with no command falls out on the empty basename.

Basename rather than substring, so a wrapper that merely *lives* in a directory containing `toolport-gateway` isn't mistaken for the binary. Genuine migrations are unaffected: older version, pre-rename `conduit-gateway`, pre-rename data dir, unversioned install path.

`repoint_stale_gateways` now logs when it stands down because the entry is user-managed. A silent skip and a silent rewrite look identical from outside, and the silence is what made this hard to diagnose.

## D — ambient `TOOLPORT_HTTP` (separate bug, found while investigating)

The report attributes the motivation to port contention: "every client-spawned gateway also attempts to bind 0.0.0.0:8765", with Jan refusing to start after `WSAEADDRINUSE`. **That mechanism is not real as described.** `gateway_entry()` writes only `TOOLPORT_CLIENT_ID`/`TOOLPORT_PROFILE`, `http_port()` enables HTTP only from `--http` or the env forms, HTTP mode *replaces* the stdio loop, and the app supervises a single `--http` child.

The one way to produce it is `TOOLPORT_HTTP`/`CONDUIT_HTTP` set as a **user or machine environment variable**. Every client inherits it and passes it to the gateway it spawns; each flips to HTTP mode, never serves stdio at all, and all but the first collide on 8765. That fits the Jan symptom exactly, and one stray `setx` breaks every client at once.

`resolve_http_port` now takes a `stdio_peer` flag and ignores the env forms when stdin is a pipe, returning a warning that names the cause and the fix. I checked every shipping path that enables HTTP — the desktop bridge, `Dockerfile`, `Dockerfile.source`, `docs/headless.md` — and all pass `--http` explicitly, so none are affected. Removed a now-redundant `ENV CONDUIT_HTTP=8765` from `Dockerfile.source` (the entrypoint flag already overrode it, and a stale env that no longer does anything is a trap) and documented the caveat in `docs/openwebui.md`.

## Tests

- `customized_gateway_entry_is_never_repointed` — the reported `npx` command plus `cmd`/`docker`/`node`/`uvx`, a wrapper living in a `toolport-gateway` directory, an empty command, and the legacy-name/legacy-env branches; then asserts all four real migrations still fire.
- `gateway_binary_provenance_matches_basename_only` — pins the matcher, including that substring matching would wrongly claim a wrapper.
- `ambient_http_env_is_ignored_when_a_client_spawned_us` — every truthy and invalid env value is ignored on a stdio spawn with a warning; `--http` still wins; no config at all stays silent.

Full suite green (699 tests). Clippy and rustfmt clean on the touched regions.

## Deliberately not in scope

**A is a heuristic on the command, not a record of what we wrote.** It can't distinguish an entry we wrote from a user's own build of the gateway, or our binary with extra args. It also doesn't address the report's *second* trigger — toggling a client's connection off/on in Integrations calls `install_gateway` directly. That's a deliberate user action that should confirm rather than refuse, which needs a state to confirm about.

Both are scoped in `docs/drafts/client-entry-ownership-plan.md` and filed as SOU-406 (ownership record + `Managed`/`Customized`/`Absent` as a first-class state) and SOU-407 (managed shared-HTTP transport per client, which removes the reason people hand-edit in the first place).

## Related

SOU-326 asked for the entry lookup to be broadened from name-only `conduit` to any identity match — that shipped in #445 and is what widened this bug's blast radius. It also listed "empty stored is never stale" as a defect to fix; this PR makes that behavior intentional instead. I've closed SOU-326 with that note so a future audit doesn't re-file it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)