### PR TITLE
docs(release): public 1.9.6 notes cleanup

### DIFF
--- a/docs/release-notes/v1.9.6.md
+++ b/docs/release-notes/v1.9.6.md
@@ -8,44 +8,43 @@ Client ownership that stays put, Shared HTTP as a real connect option, code mode
 
 A report from the community (#487) showed Toolport rewriting a hand-edited Claude Desktop `toolport` entry on every app launch. That is fixed end to end:
 
-- **Launch re-point only touches real gateway binaries** (versioned `toolport-gateway*` / legacy `conduit-gateway*`). Hand-edited commands like `npx mcp-remote` are left alone and logged. (#488 / SOU-405)
-- **Ownership is first-class: Managed / Customized / Absent.** Integrations shows a custom-configuration badge and **Reset to default** (confirm before overwrite). Connect and migrate refuse to clobber a customized entry without an explicit force. (#489 / SOU-406)
-- **Shared HTTP on Connect.** Point a client at the supervised HTTP bridge instead of spawning its own gateway: native `url` + bearer where the client supports it, or an opt-in `npx mcp-remote` form for stdio-only clients (Claude Desktop and friends). Tokens are vaulted; ownership records never store bearers. (#491 / SOU-407)
+- **Launch re-point only touches real gateway binaries** (versioned `toolport-gateway*` / legacy `conduit-gateway*`). Hand-edited commands like `npx mcp-remote` are left alone and logged. (#488)
+- **Ownership is first-class: Managed / Customized / Absent.** Integrations shows a custom-configuration badge and **Reset to default** (confirm before overwrite). Connect and migrate refuse to clobber a customized entry without an explicit force. (#489)
+- **Shared HTTP on Connect.** Point a client at the supervised HTTP bridge instead of spawning its own gateway: native `url` + bearer where the client supports it, or an opt-in `npx mcp-remote` form for stdio-only clients (Claude Desktop and friends). Tokens are vaulted; ownership records never store bearers. (#491)
 - **Machine-wide `TOOLPORT_HTTP` / `CONDUIT_HTTP` no longer hijacks client-spawned stdio gateways.** When stdin is a pipe, env forms are ignored (with a warning). Prefer `--http` for scripts and services. (#488)
 
 ### Code mode grows up
 
-- **Parallel / async tool calls** in `toolport_run_script`: `callAsync`, `Promise.all`, bounded host parallelism. (#480 / SOU-348)
+- **Parallel / async tool calls** in `toolport_run_script`: `callAsync`, `Promise.all`, bounded host parallelism. (#480)
 - **Typed `servers.*` stubs** so scripts can call scoped tools with real names. (#481)
 - **Full intermediate results** and `fetchResult` handoff so multi-step scripts stay useful. (#483)
-- **Review hardening** for promise drains and edge cases. (#482)
-- **On by default**, with Settings as the kill switch. Existing registries that already set `"codeMode": false` stay off. (SOU-397 / #485)
+- Promise drains and edge-case hardening. (#482)
+- **On by default**, with Settings as the kill switch. Existing registries that already set `"codeMode": false` stay off. (#485)
 
 ### Native MCP resources
 
-- **Subscribe / unsubscribe** and **`resources/updated` fanout** from downstream servers to clients (stdio + HTTP). (#476 and follow-ups #477–#479)
+- **Subscribe / unsubscribe** and **`resources/updated` fanout** from downstream servers to clients (stdio + HTTP). (#476–#479)
 - **Resource templates** aggregated and completions forwarded. (#475)
-- **Producer verification** before fanout so a notification is not blindly broadcast. (#484 / SOU-398)
+- **Producer verification** before fanout so a notification is not blindly broadcast. (#484)
 - **Paginated catalogs** preserved so large tool lists do not drop pages. (#474)
 
 ### Gateway performance and correctness
 
-- Search efficiency and benchmark budgets. (#472)
-- Lower routed-call audit overhead. (#473)
+- Search efficiency and lower routed-call audit overhead. (#472, #473)
 - HTTP confirm and shaped-result stash keyed by stable client id. (#478)
-- Headless **`secrets.enc` load-modify-save is locked** against concurrent writers (same idea as registry locking). (#486 / SOU-332)
+- Headless **`secrets.enc` load-modify-save is locked** against concurrent writers (same idea as registry locking). (#486)
 
 ### UI and safety polish
 
 - Profile scope panel shows tool-fetch failures and ignores stale errors after a newer load; tool loading state is scoped per server. (#468)
-- Vendor auth hints match on **domain-label boundaries only** - spoofed hosts like `clerk.evil.com` no longer skip the live probe via `force_kind`. (#417 / #492)
+- Vendor auth hints match on **domain-label boundaries only** - spoofed hosts like `clerk.evil.com` no longer skip the live probe. (#417 / #492)
 
 ## Thanks
 
 Huge thanks to everyone who filed reports, reviewed, or sent patches this cycle:
 
 - **[DanielRitter75](https://github.com/DanielRitter75)** for the detailed #487 write-up (env, repro, backups). That report drove the ownership and Shared HTTP work.
-- **[Vermitrude](https://github.com/Vermitrude)** / **cromewar** for the vendor domain-boundary fix (#490 → landed as #492).
+- **[Vermitrude](https://github.com/Vermitrude)** for the vendor domain-boundary fix (#492).
 - **[BharadwajKanneveti](https://github.com/BharadwajKanneveti)** for profile-scope tool-fetch error handling (#468).
 
 If we missed you, open an issue or ping us - credit should follow the work.
@@ -57,15 +56,6 @@ If we missed you, open an issue or ping us - credit should follow the work.
 3. Existing registries with `"codeMode": false` stay off code mode.
 4. Prefer `toolport-gateway --http` over a machine-wide `TOOLPORT_HTTP` for services.
 
-## Smoke checklist (before you publish the draft)
-
-1. **Customized entry survives restart** - hand-edit Claude's `toolport` command, restart Toolport, entry stays.
-2. **Reset to default** - customized badge → confirm → stdio gateway restored.
-3. **Shared HTTP** - Connect with Shared HTTP → bridge up, managed entry written.
-4. **Stdio Connect** still works as the default.
-5. **Vendor probe** - known host still labels; `https://clerk.evil.com` does not force Clerk "none".
-6. **Code mode** - Settings shows it on; a simple `toolport_run_script` with two parallel calls works when you want a deeper check.
-
 ## Full changelog
 
-See [CHANGELOG.md](https://github.com/tsouth89/toolport/blob/main/CHANGELOG.md#196---2026-07-27) and the PR list: #472, #468, #484, #485, #486, #488, #489, #491, #492, #493 (and stacked work in #473–#483).
+See [CHANGELOG.md](https://github.com/tsouth89/toolport/blob/main/CHANGELOG.md#196---2026-07-27) and the related PRs: #468, #472–#486, #488, #489, #491, #492.


### PR DESCRIPTION
## Summary
- Strip Linear SOU IDs, pre-publish smoke checklist, and process-only PR wording from v1.9.6 release notes
- Draft GitHub release body already matches this text

## Test plan
- [x] Notes read as user-facing only
- [x] Live Toolport 1.9.6 → Linear write smoke (SOU-407 comment)