### PR TITLE
fix(clients): record gateway ownership and surface Customized state (SOU-406)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,13 @@ Existing registries that already store `"codeMode": false` stay off. (SOU-397)
 
 ### Fixed
 
+**Client gateway ownership is now a first-class state (Managed / Customized /
+Absent).** Toolport records what it last wrote into each client's config and surfaces
+hand-edited entries as "custom configuration" in Integrations, with an explicit Reset
+to default (confirm before overwrite). Launch re-point and Connect no longer silently
+clobber a customized entry. Pre-ownership installs still use the command-basename
+heuristic. (SOU-406, follow-up to #487)
+
 **A hand-edited gateway entry is no longer reverted on every app launch.** The
 launch-time re-point recognized its own entry by _name_, so an entry still called
 `toolport` but pointed at something else — an `mcp-remote` bridge against the HTTP

--- a/src-tauri/src/clients.rs
+++ b/src-tauri/src/clients.rs
@@ -8,11 +8,12 @@
 //! Security note: we surface env-variable *names* but never their *values*.
 //! Those values are secrets (API keys, tokens) and must not leak to the UI.
 
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 use serde::Serialize;
 
-use crate::registry::ServerEntry;
+use crate::registry::{ManagedEntry, ServerEntry};
 
 /// One MCP server, normalized across every client format.
 #[derive(Debug, Clone, Serialize)]
@@ -26,6 +27,19 @@ pub struct McpServer {
     /// Names of env vars only. Values are deliberately omitted (secrets).
     pub env_keys: Vec<String>,
     pub url: Option<String>,
+}
+
+/// Ownership of the gateway entry under our name in a client config (SOU-406).
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum GatewayEntryState {
+    /// We wrote it (or pre-record install that still looks like our binary).
+    Managed,
+    /// An identity-matching entry exists but is not what we last wrote (or, with
+    /// no ownership record, its command is not a Toolport gateway binary).
+    Customized,
+    /// No identity-matching gateway entry.
+    Absent,
 }
 
 /// The result of probing a single client on this machine.
@@ -53,6 +67,9 @@ pub struct DetectedClient {
     pub plugin_servers: Vec<McpServer>,
     /// Whether the Toolport gateway is currently installed in this client's config.
     pub gateway_installed: bool,
+    /// First-class ownership of that entry: managed by us, hand-customized, or
+    /// absent (SOU-406). Computed with the registry ownership record when present.
+    pub entry_state: GatewayEntryState,
     /// Set when the config exists but could not be read or parsed.
     pub error: Option<String>,
 }
@@ -2118,6 +2135,13 @@ fn read_client(def: &ClientDef) -> DetectedClient {
                 server.command.as_deref(),
             )
         });
+        // Ownership is filled in later via [`apply_entry_states`] once the registry
+        // record is available. Until then: identity match → Managed (legacy), none → Absent.
+        let entry_state = if gateway_installed {
+            GatewayEntryState::Managed
+        } else {
+            GatewayEntryState::Absent
+        };
         // The config file's parent is the client's own data dir (e.g. `.../Code/User`,
         // `.../Claude`, `~/.codex`); its presence means the app has run here. If the
         // config itself exists the app is obviously present. An empty path means we
@@ -2139,6 +2163,7 @@ fn read_client(def: &ClientDef) -> DetectedClient {
             servers,
             plugin_servers: plugin_servers.clone(),
             gateway_installed,
+            entry_state,
             error,
         }
     };
@@ -2204,6 +2229,58 @@ pub fn detect_clients() -> Vec<DetectedClient> {
     defs().iter().map(read_client).collect()
 }
 
