### PR TITLE
chore(release): prepare v1.11.0-rc.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "toolport",
-  "version": "1.10.0",
+  "version": "1.11.0-rc.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "toolport",
-      "version": "1.10.0",
+      "version": "1.11.0-rc.1",
       "dependencies": {
         "@fontsource-variable/geist": "^5.2.9",
         "@tailwindcss/vite": "^4.3.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "toolport",
   "private": true,
-  "version": "1.10.0",
+  "version": "1.11.0-rc.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -780,7 +780,7 @@ dependencies = [
 
 [[package]]
 name = "conduit"
-version = "1.10.0"
+version = "1.11.0-rc.1"
 dependencies = [
  "base64 0.22.1",
  "boa_engine",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conduit"
-version = "1.10.0"
+version = "1.11.0-rc.1"
 description = "Local MCP gateway: manage all your MCP servers in one place, set up once and shared by every AI client, with ~90% fewer tokens per request"
 authors = ["South Forge AI"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Toolport",
-  "version": "1.10.0",
+  "version": "1.11.0-rc.1",
   "identifier": "com.tsout.conduit",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## Summary
- bump Toolport's npm, Cargo, Tauri, and lockfile versions to 1.11.0-rc.1
- prepare a draft prerelease build for modern HTTP server acceptance testing
- keep the published v1.10.0 release and updater channel unchanged until this draft is explicitly published

## Local validation
- version consistency checks across all five sources
- npm run build:bundle
- npm test (204 passed)
- npm run audit:prod (0 production vulnerabilities)
- npm run test:rust (623 library, 213 gateway, and all integration/conformance tests passed)

After merge, tag v1.11.0-rc.1 to invoke the existing draft release workflow.