### PR TITLE
fix: two inaccuracies in import-review copy

### DIFF
--- a/src-tauri/src/clients.rs
+++ b/src-tauri/src/clients.rs
@@ -1592,7 +1592,7 @@ fn parse_json_snippet(
         return Ok(vec![json_server_with_values(&name, &value)]);
     }
 
-    Err("JSON parsed but no server definition found (expected mcpServers, servers, context_servers, or a bare server object)".to_string())
+    Err("JSON parsed but no server definition found (expected mcp, mcpServers, servers, context_servers, or a bare server object)".to_string())
 }
 
 /// Parse a TOML snippet with `[mcp_servers.<name>]` tables.

--- a/src/components/ImportReviewDialog.tsx
+++ b/src/components/ImportReviewDialog.tsx
@@ -225,7 +225,9 @@ function isPrivateIpv4(host: string): boolean {
   return (
     a === 127 || // loopback
     a === 10 || // RFC1918
-    a === 0 || // "this" network / unspecified
+    // 0.0.0.0/8 "this network". Deliberately broader than Rust's is_unspecified(),
+    // which is only 0.0.0.0. Warning on the whole block is the safe direction here.
+    a === 0 ||
     (a === 192 && b === 168) ||
     (a === 172 && b >= 16 && b <= 31) ||
     (a === 169 && b === 254) || // link-local


### PR DESCRIPTION
Two small accuracy fixes noticed while reviewing #564 and #541. No behaviour change in either.

**1. The private-IP comment folded two things together.** `a === 0` was commented `// "this" network / unspecified`. `0.0.0.0/8` is "this network"; only `0.0.0.0` is unspecified, and Rust's `is_unspecified()` covers just that. The JS is deliberately broader, which is the safe direction for a warning, so the comment now states that rather than implying the two match.

**2. The generic parse error omits `mcp`.** It reads "expected mcpServers, servers, context_servers, or a bare server object", but `mcp` is handled (`clients.rs:1496`) and is exactly what an OpenCode or Crush user pastes. So someone whose `mcp` snippet failed to parse was pointed at four keys, none of them the one they had already used correctly.

Verified the new string by driving `parse_json_snippet` directly, and no test pins the old text. 129 clients tests pass, 63 ImportReviewDialog tests pass.

Context in #565, which covers the larger version of the second problem.