### PR TITLE
feat(oauth): step up runtime scopes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ Entries before the rename below shipped under the project's former name, Conduit
   advertised protected-resource metadata URL with the existing TLS and SSRF guards,
   and gives a challenge's requested scope priority without weakening discovery for
   older servers that do not return a challenge. (SOU-451)
+- Runtime OAuth `insufficient_scope` challenges now preserve previously requested
+  scopes, open a user-consent step-up flow, and retry the blocked MCP operation once
+  with the new token. Step-up attempts are bounded per operation and never consume
+  refresh tokens that cannot grant additional permissions. (SOU-451)
 
 ### Fixed
 

--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -2335,6 +2335,7 @@ async fn authenticate_oauth(
         &res.client_id,
         res.refresh_token,
         Some(resource),
+        res.scope,
         res.issued_at,
         res.expires_at,
     )?;

--- a/src-tauri/src/downstream.rs
+++ b/src-tauri/src/downstream.rs
@@ -2825,6 +2825,48 @@ fn ids_match(got: Option<&Value>, wanted: Option<&Value>) -> bool {
 /// a forced error is surfaced as a per-server authentication failure.
 pub type RefreshFn = Box<dyn Fn(bool) -> Result<Option<String>, String> + Send + Sync>;
 
+/// Interactive OAuth step-up callback. Unlike a refresh-token exchange, this
+/// obtains user consent for the challenged scope and returns a new access token.
+pub type ScopeReauthorizeFn = Box<dyn Fn(&str) -> Result<String, String> + Send + Sync>;
+
+fn insufficient_scope_challenge(response: &ureq::Response) -> Option<crate::oauth::BearerChallenge> {
+    let values = response.all("www-authenticate");
+    let challenge = crate::oauth::bearer_challenge(values.iter().copied())?;
+    challenge
+        .error
+        .as_deref()
+        .is_some_and(|error| error.eq_ignore_ascii_case("insufficient_scope"))
+        .then_some(challenge)
+}
+
+fn authorization_operation(body: &Value) -> String {
+    let method = body
+        .get("method")
+        .and_then(Value::as_str)
+        .unwrap_or("MCP request");
+    let discriminator = match method {
+        "tools/call" | "prompts/get" => body
+            .get("params")
+            .and_then(|params| params.get("name"))
+            .and_then(Value::as_str),
+        "resources/read" => body
+            .get("params")
+            .and_then(|params| params.get("uri"))
+            .and_then(Value::as_str),
+        _ => None,
+    };
+    discriminator
+        .map(|value| format!("{method}:{value}"))
+        .unwrap_or_else(|| method.to_string())
+}
+
+fn canonical_scope_set(scope: &str) -> String {
+    let mut scopes: Vec<&str> = scope.split_whitespace().collect();
+    scopes.sort_unstable();
+    scopes.dedup();
+    scopes.join(" ")
+}
+
 /// Screen resolved socket addresses against the SSRF policy, fail-closed: returns
 /// `Err` if ANY address is link-local / cloud-metadata, or - when `block_private` -
 /// private / loopback / CGNAT. Refusing the whole set (not just filtering the bad
@@ -2901,6 +2943,12 @@ pub struct HttpTransport {
     /// `None` or error keeps the current token; a forced refresh must return a new
     /// raw token or the authentication failure is surfaced.
     refresh: Option<Arc<Mutex<RefreshFn>>>,
+    /// Separate from token refresh: `insufficient_scope` requires interactive
+    /// consent and a new authorization, not another token from the old grant.
+    scope_reauthorize: Option<Arc<Mutex<ScopeReauthorizeFn>>>,
+    /// Bound repeated browser prompts and retries per operation+scope on this
+    /// connection, as required by the MCP step-up guidance.
+    scope_upgrade_attempts: Arc<Mutex<HashSet<(String, String)>>>,
     /// The token a forced refresh produced and that has not yet been accepted by
     /// the server, if any.
     ///
@@ -2986,6 +3034,8 @@ impl HttpTransport {
             next_id: 1,
             auth: Arc::new(Mutex::new(auth)),
             refresh: refresh.map(|refresh| Arc::new(Mutex::new(refresh))),
+            scope_reauthorize: None,
+            scope_upgrade_attempts: Arc::new(Mutex::new(HashSet::new())),
             forced_refresh_token: None,
             server_handler: None,
             pending_mrtr: None,
@@ -2996,6 +3046,10 @@ impl HttpTransport {
             listener_generation: Arc::new(AtomicU64::new(0)),
             subscription_listener_id: None,
         }
+    }
+
+    pub fn set_scope_reauthorize(&mut self, callback: Option<ScopeReauthorizeFn>) {
+        self.scope_reauthorize = callback.map(|callback| Arc::new(Mutex::new(callback)));
     }
 
     /// Wire the gateway sink for `notifications/resources/updated` seen on SSE
@@ -3150,6 +3204,56 @@ impl HttpTransport {
         }
     }
 
+    fn reauthorize_after_scope_challenge(
+        &mut self,
+        code: u16,
+        operation: &str,
+        challenge: crate::oauth::BearerChallenge,
+    ) -> Result<(), TransportError> {
+        let required_scope = challenge
+            .scope
+            .map(|scope| canonical_scope_set(&scope))
+            .filter(|scope| !scope.is_empty())
+            .ok_or_else(|| {
+                TransportError::Fatal(format!(
+                    "HTTP {code} (needs authentication): OAuth reported insufficient_scope without the required scope"
+                ))
+            })?;
+        let attempt_key = (operation.to_string(), required_scope.clone());
+        let first_attempt = self
+            .scope_upgrade_attempts
+            .lock()
+            .map_err(|_| TransportError::Fatal("OAuth scope-attempt lock poisoned".into()))?
+            .insert(attempt_key);
+        if !first_attempt {
+            return Err(TransportError::Fatal(format!(
+                "HTTP {code} (needs authentication): OAuth scope '{required_scope}' was already requested for {operation} and remains insufficient"
+            )));
+        }
+        let callback = self.scope_reauthorize.as_ref().ok_or_else(|| {
+            TransportError::Fatal(format!(
+                "HTTP {code} (needs authentication): OAuth scope '{required_scope}' requires interactive authorization"
+            ))
+        })?;
+        let token = callback
+            .lock()
+            .map_err(|_| TransportError::Fatal("OAuth scope callback lock poisoned".into()))?
+            (&required_scope)
+            .map_err(|e| {
+                TransportError::Fatal(format!(
+                    "HTTP {code} (needs authentication): OAuth scope authorization failed for '{required_scope}': {e}"
+                ))
+            })?;
+        *self
+            .auth
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(token.clone());
+        // Do not follow a freshly-authorized token's rejection with an automatic
+        // refresh-token exchange: it cannot add a scope the user did not grant.
+        self.forced_refresh_token = Some(token);
+        Ok(())
+    }
+
     /// POST JSON-RPC without waiting for a response body (inline replies mid-SSE).
     fn send_post_no_response(&mut self, body: &Value) -> Result<(), TransportError> {
         let payload = body.to_string();
@@ -3183,6 +3287,17 @@ impl HttpTransport {
             }
             match req.send_string(&payload) {
                 Ok(resp) => break resp,
+                Err(ureq::Error::Status(code, resp))
+                    if (code == 401 || code == 403)
+                        && insufficient_scope_challenge(&resp).is_some() =>
+                {
+                    let challenge = insufficient_scope_challenge(&resp)
+                        .expect("match guard established an insufficient-scope challenge");
+                    let _ = read_capped(resp, 8 * 1024);
+                    let operation = authorization_operation(body);
+                    self.reauthorize_after_scope_challenge(code, &operation, challenge)?;
+                    refreshed = true;
+                }
                 Err(ureq::Error::Status(code, resp))
                     if (code == 401 || code == 403)
                         && !refreshed
@@ -3372,6 +3487,18 @@ impl HttpTransport {
                         message: "HTTP 429: rate limited".to_string(),
                     });
                 }
+                Err(ureq::Error::Status(code, r))
+                    if (code == 401 || code == 403)
+                        && insufficient_scope_challenge(&r).is_some() =>
+                {
+                    let challenge = insufficient_scope_challenge(&r)
+                        .expect("match guard established an insufficient-scope challenge");
+                    let _ = read_capped(r, 8 * 1024);
+                    let operation = authorization_operation(body);
+                    self.reauthorize_after_scope_challenge(code, &operation, challenge)?;
+                    refreshed = true;
+                    continue;
+                }
                 // The access token likely expired: refresh it once and retry with
                 // the new token, so a long-running session self-heals instead of
                 // 401ing until the server is manually reconnected.
@@ -3514,6 +3641,8 @@ impl Transport for HttpTransport {
         let url = self.url.clone();
         let auth = Arc::clone(&self.auth);
         let refresh = self.refresh.clone();
+        let scope_reauthorize = self.scope_reauthorize.clone();
+        let scope_upgrade_attempts = Arc::clone(&self.scope_upgrade_attempts);
         let wire_version = self.wire_protocol_version();
         let dirty = self.change_dirty.clone();
         let resource_updated = self.resource_updated.clone();
@@ -3548,6 +3677,56 @@ impl Transport for HttpTransport {
                     }
                     match request.send_string(&payload) {
                         Ok(response) => break Some(response),
+                        Err(ureq::Error::Status(code, response))
+                            if (code == 401 || code == 403)
+                                && insufficient_scope_challenge(&response).is_some() =>
+                        {
+                            let challenge = insufficient_scope_challenge(&response)
+                                .expect("match guard established an insufficient-scope challenge");
+                            let _ = read_capped(response, 8 * 1024);
+                            let Some(scope) = challenge
+                                .scope
+                                .map(|scope| canonical_scope_set(&scope))
+                                .filter(|scope| !scope.is_empty())
+                            else {
+                                downstream_trace(
+                                    "subscriptions/listen insufficient_scope challenge omitted scope",
+                                );
+                                break None;
+                            };
+                            let attempt_key =
+                                ("subscriptions/listen".to_string(), scope.clone());
+                            let first_attempt = scope_upgrade_attempts
+                                .lock()
+                                .map(|mut attempts| attempts.insert(attempt_key))
+                                .unwrap_or(false);
+                            let upgraded = if first_attempt {
+                                scope_reauthorize.as_ref().and_then(|callback| {
+                                    callback
+                                        .lock()
+                                        .ok()
+                                        .and_then(|callback| callback(&scope).ok())
+                                })
+                            } else {
+                                None
+                            };
+                            match upgraded {
+                                Some(token) => {
+                                    *auth
+                                        .lock()
+                                        .unwrap_or_else(std::sync::PoisonError::into_inner) =
+                                        Some(token);
+                                    forced_refresh = true;
+                                    continue;
+                                }
+                                None => {
+                                    downstream_trace(&format!(
+                                        "subscriptions/listen needs interactive OAuth scope '{scope}'"
+                                    ));
+                                    break None;
+                                }
+                            }
+                        }
                         Err(ureq::Error::Status(code, response))
                             if (code == 401 || code == 403)
                                 && !forced_refresh
@@ -6369,6 +6548,91 @@ mod tests {
     }
 
     #[test]
+    fn modern_http_listener_steps_up_scope_and_retries() {
+        use super::{
+            HttpTransport, ScopeReauthorizeFn, SubscriptionFilter, Transport,
+            MODERN_PROTOCOL_VERSION,
+        };
+        use std::sync::{Arc, Mutex};
+
+        let server = tiny_http::Server::http("127.0.0.1:0").unwrap();
+        let port = server.server_addr().to_ip().unwrap().port();
+        let seen_auth = Arc::new(Mutex::new(Vec::new()));
+        let captured_auth = Arc::clone(&seen_auth);
+        let handle = std::thread::spawn(move || {
+            for hit in 0..2 {
+                let request = server
+                    .recv_timeout(std::time::Duration::from_secs(2))
+                    .unwrap()
+                    .expect("subscription listen request");
+                captured_auth.lock().unwrap().push(
+                    request
+                        .headers()
+                        .iter()
+                        .find(|header| header.field.equiv("Authorization"))
+                        .map(|header| header.value.as_str().to_string())
+                        .unwrap_or_default(),
+                );
+                let response = if hit == 0 {
+                    tiny_http::Response::from_string("more access required")
+                        .with_status_code(403)
+                        .with_header(
+                            tiny_http::Header::from_bytes(
+                                b"WWW-Authenticate",
+                                b"Bearer error=\"insufficient_scope\", scope=\" files:write files:read files:write \"",
+                            )
+                            .unwrap(),
+                        )
+                } else {
+                    tiny_http::Response::from_string(format!(
+                        "data: {}\n\n",
+                        json!({
+                            "jsonrpc": "2.0",
+                            "method": "notifications/subscriptions/acknowledged",
+                            "params": {
+                                "_meta": { "io.modelcontextprotocol/subscriptionId": 1 }
+                            }
+                        })
+                    ))
+                    .with_header(
+                        tiny_http::Header::from_bytes(b"Content-Type", b"text/event-stream")
+                            .unwrap(),
+                    )
+                };
+                request.respond(response).unwrap();
+            }
+        });
+
+        let challenged_scope = Arc::new(Mutex::new(String::new()));
+        let captured_scope = Arc::clone(&challenged_scope);
+        let reauthorize: Option<ScopeReauthorizeFn> = Some(Box::new(move |scope| {
+            *captured_scope.lock().unwrap() = scope.to_string();
+            Ok("step-up-token".to_string())
+        }));
+        let mut transport = HttpTransport::with_auth_refresh(
+            &format!("http://127.0.0.1:{port}/"),
+            Some("old-token".to_string()),
+            None,
+        );
+        transport.set_protocol_meta(Some(super::protocol_meta_for(MODERN_PROTOCOL_VERSION)));
+        transport.set_scope_reauthorize(reauthorize);
+        transport
+            .set_subscription_listener(SubscriptionFilter::default())
+            .unwrap();
+        handle.join().unwrap();
+        drop(transport);
+
+        assert_eq!(
+            seen_auth.lock().unwrap().as_slice(),
+            &["Bearer old-token".to_string(), "Bearer step-up-token".to_string()]
+        );
+        assert_eq!(
+            challenged_scope.lock().unwrap().as_str(),
+            "files:read files:write"
+        );
+    }
+
+    #[test]
     fn modern_resource_subscriptions_replace_the_listener_filter() {
         use super::{DownstreamServer, SubscriptionFilter, Transport, TransportError};
         use std::sync::{Arc, Mutex};
@@ -6963,6 +7227,236 @@ mod tests {
             error.to_string(),
             "HTTP 401 (needs authentication): no refresh callback configured"
         );
+    }
+
+    #[test]
+    fn insufficient_scope_reauthorizes_and_retries_without_refreshing() {
+        use super::{HttpTransport, RefreshFn, ScopeReauthorizeFn};
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use std::sync::{Arc, Mutex};
+
+        let server = tiny_http::Server::http("127.0.0.1:0").unwrap();
+        let port = server.server_addr().to_ip().unwrap().port();
+        let seen_auth = Arc::new(Mutex::new(Vec::new()));
+        let captured = Arc::clone(&seen_auth);
+        let handle = std::thread::spawn(move || {
+            for hit in 0..2 {
+                let request = server
+                    .recv_timeout(std::time::Duration::from_secs(2))
+                    .unwrap()
+                    .expect("step-up request");
+                captured.lock().unwrap().push(
+                    request
+                        .headers()
+                        .iter()
+                        .find(|header| header.field.equiv("Authorization"))
+                        .map(|header| header.value.as_str().to_string())
+                        .unwrap_or_default(),
+                );
+                if hit == 0 {
+                    let challenge = tiny_http::Header::from_bytes(
+                        b"WWW-Authenticate",
+                        b"Bearer error=\"insufficient_scope\", scope=\"files:write\"",
+                    )
+                    .unwrap();
+                    request
+                        .respond(
+                            tiny_http::Response::from_string("more access required")
+                                .with_status_code(403)
+                                .with_header(challenge),
+                        )
+                        .unwrap();
+                } else {
+                    let content_type =
+                        tiny_http::Header::from_bytes(b"Content-Type", b"application/json")
+                            .unwrap();
+                    request
+                        .respond(
+                            tiny_http::Response::from_string(
+                                r#"{"jsonrpc":"2.0","id":1,"result":{"ok":true}}"#,
+                            )
+                            .with_header(content_type),
+                        )
+                        .unwrap();
+                }
+            }
+        });
+
+        let forced_refreshes = Arc::new(AtomicUsize::new(0));
+        let forced = Arc::clone(&forced_refreshes);
+        let refresh: Option<RefreshFn> = Some(Box::new(move |force| {
+            if force {
+                forced.fetch_add(1, Ordering::SeqCst);
+            }
+            Ok(None)
+        }));
+        let challenged_scope = Arc::new(Mutex::new(String::new()));
+        let captured_scope = Arc::clone(&challenged_scope);
+        let reauthorize: Option<ScopeReauthorizeFn> = Some(Box::new(move |scope| {
+            *captured_scope.lock().unwrap() = scope.to_string();
+            Ok("step-up-token".to_string())
+        }));
+        let url = format!("http://127.0.0.1:{port}/");
+        let mut transport =
+            HttpTransport::with_auth_refresh(&url, Some("old-token".to_string()), refresh);
+        transport.set_scope_reauthorize(reauthorize);
+
+        let result = transport
+            .post(
+                &serde_json::json!({
+                    "jsonrpc": "2.0", "id": 1, "method": "tools/call",
+                    "params": { "name": "files_write", "arguments": {} }
+                }),
+                true,
+            )
+            .expect("step-up token should retry the original request");
+        handle.join().unwrap();
+
+        assert!(result.is_some());
+        assert_eq!(*challenged_scope.lock().unwrap(), "files:write");
+        assert_eq!(forced_refreshes.load(Ordering::SeqCst), 0);
+        assert_eq!(
+            seen_auth.lock().unwrap().as_slice(),
+            &["Bearer old-token".to_string(), "Bearer step-up-token".to_string()]
+        );
+    }
+
+    #[test]
+    fn scope_attempts_use_a_canonical_set_key() {
+        assert_eq!(
+            super::canonical_scope_set(" files:write files:read files:write "),
+            "files:read files:write"
+        );
+    }
+
+    #[test]
+    fn repeated_insufficient_scope_is_bounded_and_never_uses_refresh() {
+        use super::{HttpTransport, RefreshFn, ScopeReauthorizeFn};
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use std::sync::Arc;
+
+        let server = tiny_http::Server::http("127.0.0.1:0").unwrap();
+        let port = server.server_addr().to_ip().unwrap().port();
+        let handle = std::thread::spawn(move || {
+            for hit in 0..2 {
+                let request = server
+                    .recv_timeout(std::time::Duration::from_secs(2))
+                    .unwrap()
+                    .expect("step-up request");
+                let scope = if hit == 0 {
+                    "files:write files:read"
+                } else {
+                    "files:read files:write files:write"
+                };
+                let challenge = tiny_http::Header::from_bytes(
+                    b"WWW-Authenticate",
+                    format!("Bearer error=\"insufficient_scope\", scope=\"{scope}\"")
+                        .as_bytes(),
+                )
+                .unwrap();
+                request
+                    .respond(
+                        tiny_http::Response::from_string("still insufficient")
+                            .with_status_code(403)
+                            .with_header(challenge),
+                    )
+                    .unwrap();
+            }
+        });
+        let refresh_calls = Arc::new(AtomicUsize::new(0));
+        let refresh_count = Arc::clone(&refresh_calls);
+        let refresh: Option<RefreshFn> = Some(Box::new(move |force| {
+            if force {
+                refresh_count.fetch_add(1, Ordering::SeqCst);
+            }
+            Ok(None)
+        }));
+        let reauth_calls = Arc::new(AtomicUsize::new(0));
+        let reauth_count = Arc::clone(&reauth_calls);
+        let reauthorize: Option<ScopeReauthorizeFn> = Some(Box::new(move |_| {
+            reauth_count.fetch_add(1, Ordering::SeqCst);
+            Ok("step-up-token".to_string())
+        }));
+        let url = format!("http://127.0.0.1:{port}/");
+        let mut transport =
+            HttpTransport::with_auth_refresh(&url, Some("old-token".to_string()), refresh);
+        transport.set_scope_reauthorize(reauthorize);
+
+        let error = transport
+            .post(
+                &serde_json::json!({
+                    "jsonrpc": "2.0", "id": 1, "method": "tools/call",
+                    "params": { "name": "files_write", "arguments": {} }
+                }),
+                true,
+            )
+            .expect_err("the same rejected scope must not loop");
+        handle.join().unwrap();
+
+        assert!(error.to_string().contains("already requested"));
+        assert_eq!(reauth_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(refresh_calls.load(Ordering::SeqCst), 0);
+    }
+
+    #[test]
+    fn rejected_step_up_token_does_not_consume_a_refresh_exchange() {
+        use super::{HttpTransport, RefreshFn, ScopeReauthorizeFn};
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use std::sync::Arc;
+
+        let server = tiny_http::Server::http("127.0.0.1:0").unwrap();
+        let port = server.server_addr().to_ip().unwrap().port();
+        let handle = std::thread::spawn(move || {
+            for hit in 0..2 {
+                let request = server
+                    .recv_timeout(std::time::Duration::from_secs(2))
+                    .unwrap()
+                    .expect("step-up request");
+                let response = if hit == 0 {
+                    tiny_http::Response::from_string("more access required")
+                        .with_status_code(403)
+                        .with_header(
+                            tiny_http::Header::from_bytes(
+                                b"WWW-Authenticate",
+                                b"Bearer error=\"insufficient_scope\", scope=\"files:write\"",
+                            )
+                            .unwrap(),
+                        )
+                } else {
+                    tiny_http::Response::from_string("new token rejected").with_status_code(401)
+                };
+                request.respond(response).unwrap();
+            }
+        });
+
+        let refresh_calls = Arc::new(AtomicUsize::new(0));
+        let refresh_count = Arc::clone(&refresh_calls);
+        let refresh: Option<RefreshFn> = Some(Box::new(move |force| {
+            if force {
+                refresh_count.fetch_add(1, Ordering::SeqCst);
+            }
+            Ok(Some("refreshed-token".to_string()))
+        }));
+        let reauthorize: Option<ScopeReauthorizeFn> =
+            Some(Box::new(move |_| Ok("step-up-token".to_string())));
+        let url = format!("http://127.0.0.1:{port}/");
+        let mut transport =
+            HttpTransport::with_auth_refresh(&url, Some("old-token".to_string()), refresh);
+        transport.set_scope_reauthorize(reauthorize);
+
+        let error = transport
+            .post(
+                &serde_json::json!({
+                    "jsonrpc": "2.0", "id": 1, "method": "tools/call",
+                    "params": { "name": "files_write", "arguments": {} }
+                }),
+                true,
+            )
+            .expect_err("a rejected step-up token must surface without refreshing");
+        handle.join().unwrap();
+
+        assert!(error.to_string().contains("HTTP 401"));
+        assert_eq!(refresh_calls.load(Ordering::SeqCst), 0);
     }
 
     #[test]

--- a/src-tauri/src/oauth.rs
+++ b/src-tauri/src/oauth.rs
@@ -36,6 +36,9 @@ pub struct AuthResult {
     pub client_id: String,
     /// Validated authorization-server issuer that minted the client credentials.
     pub issuer: String,
+    /// Scope set requested for this authorization. Persisted so a later runtime
+    /// challenge can add to it without dropping previously granted access.
+    pub scope: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -109,9 +112,10 @@ struct ProtectedResource {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
-struct BearerChallenge {
-    resource_metadata: Option<String>,
-    scope: Option<String>,
+pub(crate) struct BearerChallenge {
+    pub(crate) resource_metadata: Option<String>,
+    pub(crate) scope: Option<String>,
+    pub(crate) error: Option<String>,
 }
 
 /// Split an HTTP authentication header on commas that are outside quoted
@@ -174,7 +178,9 @@ fn auth_param(value: &str) -> Option<(&str, String)> {
 /// Select the first Bearer challenge from one or more `WWW-Authenticate`
 /// fields. A response may advertise another scheme first or place Bearer
 /// parameters in later comma-separated segments.
-fn bearer_challenge<'a>(headers: impl IntoIterator<Item = &'a str>) -> Option<BearerChallenge> {
+pub(crate) fn bearer_challenge<'a>(
+    headers: impl IntoIterator<Item = &'a str>,
+) -> Option<BearerChallenge> {
     for header in headers {
         let mut bearer = false;
         let mut challenge = BearerChallenge::default();
@@ -213,6 +219,8 @@ fn bearer_challenge<'a>(headers: impl IntoIterator<Item = &'a str>) -> Option<Be
                 challenge.resource_metadata.get_or_insert(value);
             } else if name.eq_ignore_ascii_case("scope") {
                 challenge.scope.get_or_insert(value);
+            } else if name.eq_ignore_ascii_case("error") {
+                challenge.error.get_or_insert(value);
             }
         }
         if found {
@@ -459,6 +467,24 @@ fn initial_scope(
         // Compatibility for older MCP servers that predate RFC 9728 metadata.
         authorization_server_scopes.and_then(normalized_scope)
     }
+}
+
+/// Preserve the order supplied by the authorization server while removing
+/// duplicates. In a step-up flow `existing` is the scope set Toolport requested
+/// previously and `additional` is the current operation's authoritative
+/// challenge, as required by the MCP scope-union rule.
+pub(crate) fn scope_union(existing: Option<&str>, additional: Option<&str>) -> Option<String> {
+    let mut scopes: Vec<&str> = Vec::new();
+    for scope in existing
+        .into_iter()
+        .chain(additional)
+        .flat_map(str::split_whitespace)
+    {
+        if !scopes.contains(&scope) {
+            scopes.push(scope);
+        }
+    }
+    (!scopes.is_empty()).then(|| scopes.join(" "))
 }
 
 /// RFC 8414 and OIDC Discovery bind a metadata document to the issuer used to
@@ -1179,6 +1205,16 @@ fn write_callback_page(stream: &mut std::net::TcpStream, message: &str) {
 
 /// Run the full interactive flow and return tokens plus what's needed to refresh.
 pub fn authenticate(mcp_url: &str) -> Result<AuthResult, String> {
+    authenticate_with_scope(mcp_url, None)
+}
+
+/// Run interactive authorization while retaining a previously requested scope
+/// set and adding a runtime challenge. Discovery's initial scope is included too,
+/// but never replaces either side of the step-up union.
+pub fn authenticate_with_scope(
+    mcp_url: &str,
+    requested_scope_set: Option<&str>,
+) -> Result<AuthResult, String> {
     debug_log(&format!("=== oauth start: {mcp_url} ==="));
     // Same provenance rule as discover(): a public configured server must not have
     // its DCR / token POST reach a private/loopback host, even via a DNS rebind. Use the
@@ -1187,12 +1223,13 @@ pub fn authenticate(mcp_url: &str) -> Result<AuthResult, String> {
         .map(|h| host_is_definitely_private(&h))
         .unwrap_or(false);
     let endpoints = discover(mcp_url)?;
+    let scope = scope_union(requested_scope_set, endpoints.scope.as_deref());
     debug_log(&format!(
         "endpoints: authz={} token={} reg={:?} scope={:?}",
         endpoints.authorization_endpoint,
         endpoints.token_endpoint,
         endpoints.registration_endpoint,
-        endpoints.scope
+        scope
     ));
     // Bind the callback listener BEFORE registering/opening the browser, so a
     // fast redirect can't arrive before we're listening AND we know the real port.
@@ -1228,7 +1265,7 @@ pub fn authenticate(mcp_url: &str) -> Result<AuthResult, String> {
     // offline_access (the refresh-token scope) when the server supports it;
     // forcing offline_access otherwise gets the authorization rejected with
     // invalid_scope (e.g. Stripe).
-    let scope = requested_scope(endpoints.scope.clone());
+    let scope = requested_scope(scope);
     let auth_url = build_authorize_url(
         &endpoints.authorization_endpoint,
         &client_id,
@@ -1276,6 +1313,7 @@ pub fn authenticate(mcp_url: &str) -> Result<AuthResult, String> {
         token_endpoint: endpoints.token_endpoint,
         client_id,
         issuer: endpoints.issuer,
+        scope,
     })
 }
 
@@ -1727,6 +1765,7 @@ mod tests {
             Some("https://mcp.example.com/auth/meta?label=a,b")
         );
         assert_eq!(parsed.scope.as_deref(), Some("files:read files:write"));
+        assert_eq!(parsed.error.as_deref(), Some("insufficient_scope"));
     }
 
     #[test]
@@ -2095,5 +2134,19 @@ mod tests {
         handle.join().unwrap();
 
         assert!(error.contains("authorization server must use https"));
+    }
+
+    #[test]
+    fn step_up_scope_union_preserves_prior_access_and_deduplicates() {
+        assert_eq!(
+            scope_union(
+                Some("files:read profile"),
+                Some("files:write files:read")
+            )
+            .as_deref(),
+            Some("files:read profile files:write")
+        );
+        assert_eq!(scope_union(None, Some("  files:read  ")).as_deref(), Some("files:read"));
+        assert_eq!(scope_union(Some(""), None), None);
     }
 }

--- a/src-tauri/src/remote.rs
+++ b/src-tauri/src/remote.rs
@@ -12,7 +12,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::downstream::{
     DownstreamServer, HttpTransport, ProgressSink, RefreshFn, ResourceUpdatedSink,
-    ServerRequestHandler, Transport,
+    ScopeReauthorizeFn, ServerRequestHandler, Transport,
 };
 use crate::registry::ServerEntry;
 use crate::{oauth, secrets};
@@ -39,6 +39,10 @@ struct OAuthState {
     /// to. Optional for back-compat with states vaulted before this existed.
     #[serde(default)]
     resource: Option<String>,
+    /// Scope set requested for the current authorization. Optional for vaulted
+    /// states written before Toolport supported runtime scope step-up.
+    #[serde(default)]
+    scope: Option<String>,
     /// Unix timestamp when Toolport received the latest token response.
     /// Optional for states vaulted by older Toolport versions.
     #[serde(default)]
@@ -91,6 +95,7 @@ pub fn store_oauth_state(
     client_id: &str,
     refresh_token: Option<String>,
     resource: Option<String>,
+    scope: Option<String>,
     issued_at: u64,
     expires_at: Option<u64>,
 ) -> Result<(), String> {
@@ -100,6 +105,7 @@ pub fn store_oauth_state(
         client_id: client_id.to_string(),
         refresh_token,
         resource,
+        scope,
         issued_at: Some(issued_at),
         expires_at,
     };
@@ -184,6 +190,7 @@ fn refresh_token_with_expiry(server_id: &str) -> Result<RefreshedToken, String> 
         client_id: state.client_id,
         refresh_token: tokens.refresh_token.or(state.refresh_token),
         resource: state.resource,
+        scope: state.scope,
         issued_at: Some(tokens.issued_at),
         expires_at: tokens.expires_at,
     };
@@ -193,6 +200,38 @@ fn refresh_token_with_expiry(server_id: &str) -> Result<RefreshedToken, String> 
     Ok(RefreshedToken {
         access_token: tokens.access_token,
         expires_at: tokens.expires_at,
+    })
+}
+
+/// Complete an interactive step-up flow for a runtime `insufficient_scope`
+/// challenge. A fresh authorization (and client registration when needed) is
+/// intentional here: refresh-token grants cannot obtain user consent for new
+/// permissions. Persist the full new state before replacing the access token so
+/// a partial keychain write cannot strand rotated credentials.
+fn reauthorize_for_scope(
+    server_id: &str,
+    resource: &str,
+    required_scope: &str,
+) -> Result<RefreshedToken, String> {
+    let previous = load_state(server_id)
+        .ok_or("saved OAuth state is unavailable; authenticate again to grant additional scope")?;
+    let requested = oauth::scope_union(previous.scope.as_deref(), Some(required_scope));
+    let result = oauth::authenticate_with_scope(resource, requested.as_deref())?;
+    store_oauth_state(
+        server_id,
+        Some(result.issuer),
+        &result.token_endpoint,
+        &result.client_id,
+        result.refresh_token,
+        Some(resource.to_string()),
+        result.scope,
+        result.issued_at,
+        result.expires_at,
+    )?;
+    secrets::set_secret(server_id, secrets::HTTP_AUTH_KEY, &result.access_token)?;
+    Ok(RefreshedToken {
+        access_token: result.access_token,
+        expires_at: result.expires_at,
     })
 }
 
@@ -271,15 +310,26 @@ fn authed_transport(
     if token.is_some() {
         require_secure_for_auth(url)?;
     }
+    // Shared by ordinary refresh and scope step-up so a newly-authorized token's
+    // expiry replaces the previous token's proactive deadline immediately.
+    let refresh_at = load_state(server_id)
+        .and_then(|state| state.expires_at)
+        .map(|expires_at| expires_at.saturating_sub(PROACTIVE_REFRESH_SKEW_SECS));
+    let next_refresh_at = Arc::new(Mutex::new(refresh_at));
+    // The request path and the background subscription listener can refresh or
+    // step up concurrently. Serialize credential-changing flows so an older
+    // refresh result cannot overwrite a newer interactive authorization state.
+    let credential_update = Arc::new(Mutex::new(()));
     let refresh: Option<RefreshFn> = if token.is_some() {
         let sid = server_id.to_string();
         // Keep the proactive deadline in memory. This avoids a keychain read on
         // every tool call while still updating the deadline after each refresh.
-        let refresh_at = load_state(server_id)
-            .and_then(|state| state.expires_at)
-            .map(|expires_at| expires_at.saturating_sub(PROACTIVE_REFRESH_SKEW_SECS));
-        let next_refresh_at = Mutex::new(refresh_at);
+        let next_refresh_at = Arc::clone(&next_refresh_at);
+        let credential_update = Arc::clone(&credential_update);
         Some(Box::new(move |force| {
+            let _update = credential_update
+                .lock()
+                .map_err(|_| "OAuth credential-update lock poisoned".to_string())?;
             if !force {
                 let deadline = *next_refresh_at
                     .lock()
@@ -315,10 +365,33 @@ fn authed_transport(
     } else {
         None
     };
+    let scope_reauthorize: Option<ScopeReauthorizeFn> = if token.is_some() && load_state(server_id).is_some() {
+        let sid = server_id.to_string();
+        let resource = url.to_string();
+        let next_refresh_at = Arc::clone(&next_refresh_at);
+        let credential_update = Arc::clone(&credential_update);
+        Some(Box::new(move |scope| {
+            let _update = credential_update
+                .lock()
+                .map_err(|_| "OAuth credential-update lock poisoned".to_string())?;
+            let token = reauthorize_for_scope(&sid, &resource, scope)?;
+            let deadline = token
+                .expires_at
+                .map(|expires_at| expires_at.saturating_sub(PROACTIVE_REFRESH_SKEW_SECS));
+            *next_refresh_at
+                .lock()
+                .map_err(|_| "OAuth refresh deadline lock poisoned".to_string())? = deadline;
+            Ok(token.access_token)
+        }))
+    } else {
+        None
+    };
     // The resolver enforces the SSRF policy at connect time (DNS-rebind safe); it
     // mirrors `guard_connect_target`: link-local/metadata blocked for all, private
     // blocked only for untrusted-provenance servers.
-    Ok(HttpTransport::guarded(url, token, refresh, block_private))
+    let mut transport = HttpTransport::guarded(url, token, refresh, block_private);
+    transport.set_scope_reauthorize(scope_reauthorize);
+    Ok(transport)
 }
 
 /// Provenance Toolport doesn't trust to point at the user's private network. Shared
@@ -497,6 +570,7 @@ mod tests {
             client_id: "client".into(),
             refresh_token: refresh_token.map(str::to_string),
             resource: Some("https://mcp.example.com".into()),
+            scope: Some("files:read".into()),
             issued_at: Some(1_000),
             expires_at,
         }
@@ -540,6 +614,7 @@ mod tests {
         assert_eq!(state.issued_at, None);
         assert_eq!(state.expires_at, None);
         assert_eq!(state.issuer, None);
+        assert_eq!(state.scope, None);
         assert_eq!(refresh_decision(&state, 1_000), RefreshDecision::NotNeeded);
     }
 


### PR DESCRIPTION
## Summary

- persist the requested OAuth scope set in backward-compatible vaulted state
- detect runtime Bearer `insufficient_scope` challenges separately from expired-token failures
- normalize and union the challenged scope with previously requested access, open an interactive authorization flow, and retry the blocked operation with the new token
- cap step-up at one attempt per operation and canonical scope set, including modern `subscriptions/listen`
- never spend a refresh-token exchange on a rejected step-up token
- serialize background refresh and interactive step-up so stale credential writes cannot overwrite a newer authorization

## Verification

- `cargo test --manifest-path src-tauri/Cargo.toml --lib` (653 passed)
- `cargo test --manifest-path src-tauri/Cargo.toml modern_http_listener_steps_up_scope_and_retries --lib` (1 passed)
- `git diff --check`

Linear: SOU-451