### PR TITLE
fix: round token counts before unit selection

### DIFF
--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -2371,10 +2371,13 @@ fn enabled_summary(
 
 /// Compact token count for status text: "1.2M", "541k", or the raw number.
 fn fmt_tokens(n: u64) -> String {
-    if n >= 1_000_000 {
-        format!("{:.1}M", n as f64 / 1_000_000.0)
-    } else if n >= 1_000 {
-        format!("{:.0}k", n as f64 / 1_000.0)
+    if n >= 1_000 {
+        let thousands = (n as f64 / 1_000.0).round();
+        if thousands >= 1_000.0 {
+            format!("{:.1}M", n as f64 / 1_000_000.0)
+        } else {
+            format!("{thousands:.0}k")
+        }
     } else {
         n.to_string()
     }
@@ -9794,6 +9797,15 @@ mod tests {
     // Test-only: the blend-ranking test builds these directly. Kept here rather than at
     // module scope so a non-test build doesn't warn about an unused import.
     use conduit_lib::semantic::SemanticConfig;
+
+    #[test]
+    fn formats_compact_token_counts() {
+        assert_eq!(fmt_tokens(999), "999");
+        assert_eq!(fmt_tokens(1_000), "1k");
+        assert_eq!(fmt_tokens(999_950), "1.0M");
+        assert_eq!(fmt_tokens(1_000_000), "1.0M");
+        assert_eq!(fmt_tokens(1_250_000), "1.2M");
+    }
 
     #[test]
     fn http_tool_scope_merge_intersects_profiles_and_keeps_org_allowlist() {


### PR DESCRIPTION
## What and why

`fmt_tokens(999_950)` currently renders `1000k` because the formatter chooses the `k` branch from the raw value before rounding it.

This change rounds to thousands before choosing the display unit, so values that round to 1000k are formatted in millions. It preserves the existing formatting behavior for smaller counts and established million values.

Closes #524.

## Testing

- [x] `npm run build` passes
- [x] `npm run test` passes (203 tests)
- [x] `npm run audit:prod` passes (0 vulnerabilities)
- [ ] `npm run test:rust` passes
- [ ] Ran the app (`npm run tauri dev`) and checked the change by hand

Additional checks:

- focused `formats_compact_token_counts` regression passed for all five issue cases
- `npm run format:check`
- `npm run lint` (0 errors; 23 existing warnings)
- `git diff --check`

## Notes

Parser/status-formatting-only change with no interactive UI surface, so manual app verification was not applicable.

The full Rust base suite passed on the same upstream commit during this contribution batch. A repeat serial run for this branch progressed through the suite but stalled in unrelated system-keychain tests; the complete gateway binary test suite and the new regression passed.
