### PR TITLE
fix: prevent cross-server rate limit matches

### DIFF
--- a/src-tauri/src/rate_limits.rs
+++ b/src-tauri/src/rate_limits.rs
@@ -51,13 +51,6 @@ pub fn parse_caps(team_cfg: &Value) -> Vec<Cap> {
             .get("maxCalls")
             .or_else(|| v.get("max_calls"))
             .and_then(Value::as_u64)
-            .or_else(|| {
-                v.get("maxCalls")
-                    .or_else(|| v.get("max_calls"))
-                    .and_then(Value::as_i64)
-                    .filter(|n| *n > 0)
-                    .map(|n| n as u64)
-            })
             .unwrap_or(0);
         if max == 0 {
             continue;
@@ -88,9 +81,8 @@ fn tool_matches(cap_tool: &str, server_id: &str, orig_tool: &str) -> bool {
         return true;
     }
     // `server/tool` or `server__tool` forms from admin authoring.
-    let slash = format!("{server_id}/{orig_tool}");
     let dunder = format!("{server_id}__{orig_tool}");
-    cap_tool == slash || cap_tool == dunder || cap_tool.ends_with(&format!("/{orig_tool}"))
+    cap_tool == dunder || cap_tool.strip_suffix(orig_tool).and_then(|s| s.strip_suffix("/")) == Some(server_id)
 }
 
 fn utc_ymd() -> (i64, u32, u32) {
@@ -330,6 +322,7 @@ mod tests {
     #[test]
     fn tool_matches_server_slash_form() {
         assert!(tool_matches("linear/list_issues", "linear", "list_issues"));
+        assert!(!tool_matches("github/list_issues", "linear", "list_issues"));
         assert!(tool_matches("list_issues", "linear", "list_issues"));
         assert!(!tool_matches("create_issue", "linear", "list_issues"));
     }


### PR DESCRIPTION
<!-- Thanks for contributing to Toolport. Keep PRs focused and small where you can. -->

## What and why

- Fix server-specific matching for slash-form tool caps in `tool_matches`.
- Update slash-form matching to verify the server prefix instead of matching only by tool name suffix, preventing caps such as `github/list_issues` from matching calls on other servers like `linear/list_issues`.
- Preserve the existing behavior for bare tool names and dunder-prefixed tool names.
- Remove the unreachable `parse_caps` fallback that re-read `maxCalls` via `as_i64()`, since positive JSON integers are already handled by `as_u64()`.
- Add a regression test verifying that a `github/...` cap does not match calls on `linear` while preserving the existing matching behavior.

Closes #517 

## Testing

- [ ] `npm run build` passes
- [ ] `npm run test` passes
- [ ] `npm run audit:prod` passes
- [x] `npm run test:rust` passes (`npm run test:rust:windows` on Windows if the debug gateway binary is locked)
- [ ] Ran the app (`npm run tauri dev`) and checked the change by hand

### Tests run

- `cargo test detects_invented_placeholders_but_not_real_values`
- Verified the updated `tool_matches` regression test.

## Notes

- Preserves existing behavior for bare tool caps while fixing slash-form server matching.
- Removes unreachable code in `parse_caps` as suggested during review.