### PR TITLE
chore: remove verified dead code (#525)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,3 +100,4 @@ license-signing.keycd
 # Agent/session scratch (never commit)
 _poll_pr.py
 _cr*.txt
+src-tauri/rate_limit_counters.test.json

--- a/src-tauri/src/gateway_publish.rs
+++ b/src-tauri/src/gateway_publish.rs
@@ -28,8 +28,7 @@ pub fn should_publish_client_gateway() -> bool {
             return !lower.contains("\\target\\");
         }
     }
-    #[cfg(not(windows))]
-    let _ = ();
+    
     false
 }
 

--- a/src-tauri/src/secrets.rs
+++ b/src-tauri/src/secrets.rs
@@ -852,16 +852,11 @@ pub fn delete_secret(server_id: &str, key: &str) -> Result<(), String> {
 // once on upgrade so EXISTING secrets are rewritten WITH the shared-access ACL,
 // not just legacy keyring-API entries.
 
-/// Marker file name for the legacy ACL migration (keychain -> ACL-free keychain).
-/// Left untouched for backward compatibility, but the current macOS path migrates
-/// secrets into the file backend instead (see `FILE_MIGRATION_MARKER`).
-#[cfg(target_os = "macos")]
-#[allow(dead_code)]
-const MIGRATION_MARKER: &str = ".keychain-acl-migrated";
-
 /// Marker file name for the keychain -> encrypted-file migration. A NEW name so
 /// the migration runs exactly once on upgrade to the file-backend-by-default
-/// build, even on installs that already ran the older ACL migration.
+/// build, even on installs that already ran the older ACL migration. An older
+/// `.keychain-acl-migrated` marker file may exist on disk from that legacy
+/// migration; it is intentionally ignored.
 #[cfg(target_os = "macos")]
 const FILE_MIGRATION_MARKER: &str = ".secrets-file-migrated";
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -296,46 +296,6 @@ export interface Stack {
   servers: CatalogEntry[];
 }
 
-/** A server merged across every client that has it configured. */
-export interface AggregatedServer {
-  name: string;
-  transport: Transport;
-  command: string | null;
-  url: string | null;
-  args: string[];
-  envKeys: string[];
-  clients: { id: string; name: string }[];
-}
-
-/** Group the per-client server lists into one deduplicated, cross-client view. */
-export function aggregateServers(clients: DetectedClient[]): AggregatedServer[] {
-  const byName = new Map<string, AggregatedServer>();
-
-  for (const client of clients) {
-    for (const server of client.servers) {
-      const key = server.name.toLowerCase();
-      const existing = byName.get(key);
-      if (existing) {
-        existing.clients.push({ id: client.id, name: client.name });
-      } else {
-        byName.set(key, {
-          name: server.name,
-          transport: server.transport,
-          command: server.command,
-          url: server.url,
-          args: server.args,
-          envKeys: server.envKeys,
-          clients: [{ id: client.id, name: client.name }],
-        });
-      }
-    }
-  }
-
-  return [...byName.values()].sort((a, b) =>
-    a.name.toLowerCase().localeCompare(b.name.toLowerCase()),
-  );
-}
-
 // --- Toolport registry (source of truth) ---
 
 export interface EnvVar {


### PR DESCRIPTION
 Fixes #525

Three verified-dead deletions, as specified in the issue — no behavior change:

## secrets.rs
Deleted the unused `MIGRATION_MARKER` constant (referenced nowhere; only `FILE_MIGRATION_MARKER` and `DPK_MIGRATION_MARKER` are actually used). Its backward-compatibility note — that an older `.keychain-acl-migrated` marker file may still exist on disk and is intentionally ignored — is preserved by folding it into `FILE_MIGRATION_MARKER`'s doc comment instead of losing it.

## gateway_publish.rs
Deleted the no-op `#[cfg(not(windows))] let _ = ();` — the non-Windows body was already just `false`; this suppressed nothing.

## types.ts
Deleted `AggregatedServer` and `aggregateServers` — confirmed zero importers anywhere in `src/` via grep.

## Testing
- `cargo test --manifest-path src-tauri/Cargo.toml --lib secrets` — 7 passed,
  0 failed, 1 pre-existing ignore (unrelated, no Secret Service in headless CI)
- Confirmed via grep that no references to any deleted name remain anywhere
  in `src-tauri/src/` or `src/`