### PR TITLE
chore(release): 1.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,34 @@ All notable changes to Toolport are documented here. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/); versions match the GitHub releases.
 Entries before the rename below shipped under the project's former name, Conduit.
 
-## [Unreleased]
+## [1.10.0] - 2026-07-29
 
-Stale gateways actually stop after an upgrade, approvals stay bound to what you
-approved, and a batch of transport and code-mode hardening.
+Toolport speaks the current MCP revision, stale gateways actually stop after an
+upgrade, approvals stay bound to what you approved, and a batch of transport and
+code-mode hardening.
+
+### Added
+
+**Toolport speaks MCP 2026-07-28 over stdio, in both directions.** A client on the
+new revision can talk to Toolport, and Toolport can talk to a server on it, with
+every existing client and server continuing to see byte-identical traffic. Adopting
+a new protocol era normally means picking a side; here both run on the same
+endpoint, detected per connection, with nothing to migrate and nothing to configure.
+
+Over Streamable HTTP, Toolport stays on the established revision for now. A modern
+client receives exactly the response the spec defines as the fall-back signal, so it
+negotiates down cleanly instead of failing. That half arrives with
+`subscriptions/listen`.
+
+Three things now work through the gateway that could not before:
+
+- **Progress notifications reach your client.** A server reporting progress during a
+  long call has it relayed back, routed to the client that asked for it.
+- **Large results keep their full envelope.** Shaping an oversized result preserves
+  `_meta` and any fields Toolport does not recognise, so nothing a server sends is
+  dropped in transit.
+- **Structured error codes survive the hop**, so a client can act on a
+  machine-readable code rather than parsing a message string.
 
 ### Security
 
@@ -63,6 +87,41 @@ succeeding.
 **Code mode budget and isolation.** `fetchResult` shares the call and wall-clock budget
 rather than paging without limit, async workers reinstall the active session for host
 calls, and a corrupt registry no longer boots with code mode enabled.
