### PR TITLE
test(import-review): cover the runsShell and isPrivateHostUrl classifiers

### DIFF
--- a/src/components/ImportReviewDialog.test.tsx
+++ b/src/components/ImportReviewDialog.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { ImportReviewDialog } from "./ImportReviewDialog";
+import { ImportReviewDialog, runsShell, isPrivateHostUrl } from "./ImportReviewDialog";
 import type { ImportItem } from "@/lib/types";
 
 function items(): ImportItem[] {
@@ -101,5 +101,71 @@ describe("ImportReviewDialog", () => {
       />,
     );
     expect(container).toBeEmptyDOMElement();
+  });
+});
+
+describe("runsShell", () => {
+  it.each([
+    // Bare shell names.
+    ["sh", true],
+    ["bash", true],
+    ["zsh", true],
+    ["cmd", true],
+    ["powershell", true],
+    ["pwsh", true],
+    // Case-insensitive, and Windows .exe suffix is stripped.
+    ["BASH", true],
+    ["powershell.exe", true],
+    // Full paths, both separators; backslashes are normalized.
+    ["/bin/sh", true],
+    ["/usr/bin/env", false],
+    ["C:\\Windows\\System32\\cmd.exe", true],
+    ["C:\\Program Files\\PowerShell\\7\\pwsh.exe", true],
+    // Non-shell commands, including ones that merely contain a shell name.
+    ["npx", false],
+    ["node", false],
+    ["bash-language-server", false],
+    ["fish", false],
+    // Only a trailing .exe is stripped.
+    ["bash.exe.bak", false],
+    // Missing command.
+    [null, false],
+    ["", false],
+  ])("classifies %j as %s", (command, expected) => {
+    expect(runsShell(command)).toBe(expected);
+  });
+});
+
+describe("isPrivateHostUrl", () => {
+  it.each([
+    // Loopback names and addresses.
+    ["http://localhost:3000/mcp", true],
+    ["http://dev.localhost/mcp", true],
+    ["http://127.0.0.1/mcp", true],
+    ["http://[::1]:8080/mcp", true],
+    // RFC1918 ranges.
+    ["http://10.0.0.1/mcp", true],
+    ["http://192.168.1.10:8080/mcp", true],
+    ["http://172.16.0.1/mcp", true],
+    ["http://172.31.255.255/mcp", true],
+    // 172.x is only private for the second octet 16-31.
+    ["http://172.15.0.1/mcp", false],
+    ["http://172.32.0.1/mcp", false],
+    // Link-local and "this network".
+    ["http://169.254.169.254/latest/meta-data", true],
+    ["http://0.0.0.0:9000/mcp", true],
+    // Public hosts and addresses.
+    ["https://mcp.linear.app/mcp", false],
+    ["https://8.8.8.8/mcp", false],
+    // Hostnames merely containing "localhost" are not loopback.
+    ["http://localhost.example.com/mcp", false],
+    ["http://notlocalhost/mcp", false],
+    // Unparseable or missing URLs never warn.
+    ["not a url", false],
+    [null, false],
+    [undefined, false],
+    ["", false],
+  ])("classifies %j as %s", (url, expected) => {
+    expect(isPrivateHostUrl(url)).toBe(expected);
   });
 });

--- a/src/components/ImportReviewDialog.tsx
+++ b/src/components/ImportReviewDialog.tsx
@@ -153,7 +153,9 @@ export function ImportRow({ item, selected }: { item: ImportItem; selected?: boo
   );
 }
 
-function runsShell(command: string | null): boolean {
+// Exported for unit tests: security-relevant classifier behind the
+// "Runs a shell command" warning above.
+export function runsShell(command: string | null): boolean {
   if (!command) return false;
   const base = command
     .replace(/\\/g, "/")
@@ -164,7 +166,9 @@ function runsShell(command: string | null): boolean {
   return ["cmd", "sh", "bash", "zsh", "powershell", "pwsh"].includes(base);
 }
 
-function isPrivateHostUrl(url: string | null | undefined): boolean {
+// Exported for unit tests: security-relevant classifier behind the
+// "Connects to a private or internal address" warning above.
+export function isPrivateHostUrl(url: string | null | undefined): boolean {
   if (!url) return false;
   let host: string;
   try {


### PR DESCRIPTION
## Summary
Closes #534

`runsShell` and `isPrivateHostUrl` are pure, security-relevant classifiers — they gate the "Runs a shell command" and "Connects to a private or internal address" import warnings — but the only coverage was a single rendered-string assertion via a `bash` fixture, and nothing touched `isPrivateHostUrl` at all.

- Export both helpers from `ImportReviewDialog.tsx` (with a comment noting they're exported for tests). The two `react-refresh/only-export-components` warnings this adds are the repo's non-blocking warn tier.
- Add table-driven `describe`s (`it.each`) in `ImportReviewDialog.test.tsx` for the boundary cases:
  - **runsShell:** all six shell names, case-insensitivity, `powershell.exe` (.exe stripping), `C:\Windows\System32\cmd.exe` and `C:\Program Files\PowerShell\7\pwsh.exe` (backslash normalization), names that merely contain a shell (`bash-language-server`), only a *trailing* `.exe` stripped (`bash.exe.bak`), and null/empty commands.
  - **isPrivateHostUrl:** `localhost` / `*.localhost` / `[::1]` / `127.0.0.1`, all three RFC1918 ranges including the 172 edges (`172.16.0.1` and `172.31.255.255` private, `172.15.0.1` and `172.32.0.1` public), link-local `169.254.169.254`, `0.0.0.0`, public hosts, lookalikes (`localhost.example.com`, `notlocalhost`), and unparseable/missing URLs.

No behavior change.

## Tests
`npx vitest run src/components/ImportReviewDialog.test.tsx`: 45 passed. `npx tsc --noEmit` clean.