### PR TITLE
feat(mcp): add cacheable results and stable ordering (SOU-454)

### DIFF
--- a/src-tauri/src/bin/mock-mcp-server.rs
+++ b/src-tauri/src/bin/mock-mcp-server.rs
@@ -367,6 +367,7 @@ fn handle(cfg: &Config, state: &mut State, req: &Value, pre: &mut Vec<Value>) ->
         }),
         "tools/list" => tool_list(cfg, state.grown),
         "resources/list" => resource_list(state.grown),
+        "resources/templates/list" => json!({ "resourceTemplates": [] }),
         "prompts/list" => prompt_list(state.grown),
         "tools/call" => {
             let params = req.get("params");

--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -32,7 +32,7 @@ use conduit_lib::{audit, usage_report};
 use conduit_lib::clients;
 use conduit_lib::codemode;
 use conduit_lib::downstream::{
-    self, DownstreamServer, MrtrRequest, ResourceUpdatedSink, ServerRequestAction,
+    self, CacheHint, DownstreamServer, MrtrRequest, ResourceUpdatedSink, ServerRequestAction,
     ServerRequestHandler, StdioTransport, Transport,
     MODERN_PROTOCOL_VERSION, PROTOCOL_VERSION,
 };
@@ -151,6 +151,34 @@ fn decorate_for_upstream(mut result: Value) -> Value {
             json!({ "name": "toolport-gateway", "version": env!("CARGO_PKG_VERSION") }),
         );
     }
+    result
+}
+
+/// Toolport-owned cacheable results stay fresh for five minutes unless a
+/// contributing downstream server advertises a shorter window. Registry and
+/// list-changed notifications still invalidate them immediately.
+const LOCAL_CACHE_TTL_MS: u64 = 300_000;
+
+fn cacheable_for_upstream(mut result: Value, hint: CacheHint, scoped: bool) -> Value {
+    let Some(obj) = result.as_object_mut() else {
+        return result;
+    };
+    if !serving_modern_client() {
+        // A modern downstream may sit behind a legacy upstream. Keep the legacy
+        // result shape unchanged rather than leaking fields its revision lacks.
+        obj.remove("ttlMs");
+        obj.remove("cacheScope");
+        return result;
+    }
+    obj.insert("ttlMs".to_string(), json!(hint.remaining_ttl_ms()));
+    obj.insert(
+        "cacheScope".to_string(),
+        json!(if !scoped && hint.is_public() {
+            "public"
+        } else {
+            "private"
+        }),
+    );
     result
 }
 
@@ -1873,7 +1901,15 @@ struct CatalogSnapshot {
 }
 
 impl CatalogSnapshot {
-    fn new(tools: Vec<Value>) -> Self {
+    fn new(mut tools: Vec<Value>) -> Self {
+        // Normalize both fresh and disk-cached catalogs. Without this, the first
+        // tools/list after restart could replay pre-SOU-454 incidental ordering
+        // until the background router build replaced it.
+        tools.sort_by(|left, right| {
+            left.get("name")
+                .and_then(Value::as_str)
+                .cmp(&right.get("name").and_then(Value::as_str))
+        });
         let search = CatalogSearchIndex::build(&tools);
         Self { tools, search }
     }
@@ -4236,6 +4272,9 @@ fn handle_request_with_cancel(
         declared.filter(|v| v.as_str() == MODERN_PROTOCOL_VERSION),
     );
     let _capabilities = UpstreamCapabilitiesGuard::enter(req);
+    // A profile-selected or per-client filtered catalog must never be shared
+    // across authorization contexts, even when every downstream says public.
+    let cache_scoped = profile.is_some() || allowed.is_some();
 
     match method {
         // Modern clients open here instead of handshaking. Servers MUST implement
@@ -4327,7 +4366,14 @@ fn handle_request_with_cancel(
                     "tools/list -> {} meta-tools (lazy discovery)",
                     tools.len()
                 ));
-                return Some(success(id, json!({ "tools": tools })));
+                return Some(success(
+                    id,
+                    cacheable_for_upstream(
+                        json!({ "tools": tools }),
+                        CacheHint::local(LOCAL_CACHE_TTL_MS),
+                        cache_scoped,
+                    ),
+                ));
             }
             // Grouped mode: the lazy meta-tools plus a per-server help_<server> browse
             // tool, so a weak model can pick a server by name instead of inventing a
@@ -4362,7 +4408,17 @@ fn handle_request_with_cancel(
                     tools.len(),
                     distinct_server_prefixes(&scoped).len()
                 ));
-                return Some(success(id, json!({ "tools": tools })));
+                return Some(success(
+                    id,
+                    cacheable_for_upstream(
+                        json!({ "tools": tools }),
+                        router
+                            .tools_cache_hint()
+                            .map(|hint| CacheHint::local(LOCAL_CACHE_TTL_MS).merge(hint))
+                            .unwrap_or_else(|| CacheHint::local(LOCAL_CACHE_TTL_MS)),
+                        cache_scoped,
+                    ),
+                ));
             }
             let mut tools = vec![status_tool_def(), fetch_result_tool_def()];
             if code_mode_enabled() {
@@ -4388,7 +4444,17 @@ fn handle_request_with_cancel(
                 tools.len(),
                 !cached.is_empty()
             ));
-            Some(success(id, json!({ "tools": tools })))
+            Some(success(
+                id,
+                cacheable_for_upstream(
+                    json!({ "tools": tools }),
+                    router
+                        .tools_cache_hint()
+                        .map(|hint| CacheHint::local(LOCAL_CACHE_TTL_MS).merge(hint))
+                        .unwrap_or_else(|| CacheHint::local(LOCAL_CACHE_TTL_MS)),
+                    cache_scoped,
+                ),
+            ))
         }
         "tools/call" => {
             let params = req.get("params");
@@ -4890,7 +4956,16 @@ fn handle_request_with_cancel(
                 });
             }
             gtrace(&format!("resources/list -> {} resources", resources.len()));
