### PR TITLE
docs(release): stop claiming 1.10.0 names the clients needing restart

### DIFF
--- a/docs/release-notes/v1.10.0.md
+++ b/docs/release-notes/v1.10.0.md
@@ -18,9 +18,9 @@ Over Streamable HTTP, Toolport stays on the established revision for now. A mode
 
 ### Old gateway processes stop after an upgrade, on every OS
 
-Upgrading used to leave older versioned gateways (`toolport-gateway-1.9.4.exe` and friends) running, so security and policy fixes in the new binary never took effect for clients still talking to an old one. Gateway identity is now path-based across Windows, macOS, and Linux. Two platform bugs turned up in the process: on macOS the process listing used an argv Apple's `ps` rejects, so it saw zero gateways, and on Linux a binary replaced in place was treated as protected rather than obsolete. Settings gains a **Stop old gateways** action. (SOU-414, SOU-435)
+Upgrading used to leave older versioned gateways (`toolport-gateway-1.9.4.exe` and friends) running, so security and policy fixes in the new binary never took effect for clients still talking to an old one. Gateway identity is now path-based across Windows, macOS, and Linux. Two platform bugs turned up in the process: on macOS the process listing used an argv Apple's `ps` rejects, so it saw zero gateways, and on Linux a binary replaced in place was treated as protected rather than obsolete. Settings gains a **Stop old gateways** action. (SOU-414)
 
-There is one limit, and it decides whether you need to do anything. An AI client caches the gateway command when the client itself starts, so what matters is the path it cached. Where the binary is replaced in place, that path already resolves to the new build and the next spawn picks it up. Where the path is one an upgrade never rewrites, it does not: on Windows the filename carries its version, so an upgrade never has to overwrite a locked file, and on any OS a client can be pinned to an install location you have since moved away from. In those cases, restart the client app. Toolport now names which clients those are. Clients started after the upgrade are unaffected.
+There is one limit, and it decides whether you need to do anything. An AI client caches the gateway command when the client itself starts, so what matters is the path it cached. Where the binary is replaced in place, that path already resolves to the new build and the next spawn picks it up. Where the path is one an upgrade never rewrites, it does not: on Windows the filename carries its version, so an upgrade never has to overwrite a locked file, and on any OS a client can be pinned to an install location you have since moved away from. In those cases, restart the client app. The **Stop old gateways** description in Settings spells out which case applies. Clients started after the upgrade are unaffected.
 
 ### An approved tool call is re-checked before it runs
 
@@ -61,7 +61,7 @@ If we missed you, open an issue.
 ## Upgrade notes
 
 1. Install 1.10.0 and open Toolport once, so the launch pass can stop obsolete gateways.
-2. If Toolport lists clients that still need a restart, restart those client apps. It only lists the ones where a restart changes something.
+2. If an AI client was already running before the upgrade, restart it. Toolport does not yet tell you which ones need it, so if in doubt, restart the clients you had open.
 3. Nothing to configure for MCP 2026-07-28. Era detection is per connection, and clients on older revisions are unaffected.
 4. Shared HTTP users on Continue: reconnect the client once so the bearer is rewritten under `requestOptions.headers`.
 


### PR DESCRIPTION
The 1.10.0 notes said "Toolport now names which clients those are" and the upgrade notes said it "only lists the ones where a restart changes something". Neither is true for this build.

The surfacing half of SOU-435 is not in the release. #542 was closed rather than merged: three review rounds each found the previous round's fix defective, and in the shipped-if-merged state clicking **Run** in Settings overwrote correct advice with an empty snapshot, so the panel would say "No old gateway processes found" while a client was still pinned to an obsolete binary.

What did ship: the reaper itself (SOU-414), verified working on a real Windows install, and the corrected Settings wording, which went out separately in #554.

Found the honest way, by installing the draft and looking for the message the notes promised. Three lines changed: drop the naming sentence, drop the SOU-435 credit from the reaper entry, and reword upgrade step 2 to say restart the clients you had open since Toolport does not yet tell you which. CHANGELOG needed no change; it already credits only SOU-414.