### PR TITLE
fix: improve empty server search state

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,6 +19,7 @@ import {
   Store,
   TriangleAlert,
   WifiOff,
+  X,
 } from "lucide-react";
 import { toast } from "sonner";
 import { toastError } from "@/lib/toast";
@@ -816,8 +817,18 @@ function App() {
                       onBrowseCatalog={() => selectView("catalog")}
                     />
                   ) : visible.length === 0 ? (
-                    <div className="py-16 text-center text-sm text-muted-foreground">
-                      No servers match "{query}".
+                    <div className="flex flex-col items-center gap-2 rounded-lg border border-dashed px-3 py-6 text-center">
+                      <p className="text-sm text-muted-foreground">
+                        No servers match "{query}".
+                      </p>
+                      <button
+                        type="button"
+                        onClick={() => setQuery("")}
+                        className="inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1 text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+                      >
+                        <X className="size-3.5" />
+                        Clear search
+                      </button>
                     </div>
                   ) : (
                     <div className="flex flex-col gap-5">

--- a/src/components/ActivityView.tsx
+++ b/src/components/ActivityView.tsx
@@ -1262,7 +1262,7 @@ function ToolIdentities({ refreshKey }: { refreshKey: number }) {
 
           {filtered.length === 0 ? (
             <p className="py-6 text-center text-xs text-muted-foreground">
-              No server or tool matches “{query}”.
+              No server or tool matches "{query}".
             </p>
           ) : (
             <>


### PR DESCRIPTION
## Summary

- add a clear-search action when the All servers filter has no matches
- mirror the Playground empty-state styling and behavior
- use consistent straight quotes in the affected search messages

Closes #530.

## Verification

- [x] `npm run test` (20 files, 204 tests)
- [x] `npm run build`
- [x] `npm run lint` (0 errors; 23 existing warnings)
- [x] `npm run format:check`
- [x] `npm run audit:prod` (0 vulnerabilities)
- [ ] `npm run test:rust` (not run; TypeScript-only UI change)
- [ ] Manual app verification (not run)

## Screenshots

Not included; the change mirrors the existing Playground empty-state treatment.