+
+### Also in this release
+
+- Pasting a Crush config no longer fails as a malformed OpenCode one. Both use a
+  top-level `mcp` key, so the shape of `command` decides which it is. (#497)
+- Rate-limit counters stay in memory until a data directory is bound, instead of
+  writing a stray counter file into the working directory. (#543)
+- The share-link copy button confirms it copied, and says so when it could not.
+  (#549)
+- Coverage for the import-review shell and private-host classifiers, and for
+  gateway filtering during client migration. (#547, #510)
+- `fmtMs` and `fmtDollars` moved into `lib/utils` with tests. (#548)
+- Error strings, the benchmark write-up, the security notes, and CONTRIBUTING all
+  say what the code actually does. (#539, #545, #546, #540)
+
+### Thanks
+
+Real thanks to everyone who sent a patch this cycle. Several of these were more
+careful than they needed to be, which showed:
+
+- **[AnayGarodia](https://github.com/AnayGarodia)** for five in one go (#545, #546,
+  #547, #548, #549). The classifier tests hold up under mutation, which is rarer
+  than it should be.
+- **[Vermitrude](https://github.com/Vermitrude)** for the OpenCode/Crush paste
+  disambiguation (#497), and for splitting the remainder out honestly rather than
+  claiming the whole issue.
+- **[snowyukitty](https://github.com/snowyukitty)** for the rate-limit counter fix
+  (#543), including a test guard that cannot pass on a dirty working directory.
+- **[rohankumardubey](https://github.com/rohankumardubey)** for client-migration
+  gateway-filtering coverage (#510).
+- **[cyforkk](https://github.com/cyforkk)** for normalising the error strings (#539).
+- **[HaimiyaWasn](https://github.com/HaimiyaWasn)** for the CONTRIBUTING correction
+  (#540).
+
+If we missed you, open an issue. Credit should follow the work.
 
 ## [1.9.6] - 2026-07-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,10 +33,14 @@ process listing used an argv that Apple's `ps` rejects, so it saw zero gateways;
 Linux a binary replaced in place is now correctly treated as obsolete rather than
 protected. Settings gains a **Stop old gateways** action. (SOU-414)
 
-Note the limit: an AI client caches the gateway command when **it** starts, so a client
-that was already running when you upgraded will respawn the old binary even though
-Toolport has re-pointed its config. Restart the client app itself to pick up the new
-gateway. Clients started after the upgrade are unaffected.
+Note the limit: an AI client caches the gateway command when **it** starts, so whether
+stopping the old process is enough depends on the path that got cached. Where the binary
+is replaced in place, the same path already resolves to the new one and the next spawn
+picks it up. Where the path is one an upgrade never rewrites, it does not: on Windows the
+filename carries its version (so an upgrade never has to overwrite a locked file), and on
+any OS an app can still be pinned to an install location you have since moved away from.
+In those cases, restart the client app itself. Clients started after the upgrade are
+unaffected.
 
 **The Shared HTTP bridge comes back after the reaper stops it.** Reaping a bridge whose
 binary was replaced left HTTP and OpenAPI clients with nothing listening until someone

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "toolport",
   "private": true,
-  "version": "1.9.7-rc.1",
+  "version": "1.10.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -780,7 +780,7 @@ dependencies = [
 
 [[package]]
 name = "conduit"
-version = "1.9.7-rc.1"
+version = "1.10.0"
 dependencies = [
  "base64 0.22.1",
  "boa_engine",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conduit"
-version = "1.9.7-rc.1"
+version = "1.10.0"
 description = "Local MCP gateway: manage all your MCP servers in one place, set up once and shared by every AI client, with ~90% fewer tokens per request"
 authors = ["South Forge AI"]
 edition = "2021"

--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -3363,10 +3363,20 @@ pub fn run() {
                         repoint.customized.join(", ")
                     );
                 }
-                // Stop obsolete gateway processes so each client respawns the current binary
-                // on its next MCP request (no full agent restart required when the host
-                // auto-respawns). Path-based identity on all OS (SOU-414); not gated on
-                // repoint (SOU-306). Pass resolve_gateway_path so the nested macOS helper /
+                // Stop obsolete gateway processes. Path-based identity on all OS
+                // (SOU-414); not gated on repoint (SOU-306).
+                //
+                // Reaping alone does NOT always deliver new gateway code. A client reads
+                // its config once at its own startup and caches the spawn command. Where
+                // that cached path is replaced in place the next spawn picks up the new
+                // binary and the reap is sufficient. Where the path is one an upgrade
+                // never rewrites (a versioned filename, or an install location the app has
+                // since moved away from) the client relaunches the same obsolete binary
+                // and only restarting that application fixes it. Do not restate the old
+                // claim that no agent restart is needed; it was false for every client
+                // observed in the SOU-418 smoke pass (SOU-435).
+                //
+                // Pass resolve_gateway_path so the nested macOS helper /
                 // AppImage stable path is kept even when publish is Windows-only.
                 //
                 // Run once immediately, then again after a short delay so a client that

--- a/src-tauri/src/gateway_publish.rs
+++ b/src-tauri/src/gateway_publish.rs
@@ -1050,6 +1050,60 @@ mod tests {
     }
 
     #[test]
+    fn version_parsing_survives_a_two_digit_minor() {
+        // 1.9 -> 1.10 is the transition where a version parser usually bites, and
+        // every other case here stops at a single-digit minor. Nothing compares
+        // versions by ordering (a lexical compare would put "1.10.0" before
+        // "1.9.7"), so equality is all that has to hold, but it has to hold for
+        // the reaper to recognise its own image after the bump.
+        assert!(looks_like_version_suffix("1.10.0"));
+        assert!(looks_like_version_suffix("1.10.0-rc.1"));
+        assert!(is_versioned_gateway_basename("toolport-gateway-1.10.0.exe"));
+        assert!(is_versioned_gateway_basename("conduit-gateway-1.10.0"));
+
+        // The current image is kept and an older one is killed across the boundary,
+        // in both directions, so neither is mistaken for the other.
+        assert!(basename_matches_current_version(
+            "toolport-gateway-1.10.0.exe",
+            "1.10.0"
+        ));
+        assert!(!basename_matches_current_version(
+            "toolport-gateway-1.9.7.exe",
+            "1.10.0"
+        ));
+        assert!(!basename_matches_current_version(
+            "toolport-gateway-1.10.0.exe",
+            "1.9.7"
+        ));
+
+        let c = ctx("1.10.0", &[r"C:\Users\me\AppData\Roaming\Toolport\bin\toolport-gateway-1.10.0.exe"], false);
+        assert_eq!(
+            decide_reap(
+                &proc(
+                    1,
+                    "toolport-gateway-1.10.0.exe",
+                    Some(r"C:\Users\me\AppData\Roaming\Toolport\bin\toolport-gateway-1.10.0.exe")
+                ),
+                &c
+            ),
+            ReapDecision::Keep,
+            "the current 1.10.0 image must survive its own reaper"
+        );
+        assert_eq!(
+            decide_reap(
+                &proc(
+                    2,
+                    "toolport-gateway-1.9.7.exe",
+                    Some(r"C:\Users\me\AppData\Roaming\Toolport\bin\toolport-gateway-1.9.7.exe")
+                ),
+                &c
+            ),
+            ReapDecision::Kill,
+            "a pre-bump 1.9.7 image is obsolete once 1.10.0 is current"
+        );
+    }
+
+    #[test]
     fn decide_kill_all_kills_everything_gateway() {
         let c = ctx("1.9.6", &[r"C:\keep\toolport-gateway-1.9.6.exe"], true);
         assert_eq!(

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Toolport",
-  "version": "1.9.7-rc.1",
+  "version": "1.10.0",
   "identifier": "com.tsout.conduit",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src/components/SettingsView.tsx
+++ b/src/components/SettingsView.tsx
@@ -1270,9 +1270,11 @@ export function SettingsView({ registry, onRegistryChange }: Props) {
             <span className="flex min-w-0 flex-1 flex-col leading-tight">
               <span className="font-medium">Stop old gateways</span>
               <span className="text-xs text-muted-foreground">
-                End leftover gateway processes from earlier installs. Agents that
-                auto-respawn MCP pick up the current binary on the next tool call; no full
-                app restart required for those hosts.
+                End leftover gateway processes from earlier installs. Where the gateway
+                path stays the same across upgrades, a host that respawns MCP picks up the
+                new binary on its own. Where the filename carries its version, or the old
+                one sits at a path an upgrade never touches, an app that was already
+                running keeps launching it until you restart that app.
               </span>
             </span>
             <button


### PR DESCRIPTION
Release prep for **1.10.0**, plus the wording half of SOU-435 that was blocking it.

## Why 1.10.0

**Minor, not patch.** #511 adds a protocol era. `1.9.7` would have called that a bug fix.

**Not 2.0.0.** Nothing breaks. #511's entire design premise is that legacy clients and servers see byte-identical traffic, verified by five independent reviews. A major bump tells users to expect the opposite, and spends a signal that SOU-447/SOU-448 will genuinely need when protocol-level HTTP sessions and `resources/subscribe` are removed.

## What is in it

Two commits.

**`fix: correct the upgrade-restart claim in three places (SOU-435)`** — text only. The reaper docs and the Settings copy both claimed no agent restart was needed after an upgrade. That is false for every client observed in the SOU-418 smoke pass. Corrected in `desktop.rs`, the "Stop old gateways" description, and the 1.9.7 changelog note.

**`chore(release): 1.10.0`** — version in all four locations, the changelog section, and a version-parsing test for a two-digit minor.

## SOU-435's other half was withdrawn

Naming which apps need restarting was attempted in #542 and is not in this release. It failed three independent review rounds, each finding the previous fix defective. The last iteration would clobber correct advice with an empty post-kill snapshot when a user pressed the Settings button, showing "No old gateway processes found" directly above an app that was still launching an obsolete gateway.

Contradicting itself on screen is precisely what SOU-435 was filed about, so it goes back for a design pass rather than a fourth patch. #542 will be closed with all findings recorded.

## Changelog gap closed

#511 had **no changelog entry at all** despite being the largest change since 1.9.6. Added, framed around what users get rather than what was previously missing. Also credits the six contributors from this cycle, which is six patches in one day.

## Verified before tagging

- 799 Rust tests, 183 frontend tests, `tsc --noEmit` clean
- Rust warnings unchanged at the 7 baseline; frontend 0 errors (23 warnings, +2 from #547's exported helpers at warn tier)
- All four version strings agree, no `1.9.7` left anywhere
- No `[skip ci]` in any release commit, which would silently skip the release build via the squash body
- Two-digit-minor version parsing covered, since 1.9 to 1.10 is where a version parser usually bites and nothing compares versions by ordering

## After merge

Tag `v1.10.0`, which builds a **draft** release for Windows, macOS arm64 and Intel, and Linux. Nothing reaches users and no `latest.json` is emitted until the draft is published, so this is safe to build and test before deciding.

Historical note for the draft review: the mac Intel notarization job is where `v1.9.4` stalled. If the build hangs, look there first.
