### PR TITLE
chore(release): finish the 1.10.0 release prep

### DIFF
--- a/docs/release-notes/v1.10.0.md
+++ b/docs/release-notes/v1.10.0.md
@@ -1,0 +1,70 @@
+# Toolport v1.10.0
+
+MCP 2026-07-28 support over stdio in both directions, stale gateways that actually stop after an upgrade, approvals that stay bound to what you approved, and a batch of transport and code-mode hardening.
+
+## Highlights
+
+### Toolport speaks MCP 2026-07-28, in both directions, on the same endpoint
+
+A client on the new revision can talk to Toolport, and Toolport can talk to a server on it, while every existing client and server keeps seeing byte-identical traffic. Adopting a new protocol era normally means picking a side and migrating. Here both eras run on one stdio endpoint, detected per connection, with nothing to configure. (#511)
+
+Three things now work through the gateway that could not before:
+
+- **Progress notifications reach your client.** A server reporting progress during a long call has it relayed back, routed to the client that actually asked for it.
+- **Large results keep their full envelope.** Shaping an oversized result preserves `_meta` and any fields Toolport does not recognise, so nothing a server sends is dropped in transit.
+- **Structured error codes survive the hop**, so a client can act on a machine-readable code instead of parsing a message string.
+
+Over Streamable HTTP, Toolport stays on the established revision for now. A modern client gets exactly the response the spec defines as the fall-back signal, so it negotiates down cleanly rather than failing. That half lands with `subscriptions/listen`.
+
+### Old gateway processes stop after an upgrade, on every OS
+
+Upgrading used to leave older versioned gateways (`toolport-gateway-1.9.4.exe` and friends) running, which meant security and policy fixes in the new binary never took effect for clients still talking to an old one. Gateway identity is now path-based across Windows, macOS, and Linux. Two platform bugs came out of that work: on macOS the process listing used an argv Apple's `ps` rejects, so it saw zero gateways, and on Linux a binary replaced in place was treated as protected rather than obsolete. Settings gains a **Stop old gateways** action. (SOU-414, SOU-435)
+
+Worth knowing the limit, because it decides whether you need to do anything: an AI client caches the gateway command when **it** starts, so what matters is the path it cached. Where the binary is replaced in place, that same path already resolves to the new build and the next spawn picks it up. Where the path is one an upgrade never rewrites, it does not - on Windows the filename carries its version, so an upgrade never has to overwrite a locked file, and on any OS a client can still be pinned to an install location you have since moved away from. In those cases, restart the client app itself. Toolport now names the clients this applies to instead of leaving you to guess. Clients started after the upgrade are unaffected.
+
+### An approved tool call is re-checked before it runs
+
+A human approval was validated against a snapshot taken before the hold. A tool that was quarantined, released, or had its definition changed while the approval sat in the queue still executed against the pre-hold view. Approvals now rebind to the live router and fail closed if the definition fingerprint moved or the tool is blocked, with a clear "this approval is stale" message. (SOU-321, SOU-322)
+
+Separately, vendor auth hints now require an exact domain match. Lookalike apex domains (`clerkauth.com`, `evilgithub.com`) could inherit a real vendor's auth hints and token URL through prefix and suffix matching on the second-level label.
+
+### Credentials and transport
+
+- **A Continue Shared HTTP bearer now reaches the wire.** The token was written under `env`, which Continue does not forward for remote servers, so a plaintext bearer sat on disk and never authenticated anything. It now goes under `requestOptions.headers`, matching Continue's contract.
+- **Client config backups no longer accumulate live bearer tokens.** Every config write copied the previous file and nothing pruned them, so a Shared HTTP client's backups piled up carrying working credentials. Capped at five generations per file, matching the registry.
+- **The Shared HTTP bridge comes back after the reaper stops it.** Reaping a bridge whose binary had been replaced left HTTP and OpenAPI clients with nothing listening until someone reopened Settings.
+- **Resource subscriptions clean up when a session is replaced**, and a subscriber waiting on another client's open no longer gives up while that open is still succeeding.
+- **Code mode budget and isolation.** `fetchResult` shares the call and wall-clock budget instead of paging without limit, async workers reinstall the active session for host calls, and a corrupt registry no longer boots with code mode enabled.
+
+### Also in this release
+
+- Pasting a Crush config no longer fails as a malformed OpenCode one. Both use a top-level `mcp` key, so the shape of `command` decides which it is. (#497)
+- Rate-limit counters stay in memory until a data directory is bound, instead of writing a stray counter file into the working directory. (#543)
+- The share-link copy button confirms it copied, and says so when it could not. (#549)
+- Coverage for the import-review shell and private-host classifiers, and for gateway filtering during client migration. (#547, #510)
+- `fmtMs` and `fmtDollars` moved into `lib/utils` with tests. (#548)
+- Error strings, the benchmark write-up, the security notes, and CONTRIBUTING all say what the code actually does. (#539, #545, #546, #540)
+
+## Thanks
+
+Real thanks to everyone who sent a patch this cycle. Several of these were more careful than they needed to be, which showed:
+
+- **[AnayGarodia](https://github.com/AnayGarodia)** for five in one go (#545, #546, #547, #548, #549). The classifier tests hold up under mutation, which is rarer than it should be.
+- **[Vermitrude](https://github.com/Vermitrude)** for the OpenCode/Crush paste disambiguation (#497), and for splitting the remainder out honestly rather than claiming the whole issue.
+- **[snowyukitty](https://github.com/snowyukitty)** for the rate-limit counter fix (#543), including a test guard that cannot pass on a dirty working directory.
+- **[rohankumardubey](https://github.com/rohankumardubey)** for client-migration gateway-filtering coverage (#510).
+- **[cyforkk](https://github.com/cyforkk)** for normalising the error strings (#539).
+- **[HaimiyaWasn](https://github.com/HaimiyaWasn)** for the CONTRIBUTING correction (#540).
+
+If we missed you, open an issue. Credit should follow the work.
+
+## Upgrade notes
+
+1. Install 1.10.0 and open Toolport once, so the launch pass can stop obsolete gateways.
+2. If Toolport lists clients that still need a restart, restart those client apps. It only lists the ones where a restart actually changes something.
+3. Nothing to configure for MCP 2026-07-28. Era detection is per connection, and clients on older revisions are unaffected.
+4. Shared HTTP users on Continue: reconnect the client once so the bearer is rewritten under `requestOptions.headers`.
+
+## Full changelog
+
+See [CHANGELOG.md](https://github.com/tsouth89/toolport/blob/main/CHANGELOG.md#1100---2026-07-29) and the related PRs: #497, #510, #511, #539, #540, #543, #545–#549, #552, #554.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "toolport",
-  "version": "1.9.6",
+  "version": "1.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "toolport",
-      "version": "1.9.6",
+      "version": "1.10.0",
       "dependencies": {
         "@fontsource-variable/geist": "^5.2.9",
         "@tailwindcss/vite": "^4.3.1",


### PR DESCRIPTION
Two things the 1.10.0 release commit (#554) missed.

**`package-lock.json` still read `1.9.6`.** The bump touched `package.json`, `src-tauri/Cargo.toml`, `src-tauri/Cargo.lock` and `src-tauri/tauri.conf.json`, but not the npm lockfile.

This is hygiene, not a build fix. I first assumed it would break `npm ci` in the release jobs, then tested it against a real `npm ci`: npm validates the dependency tree, not the root `version` field, and the mismatch installs fine. What the stale value does affect is the version `npm ls` and the packaged metadata report. Two version fields, no dependency churn, generated with `npm install --package-lock-only`.

**No `docs/release-notes/v1.10.0.md`.** The last two releases each have one written by hand. `release.yml` sets `generate_release_notes: true`, so the file is not build-critical, but it is the notes a human reads. Follows the 1.9.6 structure, and the upgrade notes lead with the client-restart nuance from SOU-435, since that is the one thing here that can require the user to act.

The other reason to land this as a PR rather than push straight to main: **#554 merged without a CI run.** Repo-defined workflows stopped dispatching for roughly 25 minutes, and both its `pull_request` event and main's `push` event fell inside that window, so the 1.10.0 release content has never been through CI. This PR's run covers it before the tag goes on.