### PR TITLE
Add Parallel Search to the curated catalog

### DIFF
--- a/src-tauri/src/catalog.rs
+++ b/src-tauri/src/catalog.rs
@@ -61,8 +61,8 @@ fn category_for(name: &str) -> &'static str {
             "Code & infrastructure"
         }
         "Supabase" | "Neon" | "PostgreSQL" | "MongoDB" | "Elasticsearch" | "Qdrant" => "Databases",
-        "Context7" | "DeepWiki" | "Hugging Face" | "OpenRouter" | "Brave Search" | "Exa"
-        | "Tavily" | "Perplexity" | "DataForSEO" => "Search & knowledge",
+        "Context7" | "DeepWiki" | "Hugging Face" | "OpenRouter" | "Parallel Search"
+        | "Brave Search" | "Exa" | "Tavily" | "Perplexity" | "DataForSEO" => "Search & knowledge",
         "Firecrawl" | "Apify" | "Browserbase" => "Web & automation",
         "Stripe" | "Stripe (Full API)" | "Notion" | "Composio" | "Linear" | "Atlassian"
         | "Asana" | "Airtable" | "Todoist" | "Slack" | "Resend" | "Figma" | "Postiz"
@@ -267,6 +267,7 @@ pub fn curated() -> Vec<CatalogEntry> {
         http("DeepWiki", "Ask questions about any public GitHub repo. No auth.", "https://mcp.deepwiki.com/mcp", "https://deepwiki.com"),
         http("Hugging Face", "Models, datasets, and Spaces on Hugging Face.", "https://huggingface.co/mcp", "https://huggingface.co/settings/mcp"),
         http("OpenRouter", "Live model intelligence: list and compare models, prices, and your credits.", "https://mcp.openrouter.ai/mcp", "https://openrouter.ai/docs/mcp-server"),
+        http("Parallel Search", "Live web search and clean content from URLs. No account or API key required.", "https://search.parallel.ai/mcp", "https://docs.parallel.ai/search/mcp-server/quickstart"),
         cmd("Brave Search", "Web search via the Brave Search API.", "npx", &["-y", "@modelcontextprotocol/server-brave-search"], &["BRAVE_API_KEY"], "https://github.com/modelcontextprotocol/servers"),
         cmd("Exa", "AI-native web search built for agents.", "npx", &["-y", "exa-mcp-server"], &["EXA_API_KEY"], "https://github.com/exa-labs/exa-mcp-server"),
         cmd("Tavily", "Web search and content extraction built for LLMs.", "npx", &["-y", "tavily-mcp"], &["TAVILY_API_KEY"], "https://github.com/tavily-ai/tavily-mcp"),


### PR DESCRIPTION
## What and why

Toolport's curated catalog makes verified MCP servers available as one-click additions. This adds Parallel Search as a native remote HTTP entry and groups it under `Search & knowledge`, so users can add live web search and URL-content tools without creating an account or API key.

## Testing

Ran the focused catalog suite in a disposable Rust container with the checkout mounted read-only: 17 tests passed. I also completed a credential-free MCP initialize and tools-list exchange against the endpoint, which negotiated protocol `2025-06-18` and returned `web_search` and `web_fetch`. Static one-file and whitespace checks passed.

- [ ] `npm run build` passes
- [ ] `npm run test` passes
- [ ] `npm run audit:prod` passes
- [ ] `npm run test:rust` passes (`npm run test:rust:windows` on Windows if the debug gateway binary is locked)
- [ ] Ran the app (`npm run tauri dev`) and checked the change by hand

## Notes

The full app, frontend checks, production audit, full Rust suite, and manual app launch were not run for this catalog-only change. The diff contains no secrets, keys, or personal paths.

Disclosure: I work at Parallel.ai, which operates this MCP endpoint.