### PR TITLE
fix(a11y): expose sidebar and toggle states

### DIFF
--- a/src/components/AppSidebar.test.tsx
+++ b/src/components/AppSidebar.test.tsx
@@ -1,0 +1,110 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
+
+import { TooltipProvider } from "@/components/ui/tooltip";
+import type { DetectedClient } from "@/lib/types";
+import { AppSidebar } from "./AppSidebar";
+
+const getSavingsSummary = vi.fn();
+const listQuarantined = vi.fn();
+
+vi.mock("@/lib/api", () => ({
+  gatherDiagnostics: vi.fn(),
+  getSavingsSummary: (...args: unknown[]) => getSavingsSummary(...args),
+  listQuarantined: (...args: unknown[]) => listQuarantined(...args),
+  openDataDir: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/api/app", () => ({
+  getVersion: vi.fn().mockResolvedValue("1.0.0"),
+}));
+
+vi.mock("@/lib/updater", () => ({
+  checkForUpdate: vi.fn().mockResolvedValue({ kind: "current" }),
+  installUpdate: vi.fn(),
+}));
+
+vi.mock("@/components/ShareDialog", () => ({
+  ShareDialog: ({ trigger }: { trigger: ReactNode }) => trigger,
+}));
+
+function client(overrides: Partial<DetectedClient> = {}): DetectedClient {
+  return {
+    id: "cursor",
+    name: "Cursor",
+    usesConnectors: false,
+    configPath: "/tmp/cursor.json",
+    configExists: true,
+    appPresent: true,
+    servers: [],
+    pluginServers: [],
+    gatewayInstalled: false,
+    entryState: "absent",
+    error: null,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  getSavingsSummary.mockReset();
+  listQuarantined.mockReset();
+  getSavingsSummary.mockResolvedValue({
+    tokensSaved: 0,
+    listLoads: 0,
+    peakCatalog: 0,
+    sinceTs: 0,
+  });
+  listQuarantined.mockResolvedValue([]);
+});
+
+describe("AppSidebar accessibility", () => {
+  it("names both navigation landmarks and exposes client selection state", () => {
+    render(
+      <TooltipProvider>
+        <AppSidebar
+          clients={[client()]}
+          registry={null}
+          onRegistryChange={vi.fn()}
+          selectedClientId="cursor"
+          onSelectClient={vi.fn()}
+          view="servers"
+          onSelectView={vi.fn()}
+          onReplayOnboarding={vi.fn()}
+        />
+      </TooltipProvider>,
+    );
+
+    expect(screen.getByRole("navigation", { name: "Views" })).toBeInTheDocument();
+    expect(screen.getByRole("navigation", { name: "Clients" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /cursor/i })).toHaveAttribute(
+      "aria-current",
+      "page",
+    );
+  });
+
+  it("exposes whether the not-detected client list is expanded", async () => {
+    render(
+      <TooltipProvider>
+        <AppSidebar
+          clients={[client(), client({ id: "zed", name: "Zed", appPresent: false })]}
+          registry={null}
+          onRegistryChange={vi.fn()}
+          selectedClientId={null}
+          onSelectClient={vi.fn()}
+          view="servers"
+          onSelectView={vi.fn()}
+          onReplayOnboarding={vi.fn()}
+        />
+      </TooltipProvider>,
+    );
+
+    const toggle = screen.getByRole("button", { name: /not detected/i });
+    expect(toggle).toHaveAttribute("aria-expanded", "false");
+
+    await userEvent.click(toggle);
+    expect(toggle).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByRole("button", { name: /zed/i })).toBeInTheDocument();
+  });
+});

