### PR TITLE
test(app): cover Linux gateway enumeration against a real process

### DIFF
--- a/src-tauri/src/gateway_publish.rs
+++ b/src-tauri/src/gateway_publish.rs
@@ -1273,4 +1273,110 @@ mod tests {
         let back: GatewayManifest = serde_json::from_str(&json).unwrap();
         assert_eq!(m, back);
     }
+
+    /// Kills the child and removes the scratch directory even if an assertion
+    /// panics, so a failing run cannot leave a stray `sleep` behind.
+    #[cfg(all(unix, not(target_os = "macos")))]
+    struct SpawnedGateway(std::process::Child, PathBuf);
+
+    #[cfg(all(unix, not(target_os = "macos")))]
+    impl Drop for SpawnedGateway {
+        fn drop(&mut self) {
+            let _ = self.0.kill();
+            let _ = self.0.wait();
+            let _ = std::fs::remove_dir_all(&self.1);
+        }
+    }
+
+    /// Drives the real Linux enumerator against a real process.
+    ///
+    /// Linux is the one platform where detection has no margin. `/proc/<pid>/comm`
+    /// is capped at 15 usable characters and `toolport-gateway` is 16, so `comm`
+    /// can never match a Toolport-named gateway and detection depends *entirely*
+    /// on the `/proc/<pid>/exe` fallback. (macOS differs: `ucomm` allows 16, so the
+    /// name fits there exactly.) Every other test in this file is a pure fixture
+    /// over `is_gateway_basename` / `decide_reap`, and none of them can catch a
+    /// broken fallback, because the fallback is the part that reads the OS.
+    ///
+    /// That gap is not hypothetical: the sibling macOS path shipped with an argv
+    /// Apple's `ps` rejects, returning zero processes, and the fixture tests stayed
+    /// green throughout. CI runs ubuntu, so this path *can* be covered for real.
+    #[cfg(all(unix, not(target_os = "macos")))]
+    #[test]
+    fn linux_enumeration_finds_a_versioned_gateway_via_the_exe_fallback() {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        // into_iter, not iter().map(Path::new): the latter returns a &Path borrowed
+        // from the temporary array, which does not outlive the statement.
+        let src = ["/bin/sleep", "/usr/bin/sleep"]
+            .into_iter()
+            .find(|p| Path::new(p).exists())
+            .expect("no sleep binary available to stand in for a gateway");
+
+        let dir = std::env::temp_dir().join(format!("toolport-reaper-enum-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("create scratch dir");
+
+        // Deliberately longer than comm's 15-char window so the truncation this
+        // test exists for actually happens.
+        let exe = dir.join("toolport-gateway-9.9.9");
+        std::fs::copy(src, &exe).expect("copy stand-in binary");
+        std::fs::set_permissions(&exe, std::fs::Permissions::from_mode(0o755)).expect("chmod +x");
+
+        let child = std::process::Command::new(&exe)
+            .arg("30")
+            .spawn()
+            .expect("spawn stand-in gateway");
+        let pid = child.id();
+        let guard = SpawnedGateway(child, dir.clone());
+
+        // spawn() returns before the exec completes, so /proc entries are not
+        // populated yet. Wait for the exe symlink to point at our copy.
+        let exe_link = PathBuf::from(format!("/proc/{pid}/exe"));
+        let mut execed = false;
+        for _ in 0..300 {
+            if std::fs::read_link(&exe_link).map(|p| p == exe).unwrap_or(false) {
+                execed = true;
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        }
+        assert!(execed, "child never exec'd into {}", exe.display());
+
+        // The premise: comm is truncated past recognition, so a hit below can only
+        // have come from the exe fallback. If a future kernel widens comm this
+        // assertion fires, which is the correct signal that the premise changed.
+        let comm = std::fs::read_to_string(format!("/proc/{pid}/comm"))
+            .expect("read comm")
+            .trim()
+            .to_string();
+        assert!(
+            !is_gateway_basename(&comm),
+            "comm {comm:?} matched is_gateway_basename on its own, so this test no \
+             longer proves the /proc/<pid>/exe fallback works. Check whether comm's \
+             width changed before touching the fallback."
+        );
+
+        let found = linux_list_gateway_processes();
+        let hit = found.iter().find(|p| p.pid == pid).unwrap_or_else(|| {
+            panic!(
+                "linux_list_gateway_processes() missed pid {pid} running {}. comm was \
+                 {comm:?}, which cannot match, so the /proc/<pid>/exe fallback is broken \
+                 and no Toolport-named gateway would be reaped on Linux.",
+                exe.display()
+            )
+        });
+
+        assert_eq!(
+            hit.basename, "toolport-gateway-9.9.9",
+            "basename must come from the exe link, not truncated comm"
+        );
+        assert_eq!(
+            hit.path.as_deref(),
+            Some(exe.as_path()),
+            "path must be the resolved exe so keep-path comparisons work"
+        );
+
+        drop(guard);
+    }
 }


### PR DESCRIPTION
Closes the structural hole described on SOU-418: every reaper test in the repo is a pure fixture over `is_gateway_basename` / `decide_reap`, so nothing exercises the code that actually reads the OS. The macOS path shipped with an argv Apple's `ps` rejects, returned zero processes, and every fixture test stayed green throughout.

Linux is the half that can be fixed for free, because `ci.yml` already runs `ubuntu-22.04`. It is also the platform with no margin. Measured on a real 6.6 kernel rather than reasoned about:

| binary name | len | `comm` | matches `is_gateway_basename`? |
| -- | -- | -- | -- |
| `toolport-gateway-9.9.9` | 22 | `toolport-gatewa` | no |
| `toolport-gateway` | 16 | `toolport-gatewa` | no |
| `conduit-gateway` | 15 | `conduit-gateway` | **yes** |

`/proc/<pid>/comm` allows 15 usable characters and `toolport-gateway` is 16, so **comm can never match a Toolport-named gateway** and detection depends entirely on the `/proc/<pid>/exe` fallback. Note the trap in the last row: legacy conduit-named gateways still match via comm, so a machine with both would appear to reap correctly while every current-name gateway stayed invisible.

The test copies `sleep` to `toolport-gateway-9.9.9`, spawns it, waits for the exec to land, asserts comm **cannot** match (so a hit can only come from the fallback), then asserts `linux_list_gateway_processes()` finds the pid with the full basename and resolved path. A `Drop` guard kills the child and removes the scratch dir even if an assertion panics.

The comm assertion is deliberate: if a future kernel widens comm it fires, which is the correct signal that the test's premise changed rather than a silent loss of coverage.

macOS cannot be covered this way since there is no macOS test job. That row stays manual on SOU-418, where the `ps` argv probe has now passed on real hardware.