### PR TITLE
fix(oauth): reject empty authorization codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,11 @@ Entries before the rename below shipped under the project's former name, Conduit
   and gives a challenge's requested scope priority without weakening discovery for
   older servers that do not return a challenge. (SOU-451)
 
+### Fixed
+
+- OAuth loopback callbacks now reject an empty authorization code instead of showing
+  a success page and sending an invalid token-exchange request.
+
 ## [1.11.0] - 2026-08-01
 
 Toolport's Streamable HTTP endpoint now speaks the modern MCP transport while

--- a/src-tauri/src/oauth.rs
+++ b/src-tauri/src/oauth.rs
@@ -1106,8 +1106,15 @@ fn wait_for_code(
                     return Err(format!("authorization server returned an error ({error}){desc}"));
                 }
 
+                let Some(code) = code.filter(|code| !code.trim().is_empty()) else {
+                    write_callback_page(&mut stream, "Authorization failed. You can close this window and return to Toolport.");
+                    return Err(
+                        "authorization server returned an empty authorization code".to_string(),
+                    );
+                };
+
                 write_callback_page(&mut stream, "Authorization complete. You can close this window and return to Toolport.");
-                return Ok(code.cloned().unwrap_or_default());
+                return Ok(code.clone());
             }
             Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
                 std::thread::sleep(Duration::from_millis(150));
@@ -1504,6 +1511,28 @@ mod tests {
                 "must compare the issuer exactly: {different}"
             );
         }
+    }
+
+    #[test]
+    fn callback_rejects_an_empty_authorization_code() {
+        use std::io::Write;
+
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        listener.set_nonblocking(true).unwrap();
+        let address = listener.local_addr().unwrap();
+        let client = std::thread::spawn(move || {
+            let mut stream = std::net::TcpStream::connect(address).unwrap();
+            stream
+                .write_all(
+                    b"GET /callback?code=&state=expected HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n",
+                )
+                .unwrap();
+        });
+
+        let error = wait_for_code(&listener, "expected", "https://auth.example.com", false)
+            .expect_err("an empty authorization code must not reach token exchange");
+        client.join().unwrap();
+        assert!(error.contains("empty authorization code"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- reject an empty OAuth loopback `code` before token exchange
- show the failure page instead of reporting authorization success
- cover the callback path with a loopback regression test

This addresses the valid Copilot finding that arrived after #596 had already merged.

## Verification

- `cargo test --manifest-path src-tauri/Cargo.toml callback_rejects_an_empty_authorization_code --lib` (1 passed)
- `cargo test --manifest-path src-tauri/Cargo.toml oauth::tests --lib` (40 passed)
- `git diff --check`