### PR TITLE
fix: normalize 'Could not' error strings to 'Couldn't'

### DIFF
--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -199,7 +199,7 @@ function VersionFooter({
               await navigator.clipboard.writeText(await gatherDiagnostics());
               toast.success("Diagnostics copied, paste them into your bug report");
             } catch {
-              toastError("Could not copy diagnostics");
+              toastError("Couldn't copy diagnostics");
             }
           }}
           title="Copy diagnostics for a bug report"

--- a/src/components/CatalogView.tsx
+++ b/src/components/CatalogView.tsx
@@ -254,9 +254,9 @@ export function CatalogView({ registry, onAdded }: Props) {
             className="flex flex-col items-center gap-3 py-20 text-center"
           >
             <div>
-              <p className="font-medium">Catalog could not load</p>
+              <p className="font-medium">Catalog couldn't load</p>
               <p className="max-w-md text-sm text-muted-foreground">
-                Toolport could not load the curated picks. Try again in a moment.
+                Toolport couldn't load the curated picks. Try again in a moment.
               </p>
             </div>
             <Button variant="outline" size="sm" onClick={reloadPopular}>

--- a/src/components/ServerDialog.tsx
+++ b/src/components/ServerDialog.tsx
@@ -178,7 +178,7 @@ export function ServerDialog({
       setShowPaste(false);
       setPasteText("");
     } catch (e) {
-      toastError(`Could not parse: ${e}`);
+      toastError(`Couldn't parse: ${e}`);
     } finally {
       setParsing(false);
     }
@@ -241,7 +241,7 @@ export function ServerDialog({
           status: "fail",
           message: r.authRequired
             ? `Reachable, but needs credentials: ${r.error ?? "authentication required"}`
-            : (r.error ?? "Could not connect."),
+            : (r.error ?? "Couldn't connect."),
         });
       }
     } catch (e) {


### PR DESCRIPTION
## Summary

This PR resolves #529 by normalizing four outlier error strings from "Could not" to the contraction "Couldn't" used across 50+ other user-facing error messages in the codebase.

## Changes

- src/components/AppSidebar.tsx:202 - "Could not copy diagnostics" -> "Couldn't copy diagnostics"
- src/components/ServerDialog.tsx:181 - "Could not parse" -> "Couldn't parse"
- src/components/ServerDialog.tsx:244 - "Could not connect." -> "Couldn't connect."
- src/components/CatalogView.tsx:257-259 - "Catalog could not load" / "Toolport could not load" -> "Catalog couldn't load" / "Toolport couldn't load"

## Verification

- All four "Could not" outliers replaced with "Couldn't"
- No logic changes, only string edits
- Consistent with the existing codebase style