### PR TITLE
feat(mcp): route task extension handles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,11 @@ Entries before the rename below shipped under the project's former name, Conduit
 - Modern extension negotiation now passes opaque client extension settings to
   downstream servers and aggregates compatible downstream extension declarations
   in `server/discover`. Unknown `_meta` and result fields continue through unchanged;
-  conflicting settings are omitted rather than overstating gateway support. The
-  Tasks extension remains withheld until its handle-routing layer lands. (SOU-453)
+  conflicting settings are omitted rather than overstating gateway support. (SOU-453)
+- The `io.modelcontextprotocol/tasks` extension now keeps task handles bound to
+  the downstream server that created them and proxies `tasks/get`, `tasks/update`,
+  and `tasks/cancel`, including the required Streamable HTTP routing headers.
+  Toolport task ids survive router rebuilds and app restarts. (SOU-453)
 
 ### Security
 

--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -120,6 +120,16 @@ fn modern_client_supports_server_rpc(method: &str) -> bool {
     })
 }
 
+fn modern_client_supports_extension(identifier: &str) -> bool {
+    ACTIVE_UPSTREAM_CAPABILITIES.with(|cell| {
+        cell.borrow()
+            .as_ref()
+            .and_then(|caps| caps.get("extensions"))
+            .and_then(|extensions| extensions.get(identifier))
+            .is_some()
+    })
+}
+
 /// Add the fields a modern client requires to a result.
 ///
 /// No-op for legacy clients, so their responses stay byte-identical to what
@@ -5197,6 +5207,49 @@ fn handle_request_with_cancel(
                 )),
             }
         }
