### PR TITLE
chore(homebrew): bump the cask to 1.10.0

### DIFF
--- a/packaging/homebrew/toolport.rb
+++ b/packaging/homebrew/toolport.rb
@@ -1,13 +1,13 @@
 cask "toolport" do
-  version "1.9.4"
+  version "1.10.0"
 
   on_arm do
-    sha256 "bf631ba9c462e2e15568ecf17816e976da676e89d2f165fd76feebbd8368181a"
+    sha256 "47df203c2464e6765103b6f4304d426bb5e476392df0e914663a161fe5243e24"
     url "https://github.com/tsouth89/toolport/releases/download/v#{version}/Toolport_aarch64-apple-darwin.dmg",
         verified: "github.com/tsouth89/toolport/"
   end
   on_intel do
-    sha256 "6580c700cfddde7646e172f9fab78662161f0ec0736a2012430ec0e28d3f1bbf"
+    sha256 "33094f1f693a69e75677d926c35fc7b532b0fdd69097b8b728ce4d538282acea"
     url "https://github.com/tsouth89/toolport/releases/download/v#{version}/Toolport_x86_64-apple-darwin.dmg",
         verified: "github.com/tsouth89/toolport/"
   end

--- a/src-tauri/src/gateway_publish.rs
+++ b/src-tauri/src/gateway_publish.rs
@@ -1273,4 +1273,110 @@ mod tests {
         let back: GatewayManifest = serde_json::from_str(&json).unwrap();
         assert_eq!(m, back);
     }
+
+    /// Kills the child and removes the scratch directory even if an assertion
+    /// panics, so a failing run cannot leave a stray `sleep` behind.
+    #[cfg(all(unix, not(target_os = "macos")))]
+    struct SpawnedGateway(std::process::Child, PathBuf);
+
+    #[cfg(all(unix, not(target_os = "macos")))]
+    impl Drop for SpawnedGateway {
+        fn drop(&mut self) {
+            let _ = self.0.kill();
+            let _ = self.0.wait();
+            let _ = std::fs::remove_dir_all(&self.1);
+        }
+    }
+
+    /// Drives the real Linux enumerator against a real process.
+    ///
+    /// Linux is the one platform where detection has no margin. `/proc/<pid>/comm`
+    /// is capped at 15 usable characters and `toolport-gateway` is 16, so `comm`
+    /// can never match a Toolport-named gateway and detection depends *entirely*
+    /// on the `/proc/<pid>/exe` fallback. (macOS differs: `ucomm` allows 16, so the
+    /// name fits there exactly.) Every other test in this file is a pure fixture
+    /// over `is_gateway_basename` / `decide_reap`, and none of them can catch a
+    /// broken fallback, because the fallback is the part that reads the OS.
+    ///
+    /// That gap is not hypothetical: the sibling macOS path shipped with an argv
+    /// Apple's `ps` rejects, returning zero processes, and the fixture tests stayed
+    /// green throughout. CI runs ubuntu, so this path *can* be covered for real.
+    #[cfg(all(unix, not(target_os = "macos")))]
+    #[test]
+    fn linux_enumeration_finds_a_versioned_gateway_via_the_exe_fallback() {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        // into_iter, not iter().map(Path::new): the latter returns a &Path borrowed
+        // from the temporary array, which does not outlive the statement.
+        let src = ["/bin/sleep", "/usr/bin/sleep"]
+            .into_iter()
+            .find(|p| Path::new(p).exists())
+            .expect("no sleep binary available to stand in for a gateway");
+
+        let dir = std::env::temp_dir().join(format!("toolport-reaper-enum-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("create scratch dir");
+
+        // Deliberately longer than comm's 15-char window so the truncation this
+        // test exists for actually happens.
+        let exe = dir.join("toolport-gateway-9.9.9");
+        std::fs::copy(src, &exe).expect("copy stand-in binary");
+        std::fs::set_permissions(&exe, std::fs::Permissions::from_mode(0o755)).expect("chmod +x");
+
+        let child = std::process::Command::new(&exe)
+            .arg("30")
+            .spawn()
+            .expect("spawn stand-in gateway");
+        let pid = child.id();
+        let guard = SpawnedGateway(child, dir.clone());
+
+        // spawn() returns before the exec completes, so /proc entries are not
+        // populated yet. Wait for the exe symlink to point at our copy.
+        let exe_link = PathBuf::from(format!("/proc/{pid}/exe"));
+        let mut execed = false;
+        for _ in 0..300 {
+            if std::fs::read_link(&exe_link).map(|p| p == exe).unwrap_or(false) {
+                execed = true;
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        }
+        assert!(execed, "child never exec'd into {}", exe.display());
+
+        // The premise: comm is truncated past recognition, so a hit below can only
+        // have come from the exe fallback. If a future kernel widens comm this
+        // assertion fires, which is the correct signal that the premise changed.
+        let comm = std::fs::read_to_string(format!("/proc/{pid}/comm"))
+            .expect("read comm")
+            .trim()
+            .to_string();
+        assert!(
+            !is_gateway_basename(&comm),
+            "comm {comm:?} matched is_gateway_basename on its own, so this test no \
+             longer proves the /proc/<pid>/exe fallback works. Check whether comm's \
+             width changed before touching the fallback."
+        );
+
+        let found = linux_list_gateway_processes();
+        let hit = found.iter().find(|p| p.pid == pid).unwrap_or_else(|| {
+            panic!(
+                "linux_list_gateway_processes() missed pid {pid} running {}. comm was \
+                 {comm:?}, which cannot match, so the /proc/<pid>/exe fallback is broken \
+                 and no Toolport-named gateway would be reaped on Linux.",
+                exe.display()
+            )
+        });
+
+        assert_eq!(
+            hit.basename, "toolport-gateway-9.9.9",
+            "basename must come from the exe link, not truncated comm"
+        );
+        assert_eq!(
+            hit.path.as_deref(),
+            Some(exe.as_path()),
+            "path must be the resolved exe so keep-path comparisons work"
+        );
+
+        drop(guard);
+    }
 }


### PR DESCRIPTION
The cask pins the version and both dmg sha256s, so it goes stale on every release. It was still on **1.9.4**, three releases behind, meaning `brew install --cask toolport` has been serving 1.9.4 through 1.9.5 and 1.9.6.

Hashes computed from the actual published v1.10.0 dmgs:

| arch | sha256 |
| -- | -- |
| aarch64 | `47df203c2464e6765103b6f4304d426bb5e476392df0e914663a161fe5243e24` |
| x86_64 | `33094f1f693a69e75677d926c35fc7b532b0fdd69097b8b728ce4d538282acea` |

Both download URLs verified to resolve before committing.

**This is only half the change.** The tap copy at `tsouth89/homebrew-toolport` → `Casks/toolport.rb` needs the identical edit, or brew keeps serving the old version regardless of what is in this repo.

Automating this as part of the release workflow is SOU-260.