### PR TITLE
fix(oauth): bind credentials to authorization issuer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ Entries before the rename below shipped under the project's former name, Conduit
 
 ## [Unreleased]
 
+### Security
+
+- OAuth authorization responses are now bound to the validated authorization-server
+  issuer before Toolport exchanges a code or displays an authorization error. Stored
+  refresh credentials refuse to cross to a changed issuer, and loopback Dynamic Client
+  Registration identifies Toolport as a native client as required by the current MCP
+  authorization profile. Older vaulted OAuth state remains readable. (SOU-451)
+
 ## [1.11.0] - 2026-08-01
 
 Toolport's Streamable HTTP endpoint now speaks the modern MCP transport while

--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -2330,6 +2330,7 @@ async fn authenticate_oauth(
     secrets::set_secret(&server_id, secrets::HTTP_AUTH_KEY, &res.access_token)?;
     remote::store_oauth_state(
         &server_id,
+        Some(res.issuer),
         &res.token_endpoint,
         &res.client_id,
         res.refresh_token,

--- a/src-tauri/src/oauth.rs
+++ b/src-tauri/src/oauth.rs
@@ -1,7 +1,8 @@
 //! OAuth 2.1 for remote MCP servers: RFC 8414 metadata discovery, RFC 7591
-//! dynamic client registration, RFC 7636 PKCE, and an authorization-code flow
-//! with a loopback redirect. The result is a bearer access token that rides the
-//! same keychain injection path as a manually-pasted token.
+//! dynamic client registration, RFC 7636 PKCE, RFC 9207 issuer validation, and
+//! an authorization-code flow with a loopback redirect. The result is a bearer
+//! access token that rides the same keychain injection path as a manually-pasted
+//! token.
 //!
 //! The browser leg is interactive and can't be unit-tested; the deterministic
 //! pieces (PKCE, URL building, origin parsing) are.
@@ -33,14 +34,18 @@ pub struct AuthResult {
     pub expires_at: Option<u64>,
     pub token_endpoint: String,
     pub client_id: String,
+    /// Validated authorization-server issuer that minted the client credentials.
+    pub issuer: String,
 }
 
 #[derive(Debug, Clone)]
 pub struct Endpoints {
+    pub issuer: String,
     pub authorization_endpoint: String,
     pub token_endpoint: String,
     pub registration_endpoint: Option<String>,
     pub scope: Option<String>,
+    pub authorization_response_iss_parameter_supported: bool,
 }
 
 fn base64url(data: &[u8]) -> String {
@@ -103,10 +108,13 @@ struct ProtectedResource {
 
 #[derive(Deserialize)]
 struct AsMeta {
+    issuer: String,
     authorization_endpoint: String,
     token_endpoint: String,
     registration_endpoint: Option<String>,
     scopes_supported: Option<Vec<String>>,
+    #[serde(default)]
+    authorization_response_iss_parameter_supported: bool,
 }
 
 /// A ureq agent with a connect + read timeout for all OAuth HTTP. These endpoints
@@ -215,6 +223,18 @@ fn metadata_candidates(issuer: &str) -> Vec<String> {
             format!("{origin}{path}/.well-known/oauth-authorization-server"),
             format!("{origin}{path}/.well-known/openid-configuration"),
         ]
+    }
+}
+
+/// RFC 8414 and OIDC Discovery bind a metadata document to the issuer used to
+/// locate it. Keep this as an exact string comparison: normalizing case, ports,
+/// slashes, or percent encoding would weaken the value later recorded for RFC
+/// 9207 authorization-response validation.
+fn validate_metadata_issuer(expected: &str, actual: &str) -> Result<(), String> {
+    if actual == expected {
+        Ok(())
+    } else {
+        Err("authorization-server metadata issuer mismatch; refusing OAuth discovery".to_string())
     }
 }
 
@@ -415,6 +435,10 @@ pub fn discover(mcp_url: &str) -> Result<Endpoints, String> {
 
     for url in metadata_candidates(&issuer) {
         if let Ok(meta) = get_json::<AsMeta>(&url, block_private) {
+            if let Err(e) = validate_metadata_issuer(&issuer, &meta.issuer) {
+                debug_log(&format!("metadata rejected at {url}: {e}"));
+                continue;
+            }
             // OAuth 2.1 requires TLS for these endpoints. Without this check a
             // hostile/MITM'd metadata document could point the token endpoint at
             // an attacker (or an internal address), and we'd POST the auth code +
@@ -431,10 +455,13 @@ pub fn discover(mcp_url: &str) -> Result<Endpoints, String> {
                 guard_endpoint(reg, server_local, "registration endpoint")?;
             }
             return Ok(Endpoints {
+                issuer: meta.issuer,
                 authorization_endpoint: meta.authorization_endpoint,
                 token_endpoint: meta.token_endpoint,
                 registration_endpoint: meta.registration_endpoint,
                 scope: meta.scopes_supported.map(|s| s.join(" ")),
+                authorization_response_iss_parameter_supported: meta
+                    .authorization_response_iss_parameter_supported,
             });
         }
     }
@@ -455,13 +482,7 @@ fn register_client(
     redirect_uri: &str,
     block_private: bool,
 ) -> Result<String, String> {
-    let body = serde_json::json!({
-        "client_name": "Toolport",
-        "redirect_uris": [redirect_uri],
-        "grant_types": ["authorization_code", "refresh_token"],
-        "response_types": ["code"],
-        "token_endpoint_auth_method": "none"
-    });
+    let body = dcr_request_body(redirect_uri);
     let resp: DcrResponse = agent_no_redirect(block_private)
         .post(registration_endpoint)
         .send_json(body)
@@ -469,6 +490,19 @@ fn register_client(
         .into_json()
         .map_err(|e| e.to_string())?;
     Ok(resp.client_id)
+}
+
+fn dcr_request_body(redirect_uri: &str) -> serde_json::Value {
+    serde_json::json!({
+        "client_name": "Toolport",
+        "redirect_uris": [redirect_uri],
+        "grant_types": ["authorization_code", "refresh_token"],
+        "response_types": ["code"],
+        "token_endpoint_auth_method": "none",
+        // Toolport uses an RFC 8252 loopback redirect with an OS-assigned port,
+        // so it is a native public client rather than an OIDC web client.
+        "application_type": "native"
+    })
 }
 
 pub fn build_authorize_url(
@@ -613,7 +647,31 @@ fn open_browser(url: &str) {
     let _ = std::process::Command::new("xdg-open").arg(url).spawn();
 }
 
-fn wait_for_code(listener: &TcpListener, expected_state: &str) -> Result<String, String> {
+fn validate_authorization_response_issuer(
+    response_issuer: Option<&str>,
+    expected_issuer: &str,
+    issuer_parameter_required: bool,
+) -> Result<(), String> {
+    match response_issuer {
+        Some(actual) if actual == expected_issuer => Ok(()),
+        Some(_) => Err(
+            "authorization response issuer mismatch (possible mix-up attack); try connecting again"
+                .to_string(),
+        ),
+        None if issuer_parameter_required => Err(
+            "authorization server omitted the issuer it advertised; try connecting again"
+                .to_string(),
+        ),
+        None => Ok(()),
+    }
+}
+
+fn wait_for_code(
+    listener: &TcpListener,
+    expected_state: &str,
+    expected_issuer: &str,
+    issuer_parameter_required: bool,
+) -> Result<String, String> {
     let deadline = Instant::now() + Duration::from_secs(180);
 
     loop {
@@ -643,11 +701,12 @@ fn wait_for_code(listener: &TcpListener, expected_state: &str) -> Result<String,
                 let code = params.get("code");
                 let error = params.get("error");
                 debug_log(&format!(
-                    "callback request: {} bytes of query, has_code={} has_error={} has_state={}",
+                    "callback request: {} bytes of query, has_code={} has_error={} has_state={} has_iss={}",
                     query.len(),
                     code.is_some(),
                     error.is_some(),
-                    params.contains_key("state")
+                    params.contains_key("state"),
+                    params.contains_key("iss")
                 ));
 
                 // Ignore connections that carry neither an authorization result nor
@@ -660,6 +719,22 @@ fn wait_for_code(listener: &TcpListener, expected_state: &str) -> Result<String,
                     continue;
                 }
 
+                // Validate state and issuer before accepting a code OR acting on an
+                // error. RFC 9207 explicitly forbids displaying attacker-supplied
+                // error details when the response issuer does not match.
+                if params.get("state").map(String::as_str) != Some(expected_state) {
+                    write_callback_page(&mut stream, "Authorization could not be verified. You can close this window.");
+                    return Err("state mismatch (possible CSRF); try connecting again".to_string());
+                }
+                if let Err(e) = validate_authorization_response_issuer(
+                    params.get("iss").map(String::as_str),
+                    expected_issuer,
+                    issuer_parameter_required,
+                ) {
+                    write_callback_page(&mut stream, "Authorization could not be verified. You can close this window.");
+                    return Err(e);
+                }
+
                 if let Some(error) = error {
                     let desc = params
                         .get("error_description")
@@ -669,11 +744,6 @@ fn wait_for_code(listener: &TcpListener, expected_state: &str) -> Result<String,
                     return Err(format!("authorization server returned an error ({error}){desc}"));
                 }
 
-                // We have a code. Validate state before accepting it.
-                if params.get("state").map(String::as_str) != Some(expected_state) {
-                    write_callback_page(&mut stream, "Authorization could not be verified. You can close this window.");
-                    return Err("state mismatch (possible CSRF); try connecting again".to_string());
-                }
                 write_callback_page(&mut stream, "Authorization complete. You can close this window and return to Toolport.");
                 return Ok(code.cloned().unwrap_or_default());
             }
@@ -804,7 +874,12 @@ pub fn authenticate(mcp_url: &str) -> Result<AuthResult, String> {
         endpoints.authorization_endpoint
     ));
     open_browser(&auth_url);
-    let code = wait_for_code(&listener, &state)?;
+    let code = wait_for_code(
+        &listener,
+        &state,
+        &endpoints.issuer,
+        endpoints.authorization_response_iss_parameter_supported,
+    )?;
     debug_log(&format!("got code (len {})", code.len()));
     let tokens = match exchange_code(
         &endpoints.token_endpoint,
@@ -831,6 +906,7 @@ pub fn authenticate(mcp_url: &str) -> Result<AuthResult, String> {
         expires_at: tokens.expires_at,
         token_endpoint: endpoints.token_endpoint,
         client_id,
+        issuer: endpoints.issuer,
     })
 }
 
@@ -1025,6 +1101,61 @@ mod tests {
         assert!(url.contains("code_challenge_method=S256"));
         assert!(url.contains("redirect_uri=http%3A%2F%2F127.0.0.1%3A41789%2Fcallback"));
         assert!(url.contains("scope=mcp"));
+    }
+
+    #[test]
+    fn dcr_identifies_the_loopback_client_as_native() {
+        let body = dcr_request_body("http://127.0.0.1:41789/callback");
+        assert_eq!(body["application_type"], "native");
+        assert_eq!(body["token_endpoint_auth_method"], "none");
+        assert_eq!(
+            body["redirect_uris"],
+            serde_json::json!(["http://127.0.0.1:41789/callback"])
+        );
+    }
+
+    #[test]
+    fn authorization_response_issuer_follows_rfc9207_table() {
+        let expected = "https://auth.example.com";
+        assert!(validate_authorization_response_issuer(Some(expected), expected, true).is_ok());
+        assert!(validate_authorization_response_issuer(Some(expected), expected, false).is_ok());
+        assert!(validate_authorization_response_issuer(None, expected, false).is_ok());
+        assert!(validate_authorization_response_issuer(None, expected, true).is_err());
+        assert!(validate_authorization_response_issuer(
+            Some("https://evil.example.com"),
+            expected,
+            false
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn authorization_response_issuer_comparison_is_not_normalized() {
+        let expected = "https://auth.example.com";
+        for different in [
+            "https://AUTH.example.com",
+            "https://auth.example.com/",
+            "https://auth.example.com:443",
+        ] {
+            assert!(
+                validate_authorization_response_issuer(Some(different), expected, false).is_err(),
+                "must compare the issuer exactly: {different}"
+            );
+        }
+    }
+
+    #[test]
+    fn metadata_issuer_must_match_the_selected_authorization_server() {
+        assert!(validate_metadata_issuer(
+            "https://auth.example.com",
+            "https://auth.example.com"
+        )
+        .is_ok());
+        assert!(validate_metadata_issuer(
+            "https://auth.example.com",
+            "https://other.example.com"
+        )
+        .is_err());
     }
 
     #[test]

--- a/src-tauri/src/remote.rs
+++ b/src-tauri/src/remote.rs
@@ -28,6 +28,10 @@ const PROACTIVE_REFRESH_RETRY_SECS: u64 = 15;
 
 #[derive(Serialize, Deserialize)]
 struct OAuthState {
+    /// Validated authorization-server issuer that owns the client credentials.
+    /// Optional for states vaulted before Toolport recorded issuer binding.
+    #[serde(default)]
+    issuer: Option<String>,
     token_endpoint: String,
     client_id: String,
     refresh_token: Option<String>,
@@ -82,6 +86,7 @@ fn refresh_decision(state: &OAuthState, now: u64) -> RefreshDecision {
 /// Persist what's needed to refresh this server's token later.
 pub fn store_oauth_state(
     server_id: &str,
+    issuer: Option<String>,
     token_endpoint: &str,
     client_id: &str,
     refresh_token: Option<String>,
@@ -90,6 +95,7 @@ pub fn store_oauth_state(
     expires_at: Option<u64>,
 ) -> Result<(), String> {
     let state = OAuthState {
+        issuer,
         token_endpoint: token_endpoint.to_string(),
         client_id: client_id.to_string(),
         refresh_token,
@@ -104,6 +110,20 @@ pub fn store_oauth_state(
 fn load_state(server_id: &str) -> Option<OAuthState> {
     secrets::get_secret(server_id, STATE_KEY)
         .and_then(|s| serde_json::from_str(&s).ok())
+}
+
+fn issuer_bound_token_endpoint<'a>(
+    expected_issuer: &str,
+    endpoints: &'a oauth::Endpoints,
+) -> Result<&'a str, String> {
+    if endpoints.issuer == expected_issuer {
+        Ok(&endpoints.token_endpoint)
+    } else {
+        Err(
+            "the server's OAuth issuer changed; needs authentication before credentials can be reused"
+                .to_string(),
+        )
+    }
 }
 
 /// Remove refresh metadata when the user clears OAuth or replaces it with a
@@ -121,15 +141,34 @@ fn refresh_token_with_expiry(server_id: &str) -> Result<RefreshedToken, String> 
         .refresh_token
         .as_deref()
         .ok_or("no refresh token available")?;
+    // Credentials minted under a known issuer may only be sent to endpoints from
+    // that issuer's current validated metadata. If the MCP resource changes its
+    // authorization server, fail closed so the UI asks the user to authenticate
+    // and register a fresh client instead of reusing the old credentials.
+    let refreshed_endpoints = match (state.issuer.as_deref(), state.resource.as_deref()) {
+        (Some(expected_issuer), Some(resource)) => {
+            let endpoints = oauth::discover(resource).map_err(|e| {
+                format!("could not verify the stored OAuth issuer; needs authentication: {e}")
+            })?;
+            issuer_bound_token_endpoint(expected_issuer, &endpoints)?;
+            Some(endpoints)
+        }
+        _ => None,
+    };
+    let token_endpoint = refreshed_endpoints
+        .as_ref()
+        .map(|e| e.token_endpoint.as_str())
+        .unwrap_or(&state.token_endpoint);
+
     // Block a rebind to the internal network unless the token endpoint is itself a
     // local/LAN host (a self-hosted auth server). Fail closed (block) if the stored
     // endpoint host can't be parsed OR can't be positively confirmed local, so an
     // unresolvable stored endpoint stays screened rather than opening the guard (#422).
-    let block_private = oauth::host_of_url(&state.token_endpoint)
+    let block_private = oauth::host_of_url(token_endpoint)
         .map(|h| !oauth::host_is_definitely_private(&h))
         .unwrap_or(true);
     let tokens = oauth::refresh(
-        &state.token_endpoint,
+        token_endpoint,
         &state.client_id,
         rt,
         state.resource.as_deref(),
@@ -140,7 +179,8 @@ fn refresh_token_with_expiry(server_id: &str) -> Result<RefreshedToken, String> 
     // the reverse order could strand a new access token with an invalidated old
     // refresh token after a second-write failure.
     let new_state = OAuthState {
-        token_endpoint: state.token_endpoint,
+        issuer: state.issuer,
+        token_endpoint: token_endpoint.to_string(),
         client_id: state.client_id,
         refresh_token: tokens.refresh_token.or(state.refresh_token),
         resource: state.resource,
@@ -452,6 +492,7 @@ mod tests {
 
     fn oauth_state(expires_at: Option<u64>, refresh_token: Option<&str>) -> OAuthState {
         OAuthState {
+            issuer: Some("https://auth.example.com".into()),
             token_endpoint: "https://auth.example.com/token".into(),
             client_id: "client".into(),
             refresh_token: refresh_token.map(str::to_string),
@@ -498,7 +539,29 @@ mod tests {
 
         assert_eq!(state.issued_at, None);
         assert_eq!(state.expires_at, None);
+        assert_eq!(state.issuer, None);
         assert_eq!(refresh_decision(&state, 1_000), RefreshDecision::NotNeeded);
+    }
+
+    #[test]
+    fn refresh_credentials_stay_bound_to_their_issuer() {
+        let endpoints = |issuer: &str, token_endpoint: &str| oauth::Endpoints {
+            issuer: issuer.into(),
+            authorization_endpoint: "https://auth.example.com/authorize".into(),
+            token_endpoint: token_endpoint.into(),
+            registration_endpoint: None,
+            scope: None,
+            authorization_response_iss_parameter_supported: false,
+        };
+
+        let rotated = endpoints("https://auth.example.com", "https://auth.example.com/token-v2");
+        assert_eq!(
+            issuer_bound_token_endpoint("https://auth.example.com", &rotated).unwrap(),
+            "https://auth.example.com/token-v2"
+        );
+
+        let changed = endpoints("https://other.example.com", "https://other.example.com/token");
+        assert!(issuer_bound_token_endpoint("https://auth.example.com", &changed).is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- validate authorization-server metadata issuers and RFC 9207 `iss` on success and error callbacks
- persist the validated issuer and refuse refresh-token reuse after the server changes authorization issuers
- identify Toolport's loopback DCR client as `application_type: native` while preserving older vaulted OAuth state

## Verification

- `cargo test --manifest-path src-tauri/Cargo.toml oauth --lib` (25 passed)
- `cargo test --manifest-path src-tauri/Cargo.toml remote::tests::refresh_credentials_stay_bound_to_their_issuer --lib -- --exact`
- full `cargo test --manifest-path src-tauri/Cargo.toml --lib --bins --tests`: 627 passed; unrelated existing `downstream::tests::windows_job_terminates_launcher_grandchild` fails because its temporary PID file is not created
- `git diff --check`

Linear: SOU-451
