### PR TITLE
docs(release): full 1.9.6 notes and contributor thanks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ Entries before the rename below shipped under the project's former name, Conduit
 
 ## [1.9.6] - 2026-07-27
 
-Client config ownership, shared-HTTP transport, and safer vendor matching.
+Client config ownership, Shared HTTP connect, code mode v2 (parallel + typed stubs),
+native resource subscriptions, gateway hardening, and safer vendor matching.
 
 ### Discovery
 
@@ -18,6 +19,10 @@ still hits the same scope and approval gates as `toolport_call_tool`. Code mode 
 security boundary (agent-supplied JS). `TOOLPORT_CODE_MODE=1` still force-enables.
 Existing registries that already store `"codeMode": false` stay off. (SOU-397)
 
+**Code mode parallel calls and typed stubs.** Scripts get `callAsync` / `Promise.all`
+with bounded host parallelism, scoped `servers.*` typed stubs, full intermediate
+results and `fetchResult` handoff. (#480–#483 / SOU-348)
+
 ### Added
 
 **Per-client transport: Spawn (stdio) or Shared HTTP.** Integrations can connect a
@@ -25,6 +30,10 @@ client to the supervised HTTP bridge instead of spawning its own gateway. Native
 remote shapes (VS Code, OpenCode, Qwen, Hermes, Continue) get a url + bearer entry;
 clients that only support stdio (Claude Desktop, etc.) get an opt-in `npx mcp-remote`
 bridge. Tokens are vaulted; ownership records never store bearers. (SOU-407)
+
+**Native MCP resource subscriptions.** Subscribe/unsubscribe and `resources/updated`
+fanout (with producer verification), resource templates + completions, paginated
+catalogs preserved. (#474–#479, #484)
 
 ### Fixed
 
@@ -57,6 +66,13 @@ explicitly and are unaffected; use the flag in scripts and services too. (#487)
 `clerk` / `github` no longer match attacker subdomains (`clerk.evil.com`), and full
 domain needles require a real host suffix. Spoofed hosts can no longer skip the live
 probe via `force_kind`. (#417, #492)
+
+**Headless `secrets.enc` set/delete is locked** against concurrent writers. (SOU-332)
+
+**Profile scope tool-fetch UI** shows failures, ignores stale errors after a newer
+load, and scopes loading state per server. (#468)
+
+**Search efficiency and routed-call audit overhead** improvements. (#472, #473)
 
 ## [1.9.5] - 2026-07-25
 

--- a/docs/release-notes/v1.9.6.md
+++ b/docs/release-notes/v1.9.6.md
@@ -1,53 +1,71 @@
 # Toolport v1.9.6
 
-Client config ownership, shared-HTTP transport, and safer vendor matching.
+Client ownership that stays put, Shared HTTP as a real connect option, code mode that can run real multi-step scripts, native resource subscriptions, and a pile of gateway hardening.
 
-## Why this release
+## Highlights
 
-A user report (#487) showed Toolport rewriting a hand-edited Claude Desktop
-`toolport` entry on every app launch. This release stops that class of silent
-overwrite, records what Toolport manages, and offers Shared HTTP as a first-class
-connect option so users do not need to hand-edit for the documented HTTP bridge.
+### Your client config is yours (unless you ask us to rewrite it)
 
-## Client ownership and connect
+A report from the community (#487) showed Toolport rewriting a hand-edited Claude Desktop `toolport` entry on every app launch. That is fixed end to end:
 
-- **Hand-edited gateway entries are left alone on launch.** Re-point only rewrites
-  commands that look like Toolport/Conduit gateway binaries. (#487 / SOU-405)
-- **Managed / Customized / Absent** is first-class. Integrations shows a custom
-  configuration badge and **Reset to default** with confirm. Connect/migrate will
-  not clobber a customized entry without force. (SOU-406)
-- **Spawn (stdio) or Shared HTTP** on Connect. Shared HTTP starts the supervised
-  bridge, mints a per-client bearer, and writes a native remote entry or an
-  opt-in `npx mcp-remote` form for stdio-only clients (Claude Desktop, etc.).
-  (SOU-407)
+- **Launch re-point only touches real gateway binaries** (versioned `toolport-gateway*` / legacy `conduit-gateway*`). Hand-edited commands like `npx mcp-remote` are left alone and logged. (#488 / SOU-405)
+- **Ownership is first-class: Managed / Customized / Absent.** Integrations shows a custom-configuration badge and **Reset to default** (confirm before overwrite). Connect and migrate refuse to clobber a customized entry without an explicit force. (#489 / SOU-406)
+- **Shared HTTP on Connect.** Point a client at the supervised HTTP bridge instead of spawning its own gateway: native `url` + bearer where the client supports it, or an opt-in `npx mcp-remote` form for stdio-only clients (Claude Desktop and friends). Tokens are vaulted; ownership records never store bearers. (#491 / SOU-407)
+- **Machine-wide `TOOLPORT_HTTP` / `CONDUIT_HTTP` no longer hijacks client-spawned stdio gateways.** When stdin is a pipe, env forms are ignored (with a warning). Prefer `--http` for scripts and services. (#488)
 
-## Other fixes
+### Code mode grows up
 
-- **Machine-wide `TOOLPORT_HTTP` / `CONDUIT_HTTP`** no longer flips client-spawned
-  stdio gateways into HTTP mode (env ignored when stdin is a pipe). (#487)
-- **Vendor auth hints** match on domain-label boundaries only - no more
-  `clerk.evil.com` spoofing Clerk / force_kind. (#417)
-- **Code mode on by default**, with Settings as the kill switch. (SOU-397)
+- **Parallel / async tool calls** in `toolport_run_script`: `callAsync`, `Promise.all`, bounded host parallelism. (#480 / SOU-348)
+- **Typed `servers.*` stubs** so scripts can call scoped tools with real names. (#481)
+- **Full intermediate results** and `fetchResult` handoff so multi-step scripts stay useful. (#483)
+- **Review hardening** for promise drains and edge cases. (#482)
+- **On by default**, with Settings as the kill switch. Existing registries that already set `"codeMode": false` stay off. (SOU-397 / #485)
 
-## Smoke checklist (before you publish)
+### Native MCP resources
 
-1. **Customized entry survives restart**
-   - Connect Claude Desktop (stdio).
-   - Edit `toolport` to something non-gateway (e.g. `npx` / empty).
-   - Restart Toolport. Entry must stay; no new backup from re-point.
-2. **Reset to default**
-   - Customized client shows badge + Reset. Confirm overwrites to stdio gateway.
-3. **Shared HTTP**
-   - Connect a client with transport **Shared HTTP**. Bridge comes up; client
-     config has remote or `mcp-remote` entry; Integrations shows managed.
-4. **Connect still works for stdio** (default).
-5. **Vendor probe**: a known host still labels correctly; `https://clerk.evil.com`
-   must not force Clerk "none".
+- **Subscribe / unsubscribe** and **`resources/updated` fanout** from downstream servers to clients (stdio + HTTP). (#476 and follow-ups #477–#479)
+- **Resource templates** aggregated and completions forwarded. (#475)
+- **Producer verification** before fanout so a notification is not blindly broadcast. (#484 / SOU-398)
+- **Paginated catalogs** preserved so large tool lists do not drop pages. (#474)
+
+### Gateway performance and correctness
+
+- Search efficiency and benchmark budgets. (#472)
+- Lower routed-call audit overhead. (#473)
+- HTTP confirm and shaped-result stash keyed by stable client id. (#478)
+- Headless **`secrets.enc` load-modify-save is locked** against concurrent writers (same idea as registry locking). (#486 / SOU-332)
+
+### UI and safety polish
+
+- Profile scope panel shows tool-fetch failures and ignores stale errors after a newer load; tool loading state is scoped per server. (#468)
+- Vendor auth hints match on **domain-label boundaries only** - spoofed hosts like `clerk.evil.com` no longer skip the live probe via `force_kind`. (#417 / #492)
+
+## Thanks
+
+Huge thanks to everyone who filed reports, reviewed, or sent patches this cycle:
+
+- **[DanielRitter75](https://github.com/DanielRitter75)** for the detailed #487 write-up (env, repro, backups). That report drove the ownership and Shared HTTP work.
+- **[Vermitrude](https://github.com/Vermitrude)** / **cromewar** for the vendor domain-boundary fix (#490 → landed as #492).
+- **[BharadwajKanneveti](https://github.com/BharadwajKanneveti)** for profile-scope tool-fetch error handling (#468).
+
+If we missed you, open an issue or ping us - credit should follow the work.
 
 ## Upgrade notes
 
-Open Toolport once after install so launch migration / re-point runs. Restart AI
-clients so they reload MCP config. Existing `"codeMode": false` registries stay
-off code mode.
+1. Install 1.9.6 and open Toolport once so launch migration / re-point can run.
+2. Restart each AI client so it reloads MCP config.
+3. Existing registries with `"codeMode": false` stay off code mode.
+4. Prefer `toolport-gateway --http` over a machine-wide `TOOLPORT_HTTP` for services.
 
-Full changelog: [CHANGELOG.md](https://github.com/tsouth89/toolport/blob/main/CHANGELOG.md#196---2026-07-27).
+## Smoke checklist (before you publish the draft)
+
+1. **Customized entry survives restart** - hand-edit Claude's `toolport` command, restart Toolport, entry stays.
+2. **Reset to default** - customized badge → confirm → stdio gateway restored.
+3. **Shared HTTP** - Connect with Shared HTTP → bridge up, managed entry written.
+4. **Stdio Connect** still works as the default.
+5. **Vendor probe** - known host still labels; `https://clerk.evil.com` does not force Clerk "none".
+6. **Code mode** - Settings shows it on; a simple `toolport_run_script` with two parallel calls works when you want a deeper check.
+
+## Full changelog
+
+See [CHANGELOG.md](https://github.com/tsouth89/toolport/blob/main/CHANGELOG.md#196---2026-07-27) and the PR list: #472, #468, #484, #485, #486, #488, #489, #491, #492, #493 (and stacked work in #473–#483).


### PR DESCRIPTION
Expands v1.9.6 release notes and CHANGELOG to cover everything since v1.9.5 (not only the ownership stack), and thanks community contributors.

Also updates the **draft** GitHub release body (still draft; not published).