### PR TITLE
docs(release): plainer 1.10.0 notes and thanks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,9 +24,9 @@ code-mode hardening.
 
 **Toolport speaks MCP 2026-07-28 over stdio, in both directions.** A client on the
 new revision can talk to Toolport, and Toolport can talk to a server on it, with
-every existing client and server continuing to see byte-identical traffic. Adopting
-a new protocol era normally means picking a side; here both run on the same
-endpoint, detected per connection, with nothing to migrate and nothing to configure.
+every existing client and server continuing to see byte-identical traffic. Both eras
+run on the same stdio endpoint and are detected per connection, so there is nothing
+to migrate and nothing to configure.
 
 Over Streamable HTTP, Toolport stays on the established revision for now. A modern
 client receives exactly the response the spec defines as the fall-back signal, so it
@@ -114,24 +114,21 @@ calls, and a corrupt registry no longer boots with code mode enabled.
 
 ### Thanks
 
-Real thanks to everyone who sent a patch this cycle. Several of these were more
-careful than they needed to be, which showed:
+Patches this cycle came from:
 
-- **[AnayGarodia](https://github.com/AnayGarodia)** for five in one go (#545, #546,
-  #547, #548, #549). The classifier tests hold up under mutation, which is rarer
-  than it should be.
-- **[Vermitrude](https://github.com/Vermitrude)** for the OpenCode/Crush paste
-  disambiguation (#497), and for splitting the remainder out honestly rather than
-  claiming the whole issue.
-- **[snowyukitty](https://github.com/snowyukitty)** for the rate-limit counter fix
-  (#543), including a test guard that cannot pass on a dirty working directory.
-- **[rohankumardubey](https://github.com/rohankumardubey)** for client-migration
-  gateway-filtering coverage (#510).
-- **[cyforkk](https://github.com/cyforkk)** for normalising the error strings (#539).
-- **[HaimiyaWasn](https://github.com/HaimiyaWasn)** for the CONTRIBUTING correction
-  (#540).
+- **[AnayGarodia](https://github.com/AnayGarodia)** - benchmark and security docs, the
+  share-link copy fix, `fmtMs`/`fmtDollars` extraction, and tests for the
+  import-review classifiers (#545, #546, #547, #548, #549).
+- **[Vermitrude](https://github.com/Vermitrude)** - OpenCode/Crush paste
+  disambiguation (#497).
+- **[snowyukitty](https://github.com/snowyukitty)** - keeping unbound rate-limit
+  counters in memory (#543).
+- **[rohankumardubey](https://github.com/rohankumardubey)** - test coverage for
+  gateway filtering during client migration (#510).
+- **[cyforkk](https://github.com/cyforkk)** - normalised the error strings (#539).
+- **[HaimiyaWasn](https://github.com/HaimiyaWasn)** - CONTRIBUTING correction (#540).
 
-If we missed you, open an issue. Credit should follow the work.
+If we missed you, open an issue.
 
 ## [1.9.6] - 2026-07-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to Toolport are documented here. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/); versions match the GitHub releases.
 Entries before the rename below shipped under the project's former name, Conduit.
 
+## [Unreleased]
+
+### Added
+
+- **Kilo Code** is detected and configured, bringing the client count to 28. It
+  uses the same top-level `mcp` shape as OpenCode, so it reuses that adapter
+  rather than adding a parallel one, and `kilo.jsonc` is treated as whole-app
+  state: an unparseable file errors instead of being replaced, since it holds
+  much more than MCP servers. (#553)
+
 ## [1.10.0] - 2026-07-29
 
 Toolport speaks the current MCP revision, stale gateways actually stop after an

--- a/docs/release-notes/v1.10.0.md
+++ b/docs/release-notes/v1.10.0.md
@@ -1,37 +1,37 @@
 # Toolport v1.10.0
 
-MCP 2026-07-28 support over stdio in both directions, stale gateways that actually stop after an upgrade, approvals that stay bound to what you approved, and a batch of transport and code-mode hardening.
+MCP 2026-07-28 support over stdio in both directions, stale gateways that stop after an upgrade, approvals that re-check against the live gateway, and a batch of transport and code-mode fixes.
 
 ## Highlights
 
-### Toolport speaks MCP 2026-07-28, in both directions, on the same endpoint
+### MCP 2026-07-28 over stdio, both directions, same endpoint
 
-A client on the new revision can talk to Toolport, and Toolport can talk to a server on it, while every existing client and server keeps seeing byte-identical traffic. Adopting a new protocol era normally means picking a side and migrating. Here both eras run on one stdio endpoint, detected per connection, with nothing to configure. (#511)
+A client on the new revision can talk to Toolport, and Toolport can talk to a server on it. Every existing client and server keeps seeing byte-identical traffic. Both eras run on one stdio endpoint and are detected per connection, so there is nothing to migrate and nothing to configure. (#511)
 
-Three things now work through the gateway that could not before:
+Three things now work through the gateway that did not before:
 
-- **Progress notifications reach your client.** A server reporting progress during a long call has it relayed back, routed to the client that actually asked for it.
-- **Large results keep their full envelope.** Shaping an oversized result preserves `_meta` and any fields Toolport does not recognise, so nothing a server sends is dropped in transit.
+- **Progress notifications reach your client.** A server reporting progress during a long call has it relayed back, routed to the client that asked for it.
+- **Large results keep their full envelope.** Shaping an oversized result preserves `_meta` and any fields Toolport does not recognise.
 - **Structured error codes survive the hop**, so a client can act on a machine-readable code instead of parsing a message string.
 
-Over Streamable HTTP, Toolport stays on the established revision for now. A modern client gets exactly the response the spec defines as the fall-back signal, so it negotiates down cleanly rather than failing. That half lands with `subscriptions/listen`.
+Over Streamable HTTP, Toolport stays on the established revision for now. A modern client gets the response the spec defines as the fall-back signal, so it negotiates down cleanly instead of failing. That half lands with `subscriptions/listen`.
 
 ### Old gateway processes stop after an upgrade, on every OS
 
-Upgrading used to leave older versioned gateways (`toolport-gateway-1.9.4.exe` and friends) running, which meant security and policy fixes in the new binary never took effect for clients still talking to an old one. Gateway identity is now path-based across Windows, macOS, and Linux. Two platform bugs came out of that work: on macOS the process listing used an argv Apple's `ps` rejects, so it saw zero gateways, and on Linux a binary replaced in place was treated as protected rather than obsolete. Settings gains a **Stop old gateways** action. (SOU-414, SOU-435)
+Upgrading used to leave older versioned gateways (`toolport-gateway-1.9.4.exe` and friends) running, so security and policy fixes in the new binary never took effect for clients still talking to an old one. Gateway identity is now path-based across Windows, macOS, and Linux. Two platform bugs turned up in the process: on macOS the process listing used an argv Apple's `ps` rejects, so it saw zero gateways, and on Linux a binary replaced in place was treated as protected rather than obsolete. Settings gains a **Stop old gateways** action. (SOU-414, SOU-435)
 
-Worth knowing the limit, because it decides whether you need to do anything: an AI client caches the gateway command when **it** starts, so what matters is the path it cached. Where the binary is replaced in place, that same path already resolves to the new build and the next spawn picks it up. Where the path is one an upgrade never rewrites, it does not - on Windows the filename carries its version, so an upgrade never has to overwrite a locked file, and on any OS a client can still be pinned to an install location you have since moved away from. In those cases, restart the client app itself. Toolport now names the clients this applies to instead of leaving you to guess. Clients started after the upgrade are unaffected.
+There is one limit, and it decides whether you need to do anything. An AI client caches the gateway command when the client itself starts, so what matters is the path it cached. Where the binary is replaced in place, that path already resolves to the new build and the next spawn picks it up. Where the path is one an upgrade never rewrites, it does not: on Windows the filename carries its version, so an upgrade never has to overwrite a locked file, and on any OS a client can be pinned to an install location you have since moved away from. In those cases, restart the client app. Toolport now names which clients those are. Clients started after the upgrade are unaffected.
 
 ### An approved tool call is re-checked before it runs
 
-A human approval was validated against a snapshot taken before the hold. A tool that was quarantined, released, or had its definition changed while the approval sat in the queue still executed against the pre-hold view. Approvals now rebind to the live router and fail closed if the definition fingerprint moved or the tool is blocked, with a clear "this approval is stale" message. (SOU-321, SOU-322)
+A human approval used to be validated against a snapshot taken before the hold, so a tool that was quarantined, released, or had its definition changed while the approval sat in the queue still executed against the pre-hold view. Approvals now rebind to the live router and fail closed if the definition fingerprint moved or the tool is blocked, with a "this approval is stale" message. (SOU-321, SOU-322)
 
-Separately, vendor auth hints now require an exact domain match. Lookalike apex domains (`clerkauth.com`, `evilgithub.com`) could inherit a real vendor's auth hints and token URL through prefix and suffix matching on the second-level label.
+Vendor auth hints now require an exact domain match. Lookalike apex domains (`clerkauth.com`, `evilgithub.com`) could inherit a real vendor's auth hints and token URL through prefix and suffix matching on the second-level label.
 
 ### Credentials and transport
 
 - **A Continue Shared HTTP bearer now reaches the wire.** The token was written under `env`, which Continue does not forward for remote servers, so a plaintext bearer sat on disk and never authenticated anything. It now goes under `requestOptions.headers`, matching Continue's contract.
-- **Client config backups no longer accumulate live bearer tokens.** Every config write copied the previous file and nothing pruned them, so a Shared HTTP client's backups piled up carrying working credentials. Capped at five generations per file, matching the registry.
+- **Client config backups no longer accumulate live bearer tokens.** Every config write copied the previous file and nothing pruned them, so a Shared HTTP client's backups built up carrying working credentials. Capped at five generations per file, matching the registry.
 - **The Shared HTTP bridge comes back after the reaper stops it.** Reaping a bridge whose binary had been replaced left HTTP and OpenAPI clients with nothing listening until someone reopened Settings.
 - **Resource subscriptions clean up when a session is replaced**, and a subscriber waiting on another client's open no longer gives up while that open is still succeeding.
 - **Code mode budget and isolation.** `fetchResult` shares the call and wall-clock budget instead of paging without limit, async workers reinstall the active session for host calls, and a corrupt registry no longer boots with code mode enabled.
@@ -47,24 +47,24 @@ Separately, vendor auth hints now require an exact domain match. Lookalike apex 
 
 ## Thanks
 
-Real thanks to everyone who sent a patch this cycle. Several of these were more careful than they needed to be, which showed:
+Patches this cycle came from:
 
-- **[AnayGarodia](https://github.com/AnayGarodia)** for five in one go (#545, #546, #547, #548, #549). The classifier tests hold up under mutation, which is rarer than it should be.
-- **[Vermitrude](https://github.com/Vermitrude)** for the OpenCode/Crush paste disambiguation (#497), and for splitting the remainder out honestly rather than claiming the whole issue.
-- **[snowyukitty](https://github.com/snowyukitty)** for the rate-limit counter fix (#543), including a test guard that cannot pass on a dirty working directory.
-- **[rohankumardubey](https://github.com/rohankumardubey)** for client-migration gateway-filtering coverage (#510).
-- **[cyforkk](https://github.com/cyforkk)** for normalising the error strings (#539).
-- **[HaimiyaWasn](https://github.com/HaimiyaWasn)** for the CONTRIBUTING correction (#540).
+- **[AnayGarodia](https://github.com/AnayGarodia)** - benchmark and security docs, the share-link copy fix, `fmtMs`/`fmtDollars` extraction, and tests for the import-review classifiers (#545, #546, #547, #548, #549).
+- **[Vermitrude](https://github.com/Vermitrude)** - OpenCode/Crush paste disambiguation (#497).
+- **[snowyukitty](https://github.com/snowyukitty)** - keeping unbound rate-limit counters in memory (#543).
+- **[rohankumardubey](https://github.com/rohankumardubey)** - test coverage for gateway filtering during client migration (#510).
+- **[cyforkk](https://github.com/cyforkk)** - normalised the error strings (#539).
+- **[HaimiyaWasn](https://github.com/HaimiyaWasn)** - CONTRIBUTING correction (#540).
 
-If we missed you, open an issue. Credit should follow the work.
+If we missed you, open an issue.
 
 ## Upgrade notes
 
 1. Install 1.10.0 and open Toolport once, so the launch pass can stop obsolete gateways.
-2. If Toolport lists clients that still need a restart, restart those client apps. It only lists the ones where a restart actually changes something.
+2. If Toolport lists clients that still need a restart, restart those client apps. It only lists the ones where a restart changes something.
 3. Nothing to configure for MCP 2026-07-28. Era detection is per connection, and clients on older revisions are unaffected.
 4. Shared HTTP users on Continue: reconnect the client once so the bearer is rewritten under `requestOptions.headers`.
 
 ## Full changelog
 
-See [CHANGELOG.md](https://github.com/tsouth89/toolport/blob/main/CHANGELOG.md#1100---2026-07-29) and the related PRs: #497, #510, #511, #539, #540, #543, #545–#549, #552, #554.
+See [CHANGELOG.md](https://github.com/tsouth89/toolport/blob/main/CHANGELOG.md#1100---2026-07-29) and the related PRs: #497, #510, #511, #539, #540, #543, #545-#549, #552, #554, #556.


### PR DESCRIPTION
The thanks section was editorialising about contributors rather than saying what they did ("more careful than they needed to be", "rarer than it should be", "splitting the remainder out honestly", "credit should follow the work"). Replaced with what each person actually shipped.

Also dropped the pitch framing in the protocol paragraph ("normally means picking a side; here both run...") for a plain description.

Same copy existed in both CHANGELOG and the public notes doc, so both are updated.