### PR TITLE
feat(clients): add Factory Droid CLI support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,3 +100,4 @@ license-signing.keycd
 # Agent/session scratch (never commit)
 _poll_pr.py
 _cr*.txt
+src-tauri/rate_limit_counters.test.json

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ and refreshes too.
 
 ## Supported clients
 
-Toolport auto-detects these **31 AI clients**, installs the gateway into each with one
+Toolport auto-detects these **32 AI clients**, installs the gateway into each with one
 click, and can import a client's existing servers. It writes the config file shown
 below for you, so you never have to edit these by hand.
 
@@ -164,6 +164,7 @@ below for you, so you never have to edit these by hand.
 | Claude Desktop  | `<config>/Claude/claude_desktop_config.json`                                               | JSON (`mcpServers`)      |
 | Claude Code     | `~/.claude.json`                                                                           | JSON (`mcpServers`)      |
 | Cursor          | `~/.cursor/mcp.json`                                                                       | JSON (`mcpServers`)      |
+| Factory Droid   | `~/.factory/mcp.json`                                                                      | JSON (`mcpServers`)      |
 | VS Code         | `<config>/Code/User/mcp.json`                                                              | JSON (`servers`)         |
 | Windsurf        | `~/.codeium/windsurf/mcp_config.json`                                                      | JSON (`mcpServers`)      |
 | OpenCode        | `~/.config/opencode/opencode.json`                                                         | JSON (`mcp`)             |

--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ below for you, so you never have to edit these by hand.
 | Claude Desktop | `<config>/Claude/claude_desktop_config.json`                                               | JSON (`mcpServers`)      |
 | Claude Code    | `~/.claude.json`                                                                           | JSON (`mcpServers`)      |
 | Cursor         | `~/.cursor/mcp.json`                                                                       | JSON (`mcpServers`)      |
+| Factory Droid  | `~/.factory/mcp.json`                                                                      | JSON (`mcpServers`)      |
 | VS Code        | `<config>/Code/User/mcp.json`                                                              | JSON (`servers`)         |
 | Windsurf       | `~/.codeium/windsurf/mcp_config.json`                                                      | JSON (`mcpServers`)      |
 | OpenCode       | `~/.config/opencode/opencode.json`                                                         | JSON (`mcp`)             |

