### PR TITLE
fix(app): name the apps still launching an obsolete gateway (SOU-435)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,16 +33,18 @@ process listing used an argv that Apple's `ps` rejects, so it saw zero gateways;
 Linux a binary replaced in place is now correctly treated as obsolete rather than
 protected. Settings gains a **Stop old gateways** action. (SOU-414)
 
-Note the limit: an AI client caches the gateway command when **it** starts, so a client
-that was already running when you upgraded will respawn the old binary even though
-Toolport has re-pointed its config. Restart the client app itself to pick up the new
-gateway. Clients started after the upgrade are unaffected.
+Note the limit, and it is Windows-specific: the Windows gateway filename carries its
+version (so an upgrade never has to overwrite a locked file), and an AI client caches
+the gateway command when **it** starts. A client that was already running therefore keeps
+launching the old versioned binary even though Toolport has re-pointed its config, and
+stopping that process only makes it come back. Restart the client app itself. Clients
+started after the upgrade are unaffected, and on macOS and Linux the gateway path is
+stable and replaced in place, so a cached command picks up the new binary on its own.
 
-**Toolport now names the apps you need to restart.** Rather than leaving that as a note
-in the release, it checks after the reaper has run: any obsolete gateway still standing
-is one a client has already relaunched from its cached command, so no further stopping
-will help. Toolport resolves which application spawned it and reports that, once per
-app rather than once per respawn. (SOU-435)
+**Toolport now names the apps you need to restart**, rather than leaving it as a note in
+the release. It reports which application spawned each obsolete versioned gateway, in
+Settings and once at launch, so you know exactly what to restart instead of wondering why
+old processes keep reappearing. (SOU-435)
 
 **The Shared HTTP bridge comes back after the reaper stops it.** Reaping a bridge whose
 binary was replaced left HTTP and OpenAPI clients with nothing listening until someone

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,18 +33,19 @@ process listing used an argv that Apple's `ps` rejects, so it saw zero gateways;
 Linux a binary replaced in place is now correctly treated as obsolete rather than
 protected. Settings gains a **Stop old gateways** action. (SOU-414)
 
-Note the limit, and it is Windows-specific: the Windows gateway filename carries its
-version (so an upgrade never has to overwrite a locked file), and an AI client caches
-the gateway command when **it** starts. A client that was already running therefore keeps
-launching the old versioned binary even though Toolport has re-pointed its config, and
-stopping that process only makes it come back. Restart the client app itself. Clients
-started after the upgrade are unaffected, and on macOS and Linux the gateway path is
-stable and replaced in place, so a cached command picks up the new binary on its own.
+Note the limit: an AI client caches the gateway command when **it** starts, so whether
+stopping the old process is enough depends on the path that got cached. Where the binary
+is replaced in place, the same path already resolves to the new one and the next spawn
+picks it up. Where the path is one an upgrade never rewrites, it does not: on Windows the
+filename carries its version (so an upgrade never has to overwrite a locked file), and on
+any OS an app can still be pinned to an install location you have since moved away from.
+In those cases stopping the process only makes it come back, and you need to restart the
+client app itself. Clients started after the upgrade are unaffected.
 
 **Toolport now names the apps you need to restart**, rather than leaving it as a note in
-the release. It reports which application spawned each obsolete versioned gateway, in
-Settings and once at launch, so you know exactly what to restart instead of wondering why
-old processes keep reappearing. (SOU-435)
+the release. It reports which application spawned each obsolete gateway, in Settings and
+once at launch, so you know exactly what to restart instead of wondering why old
+processes keep reappearing. (SOU-435)
 
 **The Shared HTTP bridge comes back after the reaper stops it.** Reaping a bridge whose
 binary was replaced left HTTP and OpenAPI clients with nothing listening until someone

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,12 @@ that was already running when you upgraded will respawn the old binary even thou
 Toolport has re-pointed its config. Restart the client app itself to pick up the new
 gateway. Clients started after the upgrade are unaffected.
 
+**Toolport now names the apps you need to restart.** Rather than leaving that as a note
+in the release, it checks after the reaper has run: any obsolete gateway still standing
+is one a client has already relaunched from its cached command, so no further stopping
+will help. Toolport resolves which application spawned it and reports that, once per
+app rather than once per respawn. (SOU-435)
+
 **The Shared HTTP bridge comes back after the reaper stops it.** Reaping a bridge whose
 binary was replaced left HTTP and OpenAPI clients with nothing listening until someone
 reopened Settings.

--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -2784,6 +2784,20 @@ fn stop_stale_gateways(bridge: State<HttpBridgeState>) -> Vec<String> {
     reap_stale_and_restore_bridge(bridge.inner())
 }
 
+/// Applications still launching an obsolete gateway, which only restarting them
+/// can fix (SOU-435).
+///
+/// Meant to be called AFTER [`stop_stale_gateways`]: anything reported here has
+/// already survived a reap, so it is a client relaunching from a spawn command it
+/// cached at its own startup, not a process the reaper failed to stop.
+#[tauri::command]
+fn clients_needing_restart() -> Vec<crate::gateway_publish::ClientNeedingRestart> {
+    let extra_keep = clients::resolve_gateway_path()
+        .map(|p| vec![p])
+        .unwrap_or_default();
+    crate::gateway_publish::clients_needing_gateway_restart(&extra_keep)
+}
+
 /// Run the stale reaper, then bring the supervised HTTP bridge back if the reaper
 /// stopped it (SOU-418 / SOU-432).
 ///
@@ -3258,6 +3272,7 @@ pub fn run() {
             http_bridge_status,
             stop_spawned_gateways,
             stop_stale_gateways,
+            clients_needing_restart,
         ])
         // Close-to-tray: the window's X hides it instead of quitting, so the gateway and
         // approval broker keep running (HITL only works while the app is alive). Quit is

