### PR TITLE
fix: keep unbound rate-limit counters in memory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,7 +100,3 @@ license-signing.keycd
 # Agent/session scratch (never commit)
 _poll_pr.py
 _cr*.txt
-
-# Local rate-limit counter files (SOU-340)
-rate_limit_counters*.json
-

--- a/src-tauri/src/rate_limits.rs
+++ b/src-tauri/src/rate_limits.rs
@@ -140,7 +140,7 @@ struct CounterFile {
 }
 
 struct CounterState {
-    path: PathBuf,
+    path: Option<PathBuf>,
     file: CounterFile,
 }
 
@@ -155,11 +155,26 @@ fn state_lock() -> &'static Mutex<Option<CounterState>> {
 pub fn bind_data_dir(dir: &Path) {
     let path = dir.join("rate_limit_counters.json");
     let mut guard = state_lock().lock().unwrap_or_else(|e| e.into_inner());
-    if guard.is_some() {
-        return;
+    match guard.as_mut() {
+        Some(st) if st.path.is_some() => return,
+        Some(st) => {
+            let mut file = load_file(&path);
+            for (key, pending) in &st.file.counts {
+                let persisted = file.counts.entry(key.clone()).or_insert(0);
+                *persisted = persisted.saturating_add(*pending);
+            }
+            st.path = Some(path);
+            st.file = file;
+            save_file(st);
+        }
+        None => {
+            let file = load_file(&path);
+            *guard = Some(CounterState {
+                path: Some(path),
+                file,
+            });
+        }
     }
-    let file = load_file(&path);
-    *guard = Some(CounterState { path, file });
 }
 
 fn load_file(path: &Path) -> CounterFile {
@@ -170,8 +185,11 @@ fn load_file(path: &Path) -> CounterFile {
 }
 
 fn save_file(st: &CounterState) {
+    let Some(path) = st.path.as_ref() else {
+        return;
+    };
     if let Ok(raw) = serde_json::to_string(&st.file) {
-        let _ = fs::write(&st.path, raw);
+        let _ = fs::write(path, raw);
     }
 }
 
@@ -211,7 +229,7 @@ pub fn check_and_count(caps: &[Cap], server_id: &str, orig_tool: &str) -> Result
     // In-memory fallback when bind_data_dir was never called (tests / early calls).
     if guard.is_none() {
         *guard = Some(CounterState {
-            path: PathBuf::from("rate_limit_counters.json"),
+            path: None,
             file: CounterFile::default(),
         });
     }
@@ -264,7 +282,7 @@ pub fn peek(window: &str, tool: Option<&str>) -> u64 {
 pub fn reset_for_test() {
     let mut guard = state_lock().lock().unwrap_or_else(|e| e.into_inner());
     *guard = Some(CounterState {
-        path: PathBuf::from("rate_limit_counters.test.json"),
+        path: None,
         file: CounterFile::default(),
     });
 }
@@ -273,10 +291,60 @@ pub fn reset_for_test() {
 mod tests {
     use super::*;
     use serde_json::json;
+    use std::sync::atomic::{AtomicU32, Ordering};
     use std::sync::Mutex;
 
     /// Counter state is process-global; serialize tests that mutate it.
     static TEST_LOCK: Mutex<()> = Mutex::new(());
+    static TEST_DIR_SEQUENCE: AtomicU32 = AtomicU32::new(0);
+
+    struct TestDir(PathBuf);
+
+    impl TestDir {
+        fn new(label: &str) -> Self {
+            loop {
+                let sequence = TEST_DIR_SEQUENCE.fetch_add(1, Ordering::Relaxed);
+                let path = std::env::temp_dir().join(format!(
+                    "toolport-rate-limits-{label}-{}-{sequence}",
+                    std::process::id()
+                ));
+                match fs::create_dir(&path) {
+                    Ok(()) => return Self(path),
+                    Err(err) if err.kind() == std::io::ErrorKind::AlreadyExists => continue,
+                    Err(err) => {
+                        panic!("failed to create test directory {}: {err}", path.display())
+                    }
+                }
+            }
+        }
+    }
+
+    impl Drop for TestDir {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.0);
+        }
+    }
+
+    struct UnexpectedFile {
+        path: PathBuf,
+        existed: bool,
+    }
+
+    impl UnexpectedFile {
+        fn new(path: impl Into<PathBuf>) -> Self {
+            let path = path.into();
+            let existed = path.exists();
+            Self { path, existed }
+        }
+    }
+
+    impl Drop for UnexpectedFile {
+        fn drop(&mut self) {
+            if !self.existed {
+                let _ = fs::remove_file(&self.path);
+            }
+        }
+    }
 
     #[test]
     fn parse_caps_reads_camel_case_and_skips_bad() {
@@ -309,6 +377,215 @@ mod tests {
         let err = check_and_count(&caps, "srv", "echo").unwrap_err();
         assert!(err.contains("rate limit"), "{err}");
         assert_eq!(peek("day", None), 2);
+    }
+
+    #[test]
+    fn unbound_states_do_not_write_counter_files() {
+        let _lock = TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let fallback_artifact = UnexpectedFile::new("rate_limit_counters.json");
+        let test_artifact = UnexpectedFile::new("rate_limit_counters.test.json");
+        assert!(
+            !fallback_artifact.existed && !test_artifact.existed,
+            "counter artifact already exists in the test working directory"
+        );
+        let caps = vec![Cap {
+            id: "t".into(),
+            window: "day".into(),
+            max_calls: 2,
+            tool: None,
+        }];
+
+        *state_lock().lock().unwrap_or_else(|e| e.into_inner()) = None;
+        assert!(check_and_count(&caps, "srv", "echo").is_ok());
+        let fallback_path = state_lock()
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .as_ref()
+            .and_then(|st| st.path.clone());
+        let fallback_wrote_file = fallback_artifact.path.exists();
+
+        reset_for_test();
+        assert!(check_and_count(&caps, "srv", "echo").is_ok());
+        let test_path = state_lock()
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .as_ref()
+            .and_then(|st| st.path.clone());
+        let test_reset_wrote_file = test_artifact.path.exists();
+
+        assert_eq!(
+            (fallback_path, test_path),
+            (None, None),
+            "unbound counter states must not acquire filesystem paths"
+        );
+        assert!(
+            !fallback_wrote_file,
+            "the production fallback must remain in memory"
+        );
+        assert!(
+            !test_reset_wrote_file,
+            "test counter state must remain in memory"
+        );
+    }
+
+    #[test]
+    fn binding_before_calls_persists_across_restart() {
+        let _lock = TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let dir = TestDir::new("bound-persistence");
+        let path = dir.0.join("rate_limit_counters.json");
+        let caps = vec![Cap {
+            id: "day".into(),
+            window: "day".into(),
+            max_calls: 2,
+            tool: None,
+        }];
+
+        *state_lock().lock().unwrap_or_else(|e| e.into_inner()) = None;
+        bind_data_dir(&dir.0);
+        assert!(check_and_count(&caps, "srv", "echo").is_ok());
+
+        let (bound_path, key, count) = {
+            let guard = state_lock().lock().unwrap_or_else(|e| e.into_inner());
+            let st = guard.as_ref().unwrap();
+            assert_eq!(st.file.counts.len(), 1);
+            let (key, count) = st.file.counts.iter().next().unwrap();
+            (st.path.clone(), key.clone(), *count)
+        };
+        assert!(key.starts_with("day:"));
+        assert_eq!(
+            (
+                bound_path.as_deref(),
+                count,
+                load_file(&path).counts.get(&key).copied(),
+            ),
+            (Some(path.as_path()), 1, Some(1)),
+            "binding must set the path and persist the first call"
+        );
+
+        *state_lock().lock().unwrap_or_else(|e| e.into_inner()) = None;
+        bind_data_dir(&dir.0);
+        let rebound = {
+            let guard = state_lock().lock().unwrap_or_else(|e| e.into_inner());
+            let st = guard.as_ref().unwrap();
+            (st.path.clone(), st.file.counts.get(&key).copied())
+        };
+        assert_eq!(rebound, (Some(path), Some(1)));
+    }
+
+    #[test]
+    fn late_binding_merges_and_persists_pending_counters() {
+        let _lock = TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let legacy_artifact = UnexpectedFile::new("rate_limit_counters.json");
+        assert!(
+            !legacy_artifact.existed,
+            "counter artifact already exists in the test working directory"
+        );
+        let first_dir = TestDir::new("late-bind-first");
+        let second_dir = TestDir::new("late-bind-second");
+        let first_path = first_dir.0.join("rate_limit_counters.json");
+        let second_path = second_dir.0.join("rate_limit_counters.json");
+        let caps = vec![
+            Cap {
+                id: "day".into(),
+                window: "day".into(),
+                max_calls: 10,
+                tool: None,
+            },
+            Cap {
+                id: "month".into(),
+                window: "month".into(),
+                max_calls: u64::MAX,
+                tool: None,
+            },
+            Cap {
+                id: "echo".into(),
+                window: "day".into(),
+                max_calls: 10,
+                tool: Some("echo".into()),
+            },
+        ];
+
+        *state_lock().lock().unwrap_or_else(|e| e.into_inner()) = None;
+        assert!(check_and_count(&caps, "srv", "echo").is_ok());
+        assert!(check_and_count(&caps, "srv", "echo").is_ok());
+        let (day_key, month_key, echo_key, pending_counts) = {
+            let guard = state_lock().lock().unwrap_or_else(|e| e.into_inner());
+            let counts = &guard.as_ref().unwrap().file.counts;
+            let day = counts
+                .keys()
+                .find(|key| key.starts_with("day:") && key.ends_with(":*"))
+                .unwrap()
+                .clone();
+            let month = counts
+                .keys()
+                .find(|key| key.starts_with("month:"))
+                .unwrap()
+                .clone();
+            let echo = counts
+                .keys()
+                .find(|key| key.starts_with("day:") && key.ends_with(":echo"))
+                .unwrap()
+                .clone();
+            let observed = (
+                counts.get(&day).copied(),
+                counts.get(&month).copied(),
+                counts.get(&echo).copied(),
+            );
+            (day, month, echo, observed)
+        };
+        assert_eq!(pending_counts, (Some(2), Some(2), Some(2)));
+        assert!(
+            !legacy_artifact.path.exists(),
+            "unbound calls must not write the legacy fallback file"
+        );
+
+        let day_prefix = day_key.rsplit_once(':').unwrap().0;
+        let persisted_only_key = format!("{day_prefix}:persisted-only");
+        let mut first_file = CounterFile::default();
+        first_file.counts.insert(day_key.clone(), 2);
+        first_file.counts.insert(month_key.clone(), u64::MAX);
+        first_file.counts.insert(persisted_only_key.clone(), 5);
+        fs::write(&first_path, serde_json::to_string(&first_file).unwrap()).unwrap();
+
+        let mut second_file = CounterFile::default();
+        second_file.counts.insert(day_key.clone(), 1);
+        fs::write(&second_path, serde_json::to_string(&second_file).unwrap()).unwrap();
+        let second_before = fs::read(&second_path).unwrap();
+
+        let values = |file: &CounterFile| {
+            (
+                file.counts.get(&day_key).copied(),
+                file.counts.get(&month_key).copied(),
+                file.counts.get(&echo_key).copied(),
+                file.counts.get(&persisted_only_key).copied(),
+            )
+        };
+        let state_values = || {
+            let guard = state_lock().lock().unwrap_or_else(|e| e.into_inner());
+            let st = guard.as_ref().unwrap();
+            (st.path.clone(), values(&st.file))
+        };
+        let expected = (Some(4), Some(u64::MAX), Some(2), Some(5));
+
+        bind_data_dir(&first_dir.0);
+        assert_eq!(
+            state_values(),
+            (Some(first_path.clone()), expected),
+            "late binding must merge every pending and persisted counter"
+        );
+        assert_eq!(
+            values(&load_file(&first_path)),
+            expected,
+            "the merged state must be persisted immediately"
+        );
+
+        bind_data_dir(&second_dir.0);
+        assert_eq!(state_values(), (Some(first_path.clone()), expected));
+        assert_eq!(fs::read(&second_path).unwrap(), second_before);
+
+        *state_lock().lock().unwrap_or_else(|e| e.into_inner()) = None;
+        bind_data_dir(&first_dir.0);
+        assert_eq!(state_values(), (Some(first_path), expected));
     }
 
     #[test]


### PR DESCRIPTION
Closes #519.

## What and why

Rate-limit state used relative file paths before the gateway had a data directory. That made the documented in-memory fallback write into the process working directory, made tests create `rate_limit_counters.test.json`, and let an early unbound call prevent a later real bind.

This change:

- represents an unbound counter path as `None` and skips persistence until a data directory is bound;
- merges pending in-memory counts into existing persisted counts on a late bind, using saturating addition;
- preserves first-bind-wins and normal restart persistence; and
- removes the `.gitignore` rule that hid the generated files.

The on-disk JSON format is unchanged.

## Testing

- [x] `npm run build` passes
- [x] `npm run test` passes — 19 files, 137 tests
- [x] `npm run audit:prod` passes — 0 vulnerabilities
- [x] `npm run test:rust` passes — 577 library tests, 194 gateway tests, and all integration groups
- [ ] Ran the app (`npm run tauri dev`) and checked the change by hand

Additional checks:

- `cargo test --manifest-path src-tauri/Cargo.toml --no-default-features --lib rate_limits::tests` — 7 passed
- `npm run lint` — 0 errors, 21 pre-existing warnings
- `git diff --check`
- seven mutation probes covering relative-path writes, merge arithmetic, rebinding, persistence, missing keys, and overflow

## Notes

No UI behavior changes, so a manual Tauri app check was not run. No secrets, keys, or personal paths are included in the diff.