-            Some(success(id, json!({ "resources": resources })))
+            Some(success(
+                id,
+                cacheable_for_upstream(
+                    json!({ "resources": resources }),
+                    router
+                        .resources_cache_hint()
+                        .unwrap_or_else(|| CacheHint::local(LOCAL_CACHE_TTL_MS)),
+                    cache_scoped,
+                ),
+            ))
         }
         "resources/templates/list" => {
             let mut templates = router.aggregated_resource_templates();
@@ -4910,7 +4985,16 @@ fn handle_request_with_cancel(
             ));
             // Backward compatible: full aggregated list in one response (no
             // nextCursor), matching tools/resources/prompts list behavior.
-            Some(success(id, json!({ "resourceTemplates": templates })))
+            Some(success(
+                id,
+                cacheable_for_upstream(
+                    json!({ "resourceTemplates": templates }),
+                    router
+                        .resource_templates_cache_hint()
+                        .unwrap_or_else(|| CacheHint::local(LOCAL_CACHE_TTL_MS)),
+                    cache_scoped,
+                ),
+            ))
         }
         "resources/read" => {
             let params = req.get("params");
@@ -4957,7 +5041,11 @@ fn handle_request_with_cancel(
                             return Some(error(id, -32602, &msg));
                         }
                     }
-                    Some(success(id, result))
+                    let hint = CacheHint::from_result(&result);
+                    Some(success(
+                        id,
+                        cacheable_for_upstream(result, hint, cache_scoped),
+                    ))
                 }
                 // The error message is downstream-controlled and does not pass through
                 // inspect_result (it's a JSON-RPC error, not a content block), so
@@ -4983,7 +5071,16 @@ fn handle_request_with_cancel(
                 });
             }
             gtrace(&format!("prompts/list -> {} prompts", prompts.len()));
