### PR TITLE
fix: avoid placeholder false positives for keyword params

### DIFF
--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -1703,9 +1703,15 @@ fn param_is_identifier(param: &str) -> bool {
     low == "id"
         || low.ends_with("_id")
         || param.ends_with("Id") // camelCase teamId / projectId
-        || low.contains("key")
-        || low.contains("token")
-        || low.contains("secret")
+        || low == "key"
+        || low.ends_with("_key")
+        || param.ends_with("Key")
+        || low == "token"
+        || low.ends_with("_token")
+        || param.ends_with("Token")
+        || low == "secret"
+        || low.ends_with("_secret")
+        || param.ends_with("Secret")
 }
 
 /// True if a string argument value looks like an LLM-invented placeholder rather
@@ -8702,6 +8708,8 @@ mod tests {
         // (this is the false-positive the guard used to trip on).
         for (param, val) in [
             ("query", "string"),
+            ("keyword", "string"), 
+            ("tokenizer", "string"), 
             ("title", "todo"),
             ("name", "example"),
             ("message", "xxx"),


### PR DESCRIPTION
<!-- Thanks for contributing to Toolport. Keep PRs focused and small where you can. -->

## What and why

Fixes false positives in the placeholder guard by making identifier detection use word boundaries instead of substring matching.

Previously, parameter names such as `keyword` and `tokenizer` were incorrectly treated as identifier fields because `param_is_identifier()` matched `key` and `token` using substring checks. As a result, legitimate values like `"string"` could be rejected as placeholders before the request reached the downstream server.

This change updates identifier detection to recognize only exact identifier names and supported snake_case/camelCase variants (for example, `key`, `api_key`, `apiKey`, `token`, `accessToken`, `secret`, `clientSecret`) while allowing non-identifier parameter names such as `keyword` and `tokenizer`.

Regression tests were updated to cover the reported false-positive cases.

Closes #515 

## Testing

- [ ] `npm run build` passes
- [ ] `npm run test` passes
- [ ] `npm run audit:prod` passes
- [x] `npm run test:rust` passes (`cargo test detects_invented_placeholders_but_not_real_values`)
- [ ] Ran the app (`npm run tauri dev`) and checked the change by hand

## Notes

- Added regression tests for `keyword` and `tokenizer` to ensure legitimate content values are not treated as placeholders.
- No secrets, keys, or personal paths are included in the diff.