### PR TITLE
fix(clients): Shared HTTP lifecycle — bearer write, scope, revoke

### DIFF
--- a/src-tauri/src/clients.rs
+++ b/src-tauri/src/clients.rs
@@ -1154,18 +1154,22 @@ fn json_server_with_values(name: &str, def: &serde_json::Value) -> ParsedSnippet
                 .collect()
         })
         .unwrap_or_default();
-    let env = def
-        .get("env")
-        .and_then(|e| e.as_object())
-        .map(|o| {
-            o.iter()
-                .map(|(k, v)| SnippetEnvVar {
+    // Merge `env` and `headers` keys (remote MCP stores credentials under headers;
+    // ownership matching and import need both visible as env_keys).
+    let mut env: Vec<SnippetEnvVar> = Vec::new();
+    for field in ["env", "headers"] {
+        if let Some(o) = def.get(field).and_then(|e| e.as_object()) {
+            for (k, v) in o {
+                if env.iter().any(|e| e.key == *k) {
+                    continue;
+                }
+                env.push(SnippetEnvVar {
                     key: k.clone(),
                     value: json_value_to_string(v),
-                })
-                .collect()
-        })
-        .unwrap_or_default();
+                });
+            }
+        }
+    }
     let type_hint = def.get("type").and_then(|t| t.as_str());
     let transport = classify(&command, &url, type_hint);
     ParsedSnippetServer {
@@ -2434,8 +2438,22 @@ fn entry_to_json(entry: &ServerEntry) -> serde_json::Value {
     }
     if let Some(url) = &entry.url {
         map.insert("url".into(), serde_json::Value::String(url.clone()));
+        // Native remote (VS Code `servers`, etc.): clients send HTTP headers, not
+        // process env. Writing Authorization under `env` leaves the token on disk
+        // but never on the wire (WS3-3). Prefer `headers` + a type hint.
+        if entry.command.is_none() {
+            let type_hint = if entry.transport.eq_ignore_ascii_case("sse") {
+                "sse"
+            } else {
+                "http"
+            };
+            map.insert(
+                "type".into(),
+                serde_json::Value::String(type_hint.into()),
+            );
+        }
     }
-    let env: serde_json::Map<String, serde_json::Value> = entry
+    let kv: serde_json::Map<String, serde_json::Value> = entry
         .env
         .iter()
         .filter_map(|e| {
@@ -2444,8 +2462,15 @@ fn entry_to_json(entry: &ServerEntry) -> serde_json::Value {
                 .map(|v| (e.key.clone(), serde_json::Value::String(v.clone())))
         })
         .collect();
-    if !env.is_empty() {
-        map.insert("env".into(), serde_json::Value::Object(env));
+    if !kv.is_empty() {
+        // Remote → headers (sent). Stdio → env (subprocess). Qwen remaps headers
+        // further (httpUrl) in entry_to_qwen_json.
+        let key = if entry.command.is_none() && entry.url.is_some() {
+            "headers"
+        } else {
+            "env"
+        };
+        map.insert(key.into(), serde_json::Value::Object(kv));
     }
     serde_json::Value::Object(map)
 }
@@ -2459,9 +2484,13 @@ fn entry_to_qwen_json(entry: &ServerEntry) -> serde_json::Value {
                 object.insert("httpUrl".into(), url);
             }
         }
+        // entry_to_json already emits `headers` for remote; keep a remap of legacy
+        // `env` so older call sites that stuffed auth into env still work.
         if let Some(env) = object.remove("env") {
             object.insert("headers".into(), env);
         }
+        // Qwen does not use a `type` field on remote entries.
+        object.remove("type");
     }
     value
 }
@@ -2953,11 +2982,20 @@ fn entry_to_continue_yaml(entry: &ServerEntry) -> serde_yaml::Value {
         } else {
             "streamable-http"
         };