-            Some(success(id, json!({ "prompts": prompts })))
+            Some(success(
+                id,
+                cacheable_for_upstream(
+                    json!({ "prompts": prompts }),
+                    router
+                        .prompts_cache_hint()
+                        .unwrap_or_else(|| CacheHint::local(LOCAL_CACHE_TTL_MS)),
+                    cache_scoped,
+                ),
+            ))
         }
         "prompts/get" => {
             let params = req.get("params");
@@ -6552,7 +6649,15 @@ fn watch_tick(
     // A live downstream server that changed its own tool set (sent
     // tools/list_changed) sets this. Swap before acting so a notification
     // arriving mid-refresh is caught on the next tick rather than lost.
-    let downstream_changed = downstream_dirty.swap(0, Ordering::SeqCst);
+    let downstream_notified = downstream_dirty.swap(0, Ordering::SeqCst);
+    let cache_expired = {
+        let live = router
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .clone();
+        live.expired_cache_kinds()
+    };
+    let downstream_changed = downstream_notified | cache_expired;
     let current = mtime(path);
     let file_changed = current != state.last_mtime;
     if !file_changed && downstream_changed == 0 {
@@ -6704,7 +6809,11 @@ fn watch_tick(
                     .unwrap_or_else(std::sync::PoisonError::into_inner);
                 (**guard).clone()
             };
-            next.refresh_tools();
+            if downstream_notified & downstream::change::TOOLS != 0 {
+                next.refresh_tools();
+            } else {
+                next.refresh_stale_tools();
+            }
             let tools = next.aggregated_tools();
             *router
                 .lock()
@@ -6728,7 +6837,11 @@ fn watch_tick(
             };
             // Also refreshes resource templates (MCP has no separate templates
             // list_changed; they ride on resources/list_changed).
-            next.refresh_resources();
+            if downstream_notified & downstream::change::RESOURCES != 0 {
+                next.refresh_resources();
+            } else {
+                next.refresh_stale_resources();
+            }
             *router
                 .lock()
                 .unwrap_or_else(std::sync::PoisonError::into_inner) = Arc::new(next);
@@ -6746,7 +6859,11 @@ fn watch_tick(
                     .unwrap_or_else(std::sync::PoisonError::into_inner);
                 (**guard).clone()
             };
-            next.refresh_prompts();
+            if downstream_notified & downstream::change::PROMPTS != 0 {
+                next.refresh_prompts();
+            } else {
+                next.refresh_stale_prompts();
+            }
             *router
                 .lock()
                 .unwrap_or_else(std::sync::PoisonError::into_inner) = Arc::new(next);
@@ -12460,6 +12577,65 @@ mod tests {
             Ok(())
         }
     }
+
+    struct CacheRoute;
+
+    impl conduit_lib::downstream::Transport for CacheRoute {
+        fn request(
+            &mut self,
+            method: &str,
+            params: Value,
+        ) -> Result<Value, conduit_lib::downstream::TransportError> {
+            let cached = |mut result: Value, ttl_ms: u64| {
+                result["ttlMs"] = json!(ttl_ms);
+                result["cacheScope"] = json!("public");
+                result
+            };
+            match method {
+                "initialize" => Ok(json!({
+                    "protocolVersion": "2025-06-18",
+                    "capabilities": { "resources": {}, "prompts": {} }
+                })),
+                "tools/list" => Ok(cached(json!({ "tools": [{ "name": "cached" }] }), 50_000)),
+                "resources/list" => Ok(cached(
+                    json!({ "resources": [{ "uri": "fixture://cached", "name": "cached" }] }),
+                    40_000,
+                )),
+                "resources/templates/list" => Ok(cached(
+                    json!({ "resourceTemplates": [{ "uriTemplate": "fixture://{id}" }] }),
+                    30_000,
+                )),
+                "resources/read" => Ok(cached(
+                    json!({ "contents": [{ "uri": params["uri"], "text": "cached" }] }),
+                    20_000,
+                )),
+                "prompts/list" => Ok(cached(
+                    json!({ "prompts": [{ "name": "cached" }] }),
+                    10_000,
+                )),
+                other => Err(conduit_lib::downstream::TransportError::Fatal(format!(
+                    "unexpected {other}"
+                ))),
+            }
+        }
+
+        fn notify(
+            &mut self,
+            _method: &str,
+            _params: Value,
+        ) -> Result<(), conduit_lib::downstream::TransportError> {
+            Ok(())
+        }
+    }
+
+    fn cache_router() -> Router {
+        let mut server = DownstreamServer::connect("cache".to_string(), Box::new(CacheRoute))
+            .unwrap();
+        server.load_resources_prompts();
+        let mut router = Router::new();
+        router.add(server);
+        router
+    }
     struct PagingRoute {
     body: String,
     }
@@ -15510,6 +15686,77 @@ mod tests {
     }
 
     #[test]
+    fn modern_cacheable_results_preserve_hints_and_scoping_fails_private() {
+        let reg = Registry::default();
+        let router = cache_router();
+        let guard = SearchGuard::default();
+        let confirm = ConfirmGuard::new();
+        let cases = [
+            ("tools/list", json!({}), 50_000_u64),
+            ("resources/list", json!({}), 40_000),
+            ("resources/templates/list", json!({}), 30_000),
+            ("resources/read", json!({ "uri": "fixture://cached" }), 20_000),
+            ("prompts/list", json!({}), 10_000),
+        ];
+
+        for (index, (method, params, max_ttl)) in cases.into_iter().enumerate() {
+            let response = handle_request(
+                &modern_req(index as i64 + 10, method, params),
+                &reg,
+                &router,
+                &[],
+                false,
+                None,
+                &guard,
+                &confirm,
+                None,
+                None,
+            )
+            .unwrap();
+            let result = &response["result"];
+            let ttl = result["ttlMs"].as_u64().unwrap_or_default();
+            assert!(ttl > 0 && ttl <= max_ttl, "{method} must preserve remaining TTL: {result}");
+            assert_eq!(result["cacheScope"], "public", "{method}: {result}");
+        }
+
+        let scoped = handle_request(
+            &modern_req(20, "tools/list", json!({})),
+            &reg,
+            &router,
+            &[],
+            false,
+            Some("client-profile"),
+            &guard,
+            &confirm,
+            None,
+            None,
+        )
+        .unwrap();
+        assert_eq!(scoped["result"]["cacheScope"], "private");
+
+        let legacy = handle_request(
+            &json!({
+                "jsonrpc": "2.0",
+                "id": 21,
+                "method": "resources/read",
+                "params": { "uri": "fixture://cached" }
+            }),
+            &reg,
+            &router,
+            &[],
+            false,
+            None,
+            &guard,
+            &confirm,
+            None,
+            None,
+        )
+        .unwrap();
+        assert!(legacy["result"].get("ttlMs").is_none());
+        assert!(legacy["result"].get("cacheScope").is_none());
+    }
+
+    #[test]
     fn legacy_clients_see_no_modern_fields() {
         // The no-regression guarantee for every client in the wild today: a
         // request without `_meta` gets a byte-identical response to before.
@@ -15526,6 +15773,8 @@ mod tests {
             "legacy results carry no _meta, got {}",
             resp["result"]
         );
+        assert!(resp["result"].get("ttlMs").is_none());
+        assert!(resp["result"].get("cacheScope").is_none());
 
         // ...and initialize still works, unchanged.
         let init = dispatch(&json!({

--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -154,9 +154,9 @@ fn decorate_for_upstream(mut result: Value) -> Value {
     result
 }
 
-/// Toolport-owned cacheable results stay fresh for five minutes unless a
-/// contributing downstream server advertises a shorter window. Registry and
-/// list-changed notifications still invalidate them immediately.
+/// Toolport-owned cacheable results stay fresh for at most five minutes. A
+/// shorter downstream TTL wins, while a missing/zero TTL disables caching for
+/// the aggregate. Registry and list-changed notifications still invalidate it.
 const LOCAL_CACHE_TTL_MS: u64 = 300_000;
 
 fn cacheable_for_upstream(mut result: Value, hint: CacheHint, scoped: bool) -> Value {

--- a/src-tauri/src/downstream.rs
+++ b/src-tauri/src/downstream.rs
@@ -348,7 +348,9 @@ impl CacheHint {
     pub fn from_result(result: &Value) -> Self {
         let ttl_ms = result.get("ttlMs").and_then(Value::as_u64).unwrap_or(0);
         let now = Instant::now();
-        let expires_at = (ttl_ms > 0).then(|| now + Duration::from_millis(ttl_ms));
+        let expires_at = (ttl_ms > 0)
+            .then(|| Duration::from_millis(ttl_ms))
+            .and_then(|ttl| now.checked_add(ttl));
         Self {
             expires_at,
             refresh_after: expires_at,
@@ -359,7 +361,9 @@ impl CacheHint {
 
     pub fn local(ttl_ms: u64) -> Self {
         let now = Instant::now();
-        let expires_at = (ttl_ms > 0).then(|| now + Duration::from_millis(ttl_ms));
+        let expires_at = (ttl_ms > 0)
+            .then(|| Duration::from_millis(ttl_ms))
+            .and_then(|ttl| now.checked_add(ttl));
         Self {
             expires_at,
             refresh_after: expires_at,
@@ -4711,6 +4715,16 @@ mod tests {
         assert!(!listed.cache_hint.is_public());
         let ttl = listed.cache_hint.remaining_ttl_ms();
         assert!(ttl > 0 && ttl <= 30_000, "minimum page TTL should win: {ttl}");
+    }
+
+    #[test]
+    fn oversized_cache_ttl_is_handled_without_panicking() {
+        let downstream = CacheHint::from_result(&json!({
+            "ttlMs": u64::MAX,
+            "cacheScope": "public"
+        }));
+        let _ = downstream.remaining_ttl_ms();
+        let _ = CacheHint::local(u64::MAX).remaining_ttl_ms();
     }
 
     #[test]

--- a/src-tauri/src/downstream.rs
+++ b/src-tauri/src/downstream.rs
@@ -320,6 +320,94 @@ fn choose_protocol_version(discovered: &Value) -> Option<String> {
 /// and opens with `initialize`. Toolport is dual-era, so it must drive both.
 pub const MODERN_PROTOCOL_VERSION: &str = "2026-07-28";
 
+/// Conservative cache policy for one cacheable MCP result (SOU-454).
+///
+/// `expires_at` is absolute rather than a stored TTL so Toolport never resets a
+/// downstream server's freshness clock each time an upstream client asks for the
+/// aggregated result. `refresh_after` normally matches it; after a failed refresh
+/// it moves forward briefly to avoid retrying on every one-second watcher tick
+/// while the advertised remaining TTL correctly stays at zero.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct CacheHint {
+    expires_at: Option<Instant>,
+    refresh_after: Option<Instant>,
+    public: bool,
+}
+
+impl Default for CacheHint {
+    fn default() -> Self {
+        Self {
+            expires_at: None,
+            refresh_after: None,
+            public: false,
+        }
+    }
+}
+
+impl CacheHint {
+    pub fn from_result(result: &Value) -> Self {
+        let ttl_ms = result.get("ttlMs").and_then(Value::as_u64).unwrap_or(0);
+        let now = Instant::now();
+        let expires_at = (ttl_ms > 0).then(|| now + Duration::from_millis(ttl_ms));
+        Self {
+            expires_at,
+            refresh_after: expires_at,
+            // Unknown, missing, or malformed values fail closed to private.
+            public: result.get("cacheScope").and_then(Value::as_str) == Some("public"),
+        }
+    }
+
+    pub fn local(ttl_ms: u64) -> Self {
+        let now = Instant::now();
+        let expires_at = (ttl_ms > 0).then(|| now + Duration::from_millis(ttl_ms));
+        Self {
+            expires_at,
+            refresh_after: expires_at,
+            public: true,
+        }
+    }
+
+    /// Most-conservative combination for an aggregated or paginated result.
+    pub fn merge(self, other: Self) -> Self {
+        let expires_at = match (self.expires_at, other.expires_at) {
+            (Some(left), Some(right)) => Some(left.min(right)),
+            _ => None,
+        };
+        let refresh_after = match (self.refresh_after, other.refresh_after) {
+            (Some(left), Some(right)) => Some(left.min(right)),
+            _ => None,
+        };
+        Self {
+            expires_at,
+            refresh_after,
+            public: self.public && other.public,
+        }
+    }
+
+    pub fn remaining_ttl_ms(&self) -> u64 {
+        self.expires_at
+            .and_then(|expires| expires.checked_duration_since(Instant::now()))
+            .map(|remaining| remaining.as_millis().min(u128::from(u64::MAX)) as u64)
+            .unwrap_or(0)
+    }
+
+    pub fn is_public(&self) -> bool {
+        self.public
+    }
+
+    /// Only positive TTLs schedule polling. A zero/missing TTL means immediately
+    /// stale, but the protocol does not require clients to hammer the server; the
+    /// existing list-changed notification path remains the invalidation mechanism.
+    pub fn needs_refresh(&self) -> bool {
+        self.refresh_after.is_some_and(|at| Instant::now() >= at)
+    }
+
+    fn mark_stale_and_defer(&mut self) {
+        self.expires_at = None;
+        self.refresh_after = Some(Instant::now() + Duration::from_secs(30));
+    }
+}
+
 /// Error codes the 2026-07-28 allocation policy reserves for the specification
 /// (`-32020`..`-32099`). Their presence in a response is what identifies a modern
 /// server during the backward-compatibility probe.
@@ -3603,6 +3691,10 @@ pub struct DownstreamServer {
     /// MCP defines no separate templates list-change notification.
     pub resource_templates: Vec<Value>,
     pub prompts: Vec<Value>,
+    tool_cache_hint: CacheHint,
+    resource_cache_hint: CacheHint,
+    resource_template_cache_hint: CacheHint,
+    prompt_cache_hint: CacheHint,
     /// Whether the server's `initialize` advertised resources / prompts. The
     /// actual lists are fetched lazily via `load_resources_prompts`.
     caps_resources: bool,
@@ -3804,6 +3896,10 @@ impl DownstreamServer {
             resources: Vec::new(),
             resource_templates: Vec::new(),
             prompts: Vec::new(),
+            tool_cache_hint: listed.cache_hint,
+            resource_cache_hint: CacheHint::default(),
+            resource_template_cache_hint: CacheHint::default(),
+            prompt_cache_hint: CacheHint::default(),
             caps_resources,
             caps_prompts,
             caps_completions,
@@ -3956,24 +4052,44 @@ impl DownstreamServer {
     /// announced a `tools/list_changed`. Bounds the wait like the handshake so a
     /// hung server can't stall the refresh; on error the previous list is kept.
     pub fn refresh_tools(&mut self) {
+        self.refresh_tools_inner();
+    }
+
+    /// Refresh a positive-TTL catalog only once its downstream freshness window
+    /// expires. Notifications keep calling `refresh_tools` and therefore bypass
+    /// this check: they invalidate a still-fresh result immediately.
+    pub fn refresh_tools_if_stale(&mut self) {
+        if self.tool_cache_hint.needs_refresh() {
+            self.refresh_tools_inner();
+        }
+    }
+
+    fn refresh_tools_inner(&mut self) {
         self.transport.set_read_timeout(STDIO_CONNECT_TIMEOUT);
         match fetch_paginated_list(&mut *self.transport, "tools/list", "tools") {
             Ok(listed) if listed.warning.is_none() => {
+                self.tool_cache_hint = listed.cache_hint;
                 self.tools = if self.modern_http {
                     filter_modern_http_tools(&self.id, listed.items)
                 } else {
                     listed.items
                 };
             }
-            Ok(listed) => eprintln!(
-                "toolport: keeping server '{}' previous tool catalog after an incomplete refresh: {}",
-                self.id,
-                listed.warning.unwrap_or_default()
-            ),
-            Err(error) => eprintln!(
-                "toolport: keeping server '{}' previous tool catalog after refresh failed: {error}",
-                self.id
-            ),
+            Ok(listed) => {
+                self.tool_cache_hint.mark_stale_and_defer();
+                eprintln!(
+                    "toolport: keeping server '{}' previous tool catalog after an incomplete refresh: {}",
+                    self.id,
+                    listed.warning.unwrap_or_default()
+                );
+            }
+            Err(error) => {
+                self.tool_cache_hint.mark_stale_and_defer();
+                eprintln!(
+                    "toolport: keeping server '{}' previous tool catalog after refresh failed: {error}",
+                    self.id
+                );
+            }
         }
         self.transport.set_read_timeout(STDIO_READ_TIMEOUT);
     }
@@ -3987,21 +4103,42 @@ impl DownstreamServer {
     /// separate `resources/templates/list_changed`; template catalogs change
     /// under the resources capability, so this is the protocol-aligned trigger.
     pub fn refresh_resources(&mut self) {
+        self.refresh_resources_inner();
+    }
+
+    pub fn refresh_resources_if_stale(&mut self) {
+        if self.resource_cache_hint.needs_refresh()
+            || self.resource_template_cache_hint.needs_refresh()
+        {
+            self.refresh_resources_inner();
+        }
+    }
+
+    fn refresh_resources_inner(&mut self) {
         if !self.caps_resources {
             return;
         }
         self.transport.set_read_timeout(STDIO_CONNECT_TIMEOUT);
         match fetch_paginated_list(&mut *self.transport, "resources/list", "resources") {
-            Ok(listed) if listed.warning.is_none() => self.resources = listed.items,
-            Ok(listed) => eprintln!(
-                "toolport: keeping server '{}' previous resource catalog after an incomplete refresh: {}",
-                self.id,
-                listed.warning.unwrap_or_default()
-            ),
-            Err(error) => eprintln!(
-                "toolport: keeping server '{}' previous resource catalog after refresh failed: {error}",
-                self.id
-            ),
+            Ok(listed) if listed.warning.is_none() => {
+                self.resource_cache_hint = listed.cache_hint;
+                self.resources = listed.items;
+            }
+            Ok(listed) => {
+                self.resource_cache_hint.mark_stale_and_defer();
+                eprintln!(
+                    "toolport: keeping server '{}' previous resource catalog after an incomplete refresh: {}",
+                    self.id,
+                    listed.warning.unwrap_or_default()
+                );
+            }
+            Err(error) => {
+                self.resource_cache_hint.mark_stale_and_defer();
+                eprintln!(
+                    "toolport: keeping server '{}' previous resource catalog after refresh failed: {error}",
+                    self.id
+                );
+            }
         }
         // Templates share the resources capability and list-change signal.
         // Incomplete/failed traversal keeps the previous complete snapshot.
@@ -4010,16 +4147,25 @@ impl DownstreamServer {
             "resources/templates/list",
             "resourceTemplates",
         ) {
-            Ok(listed) if listed.warning.is_none() => self.resource_templates = listed.items,
-            Ok(listed) => eprintln!(
-                "toolport: keeping server '{}' previous resource-template catalog after an incomplete refresh: {}",
-                self.id,
-                listed.warning.unwrap_or_default()
-            ),
-            Err(error) => eprintln!(
-                "toolport: keeping server '{}' previous resource-template catalog after refresh failed: {error}",
-                self.id
-            ),
+            Ok(listed) if listed.warning.is_none() => {
+                self.resource_template_cache_hint = listed.cache_hint;
+                self.resource_templates = listed.items;
+            }
+            Ok(listed) => {
+                self.resource_template_cache_hint.mark_stale_and_defer();
+                eprintln!(
+                    "toolport: keeping server '{}' previous resource-template catalog after an incomplete refresh: {}",
+                    self.id,
+                    listed.warning.unwrap_or_default()
+                );
+            }
+            Err(error) => {
+                self.resource_template_cache_hint.mark_stale_and_defer();
+                eprintln!(
+                    "toolport: keeping server '{}' previous resource-template catalog after refresh failed: {error}",
+                    self.id
+                );
+            }
         }
         self.transport.set_read_timeout(STDIO_READ_TIMEOUT);
     }
@@ -4028,21 +4174,40 @@ impl DownstreamServer {
     /// announced a `prompts/list_changed`. Mirrors [`refresh_tools`]; best-effort,
     /// and a no-op if the server never advertised prompts.
     pub fn refresh_prompts(&mut self) {
+        self.refresh_prompts_inner();
+    }
+
+    pub fn refresh_prompts_if_stale(&mut self) {
+        if self.prompt_cache_hint.needs_refresh() {
+            self.refresh_prompts_inner();
+        }
+    }
+
+    fn refresh_prompts_inner(&mut self) {
         if !self.caps_prompts {
             return;
         }
         self.transport.set_read_timeout(STDIO_CONNECT_TIMEOUT);
         match fetch_paginated_list(&mut *self.transport, "prompts/list", "prompts") {
-            Ok(listed) if listed.warning.is_none() => self.prompts = listed.items,
-            Ok(listed) => eprintln!(
-                "toolport: keeping server '{}' previous prompt catalog after an incomplete refresh: {}",
-                self.id,
-                listed.warning.unwrap_or_default()
-            ),
-            Err(error) => eprintln!(
-                "toolport: keeping server '{}' previous prompt catalog after refresh failed: {error}",
-                self.id
-            ),
+            Ok(listed) if listed.warning.is_none() => {
+                self.prompt_cache_hint = listed.cache_hint;
+                self.prompts = listed.items;
+            }
+            Ok(listed) => {
+                self.prompt_cache_hint.mark_stale_and_defer();
+                eprintln!(
+                    "toolport: keeping server '{}' previous prompt catalog after an incomplete refresh: {}",
+                    self.id,
+                    listed.warning.unwrap_or_default()
+                );
+            }
+            Err(error) => {
+                self.prompt_cache_hint.mark_stale_and_defer();
+                eprintln!(
+                    "toolport: keeping server '{}' previous prompt catalog after refresh failed: {error}",
+                    self.id
+                );
+            }
         }
         self.transport.set_read_timeout(STDIO_READ_TIMEOUT);
     }
@@ -4064,6 +4229,7 @@ impl DownstreamServer {
                         self.id
                     );
                 }
+                self.resource_cache_hint = listed.cache_hint;
                 self.resources = listed.items;
             }
             if let Ok(listed) = fetch_paginated_list(
@@ -4077,6 +4243,7 @@ impl DownstreamServer {
                         self.id
                     );
                 }
+                self.resource_template_cache_hint = listed.cache_hint;
                 self.resource_templates = listed.items;
             }
         }
@@ -4090,6 +4257,7 @@ impl DownstreamServer {
                         self.id
                     );
                 }
+                self.prompt_cache_hint = listed.cache_hint;
                 self.prompts = listed.items;
             }
         }
@@ -4251,6 +4419,23 @@ impl DownstreamServer {
         self.caps_completions
     }
 
+    pub fn tool_cache_hint(&self) -> CacheHint {
+        self.tool_cache_hint
+    }
+
+    pub fn resource_cache_hint(&self) -> Option<CacheHint> {
+        self.caps_resources.then_some(self.resource_cache_hint)
+    }
+
+    pub fn resource_template_cache_hint(&self) -> Option<CacheHint> {
+        self.caps_resources
+            .then_some(self.resource_template_cache_hint)
+    }
+
+    pub fn prompt_cache_hint(&self) -> Option<CacheHint> {
+        self.caps_prompts.then_some(self.prompt_cache_hint)
+    }
+
     /// The protocol era and version this connection negotiated (SOU-445).
     pub fn era(&self) -> &Era {
         &self.era
@@ -4288,6 +4473,9 @@ fn extract_array(result: &Value, key: &str) -> Vec<Value> {
 
 struct PaginatedList {
     items: Vec<Value>,
+    /// Minimum remaining TTL and most-private scope across every page. A partial
+    /// traversal is always reset to the conservative zero/private policy.
+    cache_hint: CacheHint,
     /// Present when at least one page succeeded but traversal could not finish.
     /// Initial discovery may expose that useful prefix; refreshes keep the prior
     /// complete snapshot instead of replacing it with a partial catalog.
@@ -4307,11 +4495,13 @@ fn fetch_paginated_list(
     let mut cursor: Option<String> = None;
     let mut seen_cursors = HashSet::new();
     let started = Instant::now();
+    let mut cache_hint: Option<CacheHint> = None;
 
     for page_index in 0..MAX_LIST_PAGES {
         if page_index > 0 && started.elapsed() >= MAX_LIST_DURATION {
             return Ok(PaginatedList {
                 items,
+                cache_hint: CacheHint::default(),
                 warning: Some(format!(
                     "catalog traversal exceeded the {}-second safety cap",
                     MAX_LIST_DURATION.as_secs()
@@ -4326,11 +4516,18 @@ fn fetch_paginated_list(
             Err(error) if page_index > 0 => {
                 return Ok(PaginatedList {
                     items,
+                    cache_hint: CacheHint::default(),
                     warning: Some(format!("page {} failed: {error}", page_index + 1)),
                 });
             }
             Err(error) => return Err(error),
         };
+
+        let page_hint = CacheHint::from_result(&result);
+        cache_hint = Some(match cache_hint {
+            Some(current) => current.merge(page_hint),
+            None => page_hint,
+        });
 
         let page = extract_array(&result, key);
         let remaining = MAX_LIST_ITEMS.saturating_sub(items.len());
@@ -4338,6 +4535,7 @@ fn fetch_paginated_list(
             items.extend(page.into_iter().take(remaining));
             return Ok(PaginatedList {
                 items,
+                cache_hint: CacheHint::default(),
                 warning: Some(format!("catalog exceeded the {MAX_LIST_ITEMS}-item safety cap")),
             });
         }
@@ -4350,12 +4548,14 @@ fn fetch_paginated_list(
         else {
             return Ok(PaginatedList {
                 items,
+                cache_hint: cache_hint.unwrap_or_default(),
                 warning: None,
             });
         };
         if !seen_cursors.insert(next_cursor.clone()) {
             return Ok(PaginatedList {
                 items,
+                cache_hint: CacheHint::default(),
                 warning: Some("server repeated a pagination cursor".to_string()),
             });
         }
@@ -4364,6 +4564,7 @@ fn fetch_paginated_list(
 
     Ok(PaginatedList {
         items,
+        cache_hint: CacheHint::default(),
         warning: Some(format!("catalog exceeded the {MAX_LIST_PAGES}-page safety cap")),
     })
 }
@@ -4373,7 +4574,7 @@ mod tests {
     use super::{
         cwd_validation_error, empty_cwd_variables, expand_cwd, file_uri_to_path, resolve_command,
         resolve_root_token, screen_resolved_addrs, screen_spawn_command, screen_spawn_env,
-        validate_cwd, CancelRegistry, DownstreamServer, MrtrRequest, ServerRequestAction,
+        validate_cwd, CacheHint, CancelRegistry, DownstreamServer, MrtrRequest, ServerRequestAction,
         ServerRequestHandler, Transport, TransportError, MODERN_PROTOCOL_VERSION,
         fetch_paginated_list,
     };
@@ -4491,6 +4692,63 @@ mod tests {
     }
 
     #[test]
+    fn paginated_list_uses_the_shortest_ttl_and_most_private_scope() {
+        let mut transport = PaginationTransport::new(vec![
+            Ok(json!({
+                "tools": [{"name":"a"}],
+                "nextCursor": "two",
+                "ttlMs": 60_000,
+                "cacheScope": "public"
+            })),
+            Ok(json!({
+                "tools": [{"name":"b"}],
+                "ttlMs": 30_000,
+                "cacheScope": "private"
+            })),
+        ]);
+        let listed = fetch_paginated_list(&mut transport, "tools/list", "tools").unwrap();
+        assert_eq!(listed.items.len(), 2);
+        assert!(!listed.cache_hint.is_public());
+        let ttl = listed.cache_hint.remaining_ttl_ms();
+        assert!(ttl > 0 && ttl <= 30_000, "minimum page TTL should win: {ttl}");
+    }
+
+    #[test]
+    fn positive_ttl_refreshes_once_stale_but_zero_ttl_does_not_poll() {
+        let expiring = PaginationTransport::new(vec![
+            Ok(json!({ "capabilities": {} })),
+            Ok(json!({
+                "tools": [{"name":"old"}],
+                "ttlMs": 5,
+                "cacheScope": "public"
+            })),
+            Ok(json!({
+                "tools": [{"name":"fresh"}],
+                "ttlMs": 60_000,
+                "cacheScope": "public"
+            })),
+        ]);
+        let mut server = DownstreamServer::connect("ttl".to_string(), Box::new(expiring)).unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(15));
+        server.refresh_tools_if_stale();
+        assert_eq!(server.tools[0]["name"], "fresh");
+
+        // No third scripted response: this panics if zero/missing TTL turns the
+        // one-second watcher into an unbounded polling loop.
+        let zero = PaginationTransport::new(vec![
+            Ok(json!({ "capabilities": {} })),
+            Ok(json!({
+                "tools": [{"name":"stable"}],
+                "ttlMs": 0,
+                "cacheScope": "private"
+            })),
+        ]);
+        let mut server = DownstreamServer::connect("zero".to_string(), Box::new(zero)).unwrap();
+        server.refresh_tools_if_stale();
+        assert_eq!(server.tools[0]["name"], "stable");
+    }
+
+    #[test]
     fn paginated_list_stops_on_a_repeated_cursor() {
         let mut transport = PaginationTransport::new(vec![
             Ok(json!({"resources":[{"uri":"one:"}],"nextCursor":"same"})),
@@ -4547,6 +4805,10 @@ mod tests {
             resources: Vec::new(),
             resource_templates: Vec::new(),
             prompts: Vec::new(),
+            tool_cache_hint: CacheHint::default(),
+            resource_cache_hint: CacheHint::default(),
+            resource_template_cache_hint: CacheHint::default(),
+            prompt_cache_hint: CacheHint::default(),
             caps_resources: false,
             caps_prompts: false,
             caps_completions: false,
@@ -4575,6 +4837,10 @@ mod tests {
             resources: vec![json!({"uri":"stable-r:"})],
             resource_templates: vec![json!({"uriTemplate":"stable://{id}"})],
             prompts: Vec::new(),
+            tool_cache_hint: CacheHint::default(),
+            resource_cache_hint: CacheHint::default(),
+            resource_template_cache_hint: CacheHint::default(),
+            prompt_cache_hint: CacheHint::default(),
             caps_resources: true,
             caps_prompts: false,
             caps_completions: false,

--- a/src-tauri/src/router.rs
+++ b/src-tauri/src/router.rs
@@ -19,8 +19,8 @@ use std::time::{Duration, Instant};
 use serde_json::{json, Value};
 
 use crate::downstream::{
-    backoff_delay, CancelContext, DownstreamServer, MrtrRequest, TransportError, HTTP_MAX_RETRIES,
-    HTTP_RETRY_CAP,
+    backoff_delay, CacheHint, CancelContext, DownstreamServer, MrtrRequest, TransportError,
+    HTTP_MAX_RETRIES, HTTP_RETRY_CAP,
 };
 use crate::registry::ToolOverride;
 
@@ -705,7 +705,81 @@ impl Router {
 
     /// Every downstream tool, with its exposed (sanitized) name.
     pub fn aggregated_tools(&self) -> Vec<Value> {
-        self.tools.clone()
+        let mut tools = self.tools.clone();
+        // MCP 2026-07-28 recommends deterministic tool ordering so both response
+        // caches and LLM prompt caches survive incidental downstream reorderings.
+        // Exposed names are unique, making them a stable total key across refreshes
+        // and gateway restarts without changing routing ownership.
+        tools.sort_by(|left, right| {
+            left.get("name")
+                .and_then(Value::as_str)
+                .cmp(&right.get("name").and_then(Value::as_str))
+        });
+        tools
+    }
+
+    fn aggregate_cache_hints(
+        &self,
+        select: impl Fn(&DownstreamServer) -> Option<CacheHint>,
+    ) -> Option<CacheHint> {
+        let mut aggregate: Option<CacheHint> = None;
+        for slot in &self.servers {
+            let server = slot
+                .inner
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            let Some(hint) = select(&server) else {
+                continue;
+            };
+            aggregate = Some(match aggregate {
+                Some(current) => current.merge(hint),
+                None => hint,
+            });
+        }
+        aggregate
+    }
+
+    pub fn tools_cache_hint(&self) -> Option<CacheHint> {
+        self.aggregate_cache_hints(|server| Some(server.tool_cache_hint()))
+    }
+
+    pub fn resources_cache_hint(&self) -> Option<CacheHint> {
+        self.aggregate_cache_hints(DownstreamServer::resource_cache_hint)
+    }
+
+    pub fn resource_templates_cache_hint(&self) -> Option<CacheHint> {
+        self.aggregate_cache_hints(DownstreamServer::resource_template_cache_hint)
+    }
+
+    pub fn prompts_cache_hint(&self) -> Option<CacheHint> {
+        self.aggregate_cache_hints(DownstreamServer::prompt_cache_hint)
+    }
+
+    /// Positive downstream TTLs schedule a refresh at their expiry. Zero/missing
+    /// hints do not create a one-second polling loop; notifications still invalidate
+    /// them immediately through the existing dirty-bit path.
+    pub fn expired_cache_kinds(&self) -> u8 {
+        let mut kinds = 0;
+        for slot in &self.servers {
+            let server = slot
+                .inner
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            if server.tool_cache_hint().needs_refresh() {
+                kinds |= crate::downstream::change::TOOLS;
+            }
+            if server.resource_cache_hint().is_some_and(|hint| hint.needs_refresh())
+                || server
+                    .resource_template_cache_hint()
+                    .is_some_and(|hint| hint.needs_refresh())
+            {
+                kinds |= crate::downstream::change::RESOURCES;
+            }
+            if server.prompt_cache_hint().is_some_and(|hint| hint.needs_refresh()) {
+                kinds |= crate::downstream::change::PROMPTS;
+            }
+        }
+        kinds
     }
 
     /// Re-query every live server's tool list (a downstream announced a
@@ -720,6 +794,16 @@ impl Router {
                 .lock()
                 .unwrap_or_else(std::sync::PoisonError::into_inner)
                 .refresh_tools();
+        }
+        self.rebuild_aggregation();
+    }
+
+    pub fn refresh_stale_tools(&mut self) {
+        for slot in &self.servers {
+            slot.inner
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .refresh_tools_if_stale();
         }
         self.rebuild_aggregation();
     }
@@ -739,6 +823,16 @@ impl Router {
         self.rebuild_aggregation();
     }
 
+    pub fn refresh_stale_resources(&mut self) {
+        for slot in &self.servers {
+            slot.inner
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .refresh_resources_if_stale();
+        }
+        self.rebuild_aggregation();
+    }
+
     /// Re-query every live server's prompt list (a downstream announced a
     /// `prompts/list_changed`) and rebuild the exposed aggregation in place.
     /// Mirrors [`refresh_tools`].
@@ -748,6 +842,16 @@ impl Router {
                 .lock()
                 .unwrap_or_else(std::sync::PoisonError::into_inner)
                 .refresh_prompts();
+        }
+        self.rebuild_aggregation();
+    }
+
+    pub fn refresh_stale_prompts(&mut self) {
+        for slot in &self.servers {
+            slot.inner
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .refresh_prompts_if_stale();
         }
         self.rebuild_aggregation();
     }
@@ -1476,6 +1580,42 @@ mod tests {
         ds
     }
 
+    struct HintTransport {
+        tool: String,
+        ttl_ms: u64,
+        scope: &'static str,
+    }
+
+    impl Transport for HintTransport {
+        fn request(&mut self, method: &str, _params: Value) -> Result<Value, TransportError> {
+            match method {
+                "initialize" => Ok(json!({ "protocolVersion": "2025-06-18", "capabilities": {} })),
+                "tools/list" => Ok(json!({
+                    "tools": [{ "name": self.tool }],
+                    "ttlMs": self.ttl_ms,
+                    "cacheScope": self.scope
+                })),
+                other => Err(TransportError::Fatal(format!("unexpected method {other}"))),
+            }
+        }
+
+        fn notify(&mut self, _method: &str, _params: Value) -> Result<(), TransportError> {
+            Ok(())
+        }
+    }
+
+    fn hinted_server(id: &str, ttl_ms: u64, scope: &'static str) -> DownstreamServer {
+        DownstreamServer::connect(
+            id.to_string(),
+            Box::new(HintTransport {
+                tool: "tool".to_string(),
+                ttl_ms,
+                scope,
+            }),
+        )
+        .unwrap()
+    }
+
     /// Handshakes fine (so it can be constructed) but every `tools/call` reports the
     /// connection is dead - i.e. a crashed/hung stdio child mid-session.
     struct DeadOnCallTransport;
@@ -1585,11 +1725,51 @@ mod tests {
         assert_eq!(
             names,
             vec![
-                "github__echo",
                 "github__add",
-                "postgres__echo",
-                "postgres__add"
+                "github__echo",
+                "postgres__add",
+                "postgres__echo"
             ]
+        );
+    }
+
+    #[test]
+    fn tool_order_is_stable_across_server_add_order() {
+        let mut first = Router::new();
+        first.add(mock_server("zeta"));
+        first.add(mock_server("alpha"));
+        let mut second = Router::new();
+        second.add(mock_server("alpha"));
+        second.add(mock_server("zeta"));
+
+        assert_eq!(first.aggregated_tools(), second.aggregated_tools());
+    }
+
+    #[test]
+    fn aggregated_cache_hint_uses_minimum_ttl_and_private_wins() {
+        let mut public = Router::new();
+        public.add(hinted_server("slow", 60_000, "public"));
+        public.add(hinted_server("fast", 30_000, "public"));
+        let hint = public.tools_cache_hint().unwrap();
+        assert!(hint.is_public());
+        let ttl = hint.remaining_ttl_ms();
+        assert!(ttl > 0 && ttl <= 30_000, "minimum contributor TTL should win: {ttl}");
+
+        let mut mixed = Router::new();
+        mixed.add(hinted_server("public", 60_000, "public"));
+        mixed.add(hinted_server("private", 60_000, "private"));
+        assert!(!mixed.tools_cache_hint().unwrap().is_public());
+    }
+
+    #[test]
+    fn positive_cache_ttl_marks_its_catalog_for_refresh() {
+        let mut router = Router::new();
+        router.add(hinted_server("expiring", 5, "public"));
+        std::thread::sleep(std::time::Duration::from_millis(15));
+
+        assert_ne!(
+            router.expired_cache_kinds() & crate::downstream::change::TOOLS,
+            0
         );
     }
 
@@ -1813,7 +1993,11 @@ mod tests {
         router.add(mock_server("file-system"));
 
         let tools = router.aggregated_tools();
-        let name = tools[0]["name"].as_str().unwrap();
+        let name = tools
+            .iter()
+            .filter_map(|tool| tool["name"].as_str())
+            .find(|name| name.ends_with("__echo"))
+            .unwrap();
         assert_eq!(name, "file_system__echo");
 
         let result = router.route_call(name, json!({})).unwrap();

--- a/src-tauri/tests/spec_conformance.rs
+++ b/src-tauri/tests/spec_conformance.rs
@@ -523,7 +523,7 @@ fn gateway_connects_to_a_modern_server() {
         server.resource_template_cache_hint(),
         server.prompt_cache_hint(),
     ] {
-        let hint = hint.expect("fixture advertised this cacheable capability");
+        let hint = hint.expect("fixture advertised the resources/prompts capability");
         assert!(hint.is_public());
         assert!(hint.remaining_ttl_ms() > 0);
     }

--- a/src-tauri/tests/spec_conformance.rs
+++ b/src-tauri/tests/spec_conformance.rs
@@ -515,6 +515,18 @@ fn gateway_connects_to_a_modern_server() {
 
     assert!(server.era().is_modern(), "era should be detected as modern");
     assert_eq!(server.era().version(), MODERN);
+    assert!(server.tool_cache_hint().is_public());
+    assert!(server.tool_cache_hint().remaining_ttl_ms() > 0);
+    server.load_resources_prompts();
+    for hint in [
+        server.resource_cache_hint(),
+        server.resource_template_cache_hint(),
+        server.prompt_cache_hint(),
+    ] {
+        let hint = hint.expect("fixture advertised this cacheable capability");
+        assert!(hint.is_public());
+        assert!(hint.remaining_ttl_ms() > 0);
+    }
 
     // The connection is not merely established: it is usable. The strict fixture
     // rejects any request lacking the protocol `_meta`, so a successful call


### PR DESCRIPTION
## Summary
- preserve and conservatively aggregate `ttlMs` / `cacheScope` across modern cacheable MCP results
- refresh positive-TTL downstream catalogs at expiry while keeping notification invalidation immediate
- make exposed tool ordering deterministic across refreshes and restarts
- keep legacy response shapes unchanged and force scoped results private

## Validation
- `npm run test:rust` (622 library tests, 212 gateway tests, all integration/conformance suites)
- `git diff --check`

Linear: SOU-454