### PR TITLE
docs(security): lead with TOOLPORT_* names, keep CONDUIT_* as legacy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -58,7 +58,7 @@ written to logs. Where they live depends on the backend, selected by environment
   go to the platform keychain: the macOS data-protection keychain (under a
   team-scoped access group shared with the signed gateway), Windows Credential
   Manager, or the Linux Secret Service.
-- **Encrypted file backend (`CONDUIT_SECRET_KEY`).** Setting this env var switches
+- **Encrypted file backend (`TOOLPORT_SECRET_KEY`, legacy `CONDUIT_SECRET_KEY`).** Setting this env var switches
   storage to an encrypted `secrets.enc` file (XChaCha20-Poly1305) in Toolport's
   data directory, keyed from the passphrase. This is the backend for headless and
   containerized deployments where no OS keychain is available. The passphrase is
@@ -66,8 +66,8 @@ written to logs. Where they live depends on the backend, selected by environment
   image layers. If `secrets.enc` leaks together with a weak passphrase, the
   secrets are recoverable, so treat the file as sensitive.
 - **Environment injection (headless).** A secret can also be supplied directly as
-  `CONDUIT_SECRET_<KEY>`, or as a bare `<KEY>` only when
-  `CONDUIT_ALLOW_BARE_SECRET_ENV` is set. These are read from the process
+  `TOOLPORT_SECRET_<KEY>` (legacy `CONDUIT_SECRET_<KEY>`), or as a bare `<KEY>` only when
+  `TOOLPORT_ALLOW_BARE_SECRET_ENV` (legacy `CONDUIT_ALLOW_BARE_SECRET_ENV`) is set. These are read from the process
   environment in cleartext, so they are only as protected as the environment that
   holds them.
 
@@ -103,7 +103,7 @@ controls actively gate or block a call before it reaches an upstream server.
   or block it, so the model still receives it, clearly marked.
 
 Which of these are active depends on your settings and, for Teams, your org
-policy. Debug logging is off by default, gated behind `CONDUIT_DEBUG`, and never
+policy. Debug logging is off by default, gated behind `TOOLPORT_DEBUG` (legacy `CONDUIT_DEBUG`), and never
 records tokens or full authorization URLs.
 
 ## Telemetry and hosted services
@@ -125,8 +125,9 @@ machine only through features you explicitly turn on:
 
 ## What Toolport records locally, and how to clear it
 
-Everything below stays in Toolport's local data directory (`%APPDATA%\Conduit` on
-Windows, the platform config dir elsewhere; override with `CONDUIT_DATA_DIR`) and
+Everything below stays in Toolport's local data directory (`%APPDATA%\Toolport` on
+Windows, the platform config dir elsewhere; override with `TOOLPORT_DATA_DIR`, legacy
+`CONDUIT_DATA_DIR`) and
 never leaves your device on its own. Each log is capped and trims oldest-first:
 
 | Local record           | File                 | Retained                                | Contains                                                      |

--- a/src-tauri/src/secrets.rs
+++ b/src-tauri/src/secrets.rs
@@ -645,7 +645,8 @@ mod platform {
 }
 
 /// Encrypted-file secret backend for headless / no-keychain environments. It is
-/// activated by setting `CONDUIT_SECRET_KEY` to any non-empty string: a 32-byte key is
+/// activated by setting `TOOLPORT_SECRET_KEY` (legacy `CONDUIT_SECRET_KEY`) to any
+/// non-empty string: a 32-byte key is
 /// derived from it (SHA-256) and secrets live in `secrets.enc` as one XChaCha20-Poly1305
 /// sealed JSON map, re-sealed on every write. With the env var unset the OS keychain is
 /// used exactly as before, so desktop installs are untouched. The same env var must be
