### PR TITLE
fix(oauth): validate protected resource discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ Entries before the rename below shipped under the project's former name, Conduit
   refresh credentials refuse to cross to a changed issuer, and loopback Dynamic Client
   Registration identifies Toolport as a native client as required by the current MCP
   authorization profile. Older vaulted OAuth state remains readable. (SOU-451)
+- OAuth discovery now checks the MCP endpoint's path-specific protected-resource
+  metadata before the origin fallback, rejects metadata for a different resource,
+  and requests the resource's advertised scopes. OAuth and OIDC authorization-server
+  metadata candidates follow the current MCP priority order. (SOU-451)
 
 ## [1.11.0] - 2026-08-01
 

--- a/src-tauri/src/oauth.rs
+++ b/src-tauri/src/oauth.rs
@@ -267,7 +267,11 @@ fn validated_protected_resource(
     expected_resource: &str,
     metadata: ProtectedResource,
 ) -> Result<(String, Option<String>), String> {
-    if metadata.resource.as_deref() != Some(expected_resource) {
+    let resource = metadata.resource.ok_or_else(|| {
+        "protected-resource metadata has no resource identifier; refusing OAuth discovery"
+            .to_string()
+    })?;
+    if resource != expected_resource {
         return Err(
             "protected-resource metadata describes a different resource; refusing OAuth discovery"
                 .to_string(),
@@ -282,8 +286,15 @@ fn validated_protected_resource(
         })?;
     let scope = metadata
         .scopes_supported
-        .filter(|scopes| !scopes.is_empty())
-        .map(|scopes| scopes.join(" "));
+        .map(|scopes| {
+            scopes
+                .into_iter()
+                .map(|scope| scope.trim().to_string())
+                .filter(|scope| !scope.is_empty())
+                .collect::<Vec<_>>()
+                .join(" ")
+        })
+        .filter(|scope| !scope.is_empty());
     Ok((issuer, scope))
 }
 
@@ -506,7 +517,14 @@ pub fn discover(mcp_url: &str) -> Result<Endpoints, String> {
                     resource_scope = scope;
                     break;
                 }
-                Err(e) => debug_log(&format!("protected-resource metadata rejected at {url}: {e}")),
+                // A document was found and parsed, so rejecting its security
+                // binding must fail closed. Falling back to origin-level AS
+                // discovery here would silently bypass RFC 9728 validation.
+                Err(e) => {
+                    return Err(format!(
+                        "protected-resource metadata rejected at {url}: {e}"
+                    ))
+                }
             }
         }
     }
@@ -1348,6 +1366,23 @@ mod tests {
     }
 
     #[test]
