### PR TITLE
chore: 1.9.7-rc.1 for multi-OS smoke testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,6 @@ Entries before the rename below shipped under the project's former name, Conduit
 
 ## [Unreleased]
 
-## [1.9.7] - 2026-07-28
-
 Stale gateways actually stop after an upgrade, approvals stay bound to what you
 approved, and a batch of transport and code-mode hardening.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,11 @@ process listing used an argv that Apple's `ps` rejects, so it saw zero gateways;
 Linux a binary replaced in place is now correctly treated as obsolete rather than
 protected. Settings gains a **Stop old gateways** action. (SOU-414)
 
+Note the limit: an AI client caches the gateway command when **it** starts, so a client
+that was already running when you upgraded will respawn the old binary even though
+Toolport has re-pointed its config. Restart the client app itself to pick up the new
+gateway. Clients started after the upgrade are unaffected.
+
 **The Shared HTTP bridge comes back after the reaper stops it.** Reaping a bridge whose
 binary was replaced left HTTP and OpenAPI clients with nothing listening until someone
 reopened Settings.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,57 @@ Entries before the rename below shipped under the project's former name, Conduit
 
 ## [Unreleased]
 
+## [1.9.7] - 2026-07-28
+
+Stale gateways actually stop after an upgrade, approvals stay bound to what you
+approved, and a batch of transport and code-mode hardening.
+
+### Security
+
+**An approved tool call is re-checked against the live gateway before it runs.** A
+human approval was validated against a snapshot taken before the hold, so a tool that
+was quarantined, released, or had its definition changed during the approval window
+still executed against the pre-hold view. Approvals now rebind to the live router and
+fail closed if the definition fingerprint moved or the tool is blocked, with a clearer
+"this approval is stale" message. (SOU-321, SOU-322)
+
+**Vendor auth hints require an exact domain match.** Lookalike apex domains
+(`clerkauth.com`, `evilgithub.com`) could inherit a real vendor's auth hints and token
+URL through prefix/suffix matching on the second-level label. Matching is now exact,
+`api.githubcopilot.com` gets its own entry, and a trailing-dot FQDN still resolves.
+
+### Fixed
+
+**Old gateway processes are stopped after an upgrade, on every OS.** Upgrading left
+older versioned gateways (`toolport-gateway-1.9.4.exe` and friends) running, so
+security and policy fixes in the new binary never took effect for clients still talking
+to them. Identity is now path-based across Windows, macOS, and Linux. On macOS the
+process listing used an argv that Apple's `ps` rejects, so it saw zero gateways; on
+Linux a binary replaced in place is now correctly treated as obsolete rather than
+protected. Settings gains a **Stop old gateways** action. (SOU-414)
+
+**The Shared HTTP bridge comes back after the reaper stops it.** Reaping a bridge whose
+binary was replaced left HTTP and OpenAPI clients with nothing listening until someone
+reopened Settings.
+
+**A Continue Shared HTTP bearer now reaches the wire.** The token was written under
+`env`, which Continue does not forward for remote servers, leaving a plaintext bearer
+on disk that never authenticated. It now goes under `requestOptions.headers`, matching
+Continue's contract. Ownership re-detection reads both.
+
+**Client config backups no longer accumulate live bearer tokens.** Every config write
+copied the previous file and nothing ever pruned them, so a Shared HTTP client's
+backups piled up carrying working credentials. Capped at five generations per file,
+matching the registry.
+
+**Resource subscriptions clean up when a session is replaced**, and a subscriber
+waiting on another client's open no longer gives up while that open is still
+succeeding.
+
+**Code mode budget and isolation.** `fetchResult` shares the call and wall-clock budget
+rather than paging without limit, async workers reinstall the active session for host
+calls, and a corrupt registry no longer boots with code mode enabled.
+
 ## [1.9.6] - 2026-07-27
 
 Client config ownership, Shared HTTP connect, code mode v2 (parallel + typed stubs),

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "toolport",
   "private": true,
-  "version": "1.9.7",
+  "version": "1.9.7-rc.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "toolport",
   "private": true,
-  "version": "1.9.6",
+  "version": "1.9.7",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -780,7 +780,7 @@ dependencies = [
 
 [[package]]
 name = "conduit"
-version = "1.9.7"
+version = "1.9.7-rc.1"
 dependencies = [
  "base64 0.22.1",
  "boa_engine",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -780,7 +780,7 @@ dependencies = [
 
 [[package]]
 name = "conduit"
-version = "1.9.6"
+version = "1.9.7"
 dependencies = [
  "base64 0.22.1",
  "boa_engine",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conduit"
-version = "1.9.7"
+version = "1.9.7-rc.1"
 description = "Local MCP gateway: manage all your MCP servers in one place, set up once and shared by every AI client, with ~90% fewer tokens per request"
 authors = ["South Forge AI"]
 edition = "2021"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conduit"
-version = "1.9.6"
+version = "1.9.7"
 description = "Local MCP gateway: manage all your MCP servers in one place, set up once and shared by every AI client, with ~90% fewer tokens per request"
 authors = ["South Forge AI"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Toolport",
-  "version": "1.9.6",
+  "version": "1.9.7",
   "identifier": "com.tsout.conduit",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Toolport",
-  "version": "1.9.7",
+  "version": "1.9.7-rc.1",
   "identifier": "com.tsout.conduit",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
Version bump to a **release candidate**, plus the changelog text for the eventual 1.9.7. No code changes.

## Why an rc and not 1.9.7

Testing is not finished. The first Windows pass already produced SOU-435: the reaper stops old gateways, but a client that was already running respawns the old binary from a command it cached at its own startup (Grok is still on 1.9.4; Claude picked up the new one the moment it restarted).

Tagging `v1.9.7` now would burn the number. If further testing finds something, the fix cannot re-use that tag on any machine that already installed it, because a same-version re-cut breaks the versioned-gateway refresh (the running same-named gateway holds a file lock, the copy fails silently, clients keep old code). That is the trap the v1.9.4 re-cut hit.

`v1.9.7-rc.1` runs the identical pipeline and produces the identical draft, so the macOS and Linux VMs get signed installers for the remaining SOU-418 rows, and 1.9.7 stays available for the real cut.

## Changelog

The notes move back under `[Unreleased]`. Nothing dated should claim to have shipped until we actually publish.

## What this unblocks

* **macOS**: the row that most needs a real run. #498 fixed a `ps` argv that Apple rejects, so before it the reaper enumerated zero processes on mac. It has never been observed working there.
* **Linux**: the `(deleted)` policy that reversed twice during development.

Windows is already covered by a local rc.1 build: publish, repoint, reap, and restarted-client pickup all pass. See the SOU-418 comment.
