### PR TITLE
fix: disambiguate OpenCode vs Crush mcp shapes in parse_json_snippet (#418)

### DIFF
--- a/src-tauri/src/clients.rs
+++ b/src-tauri/src/clients.rs
@@ -1455,10 +1455,22 @@ fn parse_json_snippet(
     if let Some(mcp) = value.get("mcp") {
         let obj = mcp
             .as_object()
-            .ok_or_else(|| "OpenCode 'mcp' must be an object".to_string())?;
+            .ok_or_else(|| "'mcp' must be an object".to_string())?;
         let mut malformed = Vec::new();
         let mut servers = Vec::new();
         for (name, definition) in obj {
+            let command_is_string = definition
+                .get("command")
+                .map(|c| c.is_string())
+                .unwrap_or(false);
+
+            if command_is_string {
+                // Crush: `command` is a string, args live separately.
+                servers.push(json_server_with_values(name, definition));
+                continue;
+            }
+
+            // OpenCode: `command` is an argv array, or absent (remote/override-only).
             match opencode_server_with_values(name, definition) {
                 Ok(Some(server)) => servers.push(server),
                 Ok(None) => {}
@@ -1467,10 +1479,7 @@ fn parse_json_snippet(
         }
         if !malformed.is_empty() {
             malformed.sort();
-            return Err(format!(
-                "malformed OpenCode 'mcp' entry: {}",
-                malformed.join(", ")
-            ));
+            return Err(format!("malformed 'mcp' entry: {}", malformed.join(", ")));
         }
         if !servers.is_empty() {
             return Ok(servers);
@@ -4211,6 +4220,21 @@ mod tests {
         assert!(error.contains("broken"), "got: {error}");
         assert!(error.contains("array of strings"), "got: {error}");
     }
+
+    #[test]
+    fn parse_json_snippet_disambiguates_opencode_and_crush_mcp_shapes() {
+        // OpenCode shape: command is an argv array.
+        let opencode = r#"{"mcp":{"fs":{"type":"local","command":["npx","-y","pkg"]}}}"#;
+        let parsed = parse_json_snippet(opencode, "").unwrap();
+        assert_eq!(parsed[0].command.as_deref(), Some("npx"));
+        assert_eq!(parsed[0].args, vec!["-y", "pkg"]);
+
+        // Crush shape: command is a string, args separate.
+        let crush = r#"{"mcp":{"fs":{"type":"stdio","command":"npx","args":["-y","pkg"]}}}"#;
+        let parsed = parse_json_snippet(crush, "").unwrap();
+        assert_eq!(parsed[0].command.as_deref(), Some("npx"));
+        assert_eq!(parsed[0].args, vec!["-y", "pkg"]);
+    } 
 
     #[test]
     fn reads_windsurf_antigravity_server_url() {


### PR DESCRIPTION
 Fixes #418

`parse_json_snippet` previously assumed any top-level `mcp` key meant
OpenCode, requiring `command` to be an argv array. This broke pasting
a valid Crush config, which uses the same `mcp` key but stores
`command` as a string with `args` separate — the paste would fail with
a misleading `malformed OpenCode 'mcp' entry` error.

## Fix

Disambiguate per-entry on the shape of `command`, not on the presence
of the `mcp` key:

- `command` is an array → OpenCode → existing `opencode_server_with_values` path (unchanged)
- `command` is a string → Crush → route to `json_server_with_values`,
  which already handles this shape correctly (string command, separate
  `args`, env under `env`) — no new parsing logic needed
- `command` absent → OpenCode (remote/override-only entries), unchanged

Error message updated from `malformed OpenCode 'mcp' entry: ...` to
`malformed 'mcp' entry: ...` since it's no longer OpenCode-specific.

## Testing

Added `parse_json_snippet_disambiguates_opencode_and_crush_mcp_shapes`,
covering both shapes end to end. Full `clients` test suite passes:

test result: ok. 114 passed; 0 failed

No existing tests were affected — `parse_json_snippet` had no prior
direct test coverage, and `opencode_json_rejects_malformed_command_arrays`
exercises `parse_opencode_json` (a separate function), which this PR
doesn't touch.