### PR TITLE
feat(clients): add JetBrains Junie support

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,41 +155,42 @@ and refreshes too.
 
 ## Supported clients
 
-Toolport auto-detects these **29 AI clients**, installs the gateway into each with one
+Toolport auto-detects these **30 AI clients**, installs the gateway into each with one
 click, and can import a client's existing servers. It writes the config file shown
 below for you, so you never have to edit these by hand.
 
-| Client         | Config file                                                                                | Format                   |
-| -------------- | ------------------------------------------------------------------------------------------ | ------------------------ |
-| Claude Desktop | `<config>/Claude/claude_desktop_config.json`                                               | JSON (`mcpServers`)      |
-| Claude Code    | `~/.claude.json`                                                                           | JSON (`mcpServers`)      |
-| Cursor         | `~/.cursor/mcp.json`                                                                       | JSON (`mcpServers`)      |
-| VS Code        | `<config>/Code/User/mcp.json`                                                              | JSON (`servers`)         |
-| Windsurf       | `~/.codeium/windsurf/mcp_config.json`                                                      | JSON (`mcpServers`)      |
-| OpenCode       | `~/.config/opencode/opencode.json`                                                         | JSON (`mcp`)             |
-| Kilo Code      | `~/.config/kilo/kilo.jsonc`                                                                | JSONC (`mcp`)            |
-| Codex          | `~/.codex/config.toml`                                                                     | TOML (`mcp_servers`)     |
-| Grok Build     | `~/.grok/config.toml`                                                                      | TOML (`mcp_servers`)     |
-| Continue       | `~/.continue/config.yaml`                                                                  | YAML (`mcpServers`)      |
-| Antigravity    | `~/.gemini/config/mcp_config.json`                                                         | JSON (`mcpServers`)      |
-| Gemini CLI     | `~/.gemini/settings.json`                                                                  | JSON (`mcpServers`)      |
-| Qwen Code      | `~/.qwen/settings.json`                                                                    | JSON (`mcpServers`)      |
-| Cline          | `<config>/Code/User/globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json` | JSON (`mcpServers`)      |
-| Roo Code       | `<config>/Code/User/globalStorage/rooveterinaryinc.roo-cline/settings/mcp_settings.json`   | JSON (`mcpServers`)      |
-| Warp           | `~/.warp/.mcp.json`                                                                        | JSON (`mcpServers`)      |
-| Amazon Q       | `~/.aws/amazonq/mcp.json`                                                                  | JSON (`mcpServers`)      |
-| Kiro           | `~/.kiro/settings/mcp.json`                                                                | JSON (`mcpServers`)      |
-| Zed            | `~/.config/zed/settings.json`                                                              | JSON (`context_servers`) |
-| LM Studio      | `~/.lmstudio/mcp.json`                                                                     | JSON (`mcpServers`)      |
-| Jan            | `<data>/Jan/data/mcp_config.json`                                                          | JSON (`mcpServers`)      |
-| BoltAI         | `~/.boltai/mcp.json`                                                                       | JSON (`mcpServers`)      |
-| Pi             | `~/.pi/agent/mcp.json`                                                                     | JSON (`mcpServers`)      |
-| Oh My Pi       | `~/.omp/agent/mcp.json`                                                                    | JSON (`mcpServers`)      |
-| Goose          | `~/.config/goose/config.yaml`                                                              | YAML (`extensions`)      |
-| Hermes         | `~/.hermes/config.yaml`                                                                    | YAML (`mcp_servers`)     |
-| AnythingLLM    | `<config>/anythingllm-desktop/storage/plugins/anythingllm_mcp_servers.json`                | JSON (`mcpServers`)      |
-| Witsy          | `<config>/Witsy/settings.json`                                                             | JSON (`mcpServers`)      |
-| Amp            | `~/.config/amp/settings.json`                                                              | JSON (`amp.mcpServers`)  |
+| Client          | Config file                                                                                | Format                   |
+| --------------- | ------------------------------------------------------------------------------------------ | ------------------------ |
+| Claude Desktop  | `<config>/Claude/claude_desktop_config.json`                                               | JSON (`mcpServers`)      |
+| Claude Code     | `~/.claude.json`                                                                           | JSON (`mcpServers`)      |
+| Cursor          | `~/.cursor/mcp.json`                                                                       | JSON (`mcpServers`)      |
+| VS Code         | `<config>/Code/User/mcp.json`                                                              | JSON (`servers`)         |
+| Windsurf        | `~/.codeium/windsurf/mcp_config.json`                                                      | JSON (`mcpServers`)      |
+| OpenCode        | `~/.config/opencode/opencode.json`                                                         | JSON (`mcp`)             |
+| Kilo Code       | `~/.config/kilo/kilo.jsonc`                                                                | JSONC (`mcp`)            |
+| Codex           | `~/.codex/config.toml`                                                                     | TOML (`mcp_servers`)     |
+| Grok Build      | `~/.grok/config.toml`                                                                      | TOML (`mcp_servers`)     |
+| Continue        | `~/.continue/config.yaml`                                                                  | YAML (`mcpServers`)      |
+| Antigravity     | `~/.gemini/config/mcp_config.json`                                                         | JSON (`mcpServers`)      |
+| Gemini CLI      | `~/.gemini/settings.json`                                                                  | JSON (`mcpServers`)      |
+| Qwen Code       | `~/.qwen/settings.json`                                                                    | JSON (`mcpServers`)      |
+| JetBrains Junie | `~/.junie/mcp/mcp.json`                                                                    | JSON (`mcpServers`)      |
+| Cline           | `<config>/Code/User/globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json` | JSON (`mcpServers`)      |
+| Roo Code        | `<config>/Code/User/globalStorage/rooveterinaryinc.roo-cline/settings/mcp_settings.json`   | JSON (`mcpServers`)      |
+| Warp            | `~/.warp/.mcp.json`                                                                        | JSON (`mcpServers`)      |
+| Amazon Q        | `~/.aws/amazonq/mcp.json`                                                                  | JSON (`mcpServers`)      |
+| Kiro            | `~/.kiro/settings/mcp.json`                                                                | JSON (`mcpServers`)      |
+| Zed             | `~/.config/zed/settings.json`                                                              | JSON (`context_servers`) |
+| LM Studio       | `~/.lmstudio/mcp.json`                                                                     | JSON (`mcpServers`)      |
+| Jan             | `<data>/Jan/data/mcp_config.json`                                                          | JSON (`mcpServers`)      |
+| BoltAI          | `~/.boltai/mcp.json`                                                                       | JSON (`mcpServers`)      |
+| Pi              | `~/.pi/agent/mcp.json`                                                                     | JSON (`mcpServers`)      |
+| Oh My Pi        | `~/.omp/agent/mcp.json`                                                                    | JSON (`mcpServers`)      |
+| Goose           | `~/.config/goose/config.yaml`                                                              | YAML (`extensions`)      |
+| Hermes          | `~/.hermes/config.yaml`                                                                    | YAML (`mcp_servers`)     |
+| AnythingLLM     | `<config>/anythingllm-desktop/storage/plugins/anythingllm_mcp_servers.json`                | JSON (`mcpServers`)      |
+| Witsy           | `<config>/Witsy/settings.json`                                                             | JSON (`mcpServers`)      |
+| Amp             | `~/.config/amp/settings.json`                                                              | JSON (`amp.mcpServers`)  |
 
 `<config>` is your OS application-config dir (`%APPDATA%` on Windows, `~/Library/Application Support` on macOS, `~/.config` on Linux); `<data>` is the data dir (`~/.local/share` on Linux, the same as `<config>` elsewhere). Zed and Goose paths vary slightly by OS; Toolport resolves the right one automatically.
 

