### PR TITLE
fix(errors): headline DNS, TLS, 429, and 5xx connection failures

### DIFF
--- a/src/lib/errors.test.ts
+++ b/src/lib/errors.test.ts
@@ -30,7 +30,7 @@ describe("errorHeadline", () => {
       "Host not found (ENOTFOUND)",
     );
     expect(errorHeadline("getaddrinfo EAI_AGAIN mcp.example.com")).toBe(
-      "Host not found (EAI_AGAIN)",
+      "Temporary DNS failure (EAI_AGAIN)",
     );
     expect(errorHeadline("read ECONNRESET")).toBe("Connection reset");
     expect(errorHeadline("spawn EACCES")).toBe("Permission denied (EACCES)");
@@ -54,6 +54,16 @@ describe("errorHeadline", () => {
     expect(errorHeadline("listen EADDRINUSE 127.0.0.1:50001")).toBe(
       "Port already in use (127.0.0.1:50001)",
     );
+    expect(errorHeadline("listen EADDRINUSE 127.0.0.1:503")).toBe(
+      "Port already in use (127.0.0.1:503)",
+    );
+  });
+
+  it("does not treat a bare numeric port as an HTTP failure", () => {
+    expect(errorHeadline("connect failed on port 503")).toBe(
+      "connect failed on port 503",
+    );
+    expect(errorHeadline("retrying after 429 ms")).toBe("retrying after 429 ms");
   });
 
   it("does not treat a giant OAuth authorize URL as an auth headline by itself", () => {

--- a/src/lib/errors.test.ts
+++ b/src/lib/errors.test.ts
@@ -25,6 +25,37 @@ describe("errorHeadline", () => {
     expect(errorHeadline("HTTP 403 Forbidden")).toBe("Access forbidden (403)");
   });
 
+  it("recognizes DNS, reset, permission, rate limit, 5xx, and TLS failures", () => {
+    expect(errorHeadline("getaddrinfo ENOTFOUND api.example.com")).toBe(
+      "Host not found (ENOTFOUND)",
+    );
+    expect(errorHeadline("getaddrinfo EAI_AGAIN mcp.example.com")).toBe(
+      "Host not found (EAI_AGAIN)",
+    );
+    expect(errorHeadline("read ECONNRESET")).toBe("Connection reset");
+    expect(errorHeadline("spawn EACCES")).toBe("Permission denied (EACCES)");
+    expect(errorHeadline("bind EPERM")).toBe("Permission denied (EPERM)");
+    expect(errorHeadline("upstream returned 429 Too Many Requests")).toBe(
+      "Rate limited (429)",
+    );
+    expect(errorHeadline("service unavailable HTTP 503")).toBe("Server error (503)");
+    expect(errorHeadline("UNABLE_TO_VERIFY_LEAF_SIGNATURE")).toBe(
+      "TLS certificate not trusted",
+    );
+    expect(errorHeadline("DEPTH_ZERO_SELF_SIGNED_CERT")).toBe(
+      "TLS certificate not trusted",
+    );
+    expect(errorHeadline("SELF_SIGNED_CERT_IN_CHAIN")).toBe(
+      "TLS certificate not trusted",
+    );
+  });
+
+  it("does not treat a high port number as a 5xx server error", () => {
+    expect(errorHeadline("listen EADDRINUSE 127.0.0.1:50001")).toBe(
+      "Port already in use (127.0.0.1:50001)",
+    );
+  });
+
   it("does not treat a giant OAuth authorize URL as an auth headline by itself", () => {
     // A ~2KB authorize URL with no 401/unauthorized text should fall to the last
     // line, with the URL middle-truncated, not blow up the message.

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -17,13 +17,24 @@ const PATTERNS: Array<[RegExp, (m: RegExpMatchArray) => string]> = [
   ],
   [/EADDRINUSE/i, () => "Port already in use"],
   [/ENOENT/i, () => "Command or file not found (ENOENT)"],
+  [/ENOTFOUND/i, () => "Host not found (ENOTFOUND)"],
+  [/EAI_AGAIN/i, () => "Host not found (EAI_AGAIN)"],
   [/ECONNREFUSED/i, () => "Connection refused"],
+  [/ECONNRESET/i, () => "Connection reset"],
+  [/EACCES/i, () => "Permission denied (EACCES)"],
+  [/EPERM/i, () => "Permission denied (EPERM)"],
   [
     /timed out waiting for initialize|timed? ?out/i,
     () => "Timed out waiting for the server",
   ],
   [/\b401\b|unauthorized/i, () => "Authentication required (401)"],
   [/\b403\b|forbidden/i, () => "Access forbidden (403)"],
+  [/\b429\b/, () => "Rate limited (429)"],
+  [/\b(5\d{2})\b/, (m) => `Server error (${m[1]})`],
+  [
+    /UNABLE_TO_VERIFY_LEAF_SIGNATURE|DEPTH_ZERO_SELF_SIGNED_CERT|SELF_SIGNED_CERT_IN_CHAIN/i,
+    () => "TLS certificate not trusted",
+  ],
 ];
 
 /**

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -18,7 +18,7 @@ const PATTERNS: Array<[RegExp, (m: RegExpMatchArray) => string]> = [
   [/EADDRINUSE/i, () => "Port already in use"],
   [/ENOENT/i, () => "Command or file not found (ENOENT)"],
   [/ENOTFOUND/i, () => "Host not found (ENOTFOUND)"],
-  [/EAI_AGAIN/i, () => "Host not found (EAI_AGAIN)"],
+  [/EAI_AGAIN/i, () => "Temporary DNS failure (EAI_AGAIN)"],
   [/ECONNREFUSED/i, () => "Connection refused"],
   [/ECONNRESET/i, () => "Connection reset"],
   [/EACCES/i, () => "Permission denied (EACCES)"],
@@ -29,8 +29,14 @@ const PATTERNS: Array<[RegExp, (m: RegExpMatchArray) => string]> = [
   ],
   [/\b401\b|unauthorized/i, () => "Authentication required (401)"],
   [/\b403\b|forbidden/i, () => "Access forbidden (403)"],
-  [/\b429\b/, () => "Rate limited (429)"],
-  [/\b(5\d{2})\b/, (m) => `Server error (${m[1]})`],
+  [
+    /(?:HTTP\s+|status\s+|returned\s+)429\b|\b429\s+Too Many Requests/i,
+    () => "Rate limited (429)",
+  ],
+  [
+    /(?:HTTP\s+|status\s+|returned\s+)(5\d{2})\b|\b(5\d{2})\s+(?:Internal Server Error|Bad Gateway|Service Unavailable|Gateway Timeout|error)/i,
+    (m) => `Server error (${m[1] ?? m[2]})`,
+  ],
   [
     /UNABLE_TO_VERIFY_LEAF_SIGNATURE|DEPTH_ZERO_SELF_SIGNED_CERT|SELF_SIGNED_CERT_IN_CHAIN/i,
     () => "TLS certificate not trusted",


### PR DESCRIPTION
## Summary
Extend `errorHeadline` with patterns for common MCP connection failures (DNS, TLS, rate limits, and server errors) so status tooltips show readable headlines instead of raw stack traces.

## Motivation
When adding or probing MCP servers, failures like `ENOTFOUND`, TLS certificate errors, HTTP 429, and 5xx responses currently fall through to the last-line fallback and render as unreadable walls of text. Issue #606 documents the missing signals.

## Changes
- Add `errorHeadline` patterns for `ENOTFOUND`, `EAI_AGAIN`, `ECONNRESET`, `EACCES`, `EPERM`, HTTP 429, HTTP 5xx, and common TLS certificate errors.
- Keep pattern order so `EADDRINUSE` with an address is matched before generic 5xx detection.
- Add unit tests for each new headline and a regression test for high ports like `:50001`.

## Tests
- `npm run test -- errors` — 9 tests passed

## Notes
- TLS patterns intentionally cover only the three codes listed in the issue; additional cert errors were omitted to keep the list small per existing design.

Fixes #606