--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -2780,24 +2780,36 @@ fn stop_spawned_gateways() -> u32 {
 /// current resolved binary. Safe to run any time; used from Settings and launch.
 /// Returns labels of processes that were stopped.
 #[tauri::command]
-fn stop_stale_gateways(bridge: State<HttpBridgeState>) -> Vec<String> {
-    reap_stale_and_restore_bridge(bridge.inner())
+fn stop_stale_gateways(
+    bridge: State<HttpBridgeState>,
+    advice: State<RestartAdvice>,
+) -> Vec<String> {
+    // Refreshes the stored advice from its own pre-kill snapshot, so the Settings
+    // panel is current after the button runs without a second query.
+    reap_stale_and_restore_bridge(bridge.inner(), Some(advice.inner()))
 }
 
 /// Applications launching an obsolete gateway, which only restarting them can fix
 /// (SOU-435).
+/// Last known restart advice, recorded by whichever reaper pass produced it.
 ///
-/// Safe to call at any time, and specifically NOT dependent on a reap having run:
-/// each result names a versioned gateway image, whose path can never hold newer
-/// code, so the advice holds whether or not that process is stopped. Reading it
-/// *after* a reap is what was wrong, since reaping empties the table this reads
-/// (#542 review).
+/// Held rather than recomputed on demand because the advice is only knowable from
+/// the pre-kill process table: a fresh query can only be asked after some reap has
+/// already destroyed the evidence. Reading state also means the Settings view no
+/// longer walks the whole process table on the main thread every time the tab is
+/// opened (#542 review).
+#[derive(Default)]
+struct RestartAdvice(Mutex<Vec<crate::gateway_publish::ClientNeedingRestart>>);
+
 #[tauri::command]
-fn clients_needing_restart() -> Vec<crate::gateway_publish::ClientNeedingRestart> {
-    let extra_keep = clients::resolve_gateway_path()
-        .map(|p| vec![p])
-        .unwrap_or_default();
-    crate::gateway_publish::clients_needing_gateway_restart(&extra_keep)
+fn clients_needing_restart(
+    advice: State<RestartAdvice>,
+) -> Vec<crate::gateway_publish::ClientNeedingRestart> {
+    advice
+        .0
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .clone()
 }
 
 /// Run the stale reaper, then bring the supervised HTTP bridge back if the reaper
@@ -2812,7 +2824,10 @@ fn clients_needing_restart() -> Vec<crate::gateway_publish::ClientNeedingRestart
 ///
 /// Connected clients are unaffected by the new process: they authenticate with the
 /// per-client bearers in `http_clients`, not the bridge's own env token.
-fn reap_stale_and_restore_bridge(bridge: &HttpBridgeState) -> Vec<String> {
+fn reap_stale_and_restore_bridge(
+    bridge: &HttpBridgeState,
+    advice: Option<&RestartAdvice>,
+) -> Vec<String> {
     let mut extra_keep = Vec::new();
     if let Some(p) = clients::resolve_gateway_path() {
         extra_keep.push(p);
@@ -2823,7 +2838,16 @@ fn reap_stale_and_restore_bridge(bridge: &HttpBridgeState) -> Vec<String> {
         let mut b = bridge.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
         http_bridge_alive(&mut b).then(|| b.port).flatten()
     };
-    let killed = crate::gateway_publish::stop_stale_gateways_with_keep(&extra_keep);
+    let report = crate::gateway_publish::reap_stale(&extra_keep);
+    let killed = report.killed_labels();
+    // Recorded from the pre-kill snapshot inside the reap, which is the only place
+    // it can be known (#542 review).
+    if let Some(advice) = advice {
+        *advice
+            .0
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = report.needs_restart.clone();
+    }
     if let Some(port) = was_serving {
         let still_serving = {
             let mut b = bridge.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
@@ -3177,6 +3201,7 @@ pub fn run() {
         .manage(Mutex::new(registry))
         .manage(Mutex::new(HttpBridge::default()))
         .manage(PendingShare::default())
+        .manage(RestartAdvice::default())
         .invoke_handler(tauri::generate_handler![
             detect_clients,
             get_registry,
@@ -3402,7 +3427,16 @@ pub fn run() {
                 // Both passes go through `reap_stale_and_restore_bridge` so a supervised
                 // HTTP bridge the reaper stops (correctly, when its binary was replaced)
                 // comes back instead of leaving HTTP/OpenAPI clients dark (SOU-418).
-                let stale = reap_stale_and_restore_bridge(migrate_handle.state::<HttpBridgeState>().inner());
+                // The FIRST pass is the one that matters for the advice: it runs
+                // before anything has been killed, so its snapshot still contains the
+                // obsolete gateways their clients are running. The earlier attempt to
+                // sample "before the reap" only moved ahead of the SECOND pass and so
+                // still read a table this first pass had cleared (#542 review).
+                let advice_state = migrate_handle.state::<RestartAdvice>();
+                let stale = reap_stale_and_restore_bridge(
+                    migrate_handle.state::<HttpBridgeState>().inner(),
+                    Some(advice_state.inner()),
+                );
                 if !stale.is_empty() {
                     eprintln!(
                         "toolport: stopped {} stale gateway process(es): {}",
@@ -3410,18 +3444,19 @@ pub fn run() {
                         stale.join("; ")
                     );
                 }
+                let restart = advice_state
+                    .0
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner)
+                    .clone();
                 std::thread::spawn(move || {
                     std::thread::sleep(std::time::Duration::from_secs(3));
-                    // Read BEFORE the second reap. Reaping clears the very table
-                    // this reads, so sampling afterwards reported nothing in the
-                    // case it exists for (SOU-435, #542 review).
-                    let keep = clients::resolve_gateway_path()
-                        .map(|p| vec![p])
-                        .unwrap_or_default();
-                    let restart = crate::gateway_publish::clients_needing_gateway_restart(&keep);
-
+                    // Deliberately does NOT refresh the advice: by now the first pass
+                    // has killed the evidence, so this pass would only ever record an
+                    // emptier answer (or one made of failed kills).
                     let again = reap_stale_and_restore_bridge(
                         migrate_handle.state::<HttpBridgeState>().inner(),
+                        None,
                     );
                     if !again.is_empty() {
                         eprintln!(

--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -3363,11 +3363,19 @@ pub fn run() {
                         repoint.customized.join(", ")
                     );
                 }
-                // Stop obsolete gateway processes so each client respawns the current binary
-                // on its next MCP request (no full agent restart required when the host
-                // auto-respawns). Path-based identity on all OS (SOU-414); not gated on
-                // repoint (SOU-306). Pass resolve_gateway_path so the nested macOS helper /
-                // AppImage stable path is kept even when publish is Windows-only.
+                // Stop obsolete gateway processes. Path-based identity on all OS
+                // (SOU-414); not gated on repoint (SOU-306). Pass resolve_gateway_path so
+                // the nested macOS helper / AppImage stable path is kept even when publish
+                // is Windows-only.
+                //
+                // This does NOT deliver new gateway code to a client that is already
+                // running. An MCP client reads its config once at its own startup and
+                // caches the spawn command, and the versioned filename scheme means the
+                // path it cached will never contain anything newer, so killing that
+                // gateway just makes the same client relaunch the same obsolete binary.
+                // Reaping still earns its keep on genuinely orphaned processes and on any
+                // client started after the repoint; everything else needs the application
+                // restarted, which is why the delayed pass below reports who (SOU-435).
                 //
                 // Run once immediately, then again after a short delay so a client that
                 // race-respawns an old path between repoint and the first kill is cleaned up
@@ -3395,6 +3403,30 @@ pub fn run() {
                             again.len(),
                             again.join("; ")
                         );
+                    }
+                    // Anything obsolete still standing after two passes is being
+                    // relaunched from a cached spawn command, so no further reaping
+                    // will help. Name the applications instead (SOU-435).
+                    let keep = clients::resolve_gateway_path()
+                        .map(|p| vec![p])
+                        .unwrap_or_default();
+                    let restart = crate::gateway_publish::clients_needing_gateway_restart(&keep);
+                    if !restart.is_empty() {
+                        eprintln!(
+                            "toolport: {} app(s) are still launching an obsolete gateway and \
+                             need restarting: {}",
+                            restart.len(),
+                            restart
+                                .iter()
+                                .map(|r| format!("{} ({})", r.client, r.gateway))
+                                .collect::<Vec<_>>()
+                                .join("; ")
+                        );
+                        let payload: Vec<serde_json::Value> = restart
+                            .iter()
+                            .map(|r| serde_json::json!({ "client": r.client, "gateway": r.gateway }))
+                            .collect();
+                        let _ = migrate_handle.emit("gateway-restart-needed", payload);
                     }
                 });
             });

--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -2784,12 +2784,14 @@ fn stop_stale_gateways(bridge: State<HttpBridgeState>) -> Vec<String> {
     reap_stale_and_restore_bridge(bridge.inner())
 }
 
-/// Applications still launching an obsolete gateway, which only restarting them
-/// can fix (SOU-435).
+/// Applications launching an obsolete gateway, which only restarting them can fix
+/// (SOU-435).
 ///
-/// Meant to be called AFTER [`stop_stale_gateways`]: anything reported here has
-/// already survived a reap, so it is a client relaunching from a spawn command it
-/// cached at its own startup, not a process the reaper failed to stop.
+/// Safe to call at any time, and specifically NOT dependent on a reap having run:
+/// each result names a versioned gateway image, whose path can never hold newer
+/// code, so the advice holds whether or not that process is stopped. Reading it
+/// *after* a reap is what was wrong, since reaping empties the table this reads
+/// (#542 review).
 #[tauri::command]
 fn clients_needing_restart() -> Vec<crate::gateway_publish::ClientNeedingRestart> {
     let extra_keep = clients::resolve_gateway_path()
@@ -3383,14 +3385,15 @@ pub fn run() {
                 // the nested macOS helper / AppImage stable path is kept even when publish
                 // is Windows-only.
                 //
-                // This does NOT deliver new gateway code to a client that is already
-                // running. An MCP client reads its config once at its own startup and
-                // caches the spawn command, and the versioned filename scheme means the
-                // path it cached will never contain anything newer, so killing that
-                // gateway just makes the same client relaunch the same obsolete binary.
-                // Reaping still earns its keep on genuinely orphaned processes and on any
-                // client started after the repoint; everything else needs the application
-                // restarted, which is why the delayed pass below reports who (SOU-435).
+                // Reaping alone does not always deliver new gateway code. A client reads
+                // its config once at its own startup and caches the spawn command. Where
+                // the gateway path is stable (macOS, Linux) it is replaced in place, so
+                // that cached command yields the new binary on the next spawn and the
+                // reap is sufficient. Where the filename carries the version (the Windows
+                // publish scheme, which exists to dodge the file lock) the cached path can
+                // never hold newer code, so the client relaunches the same obsolete binary
+                // and only restarting that application fixes it. The delayed pass below
+                // reports which apps are in that state (SOU-435).
                 //
                 // Run once immediately, then again after a short delay so a client that
                 // race-respawns an old path between repoint and the first kill is cleaned up
@@ -3409,6 +3412,14 @@ pub fn run() {
                 }
                 std::thread::spawn(move || {
                     std::thread::sleep(std::time::Duration::from_secs(3));
+                    // Read BEFORE the second reap. Reaping clears the very table
+                    // this reads, so sampling afterwards reported nothing in the
+                    // case it exists for (SOU-435, #542 review).
+                    let keep = clients::resolve_gateway_path()
+                        .map(|p| vec![p])
+                        .unwrap_or_default();
+                    let restart = crate::gateway_publish::clients_needing_gateway_restart(&keep);
+
                     let again = reap_stale_and_restore_bridge(
                         migrate_handle.state::<HttpBridgeState>().inner(),
                     );
@@ -3419,16 +3430,13 @@ pub fn run() {
                             again.join("; ")
                         );
                     }
-                    // Anything obsolete still standing after two passes is being
-                    // relaunched from a cached spawn command, so no further reaping
-                    // will help. Name the applications instead (SOU-435).
-                    let keep = clients::resolve_gateway_path()
-                        .map(|p| vec![p])
-                        .unwrap_or_default();
-                    let restart = crate::gateway_publish::clients_needing_gateway_restart(&keep);
+
+                    // Stopping these does not help: each names a versioned image, so
+                    // the path the client cached can never hold newer code and it
+                    // relaunches the same binary until the app itself restarts.
                     if !restart.is_empty() {
                         eprintln!(
-                            "toolport: {} app(s) are still launching an obsolete gateway and \
+                            "toolport: {} app(s) are launching an obsolete gateway and \
                              need restarting: {}",
                             restart.len(),
                             restart
@@ -3437,11 +3445,9 @@ pub fn run() {
                                 .collect::<Vec<_>>()
                                 .join("; ")
                         );
-                        let payload: Vec<serde_json::Value> = restart
-                            .iter()
-                            .map(|r| serde_json::json!({ "client": r.client, "gateway": r.gateway }))
-                            .collect();
-                        let _ = migrate_handle.emit("gateway-restart-needed", payload);
+                        // Emit the struct, so its `Serialize` stays the single
+                        // definition of the wire shape (#542 review).
+                        let _ = migrate_handle.emit("gateway-restart-needed", &restart);
                     }
                 });
             });

--- a/src-tauri/src/gateway_publish.rs
+++ b/src-tauri/src/gateway_publish.rs
@@ -177,6 +177,23 @@ pub struct GatewayProcess {
     pub path: Option<PathBuf>,
     /// Process image basename, e.g. `toolport-gateway-1.9.4.exe` or `toolport-gateway`.
     pub basename: String,
+    /// The process that spawned this gateway, when it could be resolved.
+    ///
+    /// Never used for the keep/kill decision, only to name the application a user
+    /// has to restart (SOU-435). An MCP client reads its config once at its own
+    /// startup and caches the spawn command, so a client running since before an
+    /// upgrade relaunches the old versioned path forever. Killing that gateway
+    /// just makes the same client respawn the same obsolete binary.
+    pub parent: Option<ParentProcess>,
+}
+
+/// The process that spawned a gateway. Identity only, no path: this exists to put
+/// a name in front of the user ("restart Claude"), not to make any decision.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParentProcess {
+    pub pid: u32,
+    /// Process image basename, e.g. `claude.exe`, `grok.exe`, `Code`.
+    pub basename: String,
 }
 
 /// Inputs for the pure keep/kill decision. Built at the call site so tests do not
@@ -305,23 +322,29 @@ fn basename_from_exe_link(path: &Path) -> String {
         .unwrap_or_else(|| cleaned.to_string())
 }
 
-/// Parse one line of `ps -ax -o pid= -o ucomm=` (or `comm=`) into `(pid, name)`.
+/// Parse one line of `ps -ax -o pid= -o ppid= -o ucomm=` into `(pid, ppid, name)`.
+///
 /// Pure helper for the macOS enumerator line format. Does **not** prove the `ps`
 /// argv itself is correct — a broken `-axo pid= comm=` still needs a macOS
 /// smoke / CI job (WS4-1 / WS4-8).
+///
+/// `ppid` is carried so a gateway can name the client that spawned it without a
+/// second `ps` (SOU-435). Both numeric fields are taken positionally and the rest
+/// of the line is the name, so a process name containing spaces still parses.
 #[cfg(any(target_os = "macos", test))]
-fn parse_ps_pid_name_line(line: &str) -> Option<(u32, String)> {
+fn parse_ps_pid_ppid_name_line(line: &str) -> Option<(u32, u32, String)> {
     let line = line.trim();
     if line.is_empty() {
         return None;
     }
     let mut parts = line.split_whitespace();
     let pid = parts.next()?.parse().ok()?;
+    let ppid = parts.next()?.parse().ok()?;
     let name = parts.collect::<Vec<_>>().join(" ");
     if name.is_empty() {
         return None;
     }
-    Some((pid, name))
+    Some((pid, ppid, name))
 }
 
 /// True only for names like `toolport-gateway-1.9.4`, not `toolport-gateway-shim`.
@@ -442,6 +465,64 @@ pub fn decide_reap(proc: &GatewayProcess, ctx: &ReapContext) -> ReapDecision {
     ReapDecision::Keep
 }
 
+/// An application that keeps relaunching an obsolete gateway and therefore has to
+/// be restarted by hand.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ClientNeedingRestart {
+    /// Basename of the client application, e.g. `claude.exe`.
+    pub client: String,
+    /// The obsolete gateway image it relaunched, e.g. `toolport-gateway-1.9.4.exe`.
+    pub gateway: String,
+}
+
+/// Is `basename` one of our own processes rather than a third-party MCP client?
+///
+/// The supervised HTTP bridge is spawned by the Toolport app itself, so it would
+/// otherwise be reported as a client the user must restart.
+fn is_our_own_process(basename: &str) -> bool {
+    let lower = basename.to_ascii_lowercase();
+    lower.starts_with("toolport") || lower.starts_with("conduit")
+}
+
+/// Clients still relaunching an obsolete gateway *after* a reaper pass has run.
+///
+/// The reaper stops obsolete gateways, but it cannot make a client pick up new
+/// code: the spawn command was cached when that client started, and the versioned
+/// filename scheme means the path it cached will never contain anything newer. So
+/// a gateway the reaper would still call `Kill` on, seen after the reap, is not a
+/// process that survived - it is one a client has already relaunched, and it will
+/// keep coming back until that application restarts (SOU-435).
+///
+/// Deduplicated per (client, gateway) so one entry per app the user has to act on,
+/// not one per respawn. Pure so the grouping is testable without a process table.
+pub fn clients_needing_restart(
+    procs: &[GatewayProcess],
+    ctx: &ReapContext,
+) -> Vec<ClientNeedingRestart> {
+    let mut out: Vec<ClientNeedingRestart> = Vec::new();
+    for proc in procs {
+        if decide_reap(proc, ctx) != ReapDecision::Kill {
+            continue;
+        }
+        // No parent means no name to show. Staying silent beats telling someone to
+        // restart "something".
+        let Some(parent) = proc.parent.as_ref() else {
+            continue;
+        };
+        if is_our_own_process(&parent.basename) {
+            continue;
+        }
+        let advice = ClientNeedingRestart {
+            client: parent.basename.clone(),
+            gateway: proc.basename.clone(),
+        };
+        if !out.contains(&advice) {
+            out.push(advice);
+        }
+    }
+    out
+}
+
 fn label_process(proc: &GatewayProcess) -> String {
     match &proc.path {
         Some(p) => format!("{} (pid {} @ {})", proc.basename, proc.pid, p.display()),
@@ -547,6 +628,27 @@ pub fn stop_stale_gateways_with_keep(extra_keep: &[PathBuf]) -> Vec<String> {
     report.killed_labels()
 }
 
+/// Applications that will keep relaunching an obsolete gateway until restarted.
+///
+/// Call this AFTER a reap pass. Anything it returns has already survived one, so
+/// it is a client relaunching from a cached spawn command rather than a process
+/// the reaper missed (SOU-435).
+pub fn clients_needing_gateway_restart(extra_keep: &[PathBuf]) -> Vec<ClientNeedingRestart> {
+    let mut keep = default_keep_paths();
+    for p in extra_keep {
+        if !keep.iter().any(|e| paths_equal(e, p)) {
+            keep.push(p.clone());
+        }
+    }
+    let ctx = ReapContext {
+        current_version: env!("CARGO_PKG_VERSION").to_string(),
+        keep_paths: keep,
+        keep_pids: vec![std::process::id()],
+        kill_all: false,
+    };
+    clients_needing_restart(&list_gateway_processes(), &ctx)
+}
+
 // ----- OS process list / kill ------------------------------------------------
 
 #[cfg(windows)]
@@ -589,18 +691,26 @@ fn windows_list_gateway_processes() -> Vec<GatewayProcess> {
         }
         let mut entry: PROCESSENTRY32W = zeroed();
         entry.dwSize = size_of::<PROCESSENTRY32W>() as u32;
-        let mut out = Vec::new();
+        let mut out: Vec<(GatewayProcess, u32)> = Vec::new();
+        // Every pid in the snapshot, so a parent can be named without a second
+        // pass over the process table or an OpenProcess on a foreign app.
+        let mut names: std::collections::HashMap<u32, String> = std::collections::HashMap::new();
         if Process32FirstW(snap, &mut entry) != 0 {
             loop {
                 let basename = widestr_to_string(&entry.szExeFile);
+                let pid = entry.th32ProcessID;
+                names.insert(pid, basename.clone());
                 if is_gateway_basename(&basename) {
-                    let pid = entry.th32ProcessID;
                     let path = windows_process_path(pid);
-                    out.push(GatewayProcess {
-                        pid,
-                        path,
-                        basename,
-                    });
+                    out.push((
+                        GatewayProcess {
+                            pid,
+                            path,
+                            basename,
+                            parent: None,
+                        },
+                        entry.th32ParentProcessID,
+                    ));
                 }
                 if Process32NextW(snap, &mut entry) == 0 {
                     break;
@@ -608,7 +718,17 @@ fn windows_list_gateway_processes() -> Vec<GatewayProcess> {
             }
         }
         CloseHandle(snap);
-        out
+        // Resolve after the walk: a parent can appear later in the snapshot than
+        // its child, so this cannot be done inline.
+        out.into_iter()
+            .map(|(mut proc, ppid)| {
+                proc.parent = names.get(&ppid).map(|basename| ParentProcess {
+                    pid: ppid,
+                    basename: basename.clone(),
+                });
+                proc
+            })
+            .collect()
     }
 }
 
@@ -713,6 +833,7 @@ fn linux_list_gateway_processes() -> Vec<GatewayProcess> {
                 pid,
                 path: exe,
                 basename: exe_base,
+                parent: linux_parent_of(pid),
             });
             continue;
         }
@@ -721,9 +842,42 @@ fn linux_list_gateway_processes() -> Vec<GatewayProcess> {
             pid,
             path,
             basename,
+            parent: linux_parent_of(pid),
         });
     }
     out
+}
+
+/// Parent identity from `/proc/<pid>/status` + `/proc/<ppid>/comm` (SOU-435).
+///
+/// `status` rather than `stat`: `stat` puts `comm` in parentheses as field 2 and a
+/// process name may itself contain `) `, so positional parsing of that file is not
+/// safe. `status` is line-oriented and `PPid:` is unambiguous.
+#[cfg(all(unix, not(target_os = "macos")))]
+fn linux_parent_of(pid: u32) -> Option<ParentProcess> {
+    let status = std::fs::read_to_string(format!("/proc/{pid}/status")).ok()?;
+    let ppid: u32 = status
+        .lines()
+        .find_map(|line| line.strip_prefix("PPid:"))?
+        .trim()
+        .parse()
+        .ok()?;
+    // pid 0 is the kernel scheduler, never an application to restart.
+    if ppid == 0 {
+        return None;
+    }
+    // `comm` is truncated to 15 chars, which is fine for a display name.
+    let basename = std::fs::read_to_string(format!("/proc/{ppid}/comm"))
+        .ok()?
+        .trim()
+        .to_string();
+    if basename.is_empty() {
+        return None;
+    }
+    Some(ParentProcess {
+        pid: ppid,
+        basename,
+    })
 }
 
 /// macOS: `ps` for pid + accounting name (`ucomm`), then `proc_pidpath` for the
@@ -733,7 +887,7 @@ fn linux_list_gateway_processes() -> Vec<GatewayProcess> {
 #[cfg(target_os = "macos")]
 fn macos_list_gateway_processes() -> Vec<GatewayProcess> {
     let Ok(out) = std::process::Command::new("ps")
-        .args(["-ax", "-o", "pid=", "-o", "ucomm="])
+        .args(["-ax", "-o", "pid=", "-o", "ppid=", "-o", "ucomm="])
         .output()
     else {
         return Vec::new();
@@ -749,28 +903,45 @@ fn macos_list_gateway_processes() -> Vec<GatewayProcess> {
         return Vec::new();
     }
     let text = String::from_utf8_lossy(&out.stdout);
+    // One pass over the whole table: `-ax` already lists every process, so the
+    // parent's name is here and needs no second `ps` (SOU-435).
+    let rows: Vec<(u32, u32, String)> = text
+        .lines()
+        .filter_map(parse_ps_pid_ppid_name_line)
+        .collect();
+    let names: std::collections::HashMap<u32, &str> = rows
+        .iter()
+        .map(|(pid, _, ucomm)| (*pid, ucomm.as_str()))
+        .collect();
+
     let mut procs = Vec::new();
-    for line in text.lines() {
-        let Some((pid, ucomm)) = parse_ps_pid_name_line(line) else {
-            continue;
-        };
+    for (pid, ppid, ucomm) in &rows {
         // ucomm is the accounting basename; filter before the more expensive path lookup.
-        if !is_gateway_basename(&ucomm) {
+        if !is_gateway_basename(ucomm) {
             continue;
         }
-        let path = macos_proc_pidpath(pid);
+        let path = macos_proc_pidpath(*pid);
         let basename = path
             .as_ref()
             .and_then(|p| p.file_name())
             .map(|s| s.to_string_lossy().into_owned())
-            .unwrap_or(ucomm);
+            .unwrap_or_else(|| ucomm.clone());
         if !is_gateway_basename(&basename) {
             continue;
         }
+        // pid 1 is launchd, never an application a user can restart.
+        let parent = (*ppid > 1)
+            .then(|| names.get(ppid))
+            .flatten()
+            .map(|name| ParentProcess {
+                pid: *ppid,
+                basename: (*name).to_string(),
+            });
         procs.push(GatewayProcess {
-            pid,
+            pid: *pid,
             path,
             basename,
+            parent,
         });
     }
     procs
@@ -878,6 +1049,23 @@ mod tests {
             pid,
             basename: basename.into(),
             path: path.map(PathBuf::from),
+            parent: None,
+        }
+    }
+
+    /// Same, but spawned by a named client (SOU-435).
+    fn proc_from(
+        pid: u32,
+        basename: &str,
+        path: Option<&str>,
+        parent: (u32, &str),
+    ) -> GatewayProcess {
+        GatewayProcess {
+            parent: Some(ParentProcess {
+                pid: parent.0,
+                basename: parent.1.into(),
+            }),
+            ..proc(pid, basename, path)
         }
     }
 
@@ -1164,6 +1352,7 @@ mod tests {
                     pid: 1,
                     path: Some(keep),
                     basename: "toolport-gateway".into(),
+                    parent: None,
                 },
                 &c
             ),
@@ -1176,6 +1365,7 @@ mod tests {
                     pid: 2,
                     path: Some(deleted),
                     basename: "toolport-gateway".into(),
+                    parent: None,
                 },
                 &c
             ),
@@ -1186,25 +1376,116 @@ mod tests {
     /// WS4-1 / WS4-8: pure parse of `ps -o pid= -o ucomm=` lines (including padded pid).
     /// Does not prove the `ps` argv itself — that still needs a macOS smoke.
     #[test]
-    fn parse_ps_pid_name_line_accepts_padded_pid_and_ucomm() {
+    fn clients_needing_restart_names_the_app_behind_a_respawned_gateway() {
+        // The whole point of SOU-435: the reaper killed these, the client
+        // relaunched them from a cached command, and no amount of reaping fixes
+        // that. The user has to restart the app, so we have to name it.
+        let c = ctx("1.9.7", &[r"C:\Users\me\AppData\Roaming\Toolport\bin\toolport-gateway-1.9.7.exe"], false);
+        let procs = vec![
+            proc_from(
+                101,
+                "toolport-gateway-1.9.4.exe",
+                Some(r"C:\Users\me\AppData\Roaming\Toolport\bin\toolport-gateway-1.9.4.exe"),
+                (900, "grok.exe"),
+            ),
+            proc_from(
+                102,
+                "toolport-gateway-1.9.6.exe",
+                Some(r"C:\Users\me\AppData\Roaming\Toolport\bin\toolport-gateway-1.9.6.exe"),
+                (901, "claude.exe"),
+            ),
+        ];
+        let advice = clients_needing_restart(&procs, &c);
         assert_eq!(
-            parse_ps_pid_name_line("  123 toolport-gateway"),
-            Some((123, "toolport-gateway".into()))
+            advice,
+            vec![
+                ClientNeedingRestart {
+                    client: "grok.exe".into(),
+                    gateway: "toolport-gateway-1.9.4.exe".into()
+                },
+                ClientNeedingRestart {
+                    client: "claude.exe".into(),
+                    gateway: "toolport-gateway-1.9.6.exe".into()
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn clients_needing_restart_ignores_current_and_unattributable_gateways() {
+        let keep = r"C:\Users\me\AppData\Roaming\Toolport\bin\toolport-gateway-1.9.7.exe";
+        let c = ctx("1.9.7", &[keep], false);
+
+        // A gateway on the CURRENT version is not stale, so its client is fine.
+        let current = proc_from(200, "toolport-gateway-1.9.7.exe", Some(keep), (900, "claude.exe"));
+        assert!(clients_needing_restart(&[current], &c).is_empty());
+
+        // Stale but no resolvable parent: telling someone to restart "something"
+        // is worse than staying quiet.
+        let orphan = proc(
+            201,
+            "toolport-gateway-1.9.4.exe",
+            Some(r"C:\Users\me\AppData\Roaming\Toolport\bin\toolport-gateway-1.9.4.exe"),
+        );
+        assert!(clients_needing_restart(&[orphan], &c).is_empty());
+
+        // Spawned by the Toolport app itself (the supervised HTTP bridge), which
+        // the user cannot act on and should never be told to restart.
+        let ours = proc_from(
+            202,
+            "toolport-gateway-1.9.4.exe",
+            Some(r"C:\Users\me\AppData\Roaming\Toolport\bin\toolport-gateway-1.9.4.exe"),
+            (903, "Toolport.exe"),
+        );
+        assert!(clients_needing_restart(&[ours], &c).is_empty());
+    }
+
+    #[test]
+    fn clients_needing_restart_reports_one_entry_per_app_not_per_respawn() {
+        // A client that has been restarting its gateway in a loop produces many
+        // processes. The user still only needs to be told once.
+        let c = ctx("1.9.7", &[r"C:\Users\me\AppData\Roaming\Toolport\bin\toolport-gateway-1.9.7.exe"], false);
+        let stale = r"C:\Users\me\AppData\Roaming\Toolport\bin\toolport-gateway-1.9.4.exe";
+        let procs = vec![
+            proc_from(301, "toolport-gateway-1.9.4.exe", Some(stale), (900, "grok.exe")),
+            proc_from(302, "toolport-gateway-1.9.4.exe", Some(stale), (900, "grok.exe")),
+            proc_from(303, "toolport-gateway-1.9.4.exe", Some(stale), (900, "grok.exe")),
+        ];
+        assert_eq!(clients_needing_restart(&procs, &c).len(), 1);
+    }
+
+    #[test]
+    fn parse_ps_pid_ppid_name_line_accepts_padded_columns_and_ucomm() {
+        assert_eq!(
+            parse_ps_pid_ppid_name_line("  123   1 toolport-gateway"),
+            Some((123, 1, "toolport-gateway".into()))
         );
         assert_eq!(
-            parse_ps_pid_name_line("45678 toolport-gateway-1.9.4"),
-            Some((45678, "toolport-gateway-1.9.4".into()))
+            parse_ps_pid_ppid_name_line("45678 4321 toolport-gateway-1.9.4"),
+            Some((45678, 4321, "toolport-gateway-1.9.4".into()))
         );
-        assert_eq!(parse_ps_pid_name_line(""), None);
-        assert_eq!(parse_ps_pid_name_line("not-a-pid toolport-gateway"), None);
-        assert_eq!(parse_ps_pid_name_line("99"), None);
+        assert_eq!(parse_ps_pid_ppid_name_line(""), None);
+        assert_eq!(parse_ps_pid_ppid_name_line("not-a-pid 1 toolport-gateway"), None);
+        // A missing ppid column must not be read as the name, which is how a
+        // wrong `-o` argv would silently produce nonsense parents (SOU-435).
+        assert_eq!(parse_ps_pid_ppid_name_line("99 toolport-gateway"), None);
+        assert_eq!(parse_ps_pid_ppid_name_line("99 1"), None);
+        assert_eq!(parse_ps_pid_ppid_name_line("99"), None);
         // Full-path comm= style still parses; basename filter is applied by the caller.
         assert_eq!(
-            parse_ps_pid_name_line("  42 /Applications/Toolport.app/Contents/MacOS/toolport-gateway"),
+            parse_ps_pid_ppid_name_line(
+                "  42 7 /Applications/Toolport.app/Contents/MacOS/toolport-gateway"
+            ),
             Some((
                 42,
+                7,
                 "/Applications/Toolport.app/Contents/MacOS/toolport-gateway".into()
             ))
+        );
+        // A name with spaces survives, since only the first two columns are positional.
+        assert_eq!(
+            parse_ps_pid_ppid_name_line("5 2 Some App Helper"),
+            Some((5, 2, "Some App Helper".into()))
         );
     }
 

--- a/src-tauri/src/gateway_publish.rs
+++ b/src-tauri/src/gateway_publish.rs
@@ -181,9 +181,9 @@ pub struct GatewayProcess {
     ///
     /// Never used for the keep/kill decision, only to name the application a user
     /// has to restart (SOU-435). An MCP client reads its config once at its own
-    /// startup and caches the spawn command, so a client running since before an
-    /// upgrade relaunches the old versioned path forever. Killing that gateway
-    /// just makes the same client respawn the same obsolete binary.
+    /// startup and caches the spawn command; whether that traps it on old code
+    /// depends on the filename, so see [`clients_needing_restart`] rather than
+    /// assuming it always does.
     pub parent: Option<ParentProcess>,
 }
 
@@ -485,14 +485,40 @@ fn is_our_own_process(basename: &str) -> bool {
     lower.starts_with("toolport") || lower.starts_with("conduit")
 }
 
-/// Clients still relaunching an obsolete gateway *after* a reaper pass has run.
+/// Is this "parent" the init system or the kernel rather than an application?
 ///
-/// The reaper stops obsolete gateways, but it cannot make a client pick up new
-/// code: the spawn command was cached when that client started, and the versioned
-/// filename scheme means the path it cached will never contain anything newer. So
-/// a gateway the reaper would still call `Kill` on, seen after the reap, is not a
-/// process that survived - it is one a client has already relaunched, and it will
-/// keep coming back until that application restarts (SOU-435).
+/// An orphaned gateway is reparented to pid 1 on Unix, and Windows reports pid 0 /
+/// pid 4 for its kernel processes. None of them is something a user can restart,
+/// and each platform previously guarded a different subset of these, so the same
+/// orphan produced "restart systemd" on Linux and nothing on macOS. Name-matched
+/// as well as pid-matched because a systemd *user* session is a child subreaper
+/// with a pid of its own (#542 review).
+fn is_init_like(parent: &ParentProcess) -> bool {
+    if parent.pid <= 1 || parent.pid == 4 {
+        return true;
+    }
+    let lower = parent.basename.to_ascii_lowercase();
+    matches!(
+        lower.as_str(),
+        "systemd" | "init" | "launchd" | "system" | "[system process]"
+    )
+}
+
+/// Applications running an obsolete gateway they will relaunch from a cached path.
+///
+/// An MCP client reads its config once at its own startup and caches the spawn
+/// command. Whether that matters depends on the filename it cached:
+///
+/// * A **versioned** image (`toolport-gateway-1.9.4.exe`) names a path whose
+///   contents never change, so the client relaunches obsolete code forever and
+///   only restarting the application fixes it. This is the Windows publish scheme,
+///   which exists to dodge the Windows file lock.
+/// * An **unversioned** image is replaced in place on upgrade, so the very same
+///   cached path yields the new binary on the next spawn. Nothing to advise. This
+///   is macOS and Linux, where `should_publish_client_gateway` is always false.
+///
+/// Keying on the image rather than on `cfg!(windows)` states the actual mechanism,
+/// and stays correct if the publish scheme ever moves platforms (#542 review).
 ///
 /// Deduplicated per (client, gateway) so one entry per app the user has to act on,
 /// not one per respawn. Pure so the grouping is testable without a process table.
@@ -505,12 +531,24 @@ pub fn clients_needing_restart(
         if decide_reap(proc, ctx) != ReapDecision::Kill {
             continue;
         }
+        // A path we could not read means a process we could not inspect - a
+        // foreign user's session, or one whose ACL denied us. `decide_reap` still
+        // reaches Kill there via the basename-only fallback, but that path skips
+        // the `path_looks_like_our_install` guard, and we cannot stop the process
+        // either. Advising a restart for someone else's app is worse than silence.
+        if proc.path.is_none() {
+            continue;
+        }
+        // Unversioned images self-heal on the next spawn; see above.
+        if !is_versioned_gateway_basename(&proc.basename) {
+            continue;
+        }
         // No parent means no name to show. Staying silent beats telling someone to
         // restart "something".
         let Some(parent) = proc.parent.as_ref() else {
             continue;
         };
-        if is_our_own_process(&parent.basename) {
+        if is_our_own_process(&parent.basename) || is_init_like(parent) {
             continue;
         }
         let advice = ClientNeedingRestart {
@@ -612,42 +650,47 @@ pub fn stop_stale_gateways() -> Vec<String> {
 /// Like [`stop_stale_gateways`], with extra keep-paths (e.g. nested macOS helper
 /// from `clients::resolve_gateway_path`).
 pub fn stop_stale_gateways_with_keep(extra_keep: &[PathBuf]) -> Vec<String> {
-    let mut keep = default_keep_paths();
-    for p in extra_keep {
-        if !keep.iter().any(|e| paths_equal(e, p)) {
-            keep.push(p.clone());
-        }
-    }
-    let ctx = ReapContext {
-        current_version: env!("CARGO_PKG_VERSION").to_string(),
-        keep_paths: keep,
-        keep_pids: vec![std::process::id()],
-        kill_all: false,
-    };
+    let ctx = stale_reap_context(extra_keep);
     let report = reap_with_context(&ctx);
     log_reap_report("stale reaper", &report);
     report.killed_labels()
 }
 
-/// Applications that will keep relaunching an obsolete gateway until restarted.
+/// The one `ReapContext` both the reaper and the restart report are built from.
 ///
-/// Call this AFTER a reap pass. Anything it returns has already survived one, so
-/// it is a client relaunching from a cached spawn command rather than a process
-/// the reaper missed (SOU-435).
-pub fn clients_needing_gateway_restart(extra_keep: &[PathBuf]) -> Vec<ClientNeedingRestart> {
+/// Shared deliberately: they were byte-identical copies, and a keep rule added to
+/// one would have made the restart panel name apps whose gateway the reaper is
+/// intentionally keeping - wrong advice with no compiler signal (#542 review).
+fn stale_reap_context(extra_keep: &[PathBuf]) -> ReapContext {
     let mut keep = default_keep_paths();
     for p in extra_keep {
         if !keep.iter().any(|e| paths_equal(e, p)) {
             keep.push(p.clone());
         }
     }
-    let ctx = ReapContext {
+    ReapContext {
         current_version: env!("CARGO_PKG_VERSION").to_string(),
         keep_paths: keep,
         keep_pids: vec![std::process::id()],
         kill_all: false,
-    };
-    clients_needing_restart(&list_gateway_processes(), &ctx)
+    }
+}
+
+/// Applications that will keep relaunching an obsolete gateway until restarted.
+///
+/// Call this BEFORE reaping, not after. `reap_with_context` kills, waits, and then
+/// re-kills anything still stale, so immediately afterwards the table it would
+/// read has just been cleared. A client's respawn takes far longer than that
+/// window, so the report came back empty in exactly the case it exists for, and
+/// was non-empty mainly when a kill had FAILED - which is a permissions problem,
+/// not a cached-command one, and would have produced the opposite advice
+/// (#542 review).
+///
+/// Read before the reap the signal is unambiguous: an obsolete versioned gateway
+/// with a live parent is an application currently running old code, whether or not
+/// stopping the process happens to succeed a moment later.
+pub fn clients_needing_gateway_restart(extra_keep: &[PathBuf]) -> Vec<ClientNeedingRestart> {
+    clients_needing_restart(&list_gateway_processes(), &stale_reap_context(extra_keep))
 }
 
 // ----- OS process list / kill ------------------------------------------------
@@ -723,13 +766,70 @@ fn windows_list_gateway_processes() -> Vec<GatewayProcess> {
         // its child, so this cannot be done inline.
         out.into_iter()
             .map(|(mut proc, ppid)| {
-                proc.parent = names.get(&ppid).map(|basename| ParentProcess {
-                    pid: ppid,
-                    basename: basename.clone(),
-                });
+                proc.parent = names
+                    .get(&ppid)
+                    .filter(|_| windows_parent_predates_child(ppid, proc.pid))
+                    .map(|basename| ParentProcess {
+                        pid: ppid,
+                        basename: basename.clone(),
+                    });
                 proc
             })
             .collect()
+    }
+}
+
+/// Guard against a recycled parent pid naming an unrelated application.
+///
+/// Unlike Unix, Windows never reparents an orphan and never clears the dead
+/// parent's pid from the child, so `th32ParentProcessID` dangles once the parent
+/// exits - and orphaned gateways are exactly the population the reaper exists to
+/// clean up. Windows then recycles pids freely, so the dangling value can point at
+/// something started later, and the user is told to restart an app that never
+/// spawned a gateway (#542 review).
+///
+/// A real parent always starts before its child. Fails closed: if either creation
+/// time is unreadable we drop the attribution rather than guess, because a wrong
+/// app name is worse than none.
+#[cfg(windows)]
+fn windows_parent_predates_child(ppid: u32, child_pid: u32) -> bool {
+    match (
+        windows_process_start_time(ppid),
+        windows_process_start_time(child_pid),
+    ) {
+        (Some(parent), Some(child)) => parent <= child,
+        _ => false,
+    }
+}
+
+/// Process creation time as a raw FILETIME tick count, for ordering only.
+#[cfg(windows)]
+fn windows_process_start_time(pid: u32) -> Option<u64> {
+    use windows_sys::Win32::Foundation::{CloseHandle, FILETIME};
+    use windows_sys::Win32::System::Threading::{
+        GetProcessTimes, OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION,
+    };
+    unsafe {
+        let handle = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, pid);
+        if handle.is_null() {
+            return None;
+        }
+        let mut created: FILETIME = std::mem::zeroed();
+        let mut exited: FILETIME = std::mem::zeroed();
+        let mut kernel: FILETIME = std::mem::zeroed();
+        let mut user: FILETIME = std::mem::zeroed();
+        let ok = GetProcessTimes(
+            handle,
+            &mut created,
+            &mut exited,
+            &mut kernel,
+            &mut user,
+        );
+        CloseHandle(handle);
+        if ok == 0 {
+            return None;
+        }
+        Some(((created.dwHighDateTime as u64) << 32) | created.dwLowDateTime as u64)
     }
 }
 
@@ -1418,7 +1518,15 @@ mod tests {
         let c = ctx("1.9.7", &[keep], false);
 
         // A gateway on the CURRENT version is not stale, so its client is fine.
-        let current = proc_from(200, "toolport-gateway-1.9.7.exe", Some(keep), (900, "claude.exe"));
+        // Deliberately at a DIFFERENT path from the keep path: passing `keep` here
+        // exits `decide_reap` at the keep-paths check, so the version comparison
+        // this test is named for never ran (#542 review).
+        let current = proc_from(
+            200,
+            "toolport-gateway-1.9.7.exe",
+            Some(r"D:\elsewhere\Toolport\bin\toolport-gateway-1.9.7.exe"),
+            (900, "claude.exe"),
+        );
         assert!(clients_needing_restart(&[current], &c).is_empty());
 
         // Stale but no resolvable parent: telling someone to restart "something"
@@ -1439,6 +1547,61 @@ mod tests {
             (903, "Toolport.exe"),
         );
         assert!(clients_needing_restart(&[ours], &c).is_empty());
+    }
+
+    #[test]
+    fn clients_needing_restart_is_silent_where_a_cached_path_self_heals() {
+        // An UNVERSIONED image is replaced in place on upgrade, so the very same
+        // cached command yields the new binary on the next spawn and there is
+        // nothing for the user to do. That is macOS and Linux, where the Windows
+        // versioned-publish scheme never runs. Reporting there would repeat the
+        // false claim SOU-435 was filed against, in the other direction (#542).
+        let c = ctx("1.9.7", &["/Applications/Toolport.app/Contents/MacOS/toolport-gateway"], false);
+        let unversioned = proc_from(
+            400,
+            "toolport-gateway",
+            Some("/Applications/Toolport.app/Contents/Helpers/old/toolport-gateway"),
+            (900, "Claude"),
+        );
+        // The reaper still stops it; only the ADVICE is withheld.
+        assert_eq!(decide_reap(&unversioned, &c), ReapDecision::Kill);
+        assert!(clients_needing_restart(&[unversioned], &c).is_empty());
+    }
+
+    #[test]
+    fn clients_needing_restart_never_names_init_or_an_uninspectable_process() {
+        let keep = r"C:\Users\me\AppData\Roaming\Toolport\bin\toolport-gateway-1.9.7.exe";
+        let c = ctx("1.9.7", &[keep], false);
+        let stale = r"C:\Users\me\AppData\Roaming\Toolport\bin\toolport-gateway-1.9.4.exe";
+
+        // Orphans reparent to init. Each platform previously guarded a different
+        // subset of these, so the same orphan said "restart systemd" on Linux and
+        // nothing on macOS. A systemd *user* session has a pid of its own, which
+        // is why the name is matched too (#542 review).
+        for parent in [(1u32, "systemd"), (1, "launchd"), (0, "[System Process]"), (4, "System")] {
+            let orphan = proc_from(410, "toolport-gateway-1.9.4.exe", Some(stale), parent);
+            assert!(
+                clients_needing_restart(&[orphan], &c).is_empty(),
+                "{} must never be named as an app to restart",
+                parent.1
+            );
+        }
+        // A systemd user session: pid is ordinary, only the name gives it away.
+        let user_session = proc_from(411, "toolport-gateway-1.9.4.exe", Some(stale), (2481, "systemd"));
+        assert!(clients_needing_restart(&[user_session], &c).is_empty());
+
+        // No readable path means a process we could not inspect (another user's
+        // session, or ACL denied). `decide_reap` still reaches Kill via the
+        // basename-only fallback, but we cannot stop it and it is not ours to
+        // advise on.
+        let foreign = GatewayProcess {
+            pid: 412,
+            path: None,
+            basename: "toolport-gateway-1.9.4.exe".into(),
+            parent: Some(ParentProcess { pid: 900, basename: "claude.exe".into() }),
+        };
+        assert_eq!(decide_reap(&foreign, &c), ReapDecision::Kill);
+        assert!(clients_needing_restart(&[foreign], &c).is_empty());
     }
 
     #[test]

--- a/src-tauri/src/gateway_publish.rs
+++ b/src-tauri/src/gateway_publish.rs
@@ -230,6 +230,14 @@ pub struct ReapReport {
     pub killed: Vec<String>,
     pub kept: Vec<String>,
     pub failed: Vec<String>,
+    /// Apps that will relaunch an obsolete gateway, computed from the process table
+    /// as it was **before** anything was killed (SOU-435).
+    ///
+    /// Carried on the report rather than exposed as a separate query because the
+    /// answer only exists pre-kill. Sampling afterwards reads a table this very
+    /// function just cleared, which is how two call sites in a row ended up silent
+    /// in the exact case the feature is for (#542 review).
+    pub needs_restart: Vec<ClientNeedingRestart>,
 }
 
 impl ReapReport {
@@ -504,21 +512,37 @@ fn is_init_like(parent: &ParentProcess) -> bool {
     )
 }
 
+/// Will the path this client cached start yielding new code by itself?
+///
+/// The question is NOT versioned-vs-unversioned. It is whether the cached path
+/// still names a file that upgrades replace:
+///
+/// * `/proc/<pid>/exe` ending ` (deleted)` means the file WAS replaced underneath
+///   the running process (an in-place package upgrade), so the same cached path
+///   already resolves to the new binary and the next spawn picks it up. Nothing to
+///   advise.
+/// * Anything else that reached a `Kill` verdict does not self-heal. A versioned
+///   image (`toolport-gateway-1.9.4.exe`) names a path whose contents never change.
+///   An *unversioned* image only reaches `Kill` when its path differs from every
+///   keep path, i.e. a stale install *location* - which an upgrade does not touch
+///   either, so it is equally frozen.
+///
+/// The previous version of this gated on `is_versioned_gateway_basename`, which got
+/// the unversioned case exactly backwards: it stayed silent for a client pinned to
+/// an old install location (a real regression), while the genuine self-heal case it
+/// meant to exclude never reaches here at all, because a path equal to a keep path
+/// is `Keep` (#542 review).
+fn cached_path_self_heals(proc: &GatewayProcess) -> bool {
+    proc.path
+        .as_ref()
+        .and_then(|p| p.to_str())
+        .is_some_and(|p| p.ends_with(" (deleted)"))
+}
+
 /// Applications running an obsolete gateway they will relaunch from a cached path.
 ///
 /// An MCP client reads its config once at its own startup and caches the spawn
-/// command. Whether that matters depends on the filename it cached:
-///
-/// * A **versioned** image (`toolport-gateway-1.9.4.exe`) names a path whose
-///   contents never change, so the client relaunches obsolete code forever and
-///   only restarting the application fixes it. This is the Windows publish scheme,
-///   which exists to dodge the Windows file lock.
-/// * An **unversioned** image is replaced in place on upgrade, so the very same
-///   cached path yields the new binary on the next spawn. Nothing to advise. This
-///   is macOS and Linux, where `should_publish_client_gateway` is always false.
-///
-/// Keying on the image rather than on `cfg!(windows)` states the actual mechanism,
-/// and stays correct if the publish scheme ever moves platforms (#542 review).
+/// command; see [`cached_path_self_heals`] for when that traps it on old code.
 ///
 /// Deduplicated per (client, gateway) so one entry per app the user has to act on,
 /// not one per respawn. Pure so the grouping is testable without a process table.
@@ -537,10 +561,18 @@ pub fn clients_needing_restart(
         // the `path_looks_like_our_install` guard, and we cannot stop the process
         // either. Advising a restart for someone else's app is worse than silence.
         if proc.path.is_none() {
+            // Logged rather than dropped silently: this is the one branch that
+            // withholds advice for a reason the user cannot see, so a support case
+            // ("why does it keep coming back and say nothing?") is otherwise
+            // untraceable (#542 review).
+            eprintln!(
+                "toolport: {} (pid {}) looks obsolete but its path could not be read, \
+                 so it is not attributed to an app",
+                proc.basename, proc.pid
+            );
             continue;
         }
-        // Unversioned images self-heal on the next spawn; see above.
-        if !is_versioned_gateway_basename(&proc.basename) {
+        if cached_path_self_heals(proc) {
             continue;
         }
         // No parent means no name to show. Staying silent beats telling someone to
@@ -572,6 +604,12 @@ fn label_process(proc: &GatewayProcess) -> String {
 fn reap_with_context(ctx: &ReapContext) -> ReapReport {
     let mut report = ReapReport::default();
     let procs = list_gateway_processes();
+    // Decide the restart advice from THIS snapshot, before a single kill. After the
+    // kills below (and the verify pass, which kills again) the table no longer
+    // contains the evidence, so anything computed later is either empty or is
+    // dominated by kills that failed - a permissions problem, and the opposite
+    // advice (#542 review).
+    report.needs_restart = clients_needing_restart(&procs, ctx);
     let mut to_kill: Vec<GatewayProcess> = Vec::new();
     for proc in procs {
         match decide_reap(&proc, ctx) {
@@ -650,10 +688,20 @@ pub fn stop_stale_gateways() -> Vec<String> {
 /// Like [`stop_stale_gateways`], with extra keep-paths (e.g. nested macOS helper
 /// from `clients::resolve_gateway_path`).
 pub fn stop_stale_gateways_with_keep(extra_keep: &[PathBuf]) -> Vec<String> {
+    reap_stale(extra_keep).killed_labels()
+}
+
+/// Reap obsolete gateways and report both what was stopped and which apps will
+/// relaunch one anyway.
+///
+/// One call rather than a reap plus a follow-up query: the advice is only knowable
+/// from the pre-kill process table, so a separate query could only ever be asked at
+/// the wrong moment. Two call sites managed exactly that (#542 review).
+pub fn reap_stale(extra_keep: &[PathBuf]) -> ReapReport {
     let ctx = stale_reap_context(extra_keep);
     let report = reap_with_context(&ctx);
     log_reap_report("stale reaper", &report);
-    report.killed_labels()
+    report
 }
 
 /// The one `ReapContext` both the reaper and the restart report are built from.
@@ -676,22 +724,11 @@ fn stale_reap_context(extra_keep: &[PathBuf]) -> ReapContext {
     }
 }
 
-/// Applications that will keep relaunching an obsolete gateway until restarted.
-///
-/// Call this BEFORE reaping, not after. `reap_with_context` kills, waits, and then
-/// re-kills anything still stale, so immediately afterwards the table it would
-/// read has just been cleared. A client's respawn takes far longer than that
-/// window, so the report came back empty in exactly the case it exists for, and
-/// was non-empty mainly when a kill had FAILED - which is a permissions problem,
-/// not a cached-command one, and would have produced the opposite advice
-/// (#542 review).
-///
-/// Read before the reap the signal is unambiguous: an obsolete versioned gateway
-/// with a live parent is an application currently running old code, whether or not
-/// stopping the process happens to succeed a moment later.
-pub fn clients_needing_gateway_restart(extra_keep: &[PathBuf]) -> Vec<ClientNeedingRestart> {
-    clients_needing_restart(&list_gateway_processes(), &stale_reap_context(extra_keep))
-}
+// There is deliberately no standalone `clients_needing_gateway_restart()` query.
+// It existed, and both of its call sites asked it at the wrong moment, because the
+// only table that holds the answer is the one the reaper is about to clear. The
+// advice now rides out on `ReapReport::needs_restart` from [`reap_stale`], which
+// makes asking at the wrong moment unrepresentable (#542 review).
 
 // ----- OS process list / kill ------------------------------------------------
 
@@ -1550,22 +1587,56 @@ mod tests {
     }
 
     #[test]
-    fn clients_needing_restart_is_silent_where_a_cached_path_self_heals() {
-        // An UNVERSIONED image is replaced in place on upgrade, so the very same
-        // cached command yields the new binary on the next spawn and there is
-        // nothing for the user to do. That is macOS and Linux, where the Windows
-        // versioned-publish scheme never runs. Reporting there would repeat the
-        // false claim SOU-435 was filed against, in the other direction (#542).
-        let c = ctx("1.9.7", &["/Applications/Toolport.app/Contents/MacOS/toolport-gateway"], false);
-        let unversioned = proc_from(
+    fn clients_needing_restart_is_silent_only_when_the_binary_was_replaced_in_place() {
+        // A ` (deleted)` exe is the ONE self-healing case: the file was replaced
+        // underneath the running process, so the very same cached path already
+        // resolves to the new binary and the next spawn picks it up.
+        // An AppImage stable copy, which `path_looks_like_our_install` recognizes.
+        // A bare `/usr/bin` .deb path does NOT match that helper, so it never
+        // reaches a Kill verdict at all and would make this test vacuous.
+        let c = ctx(
+            "1.9.7",
+            &["/home/me/.local/share/Toolport/toolport-gateway"],
+            false,
+        );
+        let replaced = proc_from(
             400,
             "toolport-gateway",
-            Some("/Applications/Toolport.app/Contents/Helpers/old/toolport-gateway"),
+            Some("/home/me/.local/share/Toolport/toolport-gateway (deleted)"),
+            (900, "Cursor"),
+        );
+        // The reaper still stops it (that is what kills the old inode); only the
+        // ADVICE is withheld, because restarting the app is not required.
+        assert_eq!(decide_reap(&replaced, &c), ReapDecision::Kill);
+        assert!(clients_needing_restart(&[replaced], &c).is_empty());
+    }
+
+    #[test]
+    fn clients_needing_restart_reports_a_client_pinned_to_a_stale_install_location() {
+        // An unversioned image reaches Kill only when its path differs from every
+        // keep path, which means a stale install LOCATION - a file no upgrade
+        // touches. So it does not self-heal and the user does have to restart.
+        //
+        // Gating on `is_versioned_gateway_basename` got this backwards and stayed
+        // silent here, which was a regression against the first version of the
+        // feature (#542 review).
+        let c = ctx("1.9.7", &["/Applications/Toolport.app/Contents/MacOS/toolport-gateway"], false);
+        let moved_app = proc_from(
+            401,
+            "toolport-gateway",
+            // The user ran Toolport from ~/Downloads, configured clients, then moved
+            // the app. This file still exists and is never upgraded.
+            Some("/Users/me/Downloads/Toolport.app/Contents/MacOS/toolport-gateway"),
             (900, "Claude"),
         );
-        // The reaper still stops it; only the ADVICE is withheld.
-        assert_eq!(decide_reap(&unversioned, &c), ReapDecision::Kill);
-        assert!(clients_needing_restart(&[unversioned], &c).is_empty());
+        assert_eq!(decide_reap(&moved_app, &c), ReapDecision::Kill);
+        assert_eq!(
+            clients_needing_restart(&[moved_app], &c),
+            vec![ClientNeedingRestart {
+                client: "Claude".into(),
+                gateway: "toolport-gateway".into()
+            }]
+        );
     }
 
     #[test]

--- a/src-tauri/src/gateway_publish.rs
+++ b/src-tauri/src/gateway_publish.rs
@@ -467,7 +467,8 @@ pub fn decide_reap(proc: &GatewayProcess, ctx: &ReapContext) -> ReapDecision {
 
 /// An application that keeps relaunching an obsolete gateway and therefore has to
 /// be restarted by hand.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ClientNeedingRestart {
     /// Basename of the client application, e.g. `claude.exe`.
     pub client: String,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -278,6 +278,30 @@ function App() {
     };
   }, []);
 
+  // An app that was running before an upgrade keeps launching the gateway version
+  // it cached at its own startup, and stopping that process only makes it come
+  // back. Nothing Toolport does fixes it, so say which apps to restart (SOU-435).
+  // Fires once per launch, after the reaper has had its second pass.
+  useEffect(() => {
+    const unlisten = listen<{ client: string; gateway: string }[]>(
+      "gateway-restart-needed",
+      (event) => {
+        const apps = event.payload ?? [];
+        if (apps.length === 0) return;
+        const names = apps.map((a) => a.client).join(", ");
+        toast.warning(
+          `Restart ${names} to finish upgrading. ${
+            apps.length === 1 ? "It is" : "They are"
+          } still launching an older gateway.`,
+          { duration: 10_000 },
+        );
+      },
+    );
+    return () => {
+      void unlisten.then((f) => f());
+    };
+  }, []);
+
   // A refresh emits one `server-probed` event per server as its probe finishes, so
   // each row resolves the moment its own result is in - a slow npx cold-start no
   // longer holds the whole grid in "checking" until the slowest server returns

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -288,10 +288,13 @@ function App() {
       (event) => {
         const apps = event.payload ?? [];
         if (apps.length === 0) return;
-        const names = apps.map((a) => a.client).join(", ");
+        // One app can appear more than once, since the backend keys on
+        // (client, gateway) and two windows started either side of different
+        // upgrades yield two rows. Name it once (#542 review).
+        const names = [...new Set(apps.map((a) => a.client))];
         toast.warning(
-          `Restart ${names} to finish upgrading. ${
-            apps.length === 1 ? "It is" : "They are"
+          `Restart ${names.join(", ")} to finish upgrading. ${
+            names.length === 1 ? "It is" : "They are"
           } still launching an older gateway.`,
           { duration: 10_000 },
         );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -34,6 +34,7 @@ import {
   setAllEnabled,
   setServerEnabled,
   teamSyncWait,
+  type ClientNeedingRestart,
 } from "@/lib/api";
 import {
   importableServers,
@@ -278,28 +279,26 @@ function App() {
     };
   }, []);
 
-  // An app that was running before an upgrade keeps launching the gateway version
-  // it cached at its own startup, and stopping that process only makes it come
-  // back. Nothing Toolport does fixes it, so say which apps to restart (SOU-435).
-  // Fires once per launch, after the reaper has had its second pass.
+  // An app that was running before an upgrade can keep launching the gateway it
+  // cached at its own startup, when that path is one upgrades never rewrite. Then
+  // stopping the process only makes it come back, so name the apps to restart
+  // (SOU-435). Fires once per launch, from the first reaper pass, which is the only
+  // one whose snapshot still holds the evidence.
   useEffect(() => {
-    const unlisten = listen<{ client: string; gateway: string }[]>(
-      "gateway-restart-needed",
-      (event) => {
-        const apps = event.payload ?? [];
-        if (apps.length === 0) return;
-        // One app can appear more than once, since the backend keys on
-        // (client, gateway) and two windows started either side of different
-        // upgrades yield two rows. Name it once (#542 review).
-        const names = [...new Set(apps.map((a) => a.client))];
-        toast.warning(
-          `Restart ${names.join(", ")} to finish upgrading. ${
-            names.length === 1 ? "It is" : "They are"
-          } still launching an older gateway.`,
-          { duration: 10_000 },
-        );
-      },
-    );
+    const unlisten = listen<ClientNeedingRestart[]>("gateway-restart-needed", (event) => {
+      const apps = event.payload ?? [];
+      if (apps.length === 0) return;
+      // One app can appear more than once, since the backend keys on
+      // (client, gateway) and two windows started either side of different
+      // upgrades yield two rows. Name it once (#542 review).
+      const names = [...new Set(apps.map((a) => a.client))];
+      toast.warning(
+        `Restart ${names.join(", ")} to finish upgrading. ${
+          names.length === 1 ? "It is" : "They are"
+        } still launching an older gateway.`,
+        { duration: 10_000 },
+      );
+    });
     return () => {
       void unlisten.then((f) => f());
     };

--- a/src/components/SettingsView.tsx
+++ b/src/components/SettingsView.tsx
@@ -575,6 +575,9 @@ export function SettingsView({ registry, onRegistryChange }: Props) {
   // Apps relaunching an obsolete gateway from a cached spawn command. Stopping
   // the process cannot fix these; only restarting the app does (SOU-435).
   const [needRestart, setNeedRestart] = useState<ClientNeedingRestart[]>([]);
+  // Rows are keyed on (client, gateway), so one app can appear twice with two
+  // different gateways. Pluralize on distinct APPS, matching the toast (#542).
+  const restartAppCount = new Set(needRestart.map((c) => c.client)).size;
   const [autostartOn, setAutostartOn] = useState(false);
 
   const httpClients = registry?.httpClients ?? [];
@@ -597,6 +600,9 @@ export function SettingsView({ registry, onRegistryChange }: Props) {
   // toast is fire-and-forget and Tauri does not replay events, so a webview that
   // mounts late (hidden autostart on a loaded machine) never sees it; without
   // this, that information is lost for the whole session (#542 review).
+  //
+  // Cheap now: this reads advice the launch reaper already recorded, so it is a
+  // clone of a small Vec rather than a process-table walk on every tab switch.
   useEffect(() => {
     clientsNeedingRestart()
       .then(setNeedRestart)
@@ -1285,10 +1291,12 @@ export function SettingsView({ registry, onRegistryChange }: Props) {
             <span className="flex min-w-0 flex-1 flex-col leading-tight">
               <span className="font-medium">Stop old gateways</span>
               <span className="text-xs text-muted-foreground">
-                End leftover gateway processes from earlier installs. Most hosts respawn
-                MCP and pick up the current binary on the next tool call. On Windows the
-                gateway filename carries its version, so an app that was already running
-                keeps launching the old one until you restart that app.
+                End leftover gateway processes from earlier installs. Where the gateway
+                path stays the same across upgrades, a host that respawns MCP picks up the
+                new binary on its own. Where the filename carries its version, or the old
+                one still sits at a path an upgrade never touches, an app that was already
+                running keeps launching it until you restart that app. Anything in that
+                state is listed below.
               </span>
             </span>
             <button
@@ -1297,14 +1305,9 @@ export function SettingsView({ registry, onRegistryChange }: Props) {
               onClick={async () => {
                 setReapBusy(true);
                 setReapResult(null);
-                try {
-                  // Sample BEFORE stopping anything: reaping clears the very
-                  // processes this reads, so asking afterwards reported nothing
-                  // in the case it exists for (#542 review).
-                  setNeedRestart(await clientsNeedingRestart());
-                } catch {
-                  // Advisory only. A failure here must not mask the reap result.
-                }
+                // Cleared first so a failed refresh below cannot leave a stale
+                // amber panel sitting next to a fresh success message (#542).
+                setNeedRestart([]);
                 try {
                   const stopped = await stopStaleGateways();
                   setReapResult(
@@ -1312,6 +1315,10 @@ export function SettingsView({ registry, onRegistryChange }: Props) {
                       ? "No old gateway processes found."
                       : `Stopped ${stopped.length}: ${stopped.join("; ")}`,
                   );
+                  // Ordering no longer matters: the backend records this from the
+                  // pre-kill snapshot taken inside the reap it just ran, so reading
+                  // it afterwards returns that snapshot, not an emptied table.
+                  setNeedRestart(await clientsNeedingRestart());
                 } catch (e) {
                   toastError(`Couldn't stop old gateways: ${e}`);
                 } finally {
@@ -1327,11 +1334,11 @@ export function SettingsView({ registry, onRegistryChange }: Props) {
           {needRestart.length > 0 && (
             <div className="flex flex-col gap-1 rounded-md border border-amber-500/40 bg-amber-500/5 px-2.5 py-2">
               <span className="text-xs font-medium">
-                Restart {needRestart.length === 1 ? "this app" : "these apps"} to finish
+                Restart {restartAppCount === 1 ? "this app" : "these apps"} to finish
                 upgrading
               </span>
               <span className="text-xs text-muted-foreground">
-                {needRestart.length === 1 ? "It is" : "They are"} still launching an older
+                {restartAppCount === 1 ? "It is" : "They are"} still launching an older
                 gateway from a command cached at startup, so stopping the process just
                 brings it back.
               </span>

--- a/src/components/SettingsView.tsx
+++ b/src/components/SettingsView.tsx
@@ -593,6 +593,16 @@ export function SettingsView({ registry, onRegistryChange }: Props) {
       .catch(() => {});
   }, []);
 
+  // Populate on mount rather than only after the button is pressed. The launch
+  // toast is fire-and-forget and Tauri does not replay events, so a webview that
+  // mounts late (hidden autostart on a loaded machine) never sees it; without
+  // this, that information is lost for the whole session (#542 review).
+  useEffect(() => {
+    clientsNeedingRestart()
+      .then(setNeedRestart)
+      .catch(() => {});
+  }, []);
+
   const toggleAutostart = async (on: boolean) => {
     setBusy(true);
     try {
@@ -1275,10 +1285,10 @@ export function SettingsView({ registry, onRegistryChange }: Props) {
             <span className="flex min-w-0 flex-1 flex-col leading-tight">
               <span className="font-medium">Stop old gateways</span>
               <span className="text-xs text-muted-foreground">
-                End leftover gateway processes from earlier installs. An app that was
-                already running caches the gateway command when it starts, so it
-                relaunches the old one until you restart the app itself. Toolport lists
-                any below.
+                End leftover gateway processes from earlier installs. Most hosts respawn
+                MCP and pick up the current binary on the next tool call. On Windows the
+                gateway filename carries its version, so an app that was already running
+                keeps launching the old one until you restart that app.
               </span>
             </span>
             <button
@@ -1287,7 +1297,14 @@ export function SettingsView({ registry, onRegistryChange }: Props) {
               onClick={async () => {
                 setReapBusy(true);
                 setReapResult(null);
-                setNeedRestart([]);
+                try {
+                  // Sample BEFORE stopping anything: reaping clears the very
+                  // processes this reads, so asking afterwards reported nothing
+                  // in the case it exists for (#542 review).
+                  setNeedRestart(await clientsNeedingRestart());
+                } catch {
+                  // Advisory only. A failure here must not mask the reap result.
+                }
                 try {
                   const stopped = await stopStaleGateways();
                   setReapResult(
@@ -1295,9 +1312,6 @@ export function SettingsView({ registry, onRegistryChange }: Props) {
                       ? "No old gateway processes found."
                       : `Stopped ${stopped.length}: ${stopped.join("; ")}`,
                   );
-                  // Only meaningful after the reap: whatever is still on an old
-                  // binary now has been relaunched, not missed.
-                  setNeedRestart(await clientsNeedingRestart());
                 } catch (e) {
                   toastError(`Couldn't stop old gateways: ${e}`);
                 } finally {

--- a/src/components/SettingsView.tsx
+++ b/src/components/SettingsView.tsx
@@ -58,6 +58,8 @@ import {
   startHttpBridge,
   stopHttpBridge,
   stopStaleGateways,
+  clientsNeedingRestart,
+  type ClientNeedingRestart,
   type HttpBridgeStatus,
   type QuarantinedTool,
 } from "@/lib/api";
@@ -570,6 +572,9 @@ export function SettingsView({ registry, onRegistryChange }: Props) {
   const [clientBusy, setClientBusy] = useState(false);
   const [reapBusy, setReapBusy] = useState(false);
   const [reapResult, setReapResult] = useState<string | null>(null);
+  // Apps relaunching an obsolete gateway from a cached spawn command. Stopping
+  // the process cannot fix these; only restarting the app does (SOU-435).
+  const [needRestart, setNeedRestart] = useState<ClientNeedingRestart[]>([]);
   const [autostartOn, setAutostartOn] = useState(false);
 
   const httpClients = registry?.httpClients ?? [];
@@ -1270,9 +1275,10 @@ export function SettingsView({ registry, onRegistryChange }: Props) {
             <span className="flex min-w-0 flex-1 flex-col leading-tight">
               <span className="font-medium">Stop old gateways</span>
               <span className="text-xs text-muted-foreground">
-                End leftover gateway processes from earlier installs. Agents that
-                auto-respawn MCP pick up the current binary on the next tool call; no full
-                app restart required for those hosts.
+                End leftover gateway processes from earlier installs. An app that was
+                already running caches the gateway command when it starts, so it
+                relaunches the old one until you restart the app itself. Toolport lists
+                any below.
               </span>
             </span>
             <button
@@ -1281,6 +1287,7 @@ export function SettingsView({ registry, onRegistryChange }: Props) {
               onClick={async () => {
                 setReapBusy(true);
                 setReapResult(null);
+                setNeedRestart([]);
                 try {
                   const stopped = await stopStaleGateways();
                   setReapResult(
@@ -1288,6 +1295,9 @@ export function SettingsView({ registry, onRegistryChange }: Props) {
                       ? "No old gateway processes found."
                       : `Stopped ${stopped.length}: ${stopped.join("; ")}`,
                   );
+                  // Only meaningful after the reap: whatever is still on an old
+                  // binary now has been relaunched, not missed.
+                  setNeedRestart(await clientsNeedingRestart());
                 } catch (e) {
                   toastError(`Couldn't stop old gateways: ${e}`);
                 } finally {
@@ -1300,6 +1310,27 @@ export function SettingsView({ registry, onRegistryChange }: Props) {
             </button>
           </div>
           {reapResult && <p className="text-xs text-muted-foreground">{reapResult}</p>}
+          {needRestart.length > 0 && (
+            <div className="flex flex-col gap-1 rounded-md border border-amber-500/40 bg-amber-500/5 px-2.5 py-2">
+              <span className="text-xs font-medium">
+                Restart {needRestart.length === 1 ? "this app" : "these apps"} to finish
+                upgrading
+              </span>
+              <span className="text-xs text-muted-foreground">
+                {needRestart.length === 1 ? "It is" : "They are"} still launching an older
+                gateway from a command cached at startup, so stopping the process just
+                brings it back.
+              </span>
+              <ul className="mt-0.5 flex flex-col gap-0.5">
+                {needRestart.map((c) => (
+                  <li key={`${c.client}:${c.gateway}`} className="text-xs">
+                    <span className="font-medium">{c.client}</span>
+                    <span className="text-muted-foreground"> is running {c.gateway}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
         </div>
       </section>
     </div>

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -370,6 +370,26 @@ export function stopStaleGateways(): Promise<string[]> {
   return invoke<string[]>("stop_stale_gateways");
 }
 
+/** An app that keeps relaunching an obsolete gateway and has to be restarted. */
+export type ClientNeedingRestart = {
+  /** Process image basename of the app, e.g. `claude.exe`. */
+  client: string;
+  /** The obsolete gateway it relaunched, e.g. `toolport-gateway-1.9.4.exe`. */
+  gateway: string;
+};
+
+/**
+ * Apps still launching an obsolete gateway. Stopping those processes cannot fix
+ * this: a client caches the spawn command at its own startup, so it relaunches
+ * the same old binary until the app itself is restarted.
+ *
+ * Call after {@link stopStaleGateways} — anything returned has already survived a
+ * reap, so it is a relaunch rather than a process that was missed.
+ */
+export function clientsNeedingRestart(): Promise<ClientNeedingRestart[]> {
+  return invoke<ClientNeedingRestart[]>("clients_needing_restart");
+}
+
 /**
  * Result of {@link teamConnect} / {@link teamJoinPoll}. `status` is:
  * - `connected` — joined; `registry` is the fresh merged state.

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -381,14 +381,14 @@ export type ClientNeedingRestart = {
 /**
  * Apps launching an obsolete gateway that only restarting them can fix.
  *
- * Every result names a versioned gateway image, whose path can never hold newer
- * code, so a client that cached it relaunches the same binary forever. That is the
- * Windows publish scheme; elsewhere the gateway path is stable and replaced in
- * place, so a cached command picks up the new binary on its own and nothing is
- * reported.
+ * A client caches the gateway command at its own startup. That traps it on old
+ * code whenever the cached path is one upgrades never rewrite: a versioned
+ * filename (the Windows publish scheme), or an install location the app has since
+ * moved away from. It does NOT trap it when the binary was replaced in place,
+ * since the same path then already resolves to the new one.
  *
- * Call BEFORE {@link stopStaleGateways}, not after. Reaping clears the processes
- * this reads, so sampling afterwards reports nothing in the case it exists for.
+ * Order-independent: this returns advice the backend recorded from the process
+ * table as it was before its last reap, so it cannot be asked "too late".
  */
 export function clientsNeedingRestart(): Promise<ClientNeedingRestart[]> {
   return invoke<ClientNeedingRestart[]>("clients_needing_restart");

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -379,12 +379,16 @@ export type ClientNeedingRestart = {
 };
 
 /**
- * Apps still launching an obsolete gateway. Stopping those processes cannot fix
- * this: a client caches the spawn command at its own startup, so it relaunches
- * the same old binary until the app itself is restarted.
+ * Apps launching an obsolete gateway that only restarting them can fix.
  *
- * Call after {@link stopStaleGateways} — anything returned has already survived a
- * reap, so it is a relaunch rather than a process that was missed.
+ * Every result names a versioned gateway image, whose path can never hold newer
+ * code, so a client that cached it relaunches the same binary forever. That is the
+ * Windows publish scheme; elsewhere the gateway path is stable and replaced in
+ * place, so a cached command picks up the new binary on its own and nothing is
+ * reported.
+ *
+ * Call BEFORE {@link stopStaleGateways}, not after. Reaping clears the processes
+ * this reads, so sampling afterwards reports nothing in the case it exists for.
  */
 export function clientsNeedingRestart(): Promise<ClientNeedingRestart[]> {
   return invoke<ClientNeedingRestart[]>("clients_needing_restart");


### PR DESCRIPTION
Closes SOU-435. Blocks the 1.9.7 release, because the current changelog and Settings copy both claim something the code cannot do.

## The problem

The reaper stops obsolete gateways but **cannot deliver new code to a client that is already running**. An MCP client reads its config once at its own startup and caches the spawn command. The versioned filename scheme means the path it cached will never contain anything newer, so killing that gateway just makes the same client relaunch the same obsolete binary. The user gets whack-a-mole.

Found by the first real smoke pass on Windows, upgrading 1.9.6 to 1.9.7-rc.1:

| Gateway | Parent | Parent started |
| -- | -- | -- |
| `toolport-gateway-1.9.4.exe` | `grok.exe` | 3 days before the upgrade |
| `toolport-gateway-1.9.6.exe` | `claude.exe` | 2 days before the upgrade |

Both were **fresh spawns after** the upgrade, while all four client configs on disk had been correctly re-pointed. Repoint and publish were working; the premise was wrong.

## What this does

SOU-435 option 1 plus 3, the minimum honest outcome. It does not make the reaper deliver code it structurally cannot deliver. It stops overstating what the reaper does and names the applications to restart.

Detection runs **after** the delayed reap pass, which is what makes it meaningful: an obsolete gateway still standing at that point has already survived a reap, so it is a relaunch rather than a process that was missed.

Parent identity comes from data each platform enumerator already fetches, so there is no extra process walk:

- **Windows** — `th32ParentProcessID` is already in the `PROCESSENTRY32W` snapshot, and the same walk builds a pid to basename map to name the parent.
- **macOS** — `ps` gains `-o ppid=`, still one call, and the `-ax` listing already contains every parent's `ucomm`. The line parser now takes two positional numeric columns, so a process name with spaces still parses.
- **Linux** — `/proc/<pid>/status` for `PPid` rather than `stat`, because `stat` puts `comm` in parentheses as field 2 and a process name may itself contain `) `.

`decide_reap` is untouched. Parent identity is deliberately never an input to the keep/kill decision, only to the message.

Reported once per application rather than once per respawn, skipped when the parent cannot be resolved (telling someone to restart "something" is worse than silence), and skipped for our own processes so the supervised HTTP bridge is never reported as a client.

## Surfaces

- **Settings**, under *Stop old gateways*: running the reap now also lists which apps are still on an old binary. That is where someone goes when they suspect stale gateways, and it answers the obvious next question.
- **Launch**: a one-time toast naming the apps, from the existing delayed reaper pass.

## Corrected claims

Two places asserted something false, and both are why this issue exists:

- `desktop.rs`: "so each client respawns the current binary on its next MCP request (no full agent restart required when the host auto-respawns)".
- Settings: "Agents that auto-respawn MCP pick up the current binary on the next tool call; no full app restart required for those hosts."

The CHANGELOG already carried the limitation note, so it now also says Toolport names the apps rather than leaving that to the reader.

## Tests

798 Rust tests pass, warning count unchanged at 7. 137 frontend tests pass, typecheck clean, no new lint warnings.

Each new test was verified by breaking the production code it guards. Dropping the own-process filter, dropping the dedupe, and dropping the staleness check each fail a different test.

## Not verified in a browser

Both surfaces need the Tauri runtime (`invoke` and the event bus), so a vite preview cannot exercise either. This wants a real app run on the next smoke pass, which is where SOU-435 came from in the first place.
