### PR TITLE
fix(app): cross-platform path-based stale gateway reaper (SOU-414)

### DIFF
--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -30,6 +30,15 @@ release with auto-generated notes. Replace or augment the body with
 The **gateway container image** (`ghcr.io/tsouth89/toolport-gateway`) publishes
 separately on every push to `main` via `docker-publish.yml` — no tag required.
 
+## After users upgrade
+
+On each app launch Toolport **stops obsolete gateway processes** (older versioned
+binaries and stale paths), keeping the current published/resolved gateway. Clients
+that auto-respawn MCP pick up the new binary on the **next tool call** without a
+full agent restart. Settings → Integrations → **Stop old gateways** runs the same
+cleanup on demand. The in-app updater still kills **all** gateway processes before
+install so locked files can be replaced.
+
 ## Manual fallback
 
 If you'd rather build locally:

--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -2702,8 +2702,8 @@ fn http_bridge_alive(bridge: &mut HttpBridge) -> bool {
     alive
 }
 
-/// Stop client-spawned gateway processes before an in-app update (Windows).
-/// MCP clients stay open; only `toolport-gateway` children exit.
+/// Stop client-spawned gateway processes before an in-app update (all platforms).
+/// MCP clients stay open; only `toolport-gateway` / `conduit-gateway` children exit.
 #[tauri::command]
 fn stop_spawned_gateways() -> u32 {
     crate::gateway_publish::stop_spawned_gateways()
@@ -3215,25 +3215,21 @@ pub fn run() {
                         repoint.customized.join(", ")
                     );
                 }
-                // Stop any gateway running a version other than this one, so each client
-                // respawns the freshly-installed gateway on its next request rather than the
-                // user having to relaunch the client. Covers MANUAL updates (running the
-                // installer), which never go through the in-app updater that already calls
-                // stop_spawned_gateways.
-                //
-                // Deliberately NOT gated on `repointed` (SOU-306). That call is idempotent, so
-                // once configs point at the new binary it returns empty forever and the cleanup
-                // became one-shot: it was a proxy for "is a running gateway on an old version?"
-                // and the two come apart precisely after a manual install, or on any launch
-                // after the first. Checking versions directly makes this self-correcting, so a
-                // later launch still cleans up what an earlier one missed. Current-version
-                // gateways are left alone, so a normal launch kills nothing.
-                let stale = crate::gateway_publish::stop_stale_gateways();
+                // Stop obsolete gateway processes so each client respawns the current binary
+                // on its next MCP request (no full agent restart required when the host
+                // auto-respawns). Path-based identity on all OS (SOU-414); not gated on
+                // repoint (SOU-306). Pass resolve_gateway_path so the nested macOS helper /
+                // AppImage stable path is kept even when publish is Windows-only.
+                let mut extra_keep = Vec::new();
+                if let Some(p) = clients::resolve_gateway_path() {
+                    extra_keep.push(p);
+                }
+                let stale = crate::gateway_publish::stop_stale_gateways_with_keep(&extra_keep);
                 if !stale.is_empty() {
                     eprintln!(
-                        "toolport: stopped {} stale gateway process image(s): {}",
+                        "toolport: stopped {} stale gateway process(es): {}",
                         stale.len(),
-                        stale.join(", ")
+                        stale.join("; ")
                     );
                 }
             });

--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -2709,6 +2709,18 @@ fn stop_spawned_gateways() -> u32 {
     crate::gateway_publish::stop_spawned_gateways()
 }
 
+/// Stop obsolete gateway processes (older versions / stale paths), keeping the
+/// current resolved binary. Safe to run any time; used from Settings and launch.
+/// Returns labels of processes that were stopped.
+#[tauri::command]
+fn stop_stale_gateways() -> Vec<String> {
+    let mut extra_keep = Vec::new();
+    if let Some(p) = clients::resolve_gateway_path() {
+        extra_keep.push(p);
+    }
+    crate::gateway_publish::stop_stale_gateways_with_keep(&extra_keep)
+}
+
 /// Start `toolport-gateway --http <port>` as a supervised child so HTTP/OpenAPI
 /// clients can connect. Idempotent: if it's already running, returns the current
 /// status; otherwise spawns the bundled gateway binary and tracks it.
@@ -3113,6 +3125,7 @@ pub fn run() {
             stop_http_bridge,
             http_bridge_status,
             stop_spawned_gateways,
+            stop_stale_gateways,
         ])
         // Close-to-tray: the window's X hides it instead of quitting, so the gateway and
         // approval broker keep running (HITL only works while the app is alive). Quit is
@@ -3220,6 +3233,10 @@ pub fn run() {
                 // auto-respawns). Path-based identity on all OS (SOU-414); not gated on
                 // repoint (SOU-306). Pass resolve_gateway_path so the nested macOS helper /
                 // AppImage stable path is kept even when publish is Windows-only.
+                //
+                // Run once immediately, then again after a short delay so a client that
+                // race-respawns an old path between repoint and the first kill is cleaned up
+                // without another full app restart.
                 let mut extra_keep = Vec::new();
                 if let Some(p) = clients::resolve_gateway_path() {
                     extra_keep.push(p);
@@ -3232,6 +3249,19 @@ pub fn run() {
                         stale.join("; ")
                     );
                 }
+                let keep_for_retry = extra_keep.clone();
+                std::thread::spawn(move || {
+                    std::thread::sleep(std::time::Duration::from_secs(3));
+                    let again =
+                        crate::gateway_publish::stop_stale_gateways_with_keep(&keep_for_retry);
+                    if !again.is_empty() {
+                        eprintln!(
+                            "toolport: delayed reaper stopped {} more stale gateway process(es): {}",
+                            again.len(),
+                            again.join("; ")
+                        );
+                    }
+                });
             });
 
             // Start the human-approval broker: it publishes a loopback endpoint that every

--- a/src-tauri/src/gateway_publish.rs
+++ b/src-tauri/src/gateway_publish.rs
@@ -249,11 +249,14 @@ fn default_keep_paths() -> Vec<PathBuf> {
 }
 
 fn paths_equal(a: &Path, b: &Path) -> bool {
-    let na = normalize_path(a);
-    let nb = normalize_path(b);
-    na == nb
+    // Resolve symlinks when the files exist so macOS helper vs Contents/MacOS
+    // symlink to the same binary both match a keep path.
+    let ca = std::fs::canonicalize(a).unwrap_or_else(|_| a.to_path_buf());
+    let cb = std::fs::canonicalize(b).unwrap_or_else(|_| b.to_path_buf());
+    normalize_path(&ca) == normalize_path(&cb)
 }
 
