### PR TITLE
chore(release): prepare v1.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,28 +6,102 @@ Entries before the rename below shipped under the project's former name, Conduit
 
 ## [Unreleased]
 
+## [1.11.0] - 2026-08-01
+
+Toolport's Streamable HTTP endpoint now speaks the modern MCP transport while
+keeping the legacy initialize/session flow on the same URL. This release also
+adds four clients, hardens registry recovery, and fixes a collection of routing,
+search, and import edge cases.
+
 ### Added
 
-- **Kilo Code** and **Amp** are detected and configured, taking the client count
-  to 29. Kilo Code uses the same top-level `mcp` shape as OpenCode, so it reuses
-  that adapter rather than adding a parallel one. Amp keeps its servers under the
-  literal dotted key `amp.mcpServers` and honours `AMP_SETTINGS_FILE`. Both files
-  hold far more than MCP servers, so both are treated as whole-app state: an
-  unparseable one errors rather than being replaced with a fresh object.
-  (#553, #538)
+**MCP 2026-07-28 over Streamable HTTP.** Modern clients can use `POST /mcp`
+without `initialize` or `Mcp-Session-Id`; every request carries its own protocol
+metadata and the required `MCP-Protocol-Version`, `Mcp-Method`, and optional
+`Mcp-Name` headers. Existing clients on the legacy initialize/session flow keep
+working on the same endpoint. (#584, #586)
+
+- **Multi-round-trip requests and stateless HITL.** Modern tool calls return
+  `resultType`, surface approval as `input_required`, and resume from opaque
+  `requestState` plus `inputResponses`. A denied call never reaches the server;
+  an accepted retry executes the bound call once. (#585)
+- **Modern subscriptions.** `subscriptions/listen` replaces the legacy GET
+  stream for 2026-07-28 clients, filters notifications per listener, tags them
+  with the subscription id, and flushes events promptly. (#583, #590)
+- **Modern downstream HTTP headers.** Toolport sends per-request protocol and
+  routing headers to modern HTTP servers, including schema-declared
+  `x-mcp-header` values, while legacy downstream servers keep their existing
+  wire format. (#584)
+- **Cacheable, deterministic catalog results.** Modern list/discovery results
+  carry `ttlMs` and `cacheScope`, and tools, prompts, resources, and templates
+  use stable ordering so caches do not churn between equivalent requests.
+  (#587)
+- **Four more clients.** Kilo Code, Amp, GitHub Copilot CLI, and JetBrains Junie
+  are detected and configured, taking the supported client count to 31. Kilo
+  Code reuses the OpenCode `mcp` shape; Amp keeps its literal dotted
+  `amp.mcpServers` key and honours `AMP_SETTINGS_FILE`. (#538, #553, #576, #578)
+
+### Security
+
+- **Registry recovery fails safe.** A corrupt primary registry is restored only
+  from a valid backup; Toolport no longer silently starts from an empty registry
+  that drops configured policy. (#582)
+- **Corrupt integrity pins fail closed.** A damaged pin store can no longer make
+  an existing tool definition look trusted. (#581)
+- **Removing a server clears its security state.** Tool overrides, pins,
+  per-server result budgets, injection-block exemptions, and fingerprint-bound
+  approvals are removed with the server, so a later server reusing the id cannot
+  inherit stale policy. (#509)
+- Import-time private-host detection now matches the OAuth SSRF guard's full
+  private-address ranges. (#564)
 
 ### Fixed
 
-- **Removing a server no longer leaves its settings behind.** Tool overrides,
-  pins, the per-server result budget, the injection-block exemption and any
-  fingerprint-bound approvals are now dropped along with the server. Previously a
-  server added later under the same id could inherit a stale security exemption
-  from one you had deleted. (#509)
+- Unsupported legacy `initialize` versions now return the supported versions so
+  clients can negotiate instead of failing ambiguously. (#588)
 - **A share link survives a failed copy.** Creating a link and then failing to
   copy it reported the whole operation as failed, and where the Clipboard API is
   unavailable the failure was thrown synchronously, so a link that had been
   created fine was surfaced as `Couldn't create a link`. The link now stays
   visible and only the copy is reported as failed. (#560)
+- Empty search states are clearer, unusable MCP commands are reported directly,
+  keyword parameters no longer trigger placeholder false positives, and
+  cross-server names no longer create false rate-limit matches. (#567, #568,
+  #572, #577)
+- Inspect skips corrupt lines before applying its result limit, tiny savings
+  percentages remain visible, token counts are rounded before unit selection,
+  and search-limit errors use the configured constants. (#569-#571, #573)
+- Remote Crush entries are no longer misclassified as OpenCode during import,
+  and the import-review copy now matches the behavior it describes. (#541,
+  #566)
+
+### Maintenance
+
+- Shared cost estimation and civil-date conversion replace duplicate local
+  implementations, and verified dead client/desktop types were removed.
+  (#574, #575, #589)
+
+### Thanks
+
+Patches this cycle came from:
+
+- **[BharadwajKanneveti](https://github.com/BharadwajKanneveti)** - server-state
+  cleanup, routing/search fixes, inspect recovery, and shared helper extraction
+  (#509, #567, #572-#575).
+- **[ColumbusLabs](https://github.com/ColumbusLabs)** - GitHub Copilot CLI and
+  JetBrains Junie support plus search, reporting, and display fixes
+  (#568-#571, #576-#578).
+- **[wenn-id](https://github.com/wenn-id)** - Amp support (#538).
+- **[rohankumardubey](https://github.com/rohankumardubey)** - Kilo Code support
+  (#553).
+- **[Vam-si-krish](https://github.com/Vam-si-krish)** - preserving share links
+  when clipboard copy fails (#560).
+- **[arimu1](https://github.com/arimu1)** - aligning import-time private-host
+  detection with the OAuth SSRF guard (#564).
+- **[Vermitrude](https://github.com/Vermitrude)** - Crush/OpenCode import
+  disambiguation and dead-code cleanup (#541, #589).
+
+If we missed you, open an issue.
 
 ## [1.10.0] - 2026-07-29
 

--- a/docs/release-notes/v1.11.0.md
+++ b/docs/release-notes/v1.11.0.md
@@ -1,0 +1,97 @@
+# Toolport v1.11.0
+
+Modern MCP over Streamable HTTP, with sessionless requests, multi-round-trip
+approvals, subscription listeners, and the legacy session flow still available
+on the same endpoint.
+
+## Highlights
+
+### MCP 2026-07-28 over Streamable HTTP
+
+Modern clients can call `POST /mcp` without an `initialize` request or
+`Mcp-Session-Id`. Each request carries its protocol metadata and routing headers,
+and ordinary results identify themselves with `resultType: complete`.
+
+Nothing moves for existing HTTP clients. The legacy `2025-06-18`
+initialize/session flow remains on the same URL, and Toolport chooses the path
+from the request rather than requiring a server-wide mode switch. (#584, #586)
+
+### Multi-round-trip requests and human approval
+
+A modern destructive call no longer has to hold an HTTP request open while a
+person decides. Toolport returns `input_required` with an opaque `requestState`;
+the client supplies `inputResponses` on a fresh request to deny or resume the
+exact bound call. Denial never reaches the downstream server, and approval
+executes the accepted call once. (#585)
+
+### Modern subscriptions
+
+Modern clients use `subscriptions/listen` instead of the legacy GET stream.
+Listeners choose the notifications they need, receive their subscription id in
+each event, and clean up when the POST stream closes. A follow-up fix makes sure
+events are flushed rather than waiting in the response buffer. (#583, #590)
+
+### Cacheable catalogs and downstream headers
+
+Modern list and discovery results carry `ttlMs` and `cacheScope`, with stable
+ordering across equivalent requests. Modern HTTP servers receive the required
+protocol and routing headers, including values moved from tool arguments by
+`x-mcp-header`; legacy servers continue to receive their established wire
+format. (#584, #587)
+
+## Four more clients
+
+Toolport now detects and configures 31 AI clients. This release adds:
+
+- Kilo Code (#553)
+- Amp (#538)
+- GitHub Copilot CLI (#578)
+- JetBrains Junie (#576)
+
+Their existing config shapes and unrelated application settings are preserved;
+an unparseable whole-app config still fails safely instead of being replaced.
+
+## Reliability and security
+
+- Registry recovery accepts only a valid backup instead of silently starting
+  from an empty registry. (#582)
+- Corrupt integrity pins fail closed. (#581)
+- Removing a server also removes its overrides, pins, result budget, content
+  exemption, and fingerprint-bound approvals. (#509)
+- Import-time private-host detection matches the OAuth SSRF guard. (#564)
+- Unsupported legacy protocol versions return an actionable negotiation error.
+  (#588)
+
+Search, import review, result formatting, rate-limit matching, corrupt inspect
+lines, share-link copy failures, and several misleading error states also got
+smaller fixes. See the full changelog for the complete list.
+
+## Upgrade notes
+
+1. Install 1.11.0 and open Toolport once so the new gateway is installed.
+2. Restart AI clients that were already open. A client can cache the old
+   versioned gateway path until the client process exits.
+3. Shared HTTP users keep the same endpoint and bearer configuration. Modern
+   clients can move to the sessionless flow; legacy clients need no changes.
+4. Modern HITL requires the client's elicitation capability. Clients without it
+   fail closed rather than running a gated call.
+
+This is the modern Streamable HTTP transport milestone, not a claim that every
+optional MCP 2025-11-25 and 2026-07-28 feature is complete. Auth catch-up,
+URL-mode elicitation and icons, Tasks/extensions, and the roots replacement are
+tracked separately.
+
+## Thanks
+
+Thanks to [BharadwajKanneveti](https://github.com/BharadwajKanneveti),
+[ColumbusLabs](https://github.com/ColumbusLabs),
+[wenn-id](https://github.com/wenn-id),
+[rohankumardubey](https://github.com/rohankumardubey),
+[Vam-si-krish](https://github.com/Vam-si-krish),
+[arimu1](https://github.com/arimu1), and
+[Vermitrude](https://github.com/Vermitrude) for patches in this release.
+
+## Full changelog
+
+See [CHANGELOG.md](https://github.com/tsouth89/toolport/blob/main/CHANGELOG.md#1110---2026-08-01)
+and the related PRs: #509, #538, #541, #553, #560, #564, #567-#590.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "toolport",
-  "version": "1.11.0-rc.1",
+  "version": "1.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "toolport",
-      "version": "1.11.0-rc.1",
+      "version": "1.11.0",
       "dependencies": {
         "@fontsource-variable/geist": "^5.2.9",
         "@tailwindcss/vite": "^4.3.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "toolport",
   "private": true,
-  "version": "1.11.0-rc.1",
+  "version": "1.11.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -780,7 +780,7 @@ dependencies = [
 
 [[package]]
 name = "conduit"
-version = "1.11.0-rc.1"
+version = "1.11.0"
 dependencies = [
  "base64 0.22.1",
  "boa_engine",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conduit"
-version = "1.11.0-rc.1"
+version = "1.11.0"
 description = "Local MCP gateway: manage all your MCP servers in one place, set up once and shared by every AI client, with ~90% fewer tokens per request"
 authors = ["South Forge AI"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Toolport",
-  "version": "1.11.0-rc.1",
+  "version": "1.11.0",
   "identifier": "com.tsout.conduit",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## Summary

- promote the tested `v1.11.0-rc.1` code to final `v1.11.0`
- publish the 1.11.0 changelog and release notes
- keep the release scope frozen at the validated RC commit

## Validation

- `npm test` — 20 files, 204 tests passed
- `npm run audit:prod` — 0 vulnerabilities
- `npm run build:bundle` — production frontend and `conduit v1.11.0` release sidecar built
- RC manual validation — modern sessionless HTTP JSON/SSE, legacy sessions, subscriptions, mixed downstream transports, result paging, and MRTR/HITL deny + approve

## Scope

PR #592 is intentionally excluded from 1.11.0 pending its unresolved duplicate-key correctness fix.