### PR TITLE
feat(mcp): preserve MCP Apps discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,12 @@ Entries before the rename below shipped under the project's former name, Conduit
   Its settings report the active discovery, code-mode, agent-control, destructive
   confirmation, and human-approval state; existing meta-tools remain available as
   the core-protocol fallback for clients that ignore extensions. (SOU-453)
+- Modern downstream catalog fetches now negotiate MCP Apps' HTML MIME type, Apps
+  hosts receive UI-linked tools even in lazy or grouped discovery, and `ui://`
+  resources route through their owning tool when the server omits them from
+  `resources/list`. Negotiated app HTML stays byte-faithful for the host's sandbox
+  and CSP enforcement, while app-only tools stay out of model-facing search and
+  nested-call paths. (SOU-453)
 
 ### Security
 

--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -130,6 +130,43 @@ fn modern_client_supports_extension(identifier: &str) -> bool {
     })
 }
 
+fn mcp_app_html_settings(settings: &Value) -> bool {
+    settings
+        .get("mimeTypes")
+        .and_then(Value::as_array)
+        .is_some_and(|mime_types| mime_types.iter().any(|mime| mime == MCP_APP_HTML_MIME))
+}
+
+fn active_client_supports_mcp_app_html() -> bool {
+    ACTIVE_UPSTREAM_CAPABILITIES.with(|cell| {
+        cell.borrow()
+            .as_ref()
+            .and_then(|caps| caps.get("extensions"))
+            .and_then(|extensions| extensions.get(MCP_APPS_EXTENSION))
+            .is_some_and(mcp_app_html_settings)
+    })
+}
+
+fn server_supports_mcp_app_html(router: &Router, server: &str) -> bool {
+    router
+        .server_extension_settings(server, MCP_APPS_EXTENSION)
+        .as_ref()
+        .is_some_and(mcp_app_html_settings)
+}
+
+fn relays_mcp_app_html_to_active_client(
+    router: &Router,
+    allowed: Option<&std::collections::HashSet<String>>,
+) -> bool {
+    active_client_supports_mcp_app_html()
+        && router
+            .aggregated_extensions(|server| {
+                allowed.is_none_or(|scope| server_in_allowed_scope(server, scope))
+            })
+            .get(MCP_APPS_EXTENSION)
+            .is_some_and(mcp_app_html_settings)
+}
+
 /// Add the fields a modern client requires to a result.
 ///
 /// No-op for legacy clients, so their responses stay byte-identical to what
@@ -238,6 +275,58 @@ const MODERN_UPSTREAM_VERSIONS: [&str; 1] = [MODERN_PROTOCOL_VERSION];
 /// Toolport's third-party MCP extension identifier. `toolport.app` is a domain
 /// we own, so its required reverse-domain vendor prefix is `app.toolport`.
 const TOOLPORT_GATEWAY_EXTENSION: &str = "app.toolport/gateway";
+/// Standard MCP Apps extension identifier (SEP-1865).
+const MCP_APPS_EXTENSION: &str = "io.modelcontextprotocol/ui";
+const MCP_APP_HTML_MIME: &str = "text/html;profile=mcp-app";
+
+fn mcp_app_resource_uri(tool: &Value) -> Option<&str> {
+    tool.pointer("/_meta/ui/resourceUri")
+        .or_else(|| tool.pointer("/_meta/ui~1resourceUri"))
+        .and_then(Value::as_str)
+        .filter(|uri| uri.starts_with("ui://"))
+}
+
+fn is_mcp_app_tool(tool: &Value) -> bool {
+    mcp_app_resource_uri(tool).is_some()
+}
+
+fn mcp_app_tool_is_model_visible(tool: &Value) -> bool {
+    match tool.pointer("/_meta/ui/visibility") {
+        None => true,
+        Some(Value::Array(visibility)) => visibility.iter().any(|audience| audience == "model"),
+        Some(_) => false,
+    }
+}
+
+fn named_tool_is_model_visible(name: &str, cached: &[Value], router: &Router) -> bool {
+    cached
+        .iter()
+        .find(|tool| tool.get("name").and_then(Value::as_str) == Some(name))
+        .map(mcp_app_tool_is_model_visible)
+        .or_else(|| {
+            router
+                .aggregated_tools()
+                .into_iter()
+                .find(|tool| tool.get("name").and_then(Value::as_str) == Some(name))
+                .map(|tool| mcp_app_tool_is_model_visible(&tool))
+        })
+        .unwrap_or(true)
+}
+
+fn is_mcp_app_resource_result(uri: &str, result: &Value) -> bool {
+    uri.starts_with("ui://")
+        && result
+            .get("contents")
+            .and_then(Value::as_array)
+            .is_some_and(|contents| {
+                !contents.is_empty()
+                    && contents.iter().all(|content| {
+                        content.get("uri").and_then(Value::as_str) == Some(uri)
+                            && content.get("mimeType").and_then(Value::as_str)
+                                == Some(MCP_APP_HTML_MIME)
+                    })
+            })
+}
 
 /// The protocol version a modern client declared on this request.
 ///
