### PR TITLE
chore(release): prepare 1.9.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Entries before the rename below shipped under the project's former name, Conduit
 
 ## [Unreleased]
 
+## [1.9.6] - 2026-07-27
+
+Client config ownership, shared-HTTP transport, and safer vendor matching.
+
 ### Discovery
 
 **Code mode on by default.** `toolport_run_script` is advertised unless you turn **Code
@@ -33,21 +37,26 @@ heuristic. (SOU-406, follow-up to #487)
 
 **A hand-edited gateway entry is no longer reverted on every app launch.** The
 launch-time re-point recognized its own entry by _name_, so an entry still called
-`toolport` but pointed at something else — an `mcp-remote` bridge against the HTTP
-endpoint, a container, a wrapper script — was treated as a stale install and rewritten
+`toolport` but pointed at something else - an `mcp-remote` bridge against the HTTP
+endpoint, a container, a wrapper script - was treated as a stale install and rewritten
 back to the default stdio command every time the app started. Re-pointing now requires
 the stored command to actually name a Toolport gateway binary; anything else is treated
 as user-managed and left exactly as written (and the skip is logged). Genuine
-migrations — an older version, the pre-rename `conduit-gateway`, the pre-rename data
-directory, an unversioned install path — are unaffected. (#487)
+migrations - an older version, the pre-rename `conduit-gateway`, the pre-rename data
+directory, an unversioned install path - are unaffected. (#487, #488)
 
 **A machine-wide `TOOLPORT_HTTP` / `CONDUIT_HTTP` no longer hijacks client-spawned
 gateways.** HTTP mode replaces the stdio transport, so an inherited value left every
 MCP client with a gateway that never answered its pipe, and every gateway after the
-first colliding on the shared port (`WSAEADDRINUSE`) — which some clients treat as
+first colliding on the shared port (`WSAEADDRINUSE`) - which some clients treat as
 fatal. The env forms are now ignored, with a warning, when stdin is a pipe. The
 desktop app, the Docker images, and the documented headless setup all pass `--http`
 explicitly and are unaffected; use the flag in scripts and services too. (#487)
+
+**Vendor auth hints match on domain-label boundaries only.** Bare needles like
+`clerk` / `github` no longer match attacker subdomains (`clerk.evil.com`), and full
+domain needles require a real host suffix. Spoofed hosts can no longer skip the live
+probe via `force_kind`. (#417, #492)
 
 ## [1.9.5] - 2026-07-25
 

--- a/docs/release-notes/v1.9.6.md
+++ b/docs/release-notes/v1.9.6.md
@@ -1,0 +1,53 @@
+# Toolport v1.9.6
+
+Client config ownership, shared-HTTP transport, and safer vendor matching.
+
+## Why this release
+
+A user report (#487) showed Toolport rewriting a hand-edited Claude Desktop
+`toolport` entry on every app launch. This release stops that class of silent
+overwrite, records what Toolport manages, and offers Shared HTTP as a first-class
+connect option so users do not need to hand-edit for the documented HTTP bridge.
+
+## Client ownership and connect
+
+- **Hand-edited gateway entries are left alone on launch.** Re-point only rewrites
+  commands that look like Toolport/Conduit gateway binaries. (#487 / SOU-405)
+- **Managed / Customized / Absent** is first-class. Integrations shows a custom
+  configuration badge and **Reset to default** with confirm. Connect/migrate will
+  not clobber a customized entry without force. (SOU-406)
+- **Spawn (stdio) or Shared HTTP** on Connect. Shared HTTP starts the supervised
+  bridge, mints a per-client bearer, and writes a native remote entry or an
+  opt-in `npx mcp-remote` form for stdio-only clients (Claude Desktop, etc.).
+  (SOU-407)
+
+## Other fixes
+
+- **Machine-wide `TOOLPORT_HTTP` / `CONDUIT_HTTP`** no longer flips client-spawned
+  stdio gateways into HTTP mode (env ignored when stdin is a pipe). (#487)
+- **Vendor auth hints** match on domain-label boundaries only - no more
+  `clerk.evil.com` spoofing Clerk / force_kind. (#417)
+- **Code mode on by default**, with Settings as the kill switch. (SOU-397)
+
+## Smoke checklist (before you publish)
+
+1. **Customized entry survives restart**
+   - Connect Claude Desktop (stdio).
+   - Edit `toolport` to something non-gateway (e.g. `npx` / empty).
+   - Restart Toolport. Entry must stay; no new backup from re-point.
+2. **Reset to default**
+   - Customized client shows badge + Reset. Confirm overwrites to stdio gateway.
+3. **Shared HTTP**
+   - Connect a client with transport **Shared HTTP**. Bridge comes up; client
+     config has remote or `mcp-remote` entry; Integrations shows managed.
+4. **Connect still works for stdio** (default).
+5. **Vendor probe**: a known host still labels correctly; `https://clerk.evil.com`
+   must not force Clerk "none".
+
+## Upgrade notes
+
+Open Toolport once after install so launch migration / re-point runs. Restart AI
+clients so they reload MCP config. Existing `"codeMode": false` registries stay
+off code mode.
+
+Full changelog: [CHANGELOG.md](https://github.com/tsouth89/toolport/blob/main/CHANGELOG.md#196---2026-07-27).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "toolport",
-  "version": "1.9.5",
+  "version": "1.9.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "toolport",
-      "version": "1.9.5",
+      "version": "1.9.6",
       "dependencies": {
         "@fontsource-variable/geist": "^5.2.9",
         "@tailwindcss/vite": "^4.3.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "toolport",
   "private": true,
-  "version": "1.9.5",
+  "version": "1.9.6",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -780,7 +780,7 @@ dependencies = [
 
 [[package]]
 name = "conduit"
-version = "1.9.5"
+version = "1.9.6"
 dependencies = [
  "base64 0.22.1",
  "boa_engine",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conduit"
-version = "1.9.5"
+version = "1.9.6"
 description = "Local MCP gateway: manage all your MCP servers in one place, set up once and shared by every AI client, with ~90% fewer tokens per request"
 authors = ["South Forge AI"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Toolport",
-  "version": "1.9.5",
+  "version": "1.9.6",
   "identifier": "com.tsout.conduit",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
Version bump and changelog for 1.9.6.

Includes work already on main: #488 / #489 / #491 / #492 (client ownership, shared HTTP, ambient TOOLPORT_HTTP, vendor domain matching) plus code mode default-on.

Release notes: `docs/release-notes/v1.9.6.md` (includes smoke checklist).

After merge: tag `v1.9.6` as a **draft** GitHub release (installers attach via Release workflow; do not publish until smoke pass).