--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -335,6 +335,7 @@ function ClientRow({ client, importCount, selected, onSelect }: RowProps) {
       <TooltipTrigger asChild>
         <button
           onClick={onSelect}
+          aria-current={selected ? "page" : undefined}
           className={`${NAV_ITEM} ${selected ? "bg-accent" : ""} ${
             missing ? "opacity-50" : ""
           }`}
@@ -573,7 +574,7 @@ export function AppSidebar({
           <div className="px-2.5 pb-1.5 text-xs font-medium tracking-wide text-muted-foreground uppercase">
             Clients
           </div>
-          <nav className="flex flex-col gap-0.5">
+          <nav aria-label="Clients" className="flex flex-col gap-0.5">
             {clients.length === 0 ? (
               <p className="px-2.5 py-1.5 text-xs text-muted-foreground">
                 No MCP clients found. Install Claude Desktop, Cursor, or another supported
@@ -594,6 +595,7 @@ export function AppSidebar({
                   <>
                     <button
                       onClick={() => setShowMissing((v) => !v)}
+                      aria-expanded={showMissing}
                       className={`mt-1 flex w-full items-center gap-2 rounded-md px-2.5 py-1.5 text-left text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-foreground ${FOCUS_RING}`}
                     >
                       <ChevronRight

--- a/src/components/ImportReviewDialog.test.tsx
+++ b/src/components/ImportReviewDialog.test.tsx
@@ -60,6 +60,15 @@ describe("ImportReviewDialog", () => {
     expect(new Set(onConfirm.mock.calls[0][0])).toEqual(new Set(["a", "b", "c"]));
   });
 
+  it("exposes each server row as a pressed toggle", async () => {
+    renderDialog();
+    const stripe = screen.getByRole("button", { name: /stripe/i });
+
+    expect(stripe).toHaveAttribute("aria-pressed", "true");
+    await userEvent.click(stripe);
+    expect(stripe).toHaveAttribute("aria-pressed", "false");
+  });
+
   it("excludes a server from the confirm payload after it's deselected", async () => {
     const { onConfirm } = renderDialog();
     // Toggle "linear" off by clicking its row.

--- a/src/components/ImportReviewDialog.tsx
+++ b/src/components/ImportReviewDialog.tsx
@@ -73,6 +73,7 @@ function ImportReviewContent({
               <button
                 key={key}
                 type="button"
+                aria-pressed={isSelected}
                 className={`rounded-md text-left transition-colors ${
                   isSelected ? "ring-1 ring-success/60" : "opacity-60"
                 }`}

--- a/src/components/SettingsView.test.tsx
+++ b/src/components/SettingsView.test.tsx
@@ -94,11 +94,13 @@ describe("SettingsView tool loading", () => {
     );
 
     // Expand GitHub (request A starts).
-    await user.click(
-      screen.getByRole("button", {
-        name: /github/i,
-      }),
-    );
+    const githubToggle = screen.getByRole("button", {
+      name: /github/i,
+    });
+    expect(githubToggle).toHaveAttribute("type", "button");
+    expect(githubToggle).toHaveAttribute("aria-expanded", "false");
+    await user.click(githubToggle);
+    expect(githubToggle).toHaveAttribute("aria-expanded", "true");
 
     expect(screen.getByText("Loading tools…")).toBeInTheDocument();
 

--- a/src/components/SettingsView.tsx
+++ b/src/components/SettingsView.tsx
@@ -472,7 +472,9 @@ function ProfileToolScope({
         return (
           <div key={serverId} className="rounded border border-border/50 bg-muted/10">
             <button
+              type="button"
               onClick={() => expand(serverId)}
+              aria-expanded={open}
               className="flex w-full items-center gap-2 px-2 py-1.5 text-xs hover:bg-muted/30"
             >
               <ChevronRight

--- a/src/components/TransportPill.test.tsx
+++ b/src/components/TransportPill.test.tsx
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import { TransportPill } from "./TransportPill";
+
+describe("TransportPill", () => {
+  it("exposes its visible transport label to assistive technology", () => {
+    render(<TransportPill transport="stdio" />);
+
+    expect(screen.getByRole("img", { name: "Transport: stdio" })).toBeInTheDocument();
+  });
+});

--- a/src/components/TransportPill.tsx
+++ b/src/components/TransportPill.tsx
@@ -16,6 +16,7 @@ export function TransportPill({ transport }: { transport: Transport }) {
   const Icon = m.icon;
   return (
     <span
+      role="img"
       aria-label={`Transport: ${m.label}`}
       className="inline-flex items-center gap-1 font-mono text-2xs text-muted-foreground"
     >


### PR DESCRIPTION
## What and why

Adds the missing accessibility semantics identified in #531:

- Gives the transport pill a valid labelled role.
- Exposes import-row selection with `aria-pressed`.
- Exposes selected clients with `aria-current`.
- Labels the Clients navigation landmark.
- Exposes both collapsible sections with `aria-expanded`.
- Prevents the settings collapser from implicitly submitting forms.

These are semantic-only changes; visual behavior is unchanged.

Closes #531.

## Testing

- [x] `npm run format:check`
- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm run test`
- [x] `npm run audit:prod`
- [ ] Ran the app (`npm run tauri dev`) and checked the change by hand

Added focused tests covering accessible labels, selection state, current client
state, navigation labels, and expanded/collapsed state.

## Notes

No secrets, personal paths, or unrelated changes are included.