### PR TITLE
docs: note frontend tests are *.test.ts / *.test.tsx

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,7 +66,7 @@ The Rust suite includes unit tests in each module (`clients`, `catalog`,
 `registry`, `router`, `oauth`, etc.), binary-target tests, and integration tests
 in `src-tauri/tests/`. Use the npm script above so your local target selection
 matches CI. Frontend tests use [Vitest](https://vitest.dev) and live alongside
-the code as `*.test.ts` files inside `src/`.
+the code as `*.test.ts` / `*.test.tsx` files inside `src/`.
 
 ### Formatting
 


### PR DESCRIPTION
## Summary
Closes #537

CONTRIBUTING.md said frontend tests live alongside the code as `*.test.ts` files, but 11 of the 19 test files under `src/` are `*.test.tsx` (all the component tests: `ActivityView.test.tsx`, `ConfirmDialog.test.tsx`, `ImportReviewDialog.test.tsx`, ...). A new contributor following the doc literally would name a component test `.ts` and hit a JSX parse error.

Verified against the actual tree first: `find src -name '*.test.ts' -o -name '*.test.tsx'` gives 8 `.ts` and 11 `.tsx`. One-line change to "`*.test.ts` / `*.test.tsx`", same family as the merged #371.