### PR TITLE
docs(contributing): say not to run cargo fmt, and why

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,6 +79,23 @@ npm run format        # format all files in place
 npm run format:check  # check only (fails without writing — same as CI)
 ```
 
+**Do not run `cargo fmt`.** The Rust tree is deliberately not rustfmt-clean and
+there is no fmt gate in CI, so `cargo fmt` currently rewrites 725 places across
+33 files, which is effectively every Rust file in the project. That buries your
+actual change in unrelated reflow, and it conflicts with every other open PR
+touching the same file. Match the style of the code around you, and leave the
+rest alone.
+
+If your editor formats Rust on save, turn it off for this repo:
+
+```jsonc
+// .vscode/settings.json
+{ "[rust]": { "editor.formatOnSave": false } }
+```
+
+If a review asks you to drop a formatter run, `git checkout main -- <file>` and
+re-applying your change by hand is usually faster than unpicking the diff.
+
 ### Linting
 
 ESLint catches code-quality issues and React anti-patterns. The CI runs it on


### PR DESCRIPTION
A contributor ran a formatter over `clients.rs` in #541, which turned a focused `parse_json_snippet` fix into 58 hunks. Most of them are unrelated reflow in `parse_toml_snippet`, `read_client`, `resolve_entry_state` and six other functions the change has nothing to do with.

That was entirely reasonable of them. Nothing in the repo said not to, and running the standard formatter is the obviously tidy thing to do. This is our gap, not theirs.

## Why it matters

The tree is deliberately not rustfmt-clean and CI has no fmt gate, so a formatter run always produces a diff like that. It also conflicts with every other open PR touching the same file, and there are two queued against `clients.rs` right now (#538 for Amp, #407 for Crush client support).

## Measured, not guessed

`cargo fmt --all -- --check` currently reports **725 diff locations across 33 files**, which is every Rust file in the project.

Worth noting because this number has been passed around wrong: an internal note had it as "676 files", which was closer to the hunk count than the file count.

## Also included

The editor-level fix, since format-on-save is the most likely way someone does this without meaning to, and a pointer that `git checkout main -- <file>` plus re-applying by hand beats unpicking a formatter diff.

Docs only, no code change.
