### PR TITLE
feat(gateway): implement MRTR and stateless HITL

### DIFF
--- a/src-tauri/src/approval.rs
+++ b/src-tauri/src/approval.rs
@@ -1,11 +1,9 @@
 //! Human-in-the-loop (HITL) tool-approval: the contract both sides share.
 //!
-//! When HITL is on, the gateway holds a *gated* tool call and asks the Toolport app for a
-//! human decision before it runs. The app hosts a small approval broker; every gateway
-//! process (there is one per stdio client, plus the app's `--http` bridge) dials OUT to it,
-//! sends the pending call, and blocks reading for the decision. Arguments travel over the
-//! connection and never touch disk. Everything is fail-closed: no endpoint, no answer, a
-//! timeout, or any transport error all mean DENY.
+//! Legacy clients and code-mode calls use the app's approval broker and block for the
+//! decision. Modern direct calls use MCP multi-round-trip elicitation instead: the client
+//! returns the human's answer on a fresh request, so no gateway request remains held.
+//! Arguments never touch disk, and every path remains fail-closed.
 //!
 //! This module is the piece both the gateway-side client and the app-side broker share:
 //! the wire types, the gating policy, and the on-disk endpoint descriptor. Keeping it in

--- a/src-tauri/src/approval_broker.rs
+++ b/src-tauri/src/approval_broker.rs
@@ -1,8 +1,9 @@
 //! App-side HITL approval broker.
 //!
-//! The Toolport app hosts this broker; every `toolport-gateway` process (one per stdio
-//! client, plus the app's `--http` bridge) dials OUT to it when it holds a gated tool
-//! call, and blocks reading for the decision. This is the counterpart to the gateway's
+//! The Toolport app hosts this broker for legacy clients and code-mode calls, whose wire
+//! shape cannot return Toolport's approval as a modern multi-round-trip result. Those
+//! paths dial OUT and block for the decision. Modern direct calls use MCP elicitation and
+//! do not hold a gateway request. This is the counterpart to the gateway's
 //! `request_human_decision` (see `bin/toolport-gateway.rs`).
 //!
 //! Protocol: the gateway connects over loopback TCP, sends one JSON line

