### PR TITLE
fix: fail closed on corrupt integrity pins

### DIFF
--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -4955,8 +4955,15 @@ fn build_router(
         // On store failure, start with empty blocked and log loudly (SOU-320): there is
         // no prior live set yet. We deliberately do NOT rename/clear a corrupt file —
         // that would make the next reconcile install a permanent empty set.
-        quarantined: if reg.quarantine_on_drift_effective() {
-            match integrity::quarantined(profile) {
+        quarantined: {
+            let stored = if reg.quarantine_on_drift_effective() {
+                integrity::quarantined(profile)
+            } else {
+                // Baseline tamper invalidates the catalog's trust root, so those entries
+                // remain blocked even when optional high-risk drift quarantine is off.
+                integrity::mandatory_quarantined(profile)
+            };
+            match stored {
                 Ok(set) => set,
                 Err(e) => {
                     glog(&format!(
@@ -4967,8 +4974,6 @@ fn build_router(
                     Default::default()
                 }
             }
-        } else {
-            Default::default()
         },
     };
 
@@ -5783,9 +5788,10 @@ fn cleanup_resource_subs_for_session(state: &GatewayState, session: &str) {
 /// Run tool-definition integrity detection on a freshly built catalog (gated by
 /// the registry's `integrity_check`, on by default). Any drift is recorded to the
 /// security log inside `integrity::check`; here we also surface it in the gateway
-/// log so it's visible in "Copy diagnostics". Detection only, never blocks.
-/// Returns true if a high-risk drift was just quarantined (so the caller should
-/// re-filter the router this cycle).
+/// log so it's visible in "Copy diagnostics". Ordinary drift blocks only when its
+/// policy is enabled; baseline loss always blocks because the trust root is gone.
+/// Returns true if tools were just quarantined (so the caller should re-filter the
+/// router this cycle).
 fn maybe_check_integrity(
     registry: &Arc<Mutex<Registry>>,
     tools: &[Value],
@@ -5810,8 +5816,10 @@ fn maybe_check_integrity(
         ));
         eprintln!("toolport: SECURITY tool drift ({change}) {tool}");
     }
-    // Block high-risk drift (poisoned / destructive) until re-approved, when enabled.
-    quarantine_on && integrity::apply_quarantine(profile, tools, &events)
+    // Ordinary high-risk drift follows the user's setting. A lost baseline is mandatory:
+    // no setting may turn destruction of the trust root into a fail-open catalog.
+    (quarantine_on || integrity::baseline_tamper_detected(&events))
+        && integrity::apply_quarantine(profile, tools, &events)
 }
 
 /// Run integrity detection on a freshly built catalog; if a high-risk drift was just
@@ -5861,10 +5869,12 @@ fn effective_quarantine(
             .unwrap_or_else(std::sync::PoisonError::into_inner);
         r.quarantine_on_drift_effective()
     };
-    if !on {
-        return Some(BTreeSet::new());
-    }
-    match integrity::quarantined_checked(profile) {
+    let stored = if on {
+        integrity::quarantined_checked(profile)
+    } else {
+        integrity::mandatory_quarantined_checked(profile)
+    };
+    match stored {
         Ok(set) => {
             // Recovered: let a future failure warn again.
             QUARANTINE_READ_FAILED.store(false, Ordering::SeqCst);
@@ -14290,11 +14300,17 @@ mod tests {
     }
 
     #[test]
-    fn effective_quarantine_is_empty_while_the_feature_is_off() {
-        // Mirrors how the initial router build gates: the persisted set stays on disk so
-        // it can be restored when the feature is switched back on, but while
-        // quarantine-on-drift is OFF nothing may be enforced. The off branch returns
-        // without reading a profile file, so this stays independent of conduit_dir().
+    fn effective_quarantine_is_empty_without_mandatory_entries_while_feature_is_off() {
+        // Ordinary drift entries stay dormant while quarantine-on-drift is off. With no
+        // baseline-tamper entries persisted, the effective set is still known-empty.
+        let _env = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let dir = std::env::temp_dir().join(format!(
+            "toolport-empty-mandatory-q-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let _data_dir = conduit_lib::registry::DataDirOverride::set(&dir);
         let mut reg = Registry::default();
         reg.quarantine_on_drift = false;
         assert!(
@@ -14306,6 +14322,44 @@ mod tests {
             effective_quarantine(&registry, Some("unused-profile")),
             Some(BTreeSet::new()),
             "feature off is a known-empty set, not an unknown one"
+        );
+    }
+
+    #[test]
+    fn baseline_tamper_is_quarantined_while_optional_drift_policy_is_off() {
+        let _env = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let dir = std::env::temp_dir().join(format!(
+            "toolport-mandatory-q-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let _data_dir = conduit_lib::registry::DataDirOverride::set(&dir);
+
+        let profile = Some("baseline-tamper");
+        std::fs::write(
+            dir.join("tool-pins-baseline-tamper.json"),
+            "{ corrupt baseline",
+        )
+        .unwrap();
+        let tools = vec![json!({
+            "name": "srv__read",
+            "description": "Read records.",
+            "inputSchema": {"type": "object"}
+        })];
+
+        let mut reg = Registry::default();
+        reg.integrity_check = true;
+        reg.quarantine_on_drift = false;
+        let registry = Arc::new(Mutex::new(reg));
+        assert!(
+            maybe_check_integrity(&registry, &tools, profile),
+            "lost baseline must create a quarantine even with optional drift blocking off"
+        );
+        assert_eq!(
+            effective_quarantine(&registry, profile),
+            Some(BTreeSet::from(["srv__read".to_string()])),
+            "baseline-tamper quarantine is mandatory"
         );
     }
 

--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -1926,9 +1926,17 @@ fn release_quarantine(
         Some(profile.as_str())
     };
     if !integrity::release(prof, &tool) {
-        return Err(format!(
-            "Could not re-approve {tool}; its quarantine record or integrity pin could not be updated"
-        ));
+        // Idempotent across app/gateway instances: another process may have released the
+        // same tool after this UI last polled. Only report failure when the persisted store
+        // still says it is blocked (or cannot be read), which also preserves the useful
+        // error for a tamper release whose accepted pin could not be saved.
+        let still_blocked = integrity::quarantined(prof)
+            .map_err(|e| format!("Could not verify re-approval for {tool}: {e}"))?;
+        if still_blocked.contains(&tool) {
+            return Err(format!(
+                "Could not re-approve {tool}; its quarantine record or integrity pin could not be updated"
+            ));
+        }
     }
     // The quarantine release lives in the separate tool-pins file; the former blind re-save
     // here was only a gateway mtime-nudge (which the no-op guard usually swallowed anyway)

--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -1925,7 +1925,11 @@ fn release_quarantine(
     } else {
         Some(profile.as_str())
     };
-    integrity::release(prof, &tool);
+    if !integrity::release(prof, &tool) {
+        return Err(format!(
+            "Could not re-approve {tool}; its quarantine record or integrity pin could not be updated"
+        ));
+    }
     // The quarantine release lives in the separate tool-pins file; the former blind re-save
     // here was only a gateway mtime-nudge (which the no-op guard usually swallowed anyway)
     // and it could revert a concurrent gateway/team write (SOU-23). Refresh the cache

--- a/src-tauri/src/integrity.rs
+++ b/src-tauri/src/integrity.rs
@@ -34,6 +34,7 @@ struct QuarantineReadCache {
     mtime: SystemTime,
     len: u64,
     set: BTreeSet<String>,
+    mandatory: BTreeSet<String>,
 }
 
 static QUARANTINE_READ_CACHE: Mutex<Option<QuarantineReadCache>> = Mutex::new(None);
@@ -330,12 +331,14 @@ fn load_pins(profile: Option<&str>) -> PinsLoad {
     PinsLoad::Corrupt
 }
 
-fn save_pins(profile: Option<&str>, pins: &Pins) {
-    if let Some(path) = pins_path(profile) {
-        if let Ok(s) = serde_json::to_string(pins) {
-            let _ = crate::registry::atomic_write(&path, &s);
-        }
-    }
+fn save_pins(profile: Option<&str>, pins: &Pins) -> bool {
+    let Some(path) = pins_path(profile) else {
+        return false;
+    };
+    let Ok(s) = serde_json::to_string(pins) else {
+        return false;
+    };
+    crate::registry::atomic_write(&path, &s).is_ok()
 }
 
 /// Run a load-modify-save of an on-disk integrity store while holding the cross-process lock
@@ -371,11 +374,12 @@ fn check_inner(profile: Option<&str>, current: &[Value]) -> Vec<Value> {
         PinsLoad::Loaded(p) => p,
         PinsLoad::Fresh => Pins::new(),
         PinsLoad::Corrupt => {
-            // The baseline existed but couldn't be loaded. Silently re-baselining
-            // would reset all drift detection, which is exactly what an attacker who
-            // can touch the config dir wants, so surface it loudly instead.
-            events.push(pins_tamper_event());
-            Pins::new()
+            // Freeze instead of treating a lost baseline as first run. The tamper event
+            // drives mandatory quarantine of the live catalog; re-approving a captured
+            // tool establishes its pin before the router exposes it again.
+            let event = pins_tamper_event();
+            record_event(&event);
+            return vec![event];
         }
     };
     // Servers we've already established a baseline for.
@@ -458,7 +462,7 @@ fn check_inner(profile: Option<&str>, current: &[Value]) -> Vec<Value> {
         );
     }
     if updated != pins {
-        save_pins(profile, &updated);
+        let _ = save_pins(profile, &updated);
     }
 
     for e in &events {
@@ -598,9 +602,10 @@ pub fn all_quarantined_names() -> BTreeSet<String> {
 
 // ===== Quarantine: block high-risk tools after a drift until re-approved =====
 //
-// `check` is detection-only and re-baselines as it goes, so quarantine keeps its own
-// persistent set of blocked tools (per profile, beside the pin baseline). The router's
-// tool-exposure policy hides anything in this set; re-approval removes it.
+// Ordinary drift checks re-baseline as they go, so quarantine keeps its own persistent
+// set of blocked tools (per profile, beside the pin baseline). Baseline loss is different:
+// `check` freezes, every live tool is quarantined, and re-approval pins the captured
+// definition before removing its block.
 
 /// Quarantine map: namespaced tool name (`server__tool`) -> a record of why it's
 /// blocked (server, tool, reason, ts), shown in the UI and persisted across restarts.
@@ -669,16 +674,44 @@ pub fn quarantined_checked(profile: Option<&str>) -> Result<BTreeSet<String>, St
     quarantined_checked_at(&path)
 }
 
+/// Tools quarantined because the integrity baseline itself was lost. Unlike ordinary
+/// high-risk drift quarantine, these entries are always enforced: disabling the optional
+/// drift policy must not turn a corrupt baseline into a fail-open catalog.
+pub fn mandatory_quarantined(profile: Option<&str>) -> Result<BTreeSet<String>, String> {
+    Ok(mandatory_quarantine_set(&load_quarantine(profile)?))
+}
+
+/// Cached enforcement read for [`mandatory_quarantined`], used by the gateway watcher.
+pub fn mandatory_quarantined_checked(profile: Option<&str>) -> Result<BTreeSet<String>, String> {
+    let Some(path) = quarantine_path(profile) else {
+        return Ok(BTreeSet::new());
+    };
+    Ok(quarantined_sets_checked_at(&path)?.1)
+}
+
+fn mandatory_quarantine_set(q: &Quarantine) -> BTreeSet<String> {
+    q.iter()
+        .filter(|(_, record)| record.get("change").and_then(Value::as_str) == Some("tamper"))
+        .map(|(tool, _)| tool.clone())
+        .collect()
+}
+
 /// Path-level read used by [`quarantined_checked`]. Separated so the mtime/len
 /// pre-filter (SOU-303) and fail-closed parse sit in one place.
 fn quarantined_checked_at(path: &Path) -> Result<BTreeSet<String>, String> {
+    Ok(quarantined_sets_checked_at(path)?.0)
+}
+
+fn quarantined_sets_checked_at(
+    path: &Path,
+) -> Result<(BTreeSet<String>, BTreeSet<String>), String> {
     let meta = match std::fs::metadata(path) {
         Ok(m) => m,
         // Missing is the normal first-run state: nothing quarantined yet.
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
             // Drop a stale hit for this path so a later recreate is re-parsed.
             clear_quarantine_read_cache_for(path);
-            return Ok(BTreeSet::new());
+            return Ok((BTreeSet::new(), BTreeSet::new()));
         }
         Err(e) => return Err(format!("quarantine store at {path:?} is unreadable: {e}")),
     };
@@ -698,7 +731,7 @@ fn quarantined_checked_at(path: &Path) -> Result<BTreeSet<String>, String> {
             .unwrap_or_else(std::sync::PoisonError::into_inner);
         if let Some(c) = cache.as_ref() {
             if c.path == path && c.mtime == mtime && c.len == len {
-                return Ok(c.set.clone());
+                return Ok((c.set.clone(), c.mandatory.clone()));
             }
         }
     }
@@ -711,12 +744,14 @@ fn quarantined_checked_at(path: &Path) -> Result<BTreeSet<String>, String> {
         // Race: file vanished between metadata and open — treat as empty.
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
             clear_quarantine_read_cache_for(path);
-            return Ok(BTreeSet::new());
+            return Ok((BTreeSet::new(), BTreeSet::new()));
         }
         Err(e) => return Err(format!("quarantine store at {path:?} is unreadable: {e}")),
     };
     // Fail closed: do not cache a corrupt parse, do not return empty, do not rename.
-    let set: BTreeSet<String> = parse_quarantine_raw(&raw, path)?.into_keys().collect();
+    let records = parse_quarantine_raw(&raw, path)?;
+    let mandatory = mandatory_quarantine_set(&records);
+    let set: BTreeSet<String> = records.into_keys().collect();
 
     *QUARANTINE_READ_CACHE
         .lock()
@@ -725,8 +760,9 @@ fn quarantined_checked_at(path: &Path) -> Result<BTreeSet<String>, String> {
         mtime,
         len,
         set: set.clone(),
+        mandatory: mandatory.clone(),
     });
-    Ok(set)
+    Ok((set, mandatory))
 }
 
 fn clear_quarantine_read_cache_for(path: &Path) {
@@ -789,8 +825,9 @@ pub fn all_quarantined() -> Vec<Value> {
 }
 
 /// Re-approve a quarantined tool: drop it so the gateway re-exposes it on the next
-/// rebuild. `check` has already re-baselined the current definition, so a re-approved
-/// tool won't immediately re-flag. Returns whether the tool was actually quarantined.
+/// rebuild. Ordinary drift was already re-baselined by `check`; after baseline tamper,
+/// this first saves the definition captured while the tool was blocked. Returns whether
+/// the tool was actually quarantined.
 pub fn release(profile: Option<&str>, tool: &str) -> bool {
     let Some(path) = quarantine_path(profile) else { return false };
     // Under the cross-process lock so a concurrent gateway's quarantine write can't clobber this
@@ -805,6 +842,48 @@ pub fn release(profile: Option<&str>, tool: &str) -> bool {
                 return false;
             }
         };
+        let Some(record) = q.get(tool).cloned() else {
+            return false;
+        };
+        if record.get("change").and_then(Value::as_str) == Some("tamper") {
+            // The baseline was deliberately left corrupt. Establish the exact definition
+            // captured when this tool was quarantined before removing the router block, so
+            // re-approval cannot create a window where an unpinned tool is exposed.
+            let Some(mut pending) = record
+                .get("pending_pin")
+                .cloned()
+                .and_then(|v| serde_json::from_value::<Pin>(v).ok())
+            else {
+                eprintln!(
+                    "toolport: refusing to release {tool}; the tamper quarantine has no valid captured pin"
+                );
+                return false;
+            };
+            let stamp = epoch_millis();
+            if pending.first_seen == 0 {
+                pending.first_seen = stamp;
+            }
+            if pending.last_changed == 0 {
+                pending.last_changed = stamp;
+            }
+            let Some(pin_path) = pins_path(profile) else {
+                return false;
+            };
+            let saved = with_store_lock(&pin_path, || {
+                let mut pins = match load_pins(profile) {
+                    PinsLoad::Loaded(p) => p,
+                    PinsLoad::Fresh | PinsLoad::Corrupt => Pins::new(),
+                };
+                pins.insert(tool.to_string(), pending);
+                save_pins(profile, &pins)
+            });
+            if !saved {
+                eprintln!(
+                    "toolport: refusing to release {tool}; its accepted pin could not be saved"
+                );
+                return false;
+            }
+        }
         if q.remove(tool).is_some() {
             save_quarantine(profile, &q);
             return true;
@@ -837,6 +916,49 @@ fn apply_quarantine_inner(profile: Option<&str>, current: &[Value], events: &[Va
         }
     };
     let mut added = false;
+
+    // A corrupt baseline invalidates every trust decision in the current catalog. This
+    // path is mandatory (the gateway invokes it even when ordinary drift quarantine is
+    // disabled) and captures each definition so a later explicit re-approval can pin it
+    // before exposure. Existing ordinary quarantine records are upgraded to tamper records
+    // so their release cannot bypass baseline repair.
+    if baseline_tamper_detected(events) {
+        for tool in current {
+            let Some(name) = tool.get("name").and_then(Value::as_str) else {
+                continue;
+            };
+            let pending = pin_of(tool);
+            let already_current = q.get(name).is_some_and(|record| {
+                record.get("change").and_then(Value::as_str) == Some("tamper")
+                    && record
+                        .get("pending_pin")
+                        .cloned()
+                        .and_then(|v| serde_json::from_value::<Pin>(v).ok())
+                        .as_ref()
+                        == Some(&pending)
+            });
+            if already_current {
+                continue;
+            }
+            q.insert(
+                name.to_string(),
+                json!({
+                    "ts": epoch_millis(),
+                    "server": server_of(name),
+                    "tool": name,
+                    "reason": "the integrity baseline was corrupt or tampered with",
+                    "change": "tamper",
+                    "pending_pin": pending,
+                }),
+            );
+            added = true;
+        }
+        if added {
+            save_quarantine(profile, &q);
+        }
+        return added;
+    }
+
     for e in events {
         let (Some(tool), Some(change)) = (
             e.get("tool").and_then(Value::as_str),
@@ -1664,6 +1786,16 @@ fn pins_tamper_event() -> Value {
     })
 }
 
+/// Whether integrity checking reported a lost pin baseline. The gateway uses this to
+/// enforce quarantine independently of the optional quarantine-on-drift setting.
+pub fn baseline_tamper_detected(events: &[Value]) -> bool {
+    events.iter().any(|event| {
+        event.get("type").and_then(Value::as_str) == Some("pins_load_failed")
+            && event.get("change").and_then(Value::as_str) == Some("tamper")
+            && event.get("severity").and_then(Value::as_str) == Some(SEV_HIGH)
+    })
+}
+
 /// A tool-definition drift event tagged with its `severity` (`high` = loud/actionable,
 /// `info` = benign churn for the quiet history). See `drift_severity`.
 fn event(server: &str, tool: &str, change: &str, severity: &str) -> Value {
@@ -2178,6 +2310,70 @@ mod tests {
         assert!(matches!(load_pins(profile), PinsLoad::Loaded(_)), "valid pins load");
 
         let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn corrupt_pins_freeze_and_require_reapproval_before_exposure() {
+        let _data_dir_lock = crate::registry::data_dir_test_lock();
+        let _data_dir = TestDataDir::new("corrupt-pins-fail-closed");
+        let profile = Some("corrupt-pins-fail-closed-unit");
+        let path = pins_path(profile).expect("profile path");
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(&path, "{ attacker truncated the baseline").unwrap();
+
+        let current = vec![
+            tool("alpha__read", "Read records."),
+            tool("beta__write", "Write records."),
+        ];
+        let events = check(profile, &current);
+        assert!(baseline_tamper_detected(&events));
+        assert_eq!(events.len(), 1, "drift checks freeze at the lost trust root");
+        assert_eq!(
+            std::fs::read_to_string(&path).unwrap(),
+            "{ attacker truncated the baseline",
+            "check must not replace the corrupt baseline with the live catalog"
+        );
+
+        assert!(apply_quarantine(profile, &current, &events));
+        let blocked = quarantined(profile).expect("quarantine readable");
+        assert_eq!(
+            blocked,
+            BTreeSet::from(["alpha__read".to_string(), "beta__write".to_string()])
+        );
+        assert_eq!(mandatory_quarantined(profile).unwrap(), blocked);
+
+        let records = load_quarantine(profile).expect("quarantine records");
+        for name in ["alpha__read", "beta__write"] {
+            let record = &records[name];
+            assert_eq!(record["change"], "tamper");
+            assert!(record.get("pending_pin").is_some(), "{name} captured before approval");
+        }
+
+        // If the blocked catalog refreshes while the baseline is still frozen, approval
+        // must bind to the latest observed definition rather than the first stale capture.
+        let refreshed = vec![
+            tool("alpha__read", "Read records with filters."),
+            tool("beta__write", "Write records."),
+        ];
+        let refreshed_events = check(profile, &refreshed);
+        assert!(apply_quarantine(profile, &refreshed, &refreshed_events));
+
+        assert!(release(profile, "alpha__read"));
+        let PinsLoad::Loaded(repaired) = load_pins(profile) else {
+            panic!("re-approval must establish a readable baseline")
+        };
+        assert_eq!(
+            repaired["alpha__read"].fp,
+            pin_of(&refreshed[0]).fp,
+            "re-approval pins the latest definition observed while blocked"
+        );
+        assert!(
+            !repaired.contains_key("beta__write"),
+            "an unreleased tool is not accepted by the release operation"
+        );
+        let still_blocked = mandatory_quarantined(profile).unwrap();
+        assert!(!still_blocked.contains("alpha__read"));
+        assert!(still_blocked.contains("beta__write"));
     }
 
     #[test]

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -288,7 +288,8 @@ export function setBlockOnInjection(on: boolean): Promise<Registry> {
   return invoke<Registry>("set_block_on_injection", { on });
 }
 
-/** A tool blocked after a high-risk drift, awaiting re-approval. */
+/** A tool blocked after high-risk drift or loss of the integrity baseline,
+ * awaiting re-approval. */
 export interface QuarantinedTool {
   server: string;
   tool: string;
@@ -303,7 +304,8 @@ export interface QuarantinedTool {
   new_dh?: boolean | null;
 }
 
-/** Tools currently quarantined (blocked after a high-risk drift), across profiles. */
+/** Tools currently quarantined after high-risk drift or baseline loss,
+ * across profiles. */
 export function listQuarantined(): Promise<QuarantinedTool[]> {
   return invoke<QuarantinedTool[]>("list_quarantined");
 }


### PR DESCRIPTION
## What

- freeze integrity checks when an existing pin baseline is unreadable instead of rebuilding it from the live catalog
- quarantine every live tool after baseline tamper, even when optional drift quarantine is disabled
- capture the latest blocked definition and persist its pin before a user re-approves that tool
- surface re-approval persistence failures to the desktop UI

## Why

A corrupt `tool-pins*.json` was reported loudly but then treated as an empty first-run baseline. The same check saved the current catalog as trusted, silently resetting drift protection. The tamper event also lacked a tool name, so the existing quarantine path ignored it.

## Impact

Baseline loss now fails closed. Tools remain hidden across refreshes and restarts until individually re-approved, while ordinary quarantine policy behavior is unchanged.

## Validation

- `cargo test --manifest-path src-tauri/Cargo.toml --lib integrity::tests` (41 passed)
- `cargo test --manifest-path src-tauri/Cargo.toml --bin toolport-gateway baseline_tamper_is_quarantined_while_optional_drift_policy_is_off`
- `npm run build`
- `npm run lint -- src/lib/api.ts` (0 errors; 23 existing warnings)
- `npx prettier --check src/lib/api.ts`
- `git diff --check`

Linear: SOU-323
