### PR TITLE
fix: skip corrupt lines before applying inspect limit

### DIFF
--- a/src-tauri/src/inspect.rs
+++ b/src-tauri/src/inspect.rs
@@ -132,13 +132,12 @@ pub fn read_recent(limit: usize) -> Vec<Value> {
         Ok(c) => c,
         Err(_) => return Vec::new(),
     };
-    let mut entries: Vec<Value> = content
+    let entries: Vec<Value> = content
         .lines()
         .rev()
-        .take(limit)
         .filter_map(|line| serde_json::from_str(line).ok())
+        .take(limit)
         .collect();
-    entries.truncate(limit);
     entries
 }
 
@@ -254,5 +253,29 @@ mod tests {
     fn cap_json_keeps_small_bodies() {
         let v = json!({ "a": 1 });
         assert_eq!(cap_json(&v, MAX_BODY_BYTES), v);
+    }
+
+    #[test]
+    fn read_recent_skips_corrupt_lines_without_shrinking_page() {
+        let _data_dir = crate::registry::data_dir_test_lock();
+        reset();
+
+        let path = inspect_path().unwrap();
+
+        std::fs::write(
+            &path,
+            r#"{"i":1}
+        {"i":2}
+        not json
+        {"i":3}
+        {"i":4}"#,
+        )
+        .unwrap();
+        let recent = read_recent(3);
+        assert_eq!(recent.len(), 3);
+        assert_eq!(recent[0]["i"], 4);
+        assert_eq!(recent[1]["i"], 3);
+        assert_eq!(recent[2]["i"], 2);
+        reset();
     }
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Toolport. Keep PRs focused and small where you can. -->

## What and why

Fixed `inspect::read_recent` so corrupt JSONL entries no longer reduce the number of entries returned for a requested page size.

Previously, `read_recent` applied `.take(limit)` before filtering invalid lines, meaning a corrupt line inside the selected range could cause fewer than `limit` valid entries to be returned.

Updated the logic to filter valid JSON entries first and then apply the limit. Removed the unnecessary `truncate` call since `.take(limit)` already bounds the collected entries.

Added a regression test covering a corrupt line in the inspect ring and verifying that a full page of valid entries is returned.

Closes #518 

## Testing

<!-- How did you verify this? -->

- [ ] `npm run build` passes
- [ ] `npm run test` passes
- [ ] `npm run audit:prod` passes
- [x] `npm run test:rust` passes (`npm run test:rust:windows` on Windows if the debug gateway binary is locked)
- [ ] Ran the app (`npm run tauri dev`) and checked the change by hand

## Notes

<!-- Screenshots for UI changes, follow-ups, or anything a reviewer should know.
     Confirm no secrets, keys, or personal paths are included in the diff. -->

No UI changes. This only affects inspect log parsing behavior and adds a regression test for malformed JSONL entries.