### PR TITLE
fix: preserve tiny savings percentages

### DIFF
--- a/src/components/ActivityView.test.tsx
+++ b/src/components/ActivityView.test.tsx
@@ -2,9 +2,10 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, act } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { ActivityView } from "./ActivityView";
-import type { AuditEntry } from "@/lib/types";
+import type { AuditEntry, SearchTrace } from "@/lib/types";
 
 const getAuditLog = vi.fn();
+const getSearchTraces = vi.fn();
 
 vi.mock("@/lib/api", () => ({
   clearActivityLogs: vi.fn(),
@@ -13,7 +14,7 @@ vi.mock("@/lib/api", () => ({
   getAuditStats: vi.fn(() => Promise.resolve(null)),
   getInspectLog: vi.fn(() => Promise.resolve([])),
   getSavingsSummary: vi.fn(() => Promise.resolve(null)),
-  getSearchTraces: vi.fn(() => Promise.resolve([])),
+  getSearchTraces: (...a: unknown[]) => getSearchTraces(...a),
   getSecurityEvents: vi.fn(() => Promise.resolve([])),
   getToolIdentities: vi.fn(() => Promise.resolve([])),
 }));
@@ -50,6 +51,7 @@ const refreshedLog = [entry({ ts: 1700000002000, tool: "list_issues" }), ...init
 beforeEach(() => {
   vi.useFakeTimers({ shouldAdvanceTime: true });
   getAuditLog.mockResolvedValue(initialLog);
+  getSearchTraces.mockResolvedValue([]);
 });
 
 afterEach(() => {
@@ -79,5 +81,36 @@ describe("ActivityView recent calls", () => {
 
     expect(screen.getByText("list_issues")).toBeInTheDocument();
     expect(screen.getByText("403: token lacks repo scope")).toBeInTheDocument();
+  });
+});
+
+describe("ActivityView discovery", () => {
+  it("shows a tiny nonzero saving without rounding it down to zero", async () => {
+    const user = userEvent.setup({
+      advanceTimers: (ms) => vi.advanceTimersByTime(ms),
+    });
+    const trace: SearchTrace = {
+      ts: 1700000000000,
+      query: "tiny savings",
+      top: "github.search",
+      names: ["github.search"],
+      returned: 1,
+      total: 20,
+      returnedTokens: 1999,
+      flatTokens: 2000,
+      savedTokens: 1,
+      escalated: false,
+    };
+    getSearchTraces.mockResolvedValue([trace]);
+
+    render(<ActivityView refreshKey={0} registry={null} />);
+    await act(async () => {});
+
+    await user.click(screen.getByRole("button", { name: /Discovery/ }));
+    const row = screen.getByRole("button", { name: /tiny savings/i });
+    await user.click(row);
+
+    expect(row.parentElement).toHaveTextContent(/<0\.1% less this turn\)\./);
+    expect(row.parentElement).not.toHaveTextContent(/\(0% less this turn\)\./);
   });
 });

--- a/src/components/ActivityView.tsx
+++ b/src/components/ActivityView.tsx
@@ -845,7 +845,10 @@ function InspectRow({ e }: { e: InspectEntry }) {
  * list of returned tool names. */
 function DiscoveryRow({ t }: { t: SearchTrace }) {
   const [open, setOpen] = useState(false);
-  const pct = t.flatTokens > 0 ? Math.round((t.savedTokens / t.flatTokens) * 100) : 0;
+  const pct =
+    t.flatTokens > 0
+      ? fmtPercent(t.savedTokens / t.flatTokens, { floorNonZero: t.savedTokens > 0 })
+      : "0%";
   const hit = t.returned > 0;
   const fallbackCount = t.fallbacks ?? t.ranking?.filter((r) => r.fallback).length ?? 0;
   const resultSummary = fallbackCount
@@ -959,7 +962,7 @@ function DiscoveryRow({ t }: { t: SearchTrace }) {
               ≈{fmtTokens(t.flatTokens)}
             </span>{" "}
             to load the whole catalog
-            {t.flatTokens > 0 ? <> ({pct}% less this turn).</> : "."}
+            {t.flatTokens > 0 ? <> ({pct} less this turn).</> : "."}
           </div>
         </div>
       )}


### PR DESCRIPTION
## What and why

Discovery details currently round savings percentages with `Math.round`, so a positive but small saving can be displayed as `0% less this turn`.

This change uses the shared `fmtPercent` formatter with its nonzero floor enabled whenever tokens were actually saved. Tiny positive savings now render as `<0.1%`, while exact zero remains `0%`.

Closes #527.

## Testing

- [x] `npm run build` passes
- [x] `npm run test` passes (204 tests)
- [x] `npm run audit:prod` passes (0 vulnerabilities)
- [x] `npm run test:rust` passes
- [ ] Ran the app (`npm run tauri dev`) and checked the change by hand

Additional checks:

- focused ActivityView regression (2 tests)
- `npm run format:check`
- `npm run lint` (0 errors; 23 existing warnings, none in touched files)
- `git diff --check`

## Notes

The regression renders the Activity view, loads a 1-in-2,000 token saving, opens the discovery details, and verifies `<0.1%` appears instead of `0%`. That covers the user-visible behavior without requiring a native app session.