+/// Normalize for comparison only. Always uses `\` so callers check one form.
 fn normalize_path(p: &Path) -> String {
     p.to_string_lossy()
         .replace('/', "\\")
@@ -265,20 +268,41 @@ fn normalize_path(p: &Path) -> String {
 pub fn is_gateway_basename(name: &str) -> bool {
     let lower = name.to_ascii_lowercase();
     let stem = lower.strip_suffix(".exe").unwrap_or(&lower);
-    stem.starts_with("toolport-gateway") || stem.starts_with("conduit-gateway")
+    stem == "toolport-gateway"
+        || stem == "conduit-gateway"
+        || stem.starts_with("toolport-gateway-")
+        || stem.starts_with("conduit-gateway-")
 }
 
+/// True only for names like `toolport-gateway-1.9.4`, not `toolport-gateway-shim`.
 fn is_versioned_gateway_basename(name: &str) -> bool {
     let lower = name.to_ascii_lowercase();
     let stem = lower.strip_suffix(".exe").unwrap_or(&lower);
-    // toolport-gateway-1.9.4 or conduit-gateway-1.9.4 — not bare toolport-gateway
-    if let Some(rest) = stem.strip_prefix("toolport-gateway-") {
-        return !rest.is_empty();
+    let rest = if let Some(r) = stem.strip_prefix("toolport-gateway-") {
+        r
+    } else if let Some(r) = stem.strip_prefix("conduit-gateway-") {
+        r
+    } else {
+        return false;
+    };
+    looks_like_version_suffix(rest)
+}
+
+/// Version suffix: starts with a digit, contains `.`, and only version-ish chars
+/// (e.g. `1.9.4`, `1.9.4-beta.1`). Rejects `shim`, `helper`, target triples alone.
+fn looks_like_version_suffix(s: &str) -> bool {
+    if s.is_empty() {
+        return false;
     }
-    if let Some(rest) = stem.strip_prefix("conduit-gateway-") {
-        return !rest.is_empty();
+    let mut chars = s.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+    if !first.is_ascii_digit() || !s.contains('.') {
+        return false;
     }
-    false
+    s.chars()
+        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '-' | '+' | '_'))
 }
 
 fn basename_matches_current_version(name: &str, version: &str) -> bool {
@@ -293,10 +317,7 @@ fn basename_matches_current_version(name: &str, version: &str) -> bool {
 /// `tauri dev` is not murdered by a packaged Toolport on the same machine.
 fn is_dev_target_path(path: &Path) -> bool {
     let n = normalize_path(path);
-    n.contains("\\target\\debug\\")
-        || n.contains("\\target\\release\\")
-        || n.contains("/target/debug/")
-        || n.contains("/target/release/")
+    n.contains("\\target\\debug\\") || n.contains("\\target\\release\\")
 }
 
 /// Path is under a Toolport/Conduit product location (data dir bin, install leaf,
@@ -306,8 +327,6 @@ fn path_looks_like_our_install(path: &Path) -> bool {
     let n = normalize_path(path);
     n.contains("\\toolport\\")
         || n.contains("\\conduit\\")
-        || n.contains("/toolport/")
-        || n.contains("/conduit/")
         || n.contains("toolportgateway.app")
         || n.contains("conduitgateway.app")
         || n.contains("toolport.app")
@@ -337,7 +356,12 @@ pub fn decide_reap(proc: &GatewayProcess, ctx: &ReapContext) -> ReapDecision {
             return ReapDecision::Keep;
         }
         if is_versioned_gateway_basename(&proc.basename) {
-            return ReapDecision::Kill;
+            // Only kill versioned images under our product paths (not toolport-gateway-shim
+            // in /opt/other-vendor, and not non-version suffixes that snuck through).
+            if path_looks_like_our_install(path) {
+                return ReapDecision::Kill;
+            }
+            return ReapDecision::Keep;
         }
         // Unversioned basename (macOS/Linux/AppImage/dev packaged): path is the
         // identity. Not equal to keep_paths and looks like ours → obsolete copy.
@@ -422,9 +446,6 @@ fn log_reap_report(kind: &str, report: &ReapReport) {
             report.failed.len(),
             report.failed.join("; ")
         );
-    }
-    if report.killed.is_empty() && report.failed.is_empty() && !report.kept.is_empty() {
-        // Quiet on the common clean-launch path; only note when debugging would help.
     }
 }
 
@@ -645,11 +666,13 @@ fn linux_list_gateway_processes() -> Vec<GatewayProcess> {
     out
 }
 
-/// macOS: `ps` for pid + command line (no /proc).
+/// macOS: `ps` for pid + comm (no spaces), then `proc_pidpath` for the real
+/// executable path. Do not parse `command=` — default install paths contain
+/// spaces (`Application Support`) and break whitespace splits.
 #[cfg(target_os = "macos")]
 fn macos_list_gateway_processes() -> Vec<GatewayProcess> {
     let Ok(out) = std::process::Command::new("ps")
-        .args(["-ax", "-o", "pid=", "-o", "command="])
+        .args(["-axo", "pid=", "comm="])
         .output()
     else {
         return Vec::new();
@@ -668,22 +691,17 @@ fn macos_list_gateway_processes() -> Vec<GatewayProcess> {
         let Ok(pid) = pid_s.parse::<u32>() else {
             continue;
         };
-        let cmd = parts.collect::<Vec<_>>().join(" ");
-        if cmd.is_empty() {
+        // comm= is a single field (no path, no args).
+        let comm = parts.collect::<Vec<_>>().join(" ");
+        if comm.is_empty() || !is_gateway_basename(&comm) {
             continue;
         }
-        // First token is the executable path (or name).
-        let exe = cmd.split_whitespace().next().unwrap_or("");
-        let path = if exe.contains('/') {
-            Some(PathBuf::from(exe))
-        } else {
-            None
-        };
+        let path = macos_proc_pidpath(pid);
         let basename = path
             .as_ref()
             .and_then(|p| p.file_name())
             .map(|s| s.to_string_lossy().into_owned())
-            .unwrap_or_else(|| exe.to_string());
+            .unwrap_or(comm);
         if !is_gateway_basename(&basename) {
             continue;
         }
@@ -694,6 +712,31 @@ fn macos_list_gateway_processes() -> Vec<GatewayProcess> {
         });
     }
     procs
+}
+
+/// Full executable path for a pid via libproc (handles spaces and symlinks).
+#[cfg(target_os = "macos")]
+fn macos_proc_pidpath(pid: u32) -> Option<PathBuf> {
+    // proc_pidpath is in libSystem on macOS; no extra crate needed.
+    extern "C" {
+        fn proc_pidpath(pid: i32, buffer: *mut std::ffi::c_void, buffersize: u32) -> i32;
+    }
+    let mut buf = [0u8; 4096];
+    let n = unsafe {
+        proc_pidpath(
+            pid as i32,
+            buf.as_mut_ptr() as *mut std::ffi::c_void,
+            buf.len() as u32,
+        )
+    };
+    if n <= 0 {
+        return None;
+    }
+    let s = std::str::from_utf8(&buf[..n as usize]).ok()?;
+    if s.is_empty() {
+        return None;
+    }
+    Some(PathBuf::from(s))
 }
 
 #[cfg(unix)]
@@ -899,6 +942,51 @@ mod tests {
     }
 
     #[test]
+    fn decide_keeps_versioned_looking_stranger_outside_install() {
+        // CodeRabbit: versioned branch must not kill /opt/other-vendor/toolport-gateway-1.0.0
+        // style strangers (and non-version suffixes must not count as versioned).
+        let c = ctx(
+            "1.9.6",
+            &[r"C:\Users\me\AppData\Roaming\Toolport\bin\toolport-gateway-1.9.6.exe"],
+            false,
+        );
+        assert_eq!(
+            decide_reap(
+                &proc(
+                    11,
+                    "toolport-gateway-1.0.0",
+                    Some("/opt/other-vendor/toolport-gateway-1.0.0")
+                ),
+                &c
+            ),
+            ReapDecision::Keep
+        );
+        assert_eq!(
+            decide_reap(
+                &proc(
+                    12,
+                    "toolport-gateway-shim",
+                    Some(r"C:\Users\me\AppData\Roaming\Toolport\bin\toolport-gateway-shim.exe")
+                ),
+                &c
+            ),
+            // Non-version suffix under our path, not in keep list → unversioned-path kill
+            ReapDecision::Kill
+        );
+    }
+
+    #[test]
+    fn version_suffix_requires_digit_and_dot() {
+        assert!(looks_like_version_suffix("1.9.4"));
+        assert!(looks_like_version_suffix("1.9.4-beta.1"));
+        assert!(!looks_like_version_suffix("shim"));
+        assert!(!looks_like_version_suffix("helper"));
+        assert!(!looks_like_version_suffix("aarch64-apple-darwin"));
+        assert!(!is_versioned_gateway_basename("toolport-gateway-shim.exe"));
+        assert!(is_versioned_gateway_basename("toolport-gateway-1.9.4.exe"));
+    }
+
+    #[test]
     fn decide_kill_all_kills_everything_gateway() {
         let c = ctx("1.9.6", &[r"C:\keep\toolport-gateway-1.9.6.exe"], true);
         assert_eq!(
@@ -917,6 +1005,8 @@ mod tests {
         assert!(is_gateway_basename("conduit-gateway"));
         assert!(!is_gateway_basename("cursor.exe"));
         assert!(!is_gateway_basename("my-toolport-gateway-shim"));
+        // Prefix only — must be exact stem or stem-version
+        assert!(!is_gateway_basename("toolport-gatewayed"));
     }
 
     #[test]

--- a/src-tauri/src/gateway_publish.rs
+++ b/src-tauri/src/gateway_publish.rs
@@ -151,139 +151,589 @@ pub fn client_gateway_path() -> Option<PathBuf> {
     publish_bundled_gateway()
 }
 
-/// Suppress the console window Windows would otherwise flash for a CLI child.
-///
-/// These run at app launch, so without it the user sees black CMD windows pop up every
-/// time Toolport starts - which reads as something being wrong, especially to a
-/// non-technical user. `tasklist` in particular now runs on EVERY launch (SOU-306 made the
-/// stale-gateway check ungated), so an occasional flash became a guaranteed one.
-#[cfg(windows)]
-fn no_console(cmd: &mut std::process::Command) {
-    use std::os::windows::process::CommandExt;
-    cmd.creation_flags(0x0800_0000); // CREATE_NO_WINDOW
+// ---------------------------------------------------------------------------
+// Cross-platform gateway process reaper (SOU-414 / residual of SOU-306)
+//
+// Product rule: same outcome on Windows, macOS, and Linux. Staleness is decided
+// by process *image identity* (full path + basename rules), not by Windows
+// versioned filenames alone. macOS/Linux clients spawn unversioned
+// `toolport-gateway`, so a basename-only reaper is a permanent no-op there.
+//
+// Two modes:
+//   * stop_stale_gateways — every launch; keep current/resolved paths, kill obsolete
+//   * stop_spawned_gateways — in-app updater; kill every Toolport gateway image so
+//     the installer can replace locked files
+//
+// Parent agent apps (Cursor, Claude, …) are never touched. Clients that auto-respawn
+// MCP on a dead stdio pipe pick up the repointed binary on the next tool call.
+// ---------------------------------------------------------------------------
+
+/// A running process that looks like a Toolport/Conduit gateway.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GatewayProcess {
+    pub pid: u32,
+    /// Best-effort absolute path of the executable. Missing when the OS denied
+    /// query access; decision falls back to basename rules only.
+    pub path: Option<PathBuf>,
+    /// Process image basename, e.g. `toolport-gateway-1.9.4.exe` or `toolport-gateway`.
+    pub basename: String,
 }
 
-/// Terminate client-spawned gateway processes so the installer can replace locked binaries
-/// and so clients respawn the just-installed version instead of keeping the old one until the
-/// user relaunches them. Does not touch parent apps (Cursor, Codex, etc.). Returns how many
-/// image patterns `taskkill` reported killing.
-///
-/// The `*` globs are load-bearing: the published gateway clients actually run is VERSIONED
-/// (`toolport-gateway-1.7.2.exe`), so matching only the bare `toolport-gateway.exe` (the old
-/// behavior) killed nothing on a real update. `taskkill /IM` accepts a wildcard on the image
-/// name; nothing else on the system is named `*-gateway*`, so the match stays scoped to ours.
-#[cfg(windows)]
-pub fn stop_spawned_gateways() -> u32 {
-    let mut stopped = 0u32;
-    for image in ["toolport-gateway*.exe", "conduit-gateway*.exe"] {
-        let mut cmd = std::process::Command::new("taskkill");
-        cmd.args(["/F", "/IM", image])
-            .stdout(std::process::Stdio::null())
-            .stderr(std::process::Stdio::null());
-        no_console(&mut cmd);
-        let status = cmd.status();
-        if status.map(|s| s.success()).unwrap_or(false) {
-            stopped += 1;
+/// Inputs for the pure keep/kill decision. Built at the call site so tests do not
+/// need a live process table or a real install layout.
+#[derive(Debug, Clone)]
+pub struct ReapContext {
+    pub current_version: String,
+    /// Executable paths that must survive a *stale* reap (current published binary,
+    /// nested macOS helper, AppImage stable copy, etc.). Compared case-insensitively
+    /// with normalized separators.
+    pub keep_paths: Vec<PathBuf>,
+    /// When true (updater), every gateway process is killed, including current.
+    pub kill_all: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReapDecision {
+    Keep,
+    Kill,
+}
+
+/// Result of a reaper pass, for logging and the Tauri command surface.
+#[derive(Debug, Clone, Default)]
+pub struct ReapReport {
+    pub killed: Vec<String>,
+    pub kept: Vec<String>,
+    pub failed: Vec<String>,
+}
+
+impl ReapReport {
+    pub fn killed_labels(&self) -> Vec<String> {
+        self.killed.clone()
+    }
+}
+
+/// Build keep-paths known to this crate without calling into `clients` (avoids a
+/// module cycle). Callers that can resolve the nested macOS helper should pass
+/// extras via [`stop_stale_gateways_with_keep`].
+fn default_keep_paths() -> Vec<PathBuf> {
+    let mut paths = Vec::new();
+    let push = |paths: &mut Vec<PathBuf>, p: PathBuf| {
+        if !paths.iter().any(|e| paths_equal(e, &p)) {
+            paths.push(p);
+        }
+    };
+    if let Some(p) = client_gateway_path() {
+        push(&mut paths, p);
+    }
+    if let Some(p) = published_gateway_path() {
+        push(&mut paths, p);
+    }
+    if let Some(p) = bundled_gateway_source() {
+        push(&mut paths, p);
+    }
+    if let Some(p) = versioned_dest(env!("CARGO_PKG_VERSION")) {
+        push(&mut paths, p);
+    }
+    if let Some(dir) = gateway_bin_dir() {
+        let ext = std::env::consts::EXE_SUFFIX;
+        push(
+            &mut paths,
+            dir.join(format!("toolport-gateway{ext}")),
+        );
+        push(
+            &mut paths,
+            dir.join(format!("conduit-gateway{ext}")),
+        );
+    }
+    paths
+}
+
+fn paths_equal(a: &Path, b: &Path) -> bool {
+    let na = normalize_path(a);
+    let nb = normalize_path(b);
+    na == nb
+}
+
+fn normalize_path(p: &Path) -> String {
+    p.to_string_lossy()
+        .replace('/', "\\")
+        .trim_end_matches(['\\', '/'])
+        .to_ascii_lowercase()
+}
+
+/// Basename matches a Toolport/Conduit gateway image (versioned or not).
+pub fn is_gateway_basename(name: &str) -> bool {
+    let lower = name.to_ascii_lowercase();
+    let stem = lower.strip_suffix(".exe").unwrap_or(&lower);
+    stem.starts_with("toolport-gateway") || stem.starts_with("conduit-gateway")
+}
+
+fn is_versioned_gateway_basename(name: &str) -> bool {
+    let lower = name.to_ascii_lowercase();
+    let stem = lower.strip_suffix(".exe").unwrap_or(&lower);
+    // toolport-gateway-1.9.4 or conduit-gateway-1.9.4 — not bare toolport-gateway
+    if let Some(rest) = stem.strip_prefix("toolport-gateway-") {
+        return !rest.is_empty();
+    }
+    if let Some(rest) = stem.strip_prefix("conduit-gateway-") {
+        return !rest.is_empty();
+    }
+    false
+}
+
+fn basename_matches_current_version(name: &str, version: &str) -> bool {
+    let lower = name.to_ascii_lowercase();
+    let stem = lower.strip_suffix(".exe").unwrap_or(&lower);
+    let want_tp = format!("toolport-gateway-{version}").to_ascii_lowercase();
+    let want_cd = format!("conduit-gateway-{version}").to_ascii_lowercase();
+    stem == want_tp || stem == want_cd
+}
+
+/// Path looks like a cargo `target/...` dev binary — keep under stale mode so
+/// `tauri dev` is not murdered by a packaged Toolport on the same machine.
+fn is_dev_target_path(path: &Path) -> bool {
+    let n = normalize_path(path);
+    n.contains("\\target\\debug\\")
+        || n.contains("\\target\\release\\")
+        || n.contains("/target/debug/")
+        || n.contains("/target/release/")
+}
+
+/// Path is under a Toolport/Conduit product location (data dir bin, install leaf,
+/// macOS helper bundle, AppImage stable copy). Used to avoid killing a foreign
+/// binary that merely starts with a similar name.
+fn path_looks_like_our_install(path: &Path) -> bool {
+    let n = normalize_path(path);
+    n.contains("\\toolport\\")
+        || n.contains("\\conduit\\")
+        || n.contains("/toolport/")
+        || n.contains("/conduit/")
+        || n.contains("toolportgateway.app")
+        || n.contains("conduitgateway.app")
+        || n.contains("toolport.app")
+        || n.contains("conduit.app")
+}
+
+/// Pure keep/kill decision. Getting this wrong is expensive both ways: too eager
+/// kills the bridge we just started; too shy leaves users on old gateway code.
+pub fn decide_reap(proc: &GatewayProcess, ctx: &ReapContext) -> ReapDecision {
+    if !is_gateway_basename(&proc.basename) {
+        return ReapDecision::Keep;
+    }
+    if ctx.kill_all {
+        return ReapDecision::Kill;
+    }
+
+    if let Some(ref path) = proc.path {
+        if ctx.keep_paths.iter().any(|k| paths_equal(k, path)) {
+            return ReapDecision::Keep;
+        }
+        if is_dev_target_path(path) {
+            return ReapDecision::Keep;
+        }
+        if basename_matches_current_version(&proc.basename, &ctx.current_version) {
+            // Same version, different install path: still our build; keep unless
+            // we have keep_paths that explicitly name a different current (handled above).
+            return ReapDecision::Keep;
+        }
+        if is_versioned_gateway_basename(&proc.basename) {
+            return ReapDecision::Kill;
+        }
+        // Unversioned basename (macOS/Linux/AppImage/dev packaged): path is the
+        // identity. Not equal to keep_paths and looks like ours → obsolete copy.
+        if path_looks_like_our_install(path) {
+            if ctx.keep_paths.is_empty() {
+                // No known current path — refuse to guess.
+                return ReapDecision::Keep;
+            }
+            return ReapDecision::Kill;
+        }
+        // Unknown location with gateway basename: do not kill strangers.
+        return ReapDecision::Keep;
+    }
+
+    // Path unavailable: basename-only fallback (Windows ACL edge cases).
+    if basename_matches_current_version(&proc.basename, &ctx.current_version) {
+        return ReapDecision::Keep;
+    }
+    if is_versioned_gateway_basename(&proc.basename) {
+        return ReapDecision::Kill;
+    }
+    // Unversioned without path: cannot tell current from stale.
+    ReapDecision::Keep
+}
+
+fn label_process(proc: &GatewayProcess) -> String {
+    match &proc.path {
+        Some(p) => format!("{} (pid {} @ {})", proc.basename, proc.pid, p.display()),
+        None => format!("{} (pid {})", proc.basename, proc.pid),
+    }
+}
+
+fn reap_with_context(ctx: &ReapContext) -> ReapReport {
+    let mut report = ReapReport::default();
+    let procs = list_gateway_processes();
+    let mut to_kill: Vec<GatewayProcess> = Vec::new();
+    for proc in procs {
+        match decide_reap(&proc, ctx) {
+            ReapDecision::Keep => report.kept.push(label_process(&proc)),
+            ReapDecision::Kill => to_kill.push(proc),
         }
     }
-    stopped
+    for proc in to_kill {
+        let label = label_process(&proc);
+        if kill_gateway_process(&proc) {
+            report.killed.push(label);
+        } else {
+            report.failed.push(label);
+        }
+    }
+    // Verify: anything still present that should be gone?
+    if !report.killed.is_empty() || !report.failed.is_empty() {
+        std::thread::sleep(std::time::Duration::from_millis(150));
+        let still = list_gateway_processes();
+        for proc in still {
+            if decide_reap(&proc, ctx) == ReapDecision::Kill {
+                let label = label_process(&proc);
+                if kill_gateway_process(&proc) {
+                    if !report.killed.iter().any(|k| k == &label) {
+                        report.killed.push(format!("{label} [retry]"));
+                    }
+                } else if !report.failed.iter().any(|f| f == &label) {
+                    report.failed.push(format!("{label} [still running]"));
+                }
+            }
+        }
+    }
+    report
 }
 
-#[cfg(not(windows))]
+fn log_reap_report(kind: &str, report: &ReapReport) {
+    if !report.killed.is_empty() {
+        eprintln!(
+            "toolport: {kind} stopped {} gateway process(es): {}",
+            report.killed.len(),
+            report.killed.join("; ")
+        );
+    }
+    if !report.failed.is_empty() {
+        eprintln!(
+            "toolport: {kind} failed to stop {} gateway process(es): {}",
+            report.failed.len(),
+            report.failed.join("; ")
+        );
+    }
+    if report.killed.is_empty() && report.failed.is_empty() && !report.kept.is_empty() {
+        // Quiet on the common clean-launch path; only note when debugging would help.
+    }
+}
+
+/// Terminate every Toolport/Conduit gateway process (all platforms). Used before
+/// in-app update so locked binaries can be replaced. Does not touch parent apps.
+/// Returns how many processes were successfully killed.
 pub fn stop_spawned_gateways() -> u32 {
-    0
+    let ctx = ReapContext {
+        current_version: env!("CARGO_PKG_VERSION").to_string(),
+        keep_paths: Vec::new(),
+        kill_all: true,
+    };
+    let report = reap_with_context(&ctx);
+    log_reap_report("updater reaper", &report);
+    report.killed.len() as u32
 }
 
-/// Terminate only gateway processes running a version OTHER than the installed one, and
-/// report the image names killed. Unlike [`stop_spawned_gateways`] this leaves current
-/// gateways alone, so it is safe to run on every launch.
-///
-/// Why this exists (SOU-306): the launch-time cleanup used to be gated on
-/// `repoint_stale_gateways()` returning a non-empty list. That call is idempotent, so once
-/// client configs point at the new binary it returns empty forever and the cleanup never
-/// runs again. The gate was a proxy for "is a running gateway on an old version?", and the
-/// two come apart exactly when the repoint already happened - after a manual install, or on
-/// any launch after the first. Six 1.9.3 gateways survived a 1.9.4 update that way, two of
-/// them across an app restart.
-///
-/// This matters because the gateway is where fixes like SOU-292 live: a user who updates to
-/// get one, while their client keeps an old gateway alive, still has the bug and reasonably
-/// concludes the update did nothing. Clients respawn the gateway on their next request, so
-/// killing is enough; nothing needs relaunching here.
-#[cfg(windows)]
+/// Terminate gateway processes that are not the current install. Safe on every
+/// launch: keeps processes whose path matches the current resolved/published
+/// binary (and current-version basenames). Returns labels of killed processes.
 pub fn stop_stale_gateways() -> Vec<String> {
-    let images = running_gateway_images();
-    let mut killed = Vec::new();
-    for image in stale_gateway_images(&images, env!("CARGO_PKG_VERSION")) {
-        let mut cmd = std::process::Command::new("taskkill");
-        cmd.args(["/F", "/IM", &image])
-            .stdout(std::process::Stdio::null())
-            .stderr(std::process::Stdio::null());
-        no_console(&mut cmd);
-        let ok = cmd.status().map(|s| s.success()).unwrap_or(false);
-        if ok {
-            killed.push(image);
+    stop_stale_gateways_with_keep(&[])
+}
+
+/// Like [`stop_stale_gateways`], with extra keep-paths (e.g. nested macOS helper
+/// from `clients::resolve_gateway_path`).
+pub fn stop_stale_gateways_with_keep(extra_keep: &[PathBuf]) -> Vec<String> {
+    let mut keep = default_keep_paths();
+    for p in extra_keep {
+        if !keep.iter().any(|e| paths_equal(e, p)) {
+            keep.push(p.clone());
         }
     }
-    killed
+    let ctx = ReapContext {
+        current_version: env!("CARGO_PKG_VERSION").to_string(),
+        keep_paths: keep,
+        kill_all: false,
+    };
+    let report = reap_with_context(&ctx);
+    log_reap_report("stale reaper", &report);
+    report.killed_labels()
 }
 
-/// Which of `images` are gateways running a version other than `current`.
-///
-/// Split from the process enumeration and the killing so the decision is testable without
-/// spawning anything: getting this wrong is expensive in both directions - too eager and a
-/// launch kills the gateway it just published, too shy and the stale one survives and the
-/// user silently keeps running old code.
-fn stale_gateway_images(images: &[String], current: &str) -> Vec<String> {
-    // Names the current install may legitimately be running under. The unversioned forms are
-    // kept because a dev/unpackaged run uses them and carries no version to compare, so
-    // killing them would take out a running `tauri dev` gateway. `conduit-gateway` is the
-    // pre-rename form, kept so an in-place upgrade from an old install can't self-kill.
-    let keep = [
-        format!("toolport-gateway-{current}.exe"),
-        format!("conduit-gateway-{current}.exe"),
-        "toolport-gateway.exe".to_string(),
-        "conduit-gateway.exe".to_string(),
-    ];
-    images
-        .iter()
-        .filter(|image| !keep.iter().any(|k| k.eq_ignore_ascii_case(image)))
-        .cloned()
-        .collect()
-}
+// ----- OS process list / kill ------------------------------------------------
 
-/// Distinct image names of running gateway processes, e.g. `toolport-gateway-1.9.3.exe`.
-/// Matched on the `*-gateway*` shape rather than an exact name because the published binary
-/// clients actually run is versioned; nothing else on the system uses that shape.
 #[cfg(windows)]
-fn running_gateway_images() -> Vec<String> {
-    let mut cmd = std::process::Command::new("tasklist");
-    cmd.args(["/FO", "CSV", "/NH"]);
-    no_console(&mut cmd);
-    let Ok(out) = cmd.output() else {
+fn list_gateway_processes() -> Vec<GatewayProcess> {
+    windows_list_gateway_processes()
+}
+
+#[cfg(windows)]
+fn kill_gateway_process(proc: &GatewayProcess) -> bool {
+    windows_kill_pid(proc.pid)
+}
+
+#[cfg(all(unix, not(target_os = "macos")))]
+fn list_gateway_processes() -> Vec<GatewayProcess> {
+    linux_list_gateway_processes()
+}
+
+#[cfg(target_os = "macos")]
+fn list_gateway_processes() -> Vec<GatewayProcess> {
+    macos_list_gateway_processes()
+}
+
+#[cfg(unix)]
+fn kill_gateway_process(proc: &GatewayProcess) -> bool {
+    unix_kill_pid(proc.pid)
+}
+
+#[cfg(windows)]
+fn windows_list_gateway_processes() -> Vec<GatewayProcess> {
+    use std::mem::{size_of, zeroed};
+    use windows_sys::Win32::Foundation::{CloseHandle, INVALID_HANDLE_VALUE};
+    use windows_sys::Win32::System::Diagnostics::ToolHelp::{
+        CreateToolhelp32Snapshot, Process32FirstW, Process32NextW, PROCESSENTRY32W,
+        TH32CS_SNAPPROCESS,
+    };
+    unsafe {
+        let snap = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
+        if snap == INVALID_HANDLE_VALUE {
+            return Vec::new();
+        }
+        let mut entry: PROCESSENTRY32W = zeroed();
+        entry.dwSize = size_of::<PROCESSENTRY32W>() as u32;
+        let mut out = Vec::new();
+        if Process32FirstW(snap, &mut entry) != 0 {
+            loop {
+                let basename = widestr_to_string(&entry.szExeFile);
+                if is_gateway_basename(&basename) {
+                    let pid = entry.th32ProcessID;
+                    let path = windows_process_path(pid);
+                    out.push(GatewayProcess {
+                        pid,
+                        path,
+                        basename,
+                    });
+                }
+                if Process32NextW(snap, &mut entry) == 0 {
+                    break;
+                }
+            }
+        }
+        CloseHandle(snap);
+        out
+    }
+}
+
+#[cfg(windows)]
+fn widestr_to_string(buf: &[u16]) -> String {
+    let len = buf.iter().position(|&c| c == 0).unwrap_or(buf.len());
+    String::from_utf16_lossy(&buf[..len])
+}
+
+#[cfg(windows)]
+fn windows_process_path(pid: u32) -> Option<PathBuf> {
+    use windows_sys::Win32::Foundation::CloseHandle;
+    use windows_sys::Win32::System::Threading::{
+        OpenProcess, QueryFullProcessImageNameW, PROCESS_QUERY_LIMITED_INFORMATION,
+    };
+    unsafe {
+        let handle = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, pid);
+        if handle.is_null() {
+            return None;
+        }
+        let mut buf = [0u16; 1024];
+        let mut size = buf.len() as u32;
+        let ok = QueryFullProcessImageNameW(handle, 0, buf.as_mut_ptr(), &mut size);
+        CloseHandle(handle);
+        if ok == 0 || size == 0 {
+            return None;
+        }
+        Some(PathBuf::from(String::from_utf16_lossy(
+            &buf[..size as usize],
+        )))
+    }
+}
+
+#[cfg(windows)]
+fn windows_kill_pid(pid: u32) -> bool {
+    use windows_sys::Win32::Foundation::CloseHandle;
+    use windows_sys::Win32::System::Threading::{OpenProcess, TerminateProcess, PROCESS_TERMINATE};
+    unsafe {
+        let handle = OpenProcess(PROCESS_TERMINATE, 0, pid);
+        if handle.is_null() {
+            // Fall back to taskkill when OpenProcess is denied.
+            return windows_taskkill_pid(pid);
+        }
+        let ok = TerminateProcess(handle, 1) != 0;
+        CloseHandle(handle);
+        if ok {
+            true
+        } else {
+            windows_taskkill_pid(pid)
+        }
+    }
+}
+
+#[cfg(windows)]
+fn windows_taskkill_pid(pid: u32) -> bool {
+    use std::os::windows::process::CommandExt;
+    let mut cmd = std::process::Command::new("taskkill");
+    cmd.args(["/F", "/PID", &pid.to_string()])
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .creation_flags(0x0800_0000); // CREATE_NO_WINDOW
+    cmd.status().map(|s| s.success()).unwrap_or(false)
+}
+
+/// Linux: `/proc/<pid>/exe` + `/proc/<pid>/comm`.
+#[cfg(all(unix, not(target_os = "macos")))]
+fn linux_list_gateway_processes() -> Vec<GatewayProcess> {
+    let Ok(rd) = std::fs::read_dir("/proc") else {
+        return Vec::new();
+    };
+    let mut out = Vec::new();
+    for ent in rd.flatten() {
+        let name = ent.file_name();
+        let name = name.to_string_lossy();
+        if !name.chars().all(|c| c.is_ascii_digit()) {
+            continue;
+        }
+        let pid: u32 = match name.parse() {
+            Ok(p) => p,
+            Err(_) => continue,
+        };
+        let comm_path = ent.path().join("comm");
+        let basename = std::fs::read_to_string(&comm_path)
+            .unwrap_or_default()
+            .trim()
+            .to_string();
+        if !is_gateway_basename(&basename) {
+            // Also check exe basename — comm can be truncated to 15 chars.
+            let exe = std::fs::read_link(ent.path().join("exe")).ok();
+            let exe_base = exe
+                .as_ref()
+                .and_then(|p| p.file_name())
+                .map(|s| s.to_string_lossy().into_owned())
+                .unwrap_or_default();
+            if !is_gateway_basename(&exe_base) {
+                continue;
+            }
+            out.push(GatewayProcess {
+                pid,
+                path: exe,
+                basename: exe_base,
+            });
+            continue;
+        }
+        let path = std::fs::read_link(ent.path().join("exe")).ok();
+        // read_link may append " (deleted)" on some kernels via weird paths — keep as-is.
+        out.push(GatewayProcess {
+            pid,
+            path,
+            basename,
+        });
+    }
+    out
+}
+
+/// macOS: `ps` for pid + command line (no /proc).
+#[cfg(target_os = "macos")]
+fn macos_list_gateway_processes() -> Vec<GatewayProcess> {
+    let Ok(out) = std::process::Command::new("ps")
+        .args(["-ax", "-o", "pid=", "-o", "command="])
+        .output()
+    else {
         return Vec::new();
     };
     let text = String::from_utf8_lossy(&out.stdout);
-    let mut names: Vec<String> = Vec::new();
+    let mut procs = Vec::new();
     for line in text.lines() {
-        // CSV rows look like: "image.exe","1234","Console","1","12,345 K"
-        let Some(name) = line.trim().strip_prefix('"').and_then(|r| r.split('"').next())
-        else {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        let mut parts = line.split_whitespace();
+        let Some(pid_s) = parts.next() else {
             continue;
         };
-        let lower = name.to_ascii_lowercase();
-        let ours = (lower.starts_with("toolport-gateway") || lower.starts_with("conduit-gateway"))
-            && lower.ends_with(".exe");
-        if ours && !names.iter().any(|n: &String| n.eq_ignore_ascii_case(name)) {
-            names.push(name.to_string());
+        let Ok(pid) = pid_s.parse::<u32>() else {
+            continue;
+        };
+        let cmd = parts.collect::<Vec<_>>().join(" ");
+        if cmd.is_empty() {
+            continue;
         }
+        // First token is the executable path (or name).
+        let exe = cmd.split_whitespace().next().unwrap_or("");
+        let path = if exe.contains('/') {
+            Some(PathBuf::from(exe))
+        } else {
+            None
+        };
+        let basename = path
+            .as_ref()
+            .and_then(|p| p.file_name())
+            .map(|s| s.to_string_lossy().into_owned())
+            .unwrap_or_else(|| exe.to_string());
+        if !is_gateway_basename(&basename) {
+            continue;
+        }
+        procs.push(GatewayProcess {
+            pid,
+            path,
+            basename,
+        });
     }
-    names
+    procs
 }
 
-#[cfg(not(windows))]
-pub fn stop_stale_gateways() -> Vec<String> {
-    Vec::new()
+#[cfg(unix)]
+fn unix_kill_pid(pid: u32) -> bool {
+    // SIGTERM first, then SIGKILL — matches polite shutdown without depending on libc.
+    let term = std::process::Command::new("kill")
+        .args(["-TERM", &pid.to_string()])
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false);
+    if !term {
+        return std::process::Command::new("kill")
+            .args(["-KILL", &pid.to_string()])
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false);
+    }
+    std::thread::sleep(std::time::Duration::from_millis(100));
+    // Still alive?
+    let alive = std::process::Command::new("kill")
+        .args(["-0", &pid.to_string()])
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false);
+    if alive {
+        return std::process::Command::new("kill")
+            .args(["-KILL", &pid.to_string()])
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false);
+    }
+    true
 }
 
 /// Last path segment, regardless of OS path separator (client configs store Windows paths).
@@ -309,6 +759,22 @@ pub fn is_unversioned_install_gateway_path(stored: &str) -> bool {
 mod tests {
     use super::*;
 
+    fn ctx(version: &str, keep: &[&str], kill_all: bool) -> ReapContext {
+        ReapContext {
+            current_version: version.into(),
+            keep_paths: keep.iter().map(PathBuf::from).collect(),
+            kill_all,
+        }
+    }
+
+    fn proc(pid: u32, basename: &str, path: Option<&str>) -> GatewayProcess {
+        GatewayProcess {
+            pid,
+            basename: basename.into(),
+            path: path.map(PathBuf::from),
+        }
+    }
+
     #[test]
     fn unversioned_install_path_detected() {
         assert!(is_unversioned_install_gateway_path(
@@ -323,48 +789,134 @@ mod tests {
     }
 
     #[test]
-    fn stale_gateway_images_keeps_current_and_kills_older() {
-        // Regression for SOU-306. A 1.9.4 update left six 1.9.3 gateways running because the
-        // cleanup was gated on a repoint that had already happened, so users kept running old
-        // gateway code and did not receive the fix they had just updated for.
-        let running = vec![
-            "toolport-gateway-1.9.3.exe".to_string(),
-            "toolport-gateway-1.9.4.exe".to_string(),
-            "toolport-gateway-1.8.0.exe".to_string(),
-            "conduit-gateway-1.7.2.exe".to_string(),
-        ];
-        let stale = stale_gateway_images(&running, "1.9.4");
-
-        assert!(
-            !stale.contains(&"toolport-gateway-1.9.4.exe".to_string()),
-            "must never kill the version it just published"
+    fn decide_keeps_current_versioned_basename() {
+        // SOU-306 regression: current versioned Windows binary must survive.
+        let c = ctx("1.9.6", &[r"C:\Users\me\AppData\Roaming\Toolport\bin\toolport-gateway-1.9.6.exe"], false);
+        assert_eq!(
+            decide_reap(
+                &proc(
+                    1,
+                    "toolport-gateway-1.9.6.exe",
+                    Some(r"C:\Users\me\AppData\Roaming\Toolport\bin\toolport-gateway-1.9.6.exe")
+                ),
+                &c
+            ),
+            ReapDecision::Keep
         );
-        assert!(stale.contains(&"toolport-gateway-1.9.3.exe".to_string()));
-        assert!(stale.contains(&"toolport-gateway-1.8.0.exe".to_string()));
-        assert!(
-            stale.contains(&"conduit-gateway-1.7.2.exe".to_string()),
-            "the pre-rename image is still stale when its version differs"
-        );
-        assert_eq!(stale.len(), 3);
     }
 
     #[test]
-    fn stale_gateway_images_spares_unversioned_and_a_clean_launch() {
-        // Unversioned images are dev/unpackaged runs with no version to compare; killing them
-        // would take out a running `tauri dev` gateway.
-        let dev = vec![
-            "toolport-gateway.exe".to_string(),
-            "conduit-gateway.exe".to_string(),
-        ];
-        assert!(stale_gateway_images(&dev, "1.9.4").is_empty());
+    fn decide_kills_older_versioned_basenames() {
+        let c = ctx("1.9.6", &[r"C:\Users\me\AppData\Roaming\Toolport\bin\toolport-gateway-1.9.6.exe"], false);
+        for (name, path) in [
+            (
+                "toolport-gateway-1.9.4.exe",
+                r"C:\Users\me\AppData\Roaming\Toolport\bin\toolport-gateway-1.9.4.exe",
+            ),
+            (
+                "toolport-gateway-1.9.5.exe",
+                r"C:\Users\me\AppData\Roaming\Toolport\bin\toolport-gateway-1.9.5.exe",
+            ),
+            (
+                "conduit-gateway-1.7.2.exe",
+                r"C:\Users\me\AppData\Roaming\Conduit\bin\conduit-gateway-1.7.2.exe",
+            ),
+        ] {
+            assert_eq!(
+                decide_reap(&proc(2, name, Some(path)), &c),
+                ReapDecision::Kill,
+                "{name}"
+            );
+        }
+    }
 
-        // The common case: nothing stale, so a normal launch kills nothing.
-        let current = vec!["toolport-gateway-1.9.4.exe".to_string()];
-        assert!(stale_gateway_images(&current, "1.9.4").is_empty());
+    #[test]
+    fn decide_kills_unversioned_when_path_differs_from_keep() {
+        // macOS / AppImage: same basename, obsolete path.
+        let current = "/Users/me/Library/Application Support/Toolport/bin/toolport-gateway";
+        let c = ctx("1.9.6", &[current], false);
+        assert_eq!(
+            decide_reap(
+                &proc(
+                    3,
+                    "toolport-gateway",
+                    Some("/Applications/Toolport.app/Contents/MacOS/toolport-gateway")
+                ),
+                &c
+            ),
+            ReapDecision::Kill
+        );
+        assert_eq!(
+            decide_reap(&proc(4, "toolport-gateway", Some(current)), &c),
+            ReapDecision::Keep
+        );
+    }
 
-        // And the pre-rename image at the current version is the same install, not a leftover.
-        let renamed = vec!["conduit-gateway-1.9.4.exe".to_string()];
-        assert!(stale_gateway_images(&renamed, "1.9.4").is_empty());
+    #[test]
+    fn decide_keeps_dev_target_paths() {
+        let c = ctx("1.9.6", &[r"C:\Users\me\AppData\Roaming\Toolport\bin\toolport-gateway-1.9.6.exe"], false);
+        assert_eq!(
+            decide_reap(
+                &proc(
+                    5,
+                    "toolport-gateway.exe",
+                    Some(r"C:\projects\toolport\src-tauri\target\debug\toolport-gateway.exe")
+                ),
+                &c
+            ),
+            ReapDecision::Keep
+        );
+    }
+
+    #[test]
+    fn decide_keeps_unknown_location_unversioned() {
+        // Do not kill a foreign binary that happens to share the name.
+        let c = ctx("1.9.6", &[r"C:\Users\me\AppData\Roaming\Toolport\bin\toolport-gateway-1.9.6.exe"], false);
+        assert_eq!(
+            decide_reap(
+                &proc(6, "toolport-gateway", Some("/opt/other-vendor/toolport-gateway")),
+                &c
+            ),
+            ReapDecision::Keep
+        );
+    }
+
+    #[test]
+    fn decide_basename_only_kills_old_versioned() {
+        let c = ctx("1.9.6", &[], false);
+        assert_eq!(
+            decide_reap(&proc(7, "toolport-gateway-1.9.4.exe", None), &c),
+            ReapDecision::Kill
+        );
+        assert_eq!(
+            decide_reap(&proc(8, "toolport-gateway-1.9.6.exe", None), &c),
+            ReapDecision::Keep
+        );
+        assert_eq!(
+            decide_reap(&proc(9, "toolport-gateway.exe", None), &c),
+            ReapDecision::Keep
+        );
+    }
+
+    #[test]
+    fn decide_kill_all_kills_everything_gateway() {
+        let c = ctx("1.9.6", &[r"C:\keep\toolport-gateway-1.9.6.exe"], true);
+        assert_eq!(
+            decide_reap(
+                &proc(10, "toolport-gateway-1.9.6.exe", Some(r"C:\keep\toolport-gateway-1.9.6.exe")),
+                &c
+            ),
+            ReapDecision::Kill
+        );
+    }
+
+    #[test]
+    fn is_gateway_basename_accepts_versioned_and_plain() {
+        assert!(is_gateway_basename("toolport-gateway.exe"));
+        assert!(is_gateway_basename("toolport-gateway-1.9.6.exe"));
+        assert!(is_gateway_basename("conduit-gateway"));
+        assert!(!is_gateway_basename("cursor.exe"));
+        assert!(!is_gateway_basename("my-toolport-gateway-shim"));
     }
 
     #[test]

--- a/src/components/SettingsView.tsx
+++ b/src/components/SettingsView.tsx
@@ -16,6 +16,7 @@ import {
   Moon,
   Pin,
   Power,
+  RefreshCw,
   ShieldAlert,
   ShieldCheck,
   ShieldX,
@@ -56,6 +57,7 @@ import {
   setToolPinned,
   startHttpBridge,
   stopHttpBridge,
+  stopStaleGateways,
   type HttpBridgeStatus,
   type QuarantinedTool,
 } from "@/lib/api";
@@ -566,6 +568,8 @@ export function SettingsView({ registry, onRegistryChange }: Props) {
   const [newProfile, setNewProfile] = useState("");
   const [newToken, setNewToken] = useState<string | null>(null);
   const [clientBusy, setClientBusy] = useState(false);
+  const [reapBusy, setReapBusy] = useState(false);
+  const [reapResult, setReapResult] = useState<string | null>(null);
   const [autostartOn, setAutostartOn] = useState(false);
 
   const httpClients = registry?.httpClients ?? [];
@@ -1257,6 +1261,45 @@ export function SettingsView({ registry, onRegistryChange }: Props) {
               </div>
             </>
           )}
+        </div>
+        <div className="flex flex-col gap-2 rounded-md border px-3 py-2.5">
+          <div className="flex items-center gap-2.5 text-sm">
+            <RefreshCw
+              className={`size-4 shrink-0 text-muted-foreground ${reapBusy ? "animate-spin" : ""}`}
+            />
+            <span className="flex min-w-0 flex-1 flex-col leading-tight">
+              <span className="font-medium">Stop old gateways</span>
+              <span className="text-xs text-muted-foreground">
+                End leftover gateway processes from earlier installs. Agents that
+                auto-respawn MCP pick up the current binary on the next tool call; no full
+                app restart required for those hosts.
+              </span>
+            </span>
+            <button
+              type="button"
+              disabled={reapBusy}
+              onClick={async () => {
+                setReapBusy(true);
+                setReapResult(null);
+                try {
+                  const stopped = await stopStaleGateways();
+                  setReapResult(
+                    stopped.length === 0
+                      ? "No old gateway processes found."
+                      : `Stopped ${stopped.length}: ${stopped.join("; ")}`,
+                  );
+                } catch (e) {
+                  toastError(`Couldn't stop old gateways: ${e}`);
+                } finally {
+                  setReapBusy(false);
+                }
+              }}
+              className="h-8 shrink-0 rounded-md border bg-background px-2.5 text-xs font-medium hover:bg-accent disabled:opacity-50"
+            >
+              {reapBusy ? "Working…" : "Run"}
+            </button>
+          </div>
+          {reapResult && <p className="text-xs text-muted-foreground">{reapResult}</p>}
         </div>
       </section>
     </div>

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -361,6 +361,16 @@ export function httpBridgeStatus(): Promise<HttpBridgeStatus> {
 }
 
 /**
+ * Stop obsolete Toolport gateway processes (older versions / stale paths).
+ * Keeps the current resolved binary and the supervised HTTP bridge when they
+ * match. Clients that auto-respawn MCP pick up the current binary on the next
+ * tool call. Returns human-readable labels of processes that were stopped.
+ */
+export function stopStaleGateways(): Promise<string[]> {
+  return invoke<string[]>("stop_stale_gateways");
+}
+
+/**
  * Result of {@link teamConnect} / {@link teamJoinPoll}. `status` is:
  * - `connected` — joined; `registry` is the fresh merged state.
  * - `pending` — the link requires admin approval; poll `requestToken` via {@link teamJoinPoll}.


### PR DESCRIPTION
## Summary
- Replaces Windows-only `tasklist`/`taskkill` image-name reaping with a **path-based** keep/kill decision shared across **Windows, macOS, and Linux** (SOU-414).
- **Stale mode** (every app launch): keep processes whose executable matches the current published/resolved gateway path (plus current-version basenames); kill obsolete versioned bins and unversioned copies under Toolport/Conduit paths that are not current.
- **Kill-all mode** (in-app updater via `stop_spawned_gateways`): terminate every Toolport/Conduit gateway process so binaries unlock — now real on Unix, not a stub.
- Launch passes `resolve_gateway_path()` as an extra keep path (nested macOS helper, AppImage stable copy).
- Verify + one retry after kill; logs killed/failed labels.
- Pure unit tests for the decision table (no live process table required).

## Why
After 1.9.6, old `toolport-gateway-1.9.4/1.9.5` processes could remain. Mac/Linux clients use **unversioned** basenames, so a basename-only reaper is a permanent no-op there. True parity needs path identity.

## Test plan
- [x] `cargo test --lib gateway_publish` (10 tests)
- [ ] Windows: leave an old versioned gateway running, launch app, confirm log `stale reaper stopped` and process gone; current 1.9.6 + HTTP bridge still up
- [ ] macOS: after upgrade, obsolete unversioned path under old app location dies; current helper path kept
- [ ] Linux AppImage: stable `~/…/Toolport/bin/toolport-gateway` current kept; old install path killed
- [ ] In-app update still calls stop_spawned_gateways and can replace binaries
- [ ] `tauri dev` under `target/debug` not killed by a packaged install on the same machine