### PR TITLE
docs(release): list only shipped 1.11.0 PRs

### DIFF
--- a/docs/release-notes/v1.11.0.md
+++ b/docs/release-notes/v1.11.0.md
@@ -94,4 +94,5 @@ Thanks to [BharadwajKanneveti](https://github.com/BharadwajKanneveti),
 ## Full changelog
 
 See [CHANGELOG.md](https://github.com/tsouth89/toolport/blob/main/CHANGELOG.md#1110---2026-08-01)
-and the related PRs: #509, #538, #541, #553, #560, #564, #567-#590.
+and the related PRs: #509, #538, #541, #553, #560, #564, #566-#578, and
+#581-#590.


### PR DESCRIPTION
## Summary

Correct the v1.11.0 release-note PR shorthand so it does not imply still-open PRs #579 and #580 shipped. Contributor thanks and release content are unchanged.

## Validation

- `npx prettier --check docs/release-notes/v1.11.0.md`