### PR TITLE
docs: update frontend test file naming in CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,7 +66,8 @@ The Rust suite includes unit tests in each module (`clients`, `catalog`,
 `registry`, `router`, `oauth`, etc.), binary-target tests, and integration tests
 in `src-tauri/tests/`. Use the npm script above so your local target selection
 matches CI. Frontend tests use [Vitest](https://vitest.dev) and live alongside
-the code as `*.test.ts` files inside `src/`.
+the code as `*.test.ts` or `*.test.tsx` files inside `src/`, depending on whether
+the test contains JSX.
 
 ### Formatting
 


### PR DESCRIPTION
Closes #537 

## What and why

Updates the frontend testing documentation in `CONTRIBUTING.md` to reflect the current repository structure.

The guide previously stated that frontend tests are named `*.test.ts`, but the repository also contains React component tests using the `*.test.tsx` extension. This change clarifies that both `*.test.ts` and `*.test.tsx` are valid test file names, helping new contributors avoid confusion when creating Vitest tests.

Closes #<issue-number>

## Testing

* [ ] `npm run build` passes
* [ ] `npm run test` passes
* [ ] `npm run audit:prod` passes
* [ ] `npm run test:rust` passes (`npm run test:rust:windows` on Windows if the debug gateway binary is locked)
* [ ] Ran the app (`npm run tauri dev`) and checked the change by hand

> Documentation-only change. No code or runtime behavior was modified.

## Notes

* Documentation-only update.
* No screenshots required.
* No secrets, keys, or personal paths are included in the diff.