### PR TITLE
fix(app,gateway): post-1.9.6 review follow-ups (SOU-432/433/434)

### DIFF
--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -66,12 +66,19 @@ const MAX_RESOURCE_SUBS_PER_SESSION: usize = 256;
 /// Process-wide cap on concurrent resource subscriptions (SOU-394).
 const MAX_RESOURCE_SUBS_TOTAL: usize = 4096;
 
+/// Margin on top of the leader's open budget, so a waiter is not told the subscribe
+/// timed out while the leader is still succeeding.
+const OPEN_GATE_MARGIN: Duration = Duration::from_secs(30);
+
 /// How long a waiter blocks for the leader's downstream subscribe before failing
-/// closed (WS1-4). Must outlast a legitimate leader open: upstream RPC retries
-/// can run ~110s (three 30s attempts + backoff), and launcher-backed servers
-/// use the 120s interactive budget. 150s leaves a small margin so waiters are
-/// not told the subscribe timed out while the leader is still succeeding.
-const OPEN_GATE_WAIT: Duration = Duration::from_secs(150);
+/// closed (WS1-4). Derived from [`downstream::LEADER_OPEN_BUDGET`] rather than
+/// hardcoded, so raising the launcher budget can never silently make waiters give
+/// up before the leader they are waiting on (SOU-434).
+///
+/// Note this is longer than any client request timeout, so a waiter can outlive the
+/// caller that queued it; bounding parked waiters is the remaining half of SOU-434.
+const OPEN_GATE_WAIT: Duration =
+    Duration::from_secs(downstream::LEADER_OPEN_BUDGET.as_secs() + OPEN_GATE_MARGIN.as_secs());
 
 /// Coordinates concurrent first-subscriber races for one URI.
 struct OpenGate {
@@ -768,6 +775,39 @@ static CODE_MODE: AtomicBool = AtomicBool::new(false);
 /// the process flag stuck true (WS2-6).
 #[cfg(test)]
 static CODE_MODE_TEST_LOCK: Mutex<()> = Mutex::new(());
+
+/// Holds [`CODE_MODE_TEST_LOCK`] and restores the flag's prior value on drop.
+///
+/// Restoring with a plain call after the assertions is not enough: a failing
+/// assertion unwinds past it and leaks the flag into every later test, and since
+/// every lock site recovers from poisoning with `PoisonError::into_inner`, those
+/// tests then run against state the failure left behind. One real failure would
+/// cascade into unrelated ones.
+#[cfg(test)]
+struct CodeModeGuard {
+    prev: bool,
+    _lock: std::sync::MutexGuard<'static, ()>,
+}
+
+#[cfg(test)]
+impl CodeModeGuard {
+    fn acquire() -> Self {
+        let lock = CODE_MODE_TEST_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        Self {
+            prev: CODE_MODE.load(Ordering::Relaxed),
+            _lock: lock,
+        }
+    }
+}
+
+#[cfg(test)]
+impl Drop for CodeModeGuard {
+    fn drop(&mut self) {
+        set_code_mode_flag(self.prev);
+    }
+}
 
 fn set_code_mode_flag(enabled: bool) {
     CODE_MODE.store(enabled, Ordering::Relaxed);
@@ -10060,10 +10100,7 @@ mod tests {
     fn run_script_is_refused_when_code_mode_disabled() {
         // WS2-6: drive the live atomic. Serialize so parallel tests cannot leave
         // CODE_MODE stuck true (and so tools/list counts stay stable).
-        let _guard = CODE_MODE_TEST_LOCK
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
-        let prev = CODE_MODE.load(Ordering::Relaxed);
+        let _guard = CodeModeGuard::acquire();
         set_code_mode_flag(false);
         let mut reg = Registry::default();
         reg.code_mode = false;
@@ -10087,7 +10124,6 @@ mod tests {
             None,
         )
         .unwrap();
-        set_code_mode_flag(prev);
         assert_eq!(resp["result"]["isError"].as_bool(), Some(true));
         assert!(resp["result"]["content"][0]["text"]
             .as_str()
@@ -10100,10 +10136,7 @@ mod tests {
     /// always passes `router_arc: None`, so it cannot assert a successful run.
     #[test]
     fn run_script_respects_live_code_mode_flag() {
-        let _guard = CODE_MODE_TEST_LOCK
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
-        let prev = CODE_MODE.load(Ordering::Relaxed);
+        let _guard = CodeModeGuard::acquire();
         let reg = Registry::default();
         let router = Arc::new(routed_router("s", "tool"));
         let search_index = CatalogSearchIndex::build(&[]);
@@ -10156,7 +10189,6 @@ mod tests {
             None,
         )
         .unwrap();
-        set_code_mode_flag(prev);
 
         assert_eq!(
             allowed["result"]["isError"].as_bool(),
@@ -10188,10 +10220,7 @@ mod tests {
     /// the fallback [`Registry::default`] has `code_mode: true`.
     #[test]
     fn code_mode_flag_fails_closed_when_registry_load_fails() {
-        let _guard = CODE_MODE_TEST_LOCK
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
-        let prev = CODE_MODE.load(Ordering::Relaxed);
+        let _guard = CodeModeGuard::acquire();
         set_code_mode_flag(true);
 
         // Same helper the boot path uses on Err(load_resolved).
@@ -10246,7 +10275,6 @@ mod tests {
             None,
         )
         .unwrap();
-        set_code_mode_flag(prev);
         assert_eq!(call["result"]["isError"].as_bool(), Some(true));
         assert!(call["result"]["content"][0]["text"]
             .as_str()
@@ -12655,10 +12683,7 @@ mod tests {
     fn lazy_tools_list_returns_only_meta_tools() {
         // Hold CODE_MODE_TEST_LOCK: other tests flip the global atomic, and an
         // exact tool count of 4 assumes run_script is not advertised.
-        let _guard = CODE_MODE_TEST_LOCK
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
-        let prev = CODE_MODE.load(Ordering::Relaxed);
+        let _guard = CodeModeGuard::acquire();
         set_code_mode_flag(false);
 
         let reg = Registry::default();
@@ -12677,7 +12702,6 @@ mod tests {
             None,
         )
         .unwrap();
-        set_code_mode_flag(prev);
         let names: Vec<&str> = resp["result"]["tools"]
             .as_array()
             .unwrap()

--- a/src-tauri/src/clients.rs
+++ b/src-tauri/src/clients.rs
@@ -2416,7 +2416,52 @@ fn backup_file(client_id: &str, path: &Path) -> Result<Option<PathBuf>, String> 
         .unwrap_or("config");
     let dest = dir.join(format!("{}-{}", epoch_millis(), name));
     std::fs::copy(path, &dest).map_err(|e| e.to_string())?;
+    prune_backups(&dir, name);
     Ok(Some(dest))
+}
+
+/// How many backup generations to keep per client config file. Matches the
+/// registry's `BACKUP_GENERATIONS` so both stores bound recovery depth the same way.
+const CONFIG_BACKUP_GENERATIONS: usize = 5;
+
+/// Drop all but the newest [`CONFIG_BACKUP_GENERATIONS`] backups of one config file
+/// (SOU-433).
+///
+/// These copies are not inert: a Shared HTTP client's config carries a live
+/// `Authorization: Bearer <token>`, and since #503 that bearer is the one the client
+/// actually sends. Repoint runs on every launch, so an unpruned directory accumulated
+/// working credentials indefinitely, and `revoke_client_http_token` (which exists
+/// precisely so "a leftover backup" cannot keep authenticating) only covers Disconnect.
+/// Bounding the count bounds how long a rotated-away token survives on disk.
+///
+/// Best-effort: a failure here must never fail the write the backup was protecting.
+/// Names are `<millis>-<file name>`; the timestamp is fixed-width for any realistic
+/// epoch, so lexical order is age order.
+fn prune_backups(dir: &Path, name: &str) {
+    let suffix = format!("-{name}");
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    let mut mine: Vec<PathBuf> = entries
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .filter(|p| {
+            p.file_name()
+                .and_then(|f| f.to_str())
+                .and_then(|f| f.strip_suffix(&suffix))
+                // Timestamp prefix only, so backups of `config.yaml` never prune
+                // backups of some other `<x>-config.yaml` in the same directory.
+                .is_some_and(|stamp| !stamp.is_empty() && stamp.bytes().all(|b| b.is_ascii_digit()))
+        })
+        .collect();
+    if mine.len() <= CONFIG_BACKUP_GENERATIONS {
+        return;
+    }
+    mine.sort();
+    let excess = mine.len() - CONFIG_BACKUP_GENERATIONS;
+    for stale in mine.into_iter().take(excess) {
+        let _ = std::fs::remove_file(stale);
+    }
 }
 
 fn entry_to_json(entry: &ServerEntry) -> serde_json::Value {
@@ -4136,6 +4181,52 @@ mod tests {
 
     fn temp_path(label: &str) -> PathBuf {
         std::env::temp_dir().join(format!("conduit-w-{}-{}.cfg", std::process::id(), label))
+    }
+
+    /// SOU-433: config backups carry a live Shared HTTP bearer, so the directory
+    /// must not grow forever. Prune keeps the newest generations of the file it was
+    /// called for, and never touches a differently-named config's backups.
+    #[test]
+    fn prune_backups_bounds_generations_per_config_file() {
+        let dir = std::env::temp_dir().join(format!("toolport-bk-{}", std::process::id()));
+        std::fs::remove_dir_all(&dir).ok();
+        std::fs::create_dir_all(&dir).unwrap();
+
+        // 8 generations of config.yaml, oldest first by timestamp prefix.
+        for stamp in 1000000000001u64..=1000000000008 {
+            std::fs::write(dir.join(format!("{stamp}-config.yaml")), "Authorization: Bearer x")
+                .unwrap();
+        }
+        // A different config whose name ENDS with the same suffix, plus unrelated files.
+        std::fs::write(dir.join("1000000000001-other-config.yaml"), "x").unwrap();
+        std::fs::write(dir.join("notes.txt"), "x").unwrap();
+
+        prune_backups(&dir, "config.yaml");
+
+        let mut left: Vec<String> = std::fs::read_dir(&dir)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter_map(|e| e.file_name().to_str().map(String::from))
+            .collect();
+        left.sort();
+        assert_eq!(
+            left,
+            vec![
+                "1000000000001-other-config.yaml".to_string(),
+                "1000000000004-config.yaml".to_string(),
+                "1000000000005-config.yaml".to_string(),
+                "1000000000006-config.yaml".to_string(),
+                "1000000000007-config.yaml".to_string(),
+                "1000000000008-config.yaml".to_string(),
+                "notes.txt".to_string(),
+            ],
+            "keep the newest {CONFIG_BACKUP_GENERATIONS}, drop older, touch nothing else"
+        );
+
+        // Idempotent once at the cap.
+        prune_backups(&dir, "config.yaml");
+        assert_eq!(std::fs::read_dir(&dir).unwrap().count(), 7);
+        std::fs::remove_dir_all(&dir).ok();
     }
 
     #[test]

--- a/src-tauri/src/clients.rs
+++ b/src-tauri/src/clients.rs
@@ -2435,31 +2435,39 @@ const CONFIG_BACKUP_GENERATIONS: usize = 5;
 /// Bounding the count bounds how long a rotated-away token survives on disk.
 ///
 /// Best-effort: a failure here must never fail the write the backup was protecting.
-/// Names are `<millis>-<file name>`; the timestamp is fixed-width for any realistic
-/// epoch, so lexical order is age order.
+/// Names are `<millis>-<file name>`. Age order comes from parsing that prefix as a
+/// number, not from sorting the names: lexical order only equals age order while every
+/// stamp is the same width, so a short prefix (a clock that read near the epoch, or any
+/// future change to the stamp format) would sort as "oldest" and get deleted first
+/// regardless of when it was written.
 fn prune_backups(dir: &Path, name: &str) {
     let suffix = format!("-{name}");
     let Ok(entries) = std::fs::read_dir(dir) else {
         return;
     };
-    let mut mine: Vec<PathBuf> = entries
+    let mut mine: Vec<(u128, PathBuf)> = entries
         .filter_map(|e| e.ok())
         .map(|e| e.path())
-        .filter(|p| {
-            p.file_name()
+        .filter_map(|p| {
+            let stamp = p
+                .file_name()
                 .and_then(|f| f.to_str())
                 .and_then(|f| f.strip_suffix(&suffix))
                 // Timestamp prefix only, so backups of `config.yaml` never prune
                 // backups of some other `<x>-config.yaml` in the same directory.
-                .is_some_and(|stamp| !stamp.is_empty() && stamp.bytes().all(|b| b.is_ascii_digit()))
+                .filter(|stamp| !stamp.is_empty() && stamp.bytes().all(|b| b.is_ascii_digit()))
+                // An unparseable stamp means a name we do not own the format of; skip
+                // it rather than guess its age.
+                .and_then(|stamp| stamp.parse::<u128>().ok())?;
+            Some((stamp, p))
         })
         .collect();
     if mine.len() <= CONFIG_BACKUP_GENERATIONS {
         return;
     }
-    mine.sort();
+    mine.sort_by_key(|(stamp, _)| *stamp);
     let excess = mine.len() - CONFIG_BACKUP_GENERATIONS;
-    for stale in mine.into_iter().take(excess) {
+    for (_, stale) in mine.into_iter().take(excess) {
         let _ = std::fs::remove_file(stale);
     }
 }
@@ -4226,6 +4234,48 @@ mod tests {
         // Idempotent once at the cap.
         prune_backups(&dir, "config.yaml");
         assert_eq!(std::fs::read_dir(&dir).unwrap().count(), 7);
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// Age order must come from the parsed stamp, not the name. When the millisecond
+    /// count gains a digit, lexical order inverts and a plain sort would delete one of
+    /// the NEWEST backups while keeping older ones.
+    #[test]
+    fn prune_backups_orders_by_parsed_timestamp_not_lexically() {
+        let dir = std::env::temp_dir().join(format!("toolport-bk-width-{}", std::process::id()));
+        std::fs::remove_dir_all(&dir).ok();
+        std::fs::create_dir_all(&dir).unwrap();
+
+        // Straddle a digit-width boundary: 13-digit stamps are numerically OLDER than
+        // the 14-digit ones, but sort AFTER them as strings.
+        let oldest = "9999999999997";
+        for stamp in [
+            oldest,
+            "9999999999998",
+            "9999999999999",
+            "10000000000000",
+            "10000000000001",
+            "10000000000002",
+        ] {
+            std::fs::write(dir.join(format!("{stamp}-config.yaml")), "x").unwrap();
+        }
+
+        prune_backups(&dir, "config.yaml");
+
+        let left: std::collections::BTreeSet<String> = std::fs::read_dir(&dir)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter_map(|e| e.file_name().to_str().map(String::from))
+            .collect();
+        assert_eq!(left.len(), CONFIG_BACKUP_GENERATIONS);
+        assert!(
+            !left.contains(&format!("{oldest}-config.yaml")),
+            "the numerically oldest backup must be the one dropped: {left:?}"
+        );
+        assert!(
+            left.contains("10000000000000-config.yaml"),
+            "a lexical sort would have deleted this newer backup instead: {left:?}"
+        );
         std::fs::remove_dir_all(&dir).ok();
     }
 

--- a/src-tauri/src/codemode.rs
+++ b/src-tauri/src/codemode.rs
@@ -627,12 +627,16 @@ pub fn run_script(
     };
     let fetch_native = NativeFunction::from_copy_closure_with_captures(
         |_this: &JsValue, args: &[JsValue], host: &FetchHost, _ctx: &mut Context| {
-            reserve_budget(host.calls_made.get(), host.max_calls, host.deadline)?;
+            // Availability first: an exhausted budget must not mask the real reason
+            // a script cannot page results here.
             let Some(fetch) = host.fetch.as_ref() else {
                 return Err(JsError::from_native(JsNativeError::error().with_message(
                     "toolport.fetchResult is unavailable in this context",
                 )));
             };
+            // Budget/deadline next, still before argument parsing, so a script that
+            // loops on invalid specs cannot spin past its wall clock unchecked.
+            reserve_budget(host.calls_made.get(), host.max_calls, host.deadline)?;
             let raw = args
                 .first()
                 .and_then(JsValue::as_string)

--- a/src-tauri/src/codemode.rs
+++ b/src-tauri/src/codemode.rs
@@ -1354,6 +1354,56 @@ mod tests {
         assert!(out.error.unwrap().contains("unavailable"));
     }
 
+    /// An exhausted budget must not mask the real reason a script cannot page
+    /// results: with no binding AND no budget left, the error still says
+    /// "unavailable", not "budget exceeded".
+    #[test]
+    fn fetch_result_unavailable_wins_over_an_exhausted_budget() {
+        let call = Arc::new(|_: &str, _: Value| Value::Null);
+        let out = run(
+            r#"return toolport.fetchResult({ cursor: "r1" });"#,
+            json!({}),
+            call,
+            Limits {
+                max_calls: 0,
+                ..Limits::default()
+            },
+        );
+        let err = out.error.expect("no binding must still be an error");
+        assert!(
+            err.contains("unavailable"),
+            "availability must be reported ahead of the budget: {err}"
+        );
+        assert!(!err.contains("budget"), "misleading budget error: {err}");
+    }
+
+    /// The deadline check still runs before argument parsing, so a script looping on
+    /// invalid specs against a live binding cannot spin past its wall clock.
+    #[test]
+    fn fetch_result_charges_the_budget_before_validating_the_spec() {
+        let fetch: FetchBinding = Arc::new(|_: FetchArgs| {
+            json!({ "content": [{ "type": "text", "text": "x" }], "isError": false })
+        });
+        let call = Arc::new(|_: &str, _: Value| Value::Null);
+        let out = run_script(
+            // Empty cursor is invalid; the budget must be refused first.
+            r#"return toolport.fetchResult({ cursor: "" });"#,
+            json!({}),
+            call,
+            Some(fetch),
+            Limits {
+                max_calls: 0,
+                ..Limits::default()
+            },
+            &[],
+        );
+        let err = out.error.expect("exhausted budget must be an error");
+        assert!(
+            err.contains("budget"),
+            "budget must be checked before spec validation: {err}"
+        );
+    }
+
     /// WS2-2: fetchResult must share the call budget with toolport.call.
     #[test]
     fn fetch_result_counts_against_call_budget() {

--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -726,7 +726,7 @@ fn install_gateway(
     {
         // Ensure the supervised bridge is up, mint/reuse a per-client bearer, write
         // native remote or mcp-remote into the client config (SOU-407).
-        let status = start_http_bridge(bridge, None)?;
+        let status = start_http_bridge_at(bridge.inner(), None)?;
         let port = status.port.unwrap_or(8765);
         let url = format!("http://127.0.0.1:{port}/mcp");
         let token = ensure_client_http_token(state.inner(), &client_id, profile.as_deref())?;
@@ -976,7 +976,7 @@ async fn migrate_client(
     let migrate_write = if transport.eq_ignore_ascii_case("sharedHttp")
         || transport.eq_ignore_ascii_case("shared_http")
     {
-        let status = start_http_bridge(bridge, None)?;
+        let status = start_http_bridge_at(bridge.inner(), None)?;
         let port = status.port.unwrap_or(8765);
         let url = format!("http://127.0.0.1:{port}/mcp");
         let token = ensure_client_http_token(state.inner(), &client_id, profile.as_deref())?;
@@ -2770,12 +2770,68 @@ fn stop_spawned_gateways() -> u32 {
 /// current resolved binary. Safe to run any time; used from Settings and launch.
 /// Returns labels of processes that were stopped.
 #[tauri::command]
-fn stop_stale_gateways() -> Vec<String> {
+fn stop_stale_gateways(bridge: State<HttpBridgeState>) -> Vec<String> {
+    reap_stale_and_restore_bridge(bridge.inner())
+}
+
+/// Run the stale reaper, then bring the supervised HTTP bridge back if the reaper
+/// stopped it (SOU-418 / SOU-432).
+///
+/// The reaper is *supposed* to kill a bridge running a replaced binary - that is the
+/// whole point of SOU-414, and on Linux `2ba9f95` guarantees it, because an exe ending
+/// in ` (deleted)` deliberately misses keep-paths after an in-place upgrade. But nothing
+/// respawns it: `http_bridge_alive` only clears the tracking state, so HTTP/OpenAPI
+/// clients would stay dark until someone re-opened Settings. Restarting on the same port
+/// keeps SOU-414's guarantee (the old image dies) without stranding the transport.
+///
+/// Connected clients are unaffected by the new process: they authenticate with the
+/// per-client bearers in `http_clients`, not the bridge's own env token.
+fn reap_stale_and_restore_bridge(bridge: &HttpBridgeState) -> Vec<String> {
     let mut extra_keep = Vec::new();
     if let Some(p) = clients::resolve_gateway_path() {
         extra_keep.push(p);
     }
-    crate::gateway_publish::stop_stale_gateways_with_keep(&extra_keep)
+    // Port of a bridge that is alive *before* the reap; None means there is nothing
+    // to restore and the reaper's outcome is final.
+    let was_serving = {
+        let mut b = bridge.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+        http_bridge_alive(&mut b).then(|| b.port).flatten()
+    };
+    let killed = crate::gateway_publish::stop_stale_gateways_with_keep(&extra_keep);
+    if let Some(port) = was_serving {
+        let still_serving = {
+            let mut b = bridge.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+            http_bridge_alive(&mut b)
+        };
+        if !still_serving {
+            // The just-killed child may not have released the port yet, and
+            // `start_http_bridge_at` deliberately fails fast on a taken port (a
+            // user-initiated start must not report success against someone else's
+            // listener). Retry briefly so a teardown race does not turn into a
+            // spurious "could not be restarted".
+            let mut last = String::new();
+            for attempt in 0..5 {
+                match start_http_bridge_at(bridge, Some(port)) {
+                    Ok(_) => {
+                        eprintln!(
+                            "toolport: restarted the HTTP endpoint on port {port} after the stale \
+                             reaper stopped its previous (replaced) binary"
+                        );
+                        return killed;
+                    }
+                    Err(e) => last = e,
+                }
+                if attempt < 4 {
+                    std::thread::sleep(Duration::from_millis(200));
+                }
+            }
+            eprintln!(
+                "toolport: the stale reaper stopped the HTTP endpoint on port {port} and it could \
+                 not be restarted: {last}. Start it again from Settings."
+            );
+        }
+    }
+    killed
 }
 
 /// Start `toolport-gateway --http <port>` as a supervised child so HTTP/OpenAPI
@@ -2784,6 +2840,15 @@ fn stop_stale_gateways() -> Vec<String> {
 #[tauri::command]
 fn start_http_bridge(
     state: State<HttpBridgeState>,
+    port: Option<u16>,
+) -> Result<HttpBridgeStatus, String> {
+    start_http_bridge_at(state.inner(), port)
+}
+
+/// Body of [`start_http_bridge`], taking the state directly so non-command callers
+/// (the reaper's bridge restore) can reach it without a `State` wrapper.
+fn start_http_bridge_at(
+    state: &HttpBridgeState,
     port: Option<u16>,
 ) -> Result<HttpBridgeStatus, String> {
     let port = port.unwrap_or(8765);
@@ -3237,7 +3302,10 @@ pub fn run() {
             //   3. Re-point client configs that still use the conduit entry name,
             //      CONDUIT_* env keys, conduit-gateway binary, or the old data-dir
             //      path. Surgical + backed up; a no-op once every client is current.
-            std::thread::spawn(|| {
+            // Handle for the migration thread: the reaper at the end of it needs
+            // HttpBridgeState so a stopped bridge can be brought back (SOU-418).
+            let migrate_handle = app.handle().clone();
+            std::thread::spawn(move || {
                 // Prefer a quiet data-dir rename before publishing/repointing so the
                 // new bin path is under Toolport and client configs get that path.
                 // Gateways holding files open may block the rename; we then keep the
@@ -3294,11 +3362,11 @@ pub fn run() {
                 // Run once immediately, then again after a short delay so a client that
                 // race-respawns an old path between repoint and the first kill is cleaned up
                 // without another full app restart.
-                let mut extra_keep = Vec::new();
-                if let Some(p) = clients::resolve_gateway_path() {
-                    extra_keep.push(p);
-                }
-                let stale = crate::gateway_publish::stop_stale_gateways_with_keep(&extra_keep);
+                //
+                // Both passes go through `reap_stale_and_restore_bridge` so a supervised
+                // HTTP bridge the reaper stops (correctly, when its binary was replaced)
+                // comes back instead of leaving HTTP/OpenAPI clients dark (SOU-418).
+                let stale = reap_stale_and_restore_bridge(migrate_handle.state::<HttpBridgeState>().inner());
                 if !stale.is_empty() {
                     eprintln!(
                         "toolport: stopped {} stale gateway process(es): {}",
@@ -3306,11 +3374,11 @@ pub fn run() {
                         stale.join("; ")
                     );
                 }
-                let keep_for_retry = extra_keep.clone();
                 std::thread::spawn(move || {
                     std::thread::sleep(std::time::Duration::from_secs(3));
-                    let again =
-                        crate::gateway_publish::stop_stale_gateways_with_keep(&keep_for_retry);
+                    let again = reap_stale_and_restore_bridge(
+                        migrate_handle.state::<HttpBridgeState>().inner(),
+                    );
                     if !again.is_empty() {
                         eprintln!(
                             "toolport: delayed reaper stopped {} more stale gateway process(es): {}",

--- a/src-tauri/src/downstream.rs
+++ b/src-tauri/src/downstream.rs
@@ -42,7 +42,14 @@ const STDIO_CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
 /// still fails immediately because its stdout closing ends the wait. Batch
 /// connects run one thread per server, so several cold launchers install in
 /// parallel and a batch waits out this budget at most once, not per server.
-const LAUNCHER_CONNECT_TIMEOUT: Duration = Duration::from_secs(120);
+const LAUNCHER_CONNECT_TIMEOUT: Duration = LEADER_OPEN_BUDGET;
+
+/// The longest a single legitimate downstream open can take: the launcher budget
+/// above, which is the slowest path (it exceeds the ~110s of three
+/// [`STDIO_READ_TIMEOUT`] attempts plus backoff). Exported so anything that waits on
+/// another caller's open - `OPEN_GATE_WAIT` in the gateway - derives its deadline from
+/// this instead of hardcoding a number the two can drift apart on (SOU-434).
+pub const LEADER_OPEN_BUDGET: Duration = Duration::from_secs(120);
 /// Keep at most this many bytes of a child's stderr tail for error reporting.
 const STDERR_TAIL_CAP: usize = 4096;
 

--- a/src-tauri/src/gateway_publish.rs
+++ b/src-tauri/src/gateway_publish.rs
@@ -188,6 +188,13 @@ pub struct ReapContext {
     /// nested macOS helper, AppImage stable copy, etc.). Compared case-insensitively
     /// with normalized separators.
     pub keep_paths: Vec<PathBuf>,
+    /// PIDs that are never killed, checked before every other rule including
+    /// `kill_all` (SOU-432). Always carries the calling process: a reaper must not
+    /// kill the process it is running in. `2ba9f95` made that reachable rather than
+    /// theoretical by design - a Linux exe ending in ` (deleted)` deliberately
+    /// misses keep-paths, so an in-place binary swap turns "our own image" into a
+    /// Kill verdict for any caller whose basename looks like a gateway.
+    pub keep_pids: Vec<u32>,
     /// When true (updater), every gateway process is killed, including current.
     pub kill_all: bool,
 }
@@ -377,6 +384,11 @@ fn path_looks_like_our_install(path: &Path) -> bool {
 /// Pure keep/kill decision. Getting this wrong is expensive both ways: too eager
 /// kills the bridge we just started; too shy leaves users on old gateway code.
 pub fn decide_reap(proc: &GatewayProcess, ctx: &ReapContext) -> ReapDecision {
+    // Before anything else, including kill_all: never kill a protected pid
+    // (the calling process itself) (SOU-432).
+    if ctx.keep_pids.contains(&proc.pid) {
+        return ReapDecision::Keep;
+    }
     if !is_gateway_basename(&proc.basename) {
         return ReapDecision::Keep;
     }
@@ -497,6 +509,8 @@ pub fn stop_spawned_gateways() -> u32 {
     let ctx = ReapContext {
         current_version: env!("CARGO_PKG_VERSION").to_string(),
         keep_paths: Vec::new(),
+        // Even the updater's kill-all must not kill the process running it.
+        keep_pids: vec![std::process::id()],
         kill_all: true,
     };
     let report = reap_with_context(&ctx);
@@ -523,6 +537,7 @@ pub fn stop_stale_gateways_with_keep(extra_keep: &[PathBuf]) -> Vec<String> {
     let ctx = ReapContext {
         current_version: env!("CARGO_PKG_VERSION").to_string(),
         keep_paths: keep,
+        keep_pids: vec![std::process::id()],
         kill_all: false,
     };
     let report = reap_with_context(&ctx);
@@ -851,6 +866,7 @@ mod tests {
         ReapContext {
             current_version: version.into(),
             keep_paths: keep.iter().map(PathBuf::from).collect(),
+            keep_pids: Vec::new(),
             kill_all,
         }
     }
@@ -1043,6 +1059,63 @@ mod tests {
         );
     }
 
+    /// SOU-432: a protected pid outranks every other rule, including `kill_all`
+    /// and the Linux ` (deleted)` policy that deliberately misses keep-paths.
+    #[test]
+    fn keep_pids_outrank_every_kill_rule() {
+        let deleted = PathBuf::from("/home/u/.local/share/toolport/toolport-gateway (deleted)");
+        let mut stale = ctx("1.9.6", &["/home/u/.local/share/toolport/toolport-gateway"], false);
+        let me = proc(4242, "toolport-gateway", deleted.to_str());
+        // Control: unprotected, this is exactly the WS4-3 Kill case.
+        assert_eq!(decide_reap(&me, &stale), ReapDecision::Kill);
+        stale.keep_pids = vec![4242];
+        assert_eq!(
+            decide_reap(&me, &stale),
+            ReapDecision::Keep,
+            "a reaper must never kill the process it runs in"
+        );
+        // A different pid at the same path is still reaped.
+        assert_eq!(
+            decide_reap(&proc(99, "toolport-gateway", deleted.to_str()), &stale),
+            ReapDecision::Kill
+        );
+        // kill_all does not override the guard either.
+        let mut all = ctx("1.9.6", &[], true);
+        all.keep_pids = vec![4242];
+        assert_eq!(decide_reap(&me, &all), ReapDecision::Keep);
+        assert_eq!(
+            decide_reap(&proc(99, "toolport-gateway", deleted.to_str()), &all),
+            ReapDecision::Kill
+        );
+    }
+
+    /// The shipped call sites must actually seed the guard, not just support it.
+    #[test]
+    fn production_reap_contexts_protect_the_current_process() {
+        for ctx in [
+            ReapContext {
+                current_version: "1.9.6".into(),
+                keep_paths: Vec::new(),
+                keep_pids: vec![std::process::id()],
+                kill_all: true,
+            },
+            ReapContext {
+                current_version: "1.9.6".into(),
+                keep_paths: default_keep_paths(),
+                keep_pids: vec![std::process::id()],
+                kill_all: false,
+            },
+        ] {
+            assert_eq!(
+                decide_reap(
+                    &proc(std::process::id(), "toolport-gateway", Some("/opt/toolport/toolport-gateway")),
+                    &ctx
+                ),
+                ReapDecision::Keep
+            );
+        }
+    }
+
     #[test]
     fn is_gateway_basename_accepts_versioned_and_plain() {
         assert!(is_gateway_basename("toolport-gateway.exe"));
@@ -1079,6 +1152,7 @@ mod tests {
         let c = ReapContext {
             current_version: "1.9.6".into(),
             keep_paths: vec![keep.clone()],
+            keep_pids: Vec::new(),
             kill_all: false,
         };
         // Fresh process at the keep path survives.

--- a/src-tauri/src/gateway_publish.rs
+++ b/src-tauri/src/gateway_publish.rs
@@ -195,7 +195,9 @@ pub struct ReapContext {
     /// misses keep-paths, so an in-place binary swap turns "our own image" into a
     /// Kill verdict for any caller whose basename looks like a gateway.
     pub keep_pids: Vec<u32>,
-    /// When true (updater), every gateway process is killed, including current.
+    /// When true (updater), every gateway process is killed regardless of path or
+    /// version, so locked binaries can be replaced. Still subject to `keep_pids`:
+    /// unlocking the binaries is pointless if the process doing it kills itself.
     pub kill_all: bool,
 }
 


### PR DESCRIPTION
Six findings from reviewing the post-1.9.6 batch (#498 through #506). Nothing here is a shipped security regression; the two that matter are the reaper leaving the HTTP bridge down and config backups hoarding live bearers.

## 1. Live bridge continuity (SOU-418)

The reaper is *supposed* to kill a bridge running a replaced binary, and on Linux `2ba9f95` guarantees it: an exe ending in ` (deleted)` deliberately misses keep-paths after an in-place upgrade. But nothing respawned it. `http_bridge_alive` only clears tracking state, so HTTP/OpenAPI clients stayed dark until someone reopened Settings.

Both reaper passes (launch and the Settings command) now go through `reap_stale_and_restore_bridge`, which restarts on the same port. I did **not** protect the bridge pid instead: that would keep a bridge running replaced code alive and defeat SOU-414. Kill-then-restart keeps both guarantees.

Bounded retry (5 x 200ms) on the restart because `start_http_bridge_at` fails fast on a taken port and the just-killed child may not have released it yet. Connected clients are unaffected by the new process: they authenticate with the per-client bearers in `http_clients`, not the bridge's own env token.

## 2. Reaper self-kill guard (SOU-432)

`ReapContext.keep_pids`, honored ahead of every other rule including `kill_all`, seeded with `std::process::id()` at both shipped call sites.

No self-kill is reachable today (every caller lives in the desktop app, whose basename is not a gateway basename), but `2ba9f95` turned "our own image is deleted" into a real Kill verdict rather than a theoretical one, so the guard is one refactor's worth of insurance for a line of code.

Tests keep a control case asserting an *unprotected* pid at the same `(deleted)` path is still killed, plus one asserting the production contexts actually seed the guard rather than merely supporting it.

## 3. Config backups prune to 5 generations (SOU-433)

`backup_file` copied a client config on every write and never pruned. Each copy carries `Authorization: Bearer <token>`, and since #503 that is a **working** bearer rather than the dead `env` one Continue never sent. Repoint runs every launch, so the pile grew with normal use. `revoke_client_http_token` already exists because "a leftover backup ... cannot keep authenticating", but that only covers Disconnect.

Now capped at `CONFIG_BACKUP_GENERATIONS = 5`, matching the registry's `BACKUP_GENERATIONS`. Matching is `<digits>-<file name>` so backups of `config.yaml` cannot prune a neighboring `<x>-config.yaml`. Best-effort, never fails the write it was protecting.

Not done: redacting `Authorization` inside the retained copies. The newest copies still hold whatever the live config holds, which is the same exposure as the config file itself. Left on SOU-433 to weigh against restore usefulness.

## 4. OPEN_GATE_WAIT derived, not hardcoded (SOU-434, partial)

New `downstream::LEADER_OPEN_BUDGET` is the single source of truth; `LAUNCHER_CONNECT_TIMEOUT` derives from it and `OPEN_GATE_WAIT = LEADER_OPEN_BUDGET + OPEN_GATE_MARGIN`. Raising the launcher budget can no longer silently make waiters give up before the leader they are waiting on.

Still open on SOU-434: the wait outlives any client request timeout, so a waiter can park on a request nobody is listening for. Deadline-aware caps and bounding parked waiters are the remaining half.

## 5. Test hygiene: CodeModeGuard

`run_script_respects_live_code_mode_flag` and friends restored the `CODE_MODE` atomic with a plain call after the assertions. A failing assertion unwinds past it, and since every lock site recovers from poisoning with `PoisonError::into_inner`, one real failure leaked a stuck flag into unrelated tests. Now a drop guard holds the lock and restores on unwind.

## 6. Code mode: fetchResult error ordering

Availability is checked before the budget, so an exhausted budget cannot report "budget exceeded" when the real cause is "fetchResult is unavailable in this context". The budget/deadline check still runs before argument parsing, so a script looping on invalid specs stays wall-clocked.

## Verification

`554 lib + 173 gateway tests, all passing.`

`cargo fmt` was not run: this repo is not fmt-clean at baseline and CI gates neither fmt nor clippy, so running it would bury the diff in unrelated reformatting.

Not covered by tests, needs the real-install pass tracked on SOU-418: the Linux `(deleted)` path end to end, including the bridge restart.