+        method @ ("tasks/get" | "tasks/update" | "tasks/cancel") => {
+            if !serving_modern_client() {
+                return Some(error(
+                    id,
+                    -32601,
+                    "Tasks extension requires MCP 2026-07-28",
+                ));
+            }
+            if !modern_client_supports_extension("io.modelcontextprotocol/tasks") {
+                return Some(missing_modern_client_capability(
+                    id,
+                    "io.modelcontextprotocol/tasks",
+                ));
+            }
+            let params = req.get("params").cloned().unwrap_or_else(|| json!({}));
+            let Some(task_id) = params.get("taskId").and_then(Value::as_str) else {
+                return Some(error(
+                    id,
+                    -32602,
+                    &format!("Toolport: {method} requires params.taskId"),
+                ));
+            };
+            let Some(owner) = router.task_server(task_id) else {
+                return Some(error(id, -32602, "Toolport: invalid task id"));
+            };
+            if let Some(set) = allowed {
+                if !server_in_allowed_scope(&owner, set) {
+                    return Some(error(id, -32602, "Toolport: invalid task id"));
+                }
+            }
+            let client_meta = params.get("_meta").cloned();
+            match router.route_task(method, params, cancel.clone(), client_meta.as_ref()) {
+                Ok(result) => Some(success(id, result)),
+                Err(e) => Some(error(
+                    id,
+                    -32602,
+                    &format!(
+                        "Toolport: {}",
+                        integrity::defend_error_text("task", &e)
+                    ),
+                )),
+            }
+        }
         // `ping` was removed in 2026-07-28, so a modern client gets method-not-found
         // rather than a misleading success. Legacy clients keep it (SOU-446).
         "ping" if serving_modern_client() => Some(error(
@@ -9248,11 +9301,20 @@ fn validate_modern_http_headers(
             .get("params")
             .and_then(|params| params.get("uri"))
             .and_then(Value::as_str),
+        "tasks/get" | "tasks/update" | "tasks/cancel" => req
+            .get("params")
+            .and_then(|params| params.get("taskId"))
+            .and_then(Value::as_str),
         _ => None,
     };
     let requires_name = matches!(
         body_method,
-        "tools/call" | "prompts/get" | "resources/read"
+        "tools/call"
+            | "prompts/get"
+            | "resources/read"
+            | "tasks/get"
+            | "tasks/update"
+            | "tasks/cancel"
     );
     let encoded_name = body_name.map(downstream::encode_mcp_header_text);
     if requires_name && (body_name.is_none() || headers.name != encoded_name.as_deref()) {
@@ -14326,6 +14388,26 @@ mod tests {
             downstream::HEADER_MISMATCH
         );
 
+        for method in ["tasks/get", "tasks/update", "tasks/cancel"] {
+            let task_id = "toolport-task:v1:owner:native";
+            let task_body: Value = serde_json::from_str(&modern_http_body(
+                3,
+                method,
+                json!({ "taskId": task_id }),
+            ))
+            .unwrap();
+            assert!(validate_modern_http_headers(
+                &task_body,
+                modern_http_headers(method, Some(task_id), None, None),
+            )
+            .is_ok());
+            assert!(validate_modern_http_headers(
+                &task_body,
+                modern_http_headers(method, None, None, None),
+            )
+            .is_err());
+        }
+
         let unsupported_body = json!({
             "jsonrpc": "2.0",
             "id": 3,
@@ -15836,9 +15918,11 @@ mod tests {
                 ["version"],
             1
         );
-        assert!(response["result"]["capabilities"]["extensions"]
-            .get("io.modelcontextprotocol/tasks")
-            .is_none());
+        assert_eq!(
+            response["result"]["capabilities"]["extensions"]
+                ["io.modelcontextprotocol/tasks"],
+            json!({})
+        );
 
         let allowed = std::collections::HashSet::from(["other".to_string()]);
         let scoped = handle_request(
@@ -15857,6 +15941,42 @@ mod tests {
         assert!(scoped["result"]["capabilities"]
             .get("extensions")
             .is_none());
+    }
+
+    #[test]
+    fn task_methods_require_the_per_request_extension_capability() {
+        let missing = dispatch(&modern_req(
+            1,
+            "tasks/get",
+            json!({ "taskId": "not-a-toolport-task" }),
+        ));
+        assert_eq!(
+            missing["error"]["code"],
+            downstream::MISSING_REQUIRED_CLIENT_CAPABILITY
+        );
+
+        let mut declared = modern_req(
+            2,
+            "tasks/get",
+            json!({ "taskId": "not-a-toolport-task" }),
+        );
+        declared["params"]["_meta"]["io.modelcontextprotocol/clientCapabilities"] = json!({
+            "extensions": { "io.modelcontextprotocol/tasks": {} }
+        });
+        let invalid = dispatch(&declared);
+        assert_eq!(invalid["error"]["code"], -32602);
+        assert_eq!(invalid["error"]["message"], "Toolport: invalid task id");
+
+        let mut malformed = modern_req(3, "tasks/get", json!({}));
+        malformed["params"]["_meta"]["io.modelcontextprotocol/clientCapabilities"] = json!({
+            "extensions": { "io.modelcontextprotocol/tasks": {} }
+        });
+        let malformed = dispatch(&malformed);
+        assert_eq!(malformed["error"]["code"], -32602);
+        assert_eq!(
+            malformed["error"]["message"],
+            "Toolport: tasks/get requires params.taskId"
+        );
     }
 
     #[test]

--- a/src-tauri/src/downstream.rs
+++ b/src-tauri/src/downstream.rs
@@ -113,9 +113,22 @@ fn modern_standard_headers(body: &Value) -> Result<Vec<(String, String)>, Transp
             .get("params")
             .and_then(|params| params.get("uri"))
             .and_then(Value::as_str),
+        "tasks/get" | "tasks/update" | "tasks/cancel" => body
+            .get("params")
+            .and_then(|params| params.get("taskId"))
+            .and_then(Value::as_str),
         _ => None,
     };
-    if matches!(method, "tools/call" | "prompts/get" | "resources/read") && name.is_none() {
+    if matches!(
+        method,
+        "tools/call"
+            | "prompts/get"
+            | "resources/read"
+            | "tasks/get"
+            | "tasks/update"
+            | "tasks/cancel"
+    ) && name.is_none()
+    {
         return Err(TransportError::Fatal(format!(
             "modern HTTP request '{method}' is missing its routing name"
         )));
@@ -435,14 +448,6 @@ pub const PER_HOP_META_KEYS: [&str; 3] = [
     "io.modelcontextprotocol/clientCapabilities",
 ];
 
-/// Extensions that cannot be relayed safely by copying capability and envelope
-/// data alone. Tasks introduces follow-up `tasks/*` methods whose opaque handles
-/// must route back to the server that minted them; advertising it before that
-/// ownership layer exists would strand every returned handle.
-pub fn extension_is_transparent(identifier: &str) -> bool {
-    identifier != "io.modelcontextprotocol/tasks"
-}
-
 /// Keys relayed only once Toolport can honour what they ask for.
 ///
 /// `progressToken` lived here until the gateway learned to route
@@ -518,14 +523,7 @@ fn attach_client_extensions(params: &mut Value, meta: Option<&Value>) {
         .and_then(|capabilities| capabilities.get("extensions"))
         .and_then(Value::as_object)
         .filter(|extensions| !extensions.is_empty())
-        .map(|extensions| {
-            extensions
-                .iter()
-                .filter(|(identifier, _)| extension_is_transparent(identifier))
-                .map(|(identifier, settings)| (identifier.clone(), settings.clone()))
-                .collect::<serde_json::Map<String, Value>>()
-        })
-        .filter(|extensions| !extensions.is_empty())
+        .cloned()
     else {
         return;
     };
@@ -4704,6 +4702,25 @@ impl DownstreamServer {
         &self.caps_extensions
     }
 
+    /// Forward a Tasks extension request on the same modern hop as the call
+    /// that created it. The router has already translated the client-facing
+    /// task id back to the server's native id.
+    pub fn task_request(
+        &mut self,
+        method: &str,
+        params: Value,
+        cancel: Option<CancelContext>,
+        meta: Option<&Value>,
+    ) -> Result<Value, TransportError> {
+        if !self.caps_extensions.contains_key("io.modelcontextprotocol/tasks") {
+            return Err(TransportError::Fatal(format!(
+                "server '{}' did not advertise io.modelcontextprotocol/tasks",
+                self.id
+            )));
+        }
+        self.request_with_mrtr(method, params, cancel, meta, None, &[])
+    }
+
     /// The protocol era and version this connection negotiated (SOU-445).
     pub fn era(&self) -> &Era {
         &self.era
@@ -4852,7 +4869,7 @@ mod tests {
         fetch_paginated_list,
     };
     use serde_json::{json, Value};
-    use std::collections::VecDeque;
+    use std::collections::{HashMap, VecDeque};
     use std::path::Path;
     use std::sync::{Arc, Mutex};
 
@@ -6895,9 +6912,10 @@ mod tests {
             "text/html"
         );
         assert!(capabilities.get("sampling").is_none());
-        assert!(capabilities["extensions"]
-            .get("io.modelcontextprotocol/tasks")
-            .is_none());
+        assert_eq!(
+            capabilities["extensions"]["io.modelcontextprotocol/tasks"],
+            json!({})
+        );
         assert_eq!(params["_meta"]["com.example/request"]["keep"], true);
     }
 
@@ -6963,6 +6981,26 @@ mod tests {
         assert_eq!(headers.get("mcp-param-region").map(String::as_str), Some("west"));
         assert!(!headers.contains_key("mcp-session-id"));
         assert!(transport.session_id.is_none(), "modern responses cannot restore a legacy session");
+    }
+
+    #[test]
+    fn modern_http_task_requests_route_by_native_task_id() {
+        for method in ["tasks/get", "tasks/update", "tasks/cancel"] {
+            let headers = super::modern_standard_headers(&json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": method,
+                "params": { "taskId": "native-task-id" }
+            }))
+            .unwrap()
+            .into_iter()
+            .collect::<HashMap<_, _>>();
+            assert_eq!(headers.get("Mcp-Method").map(String::as_str), Some(method));
+            assert_eq!(
+                headers.get("Mcp-Name").map(String::as_str),
+                Some("native-task-id")
+            );
+        }
     }
 
     #[test]

--- a/src-tauri/src/router.rs
+++ b/src-tauri/src/router.rs
@@ -16,13 +16,79 @@ use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
+use base64::Engine as _;
+use chacha20poly1305::aead::{Aead, KeyInit};
+use chacha20poly1305::{XChaCha20Poly1305, XNonce};
 use serde_json::{json, Value};
 
 use crate::downstream::{
-    backoff_delay, extension_is_transparent, CacheHint, CancelContext, DownstreamServer, MrtrRequest,
-    TransportError, HTTP_MAX_RETRIES, HTTP_RETRY_CAP,
+    backoff_delay, CacheHint, CancelContext, DownstreamServer, MrtrRequest, TransportError,
+    HTTP_MAX_RETRIES, HTTP_RETRY_CAP,
 };
 use crate::registry::ToolOverride;
+
+const TASK_HANDLE_PREFIX: &str = "toolport-task:v1:";
+const TASK_HANDLE_NONCE_LEN: usize = 24;
+
+/// Seal the owner and native task id into one opaque, unguessable handle. The
+/// installation-local key survives restarts; authenticated encryption prevents
+/// a client from changing either component to reach another task (SOU-453).
+fn expose_task_id(server_id: &str, task_id: &str) -> Result<String, String> {
+    let key = crate::secrets::task_handle_key()?;
+    let cipher = XChaCha20Poly1305::new_from_slice(&key).map_err(|e| e.to_string())?;
+    let plain = serde_json::to_vec(&(server_id, task_id)).map_err(|e| e.to_string())?;
+    let mut nonce = [0u8; TASK_HANDLE_NONCE_LEN];
+    getrandom::getrandom(&mut nonce).map_err(|e| e.to_string())?;
+    let ciphertext = cipher
+        .encrypt(XNonce::from_slice(&nonce), plain.as_ref())
+        .map_err(|_| "could not seal Toolport task id".to_string())?;
+    let mut blob = nonce.to_vec();
+    blob.extend_from_slice(&ciphertext);
+    Ok(format!(
+        "{TASK_HANDLE_PREFIX}{}",
+        base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(blob)
+    ))
+}
+
+fn decode_task_id(exposed: &str) -> Result<(String, String), String> {
+    let encoded = exposed
+        .strip_prefix(TASK_HANDLE_PREFIX)
+        .ok_or_else(|| "task id was not issued by Toolport".to_string())?;
+    let blob = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .decode(encoded)
+        .map_err(|_| "malformed Toolport task id".to_string())?;
+    if blob.len() <= TASK_HANDLE_NONCE_LEN {
+        return Err("malformed Toolport task id".to_string());
+    }
+    let (nonce, ciphertext) = blob.split_at(TASK_HANDLE_NONCE_LEN);
+    let key = crate::secrets::task_handle_key()?;
+    let cipher = XChaCha20Poly1305::new_from_slice(&key).map_err(|e| e.to_string())?;
+    let plain = cipher
+        .decrypt(XNonce::from_slice(nonce), ciphertext)
+        .map_err(|_| "task id was not issued by Toolport".to_string())?;
+    let (server, task): (String, String) = serde_json::from_slice(&plain)
+        .map_err(|_| "malformed Toolport task id".to_string())?;
+    if server.is_empty() || task.is_empty() {
+        return Err("malformed Toolport task id".to_string());
+    }
+    Ok((server, task))
+}
+
+fn expose_task_result(mut result: Value, server_id: &str) -> Result<Value, String> {
+    let task_id = result
+        .get("taskId")
+        .and_then(Value::as_str)
+        .ok_or_else(|| "downstream task result is missing taskId".to_string())?;
+    result["taskId"] = json!(expose_task_id(server_id, task_id)?);
+    Ok(result)
+}
+
+fn client_supports_tasks(meta: Option<&Value>) -> bool {
+    meta.and_then(|meta| meta.get("io.modelcontextprotocol/clientCapabilities"))
+        .and_then(|capabilities| capabilities.get("extensions"))
+        .and_then(|extensions| extensions.get("io.modelcontextprotocol/tasks"))
+        .is_some()
+}
 
 /// The delay before a retry attempt. Prefers a server-advertised `Retry-After`,
 /// else our exponential backoff, but never longer than `HTTP_RETRY_CAP` so a
@@ -774,9 +840,6 @@ impl Router {
                 .lock()
                 .unwrap_or_else(std::sync::PoisonError::into_inner);
             for (identifier, settings) in server.extensions() {
-                if !extension_is_transparent(identifier) {
-                    continue;
-                }
                 match values.entry(identifier.clone()) {
                     std::collections::btree_map::Entry::Vacant(entry) => {
                         entry.insert(Some(settings.clone()));
@@ -1131,15 +1194,87 @@ impl Router {
             .get(exposed_name)
             .ok_or_else(|| format!("no route for tool '{exposed_name}'"))?;
         let slot = self.slot_for(server_id)?;
-        self.call_with_retry(&slot, |server| {
-            server.call_with_cancel_and_mrtr(
-                tool,
-                arguments.clone(),
-                cancel.clone(),
-                meta,
-                mrtr,
-            )
-        })
+        let (result, downstream_supports_tasks) = self.call_with_retry(&slot, |server| {
+            let supports_tasks = server
+                .extensions()
+                .contains_key("io.modelcontextprotocol/tasks");
+            server
+                .call_with_cancel_and_mrtr(
+                    tool,
+                    arguments.clone(),
+                    cancel.clone(),
+                    meta,
+                    mrtr,
+                )
+                .map(|result| (result, supports_tasks))
+        })?;
+        if result.get("resultType").and_then(Value::as_str) == Some("task") {
+            if !client_supports_tasks(meta) {
+                return Err(
+                    "downstream returned a task without the required client capability"
+                        .to_string(),
+                );
+            }
+            if !downstream_supports_tasks {
+                return Err(
+                    "downstream returned a task without advertising the Tasks extension"
+                        .to_string(),
+                );
+            }
+            expose_task_result(result, server_id)
+        } else {
+            Ok(result)
+        }
+    }
+
+    /// Owning server encoded into a Toolport task handle. Used for the HTTP
+    /// client's allowed-server check before any downstream request is sent.
+    pub fn task_server(&self, task_id: &str) -> Option<String> {
+        decode_task_id(task_id).ok().map(|(server, _)| server)
+    }
+
+    /// Route one Tasks extension operation to the server that minted the handle,
+    /// translating the opaque client-facing id in both directions.
+    pub fn route_task(
+        &self,
+        method: &str,
+        params: Value,
+        cancel: Option<CancelContext>,
+        meta: Option<&Value>,
+    ) -> Result<Value, String> {
+        if !matches!(method, "tasks/get" | "tasks/update" | "tasks/cancel") {
+            return Err(format!("unsupported task method '{method}'"));
+        }
+        if !client_supports_tasks(meta) {
+            return Err(format!(
+                "{method} requires the io.modelcontextprotocol/tasks client capability"
+            ));
+        }
+        let exposed = params
+            .get("taskId")
+            .and_then(Value::as_str)
+            .ok_or_else(|| format!("{method} requires params.taskId"))?
+            .to_string();
+        let (server_id, native_task_id) = decode_task_id(&exposed)?;
+        let slot = self.slot_for(&server_id)?;
+        let mut forwarded = params;
+        forwarded["taskId"] = json!(native_task_id);
+        let result = self.call_with_retry(&slot, |server| {
+            server.task_request(method, forwarded.clone(), cancel.clone(), meta)
+        })?;
+        let mut result = result;
+        if method == "tasks/get" {
+            if result.get("taskId").and_then(Value::as_str).is_none() {
+                return Err("downstream task result is missing taskId".to_string());
+            }
+            result["taskId"] = json!(exposed);
+        } else if result.get("taskId").is_some() {
+            // update/cancel are empty acknowledgements in the Tasks spec. If a
+            // non-conforming downstream includes its native id, never leak it
+            // across the gateway boundary.
+            result["taskId"] = json!(exposed);
+        }
+        Ok(result)
     }
 
     /// Every downstream resource, uris unchanged.
@@ -1673,13 +1808,205 @@ mod tests {
 
         let all = router.aggregated_extensions(|_| true);
         assert_eq!(all["com.example/passive"], json!({}));
-        assert!(all.get("io.modelcontextprotocol/tasks").is_none());
+        assert_eq!(all["io.modelcontextprotocol/tasks"], json!({}));
         assert_eq!(all["com.example/beta"]["enabled"], true);
         assert!(all.get("com.example/mode").is_none());
 
         let alpha = router.aggregated_extensions(|server_id| server_id == "alpha");
         assert_eq!(alpha["com.example/mode"]["version"], 1);
         assert!(alpha.get("com.example/beta").is_none());
+    }
+
+    struct TaskTransport {
+        seen: Arc<Mutex<Vec<(String, Value)>>>,
+        advertise_tasks: bool,
+    }
+
+    impl Transport for TaskTransport {
+        fn request(&mut self, method: &str, params: Value) -> Result<Value, TransportError> {
+            match method {
+                "initialize" => Err(TransportError::Rpc(json!({
+                    "code": -32601,
+                    "message": "method not found"
+                }))),
+                "server/discover" => Ok(json!({
+                    "supportedVersions": [crate::downstream::MODERN_PROTOCOL_VERSION],
+                    "capabilities": {
+                        "extensions": if self.advertise_tasks {
+                            json!({ "io.modelcontextprotocol/tasks": {} })
+                        } else {
+                            json!({})
+                        }
+                    }
+                })),
+                "tools/list" => Ok(json!({ "tools": [{ "name": "job" }] })),
+                "tools/call" => {
+                    self.seen.lock().unwrap().push((method.to_string(), params));
+                    Ok(json!({
+                        "resultType": "task",
+                        "taskId": "same-native-id",
+                        "status": "working",
+                        "createdAt": "2026-08-01T00:00:00Z",
+                        "lastUpdatedAt": "2026-08-01T00:00:00Z",
+                        "ttlMs": null,
+                        "pollIntervalMs": 100
+                    }))
+                }
+                "tasks/get" => {
+                    self.seen.lock().unwrap().push((method.to_string(), params.clone()));
+                    Ok(json!({
+                        "resultType": "complete",
+                        "taskId": params["taskId"],
+                        "status": "completed",
+                        "createdAt": "2026-08-01T00:00:00Z",
+                        "lastUpdatedAt": "2026-08-01T00:00:01Z",
+                        "ttlMs": null,
+                        "result": { "content": [{ "type": "text", "text": "done" }] }
+                    }))
+                }
+                "tasks/update" | "tasks/cancel" => {
+                    self.seen.lock().unwrap().push((method.to_string(), params.clone()));
+                    Ok(json!({ "resultType": "complete", "taskId": params["taskId"] }))
+                }
+                other => Err(TransportError::Fatal(format!("unexpected method {other}"))),
+            }
+        }
+
+        fn notify(&mut self, _method: &str, _params: Value) -> Result<(), TransportError> {
+            Ok(())
+        }
+    }
+
+    fn task_server(id: &str, seen: Arc<Mutex<Vec<(String, Value)>>>) -> DownstreamServer {
+        DownstreamServer::connect(
+            id.to_string(),
+            Box::new(TaskTransport {
+                seen,
+                advertise_tasks: true,
+            }),
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn task_handles_bind_owner_and_route_poll_update_and_cancel() {
+        let alpha_seen = Arc::new(Mutex::new(Vec::new()));
+        let beta_seen = Arc::new(Mutex::new(Vec::new()));
+        let mut router = Router::new();
+        router.add(task_server("alpha", Arc::clone(&alpha_seen)));
+        router.add(task_server("beta", Arc::clone(&beta_seen)));
+        let meta = json!({
+            "io.modelcontextprotocol/protocolVersion": crate::downstream::MODERN_PROTOCOL_VERSION,
+            "io.modelcontextprotocol/clientCapabilities": {
+                "extensions": { "io.modelcontextprotocol/tasks": {} }
+            }
+        });
+
+        let alpha = router
+            .route_call_with_cancel("alpha__job", json!({}), None, Some(&meta))
+            .unwrap();
+        let beta = router
+            .route_call_with_cancel("beta__job", json!({}), None, Some(&meta))
+            .unwrap();
+        let alpha_id = alpha["taskId"].as_str().unwrap();
+        let beta_id = beta["taskId"].as_str().unwrap();
+        assert_ne!(alpha_id, beta_id, "same native id on two servers must not collide");
+        assert_eq!(router.task_server(alpha_id).as_deref(), Some("alpha"));
+        assert_eq!(router.task_server(beta_id).as_deref(), Some("beta"));
+        assert_eq!(
+            Router::new().task_server(alpha_id).as_deref(),
+            Some("alpha"),
+            "task ownership must survive a router rebuild"
+        );
+        let mut tampered = alpha_id.to_string();
+        let changed = TASK_HANDLE_PREFIX.len() + 5;
+        let replacement = if &tampered[changed..=changed] == "A" { "B" } else { "A" };
+        tampered.replace_range(changed..=changed, replacement);
+        assert!(
+            router.task_server(&tampered).is_none(),
+            "an edited task handle must fail authentication"
+        );
+
+        let polled = router
+            .route_task(
+                "tasks/get",
+                json!({ "taskId": alpha_id }),
+                None,
+                Some(&meta),
+            )
+            .unwrap();
+        assert_eq!(polled["taskId"], alpha_id);
+        assert_eq!(polled["status"], "completed");
+        let updated = router
+            .route_task(
+                "tasks/update",
+                json!({
+                    "taskId": alpha_id,
+                    "inputResponses": { "answer": { "content": "yes" } }
+                }),
+                None,
+                Some(&meta),
+            )
+            .unwrap();
+        assert_eq!(updated["taskId"], alpha_id);
+        let cancelled = router
+            .route_task(
+                "tasks/cancel",
+                json!({ "taskId": alpha_id }),
+                None,
+                Some(&meta),
+            )
+            .unwrap();
+        assert_eq!(cancelled["taskId"], alpha_id);
+
+        let seen = alpha_seen.lock().unwrap();
+        for (method, params) in seen.iter().filter(|(method, _)| method.starts_with("tasks/")) {
+            assert_eq!(params["taskId"], "same-native-id", "{method} must use native id");
+            assert_eq!(
+                params["_meta"]["io.modelcontextprotocol/clientCapabilities"]["extensions"]
+                    ["io.modelcontextprotocol/tasks"],
+                json!({})
+            );
+        }
+        assert!(router.route_task("tasks/get", json!({ "taskId": "forged" }), None, Some(&meta)).is_err());
+        assert!(router
+            .route_task("tasks/get", json!({ "taskId": alpha_id }), None, None)
+            .unwrap_err()
+            .contains("client capability"));
+    }
+
+    #[test]
+    fn task_results_require_both_sides_to_advertise_the_extension() {
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let mut router = Router::new();
+        router.add(task_server("tasks", Arc::clone(&seen)));
+
+        let missing_client_capability = router
+            .route_call_with_cancel("tasks__job", json!({}), None, None)
+            .unwrap_err();
+        assert!(missing_client_capability.contains("required client capability"));
+
+        let mut unadvertised = Router::new();
+        unadvertised.add(
+            DownstreamServer::connect(
+                "plain".to_string(),
+                Box::new(TaskTransport {
+                    seen,
+                    advertise_tasks: false,
+                }),
+            )
+            .unwrap(),
+        );
+        let meta = json!({
+            "io.modelcontextprotocol/protocolVersion": crate::downstream::MODERN_PROTOCOL_VERSION,
+            "io.modelcontextprotocol/clientCapabilities": {
+                "extensions": { "io.modelcontextprotocol/tasks": {} }
+            }
+        });
+        let missing_server_capability = unadvertised
+            .route_call_with_cancel("plain__job", json!({}), None, Some(&meta))
+            .unwrap_err();
+        assert!(missing_server_capability.contains("without advertising"));
     }
 
     struct HintTransport {

--- a/src-tauri/src/secrets.rs
+++ b/src-tauri/src/secrets.rs
@@ -5,6 +5,9 @@
 
 const SERVICE: &str = "conduit-mcp";
 
+const INTERNAL_SERVER_ID: &str = "__toolport_internal__";
+const TASK_HANDLE_KEY: &str = "__task_handle_key__";
+
 /// Reserved secret key for an http server's bearer token (Tier A auth, and where
 /// the OAuth flow stores its access token).
 pub const HTTP_AUTH_KEY: &str = "__http_auth__";
@@ -478,6 +481,10 @@ mod platform {
         let mut not_found = 0;
 
         for (server_id, key) in keys {
+            if server_id.as_str() == super::INTERNAL_SERVER_ID {
+                failed += 1;
+                continue;
+            }
             let acct = account(server_id, key);
             match get_generic_password(SERVICE, &acct) {
                 Ok(bytes) => match String::from_utf8(bytes) {
@@ -537,6 +544,10 @@ mod platform {
         let mut not_found = 0;
 
         for (server_id, key) in keys {
+            if server_id.as_str() == super::INTERNAL_SERVER_ID {
+                failed += 1;
+                continue;
+            }
             let acct = account(server_id, key);
             match get_generic_password(SERVICE, &acct) {
                 Ok(bytes) => match String::from_utf8(bytes) {
@@ -771,15 +782,70 @@ mod file {
     }
 }
 
-pub fn set_secret(server_id: &str, key: &str, value: &str) -> Result<(), String> {
+fn set_secret_raw(server_id: &str, key: &str, value: &str) -> Result<(), String> {
     if file::active() {
         return file::set_secret(server_id, key, value);
     }
     platform::set_secret(server_id, key, value)
 }
 
+pub fn set_secret(server_id: &str, key: &str, value: &str) -> Result<(), String> {
+    if server_id == INTERNAL_SERVER_ID {
+        return Err("reserved Toolport secret namespace".to_string());
+    }
+    set_secret_raw(server_id, key, value)
+}
+
 pub fn get_secret(server_id: &str, key: &str) -> Option<String> {
     get_secret_result(server_id, key).ok().flatten()
+}
+
+/// Stable installation-local key used to seal client-facing Tasks handles.
+/// Keeping the owner and native task id inside an authenticated ciphertext makes
+/// the handle unguessable and tamper-evident while still surviving gateway and
+/// app restarts. It is internal metadata, never a downstream server credential.
+pub(crate) fn task_handle_key() -> Result<[u8; 32], String> {
+    #[cfg(test)]
+    {
+        return Ok([0x54; 32]);
+    }
+
+    #[cfg(not(test))]
+    {
+        use base64::Engine as _;
+        use std::sync::OnceLock;
+
+        static KEY: OnceLock<[u8; 32]> = OnceLock::new();
+        if let Some(key) = KEY.get() {
+            return Ok(*key);
+        }
+        let loaded = (|| {
+            let decode = |encoded: &str| -> Result<[u8; 32], String> {
+                let raw = base64::engine::general_purpose::STANDARD
+                    .decode(encoded.trim())
+                    .map_err(|_| "Toolport task-handle key is corrupt".to_string())?;
+                raw.try_into()
+                    .map_err(|_| "Toolport task-handle key has the wrong length".to_string())
+            };
+            let _first_use_lock = crate::registry::conduit_dir()
+                .map(|dir| crate::registry::lock_at(&dir.join("task-handle-key")))
+                .transpose()?;
+            if let Some(encoded) = get_secret_result_raw(INTERNAL_SERVER_ID, TASK_HANDLE_KEY)? {
+                return decode(&encoded);
+            }
+
+            let mut key = [0u8; 32];
+            getrandom::getrandom(&mut key).map_err(|e| e.to_string())?;
+            let encoded = base64::engine::general_purpose::STANDARD.encode(key);
+            set_secret_raw(INTERNAL_SERVER_ID, TASK_HANDLE_KEY, &encoded)?;
+            // Read back through the active backend before caching the key.
+            let stored = get_secret_result_raw(INTERNAL_SERVER_ID, TASK_HANDLE_KEY)?
+                .ok_or_else(|| "Toolport task-handle key was not persisted".to_string())?;
+            decode(&stored)
+        })()?;
+        let _ = KEY.set(loaded);
+        Ok(*KEY.get().unwrap_or(&loaded))
+    }
 }
 
 /// Like `get_secret`, but distinguishes "no such secret was saved" (`Ok(None)`)
@@ -796,7 +862,7 @@ pub fn get_secret(server_id: &str, key: &str) -> Option<String> {
 /// 3. Encrypted `secrets.enc` when `TOOLPORT_SECRET_KEY` (legacy
 ///    `CONDUIT_SECRET_KEY`) is set
 /// 4. OS keychain / platform backend
-pub fn get_secret_result(server_id: &str, key: &str) -> Result<Option<String>, String> {
+fn get_secret_result_raw(server_id: &str, key: &str) -> Result<Option<String>, String> {
     if let Some(v) = env_secret_override(key) {
         return Ok(Some(v));
     }
@@ -804,6 +870,13 @@ pub fn get_secret_result(server_id: &str, key: &str) -> Result<Option<String>, S
         return file::get_secret_result(server_id, key);
     }
     platform::get_secret_result(server_id, key)
+}
+
+pub fn get_secret_result(server_id: &str, key: &str) -> Result<Option<String>, String> {
+    if server_id == INTERNAL_SERVER_ID {
+        return Err("reserved Toolport secret namespace".to_string());
+    }
+    get_secret_result_raw(server_id, key)
 }
 
 /// Look up a secret from the process environment for container / env-file deploys.
@@ -832,11 +905,18 @@ fn env_var_nonblank(name: &str) -> Option<String> {
     std::env::var(name).ok().filter(|v| !v.trim().is_empty())
 }
 
-pub fn delete_secret(server_id: &str, key: &str) -> Result<(), String> {
+fn delete_secret_raw(server_id: &str, key: &str) -> Result<(), String> {
     if file::active() {
         return file::delete_secret(server_id, key);
     }
     platform::delete_secret(server_id, key)
+}
+
+pub fn delete_secret(server_id: &str, key: &str) -> Result<(), String> {
+    if server_id == INTERNAL_SERVER_ID {
+        return Err("reserved Toolport secret namespace".to_string());
+    }
+    delete_secret_raw(server_id, key)
 }
 
 // ── Legacy keychain migration (macOS) ──────────────────────────────────────
@@ -1030,6 +1110,13 @@ mod tests {
     /// races with a sibling that assumes the keychain path, causing spurious
     /// failures under the default multi-threaded test runner.
     static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    #[test]
+    fn server_secrets_cannot_use_the_internal_task_key_namespace() {
+        assert!(set_secret(INTERNAL_SERVER_ID, "user-key", "value").is_err());
+        assert!(get_secret_result(INTERNAL_SERVER_ID, "user-key").is_err());
+        assert!(delete_secret(INTERNAL_SERVER_ID, "user-key").is_err());
+    }
 
     // Round-trips through the real OS keychain. Headless Linux CI has no Secret
     // Service (D-Bus), so skip it there; it still runs on Windows.


### PR DESCRIPTION
## Summary

- advertise `io.modelcontextprotocol/tasks` only after Toolport can route its follow-up methods
- wrap downstream task IDs in authenticated, installation-stable Toolport handles bound to the server that created them
- proxy `tasks/get`, `tasks/update`, and `tasks/cancel` with per-request capability and allowed-server checks
- reject task results unless both the client and downstream server advertised the Tasks extension
- emit and validate the required `Mcp-Method` / `Mcp-Name` routing headers on modern Streamable HTTP
- preserve downstream task metadata, MRTR input requests, and final results unchanged apart from task-ID translation

## Tracking

- follows the extension negotiation merged in #601
- tracks [SOU-453](https://linear.app/southforge-ai/issue/SOU-453/extensions-transparent-pass-through-tasks-and-a-toolport-extension)

## Verification

- Tasks library tests: 3 passed
- Tasks gateway test: 1 passed
- full Rust library suite: 661 passed
- `cargo check --manifest-path src-tauri/Cargo.toml --bin toolport-gateway --no-default-features` passes
- `git diff --check` passes

The Tasks extension currently supports task-augmented `tools/call`; task notifications remain optional and polling is the baseline path.