--- a/src-tauri/src/bin/mock-mcp-server.rs
+++ b/src-tauri/src/bin/mock-mcp-server.rs
@@ -118,6 +118,9 @@ struct State {
     grown: bool,
     /// Whether a legacy `initialize` has been seen. Only enforced in strict mode.
     initialized: bool,
+    /// Original legacy tools/call waiting for the client to answer a
+    /// server-initiated elicitation request.
+    pending_legacy_elicitation: Option<Value>,
 }
 
 fn success(id: Value, result: Value) -> Value {
@@ -152,7 +155,9 @@ fn decorate(cfg: &Config, method: &str, mut result: Value) -> Value {
     if !cfg.revision.is_modern() {
         return result;
     }
-    result["resultType"] = json!("complete");
+    if result.get("resultType").is_none() {
+        result["resultType"] = json!("complete");
+    }
     result["_meta"] = json!({
         META_SERVER_INFO: { "name": SERVER_NAME, "version": SERVER_VERSION }
     });
@@ -188,6 +193,10 @@ fn tool_list(cfg: &Config, grown: bool) -> Value {
         json!({ "name": "echo_meta", "description": "Return the request's params._meta verbatim.",
                 "inputSchema": { "type": "object", "properties": {} } }),
         json!({ "name": "progress_ping", "description": "Emit notifications/progress, then reply.",
+                "inputSchema": { "type": "object", "properties": {} } }),
+        json!({ "name": "mrtr_confirm", "description": "Require one elicitation round before replying.",
+                "inputSchema": { "type": "object", "properties": {} } }),
+        json!({ "name": "legacy_elicitation", "description": "Issue a legacy server-to-client elicitation request.",
                 "inputSchema": { "type": "object", "properties": {} } }),
     ];
     if grown {
@@ -291,6 +300,21 @@ fn era_gate(cfg: &Config, state: &State, method: &str, req: &Value, id: &Value) 
 fn handle(cfg: &Config, state: &mut State, req: &Value, pre: &mut Vec<Value>) -> Option<Value> {
     let method = req.get("method").and_then(|m| m.as_str()).unwrap_or("");
 
+    if method.is_empty()
+        && req.get("id") == Some(&json!("mock-legacy-elicitation"))
+        && req.get("result").is_some()
+    {
+        if let Some(call_id) = state.pending_legacy_elicitation.take() {
+            return Some(success(
+                call_id,
+                json!({
+                    "content": [{ "type": "text", "text": "legacy confirmed" }],
+                    "isError": false
+                }),
+            ));
+        }
+    }
+
     // Notifications carry no id and get no response, but still drive state.
     let id = match req.get("id") {
         Some(id) if !id.is_null() => id.clone(),
@@ -381,6 +405,62 @@ fn handle(cfg: &Config, state: &mut State, req: &Value, pre: &mut Vec<Value>) ->
                         "params": { "progressToken": token, "progress": 1, "total": 2 }
                     }));
                 }
+            }
+            if name == "mrtr_confirm" {
+                let accepted = params
+                    .and_then(|p| p.get("inputResponses"))
+                    .and_then(|r| r.get("confirm"))
+                    .and_then(|r| r.get("action"))
+                    .and_then(Value::as_str)
+                    == Some("accept");
+                let state_matches = params
+                    .and_then(|p| p.get("requestState"))
+                    .and_then(Value::as_str)
+                    == Some("mock-state-byte-exact");
+                let result = if accepted && state_matches {
+                    json!({
+                        "content": [{ "type": "text", "text": "confirmed" }],
+                        "isError": false
+                    })
+                } else {
+                    json!({
+                        "resultType": "input_required",
+                        "inputRequests": {
+                            "confirm": {
+                                "method": "elicitation/create",
+                                "params": {
+                                    "mode": "form",
+                                    "message": "Continue the mock operation?",
+                                    "requestedSchema": {
+                                        "type": "object",
+                                        "properties": { "approved": { "type": "boolean" } },
+                                        "required": ["approved"]
+                                    }
+                                }
+                            }
+                        },
+                        "requestState": "mock-state-byte-exact"
+                    })
+                };
+                return Some(success(id, decorate(cfg, method, result)));
+            }
+            if name == "legacy_elicitation" && !cfg.revision.is_modern() {
+                state.pending_legacy_elicitation = Some(id);
+                pre.push(json!({
+                    "jsonrpc": "2.0",
+                    "id": "mock-legacy-elicitation",
+                    "method": "elicitation/create",
+                    "params": {
+                        "mode": "form",
+                        "message": "Continue the legacy mock operation?",
+                        "requestedSchema": {
+                            "type": "object",
+                            "properties": { "approved": { "type": "boolean" } },
+                            "required": ["approved"]
+                        }
+                    }
+                }));
+                return None;
             }
             let text = match name {
                 "echo" => args.get("text").and_then(|t| t.as_str()).unwrap_or("").to_string(),
@@ -516,7 +596,11 @@ fn serve_http(cfg: &Config) {
     println!("MOCK_MCP_URL=http://127.0.0.1:{port}/mcp");
     let _ = std::io::stdout().flush();
 
-    let mut state = State { grown: false, initialized: false };
+    let mut state = State {
+        grown: false,
+        initialized: false,
+        pending_legacy_elicitation: None,
+    };
     for mut request in server.incoming_requests() {
         let header_version = request
             .headers()
@@ -584,7 +668,11 @@ fn main() {
     let stdin = std::io::stdin();
     let stdout = std::io::stdout();
     let mut out = stdout.lock();
-    let mut state = State { grown: false, initialized: false };
+    let mut state = State {
+        grown: false,
+        initialized: false,
+        pending_legacy_elicitation: None,
+    };
     for line in stdin.lock().lines() {
         let line = match line {
             Ok(l) => l,

--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -32,7 +32,8 @@ use conduit_lib::{audit, usage_report};
 use conduit_lib::clients;
 use conduit_lib::codemode;
 use conduit_lib::downstream::{
-    self, DownstreamServer, ResourceUpdatedSink, ServerRequestHandler, StdioTransport, Transport,
+    self, DownstreamServer, MrtrRequest, ResourceUpdatedSink, ServerRequestAction,
+    ServerRequestHandler, StdioTransport, Transport,
     MODERN_PROTOCOL_VERSION, PROTOCOL_VERSION,
 };
 use conduit_lib::inspect;
@@ -58,6 +59,10 @@ thread_local! {
     /// dozen dispatch arms - including the ones that return early (SOU-446).
     static ACTIVE_UPSTREAM_VERSION: std::cell::RefCell<Option<String>> =
         const { std::cell::RefCell::new(None) };
+    /// Per-request capabilities of a modern upstream client. These decide
+    /// whether a legacy downstream server request can be surfaced as MRTR.
+    static ACTIVE_UPSTREAM_CAPABILITIES: std::cell::RefCell<Option<Value>> =
+        const { std::cell::RefCell::new(None) };
 }
 
 /// Sets the serving era for one request and restores the previous value on drop,
@@ -79,6 +84,40 @@ impl Drop for UpstreamEraGuard {
 /// True when the request being served came from a modern client.
 fn serving_modern_client() -> bool {
     ACTIVE_UPSTREAM_VERSION.with(|cell| cell.borrow().is_some())
+}
+
+struct UpstreamCapabilitiesGuard(Option<Value>);
+
+impl UpstreamCapabilitiesGuard {
+    fn enter(req: &Value) -> Self {
+        let capabilities = req
+            .get("params")
+            .and_then(|params| params.get("_meta"))
+            .and_then(|meta| meta.get("io.modelcontextprotocol/clientCapabilities"))
+            .cloned();
+        Self(ACTIVE_UPSTREAM_CAPABILITIES.with(|cell| cell.replace(capabilities)))
+    }
+}
+
+impl Drop for UpstreamCapabilitiesGuard {
+    fn drop(&mut self) {
+        ACTIVE_UPSTREAM_CAPABILITIES.with(|cell| *cell.borrow_mut() = self.0.take());
+    }
+}
+
+fn modern_client_supports_server_rpc(method: &str) -> bool {
+    let capability = match method {
+        "roots/list" => "roots",
+        "sampling/createMessage" => "sampling",
+        "elicitation/create" => "elicitation",
+        _ => return false,
+    };
+    ACTIVE_UPSTREAM_CAPABILITIES.with(|cell| {
+        cell.borrow()
+            .as_ref()
+            .and_then(|caps| caps.get(capability))
+            .is_some()
+    })
 }
 
 /// Add the fields a modern client requires to a result.
@@ -3332,6 +3371,9 @@ fn execute_call(
     // minus per-hop keys (SOU-444). `None` for calls Toolport originates
     // itself: a code-mode script step has no client request behind it.
     client_meta: Option<&Value>,
+    // Wire-only 2026-07-28 retry fields. Kept out of `arguments`, then restored
+    // beside them on the downstream hop (SOU-449).
+    mrtr: Option<&MrtrRequest>,
     opts: CallOpts,
     // Live swappable router slot (SOU-321). After HITL approval we re-clone this so
     // quarantine applied via `Arc::make_mut` during the hold is visible before execute.
@@ -3340,6 +3382,11 @@ fn execute_call(
 ) -> Value {
     let mut confirmed = opts.confirmed;
     let shape = opts.shape;
+    let resuming_modern_hitl = serving_modern_client()
+        && mrtr
+            .and_then(|retry| retry.request_state.as_ref())
+            .and_then(Value::as_str)
+            .is_some_and(|state| state.starts_with("toolport-hitl-"));
     let mut call_profiler = RoutedCallProfiler::start(name);
     // Resolve the call's real (server, original tool) from the router's route map,
     // NOT by splitting the exposed name on `__`. A renamed tool (via a tool override)
@@ -3388,17 +3435,19 @@ fn execute_call(
     // Org tool-call caps (SOU-340): cooperative local enforcement of Teams rate_limits.
     // Runs before HITL/destructive gates so a hard cap does not queue for human approval.
     // Denied calls do not increment counters (check_and_count is atomic for allow path).
-    if let Some(team) = reg.team.as_ref() {
-        if !team.rate_limits.is_empty() {
-            if let Err(msg) =
-                conduit_lib::rate_limits::check_and_count(&team.rate_limits, server_id, tool)
-            {
-                // Count as a failed call with a clear reason so Activity / export show the block.
-                audit::record_timed(srv, tool, false, None, Some("rate_limit"), client);
-                return json!({
-                    "content": [{ "type": "text", "text": msg }],
-                    "isError": true
-                });
+    if !resuming_modern_hitl {
+        if let Some(team) = reg.team.as_ref() {
+            if !team.rate_limits.is_empty() {
+                if let Err(msg) =
+                    conduit_lib::rate_limits::check_and_count(&team.rate_limits, server_id, tool)
+                {
+                    // Count as a failed call with a clear reason so Activity / export show the block.
+                    audit::record_timed(srv, tool, false, None, Some("rate_limit"), client);
+                    return json!({
+                        "content": [{ "type": "text", "text": msg }],
+                        "isError": true
+                    });
+                }
             }
         }
     }
@@ -3406,12 +3455,15 @@ fn execute_call(
     // After HITL approval we may swap to a freshly cloned live Arc so quarantine applied
     // during the hold is enforced (SOU-321). Non-HITL calls keep the request snapshot.
     let mut exec_router_owned: Option<Arc<Router>> = None;
+    let mut active_modern_hitl: Option<String> = None;
+    let mut routed_mrtr: Option<MrtrRequest> = None;
 
-    // Human-in-the-loop approval: hold a gated call (destructive, or from an
-    // untrusted-provenance server) until a person approves it in the Toolport app.
+    // Human-in-the-loop approval: gate a destructive or untrusted call until a
+    // person approves it in the Toolport app. Legacy clients hold this request;
+    // modern clients receive input_required and re-enter on a fresh request.
     // Takes precedence over the agent-facing confirm below, and is fail-closed
     // (no broker / no answer / timeout all deny). Skipped once `confirmed`.
-    if reg.human_approval_effective() && !confirmed {
+    if (reg.human_approval_effective() || resuming_modern_hitl) && !confirmed {
         // Resolve destructiveness robustly: cache, then live router, else
         // fail-closed (an unknown tool must not skip the human gate).
         let is_dest = tool_is_destructive_fail_closed(name, cached, router);
@@ -3425,24 +3477,35 @@ fn execute_call(
             .find(|s| s.id == server_id)
             .map(|s| matches!(s.source.as_deref(), Some("shared") | Some("registry")))
             .unwrap_or(false);
-        if let Some(reason) = approval::gate_reason(true, is_dest, untrusted) {
-            // The gate reason names WHY a human was asked; shared by the audit record
-            // and the agent-facing envelope on every outcome (approved included).
-            let reason_str = match reason {
-                approval::ApprovalReason::Destructive => "destructive",
-                approval::ApprovalReason::UntrustedSource => "untrusted_source",
-                approval::ApprovalReason::DestructiveAndUntrusted => {
-                    "destructive_and_untrusted"
-                }
-            };
+        let gate_fp = tool_fingerprint_for(name, cached, router);
+        let modern_always_allowed = serving_modern_client()
+            && !resuming_modern_hitl
+            && gate_fp.as_deref().is_some_and(|fingerprint| {
+                reg.is_tool_allowed(&approval::fingerprint_allow_key(srv, tool, fingerprint))
+            });
+        if modern_always_allowed {
+            confirmed = true;
+        }
+        let gate_reason = (!confirmed)
+            .then(|| approval::gate_reason(true, is_dest, untrusted))
+            .flatten()
+            .or_else(|| {
+            resuming_modern_hitl
+                .then(|| {
+                    mrtr.and_then(|retry| retry.request_state.as_ref())
+                        .and_then(Value::as_str)
+                        .and_then(modern_hitl_reason)
+                })
+                .flatten()
+            });
+        if let Some(reason) = gate_reason {
             // The exact call being approved, content-bound: the bytes that RUN must
-            // hash-match these. Captured before the (blocking) human decision.
+            // hash-match these. Modern clients park the decision behind an opaque
+            // requestState and re-enter after elicitation; legacy clients retain the
+            // original blocking broker behavior.
             let approved_args_hash = audit::args_hash(&arguments);
-            // Definition fingerprint the human is approving (SOU-322): rebound against
-            // the live router after approve, before execute.
-            let approved_fp = tool_fingerprint_for(name, cached, router);
-            let t0 = std::time::Instant::now();
-            let decision = request_human_decision(approval::ApprovalRequest {
+            let current_fp = gate_fp;
+            let approval_request = || approval::ApprovalRequest {
                 token: String::new(),
                 id: new_correlation_id(),
                 client: client.map(str::to_string),
@@ -3450,9 +3513,113 @@ fn execute_call(
                 tool: tool.to_string(),
                 reason,
                 arguments: arguments.clone(),
-                tool_fingerprint: approved_fp.clone(),
-            });
-            let held_ms = t0.elapsed().as_millis() as u64;
+                tool_fingerprint: current_fp.clone(),
+            };
+            let mut approval_reason = reason;
+            let (decision, held_ms, approved_fp, audit_approval) =
+                if serving_modern_client() && mrtr.is_some() {
+                let incoming = mrtr.cloned().unwrap_or_default();
+                let state = incoming.request_state.as_ref().and_then(Value::as_str);
+                let polled = state.map(|token| {
+                    (
+                        token,
+                        poll_modern_hitl(
+                            token,
+                            name,
+                            &approved_args_hash,
+                            client,
+                            incoming.input_responses.clone(),
+                        ),
+                    )
+                });
+                match polled {
+                    Some((token, ModernHitlPoll::Pending)) => {
+                        return modern_hitl_input_required(token)
+                    }
+                    Some((_, ModernHitlPoll::Stale)) => {
+                        (
+                            approval::ApprovalDecision::StaleState,
+                            0,
+                            current_fp.clone(),
+                            false,
+                        )
+                    }
+                    Some((_, ModernHitlPoll::Decided(decision, held_ms, stored_reason))) => {
+                        approval_reason = stored_reason;
+                        (decision, held_ms, current_fp.clone(), false)
+                    }
+                    Some((token, ModernHitlPoll::Approved {
+                        approved_fingerprint,
+                        reason: stored_reason,
+                        held_ms,
+                        downstream,
+                        newly_approved,
+                    })) => {
+                        approval_reason = stored_reason;
+                        active_modern_hitl = Some(token.to_string());
+                        routed_mrtr = Some(downstream);
+                        (
+                            approval::ApprovalDecision::Approved,
+                            held_ms,
+                            approved_fingerprint,
+                            newly_approved,
+                        )
+                    }
+                    Some((token, ModernHitlPoll::Missing))
+                        if token.starts_with("toolport-hitl-") =>
+                    {
+                        (
+                            approval::ApprovalDecision::StaleState,
+                            0,
+                            current_fp.clone(),
+                            false,
+                        )
+                    }
+                    Some((_, ModernHitlPoll::Missing)) | None => {
+                        if !modern_client_supports_server_rpc("elicitation/create") {
+                            return json!({
+                                "_toolportProtocolError": {
+                                    "code": downstream::MISSING_REQUIRED_CLIENT_CAPABILITY,
+                                    "message": "human approval requires the modern client's elicitation capability",
+                                    "requiredCapability": "elicitation"
+                                }
+                            });
+                        }
+                        match start_modern_hitl(
+                            name,
+                            approved_args_hash.clone(),
+                            current_fp.clone(),
+                            reason,
+                            client,
+                            srv,
+                            tool,
+                            &arguments,
+                            incoming,
+                        ) {
+                            Ok(token) => return modern_hitl_input_required(&token),
+                            Err(decision) => (decision, 0, current_fp.clone(), false),
+                        }
+                    }
+                }
+            } else {
+                let t0 = Instant::now();
+                let decision = request_human_decision(approval_request());
+                (
+                    decision,
+                    t0.elapsed().as_millis() as u64,
+                    current_fp.clone(),
+                    true,
+                )
+            };
+            // The gate reason names WHY a human was asked; shared by the audit record
+            // and the agent-facing envelope on every outcome (approved included).
+            let reason_str = match approval_reason {
+                approval::ApprovalReason::Destructive => "destructive",
+                approval::ApprovalReason::UntrustedSource => "untrusted_source",
+                approval::ApprovalReason::DestructiveAndUntrusted => {
+                    "destructive_and_untrusted"
+                }
+            };
             if !decision.is_approved() {
                 // Governance audit: the gate reason and which non-approval outcome
                 // (denied / no-response / unreachable), plus a content hash of the
@@ -3473,6 +3640,7 @@ fn execute_call(
             // was mutated after approval, reject the stale approval (fail-closed)
             // rather than run bytes a human never actually saw.
             if let Some(stale) = content_binding_decision(&approved_args_hash, &arguments) {
+                finish_modern_hitl(active_modern_hitl.as_deref());
                 audit::record_decision(
                     srv,
                     tool,
@@ -3491,6 +3659,7 @@ fn execute_call(
                 if let Some(stale) =
                     post_hitl_revalidation(approved_fp.as_deref(), name, &live)
                 {
+                    finish_modern_hitl(active_modern_hitl.as_deref());
                     audit::record_decision(
                         srv,
                         tool,
@@ -3506,17 +3675,29 @@ fn execute_call(
             }
             // Approved calls are audited too, so the trail shows what actually ran,
             // not only what was blocked.
-            audit::record_decision(
-                srv,
-                tool,
-                client,
-                reason_str,
-                "approved",
-                &arguments,
-                Some(held_ms),
-            );
+            if audit_approval {
+                audit::record_decision(
+                    srv,
+                    tool,
+                    client,
+                    reason_str,
+                    "approved",
+                    &arguments,
+                    Some(held_ms),
+                );
+            }
             // Skip the agent-confirm step and route the call.
             confirmed = true;
+        } else if resuming_modern_hitl {
+            let token = mrtr
+                .and_then(|retry| retry.request_state.as_ref())
+                .and_then(Value::as_str);
+            finish_modern_hitl(token);
+            return refused_call_result(
+                name,
+                approval::ApprovalDecision::StaleState,
+                "stale_state",
+            );
         }
     }
 
@@ -3605,11 +3786,25 @@ fn execute_call(
     let client_meta = relay_owned.as_ref().or(client_meta);
 
     let started = Instant::now();
-    match exec_router.route_call_with_cancel(name, arguments, cancel.clone(), client_meta) {
-        Ok(result) => {
+    let effective_mrtr = routed_mrtr.as_ref().or(mrtr);
+    match exec_router.route_call_with_cancel_and_mrtr(
+        name,
+        arguments,
+        cancel.clone(),
+        client_meta,
+        effective_mrtr,
+    ) {
+        Ok(mut result) => {
             if let Some(profiler) = &mut call_profiler {
                 profiler.mark_downstream();
             }
+            if result.get("resultType").and_then(Value::as_str) == Some("input_required") {
+                if let Some(token) = active_modern_hitl.as_deref() {
+                    update_modern_hitl_downstream(token, &mut result);
+                }
+                return result;
+            }
+            finish_modern_hitl(active_modern_hitl.as_deref());
             let ms = started.elapsed().as_millis() as u64;
             // Downstream success flag (before content defense may flip isError on a
             // high-confidence injection block — SOU-345). Live inspect keeps the RAW
@@ -3661,6 +3856,7 @@ fn execute_call(
             out
         }
         Err(e) => {
+            finish_modern_hitl(active_modern_hitl.as_deref());
             let ms = started.elapsed().as_millis() as u64;
             audit::record_timed_with_hash(
                 srv,
@@ -3879,6 +4075,7 @@ fn run_script_dispatch(
                     // A script step is Toolport's own call, not a relay of a client
                     // request, so there is no client `_meta` to carry.
                     None,
+                    None,
                     CallOpts {
                         confirmed: false,
                         shape: false,
@@ -4033,6 +4230,7 @@ fn handle_request_with_cancel(
     let _era = UpstreamEraGuard::enter(
         declared.filter(|v| v.as_str() == MODERN_PROTOCOL_VERSION),
     );
+    let _capabilities = UpstreamCapabilitiesGuard::enter(req);
 
     match method {
         // Modern clients open here instead of handshaking. Servers MUST implement
@@ -4631,26 +4829,44 @@ fn handle_request_with_cancel(
             } else {
                 (name, arguments)
             };
+            let mrtr = MrtrRequest::from_params(params);
+            let result = execute_call(
+                reg,
+                router,
+                cached,
+                client,
+                allowed,
+                cancel,
+                Some(confirm),
+                name.as_str(),
+                arguments,
+                // Relay the client's request metadata downstream (SOU-444).
+                req.get("params").and_then(|p| p.get("_meta")),
+                (!mrtr.is_empty()).then_some(&mrtr),
+                CallOpts {
+                    confirmed,
+                    shape: true,
+                },
+                live_router,
+            );
+            if let Some(protocol_error) = result.get("_toolportProtocolError") {
+                return Some(json!({
+                    "jsonrpc": "2.0",
+                    "id": id,
+                    "error": {
+                        "code": protocol_error.get("code").cloned().unwrap_or(json!(-32603)),
+                        "message": protocol_error.get("message").cloned().unwrap_or(json!("protocol error")),
+                        "data": {
+                            "requiredCapabilities": [
+                                protocol_error.get("requiredCapability").cloned().unwrap_or(Value::Null)
+                            ]
+                        }
+                    }
+                }));
+            }
             Some(success(
                 id,
-                execute_call(
-                    reg,
-                    router,
-                    cached,
-                    client,
-                    allowed,
-                    cancel,
-                    Some(confirm),
-                    name.as_str(),
-                    arguments,
-                    // Relay the client's request metadata downstream (SOU-444).
-                    req.get("params").and_then(|p| p.get("_meta")),
-                    CallOpts {
-                        confirmed,
-                        shape: true,
-                    },
-                    live_router,
-                ),
+                result,
             ))
         }
         "resources/list" => {
@@ -4692,8 +4908,8 @@ fn handle_request_with_cancel(
             Some(success(id, json!({ "resourceTemplates": templates })))
         }
         "resources/read" => {
-            let uri = req
-                .get("params")
+            let params = req.get("params");
+            let uri = params
                 .and_then(|p| p.get("uri"))
                 .and_then(|u| u.as_str())
                 .unwrap_or("");
@@ -4709,13 +4925,19 @@ fn handle_request_with_cancel(
                     return Some(error(id, -32602, &format!("Toolport: no server owns resource '{uri}'")));
                 }
             }
-            let client_meta = req.get("params").and_then(|p| p.get("_meta")).cloned();
+            let client_meta = params.and_then(|p| p.get("_meta")).cloned();
+            let mrtr = MrtrRequest::from_params(params);
             let (_progress_route, relay_owned) = match router.resource_server(uri) {
                 Some(owner) => prepare_progress(client_meta.as_ref(), owner),
                 None => (None, None),
             };
             let client_meta = relay_owned.or(client_meta);
-            match router.read_resource_with_cancel(uri, cancel.clone(), client_meta.as_ref()) {
+            match router.read_resource_with_cancel_and_mrtr(
+                uri,
+                cancel.clone(),
+                client_meta.as_ref(),
+                (!mrtr.is_empty()).then_some(&mrtr),
+            ) {
                 Ok(mut result) => {
                     // Content defense: a resource is as attacker-controllable as a tool
                     // result, so scan it for injection and label any flagged text as data.
@@ -4780,13 +5002,19 @@ fn handle_request_with_cancel(
                 }
             }
             let client_meta = params.and_then(|p| p.get("_meta")).cloned();
+            let mrtr = MrtrRequest::from_params(params);
             let (_progress_route, relay_owned) = match router.prompt_server(name) {
                 Some(owner) => prepare_progress(client_meta.as_ref(), owner),
                 None => (None, None),
             };
             let client_meta = relay_owned.or(client_meta);
-            match router.get_prompt_with_cancel(name, arguments, cancel.clone(), client_meta.as_ref())
-            {
+            match router.get_prompt_with_cancel_and_mrtr(
+                name,
+                arguments,
+                cancel.clone(),
+                client_meta.as_ref(),
+                (!mrtr.is_empty()).then_some(&mrtr),
+            ) {
                 Ok(mut result) => {
                     // Content defense: a prompt's messages are attacker-controllable too;
                     // scan for injection and label any flagged text as data.
@@ -5115,7 +5343,7 @@ fn connect_one(
             resource_updated,
         ) {
             Ok(mut t) => {
-                t.set_server_request_handler(server_handler);
+                t.set_server_request_handler(Arc::clone(&server_handler));
                 t.set_progress_sink(progress);
                 DownstreamServer::connect(server.id.clone(), Box::new(t))
             }
@@ -5135,6 +5363,7 @@ fn connect_one(
 
     match result {
         Ok(mut ds) => {
+            ds.set_server_request_handler(server_handler);
             // Only the gateway needs resources/prompts (to proxy them); fetch
             // them here, off the health-probe path.
             ds.load_resources_prompts();
@@ -7515,6 +7744,222 @@ fn upstream_client_unsupported(id: Value, method: &str) -> Value {
     })
 }
 
+enum ModernHitlStatus {
+    AwaitingClient,
+    Approved,
+}
+
+struct ModernHitlApproval {
+    name: String,
+    args_hash: String,
+    client: Option<String>,
+    approved_fingerprint: Option<String>,
+    reason: approval::ApprovalReason,
+    started: Instant,
+    downstream: MrtrRequest,
+    input_request: Value,
+    status: ModernHitlStatus,
+}
+
+enum ModernHitlPoll {
+    Missing,
+    Pending,
+    Stale,
+    Decided(approval::ApprovalDecision, u64, approval::ApprovalReason),
+    Approved {
+        approved_fingerprint: Option<String>,
+        reason: approval::ApprovalReason,
+        held_ms: u64,
+        downstream: MrtrRequest,
+        newly_approved: bool,
+    },
+}
+
+const MODERN_HITL_MAX_PENDING: usize = 64;
+const MODERN_HITL_RETENTION: Duration =
+    Duration::from_secs(approval::DEFAULT_TIMEOUT_SECS + 30);
+
+fn modern_hitl_approvals() -> &'static Mutex<HashMap<String, ModernHitlApproval>> {
+    static STORE: std::sync::OnceLock<Mutex<HashMap<String, ModernHitlApproval>>> =
+        std::sync::OnceLock::new();
+    STORE.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn modern_hitl_input_required(token: &str) -> Value {
+    let input_request = modern_hitl_approvals()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .get(token)
+        .map(|pending| pending.input_request.clone());
+    json!({
+        "resultType": "input_required",
+        "inputRequests": input_request.map(|request| json!({
+            "toolport_approval": request
+        })),
+        "requestState": token,
+    })
+}
+
+fn modern_hitl_reason(token: &str) -> Option<approval::ApprovalReason> {
+    modern_hitl_approvals()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .get(token)
+        .map(|pending| pending.reason)
+}
+
+fn start_modern_hitl(
+    name: &str,
+    args_hash: String,
+    approved_fingerprint: Option<String>,
+    reason: approval::ApprovalReason,
+    client: Option<&str>,
+    server: &str,
+    tool: &str,
+    arguments: &Value,
+    downstream: MrtrRequest,
+) -> Result<String, approval::ApprovalDecision> {
+    let token = format!("toolport-hitl-{}", new_correlation_id());
+    {
+        let mut approvals = modern_hitl_approvals()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        approvals.retain(|_, pending| pending.started.elapsed() <= MODERN_HITL_RETENTION);
+        if approvals.len() >= MODERN_HITL_MAX_PENDING {
+            return Err(approval::ApprovalDecision::Unreachable);
+        }
+        approvals.insert(
+            token.clone(),
+            ModernHitlApproval {
+                name: name.to_string(),
+                args_hash,
+                client: client.map(str::to_string),
+                approved_fingerprint,
+                reason,
+                started: Instant::now(),
+                downstream,
+                input_request: json!({
+                    "method": "elicitation/create",
+                    "params": {
+                        "mode": "form",
+                        "message": format!(
+                            "Toolport requires approval to run {server}/{tool}. Review the exact arguments before approving: {}",
+                            serde_json::to_string(arguments).unwrap_or_else(|_| "{}".to_string())
+                        ),
+                        "requestedSchema": {
+                            "type": "object",
+                            "properties": {
+                                "approved": {
+                                    "type": "boolean",
+                                    "title": "Approve this tool call"
+                                }
+                            },
+                            "required": ["approved"]
+                        }
+                    }
+                }),
+                status: ModernHitlStatus::AwaitingClient,
+            },
+        );
+    }
+    Ok(token)
+}
+
+fn poll_modern_hitl(
+    token: &str,
+    name: &str,
+    args_hash: &str,
+    client: Option<&str>,
+    input_responses: Option<Value>,
+) -> ModernHitlPoll {
+    let mut approvals = modern_hitl_approvals()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    approvals.retain(|_, pending| pending.started.elapsed() <= MODERN_HITL_RETENTION);
+    let Some(pending) = approvals.get_mut(token) else {
+        return ModernHitlPoll::Missing;
+    };
+    if pending.name != name
+        || pending.args_hash != args_hash
+        || pending.client.as_deref() != client
+    {
+        return ModernHitlPoll::Stale;
+    }
+    let decision = match &pending.status {
+        ModernHitlStatus::AwaitingClient => {
+            let response = input_responses
+                .as_ref()
+                .and_then(|responses| responses.get("toolport_approval"));
+            let Some(response) = response else {
+                return ModernHitlPoll::Pending;
+            };
+            let accepted = response.get("action").and_then(Value::as_str) == Some("accept")
+                && response
+                    .get("content")
+                    .and_then(|content| content.get("approved"))
+                    .and_then(Value::as_bool)
+                    == Some(true);
+            Some(if accepted {
+                approval::ApprovalDecision::Approved
+            } else {
+                approval::ApprovalDecision::Denied
+            })
+        }
+        ModernHitlStatus::Approved => None,
+    };
+    let newly_approved = decision.is_some();
+    if let Some(decision) = decision {
+        if !decision.is_approved() {
+            let held_ms = pending.started.elapsed().as_millis() as u64;
+            let reason = pending.reason;
+            approvals.remove(token);
+            return ModernHitlPoll::Decided(decision, held_ms, reason);
+        }
+        pending.status = ModernHitlStatus::Approved;
+    }
+    pending.downstream.input_responses = input_responses;
+    ModernHitlPoll::Approved {
+        approved_fingerprint: pending.approved_fingerprint.clone(),
+        reason: pending.reason,
+        held_ms: pending.started.elapsed().as_millis() as u64,
+        downstream: pending.downstream.clone(),
+        newly_approved,
+    }
+}
+
+fn update_modern_hitl_downstream(token: &str, result: &mut Value) {
+    let mut approvals = modern_hitl_approvals()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    if let Some(pending) = approvals.get_mut(token) {
+        pending.downstream = MrtrRequest {
+            input_responses: None,
+            request_state: result.get("requestState").cloned(),
+        };
+        result["requestState"] = json!(token);
+    }
+}
+
+fn finish_modern_hitl(token: Option<&str>) {
+    if let Some(token) = token {
+        modern_hitl_approvals()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .remove(token);
+    }
+}
+
+fn missing_modern_client_capability(id: Value, method: &str) -> Value {
+    json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "error": {
+            "code": downstream::MISSING_REQUIRED_CLIENT_CAPABILITY,
+            "message": format!("client capability required for {method}")
+        }
+    })
+}
+
 fn make_server_request_handler(
     client_upstream: Arc<Mutex<ClientUpstreamCaps>>,
     stdio_upstream: Arc<StdioUpstream>,
@@ -7530,6 +7975,13 @@ fn make_server_request_handler(
             return None;
         }
         let id = req.get("id")?.clone();
+        if serving_modern_client() {
+            return Some(if modern_client_supports_server_rpc(method) {
+                ServerRequestAction::InputRequired
+            } else {
+                ServerRequestAction::Respond(missing_modern_client_capability(id, method))
+            });
+        }
         let params = upstream_rpc_params(method, req);
         let timeout = upstream_rpc_timeout(method);
         let result = if http {
@@ -7544,7 +7996,9 @@ fn make_server_request_handler(
                 .map(|caps| client_supports_server_rpc(&caps, method))
                 .unwrap_or(false);
             if !supported {
-                return Some(upstream_client_unsupported(id, method));
+                return Some(ServerRequestAction::Respond(upstream_client_unsupported(
+                    id, method,
+                )));
             }
             session.upstream_call_timeout(method, params, timeout)
         } else {
@@ -7553,11 +8007,15 @@ fn make_server_request_handler(
                 .map(|caps| client_supports_server_rpc(&caps, method))
                 .unwrap_or(false);
             if !supported {
-                return Some(upstream_client_unsupported(id, method));
+                return Some(ServerRequestAction::Respond(upstream_client_unsupported(
+                    id, method,
+                )));
             }
             stdio_upstream.call_timeout(method, params, timeout)
         };
-        Some(upstream_json_rpc_response(id, result))
+        Some(ServerRequestAction::Respond(upstream_json_rpc_response(
+            id, result,
+        )))
     })
 }
 
@@ -8752,6 +9210,18 @@ fn handle_mcp_http(
             });
             match resp {
                 Some(resp) => {
+                    let status = if upstream_declared_version(&req)
+                        == Some(MODERN_PROTOCOL_VERSION)
+                        && resp
+                            .get("error")
+                            .and_then(|error| error.get("code"))
+                            .and_then(Value::as_i64)
+                            == Some(downstream::MISSING_REQUIRED_CLIENT_CAPABILITY)
+                    {
+                        400
+                    } else {
+                        200
+                    };
                     let body = serde_json::to_string(&resp).unwrap_or_else(|_| {
                         json!({
                             "jsonrpc": "2.0",
@@ -8760,7 +9230,7 @@ fn handle_mcp_http(
                         })
                         .to_string()
                     });
-                    mcp_rpc_response(200, body, session_id.as_deref(), prefer_sse)
+                    mcp_rpc_response(status, body, session_id.as_deref(), prefer_sse)
                 }
                 None => {
                     let body = json!({
@@ -10717,6 +11187,205 @@ mod tests {
         assert!(client_supports_server_rpc(&caps, "roots/list"));
         assert!(client_supports_server_rpc(&caps, "sampling/createMessage"));
         assert!(!client_supports_server_rpc(&caps, "elicitation/create"));
+    }
+
+    #[test]
+    fn modern_server_requests_become_mrtr_only_with_the_required_capability() {
+        let stdout = Arc::new(Mutex::new(std::io::stdout()));
+        let handler = make_server_request_handler(
+            Arc::new(Mutex::new(ClientUpstreamCaps::default())),
+            Arc::new(StdioUpstream::new(stdout)),
+            Arc::new(Mutex::new(HashMap::new())),
+            false,
+        );
+        let _era = UpstreamEraGuard::enter(Some(MODERN_PROTOCOL_VERSION.to_string()));
+        let capable = json!({
+            "params": {
+                "_meta": {
+                    "io.modelcontextprotocol/clientCapabilities": { "elicitation": {} }
+                }
+            }
+        });
+        let _caps = UpstreamCapabilitiesGuard::enter(&capable);
+        let request = json!({
+            "jsonrpc": "2.0",
+            "id": 7,
+            "method": "elicitation/create",
+            "params": { "message": "Continue?" }
+        });
+        assert_eq!(handler(&request), Some(ServerRequestAction::InputRequired));
+    }
+
+    #[test]
+    fn modern_server_request_without_capability_returns_reserved_error() {
+        let stdout = Arc::new(Mutex::new(std::io::stdout()));
+        let handler = make_server_request_handler(
+            Arc::new(Mutex::new(ClientUpstreamCaps::default())),
+            Arc::new(StdioUpstream::new(stdout)),
+            Arc::new(Mutex::new(HashMap::new())),
+            false,
+        );
+        let _era = UpstreamEraGuard::enter(Some(MODERN_PROTOCOL_VERSION.to_string()));
+        let incapable = json!({
+            "params": {
+                "_meta": { "io.modelcontextprotocol/clientCapabilities": {} }
+            }
+        });
+        let _caps = UpstreamCapabilitiesGuard::enter(&incapable);
+        let request = json!({
+            "jsonrpc": "2.0",
+            "id": 8,
+            "method": "sampling/createMessage",
+            "params": {}
+        });
+        let Some(ServerRequestAction::Respond(response)) = handler(&request) else {
+            panic!("missing capability should produce an inline error")
+        };
+        assert_eq!(
+            response["error"]["code"],
+            downstream::MISSING_REQUIRED_CLIENT_CAPABILITY
+        );
+    }
+
+    #[test]
+    fn modern_hitl_state_polls_then_carries_downstream_mrtr() {
+        let arguments = json!({ "target": "x" });
+        let hash = audit::args_hash(&arguments);
+        let token = start_modern_hitl(
+            "s__wipe",
+            hash.clone(),
+            Some("v2:approved".into()),
+            approval::ApprovalReason::Destructive,
+            Some("cursor"),
+            "s",
+            "wipe",
+            &arguments,
+            MrtrRequest::default(),
+        )
+        .unwrap();
+        let incomplete = modern_hitl_input_required(&token);
+        assert_eq!(
+            incomplete["inputRequests"]["toolport_approval"]["method"],
+            "elicitation/create"
+        );
+        assert!(matches!(
+            poll_modern_hitl(&token, "s__wipe", &hash, Some("cursor"), None),
+            ModernHitlPoll::Pending
+        ));
+        let first = poll_modern_hitl(
+            &token,
+            "s__wipe",
+            &hash,
+            Some("cursor"),
+            Some(json!({
+                "toolport_approval": {
+                    "action": "accept",
+                    "content": { "approved": true }
+                }
+            })),
+        );
+        assert!(matches!(
+            first,
+            ModernHitlPoll::Approved {
+                newly_approved: true,
+                ..
+            }
+        ));
+
+        let mut incomplete = json!({
+            "resultType": "input_required",
+            "inputRequests": { "confirm": { "method": "elicitation/create" } },
+            "requestState": "downstream-byte-exact"
+        });
+        update_modern_hitl_downstream(&token, &mut incomplete);
+        assert_eq!(incomplete["requestState"], token);
+
+        let responses = json!({ "confirm": { "action": "accept" } });
+        let resumed = poll_modern_hitl(
+            incomplete["requestState"].as_str().unwrap(),
+            "s__wipe",
+            &hash,
+            Some("cursor"),
+            Some(responses.clone()),
+        );
+        let ModernHitlPoll::Approved {
+            downstream,
+            newly_approved,
+            ..
+        } = resumed
+        else {
+            panic!("approved MRTR state should resume")
+        };
+        assert!(!newly_approved);
+        assert_eq!(downstream.request_state, Some(json!("downstream-byte-exact")));
+        assert_eq!(downstream.input_responses, Some(responses));
+        finish_modern_hitl(Some(&token));
+    }
+
+    #[test]
+    fn modern_hitl_state_is_bound_to_the_exact_call() {
+        let token = format!("test-{}", new_correlation_id());
+        modern_hitl_approvals()
+            .lock()
+            .unwrap()
+            .insert(
+                token.clone(),
+                ModernHitlApproval {
+                    name: "s__wipe".into(),
+                    args_hash: audit::args_hash(&json!({ "target": "x" })),
+                    client: Some("cursor".into()),
+                    approved_fingerprint: None,
+                    reason: approval::ApprovalReason::Destructive,
+                    started: Instant::now(),
+                    downstream: MrtrRequest::default(),
+                    input_request: json!({ "method": "elicitation/create" }),
+                    status: ModernHitlStatus::AwaitingClient,
+                },
+            );
+        assert!(matches!(
+            poll_modern_hitl(
+                &token,
+                "s__wipe",
+                &audit::args_hash(&json!({ "target": "different" })),
+                Some("cursor"),
+                None,
+            ),
+            ModernHitlPoll::Stale
+        ));
+        finish_modern_hitl(Some(&token));
+    }
+
+    #[test]
+    fn modern_hitl_decline_fails_closed_and_consumes_state() {
+        let arguments = json!({ "target": "x" });
+        let hash = audit::args_hash(&arguments);
+        let token = start_modern_hitl(
+            "s__wipe",
+            hash.clone(),
+            None,
+            approval::ApprovalReason::Destructive,
+            Some("cursor"),
+            "s",
+            "wipe",
+            &arguments,
+            MrtrRequest::default(),
+        )
+        .unwrap();
+        let declined = poll_modern_hitl(
+            &token,
+            "s__wipe",
+            &hash,
+            Some("cursor"),
+            Some(json!({ "toolport_approval": { "action": "decline" } })),
+        );
+        assert!(matches!(
+            declined,
+            ModernHitlPoll::Decided(approval::ApprovalDecision::Denied, _, _)
+        ));
+        assert!(matches!(
+            poll_modern_hitl(&token, "s__wipe", &hash, Some("cursor"), None),
+            ModernHitlPoll::Missing
+        ));
     }
 
     /// The security-critical guarantee: the human-approval broker denies (never

--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -7813,6 +7813,16 @@ fn modern_hitl_reason(token: &str) -> Option<approval::ApprovalReason> {
         .map(|pending| pending.reason)
 }
 
+fn downstream_input_responses(input_responses: Option<Value>) -> Option<Value> {
+    match input_responses {
+        Some(Value::Object(mut responses)) => {
+            responses.remove("toolport_approval");
+            (!responses.is_empty()).then_some(Value::Object(responses))
+        }
+        other => other,
+    }
+}
+
 fn start_modern_hitl(
     name: &str,
     args_hash: String,
@@ -7922,7 +7932,7 @@ fn poll_modern_hitl(
         }
         pending.status = ModernHitlStatus::Approved;
     }
-    pending.downstream.input_responses = input_responses;
+    pending.downstream.input_responses = downstream_input_responses(input_responses);
     ModernHitlPoll::Approved {
         approved_fingerprint: pending.approved_fingerprint.clone(),
         reason: pending.reason,
@@ -11342,13 +11352,19 @@ mod tests {
                 }
             })),
         );
-        assert!(matches!(
-            first,
-            ModernHitlPoll::Approved {
-                newly_approved: true,
-                ..
-            }
-        ));
+        let ModernHitlPoll::Approved {
+            downstream,
+            newly_approved,
+            ..
+        } = first
+        else {
+            panic!("accepted approval should resume")
+        };
+        assert!(newly_approved);
+        assert!(
+            downstream.input_responses.is_none(),
+            "Toolport's local approval response must not leak downstream"
+        );
 
         let mut incomplete = json!({
             "resultType": "input_required",

--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -3382,7 +3382,12 @@ fn execute_call(
 ) -> Value {
     let mut confirmed = opts.confirmed;
     let shape = opts.shape;
-    let resuming_modern_hitl = serving_modern_client()
+    // Direct modern calls can use MRTR even on their first round, before any
+    // requestState exists. Code-mode steps deliberately keep the legacy broker
+    // because they cannot surface an intermediate result to the upstream client;
+    // `confirm` is present only on the direct call path.
+    let modern_direct_call = serving_modern_client() && confirm.is_some();
+    let resuming_modern_hitl = modern_direct_call
         && mrtr
             .and_then(|retry| retry.request_state.as_ref())
             .and_then(Value::as_str)
@@ -3517,7 +3522,7 @@ fn execute_call(
             };
             let mut approval_reason = reason;
             let (decision, held_ms, approved_fp, audit_approval) =
-                if serving_modern_client() && mrtr.is_some() {
+                if modern_direct_call {
                 let incoming = mrtr.cloned().unwrap_or_default();
                 let state = incoming.request_state.as_ref().and_then(Value::as_str);
                 let polled = state.map(|token| {
@@ -11245,6 +11250,59 @@ mod tests {
             response["error"]["code"],
             downstream::MISSING_REQUIRED_CLIENT_CAPABILITY
         );
+    }
+
+    #[test]
+    fn initial_modern_hitl_call_starts_mrtr_without_retry_fields() {
+        modern_hitl_approvals()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .clear();
+        let request = json!({
+            "params": {
+                "_meta": {
+                    "io.modelcontextprotocol/clientCapabilities": {
+                        "elicitation": {}
+                    }
+                }
+            }
+        });
+        let _era = UpstreamEraGuard::enter(Some(MODERN_PROTOCOL_VERSION.to_string()));
+        let _capabilities = UpstreamCapabilitiesGuard::enter(&request);
+        let mut reg = Registry::default();
+        reg.set_human_approval(true);
+        let router = routed_router("s", "delete");
+        let cached = router.aggregated_tools();
+
+        let result = execute_call(
+            &reg,
+            &router,
+            &cached,
+            Some("cursor"),
+            None,
+            None,
+            Some(&ConfirmGuard::new()),
+            "s__delete",
+            json!({ "id": 7 }),
+            None,
+            None,
+            CallOpts {
+                confirmed: false,
+                shape: true,
+            },
+            None,
+        );
+
+        assert_eq!(result["resultType"], "input_required");
+        assert_eq!(
+            result["inputRequests"]["toolport_approval"]["method"],
+            "elicitation/create"
+        );
+        let token = result["requestState"]
+            .as_str()
+            .expect("initial HITL response has requestState");
+        assert!(token.starts_with("toolport-hitl-"));
+        finish_modern_hitl(Some(token));
     }
 
     #[test]

--- a/src-tauri/src/downstream.rs
+++ b/src-tauri/src/downstream.rs
@@ -402,6 +402,60 @@ fn with_meta(mut params: Value, meta: Option<&Value>) -> Value {
     params
 }
 
+/// Wire-only fields used when a 2026-07-28 client retries an incomplete request.
+///
+/// They are intentionally kept separate from tool arguments and `_meta`: all three
+/// live at different levels in MCP params, and collapsing them would either expose
+/// protocol bookkeeping to a tool or drop it at the gateway boundary (SOU-449).
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct MrtrRequest {
+    pub input_responses: Option<Value>,
+    pub request_state: Option<Value>,
+}
+
+impl MrtrRequest {
+    pub fn from_params(params: Option<&Value>) -> Self {
+        Self {
+            input_responses: params.and_then(|p| p.get("inputResponses")).cloned(),
+            request_state: params.and_then(|p| p.get("requestState")).cloned(),
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.input_responses.is_none() && self.request_state.is_none()
+    }
+
+    fn apply(&self, params: &mut Value) {
+        let Some(obj) = params.as_object_mut() else {
+            return;
+        };
+        if let Some(responses) = &self.input_responses {
+            obj.insert("inputResponses".to_string(), responses.clone());
+        }
+        if let Some(state) = &self.request_state {
+            obj.insert("requestState".to_string(), state.clone());
+        }
+    }
+}
+
+fn with_meta_and_mrtr(
+    params: Value,
+    meta: Option<&Value>,
+    mrtr: Option<&MrtrRequest>,
+) -> Value {
+    let mut params = with_meta(params, meta);
+    if let Some(mrtr) = mrtr {
+        mrtr.apply(&mut params);
+    }
+    params
+}
+
+fn upstream_is_modern(meta: Option<&Value>) -> bool {
+    meta.and_then(|m| m.get("io.modelcontextprotocol/protocolVersion"))
+        .and_then(Value::as_str)
+        == Some(MODERN_PROTOCOL_VERSION)
+}
+
 /// Merge the connection's standard protocol `_meta` into an outgoing request.
 ///
 /// Applied by the transport, so every request gets it regardless of which call
@@ -1039,8 +1093,117 @@ pub fn resolve_command(command: &str) -> String {
     command.to_string()
 }
 
+/// What the gateway wants a transport to do with a legacy server-initiated
+/// request. Legacy upstream clients still answer immediately; modern clients
+/// end the current request with `input_required` and answer on a fresh retry.
+#[derive(Clone, Debug, PartialEq)]
+pub enum ServerRequestAction {
+    Respond(Value),
+    InputRequired,
+}
+
 /// A bidirectional JSON-RPC channel to one downstream server.
-pub type ServerRequestHandler = Arc<dyn Fn(&Value) -> Option<Value> + Send + Sync>;
+pub type ServerRequestHandler =
+    Arc<dyn Fn(&Value) -> Option<ServerRequestAction> + Send + Sync>;
+
+#[derive(Clone, Debug)]
+struct PendingLegacyMrtr {
+    token: String,
+    input_key: String,
+    server_request: Value,
+    downstream_request_id: Value,
+    method: String,
+    base_params: Value,
+}
+
+static MRTR_BRIDGE_ID: AtomicU64 = AtomicU64::new(1);
+
+fn mrtr_base_params(params: &Value) -> Value {
+    let mut params = params.clone();
+    if let Some(obj) = params.as_object_mut() {
+        obj.remove("_meta");
+        obj.remove("inputResponses");
+        obj.remove("requestState");
+    }
+    params
+}
+
+fn new_mrtr_bridge_token() -> Result<String, TransportError> {
+    let mut bytes = [0u8; 16];
+    getrandom::getrandom(&mut bytes).map_err(|_| {
+        TransportError::Fatal("secure randomness unavailable for MRTR requestState".to_string())
+    })?;
+    Ok(base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(bytes))
+}
+
+impl PendingLegacyMrtr {
+    fn new(
+        server_request: Value,
+        downstream_request_id: Value,
+        method: &str,
+        params: &Value,
+    ) -> Result<Self, TransportError> {
+        Ok(Self {
+            token: new_mrtr_bridge_token()?,
+            input_key: format!(
+                "toolport_input_{}",
+                MRTR_BRIDGE_ID.fetch_add(1, Ordering::Relaxed)
+            ),
+            server_request,
+            downstream_request_id,
+            method: method.to_string(),
+            base_params: mrtr_base_params(params),
+        })
+    }
+
+    fn input_required(&self) -> Value {
+        let mut input = serde_json::Map::new();
+        if let Some(method) = self.server_request.get("method") {
+            input.insert("method".to_string(), method.clone());
+        }
+        if let Some(params) = self.server_request.get("params") {
+            input.insert("params".to_string(), params.clone());
+        }
+        json!({
+            "resultType": "input_required",
+            "inputRequests": {
+                self.input_key.clone(): Value::Object(input)
+            },
+            "requestState": self.token
+        })
+    }
+
+    fn response_for_retry(
+        &self,
+        method: &str,
+        params: &Value,
+    ) -> Result<Option<Value>, TransportError> {
+        if method != self.method || mrtr_base_params(params) != self.base_params {
+            return Err(TransportError::Rpc(json!({
+                "code": -32602,
+                "message": "requestState does not belong to this request"
+            })));
+        }
+        if params.get("requestState").and_then(Value::as_str) != Some(self.token.as_str()) {
+            return Err(TransportError::Rpc(json!({
+                "code": -32602,
+                "message": "unknown or expired requestState"
+            })));
+        }
+        let Some(result) = params
+            .get("inputResponses")
+            .and_then(|responses| responses.get(&self.input_key))
+            .cloned()
+        else {
+            return Ok(None);
+        };
+        Ok(Some(json!({
+            "jsonrpc": "2.0",
+            "id": self.server_request.get("id").cloned().unwrap_or(Value::Null),
+            "result": result
+        })))
+    }
+}
 
 /// True when a downstream line is a server-initiated JSON-RPC request (has method + id,
 /// no result/error). Such messages must be answered on the transport, not skipped.
@@ -1742,6 +1905,10 @@ pub struct StdioTransport {
     /// Answers server-initiated JSON-RPC (e.g. `roots/list`) by forwarding to the
     /// upstream MCP client. Set by the gateway before the connect handshake.
     server_handler: Option<ServerRequestHandler>,
+    /// A legacy server request suspended between two modern upstream round trips.
+    /// The child keeps processing the original request; the retry only supplies
+    /// the requested input and must not start a second downstream call.
+    pending_mrtr: Option<PendingLegacyMrtr>,
     /// Routes `notifications/progress` back to the client that minted the token
     /// (SOU-444). Shared with the stdout drain thread so the gateway can bind it
     /// after the transport is spawned, keeping `spawn_watched`'s signature stable.
@@ -2197,6 +2364,7 @@ impl StdioTransport {
             armed,
             launcher: is_download_launcher(command, args),
             server_handler: None,
+            pending_mrtr: None,
             progress,
             protocol_meta: None,
             subscription_listener_id: None,
@@ -2250,14 +2418,36 @@ impl Transport for StdioTransport {
         params: Value,
         cancel: Option<CancelContext>,
     ) -> Result<Value, TransportError> {
-        let id = self.next_id;
-        self.next_id += 1;
-        let downstream_id = json!(id);
         let mut params = params;
         if let Some(protocol) = &self.protocol_meta {
             merge_protocol_meta(&mut params, protocol);
         }
-        let msg = json!({ "jsonrpc": "2.0", "id": downstream_id.clone(), "method": method, "params": params });
+        let (downstream_id, outbound) = if let Some(pending) = self.pending_mrtr.take() {
+            let input_required = pending.input_required();
+            let response = match pending.response_for_retry(method, &params) {
+                Err(error) => {
+                    self.pending_mrtr = Some(pending);
+                    return Err(error);
+                }
+                Ok(Some(response)) => response,
+                Ok(None) => {
+                    self.pending_mrtr = Some(pending);
+                    return Ok(input_required);
+                }
+            };
+            (pending.downstream_request_id.clone(), response)
+        } else {
+            let id = self.next_id;
+            self.next_id += 1;
+            let downstream_id = json!(id);
+            let request = json!({
+                "jsonrpc": "2.0",
+                "id": downstream_id.clone(),
+                "method": method,
+                "params": params
+            });
+            (downstream_id, request)
+        };
 
         // A broken stdin pipe means the child is gone: a health failure, not a protocol error.
         let mut cancel_after_write = None;
@@ -2271,14 +2461,18 @@ impl Transport for StdioTransport {
                 let registry = ctx.registry.clone();
                 let guard = registry.register(
                     client_request_id.clone(),
-                    CancelEntry { stdin: Arc::clone(&self.stdin), downstream_id },
+                    CancelEntry {
+                        stdin: Arc::clone(&self.stdin),
+                        downstream_id: downstream_id.clone(),
+                    },
                 );
                 cancel_after_write = Some((registry, client_request_id));
                 Some(guard)
             } else {
                 None
             };
-            writeln!(stdin, "{msg}").map_err(|e| TransportError::Unavailable(e.to_string()))?;
+            writeln!(stdin, "{outbound}")
+                .map_err(|e| TransportError::Unavailable(e.to_string()))?;
             stdin.flush().map_err(|e| TransportError::Unavailable(e.to_string()))?;
         }
         if let Some((registry, client_request_id)) = cancel_after_write {
@@ -2331,22 +2525,36 @@ impl Transport for StdioTransport {
             };
             if is_server_initiated_request(&value) {
                 if let Some(handler) = &self.server_handler {
-                    if let Some(resp) = handler(&value) {
-                        let line = serde_json::to_string(&resp)
-                            .map_err(|e| TransportError::Fatal(e.to_string()))?;
-                        let mut stdin = self.stdin.lock().map_err(|_| {
-                            TransportError::Unavailable("downstream stdin lock poisoned".into())
-                        })?;
-                        writeln!(stdin, "{line}")
-                            .map_err(|e| TransportError::Unavailable(e.to_string()))?;
-                        stdin
-                            .flush()
-                            .map_err(|e| TransportError::Unavailable(e.to_string()))?;
-                        continue;
+                    match handler(&value) {
+                        Some(ServerRequestAction::Respond(response)) => {
+                            let mut stdin = self.stdin.lock().map_err(|_| {
+                                TransportError::Unavailable(
+                                    "downstream stdin lock poisoned".into(),
+                                )
+                            })?;
+                            writeln!(stdin, "{response}")
+                                .map_err(|e| TransportError::Unavailable(e.to_string()))?;
+                            stdin
+                                .flush()
+                                .map_err(|e| TransportError::Unavailable(e.to_string()))?;
+                            continue;
+                        }
+                        Some(ServerRequestAction::InputRequired) => {
+                            let pending = PendingLegacyMrtr::new(
+                                value,
+                                downstream_id.clone(),
+                                method,
+                                &params,
+                            )?;
+                            let result = pending.input_required();
+                            self.pending_mrtr = Some(pending);
+                            return Ok(result);
+                        }
+                        None => {}
                     }
                 }
             }
-            if ids_match(value.get("id"), Some(&json!(id))) {
+            if ids_match(value.get("id"), Some(&downstream_id)) {
                 if let Some(err) = value.get("error") {
                     return Err(TransportError::Rpc(err.clone()));
                 }
@@ -2612,6 +2820,9 @@ pub struct HttpTransport {
     /// the budget spent.
     forced_refresh_token: Option<String>,
     server_handler: Option<ServerRequestHandler>,
+    /// Open legacy SSE response suspended while a modern upstream client
+    /// fulfills a server-initiated request in a separate round trip.
+    pending_mrtr: Option<PendingHttpMrtr>,
     /// Fan `notifications/resources/updated` seen mid-SSE to subscribed
     /// upstream clients (SOU-394 follow-up for remote downstreams).
     resource_updated: Option<ResourceUpdatedSink>,
@@ -2627,6 +2838,12 @@ pub struct HttpTransport {
     /// drops its response on the next frame/keepalive, closing the old POST.
     listener_generation: Arc<AtomicU64>,
     subscription_listener_id: Option<i64>,
+}
+
+struct PendingHttpMrtr {
+    common: PendingLegacyMrtr,
+    reader: Box<dyn BufRead + Send>,
+    bytes_read: u64,
 }
 
 impl HttpTransport {
@@ -2671,6 +2888,7 @@ impl HttpTransport {
             refresh: refresh.map(|refresh| Arc::new(Mutex::new(refresh))),
             forced_refresh_token: None,
             server_handler: None,
+            pending_mrtr: None,
             resource_updated: None,
             progress: None,
             protocol_meta: None,
@@ -2724,12 +2942,42 @@ impl HttpTransport {
         params: Value,
         headers: &[(String, String)],
     ) -> Result<Value, TransportError> {
-        let id = self.next_id;
-        self.next_id += 1;
         let mut params = params;
         if let Some(protocol) = &self.protocol_meta {
             merge_protocol_meta(&mut params, protocol);
         }
+        if let Some(pending) = self.pending_mrtr.take() {
+            let input_required = pending.common.input_required();
+            let response = match pending.common.response_for_retry(method, &params) {
+                Err(error) => {
+                    self.pending_mrtr = Some(pending);
+                    return Err(error);
+                }
+                Ok(Some(response)) => response,
+                Ok(None) => {
+                    self.pending_mrtr = Some(pending);
+                    return Ok(input_required);
+                }
+            };
+            self.send_post_no_response(&response)?;
+            let resp = self.read_sse_stream(
+                pending.reader,
+                pending.common.downstream_request_id.clone(),
+                &pending.common.method,
+                &pending.common.base_params,
+                pending.bytes_read,
+            )?;
+            let resp = resp.ok_or_else(|| {
+                TransportError::Fatal("empty resumed SSE response".to_string())
+            })?;
+            if let Some(err) = resp.get("error") {
+                return Err(TransportError::Rpc(err.clone()));
+            }
+            return Ok(resp.get("result").cloned().unwrap_or(Value::Null));
+        }
+
+        let id = self.next_id;
+        self.next_id += 1;
         let body = json!({ "jsonrpc": "2.0", "id": id, "method": method, "params": params });
         let resp = self
             .post_with_headers(&body, true, headers)?
@@ -2740,20 +2988,11 @@ impl HttpTransport {
         Ok(resp.get("result").cloned().unwrap_or(Value::Null))
     }
 
-    /// Answer a server-initiated JSON-RPC request inline (SSE mid-stream or
-    /// standalone). Returns true when the message was handled.
-    fn handle_inline_server_request(&mut self, v: &Value) -> Result<bool, TransportError> {
+    fn inline_server_action(&self, v: &Value) -> Option<ServerRequestAction> {
         if !is_server_initiated_request(v) {
-            return Ok(false);
+            return None;
         }
-        let Some(handler) = &self.server_handler else {
-            return Ok(false);
-        };
-        let Some(resp) = handler(v) else {
-            return Ok(false);
-        };
-        self.send_post_no_response(&resp)?;
-        Ok(true)
+        self.server_handler.as_ref().and_then(|handler| handler(v))
     }
 
     /// Try to replace a token nearing expiry. Failure here is non-fatal because
@@ -2872,12 +3111,29 @@ impl HttpTransport {
     fn read_sse_response(
         &mut self,
         resp: ureq::Response,
-        wanted: Option<&Value>,
+        request: &Value,
     ) -> Result<Option<Value>, TransportError> {
-        use std::io::{BufRead, BufReader, Read};
-        let mut reader = BufReader::new(resp.into_reader().take(MAX_RESPONSE_BYTES + 1));
+        let wanted = request.get("id").cloned().unwrap_or(Value::Null);
+        let method = request
+            .get("method")
+            .and_then(Value::as_str)
+            .unwrap_or_default();
+        let params = request.get("params").cloned().unwrap_or_else(|| json!({}));
+        let reader: Box<dyn BufRead + Send> = Box::new(BufReader::new(
+            resp.into_reader().take(MAX_RESPONSE_BYTES + 1),
+        ));
+        self.read_sse_stream(reader, wanted, method, &params, 0)
+    }
+
+    fn read_sse_stream(
+        &mut self,
+        mut reader: Box<dyn BufRead + Send>,
+        wanted: Value,
+        method: &str,
+        params: &Value,
+        mut bytes_read: u64,
+    ) -> Result<Option<Value>, TransportError> {
         let mut line = String::new();
-        let mut bytes_read: u64 = 0;
         loop {
             line.clear();
             let n = reader
@@ -2918,10 +3174,29 @@ impl HttpTransport {
                         continue;
                     }
                 }
-                if self.handle_inline_server_request(&v)? {
-                    continue;
+                match self.inline_server_action(&v) {
+                    Some(ServerRequestAction::Respond(response)) => {
+                        self.send_post_no_response(&response)?;
+                        continue;
+                    }
+                    Some(ServerRequestAction::InputRequired) => {
+                        let common =
+                            PendingLegacyMrtr::new(v, wanted.clone(), method, params)?;
+                        let result = common.input_required();
+                        self.pending_mrtr = Some(PendingHttpMrtr {
+                            common,
+                            reader,
+                            bytes_read,
+                        });
+                        return Ok(Some(json!({
+                            "jsonrpc": "2.0",
+                            "id": wanted,
+                            "result": result
+                        })));
+                    }
+                    None => {}
                 }
-                if ids_match(v.get("id"), wanted) {
+                if ids_match(v.get("id"), Some(&wanted)) {
                     return Ok(Some(v));
                 }
             }
@@ -3056,10 +3331,8 @@ impl HttpTransport {
             .header("content-type")
             .map(|c| c.to_lowercase().contains("text/event-stream"))
             .unwrap_or(false);
-        let wanted = body.get("id").cloned();
-
         if is_sse {
-            return self.read_sse_response(resp, wanted.as_ref());
+            return self.read_sse_response(resp, body);
         }
 
         let text = read_capped(resp, MAX_RESPONSE_BYTES);
@@ -3336,7 +3609,17 @@ pub struct DownstreamServer {
     /// Desired per-resource notification set carried by the modern listener.
     /// Legacy servers keep using resources/subscribe and resources/unsubscribe.
     modern_resource_subscriptions: HashSet<String>,
+    /// Existing legacy server-to-client request bridge. Modern downstream
+    /// `input_required` results use it as a compatibility shim when the upstream
+    /// client predates MRTR.
+    server_handler: Option<ServerRequestHandler>,
 }
+
+/// The compatibility shim holds the originating legacy request open, so keep a
+/// tighter bound than the modern client driver's ten-round default.
+const MRTR_LEGACY_MAX_ROUNDS: usize = 8;
+const MRTR_STATE_ONLY_DELAY: Duration = Duration::from_millis(250);
+static MRTR_LEGACY_REQUEST_ID: AtomicU64 = AtomicU64::new(1);
 
 impl DownstreamServer {
     /// Handshake with the server and fetch its tool list. Resources and prompts
@@ -3519,7 +3802,146 @@ impl DownstreamServer {
             era,
             modern_http,
             modern_resource_subscriptions: std::collections::HashSet::new(),
+            server_handler: None,
         })
+    }
+
+    /// Install the upstream request bridge on both this server wrapper and its
+    /// transport. The transport consumes real legacy server-initiated requests;
+    /// the wrapper consumes modern `input_required` results for legacy clients.
+    pub fn set_server_request_handler(&mut self, handler: ServerRequestHandler) {
+        self.transport.set_server_request_handler(Arc::clone(&handler));
+        self.server_handler = Some(handler);
+    }
+
+    fn fulfill_input_required(&self, result: &Value) -> Result<MrtrRequest, TransportError> {
+        let requests = match result.get("inputRequests") {
+            None => None,
+            Some(Value::Object(requests)) => Some(requests),
+            Some(_) => {
+                return Err(TransportError::Fatal(
+                    "modern server returned non-object inputRequests".to_string(),
+                ))
+            }
+        };
+        let request_state = match result.get("requestState") {
+            None => None,
+            Some(Value::String(state)) => Some(Value::String(state.clone())),
+            Some(_) => {
+                return Err(TransportError::Fatal(
+                    "modern server returned non-string requestState".to_string(),
+                ))
+            }
+        };
+        if requests.map_or(true, serde_json::Map::is_empty) && request_state.is_none() {
+            return Err(TransportError::Fatal(
+                "modern server returned input_required without inputRequests or requestState"
+                    .to_string(),
+            ));
+        }
+
+        let mut input_responses = serde_json::Map::new();
+        if let Some(requests) = requests {
+            let handler = self.server_handler.as_ref().ok_or_else(|| {
+                TransportError::Fatal(
+                    "upstream client cannot fulfill the server's input_required result"
+                        .to_string(),
+                )
+            })?;
+            for (key, input) in requests {
+                let method = input
+                    .get("method")
+                    .and_then(Value::as_str)
+                    .ok_or_else(|| {
+                        TransportError::Fatal(format!(
+                            "input request '{key}' is missing a method"
+                        ))
+                    })?;
+                if !matches!(
+                    method,
+                    "roots/list" | "sampling/createMessage" | "elicitation/create"
+                ) {
+                    return Err(TransportError::Fatal(format!(
+                        "input request '{key}' uses unsupported method '{method}'"
+                    )));
+                }
+                let id = json!(format!(
+                    "toolport-mrtr-{}",
+                    MRTR_LEGACY_REQUEST_ID.fetch_add(1, Ordering::Relaxed)
+                ));
+                let request = json!({
+                    "jsonrpc": "2.0",
+                    "id": id,
+                    "method": method,
+                    "params": input.get("params").cloned().unwrap_or_else(|| json!({}))
+                });
+                let response = match handler(&request) {
+                    Some(ServerRequestAction::Respond(response)) => response,
+                    Some(ServerRequestAction::InputRequired) => {
+                        return Err(TransportError::Fatal(
+                            "cannot nest an input_required bridge while fulfilling one"
+                                .to_string(),
+                        ))
+                    }
+                    None => {
+                        return Err(TransportError::Fatal(format!(
+                            "upstream client did not handle input request '{key}' ({method})"
+                        )))
+                    }
+                };
+                if let Some(error) = response.get("error") {
+                    return Err(TransportError::Rpc(error.clone()));
+                }
+                let response = response.get("result").cloned().ok_or_else(|| {
+                    TransportError::Fatal(format!(
+                        "upstream client returned no result for input request '{key}'"
+                    ))
+                })?;
+                input_responses.insert(key.clone(), response);
+            }
+        }
+
+        if input_responses.is_empty() {
+            std::thread::sleep(MRTR_STATE_ONLY_DELAY);
+        }
+        Ok(MrtrRequest {
+            input_responses: (!input_responses.is_empty()).then(|| Value::Object(input_responses)),
+            request_state,
+        })
+    }
+
+    fn request_with_mrtr(
+        &mut self,
+        method: &str,
+        params: Value,
+        cancel: Option<CancelContext>,
+        meta: Option<&Value>,
+        mrtr: Option<&MrtrRequest>,
+        headers: &[(String, String)],
+    ) -> Result<Value, TransportError> {
+        let modern_upstream = upstream_is_modern(meta);
+        let mut retry = mrtr.cloned().unwrap_or_default();
+        for round in 0..=MRTR_LEGACY_MAX_ROUNDS {
+            let params = with_meta_and_mrtr(params.clone(), meta, Some(&retry));
+            let result = self.transport.request_with_cancel_and_headers(
+                method,
+                params,
+                cancel.clone(),
+                headers,
+            )?;
+            if result.get("resultType").and_then(Value::as_str) != Some("input_required")
+                || modern_upstream
+            {
+                return Ok(result);
+            }
+            if round == MRTR_LEGACY_MAX_ROUNDS {
+                return Err(TransportError::Fatal(format!(
+                    "modern server exceeded the {MRTR_LEGACY_MAX_ROUNDS}-round input_required limit"
+                )));
+            }
+            retry = self.fulfill_input_required(&result)?;
+        }
+        unreachable!("bounded MRTR loop always returns")
     }
 
     /// Re-fetch the server's tool list on the existing connection, after it
@@ -3679,15 +4101,28 @@ impl DownstreamServer {
         cancel: Option<CancelContext>,
         meta: Option<&Value>,
     ) -> Result<Value, TransportError> {
+        self.call_with_cancel_and_mrtr(tool, arguments, cancel, meta, None)
+    }
+
+    pub fn call_with_cancel_and_mrtr(
+        &mut self,
+        tool: &str,
+        arguments: Value,
+        cancel: Option<CancelContext>,
+        meta: Option<&Value>,
+        mrtr: Option<&MrtrRequest>,
+    ) -> Result<Value, TransportError> {
         let headers = if self.modern_http {
             tool_request_headers(&self.tools, tool, &arguments)?
         } else {
             Vec::new()
         };
-        self.transport.request_with_cancel_and_headers(
+        self.request_with_mrtr(
             "tools/call",
-            with_meta(json!({ "name": tool, "arguments": arguments }), meta),
+            json!({ "name": tool, "arguments": arguments }),
             cancel,
+            meta,
+            mrtr,
             &headers,
         )
     }
@@ -3703,10 +4138,23 @@ impl DownstreamServer {
         cancel: Option<CancelContext>,
         meta: Option<&Value>,
     ) -> Result<Value, TransportError> {
-        self.transport.request_with_cancel(
+        self.read_resource_with_cancel_and_mrtr(uri, cancel, meta, None)
+    }
+
+    pub fn read_resource_with_cancel_and_mrtr(
+        &mut self,
+        uri: &str,
+        cancel: Option<CancelContext>,
+        meta: Option<&Value>,
+        mrtr: Option<&MrtrRequest>,
+    ) -> Result<Value, TransportError> {
+        self.request_with_mrtr(
             "resources/read",
-            with_meta(json!({ "uri": uri }), meta),
+            json!({ "uri": uri }),
             cancel,
+            meta,
+            mrtr,
+            &[],
         )
     }
 
@@ -3769,10 +4217,24 @@ impl DownstreamServer {
         cancel: Option<CancelContext>,
         meta: Option<&Value>,
     ) -> Result<Value, TransportError> {
-        self.transport.request_with_cancel(
+        self.get_prompt_with_cancel_and_mrtr(name, arguments, cancel, meta, None)
+    }
+
+    pub fn get_prompt_with_cancel_and_mrtr(
+        &mut self,
+        name: &str,
+        arguments: Value,
+        cancel: Option<CancelContext>,
+        meta: Option<&Value>,
+        mrtr: Option<&MrtrRequest>,
+    ) -> Result<Value, TransportError> {
+        self.request_with_mrtr(
             "prompts/get",
-            with_meta(json!({ "name": name, "arguments": arguments }), meta),
+            json!({ "name": name, "arguments": arguments }),
             cancel,
+            meta,
+            mrtr,
+            &[],
         )
     }
 
@@ -3903,12 +4365,72 @@ mod tests {
     use super::{
         cwd_validation_error, empty_cwd_variables, expand_cwd, file_uri_to_path, resolve_command,
         resolve_root_token, screen_resolved_addrs, screen_spawn_command, screen_spawn_env,
-        validate_cwd, CancelRegistry, DownstreamServer, Transport, TransportError,
+        validate_cwd, CancelRegistry, DownstreamServer, MrtrRequest, ServerRequestAction,
+        ServerRequestHandler, Transport, TransportError, MODERN_PROTOCOL_VERSION,
         fetch_paginated_list,
     };
     use serde_json::{json, Value};
     use std::collections::VecDeque;
     use std::path::Path;
+    use std::sync::{Arc, Mutex};
+
+    struct MrtrTransport {
+        responses: VecDeque<Result<Value, TransportError>>,
+        requests: Arc<Mutex<Vec<(String, Value)>>>,
+    }
+
+    impl MrtrTransport {
+        fn modern(
+            call_responses: Vec<Result<Value, TransportError>>,
+        ) -> (Self, Arc<Mutex<Vec<(String, Value)>>>) {
+            let requests = Arc::new(Mutex::new(Vec::new()));
+            let mut responses = VecDeque::from([
+                Err(TransportError::Rpc(json!({
+                    "code": -32601,
+                    "message": "initialize removed"
+                }))),
+                Ok(json!({
+                    "supportedVersions": [MODERN_PROTOCOL_VERSION],
+                    "capabilities": {}
+                })),
+                Ok(json!({
+                    "tools": [{
+                        "name": "echo",
+                        "description": "fixture",
+                        "inputSchema": { "type": "object" }
+                    }]
+                })),
+            ]);
+            responses.extend(call_responses);
+            (
+                Self {
+                    responses,
+                    requests: Arc::clone(&requests),
+                },
+                requests,
+            )
+        }
+    }
+
+    impl Transport for MrtrTransport {
+        fn request(
+            &mut self,
+            method: &str,
+            params: Value,
+        ) -> Result<Value, TransportError> {
+            self.requests
+                .lock()
+                .unwrap()
+                .push((method.to_string(), params));
+            self.responses
+                .pop_front()
+                .expect("scripted MRTR response")
+        }
+
+        fn notify(&mut self, _method: &str, _params: Value) -> Result<(), TransportError> {
+            Ok(())
+        }
+    }
 
     struct PaginationTransport {
         responses: VecDeque<Result<Value, TransportError>>,
@@ -4023,6 +4545,7 @@ mod tests {
             era: super::Era::Legacy { version: super::PROTOCOL_VERSION.to_string() },
             modern_http: false,
             modern_resource_subscriptions: std::collections::HashSet::new(),
+            server_handler: None,
         };
         server.refresh_tools();
         assert_eq!(server.tools, vec![json!({"name":"stable"})]);
@@ -4050,6 +4573,7 @@ mod tests {
             era: super::Era::Legacy { version: super::PROTOCOL_VERSION.to_string() },
             modern_http: false,
             modern_resource_subscriptions: std::collections::HashSet::new(),
+            server_handler: None,
         };
         server.refresh_resources();
         assert_eq!(server.resources, vec![json!({"uri":"r:"})]);
@@ -4538,8 +5062,127 @@ mod tests {
     }
 
     #[test]
+    fn legacy_client_auto_fulfills_modern_input_required() {
+        let (transport, requests) = MrtrTransport::modern(vec![
+            Ok(json!({
+                "resultType": "input_required",
+                "inputRequests": {
+                    "confirm": {
+                        "method": "elicitation/create",
+                        "params": {
+                            "message": "Continue?",
+                            "requestedSchema": { "type": "object" }
+                        }
+                    },
+                    "workspace": { "method": "roots/list" }
+                },
+                "requestState": "opaque-state"
+            })),
+            Ok(json!({
+                "resultType": "complete",
+                "content": [{ "type": "text", "text": "done" }]
+            })),
+        ]);
+        let mut server = DownstreamServer::connect("modern".into(), Box::new(transport)).unwrap();
+        let handler: ServerRequestHandler = Arc::new(|request| {
+            let id = request["id"].clone();
+            match request["method"].as_str() {
+                Some("elicitation/create") => Some(ServerRequestAction::Respond(json!({
+                    "jsonrpc": "2.0",
+                    "id": id,
+                    "result": { "action": "accept", "content": { "approved": true } }
+                }))),
+                Some("roots/list") => Some(ServerRequestAction::Respond(json!({
+                    "jsonrpc": "2.0",
+                    "id": id,
+                    "result": { "roots": [{ "uri": "file:///workspace" }] }
+                }))),
+                _ => None,
+            }
+        });
+        server.set_server_request_handler(handler);
+
+        let result = server.call("echo", json!({ "text": "hi" })).unwrap();
+        assert_eq!(result["resultType"], "complete");
+
+        let requests = requests.lock().unwrap();
+        let calls: Vec<&Value> = requests
+            .iter()
+            .filter(|(method, _)| method == "tools/call")
+            .map(|(_, params)| params)
+            .collect();
+        assert_eq!(calls.len(), 2, "the retry is a new downstream request");
+        assert!(calls[0].get("inputResponses").is_none());
+        assert!(calls[0].get("requestState").is_none());
+        assert_eq!(calls[1]["requestState"], "opaque-state");
+        assert_eq!(calls[1]["inputResponses"]["confirm"]["action"], "accept");
+        assert_eq!(
+            calls[1]["inputResponses"]["workspace"]["roots"][0]["uri"],
+            "file:///workspace"
+        );
+    }
+
+    #[test]
+    fn modern_client_receives_input_required_and_controls_the_retry() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let (transport, requests) = MrtrTransport::modern(vec![
+            Ok(json!({
+                "resultType": "input_required",
+                "inputRequests": {
+                    "confirm": {
+                        "method": "elicitation/create",
+                        "params": { "message": "Continue?" }
+                    }
+                },
+                "requestState": "byte-exact-state"
+            })),
+            Ok(json!({ "resultType": "complete", "content": [] })),
+        ]);
+        let mut server = DownstreamServer::connect("modern".into(), Box::new(transport)).unwrap();
+        let handled = Arc::new(AtomicUsize::new(0));
+        let handled_by_bridge = Arc::clone(&handled);
+        server.set_server_request_handler(Arc::new(move |_| {
+            handled_by_bridge.fetch_add(1, Ordering::SeqCst);
+            None
+        }));
+        let meta = json!({
+            "io.modelcontextprotocol/protocolVersion": MODERN_PROTOCOL_VERSION
+        });
+
+        let incomplete = server
+            .call_with_cancel_and_mrtr("echo", json!({}), None, Some(&meta), None)
+            .unwrap();
+        assert_eq!(incomplete["resultType"], "input_required");
+        assert_eq!(handled.load(Ordering::SeqCst), 0, "native MRTR is not shimmed");
+
+        let retry = MrtrRequest {
+            input_responses: Some(json!({
+                "confirm": { "action": "accept", "content": { "approved": true } }
+            })),
+            request_state: Some(json!("byte-exact-state")),
+        };
+        let complete = server
+            .call_with_cancel_and_mrtr("echo", json!({}), None, Some(&meta), Some(&retry))
+            .unwrap();
+        assert_eq!(complete["resultType"], "complete");
+
+        let requests = requests.lock().unwrap();
+        let calls: Vec<&Value> = requests
+            .iter()
+            .filter(|(method, _)| method == "tools/call")
+            .map(|(_, params)| params)
+            .collect();
+        assert_eq!(calls.len(), 2);
+        assert_eq!(calls[1]["requestState"], "byte-exact-state");
+        assert_eq!(calls[1]["inputResponses"], retry.input_responses.unwrap());
+    }
+
+    #[test]
     fn http_sse_answers_inline_server_request_before_final_response() {
-        use super::{HttpTransport, RefreshFn, ServerRequestHandler, Transport};
+        use super::{
+            HttpTransport, RefreshFn, ServerRequestAction, ServerRequestHandler, Transport,
+        };
         use serde_json::Value;
         use std::io::{Read, Write};
         use std::net::TcpListener;
@@ -4623,11 +5266,11 @@ mod tests {
 
         let handler: ServerRequestHandler = Arc::new(|req| {
             if req.get("method").and_then(|m| m.as_str()) == Some("roots/list") {
-                Some(json!({
+                Some(ServerRequestAction::Respond(json!({
                     "jsonrpc": "2.0",
                     "id": req.get("id").cloned().unwrap_or(Value::Null),
                     "result": { "roots": [] }
-                }))
+                })))
             } else {
                 None
             }
@@ -4660,6 +5303,104 @@ mod tests {
                 .unwrap_or(Value::Null),
             json!({"ok": true})
         );
+    }
+
+    #[test]
+    fn http_sse_mrtr_resumes_without_reposting_the_original_request() {
+        use super::{HttpTransport, ServerRequestAction, Transport};
+        use std::io::{Read, Write};
+        use std::net::TcpListener;
+        use std::sync::Arc;
+
+        fn read_http_request(stream: &mut impl Read) -> String {
+            let mut headers = Vec::new();
+            let mut byte = [0u8; 1];
+            while stream.read(&mut byte).unwrap() > 0 {
+                headers.push(byte[0]);
+                if headers.ends_with(b"\r\n\r\n") {
+                    break;
+                }
+            }
+            let text = String::from_utf8_lossy(&headers);
+            let len = text
+                .lines()
+                .find_map(|line| {
+                    line.strip_prefix("Content-Length:")
+                        .or_else(|| line.strip_prefix("content-length:"))
+                })
+                .and_then(|value| value.trim().parse::<usize>().ok())
+                .unwrap_or(0);
+            let mut body = vec![0u8; len];
+            stream.read_exact(&mut body).unwrap();
+            String::from_utf8(body).unwrap()
+        }
+
+        fn write_chunk(stream: &mut impl Write, data: &str) {
+            write!(stream, "{:x}\r\n{data}\r\n", data.len()).unwrap();
+            stream.flush().unwrap();
+        }
+
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let server = std::thread::spawn(move || {
+            let mut original = listener.accept().unwrap().0;
+            let original_body = read_http_request(&mut original);
+            assert!(original_body.contains("\"method\":\"tools/call\""));
+            original
+                .write_all(
+                    b"HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\nTransfer-Encoding: chunked\r\nConnection: close\r\n\r\n",
+                )
+                .unwrap();
+            write_chunk(
+                &mut original,
+                "data: {\"jsonrpc\":\"2.0\",\"id\":99,\"method\":\"elicitation/create\",\"params\":{\"message\":\"Continue?\"}}\n",
+            );
+
+            let mut response = listener.accept().unwrap().0;
+            let response_body = read_http_request(&mut response);
+            assert!(response_body.contains("\"id\":99"));
+            assert!(response_body.contains("\"action\":\"accept\""));
+            response
+                .write_all(
+                    b"HTTP/1.1 202 Accepted\r\nContent-Length: 2\r\nConnection: close\r\n\r\n{}",
+                )
+                .unwrap();
+
+            write_chunk(
+                &mut original,
+                "data: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"ok\":true}}\n",
+            );
+            original.write_all(b"0\r\n\r\n").unwrap();
+        });
+
+        let mut transport = HttpTransport::new(&format!("http://127.0.0.1:{port}/"));
+        transport.set_server_request_handler(Arc::new(|request| {
+            (request["method"] == "elicitation/create")
+                .then_some(ServerRequestAction::InputRequired)
+        }));
+        let first = transport
+            .request("tools/call", json!({ "name": "interactive", "arguments": {} }))
+            .expect("first round");
+        assert_eq!(first["resultType"], "input_required");
+        let state = first["requestState"].clone();
+        let requests = first["inputRequests"].as_object().unwrap();
+        let key = requests.keys().next().unwrap().clone();
+
+        let final_result = transport
+            .request(
+                "tools/call",
+                json!({
+                    "name": "interactive",
+                    "arguments": {},
+                    "requestState": state,
+                    "inputResponses": {
+                        key: { "action": "accept", "content": { "approved": true } }
+                    }
+                }),
+            )
+            .expect("resumed round");
+        assert_eq!(final_result, json!({ "ok": true }));
+        server.join().unwrap();
     }
 
 

--- a/src-tauri/src/downstream.rs
+++ b/src-tauri/src/downstream.rs
@@ -416,8 +416,14 @@ pub struct MrtrRequest {
 impl MrtrRequest {
     pub fn from_params(params: Option<&Value>) -> Self {
         Self {
-            input_responses: params.and_then(|p| p.get("inputResponses")).cloned(),
-            request_state: params.and_then(|p| p.get("requestState")).cloned(),
+            input_responses: params
+                .and_then(|p| p.get("inputResponses"))
+                .filter(|value| !value.is_null())
+                .cloned(),
+            request_state: params
+                .and_then(|p| p.get("requestState"))
+                .filter(|value| !value.is_null())
+                .cloned(),
         }
     }
 
@@ -5120,6 +5126,20 @@ mod tests {
             calls[1]["inputResponses"]["workspace"]["roots"][0]["uri"],
             "file:///workspace"
         );
+    }
+
+    #[test]
+    fn mrtr_null_retry_fields_are_treated_as_absent() {
+        let retry = MrtrRequest::from_params(Some(&json!({
+            "inputResponses": null,
+            "requestState": null
+        })));
+
+        assert!(retry.is_empty());
+        let mut params = json!({ "name": "echo", "arguments": {} });
+        retry.apply(&mut params);
+        assert!(params.get("inputResponses").is_none());
+        assert!(params.get("requestState").is_none());
     }
 
     #[test]

--- a/src-tauri/src/router.rs
+++ b/src-tauri/src/router.rs
@@ -19,7 +19,7 @@ use std::time::{Duration, Instant};
 use serde_json::{json, Value};
 
 use crate::downstream::{
-    backoff_delay, CancelContext, DownstreamServer, TransportError, HTTP_MAX_RETRIES,
+    backoff_delay, CancelContext, DownstreamServer, MrtrRequest, TransportError, HTTP_MAX_RETRIES,
     HTTP_RETRY_CAP,
 };
 use crate::registry::ToolOverride;
@@ -968,6 +968,17 @@ impl Router {
         cancel: Option<CancelContext>,
         meta: Option<&Value>,
     ) -> Result<Value, String> {
+        self.route_call_with_cancel_and_mrtr(exposed_name, arguments, cancel, meta, None)
+    }
+
+    pub fn route_call_with_cancel_and_mrtr(
+        &self,
+        exposed_name: &str,
+        arguments: Value,
+        cancel: Option<CancelContext>,
+        meta: Option<&Value>,
+        mrtr: Option<&MrtrRequest>,
+    ) -> Result<Value, String> {
         if let Some(reason) = self.blocked.get(exposed_name) {
             return Err(format!("tool '{exposed_name}' is {reason}"));
         }
@@ -977,7 +988,13 @@ impl Router {
             .ok_or_else(|| format!("no route for tool '{exposed_name}'"))?;
         let slot = self.slot_for(server_id)?;
         self.call_with_retry(&slot, |server| {
-            server.call_with_cancel(tool, arguments.clone(), cancel.clone(), meta)
+            server.call_with_cancel_and_mrtr(
+                tool,
+                arguments.clone(),
+                cancel.clone(),
+                meta,
+                mrtr,
+            )
         })
     }
 
@@ -1109,13 +1126,23 @@ impl Router {
         cancel: Option<CancelContext>,
         meta: Option<&Value>,
     ) -> Result<Value, String> {
+        self.read_resource_with_cancel_and_mrtr(uri, cancel, meta, None)
+    }
+
+    pub fn read_resource_with_cancel_and_mrtr(
+        &self,
+        uri: &str,
+        cancel: Option<CancelContext>,
+        meta: Option<&Value>,
+        mrtr: Option<&MrtrRequest>,
+    ) -> Result<Value, String> {
         let server_id = self
             .resource_server(uri)
             .ok_or_else(|| format!("no server owns resource '{uri}'"))?
             .to_string();
         let slot = self.slot_for(&server_id)?;
         self.call_with_retry(&slot, |server| {
-            server.read_resource_with_cancel(uri, cancel.clone(), meta)
+            server.read_resource_with_cancel_and_mrtr(uri, cancel.clone(), meta, mrtr)
         })
     }
 
@@ -1169,6 +1196,17 @@ impl Router {
         cancel: Option<CancelContext>,
         meta: Option<&Value>,
     ) -> Result<Value, String> {
+        self.get_prompt_with_cancel_and_mrtr(exposed_name, arguments, cancel, meta, None)
+    }
+
+    pub fn get_prompt_with_cancel_and_mrtr(
+        &self,
+        exposed_name: &str,
+        arguments: Value,
+        cancel: Option<CancelContext>,
+        meta: Option<&Value>,
+        mrtr: Option<&MrtrRequest>,
+    ) -> Result<Value, String> {
         let (server_id, name) = self
             .prompt_routes
             .get(exposed_name)
@@ -1176,7 +1214,13 @@ impl Router {
             .ok_or_else(|| format!("no route for prompt '{exposed_name}'"))?;
         let slot = self.slot_for(&server_id)?;
         self.call_with_retry(&slot, |server| {
-            server.get_prompt_with_cancel(&name, arguments.clone(), cancel.clone(), meta)
+            server.get_prompt_with_cancel_and_mrtr(
+                &name,
+                arguments.clone(),
+                cancel.clone(),
+                meta,
+                mrtr,
+            )
         })
     }
 

--- a/src-tauri/tests/spec_conformance.rs
+++ b/src-tauri/tests/spec_conformance.rs
@@ -26,7 +26,8 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use conduit_lib::downstream::{
-    DownstreamServer, HttpTransport, StdioTransport, Transport, TransportError,
+    DownstreamServer, HttpTransport, MrtrRequest, ServerRequestAction, ServerRequestHandler,
+    StdioTransport, Transport, TransportError,
 };
 use serde_json::{json, Value};
 
@@ -559,6 +560,177 @@ fn gateway_connects_to_a_modern_server() {
         "expected the tools/list and tools/call records to be checked, saw {checked}"
     );
 
+    let _ = std::fs::remove_file(&path);
+}
+
+#[test]
+fn legacy_client_is_shimmed_across_a_modern_mrtr_server() {
+    let path = scratch_path("mrtr-legacy-shim");
+    let _ = std::fs::remove_file(&path);
+    let env = env_for(Some(MODERN), true, Some(&path.to_string_lossy()));
+    let dirty = Arc::new(AtomicU8::new(0));
+    let transport = StdioTransport::spawn_watched(mock_bin(), &[], &env, None, dirty, None)
+        .expect("spawn fixture");
+    let mut server =
+        DownstreamServer::connect("mock".to_string(), Box::new(transport)).expect("connect");
+    let seen: Arc<Mutex<Vec<Value>>> = Arc::new(Mutex::new(Vec::new()));
+    let seen_request = Arc::clone(&seen);
+    let handler: ServerRequestHandler = Arc::new(move |request| {
+        seen_request.lock().unwrap().push(request.clone());
+        Some(ServerRequestAction::Respond(json!({
+            "jsonrpc": "2.0",
+            "id": request["id"].clone(),
+            "result": { "action": "accept", "content": { "approved": true } }
+        })))
+    });
+    server.set_server_request_handler(handler);
+
+    let result = server
+        .call("mrtr_confirm", json!({}))
+        .expect("legacy compatibility shim should complete the call");
+    assert_eq!(result["resultType"], "complete");
+    assert_eq!(result["content"][0]["text"], "confirmed");
+    let seen = seen.lock().unwrap();
+    assert_eq!(seen.len(), 1);
+    assert_eq!(seen[0]["method"], "elicitation/create");
+    drop(seen);
+    drop(server);
+
+    let transcript = read_transcript(&path);
+    let calls: Vec<&Value> = transcript
+        .iter()
+        .filter(|request| {
+            request["method"] == "tools/call"
+                && request["params"]["name"] == "mrtr_confirm"
+        })
+        .collect();
+    assert_eq!(calls.len(), 2, "MRTR retry must be a new request");
+    assert_ne!(calls[0]["id"], calls[1]["id"], "retry id must change");
+    assert_eq!(calls[1]["params"]["requestState"], "mock-state-byte-exact");
+    assert_eq!(
+        calls[1]["params"]["inputResponses"]["confirm"]["action"],
+        "accept"
+    );
+    let _ = std::fs::remove_file(&path);
+}
+
+#[test]
+fn modern_client_controls_native_mrtr_retry_fields() {
+    let path = scratch_path("mrtr-native");
+    let _ = std::fs::remove_file(&path);
+    let env = env_for(Some(MODERN), true, Some(&path.to_string_lossy()));
+    let dirty = Arc::new(AtomicU8::new(0));
+    let transport = StdioTransport::spawn_watched(mock_bin(), &[], &env, None, dirty, None)
+        .expect("spawn fixture");
+    let mut server =
+        DownstreamServer::connect("mock".to_string(), Box::new(transport)).expect("connect");
+    let meta = json!({ "io.modelcontextprotocol/protocolVersion": MODERN });
+
+    let incomplete = server
+        .call_with_cancel_and_mrtr("mrtr_confirm", json!({}), None, Some(&meta), None)
+        .expect("native MRTR first round");
+    assert_eq!(incomplete["resultType"], "input_required");
+    assert_eq!(incomplete["requestState"], "mock-state-byte-exact");
+
+    let retry = MrtrRequest {
+        input_responses: Some(json!({
+            "confirm": { "action": "accept", "content": { "approved": true } }
+        })),
+        request_state: Some(json!("mock-state-byte-exact")),
+    };
+    let complete = server
+        .call_with_cancel_and_mrtr(
+            "mrtr_confirm",
+            json!({}),
+            None,
+            Some(&meta),
+            Some(&retry),
+        )
+        .expect("native MRTR retry");
+    assert_eq!(complete["resultType"], "complete");
+    assert_eq!(complete["content"][0]["text"], "confirmed");
+    drop(server);
+
+    let transcript = read_transcript(&path);
+    let calls: Vec<&Value> = transcript
+        .iter()
+        .filter(|request| {
+            request["method"] == "tools/call"
+                && request["params"]["name"] == "mrtr_confirm"
+        })
+        .collect();
+    assert_eq!(calls.len(), 2);
+    assert_ne!(calls[0]["id"], calls[1]["id"]);
+    assert_eq!(calls[1]["params"]["requestState"], retry.request_state.unwrap());
+    assert_eq!(calls[1]["params"]["inputResponses"], retry.input_responses.unwrap());
+    let _ = std::fs::remove_file(&path);
+}
+
+#[test]
+fn modern_client_resumes_legacy_stdio_hitl_without_replaying_the_tool() {
+    let path = scratch_path("mrtr-legacy-downstream");
+    let _ = std::fs::remove_file(&path);
+    let env = env_for(Some("2025-11-25"), true, Some(&path.to_string_lossy()));
+    let dirty = Arc::new(AtomicU8::new(0));
+    let transport = StdioTransport::spawn_watched(mock_bin(), &[], &env, None, dirty, None)
+        .expect("spawn legacy fixture");
+    let mut server =
+        DownstreamServer::connect("mock".to_string(), Box::new(transport)).expect("connect");
+    server.set_server_request_handler(Arc::new(|request| {
+        (request["method"] == "elicitation/create").then_some(ServerRequestAction::InputRequired)
+    }));
+    let meta = json!({ "io.modelcontextprotocol/protocolVersion": MODERN });
+
+    let incomplete = server
+        .call_with_cancel_and_mrtr(
+            "legacy_elicitation",
+            json!({}),
+            None,
+            Some(&meta),
+            None,
+        )
+        .expect("legacy server request should become MRTR");
+    assert_eq!(incomplete["resultType"], "input_required");
+    let state = incomplete["requestState"].clone();
+    let requests = incomplete["inputRequests"]
+        .as_object()
+        .expect("inputRequests map");
+    assert_eq!(requests.len(), 1);
+    let key = requests.keys().next().unwrap().clone();
+    assert_eq!(requests[&key]["method"], "elicitation/create");
+
+    let retry = MrtrRequest {
+        input_responses: Some(json!({
+            key: { "action": "accept", "content": { "approved": true } }
+        })),
+        request_state: Some(state),
+    };
+    let complete = server
+        .call_with_cancel_and_mrtr(
+            "legacy_elicitation",
+            json!({}),
+            None,
+            Some(&meta),
+            Some(&retry),
+        )
+        .expect("MRTR retry should resume the suspended legacy request");
+    assert_eq!(complete["content"][0]["text"], "legacy confirmed");
+    drop(server);
+
+    let transcript = read_transcript(&path);
+    let calls: Vec<&Value> = transcript
+        .iter()
+        .filter(|request| {
+            request["method"] == "tools/call"
+                && request["params"]["name"] == "legacy_elicitation"
+        })
+        .collect();
+    assert_eq!(calls.len(), 1, "the modern retry must not replay tools/call");
+    let replies: Vec<&Value> = transcript
+        .iter()
+        .filter(|request| request["id"] == "mock-legacy-elicitation")
+        .collect();
+    assert_eq!(replies.len(), 1, "one input response resumes the legacy call");
     let _ = std::fs::remove_file(&path);
 }
 


### PR DESCRIPTION
## What and why

Implements [SOU-449](https://linear.app/southforge-ai/issue/SOU-449/multi-round-trip-requests-mrtr-resulttype-and-rewire-hitl-onto-it) across the Toolport gateway:

- adds MCP 2026-07-28 MRTR fields (`resultType`, `inputRequests`, `inputResponses`, and opaque `requestState`) to tool calls, resource reads, and prompt requests
- bridges modern `input_required` responses to legacy client server-request handlers, with bounded retries and fresh downstream request IDs
- bridges legacy upstream server requests into modern MRTR responses over stdio and HTTP SSE without replaying the original downstream request
- moves modern direct-call HITL onto MRTR elicitation while preserving the existing approval broker for legacy clients and code mode
- binds short-lived HITL state to the exact client, tool, arguments, fingerprint, and reason, then revalidates policy and fingerprint before execution
- preserves backward compatibility by treating results without `resultType` as complete

## Testing

- [ ] `npm run build` passes
- [ ] `npm run test` passes
- [ ] `npm run audit:prod` passes
- [ ] `npm run test:rust` passes (`npm run test:rust:windows` on Windows if the debug gateway binary is locked)
- [ ] Ran the app (`npm run tauri dev`) and checked the change by hand

Validated the Rust scope directly:

- `cargo check --lib --bin toolport-gateway --bin mock-mcp-server`
- `cargo test --tests --no-fail-fast` (850 tests passed, including 26 spec-conformance tests)
- `cargo test --bin toolport-gateway --no-fail-fast` (206 tests passed)
- `git diff --check`

## Notes

- This makes the request/transport flow stateless. Pending HITL correlation is currently held in a short-lived in-memory map, so multi-instance or serverless coordination remains a follow-up if Toolport adopts that deployment model.
- `cargo fmt --all -- --check` is not currently a clean repository-wide gate because existing baseline files produce unrelated formatting diffs; no broad formatting rewrite was included here.
- No UI changes or screenshots.