### PR TITLE
refactor(utils): move fmtMs and fmtDollars into lib/utils with tests

### DIFF
--- a/src/components/ActivityView.tsx
+++ b/src/components/ActivityView.tsx
@@ -18,7 +18,14 @@ import {
   XCircle,
 } from "lucide-react";
 import { toast } from "sonner";
-import { fmtPercent, fmtTokens, fmtTs, stableListKeys } from "@/lib/utils";
+import {
+  fmtDollars,
+  fmtMs,
+  fmtPercent,
+  fmtTokens,
+  fmtTs,
+  stableListKeys,
+} from "@/lib/utils";
 import { toastError } from "@/lib/toast";
 import { save } from "@tauri-apps/plugin-dialog";
 import { Input } from "@/components/ui/input";
@@ -55,12 +62,6 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 
-/** Compact latency string: "180 ms" or "1.2 s", or a dash when unmeasured. */
-function fmtMs(ms: number | null): string {
-  if (ms == null) return "-";
-  return ms >= 1000 ? `${(ms / 1000).toFixed(1)} s` : `${ms} ms`;
-}
-
 /** Models for the dollar estimate, input-token list prices ($/1M), grouped by
  *  provider. Matches the public calculator at toolport.app/calculator. */
 const SAVINGS_MODELS = [
@@ -92,13 +93,6 @@ const SAVINGS_MODELS = [
 const SAVINGS_MODEL_PRICE = new Map(
   SAVINGS_MODELS.flatMap((g) => g.items).map((m) => [m.label, m.price]),
 );
-
-/** Dollar value of saved input tokens, scaled to the number's size. */
-function fmtDollars(n: number): string {
-  if (n >= 1000) return `$${Math.round(n).toLocaleString()}`;
-  if (n >= 10) return `$${n.toFixed(0)}`;
-  return `$${n.toFixed(2)}`;
-}
 
 /** A badge describing one security event by kind. */
 function eventBadge(e: SecurityEvent): { label: string; cls: string } {

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { fmtPercent, fmtTokens, fmtTs, stableListKeys } from "./utils";
+import { fmtDollars, fmtMs, fmtPercent, fmtTokens, fmtTs, stableListKeys } from "./utils";
 
 describe("stableListKeys", () => {
   it("uses the bare identity when there are no collisions", () => {
@@ -65,6 +65,48 @@ describe("fmtTokens", () => {
     expect(fmtTokens(0)).toBe("0");
     expect(fmtTokens(-1)).toBe("-1");
     expect(fmtTokens(-12345)).toBe("-12345");
+  });
+});
+
+describe("fmtMs", () => {
+  it("renders a dash when the duration was not measured", () => {
+    expect(fmtMs(null)).toBe("-");
+  });
+
+  it("renders sub-second durations in milliseconds", () => {
+    expect(fmtMs(0)).toBe("0 ms");
+    expect(fmtMs(180)).toBe("180 ms");
+    expect(fmtMs(999)).toBe("999 ms");
+  });
+
+  it("switches to seconds at exactly 1000 ms", () => {
+    expect(fmtMs(1000)).toBe("1.0 s");
+    expect(fmtMs(1234)).toBe("1.2 s");
+    expect(fmtMs(59_600)).toBe("59.6 s");
+  });
+});
+
+describe("fmtDollars", () => {
+  it("shows cents below ten dollars", () => {
+    expect(fmtDollars(0)).toBe("$0.00");
+    expect(fmtDollars(1.234)).toBe("$1.23");
+    expect(fmtDollars(9.99)).toBe("$9.99");
+  });
+
+  it("drops cents at exactly ten dollars", () => {
+    expect(fmtDollars(10)).toBe("$10");
+    expect(fmtDollars(42.6)).toBe("$43");
+  });
+
+  it("handles the boundary at 999.5 (rounds up to $1000, not $1,000)", () => {
+    // 999.5 is below the 1000 threshold, so it takes the toFixed(0) branch and
+    // rounds to "1000" without a thousands separator.
+    expect(fmtDollars(999.5)).toBe("$1000");
+  });
+
+  it("adds a thousands separator from 1000 up", () => {
+    expect(fmtDollars(1000)).toBe(`$${(1000).toLocaleString()}`);
+    expect(fmtDollars(1234.56)).toBe(`$${(1235).toLocaleString()}`);
   });
 });
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -44,6 +44,19 @@ export function stableListKeys<T>(items: T[], identity: (item: T) => string): st
   return keys;
 }
 
+/** Compact latency string: "180 ms" or "1.2 s", or a dash when unmeasured. */
+export function fmtMs(ms: number | null): string {
+  if (ms == null) return "-";
+  return ms >= 1000 ? `${(ms / 1000).toFixed(1)} s` : `${ms} ms`;
+}
+
+/** Dollar value of saved input tokens, scaled to the number's size. */
+export function fmtDollars(n: number): string {
+  if (n >= 1000) return `$${Math.round(n).toLocaleString()}`;
+  if (n >= 10) return `$${n.toFixed(0)}`;
+  return `$${n.toFixed(2)}`;
+}
+
 /**
  * Format a ratio as a percent with the same adaptive precision everywhere.
  * When `floorNonZero` is true, tiny positive rates render as "<0.1%" instead


### PR DESCRIPTION
## Summary
Closes #533

`fmtMs` and `fmtDollars` were module-private in `ActivityView.tsx` (a 1,686-line component with no unit tests) while their three siblings (`fmtTokens`, `fmtPercent`, `fmtTs`) already live in `src/lib/utils.ts` with full coverage. Directly mirrors the merged #265.

- Move both into `src/lib/utils.ts` unchanged (doc comments included), next to the other formatters.
- `ActivityView.tsx` (the only call sites — 1x `fmtDollars`, 6x `fmtMs`) now imports them from `@/lib/utils`.
- Boundary tests in `utils.test.ts`, matching the existing style:
  - **fmtMs:** `null` -> "-", 0/180/999 ms stay in ms, the switch to seconds at exactly 1000 ("1.0 s"), 1234 -> "1.2 s".
  - **fmtDollars:** cents below $10 ("$9.99"), whole dollars from exactly $10 ("$10"), the 999.5 edge (below the 1000 threshold, so `toFixed(0)` rounds it to "$1000" with no separator), and the locale-aware thousands separator via `toLocaleString` from 1000 up (asserted the same way the `fmtTs` tests handle locale).

No behavior change.

## Tests
`npx vitest run src/lib/utils.test.ts src/components/ActivityView.test.tsx`: 27 passed. eslint and `tsc --noEmit` clean.