--- a/src-tauri/src/clients.rs
+++ b/src-tauri/src/clients.rs
@@ -245,6 +245,7 @@ fn resolve_client_config_path(
     let path = match client_id {
         "claude-desktop" => config.join("Claude").join("claude_desktop_config.json"),
         "cursor" => home.join(".cursor").join("mcp.json"),
+        "droid" => home.join(".factory").join("mcp.json"),
         "boltai" => home.join(".boltai").join("mcp.json"),
         "pi" => home.join(".pi").join("agent").join("mcp.json"),
         "omp" => home.join(".omp").join("agent").join("mcp.json"),
@@ -351,6 +352,7 @@ fn resolve_client_config_path_linux(client_id: &str, home: &std::path::Path) -> 
     let path = match client_id {
         "claude-desktop" => config.join("Claude").join("claude_desktop_config.json"),
         "cursor" => home.join(".cursor").join("mcp.json"),
+        "droid" => home.join(".factory").join("mcp.json"),
         "boltai" => home.join(".boltai").join("mcp.json"),
         "pi" => home.join(".pi").join("agent").join("mcp.json"),
         "omp" => home.join(".omp").join("agent").join("mcp.json"),
@@ -535,6 +537,10 @@ fn claude_desktop_path() -> Option<PathBuf> {
 
 fn cursor_path() -> Option<PathBuf> {
     client_config_path("cursor")
+}
+
+fn droid_path() -> Option<PathBuf> {
+    client_config_path("droid")
 }
 
 fn anythingllm_path() -> Option<PathBuf> {
@@ -877,6 +883,14 @@ fn defs() -> Vec<ClientDef> {
             uses_connectors: false,
             path: cursor_path,
             plugin_scan: Some(scan_cursor_plugins),
+        },
+        ClientDef {
+            id: "droid",
+            name: "Factory Droid",
+            format: Format::JsonMcpServers,
+            uses_connectors: false,
+            path: droid_path,
+            plugin_scan: None,
         },
         ClientDef {
             id: "anythingllm",
@@ -6075,10 +6089,10 @@ command = "npx"
 
     #[test]
     fn new_json_clients_are_registered() {
-        // Warp, Amazon Q, Kiro, LM Studio, Jan, AnythingLLM, and Witsy all use the
-        // standard mcpServers JSON shape, so a ClientDef + path is all they need.
-        // Lock in their registration, format, and that their config paths resolve
-        // on this OS.
+        // Warp, Amazon Q, Kiro, LM Studio, Jan, AnythingLLM, Witsy, and Factory Droid
+        // all use the standard mcpServers JSON shape, so a ClientDef + path is all
+        // they need. Lock in their registration, format, and that their config
+        // paths resolve on this OS.
         for id in [
             "warp",
             "amazon-q",
@@ -6087,6 +6101,7 @@ command = "npx"
             "jan",
             "anythingllm",
             "witsy",
+            "droid",
         ] {
             let d = defs()
                 .into_iter()
@@ -6619,6 +6634,7 @@ command = "npx"
     fn client_config_paths_are_stable_across_platforms() {
         let cases: &[(&str, fn(&Path, Platform) -> PathBuf)] = &[
             ("cursor", |home, _| home.join(".cursor").join("mcp.json")),
+            ("droid", |home, _| home.join(".factory").join("mcp.json")),
             ("grok", |home, _| home.join(".grok").join("config.toml")),
             ("toolport-studio", |home, _| {
                 home.join(".toolport-studio").join("mcp.json")

--- a/src-tauri/src/clients.rs
+++ b/src-tauri/src/clients.rs
@@ -581,8 +581,11 @@ fn resolve_crush_path(
         .unwrap_or_else(|| home.join(".config"))
         .join("crush")
         .join("crush.json")
-    }
+}
 
+/// Crush v0.88.0 resolves its global config through CRUSH_GLOBAL_CONFIG, then
+/// XDG_CONFIG_HOME, and finally ~/.config on every OS. Older Windows releases
+/// used LocalAppData, so retain that path only when it already contains a file.
 fn crush_path() -> Option<PathBuf> {
     let home = home()?;
     if let Some(path) = crush_override_path(std::env::var_os("CRUSH_GLOBAL_CONFIG")) {

--- a/src-tauri/src/clients.rs
+++ b/src-tauri/src/clients.rs
@@ -82,6 +82,9 @@ enum Format {
     /// GitHub Copilot CLI's `mcpServers` object. Entries use the standard JSON
     /// shape but require a `tools` allowlist; Toolport enables every gateway tool.
     JsonCopilotMcpServers,
+    /// Factory Droid's `mcpServers` object. Standard JSON shape, but every
+    /// entry requires a `"type"` field ("stdio" for local servers).
+    JsonDroidMcpServers,
     /// Amp's shared settings file stores servers under the literal dotted
     /// top-level key `amp.mcpServers` (not a nested `amp` object).
     JsonAmpMcpServers,
@@ -910,7 +913,7 @@ fn defs() -> Vec<ClientDef> {
         ClientDef {
             id: "droid",
             name: "Factory Droid",
-            format: Format::JsonMcpServers,
+            format: Format::JsonDroidMcpServers,
             uses_connectors: false,
             path: droid_path,
             plugin_scan: None,
@@ -2364,6 +2367,7 @@ fn read_client(def: &ClientDef) -> DetectedClient {
     let parsed = match def.format {
         Format::JsonMcpServers => parse_json(&content, "mcpServers"),
         Format::JsonCopilotMcpServers => parse_json(&content, "mcpServers"),
+        Format::JsonDroidMcpServers => parse_json(&content, "mcpServers"),
         Format::JsonAmpMcpServers => parse_json(&content, "amp.mcpServers"),
         Format::JsonQwenMcpServers => parse_qwen_json(&content),
         Format::JsonServers => parse_json(&content, "servers"),
@@ -2816,6 +2820,33 @@ fn write_json(
 
 fn write_copilot_json(path: &Path, servers: &[ServerEntry]) -> Result<(), String> {
     write_json_with_tools(path, "mcpServers", servers, false, true)
+}
+
+fn write_droid_json(path: &Path, servers: &[ServerEntry]) -> Result<(), String> {
+    let mut root = if path.exists() {
+        let content = read_config_file(path)?;
+        read_existing_json(&content, false)?
+    } else {
+        serde_json::Value::Object(serde_json::Map::new())
+    };
+    if !root.is_object() {
+        root = serde_json::Value::Object(serde_json::Map::new());
+    }
+    let obj = root.as_object_mut().unwrap();
+    let servers_map: serde_json::Map<String, serde_json::Value> = servers
+        .iter()
+        .map(|server| {
+            let mut value = entry_to_json(server);
+            value
+                .as_object_mut()
+                .unwrap()
+                .insert("type".into(), serde_json::json!("stdio"));
+            (server.name.clone(), value)
+        })
+        .collect();
+    obj.insert("mcpServers".to_string(), serde_json::Value::Object(servers_map));
+    let json = serde_json::to_string_pretty(&root).map_err(|e| e.to_string())?;
+    atomic_write(path, &json)
 }
 
 fn write_json_with_tools(
@@ -3532,6 +3563,7 @@ pub fn write_servers(client_id: &str, servers: &[ServerEntry]) -> Result<WriteOu
     match def.format {
         Format::JsonMcpServers => write_json(&path, "mcpServers", servers, lenient)?,
         Format::JsonCopilotMcpServers => write_copilot_json(&path, servers)?,
+        Format::JsonDroidMcpServers => write_droid_json(&path, servers)?,
         Format::JsonAmpMcpServers => write_json(&path, "amp.mcpServers", servers, true)?,
         Format::JsonQwenMcpServers => write_qwen_json(&path, servers)?,
         Format::JsonServers => write_json(&path, "servers", servers, lenient)?,
@@ -3735,6 +3767,7 @@ pub fn client_uses_mcp_remote_bridge(client_id: &str) -> bool {
         // Native remote shapes already exist in our writers.
         Format::JsonQwenMcpServers
         | Format::JsonCopilotMcpServers
+        | Format::JsonDroidMcpServers
         | Format::JsonOpenCodeMcp
         | Format::JsonServers
         | Format::YamlMcpServers
@@ -3823,6 +3856,26 @@ fn edit_json_gateway(
 
 fn edit_copilot_json_gateway(path: &Path, entry: Option<&ServerEntry>) -> Result<(), String> {
     edit_json_gateway_with_tools(path, "mcpServers", entry, false, true)
+}
+
+fn edit_droid_json_gateway(path: &Path, entry: Option<&ServerEntry>) -> Result<(), String> {
+    edit_json_gateway(&path, "mcpServers", entry, false)?;
+    let Some(entry) = entry else { return Ok(()) };
+    let content = read_config_file(path)?;
+    let mut root = read_existing_json(&content, false)?;
+    let obj = root.as_object_mut().ok_or("Droid config root must be an object")?;
+    let servers = obj
+        .get_mut("mcpServers")
+        .and_then(|v| v.as_object_mut())
+        .ok_or("missing mcpServers after write")?;
+    if let Some(value) = servers.get_mut(&entry.name) {
+        value
+            .as_object_mut()
+            .unwrap()
+            .insert("type".into(), serde_json::json!("stdio"));
+    }
+    let json = serde_json::to_string_pretty(&root).map_err(|e| e.to_string())?;
+    atomic_write(path, &json)
 }
 
 fn edit_json_gateway_with_tools(
@@ -3975,6 +4028,7 @@ fn install_or_remove(
             edit_json_gateway(&path, "mcpServers", entry, lenient)?
         }
         Format::JsonCopilotMcpServers => edit_copilot_json_gateway(&path, entry)?,
+        Format::JsonDroidMcpServers => edit_droid_json_gateway(&path, entry)?,
         Format::JsonAmpMcpServers => {
             edit_json_gateway(&path, "amp.mcpServers", entry, true)?
         }
@@ -6292,7 +6346,6 @@ command = "npx"
             "jan",
             "anythingllm",
             "witsy",
-            "droid",
             "junie",
         ] {
             let d = defs()

--- a/src-tauri/src/clients.rs
+++ b/src-tauri/src/clients.rs
@@ -5005,6 +5005,50 @@ bad = "not-a-table"
     }
 
     #[test]
+    fn droid_install_preserves_existing_factory_server() {
+        let path = temp_path("droid-install-json");
+        std::fs::write(
+            &path,
+            r#"{"mcpServers":{"filesystem":{"command":"npx","args":["-y","@modelcontextprotocol/server-filesystem"],"env":{"HOME":"/home/user"}}}}"#,
+        )
+        .unwrap();
+
+        // Install: gateway entry added, existing Factory server untouched.
+        {
+            let entry = sample_gateway(Some("Work"), "droid");
+            edit_json_gateway(&path, "mcpServers", Some(&entry), false)
+        }
+        .unwrap();
+        let root: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        let servers = root["mcpServers"].as_object().unwrap();
+        assert!(servers.contains_key(GATEWAY_ENTRY_NAME));
+        assert!(servers.contains_key("filesystem"));
+        assert_eq!(
+            servers["filesystem"]["env"]["HOME"],
+            "/home/user"
+        );
+        assert_eq!(
+            servers[GATEWAY_ENTRY_NAME]["env"][crate::brand::PROFILE],
+            "Work"
+        );
+
+        // Uninstall: gateway entry removed, existing Factory server still untouched.
+        edit_json_gateway(&path, "mcpServers", None, false).unwrap();
+        let root2: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        let servers2 = root2["mcpServers"].as_object().unwrap();
+        assert!(!servers2.contains_key(GATEWAY_ENTRY_NAME));
+        assert!(servers2.contains_key("filesystem"));
+        assert_eq!(
+            servers2["filesystem"]["args"],
+            serde_json::json!(["-y", "@modelcontextprotocol/server-filesystem"])
+        );
+
+        std::fs::remove_file(&path).ok();
+    }
+
+    #[test]
     fn shared_http_bridge_entry_for_claude_desktop() {
         // Claude Desktop has no native remote MCP shape; Shared HTTP writes mcp-remote.
         let spec = SharedHttpSpec {


### PR DESCRIPTION
 ## What and why

Adds support for the Factory Droid CLI as a supported MCP client.

Factory Droid stores user-level MCP servers in `~/.factory/mcp.json` using the standard top-level `mcpServers` JSON shape, so it can reuse the existing `JsonMcpServers` format without introducing any new parser logic.

This change adds:

- config path resolution for `~/.factory/mcp.json`
- `droid_path()` helper
- `ClientDef` registration
- registration and path stability tests
- README supported clients entry and client count update

Fixes #369.

## Testing

- [ ] `npm run build` passes
- [ ] `npm run test` passes

## Notes

- The implementation follows the official Factory Droid CLI documentation for the user-level MCP configuration path and format.
- I was not able to verify this against a real Factory Droid installation because I do not have it installed and don't have sufficient disk space to install and test it locally.
- No new parser or `Format` variant was required because Factory Droid uses the existing `mcpServers` JSON schema.