### PR TITLE
refactor: reuse shared civil date conversion

### DIFF
--- a/src-tauri/src/rate_limits.rs
+++ b/src-tauri/src/rate_limits.rs
@@ -13,6 +13,7 @@ use std::sync::{Mutex, OnceLock};
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use crate::usage_report;
 
 /// One resolved cap from the team config pull (member-scoped on the server).
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -102,17 +103,7 @@ fn utc_ymd() -> (i64, u32, u32) {
 }
 
 fn ymd_from_ms(ms: i64) -> (i64, u32, u32) {
-    let days = ms.div_euclid(86_400_000);
-    let z = days + 719_468;
-    let era = if z >= 0 { z } else { z - 146_096 } / 146_097;
-    let doe = z - era * 146_097;
-    let yoe = (doe - doe / 1460 + doe / 36_524 - doe / 146_096) / 365;
-    let y = yoe + era * 400;
-    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
-    let mp = (5 * doy + 2) / 153;
-    let d = doy - (153 * mp + 2) / 5 + 1;
-    let m = if mp < 10 { mp + 3 } else { mp - 9 };
-    (if m <= 2 { y + 1 } else { y }, m as u32, d as u32)
+   usage_report::civil_from_days(ms.div_euclid(86_400_000))
 }
 
 fn window_key(window: &str) -> String {
@@ -332,5 +323,10 @@ mod tests {
         assert!(tool_matches("linear/list_issues", "linear", "list_issues"));
         assert!(tool_matches("list_issues", "linear", "list_issues"));
         assert!(!tool_matches("create_issue", "linear", "list_issues"));
+    }
+
+    #[test]
+    fn ymd_from_ms_handles_pre_epoch_dates() {
+       assert_eq!(ymd_from_ms(-86_400_000), (1969, 12, 31));
     }
 }

--- a/src-tauri/src/usage_report.rs
+++ b/src-tauri/src/usage_report.rs
@@ -49,7 +49,7 @@ pub fn utc_day_back(offset_back: u64) -> String {
 
 /// Days-since-epoch -> (year, month, day), proleptic Gregorian. Howard Hinnant's
 /// `civil_from_days`; used instead of pulling a date crate in for one function.
-fn civil_from_days(z: i64) -> (i64, u32, u32) {
+pub(crate) fn civil_from_days(z: i64) -> (i64, u32, u32) {
     let z = z + 719_468;
     let era = if z >= 0 { z } else { z - 146_096 } / 146_097;
     let doe = (z - era * 146_097) as u64;
@@ -58,8 +58,8 @@ fn civil_from_days(z: i64) -> (i64, u32, u32) {
     let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
     let mp = (5 * doy + 2) / 153;
     let d = (doy - (153 * mp + 2) / 5 + 1) as u32;
-    let m = if mp < 10 { mp + 3 } else { mp - 9 } as u32;
-    (if m <= 2 { y + 1 } else { y }, m as u32, d)
+    let m = (if mp < 10 { mp + 3 } else { mp - 9 }) as u32;
+    (if m <= 2 { y + 1 } else { y }, m, d)
 }
 
 /// Roll audit + savings lines up into per-server rows for one UTC day, counting


### PR DESCRIPTION
<!-- Thanks for contributing to Toolport. Keep PRs focused and small where you can. -->

## What and why

Removed the duplicate civil date conversion logic from `rate_limits::ymd_from_ms` and reused the shared `usage_report::civil_from_days` implementation instead.

This keeps date conversion logic in one place and avoids having two copies of the same algorithm with different integer handling. Also cleaned up the redundant `as u32` cast in `usage_report::civil_from_days`.

Closes #521 

## Testing

<!-- How did you verify this? -->

- [ ] `npm run build` passes
- [ ] `npm run test` passes
- [ ] `npm run audit:prod` passes
- [x] `npm run test:rust` passes (`npm run test:rust:windows` on Windows if the debug gateway binary is locked)
- [ ] Ran the app (`npm run tauri dev`) and checked the change by hand

## Notes

<!-- Screenshots for UI changes, follow-ups, or anything a reviewer should know.
     Confirm no secrets, keys, or personal paths are included in the diff. -->

No UI changes. This is an internal refactor to share the existing date conversion implementation and remove duplicated logic.