@@ -293,6 +382,20 @@ fn gateway_capabilities(
         // on the upstream hop. Remove the whole namespace, not only the one
         // extension known to this build, before adding Toolport's declaration.
         extensions.retain(|identifier, _| !identifier.starts_with("app.toolport/"));
+        // Toolport currently relays only the reserved MCP App HTML payload.
+        // Advertise the intersection rather than copying downstream MIME types
+        // that this gateway did not negotiate or validate.
+        if extensions
+            .get(MCP_APPS_EXTENSION)
+            .is_some_and(mcp_app_html_settings)
+        {
+            extensions.insert(
+                MCP_APPS_EXTENSION.to_string(),
+                json!({ "mimeTypes": [MCP_APP_HTML_MIME] }),
+            );
+        } else {
+            extensions.remove(MCP_APPS_EXTENSION);
+        }
         let discovery_mode = if lazy {
             DiscoveryMode::Lazy
         } else if grouped_discovery() {
@@ -2924,6 +3027,35 @@ fn scope_tools(
     }
 }
 
+/// UI-linked tools are part of MCP Apps discovery, not ordinary model-context
+/// discovery. An Apps-capable host must receive their `_meta.ui.resourceUri`
+/// even when Toolport is otherwise in lazy/grouped mode; hosts then apply the
+/// extension's model/app visibility rules themselves.
+fn mcp_app_tools_for_client(
+    catalog: &[Value],
+    allowed: Option<&std::collections::HashSet<String>>,
+    router: &Router,
+) -> Vec<Value> {
+    if !relays_mcp_app_html_to_active_client(router, allowed) {
+        return Vec::new();
+    }
+    scope_tools(catalog, allowed, |name| {
+        router.route_of(name).map(|(server, _)| server.to_string())
+    })
+    .into_iter()
+    .filter(|tool| {
+        is_mcp_app_tool(tool)
+            && tool
+                .get("name")
+                .and_then(Value::as_str)
+                .and_then(|name| router.route_of(name))
+                .is_some_and(|(server, _)| {
+                    server_supports_mcp_app_html(router, server)
+                })
+    })
+    .collect()
+}
+
 /// Whether a client scoped to `allowed` may see the exposed tool `name`. See
 /// [`scope_tools`] for how `route_of` is resolved and why the `server__` prefix is only a
 /// fallback.
@@ -3470,6 +3602,12 @@ fn execute_call(
 ) -> Value {
     let mut confirmed = opts.confirmed;
     let shape = opts.shape;
+    if !opts.allow_app_only && !named_tool_is_model_visible(name, cached, router) {
+        return json!({
+            "content": [{ "type": "text", "text": format!("Toolport: '{name}' is available only to its MCP App.") }],
+            "isError": true
+        });
+    }
     // Direct modern calls can use MRTR even on their first round, before any
     // requestState exists. Code-mode steps deliberately keep the legacy broker
     // because they cannot surface an intermediate result to the upstream client;
@@ -3997,6 +4135,9 @@ struct CallOpts {
     /// intermediate calls pass full bodies into the sandbox (they never enter model
     /// context); only the script's final aggregate is shaped for the client.
     shape: bool,
+    /// App-only tools bypass the model-facing visibility guard only for a
+    /// direct call from a host that negotiated the supported Apps MIME.
+    allow_app_only: bool,
 }
 
 /// Run untrusted tool-call output through content defense and result shaping, then
@@ -4172,6 +4313,7 @@ fn run_script_dispatch(
                     CallOpts {
                         confirmed: false,
                         shape: false,
+                        allow_app_only: false,
                     },
                     live_owned.as_ref(),
                 )
@@ -4408,6 +4550,11 @@ fn handle_request_with_cancel(
                 } else {
                     cached
                 };
+                // MCP Apps hosts discover the UI resource linkage only through
+                // tools/list. Preserve those few tools when the requesting host
+                // explicitly negotiated the UI extension; the rest of the
+                // downstream catalog remains behind lazy discovery.
+                tools.extend(mcp_app_tools_for_client(catalog, allowed, router));
                 let status = status_tool_def();
                 let full_tokens = savings::estimate_tokens(catalog)
                     + savings::estimate_tokens(std::slice::from_ref(&status));
@@ -4446,8 +4593,9 @@ fn handle_request_with_cancel(
                 let scoped = scope_tools(catalog, allowed, |n| {
                     router.route_of(n).map(|(s, _)| s.to_string())
                 });
-                let tools =
+                let mut tools =
                     grouped_tool_defs(reg.allow_agent_control, reg.confirm_destructive, &scoped);
+                tools.extend(mcp_app_tools_for_client(catalog, allowed, router));
                 // Savings vs. advertising the whole (scoped) catalog + status.
                 let status = status_tool_def();
                 let full_tokens = savings::estimate_tokens(&scoped)
@@ -4493,9 +4641,13 @@ fn handle_request_with_cancel(
             } else {
                 cached.to_vec()
             };
-            tools.extend(scope_tools(&catalog, allowed, |n| {
+            let mut scoped = scope_tools(&catalog, allowed, |n| {
                 router.route_of(n).map(|(s, _)| s.to_string())
-            }));
+            });
+            if !relays_mcp_app_html_to_active_client(router, allowed) {
+                scoped.retain(mcp_app_tool_is_model_visible);
+            }
+            tools.extend(scoped);
             gtrace(&format!(
                 "tools/list -> {} tools (cache={})",
                 tools.len(),
@@ -4651,6 +4803,20 @@ fn handle_request_with_cancel(
                     &live
                 } else {
                     cached
+                };
+                // This meta-tool feeds the model directly, so app-only tools
+                // must never appear in its results even for an Apps-capable
+                // host. Such tools are exposed separately for the host/view.
+                let model_visible;
+                let base = if base.iter().any(|tool| !mcp_app_tool_is_model_visible(tool)) {
+                    model_visible = base
+                        .iter()
+                        .filter(|tool| mcp_app_tool_is_model_visible(tool))
+                        .cloned()
+                        .collect::<Vec<_>>();
+                    model_visible.as_slice()
+                } else {
+                    base
                 };
                 // Avoid cloning the entire catalog for the normal local/unscoped path.
                 // Scoped HTTP callers still get a fail-closed filtered copy and a
@@ -4952,11 +5118,17 @@ fn handle_request_with_cancel(
             // toolport_call_tool dispatches a discovered tool: unwrap to its real
             // name + arguments, then run it through the shared execute path (scope,
             // approval, confirm, shaping) that a code-mode toolport.call() also uses.
-            let (name, arguments) = if name == "toolport_call_tool" {
+            let model_facing_meta_call = name == "toolport_call_tool";
+            let (name, arguments) = if model_facing_meta_call {
                 unwrap_call_tool(&arguments)
             } else {
                 (name, arguments)
             };
+            let allow_app_only = !model_facing_meta_call
+                && relays_mcp_app_html_to_active_client(router, allowed)
+                && router
+                    .route_of(&name)
+                    .is_some_and(|(server, _)| server_supports_mcp_app_html(router, server));
             let mrtr = MrtrRequest::from_params(params);
             let result = execute_call(
                 reg,
@@ -4974,6 +5146,7 @@ fn handle_request_with_cancel(
                 CallOpts {
                     confirmed,
                     shape: true,
+                    allow_app_only,
                 },
                 live_router,
             );
@@ -5085,11 +5258,26 @@ fn handle_request_with_cancel(
                 (!mrtr.is_empty()).then_some(&mrtr),
             ) {
                 Ok(mut result) => {
+                    // MCP App HTML is executable UI payload for the host's
+                    // sandbox, not model-facing resource text. The Apps spec
+                    // requires the raw document so the host can apply its CSP;
+                    // wrapping a scanner hit would corrupt the HTML. Only take
+                    // this path after the modern host explicitly negotiates UI
+                    // support and the response matches the reserved URI + MIME.
+                    let preserve_mcp_app =
+                        relays_mcp_app_html_to_active_client(router, allowed)
+                        && router.resource_server(uri).is_some_and(|server| {
+                            server_supports_mcp_app_html(router, server)
+                        })
+                        && is_mcp_app_resource_result(uri, &result);
                     // Content defense: a resource is as attacker-controllable as a tool
                     // result, so scan it for injection and label any flagged text as data.
                     // Block mode (SOU-345) uses the owning server id for the exempt map
                     // and still runs when contentDefense is off but block is on.
-                    if reg.content_defense_effective() || reg.block_on_injection_effective() {
+                    if !preserve_mcp_app
+                        && (reg.content_defense_effective()
+                            || reg.block_on_injection_effective())
+                    {
                         let srv = router.resource_server(uri).unwrap_or(uri);
                         let block = reg.should_block_injection_for(srv);
                         if let Some(msg) =
@@ -11780,6 +11968,7 @@ mod tests {
             CallOpts {
                 confirmed: false,
                 shape: true,
+                allow_app_only: false,
             },
             None,
         );
@@ -16066,6 +16255,409 @@ mod tests {
         assert!(scoped_extensions.contains_key(TOOLPORT_GATEWAY_EXTENSION));
         assert!(!scoped_extensions.contains_key("com.example/passive"));
         assert!(!scoped_extensions.contains_key("io.modelcontextprotocol/tasks"));
+    }
+
+    #[derive(Default)]
+    struct McpAppsServer {
+        protocol_meta: Option<Value>,
+    }
+
+    impl Transport for McpAppsServer {
+        fn request(
+            &mut self,
+            method: &str,
+            params: Value,
+        ) -> Result<Value, downstream::TransportError> {
+            match method {
+                "initialize" => Err(downstream::TransportError::Rpc(json!({
+                    "code": -32601,
+                    "message": "method not found"
+                }))),
+                "server/discover" => Ok(json!({
+                    "supportedVersions": [MODERN_PROTOCOL_VERSION],
+                    "capabilities": {
+                        "resources": {},
+                        "extensions": {
+                            "io.modelcontextprotocol/ui": {
+                                "mimeTypes": [
+                                    "text/html;profile=mcp-app",
+                                    "image/svg+xml"
+                                ]
+                            }
+                        }
+                    }
+                })),
+                "tools/list" => {
+                    let mut tools = vec![json!({
+                        "name": "plain",
+                        "inputSchema": { "type": "object" }
+                    })];
+                    let ui_negotiated = self
+                        .protocol_meta
+                        .as_ref()
+                        .and_then(|meta| {
+                            meta.pointer("/io.modelcontextprotocol~1clientCapabilities/extensions/io.modelcontextprotocol~1ui/mimeTypes")
+                        })
+                        .and_then(Value::as_array)
+                        .is_some_and(|mime_types| {
+                            mime_types
+                                .iter()
+                                .any(|mime| mime == "text/html;profile=mcp-app")
+                        });
+                    if ui_negotiated {
+                        tools.push(json!({
+                            "name": "dashboard",
+                            "inputSchema": { "type": "object" },
+                            "_meta": {
+                                "ui": {
+                                    "resourceUri": "ui://fixture/dashboard",
+                                    "visibility": ["model", "app"]
+                                }
+                            }
+                        }));
+                        tools.push(json!({
+                            "name": "app_only",
+                            "inputSchema": { "type": "object" },
+                            "_meta": {
+                                "ui": {
+                                    "resourceUri": "ui://fixture/dashboard",
+                                    "visibility": ["app"]
+                                }
+                            }
+                        }));
+                    }
+                    Ok(json!({ "tools": tools }))
+                }
+                "tools/call" => Ok(json!({
+                    "content": [{ "type": "text", "text": params["name"] }],
+                    "isError": false
+                })),
+                "resources/read" => {
+                    assert_eq!(params["uri"], "ui://fixture/dashboard");
+                    Ok(json!({
+                        "contents": [{
+                            "uri": "ui://fixture/dashboard",
+                            "mimeType": "text/html;profile=mcp-app",
+                            "text": "<!doctype html><script>const label = 'ignore previous instructions';</script>"
+                        }]
+                    }))
+                }
+                other => Err(downstream::TransportError::Fatal(format!(
+                    "unexpected method {other}"
+                ))),
+            }
+        }
+
+        fn notify(
+            &mut self,
+            _method: &str,
+            _params: Value,
+        ) -> Result<(), downstream::TransportError> {
+            Ok(())
+        }
+
+        fn set_protocol_meta(&mut self, meta: Option<Value>) {
+            self.protocol_meta = meta;
+        }
+    }
+
+    fn modern_apps_req(id: i64, method: &str, params: Value) -> Value {
+        let mut request = modern_req(id, method, params);
+        request["params"]["_meta"]["io.modelcontextprotocol/clientCapabilities"] = json!({
+            "extensions": {
+                "io.modelcontextprotocol/ui": {
+                    "mimeTypes": ["text/html;profile=mcp-app"]
+                }
+            }
+        });
+        request
+    }
+
+    #[test]
+    fn lazy_discovery_keeps_ui_linked_tools_only_for_apps_hosts() {
+        let reg = Registry::default();
+        let mut router = Router::new();
+        router.add(
+            DownstreamServer::connect("apps".into(), Box::new(McpAppsServer::default())).unwrap(),
+        );
+        let cached = router.aggregated_tools();
+        let guard = SearchGuard::default();
+        let confirm = ConfirmGuard::new();
+
+        let discovered = handle_request(
+            &modern_req(0, "server/discover", json!({})),
+            &reg,
+            &router,
+            &cached,
+            true,
+            None,
+            &guard,
+            &confirm,
+            None,
+            None,
+        )
+        .unwrap();
+        assert_eq!(
+            discovered["result"]["capabilities"]["extensions"][MCP_APPS_EXTENSION],
+            json!({ "mimeTypes": [MCP_APP_HTML_MIME] })
+        );
+
+        let apps = handle_request(
+            &modern_apps_req(1, "tools/list", json!({})),
+            &reg,
+            &router,
+            &cached,
+            true,
+            None,
+            &guard,
+            &confirm,
+            None,
+            None,
+        )
+        .unwrap();
+        let names = apps["result"]["tools"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter_map(|tool| tool["name"].as_str())
+            .collect::<Vec<_>>();
+        assert!(names.contains(&"apps__dashboard"));
+        assert!(names.contains(&"apps__app_only"));
+        assert!(!names.contains(&"apps__plain"));
+        assert_eq!(
+            apps["result"]["tools"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .find(|tool| tool["name"] == "apps__dashboard")
+                .unwrap()["_meta"]["ui"]["resourceUri"],
+            "ui://fixture/dashboard"
+        );
+
+        let ordinary = handle_request(
+            &modern_req(2, "tools/list", json!({})),
+            &reg,
+            &router,
+            &cached,
+            true,
+            None,
+            &guard,
+            &confirm,
+            None,
+            None,
+        )
+        .unwrap();
+        assert!(ordinary["result"]["tools"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .all(|tool| !tool["name"]
+                .as_str()
+                .is_some_and(|name| name.starts_with("apps__"))));
+
+        let mut wrong_mime = modern_req(3, "tools/list", json!({}));
+        wrong_mime["params"]["_meta"]["io.modelcontextprotocol/clientCapabilities"] = json!({
+            "extensions": {
+                "io.modelcontextprotocol/ui": { "mimeTypes": ["image/svg+xml"] }
+            }
+        });
+        let wrong_mime = handle_request(
+            &wrong_mime,
+            &reg,
+            &router,
+            &cached,
+            true,
+            None,
+            &guard,
+            &confirm,
+            None,
+            None,
+        )
+        .unwrap();
+        assert!(wrong_mime["result"]["tools"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .all(|tool| !tool["name"]
+                .as_str()
+                .is_some_and(|name| name.starts_with("apps__"))));
+    }
+
+    #[test]
+    fn app_only_tools_stay_out_of_model_facing_gateway_paths() {
+        let reg = Registry::default();
+        let mut router = Router::new();
+        router.add(
+            DownstreamServer::connect("apps".into(), Box::new(McpAppsServer::default())).unwrap(),
+        );
+        let cached = router.aggregated_tools();
+        let guard = SearchGuard::default();
+        let confirm = ConfirmGuard::new();
+
+        let ordinary_full = handle_request(
+            &modern_req(10, "tools/list", json!({})),
+            &reg,
+            &router,
+            &cached,
+            false,
+            None,
+            &guard,
+            &confirm,
+            None,
+            None,
+        )
+        .unwrap();
+        assert!(ordinary_full["result"]["tools"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .all(|tool| tool["name"] != "apps__app_only"));
+
+        let apps_full = handle_request(
+            &modern_apps_req(11, "tools/list", json!({})),
+            &reg,
+            &router,
+            &cached,
+            false,
+            None,
+            &guard,
+            &confirm,
+            None,
+            None,
+        )
+        .unwrap();
+        assert!(apps_full["result"]["tools"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|tool| tool["name"] == "apps__app_only"));
+
+        let searched = handle_request(
+            &modern_apps_req(
+                12,
+                "tools/call",
+                json!({
+                    "name": "toolport_search_tools",
+                    "arguments": { "query": "app only" }
+                }),
+            ),
+            &reg,
+            &router,
+            &cached,
+            true,
+            None,
+            &guard,
+            &confirm,
+            None,
+            None,
+        )
+        .unwrap();
+        assert!(!searched.to_string().contains("apps__app_only"));
+
+        let nested = handle_request(
+            &modern_apps_req(
+                13,
+                "tools/call",
+                json!({
+                    "name": "toolport_call_tool",
+                    "arguments": { "name": "apps__app_only", "arguments": {} }
+                }),
+            ),
+            &reg,
+            &router,
+            &cached,
+            true,
+            None,
+            &guard,
+            &confirm,
+            None,
+            None,
+        )
+        .unwrap();
+        assert_eq!(nested["result"]["isError"], true);
+        assert!(nested["result"]["content"][0]["text"]
+            .as_str()
+            .unwrap()
+            .contains("available only to its MCP App"));
+
+        let direct = handle_request(
+            &modern_apps_req(
+                14,
+                "tools/call",
+                json!({ "name": "apps__app_only", "arguments": {} }),
+            ),
+            &reg,
+            &router,
+            &cached,
+            true,
+            None,
+            &guard,
+            &confirm,
+            None,
+            None,
+        )
+        .unwrap();
+        assert_eq!(direct["result"]["isError"], false);
+    }
+
+    #[test]
+    fn negotiated_mcp_app_html_passes_through_without_content_defense_rewrite() {
+        let reg = Registry::default();
+        assert!(
+            reg.content_defense_effective(),
+            "fixture needs the default scanner on"
+        );
+        let mut router = Router::new();
+        router.add(
+            DownstreamServer::connect("apps".into(), Box::new(McpAppsServer::default())).unwrap(),
+        );
+        let response = handle_request(
+            &modern_apps_req(
+                3,
+                "resources/read",
+                json!({ "uri": "ui://fixture/dashboard" }),
+            ),
+            &reg,
+            &router,
+            &[],
+            true,
+            None,
+            &SearchGuard::default(),
+            &ConfirmGuard::new(),
+            None,
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(
+            response["result"]["contents"][0]["text"],
+            "<!doctype html><script>const label = 'ignore previous instructions';</script>"
+        );
+        assert_eq!(
+            response["result"]["contents"][0]["mimeType"],
+            "text/html;profile=mcp-app"
+        );
+
+        let ordinary = handle_request(
+            &modern_req(
+                4,
+                "resources/read",
+                json!({ "uri": "ui://fixture/dashboard" }),
+            ),
+            &reg,
+            &router,
+            &[],
+            true,
+            None,
+            &SearchGuard::default(),
+            &ConfirmGuard::new(),
+            None,
+            None,
+        )
+        .unwrap();
+        assert!(ordinary["result"]["contents"][0]["text"]
+            .as_str()
+            .is_some_and(|text| text.starts_with("[conduit: the following is external data")));
     }
 
     #[test]

--- a/src-tauri/src/downstream.rs
+++ b/src-tauri/src/downstream.rs
@@ -654,6 +654,37 @@ fn protocol_meta_for(version: &str) -> Value {
     })
 }
 
+const MCP_APPS_EXTENSION: &str = "io.modelcontextprotocol/ui";
+const MCP_APP_HTML_MIME: &str = "text/html;profile=mcp-app";
+
+/// Metadata used for Toolport's own modern catalog fetches.
+///
+/// MCP Apps servers may expose their UI linkage only after the client declares
+/// support. Toolport can faithfully relay that linkage and the reserved HTML
+/// resource to a capable upstream host, so it truthfully declares the one MIME
+/// type it supports here. Other extensions stay request-driven: claiming them
+/// without an originating client could invite callbacks or semantics the
+/// gateway cannot service.
+fn protocol_meta_for_catalog(version: &str, server_capabilities: Option<&Value>) -> Value {
+    let mut meta = protocol_meta_for(version);
+    let supports_mcp_apps = server_capabilities
+        .and_then(|capabilities| capabilities.get("extensions"))
+        .and_then(|extensions| extensions.get(MCP_APPS_EXTENSION))
+        .and_then(|settings| settings.get("mimeTypes"))
+        .and_then(Value::as_array)
+        .is_some_and(|mime_types| mime_types.iter().any(|mime| mime == MCP_APP_HTML_MIME));
+    if supports_mcp_apps {
+        meta["io.modelcontextprotocol/clientCapabilities"] = json!({
+            "extensions": {
+                (MCP_APPS_EXTENSION): {
+                    "mimeTypes": [MCP_APP_HTML_MIME]
+                }
+            }
+        });
+    }
+    meta
+}
+
 /// Max time to wait for a single stdio response before giving up. Without this a
 /// server that never replies would block its thread (and the batch health probe)
 /// forever.
@@ -4094,10 +4125,17 @@ impl DownstreamServer {
                         discovered.get("supportedVersions")
                     )
                 })?;
+                let capabilities = discovered.get("capabilities").cloned();
                 // From here every request carries its own protocol metadata;
                 // there is no handshake and no `notifications/initialized`.
-                transport.set_protocol_meta(Some(protocol_meta_for(&version)));
-                (Era::Modern { version }, discovered.get("capabilities").cloned())
+                // Catalog fetches additionally declare the MCP Apps MIME when
+                // this server offers it, so a capability-aware server includes
+                // its UI tool metadata in tools/list.
+                transport.set_protocol_meta(Some(protocol_meta_for_catalog(
+                    &version,
+                    capabilities.as_ref(),
+                )));
+                (Era::Modern { version }, capabilities)
             }
         };
         let caps = caps.as_ref();
@@ -4128,6 +4166,13 @@ impl DownstreamServer {
         } else {
             listed.items
         };
+
+        // MCP Apps is advertised only for capability-aware catalog fetches.
+        // Restore Toolport's ordinary per-request metadata before any live call
+        // so a non-Apps upstream client cannot inherit that capability.
+        if let Era::Modern { version } = &era {
+            transport.set_protocol_meta(Some(protocol_meta_for(version)));
+        }
 
         // Restore the longer timeout: actual tool calls can legitimately be slow.
         transport.set_read_timeout(STDIO_READ_TIMEOUT);
@@ -4327,7 +4372,23 @@ impl DownstreamServer {
 
     fn refresh_tools_inner(&mut self) {
         self.transport.set_read_timeout(STDIO_CONNECT_TIMEOUT);
-        match fetch_paginated_list(&mut *self.transport, "tools/list", "tools") {
+        let modern_version = match &self.era {
+            Era::Modern { version } => Some(version.clone()),
+            Era::Legacy { .. } => None,
+        };
+        if let Some(version) = modern_version.as_deref() {
+            let capabilities = json!({ "extensions": self.caps_extensions.clone() });
+            self.transport.set_protocol_meta(Some(protocol_meta_for_catalog(
+                version,
+                Some(&capabilities),
+            )));
+        }
+        let listed = fetch_paginated_list(&mut *self.transport, "tools/list", "tools");
+        if let Some(version) = modern_version.as_deref() {
+            self.transport
+                .set_protocol_meta(Some(protocol_meta_for(version)));
+        }
+        match listed {
             Ok(listed) if listed.warning.is_none() => {
                 self.tool_cache_hint = listed.cache_hint;
                 self.tools = if self.modern_http {

--- a/src-tauri/src/router.rs
+++ b/src-tauri/src/router.rs
@@ -29,6 +29,27 @@ use crate::registry::ToolOverride;
 
 const TASK_HANDLE_PREFIX: &str = "toolport-task:v1:";
 const TASK_HANDLE_NONCE_LEN: usize = 24;
+const MCP_APPS_EXTENSION: &str = "io.modelcontextprotocol/ui";
+const MCP_APP_HTML_MIME: &str = "text/html;profile=mcp-app";
+
+fn supports_mcp_app_html(extensions: &serde_json::Map<String, Value>) -> bool {
+    extensions
+        .get(MCP_APPS_EXTENSION)
+        .and_then(|settings| settings.get("mimeTypes"))
+        .and_then(Value::as_array)
+        .is_some_and(|mime_types| mime_types.iter().any(|mime| mime == MCP_APP_HTML_MIME))
+}
+
+/// MCP Apps resources are primarily discovered through tool metadata and MAY be
+/// omitted from `resources/list`. Keep both the current nested field and the
+/// pre-GA flat spelling so a transparent gateway can still route the host's
+/// subsequent `resources/read` to the tool's owning server.
+fn mcp_app_resource_uri(tool: &Value) -> Option<&str> {
+    tool.pointer("/_meta/ui/resourceUri")
+        .or_else(|| tool.pointer("/_meta/ui~1resourceUri"))
+        .and_then(Value::as_str)
+        .filter(|uri| uri.starts_with("ui://"))
+}
 
 /// Seal the owner and native task id into one opaque, unguessable handle. The
 /// installation-local key survives restarts; authenticated encryption prevents
@@ -572,6 +593,7 @@ impl Router {
         resources: &[Value],
         resource_templates: &[Value],
         prompts: &[Value],
+        route_mcp_apps: bool,
     ) {
         // Allocate the exposed name regardless of policy so toggling one tool
         // never renames its siblings (their `_2` suffixes stay put), and in an
@@ -626,6 +648,26 @@ impl Router {
             self.tools.push(t);
             self.routes
                 .insert(exposed, (server_id.to_string(), orig.to_string()));
+
+            // UI-only resources are allowed to stay out of resources/list. The
+            // tool linkage is therefore an authoritative route hint, subject to
+            // the same first-writer collision rule as ordinary resources below.
+            if route_mcp_apps {
+                if let Some(uri) = mcp_app_resource_uri(tool) {
+                    match self.resource_routes.get(uri) {
+                        Some(owner) if owner != server_id => {
+                            eprintln!(
+                                "toolport: MCP App resource URI collision on '{uri}': keeping owner '{owner}', refusing claim from '{server_id}'"
+                            );
+                        }
+                        Some(_) => {}
+                        None => {
+                            self.resource_routes
+                                .insert(uri.to_string(), server_id.to_string());
+                        }
+                    }
+                }
+            }
         }
 
         // Resources: pass uris through unchanged and remember which server owns
@@ -641,7 +683,14 @@ impl Router {
                         );
                     }
                     Some(_) => {
-                        // Same server re-advertising the URI (rebuild); keep one entry.
+                        // The route may already have come from this server's MCP
+                        // App tool metadata. Keep the explicit resource visible in
+                        // resources/list, while still deduplicating repeated rows.
+                        if !self.resources.iter().any(|listed| {
+                            listed.get("uri").and_then(Value::as_str) == Some(uri)
+                        }) {
+                            self.resources.push(resource.clone());
+                        }
                     }
                     None => {
                         self.resources.push(resource.clone());
@@ -699,12 +748,14 @@ impl Router {
     /// non-reconnectable variant kept for tests and callers with no factory.
     pub fn add_with_reconnect(&mut self, server: DownstreamServer, reconnect: Option<Reconnect>) {
         let id = server.id.clone();
+        let route_mcp_apps = supports_mcp_app_html(server.extensions());
         self.index_server(
             &id,
             &server.tools,
             &server.resources,
             &server.resource_templates,
             &server.prompts,
+            route_mcp_apps,
         );
         let idx = self.servers.len();
         self.servers.push(Arc::new(ServerSlot {
@@ -856,6 +907,20 @@ impl Router {
             .into_iter()
             .filter_map(|(identifier, settings)| settings.map(|settings| (identifier, settings)))
             .collect()
+    }
+
+    /// One connected server's settings for an extension. Callers that depend on
+    /// a particular setting (rather than mere identifier presence) must inspect
+    /// this server-local value instead of the aggregate.
+    pub fn server_extension_settings(&self, server_id: &str, identifier: &str) -> Option<Value> {
+        let &index = self.by_id.get(server_id)?;
+        self.servers[index]
+            .inner
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .extensions()
+            .get(identifier)
+            .cloned()
     }
 
     /// Positive downstream TTLs schedule a refresh at their expiry. Zero/missing
@@ -1011,7 +1076,7 @@ impl Router {
         // `&mut self` re-index.
         let slots: Vec<Arc<ServerSlot>> = self.servers.clone();
         for slot in &slots {
-            let (tools, resources, resource_templates, prompts) = {
+            let (tools, resources, resource_templates, prompts, route_mcp_apps) = {
                 let s = slot
                     .inner
                     .lock()
@@ -1021,6 +1086,7 @@ impl Router {
                     s.resources.clone(),
                     s.resource_templates.clone(),
                     s.prompts.clone(),
+                    supports_mcp_app_html(s.extensions()),
                 )
             };
             self.index_server(
@@ -1029,6 +1095,7 @@ impl Router {
                 &resources,
                 &resource_templates,
                 &prompts,
+                route_mcp_apps,
             );
         }
     }
@@ -1785,6 +1852,105 @@ mod tests {
         .unwrap()
     }
 
+    struct AppTransport {
+        resource_uri: &'static str,
+        legacy_meta: bool,
+        protocol_meta: Option<Value>,
+    }
+
+    impl Transport for AppTransport {
+        fn request(&mut self, method: &str, params: Value) -> Result<Value, TransportError> {
+            match method {
+                "initialize" => Err(TransportError::Rpc(json!({
+                    "code": -32601,
+                    "message": "method not found"
+                }))),
+                "server/discover" => Ok(json!({
+                    "supportedVersions": [crate::downstream::MODERN_PROTOCOL_VERSION],
+                    "capabilities": {
+                        "resources": {},
+                        "extensions": {
+                            "io.modelcontextprotocol/ui": {
+                                "mimeTypes": ["text/html;profile=mcp-app"]
+                            }
+                        }
+                    }
+                })),
+                "tools/list" => {
+                    let ui_negotiated = self
+                        .protocol_meta
+                        .as_ref()
+                        .and_then(|meta| {
+                            meta.pointer("/io.modelcontextprotocol~1clientCapabilities/extensions/io.modelcontextprotocol~1ui/mimeTypes")
+                        })
+                        .and_then(Value::as_array)
+                        .is_some_and(|mime_types| {
+                            mime_types
+                                .iter()
+                                .any(|mime| mime == "text/html;profile=mcp-app")
+                        });
+                    if !ui_negotiated {
+                        return Ok(json!({ "tools": [] }));
+                    }
+                    let meta = if self.legacy_meta {
+                        json!({ "ui/resourceUri": self.resource_uri })
+                    } else {
+                        json!({ "ui": { "resourceUri": self.resource_uri } })
+                    };
+                    Ok(json!({
+                        "tools": [{
+                            "name": "dashboard",
+                            "inputSchema": { "type": "object" },
+                            "_meta": meta
+                        }]
+                    }))
+                }
+                "resources/list" => Ok(json!({ "resources": [] })),
+                "resources/templates/list" => Ok(json!({ "resourceTemplates": [] })),
+                "resources/read" => {
+                    assert_eq!(params["uri"], self.resource_uri);
+                    assert!(
+                        self.protocol_meta
+                            .as_ref()
+                            .and_then(|meta| meta.pointer(
+                                "/io.modelcontextprotocol~1clientCapabilities/extensions/io.modelcontextprotocol~1ui"
+                            ))
+                            .is_none(),
+                        "catalog-only Apps capability leaked into resources/read"
+                    );
+                    Ok(json!({
+                        "contents": [{
+                            "uri": self.resource_uri,
+                            "mimeType": "text/html;profile=mcp-app",
+                            "text": "<!doctype html><title>Toolport App</title>"
+                        }]
+                    }))
+                }
+                other => Err(TransportError::Fatal(format!("unexpected method {other}"))),
+            }
+        }
+
+        fn notify(&mut self, _method: &str, _params: Value) -> Result<(), TransportError> {
+            Ok(())
+        }
+
+        fn set_protocol_meta(&mut self, meta: Option<Value>) {
+            self.protocol_meta = meta;
+        }
+    }
+
+    fn app_server(id: &str, uri: &'static str, legacy_meta: bool) -> DownstreamServer {
+        DownstreamServer::connect(
+            id.to_string(),
+            Box::new(AppTransport {
+                resource_uri: uri,
+                legacy_meta,
+                protocol_meta: None,
+            }),
+        )
+        .unwrap()
+    }
+
     #[test]
     fn extension_aggregation_is_scoped_and_omits_conflicting_settings() {
         let mut router = Router::new();
@@ -1815,6 +1981,68 @@ mod tests {
         let alpha = router.aggregated_extensions(|server_id| server_id == "alpha");
         assert_eq!(alpha["com.example/mode"]["version"], 1);
         assert!(alpha.get("com.example/beta").is_none());
+    }
+
+    #[test]
+    fn mcp_app_tool_metadata_routes_unlisted_ui_resources() {
+        for (legacy_meta, uri) in [
+            (false, "ui://modern/dashboard"),
+            (true, "ui://legacy/dashboard"),
+        ] {
+            let mut router = Router::new();
+            router.add(app_server("apps", uri, legacy_meta));
+            router.refresh_tools();
+
+            assert_eq!(
+                router.aggregated_resources(),
+                Vec::<Value>::new(),
+                "the fixture intentionally omits its UI resource from resources/list"
+            );
+            assert_eq!(router.resource_server(uri), Some("apps"));
+            let result = router
+                .read_resource(uri)
+                .expect("UI resource routes through tool metadata");
+            assert_eq!(result["contents"][0]["uri"], uri);
+        }
+    }
+
+    #[test]
+    fn listed_mcp_app_resource_stays_visible_after_tool_route_hint() {
+        let uri = "ui://listed/dashboard";
+        let mut server = app_server("apps", uri, false);
+        server.resources.push(json!({
+            "uri": uri,
+            "name": "Dashboard",
+            "mimeType": "text/html;profile=mcp-app"
+        }));
+        let mut router = Router::new();
+        router.add(server);
+
+        assert_eq!(router.aggregated_resources().len(), 1);
+        assert_eq!(router.aggregated_resources()[0]["uri"], uri);
+        assert_eq!(router.resource_server(uri), Some("apps"));
+    }
+
+    #[test]
+    fn ui_route_hints_require_the_reserved_html_mime_capability() {
+        let uri = "ui://unsupported/dashboard";
+        let mut server = extension_server(
+            "unsupported",
+            json!({
+                "io.modelcontextprotocol/ui": {
+                    "mimeTypes": ["image/svg+xml"]
+                }
+            }),
+        );
+        server.tools.push(json!({
+            "name": "dashboard",
+            "inputSchema": { "type": "object" },
+            "_meta": { "ui": { "resourceUri": uri } }
+        }));
+        let mut router = Router::new();
+        router.add(server);
+
+        assert_eq!(router.resource_server(uri), None);
     }
 
     struct TaskTransport {


### PR DESCRIPTION
## Summary

- negotiate `io.modelcontextprotocol/ui` with modern downstream servers only for catalog fetches and only for the reserved MCP App HTML MIME type Toolport actually relays
- preserve UI-linked discovery in lazy/grouped mode and route `ui://` resources from current or deprecated tool metadata even when omitted from `resources/list`
- advertise only Toolport's supported App HTML MIME upstream and keep negotiated App HTML bytes intact for the host's sandbox/CSP enforcement
- keep app-only tools out of model-facing lists, search, nested calls, and code mode while allowing a directly negotiated Apps host to call them
- preserve server scoping, first-writer URI collision handling, ordinary content defense, and non-Apps request isolation

## Why

MCP Apps discovery is capability-aware: a server may reveal UI linkage only after the client declares compatible MIME support, and UI-only resources may be absent from `resources/list`. Toolport previously could miss or misroute those resources. The gateway also needs to honor Apps visibility so app-only tools never become model tools through Toolport's abstractions.

## Review fixes

- prevent the catalog-only Apps capability from leaking into subsequent downstream requests or calls
- require exact `text/html;profile=mcp-app` support instead of trusting extension identifier presence
- clamp Toolport's upstream declaration to the one MIME type it relays
- enforce app-only visibility across full discovery, search, nested calls, and code-mode execution

## Validation

- 665 library tests passed
- 219 gateway tests passed
- focused tests cover exact MIME negotiation, catalog capability reset, unlisted/listed routing, app-only visibility, direct Apps calls, and byte-faithful HTML
- `cargo check --manifest-path src-tauri/Cargo.toml --no-default-features --bin toolport-gateway`
- `npx prettier --check CHANGELOG.md`
- `git diff --check`

Tracks SOU-453.