+    fn protected_resource_metadata_normalizes_advertised_scopes() {
+        let metadata = ProtectedResource {
+            resource: Some("https://mcp.example.com/mcp".into()),
+            authorization_servers: Some(vec!["https://auth.example.com".into()]),
+            scopes_supported: Some(vec![
+                " files:read ".into(),
+                "".into(),
+                "  ".into(),
+                "files:write".into(),
+            ]),
+        };
+        let (_, scope) =
+            validated_protected_resource("https://mcp.example.com/mcp", metadata).unwrap();
+        assert_eq!(scope.as_deref(), Some("files:read files:write"));
+    }
+
+    #[test]
     fn protected_resource_scope_absence_does_not_expand_to_all_as_scopes() {
         assert_eq!(
             initial_scope(
@@ -1365,6 +1400,18 @@ mod tests {
 
     #[test]
     fn protected_resource_metadata_rejects_impersonation_and_empty_issuers() {
+        let missing_resource = ProtectedResource {
+            resource: None,
+            authorization_servers: Some(vec!["https://auth.example.com".into()]),
+            scopes_supported: None,
+        };
+        let error = validated_protected_resource(
+            "https://mcp.example.com/mcp",
+            missing_resource,
+        )
+        .unwrap_err();
+        assert!(error.contains("no resource identifier"));
+
         let wrong_resource = ProtectedResource {
             resource: Some("https://other.example.com/mcp".into()),
             authorization_servers: Some(vec!["https://auth.example.com".into()]),
@@ -1382,5 +1429,41 @@ mod tests {
             scopes_supported: None,
         };
         assert!(validated_protected_resource("https://mcp.example.com/mcp", no_issuer).is_err());
+    }
+
+    #[test]
+    fn discover_fails_closed_on_invalid_protected_resource_metadata() {
+        use std::sync::{Arc, Mutex};
+        use std::time::Duration;
+
+        let server = tiny_http::Server::http("127.0.0.1:0").unwrap();
+        let address = server.server_addr().to_ip().unwrap();
+        let resource = format!("http://{address}");
+        let requested_paths = Arc::new(Mutex::new(Vec::new()));
+        let seen = Arc::clone(&requested_paths);
+        let handle = std::thread::spawn(move || {
+            while let Ok(Some(request)) = server.recv_timeout(Duration::from_millis(250)) {
+                seen.lock().unwrap().push(request.url().to_string());
+                let response = tiny_http::Response::from_string(
+                    serde_json::json!({
+                        "authorization_servers": ["https://auth.example.com"]
+                    })
+                    .to_string(),
+                )
+                .with_header(
+                    tiny_http::Header::from_bytes(b"Content-Type", b"application/json").unwrap(),
+                );
+                request.respond(response).unwrap();
+            }
+        });
+
+        let error = discover(&resource).unwrap_err();
+        handle.join().unwrap();
+
+        assert!(error.contains("no resource identifier"));
+        assert_eq!(
+            requested_paths.lock().unwrap().as_slice(),
+            ["/.well-known/oauth-protected-resource"]
+        );
     }
 }

--- a/src-tauri/src/oauth.rs
+++ b/src-tauri/src/oauth.rs
@@ -193,6 +193,24 @@ fn get_json<T: serde::de::DeserializeOwned>(url: &str, block_private: bool) -> R
         .map_err(|e| e.to_string())
 }
 
+/// Fetch optional discovery metadata while distinguishing an absent/unreachable
+/// endpoint from a reachable endpoint that returned malformed JSON. Older MCP
+/// servers may not implement the protected-resource well-known URI, but a 2xx
+/// response must not bypass validation merely by being unparseable.
+fn get_optional_discovery_json<T: serde::de::DeserializeOwned>(
+    url: &str,
+    block_private: bool,
+) -> Result<Option<T>, String> {
+    let response = match agent(block_private).get(url).call() {
+        Ok(response) => response,
+        Err(_) => return Ok(None),
+    };
+    response
+        .into_json::<T>()
+        .map(Some)
+        .map_err(|e| format!("metadata response was not valid JSON: {e}"))
+}
+
 fn split_origin_path(url: &str) -> (String, String) {
     if let Some(scheme_end) = url.find("://") {
         let after = &url[scheme_end + 3..];
@@ -289,18 +307,18 @@ fn validated_protected_resource(
             "protected-resource metadata has no authorization server; refusing OAuth discovery"
                 .to_string()
         })?;
-    let scope = metadata
-        .scopes_supported
-        .map(|scopes| {
-            scopes
-                .into_iter()
-                .map(|scope| scope.trim().to_string())
-                .filter(|scope| !scope.is_empty())
-                .collect::<Vec<_>>()
-                .join(" ")
-        })
-        .filter(|scope| !scope.is_empty());
+    let scope = metadata.scopes_supported.and_then(normalized_scope);
     Ok((issuer, scope))
+}
+
+fn normalized_scope(scopes: Vec<String>) -> Option<String> {
+    let scope = scopes
+        .into_iter()
+        .map(|scope| scope.trim().to_string())
+        .filter(|scope| !scope.is_empty())
+        .collect::<Vec<_>>()
+        .join(" ");
+    (!scope.is_empty()).then_some(scope)
 }
 
 fn initial_scope(
@@ -314,7 +332,7 @@ fn initial_scope(
         protected_resource_scope
     } else {
         // Compatibility for older MCP servers that predate RFC 9728 metadata.
-        authorization_server_scopes.map(|scopes| scopes.join(" "))
+        authorization_server_scopes.and_then(normalized_scope)
     }
 }
 
@@ -514,8 +532,8 @@ pub fn discover(mcp_url: &str) -> Result<Endpoints, String> {
     let mut resource_scope = None;
     let mut discovered_issuer = None;
     for url in protected_resource_metadata_candidates(mcp_url) {
-        if let Ok(metadata) = get_json::<ProtectedResource>(&url, block_private) {
-            match validated_protected_resource(mcp_url, metadata) {
+        match get_optional_discovery_json::<ProtectedResource>(&url, block_private) {
+            Ok(Some(metadata)) => match validated_protected_resource(mcp_url, metadata) {
                 Ok((issuer, scope)) => {
                     protected_resource_found = true;
                     discovered_issuer = Some(issuer);
@@ -530,6 +548,12 @@ pub fn discover(mcp_url: &str) -> Result<Endpoints, String> {
                         "protected-resource metadata rejected at {url}: {e}"
                     ))
                 }
+            },
+            Ok(None) => {}
+            Err(e) => {
+                return Err(format!(
+                    "protected-resource metadata rejected at {url}: {e}"
+                ))
             }
         }
     }
@@ -1402,7 +1426,11 @@ mod tests {
             None
         );
         assert_eq!(
-            initial_scope(false, None, Some(vec!["legacy:mcp".into()])),
+            initial_scope(
+                false,
+                None,
+                Some(vec![" ".into(), " legacy:mcp ".into(), "".into()])
+            ),
             Some("legacy:mcp".into())
         );
     }
@@ -1474,6 +1502,37 @@ mod tests {
             requested_paths.lock().unwrap().as_slice(),
             ["/.well-known/oauth-protected-resource"]
         );
+    }
+
+    #[test]
+    fn discover_fails_closed_on_malformed_protected_resource_metadata() {
+        use std::time::Duration;
+
+        let server = tiny_http::Server::http("127.0.0.1:0").unwrap();
+        let address = server.server_addr().to_ip().unwrap();
+        let resource = format!("http://{address}");
+        let handle = std::thread::spawn(move || {
+            let request = server
+                .recv_timeout(Duration::from_secs(2))
+                .unwrap()
+                .expect("protected-resource metadata request");
+            request
+                .respond(
+                    tiny_http::Response::from_string("not json").with_header(
+                        tiny_http::Header::from_bytes(
+                            b"Content-Type",
+                            b"application/json",
+                        )
+                        .unwrap(),
+                    ),
+                )
+                .unwrap();
+        });
+
+        let error = discover(&resource).unwrap_err();
+        handle.join().unwrap();
+
+        assert!(error.contains("metadata response was not valid JSON"));
     }
 
     #[test]

--- a/src-tauri/src/oauth.rs
+++ b/src-tauri/src/oauth.rs
@@ -103,7 +103,9 @@ fn origin_of(url: &str) -> String {
 
 #[derive(Deserialize)]
 struct ProtectedResource {
+    resource: Option<String>,
     authorization_servers: Option<Vec<String>>,
+    scopes_supported: Option<Vec<String>>,
 }
 
 #[derive(Deserialize)]
@@ -220,9 +222,83 @@ fn metadata_candidates(issuer: &str) -> Vec<String> {
         vec![
             format!("{origin}/.well-known/oauth-authorization-server{path}"),
             format!("{origin}/.well-known/openid-configuration{path}"),
-            format!("{origin}{path}/.well-known/oauth-authorization-server"),
             format!("{origin}{path}/.well-known/openid-configuration"),
+            // Compatibility fallback used by some pre-spec servers. The three
+            // required MCP candidates above retain their normative priority.
+            format!("{origin}{path}/.well-known/oauth-authorization-server"),
         ]
+    }
+}
+
+/// RFC 9728 inserts the protected-resource well-known suffix between the origin
+/// and the resource path. MCP additionally requires clients to fall back to the
+/// origin-level document after trying the path-specific form.
+fn protected_resource_metadata_candidates(resource: &str) -> Vec<String> {
+    let Ok(parsed) = url::Url::parse(resource) else {
+        return vec![format!(
+            "{}/.well-known/oauth-protected-resource",
+            origin_of(resource).trim_end_matches('/')
+        )];
+    };
+    let mut origin_url = parsed.clone();
+    origin_url.set_path("");
+    origin_url.set_query(None);
+    origin_url.set_fragment(None);
+    let origin = origin_url.as_str().trim_end_matches('/');
+    let root = format!("{origin}/.well-known/oauth-protected-resource");
+    let path = parsed.path().trim_start_matches('/');
+    let mut specific = root.clone();
+    if !path.is_empty() {
+        specific.push('/');
+        specific.push_str(path);
+    }
+    if let Some(query) = parsed.query() {
+        specific.push('?');
+        specific.push_str(query);
+    }
+    if specific == root {
+        vec![root]
+    } else {
+        vec![specific, root]
+    }
+}
+
+fn validated_protected_resource(
+    expected_resource: &str,
+    metadata: ProtectedResource,
+) -> Result<(String, Option<String>), String> {
+    if metadata.resource.as_deref() != Some(expected_resource) {
+        return Err(
+            "protected-resource metadata describes a different resource; refusing OAuth discovery"
+                .to_string(),
+        );
+    }
+    let issuer = metadata
+        .authorization_servers
+        .and_then(|servers| servers.into_iter().find(|issuer| !issuer.trim().is_empty()))
+        .ok_or_else(|| {
+            "protected-resource metadata has no authorization server; refusing OAuth discovery"
+                .to_string()
+        })?;
+    let scope = metadata
+        .scopes_supported
+        .filter(|scopes| !scopes.is_empty())
+        .map(|scopes| scopes.join(" "));
+    Ok((issuer, scope))
+}
+
+fn initial_scope(
+    protected_resource_found: bool,
+    protected_resource_scope: Option<String>,
+    authorization_server_scopes: Option<Vec<String>>,
+) -> Option<String> {
+    if protected_resource_found {
+        // Absence is meaningful: current MCP says to omit `scope` when the
+        // resource did not advertise one, not to request every AS-wide scope.
+        protected_resource_scope
+    } else {
+        // Compatibility for older MCP servers that predate RFC 9728 metadata.
+        authorization_server_scopes.map(|scopes| scopes.join(" "))
     }
 }
 
@@ -418,16 +494,26 @@ pub fn discover(mcp_url: &str) -> Result<Endpoints, String> {
         .map(|h| host_is_definitely_private(&h))
         .unwrap_or(false);
     let block_private = !server_local;
-    let issuer = match get_json::<ProtectedResource>(
-        &format!("{origin}/.well-known/oauth-protected-resource"),
-        block_private,
-    ) {
-        Ok(pr) => pr
-            .authorization_servers
-            .and_then(|v| v.into_iter().next())
-            .unwrap_or_else(|| origin.clone()),
-        Err(_) => origin.clone(),
-    };
+    let mut protected_resource_found = false;
+    let mut resource_scope = None;
+    let mut discovered_issuer = None;
+    for url in protected_resource_metadata_candidates(mcp_url) {
+        if let Ok(metadata) = get_json::<ProtectedResource>(&url, block_private) {
+            match validated_protected_resource(mcp_url, metadata) {
+                Ok((issuer, scope)) => {
+                    protected_resource_found = true;
+                    discovered_issuer = Some(issuer);
+                    resource_scope = scope;
+                    break;
+                }
+                Err(e) => debug_log(&format!("protected-resource metadata rejected at {url}: {e}")),
+            }
+        }
+    }
+    // Preserve compatibility with pre-RFC 9728 servers that publish only
+    // authorization-server metadata at the MCP origin. Current MCP servers are
+    // expected to take the validated protected-resource path above.
+    let issuer = discovered_issuer.unwrap_or_else(|| origin.clone());
 
     // The issuer can come from the protected-resource document, so guard the
     // metadata fetch too, not just the final endpoints.
@@ -459,7 +545,14 @@ pub fn discover(mcp_url: &str) -> Result<Endpoints, String> {
                 authorization_endpoint: meta.authorization_endpoint,
                 token_endpoint: meta.token_endpoint,
                 registration_endpoint: meta.registration_endpoint,
-                scope: meta.scopes_supported.map(|s| s.join(" ")),
+                // The protected resource defines the scopes needed to access it.
+                // Keep AS metadata as a compatibility fallback for older servers
+                // that did not publish RFC 9728 protected-resource metadata.
+                scope: initial_scope(
+                    protected_resource_found,
+                    resource_scope,
+                    meta.scopes_supported,
+                ),
                 authorization_response_iss_parameter_supported: meta
                     .authorization_response_iss_parameter_supported,
             });
@@ -1213,5 +1306,81 @@ mod tests {
             c2[0],
             "https://as.example.com/.well-known/oauth-authorization-server"
         );
+        assert_eq!(
+            c[2],
+            "https://access.stripe.com/mcp/.well-known/openid-configuration"
+        );
+    }
+
+    #[test]
+    fn protected_resource_candidates_try_the_endpoint_path_then_origin() {
+        assert_eq!(
+            protected_resource_metadata_candidates("https://mcp.example.com/public/mcp"),
+            vec![
+                "https://mcp.example.com/.well-known/oauth-protected-resource/public/mcp",
+                "https://mcp.example.com/.well-known/oauth-protected-resource",
+            ]
+        );
+        assert_eq!(
+            protected_resource_metadata_candidates("https://mcp.example.com"),
+            vec!["https://mcp.example.com/.well-known/oauth-protected-resource"]
+        );
+        assert_eq!(
+            protected_resource_metadata_candidates("https://mcp.example.com/mcp?tenant=acme"),
+            vec![
+                "https://mcp.example.com/.well-known/oauth-protected-resource/mcp?tenant=acme",
+                "https://mcp.example.com/.well-known/oauth-protected-resource",
+            ]
+        );
+    }
+
+    #[test]
+    fn protected_resource_metadata_is_bound_and_supplies_scopes() {
+        let metadata = ProtectedResource {
+            resource: Some("https://mcp.example.com/mcp".into()),
+            authorization_servers: Some(vec!["https://auth.example.com".into()]),
+            scopes_supported: Some(vec!["files:read".into(), "files:write".into()]),
+        };
+        let (issuer, scope) =
+            validated_protected_resource("https://mcp.example.com/mcp", metadata).unwrap();
+        assert_eq!(issuer, "https://auth.example.com");
+        assert_eq!(scope.as_deref(), Some("files:read files:write"));
+    }
+
+    #[test]
+    fn protected_resource_scope_absence_does_not_expand_to_all_as_scopes() {
+        assert_eq!(
+            initial_scope(
+                true,
+                None,
+                Some(vec!["openid".into(), "admin".into()])
+            ),
+            None
+        );
+        assert_eq!(
+            initial_scope(false, None, Some(vec!["legacy:mcp".into()])),
+            Some("legacy:mcp".into())
+        );
+    }
+
+    #[test]
+    fn protected_resource_metadata_rejects_impersonation_and_empty_issuers() {
+        let wrong_resource = ProtectedResource {
+            resource: Some("https://other.example.com/mcp".into()),
+            authorization_servers: Some(vec!["https://auth.example.com".into()]),
+            scopes_supported: None,
+        };
+        assert!(validated_protected_resource(
+            "https://mcp.example.com/mcp",
+            wrong_resource
+        )
+        .is_err());
+
+        let no_issuer = ProtectedResource {
+            resource: Some("https://mcp.example.com/mcp".into()),
+            authorization_servers: Some(vec!["".into()]),
+            scopes_supported: None,
+        };
+        assert!(validated_protected_resource("https://mcp.example.com/mcp", no_issuer).is_err());
     }
 }

--- a/src-tauri/src/oauth.rs
+++ b/src-tauri/src/oauth.rs
@@ -279,7 +279,12 @@ fn validated_protected_resource(
     }
     let issuer = metadata
         .authorization_servers
-        .and_then(|servers| servers.into_iter().find(|issuer| !issuer.trim().is_empty()))
+        .and_then(|servers| {
+            servers
+                .into_iter()
+                .map(|issuer| issuer.trim().to_string())
+                .find(|issuer| !issuer.is_empty())
+        })
         .ok_or_else(|| {
             "protected-resource metadata has no authorization server; refusing OAuth discovery"
                 .to_string()
@@ -534,7 +539,10 @@ pub fn discover(mcp_url: &str) -> Result<Endpoints, String> {
     let issuer = discovered_issuer.unwrap_or_else(|| origin.clone());
 
     // The issuer can come from the protected-resource document, so guard the
-    // metadata fetch too, not just the final endpoints.
+    // metadata fetch too, not just the final endpoints. Requiring TLS here
+    // prevents an attacker from substituting the metadata before its endpoint
+    // URLs receive their own HTTPS and SSRF checks.
+    require_https(&issuer, "authorization server")?;
     guard_endpoint(&issuer, server_local, "authorization server")?;
 
     for url in metadata_candidates(&issuer) {
@@ -1369,7 +1377,7 @@ mod tests {
     fn protected_resource_metadata_normalizes_advertised_scopes() {
         let metadata = ProtectedResource {
             resource: Some("https://mcp.example.com/mcp".into()),
-            authorization_servers: Some(vec!["https://auth.example.com".into()]),
+            authorization_servers: Some(vec!["  https://auth.example.com  ".into()]),
             scopes_supported: Some(vec![
                 " files:read ".into(),
                 "".into(),
@@ -1377,8 +1385,9 @@ mod tests {
                 "files:write".into(),
             ]),
         };
-        let (_, scope) =
+        let (issuer, scope) =
             validated_protected_resource("https://mcp.example.com/mcp", metadata).unwrap();
+        assert_eq!(issuer, "https://auth.example.com");
         assert_eq!(scope.as_deref(), Some("files:read files:write"));
     }
 
@@ -1465,5 +1474,37 @@ mod tests {
             requested_paths.lock().unwrap().as_slice(),
             ["/.well-known/oauth-protected-resource"]
         );
+    }
+
+    #[test]
+    fn discover_refuses_cleartext_authorization_server_metadata() {
+        use std::time::Duration;
+
+        let server = tiny_http::Server::http("127.0.0.1:0").unwrap();
+        let address = server.server_addr().to_ip().unwrap();
+        let resource = format!("http://{address}");
+        let document_resource = resource.clone();
+        let handle = std::thread::spawn(move || {
+            let request = server
+                .recv_timeout(Duration::from_secs(2))
+                .unwrap()
+                .expect("protected-resource metadata request");
+            let response = tiny_http::Response::from_string(
+                serde_json::json!({
+                    "resource": document_resource,
+                    "authorization_servers": ["http://8.8.8.8"]
+                })
+                .to_string(),
+            )
+            .with_header(
+                tiny_http::Header::from_bytes(b"Content-Type", b"application/json").unwrap(),
+            );
+            request.respond(response).unwrap();
+        });
+
+        let error = discover(&resource).unwrap_err();
+        handle.join().unwrap();
+
+        assert!(error.contains("authorization server must use https"));
     }
 }


### PR DESCRIPTION
Stacked on #596; review this PR as the RFC 9728 discovery delta only.

## Summary

- try path-specific protected-resource metadata before the MCP origin fallback
- reject metadata that describes a different resource, omits an authorization server, or returns malformed JSON
- preserve legacy fallback only when protected-resource metadata is absent or unreachable
- require HTTPS for authorization-server metadata discovery and normalize advertised issuer/scope values
- source initial OAuth scopes from protected-resource metadata without expanding to every AS-wide scope
- preserve origin-only discovery for older servers and put the required OAuth/OIDC metadata candidates in current MCP priority order

## Verification

- `cargo test --manifest-path src-tauri/Cargo.toml oauth --lib` (33 passed)
- `git diff --check`

Linear: SOU-451