### PR TITLE
refactor: reuse shared cost estimation

### DIFF
--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -28,7 +28,7 @@ use std::time::{Duration, Instant, SystemTime};
 
 use serde_json::{json, Value};
 
-use conduit_lib::audit;
+use conduit_lib::{audit, usage_report};
 use conduit_lib::clients;
 use conduit_lib::codemode;
 use conduit_lib::downstream::{
@@ -1533,7 +1533,7 @@ fn savings_line() -> String {
     if saved > 0 {
         let loads = s.get("listLoads").and_then(Value::as_u64).unwrap_or(0);
         let peak = s.get("peakCatalog").and_then(Value::as_u64).unwrap_or(0);
-        let dollars = (saved as f64 / 1_000_000.0) * 3.0; // Claude Sonnet input $/M
+        let dollars = usage_report::est_cost(saved); // Claude Sonnet input $/M
         line.push_str(&format!(
             "Lazy discovery has kept ~{} tokens of tool definitions out of your agent's \
              context so far (about ${:.2} at Claude Sonnet input rates) across {loads} \


### PR DESCRIPTION
<!-- Thanks for contributing to Toolport. Keep PRs focused and small where you can. -->

## What and why

Replaced the duplicate token cost calculation in `toolport-gateway` with the shared `usage_report::est_cost` helper.

Previously, `toolport-gateway` calculated estimated savings using its own hardcoded rate, which duplicated the logic already maintained in `usage_report`. This change makes the shared helper the single source of truth and prevents future drift if the estimation rate changes.

Closes #522 

## Testing

<!-- How did you verify this? -->

- [ ] `npm run build` passes
- [ ] `npm run test` passes
- [ ] `npm run audit:prod` passes
- [x] `npm run test:rust` passes (`npm run test:rust:windows` on Windows if the debug gateway binary is locked)
- [ ] Ran the app (`npm run tauri dev`) and checked the change by hand

## Notes

<!-- Screenshots for UI changes, follow-ups, or anything a reviewer should know.
     Confirm no secrets, keys, or personal paths are included in the diff. -->

No UI changes. This is an internal refactor only; the estimated cost calculation remains unchanged.