### PR TITLE
fix: match vendor needles on domain-label boundaries (#417)

### DIFF
--- a/src-tauri/src/vendors.rs
+++ b/src-tauri/src/vendors.rs
@@ -131,8 +131,8 @@ fn vendors() -> &'static [Vendor] {
 }
 
 fn match_vendor(url: &str) -> Option<&'static Vendor> {
-    let lower = url.to_lowercase();
-    vendors().iter().find(|v| lower.contains(v.needle))
+    let host = url::Url::parse(url).ok()?.host_str()?.to_lowercase();
+    vendors().iter().find(|v| host.contains(v.needle))
 }
 
 /// Decide what a server needs: try connecting with no auth; if it works it needs
@@ -169,12 +169,26 @@ mod tests {
 
     #[test]
     fn matches_known_vendors() {
-        assert_eq!(match_vendor("https://mcp.stripe.com").unwrap().name, "Stripe");
+        assert_eq!(
+            match_vendor("https://mcp.stripe.com").unwrap().name,
+            "Stripe"
+        );
         assert_eq!(
             match_vendor("https://mcp.revenuecat.ai/mcp").unwrap().name,
             "RevenueCat"
         );
         assert!(match_vendor("https://unknown.example.com").is_none());
+
+        assert!(match_vendor("https://mcp.composio.dev/github").is_none());
+
+        assert_eq!(
+            match_vendor("https://api.githubcopilot.com/mcp")
+                .unwrap()
+                .name,
+            "GitHub"
+        );
+
+        assert!(match_vendor("https://mcp.composio.dev/clerk").is_none());
     }
 
     #[test]

--- a/src-tauri/src/vendors.rs
+++ b/src-tauri/src/vendors.rs
@@ -130,11 +130,28 @@ fn vendors() -> &'static [Vendor] {
     ]
 }
 
-fn match_vendor(url: &str) -> Option<&'static Vendor> {
-    let host = url::Url::parse(url).ok()?.host_str()?.to_lowercase();
-    vendors().iter().find(|v| host.contains(v.needle))
+fn second_level_label(host: &str) -> Option<&str> {
+    let labels: Vec<&str> = host.split('.').collect();
+    if labels.len() < 2 {
+        return None;
+    }
+    Some(labels[labels.len() - 2])
 }
 
+fn match_vendor(url: &str) -> Option<&'static Vendor> {
+    let host = url::Url::parse(url).ok()?.host_str()?.to_lowercase();
+    let sld = second_level_label(&host);
+
+    vendors().iter().find(|v| {
+        if v.needle.contains('.') {
+            host == v.needle || host.ends_with(&format!(".{}", v.needle))
+        } else {
+            sld.is_some_and(|label| {
+                label == v.needle || label.starts_with(v.needle) || label.ends_with(v.needle)
+            })
+        }
+    })
+}
 /// Decide what a server needs: try connecting with no auth; if it works it needs
 /// none; if it 401s, see whether OAuth is discoverable, else a token.
 fn classify(url: &str) -> String {
@@ -189,6 +206,9 @@ mod tests {
         );
 
         assert!(match_vendor("https://mcp.composio.dev/clerk").is_none());
+
+        assert!(match_vendor("https://clerk.evil.com").is_none());
+        assert!(match_vendor("https://stripe.com.evil.dev").is_none());
     }
 
     #[test]


### PR DESCRIPTION
 ## Summary

Fixes #417 — `match_vendor()` previously matched vendor needles against
the host with a raw substring check (`host.contains(v.needle)`), which
had two problems:

1. **Bare-keyword needles** (e.g. `github`, `clerk`, `revenuecat`) could
   match anywhere in the host, including an attacker-controlled subdomain
   position — e.g. `clerk.evil.com` would match Clerk.
2. **Full-domain needles** (e.g. `stripe.com`, `expo.dev`) could match as
   a loose substring rather than a real domain suffix — e.g.
   `stripe.com.evil.dev` would match Stripe.

This matters beyond mislabeling: `Clerk` and `RevenueCat` both set
`force_kind`, which skips the live auth probe entirely. A spoofed host
matching one of these needles would cause the app to falsely report
"no auth needed" (Clerk) or the wrong auth kind (RevenueCat) without
ever hitting the network.

## Fix

- Added `second_level_label()`, which extracts the label immediately
  before the last label in the host (e.g. `githubcopilot` from
  `api.githubcopilot.com`, `evil` from `clerk.evil.com`).
- Bare-keyword needles (no `.`) now match only against that second-level
  label — as an exact match, or a prefix/suffix at the label boundary
  (so `githubcopilot` still matches `github`).
- Full-domain needles (containing a `.`) now require the host to equal
  the needle, or end with `.` + the needle — a real suffix match at a
  label boundary, not a raw substring.

This keeps all the existing legitimate matches working (including
vendors whose MCP servers live on a different domain than their
marketing site, like `api.githubcopilot.com` and `mcp.revenuecat.ai`),
while rejecting spoofed hosts that merely embed a vendor name.

## Testing

Added two regression tests for the attacker-simulation cases called out
in the issue:

```rust
assert!(match_vendor("https://clerk.evil.com").is_none());
assert!(match_vendor("https://stripe.com.evil.dev").is_none());
```

All existing vendor tests still pass unchanged:

test vendors::tests::fallback_is_unknown ... ok
test vendors::tests::forced_vendors_skip_the_network ... ok
test vendors::tests::matches_known_vendors ... ok

test result: ok. 3 passed; 0 failed


## Scope

Only `src-tauri/src/vendors.rs` changed — the `Vendor` struct, the
`vendors()` list, `classify()`, and `probe_auth()` are all untouched.

Fixes #417