### PR TITLE
docs(changelog): record Amp, server-state cleanup and the share-link fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,26 @@ Entries before the rename below shipped under the project's former name, Conduit
 
 ### Added
 
-- **Kilo Code** is detected and configured, bringing the client count to 28. It
-  uses the same top-level `mcp` shape as OpenCode, so it reuses that adapter
-  rather than adding a parallel one, and `kilo.jsonc` is treated as whole-app
-  state: an unparseable file errors instead of being replaced, since it holds
-  much more than MCP servers. (#553)
+- **Kilo Code** and **Amp** are detected and configured, taking the client count
+  to 29. Kilo Code uses the same top-level `mcp` shape as OpenCode, so it reuses
+  that adapter rather than adding a parallel one. Amp keeps its servers under the
+  literal dotted key `amp.mcpServers` and honours `AMP_SETTINGS_FILE`. Both files
+  hold far more than MCP servers, so both are treated as whole-app state: an
+  unparseable one errors rather than being replaced with a fresh object.
+  (#553, #538)
+
+### Fixed
+
+- **Removing a server no longer leaves its settings behind.** Tool overrides,
+  pins, the per-server result budget, the injection-block exemption and any
+  fingerprint-bound approvals are now dropped along with the server. Previously a
+  server added later under the same id could inherit a stale security exemption
+  from one you had deleted. (#509)
+- **A share link survives a failed copy.** Creating a link and then failing to
+  copy it reported the whole operation as failed, and where the Clipboard API is
+  unavailable the failure was thrown synchronously, so a link that had been
+  created fine was surfaced as `Couldn't create a link`. The link now stays
+  visible and only the copy is reported as failed. (#560)
 
 ## [1.10.0] - 2026-07-29
 


### PR DESCRIPTION
Three PRs merged after the `v1.10.0` tag (#538, #509, #560) and the `[Unreleased]` section only had Kilo Code. It also said the client count was **28**, which stopped being true the moment Amp landed.

- Kilo Code and Amp are now named together at **29**, consistent with the README prose and its 29 table rows. For the record the code has 30 `ClientDef`s; `toolport-studio` is first-party and deliberately not in that count.
- Adds #509 (per-server state dropped on removal, so a re-used id can't inherit a stale injection-block exemption) and #560 (a created share link is no longer reported as a failure when the copy fails).

Without this the next release's notes would silently omit two fixes and a client.