### PR TITLE
fix: disambiguate Crush remote mcp entries from OpenCode (#418)

### DIFF
--- a/src-tauri/src/clients.rs
+++ b/src-tauri/src/clients.rs
@@ -1463,22 +1463,34 @@ fn parse_json_snippet(
         let mut malformed = Vec::new();
         let mut servers = Vec::new();
         for (name, definition) in obj {
-            let command_is_string = definition
-                .get("command")
-                .map(|c| c.is_string())
-                .unwrap_or(false);
+            let command = definition.get("command");
+            let type_hint = definition.get("type").and_then(|t| t.as_str());
+            let is_explicit_opencode_type = matches!(type_hint, Some("local") | Some("remote"));
 
-            if command_is_string {
-                // Crush: `command` is a string, args live separately.
+            if command.map(|c| c.is_string()).unwrap_or(false) {
+                if is_explicit_opencode_type {
+                    malformed.push(format!("{name} ('command' must be an array of strings)"));
+                    continue;
+                }
                 servers.push(json_server_with_values(name, definition));
                 continue;
             }
 
-            // OpenCode: `command` is an argv array, or absent (remote/override-only).
-            match opencode_server_with_values(name, definition) {
-                Ok(Some(server)) => servers.push(server),
-                Ok(None) => {}
-                Err(error) => malformed.push(format!("{name} ({error})")),
+            let is_array = command.map(|c| c.is_array()).unwrap_or(false);
+            let is_absent = command.is_none();
+
+            if is_absent && matches!(type_hint, Some("http") | Some("sse")) {
+                servers.push(json_server_with_values(name, definition));
+                continue;
+            }
+
+            if is_array || is_absent {
+                match opencode_server_with_values(name, definition) {
+                    Ok(Some(server)) => servers.push(server),
+                    Ok(None) => {}
+                    Err(error) => malformed.push(format!("{name} ({error})")),
+                }
+                continue;
             }
         }
         if !malformed.is_empty() {
@@ -4450,7 +4462,32 @@ mod tests {
         let parsed = parse_json_snippet(crush, "").unwrap();
         assert_eq!(parsed[0].command.as_deref(), Some("npx"));
         assert_eq!(parsed[0].args, vec!["-y", "pkg"]);
-    } 
+    }
+
+    #[test]
+    fn parse_json_snippet_disambiguates_crush_sse_remote() {
+        let crush_remote = r#"{"mcp":{"remote":{"type":"sse","url":"https://example.com/mcp","env":{"TOKEN":"secret"}}}}"#;
+        let parsed = parse_json_snippet(crush_remote, "").unwrap();
+        assert_eq!(parsed[0].transport, "sse");
+        assert_eq!(parsed[0].url.as_deref(), Some("https://example.com/mcp"));
+        assert_eq!(parsed[0].env[0].key, "TOKEN");
+    }
+
+    #[test]
+    fn parse_json_snippet_unmatched_command_falls_through_to_wrapper_key() {
+        let mixed = r#"{"mcp":{"unmatched":{"command":null}},"mcpServers":{"fallback":{"command":"npx"}}}"#;
+        let parsed = parse_json_snippet(mixed, "").unwrap();
+        assert_eq!(parsed.len(), 1);
+        assert_eq!(parsed[0].name, "fallback");
+    }
+
+    #[test]
+    fn parse_json_snippet_rejects_explicit_opencode_with_string_command() {
+        let malformed = r#"{"mcp":{"fs":{"type":"local","command":"npx"}}}"#;
+        let error = parse_json_snippet(malformed, "").unwrap_err();
+        assert!(error.contains("fs"), "got: {error}");
+        assert!(error.contains("array of strings"), "got: {error}");
+    }
 
     #[test]
     fn reads_windsurf_antigravity_server_url() {

--- a/src-tauri/src/clients.rs
+++ b/src-tauri/src/clients.rs
@@ -1465,13 +1465,21 @@ fn parse_json_snippet(
         for (name, definition) in obj {
             let command = definition.get("command");
             let type_hint = definition.get("type").and_then(|t| t.as_str());
+            // Both clients use a top-level `mcp` key, so the entry shape decides which
+            // one wrote it. OpenCode types entries `local`/`remote`; Crush uses
+            // `http`/`sse`. Those vocabularies do not overlap, which is what makes the
+            // branches below decidable.
             let is_explicit_opencode_type = matches!(type_hint, Some("local") | Some("remote"));
 
             if command.map(|c| c.is_string()).unwrap_or(false) {
                 if is_explicit_opencode_type {
+                    // Typed as OpenCode, but `command` is a string where OpenCode
+                    // requires an array. A malformed OpenCode entry, not a Crush one,
+                    // so say so rather than silently importing it as Crush.
                     malformed.push(format!("{name} ('command' must be an array of strings)"));
                     continue;
                 }
+                // Crush stdio: `command` is a string, args live separately.
                 servers.push(json_server_with_values(name, definition));
                 continue;
             }
@@ -1480,11 +1488,18 @@ fn parse_json_snippet(
             let is_absent = command.is_none();
 
             if is_absent && matches!(type_hint, Some("http") | Some("sse")) {
+                // Crush remote: no `command`, transport comes from `type`, and env
+                // lives under `env`. Checked before the OpenCode branch below, which
+                // would otherwise claim it and hardcode http while reading
+                // `environment`. (Crush requires `type` on every entry, so a typeless
+                // remote is not a valid Crush config.)
                 servers.push(json_server_with_values(name, definition));
                 continue;
             }
 
             if is_array || is_absent {
+                // OpenCode: `command` is an argv array, or absent for remote and
+                // override-only entries, which carry env under `environment`.
                 match opencode_server_with_values(name, definition) {
                     Ok(Some(server)) => servers.push(server),
                     Ok(None) => {}
@@ -1492,6 +1507,10 @@ fn parse_json_snippet(
                 }
                 continue;
             }
+
+            // `command` is null, a number, or an object: not a shape either client
+            // writes. Skipped rather than reported, so the wrapper-key fallthrough
+            // below still runs when this was the only entry.
         }
         if !malformed.is_empty() {
             malformed.sort();


### PR DESCRIPTION
 Follow-up to #497. Fixes #418 (remote/env disambiguation half).

## What this adds

#497 fixed the stdio/string-command half of the OpenCode/Crush `mcp` collision. This closes the remaining gap flagged in that review:

**Crush remotes were still misclassified as OpenCode.** When `command` is absent, every entry was routed to `opencode_server_with_values`, which:
- hardcodes transport to `"http"` regardless of Crush's actual  `type: "sse"` / `"http"`
- reads env from `environment`, ignoring Crush's `env` key entirely

Now, an absent `command` with `type: "http"` or `type: "sse"` routes to `json_server_with_values` instead — the same function already handling Crush's stdio shape, which correctly reads `env` and calls `classify`.

## Deliberate behavior change — flagging explicitly

While fixing this, I also closed a related gap from the #497 review (Copilot's comment): an entry explicitly typed as OpenCode (`type: "local"` or `"remote"`) but with `command` as a *string* instead of the required array is now reported as a malformed OpenCode entry, rather than being silently accepted as valid Crush data. This only applies when `type` explicitly says `local`/`remote` — an
*untyped* string command is still treated as Crush, unchanged from #497.

Entries matching neither shape (`command: null`, a number, an object) are now skipped rather than hard-erroring, so the `mcpServers`/ `servers`/`context_servers` wrapper-key fallthrough can still run — per the original ask in #418.

## Testing

Three new tests, plus the full `clients` suite:

- `parse_json_snippet_disambiguates_crush_sse_remote` — Crush SSE
  remote with `env`, asserts URL and env value both parse correctly
- `parse_json_snippet_unmatched_command_falls_through_to_wrapper_key` —
  a null-command `mcp` entry alongside a valid `mcpServers` wrapper,
  asserts the wrapper is used
- `parse_json_snippet_rejects_explicit_opencode_with_string_command` —
  the deliberate behavior change above, pinned down explicitly

```
test result: ok. 121 passed; 0 failed
```