@@ -667,8 +668,8 @@ mod file {
     /// The 32-byte key that encrypts `secrets.enc`, or None when the file backend
     /// is inactive (the signal to use the OS keychain directly).
     ///
-    /// The file backend is **headless-only**: it activates IFF `CONDUIT_SECRET_KEY`
-    /// is set + non-empty (the key is SHA-256 of it; the app and gateway must agree
+    /// The file backend is **headless-only**: it activates IFF `TOOLPORT_SECRET_KEY`
+    /// (legacy `CONDUIT_SECRET_KEY`) is set + non-empty (the key is SHA-256 of it; the app and gateway must agree
     /// on the env var). On every desktop OS this returns None, so secrets live in
     /// the OS keychain — on macOS that is the *data-protection* keychain under the
     /// team-scoped shared access group (`platform`), which keeps keys off disk and
@@ -721,13 +722,15 @@ mod file {
         }
         let (nonce, ct) = blob.split_at(NONCE_LEN);
         let cipher = XChaCha20Poly1305::new_from_slice(key).map_err(|e| e.to_string())?;
-        cipher
-            .decrypt(XNonce::from_slice(nonce), ct)
-            .map_err(|_| "could not decrypt secrets.enc (wrong CONDUIT_SECRET_KEY?)".to_string())
+        cipher.decrypt(XNonce::from_slice(nonce), ct).map_err(|_| {
+            "could not decrypt secrets.enc (wrong TOOLPORT_SECRET_KEY/CONDUIT_SECRET_KEY?)"
+                .to_string()
+        })
     }
 
     fn load() -> Result<Store, String> {
-        let key = key_material().ok_or("CONDUIT_SECRET_KEY is not set")?;
+        let key =
+            key_material().ok_or("TOOLPORT_SECRET_KEY (legacy CONDUIT_SECRET_KEY) is not set")?;
         let encoded = match std::fs::read_to_string(path()?) {
             Ok(s) => s,
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(Store::new()),
@@ -737,7 +740,8 @@ mod file {
     }
 
     fn save(store: &Store) -> Result<(), String> {
-        let key = key_material().ok_or("CONDUIT_SECRET_KEY is not set")?;
+        let key =
+            key_material().ok_or("TOOLPORT_SECRET_KEY (legacy CONDUIT_SECRET_KEY) is not set")?;
         let plain = serde_json::to_vec(store).map_err(|e| e.to_string())?;
         crate::registry::atomic_write(&path()?, &seal(&key, &plain)?)
     }
@@ -784,10 +788,13 @@ pub fn get_secret(server_id: &str, key: &str) -> Option<String> {
 /// use this so a read failure isn't silently treated as "never saved".
 ///
 /// Resolution order for headless / container deploys:
-/// 1. Process env `CONDUIT_SECRET_<KEY>` (preferred; avoids colliding with
-///    unrelated host env vars that share a common name like `TOKEN`)
-/// 2. Process env `<KEY>` when `CONDUIT_ALLOW_BARE_SECRET_ENV=1` (opt-in)
-/// 3. Encrypted `secrets.enc` when `CONDUIT_SECRET_KEY` is set
+/// 1. Process env `TOOLPORT_SECRET_<KEY>` (legacy `CONDUIT_SECRET_<KEY>`; preferred
+///    over bare names, avoids colliding with unrelated host env vars that share a
+///    common name like `TOKEN`)
+/// 2. Process env `<KEY>` when `TOOLPORT_ALLOW_BARE_SECRET_ENV=1` (legacy
+///    `CONDUIT_ALLOW_BARE_SECRET_ENV=1`; opt-in)
+/// 3. Encrypted `secrets.enc` when `TOOLPORT_SECRET_KEY` (legacy
+///    `CONDUIT_SECRET_KEY`) is set
 /// 4. OS keychain / platform backend
 pub fn get_secret_result(server_id: &str, key: &str) -> Result<Option<String>, String> {
     if let Some(v) = env_secret_override(key) {
@@ -800,8 +807,9 @@ pub fn get_secret_result(server_id: &str, key: &str) -> Result<Option<String>, S
 }
 
 /// Look up a secret from the process environment for container / env-file deploys.
-/// Prefers `CONDUIT_SECRET_<KEY>`; falls back to the bare key name only when
-/// `CONDUIT_ALLOW_BARE_SECRET_ENV` is set. Empty values are treated as unset.
+/// Prefers `TOOLPORT_SECRET_<KEY>` (legacy `CONDUIT_SECRET_<KEY>`); falls back to the
+/// bare key name only when `TOOLPORT_ALLOW_BARE_SECRET_ENV` (legacy
+/// `CONDUIT_ALLOW_BARE_SECRET_ENV`) is set. Empty values are treated as unset.
 fn env_secret_override(key: &str) -> Option<String> {
     let toolport_prefixed = format!("TOOLPORT_SECRET_{key}");
     let conduit_prefixed = format!("CONDUIT_SECRET_{key}");


### PR DESCRIPTION
## Summary
Closes #535

Since the rename, `TOOLPORT_*` is primary and `CONDUIT_*` is the accepted legacy fallback (`key_material` resolves `TOOLPORT_SECRET_KEY` first via `brand::env_var`; README says "Prefer TOOLPORT_* in new configs"), but several user-facing surfaces still presented the legacy name as current. Copy changes only: the legacy env vars keep working and nothing frozen is renamed.

**`src-tauri/src/secrets.rs`**
- Error strings: `"CONDUIT_SECRET_KEY is not set"` -> `"TOOLPORT_SECRET_KEY (legacy CONDUIT_SECRET_KEY) is not set"`, and `"wrong CONDUIT_SECRET_KEY?"` -> `"wrong TOOLPORT_SECRET_KEY/CONDUIT_SECRET_KEY?"` — these are what headless/Docker users see.
- Module docs and the resolution-order / env-override doc comments now use the "TOOLPORT_X (legacy CONDUIT_X)" form already used at SECURITY.md:157 and in shaping.rs.

**`SECURITY.md`**
- Encrypted file backend, env injection, and debug logging now lead with `TOOLPORT_SECRET_KEY`, `TOOLPORT_SECRET_<KEY>`, `TOOLPORT_ALLOW_BARE_SECRET_ENV`, and `TOOLPORT_DEBUG`, each with the legacy name in parentheses (matching the style the file already uses at lines 34/38/45 for the HTTP bridge vars).
- Data-dir paragraph: the Windows leaf is `%APPDATA%\Toolport` per `brand.rs::data_dir_leaf_name` (`Conduit` is only the legacy read fallback), and the override is `TOOLPORT_DATA_DIR` (legacy `CONDUIT_DATA_DIR`).

## Tests
`cargo test --lib secrets`: 9 passed, 4 ignored (the DP-keychain tests that need a signed build). rustfmt clean on the touched lines.