### PR TITLE
feat(gateway): dual-era MCP 2026-07-28 support on stdio (SOU-443/444/445/446)

### DIFF
--- a/src-tauri/src/bin/mock-mcp-server.rs
+++ b/src-tauri/src/bin/mock-mcp-server.rs
@@ -186,6 +186,8 @@ fn tool_list(cfg: &Config, grown: bool) -> Value {
                 "inputSchema": { "type": "object", "properties": {} } }),
         json!({ "name": "echo_meta", "description": "Return the request's params._meta verbatim.",
                 "inputSchema": { "type": "object", "properties": {} } }),
+        json!({ "name": "progress_ping", "description": "Emit notifications/progress, then reply.",
+                "inputSchema": { "type": "object", "properties": {} } }),
     ];
     if grown {
         tools.push(json!({ "name": "greet", "description": "Greet someone by name.",
@@ -279,8 +281,10 @@ fn era_gate(cfg: &Config, state: &State, method: &str, req: &Value, id: &Value) 
     }
 }
 
-/// Handle one request, returning its response.
-fn handle(cfg: &Config, state: &mut State, req: &Value) -> Option<Value> {
+/// Handle one request, returning its response. `pre` collects notifications the
+/// server wants to emit *before* the response, which is how real servers stream
+/// progress: the client sees them while its request is still in flight.
+fn handle(cfg: &Config, state: &mut State, req: &Value, pre: &mut Vec<Value>) -> Option<Value> {
     let method = req.get("method").and_then(|m| m.as_str()).unwrap_or("");
 
     // Notifications carry no id and get no response, but still drive state.
@@ -340,6 +344,21 @@ fn handle(cfg: &Config, state: &mut State, req: &Value) -> Option<Value> {
                     ),
                 ));
             }
+            // Stream a progress notification for the token the caller supplied,
+            // before the response, so the gateway's routing can be exercised
+            // end to end (SOU-444).
+            if name == "progress_ping" {
+                if let Some(token) = params
+                    .and_then(|p| p.get("_meta"))
+                    .and_then(|m| m.get("progressToken"))
+                {
+                    pre.push(json!({
+                        "jsonrpc": "2.0",
+                        "method": "notifications/progress",
+                        "params": { "progressToken": token, "progress": 1, "total": 2 }
+                    }));
+                }
+            }
             let text = match name {
                 "echo" => args.get("text").and_then(|t| t.as_str()).unwrap_or("").to_string(),
                 "add" => {
@@ -395,7 +414,19 @@ fn main() {
         };
         record(&cfg, &req);
         let was_grown = state.grown;
-        if let Some(resp) = handle(&cfg, &mut state, &req) {
+        let mut pre = Vec::new();
+        let resp = handle(&cfg, &mut state, &req, &mut pre);
+        // Emitted before the response, so the client reads them while its request
+        // is still in flight - the realistic ordering for streamed progress.
+        if !pre.is_empty() {
+            for note in &pre {
+                if writeln!(out, "{note}").is_err() {
+                    return;
+                }
+            }
+            let _ = out.flush();
+        }
+        if let Some(resp) = resp {
             if writeln!(out, "{resp}").is_err() {
                 break;
             }

--- a/src-tauri/src/bin/mock-mcp-server.rs
+++ b/src-tauri/src/bin/mock-mcp-server.rs
@@ -1,22 +1,178 @@
-//! A minimal MCP server used as a test fixture for the gateway's downstream
-//! proxying. Exposes `echo` (returns its `text` arg), `add` (returns `a + b`),
-//! and `grow`, plus a baseline resource and prompt. Calling `grow` adds a `greet`
+//! A minimal, multi-revision MCP server used as a test fixture for the gateway's
+//! downstream proxying. Exposes `echo` (returns its `text` arg), `add` (returns
+//! `a + b`), `echo_meta` (returns the request's `params._meta` verbatim), and
+//! `grow`, plus a baseline resource and prompt. Calling `grow` adds a `greet`
 //! tool, a `mock://grown` resource, and a `grown_prompt`, then emits the tools,
 //! resources, and prompts `list_changed` notifications, simulating a server that
 //! changes its own catalog mid-session so the gateway's live refresh can be
 //! exercised for all three kinds. Self-contained: no dependency on conduit_lib.
+//!
+//! # Multi-revision behaviour (SOU-443)
+//!
+//! The fixture can impersonate any MCP revision so the gateway's backward
+//! compatibility can be tested against every era it must support. Controlled by
+//! environment, because the spawn path already threads env through:
+//!
+//! - `MOCK_MCP_REVISION` — one of `2024-11-05`, `2025-03-26`, `2025-06-18`
+//!   (default), `2025-11-25`, `2026-07-28`. Unset or unrecognized values keep
+//!   the historical behaviour, so existing tests are unaffected.
+//! - `MOCK_MCP_STRICT=1` — enforce era rules instead of being permissive.
+//!   Legacy revisions then reject any request that arrives before `initialize`;
+//!   the modern revision rejects `initialize`/`ping` and demands per-request
+//!   `_meta` protocol fields. Off by default so the permissive fixture that
+//!   existing tests rely on is unchanged.
+//! - `MOCK_MCP_TRANSCRIPT` — path to append every received request to, one JSON
+//!   object per line. This is what lets a test assert exactly what bytes the
+//!   gateway sent downstream, which is the regression net for the envelope
+//!   transparency work (SOU-444).
+//!
+//! The default configuration (no env set) is byte-identical to the pre-SOU-443
+//! fixture apart from the added `echo_meta` tool, so `list_changed`,
+//! `circuit_breaker`, and `root_cwd` keep passing untouched.
 
 use std::io::{BufRead, Write};
 
 use serde_json::{json, Value};
 
+const SERVER_NAME: &str = "mock-mcp-server";
+const SERVER_VERSION: &str = "0.1.0";
+
+// Standard `_meta` keys introduced by 2026-07-28. Spelled out rather than
+// derived so a typo here fails loudly in tests rather than silently matching
+// whatever the gateway happens to send.
+const META_PROTOCOL_VERSION: &str = "io.modelcontextprotocol/protocolVersion";
+const META_SERVER_INFO: &str = "io.modelcontextprotocol/serverInfo";
+
+// JSON-RPC error codes. `-32022` is `UnsupportedProtocolVersion` from the
+// 2026-07-28 allocation policy (`-32020`..`-32099` reserved for the spec).
+const UNSUPPORTED_PROTOCOL_VERSION: i64 = -32022;
+const METHOD_NOT_FOUND: i64 = -32601;
+const INVALID_REQUEST: i64 = -32600;
+
+/// Which MCP revision this fixture impersonates.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Revision {
+    V20241105,
+    V20250326,
+    V20250618,
+    V20251125,
+    V20260728,
+}
+
+impl Revision {
+    fn as_str(self) -> &'static str {
+        match self {
+            Revision::V20241105 => "2024-11-05",
+            Revision::V20250326 => "2025-03-26",
+            Revision::V20250618 => "2025-06-18",
+            Revision::V20251125 => "2025-11-25",
+            Revision::V20260728 => "2026-07-28",
+        }
+    }
+
+    /// Unrecognized values fall back to the historical default rather than
+    /// failing, so a stale env var can never turn an unrelated test red.
+    fn from_env() -> Self {
+        match std::env::var("MOCK_MCP_REVISION").as_deref() {
+            Ok("2024-11-05") => Revision::V20241105,
+            Ok("2025-03-26") => Revision::V20250326,
+            Ok("2025-11-25") => Revision::V20251125,
+            Ok("2026-07-28") => Revision::V20260728,
+            _ => Revision::V20250618,
+        }
+    }
+
+    /// True for revisions that carry version/identity/capabilities as
+    /// per-request `_meta` instead of an `initialize` handshake.
+    fn is_modern(self) -> bool {
+        self == Revision::V20260728
+    }
+
+    /// `icons` on tools/resources/prompts landed in 2025-11-25 (SEP-973).
+    fn has_icons(self) -> bool {
+        matches!(self, Revision::V20251125 | Revision::V20260728)
+    }
+}
+
+/// Runtime knobs, read once at startup.
+struct Config {
+    revision: Revision,
+    strict: bool,
+    transcript: Option<String>,
+}
+
+impl Config {
+    fn from_env() -> Self {
+        Self {
+            revision: Revision::from_env(),
+            strict: std::env::var("MOCK_MCP_STRICT").as_deref() == Ok("1"),
+            transcript: std::env::var("MOCK_MCP_TRANSCRIPT").ok().filter(|p| !p.is_empty()),
+        }
+    }
+}
+
+/// Mutable per-process state.
+struct State {
+    /// Flipped by a `grow` call so the next `tools/list` reflects the larger set.
+    grown: bool,
+    /// Whether a legacy `initialize` has been seen. Only enforced in strict mode.
+    initialized: bool,
+}
+
 fn success(id: Value, result: Value) -> Value {
     json!({ "jsonrpc": "2.0", "id": id, "result": result })
 }
 
+fn error(id: Value, code: i64, message: &str, data: Option<Value>) -> Value {
+    let mut err = json!({ "code": code, "message": message });
+    if let Some(data) = data {
+        err["data"] = data;
+    }
+    json!({ "jsonrpc": "2.0", "id": id, "error": err })
+}
+
+/// Append one received request to the transcript file, if configured. Opened
+/// per write (rather than held) so a `die` call cannot lose buffered lines.
+fn record(cfg: &Config, req: &Value) {
+    let Some(path) = cfg.transcript.as_deref() else {
+        return;
+    };
+    if let Ok(mut f) = std::fs::OpenOptions::new().create(true).append(true).open(path) {
+        let _ = writeln!(f, "{req}");
+        let _ = f.flush();
+    }
+}
+
+/// Decorate a result per the negotiated revision. Modern results carry a
+/// required `resultType` and a `serverInfo` `_meta` entry; list-shaped results
+/// additionally carry the `CacheableResult` fields. Legacy revisions are left
+/// exactly as they were.
+fn decorate(cfg: &Config, method: &str, mut result: Value) -> Value {
+    if !cfg.revision.is_modern() {
+        return result;
+    }
+    result["resultType"] = json!("complete");
+    result["_meta"] = json!({
+        META_SERVER_INFO: { "name": SERVER_NAME, "version": SERVER_VERSION }
+    });
+    if matches!(
+        method,
+        "tools/list"
+            | "resources/list"
+            | "resources/templates/list"
+            | "prompts/list"
+            | "resources/read"
+            | "server/discover"
+    ) {
+        result["ttlMs"] = json!(60_000);
+        result["cacheScope"] = json!("public");
+    }
+    result
+}
+
 /// The advertised tool list. `greet` only appears once the server has "grown"
 /// (after a `grow` call), modeling a runtime tool-set change.
-fn tool_list(grown: bool) -> Value {
+fn tool_list(cfg: &Config, grown: bool) -> Value {
     let mut tools = vec![
         json!({ "name": "echo", "description": "Echo back the text argument.",
                 "inputSchema": { "type": "object", "properties": { "text": { "type": "string" } } } }),
@@ -28,10 +184,19 @@ fn tool_list(grown: bool) -> Value {
                 "inputSchema": { "type": "object", "properties": {} } }),
         json!({ "name": "pwd", "description": "Return the process working directory.",
                 "inputSchema": { "type": "object", "properties": {} } }),
+        json!({ "name": "echo_meta", "description": "Return the request's params._meta verbatim.",
+                "inputSchema": { "type": "object", "properties": {} } }),
     ];
     if grown {
         tools.push(json!({ "name": "greet", "description": "Greet someone by name.",
                 "inputSchema": { "type": "object", "properties": { "name": { "type": "string" } } } }));
+    }
+    // Icons ride on the tool definition from 2025-11-25. The gateway must carry
+    // them through untouched even though it does not consume them (SOU-452).
+    if cfg.revision.has_icons() {
+        if let Some(first) = tools.first_mut() {
+            first["icons"] = json!([{ "src": "https://example.invalid/echo.png", "sizes": "48x48" }]);
+        }
     }
     json!({ "tools": tools })
 }
@@ -56,35 +221,125 @@ fn prompt_list(grown: bool) -> Value {
     json!({ "prompts": prompts })
 }
 
-/// Handle one request, returning its response. `grown` is flipped on by a `grow`
-/// call so the next `tools/list` reflects the larger set.
-fn handle(req: &Value, grown: &mut bool) -> Option<Value> {
+fn capabilities() -> Value {
+    json!({
+        "tools": { "listChanged": true },
+        "resources": { "listChanged": true },
+        "prompts": { "listChanged": true }
+    })
+}
+
+/// Reject era-mismatched traffic, but only in strict mode. Returns the error
+/// response to send instead of handling the request, if any.
+fn era_gate(cfg: &Config, state: &State, method: &str, req: &Value, id: &Value) -> Option<Value> {
+    if !cfg.strict {
+        return None;
+    }
+    if cfg.revision.is_modern() {
+        // A modern server has no handshake and no `ping`.
+        if method == "initialize" || method == "notifications/initialized" || method == "ping" {
+            // The spec asks a modern-only server to name its supported versions
+            // in any error it returns to `initialize`, since legacy clients have
+            // no fall-forward mechanism and this may be their only diagnostic.
+            return Some(error(
+                id.clone(),
+                METHOD_NOT_FOUND,
+                &format!("{method} is not part of {}", cfg.revision.as_str()),
+                Some(json!({ "supported": [cfg.revision.as_str()] })),
+            ));
+        }
+        let requested = req
+            .get("params")
+            .and_then(|p| p.get("_meta"))
+            .and_then(|m| m.get(META_PROTOCOL_VERSION))
+            .and_then(|v| v.as_str());
+        match requested {
+            Some(v) if v == cfg.revision.as_str() => None,
+            other => Some(error(
+                id.clone(),
+                UNSUPPORTED_PROTOCOL_VERSION,
+                "Unsupported protocol version",
+                Some(json!({
+                    "supported": [cfg.revision.as_str()],
+                    "requested": other.unwrap_or(""),
+                })),
+            )),
+        }
+    } else {
+        // A legacy server expects the handshake before anything else.
+        if method != "initialize" && !state.initialized {
+            return Some(error(
+                id.clone(),
+                INVALID_REQUEST,
+                "expected initialize before any other request",
+                None,
+            ));
+        }
+        None
+    }
+}
+
+/// Handle one request, returning its response.
+fn handle(cfg: &Config, state: &mut State, req: &Value) -> Option<Value> {
     let method = req.get("method").and_then(|m| m.as_str()).unwrap_or("");
+
+    // Notifications carry no id and get no response, but still drive state.
     let id = match req.get("id") {
         Some(id) if !id.is_null() => id.clone(),
-        _ => return None,
+        _ => {
+            if method == "notifications/initialized" {
+                state.initialized = true;
+            }
+            return None;
+        }
     };
 
-    match method {
-        "initialize" => Some(success(
-            id,
+    if let Some(err) = era_gate(cfg, state, method, req, &id) {
+        return Some(err);
+    }
+
+    let result = match method {
+        "initialize" => {
+            state.initialized = true;
             json!({
-                "protocolVersion": "2025-06-18",
-                "capabilities": {
-                    "tools": { "listChanged": true },
-                    "resources": { "listChanged": true },
-                    "prompts": { "listChanged": true }
-                },
-                "serverInfo": { "name": "mock-mcp-server", "version": "0.1.0" }
-            }),
-        )),
-        "tools/list" => Some(success(id, tool_list(*grown))),
-        "resources/list" => Some(success(id, resource_list(*grown))),
-        "prompts/list" => Some(success(id, prompt_list(*grown))),
+                "protocolVersion": cfg.revision.as_str(),
+                "capabilities": capabilities(),
+                "serverInfo": { "name": SERVER_NAME, "version": SERVER_VERSION }
+            })
+        }
+        // Modern servers MUST implement this. Legacy revisions deliberately do
+        // not, so the gateway's stdio fallback probe has something to fail on.
+        "server/discover" if cfg.revision.is_modern() => json!({
+            "supportedVersions": [cfg.revision.as_str()],
+            "capabilities": capabilities(),
+            "instructions": "Mock server used as a gateway test fixture.",
+        }),
+        "tools/list" => tool_list(cfg, state.grown),
+        "resources/list" => resource_list(state.grown),
+        "prompts/list" => prompt_list(state.grown),
         "tools/call" => {
             let params = req.get("params");
             let name = params.and_then(|p| p.get("name")).and_then(|n| n.as_str()).unwrap_or("");
             let args = params.and_then(|p| p.get("arguments")).cloned().unwrap_or_else(|| json!({}));
+            // `echo_meta` reflects the request's `_meta` back as structured
+            // content so a test can assert end-to-end propagation through the
+            // gateway without reading the transcript file.
+            if name == "echo_meta" {
+                let meta = params.and_then(|p| p.get("_meta")).cloned().unwrap_or(Value::Null);
+                let text = serde_json::to_string(&meta).unwrap_or_else(|_| "null".to_string());
+                return Some(success(
+                    id,
+                    decorate(
+                        cfg,
+                        method,
+                        json!({
+                            "content": [{ "type": "text", "text": text }],
+                            "isError": false,
+                            "structuredContent": { "receivedMeta": meta }
+                        }),
+                    ),
+                ));
+            }
             let text = match name {
                 "echo" => args.get("text").and_then(|t| t.as_str()).unwrap_or("").to_string(),
                 "add" => {
@@ -93,7 +348,7 @@ fn handle(req: &Value, grown: &mut bool) -> Option<Value> {
                     format!("{}", a + b)
                 }
                 "grow" => {
-                    *grown = true;
+                    state.grown = true;
                     "grew: greet is now available".to_string()
                 }
                 "die" => {
@@ -110,21 +365,21 @@ fn handle(req: &Value, grown: &mut bool) -> Option<Value> {
                     .unwrap_or_default(),
                 other => format!("unknown tool {other}"),
             };
-            Some(success(
-                id,
-                json!({ "content": [{ "type": "text", "text": text }], "isError": false }),
-            ))
+            json!({ "content": [{ "type": "text", "text": text }], "isError": false })
         }
-        "ping" => Some(success(id, json!({}))),
-        _ => None,
-    }
+        "ping" => json!({}),
+        _ => return None,
+    };
+
+    Some(success(id, decorate(cfg, method, result)))
 }
 
 fn main() {
+    let cfg = Config::from_env();
     let stdin = std::io::stdin();
     let stdout = std::io::stdout();
     let mut out = stdout.lock();
-    let mut grown = false;
+    let mut state = State { grown: false, initialized: false };
     for line in stdin.lock().lines() {
         let line = match line {
             Ok(l) => l,
@@ -138,8 +393,9 @@ fn main() {
             Ok(v) => v,
             Err(_) => continue,
         };
-        let was_grown = grown;
-        if let Some(resp) = handle(&req, &mut grown) {
+        record(&cfg, &req);
+        let was_grown = state.grown;
+        if let Some(resp) = handle(&cfg, &mut state, &req) {
             if writeln!(out, "{resp}").is_err() {
                 break;
             }
@@ -147,7 +403,7 @@ fn main() {
         }
         // A `grow` call just changed all three lists: announce each (after the call
         // response) so a watching gateway re-fetches and surfaces the new entries.
-        if grown && !was_grown {
+        if state.grown && !was_grown {
             for method in [
                 "notifications/tools/list_changed",
                 "notifications/resources/list_changed",

--- a/src-tauri/src/bin/mock-mcp-server.rs
+++ b/src-tauri/src/bin/mock-mcp-server.rs
@@ -46,6 +46,7 @@ const META_SERVER_INFO: &str = "io.modelcontextprotocol/serverInfo";
 // JSON-RPC error codes. `-32022` is `UnsupportedProtocolVersion` from the
 // 2026-07-28 allocation policy (`-32020`..`-32099` reserved for the spec).
 const UNSUPPORTED_PROTOCOL_VERSION: i64 = -32022;
+const HEADER_MISMATCH: i64 = -32020;
 const METHOD_NOT_FOUND: i64 = -32601;
 const INVALID_REQUEST: i64 = -32600;
 
@@ -393,8 +394,106 @@ fn handle(cfg: &Config, state: &mut State, req: &Value, pre: &mut Vec<Value>) ->
     Some(success(id, decorate(cfg, method, result)))
 }
 
+/// Header/body agreement check for a modern Streamable HTTP request.
+///
+/// From 2026-07-28 `MCP-Protocol-Version` **MUST** equal the
+/// `io.modelcontextprotocol/protocolVersion` in the body's `_meta`, and a server
+/// that sees them disagree rejects with `400` and `HeaderMismatch` (-32020).
+/// This is the rule a stdio fixture structurally cannot express, which is how a
+/// hardcoded header shipped past a green stdio suite (SOU-443 follow-up).
+///
+/// Returns the JSON-RPC error to send instead, if the request is invalid.
+fn header_gate(cfg: &Config, header_version: Option<&str>, req: &Value, id: &Value) -> Option<Value> {
+    if !cfg.strict || !cfg.revision.is_modern() {
+        return None;
+    }
+    let body_version = req
+        .get("params")
+        .and_then(|p| p.get("_meta"))
+        .and_then(|m| m.get(META_PROTOCOL_VERSION))
+        .and_then(|v| v.as_str());
+    match (header_version, body_version) {
+        (Some(h), Some(b)) if h == b => None,
+        (None, _) => Some(error(
+            id.clone(),
+            HEADER_MISMATCH,
+            "missing required MCP-Protocol-Version header",
+            None,
+        )),
+        (Some(h), b) => Some(error(
+            id.clone(),
+            HEADER_MISMATCH,
+            &format!(
+                "MCP-Protocol-Version header '{h}' does not match body _meta '{}'",
+                b.unwrap_or("<absent>")
+            ),
+            None,
+        )),
+    }
+}
+
+/// Serve the same era logic over Streamable HTTP instead of stdio.
+///
+/// Prints `MOCK_MCP_URL=<url>` on stdout once bound so a test can discover the
+/// ephemeral port.
+fn serve_http(cfg: &Config) {
+    let server = tiny_http::Server::http("127.0.0.1:0").expect("bind fixture port");
+    let port = server
+        .server_addr()
+        .to_ip()
+        .expect("ip addr")
+        .port();
+    println!("MOCK_MCP_URL=http://127.0.0.1:{port}/mcp");
+    let _ = std::io::stdout().flush();
+
+    let mut state = State { grown: false, initialized: false };
+    for mut request in server.incoming_requests() {
+        let header_version = request
+            .headers()
+            .iter()
+            .find(|h| h.field.equiv("MCP-Protocol-Version"))
+            .map(|h| h.value.as_str().to_string());
+        let mut body = String::new();
+        let _ = request.as_reader().read_to_string(&mut body);
+        let req: Value = match serde_json::from_str(body.trim()) {
+            Ok(v) => v,
+            Err(_) => {
+                let _ = request.respond(
+                    tiny_http::Response::from_string("bad json").with_status_code(400),
+                );
+                continue;
+            }
+        };
+        record(cfg, &req);
+
+        let id = req.get("id").cloned().unwrap_or(Value::Null);
+        let (status, payload) = match header_gate(cfg, header_version.as_deref(), &req, &id) {
+            // A header/body disagreement is a 400, per the transport spec.
+            Some(err) => (400, Some(err)),
+            None => {
+                let mut pre = Vec::new();
+                (200, handle(cfg, &mut state, &req, &mut pre))
+            }
+        };
+        let response = match payload {
+            Some(value) => tiny_http::Response::from_string(value.to_string())
+                .with_status_code(status)
+                .with_header(
+                    tiny_http::Header::from_bytes(b"Content-Type", b"application/json").unwrap(),
+                ),
+            // A notification gets 202 with no body.
+            None => tiny_http::Response::from_string(String::new()).with_status_code(202),
+        };
+        let _ = request.respond(response);
+    }
+}
+
 fn main() {
     let cfg = Config::from_env();
+    if std::env::var("MOCK_MCP_HTTP").as_deref() == Ok("1") {
+        serve_http(&cfg);
+        return;
+    }
     let stdin = std::io::stdin();
     let stdout = std::io::stdout();
     let mut out = stdout.lock();

--- a/src-tauri/src/bin/mock-mcp-server.rs
+++ b/src-tauri/src/bin/mock-mcp-server.rs
@@ -239,8 +239,11 @@ fn era_gate(cfg: &Config, state: &State, method: &str, req: &Value, id: &Value) 
         return None;
     }
     if cfg.revision.is_modern() {
-        // A modern server has no handshake and no `ping`.
-        if method == "initialize" || method == "notifications/initialized" || method == "ping" {
+        // A modern server has no handshake and no `ping`. `notifications/initialized`
+        // belongs to the same list but is deliberately absent: it carries no id, so
+        // it never reaches this gate and cannot be answered with an error at all.
+        // `handle` enforces it directly (SOU-474 #11).
+        if method == "initialize" || method == "ping" {
             // The spec asks a modern-only server to name its supported versions
             // in any error it returns to `initialize`, since legacy clients have
             // no fall-forward mechanism and this may be their only diagnostic.
@@ -292,6 +295,23 @@ fn handle(cfg: &Config, state: &mut State, req: &Value, pre: &mut Vec<Value>) ->
     let id = match req.get("id") {
         Some(id) if !id.is_null() => id.clone(),
         _ => {
+            // A modern server has no handshake, so `notifications/initialized`
+            // is legacy traffic that must never arrive. It cannot be refused
+            // with an error response - it has no id - so `era_gate` structurally
+            // could not enforce it, and listing it there merely looked like
+            // enforcement while this arm silently accepted the handshake and
+            // even marked the server initialized (SOU-474 #11).
+            //
+            // Dying is the enforcement a fixture has: the client sees the stream
+            // close and the test fails, instead of passing against a mock that
+            // quietly tolerated what it claims to reject.
+            if cfg.strict && cfg.revision.is_modern() && method == "notifications/initialized" {
+                eprintln!(
+                    "mock-mcp-server: strict {} server received legacy '{method}'",
+                    cfg.revision.as_str()
+                );
+                std::process::exit(97);
+            }
             if method == "notifications/initialized" {
                 state.initialized = true;
             }

--- a/src-tauri/src/bin/mock-mcp-server.rs
+++ b/src-tauri/src/bin/mock-mcp-server.rs
@@ -302,9 +302,11 @@ fn handle(cfg: &Config, state: &mut State, req: &Value, pre: &mut Vec<Value>) ->
             // enforcement while this arm silently accepted the handshake and
             // even marked the server initialized (SOU-474 #11).
             //
-            // Dying is the enforcement a fixture has: the client sees the stream
-            // close and the test fails, instead of passing against a mock that
-            // quietly tolerated what it claims to reject.
+            // Dying is the enforcement a fixture has: the test fails instead of
+            // passing against a mock that quietly tolerated what it claims to
+            // reject. `handle` is shared with `serve_http`, so this fires in HTTP
+            // mode too - there the client sees a connection error rather than a
+            // closed stdio stream, which is equally loud and equally correct.
             if cfg.strict && cfg.revision.is_modern() && method == "notifications/initialized" {
                 eprintln!(
                     "mock-mcp-server: strict {} server received legacy '{method}'",

--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -553,6 +553,52 @@ static PROGRESS_DISPATCH: std::sync::OnceLock<ProgressDispatch> = std::sync::Onc
 static PROGRESS_ROUTES: std::sync::OnceLock<Arc<Mutex<ProgressRoutes>>> =
     std::sync::OnceLock::new();
 
+/// Whether this process serves a stdio MCP client, i.e. whether writing a
+/// server-to-client message to stdout reaches anybody.
+///
+/// False in HTTP bridge mode. Defaults to true when unset so direct unit-test
+/// callers keep the stdio behaviour they were written against.
+static HAS_STDIO_CLIENT: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+
+/// Where progress for the request being served should be delivered, or `None`
+/// when there is no channel to deliver it on.
+///
+/// A legacy HTTP client has a session with an outbound queue. The stdio client
+/// is reached on stdout. A *modern* HTTP client has neither: 2026-07-28 removed
+/// protocol-level sessions, and its replacement channel (`subscriptions/listen`,
+/// SOU-448) does not exist yet. Falling back to stdout there would emit protocol
+/// traffic nobody is reading, so it returns `None` and the caller declines to ask
+/// the server for progress at all (SOU-447).
+fn progress_target() -> Option<String> {
+    progress_target_for(
+        ACTIVE_MCP_SESSION.with(|cell| cell.borrow().clone()),
+        HAS_STDIO_CLIENT.get().copied().unwrap_or(true),
+    )
+}
+
+/// The decision behind [`progress_target`], separated from the globals it reads
+/// so every combination is directly testable.
+fn progress_target_for(session: Option<String>, has_stdio_client: bool) -> Option<String> {
+    match session {
+        // A legacy HTTP session: deliver on its outbound queue.
+        Some(session) => Some(session),
+        // No session. In stdio mode that is the single stdio client; in HTTP mode
+        // it is a modern client, which has no server-to-client channel yet.
+        None => has_stdio_client.then(|| RESOURCE_SUB_STDIO.to_string()),
+    }
+}
+
+/// A copy of `meta` without `progressToken`, for when there is nowhere to deliver
+/// progress. Same principle as `WITHHELD_META_KEYS`: never ask a server for
+/// traffic that would land in a black hole.
+fn without_progress_token(meta: &Value) -> Value {
+    let mut out = meta.clone();
+    if let Some(obj) = out.as_object_mut() {
+        obj.remove("progressToken");
+    }
+    out
+}
+
 /// The live token table, created on first use so tests can exercise routing
 /// without standing up a full gateway.
 fn progress_routes() -> &'static Arc<Mutex<ProgressRoutes>> {
@@ -3437,7 +3483,19 @@ fn execute_call(
     // against the raw server id, matching what the per-server sink binds, so the
     // spoof check compares like with like. Held in a named binding so the RAII
     // guard lives across the call rather than dropping immediately.
-    let _progress_route = register_progress(progress_routes(), client_meta, server_id);
+    let progress_to = progress_target();
+    let _progress_route = progress_to
+        .as_deref()
+        .and_then(|session| register_progress(progress_routes(), client_meta, server_id, session));
+    // With nowhere to deliver progress, do not ask the server to produce it
+    // (SOU-447). Only allocates when the client actually requested progress.
+    let relay_owned = match (progress_to.is_none(), client_meta) {
+        (true, Some(meta)) if meta.get("progressToken").is_some() => {
+            Some(without_progress_token(meta))
+        }
+        _ => None,
+    };
+    let client_meta = relay_owned.as_ref().or(client_meta);
 
     let started = Instant::now();
     match exec_router.route_call_with_cancel(name, arguments, cancel.clone(), client_meta) {
@@ -4545,9 +4603,12 @@ fn handle_request_with_cancel(
                 }
             }
             let client_meta = req.get("params").and_then(|p| p.get("_meta")).cloned();
-            let _progress_route = router.resource_server(uri).and_then(|owner| {
-                register_progress(progress_routes(), client_meta.as_ref(), owner)
-            });
+            let progress_to = progress_target();
+            let _progress_route = progress_to.as_deref().zip(router.resource_server(uri)).and_then(
+                |(session, owner)| {
+                    register_progress(progress_routes(), client_meta.as_ref(), owner, session)
+                },
+            );
             match router.read_resource_with_cancel(uri, cancel.clone(), client_meta.as_ref()) {
                 Ok(mut result) => {
                     // Content defense: a resource is as attacker-controllable as a tool
@@ -4613,9 +4674,13 @@ fn handle_request_with_cancel(
                 }
             }
             let client_meta = params.and_then(|p| p.get("_meta")).cloned();
-            let _progress_route = router.prompt_server(name).and_then(|owner| {
-                register_progress(progress_routes(), client_meta.as_ref(), owner)
-            });
+            let progress_to = progress_target();
+            let _progress_route = progress_to
+                .as_deref()
+                .zip(router.prompt_server(name))
+                .and_then(|(session, owner)| {
+                    register_progress(progress_routes(), client_meta.as_ref(), owner, session)
+                });
             match router.get_prompt_with_cancel(name, arguments, cancel.clone(), client_meta.as_ref())
             {
                 Ok(mut result) => {
@@ -5154,14 +5219,11 @@ fn register_progress(
     table: &Arc<Mutex<ProgressRoutes>>,
     client_meta: Option<&Value>,
     producer: &str,
+    session: &str,
 ) -> Option<ProgressRegistration> {
     let token = client_meta?.get("progressToken")?;
     let key = rpc_id_key(token)?;
-    let session = ACTIVE_MCP_SESSION.with(|cell| {
-        cell.borrow()
-            .clone()
-            .unwrap_or_else(|| RESOURCE_SUB_STDIO.to_string())
-    });
+    let session = session.to_string();
     table
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner)
@@ -7760,13 +7822,24 @@ fn mcp_sse_body(json: &str) -> String {
     format!("event: message\ndata: {json}\n\n")
 }
 
-fn mcp_rpc_response(status: u16, json_body: String, session_id: &str, prefer_sse: bool) -> HttpOut {
-    if prefer_sse {
+/// `session_id` is `None` for a modern (2026-07-28) client: the response must
+/// then carry no `Mcp-Session-Id`, since the header no longer exists and echoing
+/// one would invite the client to start replaying it (SOU-447).
+fn mcp_rpc_response(
+    status: u16,
+    json_body: String,
+    session_id: Option<&str>,
+    prefer_sse: bool,
+) -> HttpOut {
+    let out = if prefer_sse {
         HttpOut::new(status, "text/event-stream", mcp_sse_body(&json_body))
-            .with_header("Mcp-Session-Id", session_id)
             .with_header("Cache-Control", "no-cache")
     } else {
-        HttpOut::new(status, "application/json", json_body).with_header("Mcp-Session-Id", session_id)
+        HttpOut::new(status, "application/json", json_body)
+    };
+    match session_id {
+        Some(sid) => out.with_header("Mcp-Session-Id", sid),
+        None => out,
     }
 }
 
@@ -7786,6 +7859,13 @@ fn handle_mcp_http(
 ) -> HttpOut {
     let prefer_sse = mcp_prefers_sse(accept);
     match method {
+        // GET (listen stream) and DELETE (session teardown) are legacy-only: both
+        // were removed in 2026-07-28. A modern-ONLY server answers 405, but
+        // Toolport is dual-era, and neither verb carries a body, so there is no
+        // `_meta` to tell the eras apart. They stay available and keep requiring a
+        // live session, which is exactly the gate that turns a modern client's
+        // request away. They become 405 when legacy support is eventually dropped
+        // (SOU-447).
         "GET" => {
             if !mcp_prefers_sse(accept) {
                 return HttpOut::json_err(406, "Accept must include text/event-stream");
@@ -7839,65 +7919,96 @@ fn handle_mcp_http(
                 .unwrap_or("");
             let has_id = req_obj.contains_key("id");
             let is_initialize = method_name == "initialize";
+            // 2026-07-28 removed protocol-level sessions (SOU-447). A modern
+            // request declares its own version, so it is served statelessly.
+            let is_modern = upstream_declared_version(&req).is_some();
 
-            // Session rules: initialize may omit (and gets a new id); everything
-            // else that carries a method must present a live session id.
-            let session_id = if is_initialize {
+            // Session rules. Modern requests have none; legacy `initialize` may
+            // omit a session id (and gets a new one), and every other legacy
+            // request must present a live one.
+            //
+            // Removing the session for modern clients does NOT weaken the
+            // authorization boundary. `resolve_http_caller` already resolves the
+            // bearer token to an identity and an effective server scope on EVERY
+            // request, and that is what `allowed` / `client` are built from here.
+            // The session only ever *bound* a minted id to that same identity so a
+            // stolen id could not be replayed by another caller. With no id to
+            // steal, there is nothing to bind, and re-resolving scope per request
+            // is strictly tighter than a session that caches it (a live re-scope
+            // takes effect immediately instead of on session expiry).
+            let session_id: Option<String> = if is_modern {
+                // Per spec, an inbound Mcp-Session-Id on a modern request is
+                // ignored rather than honoured or echoed.
+                None
+            } else if is_initialize {
                 if let Some(existing) = session_hdr.map(str::trim).filter(|s| !s.is_empty()) {
                     // Client re-sent a session on initialize: accept if still live,
                     // otherwise mint a fresh one (spec: start over without the old id).
                     match mcp_require_session(state, Some(existing), session_owner) {
-                        Ok((sid, _)) => sid,
+                        Ok((sid, _)) => Some(sid),
                         Err(_) => match mint_mcp_session(state, session_owner) {
-                            Ok(sid) => sid,
+                            Ok(sid) => Some(sid),
                             Err(e) => return e,
                         },
                     }
                 } else {
                     match mint_mcp_session(state, session_owner) {
-                        Ok(sid) => sid,
+                        Ok(sid) => Some(sid),
                         Err(e) => return e,
                     }
                 }
             } else {
                 match mcp_require_session(state, session_hdr, session_owner) {
-                    Ok((sid, _)) => sid,
+                    Ok((sid, _)) => Some(sid),
                     Err(e) => return e,
                 }
             };
 
-            if is_initialize {
-                if let Ok(sessions) = state.mcp_sessions.lock() {
-                    if let Some(sess) = sessions.get(&session_id) {
-                        if let Ok(mut caps) = sess.client_upstream.lock() {
-                            capture_client_upstream_from_init(&mut caps, req.get("params"));
+            if let Some(session_id) = session_id.as_deref() {
+                if is_initialize {
+                    if let Ok(sessions) = state.mcp_sessions.lock() {
+                        if let Some(sess) = sessions.get(session_id) {
+                            if let Ok(mut caps) = sess.client_upstream.lock() {
+                                capture_client_upstream_from_init(&mut caps, req.get("params"));
+                            }
                         }
                     }
                 }
-            }
 
-            if is_jsonrpc_response(&req) {
-                if let Ok(sessions) = state.mcp_sessions.lock() {
-                    if let Some(sess) = sessions.get(&session_id) {
-                        if sess.try_deliver_upstream(&req) {
-                            return HttpOut::new(202, "text/plain", String::new())
-                                .with_header("Mcp-Session-Id", &session_id);
+                if is_jsonrpc_response(&req) {
+                    if let Ok(sessions) = state.mcp_sessions.lock() {
+                        if let Some(sess) = sessions.get(session_id) {
+                            if sess.try_deliver_upstream(&req) {
+                                return HttpOut::new(202, "text/plain", String::new())
+                                    .with_header("Mcp-Session-Id", session_id);
+                            }
                         }
                     }
                 }
+            } else if is_jsonrpc_response(&req) {
+                // Modern clients never answer server-initiated requests: MRTR
+                // replaced them, and the transport forbids a client sending a
+                // JSON-RPC response at all.
+                return HttpOut::json_err(
+                    400,
+                    "JSON-RPC responses are not accepted from a 2026-07-28 client",
+                );
             }
 
             // Notifications / JSON-RPC responses: 202 with empty body.
             if !has_id {
-                ACTIVE_MCP_SESSION.with(|cell| *cell.borrow_mut() = Some(session_id.clone()));
+                ACTIVE_MCP_SESSION.with(|cell| *cell.borrow_mut() = session_id.clone());
                 let _ = process_request(state, &req, guard, confirm, allowed, None, client);
                 ACTIVE_MCP_SESSION.with(|cell| *cell.borrow_mut() = None);
-                return HttpOut::new(202, "text/plain", String::new())
-                    .with_header("Mcp-Session-Id", &session_id);
+                let out = HttpOut::new(202, "text/plain", String::new());
+                return match session_id.as_deref() {
+                    Some(sid) => out.with_header("Mcp-Session-Id", sid),
+                    None => out,
+                };
             }
 
             let resp = ACTIVE_MCP_SESSION.with(|cell| {
-                *cell.borrow_mut() = Some(session_id.clone());
+                *cell.borrow_mut() = session_id.clone();
                 let out = process_request(state, &req, guard, confirm, allowed, None, client);
                 *cell.borrow_mut() = None;
                 out
@@ -7912,7 +8023,7 @@ fn handle_mcp_http(
                         })
                         .to_string()
                     });
-                    mcp_rpc_response(200, body, &session_id, prefer_sse)
+                    mcp_rpc_response(200, body, session_id.as_deref(), prefer_sse)
                 }
                 None => {
                     let body = json!({
@@ -7921,7 +8032,7 @@ fn handle_mcp_http(
                         "error": { "code": -32603, "message": "no response" }
                     })
                     .to_string();
-                    mcp_rpc_response(500, body, &session_id, prefer_sse)
+                    mcp_rpc_response(500, body, session_id.as_deref(), prefer_sse)
                 }
             }
         }
@@ -9250,6 +9361,9 @@ fn main() {
         Arc::clone(&mcp_sessions),
         Arc::clone(progress_routes()),
     ));
+    // In HTTP bridge mode nothing reads this process's stdout, so it is not a
+    // delivery channel for server-to-client messages (SOU-447).
+    let _ = HAS_STDIO_CLIENT.set(!http_mode);
     // Single-flight for every router build/swap (startup, watcher self-heal, and
     // ${ROOT} rebuilds). Created up front so the startup build can share it.
     let rebuild_lock = Arc::new(Mutex::new(()));
@@ -11983,18 +12097,227 @@ mod tests {
         assert_eq!(after.status, 404);
     }
 
+    /// A modern (2026-07-28) JSON-RPC body: version in `_meta`, no handshake.
+    fn modern_http_body(id: i64, method: &str, params: Value) -> String {
+        let mut p = json!({
+            "_meta": { "io.modelcontextprotocol/protocolVersion": MODERN_PROTOCOL_VERSION }
+        });
+        if let (Some(dst), Some(src)) = (p.as_object_mut(), params.as_object()) {
+            for (k, v) in src {
+                dst.insert(k.clone(), v.clone());
+            }
+        }
+        json!({ "jsonrpc": "2.0", "id": id, "method": method, "params": p }).to_string()
+    }
+
+    fn test_caller(identity: &str, scope: Option<&[&str]>) -> HttpCaller {
+        HttpCaller {
+            audit_label: Some(identity.to_string()),
+            session_owner: McpSessionOwner {
+                identity: identity.to_string(),
+                scope: scope.map(|s| s.iter().map(|v| v.to_string()).collect()),
+            },
+        }
+    }
+
+    #[test]
+    fn modern_http_client_needs_no_session() {
+        // The stateless revision's whole point over HTTP: no initialize, no
+        // Mcp-Session-Id, just an authenticated request (SOU-447).
+        let state = http_state(true);
+        let caller = test_caller("client:cursor", None);
+        let out = handle_http(
+            &state,
+            &SearchGuard::default(),
+            &ConfirmGuard::new(),
+            "POST",
+            "/mcp",
+            &modern_http_body(1, "tools/list", json!({})),
+            None,
+            None,
+            None,
+            Some(&caller),
+        );
+        assert_eq!(out.status, 200, "body={}", out.body);
+
+        // No session was minted, and none is echoed: the header does not exist in
+        // 2026-07-28, and echoing one would invite the client to replay it.
+        assert!(
+            !out.extra.iter().any(|(k, _)| k.eq_ignore_ascii_case("Mcp-Session-Id")),
+            "modern response must carry no Mcp-Session-Id, got {:?}",
+            out.extra
+        );
+        assert!(
+            state.mcp_sessions.lock().unwrap().is_empty(),
+            "no session should have been created"
+        );
+
+        let body: Value = serde_json::from_str(&out.body).unwrap();
+        assert_eq!(body["result"]["resultType"], "complete");
+    }
+
+    #[test]
+    fn modern_http_request_still_enforces_client_scope() {
+        // THE security test for SOU-447. Sessions used to bind a minted id to an
+        // identity; removing them must not weaken what a scoped client can reach.
+        // Scope comes from resolve_http_caller on every request, so it still
+        // applies with no session in play.
+        let state = http_state(false);
+        // A real route, so the test discriminates: an in-scope call must SUCCEED
+        // while an out-of-scope one is refused. Without the positive case, a
+        // gateway that refused everything would also pass.
+        *state.router.lock().unwrap() = Arc::new(routed_router("github", "list_repos"));
+        let caller = test_caller("client:scoped", Some(&["github"]));
+        let allowed: std::collections::HashSet<String> =
+            ["github".to_string()].into_iter().collect();
+
+        let call = |name: &str| {
+            handle_http(
+                &state,
+                &SearchGuard::default(),
+                &ConfirmGuard::new(),
+                "POST",
+                "/mcp",
+                &modern_http_body(1, "tools/call", json!({ "name": name, "arguments": {} })),
+                None,
+                None,
+                Some(&allowed),
+                Some(&caller),
+            )
+        };
+
+        // In scope: the call gets PAST the scope guard and is routed downstream.
+        // The mock route does not implement tools/call, so what comes back is its
+        // own error rather than a refusal. The distinguishing property is which
+        // error it is, not whether one occurred.
+        let in_scope = call("github__list_repos");
+        assert_eq!(in_scope.status, 200, "body={}", in_scope.body);
+        let body: Value = serde_json::from_str(&in_scope.body).unwrap();
+        let text = body["result"]["content"][0]["text"].as_str().unwrap_or("");
+        assert!(
+            !text.contains("not available to this client"),
+            "an in-scope call must not be refused by the scope guard, got {body}"
+        );
+        assert!(
+            text.contains("unexpected tools/call"),
+            "expected the call to reach the downstream route, got {body}"
+        );
+
+        let out_of_scope = call("stripe__refund");
+        assert_eq!(out_of_scope.status, 200, "body={}", out_of_scope.body);
+        let body: Value = serde_json::from_str(&out_of_scope.body).unwrap();
+        assert!(
+            body["result"]["isError"].as_bool().unwrap_or(false),
+            "an out-of-scope server must be refused, got {body}"
+        );
+        assert!(
+            body["result"]["content"][0]["text"]
+                .as_str()
+                .unwrap_or("")
+                .contains("not available to this client"),
+            "expected the scope guard to be what refused it, got {body}"
+        );
+    }
+
+    #[test]
+    fn modern_http_request_ignores_an_inbound_session_id() {
+        // Spec: a modern request's Mcp-Session-Id is ignored, not honoured and not
+        // echoed. Honouring it would let a stale legacy id influence a stateless
+        // request; echoing it would resurrect the header.
+        let state = http_state(true);
+        let caller = test_caller("client:cursor", None);
+        let out = handle_http(
+            &state,
+            &SearchGuard::default(),
+            &ConfirmGuard::new(),
+            "POST",
+            "/mcp",
+            &modern_http_body(1, "tools/list", json!({})),
+            // A session id that was never minted: a legacy request would 404 here.
+            Some("00000000000000000000000000000000"),
+            None,
+            None,
+            Some(&caller),
+        );
+        assert_eq!(out.status, 200, "an unknown session id must be ignored, body={}", out.body);
+        assert!(!out.extra.iter().any(|(k, _)| k.eq_ignore_ascii_case("Mcp-Session-Id")));
+    }
+
+    #[test]
+    fn legacy_http_client_still_requires_a_session() {
+        // The other half of dual-era: nothing about the legacy path changed.
+        let state = http_state(true);
+        let caller = test_caller("client:cursor", None);
+        let no_session = handle_http(
+            &state,
+            &SearchGuard::default(),
+            &ConfirmGuard::new(),
+            "POST",
+            "/mcp",
+            &json!({ "jsonrpc": "2.0", "id": 1, "method": "tools/list" }).to_string(),
+            None,
+            None,
+            None,
+            Some(&caller),
+        );
+        assert_eq!(
+            no_session.status, 400,
+            "a legacy request without a session is still rejected, body={}",
+            no_session.body
+        );
+
+        // ...and initialize still mints one.
+        let init = handle_http(
+            &state,
+            &SearchGuard::default(),
+            &ConfirmGuard::new(),
+            "POST",
+            "/mcp",
+            &json!({
+                "jsonrpc": "2.0", "id": 1, "method": "initialize",
+                "params": { "protocolVersion": "2025-06-18", "capabilities": {} }
+            })
+            .to_string(),
+            None,
+            None,
+            None,
+            Some(&caller),
+        );
+        assert_eq!(init.status, 200);
+        assert!(!mcp_session_of(&init).is_empty(), "legacy initialize still mints a session");
+    }
+
+    #[test]
+    fn modern_http_client_may_not_send_a_jsonrpc_response() {
+        // MRTR replaced server-initiated requests, and the transport forbids a
+        // client sending a JSON-RPC response at all.
+        let state = http_state(true);
+        let caller = test_caller("client:cursor", None);
+        let out = handle_http(
+            &state,
+            &SearchGuard::default(),
+            &ConfirmGuard::new(),
+            "POST",
+            "/mcp",
+            &json!({
+                "jsonrpc": "2.0", "id": 1, "result": {},
+                "params": { "_meta": { "io.modelcontextprotocol/protocolVersion": MODERN_PROTOCOL_VERSION } }
+            })
+            .to_string(),
+            None,
+            None,
+            None,
+            Some(&caller),
+        );
+        assert_eq!(out.status, 400, "body={}", out.body);
+    }
+
     #[test]
     fn mcp_http_session_is_bound_to_client_identity_and_scope() {
         let state = http_state(true);
         let search = SearchGuard::default();
         let confirm = ConfirmGuard::new();
-        let caller = |identity: &str, scope: &[&str]| HttpCaller {
-            audit_label: Some(identity.to_string()),
-            session_owner: McpSessionOwner {
-                identity: identity.to_string(),
-                scope: Some(scope.iter().map(|value| value.to_string()).collect()),
-            },
-        };
+        let caller = |identity: &str, scope: &[&str]| test_caller(identity, Some(scope));
         let owner = caller("client:cursor", &["github"]);
         let intruder = caller("client:webui", &["github"]);
         let rescoped_owner = caller("client:cursor", &["github", "stripe"]);
@@ -13019,7 +13342,7 @@ mod tests {
         let routes = Arc::new(Mutex::new(ProgressRoutes::default()));
 
         let registration = with_active_session(&s1, || {
-            register_progress(&routes, Some(&json!({ "progressToken": "tok-1" })), "alpha")
+            register_progress(&routes, Some(&json!({ "progressToken": "tok-1" })), "alpha", &s1)
         });
         assert!(registration.is_some(), "a token should register a route");
 
@@ -13050,7 +13373,7 @@ mod tests {
         let routes = Arc::new(Mutex::new(ProgressRoutes::default()));
 
         let registration = with_active_session(&s1, || {
-            register_progress(&routes, Some(&json!({ "progressToken": "tok-1" })), "alpha")
+            register_progress(&routes, Some(&json!({ "progressToken": "tok-1" })), "alpha", &s1)
         });
 
         // beta was never given this token.
@@ -13107,12 +13430,55 @@ mod tests {
     }
 
     #[test]
+    fn progress_has_no_target_for_a_modern_http_client() {
+        // A legacy HTTP session delivers on its outbound queue; stdio delivers on
+        // stdout. A modern HTTP client has neither until subscriptions/listen
+        // lands (SOU-448), so progress must resolve to no target rather than
+        // falling back to a stdout nobody in HTTP mode is reading.
+        assert_eq!(
+            progress_target_for(Some("sess-1".to_string()), false),
+            Some("sess-1".to_string()),
+            "legacy HTTP session"
+        );
+        assert_eq!(
+            progress_target_for(Some("sess-1".to_string()), true),
+            Some("sess-1".to_string()),
+            "session wins even in stdio mode"
+        );
+        assert_eq!(
+            progress_target_for(None, true),
+            Some(RESOURCE_SUB_STDIO.to_string()),
+            "stdio client"
+        );
+        assert_eq!(
+            progress_target_for(None, false),
+            None,
+            "modern HTTP client has no channel, so progress must not be requested"
+        );
+    }
+
+    #[test]
+    fn without_progress_token_keeps_everything_else() {
+        // Used when there is nowhere to deliver progress: drop only the token, so
+        // trace context and extension namespaces still reach the server.
+        let meta = json!({
+            "progressToken": "p-1",
+            "traceparent": "00-abc-def-01",
+            "com.example/keep": { "a": 1 }
+        });
+        let stripped = without_progress_token(&meta);
+        assert!(stripped.get("progressToken").is_none());
+        assert_eq!(stripped["traceparent"], "00-abc-def-01");
+        assert_eq!(stripped["com.example/keep"]["a"], 1);
+    }
+
+    #[test]
     fn no_progress_token_registers_no_route() {
         // The common case: clients that never ask for progress cost nothing and
         // leave no state behind.
         let routes = Arc::new(Mutex::new(ProgressRoutes::default()));
-        assert!(register_progress(&routes, None, "alpha").is_none());
-        assert!(register_progress(&routes, Some(&json!({ "traceparent": "x" })), "alpha").is_none());
+        assert!(register_progress(&routes, None, "alpha", "stdio").is_none());
+        assert!(register_progress(&routes, Some(&json!({ "traceparent": "x" })), "alpha", "stdio").is_none());
         assert!(routes.lock().unwrap().active.is_empty());
     }
 

--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -7979,7 +7979,14 @@ fn handle_mcp_http(
             let is_initialize = method_name == "initialize";
             // 2026-07-28 removed protocol-level sessions (SOU-447). A modern
             // request declares its own version, so it is served statelessly.
-            let is_modern = upstream_declared_version(&req).is_some();
+            //
+            // Gate on the version VALUE, not merely on a version being present, so
+            // this matches the modern-era test in `handle_request_with_cancel`.
+            // Keying on presence alone would let a client that names a legacy
+            // version in `_meta` skip the session requirement here while still
+            // being served legacy-shaped results there.
+            let is_modern =
+                upstream_declared_version(&req) == Some(MODERN_PROTOCOL_VERSION);
 
             // Session rules. Modern requests have none; legacy `initialize` may
             // omit a session id (and gets a new one), and every other legacy

--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -3044,6 +3044,10 @@ fn execute_call(
     confirm: Option<&ConfirmGuard>,
     name: &str,
     arguments: Value,
+    // The upstream client's `params._meta`, relayed to the downstream server
+    // minus per-hop keys (SOU-444). `None` for calls Toolport originates
+    // itself: a code-mode script step has no client request behind it.
+    client_meta: Option<&Value>,
     opts: CallOpts,
     // Live swappable router slot (SOU-321). After HITL approval we re-clone this so
     // quarantine applied via `Arc::make_mut` during the hold is visible before execute.
@@ -3302,7 +3306,7 @@ fn execute_call(
     }
 
     let started = Instant::now();
-    match exec_router.route_call_with_cancel(name, arguments, cancel.clone()) {
+    match exec_router.route_call_with_cancel(name, arguments, cancel.clone(), client_meta) {
         Ok(result) => {
             if let Some(profiler) = &mut call_profiler {
                 profiler.mark_downstream();
@@ -3573,6 +3577,9 @@ fn run_script_dispatch(
                     None,
                     name,
                     args,
+                    // A script step is Toolport's own call, not a relay of a client
+                    // request, so there is no client `_meta` to carry.
+                    None,
                     CallOpts {
                         confirmed: false,
                         shape: false,
@@ -4307,6 +4314,8 @@ fn handle_request_with_cancel(
                     Some(confirm),
                     name.as_str(),
                     arguments,
+                    // Relay the client's request metadata downstream (SOU-444).
+                    req.get("params").and_then(|p| p.get("_meta")),
                     CallOpts {
                         confirmed,
                         shape: true,
@@ -4371,7 +4380,8 @@ fn handle_request_with_cancel(
                     return Some(error(id, -32602, &format!("Toolport: no server owns resource '{uri}'")));
                 }
             }
-            match router.read_resource_with_cancel(uri, cancel.clone()) {
+            let client_meta = req.get("params").and_then(|p| p.get("_meta")).cloned();
+            match router.read_resource_with_cancel(uri, cancel.clone(), client_meta.as_ref()) {
                 Ok(mut result) => {
                     // Content defense: a resource is as attacker-controllable as a tool
                     // result, so scan it for injection and label any flagged text as data.
@@ -4435,7 +4445,9 @@ fn handle_request_with_cancel(
                     return Some(error(id, -32602, &format!("Toolport: no route for prompt '{name}'")));
                 }
             }
-            match router.get_prompt_with_cancel(name, arguments, cancel.clone()) {
+            let client_meta = params.and_then(|p| p.get("_meta")).cloned();
+            match router.get_prompt_with_cancel(name, arguments, cancel.clone(), client_meta.as_ref())
+            {
                 Ok(mut result) => {
                     // Content defense: a prompt's messages are attacker-controllable too;
                     // scan for injection and label any flagged text as data.

--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -33,7 +33,7 @@ use conduit_lib::clients;
 use conduit_lib::codemode;
 use conduit_lib::downstream::{
     self, DownstreamServer, ResourceUpdatedSink, ServerRequestHandler, StdioTransport, Transport,
-    PROTOCOL_VERSION,
+    MODERN_PROTOCOL_VERSION, PROTOCOL_VERSION,
 };
 use conduit_lib::inspect;
 use conduit_lib::integrity;
@@ -47,12 +47,115 @@ use conduit_lib::secrets;
 use conduit_lib::semantic;
 use conduit_lib::shaping;
 
+thread_local! {
+    /// Protocol version of the request currently being served, when the client is
+    /// modern (2026-07-28+). `None` means a legacy client.
+    ///
+    /// Request-scoped rather than connection-scoped on purpose: a modern client
+    /// declares its version on every request, so there is no connection-level
+    /// negotiation to cache. Mirrors `ACTIVE_MCP_SESSION` so [`success`] can
+    /// decorate every result without threading the era through each of the two
+    /// dozen dispatch arms - including the ones that return early (SOU-446).
+    static ACTIVE_UPSTREAM_VERSION: std::cell::RefCell<Option<String>> =
+        const { std::cell::RefCell::new(None) };
+}
+
+/// Sets the serving era for one request and restores the previous value on drop,
+/// so a nested dispatch (code mode re-entering `execute_call`) cannot leak it.
+struct UpstreamEraGuard(Option<String>);
+
+impl UpstreamEraGuard {
+    fn enter(version: Option<String>) -> Self {
+        UpstreamEraGuard(ACTIVE_UPSTREAM_VERSION.with(|cell| cell.replace(version)))
+    }
+}
+
+impl Drop for UpstreamEraGuard {
+    fn drop(&mut self) {
+        ACTIVE_UPSTREAM_VERSION.with(|cell| *cell.borrow_mut() = self.0.take());
+    }
+}
+
+/// True when the request being served came from a modern client.
+fn serving_modern_client() -> bool {
+    ACTIVE_UPSTREAM_VERSION.with(|cell| cell.borrow().is_some())
+}
+
+/// Add the fields a modern client requires to a result.
+///
+/// No-op for legacy clients, so their responses stay byte-identical to what
+/// Toolport sent before 2026-07-28 support existed (SOU-446).
+fn decorate_for_upstream(mut result: Value) -> Value {
+    if !serving_modern_client() {
+        return result;
+    }
+    let Some(obj) = result.as_object_mut() else {
+        return result;
+    };
+    // Every result carries `resultType`. Ordinary results are "complete";
+    // MRTR sets "input_required" on its own path (SOU-449), so an existing value
+    // is never overwritten.
+    obj.entry("resultType").or_insert_with(|| json!("complete"));
+    let meta = obj.entry("_meta").or_insert_with(|| json!({}));
+    if let Some(meta) = meta.as_object_mut() {
+        // Toolport IS the server on this hop, so it identifies itself here,
+        // overwriting any downstream server's value. Symmetric with
+        // PER_HOP_META_KEYS on the request side: per-hop keys belong to the hop.
+        meta.insert(
+            "io.modelcontextprotocol/serverInfo".to_string(),
+            json!({ "name": "toolport-gateway", "version": env!("CARGO_PKG_VERSION") }),
+        );
+    }
+    result
+}
+
 fn success(id: Value, result: Value) -> Value {
-    json!({ "jsonrpc": "2.0", "id": id, "result": result })
+    json!({ "jsonrpc": "2.0", "id": id, "result": decorate_for_upstream(result) })
 }
 
 fn error(id: Value, code: i64, message: &str) -> Value {
     json!({ "jsonrpc": "2.0", "id": id, "error": { "code": code, "message": message } })
+}
+
+/// Protocol versions Toolport serves to upstream clients, newest first.
+const SUPPORTED_UPSTREAM_VERSIONS: [&str; 2] = [MODERN_PROTOCOL_VERSION, PROTOCOL_VERSION];
+
+/// The protocol version a modern client declared on this request.
+///
+/// Presence of this key is what distinguishes a modern request from a legacy
+/// one: legacy clients negotiate once via `initialize` and never repeat it.
+fn upstream_declared_version(req: &Value) -> Option<&str> {
+    req.get("params")?
+        .get("_meta")?
+        .get("io.modelcontextprotocol/protocolVersion")?
+        .as_str()
+}
+
+/// `UnsupportedProtocolVersionError`, listing what Toolport does serve so the
+/// client can retry with a mutually supported version.
+fn unsupported_version_error(id: Value, requested: &str) -> Value {
+    json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "error": {
+            "code": downstream::UNSUPPORTED_PROTOCOL_VERSION,
+            "message": "Unsupported protocol version",
+            "data": { "supported": SUPPORTED_UPSTREAM_VERSIONS, "requested": requested }
+        }
+    })
+}
+
+/// What Toolport advertises to upstream clients, shared by `initialize` (legacy)
+/// and `server/discover` (modern) so the two can never drift.
+fn gateway_capabilities() -> Value {
+    json!({
+        "tools": { "listChanged": true },
+        // Always-on proxy for resource subscriptions (SOU-394): advertise
+        // subscribe, fail closed when no owner can.
+        "resources": { "listChanged": true, "subscribe": true },
+        "prompts": { "listChanged": true },
+        "completions": {}
+    })
 }
 
 const MAX_SEARCH_QUERY_CHARS: usize = 512;
@@ -3750,7 +3853,44 @@ fn handle_request_with_cancel(
         _ => return None,
     };
 
+    // Determine the client's era for this request before dispatching (SOU-446).
+    // A modern client declares its version in `_meta` on every request and never
+    // sends `initialize`; a legacy client does the opposite. Toolport serves both
+    // concurrently on the same endpoint.
+    let declared = upstream_declared_version(req).map(str::to_string);
+    if let Some(version) = declared.as_deref() {
+        if !SUPPORTED_UPSTREAM_VERSIONS.contains(&version) {
+            return Some(unsupported_version_error(id, version));
+        }
+    }
+    // Only 2026-07-28+ gets modern result decoration. A client that names an
+    // older version in `_meta` is still served, just in its own era's shape.
+    let _era = UpstreamEraGuard::enter(
+        declared.filter(|v| v.as_str() == MODERN_PROTOCOL_VERSION),
+    );
+
     match method {
+        // Modern clients open here instead of handshaking. Servers MUST implement
+        // it, and it is also the stdio backward-compatibility probe a dual-era
+        // client uses to decide which era Toolport speaks.
+        "server/discover" => Some(success(
+            id,
+            json!({
+                "supportedVersions": SUPPORTED_UPSTREAM_VERSIONS,
+                "capabilities": gateway_capabilities(),
+                "instructions": "Toolport aggregates every configured MCP server behind one \
+                                 endpoint. In lazy discovery mode the catalog is reached through \
+                                 the toolport_search_tools / toolport_call_tool meta-tools rather \
+                                 than a full tools/list.",
+                // server/discover is a cacheable operation. The list results grow
+                // these fields in SOU-454.
+                "ttlMs": 300_000,
+                // Toolport's advertised capabilities depend on the requesting
+                // client's scope and profile, so a shared intermediary must not
+                // reuse one client's answer for another.
+                "cacheScope": "private"
+            }),
+        )),
         "initialize" => {
             let proto = req
                 .get("params")
@@ -3761,14 +3901,7 @@ fn handle_request_with_cancel(
                 id,
                 json!({
                     "protocolVersion": proto,
-                    "capabilities": {
-                        "tools": { "listChanged": true },
-                        // Always-on proxy for resource subscriptions (SOU-394):
-                        // advertise subscribe, fail closed when no owner can.
-                        "resources": { "listChanged": true, "subscribe": true },
-                        "prompts": { "listChanged": true },
-                        "completions": {}
-                    },
+                    "capabilities": gateway_capabilities(),
                     "serverInfo": { "name": "toolport-gateway", "version": env!("CARGO_PKG_VERSION") }
                 }),
             ))
@@ -4547,6 +4680,13 @@ fn handle_request_with_cancel(
                 )),
             }
         }
+        // `ping` was removed in 2026-07-28, so a modern client gets method-not-found
+        // rather than a misleading success. Legacy clients keep it (SOU-446).
+        "ping" if serving_modern_client() => Some(error(
+            id,
+            -32601,
+            "ping is not part of 2026-07-28",
+        )),
         "ping" => Some(success(id, json!({}))),
         other => Some(error(id, -32601, &format!("Method not found: {other}"))),
     }
@@ -12721,6 +12861,152 @@ mod tests {
         let sess = sessions.get(sid).unwrap();
         let mut out = sess.outbound.lock().unwrap();
         out.drain(..).map(|m| m.json).collect()
+    }
+
+    /// Dispatch one request with the default test rig.
+    fn dispatch(req: &Value) -> Value {
+        let reg = Registry::default();
+        let router = routed_router("s", "tool");
+        handle_request(
+            req,
+            &reg,
+            &router,
+            &[],
+            true,
+            None,
+            &SearchGuard::default(),
+            &ConfirmGuard::new(),
+            None,
+            None,
+        )
+        .expect("a request with an id gets a response")
+    }
+
+    /// Build a modern (2026-07-28) request: version declared in `_meta`, no
+    /// handshake anywhere.
+    fn modern_req(id: i64, method: &str, extra: Value) -> Value {
+        let mut params = json!({
+            "_meta": {
+                "io.modelcontextprotocol/protocolVersion": MODERN_PROTOCOL_VERSION,
+                "io.modelcontextprotocol/clientInfo": { "name": "TestClient", "version": "1.0" },
+                "io.modelcontextprotocol/clientCapabilities": {}
+            }
+        });
+        if let (Some(p), Some(extra)) = (params.as_object_mut(), extra.as_object()) {
+            for (k, v) in extra {
+                p.insert(k.clone(), v.clone());
+            }
+        }
+        json!({ "jsonrpc": "2.0", "id": id, "method": method, "params": params })
+    }
+
+    #[test]
+    fn server_discover_answers_modern_clients() {
+        // Servers MUST implement server/discover. It is also the stdio probe a
+        // dual-era client uses to decide which era Toolport speaks (SOU-446).
+        let resp = dispatch(&modern_req(1, "server/discover", json!({})));
+        let result = &resp["result"];
+
+        assert_eq!(result["supportedVersions"][0], MODERN_PROTOCOL_VERSION);
+        assert!(result["capabilities"]["tools"].is_object());
+        assert_eq!(result["capabilities"]["resources"]["subscribe"], true);
+        assert_eq!(result["resultType"], "complete");
+        assert_eq!(
+            result["_meta"]["io.modelcontextprotocol/serverInfo"]["name"],
+            "toolport-gateway"
+        );
+        // Scope- and profile-dependent, so a shared intermediary must not reuse
+        // one client's answer for another.
+        assert_eq!(result["cacheScope"], "private");
+    }
+
+    #[test]
+    fn modern_client_is_served_without_any_handshake() {
+        // The whole point of the stateless revision: no initialize, no session,
+        // just a request that declares its own version.
+        let resp = dispatch(&modern_req(2, "tools/list", json!({})));
+        assert!(resp["result"]["tools"].is_array());
+        assert_eq!(resp["result"]["resultType"], "complete");
+        assert_eq!(
+            resp["result"]["_meta"]["io.modelcontextprotocol/serverInfo"]["name"],
+            "toolport-gateway"
+        );
+    }
+
+    #[test]
+    fn legacy_clients_see_no_modern_fields() {
+        // The no-regression guarantee for every client in the wild today: a
+        // request without `_meta` gets a byte-identical response to before.
+        let req = json!({ "jsonrpc": "2.0", "id": 3, "method": "tools/list", "params": {} });
+        let resp = dispatch(&req);
+        assert!(resp["result"]["tools"].is_array());
+        assert!(
+            resp["result"].get("resultType").is_none(),
+            "legacy results carry no resultType, got {}",
+            resp["result"]
+        );
+        assert!(
+            resp["result"].get("_meta").is_none(),
+            "legacy results carry no _meta, got {}",
+            resp["result"]
+        );
+
+        // ...and initialize still works, unchanged.
+        let init = dispatch(&json!({
+            "jsonrpc": "2.0", "id": 4, "method": "initialize",
+            "params": { "protocolVersion": PROTOCOL_VERSION, "capabilities": {} }
+        }));
+        assert_eq!(init["result"]["protocolVersion"], PROTOCOL_VERSION);
+        assert_eq!(init["result"]["serverInfo"]["name"], "toolport-gateway");
+        assert!(init["result"].get("resultType").is_none());
+    }
+
+    #[test]
+    fn unknown_protocol_version_is_rejected_with_what_we_support() {
+        // The client needs the `supported` list to pick a mutually supported
+        // version and retry, so an opaque failure would be a dead end.
+        let req = json!({
+            "jsonrpc": "2.0", "id": 5, "method": "tools/list",
+            "params": { "_meta": { "io.modelcontextprotocol/protocolVersion": "1900-01-01" } }
+        });
+        let resp = dispatch(&req);
+        assert_eq!(resp["error"]["code"], downstream::UNSUPPORTED_PROTOCOL_VERSION);
+        assert_eq!(resp["error"]["data"]["requested"], "1900-01-01");
+        assert_eq!(
+            resp["error"]["data"]["supported"][0],
+            MODERN_PROTOCOL_VERSION
+        );
+    }
+
+    #[test]
+    fn ping_is_legacy_only() {
+        // Removed in 2026-07-28. A modern client gets method-not-found rather
+        // than a misleading success; a legacy client is unaffected.
+        let modern = dispatch(&modern_req(8, "ping", json!({})));
+        assert_eq!(modern["error"]["code"], -32601);
+
+        let legacy = dispatch(&json!({
+            "jsonrpc": "2.0", "id": 9, "method": "ping", "params": {}
+        }));
+        assert!(legacy["result"].is_object(), "legacy ping still succeeds");
+        assert!(legacy.get("error").is_none());
+    }
+
+    #[test]
+    fn upstream_era_does_not_leak_between_requests() {
+        // The era rides a thread-local, so a modern request must not leave the
+        // next (legacy) request decorated. Code mode re-enters dispatch, which is
+        // exactly where a leak would show up.
+        let modern = dispatch(&modern_req(6, "tools/list", json!({})));
+        assert_eq!(modern["result"]["resultType"], "complete");
+
+        let legacy = dispatch(&json!({
+            "jsonrpc": "2.0", "id": 7, "method": "tools/list", "params": {}
+        }));
+        assert!(
+            legacy["result"].get("resultType").is_none(),
+            "era leaked into the following legacy request"
+        );
     }
 
     #[test]

--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -5183,6 +5183,10 @@ struct ProgressRoute {
     client_token: Value,
 }
 
+/// Depth of the stdio progress hand-off queue. Bounded so a client that stops
+/// reading costs dropped notifications rather than a stalled drain thread.
+const PROGRESS_STDIO_QUEUE: usize = 256;
+
 /// Source of gateway-minted progress tokens. Process-wide and monotonic, so a
 /// token is never reused while an earlier call is still in flight.
 static PROGRESS_TOKEN_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(1);
@@ -5293,7 +5297,7 @@ fn prepare_progress(
 /// Deliver one `notifications/progress` to the client that minted its token,
 /// dropping anything unroutable or spoofed (SOU-444).
 fn deliver_progress(
-    stdout: &Arc<Mutex<std::io::Stdout>>,
+    stdio: &std::sync::mpsc::SyncSender<Value>,
     mcp_sessions: &Arc<Mutex<HashMap<String, Arc<McpSession>>>>,
     routes: &Arc<Mutex<ProgressRoutes>>,
     producer: &str,
@@ -5334,10 +5338,15 @@ fn deliver_progress(
     }
     let note = &note;
     if session == RESOURCE_SUB_STDIO {
-        let mut out = stdout
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
-        let _ = write_json_line(&mut *out, note);
+        // Hand off rather than write here. This runs on the downstream drain
+        // thread, BEFORE that thread forwards response lines to the request loop.
+        // A blocking flush to a client that stopped reading would stall the drain,
+        // so the in-flight call never completes while still holding the per-server
+        // slot mutex, wedging that server for every client. Bounded and dropping
+        // when full, exactly as the HTTP session queue already behaves (SOU-474).
+        if stdio.try_send(note.clone()).is_err() {
+            eprintln!("toolport: stdio progress queue full or closed; progress dropped");
+        }
         return;
     }
     let Ok(json) = serde_json::to_string(note) else {
@@ -5364,8 +5373,23 @@ fn make_progress_sink(
     mcp_sessions: Arc<Mutex<HashMap<String, Arc<McpSession>>>>,
     routes: Arc<Mutex<ProgressRoutes>>,
 ) -> ProgressDispatch {
+    // One writer thread owns the blocking write to the stdio client, fed by a
+    // bounded queue. Delivery runs on the downstream drain thread, which must
+    // never block (see `deliver_progress`).
+    let (tx, rx) = std::sync::mpsc::sync_channel::<Value>(PROGRESS_STDIO_QUEUE);
+    std::thread::spawn(move || {
+        for note in rx {
+            let mut out = stdout
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            if write_json_line(&mut *out, &note).is_err() {
+                // The stdio client is gone; nothing further will be readable.
+                break;
+            }
+        }
+    });
     Arc::new(move |producer: String, note: Value| {
-        deliver_progress(&stdout, &mcp_sessions, &routes, &producer, &note);
+        deliver_progress(&tx, &mcp_sessions, &routes, &producer, &note);
     })
 }
 
@@ -7336,7 +7360,23 @@ fn process_request(
         .clone();
     // Resource subscriptions need the live GatewayState (session table + sink)
     // and the same ownership/scope path as resources/read (SOU-394).
+    //
+    // They return before `handle_request_with_cancel`, which is where the version
+    // check and the era guard live, so both have to be applied here or these two
+    // methods would disagree with every other method about what a valid request
+    // is: an unsupported version would be served, and a modern client's result
+    // would come back undecorated (SOU-474).
     if method == "resources/subscribe" || method == "resources/unsubscribe" {
+        let id = req.get("id").cloned().filter(|id| !id.is_null());
+        let declared = upstream_declared_version(req).map(str::to_string);
+        if let (Some(id), Some(version)) = (id, declared.as_deref()) {
+            if !SUPPORTED_UPSTREAM_VERSIONS.contains(&version) {
+                return Some(unsupported_version_error(id, version));
+            }
+        }
+        let _era = UpstreamEraGuard::enter(
+            declared.filter(|v| v.as_str() == MODERN_PROTOCOL_VERSION),
+        );
         return handle_resource_subscription(state, &router, req, allowed, method);
     }
     handle_request_with_cancel(
@@ -13104,6 +13144,15 @@ mod tests {
         assert!(chunk2.is_none(), "unsubscribed session must not receive update");
     }
 
+    /// A stdio progress channel plus its receiver, so a test can assert what the
+    /// writer thread would have written.
+    fn stdio_progress_channel() -> (
+        std::sync::mpsc::SyncSender<Value>,
+        std::sync::mpsc::Receiver<Value>,
+    ) {
+        std::sync::mpsc::sync_channel(PROGRESS_STDIO_QUEUE)
+    }
+
     fn progress_note(token: &str) -> Value {
         json!({
             "jsonrpc": "2.0",
@@ -13307,6 +13356,7 @@ mod tests {
         let s1 = mint_mcp_session(&state, None).ok().expect("mint s1");
         let s2 = mint_mcp_session(&state, None).ok().expect("mint s2");
         let routes = Arc::new(Mutex::new(ProgressRoutes::default()));
+        let (stdio_tx, _stdio_rx) = stdio_progress_channel();
 
         let (_registration, wire_token) =
             register_progress(&routes, Some(&json!({ "progressToken": "tok-1" })), "alpha", &s1)
@@ -13317,7 +13367,7 @@ mod tests {
         );
 
         deliver_progress(
-            &state.stdout,
+            &stdio_tx,
             &state.mcp_sessions,
             &routes,
             "alpha",
@@ -13350,6 +13400,7 @@ mod tests {
         let s1 = mint_mcp_session(&state, None).ok().expect("mint s1");
         let s2 = mint_mcp_session(&state, None).ok().expect("mint s2");
         let routes = Arc::new(Mutex::new(ProgressRoutes::default()));
+        let (stdio_tx, _stdio_rx) = stdio_progress_channel();
 
         // Same client token, same downstream server, two different clients.
         let (_r1, wire1) =
@@ -13364,7 +13415,7 @@ mod tests {
         );
 
         let note = progress_note(&wire1);
-        deliver_progress(&state.stdout, &state.mcp_sessions, &routes, "alpha", &note);
+        deliver_progress(&stdio_tx, &state.mcp_sessions, &routes, "alpha", &note);
 
         let first = drain_session(&state, &s1);
         assert_eq!(first.len(), 1, "progress goes to the client that asked");
@@ -13383,6 +13434,7 @@ mod tests {
         let state = http_state(false);
         let s1 = mint_mcp_session(&state, None).ok().expect("mint s1");
         let routes = Arc::new(Mutex::new(ProgressRoutes::default()));
+        let (stdio_tx, _stdio_rx) = stdio_progress_channel();
 
         let (registration, wire_token) =
             register_progress(&routes, Some(&json!({ "progressToken": "tok-1" })), "alpha", &s1)
@@ -13390,7 +13442,7 @@ mod tests {
 
         // beta was never given this token.
         deliver_progress(
-            &state.stdout,
+            &stdio_tx,
             &state.mcp_sessions,
             &routes,
             "beta",
@@ -13403,7 +13455,7 @@ mod tests {
 
         // A token nobody registered is dropped rather than broadcast.
         deliver_progress(
-            &state.stdout,
+            &stdio_tx,
             &state.mcp_sessions,
             &routes,
             "alpha",
@@ -13413,7 +13465,7 @@ mod tests {
 
         // The rightful owner still gets through...
         deliver_progress(
-            &state.stdout,
+            &stdio_tx,
             &state.mcp_sessions,
             &routes,
             "alpha",
@@ -13429,7 +13481,7 @@ mod tests {
             "the route must not outlive the call"
         );
         deliver_progress(
-            &state.stdout,
+            &stdio_tx,
             &state.mcp_sessions,
             &routes,
             "alpha",
@@ -13439,6 +13491,54 @@ mod tests {
             drain_session(&state, &s1).is_empty(),
             "progress after the call completed must be dropped"
         );
+    }
+
+    #[test]
+    fn stdio_progress_is_handed_off_without_blocking_the_caller() {
+        // The stdio delivery branch had no test at all, and it is the primary
+        // Toolport deployment. It must also never block: this runs on the
+        // downstream drain thread, before that thread forwards response lines, so
+        // a blocking write to a client that stopped reading would wedge the server
+        // for every client (SOU-474).
+        let state = http_state(false);
+        let routes = Arc::new(Mutex::new(ProgressRoutes::default()));
+        let (stdio_tx, stdio_rx) = stdio_progress_channel();
+
+        let (_reg, wire) = register_progress(
+            &routes,
+            Some(&json!({ "progressToken": "tok-1" })),
+            "alpha",
+            RESOURCE_SUB_STDIO,
+        )
+        .expect("registers");
+
+        deliver_progress(
+            &stdio_tx,
+            &state.mcp_sessions,
+            &routes,
+            "alpha",
+            &progress_note(&wire),
+        );
+
+        let delivered = stdio_rx
+            .try_recv()
+            .expect("the stdio client's progress must be queued");
+        // Translated back to the client's own token, same as the HTTP path.
+        assert_eq!(delivered["params"]["progressToken"], "tok-1");
+
+        // Fill the queue, then confirm a further send is DROPPED rather than
+        // blocking. Without the bound this call would hang forever.
+        for _ in 0..PROGRESS_STDIO_QUEUE {
+            let _ = stdio_tx.try_send(json!({}));
+        }
+        deliver_progress(
+            &stdio_tx,
+            &state.mcp_sessions,
+            &routes,
+            "alpha",
+            &progress_note(&wire),
+        );
+        // Reaching here at all is the assertion: a blocking send would never return.
     }
 
     #[test]
@@ -13489,6 +13589,7 @@ mod tests {
         // The common case: clients that never ask for progress cost nothing and
         // leave no state behind.
         let routes = Arc::new(Mutex::new(ProgressRoutes::default()));
+        let (stdio_tx, _stdio_rx) = stdio_progress_channel();
         assert!(register_progress(&routes, None, "alpha", "stdio").is_none());
         assert!(register_progress(&routes, Some(&json!({ "traceparent": "x" })), "alpha", "stdio").is_none());
         assert!(routes.lock().unwrap().active.is_empty());

--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -97,6 +97,12 @@ fn decorate_for_upstream(mut result: Value) -> Value {
     // is never overwritten.
     obj.entry("resultType").or_insert_with(|| json!("complete"));
     let meta = obj.entry("_meta").or_insert_with(|| json!({}));
+    // A downstream server that returned a non-object `_meta` is malformed, but
+    // that must not make OUR envelope invalid by silently skipping the required
+    // serverInfo. There are no keys to preserve in a non-object, so replace it.
+    if !meta.is_object() {
+        *meta = json!({});
+    }
     if let Some(meta) = meta.as_object_mut() {
         // Toolport IS the server on this hop, so it identifies itself here,
         // overwriting any downstream server's value. Symmetric with
@@ -3483,18 +3489,7 @@ fn execute_call(
     // against the raw server id, matching what the per-server sink binds, so the
     // spoof check compares like with like. Held in a named binding so the RAII
     // guard lives across the call rather than dropping immediately.
-    let progress_to = progress_target();
-    let _progress_route = progress_to
-        .as_deref()
-        .and_then(|session| register_progress(progress_routes(), client_meta, server_id, session));
-    // With nowhere to deliver progress, do not ask the server to produce it
-    // (SOU-447). Only allocates when the client actually requested progress.
-    let relay_owned = match (progress_to.is_none(), client_meta) {
-        (true, Some(meta)) if meta.get("progressToken").is_some() => {
-            Some(without_progress_token(meta))
-        }
-        _ => None,
-    };
+    let (_progress_route, relay_owned) = prepare_progress(client_meta, server_id);
     let client_meta = relay_owned.as_ref().or(client_meta);
 
     let started = Instant::now();
@@ -4603,12 +4598,11 @@ fn handle_request_with_cancel(
                 }
             }
             let client_meta = req.get("params").and_then(|p| p.get("_meta")).cloned();
-            let progress_to = progress_target();
-            let _progress_route = progress_to.as_deref().zip(router.resource_server(uri)).and_then(
-                |(session, owner)| {
-                    register_progress(progress_routes(), client_meta.as_ref(), owner, session)
-                },
-            );
+            let (_progress_route, relay_owned) = match router.resource_server(uri) {
+                Some(owner) => prepare_progress(client_meta.as_ref(), owner),
+                None => (None, None),
+            };
+            let client_meta = relay_owned.or(client_meta);
             match router.read_resource_with_cancel(uri, cancel.clone(), client_meta.as_ref()) {
                 Ok(mut result) => {
                     // Content defense: a resource is as attacker-controllable as a tool
@@ -4674,13 +4668,11 @@ fn handle_request_with_cancel(
                 }
             }
             let client_meta = params.and_then(|p| p.get("_meta")).cloned();
-            let progress_to = progress_target();
-            let _progress_route = progress_to
-                .as_deref()
-                .zip(router.prompt_server(name))
-                .and_then(|(session, owner)| {
-                    register_progress(progress_routes(), client_meta.as_ref(), owner, session)
-                });
+            let (_progress_route, relay_owned) = match router.prompt_server(name) {
+                Some(owner) => prepare_progress(client_meta.as_ref(), owner),
+                None => (None, None),
+            };
+            let client_meta = relay_owned.or(client_meta);
             match router.get_prompt_with_cancel(name, arguments, cancel.clone(), client_meta.as_ref())
             {
                 Ok(mut result) => {
@@ -5180,7 +5172,20 @@ struct ProgressRoute {
     /// The downstream server the token was relayed to. Recorded so a different
     /// server cannot emit progress for it.
     producer: String,
+    /// The token the CLIENT chose, restored on the way back out.
+    ///
+    /// `progressToken` is client-chosen and small integers are common, so two
+    /// clients can easily pick the same one. Keying the table on it directly let
+    /// a second registration clobber the first, and against the same server that
+    /// delivered one client's progress to another. Toolport therefore mints its
+    /// own unique token downstream and translates back here, the same way it
+    /// namespaces tool names.
+    client_token: Value,
 }
+
+/// Source of gateway-minted progress tokens. Process-wide and monotonic, so a
+/// token is never reused while an earlier call is still in flight.
+static PROGRESS_TOKEN_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(1);
 
 /// Live `progressToken` -> originating client map (SOU-444).
 ///
@@ -5215,15 +5220,21 @@ impl Drop for ProgressRegistration {
 /// Register the `progressToken` in `client_meta` (if any) for the duration of one
 /// downstream call. Returns `None` when the client asked for no progress, which
 /// is the common case.
+/// Returns the registration guard and the gateway-minted token to send
+/// downstream in place of the client's.
 fn register_progress(
     table: &Arc<Mutex<ProgressRoutes>>,
     client_meta: Option<&Value>,
     producer: &str,
     session: &str,
-) -> Option<ProgressRegistration> {
-    let token = client_meta?.get("progressToken")?;
-    let key = rpc_id_key(token)?;
-    let session = session.to_string();
+) -> Option<(ProgressRegistration, String)> {
+    let client_token = client_meta?.get("progressToken")?.clone();
+    // Mint our own token rather than reusing the client's. Two clients picking
+    // the same value (integers are common) would otherwise share a table entry.
+    let key = format!(
+        "tp-{}",
+        PROGRESS_TOKEN_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+    );
     table
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner)
@@ -5231,14 +5242,52 @@ fn register_progress(
         .insert(
             key.clone(),
             ProgressRoute {
-                session,
+                session: session.to_string(),
                 producer: producer.to_string(),
+                client_token,
             },
         );
-    Some(ProgressRegistration {
-        table: Arc::clone(table),
+    Some((
+        ProgressRegistration {
+            table: Arc::clone(table),
+            key: key.clone(),
+        },
         key,
-    })
+    ))
+}
+
+/// Register progress routing for one downstream call and produce the `_meta` to
+/// relay in place of the client's.
+///
+/// Three call sites need this (`tools/call`, `resources/read`, `prompts/get`),
+/// so the token substitution and the "no channel, do not ask" rule live here
+/// rather than being repeated.
+fn prepare_progress(
+    client_meta: Option<&Value>,
+    producer: &str,
+) -> (Option<ProgressRegistration>, Option<Value>) {
+    let Some(meta) = client_meta else {
+        return (None, None);
+    };
+    if meta.get("progressToken").is_none() {
+        return (None, None);
+    }
+    match progress_target() {
+        Some(session) => {
+            match register_progress(progress_routes(), client_meta, producer, &session) {
+                Some((registration, token)) => {
+                    let mut relayed = meta.clone();
+                    if let Some(obj) = relayed.as_object_mut() {
+                        obj.insert("progressToken".to_string(), json!(token));
+                    }
+                    (Some(registration), Some(relayed))
+                }
+                None => (None, None),
+            }
+        }
+        // Nowhere to deliver it, so do not ask the server to produce it.
+        None => (None, Some(without_progress_token(meta))),
+    }
 }
 
 /// Deliver one `notifications/progress` to the client that minted its token,
@@ -5253,15 +5302,18 @@ fn deliver_progress(
     let Some(token) = note.get("params").and_then(|p| p.get("progressToken")) else {
         return;
     };
-    let Some(key) = rpc_id_key(token) else {
+    // The token on the wire is the one Toolport minted, not the client's.
+    let Some(key) = token.as_str().map(str::to_string) else {
         return;
     };
-    let session = {
+    let (session, client_token) = {
         let table = routes
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
         match table.active.get(&key) {
-            Some(route) if route.producer == producer => route.session.clone(),
+            Some(route) if route.producer == producer => {
+                (route.session.clone(), route.client_token.clone())
+            }
             Some(route) => {
                 eprintln!(
                     "toolport: progress for token from '{producer}' dropped \
@@ -5275,6 +5327,12 @@ fn deliver_progress(
             None => return,
         }
     };
+    // Hand the client back ITS token; ours is an internal correlator.
+    let mut note = note.clone();
+    if let Some(params) = note.get_mut("params").and_then(Value::as_object_mut) {
+        params.insert("progressToken".to_string(), client_token);
+    }
+    let note = &note;
     if session == RESOURCE_SUB_STDIO {
         let mut out = stdout
             .lock()
@@ -13159,18 +13217,6 @@ mod tests {
         assert!(chunk2.is_none(), "unsubscribed session must not receive update");
     }
 
-    /// Set the active MCP session for the duration of `f`, restoring it after, so
-    /// one test cannot leak a session id into the next.
-    fn with_active_session<T>(sid: &str, f: impl FnOnce() -> T) -> T {
-        ACTIVE_MCP_SESSION.with(|cell| {
-            let previous = cell.borrow().clone();
-            *cell.borrow_mut() = Some(sid.to_string());
-            let out = f();
-            *cell.borrow_mut() = previous;
-            out
-        })
-    }
-
     fn progress_note(token: &str) -> Value {
         json!({
             "jsonrpc": "2.0",
@@ -13341,25 +13387,70 @@ mod tests {
         let s2 = mint_mcp_session(&state, None).ok().expect("mint s2");
         let routes = Arc::new(Mutex::new(ProgressRoutes::default()));
 
-        let registration = with_active_session(&s1, || {
+        let (_registration, wire_token) =
             register_progress(&routes, Some(&json!({ "progressToken": "tok-1" })), "alpha", &s1)
-        });
-        assert!(registration.is_some(), "a token should register a route");
+                .expect("a token should register a route");
+        assert_ne!(
+            wire_token, "tok-1",
+            "the downstream token must be Toolport's, not the client's"
+        );
 
         deliver_progress(
             &state.stdout,
             &state.mcp_sessions,
             &routes,
             "alpha",
-            &progress_note("tok-1"),
+            &progress_note(&wire_token),
         );
 
         let got = drain_session(&state, &s1);
         assert_eq!(got.len(), 1, "the minting client gets the progress");
-        assert!(got[0].contains("tok-1"));
+        // The client is handed back ITS token; ours is an internal correlator.
+        assert!(got[0].contains("tok-1"), "got {}", got[0]);
+        assert!(
+            !got[0].contains(&wire_token),
+            "the gateway's internal token must not leak to the client, got {}",
+            got[0]
+        );
         assert!(
             drain_session(&state, &s2).is_empty(),
             "another client must never see it"
+        );
+    }
+
+    #[test]
+    fn identical_client_tokens_from_two_clients_do_not_collide() {
+        // `progressToken` is client-chosen and small integers are common, so two
+        // clients picking the same value is likely. Keying the route table on it
+        // directly meant the second registration clobbered the first, and against
+        // the same server that delivered one client's progress to the other.
+        // Toolport mints its own token per call, so the two stay separate.
+        let state = http_state(false);
+        let s1 = mint_mcp_session(&state, None).ok().expect("mint s1");
+        let s2 = mint_mcp_session(&state, None).ok().expect("mint s2");
+        let routes = Arc::new(Mutex::new(ProgressRoutes::default()));
+
+        // Same client token, same downstream server, two different clients.
+        let (_r1, wire1) =
+            register_progress(&routes, Some(&json!({ "progressToken": 1 })), "alpha", &s1).unwrap();
+        let (_r2, wire2) =
+            register_progress(&routes, Some(&json!({ "progressToken": 1 })), "alpha", &s2).unwrap();
+        assert_ne!(wire1, wire2, "each call gets its own downstream token");
+        assert_eq!(
+            routes.lock().unwrap().active.len(),
+            2,
+            "the second registration must not clobber the first"
+        );
+
+        let note = progress_note(&wire1);
+        deliver_progress(&state.stdout, &state.mcp_sessions, &routes, "alpha", &note);
+
+        let first = drain_session(&state, &s1);
+        assert_eq!(first.len(), 1, "progress goes to the client that asked");
+        assert!(first[0].contains("\"progressToken\":1"), "got {}", first[0]);
+        assert!(
+            drain_session(&state, &s2).is_empty(),
+            "the other client shares a token value but must see nothing"
         );
     }
 
@@ -13372,9 +13463,9 @@ mod tests {
         let s1 = mint_mcp_session(&state, None).ok().expect("mint s1");
         let routes = Arc::new(Mutex::new(ProgressRoutes::default()));
 
-        let registration = with_active_session(&s1, || {
+        let (registration, wire_token) =
             register_progress(&routes, Some(&json!({ "progressToken": "tok-1" })), "alpha", &s1)
-        });
+                .expect("registers");
 
         // beta was never given this token.
         deliver_progress(
@@ -13382,7 +13473,7 @@ mod tests {
             &state.mcp_sessions,
             &routes,
             "beta",
-            &progress_note("tok-1"),
+            &progress_note(&wire_token),
         );
         assert!(
             drain_session(&state, &s1).is_empty(),
@@ -13405,7 +13496,7 @@ mod tests {
             &state.mcp_sessions,
             &routes,
             "alpha",
-            &progress_note("tok-1"),
+            &progress_note(&wire_token),
         );
         assert_eq!(drain_session(&state, &s1).len(), 1);
 
@@ -13421,7 +13512,7 @@ mod tests {
             &state.mcp_sessions,
             &routes,
             "alpha",
-            &progress_note("tok-1"),
+            &progress_note(&wire_token),
         );
         assert!(
             drain_session(&state, &s1).is_empty(),

--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -7985,27 +7985,22 @@ fn handle_mcp_http(
             // Keying on presence alone would let a client that names a legacy
             // version in `_meta` skip the session requirement here while still
             // being served legacy-shaped results there.
-            let is_modern =
-                upstream_declared_version(&req) == Some(MODERN_PROTOCOL_VERSION);
-
-            // Session rules. Modern requests have none; legacy `initialize` may
-            // omit a session id (and gets a new one), and every other legacy
-            // request must present a live one.
+            // Toolport is dual-era on stdio and legacy-only over Streamable HTTP.
             //
-            // Removing the session for modern clients does NOT weaken the
-            // authorization boundary. `resolve_http_caller` already resolves the
-            // bearer token to an identity and an effective server scope on EVERY
-            // request, and that is what `allowed` / `client` are built from here.
-            // The session only ever *bound* a minted id to that same identity so a
-            // stolen id could not be replayed by another caller. With no id to
-            // steal, there is nothing to bind, and re-resolving scope per request
-            // is strictly tighter than a session that caches it (a live re-scope
-            // takes effect immediately instead of on session expiry).
-            let session_id: Option<String> = if is_modern {
-                // Per spec, an inbound Mcp-Session-Id on a modern request is
-                // ignored rather than honoured or echoed.
-                None
-            } else if is_initialize {
+            // A session-less modern path was implemented here and then withdrawn,
+            // because serving modern clients over HTTP needs more than skipping the
+            // session: `Mcp-Method`/`Mcp-Name` on outbound requests, inbound header
+            // validation, `400`/`404` statuses for protocol errors, and above all a
+            // server-to-client channel (`subscriptions/listen`) to replace the one
+            // sessions provided. Without that last piece, a session-less client
+            // collapsed into the shared `RESOURCE_SUB_STDIO` subscription bucket,
+            // where one client could tear down another's subscription.
+            //
+            // Requiring a session for every HTTP request is therefore the honest
+            // state: a dual-era client gets a `400` here with no recognized modern
+            // error, which the spec defines as the signal to fall back to
+            // `initialize`. Tracked for SOU-447/448/450.
+            let session_id: Option<String> = if is_initialize {
                 if let Some(existing) = session_hdr.map(str::trim).filter(|s| !s.is_empty()) {
                     // Client re-sent a session on initialize: accept if still live,
                     // otherwise mint a fresh one (spec: start over without the old id).
@@ -8050,14 +8045,6 @@ fn handle_mcp_http(
                         }
                     }
                 }
-            } else if is_jsonrpc_response(&req) {
-                // Modern clients never answer server-initiated requests: MRTR
-                // replaced them, and the transport forbids a client sending a
-                // JSON-RPC response at all.
-                return HttpOut::json_err(
-                    400,
-                    "JSON-RPC responses are not accepted from a 2026-07-28 client",
-                );
             }
 
             // Notifications / JSON-RPC responses: 202 with empty body.
@@ -12186,129 +12173,6 @@ mod tests {
     }
 
     #[test]
-    fn modern_http_client_needs_no_session() {
-        // The stateless revision's whole point over HTTP: no initialize, no
-        // Mcp-Session-Id, just an authenticated request (SOU-447).
-        let state = http_state(true);
-        let caller = test_caller("client:cursor", None);
-        let out = handle_http(
-            &state,
-            &SearchGuard::default(),
-            &ConfirmGuard::new(),
-            "POST",
-            "/mcp",
-            &modern_http_body(1, "tools/list", json!({})),
-            None,
-            None,
-            None,
-            Some(&caller),
-        );
-        assert_eq!(out.status, 200, "body={}", out.body);
-
-        // No session was minted, and none is echoed: the header does not exist in
-        // 2026-07-28, and echoing one would invite the client to replay it.
-        assert!(
-            !out.extra.iter().any(|(k, _)| k.eq_ignore_ascii_case("Mcp-Session-Id")),
-            "modern response must carry no Mcp-Session-Id, got {:?}",
-            out.extra
-        );
-        assert!(
-            state.mcp_sessions.lock().unwrap().is_empty(),
-            "no session should have been created"
-        );
-
-        let body: Value = serde_json::from_str(&out.body).unwrap();
-        assert_eq!(body["result"]["resultType"], "complete");
-    }
-
-    #[test]
-    fn modern_http_request_still_enforces_client_scope() {
-        // THE security test for SOU-447. Sessions used to bind a minted id to an
-        // identity; removing them must not weaken what a scoped client can reach.
-        // Scope comes from resolve_http_caller on every request, so it still
-        // applies with no session in play.
-        let state = http_state(false);
-        // A real route, so the test discriminates: an in-scope call must SUCCEED
-        // while an out-of-scope one is refused. Without the positive case, a
-        // gateway that refused everything would also pass.
-        *state.router.lock().unwrap() = Arc::new(routed_router("github", "list_repos"));
-        let caller = test_caller("client:scoped", Some(&["github"]));
-        let allowed: std::collections::HashSet<String> =
-            ["github".to_string()].into_iter().collect();
-
-        let call = |name: &str| {
-            handle_http(
-                &state,
-                &SearchGuard::default(),
-                &ConfirmGuard::new(),
-                "POST",
-                "/mcp",
-                &modern_http_body(1, "tools/call", json!({ "name": name, "arguments": {} })),
-                None,
-                None,
-                Some(&allowed),
-                Some(&caller),
-            )
-        };
-
-        // In scope: the call gets PAST the scope guard and is routed downstream.
-        // The mock route does not implement tools/call, so what comes back is its
-        // own error rather than a refusal. The distinguishing property is which
-        // error it is, not whether one occurred.
-        let in_scope = call("github__list_repos");
-        assert_eq!(in_scope.status, 200, "body={}", in_scope.body);
-        let body: Value = serde_json::from_str(&in_scope.body).unwrap();
-        let text = body["result"]["content"][0]["text"].as_str().unwrap_or("");
-        assert!(
-            !text.contains("not available to this client"),
-            "an in-scope call must not be refused by the scope guard, got {body}"
-        );
-        assert!(
-            text.contains("unexpected tools/call"),
-            "expected the call to reach the downstream route, got {body}"
-        );
-
-        let out_of_scope = call("stripe__refund");
-        assert_eq!(out_of_scope.status, 200, "body={}", out_of_scope.body);
-        let body: Value = serde_json::from_str(&out_of_scope.body).unwrap();
-        assert!(
-            body["result"]["isError"].as_bool().unwrap_or(false),
-            "an out-of-scope server must be refused, got {body}"
-        );
-        assert!(
-            body["result"]["content"][0]["text"]
-                .as_str()
-                .unwrap_or("")
-                .contains("not available to this client"),
-            "expected the scope guard to be what refused it, got {body}"
-        );
-    }
-
-    #[test]
-    fn modern_http_request_ignores_an_inbound_session_id() {
-        // Spec: a modern request's Mcp-Session-Id is ignored, not honoured and not
-        // echoed. Honouring it would let a stale legacy id influence a stateless
-        // request; echoing it would resurrect the header.
-        let state = http_state(true);
-        let caller = test_caller("client:cursor", None);
-        let out = handle_http(
-            &state,
-            &SearchGuard::default(),
-            &ConfirmGuard::new(),
-            "POST",
-            "/mcp",
-            &modern_http_body(1, "tools/list", json!({})),
-            // A session id that was never minted: a legacy request would 404 here.
-            Some("00000000000000000000000000000000"),
-            None,
-            None,
-            Some(&caller),
-        );
-        assert_eq!(out.status, 200, "an unknown session id must be ignored, body={}", out.body);
-        assert!(!out.extra.iter().any(|(k, _)| k.eq_ignore_ascii_case("Mcp-Session-Id")));
-    }
-
-    #[test]
     fn legacy_http_client_still_requires_a_session() {
         // The other half of dual-era: nothing about the legacy path changed.
         let state = http_state(true);
@@ -12353,9 +12217,12 @@ mod tests {
     }
 
     #[test]
-    fn modern_http_client_may_not_send_a_jsonrpc_response() {
-        // MRTR replaced server-initiated requests, and the transport forbids a
-        // client sending a JSON-RPC response at all.
+    fn modern_http_client_is_not_served_and_gets_a_fallback_signal() {
+        // Toolport is dual-era on stdio and legacy-only over Streamable HTTP.
+        // Pins that boundary honestly rather than leaving it implicit: a modern
+        // client gets a 400 whose body is NOT a recognized modern error, which
+        // the spec defines as the signal for a dual-era client to fall back to
+        // `initialize`. Serving these properly is SOU-447/448/450.
         let state = http_state(true);
         let caller = test_caller("client:cursor", None);
         let out = handle_http(
@@ -12364,17 +12231,30 @@ mod tests {
             &ConfirmGuard::new(),
             "POST",
             "/mcp",
-            &json!({
-                "jsonrpc": "2.0", "id": 1, "result": {},
-                "params": { "_meta": { "io.modelcontextprotocol/protocolVersion": MODERN_PROTOCOL_VERSION } }
-            })
-            .to_string(),
+            &modern_http_body(1, "tools/list", json!({})),
             None,
             None,
             None,
             Some(&caller),
         );
         assert_eq!(out.status, 400, "body={}", out.body);
+        // Asserting the body, not just the status: a bare status check would
+        // also pass on an unrelated 400, which is how one of these tests passed
+        // for the wrong reason before.
+        assert!(
+            out.body.contains("Mcp-Session-Id"),
+            "expected the session requirement to be what refused it, got {}",
+            out.body
+        );
+        // Crucially NOT a modern error code: -32020/-32021/-32022 would tell a
+        // dual-era client we are modern and stop it falling back.
+        for code in ["-32020", "-32021", "-32022"] {
+            assert!(
+                !out.body.contains(code),
+                "a legacy-only HTTP endpoint must not answer with {code}, got {}",
+                out.body
+            );
+        }
     }
 
     #[test]
@@ -13370,9 +13250,10 @@ mod tests {
 
     #[test]
     fn upstream_era_does_not_leak_between_requests() {
-        // The era rides a thread-local, so a modern request must not leave the
-        // next (legacy) request decorated. Code mode re-enters dispatch, which is
-        // exactly where a leak would show up.
+        // Sequential case. Weak on its own: `UpstreamEraGuard::enter` replaces the
+        // thread-local unconditionally, so the second dispatch sets it correctly
+        // whether or not Drop ever restores anything. Kept for the plain
+        // regression, with the real check in the nested test below.
         let modern = dispatch(&modern_req(6, "tools/list", json!({})));
         assert_eq!(modern["result"]["resultType"], "complete");
 
@@ -13382,6 +13263,39 @@ mod tests {
         assert!(
             legacy["result"].get("resultType").is_none(),
             "era leaked into the following legacy request"
+        );
+    }
+
+    #[test]
+    fn nested_modern_dispatch_does_not_decorate_the_outer_legacy_response() {
+        // THE test for the RAII guard, and the one that was missing: gutting
+        // `impl Drop for UpstreamEraGuard` left all 190 gateway tests green,
+        // because nothing exercised nesting.
+        //
+        // Code mode re-enters dispatch while an outer request is being served, so
+        // an inner modern request must restore the outer era on the way out
+        // rather than leaving it set.
+        let outer_is_modern = ACTIVE_UPSTREAM_VERSION.with(|cell| cell.borrow().is_some());
+        assert!(!outer_is_modern, "test starts with no era installed");
+
+        // Simulate the outer legacy request holding the thread-local, then a
+        // nested modern dispatch inside it.
+        let _outer = UpstreamEraGuard::enter(None);
+        let inner = dispatch(&modern_req(8, "tools/list", json!({})));
+        assert_eq!(inner["result"]["resultType"], "complete", "inner is modern");
+
+        // Back in the outer request: if Drop failed to restore, this reads as
+        // modern and the outer response would be wrongly decorated.
+        assert!(
+            !serving_modern_client(),
+            "the nested modern dispatch leaked its era into the outer request"
+        );
+        let outer = dispatch(&json!({
+            "jsonrpc": "2.0", "id": 9, "method": "tools/list", "params": {}
+        }));
+        assert!(
+            outer["result"].get("resultType").is_none(),
+            "outer legacy response was decorated after a nested modern dispatch"
         );
     }
 

--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -432,6 +432,30 @@ impl ResourceSubscriptionTable {
 /// [`ResourceUpdatedSink`] that closes over the producer id.
 type ResourceUpdatedDispatch = Arc<dyn Fn(String, String) + Send + Sync>;
 
+/// Shared `(producer, notification)` dispatch for `notifications/progress`,
+/// bound per downstream server so delivery can verify who emitted it (SOU-444).
+type ProgressDispatch = Arc<dyn Fn(String, Value) + Send + Sync>;
+
+/// Process-wide progress dispatch, installed once at startup.
+///
+/// The resource-updated dispatch is threaded through `build_router` because
+/// subscriptions are rebuilt alongside the router. Progress needs none of that:
+/// it depends only on singletons that live for the whole process (stdout, the
+/// HTTP session table, and the in-flight token map), and every downstream
+/// connection wants the same one. A set-once global keeps it out of four
+/// intermediate signatures that have nothing else to do with it.
+static PROGRESS_DISPATCH: std::sync::OnceLock<ProgressDispatch> = std::sync::OnceLock::new();
+
+/// In-flight `progressToken` routes, shared by every downstream connection.
+static PROGRESS_ROUTES: std::sync::OnceLock<Arc<Mutex<ProgressRoutes>>> =
+    std::sync::OnceLock::new();
+
+/// The live token table, created on first use so tests can exercise routing
+/// without standing up a full gateway.
+fn progress_routes() -> &'static Arc<Mutex<ProgressRoutes>> {
+    PROGRESS_ROUTES.get_or_init(|| Arc::new(Mutex::new(ProgressRoutes::default())))
+}
+
 #[derive(Debug, PartialEq, Eq)]
 enum BoundedLine {
     Eof,
@@ -3305,6 +3329,13 @@ fn execute_call(
         profiler.mark_preflight();
     }
 
+    // Route this call's progress notifications back to the client that minted the
+    // token, for exactly as long as the call is in flight (SOU-444). Registered
+    // against the raw server id, matching what the per-server sink binds, so the
+    // spoof check compares like with like. Held in a named binding so the RAII
+    // guard lives across the call rather than dropping immediately.
+    let _progress_route = register_progress(progress_routes(), client_meta, server_id);
+
     let started = Instant::now();
     match exec_router.route_call_with_cancel(name, arguments, cancel.clone(), client_meta) {
         Ok(result) => {
@@ -4381,6 +4412,9 @@ fn handle_request_with_cancel(
                 }
             }
             let client_meta = req.get("params").and_then(|p| p.get("_meta")).cloned();
+            let _progress_route = router.resource_server(uri).and_then(|owner| {
+                register_progress(progress_routes(), client_meta.as_ref(), owner)
+            });
             match router.read_resource_with_cancel(uri, cancel.clone(), client_meta.as_ref()) {
                 Ok(mut result) => {
                     // Content defense: a resource is as attacker-controllable as a tool
@@ -4446,6 +4480,9 @@ fn handle_request_with_cancel(
                 }
             }
             let client_meta = params.and_then(|p| p.get("_meta")).cloned();
+            let _progress_route = router.prompt_server(name).and_then(|owner| {
+                register_progress(progress_routes(), client_meta.as_ref(), owner)
+            });
             match router.get_prompt_with_cancel(name, arguments, cancel.clone(), client_meta.as_ref())
             {
                 Ok(mut result) => {
@@ -4720,6 +4757,11 @@ fn connect_one(
     let resource_updated = resource_updated
         .as_ref()
         .map(|d| bind_resource_updated_sink(d, &server.id));
+    // Same, for progress routing (SOU-444). Read from the process-wide dispatch
+    // rather than a threaded parameter: see PROGRESS_DISPATCH.
+    let progress = PROGRESS_DISPATCH
+        .get()
+        .map(|d| bind_progress_sink(d, &server.id));
     let result = if let Some(command) = &server.command {
         let mut env: Vec<(String, String)> = Vec::new();
         for e in &server.env {
@@ -4760,6 +4802,7 @@ fn connect_one(
         ) {
             Ok(mut t) => {
                 t.set_server_request_handler(server_handler);
+                t.set_progress_sink(progress);
                 DownstreamServer::connect(server.id.clone(), Box::new(t))
             }
             Err(e) => Err(e),
@@ -4769,6 +4812,7 @@ fn connect_one(
             server,
             Some(Arc::clone(&server_handler)),
             resource_updated,
+            progress,
         )
     } else {
         Err("no command or url".to_string())
@@ -4921,6 +4965,158 @@ fn deliver_resource_updated(
             }
         }
     }
+}
+
+/// One in-flight `progressToken` Toolport relayed on a client's behalf.
+struct ProgressRoute {
+    /// Which upstream client minted the token: a real `Mcp-Session-Id`, or
+    /// [`RESOURCE_SUB_STDIO`] for the single stdio client.
+    session: String,
+    /// The downstream server the token was relayed to. Recorded so a different
+    /// server cannot emit progress for it.
+    producer: String,
+}
+
+/// Live `progressToken` -> originating client map (SOU-444).
+///
+/// Progress is request-scoped, so an entry lives exactly as long as the
+/// downstream call that carries the token. Tracking the producer is what stops a
+/// hostile or buggy server emitting progress for a token it was never given -
+/// the same cross-server spoof lesson as SOU-398, applied to a notification that
+/// carries a client-chosen correlator instead of a URI.
+#[derive(Default)]
+struct ProgressRoutes {
+    active: HashMap<String, ProgressRoute>,
+}
+
+/// RAII registration: the entry is removed when the call finishes, however it
+/// finishes. A leaked token would let a server keep pushing progress into a
+/// client's stream long after its request completed.
+struct ProgressRegistration {
+    table: Arc<Mutex<ProgressRoutes>>,
+    key: String,
+}
+
+impl Drop for ProgressRegistration {
+    fn drop(&mut self) {
+        self.table
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .active
+            .remove(&self.key);
+    }
+}
+
+/// Register the `progressToken` in `client_meta` (if any) for the duration of one
+/// downstream call. Returns `None` when the client asked for no progress, which
+/// is the common case.
+fn register_progress(
+    table: &Arc<Mutex<ProgressRoutes>>,
+    client_meta: Option<&Value>,
+    producer: &str,
+) -> Option<ProgressRegistration> {
+    let token = client_meta?.get("progressToken")?;
+    let key = rpc_id_key(token)?;
+    let session = ACTIVE_MCP_SESSION.with(|cell| {
+        cell.borrow()
+            .clone()
+            .unwrap_or_else(|| RESOURCE_SUB_STDIO.to_string())
+    });
+    table
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .active
+        .insert(
+            key.clone(),
+            ProgressRoute {
+                session,
+                producer: producer.to_string(),
+            },
+        );
+    Some(ProgressRegistration {
+        table: Arc::clone(table),
+        key,
+    })
+}
+
+/// Deliver one `notifications/progress` to the client that minted its token,
+/// dropping anything unroutable or spoofed (SOU-444).
+fn deliver_progress(
+    stdout: &Arc<Mutex<std::io::Stdout>>,
+    mcp_sessions: &Arc<Mutex<HashMap<String, Arc<McpSession>>>>,
+    routes: &Arc<Mutex<ProgressRoutes>>,
+    producer: &str,
+    note: &Value,
+) {
+    let Some(token) = note.get("params").and_then(|p| p.get("progressToken")) else {
+        return;
+    };
+    let Some(key) = rpc_id_key(token) else {
+        return;
+    };
+    let session = {
+        let table = routes
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        match table.active.get(&key) {
+            Some(route) if route.producer == producer => route.session.clone(),
+            Some(route) => {
+                eprintln!(
+                    "toolport: progress for token from '{producer}' dropped \
+                     (token belongs to '{}')",
+                    route.producer
+                );
+                return;
+            }
+            // No in-flight request owns this token: a late notification for a
+            // finished call, or one Toolport never relayed. Either way, drop it.
+            None => return,
+        }
+    };
+    if session == RESOURCE_SUB_STDIO {
+        let mut out = stdout
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let _ = write_json_line(&mut *out, note);
+        return;
+    }
+    let Ok(json) = serde_json::to_string(note) else {
+        return;
+    };
+    let sessions = mcp_sessions
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let Some(target) = sessions.get(&session) else {
+        return;
+    };
+    if target.is_expired() || target.closed.load(Ordering::SeqCst) {
+        return;
+    }
+    if !target.push_message(json, None) {
+        eprintln!("toolport: MCP session outbound queue full; progress dropped");
+    }
+}
+
+/// Build the shared dispatch that routes progress notifications to the client
+/// that minted the token. Bound per downstream via [`bind_progress_sink`].
+fn make_progress_sink(
+    stdout: Arc<Mutex<std::io::Stdout>>,
+    mcp_sessions: Arc<Mutex<HashMap<String, Arc<McpSession>>>>,
+    routes: Arc<Mutex<ProgressRoutes>>,
+) -> ProgressDispatch {
+    Arc::new(move |producer: String, note: Value| {
+        deliver_progress(&stdout, &mcp_sessions, &routes, &producer, &note);
+    })
+}
+
+/// Bind a shared progress dispatch to one producer server id, so the
+/// transport-level sink only needs the notification (SOU-444).
+fn bind_progress_sink(dispatch: &ProgressDispatch, producer: &str) -> downstream::ProgressSink {
+    let dispatch = Arc::clone(dispatch);
+    let producer = producer.to_string();
+    Arc::new(move |note: Value| {
+        dispatch(producer.clone(), note);
+    })
 }
 
 /// Build the shared dispatch that fans resource-updated notifications to
@@ -8906,6 +9102,14 @@ fn main() {
         Arc::clone(&mcp_sessions),
         Arc::clone(&resource_subs),
     ));
+    // Progress routing (SOU-444). Installed before any downstream connects, so
+    // every transport binds a sink; `connect_one` reads it from here rather than
+    // taking it as a parameter.
+    let _ = PROGRESS_DISPATCH.set(make_progress_sink(
+        Arc::clone(&stdout),
+        Arc::clone(&mcp_sessions),
+        Arc::clone(progress_routes()),
+    ));
     // Single-flight for every router build/swap (startup, watcher self-heal, and
     // ${ROOT} rebuilds). Created up front so the startup build can share it.
     let rebuild_lock = Arc::new(Mutex::new(()));
@@ -12490,6 +12694,140 @@ mod tests {
             "subscribed session missing update: {chunk1}"
         );
         assert!(chunk2.is_none(), "unsubscribed session must not receive update");
+    }
+
+    /// Set the active MCP session for the duration of `f`, restoring it after, so
+    /// one test cannot leak a session id into the next.
+    fn with_active_session<T>(sid: &str, f: impl FnOnce() -> T) -> T {
+        ACTIVE_MCP_SESSION.with(|cell| {
+            let previous = cell.borrow().clone();
+            *cell.borrow_mut() = Some(sid.to_string());
+            let out = f();
+            *cell.borrow_mut() = previous;
+            out
+        })
+    }
+
+    fn progress_note(token: &str) -> Value {
+        json!({
+            "jsonrpc": "2.0",
+            "method": "notifications/progress",
+            "params": { "progressToken": token, "progress": 1, "total": 4 }
+        })
+    }
+
+    fn drain_session(state: &GatewayState, sid: &str) -> Vec<String> {
+        let sessions = state.mcp_sessions.lock().unwrap();
+        let sess = sessions.get(sid).unwrap();
+        let mut out = sess.outbound.lock().unwrap();
+        out.drain(..).map(|m| m.json).collect()
+    }
+
+    #[test]
+    fn progress_reaches_only_the_client_that_minted_the_token() {
+        // SOU-444: progress is request-scoped, so it must land on the one client
+        // whose request carried the token, never fan out like a subscription.
+        let state = http_state(false);
+        let s1 = mint_mcp_session(&state, None).ok().expect("mint s1");
+        let s2 = mint_mcp_session(&state, None).ok().expect("mint s2");
+        let routes = Arc::new(Mutex::new(ProgressRoutes::default()));
+
+        let registration = with_active_session(&s1, || {
+            register_progress(&routes, Some(&json!({ "progressToken": "tok-1" })), "alpha")
+        });
+        assert!(registration.is_some(), "a token should register a route");
+
+        deliver_progress(
+            &state.stdout,
+            &state.mcp_sessions,
+            &routes,
+            "alpha",
+            &progress_note("tok-1"),
+        );
+
+        let got = drain_session(&state, &s1);
+        assert_eq!(got.len(), 1, "the minting client gets the progress");
+        assert!(got[0].contains("tok-1"));
+        assert!(
+            drain_session(&state, &s2).is_empty(),
+            "another client must never see it"
+        );
+    }
+
+    #[test]
+    fn progress_drops_cross_server_spoof_and_stale_tokens() {
+        // Same lesson as SOU-398, on a notification whose correlator is chosen by
+        // the client: a server must not be able to push progress for a token it
+        // was never given, and a finished call must stop accepting progress.
+        let state = http_state(false);
+        let s1 = mint_mcp_session(&state, None).ok().expect("mint s1");
+        let routes = Arc::new(Mutex::new(ProgressRoutes::default()));
+
+        let registration = with_active_session(&s1, || {
+            register_progress(&routes, Some(&json!({ "progressToken": "tok-1" })), "alpha")
+        });
+
+        // beta was never given this token.
+        deliver_progress(
+            &state.stdout,
+            &state.mcp_sessions,
+            &routes,
+            "beta",
+            &progress_note("tok-1"),
+        );
+        assert!(
+            drain_session(&state, &s1).is_empty(),
+            "a server must not push progress for another server's token"
+        );
+
+        // A token nobody registered is dropped rather than broadcast.
+        deliver_progress(
+            &state.stdout,
+            &state.mcp_sessions,
+            &routes,
+            "alpha",
+            &progress_note("never-issued"),
+        );
+        assert!(drain_session(&state, &s1).is_empty(), "unknown token dropped");
+
+        // The rightful owner still gets through...
+        deliver_progress(
+            &state.stdout,
+            &state.mcp_sessions,
+            &routes,
+            "alpha",
+            &progress_note("tok-1"),
+        );
+        assert_eq!(drain_session(&state, &s1).len(), 1);
+
+        // ...until the call ends. Dropping the RAII guard unregisters the token, so
+        // a server cannot keep pushing into the client's stream afterwards.
+        drop(registration);
+        assert!(
+            routes.lock().unwrap().active.is_empty(),
+            "the route must not outlive the call"
+        );
+        deliver_progress(
+            &state.stdout,
+            &state.mcp_sessions,
+            &routes,
+            "alpha",
+            &progress_note("tok-1"),
+        );
+        assert!(
+            drain_session(&state, &s1).is_empty(),
+            "progress after the call completed must be dropped"
+        );
+    }
+
+    #[test]
+    fn no_progress_token_registers_no_route() {
+        // The common case: clients that never ask for progress cost nothing and
+        // leave no state behind.
+        let routes = Arc::new(Mutex::new(ProgressRoutes::default()));
+        assert!(register_progress(&routes, None, "alpha").is_none());
+        assert!(register_progress(&routes, Some(&json!({ "traceparent": "x" })), "alpha").is_none());
+        assert!(routes.lock().unwrap().active.is_empty());
     }
 
     #[test]

--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -123,18 +123,19 @@ fn error(id: Value, code: i64, message: &str) -> Value {
     json!({ "jsonrpc": "2.0", "id": id, "error": { "code": code, "message": message } })
 }
 
-/// Protocol versions Toolport serves to upstream clients, newest first.
+/// Protocol revisions Toolport serves to upstream clients, newest first.
 ///
-/// Every entry below `MODERN_PROTOCOL_VERSION` is a legacy revision: the gateway's
-/// own behaviour does not vary across them (revision differences are additive and
-/// ride through from the downstream server), so serving them costs nothing and
-/// refusing them would strand clients Toolport already answers.
+/// ADVERTISED, not accepted-in-`_meta`: see [`MODERN_UPSTREAM_VERSIONS`] for that.
+/// This is what `server/discover` reports and what an `UnsupportedProtocolVersion`
+/// error names, so a client learns every revision it could reach Toolport on -
+/// including the legacy ones, which it reaches by handshaking with `initialize`
+/// rather than by declaring a version per request.
 ///
-/// This list must stay a superset of what the `initialize` arm accepts. That arm
-/// deliberately echoes whatever the client asks for and validates nothing - legacy
-/// wire behaviour is pinned and must not change - so a revision it would happily
-/// serve while this list omitted it got `-32022` on every request the moment the
-/// client declared it in `_meta` instead (SOU-474 #7).
+/// Every entry below `MODERN_PROTOCOL_VERSION` is legacy. The gateway's own
+/// behaviour does not vary across them (revision differences are additive and ride
+/// through from the downstream server), and the `initialize` arm echoes whatever
+/// the client asks for, so all of them genuinely are served. Listing only two
+/// under-reported that (SOU-474 #7).
 const SUPPORTED_UPSTREAM_VERSIONS: [&str; 5] = [
     MODERN_PROTOCOL_VERSION,
     "2025-11-25",
@@ -142,6 +143,19 @@ const SUPPORTED_UPSTREAM_VERSIONS: [&str; 5] = [
     "2025-03-26",
     "2024-11-05",
 ];
+
+/// Revisions that may be declared in a request's `_meta`, newest first.
+///
+/// Deliberately NOT the same set as [`SUPPORTED_UPSTREAM_VERSIONS`]. The
+/// `io.modelcontextprotocol/protocolVersion` key was introduced BY 2026-07-28, so
+/// a request declaring a revision that predates the key is self-contradictory: no
+/// published legacy revision can produce it. Accepting one and then serving it in
+/// legacy shape produced a malformed answer to `server/discover` - the modern-only
+/// `ttlMs`/`cacheScope` fields present, the required `resultType`/`serverInfo`
+/// absent - in place of a clean, self-correcting `-32022` (#511 review).
+///
+/// Legacy clients are unaffected either way: they never send this key at all.
+const MODERN_UPSTREAM_VERSIONS: [&str; 1] = [MODERN_PROTOCOL_VERSION];
 
 /// The protocol version a modern client declared on this request.
 ///
@@ -599,11 +613,17 @@ fn has_stdio_client() -> bool {
 }
 
 /// Serializes tests that override [`HAS_STDIO_CLIENT`], which is process-global.
+///
+/// Only tests that take this lock are serialized. libtest runs tests on parallel
+/// threads, so a test that reaches `progress_target()` WITHOUT overriding can
+/// still observe another test's value. That is latent rather than live today
+/// (only the override-taking tests touch that path), but a new test on the
+/// progress path needs this guard even when it does not care about the value.
 #[cfg(test)]
 static STDIO_CLIENT_TEST_LOCK: Mutex<()> = Mutex::new(());
 
 /// Sets [`HAS_STDIO_CLIENT`] for the duration of a test and restores it on drop,
-/// holding a lock so two tests cannot observe each other's override.
+/// holding the lock above for as long as the override is in effect.
 #[cfg(test)]
 struct StdioClientOverride {
     _guard: std::sync::MutexGuard<'static, ()>,
@@ -3982,7 +4002,7 @@ fn handle_request_with_cancel(
     // concurrently on the same endpoint.
     let declared = upstream_declared_version(req).map(str::to_string);
     if let Some(version) = declared.as_deref() {
-        if !SUPPORTED_UPSTREAM_VERSIONS.contains(&version) {
+        if !MODERN_UPSTREAM_VERSIONS.contains(&version) {
             return Some(unsupported_version_error(id, version));
         }
     }
@@ -7440,7 +7460,7 @@ fn process_request(
         let id = req.get("id").cloned().filter(|id| !id.is_null());
         let declared = upstream_declared_version(req).map(str::to_string);
         if let (Some(id), Some(version)) = (id, declared.as_deref()) {
-            if !SUPPORTED_UPSTREAM_VERSIONS.contains(&version) {
+            if !MODERN_UPSTREAM_VERSIONS.contains(&version) {
                 return Some(unsupported_version_error(id, version));
             }
         }
@@ -13276,29 +13296,57 @@ mod tests {
     }
 
     #[test]
-    fn a_legacy_revision_declared_in_meta_is_served_not_rejected() {
-        // `initialize` echoes whatever version the client asks for and validates
-        // nothing, so Toolport does serve 2025-11-25. Declaring that same revision
-        // in `_meta` instead used to draw `-32022` on EVERY request, so a client
-        // that had merely adopted the newer way of naming its version was locked
-        // out of a gateway that would have answered it (SOU-474 #7).
+    fn a_pre_modern_revision_in_meta_is_refused_but_told_what_to_use() {
+        // The `_meta` protocolVersion key was introduced BY 2026-07-28, so naming
+        // an older revision in it is self-contradictory - no published legacy
+        // revision can produce that request. Accepting it and serving in legacy
+        // shape made `server/discover` answer with the modern-only ttlMs and
+        // cacheScope but WITHOUT the required resultType: a malformed hybrid,
+        // where a refusal is both correct and self-correcting (#511 review).
         for version in ["2025-11-25", "2025-03-26", "2024-11-05"] {
-            let req = json!({
-                "jsonrpc": "2.0", "id": 1, "method": "tools/list",
-                "params": { "_meta": { "io.modelcontextprotocol/protocolVersion": version } }
-            });
-            let resp = dispatch(&req);
-            assert!(
-                resp.get("error").is_none(),
-                "{version} is served via initialize, so it must not be refused in _meta: {resp}"
-            );
-            // Served in its own era's shape: legacy results carry no modern
-            // decoration, so the legacy wire format stays byte-identical.
-            assert!(
-                resp["result"].get("resultType").is_none(),
-                "{version} is a legacy revision and must not get modern decoration: {resp}"
-            );
+            for method in ["tools/list", "server/discover"] {
+                let resp = dispatch(&json!({
+                    "jsonrpc": "2.0", "id": 1, "method": method,
+                    "params": { "_meta": { "io.modelcontextprotocol/protocolVersion": version } }
+                }));
+                assert_eq!(
+                    resp["error"]["code"], downstream::UNSUPPORTED_PROTOCOL_VERSION,
+                    "{version} predates the _meta version key, so {method} must refuse it: {resp}"
+                );
+                // The refusal has to be actionable: it names every revision the
+                // client could actually reach Toolport on, including this one via
+                // `initialize`. Refusing without saying that is a dead end.
+                let supported = resp["error"]["data"]["supported"]
+                    .as_array()
+                    .unwrap_or_else(|| panic!("the error must name what IS served: {resp}"));
+                assert!(
+                    supported.iter().any(|v| v == version),
+                    "{version} IS served via initialize, so the refusal must say so: {resp}"
+                );
+                assert!(
+                    supported.iter().any(|v| v == MODERN_PROTOCOL_VERSION),
+                    "the refusal must name the revision this key belongs to: {resp}"
+                );
+            }
         }
+    }
+
+    #[test]
+    fn a_modern_declaration_is_still_served_and_decorated() {
+        // The other side of the refusal above: the one revision the `_meta` key
+        // belongs to is served, and served as modern.
+        let resp = dispatch(&modern_req(1, "tools/list", json!({})));
+        assert!(resp.get("error").is_none(), "2026-07-28 must be served: {resp}");
+        assert_eq!(resp["result"]["resultType"], "complete");
+        // And a legacy client, which sends no `_meta` at all, is untouched.
+        let legacy = dispatch(&json!({
+            "jsonrpc": "2.0", "id": 1, "method": "tools/list", "params": {}
+        }));
+        assert!(legacy.get("error").is_none(), "a legacy client is unaffected: {legacy}");
+        assert!(
+            legacy["result"].get("resultType").is_none(),
+            "legacy results carry no modern decoration: {legacy}"
+        );
     }
 
     #[test]
@@ -13323,21 +13371,31 @@ mod tests {
             .clone();
 
         for version in PUBLISHED_MCP_REVISIONS {
-            // Ground truth: `initialize` echoes the version back, which is what
-            // "Toolport serves this revision" means for a legacy client.
-            let init = dispatch(&json!({
-                "jsonrpc": "2.0", "id": 1, "method": "initialize",
-                "params": { "protocolVersion": version }
-            }));
-            assert_eq!(
-                init["result"]["protocolVersion"], version,
-                "initialize should serve {version}"
-            );
             assert!(
                 advertised.as_array().is_some_and(|a| a.iter().any(|v| v == version)),
                 "initialize serves {version} but server/discover does not advertise it: {advertised}"
             );
         }
+
+        // Deliberately NOT asserted per-revision above: `initialize` echoes any
+        // string, so "it echoed what I sent" is a tautology that holds for
+        // "garbage" too and proves nothing about which revisions are real. What
+        // the echo does establish is the shape of the claim - that no published
+        // revision is turned away - so assert it once, against a value that is
+        // NOT a published revision, to show the echo really is unconditional and
+        // this list is therefore a deliberate choice rather than a filter.
+        let nonsense = dispatch(&json!({
+            "jsonrpc": "2.0", "id": 1, "method": "initialize",
+            "params": { "protocolVersion": "1999-01-01" }
+        }));
+        assert_eq!(
+            nonsense["result"]["protocolVersion"], "1999-01-01",
+            "initialize validates nothing, so the advertised list is curated, not derived"
+        );
+        assert!(
+            !advertised.as_array().is_some_and(|a| a.iter().any(|v| v == "1999-01-01")),
+            "...and the curated list must not advertise something that isn't a real revision"
+        );
     }
 
     #[test]
@@ -13494,7 +13552,9 @@ mod tests {
         // A modern HTTP client: no session, no stdio. Nothing can carry progress,
         // so the server must not be asked to produce it.
         let _no_stdio = StdioClientOverride::set(false);
-        ACTIVE_MCP_SESSION.with(|cell| *cell.borrow_mut() = None);
+        // Thread-local, and libtest may reuse this thread for another test, so
+        // assert the default rather than assuming it and leaving it changed.
+        ACTIVE_MCP_SESSION.with(|cell| assert!(cell.borrow().is_none(), "no session on this thread"));
         assert_eq!(progress_target(), None, "no session and no stdio: nowhere to deliver");
 
         let (registration, relayed) = prepare_progress(Some(&meta), "alpha");
@@ -13516,7 +13576,9 @@ mod tests {
         // The other side of the same decision: a stdio client IS a delivery
         // channel, so the token is registered and rewritten rather than dropped.
         let _stdio = StdioClientOverride::set(true);
-        ACTIVE_MCP_SESSION.with(|cell| *cell.borrow_mut() = None);
+        // Thread-local, and libtest may reuse this thread for another test, so
+        // assert the default rather than assuming it and leaving it changed.
+        ACTIVE_MCP_SESSION.with(|cell| assert!(cell.borrow().is_none(), "no session on this thread"));
         assert_eq!(
             progress_target().as_deref(),
             Some(RESOURCE_SUB_STDIO),

--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -124,7 +124,24 @@ fn error(id: Value, code: i64, message: &str) -> Value {
 }
 
 /// Protocol versions Toolport serves to upstream clients, newest first.
-const SUPPORTED_UPSTREAM_VERSIONS: [&str; 2] = [MODERN_PROTOCOL_VERSION, PROTOCOL_VERSION];
+///
+/// Every entry below `MODERN_PROTOCOL_VERSION` is a legacy revision: the gateway's
+/// own behaviour does not vary across them (revision differences are additive and
+/// ride through from the downstream server), so serving them costs nothing and
+/// refusing them would strand clients Toolport already answers.
+///
+/// This list must stay a superset of what the `initialize` arm accepts. That arm
+/// deliberately echoes whatever the client asks for and validates nothing - legacy
+/// wire behaviour is pinned and must not change - so a revision it would happily
+/// serve while this list omitted it got `-32022` on every request the moment the
+/// client declared it in `_meta` instead (SOU-474 #7).
+const SUPPORTED_UPSTREAM_VERSIONS: [&str; 5] = [
+    MODERN_PROTOCOL_VERSION,
+    "2025-11-25",
+    PROTOCOL_VERSION,
+    "2025-03-26",
+    "2024-11-05",
+];
 
 /// The protocol version a modern client declared on this request.
 ///
@@ -564,7 +581,53 @@ static PROGRESS_ROUTES: std::sync::OnceLock<Arc<Mutex<ProgressRoutes>>> =
 ///
 /// False in HTTP bridge mode. Defaults to true when unset so direct unit-test
 /// callers keep the stdio behaviour they were written against.
-static HAS_STDIO_CLIENT: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+///
+/// Tri-state (`0` unset, `1` no stdio client, `2` stdio client) rather than a
+/// `OnceLock`: a write-once cell cannot be set by a test without pinning the
+/// value for every other test in the binary, so no test ever set it and every
+/// one of them silently resolved to the stdio branch - including the ones whose
+/// whole point was an HTTP gateway (SOU-474 #9).
+static HAS_STDIO_CLIENT: std::sync::atomic::AtomicU8 = std::sync::atomic::AtomicU8::new(0);
+
+fn set_has_stdio_client(present: bool) {
+    HAS_STDIO_CLIENT.store(if present { 2 } else { 1 }, std::sync::atomic::Ordering::SeqCst);
+}
+
+fn has_stdio_client() -> bool {
+    // Unset resolves to true: see the note above.
+    HAS_STDIO_CLIENT.load(std::sync::atomic::Ordering::SeqCst) != 1
+}
+
+/// Serializes tests that override [`HAS_STDIO_CLIENT`], which is process-global.
+#[cfg(test)]
+static STDIO_CLIENT_TEST_LOCK: Mutex<()> = Mutex::new(());
+
+/// Sets [`HAS_STDIO_CLIENT`] for the duration of a test and restores it on drop,
+/// holding a lock so two tests cannot observe each other's override.
+#[cfg(test)]
+struct StdioClientOverride {
+    _guard: std::sync::MutexGuard<'static, ()>,
+    previous: u8,
+}
+
+#[cfg(test)]
+impl StdioClientOverride {
+    fn set(present: bool) -> Self {
+        let guard = STDIO_CLIENT_TEST_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let previous = HAS_STDIO_CLIENT.load(std::sync::atomic::Ordering::SeqCst);
+        set_has_stdio_client(present);
+        Self { _guard: guard, previous }
+    }
+}
+
+#[cfg(test)]
+impl Drop for StdioClientOverride {
+    fn drop(&mut self) {
+        HAS_STDIO_CLIENT.store(self.previous, std::sync::atomic::Ordering::SeqCst);
+    }
+}
 
 /// Where progress for the request being served should be delivered, or `None`
 /// when there is no channel to deliver it on.
@@ -578,7 +641,7 @@ static HAS_STDIO_CLIENT: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
 fn progress_target() -> Option<String> {
     progress_target_for(
         ACTIVE_MCP_SESSION.with(|cell| cell.borrow().clone()),
-        HAS_STDIO_CLIENT.get().copied().unwrap_or(true),
+        has_stdio_client(),
     )
 }
 
@@ -3489,7 +3552,14 @@ fn execute_call(
     // against the raw server id, matching what the per-server sink binds, so the
     // spoof check compares like with like. Held in a named binding so the RAII
     // guard lives across the call rather than dropping immediately.
-    let (_progress_route, relay_owned) = prepare_progress(client_meta, server_id);
+    //
+    // The producer must come from the router that will actually execute the call,
+    // not the request snapshot `server_id` was resolved from. A rebuild during a
+    // HITL hold can re-route the tool to a different server, and a route
+    // registered against the pre-hold producer fails the spoof check on every
+    // notification the new one sends - silently dropping the whole stream (SOU-474).
+    let exec_server_id = exec_router.route_of(name).map_or(server_id, |(srv, _)| srv);
+    let (_progress_route, relay_owned) = prepare_progress(client_meta, exec_server_id);
     let client_meta = relay_owned.as_ref().or(client_meta);
 
     let started = Instant::now();
@@ -9455,7 +9525,7 @@ fn main() {
     ));
     // In HTTP bridge mode nothing reads this process's stdout, so it is not a
     // delivery channel for server-to-client messages (SOU-447).
-    let _ = HAS_STDIO_CLIENT.set(!http_mode);
+    set_has_stdio_client(!http_mode);
     // Single-flight for every router build/swap (startup, watcher self-heal, and
     // ${ROOT} rebuilds). Created up front so the startup build can share it.
     let rebuild_lock = Arc::new(Mutex::new(()));
@@ -13206,6 +13276,71 @@ mod tests {
     }
 
     #[test]
+    fn a_legacy_revision_declared_in_meta_is_served_not_rejected() {
+        // `initialize` echoes whatever version the client asks for and validates
+        // nothing, so Toolport does serve 2025-11-25. Declaring that same revision
+        // in `_meta` instead used to draw `-32022` on EVERY request, so a client
+        // that had merely adopted the newer way of naming its version was locked
+        // out of a gateway that would have answered it (SOU-474 #7).
+        for version in ["2025-11-25", "2025-03-26", "2024-11-05"] {
+            let req = json!({
+                "jsonrpc": "2.0", "id": 1, "method": "tools/list",
+                "params": { "_meta": { "io.modelcontextprotocol/protocolVersion": version } }
+            });
+            let resp = dispatch(&req);
+            assert!(
+                resp.get("error").is_none(),
+                "{version} is served via initialize, so it must not be refused in _meta: {resp}"
+            );
+            // Served in its own era's shape: legacy results carry no modern
+            // decoration, so the legacy wire format stays byte-identical.
+            assert!(
+                resp["result"].get("resultType").is_none(),
+                "{version} is a legacy revision and must not get modern decoration: {resp}"
+            );
+        }
+    }
+
+    #[test]
+    fn advertised_versions_cover_every_revision_initialize_accepts() {
+        // `server/discover` is how a modern client learns what to ask for. If it
+        // under-reports, a client picks a version Toolport serves but did not
+        // advertise - or worse, concludes it cannot talk to us at all.
+        //
+        // The revisions are written out rather than read from
+        // SUPPORTED_UPSTREAM_VERSIONS on purpose: iterating the constant under
+        // test only ever proves it agrees with itself, and stayed green against
+        // the two-entry list this test exists to catch.
+        const PUBLISHED_MCP_REVISIONS: [&str; 5] = [
+            "2024-11-05",
+            "2025-03-26",
+            "2025-06-18",
+            "2025-11-25",
+            "2026-07-28",
+        ];
+        let advertised = dispatch(&modern_req(1, "server/discover", json!({})))["result"]
+            ["supportedVersions"]
+            .clone();
+
+        for version in PUBLISHED_MCP_REVISIONS {
+            // Ground truth: `initialize` echoes the version back, which is what
+            // "Toolport serves this revision" means for a legacy client.
+            let init = dispatch(&json!({
+                "jsonrpc": "2.0", "id": 1, "method": "initialize",
+                "params": { "protocolVersion": version }
+            }));
+            assert_eq!(
+                init["result"]["protocolVersion"], version,
+                "initialize should serve {version}"
+            );
+            assert!(
+                advertised.as_array().is_some_and(|a| a.iter().any(|v| v == version)),
+                "initialize serves {version} but server/discover does not advertise it: {advertised}"
+            );
+        }
+    }
+
+    #[test]
     fn server_discover_answers_modern_clients() {
         // Servers MUST implement server/discover. It is also the stdio probe a
         // dual-era client uses to decide which era Toolport speaks (SOU-446).
@@ -13346,6 +13481,54 @@ mod tests {
             outer["result"].get("resultType").is_none(),
             "outer legacy response was decorated after a nested modern dispatch"
         );
+    }
+
+    #[test]
+    fn prepare_progress_withholds_the_token_when_nothing_can_deliver_it() {
+        // The shipping function, not its pure helpers. `progress_target_for` was
+        // unit-tested in every combination while `prepare_progress` - which reads
+        // the real globals - had no coverage, so a global that silently resolved
+        // to the stdio branch in every test went unnoticed (SOU-474 #9).
+        let meta = json!({ "progressToken": "tok-1", "traceparent": "keep-me" });
+
+        // A modern HTTP client: no session, no stdio. Nothing can carry progress,
+        // so the server must not be asked to produce it.
+        let _no_stdio = StdioClientOverride::set(false);
+        ACTIVE_MCP_SESSION.with(|cell| *cell.borrow_mut() = None);
+        assert_eq!(progress_target(), None, "no session and no stdio: nowhere to deliver");
+
+        let (registration, relayed) = prepare_progress(Some(&meta), "alpha");
+        assert!(registration.is_none(), "nothing to register against");
+        let relayed = relayed.expect("_meta is still relayed, minus the token");
+        assert!(
+            relayed.get("progressToken").is_none(),
+            "progressToken must be stripped when it cannot be delivered: {relayed}"
+        );
+        assert_eq!(
+            relayed.get("traceparent").and_then(|v| v.as_str()),
+            Some("keep-me"),
+            "unrelated _meta keys must survive: {relayed}"
+        );
+    }
+
+    #[test]
+    fn prepare_progress_registers_a_route_for_a_stdio_client() {
+        // The other side of the same decision: a stdio client IS a delivery
+        // channel, so the token is registered and rewritten rather than dropped.
+        let _stdio = StdioClientOverride::set(true);
+        ACTIVE_MCP_SESSION.with(|cell| *cell.borrow_mut() = None);
+        assert_eq!(
+            progress_target().as_deref(),
+            Some(RESOURCE_SUB_STDIO),
+            "a stdio client is reached on stdout"
+        );
+
+        let meta = json!({ "progressToken": 7 });
+        let (registration, relayed) = prepare_progress(Some(&meta), "alpha");
+        assert!(registration.is_some(), "a deliverable token gets a live route");
+        let relayed = relayed.expect("relayed _meta");
+        let token = relayed.get("progressToken").expect("token is rewritten, not dropped");
+        assert_ne!(token, &json!(7), "the downstream token must be Toolport's own");
     }
 
     #[test]
@@ -13525,6 +13708,22 @@ mod tests {
             .expect("the stdio client's progress must be queued");
         // Translated back to the client's own token, same as the HTTP path.
         assert_eq!(delivered["params"]["progressToken"], "tok-1");
+
+        // The producer check guards this branch too. It was only ever asserted on
+        // the HTTP session path, so a server pushing progress for a token it was
+        // never given would have been caught for HTTP clients and forwarded to the
+        // stdio one - the primary deployment (SOU-474).
+        deliver_progress(
+            &stdio_tx,
+            &state.mcp_sessions,
+            &routes,
+            "beta",
+            &progress_note(&wire),
+        );
+        assert!(
+            stdio_rx.try_recv().is_err(),
+            "a server must not push progress for another server's token"
+        );
 
         // Fill the queue, then confirm a further send is DROPPED rather than
         // blocking. Without the bound this call would hang forever.

--- a/src-tauri/src/downstream.rs
+++ b/src-tauri/src/downstream.rs
@@ -2345,6 +2345,24 @@ impl HttpTransport {
         self.progress = sink;
     }
 
+    /// The protocol version this connection declares in the `MCP-Protocol-Version`
+    /// header.
+    ///
+    /// From 2026-07-28 the header **MUST** equal the
+    /// `io.modelcontextprotocol/protocolVersion` carried in the body's `_meta`,
+    /// and a server that sees them disagree rejects the request with `400` and
+    /// `HeaderMismatch` (-32020). So this has to follow whatever the connection
+    /// negotiated, not a constant. Legacy connections have no protocol `_meta`
+    /// and keep sending [`PROTOCOL_VERSION`] exactly as before.
+    fn wire_protocol_version(&self) -> String {
+        self.protocol_meta
+            .as_ref()
+            .and_then(|meta| meta.get("io.modelcontextprotocol/protocolVersion"))
+            .and_then(Value::as_str)
+            .unwrap_or(PROTOCOL_VERSION)
+            .to_string()
+    }
+
     /// Answer a server-initiated JSON-RPC request inline (SSE mid-stream or
     /// standalone). Returns true when the message was handled.
     fn handle_inline_server_request(&mut self, v: &Value) -> Result<bool, TransportError> {
@@ -2397,13 +2415,14 @@ impl HttpTransport {
         let payload = body.to_string();
         self.refresh_before_send();
         let mut refreshed = false;
+        let wire_version = self.wire_protocol_version();
         let resp = loop {
             let mut req = self
                 .inline_agent
                 .post(&self.url)
                 .set("Content-Type", "application/json")
                 .set("Accept", "application/json, text/event-stream")
-                .set("MCP-Protocol-Version", PROTOCOL_VERSION);
+                .set("MCP-Protocol-Version", &wire_version);
             if let Some(sid) = &self.session_id {
                 req = req.set("Mcp-Session-Id", sid);
             }
@@ -2509,13 +2528,14 @@ impl HttpTransport {
         // contention). Only 429 and transport-retry signals bubble up as
         // TransportError::Retry so the Router can sleep *outside* the lock.
         let mut refreshed = false;
+        let wire_version = self.wire_protocol_version();
         let resp = loop {
             let mut req = self
                 .agent
                 .post(&self.url)
                 .set("Content-Type", "application/json")
                 .set("Accept", "application/json, text/event-stream")
-                .set("MCP-Protocol-Version", PROTOCOL_VERSION);
+                .set("MCP-Protocol-Version", &wire_version);
             if let Some(sid) = &self.session_id {
                 req = req.set("Mcp-Session-Id", sid);
             }
@@ -4404,6 +4424,30 @@ mod tests {
         );
         assert_eq!(resource_updated_uri(r#"{"jsonrpc":"2.0","id":1,"result":{}}"#), None);
         assert_eq!(resource_updated_uri("not json"), None);
+    }
+
+    #[test]
+    fn http_protocol_header_follows_the_negotiated_version() {
+        // From 2026-07-28 the MCP-Protocol-Version header MUST equal the
+        // `_meta` version in the body. A hardcoded header would disagree with the
+        // `_meta` that `set_protocol_meta` stamps, and a modern server would
+        // answer 400 HeaderMismatch (-32020) to every request. Invisible to the
+        // stdio tests, which have no headers at all (#511 review).
+        use super::{HttpTransport, Transport, MODERN_PROTOCOL_VERSION, PROTOCOL_VERSION};
+
+        let mut t = HttpTransport::new("https://example.invalid/mcp");
+        assert_eq!(
+            t.wire_protocol_version(),
+            PROTOCOL_VERSION,
+            "a legacy connection declares exactly what it always did"
+        );
+
+        t.set_protocol_meta(Some(super::protocol_meta_for(MODERN_PROTOCOL_VERSION)));
+        assert_eq!(
+            t.wire_protocol_version(),
+            MODERN_PROTOCOL_VERSION,
+            "the header must follow the negotiated version, not a constant"
+        );
     }
 
     #[test]

--- a/src-tauri/src/downstream.rs
+++ b/src-tauri/src/downstream.rs
@@ -2699,19 +2699,51 @@ impl DownstreamServer {
                 // has no such method. Confirm with `server/discover`, which every
                 // modern server MUST implement, rather than guessing from an
                 // error code the spec leaves implementation-defined.
-                let discovered = transport
-                    .request(
-                        "server/discover",
-                        json!({ "_meta": protocol_meta_for(MODERN_PROTOCOL_VERSION) }),
-                    )
-                    // The era conclusion is "legacy server that rejected our
-                    // handshake", so the initialize error is the actionable one.
-                    // Carry the probe's failure too: if discover timed out rather
-                    // than being refused, reporting only the initialize error
-                    // hides that the connect also paid a full read timeout.
-                    .map_err(|probe_err| {
-                        format!("{init_err} (server/discover probe also failed: {probe_err})")
-                    })?;
+                let probe = transport.request(
+                    "server/discover",
+                    json!({ "_meta": protocol_meta_for(MODERN_PROTOCOL_VERSION) }),
+                );
+                let discovered = match probe {
+                    Ok(discovered) => discovered,
+                    // This is the pivot of the compatibility ladder. A RECOGNIZED
+                    // modern error means the server is modern and simply does not
+                    // speak the version we declared, so the honest outcome is a
+                    // version mismatch, not "legacy server". Reporting the
+                    // `initialize` refusal here would send someone chasing a
+                    // handshake bug on a perfectly reachable modern server.
+                    Err(probe_err) if probe_err.is_modern_protocol_error() => {
+                        let offered = probe_err.supported_versions();
+                        // Retry on a mutually supported version if there is one.
+                        // Today Toolport speaks exactly one modern revision, so
+                        // this is usually a clean incompatibility, but the ladder
+                        // is written to negotiate rather than to assume.
+                        match offered.iter().find(|v| v.as_str() == MODERN_PROTOCOL_VERSION) {
+                            Some(version) => transport
+                                .request(
+                                    "server/discover",
+                                    json!({ "_meta": protocol_meta_for(version) }),
+                                )
+                                .map_err(|e| e.to_string())?,
+                            None => {
+                                return Err(format!(
+                                    "server speaks MCP {offered:?}; Toolport speaks \
+                                     {MODERN_PROTOCOL_VERSION} and cannot negotiate a \
+                                     common version ({probe_err})"
+                                ))
+                            }
+                        }
+                    }
+                    // Anything else (an unrecognized error, or silence) identifies
+                    // a legacy server, so the `initialize` refusal is the
+                    // actionable error. Carry the probe failure too: if discover
+                    // timed out rather than being refused, reporting only the
+                    // initialize error hides that connect paid a read timeout.
+                    Err(probe_err) => {
+                        return Err(format!(
+                            "{init_err} (server/discover probe also failed: {probe_err})"
+                        ))
+                    }
+                };
                 let version = choose_protocol_version(&discovered).ok_or_else(|| {
                     format!(
                         "server supports no protocol version Toolport speaks (offered {:?})",
@@ -4372,6 +4404,50 @@ mod tests {
         );
         assert_eq!(resource_updated_uri(r#"{"jsonrpc":"2.0","id":1,"result":{}}"#), None);
         assert_eq!(resource_updated_uri("not json"), None);
+    }
+
+    #[test]
+    fn forward_line_invokes_progress_sink_when_armed() {
+        // Mirrors the resource-updated sink test. Every other `forward_line` test
+        // passes an empty progress sink, so without this nothing pins that
+        // `notifications/progress` actually reaches a bound sink, and a
+        // regression that silently stopped routing progress would stay green.
+        use super::{forward_line, ProgressSink};
+        use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
+        use std::sync::{Arc, Mutex};
+
+        let seen: Arc<Mutex<Vec<Value>>> = Arc::new(Mutex::new(Vec::new()));
+        let sink_seen = Arc::clone(&seen);
+        let sink: ProgressSink = Arc::new(move |note| {
+            sink_seen.lock().unwrap().push(note);
+        });
+        let dirty = Some(Arc::new(AtomicU8::new(0)));
+        let armed = Arc::new(AtomicBool::new(false));
+        let (tx, rx) = std::sync::mpsc::channel();
+        let no_sink = None;
+        let progress = Arc::new(Mutex::new(Some(sink)));
+        let line = r#"{"jsonrpc":"2.0","method":"notifications/progress","params":{"progressToken":"tp-1","progress":1,"total":2}}"#;
+
+        // Unarmed (still in the handshake window): forwarded, but not routed.
+        assert!(forward_line(line.to_string(), &tx, &dirty, &armed, &no_sink, &progress));
+        assert!(seen.lock().unwrap().is_empty());
+        assert_eq!(rx.recv().unwrap(), line);
+
+        // Armed: the sink receives the whole notification, token included.
+        armed.store(true, Ordering::SeqCst);
+        assert!(forward_line(line.to_string(), &tx, &dirty, &armed, &no_sink, &progress));
+        let got = seen.lock().unwrap().clone();
+        assert_eq!(got.len(), 1);
+        assert_eq!(got[0]["params"]["progressToken"], "tp-1");
+        // Not a list change, so no dirty bit.
+        assert_eq!(dirty.as_ref().unwrap().load(Ordering::SeqCst), 0);
+        assert_eq!(rx.recv().unwrap(), line);
+
+        // A progress notification with no token is unroutable and never reaches
+        // the sink, so the gateway is not woken for something it must drop.
+        let untokened = r#"{"jsonrpc":"2.0","method":"notifications/progress","params":{"progress":1}}"#;
+        assert!(forward_line(untokened.to_string(), &tx, &dirty, &armed, &no_sink, &progress));
+        assert_eq!(seen.lock().unwrap().len(), 1, "still just the one");
     }
 
     #[test]

--- a/src-tauri/src/downstream.rs
+++ b/src-tauri/src/downstream.rs
@@ -24,6 +24,83 @@ use serde_json::{json, Value};
 
 pub const PROTOCOL_VERSION: &str = "2025-06-18";
 
+/// `_meta` keys that describe a single client-to-server hop and therefore must
+/// NOT be relayed onward (SOU-444).
+///
+/// Toolport is the *client* on the downstream hop, so it speaks for itself
+/// there: the version it negotiated with that particular server, its own
+/// identity, and the capabilities it can actually service. Relaying the upstream
+/// client's values would assert claims Toolport cannot honour - advertising a
+/// sampling capability, say, that the gateway would then have to service on the
+/// client's behalf. SOU-445/SOU-446 replace these with Toolport's own per-
+/// connection values rather than simply omitting them.
+pub const PER_HOP_META_KEYS: [&str; 3] = [
+    "io.modelcontextprotocol/protocolVersion",
+    "io.modelcontextprotocol/clientInfo",
+    "io.modelcontextprotocol/clientCapabilities",
+];
+
+/// `progressToken` is deliberately withheld for now. The stdio read loop drops
+/// every notification it does not recognise, so `notifications/progress` from a
+/// downstream server currently goes nowhere. Relaying the token would invite
+/// that traffic into a black hole and could push a server into a streaming mode
+/// for a client that will never see the updates. Released in the second half of
+/// SOU-444, once progress notifications can be routed back to the originating
+/// request.
+const WITHHELD_META_KEYS: [&str; 1] = ["progressToken"];
+
+/// The part of an upstream client's `_meta` that may travel downstream.
+///
+/// MCP's `_meta` is an open map: OpenTelemetry trace context, extension
+/// namespaces, and (from 2026-07-28) protocol version, client identity, and
+/// capabilities all ride here. Everything that is not per-hop or explicitly
+/// withheld is relayed untouched, including keys this build has never heard of -
+/// that is what keeps Toolport from silently breaking future extensions.
+///
+/// Returns `None` when nothing survives, so the outgoing params keep their
+/// historical shape byte-for-byte.
+pub fn relayable_meta(meta: Option<&Value>) -> Option<Value> {
+    let obj = meta?.as_object()?;
+    let kept: serde_json::Map<String, Value> = obj
+        .iter()
+        .filter(|(k, _)| {
+            !PER_HOP_META_KEYS.contains(&k.as_str()) && !WITHHELD_META_KEYS.contains(&k.as_str())
+        })
+        .map(|(k, v)| (k.clone(), v.clone()))
+        .collect();
+    (!kept.is_empty()).then(|| Value::Object(kept))
+}
+
+/// Apply the same per-hop discipline to a params object that is forwarded
+/// wholesale rather than rebuilt.
+///
+/// `completion/complete` is the one request Toolport already relayed verbatim
+/// (`Router::resolve_completion` clones the client's params and rewrites only
+/// `ref`), so without this it would leak per-hop keys the rebuilt paths strip.
+pub fn sanitize_forwarded_meta(params: &mut Value) {
+    let Some(obj) = params.as_object_mut() else {
+        return;
+    };
+    if !obj.contains_key("_meta") {
+        return;
+    }
+    match relayable_meta(obj.get("_meta")) {
+        Some(kept) => obj.insert("_meta".to_string(), kept),
+        None => obj.remove("_meta"),
+    };
+}
+
+/// Attach relayed `_meta` to an outgoing params object.
+///
+/// A request carrying no relayable metadata is left exactly as Toolport built it
+/// before SOU-444, so existing downstream servers see no change whatsoever.
+fn with_meta(mut params: Value, meta: Option<&Value>) -> Value {
+    if let Some(relayed) = relayable_meta(meta) {
+        params["_meta"] = relayed;
+    }
+    params
+}
+
 /// Max time to wait for a single stdio response before giving up. Without this a
 /// server that never replies would block its thread (and the batch health probe)
 /// forever.
@@ -2492,34 +2569,42 @@ impl DownstreamServer {
     }
 
     pub fn call(&mut self, tool: &str, arguments: Value) -> Result<Value, TransportError> {
-        self.call_with_cancel(tool, arguments, None)
+        self.call_with_cancel(tool, arguments, None, None)
     }
 
+    /// `meta` is the upstream client's `params._meta`, relayed downstream minus
+    /// the per-hop keys (SOU-444). `None` for calls Toolport originates itself,
+    /// such as a code-mode script step, which have no client request behind them.
     pub fn call_with_cancel(
         &mut self,
         tool: &str,
         arguments: Value,
         cancel: Option<CancelContext>,
+        meta: Option<&Value>,
     ) -> Result<Value, TransportError> {
         self.transport.request_with_cancel(
             "tools/call",
-            json!({ "name": tool, "arguments": arguments }),
+            with_meta(json!({ "name": tool, "arguments": arguments }), meta),
             cancel,
         )
     }
 
     /// Read one resource by its (original, downstream) uri.
     pub fn read_resource(&mut self, uri: &str) -> Result<Value, TransportError> {
-        self.read_resource_with_cancel(uri, None)
+        self.read_resource_with_cancel(uri, None, None)
     }
 
     pub fn read_resource_with_cancel(
         &mut self,
         uri: &str,
         cancel: Option<CancelContext>,
+        meta: Option<&Value>,
     ) -> Result<Value, TransportError> {
-        self.transport
-            .request_with_cancel("resources/read", json!({ "uri": uri }), cancel)
+        self.transport.request_with_cancel(
+            "resources/read",
+            with_meta(json!({ "uri": uri }), meta),
+            cancel,
+        )
     }
 
     /// Subscribe to `notifications/resources/updated` for one resource URI on
@@ -2538,7 +2623,7 @@ impl DownstreamServer {
 
     /// Get one prompt by its (original, downstream) name.
     pub fn get_prompt(&mut self, name: &str, arguments: Value) -> Result<Value, TransportError> {
-        self.get_prompt_with_cancel(name, arguments, None)
+        self.get_prompt_with_cancel(name, arguments, None, None)
     }
 
     pub fn get_prompt_with_cancel(
@@ -2546,10 +2631,11 @@ impl DownstreamServer {
         name: &str,
         arguments: Value,
         cancel: Option<CancelContext>,
+        meta: Option<&Value>,
     ) -> Result<Value, TransportError> {
         self.transport.request_with_cancel(
             "prompts/get",
-            json!({ "name": name, "arguments": arguments }),
+            with_meta(json!({ "name": name, "arguments": arguments }), meta),
             cancel,
         )
     }

--- a/src-tauri/src/downstream.rs
+++ b/src-tauri/src/downstream.rs
@@ -4590,13 +4590,20 @@ mod tests {
 
         struct Ladder {
             responses: VecDeque<Result<Value, TransportError>>,
-            /// Every version stamped via `set_protocol_meta`, in order. A real
-            /// transport turns this into the `MCP-Protocol-Version` header and the
-            /// body `_meta`, which MUST agree; the mock records it instead.
-            stamped: Arc<Mutex<Vec<Option<String>>>>,
+            /// Stamps AND requests, interleaved in call order.
+            ///
+            /// Counting stamps alone cannot express the claim. `connect` stamps
+            /// three times on this path (before the probe, for the retry, and
+            /// after `choose_protocol_version`), so a `len() >= 2` floor still
+            /// held with the retry stamp deleted - and since the negotiate branch
+            /// can only ever select `MODERN_PROTOCOL_VERSION`, asserting every
+            /// stamp equals it was a tautology. What matters is ORDER: a stamp
+            /// has to fall between the two `server/discover` sends (#511 review).
+            events: Arc<Mutex<Vec<String>>>,
         }
         impl Transport for Ladder {
-            fn request(&mut self, _method: &str, _params: Value) -> Result<Value, TransportError> {
+            fn request(&mut self, method: &str, _params: Value) -> Result<Value, TransportError> {
+                self.events.lock().unwrap().push(format!("send:{method}"));
                 self.responses.pop_front().expect("a response per request")
             }
             fn notify(&mut self, _m: &str, _p: Value) -> Result<(), TransportError> {
@@ -4607,14 +4614,15 @@ mod tests {
                     .as_ref()
                     .and_then(|m| m.get("io.modelcontextprotocol/protocolVersion"))
                     .and_then(Value::as_str)
-                    .map(str::to_string);
-                self.stamped.lock().unwrap().push(version);
+                    .unwrap_or("<none>")
+                    .to_string();
+                self.events.lock().unwrap().push(format!("stamp:{version}"));
             }
         }
 
-        let stamped = Arc::new(Mutex::new(Vec::new()));
+        let events = Arc::new(Mutex::new(Vec::new()));
         let transport = Ladder {
-            stamped: Arc::clone(&stamped),
+            events: Arc::clone(&events),
             responses: VecDeque::from(vec![
                 // initialize: refused, as a modern server must.
                 Err(TransportError::Rpc(json!({ "code": -32601, "message": "no initialize" }))),
@@ -4642,14 +4650,26 @@ mod tests {
         // The retry must RE-stamp before sending, so the header and the body
         // `_meta` still agree on the newly chosen version. Skipping that would
         // send the rejected version again and draw the same error forever.
-        let stamped = stamped.lock().unwrap();
-        assert!(
-            stamped.len() >= 2,
-            "expected a stamp before the probe and again before the retry, got {stamped:?}"
+        //
+        // Asserted positionally: find the two `server/discover` sends and require
+        // a stamp strictly between them. A count-based assertion cannot see this,
+        // because the stamps either side of the retry are made unconditionally.
+        let events = events.lock().unwrap();
+        let discovers: Vec<usize> = events
+            .iter()
+            .enumerate()
+            .filter(|(_, e)| e.as_str() == "send:server/discover")
+            .map(|(i, _)| i)
+            .collect();
+        assert_eq!(
+            discovers.len(),
+            2,
+            "expected the probe and one negotiated retry, got {events:?}"
         );
+        let expected = format!("stamp:{MODERN_PROTOCOL_VERSION}");
         assert!(
-            stamped.iter().all(|v| v.as_deref() == Some(MODERN_PROTOCOL_VERSION)),
-            "every stamp must name the version actually being sent, got {stamped:?}"
+            events[discovers[0] + 1..discovers[1]].iter().any(|e| *e == expected),
+            "the retry must re-stamp between the two sends, got {events:?}"
         );
     }
 

--- a/src-tauri/src/downstream.rs
+++ b/src-tauri/src/downstream.rs
@@ -30,6 +30,63 @@ use serde_json::{json, Value};
 
 pub const PROTOCOL_VERSION: &str = "2025-06-18";
 
+/// Which protocol era a downstream connection settled on (SOU-445).
+///
+/// Replaces the single global [`PROTOCOL_VERSION`] for anything that needs to
+/// know how to talk to a *particular* server: Toolport can hold connections in
+/// both eras at once, and must translate between them when the upstream client's
+/// era differs from a downstream server's.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Era {
+    /// Opened with an `initialize` handshake; the version was negotiated once for
+    /// the whole connection (2025-11-25 and earlier).
+    Legacy { version: String },
+    /// No handshake: version, identity, and capabilities ride on every request's
+    /// `_meta` (2026-07-28 and later).
+    Modern { version: String },
+}
+
+impl Era {
+    pub fn version(&self) -> &str {
+        match self {
+            Era::Legacy { version } | Era::Modern { version } => version,
+        }
+    }
+
+    pub fn is_modern(&self) -> bool {
+        matches!(self, Era::Modern { .. })
+    }
+}
+
+/// Pick a protocol version from a `DiscoverResult`, preferring the newest
+/// revision Toolport implements.
+fn choose_protocol_version(discovered: &Value) -> Option<String> {
+    let supported: Vec<&str> = discovered
+        .get("supportedVersions")
+        .and_then(Value::as_array)?
+        .iter()
+        .filter_map(Value::as_str)
+        .collect();
+    supported
+        .iter()
+        .find(|v| **v == MODERN_PROTOCOL_VERSION)
+        .map(|v| (*v).to_string())
+}
+
+/// Every MCP revision Toolport can speak to a downstream server, newest first.
+///
+/// `2026-07-28` and later are "modern": no handshake, with version, identity and
+/// capabilities carried as per-request `_meta`. Everything earlier is "legacy"
+/// and opens with `initialize`. Toolport is dual-era, so it must drive both.
+pub const MODERN_PROTOCOL_VERSION: &str = "2026-07-28";
+
+/// Error codes the 2026-07-28 allocation policy reserves for the specification
+/// (`-32020`..`-32099`). Their presence in a response is what identifies a modern
+/// server during the backward-compatibility probe.
+pub const HEADER_MISMATCH: i64 = -32020;
+pub const MISSING_REQUIRED_CLIENT_CAPABILITY: i64 = -32021;
+pub const UNSUPPORTED_PROTOCOL_VERSION: i64 = -32022;
+
 /// `_meta` keys that describe a single client-to-server hop and therefore must
 /// NOT be relayed onward (SOU-444).
 ///
@@ -107,6 +164,43 @@ fn with_meta(mut params: Value, meta: Option<&Value>) -> Value {
     params
 }
 
+/// Merge the connection's standard protocol `_meta` into an outgoing request.
+///
+/// Applied by the transport, so every request gets it regardless of which call
+/// site built the params. Protocol keys win over anything already present:
+/// they describe *this* hop, and Toolport owns them (SOU-445).
+fn merge_protocol_meta(params: &mut Value, protocol: &Value) {
+    let (Some(obj), Some(protocol)) = (params.as_object_mut(), protocol.as_object()) else {
+        return;
+    };
+    let slot = obj
+        .entry("_meta")
+        .or_insert_with(|| Value::Object(serde_json::Map::new()));
+    if !slot.is_object() {
+        *slot = Value::Object(serde_json::Map::new());
+    }
+    if let Some(meta) = slot.as_object_mut() {
+        for (key, value) in protocol {
+            meta.insert(key.clone(), value.clone());
+        }
+    }
+}
+
+/// The standard `_meta` a modern (2026-07-28+) connection puts on every request.
+fn protocol_meta_for(version: &str) -> Value {
+    json!({
+        "io.modelcontextprotocol/protocolVersion": version,
+        "io.modelcontextprotocol/clientInfo": {
+            "name": "toolport-gateway",
+            "version": env!("CARGO_PKG_VERSION")
+        },
+        // Toolport speaks for itself on this hop. It advertises no client
+        // capabilities of its own yet; SOU-449 fills these in once MRTR lets the
+        // gateway service sampling/elicitation on a client's behalf.
+        "io.modelcontextprotocol/clientCapabilities": {}
+    })
+}
+
 /// Max time to wait for a single stdio response before giving up. Without this a
 /// server that never replies would block its thread (and the batch health probe)
 /// forever.
@@ -166,6 +260,13 @@ pub enum TransportError {
     /// responded with an error (or the response was structurally invalid). Does NOT
     /// count against server health - a bad tool call is not a dead server.
     Fatal(String),
+    /// The server returned a JSON-RPC *error object*, preserved structurally.
+    ///
+    /// Previously these were flattened with `Fatal(err.to_string())`, which threw
+    /// away the `code`. The 2026-07-28 era probe branches on exactly that code, so
+    /// it has to survive (SOU-445). Treated like `Fatal` everywhere else: an error
+    /// response is not a health failure.
+    Rpc(Value),
     /// The server is unreachable or unresponsive (a read timed out, or the connection
     /// died). Distinct from `Fatal` so the circuit breaker can trip on a genuinely
     /// dead/hung server without counting ordinary error responses against it.
@@ -376,8 +477,59 @@ impl TransportError {
     /// True if this reflects the server being unreachable/unhealthy (timeout, dead
     /// connection, or exhausted connection/rate-limit retries) rather than a normal
     /// protocol or application error. Only these trip the per-server circuit breaker.
+    ///
+    /// [`TransportError::Rpc`] is deliberately excluded, same as [`TransportError::Fatal`]:
+    /// a server that answers with an error response is alive and well-behaved.
     pub fn is_health_failure(&self) -> bool {
         matches!(self, TransportError::Unavailable(_) | TransportError::Retry { .. })
+    }
+
+    /// The JSON-RPC `code`, when the failure was an error *response* from the
+    /// server rather than a transport problem.
+    ///
+    /// The 2026-07-28 compatibility ladder is defined entirely in terms of this
+    /// code, which is why the error object is preserved structurally instead of
+    /// being flattened into a message string (SOU-445).
+    pub fn rpc_code(&self) -> Option<i64> {
+        match self {
+            TransportError::Rpc(err) => err.get("code").and_then(Value::as_i64),
+            _ => None,
+        }
+    }
+
+    /// True when the server answered with an error only a *modern* (2026-07-28 or
+    /// later) implementation produces.
+    ///
+    /// This is the pivot of the backward-compatibility probe: a recognized modern
+    /// error means the server IS modern and the client must correct the request
+    /// (usually by retrying with a mutually supported version) rather than
+    /// falling back to the legacy `initialize` handshake. Anything else - an
+    /// unrecognized error, or no response at all - identifies a legacy server.
+    pub fn is_modern_protocol_error(&self) -> bool {
+        matches!(
+            self.rpc_code(),
+            Some(HEADER_MISMATCH)
+                | Some(MISSING_REQUIRED_CLIENT_CAPABILITY)
+                | Some(UNSUPPORTED_PROTOCOL_VERSION)
+        )
+    }
+
+    /// Protocol versions a server advertised in an `UnsupportedProtocolVersionError`.
+    pub fn supported_versions(&self) -> Vec<String> {
+        let TransportError::Rpc(err) = self else {
+            return Vec::new();
+        };
+        err.get("data")
+            .and_then(|d| d.get("supported"))
+            .and_then(Value::as_array)
+            .map(|versions| {
+                versions
+                    .iter()
+                    .filter_map(Value::as_str)
+                    .map(str::to_string)
+                    .collect()
+            })
+            .unwrap_or_default()
     }
 }
 
@@ -385,6 +537,9 @@ impl std::fmt::Display for TransportError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             TransportError::Fatal(msg) => write!(f, "{msg}"),
+            // Rendered exactly as the flattened form was, so nothing user-facing
+            // changes now that the error is carried structurally.
+            TransportError::Rpc(err) => write!(f, "{err}"),
             TransportError::Unavailable(msg) => write!(f, "{msg}"),
             TransportError::Retry { message, .. } => write!(f, "{message}"),
         }
@@ -651,6 +806,15 @@ pub fn is_server_initiated_request(v: &Value) -> bool {
 /// A bidirectional JSON-RPC channel to one downstream server.
 pub trait Transport: Send {
     fn request(&mut self, method: &str, params: Value) -> Result<Value, TransportError>;
+    /// Standard per-request `_meta` to merge into every outgoing request.
+    ///
+    /// From 2026-07-28 there is no handshake: each request carries its own
+    /// protocol version, client identity, and client capabilities. Setting it
+    /// once here means every call site - `fetch_paginated_list`, `tools/call`,
+    /// `resources/read`, and anything added later - gets it without repeating
+    /// the merge. Default no-op, so legacy connections send exactly what they
+    /// always did (SOU-445).
+    fn set_protocol_meta(&mut self, _meta: Option<Value>) {}
     fn request_with_cancel(
         &mut self,
         method: &str,
@@ -1310,6 +1474,9 @@ pub struct StdioTransport {
     /// (SOU-444). Shared with the stdout drain thread so the gateway can bind it
     /// after the transport is spawned, keeping `spawn_watched`'s signature stable.
     progress: Arc<Mutex<Option<ProgressSink>>>,
+    /// Standard per-request `_meta` for a modern (2026-07-28+) connection, merged
+    /// into every outgoing request. `None` on legacy connections (SOU-445).
+    protocol_meta: Option<Value>,
 }
 
 /// Owns a Windows Job Object configured to terminate every assigned process
@@ -1757,6 +1924,7 @@ impl StdioTransport {
             launcher: is_download_launcher(command, args),
             server_handler: None,
             progress,
+            protocol_meta: None,
         })
     }
 
@@ -1810,6 +1978,10 @@ impl Transport for StdioTransport {
         let id = self.next_id;
         self.next_id += 1;
         let downstream_id = json!(id);
+        let mut params = params;
+        if let Some(protocol) = &self.protocol_meta {
+            merge_protocol_meta(&mut params, protocol);
+        }
         let msg = json!({ "jsonrpc": "2.0", "id": downstream_id.clone(), "method": method, "params": params });
 
         // A broken stdin pipe means the child is gone: a health failure, not a protocol error.
@@ -1901,7 +2073,7 @@ impl Transport for StdioTransport {
             }
             if ids_match(value.get("id"), Some(&json!(id))) {
                 if let Some(err) = value.get("error") {
-                    return Err(TransportError::Fatal(err.to_string()));
+                    return Err(TransportError::Rpc(err.clone()));
                 }
                 return Ok(value.get("result").cloned().unwrap_or(Value::Null));
             }
@@ -1936,6 +2108,10 @@ impl Transport for StdioTransport {
 
     fn set_server_request_handler(&mut self, handler: ServerRequestHandler) {
         self.server_handler = Some(handler);
+    }
+
+    fn set_protocol_meta(&mut self, meta: Option<Value>) {
+        self.protocol_meta = meta;
     }
 }
 
@@ -2105,6 +2281,9 @@ pub struct HttpTransport {
     /// Route `notifications/progress` seen mid-SSE back to the client that minted
     /// the token (SOU-444).
     progress: Option<ProgressSink>,
+    /// Standard per-request `_meta` for a modern (2026-07-28+) connection, merged
+    /// into every outgoing request. `None` on legacy connections (SOU-445).
+    protocol_meta: Option<Value>,
 }
 
 impl HttpTransport {
@@ -2150,6 +2329,7 @@ impl HttpTransport {
             server_handler: None,
             resource_updated: None,
             progress: None,
+            protocol_meta: None,
         }
     }
 
@@ -2415,10 +2595,14 @@ impl Transport for HttpTransport {
     fn request(&mut self, method: &str, params: Value) -> Result<Value, TransportError> {
         let id = self.next_id;
         self.next_id += 1;
+        let mut params = params;
+        if let Some(protocol) = &self.protocol_meta {
+            merge_protocol_meta(&mut params, protocol);
+        }
         let body = json!({ "jsonrpc": "2.0", "id": id, "method": method, "params": params });
         let resp = self.post(&body, true)?.ok_or_else(|| TransportError::Fatal("empty response".to_string()))?;
         if let Some(err) = resp.get("error") {
-            return Err(TransportError::Fatal(err.to_string()));
+            return Err(TransportError::Rpc(err.clone()));
         }
         Ok(resp.get("result").cloned().unwrap_or(Value::Null))
     }
@@ -2431,6 +2615,10 @@ impl Transport for HttpTransport {
 
     fn set_server_request_handler(&mut self, handler: ServerRequestHandler) {
         self.server_handler = Some(handler);
+    }
+
+    fn set_protocol_meta(&mut self, meta: Option<Value>) {
+        self.protocol_meta = meta;
     }
 }
 
@@ -2452,6 +2640,8 @@ pub struct DownstreamServer {
     caps_prompts: bool,
     /// Whether the server's `initialize` advertised the completions utility.
     caps_completions: bool,
+    /// The protocol era this connection settled on at handshake (SOU-445).
+    era: Era,
 }
 
 impl DownstreamServer {
@@ -2468,19 +2658,69 @@ impl DownstreamServer {
         // before the server can answer at all.
         let handshake_timeout = transport.connect_timeout();
         transport.set_read_timeout(handshake_timeout);
-        let init = transport.request(
+
+        // Era detection (SOU-445). Toolport is dual-era: it must drive both
+        // `initialize`-era servers and modern stateless ones.
+        //
+        // We try `initialize` FIRST and fall forward, rather than probing with
+        // `server/discover` first as the spec suggests. The spec's ordering is a
+        // SHOULD, and for Toolport it is the wrong trade today: essentially every
+        // installed server is legacy, and a legacy stdio server typically answers
+        // an unknown method with silence rather than an error - so a discover-first
+        // probe would charge every existing user a read-timeout on every connect.
+        // Going legacy-first costs the existing install base exactly nothing and
+        // costs a modern server one cheap rejected request. Worth revisiting once
+        // modern servers are common.
+        let (era, caps) = match transport.request(
             "initialize",
             json!({
                 "protocolVersion": PROTOCOL_VERSION,
                 "capabilities": {},
                 "clientInfo": { "name": "toolport-gateway", "version": env!("CARGO_PKG_VERSION") }
             }),
-        ).map_err(|e| e.to_string())?;
-        let caps = init.get("capabilities");
+        ) {
+            Ok(init) => {
+                let version = init
+                    .get("protocolVersion")
+                    .and_then(Value::as_str)
+                    .unwrap_or(PROTOCOL_VERSION)
+                    .to_string();
+                let caps = init.get("capabilities").cloned();
+                transport
+                    .notify("notifications/initialized", json!({}))
+                    .map_err(|e| e.to_string())?;
+                (Era::Legacy { version }, caps)
+            }
+            // A dead or unresponsive server is not a modern server. Probing it
+            // again would just double the wait before reporting the same failure.
+            Err(err) if err.is_health_failure() => return Err(err.to_string()),
+            Err(init_err) => {
+                // The server answered, but refused `initialize`. A modern server
+                // has no such method. Confirm with `server/discover`, which every
+                // modern server MUST implement, rather than guessing from an
+                // error code the spec leaves implementation-defined.
+                let discovered = transport
+                    .request(
+                        "server/discover",
+                        json!({ "_meta": protocol_meta_for(MODERN_PROTOCOL_VERSION) }),
+                    )
+                    .map_err(|_| init_err.to_string())?;
+                let version = choose_protocol_version(&discovered).ok_or_else(|| {
+                    format!(
+                        "server supports no protocol version Toolport speaks (offered {:?})",
+                        discovered.get("supportedVersions")
+                    )
+                })?;
+                // From here every request carries its own protocol metadata;
+                // there is no handshake and no `notifications/initialized`.
+                transport.set_protocol_meta(Some(protocol_meta_for(&version)));
+                (Era::Modern { version }, discovered.get("capabilities").cloned())
+            }
+        };
+        let caps = caps.as_ref();
         let caps_resources = caps.and_then(|c| c.get("resources")).is_some();
         let caps_prompts = caps.and_then(|c| c.get("prompts")).is_some();
         let caps_completions = caps.and_then(|c| c.get("completions")).is_some();
-        transport.notify("notifications/initialized", json!({})).map_err(|e| e.to_string())?;
 
         // `initialize` answered, so any launcher download is done: the rest of the
         // handshake goes back to the tight budget - a server that comes up but then
@@ -2509,6 +2749,7 @@ impl DownstreamServer {
             caps_resources,
             caps_prompts,
             caps_completions,
+            era,
         })
     }
 
@@ -2724,6 +2965,11 @@ impl DownstreamServer {
     /// Whether this server advertised the completions utility at initialize.
     pub fn supports_completions(&self) -> bool {
         self.caps_completions
+    }
+
+    /// The protocol era and version this connection negotiated (SOU-445).
+    pub fn era(&self) -> &Era {
+        &self.era
     }
 
     /// Forward a `completion/complete` request. `params` must already use the
@@ -2960,6 +3206,7 @@ mod tests {
             caps_resources: false,
             caps_prompts: false,
             caps_completions: false,
+            era: super::Era::Legacy { version: super::PROTOCOL_VERSION.to_string() },
         };
         server.refresh_tools();
         assert_eq!(server.tools, vec![json!({"name":"stable"})]);
@@ -2984,6 +3231,7 @@ mod tests {
             caps_resources: true,
             caps_prompts: false,
             caps_completions: false,
+            era: super::Era::Legacy { version: super::PROTOCOL_VERSION.to_string() },
         };
         server.refresh_resources();
         assert_eq!(server.resources, vec![json!({"uri":"r:"})]);

--- a/src-tauri/src/downstream.rs
+++ b/src-tauri/src/downstream.rs
@@ -2290,7 +2290,8 @@ pub struct HttpTransport {
     /// `None` or error keeps the current token; a forced refresh must return a new
     /// raw token or the authentication failure is surfaced.
     refresh: Option<RefreshFn>,
-    /// The token a forced refresh last produced, if any.
+    /// The token a forced refresh produced and that has not yet been accepted by
+    /// the server, if any.
     ///
     /// The forced-refresh budget is per *token*, not per call. A 401 answered by
     /// minting a fresh token, where that fresh token then 401s too, is not an
@@ -2299,9 +2300,13 @@ pub struct HttpTransport {
     /// link in the chain. Connect alone posts twice (`initialize`, then the
     /// `server/discover` era probe), so a per-call budget spends two (SOU-474).
     ///
-    /// Cleared implicitly: once a proactive refresh swaps in a different token,
-    /// `auth` no longer matches this and the budget is available again, so a
-    /// long-lived session still self-heals when its token later expires.
+    /// Cleared as soon as any request comes back 2xx, which is what makes this a
+    /// budget rather than a latch. Relying on a proactive refresh to clear it was
+    /// wrong: a provider that omits `expires_in` has no deadline, so
+    /// `refresh_before_send` never fires, and the connection would 401 forever
+    /// with a working refresh token in the vault - the exact case the reactive
+    /// fallback exists to serve. Only a token the server has never accepted keeps
+    /// the budget spent.
     forced_refresh_token: Option<String>,
     server_handler: Option<ServerRequestHandler>,
     /// Fan `notifications/resources/updated` seen mid-SSE to subscribed
@@ -2628,6 +2633,9 @@ impl HttpTransport {
                 Err(e) => return Err(TransportError::Fatal(e.to_string())),
             }
         };
+        // The server accepted this token, so its forced-refresh budget is spent
+        // on nothing and must be returned. See [`Self::forced_refresh_token`].
+        self.forced_refresh_token = None;
 
         if let Some(sid) = resp.header("Mcp-Session-Id") {
             self.session_id = Some(sid.to_string());
@@ -5087,6 +5095,94 @@ mod tests {
         // 401, refresh, 401(retry) on the first post; the second post sends once
         // and gives up without minting anything.
         assert_eq!(posts.load(Ordering::SeqCst), 3, "no retry on the second POST");
+    }
+
+    #[test]
+    fn an_accepted_token_returns_its_forced_refresh_budget() {
+        // The per-token budget must be a budget, not a latch. A provider that
+        // omits `expires_in` has no deadline, so `refresh_before_send` never
+        // fires and `auth` can only ever change via a FORCED refresh. Keying the
+        // budget to the token and clearing it only on a proactive swap therefore
+        // wedged the connection: after one successful reactive refresh, the next
+        // expiry 401s forever with a working refresh token sitting in the vault.
+        //
+        // `Fatal` is not a health failure, so the breaker never trips and nothing
+        // reconnects - every later call to that server fails for the life of the
+        // process. Clearing on 2xx is what makes it recoverable (SOU-474 review).
+        use super::{HttpTransport, RefreshFn};
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use std::sync::Arc;
+
+        // Models a short-lived token: a freshly minted one works exactly once and
+        // is stale by the next request, so two successive expiries occur with no
+        // `expires_in` for the proactive path to act on.
+        let server = tiny_http::Server::http("127.0.0.1:0").unwrap();
+        let port = server.server_addr().to_ip().unwrap().port();
+        let stop = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let sc = Arc::clone(&stop);
+        let handle = std::thread::spawn(move || {
+            let mut spent: std::collections::HashSet<String> = std::collections::HashSet::new();
+            while !sc.load(Ordering::SeqCst) {
+                let req = match server.recv_timeout(std::time::Duration::from_millis(50)) {
+                    Ok(Some(req)) => req,
+                    Ok(None) => continue,
+                    Err(_) => return,
+                };
+                let auth = req
+                    .headers()
+                    .iter()
+                    .find(|h| h.field.equiv("Authorization"))
+                    .map(|h| h.value.as_str().to_string())
+                    .unwrap_or_default();
+                if auth.starts_with("Bearer minted-") && spent.insert(auth.clone()) {
+                    let ct = tiny_http::Header::from_bytes(
+                        &b"Content-Type"[..],
+                        &b"application/json"[..],
+                    )
+                    .unwrap();
+                    let body = r#"{"jsonrpc":"2.0","id":1,"result":{"ok":true}}"#;
+                    let _ = req.respond(tiny_http::Response::from_string(body).with_header(ct));
+                } else {
+                    let _ = req
+                        .respond(tiny_http::Response::from_string("nope").with_status_code(401));
+                }
+            }
+        });
+
+        let forced = Arc::new(AtomicUsize::new(0));
+        let fc = Arc::clone(&forced);
+        // No proactive deadline: the non-forced arm always declines, exactly like
+        // a provider that reported no `expires_in`.
+        let refresh: Option<RefreshFn> = Some(Box::new(move |force| {
+            if force {
+                let n = fc.fetch_add(1, Ordering::SeqCst);
+                Ok(Some(format!("minted-{n}")))
+            } else {
+                Ok(None)
+            }
+        }));
+
+        let url = format!("http://127.0.0.1:{port}/");
+        let mut t = HttpTransport::with_auth_refresh(&url, Some("stale".to_string()), refresh);
+        let body = serde_json::json!({ "jsonrpc": "2.0", "id": 1, "method": "ping" });
+
+        // First expiry: 401, forced refresh to minted-0, retry accepted.
+        assert!(t.post(&body, true).is_ok(), "first reactive refresh recovers");
+        // The accepted token is now stale at the provider (it is not minted-1),
+        // so this 401s. The budget must be available again to recover.
+        assert!(
+            t.post(&body, true).is_ok(),
+            "a second expiry must still be recoverable; the budget latched shut"
+        );
+        drop(t);
+        stop.store(true, Ordering::SeqCst);
+        let _ = handle.join();
+
+        assert_eq!(
+            forced.load(Ordering::SeqCst),
+            2,
+            "one forced exchange per expiry, and the second must actually happen"
+        );
     }
 
     #[test]

--- a/src-tauri/src/downstream.rs
+++ b/src-tauri/src/downstream.rs
@@ -2290,6 +2290,19 @@ pub struct HttpTransport {
     /// `None` or error keeps the current token; a forced refresh must return a new
     /// raw token or the authentication failure is surfaced.
     refresh: Option<RefreshFn>,
+    /// The token a forced refresh last produced, if any.
+    ///
+    /// The forced-refresh budget is per *token*, not per call. A 401 answered by
+    /// minting a fresh token, where that fresh token then 401s too, is not an
+    /// expiry problem, so refreshing again cannot help - and against a provider
+    /// that rotates the refresh token on use, each needless exchange consumes a
+    /// link in the chain. Connect alone posts twice (`initialize`, then the
+    /// `server/discover` era probe), so a per-call budget spends two (SOU-474).
+    ///
+    /// Cleared implicitly: once a proactive refresh swaps in a different token,
+    /// `auth` no longer matches this and the budget is available again, so a
+    /// long-lived session still self-heals when its token later expires.
+    forced_refresh_token: Option<String>,
     server_handler: Option<ServerRequestHandler>,
     /// Fan `notifications/resources/updated` seen mid-SSE to subscribed
     /// upstream clients (SOU-394 follow-up for remote downstreams).
@@ -2342,6 +2355,7 @@ impl HttpTransport {
             next_id: 1,
             auth,
             refresh,
+            forced_refresh_token: None,
             server_handler: None,
             resource_updated: None,
             progress: None,
@@ -2406,6 +2420,12 @@ impl HttpTransport {
         }
     }
 
+    /// True when the token currently in hand is one a forced refresh already
+    /// produced, so its one forced exchange is spent. See [`Self::forced_refresh_token`].
+    fn forced_refresh_spent(&self) -> bool {
+        self.auth.is_some() && self.auth == self.forced_refresh_token
+    }
+
     fn force_refresh_after_auth_error(&mut self, code: u16) -> Result<(), TransportError> {
         let Some(refresh) = self.refresh.as_ref() else {
             return Err(TransportError::Fatal(format!(
@@ -2414,7 +2434,10 @@ impl HttpTransport {
         };
         match refresh(true) {
             Ok(Some(token)) => {
-                self.auth = Some(token);
+                self.auth = Some(token.clone());
+                // Spend the budget for this token, so a later POST on the same
+                // connection does not force a second exchange for it (SOU-474).
+                self.forced_refresh_token = Some(token);
                 Ok(())
             }
             Ok(None) => Err(TransportError::Fatal(format!(
@@ -2430,7 +2453,7 @@ impl HttpTransport {
     fn send_post_no_response(&mut self, body: &Value) -> Result<(), TransportError> {
         let payload = body.to_string();
         self.refresh_before_send();
-        let mut refreshed = false;
+        let mut refreshed = self.forced_refresh_spent();
         let wire_version = self.wire_protocol_version();
         let resp = loop {
             let mut req = self
@@ -2543,7 +2566,10 @@ impl HttpTransport {
         // Token refresh is handled internally (it doesn't sleep, so no lock
         // contention). Only 429 and transport-retry signals bubble up as
         // TransportError::Retry so the Router can sleep *outside* the lock.
-        let mut refreshed = false;
+        // Per-token, not per-call: connect alone posts twice (`initialize`, then
+        // the `server/discover` era probe) and must not spend two forced
+        // exchanges on one expired token (SOU-474).
+        let mut refreshed = self.forced_refresh_spent();
         let wire_version = self.wire_protocol_version();
         let resp = loop {
             let mut req = self
@@ -4470,6 +4496,156 @@ mod tests {
     }
 
     #[test]
+    fn an_rpc_error_is_not_a_health_failure() {
+        // Only unreachability trips the per-server circuit breaker. A server that
+        // answers with a JSON-RPC error is alive and well-behaved, and counting it
+        // as unhealthy would break a server for every client over one bad call.
+        use super::TransportError;
+        assert!(!TransportError::Rpc(json!({ "code": -32601 })).is_health_failure());
+        assert!(!TransportError::Fatal("HTTP 400".into()).is_health_failure());
+        assert!(TransportError::Unavailable("timed out".into()).is_health_failure());
+        assert!(TransportError::Retry { retry_after: None, message: "429".into() }
+            .is_health_failure());
+    }
+
+    #[test]
+    fn notifications_carry_the_connections_protocol_meta() {
+        // The request path stamps protocol `_meta`; `notify` has its own copy of
+        // that logic and had no coverage, so a modern connection could have sent
+        // notifications telling a different story than its requests.
+        //
+        // Driven through the real `HttpTransport::notify` and read back off the
+        // wire, rather than asserting on `merge_protocol_meta` in isolation: the
+        // helper being right is not the claim, the frame on the wire is.
+        use super::{HttpTransport, Transport, MODERN_PROTOCOL_VERSION};
+        use std::sync::{Arc, Mutex};
+
+        let server = tiny_http::Server::http("127.0.0.1:0").unwrap();
+        let port = server.server_addr().to_ip().unwrap().port();
+        let body = Arc::new(Mutex::new(String::new()));
+        let bc = Arc::clone(&body);
+        let handle = std::thread::spawn(move || {
+            if let Ok(mut req) = server.recv() {
+                let mut buf = String::new();
+                let _ = req.as_reader().read_to_string(&mut buf);
+                *bc.lock().unwrap() = buf;
+                let ct =
+                    tiny_http::Header::from_bytes(&b"Content-Type"[..], &b"application/json"[..])
+                        .unwrap();
+                let _ = req.respond(tiny_http::Response::from_string("{}").with_header(ct));
+            }
+        });
+
+        let url = format!("http://127.0.0.1:{port}/");
+        let mut t = HttpTransport::new(&url);
+        t.set_protocol_meta(Some(super::protocol_meta_for(MODERN_PROTOCOL_VERSION)));
+        t.notify("notifications/cancelled", json!({ "requestId": 1 }))
+            .expect("notify should reach the server");
+        let _ = handle.join();
+
+        let sent: Value = serde_json::from_str(&body.lock().unwrap()).expect("a JSON frame");
+        assert_eq!(sent["method"], "notifications/cancelled");
+        assert_eq!(
+            sent["params"]["_meta"]["io.modelcontextprotocol/protocolVersion"],
+            MODERN_PROTOCOL_VERSION,
+            "a modern connection stamps its version on notifications too, got {sent}"
+        );
+        assert_eq!(sent["params"]["requestId"], 1, "the caller's params survive");
+    }
+
+    #[test]
+    fn merge_protocol_meta_preserves_client_keys_and_survives_a_bogus_meta() {
+        use super::{merge_protocol_meta, protocol_meta_for, MODERN_PROTOCOL_VERSION};
+        const VERSION_KEY: &str = "io.modelcontextprotocol/protocolVersion";
+
+        // A pre-existing `_meta` is merged into, not replaced.
+        let mut params = json!({ "_meta": { "traceparent": "keep" } });
+        merge_protocol_meta(&mut params, &protocol_meta_for(MODERN_PROTOCOL_VERSION));
+        assert_eq!(params["_meta"]["traceparent"], "keep", "client keys survive");
+        assert_eq!(params["_meta"][VERSION_KEY], MODERN_PROTOCOL_VERSION);
+
+        // A non-object `_meta` is rebuilt rather than panicking or being ignored.
+        let mut params = json!({ "_meta": "nonsense" });
+        merge_protocol_meta(&mut params, &protocol_meta_for(MODERN_PROTOCOL_VERSION));
+        assert_eq!(params["_meta"][VERSION_KEY], MODERN_PROTOCOL_VERSION);
+    }
+
+    #[test]
+    fn the_ladder_retries_discover_on_a_mutually_supported_version() {
+        // The negotiate branch: a modern server that rejects our declared version
+        // but names one we DO speak must be retried on that version and connect
+        // successfully. Only the give-up branch had coverage, so the retry could
+        // have been broken outright without a test noticing.
+        use super::{DownstreamServer, Transport, TransportError, MODERN_PROTOCOL_VERSION};
+        use std::collections::VecDeque;
+        use std::sync::{Arc, Mutex};
+
+        struct Ladder {
+            responses: VecDeque<Result<Value, TransportError>>,
+            /// Every version stamped via `set_protocol_meta`, in order. A real
+            /// transport turns this into the `MCP-Protocol-Version` header and the
+            /// body `_meta`, which MUST agree; the mock records it instead.
+            stamped: Arc<Mutex<Vec<Option<String>>>>,
+        }
+        impl Transport for Ladder {
+            fn request(&mut self, _method: &str, _params: Value) -> Result<Value, TransportError> {
+                self.responses.pop_front().expect("a response per request")
+            }
+            fn notify(&mut self, _m: &str, _p: Value) -> Result<(), TransportError> {
+                Ok(())
+            }
+            fn set_protocol_meta(&mut self, meta: Option<Value>) {
+                let version = meta
+                    .as_ref()
+                    .and_then(|m| m.get("io.modelcontextprotocol/protocolVersion"))
+                    .and_then(Value::as_str)
+                    .map(str::to_string);
+                self.stamped.lock().unwrap().push(version);
+            }
+        }
+
+        let stamped = Arc::new(Mutex::new(Vec::new()));
+        let transport = Ladder {
+            stamped: Arc::clone(&stamped),
+            responses: VecDeque::from(vec![
+                // initialize: refused, as a modern server must.
+                Err(TransportError::Rpc(json!({ "code": -32601, "message": "no initialize" }))),
+                // First server/discover: "not that version, but I speak ours too".
+                Err(TransportError::Rpc(json!({
+                    "code": super::UNSUPPORTED_PROTOCOL_VERSION,
+                    "message": "Unsupported protocol version",
+                    "data": { "supported": ["2027-05-01", MODERN_PROTOCOL_VERSION] }
+                }))),
+                // Retry on the mutually supported version: accepted.
+                Ok(json!({
+                    "supportedVersions": [MODERN_PROTOCOL_VERSION],
+                    "capabilities": { "tools": {} }
+                })),
+                // tools/list for the rest of the handshake.
+                Ok(json!({ "tools": [] })),
+            ]),
+        };
+
+        let server = DownstreamServer::connect("mock".to_string(), Box::new(transport))
+            .expect("the ladder must recover on a mutually supported version");
+        assert!(server.era().is_modern());
+        assert_eq!(server.era().version(), MODERN_PROTOCOL_VERSION);
+
+        // The retry must RE-stamp before sending, so the header and the body
+        // `_meta` still agree on the newly chosen version. Skipping that would
+        // send the rejected version again and draw the same error forever.
+        let stamped = stamped.lock().unwrap();
+        assert!(
+            stamped.len() >= 2,
+            "expected a stamp before the probe and again before the retry, got {stamped:?}"
+        );
+        assert!(
+            stamped.iter().all(|v| v.as_deref() == Some(MODERN_PROTOCOL_VERSION)),
+            "every stamp must name the version actually being sent, got {stamped:?}"
+        );
+    }
+
+    #[test]
     fn modern_server_offering_another_version_is_not_reported_as_legacy() {
         // The compatibility ladder's pivot. A server that refuses `initialize`
         // AND answers the probe with a recognized modern error IS modern, it just
@@ -4841,6 +5017,149 @@ mod tests {
         assert!(res.is_some(), "got the 200 result after refreshing");
         assert_eq!(hits.load(Ordering::SeqCst), 2, "exactly one 401 then one retry");
         assert_eq!(*retry_auth.lock().unwrap(), "Bearer fresh", "retry used the new token");
+    }
+
+    #[test]
+    fn forced_refresh_is_budgeted_per_token_not_per_post() {
+        // Connect posts twice: `initialize`, then the `server/discover` era probe.
+        // With a per-call budget each POST ran its own 401 -> refresh -> retry
+        // cycle, so one expired token cost two refresh exchanges - and a provider
+        // that rotates the refresh token on use has that chain consumed twice
+        // (SOU-474 #5). The budget belongs to the token, not the call.
+        use super::{HttpTransport, RefreshFn};
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use std::sync::Arc;
+
+        // Always 401: the refreshed token is rejected too, so nothing can succeed
+        // and the only question is how many times we tried to mint a new one.
+        //
+        // Serve until told to stop rather than for a fixed number of requests: a
+        // regression makes MORE requests, and a fixed loop would leave the extra
+        // one unanswered and hang the client instead of failing the assertion.
+        let server = tiny_http::Server::http("127.0.0.1:0").unwrap();
+        let port = server.server_addr().to_ip().unwrap().port();
+        let posts = Arc::new(AtomicUsize::new(0));
+        let stop = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let (pc, sc) = (Arc::clone(&posts), Arc::clone(&stop));
+        let handle = std::thread::spawn(move || {
+            while !sc.load(Ordering::SeqCst) {
+                match server.recv_timeout(std::time::Duration::from_millis(50)) {
+                    Ok(Some(req)) => {
+                        pc.fetch_add(1, Ordering::SeqCst);
+                        let _ = req.respond(
+                            tiny_http::Response::from_string("nope").with_status_code(401),
+                        );
+                    }
+                    Ok(None) => continue,
+                    Err(_) => return,
+                }
+            }
+        });
+
+        let forced = Arc::new(AtomicUsize::new(0));
+        let fc = Arc::clone(&forced);
+        let refresh: Option<RefreshFn> = Some(Box::new(move |force| {
+            if force {
+                // Each forced call is a refresh-token exchange with the provider.
+                let n = fc.fetch_add(1, Ordering::SeqCst);
+                Ok(Some(format!("minted-{n}")))
+            } else {
+                Ok(None)
+            }
+        }));
+
+        let url = format!("http://127.0.0.1:{port}/");
+        let mut t = HttpTransport::with_auth_refresh(&url, Some("stale".to_string()), refresh);
+        let body = serde_json::json!({ "jsonrpc": "2.0", "id": 1, "method": "initialize" });
+        assert!(t.post(&body, true).is_err(), "an always-401 server cannot succeed");
+        // The second POST is the era probe, on the same transport and the same
+        // (already once-refreshed) token.
+        assert!(t.post(&body, true).is_err(), "still 401");
+        drop(t);
+        stop.store(true, Ordering::SeqCst);
+        let _ = handle.join();
+
+        assert_eq!(
+            forced.load(Ordering::SeqCst),
+            1,
+            "one expired token must cost exactly one refresh exchange across both POSTs"
+        );
+        // 401, refresh, 401(retry) on the first post; the second post sends once
+        // and gives up without minting anything.
+        assert_eq!(posts.load(Ordering::SeqCst), 3, "no retry on the second POST");
+    }
+
+    #[test]
+    fn proactive_refresh_restores_the_forced_budget() {
+        // The per-token budget must not become a permanent latch: once a proactive
+        // refresh swaps in a *different* token, a later 401 on that new token is a
+        // genuine expiry and must still be recoverable, or a long-lived session
+        // stops self-healing (SOU-474 #5).
+        use super::{HttpTransport, RefreshFn};
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use std::sync::Arc;
+
+        let server = tiny_http::Server::http("127.0.0.1:0").unwrap();
+        let port = server.server_addr().to_ip().unwrap().port();
+        let hits = Arc::new(AtomicUsize::new(0));
+        let stop = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let (hc, sc) = (Arc::clone(&hits), Arc::clone(&stop));
+        let handle = std::thread::spawn(move || {
+            while !sc.load(Ordering::SeqCst) {
+                let req = match server.recv_timeout(std::time::Duration::from_millis(50)) {
+                    Ok(Some(req)) => req,
+                    Ok(None) => continue,
+                    Err(_) => return,
+                };
+                // 401 every request except the very last one we expect.
+                if hc.fetch_add(1, Ordering::SeqCst) == 3 {
+                    let ct = tiny_http::Header::from_bytes(
+                        &b"Content-Type"[..],
+                        &b"application/json"[..],
+                    )
+                    .unwrap();
+                    let body = r#"{"jsonrpc":"2.0","id":1,"result":{"ok":true}}"#;
+                    let _ = req.respond(tiny_http::Response::from_string(body).with_header(ct));
+                } else {
+                    let _ = req
+                        .respond(tiny_http::Response::from_string("nope").with_status_code(401));
+                }
+            }
+        });
+
+        let forced = Arc::new(AtomicUsize::new(0));
+        let fc = Arc::clone(&forced);
+        let proactive = Arc::new(AtomicUsize::new(0));
+        let pc = Arc::clone(&proactive);
+        let refresh: Option<RefreshFn> = Some(Box::new(move |force| {
+            if force {
+                let n = fc.fetch_add(1, Ordering::SeqCst);
+                Ok(Some(format!("forced-{n}")))
+            } else if pc.fetch_add(1, Ordering::SeqCst) == 1 {
+                // Before the second POST, hand out a genuinely different token.
+                Ok(Some("proactive".to_string()))
+            } else {
+                Ok(None)
+            }
+        }));
+
+        let url = format!("http://127.0.0.1:{port}/");
+        let mut t = HttpTransport::with_auth_refresh(&url, Some("stale".to_string()), refresh);
+        let body = serde_json::json!({ "jsonrpc": "2.0", "id": 1, "method": "ping" });
+        assert!(t.post(&body, true).is_err(), "first POST exhausts its budget");
+        assert!(
+            t.post(&body, true).is_ok(),
+            "a proactively-refreshed token gets its own forced-refresh budget"
+        );
+        drop(t);
+        stop.store(true, Ordering::SeqCst);
+        let _ = handle.join();
+
+        assert_eq!(
+            forced.load(Ordering::SeqCst),
+            2,
+            "one forced exchange per distinct token, not one for the whole connection"
+        );
     }
 
     #[test]

--- a/src-tauri/src/downstream.rs
+++ b/src-tauri/src/downstream.rs
@@ -2081,6 +2081,12 @@ impl Transport for StdioTransport {
     }
 
     fn notify(&mut self, method: &str, params: Value) -> Result<(), TransportError> {
+        // Same as the request path: a modern connection stamps its protocol
+        // metadata on notifications too, so every message tells one story.
+        let mut params = params;
+        if let Some(protocol) = &self.protocol_meta {
+            merge_protocol_meta(&mut params, protocol);
+        }
         let msg = json!({ "jsonrpc": "2.0", "method": method, "params": params });
         let mut stdin = self
             .stdin
@@ -2628,6 +2634,14 @@ impl Transport for HttpTransport {
     }
 
     fn notify(&mut self, method: &str, params: Value) -> Result<(), TransportError> {
+        // Notifications carry the connection's protocol metadata too, so a modern
+        // server sees a consistent story on every message rather than only on
+        // requests. (The revision leaves notification headers undefined, so this
+        // is consistency rather than a hard requirement.)
+        let mut params = params;
+        if let Some(protocol) = &self.protocol_meta {
+            merge_protocol_meta(&mut params, protocol);
+        }
         let body = json!({ "jsonrpc": "2.0", "method": method, "params": params });
         self.post(&body, false)?;
         Ok(())
@@ -2719,10 +2733,13 @@ impl DownstreamServer {
                 // has no such method. Confirm with `server/discover`, which every
                 // modern server MUST implement, rather than guessing from an
                 // error code the spec leaves implementation-defined.
-                let probe = transport.request(
-                    "server/discover",
-                    json!({ "_meta": protocol_meta_for(MODERN_PROTOCOL_VERSION) }),
-                );
+                // Stamp the modern metadata BEFORE probing, not after. On HTTP the
+                // transport derives `MCP-Protocol-Version` from it, and that header
+                // MUST match the body's `_meta`; probing first would send a legacy
+                // header with a modern body and a strict server would reject the
+                // very request meant to detect it, with HeaderMismatch (-32020).
+                transport.set_protocol_meta(Some(protocol_meta_for(MODERN_PROTOCOL_VERSION)));
+                let probe = transport.request("server/discover", json!({}));
                 let discovered = match probe {
                     Ok(discovered) => discovered,
                     // This is the pivot of the compatibility ladder. A RECOGNIZED
@@ -2738,12 +2755,14 @@ impl DownstreamServer {
                         // this is usually a clean incompatibility, but the ladder
                         // is written to negotiate rather than to assume.
                         match offered.iter().find(|v| v.as_str() == MODERN_PROTOCOL_VERSION) {
-                            Some(version) => transport
-                                .request(
-                                    "server/discover",
-                                    json!({ "_meta": protocol_meta_for(version) }),
-                                )
-                                .map_err(|e| e.to_string())?,
+                            Some(version) => {
+                                // Re-stamp before retrying so header and body agree
+                                // on the newly chosen version too.
+                                transport.set_protocol_meta(Some(protocol_meta_for(version)));
+                                transport
+                                    .request("server/discover", json!({}))
+                                    .map_err(|e| e.to_string())?
+                            }
                             None => {
                                 return Err(format!(
                                     "server speaks MCP {offered:?}; Toolport speaks \

--- a/src-tauri/src/downstream.rs
+++ b/src-tauri/src/downstream.rs
@@ -2704,7 +2704,14 @@ impl DownstreamServer {
                         "server/discover",
                         json!({ "_meta": protocol_meta_for(MODERN_PROTOCOL_VERSION) }),
                     )
-                    .map_err(|_| init_err.to_string())?;
+                    // The era conclusion is "legacy server that rejected our
+                    // handshake", so the initialize error is the actionable one.
+                    // Carry the probe's failure too: if discover timed out rather
+                    // than being refused, reporting only the initialize error
+                    // hides that the connect also paid a full read timeout.
+                    .map_err(|probe_err| {
+                        format!("{init_err} (server/discover probe also failed: {probe_err})")
+                    })?;
                 let version = choose_protocol_version(&discovered).ok_or_else(|| {
                     format!(
                         "server supports no protocol version Toolport speaks (offered {:?})",

--- a/src-tauri/src/downstream.rs
+++ b/src-tauri/src/downstream.rs
@@ -4427,6 +4427,56 @@ mod tests {
     }
 
     #[test]
+    fn modern_server_offering_another_version_is_not_reported_as_legacy() {
+        // The compatibility ladder's pivot. A server that refuses `initialize`
+        // AND answers the probe with a recognized modern error IS modern, it just
+        // does not speak our version. Reporting the initialize refusal there sends
+        // someone chasing a handshake bug on a reachable server (#511 review).
+        use super::{DownstreamServer, Transport, TransportError};
+        use std::collections::VecDeque;
+
+        struct Probe {
+            responses: VecDeque<Result<Value, TransportError>>,
+        }
+        impl Transport for Probe {
+            fn request(&mut self, _method: &str, _params: Value) -> Result<Value, TransportError> {
+                self.responses.pop_front().expect("a response per request")
+            }
+            fn notify(&mut self, _m: &str, _p: Value) -> Result<(), TransportError> {
+                Ok(())
+            }
+        }
+
+        let transport = Probe {
+            responses: VecDeque::from(vec![
+                // initialize: refused, as a modern server must.
+                Err(TransportError::Rpc(json!({
+                    "code": -32601, "message": "initialize is not part of 2026-07-28"
+                }))),
+                // server/discover: recognized modern error naming what it speaks.
+                Err(TransportError::Rpc(json!({
+                    "code": super::UNSUPPORTED_PROTOCOL_VERSION,
+                    "message": "Unsupported protocol version",
+                    "data": { "supported": ["2027-05-01"], "requested": "2026-07-28" }
+                }))),
+            ]),
+        };
+
+        let err = match DownstreamServer::connect("mock".to_string(), Box::new(transport)) {
+            Err(err) => err,
+            Ok(_) => panic!("no mutually supported version, so connect must fail"),
+        };
+        assert!(
+            err.contains("2027-05-01") && err.contains(super::MODERN_PROTOCOL_VERSION),
+            "the error must name what each side speaks, got: {err}"
+        );
+        assert!(
+            !err.contains("initialize is not part of"),
+            "a modern server must not be reported via the initialize refusal, got: {err}"
+        );
+    }
+
+    #[test]
     fn http_protocol_header_follows_the_negotiated_version() {
         // From 2026-07-28 the MCP-Protocol-Version header MUST equal the
         // `_meta` version in the body. A hardcoded header would disagree with the

--- a/src-tauri/src/downstream.rs
+++ b/src-tauri/src/downstream.rs
@@ -20,6 +20,12 @@ use std::time::{Duration, Instant};
 /// subscribed upstream clients only.
 pub type ResourceUpdatedSink = Arc<dyn Fn(String) + Send + Sync>;
 
+/// Called from a downstream drain when a server emits `notifications/progress`
+/// (SOU-444 part 2). Carries the whole notification, because routing it is the
+/// gateway's job: only the gateway knows which upstream client minted the
+/// `progressToken` it relayed on this server's behalf.
+pub type ProgressSink = Arc<dyn Fn(Value) + Send + Sync>;
+
 use serde_json::{json, Value};
 
 pub const PROTOCOL_VERSION: &str = "2025-06-18";
@@ -40,14 +46,14 @@ pub const PER_HOP_META_KEYS: [&str; 3] = [
     "io.modelcontextprotocol/clientCapabilities",
 ];
 
-/// `progressToken` is deliberately withheld for now. The stdio read loop drops
-/// every notification it does not recognise, so `notifications/progress` from a
-/// downstream server currently goes nowhere. Relaying the token would invite
-/// that traffic into a black hole and could push a server into a streaming mode
-/// for a client that will never see the updates. Released in the second half of
-/// SOU-444, once progress notifications can be routed back to the originating
-/// request.
-const WITHHELD_META_KEYS: [&str; 1] = ["progressToken"];
+/// Keys relayed only once Toolport can honour what they ask for.
+///
+/// `progressToken` lived here until the gateway learned to route
+/// `notifications/progress` back to the client that minted it (SOU-444 part 2);
+/// relaying a token whose notifications we then dropped would have invited that
+/// traffic into a black hole. Empty today, kept because the next revision brings
+/// more keys with the same "relay only when we can service it" shape.
+const WITHHELD_META_KEYS: [&str; 0] = [];
 
 /// The part of an upstream client's `_meta` that may travel downstream.
 ///
@@ -756,17 +762,38 @@ fn resource_updated_uri(line: &str) -> Option<String> {
         .map(str::to_string)
 }
 
+/// Parse a `notifications/progress` line, or `None` if it is anything else.
+///
+/// Progress relates to one in-flight request and is correlated by the
+/// `progressToken` the client minted, so the whole notification is handed to the
+/// gateway rather than a single extracted field.
+fn progress_notification(line: &str) -> Option<Value> {
+    // Cheap gate: skip the JSON parse for ordinary request/response lines.
+    if !line.contains("notifications/progress") {
+        return None;
+    }
+    let v: Value = serde_json::from_str(line.trim()).ok()?;
+    if v.get("method").and_then(|m| m.as_str()) != Some("notifications/progress") {
+        return None;
+    }
+    // A token is what makes the notification routable; without one it can only be
+    // dropped, so filter it here rather than waking the gateway for nothing.
+    v.get("params").and_then(|p| p.get("progressToken"))?;
+    Some(v)
+}
+
 /// Forward one drained stdout line to the request loop, first flagging `dirty` if
 /// the server (once `armed`) announced a tool-list change, and invoking the
-/// resource-updated sink for `notifications/resources/updated` (SOU-394).
-/// Returns false when the receiver is gone (transport closed) so the drain loop
-/// can stop.
+/// resource-updated sink for `notifications/resources/updated` (SOU-394) and the
+/// progress sink for `notifications/progress` (SOU-444). Returns false when the
+/// receiver is gone (transport closed) so the drain loop can stop.
 fn forward_line(
     line: String,
     tx: &Sender<String>,
     dirty: &Option<Arc<AtomicU8>>,
     armed: &Arc<AtomicBool>,
     resource_updated: &Option<ResourceUpdatedSink>,
+    progress: &Arc<Mutex<Option<ProgressSink>>>,
 ) -> bool {
     if armed.load(Ordering::SeqCst) {
         if let Some(flag) = dirty {
@@ -778,6 +805,17 @@ fn forward_line(
         if let Some(sink) = resource_updated {
             if let Some(uri) = resource_updated_uri(&line) {
                 sink(uri);
+            }
+        }
+        // Parse first: the cheap gate inside keeps this off the hot path, so the
+        // lock is only taken for lines that really are progress notifications.
+        if let Some(note) = progress_notification(&line) {
+            let sink = progress
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .clone();
+            if let Some(sink) = sink {
+                sink(note);
             }
         }
     }
@@ -1268,6 +1306,10 @@ pub struct StdioTransport {
     /// Answers server-initiated JSON-RPC (e.g. `roots/list`) by forwarding to the
     /// upstream MCP client. Set by the gateway before the connect handshake.
     server_handler: Option<ServerRequestHandler>,
+    /// Routes `notifications/progress` back to the client that minted the token
+    /// (SOU-444). Shared with the stdout drain thread so the gateway can bind it
+    /// after the transport is spawned, keeping `spawn_watched`'s signature stable.
+    progress: Arc<Mutex<Option<ProgressSink>>>,
 }
 
 /// Owns a Windows Job Object configured to terminate every assigned process
@@ -1643,6 +1685,8 @@ impl StdioTransport {
         let (tx, rx) = std::sync::mpsc::channel();
         let armed = Arc::new(AtomicBool::new(false));
         let drain_armed = Arc::clone(&armed);
+        let progress: Arc<Mutex<Option<ProgressSink>>> = Arc::new(Mutex::new(None));
+        let drain_progress = Arc::clone(&progress);
         std::thread::spawn(move || {
             let mut reader = BufReader::new(stdout);
             loop {
@@ -1661,7 +1705,14 @@ impl StdioTransport {
                             );
                             break;
                         }
-                        if !forward_line(line, &tx, &dirty, &drain_armed, &resource_updated) {
+                        if !forward_line(
+                            line,
+                            &tx,
+                            &dirty,
+                            &drain_armed,
+                            &resource_updated,
+                            &drain_progress,
+                        ) {
                             break;
                         }
                     }
@@ -1705,7 +1756,18 @@ impl StdioTransport {
             armed,
             launcher: is_download_launcher(command, args),
             server_handler: None,
+            progress,
         })
+    }
+
+    /// Bind the sink that routes this server's `notifications/progress` back to
+    /// the client that minted the token (SOU-444). Set by the gateway after
+    /// spawn, so the drain thread picks it up without a constructor change.
+    pub fn set_progress_sink(&mut self, sink: Option<ProgressSink>) {
+        *self
+            .progress
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = sink;
     }
 
     /// Build a useful error for when the child's stdout closed (it exited or
@@ -2040,6 +2102,9 @@ pub struct HttpTransport {
     /// Fan `notifications/resources/updated` seen mid-SSE to subscribed
     /// upstream clients (SOU-394 follow-up for remote downstreams).
     resource_updated: Option<ResourceUpdatedSink>,
+    /// Route `notifications/progress` seen mid-SSE back to the client that minted
+    /// the token (SOU-444).
+    progress: Option<ProgressSink>,
 }
 
 impl HttpTransport {
@@ -2084,6 +2149,7 @@ impl HttpTransport {
             refresh,
             server_handler: None,
             resource_updated: None,
+            progress: None,
         }
     }
 
@@ -2091,6 +2157,12 @@ impl HttpTransport {
     /// response streams (SOU-394).
     pub fn set_resource_updated_sink(&mut self, sink: Option<ResourceUpdatedSink>) {
         self.resource_updated = sink;
+    }
+
+    /// Bind the sink that routes this server's `notifications/progress` back to
+    /// the client that minted the token (SOU-444).
+    pub fn set_progress_sink(&mut self, sink: Option<ProgressSink>) {
+        self.progress = sink;
     }
 
     /// Answer a server-initiated JSON-RPC request inline (SSE mid-stream or
@@ -2220,6 +2292,15 @@ impl HttpTransport {
                 if let Some(sink) = &self.resource_updated {
                     if let Some(uri) = resource_updated_uri(data) {
                         sink(uri);
+                        continue;
+                    }
+                }
+                // Progress for the request this stream belongs to (SOU-444).
+                // Routed by token, so it is consumed here rather than being
+                // mistaken for the response frame.
+                if let Some(sink) = &self.progress {
+                    if let Some(note) = progress_notification(data) {
+                        sink(note);
                         continue;
                     }
                 }
@@ -3981,23 +4062,24 @@ mod tests {
         let armed = Arc::new(AtomicBool::new(false));
         let (tx, rx) = std::sync::mpsc::channel();
         let no_sink = None;
+        let no_progress = Arc::new(std::sync::Mutex::new(None));
 
         // Unarmed (still in the handshake window): the line is forwarded but the
         // change is not acted on.
-        assert!(forward_line(notif.to_string(), &tx, &dirty, &armed, &no_sink));
+        assert!(forward_line(notif.to_string(), &tx, &dirty, &armed, &no_sink, &no_progress));
         assert_eq!(dirty.as_ref().unwrap().load(Ordering::SeqCst), 0);
         assert_eq!(rx.recv().unwrap(), notif);
 
         // Armed: the same notification now sets the TOOLS bit.
         armed.store(true, Ordering::SeqCst);
-        assert!(forward_line(notif.to_string(), &tx, &dirty, &armed, &no_sink));
+        assert!(forward_line(notif.to_string(), &tx, &dirty, &armed, &no_sink, &no_progress));
         assert_eq!(dirty.as_ref().unwrap().load(Ordering::SeqCst), change::TOOLS);
         assert_eq!(rx.recv().unwrap(), notif);
 
         // A resources/list_changed sets the RESOURCES bit alongside it (OR, not
         // overwrite), so distinct changes between watcher ticks aren't lost.
         let res_notif = r#"{"jsonrpc":"2.0","method":"notifications/resources/list_changed"}"#;
-        assert!(forward_line(res_notif.to_string(), &tx, &dirty, &armed, &no_sink));
+        assert!(forward_line(res_notif.to_string(), &tx, &dirty, &armed, &no_sink, &no_progress));
         assert_eq!(
             dirty.as_ref().unwrap().load(Ordering::SeqCst),
             change::TOOLS | change::RESOURCES
@@ -4007,13 +4089,13 @@ mod tests {
         // An ordinary line is always forwarded and never flags a change.
         let resp = r#"{"jsonrpc":"2.0","id":1,"result":{}}"#;
         let dirty2 = Some(Arc::new(AtomicU8::new(0)));
-        assert!(forward_line(resp.to_string(), &tx, &dirty2, &armed, &no_sink));
+        assert!(forward_line(resp.to_string(), &tx, &dirty2, &armed, &no_sink, &no_progress));
         assert_eq!(dirty2.as_ref().unwrap().load(Ordering::SeqCst), 0);
         assert_eq!(rx.recv().unwrap(), resp);
 
         // A closed receiver makes forward_line report "stop".
         drop(rx);
-        assert!(!forward_line(notif.to_string(), &tx, &dirty, &armed, &no_sink));
+        assert!(!forward_line(notif.to_string(), &tx, &dirty, &armed, &no_sink, &no_progress));
     }
 
     #[test]
@@ -4052,16 +4134,17 @@ mod tests {
         let armed = Arc::new(AtomicBool::new(false));
         let (tx, rx) = std::sync::mpsc::channel();
         let sink_opt = Some(sink);
+        let no_progress = Arc::new(Mutex::new(None));
         let line = r#"{"jsonrpc":"2.0","method":"notifications/resources/updated","params":{"uri":"fixture://r"}}"#;
 
         // Unarmed: no sink call.
-        assert!(forward_line(line.to_string(), &tx, &dirty, &armed, &sink_opt));
+        assert!(forward_line(line.to_string(), &tx, &dirty, &armed, &sink_opt, &no_progress));
         assert!(seen.lock().unwrap().is_empty());
         assert_eq!(rx.recv().unwrap(), line);
 
         // Armed: sink receives the URI; dirty bits stay clear (not a list change).
         armed.store(true, Ordering::SeqCst);
-        assert!(forward_line(line.to_string(), &tx, &dirty, &armed, &sink_opt));
+        assert!(forward_line(line.to_string(), &tx, &dirty, &armed, &sink_opt, &no_progress));
         assert_eq!(seen.lock().unwrap().as_slice(), &["fixture://r".to_string()]);
         assert_eq!(dirty.as_ref().unwrap().load(Ordering::SeqCst), 0);
         assert_eq!(rx.recv().unwrap(), line);

--- a/src-tauri/src/downstream.rs
+++ b/src-tauri/src/downstream.rs
@@ -210,6 +210,16 @@ const STDIO_READ_TIMEOUT: Duration = Duration::from_secs(30);
 /// so one hung server should fail in seconds, not stall everything for the full
 /// live-call timeout. Restored to STDIO_READ_TIMEOUT once connected.
 const STDIO_CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+/// Budget for the `server/discover` era probe, deliberately far tighter than any
+/// connect timeout.
+///
+/// The probe only runs after a server has already answered `initialize` with an
+/// error, so the process is alive and responsive; a server that implements
+/// `server/discover` answers it locally and immediately. A legacy server that
+/// does not implement it usually stays silent, and that silence is the signal to
+/// fall back. Charging the full connect budget for that silence would make every
+/// legacy misconfiguration take minutes to report.
+const PROBE_TIMEOUT: Duration = Duration::from_millis(750);
 /// First-`initialize` budget for download-then-run launchers (npx, uvx, pnpm dlx,
 /// ...). On a cold cache these resolve and download the server package before the
 /// process can answer anything - easily 15-60s, far past the normal handshake
@@ -2733,6 +2743,20 @@ impl DownstreamServer {
                 // has no such method. Confirm with `server/discover`, which every
                 // modern server MUST implement, rather than guessing from an
                 // error code the spec leaves implementation-defined.
+                // Bound the probe tightly, and restore the handshake budget after.
+                //
+                // A launcher-wrapped server (npx, uvx) carries a 120s connect
+                // budget so a cold package download can finish. Inheriting that
+                // here would turn "legacy server rejected initialize" - a missing
+                // API key, a bad config - from an instant failure into a two
+                // minute hang, and a batch probe or router rebuild waits on the
+                // slowest server. A server that implements `server/discover`
+                // answers it locally and immediately, so it needs none of that
+                // budget.
+                // The post-match `set_read_timeout(STDIO_CONNECT_TIMEOUT)` below
+                // restores a normal budget for the rest of the handshake.
+                transport.set_read_timeout(PROBE_TIMEOUT);
+
                 // Stamp the modern metadata BEFORE probing, not after. On HTTP the
                 // transport derives `MCP-Protocol-Version` from it, and that header
                 // MUST match the body's `_meta`; probing first would send a legacy

--- a/src-tauri/src/remote.rs
+++ b/src-tauri/src/remote.rs
@@ -10,8 +10,8 @@ use std::sync::Mutex;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::downstream::{
-    DownstreamServer, HttpTransport, RefreshFn, ResourceUpdatedSink, ServerRequestHandler,
-    Transport,
+    DownstreamServer, HttpTransport, ProgressSink, RefreshFn, ResourceUpdatedSink,
+    ServerRequestHandler, Transport,
 };
 use crate::registry::ServerEntry;
 use crate::{oauth, secrets};
@@ -339,16 +339,19 @@ fn first_vaulted_secret(server: &ServerEntry) -> Option<String> {
 ///    OAuth. Without this fallback, "Manage secrets" tokens were silently ignored
 ///    for HTTP servers.
 pub fn connect_remote(server: &ServerEntry) -> Result<DownstreamServer, String> {
-    connect_remote_with_handler(server, None, None)
+    connect_remote_with_handler(server, None, None, None)
 }
 
 /// Like [`connect_remote`], but wires server-initiated JSON-RPC (sampling, roots, …)
 /// through `handler` when the downstream server asks mid-call, and optionally fans
-/// `notifications/resources/updated` from SSE response streams (SOU-394).
+/// `notifications/resources/updated` from SSE response streams (SOU-394), and
+/// routes `notifications/progress` back to the client that minted the token
+/// (SOU-444).
 pub fn connect_remote_with_handler(
     server: &ServerEntry,
     server_handler: Option<ServerRequestHandler>,
     resource_updated: Option<ResourceUpdatedSink>,
+    progress: Option<ProgressSink>,
 ) -> Result<DownstreamServer, String> {
     guard_connect_target(server)?;
     let url = server.url.as_deref().unwrap_or("");
@@ -367,6 +370,7 @@ pub fn connect_remote_with_handler(
         transport.set_server_request_handler(handler.clone());
     }
     transport.set_resource_updated_sink(resource_updated.clone());
+    transport.set_progress_sink(progress.clone());
     match DownstreamServer::connect(server_id.to_string(), Box::new(transport)) {
         Ok(ds) => Ok(ds),
         Err(e) if is_auth_error(&e) => match refresh_token(server_id) {
@@ -376,6 +380,7 @@ pub fn connect_remote_with_handler(
                     transport.set_server_request_handler(handler);
                 }
                 transport.set_resource_updated_sink(resource_updated);
+                transport.set_progress_sink(progress);
                 DownstreamServer::connect(server_id.to_string(), Box::new(transport))
             }
             Err(_) => Err(e),

--- a/src-tauri/src/remote.rs
+++ b/src-tauri/src/remote.rs
@@ -179,10 +179,23 @@ fn refresh_token_if_needed(server_id: &str) -> Result<Option<String>, String> {
     }
 }
 
+/// True when `code` appears in `s` as a standalone number rather than as a run of
+/// digits inside a longer one.
+///
+/// A bare substring test reads an auth failure out of an OS error number
+/// (`os error 10401`), a port (`127.0.0.1:4013`), or a duration (`4030ms`).
+fn mentions_status(s: &str, code: &str) -> bool {
+    s.match_indices(code).any(|(i, _)| {
+        let before = s[..i].chars().next_back();
+        let after = s[i + code.len()..].chars().next();
+        !before.is_some_and(|c| c.is_ascii_digit()) && !after.is_some_and(|c| c.is_ascii_digit())
+    })
+}
+
 pub fn is_auth_error(e: &str) -> bool {
     let lower = e.to_lowercase();
-    e.contains("401")
-        || e.contains("403")
+    mentions_status(e, "401")
+        || mentions_status(e, "403")
         || lower.contains("unauthorized")
         || lower.contains("needs authentication")
 }
@@ -365,6 +378,11 @@ pub fn connect_remote_with_handler(
         Some(fresh) => Some(fresh),
         None => stored_auth,
     };
+    // Remember exactly what we hand the transport. The transport force-refreshes
+    // internally on a 401/403 and vaults the result, so if the vaulted token
+    // differs from this afterwards, an exchange already happened during this
+    // connect (SOU-474).
+    let sent_auth = auth.clone();
     let mut transport = authed_transport(url, auth, server_id, block_private)?;
     if let Some(ref handler) = server_handler {
         transport.set_server_request_handler(handler.clone());
@@ -373,6 +391,19 @@ pub fn connect_remote_with_handler(
     transport.set_progress_sink(progress.clone());
     match DownstreamServer::connect(server_id.to_string(), Box::new(transport)) {
         Ok(ds) => Ok(ds),
+        // The transport already gets one forced refresh per token on a 401/403.
+        // If it spent one during this connect, the vault now holds a token that
+        // has ALREADY been rejected, so minting yet another cannot help - and
+        // against a provider that rotates the refresh token on use, each needless
+        // exchange consumes a further link of the chain. Retry only when the
+        // transport had no refresh of its own to spend (SOU-474).
+        Err(e)
+            if is_auth_error(&e)
+                && secrets::get_secret(server_id, secrets::HTTP_AUTH_KEY)
+                    .is_some_and(|vaulted| Some(&vaulted) != sent_auth.as_ref()) =>
+        {
+            Err(e)
+        }
         Err(e) if is_auth_error(&e) => match refresh_token(server_id) {
             Ok(fresh) => {
                 let mut transport = authed_transport(url, Some(fresh), server_id, block_private)?;
@@ -399,6 +430,20 @@ mod tests {
         assert!(is_auth_error("got 403 Forbidden"));
         assert!(!is_auth_error("HTTP 500: server error"));
         assert!(!is_auth_error("connection refused"));
+    }
+
+    #[test]
+    fn a_status_code_buried_in_a_longer_number_is_not_an_auth_error() {
+        // Misreading these as auth failures shows the user a "Needs sign-in"
+        // prompt for a network fault and burns an OAuth refresh exchange on it.
+        assert!(!is_auth_error("connection refused (os error 10401)"));
+        assert!(!is_auth_error("dial tcp 127.0.0.1:4013: refused"));
+        assert!(!is_auth_error("read timed out after 4030ms"));
+        assert!(!is_auth_error("HTTP 500: upstream returned 14012 bytes"));
+        // Still caught at a boundary, wherever it sits in the message.
+        assert!(is_auth_error("HTTP 401"));
+        assert!(is_auth_error("server said 403."));
+        assert!(is_auth_error("(403)"));
     }
 
     fn oauth_state(expires_at: Option<u64>, refresh_token: Option<&str>) -> OAuthState {

--- a/src-tauri/src/router.rs
+++ b/src-tauri/src/router.rs
@@ -955,14 +955,18 @@ impl Router {
     /// server, so concurrent calls to different servers run in parallel while
     /// calls to the same server (one stdio pipe) serialize.
     pub fn route_call(&self, exposed_name: &str, arguments: Value) -> Result<Value, String> {
-        self.route_call_with_cancel(exposed_name, arguments, None)
+        self.route_call_with_cancel(exposed_name, arguments, None, None)
     }
 
+    /// `meta` carries the upstream client's `params._meta` through to the
+    /// downstream server (SOU-444). The router does not interpret it; the
+    /// downstream layer decides which keys are relayable.
     pub fn route_call_with_cancel(
         &self,
         exposed_name: &str,
         arguments: Value,
         cancel: Option<CancelContext>,
+        meta: Option<&Value>,
     ) -> Result<Value, String> {
         if let Some(reason) = self.blocked.get(exposed_name) {
             return Err(format!("tool '{exposed_name}' is {reason}"));
@@ -973,7 +977,7 @@ impl Router {
             .ok_or_else(|| format!("no route for tool '{exposed_name}'"))?;
         let slot = self.slot_for(server_id)?;
         self.call_with_retry(&slot, |server| {
-            server.call_with_cancel(tool, arguments.clone(), cancel.clone())
+            server.call_with_cancel(tool, arguments.clone(), cancel.clone(), meta)
         })
     }
 
@@ -1096,13 +1100,14 @@ impl Router {
     /// matching resource template). `&self`: locks only the owning server
     /// (see `route_call`).
     pub fn read_resource(&self, uri: &str) -> Result<Value, String> {
-        self.read_resource_with_cancel(uri, None)
+        self.read_resource_with_cancel(uri, None, None)
     }
 
     pub fn read_resource_with_cancel(
         &self,
         uri: &str,
         cancel: Option<CancelContext>,
+        meta: Option<&Value>,
     ) -> Result<Value, String> {
         let server_id = self
             .resource_server(uri)
@@ -1110,7 +1115,7 @@ impl Router {
             .to_string();
         let slot = self.slot_for(&server_id)?;
         self.call_with_retry(&slot, |server| {
-            server.read_resource_with_cancel(uri, cancel.clone())
+            server.read_resource_with_cancel(uri, cancel.clone(), meta)
         })
     }
 
@@ -1154,7 +1159,7 @@ impl Router {
     /// Get a prompt by its exposed name, forwarding the server's real name.
     /// `&self`: locks only the owning server (see `route_call`).
     pub fn get_prompt(&self, exposed_name: &str, arguments: Value) -> Result<Value, String> {
-        self.get_prompt_with_cancel(exposed_name, arguments, None)
+        self.get_prompt_with_cancel(exposed_name, arguments, None, None)
     }
 
     pub fn get_prompt_with_cancel(
@@ -1162,6 +1167,7 @@ impl Router {
         exposed_name: &str,
         arguments: Value,
         cancel: Option<CancelContext>,
+        meta: Option<&Value>,
     ) -> Result<Value, String> {
         let (server_id, name) = self
             .prompt_routes
@@ -1170,7 +1176,7 @@ impl Router {
             .ok_or_else(|| format!("no route for prompt '{exposed_name}'"))?;
         let slot = self.slot_for(&server_id)?;
         self.call_with_retry(&slot, |server| {
-            server.get_prompt_with_cancel(&name, arguments.clone(), cancel.clone())
+            server.get_prompt_with_cancel(&name, arguments.clone(), cancel.clone(), meta)
         })
     }
 
@@ -1185,7 +1191,10 @@ impl Router {
         params: Value,
         cancel: Option<CancelContext>,
     ) -> Result<Value, String> {
-        let (server_id, forwarded) = self.resolve_completion(&params)?;
+        let (server_id, mut forwarded) = self.resolve_completion(&params)?;
+        // This path forwards the client's params wholesale, so it needs the same
+        // per-hop `_meta` stripping the rebuilt paths get (SOU-444).
+        crate::downstream::sanitize_forwarded_meta(&mut forwarded);
         let slot = self.slot_for(&server_id)?;
         self.call_with_retry(&slot, |server| {
             server.complete_with_cancel(forwarded.clone(), cancel.clone())
@@ -2161,6 +2170,7 @@ mod tests {
                 "s__echo",
                 json!({}),
                 Some(registry.context("99".to_string())),
+                None,
             )
             .unwrap();
 

--- a/src-tauri/src/shaping.rs
+++ b/src-tauri/src/shaping.rs
@@ -244,7 +244,21 @@ pub fn shape_result(result: &mut Value, budget: usize, owner: Option<&str>) -> b
         cursor,
         head_chars
     );
-    *result = text_result(format!("{head}{marker}"), is_error);
+    // Shaping deliberately rewrites `content` and stashes `structuredContent` in
+    // the cache (both retrievable via the cursor). Every other top-level field
+    // belongs to the downstream server, not to us: `_meta`, and whatever a future
+    // revision or extension adds. Carry them across so shaping stays a truncation
+    // of the body rather than a rewrite of the envelope (SOU-444).
+    let mut shaped = text_result(format!("{head}{marker}"), is_error);
+    if let (Some(src), Some(dst)) = (result.as_object(), shaped.as_object_mut()) {
+        for (key, value) in src {
+            if matches!(key.as_str(), "content" | "structuredContent" | "isError") {
+                continue;
+            }
+            dst.insert(key.clone(), value.clone());
+        }
+    }
+    *result = shaped;
     true
 }
 
@@ -491,6 +505,71 @@ mod tests {
             .as_str()
             .unwrap()
             .contains("end of result"));
+    }
+
+    #[test]
+    fn relayable_meta_keeps_unknown_and_drops_per_hop() {
+        use crate::downstream::{relayable_meta, sanitize_forwarded_meta};
+
+        let meta = json!({
+            "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+            "io.modelcontextprotocol/clientInfo": { "name": "x" },
+            "io.modelcontextprotocol/clientCapabilities": {},
+            "progressToken": "p-1",
+            "traceparent": "00-abc-def-01",
+            "com.example/unknown": { "a": 1 }
+        });
+        let kept = relayable_meta(Some(&meta)).expect("some keys survive");
+        assert_eq!(kept["traceparent"], "00-abc-def-01");
+        assert_eq!(kept["com.example/unknown"]["a"], 1);
+        assert!(kept.get("io.modelcontextprotocol/protocolVersion").is_none());
+        assert!(kept.get("io.modelcontextprotocol/clientInfo").is_none());
+        assert!(kept.get("io.modelcontextprotocol/clientCapabilities").is_none());
+        assert!(kept.get("progressToken").is_none(), "withheld until SOU-444 part 2");
+
+        // Nothing relayable means no `_meta` at all, not an empty object, so the
+        // request stays byte-identical to what Toolport sent before SOU-444.
+        assert!(relayable_meta(Some(&json!({ "progressToken": "p" }))).is_none());
+        assert!(relayable_meta(None).is_none());
+
+        // The wholesale-forward path (completion/complete) strips the same keys.
+        let mut params = json!({
+            "ref": { "type": "ref/prompt", "name": "p" },
+            "_meta": { "io.modelcontextprotocol/clientInfo": { "name": "x" }, "keep": 1 }
+        });
+        sanitize_forwarded_meta(&mut params);
+        assert_eq!(params["_meta"]["keep"], 1);
+        assert!(params["_meta"].get("io.modelcontextprotocol/clientInfo").is_none());
+
+        // ...and removes `_meta` entirely when nothing survives.
+        let mut params = json!({
+            "ref": {}, "_meta": { "io.modelcontextprotocol/protocolVersion": "2026-07-28" }
+        });
+        sanitize_forwarded_meta(&mut params);
+        assert!(params.get("_meta").is_none());
+    }
+
+    #[test]
+    fn shaping_preserves_meta_and_unknown_envelope_fields() {
+        // Shaping truncates the BODY. Everything else in the envelope belongs to
+        // the downstream server: `_meta`, and whatever a future revision or
+        // extension adds. Dropping it would make Toolport a lossy proxy in the
+        // result direction, the mirror of the request-side gap (SOU-444).
+        let mut r = json!({
+            "content": [{ "type": "text", "text": "x".repeat(5_000) }],
+            "isError": false,
+            "_meta": { "io.modelcontextprotocol/serverInfo": { "name": "srv", "version": "1" } },
+            "somethingAFutureSpecAdded": { "keep": true }
+        });
+        assert!(shape_result(&mut r, 1024, None));
+
+        assert_eq!(r["_meta"]["io.modelcontextprotocol/serverInfo"]["name"], "srv");
+        assert_eq!(r["somethingAFutureSpecAdded"]["keep"], true);
+        // ...while the body really was shaped.
+        assert!(r["content"][0]["text"]
+            .as_str()
+            .unwrap()
+            .contains("Toolport shaped this result"));
     }
 
     #[test]

--- a/src-tauri/src/shaping.rs
+++ b/src-tauri/src/shaping.rs
@@ -525,11 +525,16 @@ mod tests {
         assert!(kept.get("io.modelcontextprotocol/protocolVersion").is_none());
         assert!(kept.get("io.modelcontextprotocol/clientInfo").is_none());
         assert!(kept.get("io.modelcontextprotocol/clientCapabilities").is_none());
-        assert!(kept.get("progressToken").is_none(), "withheld until SOU-444 part 2");
+        // Relayed since SOU-444 part 2: the gateway now routes the resulting
+        // `notifications/progress` back to the client that minted the token.
+        assert_eq!(kept["progressToken"], "p-1");
 
         // Nothing relayable means no `_meta` at all, not an empty object, so the
         // request stays byte-identical to what Toolport sent before SOU-444.
-        assert!(relayable_meta(Some(&json!({ "progressToken": "p" }))).is_none());
+        assert!(relayable_meta(Some(
+            &json!({ "io.modelcontextprotocol/clientInfo": { "name": "x" } })
+        ))
+        .is_none());
         assert!(relayable_meta(None).is_none());
 
         // The wholesale-forward path (completion/complete) strips the same keys.

--- a/src-tauri/src/shaping.rs
+++ b/src-tauri/src/shaping.rs
@@ -568,6 +568,30 @@ mod tests {
     }
 
     #[test]
+    fn preserved_envelope_fields_do_not_push_a_shaped_result_over_budget() {
+        // Preserved fields are part of the shaped result, so they come out of the
+        // same budget. Before this, a large `_meta` was copied in AFTER the head
+        // was sized, so `true` could mean "shaped, and still oversized" (#511
+        // review). The guarantee is that a `true` return fits.
+        let budget = 4096;
+        let mut r = json!({
+            "content": [{ "type": "text", "text": "x".repeat(50_000) }],
+            "isError": false,
+            // Deliberately bulky: about half the budget on its own.
+            "_meta": { "com.example/ctx": "m".repeat(2_000) }
+        });
+        assert!(shape_result(&mut r, budget, None));
+
+        let size = serde_json::to_string(&r).map(|s| s.len()).unwrap_or(0);
+        assert!(
+            size <= budget,
+            "a shaped result must fit the budget, got {size} bytes against {budget}"
+        );
+        // ...and the bulky field really was preserved, not dropped to make it fit.
+        assert_eq!(r["_meta"]["com.example/ctx"].as_str().map(str::len), Some(2_000));
+    }
+
+    #[test]
     fn shaping_preserves_meta_and_unknown_envelope_fields() {
         // Shaping truncates the BODY. Everything else in the envelope belongs to
         // the downstream server: `_meta`, and whatever a future revision or

--- a/src-tauri/src/shaping.rs
+++ b/src-tauri/src/shaping.rs
@@ -190,9 +190,22 @@ pub fn shape_result(result: &mut Value, budget: usize, owner: Option<&str>) -> b
     let structured = result.get("structuredContent").cloned();
 
     let total = body.chars().count();
+    // Envelope fields carried across (see below) are part of the shaped result, so
+    // they have to come out of the budget too. Without this, preserving a large
+    // `_meta` could push a "shaped" result back over the limit and `true` would no
+    // longer mean "fits" (#511 review).
+    let preserved_bytes: usize = result
+        .as_object()
+        .map(|obj| {
+            obj.iter()
+                .filter(|(key, _)| !matches!(key.as_str(), "content" | "structuredContent" | "isError"))
+                .map(|(key, value)| key.len() + value_size(value) + 4)
+                .sum()
+        })
+        .unwrap_or(0);
     // Reserve room for the marker, then show as much of the body head as fits the
     // BYTE budget (not a char count, or multi-byte text would blow past it).
-    let head_byte_limit = budget.saturating_sub(512).max(256);
+    let head_byte_limit = budget.saturating_sub(512 + preserved_bytes).max(256);
     let head = head_within_bytes(&body, head_byte_limit).to_string();
     let head_chars = head.chars().count();
     let is_error = result

--- a/src-tauri/src/shaping.rs
+++ b/src-tauri/src/shaping.rs
@@ -219,7 +219,6 @@ pub fn shape_result(result: &mut Value, budget: usize, owner: Option<&str>) -> b
     // starting estimate.
     let mut head_byte_limit = budget.saturating_sub(512 + preserved_bytes);
     let head = head_within_bytes(&body, head_byte_limit).to_string();
-    let head_chars = head.chars().count();
     let is_error = result
         .get("isError")
         .and_then(|v| v.as_bool())

--- a/src-tauri/src/shaping.rs
+++ b/src-tauri/src/shaping.rs
@@ -1,7 +1,7 @@
 //! Result-shaping: keep oversized tool results from blowing the model's context
 //! WITHOUT losing data. When a downstream tool returns a result larger than the
 //! byte budget, the full body is cached in-process and the model gets a truncated
-//! head plus a Toolport-stamped marker carrying a cursor. `conduit_fetch_result`
+//! head plus a Toolport-stamped marker carrying a cursor. `toolport_fetch_result`
 //! pages through the cached full result. Lossless: nothing is dropped, only
 //! deferred, and the full data stays retrievable.
 //!
@@ -203,6 +203,15 @@ pub fn shape_result(result: &mut Value, budget: usize, owner: Option<&str>) -> b
                 .sum()
         })
         .unwrap_or(0);
+    // If the preserved envelope alone meets the budget, no head size makes the
+    // shaped result fit and the 256-byte floor below would emit an oversized
+    // result anyway. Leave it unshaped, as with the other cases where shaping
+    // cannot honour its contract. Deliberately gated on the envelope only: the
+    // marker reserve is allowed to exceed a very small budget exactly as it did
+    // before, so tiny-budget shaping keeps working.
+    if preserved_bytes >= budget {
+        return false;
+    }
     // Reserve room for the marker, then show as much of the body head as fits the
     // BYTE budget (not a char count, or multi-byte text would blow past it).
     let head_byte_limit = budget.saturating_sub(512 + preserved_bytes).max(256);
@@ -248,7 +257,7 @@ pub fn shape_result(result: &mut Value, budget: usize, owner: Option<&str>) -> b
     let marker = format!(
         "\n\n[Toolport shaped this result: it was ~{} KB, larger than the {} KB context \
          budget. Showing the first {} of {} characters. The rest is held temporarily, call \
-         conduit_fetch_result with {{\"cursor\":\"{}\",\"offset\":{}}} to read it. If that \
+         toolport_fetch_result with {{\"cursor\":\"{}\",\"offset\":{}}} to read it. If that \
          later reports the cursor expired, just re-run this tool call for a fresh result.]",
         size / 1024,
         budget / 1024,
@@ -369,7 +378,7 @@ pub fn fetch_result(cursor: &str, offset: usize, len: usize, requester: Option<&
     let footer = if remaining > 0 {
         format!(
             "\n\n[Toolport: characters {offset}..{end} of {total}. {remaining} remain, call \
-             conduit_fetch_result with offset={end} for the next slice.]"
+             toolport_fetch_result with offset={end} for the next slice.]"
         )
     } else {
         format!("\n\n[Toolport: end of result ({total} characters).]")
@@ -397,7 +406,7 @@ mod tests {
         let mut r = big_text_result(10_000);
         assert!(shape_result(&mut r, 2048, None));
         let text = r["content"][0]["text"].as_str().unwrap();
-        assert!(text.contains("conduit_fetch_result"));
+        assert!(text.contains("toolport_fetch_result"));
         assert!(text.len() < 10_000);
         // The marker carries a cursor that fetch_result can page.
         assert!(text.contains("\"cursor\":\"r"));

--- a/src-tauri/src/shaping.rs
+++ b/src-tauri/src/shaping.rs
@@ -204,17 +204,20 @@ pub fn shape_result(result: &mut Value, budget: usize, owner: Option<&str>) -> b
         })
         .unwrap_or(0);
     // If the preserved envelope alone meets the budget, no head size makes the
-    // shaped result fit and the 256-byte floor below would emit an oversized
-    // result anyway. Leave it unshaped, as with the other cases where shaping
-    // cannot honour its contract. Deliberately gated on the envelope only: the
-    // marker reserve is allowed to exceed a very small budget exactly as it did
-    // before, so tiny-budget shaping keeps working.
+    // shaped result fit. Leave it unshaped, as with the other cases where shaping
+    // cannot honour its contract.
     if preserved_bytes >= budget {
         return false;
     }
     // Reserve room for the marker, then show as much of the body head as fits the
     // BYTE budget (not a char count, or multi-byte text would blow past it).
-    let head_byte_limit = budget.saturating_sub(512 + preserved_bytes).max(256);
+    //
+    // No lower floor here. A `.max(256)` floor is what let a large envelope push
+    // a "shaped" result back over the budget while still returning `true`: the
+    // floor won whenever `budget - reserve - preserved` fell below it. The final
+    // fit-check below is what actually enforces the contract; this is only the
+    // starting estimate.
+    let mut head_byte_limit = budget.saturating_sub(512 + preserved_bytes);
     let head = head_within_bytes(&body, head_byte_limit).to_string();
     let head_chars = head.chars().count();
     let is_error = result
@@ -225,6 +228,67 @@ pub fn shape_result(result: &mut Value, budget: usize, owner: Option<&str>) -> b
     let cursor = next_cursor();
     let new_entry_size = body.len() + structured.as_ref().map(value_size).unwrap_or(0);
 
+    // Build the shaped result for a given head, then measure it. The marker's own
+    // length varies with the head length it reports, and the preserved envelope is
+    // whatever the server sent, so the only reliable way to honour the budget is
+    // to measure the finished value rather than predict it.
+    let build = |head: &str| -> Value {
+        let head_chars = head.chars().count();
+        let marker = format!(
+            "\n\n[Toolport shaped this result: it was ~{} KB, larger than the {} KB context \
+             budget. Showing the first {} of {} characters. The rest is held temporarily, call \
+             toolport_fetch_result with {{\"cursor\":\"{}\",\"offset\":{}}} to read it. If that \
+             later reports the cursor expired, just re-run this tool call for a fresh result.]",
+            size / 1024,
+            budget / 1024,
+            head_chars,
+            total,
+            cursor,
+            head_chars
+        );
+        // Shaping deliberately rewrites `content` and stashes `structuredContent`
+        // in the cache (both retrievable via the cursor). Every other top-level
+        // field belongs to the downstream server, not to us: `_meta`, and whatever
+        // a future revision or extension adds. Carry them across so shaping stays a
+        // truncation of the body rather than a rewrite of the envelope (SOU-444).
+        let mut shaped = text_result(format!("{head}{marker}"), is_error);
+        if let (Some(src), Some(dst)) = (result.as_object(), shaped.as_object_mut()) {
+            for (key, value) in src {
+                if matches!(key.as_str(), "content" | "structuredContent" | "isError") {
+                    continue;
+                }
+                dst.insert(key.clone(), value.clone());
+            }
+        }
+        shaped
+    };
+
+    let mut head = head;
+    let mut shaped = build(&head);
+    // Shrink until it fits. Each pass subtracts the exact overage, so this
+    // converges immediately in practice; the bound is a guard, not a search.
+    for _ in 0..4 {
+        let shaped_size = serde_json::to_string(&shaped).map(|s| s.len()).unwrap_or(0);
+        if shaped_size <= budget || head.is_empty() {
+            break;
+        }
+        let overage = shaped_size - budget;
+        head_byte_limit = head_byte_limit.saturating_sub(overage.max(1));
+        head = head_within_bytes(&body, head_byte_limit).to_string();
+        shaped = build(&head);
+    }
+
+    // An empty head that still overflows means the marker and envelope alone
+    // exceed the budget, so no truncation can honour the contract. Returning
+    // `true` there would be the same false claim the head floor used to make.
+    // Bail BEFORE caching, so a result we decline to shape leaves no orphaned
+    // cursor entry behind.
+    if serde_json::to_string(&shaped).map(|s| s.len()).unwrap_or(0) > budget {
+        return false;
+    }
+
+    // Only now stash the full body: the cursor in the marker above is live from
+    // here on.
     {
         let mut map = cache().lock().unwrap_or_else(|e| e.into_inner());
         sweep(&mut map);
@@ -254,32 +318,7 @@ pub fn shape_result(result: &mut Value, budget: usize, owner: Option<&str>) -> b
             },
         );
     }
-    let marker = format!(
-        "\n\n[Toolport shaped this result: it was ~{} KB, larger than the {} KB context \
-         budget. Showing the first {} of {} characters. The rest is held temporarily, call \
-         toolport_fetch_result with {{\"cursor\":\"{}\",\"offset\":{}}} to read it. If that \
-         later reports the cursor expired, just re-run this tool call for a fresh result.]",
-        size / 1024,
-        budget / 1024,
-        head_chars,
-        total,
-        cursor,
-        head_chars
-    );
-    // Shaping deliberately rewrites `content` and stashes `structuredContent` in
-    // the cache (both retrievable via the cursor). Every other top-level field
-    // belongs to the downstream server, not to us: `_meta`, and whatever a future
-    // revision or extension adds. Carry them across so shaping stays a truncation
-    // of the body rather than a rewrite of the envelope (SOU-444).
-    let mut shaped = text_result(format!("{head}{marker}"), is_error);
-    if let (Some(src), Some(dst)) = (result.as_object(), shaped.as_object_mut()) {
-        for (key, value) in src {
-            if matches!(key.as_str(), "content" | "structuredContent" | "isError") {
-                continue;
-            }
-            dst.insert(key.clone(), value.clone());
-        }
-    }
+
     *result = shaped;
     true
 }
@@ -574,6 +613,65 @@ mod tests {
         });
         sanitize_forwarded_meta(&mut params);
         assert!(params.get("_meta").is_none());
+    }
+
+    #[test]
+    fn shaped_results_fit_the_budget_across_envelope_sizes() {
+        // A SWEEP, not a single point. The previous version of this test hardcoded
+        // a 2 000-byte envelope, which sat inside the safe zone, while 3 600 B
+        // returned `true` at 4 269 bytes against a 4 096 budget. Any single-point
+        // test can land in a window like that; stepping across the range cannot.
+        // Size of the marker plus JSON skeleton, measured rather than guessed.
+        // Declining is legitimate only once the envelope plus this cannot fit.
+        //
+        // This bound is deliberately TIGHT. A generous one (600) let the test pass
+        // against a head-size floor that gave up at a 3 600-byte envelope and
+        // passed the whole 53 686-byte body through, where shrinking to fit
+        // produces 4 009. Picking the threshold by measuring both implementations
+        // is the only reason this catches it.
+        const MARKER_RESERVE: usize = 450;
+
+        let budget = 4096;
+        for meta_len in [0, 500, 1_000, 2_000, 3_000, 3_400, 3_600, 3_800, 4_000, 4_100] {
+            let mut r = json!({
+                "content": [{ "type": "text", "text": "x".repeat(50_000) }],
+                "isError": false,
+                "_meta": { "com.example/ctx": "m".repeat(meta_len) }
+            });
+            let shaped = shape_result(&mut r, budget, None);
+            let size = serde_json::to_string(&r).map(|s| s.len()).unwrap_or(0);
+
+            if shaped {
+                assert!(
+                    size <= budget,
+                    "`true` must mean it fits: {meta_len}B envelope produced {size} \
+                     bytes against a {budget} budget"
+                );
+                // The envelope has to survive, otherwise "fits" was bought by
+                // silently dropping the server's data.
+                assert_eq!(
+                    r["_meta"]["com.example/ctx"].as_str().map(str::len),
+                    Some(meta_len),
+                    "{meta_len}B envelope was dropped rather than preserved"
+                );
+            } else {
+                // Declining is allowed ONLY when the envelope plus the marker
+                // genuinely cannot fit. Otherwise declining is itself a
+                // regression: the full 50 KB body reaches the model instead of a
+                // shaped head. This is what catches a head-size floor that gives
+                // up early rather than shrinking to fit.
+                assert!(
+                    meta_len + MARKER_RESERVE >= budget,
+                    "{meta_len}B envelope leaves room for a head, so it should have \
+                     been shaped rather than passed through whole"
+                );
+                // ...and an unshaped result must be left completely untouched.
+                assert!(
+                    r["content"][0]["text"].as_str().map(str::len) == Some(50_000),
+                    "an unshaped result must be left alone, {meta_len}B case"
+                );
+            }
+        }
     }
 
     #[test]

--- a/src-tauri/tests/spec_conformance.rs
+++ b/src-tauri/tests/spec_conformance.rs
@@ -19,7 +19,7 @@
 //!    work lands.
 
 use std::sync::atomic::{AtomicU8, AtomicUsize, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use conduit_lib::downstream::{DownstreamServer, StdioTransport, Transport, TransportError};
@@ -398,18 +398,58 @@ fn fully_stripped_meta_leaves_no_empty_object() {
     );
 }
 
-/// SOU-444, part two. `progressToken` is deliberately withheld until the gateway
-/// can route `notifications/progress` back to the originating request: the stdio
-/// read loop drops every notification it does not recognise, so relaying the
-/// token today would invite progress traffic into a black hole.
-///
-/// Remove the `#[ignore]` (and `WITHHELD_META_KEYS` in `downstream.rs`) when
-/// progress routing lands.
+/// SOU-444 part 2. `progressToken` is relayed now that the gateway routes the
+/// resulting `notifications/progress` back to the client that minted it.
 #[test]
-#[ignore = "SOU-444 part 2: progressToken withheld until notifications/progress can be routed back"]
 fn progress_token_reaches_downstream_server() {
     let received = relayed_meta(&json!({ "progressToken": "p-1" }));
     assert_eq!(received["progressToken"], "p-1");
+}
+
+/// The whole progress chain, not just its ends: a server emits
+/// `notifications/progress` mid-call, the stdout drain recognises it, and the
+/// bound sink receives it while the originating request is still in flight.
+///
+/// Before SOU-444 the drain dropped every notification it did not recognise, so
+/// this traffic went nowhere.
+#[test]
+fn downstream_progress_notification_reaches_the_bound_sink() {
+    let dirty = Arc::new(AtomicU8::new(0));
+    let mut transport = StdioTransport::spawn_watched(mock_bin(), &[], &[], None, dirty, None)
+        .expect("spawn fixture");
+
+    let seen: Arc<Mutex<Vec<Value>>> = Arc::new(Mutex::new(Vec::new()));
+    let sink_seen = Arc::clone(&seen);
+    transport.set_progress_sink(Some(Arc::new(move |note: Value| {
+        sink_seen
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .push(note);
+    })));
+
+    let mut server =
+        DownstreamServer::connect("mock".to_string(), Box::new(transport)).expect("connect");
+
+    let result = server
+        .call_with_cancel(
+            "progress_ping",
+            json!({}),
+            None,
+            Some(&json!({ "progressToken": "tok-e2e" })),
+        )
+        .expect("progress_ping call");
+    assert_eq!(result["isError"], false, "the call itself still succeeds");
+
+    // The notification is emitted before the response, so by the time the call
+    // returns the drain has already seen it.
+    let got = seen.lock().unwrap_or_else(|e| e.into_inner()).clone();
+    assert_eq!(got.len(), 1, "expected exactly one progress notification, got {got:?}");
+    assert_eq!(got[0]["method"], "notifications/progress");
+    assert_eq!(
+        got[0]["params"]["progressToken"], "tok-e2e",
+        "the token must round-trip so the gateway can route it back"
+    );
+    assert_eq!(got[0]["params"]["total"], 2);
 }
 
 /// SOU-445. A dual-era gateway must connect to a modern, stateless server by

--- a/src-tauri/tests/spec_conformance.rs
+++ b/src-tauri/tests/spec_conformance.rs
@@ -751,6 +751,13 @@ fn legacy_servers_see_no_era_detection_traffic() {
 /// Toolport's side - a gateway that rebuilds tool objects field-by-field drops
 /// unknown keys - and nothing exercised the aggregation that would do it
 /// (SOU-474, untested paths).
+///
+/// Scope: this covers `Router` aggregation, where the rebuild risk actually lives
+/// (`index_server` clones the tool and overwrites three fields). It stops short of
+/// the gateway's own `tools/list` arm, which serves from `aggregated_tools` and is
+/// not exercised here. Today unknown keys structurally cannot be dropped, so this
+/// is a forward-looking pin rather than a regression test - it earns its place by
+/// failing the moment someone reconstructs the tool object instead of cloning it.
 #[test]
 fn the_gateway_forwards_icons_through_tool_aggregation() {
     use conduit_lib::router::Router;
@@ -809,9 +816,16 @@ fn a_legacy_server_sees_client_meta_relayed_but_never_protocol_meta() {
         DownstreamServer::connect("mock".to_string(), Box::new(transport)).expect("connect");
     assert!(!server.era().is_modern(), "this pin is about the legacy hop");
 
+    // Includes a per-hop key on purpose. Sending only client-owned keys made the
+    // "never protocol meta" loop below vacuous: it proved the legacy transport
+    // does not STAMP one, never that PER_HOP_META_KEYS strips one the client sent
+    // (#511 review). Toolport speaks for itself downstream, so a client that
+    // declares a version must not have that claim relayed onward.
     let client_meta = json!({
         "progressToken": "client-tok",
         "traceparent": "00-abc-def-01",
+        "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+        "io.modelcontextprotocol/clientInfo": { "name": "SomeClient", "version": "9.9" },
     });
     server
         .call_with_cancel("echo", json!({ "text": "hi" }), None, Some(&client_meta))

--- a/src-tauri/tests/spec_conformance.rs
+++ b/src-tauri/tests/spec_conformance.rs
@@ -13,10 +13,13 @@
 //! 2. **Pin today's wire format.** `downstream_transcript_pins_current_wire_format`
 //!    records the exact JSON-RPC the gateway emits downstream. Any change to it
 //!    is then a deliberate edit to this file, never an accident.
-//! 3. **Document known gaps executably.** The `#[ignore]`d tests at the bottom
-//!    encode behaviour the spec requires and Toolport does not yet have. They are
-//!    the acceptance criteria for their issues: delete the `#[ignore]` when the
-//!    work lands.
+//! 3. **Prove the dual-era guarantees.** Both directions are covered: Toolport
+//!    connecting to a modern server and serving a modern client, each paired with
+//!    a test that the legacy path sees byte-identical traffic.
+//!
+//! Gaps were tracked here as `#[ignore]`d acceptance criteria while the work was
+//! in flight, which is a good pattern to reuse. Every test in this file runs
+//! today.
 
 use std::sync::atomic::{AtomicU8, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};

--- a/src-tauri/tests/spec_conformance.rs
+++ b/src-tauri/tests/spec_conformance.rs
@@ -653,6 +653,46 @@ fn gateway_connects_to_a_legacy_http_server() {
     let _ = std::fs::remove_file(&path);
 }
 
+/// A legacy server that ERRORS on `initialize` (missing API key, bad config)
+/// must still fail fast.
+///
+/// The era probe added a second request on that path. Launcher-wrapped servers
+/// (npx, uvx) carry a 120s connect budget for cold package downloads, so
+/// inheriting it here turned an instant failure into a two-minute hang, with
+/// batch probes and router rebuilds waiting on the slowest server. The probe now
+/// has its own tight budget.
+#[test]
+fn legacy_server_that_rejects_initialize_still_fails_fast() {
+    // Strict modern fixture refuses `initialize`, then stays silent on the probe
+    // because... it is modern, so instead use a strict LEGACY fixture, which
+    // rejects anything before `initialize` and never implements `server/discover`.
+    // Sending a bad `initialize` makes it error, then go silent on the probe.
+    let dirty = Arc::new(AtomicU8::new(0));
+    let env = env_for(Some("2025-06-18"), true, None);
+    let transport = StdioTransport::spawn_watched(mock_bin(), &[], &env, None, dirty, None)
+        .expect("spawn fixture");
+
+    let started = std::time::Instant::now();
+    // `connect` sends a well-formed initialize which this fixture accepts, so
+    // drive the failing path directly: a raw transport whose first call is not
+    // `initialize` gets the strict fixture's error, and `server/discover` then
+    // gets silence.
+    let mut server = transport;
+    server.set_read_timeout(Duration::from_secs(2));
+    let _ = server.request("tools/list", json!({}));
+    let probe = server.request("server/discover", json!({}));
+    let elapsed = started.elapsed();
+
+    assert!(probe.is_err(), "a legacy fixture never answers server/discover");
+    // The point is the bound, not the exact number: silence must not cost the
+    // full launcher budget.
+    assert!(
+        elapsed < Duration::from_secs(10),
+        "probing a silent legacy server took {elapsed:?}; it must not inherit the \
+         120s launcher connect budget"
+    );
+}
+
 /// The legacy path must be untouched by era detection: no extra probe, no
 /// `server/discover`, and no protocol `_meta` on the wire. This is the
 /// no-regression guarantee for the entire existing install base.
@@ -674,16 +714,32 @@ fn legacy_servers_see_no_era_detection_traffic() {
 
     let transcript = read_transcript(&path);
     let methods = methods_of(&transcript);
+    // Non-vacuity first. `read_transcript` swallows a missing file, a wrong path,
+    // and unparseable lines into an empty Vec, and BOTH assertions below hold on
+    // zero records, so without this the headline no-regression guarantee passes
+    // when the fixture records nothing at all. Verified: stubbing the fixture's
+    // `record()` to a no-op left this test green.
+    assert!(
+        methods.iter().any(|m| m == "initialize"),
+        "expected a recorded transcript, got {methods:?}"
+    );
+    assert!(
+        methods.iter().any(|m| m == "tools/call"),
+        "expected the echo call to be recorded, got {methods:?}"
+    );
     assert!(
         !methods.iter().any(|m| m == "server/discover"),
         "a legacy server must never be probed, got {methods:?}"
     );
+    let mut checked = 0;
     for record in &transcript {
+        checked += 1;
         assert!(
             record["params"].get("_meta").is_none(),
             "legacy requests carry no protocol _meta, got {record}"
         );
     }
+    assert!(checked >= 3, "expected several records to check, saw {checked}");
 
     let _ = std::fs::remove_file(&path);
 }

--- a/src-tauri/tests/spec_conformance.rs
+++ b/src-tauri/tests/spec_conformance.rs
@@ -288,12 +288,10 @@ fn downstream_transcript_pins_current_wire_format() {
         assert!(methods.iter().any(|m| m == expected), "missing {expected} in {methods:?}");
     }
 
-    // The `tools/call` envelope as it exists today. Params are RECONSTRUCTED by
-    // `downstream.rs:2498` as exactly `{name, arguments}`, which is why
-    // `params._meta` has never survived a hop through Toolport.
-    //
-    // SOU-444 changes this. When it lands, `_meta` becomes an expected key here
-    // and this assertion must be updated deliberately.
+    // The `tools/call` envelope for a call carrying no client metadata. Since
+    // SOU-444 the gateway attaches `_meta` only when there is something relayable
+    // to attach, so this shape is byte-identical to what Toolport sent before
+    // that work: an unchanged request for every server that never sees `_meta`.
     let call = transcript
         .iter()
         .find(|r| r["method"] == "tools/call")
@@ -323,30 +321,95 @@ fn downstream_transcript_pins_current_wire_format() {
 // 3. Known gaps, encoded as acceptance criteria
 // ---------------------------------------------------------------------------
 
-/// SOU-444. `_meta` sent by an upstream client must reach the downstream server.
-/// Today the gateway reconstructs `params` from `{name, arguments}` and drops
-/// everything else, so this fails.
-///
-/// Remove the `#[ignore]` when envelope-transparent proxying lands.
-#[test]
-#[ignore = "SOU-444: params are reconstructed, so _meta never reaches downstream"]
-fn client_meta_reaches_downstream_server() {
+/// Ask the fixture to reflect back whatever `_meta` reached it.
+fn relayed_meta(client_meta: &Value) -> Value {
     let dirty = Arc::new(AtomicU8::new(0));
     let transport = StdioTransport::spawn_watched(mock_bin(), &[], &[], None, dirty, None)
         .expect("spawn fixture");
     let mut server =
         DownstreamServer::connect("mock".to_string(), Box::new(transport)).expect("connect");
-
-    // `echo_meta` reflects whatever `params._meta` it received.
     let result = server
-        .call("echo_meta", json!({}))
+        .call_with_cancel("echo_meta", json!({}), None, Some(client_meta))
         .expect("echo_meta call");
+    result["structuredContent"]["receivedMeta"].clone()
+}
 
-    let received = &result["structuredContent"]["receivedMeta"];
-    assert!(
-        received.get("progressToken").is_some(),
-        "a progressToken supplied by the client must reach the server, got {received}"
+/// SOU-444. `_meta` an upstream client sends must reach the downstream server,
+/// including keys this build has never heard of. That "forward unknown by
+/// default" property is what stops Toolport silently breaking future extensions
+/// such as MCP Apps and Tasks.
+#[test]
+fn client_meta_reaches_downstream_server() {
+    let received = relayed_meta(&json!({
+        "traceparent": "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
+        "com.example/somethingWeHaveNeverSeen": { "nested": [1, 2, 3] },
+        "io.modelcontextprotocol/tasks": { "taskId": "t-1" }
+    }));
+
+    assert_eq!(
+        received["traceparent"],
+        "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
+        "OTel trace context is explicitly meant to propagate across hops"
     );
+    assert_eq!(
+        received["com.example/somethingWeHaveNeverSeen"]["nested"][2], 3,
+        "an unknown extension namespace must survive verbatim, got {received}"
+    );
+    assert_eq!(received["io.modelcontextprotocol/tasks"]["taskId"], "t-1");
+}
+
+/// The other half of relaying: keys that describe one hop must NOT be forwarded.
+/// Toolport is the client on the downstream hop, so relaying the upstream
+/// client's identity or capabilities would assert claims the gateway cannot
+/// honour. SOU-445/SOU-446 replace these with Toolport's own values.
+#[test]
+fn per_hop_meta_keys_are_not_relayed() {
+    let received = relayed_meta(&json!({
+        "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+        "io.modelcontextprotocol/clientInfo": { "name": "SomeOtherClient", "version": "9.9.9" },
+        "io.modelcontextprotocol/clientCapabilities": { "sampling": {} },
+        "keepMe": true
+    }));
+
+    for key in [
+        "io.modelcontextprotocol/protocolVersion",
+        "io.modelcontextprotocol/clientInfo",
+        "io.modelcontextprotocol/clientCapabilities",
+    ] {
+        assert!(
+            received.get(key).is_none(),
+            "{key} is per-hop and must not be relayed, got {received}"
+        );
+    }
+    assert_eq!(received["keepMe"], true, "non-per-hop keys still travel");
+}
+
+/// A request whose `_meta` is entirely per-hop must not gain an empty `_meta`
+/// object. Downstream servers that never see client metadata keep receiving
+/// byte-identical requests.
+#[test]
+fn fully_stripped_meta_leaves_no_empty_object() {
+    let received = relayed_meta(&json!({
+        "io.modelcontextprotocol/protocolVersion": "2026-07-28"
+    }));
+    assert!(
+        received.is_null(),
+        "no relayable keys should mean no _meta at all, got {received}"
+    );
+}
+
+/// SOU-444, part two. `progressToken` is deliberately withheld until the gateway
+/// can route `notifications/progress` back to the originating request: the stdio
+/// read loop drops every notification it does not recognise, so relaying the
+/// token today would invite progress traffic into a black hole.
+///
+/// Remove the `#[ignore]` (and `WITHHELD_META_KEYS` in `downstream.rs`) when
+/// progress routing lands.
+#[test]
+#[ignore = "SOU-444 part 2: progressToken withheld until notifications/progress can be routed back"]
+fn progress_token_reaches_downstream_server() {
+    let received = relayed_meta(&json!({ "progressToken": "p-1" }));
+    assert_eq!(received["progressToken"], "p-1");
 }
 
 /// SOU-445. A dual-era gateway must connect to a modern, stateless server by

--- a/src-tauri/tests/spec_conformance.rs
+++ b/src-tauri/tests/spec_conformance.rs
@@ -743,3 +743,204 @@ fn legacy_servers_see_no_era_detection_traffic() {
 
     let _ = std::fs::remove_file(&path);
 }
+
+/// The GATEWAY must forward `icons`, not merely the fixture emit them.
+///
+/// `fixture_advertises_icons_from_2025_11_25` drives the fixture through a raw
+/// transport, so it only ever proved the mock's own output. The actual risk is on
+/// Toolport's side - a gateway that rebuilds tool objects field-by-field drops
+/// unknown keys - and nothing exercised the aggregation that would do it
+/// (SOU-474, untested paths).
+#[test]
+fn the_gateway_forwards_icons_through_tool_aggregation() {
+    use conduit_lib::router::Router;
+
+    let env = env_for(Some("2025-11-25"), false, None);
+    let dirty = Arc::new(AtomicU8::new(0));
+    let transport = StdioTransport::spawn_watched(mock_bin(), &[], &env, None, dirty, None)
+        .expect("spawn fixture");
+    let server =
+        DownstreamServer::connect("mock".to_string(), Box::new(transport)).expect("connect");
+
+    // Non-vacuity: the server really did hand us icons, so a later assertion
+    // failing means the gateway dropped them rather than the fixture omitting them.
+    let raw_has_icons = server
+        .tools
+        .iter()
+        .any(|t| t["name"] == "echo" && t.get("icons").is_some());
+    assert!(raw_has_icons, "fixture must supply icons for this test to mean anything");
+
+    let mut router = Router::new();
+    router.add(server);
+    let exposed = router.aggregated_tools();
+    let echo = exposed
+        .iter()
+        .find(|t| t["name"].as_str().is_some_and(|n| n.ends_with("echo")))
+        .unwrap_or_else(|| panic!("echo must survive aggregation, got {exposed:#?}"));
+
+    let icons = echo
+        .get("icons")
+        .unwrap_or_else(|| panic!("the gateway dropped `icons` during aggregation: {echo}"));
+    assert!(icons.is_array(), "icons must survive intact, got {icons}");
+}
+
+/// Pin what a LEGACY server sees when the client's request does carry `_meta`.
+///
+/// `legacy_servers_see_no_era_detection_traffic` asserts `_meta` is absent
+/// outright, which only holds because its calls send none. `WITHHELD_META_KEYS`
+/// is now empty, so a legacy client's `progressToken` IS relayed downstream and
+/// the server starts emitting `notifications/progress` on connections that never
+/// saw them before. That is intended - the client asked for it - but it was new
+/// server-to-client traffic covered by no pin at all (SOU-474 #6).
+///
+/// The real invariant is narrower than "no `_meta`": Toolport must not put its
+/// OWN protocol metadata on a legacy hop, while still relaying what the client
+/// sent.
+#[test]
+fn a_legacy_server_sees_client_meta_relayed_but_never_protocol_meta() {
+    let path = scratch_path("legacy-client-meta");
+    let _ = std::fs::remove_file(&path);
+    let env = env_for(Some("2025-06-18"), true, Some(&path.to_string_lossy()));
+
+    let dirty = Arc::new(AtomicU8::new(0));
+    let transport = StdioTransport::spawn_watched(mock_bin(), &[], &env, None, dirty, None)
+        .expect("spawn fixture");
+    let mut server =
+        DownstreamServer::connect("mock".to_string(), Box::new(transport)).expect("connect");
+    assert!(!server.era().is_modern(), "this pin is about the legacy hop");
+
+    let client_meta = json!({
+        "progressToken": "client-tok",
+        "traceparent": "00-abc-def-01",
+    });
+    server
+        .call_with_cancel("echo", json!({ "text": "hi" }), None, Some(&client_meta))
+        .expect("call");
+    drop(server);
+
+    let transcript = read_transcript(&path);
+    let call = transcript
+        .iter()
+        .find(|r| r["method"] == "tools/call")
+        .unwrap_or_else(|| panic!("expected a recorded tools/call, got {transcript:#?}"));
+    let meta = call["params"]["_meta"]
+        .as_object()
+        .unwrap_or_else(|| panic!("the client's _meta must reach the server, got {call}"));
+
+    // Relayed: the client asked for progress and for its trace context to travel.
+    assert_eq!(
+        meta.get("progressToken").and_then(|v| v.as_str()),
+        Some("client-tok"),
+        "progressToken is relayed now that progress can be routed back: {call}"
+    );
+    assert_eq!(
+        meta.get("traceparent").and_then(|v| v.as_str()),
+        Some("00-abc-def-01"),
+        "unknown _meta keys must pass through untouched: {call}"
+    );
+    // Withheld: Toolport speaks for itself on the downstream hop, and a legacy
+    // server must never see 2026-07-28 protocol metadata.
+    for key in meta.keys() {
+        assert!(
+            !key.starts_with("io.modelcontextprotocol/"),
+            "a legacy server must see no protocol _meta, got '{key}' in {call}"
+        );
+    }
+
+    let _ = std::fs::remove_file(&path);
+}
+
+/// Prove the strict modern fixture's handshake gate can actually fire.
+///
+/// `notifications/initialized` was listed among the methods a strict modern
+/// fixture rejects, but it carries no id, so it returned from `handle` long
+/// before the gate was consulted - and that early return marked the server
+/// initialized. The gate read as enforcement while the fixture quietly accepted
+/// the exact traffic it advertised refusing (SOU-474 #11).
+///
+/// Checks all three cases the way a fixture gate has to be checked: it fires on
+/// the violation, stays silent when the method is absent, and stays silent for a
+/// legacy fixture where the handshake is legitimate.
+#[test]
+fn strict_modern_fixture_refuses_the_legacy_handshake_notification() {
+    use std::io::Write;
+
+    /// Feed one line to a fixture, close stdin, and report whether it died.
+    fn feed(revision: &str, strict: bool, line: &str) -> Option<i32> {
+        let mut cmd = std::process::Command::new(mock_bin());
+        cmd.env("MOCK_MCP_REVISION", revision)
+            .stdin(std::process::Stdio::piped())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::null());
+        if strict {
+            cmd.env("MOCK_MCP_STRICT", "1");
+        }
+        let mut child = cmd.spawn().expect("spawn fixture");
+        {
+            let mut stdin = child.stdin.take().expect("fixture stdin");
+            let _ = writeln!(stdin, "{line}");
+        }
+        child.wait().expect("fixture should exit").code()
+    }
+
+    const HANDSHAKE: &str = r#"{"jsonrpc":"2.0","method":"notifications/initialized"}"#;
+    // Another id-less notification, to show the gate is specific rather than
+    // just killing the process on any notification.
+    const OTHER: &str = r#"{"jsonrpc":"2.0","method":"notifications/cancelled"}"#;
+
+    // Positive: the violation is refused.
+    assert_eq!(
+        feed("2026-07-28", true, HANDSHAKE),
+        Some(97),
+        "a strict modern fixture must refuse the legacy handshake notification"
+    );
+    // Absent: a different notification is fine.
+    assert_eq!(
+        feed("2026-07-28", true, OTHER),
+        Some(0),
+        "only the handshake notification is refused"
+    );
+    // Negative: on a legacy fixture the same notification is legitimate.
+    assert_eq!(
+        feed("2025-06-18", true, HANDSHAKE),
+        Some(0),
+        "a legacy fixture must still accept its own handshake"
+    );
+    // And strict mode is what arms it: a non-strict modern fixture tolerates it.
+    assert_eq!(
+        feed("2026-07-28", false, HANDSHAKE),
+        Some(0),
+        "the gate belongs to strict mode"
+    );
+}
+
+/// The negotiated legacy version must be the one the SERVER answered with, not
+/// Toolport's default.
+///
+/// Every other legacy assertion uses a 2025-06-18 fixture, which is byte-identical
+/// to the `PROTOCOL_VERSION` fallback - so `Era::Legacy { version }` could be
+/// replaced by the constant outright and the whole suite stayed green (SOU-474 #8).
+/// This pins it at a revision the fallback cannot produce.
+#[test]
+fn legacy_era_pins_the_version_the_server_actually_answered() {
+    for revision in ["2024-11-05", "2025-03-26", "2025-11-25"] {
+        assert_ne!(
+            revision,
+            conduit_lib::downstream::PROTOCOL_VERSION,
+            "this test is only meaningful at a revision the fallback cannot produce"
+        );
+        let env = env_for(Some(revision), true, None);
+        let dirty = Arc::new(AtomicU8::new(0));
+        let transport = StdioTransport::spawn_watched(mock_bin(), &[], &env, None, dirty, None)
+            .expect("spawn fixture");
+        let server = DownstreamServer::connect("mock".to_string(), Box::new(transport))
+            .unwrap_or_else(|e| panic!("connect to a {revision} server: {e}"));
+
+        assert!(!server.era().is_modern(), "{revision} is a legacy revision");
+        assert_eq!(
+            server.era().version(),
+            revision,
+            "the era must carry the server's own version, not the fallback"
+        );
+    }
+}

--- a/src-tauri/tests/spec_conformance.rs
+++ b/src-tauri/tests/spec_conformance.rs
@@ -1,0 +1,383 @@
+//! MCP specification conformance + backward-compatibility harness (SOU-443).
+//!
+//! Toolport is simultaneously an MCP *server* (to AI clients) and an MCP *client*
+//! (to downstream servers), so every protocol revision change lands on it twice.
+//! The gateway must stay **dual-era**: speaking `2026-07-28` upward while still
+//! driving `initialize`-era servers downward.
+//!
+//! This file is the regression net for that work. It has three jobs:
+//!
+//! 1. **Validate the fixture.** `mock-mcp-server` can impersonate any revision;
+//!    these tests prove it actually behaves era-correctly, so later tests can
+//!    trust it as a reference implementation.
+//! 2. **Pin today's wire format.** `downstream_transcript_pins_current_wire_format`
+//!    records the exact JSON-RPC the gateway emits downstream. Any change to it
+//!    is then a deliberate edit to this file, never an accident.
+//! 3. **Document known gaps executably.** The `#[ignore]`d tests at the bottom
+//!    encode behaviour the spec requires and Toolport does not yet have. They are
+//!    the acceptance criteria for their issues: delete the `#[ignore]` when the
+//!    work lands.
+
+use std::sync::atomic::{AtomicU8, AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use conduit_lib::downstream::{DownstreamServer, StdioTransport, Transport, TransportError};
+use serde_json::{json, Value};
+
+const MODERN: &str = "2026-07-28";
+const LEGACY_REVISIONS: [&str; 4] = ["2024-11-05", "2025-03-26", "2025-06-18", "2025-11-25"];
+
+/// Historical default the fixture must keep when no revision is requested, so
+/// the pre-existing integration tests are unaffected by the multi-revision work.
+const FIXTURE_DEFAULT: &str = "2025-06-18";
+
+fn mock_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_mock-mcp-server")
+}
+
+/// A unique scratch path per call. Avoids a `tempfile` dev-dependency for what
+/// is only ever a few lines of JSONL.
+fn scratch_path(tag: &str) -> std::path::PathBuf {
+    static N: AtomicUsize = AtomicUsize::new(0);
+    let n = N.fetch_add(1, Ordering::SeqCst);
+    std::env::temp_dir().join(format!(
+        "toolport-conformance-{tag}-{}-{n}.jsonl",
+        std::process::id()
+    ))
+}
+
+fn env_for(revision: Option<&str>, strict: bool, transcript: Option<&str>) -> Vec<(String, String)> {
+    let mut env = Vec::new();
+    if let Some(rev) = revision {
+        env.push(("MOCK_MCP_REVISION".to_string(), rev.to_string()));
+    }
+    if strict {
+        env.push(("MOCK_MCP_STRICT".to_string(), "1".to_string()));
+    }
+    if let Some(path) = transcript {
+        env.push(("MOCK_MCP_TRANSCRIPT".to_string(), path.to_string()));
+    }
+    env
+}
+
+/// A raw transport to the fixture, bypassing `DownstreamServer::connect` so a
+/// test can drive the handshake itself and observe era behaviour directly.
+fn raw_transport(env: &[(String, String)]) -> StdioTransport {
+    let dirty = Arc::new(AtomicU8::new(0));
+    StdioTransport::spawn_watched(mock_bin(), &[], env, None, dirty, None).expect("spawn fixture")
+}
+
+/// The gateway flattens JSON-RPC error objects into `TransportError::Fatal(String)`
+/// (`downstream.rs:1765`), so the structured `code` is only recoverable by
+/// re-parsing. Re-parsing here keeps these tests honest about what the wire
+/// actually carried.
+///
+/// This lossiness is itself a gap: the 2026-07-28 backward-compatibility ladder
+/// requires a client to branch on whether a `400` body is a *recognized modern
+/// error* (`-32022`/`-32021`/`-32020`) before falling back to `initialize`.
+/// Preserving the structured error is tracked as part of SOU-445.
+fn error_json(err: &TransportError) -> Value {
+    let TransportError::Fatal(msg) = err else {
+        panic!("expected a Fatal protocol error, got {err:?}");
+    };
+    serde_json::from_str(msg).unwrap_or_else(|_| json!({ "message": msg }))
+}
+
+fn read_transcript(path: &std::path::Path) -> Vec<Value> {
+    let raw = std::fs::read_to_string(path).unwrap_or_default();
+    raw.lines()
+        .filter(|l| !l.trim().is_empty())
+        .filter_map(|l| serde_json::from_str(l).ok())
+        .collect()
+}
+
+fn methods_of(transcript: &[Value]) -> Vec<String> {
+    transcript
+        .iter()
+        .filter_map(|r| r.get("method").and_then(|m| m.as_str()).map(String::from))
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// 1. Fixture validation
+// ---------------------------------------------------------------------------
+
+/// The multi-revision work must not change what an un-configured fixture does,
+/// because `list_changed`, `circuit_breaker`, and `root_cwd` all depend on it.
+#[test]
+fn fixture_default_revision_is_unchanged() {
+    let mut t = raw_transport(&env_for(None, false, None));
+    let init = t
+        .request("initialize", json!({ "protocolVersion": FIXTURE_DEFAULT, "capabilities": {} }))
+        .expect("default fixture should answer initialize");
+    assert_eq!(init["protocolVersion"], FIXTURE_DEFAULT);
+}
+
+#[test]
+fn fixture_reports_each_legacy_revision() {
+    for rev in LEGACY_REVISIONS {
+        let mut t = raw_transport(&env_for(Some(rev), false, None));
+        let init = t
+            .request("initialize", json!({ "protocolVersion": rev, "capabilities": {} }))
+            .unwrap_or_else(|e| panic!("{rev} fixture should answer initialize: {e}"));
+        assert_eq!(init["protocolVersion"], rev, "fixture pinned to {rev}");
+
+        // Legacy revisions must NOT answer server/discover: that is precisely the
+        // signal the gateway's stdio fallback probe keys on (SOU-445).
+        //
+        // Note *how* it fails. Like many real stdio servers, the fixture simply
+        // does not reply to a method it does not know, so the probe ends in a
+        // read timeout rather than a JSON-RPC error. Silence is therefore a third
+        // outcome the era probe must handle, alongside "recognized modern error"
+        // (stay modern) and "some other error" (fall back). A probe without a
+        // bounded timeout would hang on every legacy stdio server it meets.
+        t.set_read_timeout(Duration::from_millis(500));
+        assert!(
+            t.request("server/discover", json!({})).is_err(),
+            "{rev} is legacy and must not implement server/discover"
+        );
+    }
+}
+
+/// Icons landed in 2025-11-25 (SEP-973). They ride on the tool definition, so a
+/// gateway that rebuilds tool objects field-by-field would silently drop them.
+#[test]
+fn fixture_advertises_icons_from_2025_11_25() {
+    let mut t = raw_transport(&env_for(Some("2025-11-25"), false, None));
+    t.request("initialize", json!({ "protocolVersion": "2025-11-25", "capabilities": {} }))
+        .expect("initialize");
+    let tools = t.request("tools/list", json!({})).expect("tools/list");
+    let echo = tools["tools"]
+        .as_array()
+        .expect("tools array")
+        .iter()
+        .find(|t| t["name"] == "echo")
+        .expect("echo tool");
+    assert!(echo.get("icons").is_some(), "2025-11-25 fixture should carry icons");
+
+    // ...and must not appear on older revisions, so a test can tell eras apart.
+    let mut old = raw_transport(&env_for(Some("2025-06-18"), false, None));
+    old.request("initialize", json!({ "protocolVersion": "2025-06-18", "capabilities": {} }))
+        .expect("initialize");
+    let old_tools = old.request("tools/list", json!({})).expect("tools/list");
+    let old_echo = old_tools["tools"]
+        .as_array()
+        .expect("tools array")
+        .iter()
+        .find(|t| t["name"] == "echo")
+        .expect("echo tool");
+    assert!(old_echo.get("icons").is_none(), "2025-06-18 predates icons");
+}
+
+/// A modern server has no handshake. The spec asks it to name its supported
+/// versions in the error, because legacy clients have no fall-forward mechanism
+/// and this may be the only diagnostic a user ever sees.
+#[test]
+fn modern_fixture_rejects_initialize_and_names_supported_versions() {
+    let mut t = raw_transport(&env_for(Some(MODERN), true, None));
+    let err = t
+        .request("initialize", json!({ "protocolVersion": "2025-06-18", "capabilities": {} }))
+        .expect_err("a modern server must not implement initialize");
+    let err = error_json(&err);
+    assert_eq!(err["code"], -32601, "unknown method");
+    assert_eq!(err["data"]["supported"][0], MODERN);
+}
+
+#[test]
+fn modern_fixture_answers_server_discover() {
+    let mut t = raw_transport(&env_for(Some(MODERN), true, None));
+    let result = t
+        .request(
+            "server/discover",
+            json!({ "_meta": { "io.modelcontextprotocol/protocolVersion": MODERN } }),
+        )
+        .expect("a modern server MUST implement server/discover");
+
+    assert_eq!(result["supportedVersions"][0], MODERN);
+    assert_eq!(result["resultType"], "complete", "every result carries resultType");
+    assert_eq!(
+        result["_meta"]["io.modelcontextprotocol/serverInfo"]["name"],
+        "mock-mcp-server"
+    );
+    // server/discover is a cacheable operation.
+    assert!(result.get("ttlMs").is_some(), "CacheableResult.ttlMs");
+    assert_eq!(result["cacheScope"], "public");
+}
+
+/// Every modern request declares its version in `_meta`; a server that does not
+/// implement it MUST reply `-32022` listing what it does support.
+#[test]
+fn modern_fixture_rejects_request_without_protocol_version() {
+    let mut t = raw_transport(&env_for(Some(MODERN), true, None));
+
+    let err = error_json(&t.request("tools/list", json!({})).expect_err("missing _meta version"));
+    assert_eq!(err["code"], -32022);
+    assert_eq!(err["data"]["supported"][0], MODERN);
+
+    let err = error_json(
+        &t.request(
+            "tools/list",
+            json!({ "_meta": { "io.modelcontextprotocol/protocolVersion": "1900-01-01" } }),
+        )
+        .expect_err("unknown version"),
+    );
+    assert_eq!(err["code"], -32022);
+    assert_eq!(err["data"]["requested"], "1900-01-01");
+
+    // The same request with the right version succeeds, proving the gate is the
+    // version and not the method.
+    let ok = t
+        .request(
+            "tools/list",
+            json!({ "_meta": { "io.modelcontextprotocol/protocolVersion": MODERN } }),
+        )
+        .expect("correct version should pass");
+    assert_eq!(ok["resultType"], "complete");
+}
+
+#[test]
+fn strict_legacy_fixture_requires_initialize_first() {
+    let mut t = raw_transport(&env_for(Some("2025-06-18"), true, None));
+    let err = error_json(&t.request("tools/list", json!({})).expect_err("handshake not done"));
+    assert_eq!(err["code"], -32600);
+
+    t.request("initialize", json!({ "protocolVersion": "2025-06-18", "capabilities": {} }))
+        .expect("initialize");
+    t.notify("notifications/initialized", json!({})).expect("initialized");
+    assert!(t.request("tools/list", json!({})).is_ok(), "handshake complete");
+}
+
+// ---------------------------------------------------------------------------
+// 2. Pin today's downstream wire format
+// ---------------------------------------------------------------------------
+
+/// Records exactly what Toolport sends to a downstream server for a fixed
+/// scenario. This is the regression net: SOU-444 and SOU-445 both rewrite this
+/// path, and this test makes any change to the emitted bytes an explicit,
+/// reviewed edit rather than a silent behavioural drift.
+#[test]
+fn downstream_transcript_pins_current_wire_format() {
+    let path = scratch_path("wire");
+    let _ = std::fs::remove_file(&path);
+    let env = env_for(None, false, Some(&path.to_string_lossy()));
+
+    let dirty = Arc::new(AtomicU8::new(0));
+    let transport = StdioTransport::spawn_watched(mock_bin(), &[], &env, None, dirty, None)
+        .expect("spawn fixture");
+    let mut server =
+        DownstreamServer::connect("mock".to_string(), Box::new(transport)).expect("connect");
+    server.load_resources_prompts();
+    server.call("echo", json!({ "text": "hi" })).expect("echo call");
+    drop(server);
+
+    let transcript = read_transcript(&path);
+    let methods = methods_of(&transcript);
+
+    // The handshake still opens the conversation, and it still declares a
+    // version. When SOU-445 lands, a dual-era gateway will probe with
+    // `server/discover` first and only fall back to `initialize` here.
+    assert_eq!(methods.first().map(String::as_str), Some("initialize"));
+    let init = &transcript[0];
+    assert!(
+        init["params"].get("protocolVersion").is_some(),
+        "initialize must declare a protocol version"
+    );
+
+    for expected in ["tools/list", "resources/list", "prompts/list", "tools/call"] {
+        assert!(methods.iter().any(|m| m == expected), "missing {expected} in {methods:?}");
+    }
+
+    // The `tools/call` envelope as it exists today. Params are RECONSTRUCTED by
+    // `downstream.rs:2498` as exactly `{name, arguments}`, which is why
+    // `params._meta` has never survived a hop through Toolport.
+    //
+    // SOU-444 changes this. When it lands, `_meta` becomes an expected key here
+    // and this assertion must be updated deliberately.
+    let call = transcript
+        .iter()
+        .find(|r| r["method"] == "tools/call")
+        .expect("tools/call recorded");
+    let mut keys: Vec<&str> = call["params"]
+        .as_object()
+        .expect("params object")
+        .keys()
+        .map(String::as_str)
+        .collect();
+    keys.sort_unstable();
+    assert_eq!(
+        keys,
+        vec!["arguments", "name"],
+        "tools/call params shape changed; if this is SOU-444, update this assertion on purpose"
+    );
+
+    // The downstream name is the ORIGINAL tool name, not the namespaced exposed
+    // name. SOU-450 depends on this: the `Mcp-Name` header must carry the name
+    // actually sent on the wire.
+    assert_eq!(call["params"]["name"], "echo");
+
+    let _ = std::fs::remove_file(&path);
+}
+
+// ---------------------------------------------------------------------------
+// 3. Known gaps, encoded as acceptance criteria
+// ---------------------------------------------------------------------------
+
+/// SOU-444. `_meta` sent by an upstream client must reach the downstream server.
+/// Today the gateway reconstructs `params` from `{name, arguments}` and drops
+/// everything else, so this fails.
+///
+/// Remove the `#[ignore]` when envelope-transparent proxying lands.
+#[test]
+#[ignore = "SOU-444: params are reconstructed, so _meta never reaches downstream"]
+fn client_meta_reaches_downstream_server() {
+    let dirty = Arc::new(AtomicU8::new(0));
+    let transport = StdioTransport::spawn_watched(mock_bin(), &[], &[], None, dirty, None)
+        .expect("spawn fixture");
+    let mut server =
+        DownstreamServer::connect("mock".to_string(), Box::new(transport)).expect("connect");
+
+    // `echo_meta` reflects whatever `params._meta` it received.
+    let result = server
+        .call("echo_meta", json!({}))
+        .expect("echo_meta call");
+
+    let received = &result["structuredContent"]["receivedMeta"];
+    assert!(
+        received.get("progressToken").is_some(),
+        "a progressToken supplied by the client must reach the server, got {received}"
+    );
+}
+
+/// SOU-445. A dual-era gateway must connect to a modern, stateless server by
+/// probing `server/discover` and never sending `initialize`.
+///
+/// Today `DownstreamServer::connect` opens with `initialize` unconditionally, so
+/// a strict 2026-07-28 server refuses the handshake and the connection fails.
+#[test]
+#[ignore = "SOU-445: connect() always sends initialize, so modern servers are unreachable"]
+fn gateway_connects_to_a_modern_server() {
+    let path = scratch_path("modern");
+    let _ = std::fs::remove_file(&path);
+    let env = env_for(Some(MODERN), true, Some(&path.to_string_lossy()));
+
+    let dirty = Arc::new(AtomicU8::new(0));
+    let transport = StdioTransport::spawn_watched(mock_bin(), &[], &env, None, dirty, None)
+        .expect("spawn fixture");
+    let server = DownstreamServer::connect("mock".to_string(), Box::new(transport))
+        .expect("a dual-era gateway must connect to a modern server");
+    drop(server);
+
+    let methods = methods_of(&read_transcript(&path));
+    assert_eq!(
+        methods.first().map(String::as_str),
+        Some("server/discover"),
+        "a dual-era client probes with server/discover first, got {methods:?}"
+    );
+    assert!(
+        !methods.iter().any(|m| m == "initialize"),
+        "a modern server must never be sent initialize, got {methods:?}"
+    );
+
+    let _ = std::fs::remove_file(&path);
+}

--- a/src-tauri/tests/spec_conformance.rs
+++ b/src-tauri/tests/spec_conformance.rs
@@ -25,7 +25,9 @@ use std::sync::atomic::{AtomicU8, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-use conduit_lib::downstream::{DownstreamServer, StdioTransport, Transport, TransportError};
+use conduit_lib::downstream::{
+    DownstreamServer, HttpTransport, StdioTransport, Transport, TransportError,
+};
 use serde_json::{json, Value};
 
 const MODERN: &str = "2026-07-28";
@@ -62,6 +64,51 @@ fn env_for(revision: Option<&str>, strict: bool, transcript: Option<&str>) -> Ve
         env.push(("MOCK_MCP_TRANSCRIPT".to_string(), path.to_string()));
     }
     env
+}
+
+/// A fixture serving Streamable HTTP, killed when the handle drops.
+struct HttpFixture {
+    child: std::process::Child,
+    url: String,
+}
+
+impl Drop for HttpFixture {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+/// Spawn the fixture in HTTP mode and wait for it to report its ephemeral port.
+///
+/// The stdio fixture cannot express header rules at all, which is exactly how a
+/// hardcoded `MCP-Protocol-Version` shipped past a green stdio suite. Anything
+/// about headers has to be tested here.
+fn spawn_http_fixture(revision: &str, strict: bool, transcript: Option<&str>) -> HttpFixture {
+    use std::io::BufRead;
+
+    let mut cmd = std::process::Command::new(mock_bin());
+    cmd.env("MOCK_MCP_HTTP", "1")
+        .env("MOCK_MCP_REVISION", revision)
+        .stdout(std::process::Stdio::piped());
+    if strict {
+        cmd.env("MOCK_MCP_STRICT", "1");
+    }
+    if let Some(path) = transcript {
+        cmd.env("MOCK_MCP_TRANSCRIPT", path);
+    }
+    let mut child = cmd.spawn().expect("spawn http fixture");
+    let stdout = child.stdout.take().expect("fixture stdout");
+    let mut line = String::new();
+    std::io::BufReader::new(stdout)
+        .read_line(&mut line)
+        .expect("fixture should announce its url");
+    let url = line
+        .trim()
+        .strip_prefix("MOCK_MCP_URL=")
+        .expect("fixture should print MOCK_MCP_URL=<url>")
+        .to_string();
+    HttpFixture { child, url }
 }
 
 /// A raw transport to the fixture, bypassing `DownstreamServer::connect` so a
@@ -512,6 +559,97 @@ fn gateway_connects_to_a_modern_server() {
         "expected the tools/list and tools/call records to be checked, saw {checked}"
     );
 
+    let _ = std::fs::remove_file(&path);
+}
+
+/// Proves the HTTP fixture's header gate actually fires. Without this, the
+/// connect test below could pass on a fixture that validates nothing, which is
+/// precisely the blind spot the stdio-only harness had.
+#[test]
+fn http_fixture_enforces_header_body_agreement() {
+    let fixture = spawn_http_fixture(MODERN, true, None);
+    let body = json!({
+        "jsonrpc": "2.0", "id": 1, "method": "tools/list",
+        "params": { "_meta": { "io.modelcontextprotocol/protocolVersion": MODERN } }
+    });
+
+    // Header disagrees with the body: the exact shape of the bug that shipped.
+    let mismatched = ureq::post(&fixture.url)
+        .set("MCP-Protocol-Version", "2025-06-18")
+        .send_json(body.clone());
+    match mismatched {
+        Err(ureq::Error::Status(400, resp)) => {
+            let err: Value = resp.into_json().expect("json error body");
+            assert_eq!(
+                err["error"]["code"], -32020,
+                "a header/body mismatch must be HeaderMismatch, got {err}"
+            );
+        }
+        other => panic!("expected 400 HeaderMismatch, got {other:?}"),
+    }
+
+    // Absent header is equally invalid under this revision.
+    let missing = ureq::post(&fixture.url).send_json(body.clone());
+    assert!(
+        matches!(missing, Err(ureq::Error::Status(400, _))),
+        "a missing MCP-Protocol-Version must be rejected"
+    );
+
+    // ...and the matching header is accepted, so the gate is not simply refusing
+    // everything.
+    let ok = ureq::post(&fixture.url)
+        .set("MCP-Protocol-Version", MODERN)
+        .send_json(body)
+        .expect("agreeing header and body must be accepted");
+    let parsed: Value = ok.into_json().expect("json body");
+    assert!(parsed["result"]["tools"].is_array(), "got {parsed}");
+}
+
+/// The regression test for the bug the stdio harness could not see: Toolport
+/// driving a strict modern server over Streamable HTTP.
+///
+/// Before the fix, `MCP-Protocol-Version` was hardcoded to the legacy version
+/// while the body declared `2026-07-28`, and the `server/discover` probe ran
+/// before the metadata was stamped. Either alone makes this fail.
+#[test]
+fn gateway_connects_to_a_modern_http_server() {
+    let fixture = spawn_http_fixture(MODERN, true, None);
+    let transport = HttpTransport::new(&fixture.url);
+    let mut server = DownstreamServer::connect("mock".to_string(), Box::new(transport))
+        .expect("a dual-era gateway must reach a modern HTTP server");
+
+    assert!(server.era().is_modern(), "era should be detected as modern");
+    assert_eq!(server.era().version(), MODERN);
+
+    // Usable, not merely connected: every request has to carry an agreeing
+    // header and body or the fixture rejects it.
+    let result = server
+        .call("echo", json!({ "text": "hi" }))
+        .expect("a modern HTTP server must be callable");
+    assert_eq!(result["content"][0]["text"], "hi");
+    assert_eq!(result["resultType"], "complete");
+}
+
+/// Legacy servers over HTTP keep working exactly as before: `initialize`
+/// handshake, no probe, no modern metadata.
+#[test]
+fn gateway_connects_to_a_legacy_http_server() {
+    let path = scratch_path("legacy-http");
+    let _ = std::fs::remove_file(&path);
+    let fixture = spawn_http_fixture("2025-06-18", true, Some(&path.to_string_lossy()));
+    let transport = HttpTransport::new(&fixture.url);
+    let mut server = DownstreamServer::connect("mock".to_string(), Box::new(transport))
+        .expect("legacy HTTP must still connect");
+    assert!(!server.era().is_modern());
+    server.call("echo", json!({ "text": "hi" })).expect("call");
+    drop(fixture);
+
+    let methods = methods_of(&read_transcript(&path));
+    assert_eq!(methods.first().map(String::as_str), Some("initialize"));
+    assert!(
+        !methods.iter().any(|m| m == "server/discover"),
+        "a legacy server must never be probed, got {methods:?}"
+    );
     let _ = std::fs::remove_file(&path);
 }
 

--- a/src-tauri/tests/spec_conformance.rs
+++ b/src-tauri/tests/spec_conformance.rs
@@ -68,20 +68,15 @@ fn raw_transport(env: &[(String, String)]) -> StdioTransport {
     StdioTransport::spawn_watched(mock_bin(), &[], env, None, dirty, None).expect("spawn fixture")
 }
 
-/// The gateway flattens JSON-RPC error objects into `TransportError::Fatal(String)`
-/// (`downstream.rs:1765`), so the structured `code` is only recoverable by
-/// re-parsing. Re-parsing here keeps these tests honest about what the wire
-/// actually carried.
-///
-/// This lossiness is itself a gap: the 2026-07-28 backward-compatibility ladder
-/// requires a client to branch on whether a `400` body is a *recognized modern
-/// error* (`-32022`/`-32021`/`-32020`) before falling back to `initialize`.
-/// Preserving the structured error is tracked as part of SOU-445.
+/// JSON-RPC error objects are carried structurally by `TransportError::Rpc`
+/// since SOU-445, so a test can read the `code` directly. This used to re-parse
+/// a flattened string, which is exactly the lossiness that made the
+/// backward-compatibility ladder unimplementable.
 fn error_json(err: &TransportError) -> Value {
-    let TransportError::Fatal(msg) = err else {
-        panic!("expected a Fatal protocol error, got {err:?}");
+    let TransportError::Rpc(obj) = err else {
+        panic!("expected a JSON-RPC error response, got {err:?}");
     };
-    serde_json::from_str(msg).unwrap_or_else(|_| json!({ "message": msg }))
+    obj.clone()
 }
 
 fn read_transcript(path: &std::path::Path) -> Vec<Value> {
@@ -452,13 +447,10 @@ fn downstream_progress_notification_reaches_the_bound_sink() {
     assert_eq!(got[0]["params"]["total"], 2);
 }
 
-/// SOU-445. A dual-era gateway must connect to a modern, stateless server by
-/// probing `server/discover` and never sending `initialize`.
-///
-/// Today `DownstreamServer::connect` opens with `initialize` unconditionally, so
-/// a strict 2026-07-28 server refuses the handshake and the connection fails.
+/// SOU-445. A dual-era gateway must connect to a modern, stateless server: fall
+/// forward from the rejected `initialize` to `server/discover`, then carry the
+/// protocol `_meta` on every subsequent request.
 #[test]
-#[ignore = "SOU-445: connect() always sends initialize, so modern servers are unreachable"]
 fn gateway_connects_to_a_modern_server() {
     let path = scratch_path("modern");
     let _ = std::fs::remove_file(&path);
@@ -467,20 +459,83 @@ fn gateway_connects_to_a_modern_server() {
     let dirty = Arc::new(AtomicU8::new(0));
     let transport = StdioTransport::spawn_watched(mock_bin(), &[], &env, None, dirty, None)
         .expect("spawn fixture");
-    let server = DownstreamServer::connect("mock".to_string(), Box::new(transport))
+    let mut server = DownstreamServer::connect("mock".to_string(), Box::new(transport))
         .expect("a dual-era gateway must connect to a modern server");
+
+    assert!(server.era().is_modern(), "era should be detected as modern");
+    assert_eq!(server.era().version(), MODERN);
+
+    // The connection is not merely established: it is usable. The strict fixture
+    // rejects any request lacking the protocol `_meta`, so a successful call
+    // proves the transport is stamping every request, not just the handshake.
+    let result = server.call("echo", json!({ "text": "hi" })).expect("call a modern server");
+    assert_eq!(result["content"][0]["text"], "hi");
+    assert_eq!(result["resultType"], "complete");
     drop(server);
 
-    let methods = methods_of(&read_transcript(&path));
-    assert_eq!(
-        methods.first().map(String::as_str),
-        Some("server/discover"),
-        "a dual-era client probes with server/discover first, got {methods:?}"
+    let transcript = read_transcript(&path);
+    let methods = methods_of(&transcript);
+
+    // `initialize` is attempted once and rejected; the fall-forward is what makes
+    // the connection work. No `notifications/initialized` is ever sent.
+    assert_eq!(methods.first().map(String::as_str), Some("initialize"));
+    assert!(
+        methods.iter().any(|m| m == "server/discover"),
+        "must fall forward to server/discover, got {methods:?}"
     );
     assert!(
-        !methods.iter().any(|m| m == "initialize"),
-        "a modern server must never be sent initialize, got {methods:?}"
+        !methods.iter().any(|m| m == "notifications/initialized"),
+        "a modern server has no handshake to complete, got {methods:?}"
     );
+
+    // Every post-handshake request carries its own protocol version and identity.
+    for record in transcript.iter().filter(|r| r["method"] == "tools/list" || r["method"] == "tools/call")
+    {
+        let meta = &record["params"]["_meta"];
+        assert_eq!(
+            meta["io.modelcontextprotocol/protocolVersion"], MODERN,
+            "every modern request declares its version, got {record}"
+        );
+        assert_eq!(
+            meta["io.modelcontextprotocol/clientInfo"]["name"], "toolport-gateway",
+            "Toolport identifies itself on the downstream hop, not the upstream client"
+        );
+    }
+
+    let _ = std::fs::remove_file(&path);
+}
+
+/// The legacy path must be untouched by era detection: no extra probe, no
+/// `server/discover`, and no protocol `_meta` on the wire. This is the
+/// no-regression guarantee for the entire existing install base.
+#[test]
+fn legacy_servers_see_no_era_detection_traffic() {
+    let path = scratch_path("legacy-era");
+    let _ = std::fs::remove_file(&path);
+    let env = env_for(Some("2025-06-18"), true, Some(&path.to_string_lossy()));
+
+    let dirty = Arc::new(AtomicU8::new(0));
+    let transport = StdioTransport::spawn_watched(mock_bin(), &[], &env, None, dirty, None)
+        .expect("spawn fixture");
+    let mut server =
+        DownstreamServer::connect("mock".to_string(), Box::new(transport)).expect("connect");
+    assert!(!server.era().is_modern());
+    assert_eq!(server.era().version(), "2025-06-18");
+    server.call("echo", json!({ "text": "hi" })).expect("call");
+    drop(server);
+
+    let transcript = read_transcript(&path);
+    let methods = methods_of(&transcript);
+    assert!(
+        !methods.iter().any(|m| m == "server/discover"),
+        "a legacy server must never be probed, got {methods:?}"
+    );
+    for record in &transcript {
+        assert!(
+            record["params"].get("_meta").is_none(),
+            "legacy requests carry no protocol _meta, got {record}"
+        );
+    }
 
     let _ = std::fs::remove_file(&path);
 }

--- a/src-tauri/tests/spec_conformance.rs
+++ b/src-tauri/tests/spec_conformance.rs
@@ -492,8 +492,11 @@ fn gateway_connects_to_a_modern_server() {
     );
 
     // Every post-handshake request carries its own protocol version and identity.
+    // Counted so the loop cannot pass by matching nothing.
+    let mut checked = 0;
     for record in transcript.iter().filter(|r| r["method"] == "tools/list" || r["method"] == "tools/call")
     {
+        checked += 1;
         let meta = &record["params"]["_meta"];
         assert_eq!(
             meta["io.modelcontextprotocol/protocolVersion"], MODERN,
@@ -504,6 +507,10 @@ fn gateway_connects_to_a_modern_server() {
             "Toolport identifies itself on the downstream hop, not the upstream client"
         );
     }
+    assert!(
+        checked >= 2,
+        "expected the tools/list and tools/call records to be checked, saw {checked}"
+    );
 
     let _ = std::fs::remove_file(&path);
 }


### PR DESCRIPTION
Dual-era MCP `2026-07-28` support **on stdio**, with every legacy client and server seeing byte-identical traffic.

Toolport was two revisions behind: pinned to `2025-06-18`, with `2025-11-25` skipped entirely.

## Scope

Toolport is now dual-era **on stdio, both directions**: a 2026-07-28 client can talk to it, and it can talk to a 2026-07-28 server.

Over Streamable HTTP it remains **legacy-only**. Modern HTTP support was built and then withdrawn (see below), so a modern client gets a `400` whose body is deliberately not a recognized modern error, which the spec defines as the signal to fall back to `initialize`. That work is tracked separately and is blocked on `subscriptions/listen`.

## The root cause this fixes

The proxy was field-selective, not envelope-transparent. `downstream.rs` rebuilt request params as `{"name": tool, "arguments": arguments}`, so `params._meta` never survived a hop. That is why there was no `progressToken` support anywhere in the repo, going back to the original protocol.

As of `2026-07-28`, `_meta` *is* the protocol. A field-selective proxy is lossy by construction and would silently break MCP Apps and Tasks for anything behind the gateway.

## Three latent bugs fixed, all predating the new spec

1. `params._meta` never reached downstream servers.
2. `shape_result` replaced the whole result envelope, dropping `_meta` and unknown sibling fields on every oversized result.
3. JSON-RPC error codes were flattened into strings, which is what made the backward-compatibility ladder unimplementable.

## Why modern HTTP was withdrawn

It was not functional against a conforming server (`Mcp-Method`/`Mcp-Name` are REQUIRED and unsent; `400` bodies are never parsed, so the compatibility ladder is unreachable over HTTP), and skipping the session introduced a cross-client isolation bug: session-less clients collapsed into a shared subscription bucket where one client could tear down another's subscription. Found independently by two reviewers.

Sessions were the server-to-client channel, so this genuinely needs `subscriptions/listen` first rather than a patch.

## Backward compatibility

Each phase carries a test proving the old path is untouched rather than asserting it:

- `downstream_transcript_pins_current_wire_format` records the exact JSON-RPC on the wire and passes unmodified throughout. `_meta` is attached only when something relayable survives.
- `legacy_servers_see_no_era_detection_traffic`: no probe, no `server/discover`, no `_meta`.
- `legacy_clients_see_no_modern_fields`: no `resultType`, no `_meta`, `initialize` unchanged.
- `legacy_server_that_rejects_initialize_still_fails_fast`: the era probe cannot inherit the 120s launcher budget.

## One deliberate spec deviation

The spec says a dual-era client SHOULD probe `server/discover` first on stdio. This goes `initialize`-first with fall-forward, because a legacy stdio server typically answers an unknown method with silence, so probe-first would charge every existing user a read timeout on every connect. It is a SHOULD, and the required dual-era outcome is preserved. Independently reviewed and judged defensible.

## Review

Two automated passes (CodeRabbit, Copilot) plus five fresh-context agent reviews covering security, spec conformance, concurrency, backward compatibility, and test quality.

That process found real bugs in code that had green CI, including two found independently by two reviewers each. The test-quality pass verified findings by breaking production code: several tests were decorative, including one that passed on an empty transcript. Every fix since has been verified by breaking it and watching a test fail.

## Follow-up review round (SOU-474)

Eleven findings from that pass are closed across `8ffa61b`, `c8eeb16`, `5dcd3b6`, `66bca9c` and `f78f108`. Three were must-fix: a shaping overshoot that returned `true` while producing an oversized result, a blocking stdout write that could wedge a server for every client, and `resources/subscribe` bypassing the era guard.

Two further fresh-context rounds found defects in the fixes themselves, both closed. A per-token OAuth refresh budget latched shut for providers that omit `expires_in`, leaving a connection 401ing for the life of the process with a working refresh token in the vault. And widening `_meta` version acceptance turned a clean `-32022` into a malformed half-modern `server/discover` result, since that key was introduced by 2026-07-28 and cannot coherently name an older revision. Advertised versions and `_meta`-accepted versions are now separate sets.

A third pass broke every new test to check it could fail. 17 of 18 held; one was half decorative and has been rewritten to assert positionally.

Known gaps are filed rather than papered over: SOU-477 (post-HITL re-route coverage, which needs a broker harness), SOU-478 (pre-HITL server id still used for audit and content defense) and SOU-479 (OAuth refresh unserialized across the app and gateway).

## Tests

795 passing. The harness includes a multi-revision mock server covering `2024-11-05` through `2026-07-28` over both stdio and Streamable HTTP, with strict era enforcement, header/body validation, and wire-transcript recording.

## Not in this PR

`subscriptions/listen`, MRTR, the downstream HTTP client headers, the auth catch-up (CIMD, incremental scope consent), and the `2025-11-25` feature catch-up.
