### PR TITLE
fix: preserve share link on clipboard failure

### DIFF
--- a/src/components/ShareDialog.test.tsx
+++ b/src/components/ShareDialog.test.tsx
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
@@ -39,6 +39,18 @@ describe("ShareDialog share links", () => {
     mocks.exportConfig.mockResolvedValue('{"servers":[]}');
     mocks.getRegistry.mockResolvedValue({ servers: [] });
     mocks.shareStack.mockResolvedValue("https://toolport.app/s/example");
+  });
+
+  // Both tests replace navigator.clipboard, so restore the real descriptor
+  // afterwards. Without this the second test's `undefined` sticks, which makes
+  // any later test in this file order-dependent.
+  const originalClipboard = Object.getOwnPropertyDescriptor(navigator, "clipboard");
+  afterEach(() => {
+    if (originalClipboard) {
+      Object.defineProperty(navigator, "clipboard", originalClipboard);
+    } else {
+      delete (navigator as { clipboard?: unknown }).clipboard;
+    }
   });
 
   it("keeps the generated link visible when clipboard access fails", async () => {

--- a/src/components/ShareDialog.test.tsx
+++ b/src/components/ShareDialog.test.tsx
@@ -1,0 +1,81 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+const mocks = vi.hoisted(() => ({
+  exportConfig: vi.fn(),
+  getRegistry: vi.fn(),
+  shareStack: vi.fn(),
+  success: vi.fn(),
+  toastError: vi.fn(),
+}));
+
+vi.mock("sonner", () => ({ toast: { success: mocks.success } }));
+vi.mock("@/lib/toast", () => ({ toastError: mocks.toastError }));
+vi.mock("@/lib/api", () => ({
+  exportConfig: mocks.exportConfig,
+  exportConfigToPath: vi.fn(),
+  fetchSharedSetup: vi.fn(),
+  getRegistry: mocks.getRegistry,
+  importConfig: vi.fn(),
+  previewImport: vi.fn(),
+  readSetupFile: vi.fn(),
+  shareStack: mocks.shareStack,
+  takePendingShared: vi.fn().mockResolvedValue(null),
+}));
+vi.mock("@tauri-apps/plugin-dialog", () => ({
+  open: vi.fn(),
+  save: vi.fn(),
+}));
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: vi.fn().mockResolvedValue(() => {}),
+}));
+
+import { ShareDialog } from "./ShareDialog";
+
+describe("ShareDialog share links", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.exportConfig.mockResolvedValue('{"servers":[]}');
+    mocks.getRegistry.mockResolvedValue({ servers: [] });
+    mocks.shareStack.mockResolvedValue("https://toolport.app/s/example");
+  });
+
+  it("keeps the generated link visible when clipboard access fails", async () => {
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText: vi.fn().mockRejectedValue(new Error("denied")) },
+    });
+
+    render(<ShareDialog trigger={<button>Share</button>} onImported={vi.fn()} />);
+    await userEvent.click(screen.getByRole("button", { name: "Share" }));
+    const create = await screen.findByRole("button", { name: /create share link/i });
+    await waitFor(() => expect(create).toBeEnabled());
+    await userEvent.click(create);
+
+    expect(await screen.findByText("https://toolport.app/s/example")).toBeVisible();
+    expect(mocks.success).toHaveBeenCalledWith("Share link created");
+    expect(mocks.toastError).toHaveBeenCalledWith(
+      "Couldn't copy automatically. Select the link and copy it.",
+    );
+  });
+
+  it("does not report link creation as failed when the clipboard API is absent", async () => {
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: undefined,
+    });
+
+    render(<ShareDialog trigger={<button>Share</button>} onImported={vi.fn()} />);
+    await userEvent.click(screen.getByRole("button", { name: "Share" }));
+    const create = await screen.findByRole("button", { name: /create share link/i });
+    await waitFor(() => expect(create).toBeEnabled());
+    await userEvent.click(create);
+
+    expect(await screen.findByText("https://toolport.app/s/example")).toBeVisible();
+    expect(mocks.success).toHaveBeenCalledWith("Share link created");
+    expect(mocks.toastError).not.toHaveBeenCalledWith(
+      expect.stringContaining("Couldn't create a link"),
+    );
+  });
+});

--- a/src/components/ShareDialog.tsx
+++ b/src/components/ShareDialog.tsx
@@ -138,8 +138,13 @@ export function ShareDialog({ trigger, onImported }: Props) {
     try {
       const url = await shareStack(exported);
       setShareLink(url);
-      navigator.clipboard.writeText(url).catch(() => {});
-      toast.success("Share link created and copied");
+      try {
+        await navigator.clipboard.writeText(url);
+        toast.success("Share link created and copied");
+      } catch {
+        toast.success("Share link created");
+        toastError("Couldn't copy automatically. Select the link and copy it.");
+      }
     } catch (e) {
       toastError(`Couldn't create a link: ${e}`);
     } finally {


### PR DESCRIPTION
## Summary

- Keep a successfully created share link visible when clipboard copying fails or the Clipboard API is unavailable.
- Show the copy-success toast only after `writeText` succeeds.
- Fall back to the normal “Share link created” message and the existing copy error so users can copy the displayed link manually.
- Add regression coverage for rejected and unavailable clipboard APIs.

Closes #550

## Testing

- [x] `npm run build`
- [x] ShareDialog regression tests — 2 passed
- [x] Prettier check on touched files
- [x] ESLint on touched files — 0 errors; 1 pre-existing warning
- [ ] `npm audit:prod`
- [ ] Rust tests
- [ ] Manual desktop application test

## DCO

The commit includes a `Signed-off-by` trailer.