-        serde_json::json!({
+        // Include env (Authorization + client id) so Shared HTTP tokens reach the
+        // file and re-detect sees the same keys as ManagedEntry (WS3-1).
+        let mut remote = serde_json::json!({
             "name": entry.name,
             "type": transport,
             "url": url,
-        })
+        });
+        if !env.is_empty() {
+            remote
+                .as_object_mut()
+                .unwrap()
+                .insert("env".into(), serde_json::Value::Object(env));
+        }
+        remote
     } else {
         // Preserve invalid entries visibly instead of silently dropping them.
         serde_json::json!({
@@ -3136,9 +3174,9 @@ fn entry_to_hermes_yaml(entry: &ServerEntry) -> serde_yaml::Value {
             serde_yaml::Value::String(url.clone()),
         );
     }
-    // Hermes stores subprocess env vars under `env` (same purpose as Goose's `envs`).
-    // Auth headers for HTTP servers are handled at import time, not reconstructed here.
-    let env: serde_yaml::Mapping = entry
+    // Stdio: env vars go under `env`. Remote: credentials must be under `headers`
+    // or Hermes never sends them (WS3-3). Same split as OpenCode / VS Code.
+    let kv: serde_yaml::Mapping = entry
         .env
         .iter()
         .filter_map(|e| {
@@ -3150,10 +3188,15 @@ fn entry_to_hermes_yaml(entry: &ServerEntry) -> serde_yaml::Value {
             })
         })
         .collect();
-    if !env.is_empty() {
+    if !kv.is_empty() {
+        let key = if entry.command.is_none() && entry.url.is_some() {
+            "headers"
+        } else {
+            "env"
+        };
         cfg.insert(
-            serde_yaml::Value::String("env".into()),
-            serde_yaml::Value::Mapping(env),
+            serde_yaml::Value::String(key.into()),
+            serde_yaml::Value::Mapping(kv),
         );
     }
     serde_yaml::Value::Mapping(cfg)
@@ -3679,8 +3722,24 @@ pub fn uninstall_gateway(client_id: &str) -> Result<WriteOutcome, String> {
 /// "migrate": after the client's servers are imported into Toolport, this leaves
 /// the client talking only to the gateway. Backs up first; unrelated config keys
 /// are preserved. Caller is responsible for importing first so nothing is lost.
+///
+/// When `shared` is set, write a Shared HTTP entry instead of stdio so migrate
+/// does not silently downgrade an existing Shared HTTP install (WS3-2).
 pub fn migrate_to_gateway(client_id: &str, profile: Option<&str>) -> Result<WriteOutcome, String> {
-    write_servers(client_id, &[gateway_entry(profile, client_id)?])
+    migrate_to_gateway_with_transport(client_id, profile, None)
+}
+
+/// Like [`migrate_to_gateway`], with an optional Shared HTTP spec (WS3-2).
+pub fn migrate_to_gateway_with_transport(
+    client_id: &str,
+    profile: Option<&str>,
+    shared: Option<&SharedHttpSpec>,
+) -> Result<WriteOutcome, String> {
+    let entry = match shared {
+        Some(spec) => gateway_entry_shared_http(client_id, profile, spec),
+        None => gateway_entry(profile, client_id)?,
+    };
+    write_servers(client_id, &[entry])
 }
 
 /// Whether a stored client-config command is recognizably one of *our* gateway
@@ -4437,6 +4496,125 @@ bad = "not-a-table"
         let rec = ManagedEntry::from_gateway_entry(&entry);
         assert!(!rec.env.contains_key("Authorization"));
         assert_eq!(rec.transport, "sharedHttp");
+    }
+
+    /// WS3-1 / WS3-3: write Shared HTTP to a real config file, re-detect, assert
+    /// the bearer reaches a field that is sent (env/headers), across native formats.
+    #[test]
+    fn shared_http_write_redetect_preserves_token_keys_across_formats() {
+        let spec = SharedHttpSpec {
+            url: "http://127.0.0.1:8765/mcp".into(),
+            token: "roundtrip-secret".into(),
+        };
+        let auth = "Bearer roundtrip-secret";
+
+        // Continue (YamlMcpServersList): env must be present on the url entry (WS3-1).
+        {
+            let path = temp_path("ws3-continue.yaml");
+            std::fs::write(&path, "name: Test\nmcpServers: []\n").unwrap();
+            let entry = gateway_entry_shared_http("continue", Some("Work"), &spec);
+            edit_continue_yaml_gateway(&path, Some(&entry)).unwrap();
+            let content = std::fs::read_to_string(&path).unwrap();
+            assert!(
+                content.contains(auth),
+                "Continue config must contain the bearer: {content}"
+            );
+            assert!(
+                content.contains("env:") || content.contains("Authorization"),
+                "Continue must write env with Authorization: {content}"
+            );
+            let parsed = parse_continue_yaml_servers(&content).unwrap();
+            let gw = parsed
+                .iter()
+                .find(|s| s.name == GATEWAY_ENTRY_NAME)
+                .expect("gateway entry");
+            assert_eq!(gw.url.as_deref(), Some(spec.url.as_str()));
+            assert!(
+                gw.env_keys.iter().any(|k| k == "Authorization"),
+                "re-detect must see Authorization key: {:?}",
+                gw.env_keys
+            );
+            let rec = ManagedEntry::from_gateway_entry(&entry);
+            assert_eq!(
+                resolve_entry_state(&[gw.clone()], Some(&rec)),
+                GatewayEntryState::Managed
+            );
+            std::fs::remove_file(&path).ok();
+        }
+
+        // VS Code (JsonServers): headers, not env (WS3-3).
+        {
+            let path = temp_path("ws3-vscode.json");
+            std::fs::write(&path, r#"{"servers":{}}"#).unwrap();
+            let entry = gateway_entry_shared_http("vscode", None, &spec);
+            edit_json_gateway(&path, "servers", Some(&entry), false).unwrap();
+            let root: serde_json::Value =
+                serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+            let slot = &root["servers"][GATEWAY_ENTRY_NAME];
+            assert_eq!(slot["url"], spec.url);
+            assert_eq!(slot["headers"]["Authorization"], auth);
+            assert!(
+                slot.get("env").is_none(),
+                "VS Code must not put the bearer under env: {slot}"
+            );
+            let parsed = parse_json(&std::fs::read_to_string(&path).unwrap(), "servers").unwrap();
+            let gw = parsed
+                .iter()
+                .find(|s| s.name == GATEWAY_ENTRY_NAME)
+                .expect("gateway");
+            assert!(gw.env_keys.iter().any(|k| k == "Authorization"));
+            std::fs::remove_file(&path).ok();
+        }
+
+        // Hermes (YamlMcpServers): headers for remote (WS3-3).
+        {
+            let path = temp_path("ws3-hermes.yaml");
+            std::fs::write(&path, "mcp_servers: {}\n").unwrap();
+            let entry = gateway_entry_shared_http("hermes", None, &spec);
+            edit_hermes_yaml_gateway(&path, Some(&entry)).unwrap();
+            let content = std::fs::read_to_string(&path).unwrap();
+            assert!(content.contains(auth), "Hermes must contain bearer: {content}");
+            assert!(
+                content.contains("headers:"),
+                "Hermes remote auth under headers: {content}"
+            );
+            let parsed = parse_hermes_yaml_servers(&content).unwrap();
+            let gw = parsed
+                .iter()
+                .find(|s| s.name == GATEWAY_ENTRY_NAME)
+                .expect("gateway");
+            assert!(gw.env_keys.iter().any(|k| k == "Authorization"));
+            std::fs::remove_file(&path).ok();
+        }
+
+        // OpenCode: headers on remote type.
+        {
+            let path = temp_path("ws3-opencode.json");
+            std::fs::write(&path, r#"{"mcp":{}}"#).unwrap();
+            let entry = gateway_entry_shared_http("opencode", Some("Work"), &spec);
+            edit_opencode_gateway(&path, Some(&entry)).unwrap();
+            let root: serde_json::Value =
+                serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+            let slot = &root["mcp"][GATEWAY_ENTRY_NAME];
+            assert_eq!(slot["type"], "remote");
+            assert_eq!(slot["headers"]["Authorization"], auth);
+            std::fs::remove_file(&path).ok();
+        }
+
+        // Qwen: httpUrl + headers.
+        {
+            let path = temp_path("ws3-qwen.json");
+            std::fs::write(&path, r#"{"mcpServers":{}}"#).unwrap();
+            let entry = gateway_entry_shared_http("qwen-code", None, &spec);
+            edit_json_gateway(&path, "mcpServers", Some(&entry), true).unwrap();
+            let root: serde_json::Value =
+                serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+            let slot = &root["mcpServers"][GATEWAY_ENTRY_NAME];
+            assert_eq!(slot["httpUrl"], spec.url);
+            assert_eq!(slot["headers"]["Authorization"], auth);
+            assert!(slot.get("env").is_none());
+            std::fs::remove_file(&path).ok();
+        }
     }
 
     #[test]

--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -763,6 +763,10 @@ fn install_gateway(
 
 /// Mint or reuse a bearer token for a managed shared-HTTP client install.
 /// Plaintext lives in the OS keychain; only the hash is in `http_clients`.
+///
+/// When reusing a vaulted token, rewrite the row's `profile` if the caller asked
+/// for a different scope — Shared HTTP scope is derived solely from that row
+/// (WS3-5), not from `client_scopes` / TOOLPORT_PROFILE env.
 fn ensure_client_http_token(
     state: &RegistryState,
     client_id: &str,
@@ -770,34 +774,66 @@ fn ensure_client_http_token(
 ) -> Result<String, String> {
     const VAULT_SERVER: &str = "__toolport_http_clients__";
     let http_id = format!("client:{client_id}");
+    let desired_profile = profile.unwrap_or("").trim().to_string();
     // Reuse vaulted token when we still have a matching http_clients row.
     if let Some(existing) = crate::secrets::get_secret(VAULT_SERVER, client_id) {
-        let reg = state
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let hash = registry::sha256_hex(&existing);
-        if reg
-            .http_clients
-            .iter()
-            .any(|c| c.id == http_id && c.token_sha256 == hash)
+        let mut matched = false;
+        let mut profile_stale = false;
         {
+            let reg = state
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            if let Some(row) = reg
+                .http_clients
+                .iter()
+                .find(|c| c.id == http_id && c.token_sha256 == hash)
+            {
+                matched = true;
+                profile_stale = row.profile != desired_profile;
+            }
+        }
+        if matched {
+            if profile_stale {
+                write_registry(state, |reg| {
+                    if let Some(row) = reg
+                        .http_clients
+                        .iter_mut()
+                        .find(|c| c.id == http_id && c.token_sha256 == hash)
+                    {
+                        row.profile = desired_profile;
+                    }
+                    Ok(())
+                })?;
+            }
             return Ok(existing);
         }
     }
     let token = random_hex()?;
     crate::secrets::set_secret(VAULT_SERVER, client_id, &token)?;
-    let profile = profile.unwrap_or("").trim().to_string();
     write_registry(state, |reg| {
         reg.http_clients.retain(|c| c.id != http_id);
         reg.http_clients.push(registry::HttpClient {
             id: http_id,
             label: format!("Client: {client_id}"),
             token_sha256: registry::sha256_hex(&token),
-            profile,
+            profile: desired_profile,
         });
         Ok(())
     })?;
     Ok(token)
+}
+
+/// Drop the managed shared-HTTP bearer for this client (registry row + vault).
+/// Best-effort on vault delete so a missing secret never blocks Disconnect (WS3-4).
+fn revoke_client_http_token(state: &RegistryState, client_id: &str) {
+    const VAULT_SERVER: &str = "__toolport_http_clients__";
+    let http_id = format!("client:{client_id}");
+    let _ = crate::secrets::delete_secret(VAULT_SERVER, client_id);
+    let _ = write_registry(state, |reg| {
+        reg.http_clients.retain(|c| c.id != http_id);
+        Ok(())
+    });
 }
 
 /// Remove the Toolport gateway from a client.
@@ -807,6 +843,9 @@ fn uninstall_gateway(
     client_id: String,
 ) -> Result<clients::WriteOutcome, String> {
     let outcome = clients::uninstall_gateway(&client_id)?;
+    // Config entry is gone; also revoke the bridge bearer so a leftover backup or
+    // stale token cannot keep authenticating (WS3-4).
+    revoke_client_http_token(state.inner(), &client_id);
     write_registry(state.inner(), |reg| {
         reg.set_client_scope(&client_id, None);
         reg.clear_client_managed_entry(&client_id);
@@ -889,9 +928,11 @@ struct MigrateResult {
 #[tauri::command]
 async fn migrate_client(
     state: State<'_, RegistryState>,
+    bridge: State<'_, HttpBridgeState>,
     client_id: String,
     profile: Option<String>,
     force: Option<bool>,
+    transport: Option<String>,
 ) -> Result<MigrateResult, String> {
     // Guard before import or rewrite so a hand-edited gateway entry is not wiped.
     refuse_if_customized(state.inner(), &client_id, force.unwrap_or(false))?;
@@ -925,9 +966,25 @@ async fn migrate_client(
         Ok((imported, moved))
     })?;
 
-    // Rewrite the client to only the gateway (backs up first). External to the registry, so
-    // it stays outside the lock; the scope record below is a separate locked write.
-    let migrate_write = clients::migrate_to_gateway(&client_id, profile.as_deref())?;
+    // Rewrite the client to only the gateway (backs up first). Honor transport so
+    // migrate does not silently force stdio when the UI chose Shared HTTP (WS3-2).
+    let transport = transport
+        .as_deref()
+        .map(str::trim)
+        .filter(|t| !t.is_empty())
+        .unwrap_or("stdio");
+    let migrate_write = if transport.eq_ignore_ascii_case("sharedHttp")
+        || transport.eq_ignore_ascii_case("shared_http")
+    {
+        let status = start_http_bridge(bridge, None)?;
+        let port = status.port.unwrap_or(8765);
+        let url = format!("http://127.0.0.1:{port}/mcp");
+        let token = ensure_client_http_token(state.inner(), &client_id, profile.as_deref())?;
+        let spec = clients::SharedHttpSpec { url, token };
+        clients::migrate_to_gateway_with_transport(&client_id, profile.as_deref(), Some(&spec))?
+    } else {
+        clients::migrate_to_gateway(&client_id, profile.as_deref())?
+    };
 
     // Record the scope now that the client config was rewritten to the gateway.
     // "No profile" becomes an explicit-unscoped marker (not a removal) so a live

--- a/src/components/ClientDetail.test.tsx
+++ b/src/components/ClientDetail.test.tsx
@@ -143,6 +143,61 @@ describe("ClientDetail customized entry (SOU-406)", () => {
       ),
     );
   });
+
+  it("passes live sharedHttp transport when applying scope (WS3-2)", async () => {
+    // Regression: installGateway defaults missing transport to stdio and would
+    // silently rewrite a Shared HTTP client as a stdio spawn.
+    installGateway.mockResolvedValue({ backup: false });
+    const reg = emptyRegistry();
+    // Profile picker only renders when profiles.length > 1.
+    reg.profiles = [
+      { id: "p1", name: "Work", enabledServerIds: [] },
+      { id: "p2", name: "Home", enabledServerIds: [] },
+    ];
+    reg.clientScopes = { "claude-desktop": "Work" };
+    reg.clientManagedEntries = {
+      "claude-desktop": {
+        command: "",
+        args: [],
+        env: {},
+        transport: "sharedHttp",
+        url: "http://127.0.0.1:8765/mcp",
+        updatedAt: 1,
+      },
+    };
+    const connected = {
+      ...client(),
+      gatewayInstalled: true,
+      entryState: "managed" as const,
+    };
+    render(
+      <ClientDetail
+        client={connected}
+        registry={reg}
+        onChanged={() => {}}
+        onRegistryChange={() => {}}
+      />,
+    );
+
+    // Change scope so Apply scope is enabled (profile !== currentScope).
+    // Scope select is the first combobox in the header (w-52); discovery is lower.
+    const scopeSelect = screen.getAllByRole("combobox")[0]!;
+    await userEvent.click(scopeSelect);
+    const home = await screen.findByRole("option", { name: /Only: Home/i });
+    await userEvent.click(home);
+
+    const apply = await screen.findByRole("button", { name: /apply scope/i });
+    await userEvent.click(apply);
+
+    await waitFor(() =>
+      expect(installGateway).toHaveBeenCalledWith(
+        "claude-desktop",
+        "Home",
+        false,
+        "sharedHttp",
+      ),
+    );
+  });
 });
 
 describe("ClientDetail connect toast (SOU-317)", () => {

--- a/src/components/ClientDetail.tsx
+++ b/src/components/ClientDetail.tsx
@@ -184,7 +184,8 @@ export function ClientDetail({ client, registry, onChanged, onRegistryChange }: 
     }
     setBusy(true);
     try {
-      await installGateway(client.id, profile || undefined);
+      // Pass live transport so Apply scope does not rewrite Shared HTTP → stdio (WS3-2).
+      await installGateway(client.id, profile || undefined, false, transport);
       // Rescope rewrites the client's MCP config the same way Connect does; without a
       // restart hint the change is invisible until the next cold start (SOU-317).
       toast.success(
@@ -232,6 +233,7 @@ export function ClientDetail({ client, registry, onChanged, onRegistryChange }: 
         client.id,
         profile || undefined,
         customized || undefined,
+        transport,
       );
       onRegistryChange(result.registry);
       toast.success(

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -479,7 +479,9 @@ export function detectClients(): Promise<DetectedClient[]> {
 /** Install the Toolport gateway into a client's config, optionally scoped to a
  * profile (by name). Omit profile to expose all enabled servers.
  * Pass `force: true` after the user confirms overwriting a custom entry (SOU-406).
- * `transport` is `"stdio"` (default) or `"sharedHttp"` (SOU-407). */
+ * `transport` is `"stdio"` (default) or `"sharedHttp"` (SOU-407).
+ * Callers that already know the live transport (Apply scope) must pass it —
+ * omitting defaults to stdio and would silently downgrade Shared HTTP (WS3-2). */
 export function installGateway(
   clientId: string,
   profile?: string,
@@ -501,16 +503,19 @@ export function uninstallGateway(clientId: string): Promise<WriteOutcome> {
 
 /** Import a client's servers into Toolport, then leave the client with only the
  * Toolport gateway (optionally scoped to a profile). Backs up the config first.
- * Pass `force: true` after the user confirms overwriting a custom entry (SOU-406). */
+ * Pass `force: true` after the user confirms overwriting a custom entry (SOU-406).
+ * Pass `transport` to preserve Shared HTTP on migrate (WS3-2). */
 export function migrateClient(
   clientId: string,
   profile?: string,
   force?: boolean,
+  transport?: "stdio" | "sharedHttp",
 ): Promise<MigrateResult> {
   return invoke<MigrateResult>("migrate_client", {
     clientId,
     profile: profile ?? null,
     force: force ?? false,
+    transport: transport ?? "stdio",
   });
 }
 


### PR DESCRIPTION
## Summary
- Write Authorization where clients actually send it: Continue `env` (WS3-1); VS Code / Hermes / remote JSON `headers` (WS3-3).
- Preserve Shared HTTP on Apply scope and migrate instead of defaulting to stdio (WS3-2).
- On Disconnect, revoke the vaulted bearer and `http_clients` row (WS3-4).
- On token reuse, update `http_clients.profile` so re-scope changes the bridge server set (WS3-5).
- Round-trip tests across Continue, VS Code, Hermes, OpenCode, and Qwen; frontend test for Apply scope + sharedHttp.

## Test plan
- [x] `cargo test --lib clients::` (111 passed)
- [x] `npx vitest run src/components/ClientDetail.test.tsx` (6 passed)
- [ ] Manual: Connect Continue / VS Code with Shared HTTP; confirm tool calls auth
- [ ] Manual: Apply scope on Shared HTTP client; stays Shared HTTP and sees new profile servers
- [ ] Manual: Disconnect; bearer no longer accepted on the bridge