--- a/src-tauri/src/clients.rs
+++ b/src-tauri/src/clients.rs
@@ -261,6 +261,7 @@ fn resolve_client_config_path(
         "claude-code" => home.join(".claude.json"),
         "gemini-cli" => home.join(".gemini").join("settings.json"),
         "qwen-code" => home.join(".qwen").join("settings.json"),
+        "junie" => home.join(".junie").join("mcp").join("mcp.json"),
         "antigravity" => home.join(".gemini").join("config").join("mcp_config.json"),
         "cline" => config
             .join("Code")
@@ -370,6 +371,7 @@ fn resolve_client_config_path_linux(client_id: &str, home: &std::path::Path) -> 
         "claude-code" => home.join(".claude.json"),
         "gemini-cli" => home.join(".gemini").join("settings.json"),
         "qwen-code" => home.join(".qwen").join("settings.json"),
+        "junie" => home.join(".junie").join("mcp").join("mcp.json"),
         "antigravity" => home.join(".gemini").join("config").join("mcp_config.json"),
         "cline" => config
             .join("Code")
@@ -658,6 +660,12 @@ fn gemini_cli_path() -> Option<PathBuf> {
 /// supported platform.
 fn qwen_code_path() -> Option<PathBuf> {
     client_config_path("qwen-code")
+}
+
+/// Junie stores user-scoped MCP servers at ~/.junie/mcp/mcp.json on every
+/// supported platform. Project-scoped configs are intentionally left untouched.
+fn junie_path() -> Option<PathBuf> {
+    client_config_path("junie")
 }
 
 /// Google Antigravity reads MCP servers from `mcp_config.json` under `~/.gemini`.
@@ -987,6 +995,14 @@ fn defs() -> Vec<ClientDef> {
             format: Format::JsonQwenMcpServers,
             uses_connectors: false,
             path: qwen_code_path,
+            plugin_scan: None,
+        },
+        ClientDef {
+            id: "junie",
+            name: "JetBrains Junie",
+            format: Format::JsonMcpServers,
+            uses_connectors: false,
+            path: junie_path,
             plugin_scan: None,
         },
         ClientDef {
@@ -2208,6 +2224,9 @@ fn install_override(id: &str) -> Option<PathBuf> {
         // ~/.kiro/settings may not exist until something is configured; ~/.kiro is
         // created on install.
         "kiro" => Some(home()?.join(".kiro")),
+        // ~/.junie/mcp may not exist until MCP is configured; ~/.junie is the
+        // stable user-scope data root created by Junie.
+        "junie" => Some(home()?.join(".junie")),
         // MCP file lives under ~/.toolport-studio, but presence also includes
         // Electron userData and installer dirs (and the transitional t3code path).
         "toolport-studio" => toolport_studio_install_marker(),
@@ -5575,6 +5594,7 @@ command = "npx"
             "Claude Code must check ~/.claude, not the home dir its config sits in"
         );
         assert!(install_override("kiro").unwrap().ends_with(".kiro"));
+        assert!(install_override("junie").unwrap().ends_with(".junie"));
         let _ = install_override("warp"); // env-dependent; just ensure no panic.
         assert!(
             install_override("toolport-studio").is_some(),
@@ -6075,10 +6095,9 @@ command = "npx"
 
     #[test]
     fn new_json_clients_are_registered() {
-        // Warp, Amazon Q, Kiro, LM Studio, Jan, AnythingLLM, and Witsy all use the
-        // standard mcpServers JSON shape, so a ClientDef + path is all they need.
-        // Lock in their registration, format, and that their config paths resolve
-        // on this OS.
+        // These clients all use the standard mcpServers JSON shape, so a ClientDef
+        // plus a path is all they need. Lock in their registration, format, and
+        // that their config paths resolve on this OS.
         for id in [
             "warp",
             "amazon-q",
@@ -6087,6 +6106,7 @@ command = "npx"
             "jan",
             "anythingllm",
             "witsy",
+            "junie",
         ] {
             let d = defs()
                 .into_iter()
@@ -6098,6 +6118,37 @@ command = "npx"
             );
             assert!((d.path)().is_some(), "{id} path should resolve");
         }
+    }
+
+    #[test]
+    fn junie_mcp_config_round_trips() {
+        let path = temp_path("junie-mcp.json");
+        std::fs::write(
+            &path,
+            r#"{"mcpServers":{"existing":{"command":"node","args":["server.js"],"env":{"TOKEN":"keep"}}}}"#,
+        )
+        .unwrap();
+
+        let before = parse_json(&std::fs::read_to_string(&path).unwrap(), "mcpServers").unwrap();
+        assert_eq!(before.len(), 1);
+        assert_eq!(before[0].name, "existing");
+
+        { let _e = sample_gateway(None, "junie"); edit_json_gateway(&path, "mcpServers", Some(&_e), false) }
+            .unwrap();
+        let installed =
+            parse_json(&std::fs::read_to_string(&path).unwrap(), "mcpServers").unwrap();
+        assert_eq!(installed.len(), 2);
+        assert!(installed.iter().any(|server| server.name == "existing"));
+        assert!(installed
+            .iter()
+            .any(|server| server.name == GATEWAY_ENTRY_NAME));
+
+        edit_json_gateway(&path, "mcpServers", None, false).unwrap();
+        let removed =
+            parse_json(&std::fs::read_to_string(&path).unwrap(), "mcpServers").unwrap();
+        assert_eq!(removed.len(), 1);
+        assert_eq!(removed[0].name, "existing");
+        std::fs::remove_file(&path).ok();
     }
 
     #[test]
@@ -6631,6 +6682,9 @@ command = "npx"
             }),
             ("qwen-code", |home, _| {
                 home.join(".qwen").join("settings.json")
+            }),
+            ("junie", |home, _| {
+                home.join(".junie").join("mcp").join("mcp.json")
             }),
             ("continue", |home, _| {
                 home.join(".continue").join("config.yaml")

--- a/src-tauri/src/clients.rs
+++ b/src-tauri/src/clients.rs
@@ -2179,6 +2179,17 @@ fn app_present_for(config_path: &str, config_exists: bool) -> bool {
                 .unwrap_or(false))
 }
 
+fn app_present_with_override(
+    config_path: &str,
+    config_exists: bool,
+    install_marker: Option<&Path>,
+) -> bool {
+    match install_marker {
+        Some(marker) => config_exists || marker.exists(),
+        None => app_present_for(config_path, config_exists),
+    }
+}
+
 /// Warp keeps its state under the OS data dir, not next to its MCP config: it reads
 /// file-based servers from `~/.warp/.mcp.json` but only creates `~/.warp` on first
 /// file-based use, while the app itself lives under the data dir. So the
@@ -2262,10 +2273,9 @@ fn read_client(def: &ClientDef) -> DetectedClient {
         // Clients with an explicit install dir use it (and ignore the config-parent
         // heuristic, which for them is wrong); everyone else uses the parent of
         // their resolved config path (which is their data dir, e.g. ~/.codex).
-        let app_present = match install_override(def.id) {
-            Some(marker) => config_exists || marker.exists(),
-            None => app_present_for(&config_path, config_exists),
-        };
+        let install_marker = install_override(def.id);
+        let app_present =
+            app_present_with_override(&config_path, config_exists, install_marker.as_deref());
         DetectedClient {
             id: def.id.to_string(),
             name: def.name.to_string(),
@@ -5607,6 +5617,31 @@ command = "npx"
     }
 
     #[test]
+    fn junie_install_marker_controls_detection_without_config() {
+        let marker = std::env::temp_dir().join(format!(
+            "toolport-junie-marker-{}",
+            std::process::id()
+        ));
+        std::fs::remove_dir_all(&marker).ok();
+        let config = marker.join("mcp").join("mcp.json");
+
+        assert!(!app_present_with_override(
+            &config.to_string_lossy(),
+            false,
+            Some(&marker)
+        ));
+
+        std::fs::create_dir_all(&marker).unwrap();
+        assert!(app_present_with_override(
+            &config.to_string_lossy(),
+            false,
+            Some(&marker)
+        ));
+
+        std::fs::remove_dir_all(&marker).ok();
+    }
+
+    #[test]
     fn toolport_studio_is_registered_with_session_client_id() {
         let d = defs()
             .into_iter()
@@ -6129,6 +6164,10 @@ command = "npx"
         )
         .unwrap();
 
+        let original: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        let original_existing = original["mcpServers"]["existing"].clone();
+
         let before = parse_json(&std::fs::read_to_string(&path).unwrap(), "mcpServers").unwrap();
         assert_eq!(before.len(), 1);
         assert_eq!(before[0].name, "existing");
@@ -6142,12 +6181,21 @@ command = "npx"
         assert!(installed
             .iter()
             .any(|server| server.name == GATEWAY_ENTRY_NAME));
+        let installed_json: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        assert_eq!(
+            installed_json["mcpServers"]["existing"],
+            original_existing
+        );
 
         edit_json_gateway(&path, "mcpServers", None, false).unwrap();
         let removed =
             parse_json(&std::fs::read_to_string(&path).unwrap(), "mcpServers").unwrap();
         assert_eq!(removed.len(), 1);
         assert_eq!(removed[0].name, "existing");
+        let removed_json: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        assert_eq!(removed_json["mcpServers"]["existing"], original_existing);
         std::fs::remove_file(&path).ok();
     }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Toolport. Keep PRs focused and small where you can. -->

## What and why

Adds JetBrains Junie as a standard `mcpServers` client using its documented user-scope config at `~/.junie/mcp/mcp.json`.

The client is registered in the Clients view, uses `~/.junie` as its install marker so first-time MCP setup is detectable, and is listed in the supported-client table. Regression coverage locks the cross-platform path, `ClientDef` format, and a fixture round trip that preserves an existing server while installing and removing Toolport.

Closes #514.

## Testing

- [x] `npm run build` passes
- [x] `npm run test` passes
- [x] `npm run audit:prod` passes
- [ ] `npm run test:rust` passes (`npm run test:rust:windows` on Windows if the debug gateway binary is locked)
- [ ] Ran the app (`npm run tauri dev`) and checked the change by hand

Additional verification:

- `cargo test --manifest-path src-tauri/Cargo.toml clients` — 139 affected tests passed
- `cargo test --manifest-path src-tauri/Cargo.toml --lib --bins --tests -- --skip master_key` — broad suite passed with only the two unchanged unsigned-development Keychain tests excluded; the unfiltered run reached those two tests and hung
- `npm run lint` — 0 errors; 23 pre-existing warnings outside the changed files
- `npm run format:check`
- `git diff --check`

## Notes

No UI component code changed. The Clients view is populated from the tested backend `ClientDef`. No secrets, keys, personal paths, or generated artifacts are included.
