### PR TITLE
feat(clients): add GitHub Copilot CLI support

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ and refreshes too.
 
 ## Supported clients
 
-Toolport auto-detects these **29 AI clients**, installs the gateway into each with one
+Toolport auto-detects these **30 AI clients**, installs the gateway into each with one
 click, and can import a client's existing servers. It writes the config file shown
 below for you, so you never have to edit these by hand.
 
@@ -169,6 +169,7 @@ below for you, so you never have to edit these by hand.
 | OpenCode       | `~/.config/opencode/opencode.json`                                                         | JSON (`mcp`)             |
 | Kilo Code      | `~/.config/kilo/kilo.jsonc`                                                                | JSONC (`mcp`)            |
 | Codex          | `~/.codex/config.toml`                                                                     | TOML (`mcp_servers`)     |
+| Copilot CLI    | `~/.copilot/mcp-config.json`                                                               | JSON (`mcpServers`)      |
 | Grok Build     | `~/.grok/config.toml`                                                                      | TOML (`mcp_servers`)     |
 | Continue       | `~/.continue/config.yaml`                                                                  | YAML (`mcpServers`)      |
 | Antigravity    | `~/.gemini/config/mcp_config.json`                                                         | JSON (`mcpServers`)      |

--- a/src-tauri/src/clients.rs
+++ b/src-tauri/src/clients.rs
@@ -79,6 +79,9 @@ pub struct DetectedClient {
 enum Format {
     /// JSON with a top-level `mcpServers` object (Claude Desktop, Cursor, Windsurf).
     JsonMcpServers,
+    /// GitHub Copilot CLI's `mcpServers` object. Entries use the standard JSON
+    /// shape but require a `tools` allowlist; Toolport enables every gateway tool.
+    JsonCopilotMcpServers,
     /// Amp's shared settings file stores servers under the literal dotted
     /// top-level key `amp.mcpServers` (not a nested `amp` object).
     JsonAmpMcpServers,
@@ -258,6 +261,7 @@ fn resolve_client_config_path(
         "kilo-code" => home.join(".config").join("kilo").join("kilo.jsonc"),
         "grok" => home.join(".grok").join("config.toml"),
         "codex" => home.join(".codex").join("config.toml"),
+        "github-copilot-cli" => home.join(".copilot").join("mcp-config.json"),
         "claude-code" => home.join(".claude.json"),
         "gemini-cli" => home.join(".gemini").join("settings.json"),
         "qwen-code" => home.join(".qwen").join("settings.json"),
@@ -367,6 +371,7 @@ fn resolve_client_config_path_linux(client_id: &str, home: &std::path::Path) -> 
         "kilo-code" => home.join(".config").join("kilo").join("kilo.jsonc"),
         "grok" => home.join(".grok").join("config.toml"),
         "codex" => home.join(".codex").join("config.toml"),
+        "github-copilot-cli" => home.join(".copilot").join("mcp-config.json"),
         "claude-code" => home.join(".claude.json"),
         "gemini-cli" => home.join(".gemini").join("settings.json"),
         "qwen-code" => home.join(".qwen").join("settings.json"),
@@ -575,6 +580,16 @@ fn windsurf_path() -> Option<PathBuf> {
 
 fn codex_path() -> Option<PathBuf> {
     client_config_path("codex")
+}
+
+/// GitHub Copilot CLI stores user-level MCP servers under `COPILOT_HOME`,
+/// defaulting to `~/.copilot/mcp-config.json` on every supported platform.
+fn github_copilot_cli_path() -> Option<PathBuf> {
+    std::env::var_os("COPILOT_HOME")
+        .filter(|path| !path.is_empty())
+        .map(PathBuf::from)
+        .map(|home| home.join("mcp-config.json"))
+        .or_else(|| client_config_path("github-copilot-cli"))
 }
 
 /// Grok Build (xAI's terminal coding agent) stores MCP servers in
@@ -955,6 +970,14 @@ fn defs() -> Vec<ClientDef> {
             format: Format::TomlMcpServers,
             uses_connectors: false,
             path: codex_path,
+            plugin_scan: None,
+        },
+        ClientDef {
+            id: "github-copilot-cli",
+            name: "GitHub Copilot CLI",
+            format: Format::JsonCopilotMcpServers,
+            uses_connectors: false,
+            path: github_copilot_cli_path,
             plugin_scan: None,
         },
         ClientDef {
@@ -2297,6 +2320,7 @@ fn read_client(def: &ClientDef) -> DetectedClient {
 
     let parsed = match def.format {
         Format::JsonMcpServers => parse_json(&content, "mcpServers"),
+        Format::JsonCopilotMcpServers => parse_json(&content, "mcpServers"),
         Format::JsonAmpMcpServers => parse_json(&content, "amp.mcpServers"),
         Format::JsonQwenMcpServers => parse_qwen_json(&content),
         Format::JsonServers => parse_json(&content, "servers"),
@@ -2744,6 +2768,20 @@ fn write_json(
     servers: &[ServerEntry],
     lenient: bool,
 ) -> Result<(), String> {
+    write_json_with_tools(path, key, servers, lenient, false)
+}
+
+fn write_copilot_json(path: &Path, servers: &[ServerEntry]) -> Result<(), String> {
+    write_json_with_tools(path, "mcpServers", servers, false, true)
+}
+
+fn write_json_with_tools(
+    path: &Path,
+    key: &str,
+    servers: &[ServerEntry],
+    lenient: bool,
+    include_tools: bool,
+) -> Result<(), String> {
     let mut root = if path.exists() {
         let content = read_config_file(path)?;
         read_existing_json(&content, lenient)?
@@ -2758,7 +2796,16 @@ fn write_json(
     let obj = root.as_object_mut().unwrap();
     let servers_map: serde_json::Map<String, serde_json::Value> = servers
         .iter()
-        .map(|s| (s.name.clone(), entry_to_json(s)))
+        .map(|server| {
+            let mut value = entry_to_json(server);
+            if include_tools {
+                value.as_object_mut().unwrap().insert(
+                    "tools".into(),
+                    serde_json::json!(["*"]),
+                );
+            }
+            (server.name.clone(), value)
+        })
         .collect();
     obj.insert(key.to_string(), serde_json::Value::Object(servers_map));
 
@@ -3441,6 +3488,7 @@ pub fn write_servers(client_id: &str, servers: &[ServerEntry]) -> Result<WriteOu
     let lenient = config_is_whole_app_state(client_id);
     match def.format {
         Format::JsonMcpServers => write_json(&path, "mcpServers", servers, lenient)?,
+        Format::JsonCopilotMcpServers => write_copilot_json(&path, servers)?,
         Format::JsonAmpMcpServers => write_json(&path, "amp.mcpServers", servers, true)?,
         Format::JsonQwenMcpServers => write_qwen_json(&path, servers)?,
         Format::JsonServers => write_json(&path, "servers", servers, lenient)?,
@@ -3643,6 +3691,7 @@ pub fn client_uses_mcp_remote_bridge(client_id: &str) -> bool {
     match def.format {
         // Native remote shapes already exist in our writers.
         Format::JsonQwenMcpServers
+        | Format::JsonCopilotMcpServers
         | Format::JsonOpenCodeMcp
         | Format::JsonServers
         | Format::YamlMcpServers
@@ -3726,6 +3775,20 @@ fn edit_json_gateway(
     entry: Option<&ServerEntry>,
     lenient: bool,
 ) -> Result<(), String> {
+    edit_json_gateway_with_tools(path, key, entry, lenient, false)
+}
+
+fn edit_copilot_json_gateway(path: &Path, entry: Option<&ServerEntry>) -> Result<(), String> {
+    edit_json_gateway_with_tools(path, "mcpServers", entry, false, true)
+}
+
+fn edit_json_gateway_with_tools(
+    path: &Path,
+    key: &str,
+    entry: Option<&ServerEntry>,
+    lenient: bool,
+    include_tools: bool,
+) -> Result<(), String> {
     let mut root = if path.exists() {
         let content = read_config_file(path)?;
         read_existing_json(&content, lenient)?
@@ -3752,7 +3815,9 @@ fn edit_json_gateway(
     if let Some(entry) = entry {
         // Remote-only entries: Qwen wants httpUrl+headers; VS Code "servers" keeps url.
         // entry_to_qwen_json leaves url as-is for SSE and renames for streamable HTTP.
-        let value = if entry.command.is_none() && entry.url.is_some() {
+        let mut value = if include_tools {
+            entry_to_json(entry)
+        } else if entry.command.is_none() && entry.url.is_some() {
             if key == "servers" {
                 entry_to_json(entry)
             } else {
@@ -3761,6 +3826,12 @@ fn edit_json_gateway(
         } else {
             entry_to_json(entry)
         };
+        if include_tools {
+            value.as_object_mut().unwrap().insert(
+                "tools".into(),
+                serde_json::json!(["*"]),
+            );
+        }
         servers.insert(GATEWAY_ENTRY_NAME.to_string(), value);
     }
 
@@ -3860,6 +3931,7 @@ fn install_or_remove(
         Format::JsonMcpServers => {
             edit_json_gateway(&path, "mcpServers", entry, lenient)?
         }
+        Format::JsonCopilotMcpServers => edit_copilot_json_gateway(&path, entry)?,
         Format::JsonAmpMcpServers => {
             edit_json_gateway(&path, "amp.mcpServers", entry, true)?
         }
@@ -4910,6 +4982,27 @@ bad = "not-a-table"
         assert!(client_uses_mcp_remote_bridge("amp"));
         assert!(!client_uses_mcp_remote_bridge("opencode"));
         assert!(!client_uses_mcp_remote_bridge("vscode"));
+        assert!(!client_uses_mcp_remote_bridge("github-copilot-cli"));
+    }
+
+    #[test]
+    fn github_copilot_cli_shared_http_entry_uses_native_schema() {
+        let path = temp_path("github-copilot-cli-http.json");
+        let spec = SharedHttpSpec {
+            url: "http://127.0.0.1:8765/mcp".into(),
+            token: "tok".into(),
+        };
+        let entry = gateway_entry_shared_http("github-copilot-cli", None, &spec);
+
+        edit_copilot_json_gateway(&path, Some(&entry)).unwrap();
+        let root: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        let gateway = &root["mcpServers"][GATEWAY_ENTRY_NAME];
+        assert_eq!(gateway["type"], "http");
+        assert_eq!(gateway["url"], "http://127.0.0.1:8765/mcp");
+        assert_eq!(gateway["tools"], serde_json::json!(["*"]));
+        assert_eq!(gateway["headers"]["Authorization"], "Bearer tok");
+        std::fs::remove_file(&path).ok();
     }
 
     #[test]
@@ -6101,6 +6194,79 @@ command = "npx"
     }
 
     #[test]
+    fn github_copilot_cli_is_registered_with_required_tools_format() {
+        let definition = defs()
+            .into_iter()
+            .find(|definition| definition.id == "github-copilot-cli")
+            .unwrap();
+        assert_eq!(definition.name, "GitHub Copilot CLI");
+        assert!(matches!(
+            definition.format,
+            Format::JsonCopilotMcpServers
+        ));
+        assert!((definition.path)().is_some());
+    }
+
+    #[test]
+    fn github_copilot_cli_mcp_config_round_trips() {
+        let path = temp_path("github-copilot-cli-mcp.json");
+        std::fs::write(
+            &path,
+            r#"{"mcpServers":{"existing":{"command":"node","args":["server.js"],"env":{"TOKEN":"keep"}}}}"#,
+        )
+        .unwrap();
+
+        let original: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        let original_existing = original["mcpServers"]["existing"].clone();
+
+        let before = parse_json(&std::fs::read_to_string(&path).unwrap(), "mcpServers").unwrap();
+        assert_eq!(before.len(), 1);
+        assert_eq!(before[0].name, "existing");
+
+        {
+            let gateway = sample_gateway(None, "github-copilot-cli");
+            edit_copilot_json_gateway(&path, Some(&gateway))
+        }
+        .unwrap();
+        let installed =
+            parse_json(&std::fs::read_to_string(&path).unwrap(), "mcpServers").unwrap();
+        assert_eq!(installed.len(), 2);
+        assert!(installed.iter().any(|server| server.name == "existing"));
+        assert!(installed
+            .iter()
+            .any(|server| server.name == GATEWAY_ENTRY_NAME));
+        let installed_json: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        assert_eq!(
+            installed_json["mcpServers"]["existing"],
+            original_existing
+        );
+        assert_eq!(
+            installed_json["mcpServers"][GATEWAY_ENTRY_NAME]["tools"],
+            serde_json::json!(["*"])
+        );
+
+        edit_copilot_json_gateway(&path, None).unwrap();
+        let removed =
+            parse_json(&std::fs::read_to_string(&path).unwrap(), "mcpServers").unwrap();
+        assert_eq!(removed.len(), 1);
+        assert_eq!(removed[0].name, "existing");
+        let removed_json: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        assert_eq!(removed_json["mcpServers"]["existing"], original_existing);
+
+        write_copilot_json(&path, &[stdio("replacement")]).unwrap();
+        let replaced_json: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        assert_eq!(
+            replaced_json["mcpServers"]["replacement"]["tools"],
+            serde_json::json!(["*"])
+        );
+        std::fs::remove_file(&path).ok();
+    }
+
+    #[test]
     fn goose_yaml_round_trip_preserves_config() {
         let path = temp_path("goose.yaml");
         // A real config.yaml has model settings AND extensions; touch neither but ours.
@@ -6590,11 +6756,23 @@ command = "npx"
     }
 
     #[test]
+    fn github_copilot_cli_home_overrides_default_path() {
+        let _env = ENV_LOCK.lock().unwrap_or_else(|error| error.into_inner());
+        let override_path = std::env::temp_dir().join("copilot-custom-home");
+        let _restore = EnvRestore::set("COPILOT_HOME", &override_path);
+        assert_eq!(
+            github_copilot_cli_path(),
+            Some(override_path.join("mcp-config.json"))
+        );
+    }
+
+    #[test]
     fn client_config_paths_match_current_platform() {
         // Hold the env lock: the path resolution reads `dirs::config_dir()`, which
         // another test mutates via `XDG_CONFIG_HOME`. Serialize so we never read it
         // mid-change.
         let _env = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _copilot_home = EnvRestore::set("COPILOT_HOME", Path::new(""));
         let home = home().expect("home dir should be available in tests");
         let platform = Platform::current();
         for client in defs() {
@@ -6620,6 +6798,9 @@ command = "npx"
         let cases: &[(&str, fn(&Path, Platform) -> PathBuf)] = &[
             ("cursor", |home, _| home.join(".cursor").join("mcp.json")),
             ("grok", |home, _| home.join(".grok").join("config.toml")),
+            ("github-copilot-cli", |home, _| {
+                home.join(".copilot").join("mcp-config.json")
+            }),
             ("toolport-studio", |home, _| {
                 home.join(".toolport-studio").join("mcp.json")
             }),


### PR DESCRIPTION
## What and why

Adds first-class GitHub Copilot CLI support using its user-level `~/.copilot/mcp-config.json` file (or `COPILOT_HOME` override). Toolport now detects the client, preserves existing servers during gateway installation and removal, emits Copilot's required `tools: ["*"]` allowlist, and uses Copilot's native HTTP schema for Shared HTTP connections.

Fixes #512

## Testing

- [x] `npm run build` passes
- [x] `npm run test` passes
- [x] `npm run audit:prod` passes
- [ ] `npm run test:rust` passes (`npm run test:rust:windows` on Windows if the debug gateway binary is locked)
- [ ] Ran the app (`npm run tauri dev`) and checked the change by hand

The equivalent Rust library, binary, and integration suite passes with only the signed-build keychain `master_key` tests filtered: 602 library tests, 195 gateway tests, and all integration/spec tests. The client-specific suite passes 135 tests. The app was not run because this is config serialization and path-resolution behavior covered by automated fixtures.

## Notes

No UI visuals, credentials, secrets, or personal paths are included. The fixtures cover default and overridden paths, existing-server preservation, required tool allowlists, and native Shared HTTP output.

This PR and #576 both add one client from the same 29-client base, so whichever lands second should resolve the README total to 31 while retaining both rows.