+/// Whether a detected gateway slot matches the ownership record we last wrote.
+fn managed_matches_detected(server: &McpServer, rec: &ManagedEntry) -> bool {
+    let cmd = server.command.as_deref().unwrap_or("");
+    if cmd != rec.command {
+        return false;
+    }
+    if server.args != rec.args {
+        return false;
+    }
+    let mut keys = server.env_keys.clone();
+    keys.sort();
+    let rec_keys: Vec<String> = rec.env.keys().cloned().collect();
+    keys == rec_keys
+}
+
+/// Resolve Managed / Customized / Absent for one client (SOU-406).
+pub fn resolve_entry_state(
+    servers: &[McpServer],
+    record: Option<&ManagedEntry>,
+) -> GatewayEntryState {
+    let entry = servers.iter().find(|s| {
+        gateway_identity_matches(&s.name, &s.name, s.command.as_deref())
+    });
+    let Some(entry) = entry else {
+        return GatewayEntryState::Absent;
+    };
+    match record {
+        Some(rec) if managed_matches_detected(entry, rec) => GatewayEntryState::Managed,
+        Some(_) => GatewayEntryState::Customized,
+        // No ownership record (install predates SOU-406): fall back to the
+        // SOU-405 command-basename heuristic so genuine installs stay Managed
+        // and hand-edited npx/docker/etc. entries surface as Customized.
+        None if command_is_gateway_binary(entry.command.as_deref().unwrap_or("")) => {
+            GatewayEntryState::Managed
+        }
+        None => GatewayEntryState::Customized,
+    }
+}
+
+/// Fill [`DetectedClient::entry_state`] from the registry ownership map.
+pub fn apply_entry_states(
+    clients: &mut [DetectedClient],
+    managed: &HashMap<String, ManagedEntry>,
+) {
+    for client in clients.iter_mut() {
+        client.entry_state =
+            resolve_entry_state(&client.servers, managed.get(&client.id));
+        // Keep gateway_installed aligned with identity presence (not ownership).
+        client.gateway_installed = client.entry_state != GatewayEntryState::Absent;
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Write path
 //
@@ -2219,6 +2296,20 @@ pub fn detect_clients() -> Vec<DetectedClient> {
 pub struct WriteOutcome {
     pub path: String,
     pub backup: Option<String>,
+    /// Snapshot of the gateway entry just installed (for the ownership record).
+    /// Absent on uninstall or when the write did not install a gateway entry.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub managed: Option<ManagedEntry>,
+}
+
+/// Result of launch-time re-point (SOU-405/406).
+#[derive(Debug, Default)]
+pub struct RepointOutcome {
+    /// Client ids whose gateway entry was rewritten to the current binary, with
+    /// the ownership snapshot that was written.
+    pub repointed: Vec<(String, ManagedEntry)>,
+    /// Client ids left alone because their entry is user-customized.
+    pub customized: Vec<String>,
 }
 
 fn find_def(client_id: &str) -> Option<ClientDef> {
@@ -3135,9 +3226,17 @@ pub fn write_servers(client_id: &str, servers: &[ServerEntry]) -> Result<WriteOu
         Format::YamlMcpServers => write_hermes_yaml_servers(&path, servers)?,
         Format::YamlMcpServersList => write_continue_yaml_servers(&path, servers)?,
     }
+    // migrate_to_gateway writes a single gateway entry; capture ownership when so.
+    let managed = servers
+        .iter()
+        .find(|s| is_gateway_server(s))
+        .filter(|_| servers.len() == 1)
+        .map(ManagedEntry::from_gateway_entry);
+
     Ok(WriteOutcome {
         path: path.display().to_string(),
         backup: backup.map(|b| b.display().to_string()),
+        managed,
     })
 }
 
@@ -3440,6 +3539,15 @@ fn install_or_remove(
     let path = (def.path)().ok_or("Could not resolve a config path on this OS")?;
     let backup = backup_file(client_id, &path)?;
     let lenient = config_is_whole_app_state(client_id);
+    // Build the snapshot before writing so the ownership record matches the bytes
+    // we put on disk (SOU-406).
+    let managed = if install {
+        Some(ManagedEntry::from_gateway_entry(&gateway_entry(
+            profile, client_id,
+        )?))
+    } else {
+        None
+    };
     match def.format {
         Format::JsonMcpServers => {
             edit_json_gateway(&path, "mcpServers", install, profile, lenient, client_id)?
@@ -3466,6 +3574,7 @@ fn install_or_remove(
     Ok(WriteOutcome {
         path: path.display().to_string(),
         backup: backup.map(|b| b.display().to_string()),
+        managed,
     })
 }
 
@@ -3652,22 +3761,21 @@ fn read_gateway_profile(client_id: &str) -> Option<String> {
 /// independent of the entry name). Guarded so it never writes a path that doesn't
 /// exist. Returns the ids of clients it rewrote.
 ///
-/// Only entries whose command is one of our own gateway binaries are ever rewritten
-/// (see [`command_is_gateway_binary`]). An entry under our name pointing at anything
-/// else - an HTTP bridge, a container, a wrapper script - is the user's, and is left
-/// exactly as they wrote it (issue #487).
-pub fn repoint_stale_gateways() -> Vec<String> {
+/// Only entries we still own are ever rewritten. Ownership is the registry record
+/// when present, else the SOU-405 command-basename heuristic (issue #487 / SOU-406).
+/// A Customized entry is left byte-identical and reported in [`RepointOutcome::customized`].
+pub fn repoint_stale_gateways(managed: &HashMap<String, ManagedEntry>) -> RepointOutcome {
+    let mut outcome = RepointOutcome::default();
     let Some(current) = resolve_gateway_path().map(|p| p.to_string_lossy().into_owned()) else {
-        return Vec::new();
+        return outcome;
     };
     // Never re-point onto a binary that isn't there (resolve_gateway_path returns a
     // best-guess path even when nothing is found, for clearer error messages).
     if !Path::new(&current).exists() {
-        return Vec::new();
+        return outcome;
     }
-    let mut repointed = Vec::new();
     for client in detect_clients() {
-        if !client.gateway_installed || !client.config_exists || client.error.is_some() {
+        if !client.config_exists || client.error.is_some() {
             continue;
         }
         // Find our entry by identity (recognizes the legacy `conduit` name too), so
@@ -3676,37 +3784,41 @@ pub fn repoint_stale_gateways() -> Vec<String> {
             .servers
             .iter()
             .find(|s| gateway_identity_matches(&s.name, &s.name, s.command.as_deref()));
-        let stored = entry.and_then(|s| s.command.as_deref()).unwrap_or("");
-        let entry_name = entry.map(|s| s.name.as_str()).unwrap_or("");
+        let Some(entry) = entry else {
+            continue;
+        };
+        let stored = entry.command.as_deref().unwrap_or("");
+        let entry_name = entry.name.as_str();
+        let state = resolve_entry_state(&client.servers, managed.get(&client.id));
+        if state == GatewayEntryState::Customized {
+            eprintln!(
+                "toolport: leaving {}'s '{}' entry alone - custom configuration (not managed \
+                 by Toolport); command={}",
+                client.id,
+                entry_name,
+                if stored.is_empty() { "none" } else { stored },
+            );
+            outcome.customized.push(client.id.clone());
+            continue;
+        }
         // Raw config text for profile preservation + legacy CONDUIT_* env detection.
         let config_text = find_def(&client.id)
             .and_then(|def| (def.path)())
             .and_then(|path| read_config_file(&path).ok());
         if !gateway_entry_needs_rewrite(entry_name, stored, &current, config_text.as_deref()) {
-            // Say so when we're standing down because the entry is the user's, rather
-            // than because it was already current. Both are no-ops here, but they mean
-            // very different things, and a silent skip is what made issue #487's
-            // opposite (a silent rewrite) so hard to diagnose.
-            if entry.is_some() && !command_is_gateway_binary(stored) {
-                eprintln!(
-                    "toolport: leaving {}'s '{}' entry alone - its command ({}) is not a Toolport \
-                     gateway binary, so the entry is treated as user-managed",
-                    client.id,
-                    entry_name,
-                    if stored.is_empty() { "none" } else { stored },
-                );
-            }
             continue;
         }
         let profile = config_text
             .as_deref()
             .and_then(profile_from_config_text)
             .or_else(|| read_gateway_profile(&client.id));
-        if install_gateway(&client.id, profile.as_deref()).is_ok() {
-            repointed.push(client.id.clone());
+        if let Ok(write) = install_gateway(&client.id, profile.as_deref()) {
+            if let Some(m) = write.managed {
+                outcome.repointed.push((client.id.clone(), m));
+            }
         }
     }
-    repointed
+    outcome
 }
 
 #[cfg(test)]
@@ -4168,6 +4280,77 @@ bad = "not-a-table"
         assert!(!servers2.contains_key(GATEWAY_ENTRY_NAME));
         assert!(servers2.contains_key("existing"));
         std::fs::remove_file(&path).ok();
+    }
+
+    #[test]
+    fn entry_state_from_record_and_heuristic() {
+        // SOU-406: ownership record when present; SOU-405 basename heuristic when not.
+        let managed_cmd = r"C:\Users\me\AppData\Roaming\Toolport\bin\toolport-gateway-1.9.5.exe";
+        let rec = ManagedEntry {
+            command: managed_cmd.to_string(),
+            args: vec![],
+            env: [
+                (crate::brand::CLIENT_ID.to_string(), "claude-desktop".into()),
+            ]
+            .into_iter()
+            .collect(),
+            updated_at: 1,
+        };
+        let matching = McpServer {
+            name: GATEWAY_ENTRY_NAME.into(),
+            transport: "stdio".into(),
+            command: Some(managed_cmd.into()),
+            args: vec![],
+            env_keys: vec![crate::brand::CLIENT_ID.to_string()],
+            url: None,
+        };
+        assert_eq!(
+            resolve_entry_state(&[matching.clone()], Some(&rec)),
+            GatewayEntryState::Managed
+        );
+
+        let mut args_changed = matching.clone();
+        args_changed.args = vec!["--extra".into()];
+        assert_eq!(
+            resolve_entry_state(&[args_changed], Some(&rec)),
+            GatewayEntryState::Customized
+        );
+
+        let mut cmd_changed = matching.clone();
+        cmd_changed.command = Some("npx".into());
+        assert_eq!(
+            resolve_entry_state(&[cmd_changed.clone()], Some(&rec)),
+            GatewayEntryState::Customized
+        );
+        // No record + npx → Customized (heuristic).
+        assert_eq!(
+            resolve_entry_state(&[cmd_changed], None),
+            GatewayEntryState::Customized
+        );
+        // No record + our binary → Managed (back-compat).
+        assert_eq!(
+            resolve_entry_state(&[matching], None),
+            GatewayEntryState::Managed
+        );
+        // No identity entry → Absent.
+        assert_eq!(
+            resolve_entry_state(&[], None),
+            GatewayEntryState::Absent
+        );
+        assert_eq!(
+            resolve_entry_state(
+                &[McpServer {
+                    name: "other".into(),
+                    transport: "stdio".into(),
+                    command: Some("node".into()),
+                    args: vec![],
+                    env_keys: vec![],
+                    url: None,
+                }],
+                Some(&rec)
+            ),
+            GatewayEntryState::Absent
+        );
     }
 
     #[test]

--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -386,11 +386,21 @@ async fn test_server(entry: ServerEntry) -> Result<ProbeResult, String> {
 
 /// Probe every supported MCP client and return its current server configuration.
 #[tauri::command]
-async fn detect_clients() -> Result<Vec<clients::DetectedClient>, String> {
+async fn detect_clients(
+    state: State<'_, RegistryState>,
+) -> Result<Vec<clients::DetectedClient>, String> {
     // Reads several config files and scans plugin dirs - off the UI thread.
-    tauri::async_runtime::spawn_blocking(clients::detect_clients)
+    let mut list = tauri::async_runtime::spawn_blocking(clients::detect_clients)
         .await
-        .map_err(|e| e.to_string())
+        .map_err(|e| e.to_string())?;
+    // Ownership record lives on the registry (SOU-406).
+    let managed = state
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .client_managed_entries
+        .clone();
+    clients::apply_entry_states(&mut list, &managed);
+    Ok(list)
 }
 
 #[tauri::command]
@@ -663,12 +673,38 @@ fn write_to_client(
 
 /// Install the Toolport gateway into a client (one click "connect to Toolport").
 /// `profile` scopes that client to one profile (None = all enabled servers).
+/// When the live entry is user-customized, pass `force: true` after the UI confirms
+/// overwrite (SOU-406); otherwise the install is refused.
 #[tauri::command]
 fn install_gateway(
     state: State<RegistryState>,
     client_id: String,
     profile: Option<String>,
+    force: Option<bool>,
 ) -> Result<clients::WriteOutcome, String> {
+    let force = force.unwrap_or(false);
+    if !force {
+        // Refuse to silently clobber a hand-edited gateway entry (Integrations toggle
+        // / apply-scope). The UI must confirm and retry with force=true.
+        let mut list = clients::detect_clients();
+        let managed = state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .client_managed_entries
+            .clone();
+        clients::apply_entry_states(&mut list, &managed);
+        if list
+            .iter()
+            .find(|c| c.id == client_id)
+            .is_some_and(|c| c.entry_state == clients::GatewayEntryState::Customized)
+        {
+            return Err(
+                "This client's Toolport entry has a custom configuration. Confirm to \
+                 reset it to the default gateway, or leave it as-is."
+                    .into(),
+            );
+        }
+    }
     let outcome = clients::install_gateway(&client_id, profile.as_deref())?;
     // Record the scope we just wrote into the client's config, so the UI can show
     // and re-apply this client's effective scope without re-reading the config.
@@ -682,10 +718,14 @@ fn install_gateway(
         .map(str::trim)
         .filter(|p| !p.is_empty())
         .map(str::to_string);
+    let managed = outcome.managed.clone();
     write_registry(state.inner(), |reg| {
         match scope.as_deref() {
             Some(p) => reg.set_client_scope(&client_id, Some(p)),
             None => reg.set_client_unscoped(&client_id),
+        }
+        if let Some(m) = managed {
+            reg.set_client_managed_entry(&client_id, m);
         }
         Ok(())
     })?;
@@ -701,6 +741,7 @@ fn uninstall_gateway(
     let outcome = clients::uninstall_gateway(&client_id)?;
     write_registry(state.inner(), |reg| {
         reg.set_client_scope(&client_id, None);
+        reg.clear_client_managed_entry(&client_id);
         Ok(())
     })?;
     Ok(outcome)
@@ -811,7 +852,7 @@ async fn migrate_client(
 
     // Rewrite the client to only the gateway (backs up first). External to the registry, so
     // it stays outside the lock; the scope record below is a separate locked write.
-    clients::migrate_to_gateway(&client_id, profile.as_deref())?;
+    let migrate_write = clients::migrate_to_gateway(&client_id, profile.as_deref())?;
 
     // Record the scope now that the client config was rewritten to the gateway.
     // "No profile" becomes an explicit-unscoped marker (not a removal) so a live
@@ -821,10 +862,14 @@ async fn migrate_client(
         .map(str::trim)
         .filter(|p| !p.is_empty())
         .map(str::to_string);
+    let managed = migrate_write.managed;
     let (registry, _) = write_registry(state.inner(), |reg| {
         match scope.as_deref() {
             Some(p) => reg.set_client_scope(&client_id, Some(p)),
             None => reg.set_client_unscoped(&client_id),
+        }
+        if let Some(m) = managed {
+            reg.set_client_managed_entry(&client_id, m);
         }
         Ok(())
     })?;
@@ -3064,12 +3109,35 @@ pub fn run() {
                         published.display()
                     );
                 }
-                let repointed = clients::repoint_stale_gateways();
-                if !repointed.is_empty() {
+                // Ownership map from disk (this launch thread has no RegistryState handle).
+                let managed_snapshot = registry::load()
+                    .map(|r| r.client_managed_entries)
+                    .unwrap_or_default();
+                let repoint = clients::repoint_stale_gateways(&managed_snapshot);
+                if !repoint.repointed.is_empty() {
+                    let ids: Vec<&str> = repoint
+                        .repointed
+                        .iter()
+                        .map(|(id, _)| id.as_str())
+                        .collect();
                     eprintln!(
                         "toolport: re-pointed {} client config(s) to the renamed gateway: {}",
-                        repointed.len(),
-                        repointed.join(", ")
+                        repoint.repointed.len(),
+                        ids.join(", ")
+                    );
+                    // Refresh ownership records for everything we rewrote (SOU-406).
+                    let _ = registry::update(|reg| {
+                        for (id, entry) in &repoint.repointed {
+                            reg.set_client_managed_entry(id, entry.clone());
+                        }
+                        Ok(())
+                    });
+                }
+                if !repoint.customized.is_empty() {
+                    eprintln!(
+                        "toolport: left {} client config(s) alone (custom configuration): {}",
+                        repoint.customized.len(),
+                        repoint.customized.join(", ")
                     );
                 }
                 // Stop any gateway running a version other than this one, so each client
@@ -3266,6 +3334,7 @@ mod tests {
             servers: servers.into_iter().map(detected_mcp_server).collect(),
             plugin_servers: plugin_servers.into_iter().map(detected_mcp_server).collect(),
             gateway_installed: false,
+            entry_state: clients::GatewayEntryState::Absent,
             error: None,
         }
     }

--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -671,6 +671,36 @@ fn write_to_client(
     clients::write_servers(&client_id, &servers)
 }
 
+/// Refuse to overwrite a hand-edited gateway entry unless `force` is true (SOU-406).
+fn refuse_if_customized(
+    state: &RegistryState,
+    client_id: &str,
+    force: bool,
+) -> Result<(), String> {
+    if force {
+        return Ok(());
+    }
+    let mut list = clients::detect_clients();
+    let managed = state
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .client_managed_entries
+        .clone();
+    clients::apply_entry_states(&mut list, &managed);
+    if list
+        .iter()
+        .find(|c| c.id == client_id)
+        .is_some_and(|c| c.entry_state == clients::GatewayEntryState::Customized)
+    {
+        return Err(
+            "This client's Toolport entry has a custom configuration. Confirm to \
+             reset it to the default gateway, or leave it as-is."
+                .into(),
+        );
+    }
+    Ok(())
+}
+
 /// Install the Toolport gateway into a client (one click "connect to Toolport").
 /// `profile` scopes that client to one profile (None = all enabled servers).
 /// When the live entry is user-customized, pass `force: true` after the UI confirms
@@ -682,29 +712,7 @@ fn install_gateway(
     profile: Option<String>,
     force: Option<bool>,
 ) -> Result<clients::WriteOutcome, String> {
-    let force = force.unwrap_or(false);
-    if !force {
-        // Refuse to silently clobber a hand-edited gateway entry (Integrations toggle
-        // / apply-scope). The UI must confirm and retry with force=true.
-        let mut list = clients::detect_clients();
-        let managed = state
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
-            .client_managed_entries
-            .clone();
-        clients::apply_entry_states(&mut list, &managed);
-        if list
-            .iter()
-            .find(|c| c.id == client_id)
-            .is_some_and(|c| c.entry_state == clients::GatewayEntryState::Customized)
-        {
-            return Err(
-                "This client's Toolport entry has a custom configuration. Confirm to \
-                 reset it to the default gateway, or leave it as-is."
-                    .into(),
-            );
-        }
-    }
+    refuse_if_customized(state.inner(), &client_id, force.unwrap_or(false))?;
     let outcome = clients::install_gateway(&client_id, profile.as_deref())?;
     // Record the scope we just wrote into the client's config, so the UI can show
     // and re-apply this client's effective scope without re-reading the config.
@@ -815,12 +823,19 @@ struct MigrateResult {
 /// directly - everything routes through Toolport. Backs the config up first.
 ///
 /// Plugin servers (read-only, outside the config file) are left untouched.
+/// When the live gateway entry is user-customized, pass `force: true` after the
+/// UI confirms overwrite (SOU-406); otherwise migration is refused before any
+/// config rewrite.
 #[tauri::command]
 async fn migrate_client(
     state: State<'_, RegistryState>,
     client_id: String,
     profile: Option<String>,
+    force: Option<bool>,
 ) -> Result<MigrateResult, String> {
+    // Guard before import or rewrite so a hand-edited gateway entry is not wiped.
+    refuse_if_customized(state.inner(), &client_id, force.unwrap_or(false))?;
+
     let detected = tauri::async_runtime::spawn_blocking(clients::detect_clients)
         .await
         .map_err(|e| e.to_string())?;

--- a/src-tauri/src/registry.rs
+++ b/src-tauri/src/registry.rs
@@ -8,7 +8,7 @@
 //! Secrets are never stored here. Env vars marked `secret` keep their value in
 //! the OS keychain; this file only records that a secret exists.
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 
@@ -423,6 +423,12 @@ pub struct Registry {
     /// reinstalling the client (same mechanism as `client_scopes`).
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub client_discovery: HashMap<String, String>,
+    /// What Toolport last wrote into each client's config as its gateway entry
+    /// (command/args/env), keyed by client id. Used to distinguish a managed install
+    /// from a hand-edited entry under the same name (SOU-406 / #487). Absent = pre-
+    /// ownership install; fall back to the command-basename heuristic.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub client_managed_entries: HashMap<String, ManagedEntry>,
     /// Consumers registered to reach the gateway over the HTTP/OpenAPI bridge,
     /// each with its own hashed bearer token and scope. Empty = the bridge uses
     /// only the legacy single `CONDUIT_HTTP_TOKEN` (back-compat).
@@ -441,6 +447,48 @@ pub struct Registry {
     /// pass-through-safe.
     #[serde(flatten)]
     pub unknown_fields: serde_json::Map<String, serde_json::Value>,
+}
+
+/// Snapshot of the gateway entry Toolport last wrote into a client config (SOU-406).
+/// Compared against the live entry on detect so a deliberate hand-edit is not treated
+/// as a stale install.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ManagedEntry {
+    pub command: String,
+    #[serde(default)]
+    pub args: Vec<String>,
+    /// Env key→value pairs we wrote (gateway env is non-secret: client id / profile).
+    /// `BTreeMap` keeps serde order stable for equality checks.
+    #[serde(default)]
+    pub env: BTreeMap<String, String>,
+    /// Unix epoch seconds when we last wrote this entry.
+    #[serde(default)]
+    pub updated_at: u64,
+}
+
+impl ManagedEntry {
+    /// Build a record from the [`ServerEntry`] we are about to (or just did) write.
+    pub fn from_gateway_entry(entry: &ServerEntry) -> Self {
+        let env = entry
+            .env
+            .iter()
+            .filter_map(|e| {
+                e.value
+                    .as_ref()
+                    .map(|v| (e.key.clone(), v.clone()))
+            })
+            .collect();
+        Self {
+            command: entry.command.clone().unwrap_or_default(),
+            args: entry.args.clone(),
+            env,
+            updated_at: std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_secs())
+                .unwrap_or(0),
+        }
+    }
 }
 
 /// A joined Conduit Teams server. Holds only non-secret connection metadata; the
@@ -584,6 +632,7 @@ impl Default for Registry {
             client_scopes: HashMap::new(),
             folder_profiles: Vec::new(),
             client_discovery: HashMap::new(),
+            client_managed_entries: HashMap::new(),
             http_clients: Vec::new(),
             secrets_generation: 0,
             unknown_fields: serde_json::Map::new(),
@@ -1123,6 +1172,22 @@ impl Registry {
     /// This client's discovery-mode override, if any (`None` = inherit the global mode).
     pub fn client_discovery_mode(&self, client_id: &str) -> Option<&str> {
         self.client_discovery.get(client_id).map(String::as_str)
+    }
+
+    /// Record what we just wrote into a client's gateway entry (SOU-406).
+    pub fn set_client_managed_entry(&mut self, client_id: &str, entry: ManagedEntry) {
+        self.client_managed_entries
+            .insert(client_id.to_string(), entry);
+    }
+
+    /// Clear the ownership record (uninstall or explicit forget).
+    pub fn clear_client_managed_entry(&mut self, client_id: &str) {
+        self.client_managed_entries.remove(client_id);
+    }
+
+    /// What we last wrote for this client, if anything.
+    pub fn client_managed_entry(&self, client_id: &str) -> Option<&ManagedEntry> {
+        self.client_managed_entries.get(client_id)
     }
 
     /// Record that a client is *explicitly* unscoped: it follows the active
@@ -2189,6 +2254,24 @@ mod tests {
         r.set_client_scope("claude", Some("Work"));
         r.set_client_scope("claude", None);
         assert!(!r.client_scopes.contains_key("claude"));
+    }
+
+    #[test]
+    fn client_managed_entries_set_and_clear() {
+        let mut r = Registry::default();
+        assert!(r.client_managed_entry("claude-desktop").is_none());
+        let entry = ManagedEntry {
+            command: "/opt/toolport/toolport-gateway".into(),
+            args: vec![],
+            env: [("TOOLPORT_CLIENT_ID".into(), "claude-desktop".into())]
+                .into_iter()
+                .collect(),
+            updated_at: 42,
+        };
+        r.set_client_managed_entry("claude-desktop", entry.clone());
+        assert_eq!(r.client_managed_entry("claude-desktop"), Some(&entry));
+        r.clear_client_managed_entry("claude-desktop");
+        assert!(r.client_managed_entry("claude-desktop").is_none());
     }
 
     #[test]

--- a/src/components/ClientDetail.test.tsx
+++ b/src/components/ClientDetail.test.tsx
@@ -82,23 +82,27 @@ describe("ClientDetail detection errors", () => {
 });
 
 describe("ClientDetail customized entry (SOU-406)", () => {
+  function customizedClient() {
+    return client({
+      gatewayInstalled: true,
+      entryState: "customized",
+      servers: [
+        {
+          name: "toolport",
+          transport: "stdio",
+          command: "npx",
+          args: ["-y", "mcp-remote", "http://localhost:8765/mcp"],
+          envKeys: [],
+          url: null,
+        },
+      ],
+    });
+  }
+
   it("shows custom configuration badge and Reset to default", () => {
     render(
       <ClientDetail
-        client={client({
-          gatewayInstalled: true,
-          entryState: "customized",
-          servers: [
-            {
-              name: "toolport",
-              transport: "stdio",
-              command: "npx",
-              args: ["-y", "mcp-remote", "http://localhost:8765/mcp"],
-              envKeys: [],
-              url: null,
-            },
-          ],
-        })}
+        client={customizedClient()}
         registry={emptyRegistry()}
         onChanged={() => {}}
         onRegistryChange={() => {}}
@@ -110,6 +114,29 @@ describe("ClientDetail customized entry (SOU-406)", () => {
     expect(
       screen.queryByRole("button", { name: /connect to toolport/i }),
     ).not.toBeInTheDocument();
+    // Managed onboarding copy must not claim scope is reachable for a customized entry.
+    expect(screen.queryByText(/connect .* once and it reaches/i)).not.toBeInTheDocument();
+  });
+
+  it("calls installGateway with force=true after confirming Reset to default", async () => {
+    installGateway.mockResolvedValue({ backup: false });
+    render(
+      <ClientDetail
+        client={customizedClient()}
+        registry={emptyRegistry()}
+        onChanged={() => {}}
+        onRegistryChange={() => {}}
+      />,
+    );
+
+    // Open confirm dialog, then click the dialog's confirm action (last match).
+    await userEvent.click(screen.getByRole("button", { name: /reset to default/i }));
+    const confirms = screen.getAllByRole("button", { name: /reset to default/i });
+    await userEvent.click(confirms[confirms.length - 1]!);
+
+    await waitFor(() =>
+      expect(installGateway).toHaveBeenCalledWith("claude-desktop", undefined, true),
+    );
   });
 });
 

--- a/src/components/ClientDetail.test.tsx
+++ b/src/components/ClientDetail.test.tsx
@@ -38,6 +38,7 @@ function client(over: Partial<DetectedClient> = {}): DetectedClient {
     configPath: "C:\\Users\\me\\Claude\\claude_desktop_config.json",
     configExists: true,
     gatewayInstalled: false,
+    entryState: "absent",
     appPresent: true,
     servers: [],
     pluginServers: [],
@@ -77,6 +78,38 @@ describe("ClientDetail detection errors", () => {
       "Couldn't parse config: unexpected token",
     );
     expect(screen.getByRole("button", { name: /connect to toolport/i })).toBeEnabled();
+  });
+});
+
+describe("ClientDetail customized entry (SOU-406)", () => {
+  it("shows custom configuration badge and Reset to default", () => {
+    render(
+      <ClientDetail
+        client={client({
+          gatewayInstalled: true,
+          entryState: "customized",
+          servers: [
+            {
+              name: "toolport",
+              transport: "stdio",
+              command: "npx",
+              args: ["-y", "mcp-remote", "http://localhost:8765/mcp"],
+              envKeys: [],
+              url: null,
+            },
+          ],
+        })}
+        registry={emptyRegistry()}
+        onChanged={() => {}}
+        onRegistryChange={() => {}}
+      />,
+    );
+
+    expect(screen.getAllByText(/custom configuration/i).length).toBeGreaterThan(0);
+    expect(screen.getByRole("button", { name: /reset to default/i })).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /connect to toolport/i }),
+    ).not.toBeInTheDocument();
   });
 });
 

--- a/src/components/ClientDetail.tsx
+++ b/src/components/ClientDetail.tsx
@@ -94,7 +94,9 @@ export function ClientDetail({ client, registry, onChanged, onRegistryChange }: 
   // "" = follow the active profile; else scope to one.
   const [profile, setProfile] = useState("");
   const [migrateOpen, setMigrateOpen] = useState(false);
+  const [resetOpen, setResetOpen] = useState(false);
   const installed = client.gatewayInstalled;
+  const customized = client.entryState === "customized";
   // Whether the client app is actually on this machine. We allow Disconnect even
   // when absent (to clean up a stale entry), but block a fresh Connect, writing a
   // config into a client that isn't installed just creates a file nothing reads.
@@ -166,6 +168,11 @@ export function ClientDetail({ client, registry, onChanged, onRegistryChange }: 
   /** Re-apply a scope to an already-connected client (overwrites its gateway
    * entry's TOOLPORT_PROFILE in place, no disconnect needed). */
   async function applyScope() {
+    if (customized) {
+      // Must not silently overwrite a hand-edited entry (SOU-406).
+      setResetOpen(true);
+      return;
+    }
     setBusy(true);
     try {
       await installGateway(client.id, profile || undefined);
@@ -177,6 +184,23 @@ export function ClientDetail({ client, registry, onChanged, onRegistryChange }: 
           : `${client.name} now follows the active profile.`,
         { description: clientRestartHint(client.name, client.id) },
       );
+      onChanged();
+    } catch (e) {
+      toastError(`${e}`);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  /** Overwrite a customized entry with the default gateway (after confirm). */
+  async function resetToDefault() {
+    setBusy(true);
+    try {
+      await installGateway(client.id, profile || undefined, true);
+      toast.success(`Reset ${client.name} to the default Toolport gateway`, {
+        description: clientRestartHint(client.name, client.id),
+      });
+      setResetOpen(false);
       onChanged();
     } catch (e) {
       toastError(`${e}`);
@@ -336,7 +360,12 @@ export function ClientDetail({ client, registry, onChanged, onRegistryChange }: 
       {/* Connection: the one thing that actually matters in a client. */}
       <div className="flex items-start justify-between gap-4">
         <div className="min-w-0">
-          {installed ? (
+          {customized ? (
+            <span className="mb-1 inline-flex items-center gap-1 rounded-full border border-warning/30 bg-warning/10 px-2 py-0.5 text-xs font-medium text-warning">
+              <TriangleAlert className="size-3" />
+              custom configuration
+            </span>
+          ) : installed ? (
             <span className="mb-1 inline-flex items-center gap-1 rounded-full border border-success/30 bg-success/10 px-2 py-0.5 text-xs font-medium text-success">
               <Link2 className="size-3" />
               connected to Toolport
@@ -358,7 +387,13 @@ export function ClientDetail({ client, registry, onChanged, onRegistryChange }: 
               {toolportStudioClientBlurb()}
             </p>
           )}
-          {installed && (
+          {customized && (
+            <p className="mt-1 text-xs text-muted-foreground">
+              Custom configuration - not managed by Toolport. Hand-edited gateway entry is
+              left as-is until you reset it.
+            </p>
+          )}
+          {installed && !customized && (
             <p className="mt-1 text-xs text-muted-foreground">
               Sees{" "}
               <span className="font-medium text-foreground">
@@ -376,7 +411,7 @@ export function ClientDetail({ client, registry, onChanged, onRegistryChange }: 
           )}
         </div>
         <div className="flex shrink-0 items-center gap-2">
-          {profiles.length > 1 && (
+          {profiles.length > 1 && !customized && (
             <Select
               value={profile || "__all__"}
               onValueChange={(v) => setProfile(v === "__all__" ? "" : v)}
@@ -394,11 +429,27 @@ export function ClientDetail({ client, registry, onChanged, onRegistryChange }: 
               </SelectContent>
             </Select>
           )}
-          {installed && profile !== currentScope && (
+          {installed && !customized && profile !== currentScope && (
             <Button size="sm" onClick={applyScope} disabled={busy}>
               <Check className="size-4" />
               Apply scope
             </Button>
+          )}
+          {customized && (
+            <ConfirmDialog
+              open={resetOpen}
+              onOpenChange={setResetOpen}
+              trigger={
+                <Button size="sm" variant="default" disabled={busy}>
+                  <Check className="size-4" />
+                  Reset to default
+                </Button>
+              }
+              title={`Reset ${client.name} to the default Toolport gateway?`}
+              description="This overwrites the hand-edited toolport entry with the standard stdio gateway command. Your other MCP servers are left alone."
+              confirmLabel="Reset to default"
+              onConfirm={resetToDefault}
+            />
           )}
           {installed ? (
             <ConfirmDialog
@@ -409,7 +460,11 @@ export function ClientDetail({ client, registry, onChanged, onRegistryChange }: 
                 </Button>
               }
               title={`Disconnect Toolport from ${client.name}?`}
-              description="This rewrites the client's MCP config to remove the gateway. You can reconnect anytime."
+              description={
+                customized
+                  ? "This removes the custom toolport entry from the client's MCP config. You can reconnect anytime."
+                  : "This rewrites the client's MCP config to remove the gateway. You can reconnect anytime."
+              }
               confirmLabel="Disconnect"
               destructive
               onConfirm={toggleInstall}
@@ -441,7 +496,7 @@ export function ClientDetail({ client, registry, onChanged, onRegistryChange }: 
         </div>
       )}
 
-      {installed && (
+      {installed && !customized && (
         <div className="flex items-center justify-between gap-3 rounded-lg border border-border/60 bg-muted/20 px-3 py-2">
           <div className="min-w-0">
             <div className="text-xs font-medium text-foreground">
@@ -484,7 +539,7 @@ export function ClientDetail({ client, registry, onChanged, onRegistryChange }: 
         </div>
       )}
 
-      {installed ? (
+      {installed && !customized ? (
         <div>
           <div className="mb-1.5 text-xs font-medium tracking-wide text-muted-foreground uppercase">
             Servers it can reach

--- a/src/components/ClientDetail.tsx
+++ b/src/components/ClientDetail.tsx
@@ -204,6 +204,8 @@ export function ClientDetail({ client, registry, onChanged, onRegistryChange }: 
       onChanged();
     } catch (e) {
       toastError(`${e}`);
+      // Rethrow so ConfirmDialog stays open for retry (SOU-406 / CodeRabbit).
+      throw e;
     } finally {
       setBusy(false);
     }
@@ -215,7 +217,13 @@ export function ClientDetail({ client, registry, onChanged, onRegistryChange }: 
   async function migrate() {
     setBusy(true);
     try {
-      const result = await migrateClient(client.id, profile || undefined);
+      // Migrate rewrites the whole gateway slot; force only after the user confirmed
+      // the migrate dialog when the entry is customized (SOU-406).
+      const result = await migrateClient(
+        client.id,
+        profile || undefined,
+        customized || undefined,
+      );
       onRegistryChange(result.registry);
       toast.success(
         `Moved ${result.moved.length} server${result.moved.length === 1 ? "" : "s"} into Toolport`,
@@ -561,7 +569,7 @@ export function ClientDetail({ client, registry, onChanged, onRegistryChange }: 
             </div>
           )}
         </div>
-      ) : scopeServerCount(profile) > 0 ? (
+      ) : !customized && scopeServerCount(profile) > 0 ? (
         <div className="flex flex-col gap-4">
           <p className="max-w-prose text-sm text-muted-foreground">
             Connect {client.name} once and it reaches your{" "}
@@ -577,13 +585,13 @@ export function ClientDetail({ client, registry, onChanged, onRegistryChange }: 
             servers={scopeServers(profile).map((s) => s.name)}
           />
         </div>
-      ) : (
+      ) : !customized ? (
         <p className="max-w-prose text-sm text-muted-foreground">
           Connect {client.name}, then enable servers under{" "}
           <span className="font-medium text-foreground">All servers</span> and
           they&apos;ll all route through Toolport, no per-client setup.
         </p>
-      )}
+      ) : null}
 
       {client.usesConnectors && (
         <Card className="gap-0 border-info/20 bg-info/5">
@@ -718,6 +726,12 @@ export function ClientDetail({ client, registry, onChanged, onRegistryChange }: 
               backed-up config. After migrating, re-enter them under each server's secrets
               so the gateway can connect.
             </p>
+            {customized && (
+              <p className="rounded-md bg-warning/10 p-2 text-xs text-warning">
+                This client has a custom Toolport entry. Migrating replaces it with the
+                default gateway command.
+              </p>
+            )}
             <div className="rounded-md bg-muted/40 p-2 font-mono text-xs text-muted-foreground">
               {movable.map((s) => s.name).join(", ")}
             </div>

--- a/src/components/Onboarding.verify.test.tsx
+++ b/src/components/Onboarding.verify.test.tsx
@@ -17,6 +17,7 @@ const client = {
   name: "Cursor",
   appPresent: true,
   gatewayInstalled: true,
+  entryState: "managed" as const,
   servers: [],
   pluginServers: [],
   configPath: "",

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -467,14 +467,17 @@ export function detectClients(): Promise<DetectedClient[]> {
 }
 
 /** Install the Toolport gateway into a client's config, optionally scoped to a
- * profile (by name). Omit profile to expose all enabled servers. */
+ * profile (by name). Omit profile to expose all enabled servers.
+ * Pass `force: true` after the user confirms overwriting a custom entry (SOU-406). */
 export function installGateway(
   clientId: string,
   profile?: string,
+  force?: boolean,
 ): Promise<WriteOutcome> {
   return invoke<WriteOutcome>("install_gateway", {
     clientId,
     profile: profile ?? null,
+    force: force ?? false,
   });
 }
 

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -487,14 +487,17 @@ export function uninstallGateway(clientId: string): Promise<WriteOutcome> {
 }
 
 /** Import a client's servers into Toolport, then leave the client with only the
- * Toolport gateway (optionally scoped to a profile). Backs up the config first. */
+ * Toolport gateway (optionally scoped to a profile). Backs up the config first.
+ * Pass `force: true` after the user confirms overwriting a custom entry (SOU-406). */
 export function migrateClient(
   clientId: string,
   profile?: string,
+  force?: boolean,
 ): Promise<MigrateResult> {
   return invoke<MigrateResult>("migrate_client", {
     clientId,
     profile: profile ?? null,
+    force: force ?? false,
   });
 }
 

--- a/src/lib/types.test.ts
+++ b/src/lib/types.test.ts
@@ -44,6 +44,7 @@ describe("gateway identity", () => {
       ],
       pluginServers: [],
       gatewayInstalled: true,
+      entryState: "managed",
       error: null,
     };
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -24,6 +24,9 @@ export interface ParsedSnippetServer {
   env: { key: string; value: string | null }[];
 }
 
+/** Ownership of the gateway entry under our name in a client config (SOU-406). */
+export type GatewayEntryState = "managed" | "customized" | "absent";
+
 export interface DetectedClient {
   id: string;
   name: string;
@@ -37,6 +40,8 @@ export interface DetectedClient {
   /** Servers found outside the config file (e.g. Cursor plugins); read-only. */
   pluginServers: McpServer[];
   gatewayInstalled: boolean;
+  /** First-class ownership: managed by us, hand-customized, or absent (SOU-406). */
+  entryState: GatewayEntryState;
   error: string | null;
 }
 
@@ -451,9 +456,20 @@ export interface Registry {
   /** Which profile each client was connected with, keyed by client id (e.g.
    * "cursor" -> "Billing"). Absent = that client follows the active profile. */
   clientScopes?: Record<string, string>;
+  /** What Toolport last wrote into each client config as its gateway entry
+   * (SOU-406 ownership record). Absent key = pre-ownership install. */
+  clientManagedEntries?: Record<string, ManagedEntry>;
   /** Consumers registered to reach the gateway over the HTTP/OpenAPI bridge,
    * each with its own hashed token and scope (multi-tenant bridge). */
   httpClients?: HttpClient[];
+}
+
+/** Snapshot of the gateway entry Toolport last wrote (SOU-406). */
+export interface ManagedEntry {
+  command: string;
+  args: string[];
+  env: Record<string, string>;
+  updatedAt: number;
 }
 
 /** A consumer registered to reach the HTTP/OpenAPI bridge with its own token and


### PR DESCRIPTION
Follow-up to #488 / SOU-405 / #487.

## Why

SOU-405 stopped the silent every-launch rewrite via a command-basename heuristic. That still could not tell an entry we wrote from a user customization of our binary, and the Integrations connect/apply paths could still overwrite a hand-edited entry without asking.

## What

1. **Ownership record** on `Registry.clientManagedEntries` (`ManagedEntry`: command, args, env, timestamp). Written on install/migrate/repoint; cleared on uninstall.
2. **`entryState`**: `managed` | `customized` | `absent` on `DetectedClient`. Record match -> Managed; record mismatch -> Customized; no record -> SOU-405 basename fallback.
3. **`repoint_stale_gateways`** skips Customized and reports those client ids separately.
4. **`install_gateway`** refuses Customized unless `force: true` (UI confirms first).
5. **Integrations UI**: warning badge, explainer, **Reset to default** (confirm + force install). Disconnect still available.

## Tests

- `entry_state_from_record_and_heuristic`
- `client_managed_entries_set_and_clear`
- ClientDetail customized badge / Reset button
- Prior SOU-405 tests still green

## Not in this PR

Managed shared-HTTP transport per client remains **SOU-407** (blocked on this).