### PR TITLE
docs(changelog): record Kilo Code under Unreleased

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to Toolport are documented here. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/); versions match the GitHub releases.
 Entries before the rename below shipped under the project's former name, Conduit.
 
+## [Unreleased]
+
+### Added
+
+- **Kilo Code** is detected and configured, bringing the client count to 28. It
+  uses the same top-level `mcp` shape as OpenCode, so it reuses that adapter
+  rather than adding a parallel one, and `kilo.jsonc` is treated as whole-app
+  state: an unparseable file errors instead of being replaced, since it holds
+  much more than MCP servers. (#553)
+
 ## [1.10.0] - 2026-07-29
 
 Toolport speaks the current MCP revision, stale gateways actually stop after an


### PR DESCRIPTION
#553 merged after the `v1.10.0` tag, so Kilo Code is on main but deliberately not in the 1.10.0 build or its notes.

The changelog had no `[Unreleased]` section after the 1.10.0 promotion, so the new client was documented nowhere. That is how a shipped client quietly misses the next release's notes.

Records what #553 actually did, including the two details worth keeping: it reuses the OpenCode `mcp` adapter instead of adding a parallel one, and it registers `kilo.jsonc` as whole-app state so an unparseable file errors rather than being overwritten.