### PR TITLE
fix(app): name the apps still launching an obsolete gateway (SOU-435)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ Entries before the rename below shipped under the project's former name, Conduit
 
 ### Added
 
+- Toolport now names the apps that keep launching an obsolete gateway. Stopping a
+  stale gateway process is not always enough: an app caches its spawn command when
+  it starts, so one pinned to a path an upgrade never rewrites simply launches the
+  same old binary again, and only restarting that app picks up the current gateway.
+  Settings lists which apps are in that state, a launch notification names them, and
+  each entry clears itself once you restart that app. Settings also now reports
+  processes it found but could not stop, instead of reading as if nothing was
+  stale. (SOU-435)
 - Modern extension negotiation now passes opaque client extension settings to
   downstream servers and aggregates compatible downstream extension declarations
   in `server/discover`. Unknown `_meta` and result fields continue through unchanged;

--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -2791,12 +2791,125 @@ fn stop_spawned_gateways() -> u32 {
     crate::gateway_publish::stop_spawned_gateways()
 }
 
+/// Apps still launching an obsolete gateway, accumulated across reaper passes.
+///
+/// Held rather than recomputed on demand because the advice is only knowable from
+/// a pre-kill process table: once a pass has stopped the obsolete gateways, a fresh
+/// query reads a table with the evidence already removed.
+///
+/// The merge is a **union keyed by client pid**, never a replace. #542 shipped an
+/// unconditional write and the failure was immediate: the launch pass correctly
+/// recorded "restart Claude" and killed the process, the user opened Settings and
+/// clicked **Run** (the obvious next action), Claude had not made a tool call yet so
+/// the new snapshot was empty, and the empty snapshot overwrote the good advice. The
+/// panel vanished and the UI claimed "No old gateway processes found" while Claude
+/// was still pinned to an obsolete binary, for the rest of the session.
+///
+/// Entries expire on their own terms: a pid that is no longer running means the user
+/// restarted that app, which is the only evidence of compliance that actually exists.
+/// Absence of a respawned gateway is not evidence, because a client that simply has
+/// not made a tool call yet looks identical.
+#[derive(Default)]
+struct RestartAdvice(Mutex<Vec<crate::gateway_publish::ClientNeedingRestart>>);
+
+impl RestartAdvice {
+    /// Fold one pass's pre-kill findings into the stored set and return the result.
+    fn merge(
+        &self,
+        fresh: Vec<crate::gateway_publish::ClientNeedingRestart>,
+    ) -> Vec<crate::gateway_publish::ClientNeedingRestart> {
+        let mut stored = self.0.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+        for entry in fresh {
+            // One row per app to act on. A client that respawned two different
+            // obsolete gateways is still one restart.
+            if !stored.iter().any(|e| e.client_pid == entry.client_pid) {
+                stored.push(entry);
+            }
+        }
+        stored.retain(|e| crate::gateway_publish::pid_is_running(e.client_pid));
+        stored.clone()
+    }
+
+    fn current(&self) -> Vec<crate::gateway_publish::ClientNeedingRestart> {
+        let mut stored = self.0.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+        stored.retain(|e| crate::gateway_publish::pid_is_running(e.client_pid));
+        stored.clone()
+    }
+}
+
+/// What a reaper run did and what the user still has to do about it.
+///
+/// One payload rather than a killed-list plus a separate advice query, so the two
+/// cannot describe different moments: any second call necessarily observes a table
+/// the first one already changed.
+#[derive(Debug, Clone, Default, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ReapOutcome {
+    killed: Vec<String>,
+    /// Processes that matched but could not be stopped. Previously dropped, which
+    /// made "found nothing stale" and "found something and failed to kill it"
+    /// indistinguishable in the UI (#542 review).
+    failed: Vec<String>,
+    needs_restart: Vec<crate::gateway_publish::ClientNeedingRestart>,
+}
+
 /// Stop obsolete gateway processes (older versions / stale paths), keeping the
 /// current resolved binary. Safe to run any time; used from Settings and launch.
-/// Returns labels of processes that were stopped.
 #[tauri::command]
-fn stop_stale_gateways(bridge: State<HttpBridgeState>) -> Vec<String> {
-    reap_stale_and_restore_bridge(bridge.inner())
+fn stop_stale_gateways(bridge: State<HttpBridgeState>, advice: State<RestartAdvice>) -> ReapOutcome {
+    reap_stale_and_restore_bridge(bridge.inner(), advice.inner())
+}
+
+/// Apps that need restarting, without running a reaper pass.
+#[tauri::command]
+fn clients_needing_restart(
+    advice: State<RestartAdvice>,
+) -> Vec<crate::gateway_publish::ClientNeedingRestart> {
+    advice.current()
+}
+
+/// Log a reaper pass. `failed` is logged separately from `killed` so "found nothing"
+/// and "found something and could not stop it" are distinguishable in a support log.
+fn log_reap_outcome(kind: &str, outcome: &ReapOutcome) {
+    if !outcome.killed.is_empty() {
+        eprintln!(
+            "toolport: {kind} stopped {} stale gateway process(es): {}",
+            outcome.killed.len(),
+            outcome.killed.join("; ")
+        );
+    }
+    if !outcome.failed.is_empty() {
+        eprintln!(
+            "toolport: {kind} could not stop {} gateway process(es): {}",
+            outcome.failed.len(),
+            outcome.failed.join("; ")
+        );
+    }
+    if !outcome.needs_restart.is_empty() {
+        eprintln!(
+            "toolport: {} app(s) are still launching an obsolete gateway and need restarting: {}",
+            outcome.needs_restart.len(),
+            outcome
+                .needs_restart
+                .iter()
+                .map(|c| format!("{} (pid {}) -> {}", c.client, c.client_pid, c.gateway))
+                .collect::<Vec<_>>()
+                .join("; ")
+        );
+    }
+}
+
+/// Tell the frontend which apps need restarting, if any.
+fn announce_restart_needed(
+    handle: &tauri::AppHandle,
+    needs_restart: &[crate::gateway_publish::ClientNeedingRestart],
+) {
+    if needs_restart.is_empty() {
+        return;
+    }
+    if let Err(e) = handle.emit("gateway-restart-needed", needs_restart) {
+        eprintln!("toolport: could not emit gateway-restart-needed: {e}");
+    }
 }
 
 /// Run the stale reaper, then bring the supervised HTTP bridge back if the reaper
@@ -2811,7 +2924,10 @@ fn stop_stale_gateways(bridge: State<HttpBridgeState>) -> Vec<String> {
 ///
 /// Connected clients are unaffected by the new process: they authenticate with the
 /// per-client bearers in `http_clients`, not the bridge's own env token.
-fn reap_stale_and_restore_bridge(bridge: &HttpBridgeState) -> Vec<String> {
+fn reap_stale_and_restore_bridge(
+    bridge: &HttpBridgeState,
+    advice: &RestartAdvice,
+) -> ReapOutcome {
     let mut extra_keep = Vec::new();
     if let Some(p) = clients::resolve_gateway_path() {
         extra_keep.push(p);
@@ -2822,7 +2938,14 @@ fn reap_stale_and_restore_bridge(bridge: &HttpBridgeState) -> Vec<String> {
         let mut b = bridge.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
         http_bridge_alive(&mut b).then(|| b.port).flatten()
     };
-    let killed = crate::gateway_publish::stop_stale_gateways_with_keep(&extra_keep);
+    let report = crate::gateway_publish::reap_stale(&extra_keep);
+    // Merged from this pass's pre-kill snapshot, which is the only moment it can be
+    // known. Union, not replace: see `RestartAdvice`.
+    let outcome = ReapOutcome {
+        killed: report.killed.clone(),
+        failed: report.failed.clone(),
+        needs_restart: advice.merge(report.needs_restart),
+    };
     if let Some(port) = was_serving {
         let still_serving = {
             let mut b = bridge.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
@@ -2842,7 +2965,7 @@ fn reap_stale_and_restore_bridge(bridge: &HttpBridgeState) -> Vec<String> {
                             "toolport: restarted the HTTP endpoint on port {port} after the stale \
                              reaper stopped its previous (replaced) binary"
                         );
-                        return killed;
+                        return outcome;
                     }
                     Err(e) => last = e,
                 }
@@ -2856,7 +2979,7 @@ fn reap_stale_and_restore_bridge(bridge: &HttpBridgeState) -> Vec<String> {
             );
         }
     }
-    killed
+    outcome
 }
 
 /// Start `toolport-gateway --http <port>` as a supervised child so HTTP/OpenAPI
@@ -3182,6 +3305,7 @@ pub fn run() {
         .manage(Mutex::new(registry))
         .manage(Mutex::new(HttpBridge::default()))
         .manage(PendingShare::default())
+        .manage(RestartAdvice::default())
         .invoke_handler(tauri::generate_handler![
             detect_clients,
             get_registry,
@@ -3279,6 +3403,7 @@ pub fn run() {
             http_bridge_status,
             stop_spawned_gateways,
             stop_stale_gateways,
+            clients_needing_restart,
         ])
         // Close-to-tray: the window's X hides it instead of quitting, so the gateway and
         // approval broker keep running (HITL only works while the app is alive). Quit is
@@ -3407,26 +3532,27 @@ pub fn run() {
                 // Both passes go through `reap_stale_and_restore_bridge` so a supervised
                 // HTTP bridge the reaper stops (correctly, when its binary was replaced)
                 // comes back instead of leaving HTTP/OpenAPI clients dark (SOU-418).
-                let stale = reap_stale_and_restore_bridge(migrate_handle.state::<HttpBridgeState>().inner());
-                if !stale.is_empty() {
-                    eprintln!(
-                        "toolport: stopped {} stale gateway process(es): {}",
-                        stale.len(),
-                        stale.join("; ")
-                    );
-                }
+                //
+                // The FIRST pass is the one that can see the restart advice: it runs
+                // before anything has been killed, so its snapshot still holds the
+                // obsolete gateways their clients spawned. The delayed pass contributes
+                // whatever raced in after it, which the union in `RestartAdvice`
+                // folds together rather than overwriting.
+                let advice_state = migrate_handle.state::<RestartAdvice>();
+                let stale = reap_stale_and_restore_bridge(
+                    migrate_handle.state::<HttpBridgeState>().inner(),
+                    advice_state.inner(),
+                );
+                log_reap_outcome("stale reaper", &stale);
+                announce_restart_needed(&migrate_handle, &stale.needs_restart);
                 std::thread::spawn(move || {
                     std::thread::sleep(std::time::Duration::from_secs(3));
                     let again = reap_stale_and_restore_bridge(
                         migrate_handle.state::<HttpBridgeState>().inner(),
+                        migrate_handle.state::<RestartAdvice>().inner(),
                     );
-                    if !again.is_empty() {
-                        eprintln!(
-                            "toolport: delayed reaper stopped {} more stale gateway process(es): {}",
-                            again.len(),
-                            again.join("; ")
-                        );
-                    }
+                    log_reap_outcome("delayed reaper", &again);
+                    announce_restart_needed(&migrate_handle, &again.needs_restart);
                 });
             });
 
@@ -4236,5 +4362,105 @@ mod tests {
         assert!(!s.contains("sk-live-xyz"), "secret token leaked: {s}");
         assert!(s.contains("<redacted>"), "missing redaction marker: {s}");
         assert!(s.contains("https://api.example.com/path"), "safe URL was over-redacted: {s}");
+    }
+
+    // ----- SOU-435: restart advice survives later passes ----------------------
+
+    fn advice_entry(pid: u32, client: &str) -> crate::gateway_publish::ClientNeedingRestart {
+        crate::gateway_publish::ClientNeedingRestart {
+            client: client.into(),
+            client_pid: pid,
+            gateway: "toolport-gateway-1.9.4.exe".into(),
+        }
+    }
+
+    /// A pid guaranteed to be running for the length of the test.
+    fn live_pid() -> u32 {
+        std::process::id()
+    }
+
+    /// A pid guaranteed not to be running. Near the top of the numeric range, so it
+    /// is not a pid any real process on the machine would have been assigned.
+    fn dead_pid() -> u32 {
+        u32::MAX - 1
+    }
+
+    /// The exact #542 failure, as a test.
+    ///
+    /// Launch pass finds "restart Claude" and kills the process. The user opens
+    /// Settings and clicks Run. Claude has not made a tool call yet, so that pass
+    /// finds nothing. The old code wrote unconditionally, so the empty result erased
+    /// the advice and the UI then claimed nothing was stale while Claude was still
+    /// pinned to an obsolete binary.
+    #[test]
+    fn an_empty_later_pass_does_not_erase_earlier_advice() {
+        let advice = RestartAdvice::default();
+        let pid = live_pid();
+
+        let after_launch = advice.merge(vec![advice_entry(pid, "claude.exe")]);
+        assert_eq!(after_launch.len(), 1, "launch pass records the advice");
+
+        // The Settings button: a second pass whose snapshot is empty.
+        let after_button = advice.merge(Vec::new());
+        assert_eq!(
+            after_button,
+            after_launch,
+            "an empty pass must not erase advice the user has not acted on yet"
+        );
+        assert_eq!(
+            advice.current().len(),
+            1,
+            "and the panel must still have something to show"
+        );
+    }
+
+    #[test]
+    fn merge_unions_new_apps_and_keeps_one_row_per_app() {
+        let advice = RestartAdvice::default();
+        let pid = live_pid();
+
+        advice.merge(vec![advice_entry(pid, "claude.exe")]);
+        // A later pass sees a different app; both must be present.
+        let merged = advice.merge(vec![advice_entry(pid, "claude.exe")]);
+        assert_eq!(
+            merged.len(),
+            1,
+            "the same app seen twice is still one restart to perform"
+        );
+
+        // Same app, second obsolete gateway: still one thing for the user to do.
+        let mut second_gateway = advice_entry(pid, "claude.exe");
+        second_gateway.gateway = "toolport-gateway-1.9.5.exe".into();
+        let merged = advice.merge(vec![second_gateway]);
+        assert_eq!(
+            merged.len(),
+            1,
+            "advice is keyed by client pid, so one row per app regardless of gateway count"
+        );
+    }
+
+    /// Compliance is only observable through the pid disappearing. Absence of a
+    /// respawned gateway is not evidence: a client that has not made a tool call yet
+    /// looks exactly the same.
+    #[test]
+    fn advice_expires_once_the_user_restarts_the_app() {
+        let advice = RestartAdvice::default();
+        let stored = advice.merge(vec![advice_entry(dead_pid(), "claude.exe")]);
+        assert!(
+            stored.is_empty(),
+            "a client pid that is no longer running means the app was restarted"
+        );
+        assert!(advice.current().is_empty());
+    }
+
+    #[test]
+    fn expiry_is_per_entry_not_all_or_nothing() {
+        let advice = RestartAdvice::default();
+        let merged = advice.merge(vec![
+            advice_entry(live_pid(), "claude.exe"),
+            advice_entry(dead_pid(), "grok.exe"),
+        ]);
+        assert_eq!(merged.len(), 1, "only the restarted app drops out");
+        assert_eq!(merged[0].client, "claude.exe");
     }
 }

--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -2899,6 +2899,22 @@ fn log_reap_outcome(kind: &str, outcome: &ReapOutcome) {
     }
 }
 
+/// Entries whose client has not already been announced.
+///
+/// A later pass reads the merged advice, which by design still holds everything an
+/// earlier pass found, so it must be filtered before it becomes a second toast for
+/// the same app. Pure so the "only new clients interrupt the user" rule is pinned by
+/// a test rather than by the shape of a closure.
+fn unannounced(
+    already: &[u32],
+    current: Vec<crate::gateway_publish::ClientNeedingRestart>,
+) -> Vec<crate::gateway_publish::ClientNeedingRestart> {
+    current
+        .into_iter()
+        .filter(|c| !already.contains(&c.client_pid))
+        .collect()
+}
+
 /// Tell the frontend which apps need restarting, if any.
 fn announce_restart_needed(
     handle: &tauri::AppHandle,
@@ -3545,6 +3561,13 @@ pub fn run() {
                 );
                 log_reap_outcome("stale reaper", &stale);
                 announce_restart_needed(&migrate_handle, &stale.needs_restart);
+                // What the user has already been told about. The delayed pass reads
+                // the MERGED list, which by design still contains everything the
+                // first pass found, so announcing it wholesale would toast the same
+                // apps twice three seconds apart. Only genuinely new clients are
+                // worth interrupting for; the Settings panel is the durable view.
+                let already_announced: Vec<u32> =
+                    stale.needs_restart.iter().map(|c| c.client_pid).collect();
                 std::thread::spawn(move || {
                     std::thread::sleep(std::time::Duration::from_secs(3));
                     let again = reap_stale_and_restore_bridge(
@@ -3552,7 +3575,8 @@ pub fn run() {
                         migrate_handle.state::<RestartAdvice>().inner(),
                     );
                     log_reap_outcome("delayed reaper", &again);
-                    announce_restart_needed(&migrate_handle, &again.needs_restart);
+                    let newly_found = unannounced(&already_announced, again.needs_restart);
+                    announce_restart_needed(&migrate_handle, &newly_found);
                 });
             });
 
@@ -4462,5 +4486,31 @@ mod tests {
         ]);
         assert_eq!(merged.len(), 1, "only the restarted app drops out");
         assert_eq!(merged[0].client, "claude.exe");
+    }
+
+    /// The delayed launch pass reads the merged advice, so without this filter the
+    /// same app would toast twice three seconds apart (Copilot review, PR #622).
+    #[test]
+    fn only_newly_seen_clients_are_announced_again() {
+        let first = advice_entry(101, "claude.exe");
+        let second = advice_entry(202, "grok.exe");
+        let already = vec![first.client_pid];
+
+        // The delayed pass sees the merged list: the first app plus a new one.
+        let merged = vec![first.clone(), second.clone()];
+        assert_eq!(
+            unannounced(&already, merged),
+            vec![second],
+            "only the app the user has not been told about interrupts them again"
+        );
+
+        // Nothing new raced in: the merged list is entirely old news.
+        assert!(
+            unannounced(&already, vec![first]).is_empty(),
+            "re-announcing stored advice would double-toast the same app"
+        );
+
+        // Nothing announced yet (an empty first pass): everything is new.
+        assert_eq!(unannounced(&[], vec![advice_entry(303, "cursor.exe")]).len(), 1);
     }
 }

--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -4438,19 +4438,59 @@ mod tests {
         );
     }
 
+    /// A second live pid, for union cases that need two distinct surviving entries.
+    /// Killed by the caller; the merge only ever asks whether the pid is running.
+    fn spawn_live_child() -> std::process::Child {
+        let mut cmd = if cfg!(windows) {
+            let mut c = std::process::Command::new("cmd");
+            c.args(["/c", "ping", "-n", "30", "127.0.0.1"]);
+            c
+        } else {
+            let mut c = std::process::Command::new("sleep");
+            c.arg("30");
+            c
+        };
+        cmd.stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+            .expect("spawn a short-lived helper process")
+    }
+
+    /// Union across SEPARATE passes is the behaviour `RestartAdvice` exists for:
+    /// the delayed launch pass must add what it finds without discarding what the
+    /// first pass already recorded.
     #[test]
-    fn merge_unions_new_apps_and_keeps_one_row_per_app() {
+    fn merge_unions_apps_found_by_different_passes() {
+        let advice = RestartAdvice::default();
+        let mut child = spawn_live_child();
+        let other_pid = child.id();
+
+        let first = advice.merge(vec![advice_entry(live_pid(), "claude.exe")]);
+        assert_eq!(first.len(), 1);
+
+        // A later pass finds a genuinely different app. Both must survive.
+        let merged = advice.merge(vec![advice_entry(other_pid, "grok.exe")]);
+        let mut names: Vec<&str> = merged.iter().map(|c| c.client.as_str()).collect();
+        names.sort_unstable();
+        assert_eq!(
+            names,
+            vec!["claude.exe", "grok.exe"],
+            "a later pass adds to the advice instead of replacing it"
+        );
+
+        child.kill().ok();
+        child.wait().ok();
+    }
+
+    #[test]
+    fn merge_keeps_one_row_per_app() {
         let advice = RestartAdvice::default();
         let pid = live_pid();
 
         advice.merge(vec![advice_entry(pid, "claude.exe")]);
-        // A later pass sees a different app; both must be present.
+        // The same app seen by a later pass is still one restart to perform.
         let merged = advice.merge(vec![advice_entry(pid, "claude.exe")]);
-        assert_eq!(
-            merged.len(),
-            1,
-            "the same app seen twice is still one restart to perform"
-        );
+        assert_eq!(merged.len(), 1);
 
         // Same app, second obsolete gateway: still one thing for the user to do.
         let mut second_gateway = advice_entry(pid, "claude.exe");

--- a/src-tauri/src/gateway_publish.rs
+++ b/src-tauri/src/gateway_publish.rs
@@ -176,6 +176,18 @@ pub struct GatewayProcess {
     pub path: Option<PathBuf>,
     /// Process image basename, e.g. `toolport-gateway-1.9.4.exe` or `toolport-gateway`.
     pub basename: String,
+    /// The application that spawned this gateway, when it can be attributed.
+    /// `None` when the parent is gone, unreadable, or cannot be trusted (see
+    /// `windows_parent_predates_child`). Only used to name apps needing a restart;
+    /// the keep/kill decision never reads it.
+    pub parent: Option<ParentProcess>,
+}
+
+/// The application that spawned a gateway, e.g. `claude.exe`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParentProcess {
+    pub pid: u32,
+    pub basename: String,
 }
 
 /// Inputs for the pure keep/kill decision. Built at the call site so tests do not
@@ -207,17 +219,43 @@ pub enum ReapDecision {
 }
 
 /// Result of a reaper pass, for logging and the Tauri command surface.
+///
+/// `needs_restart` is carried here rather than queried separately because it is
+/// only knowable from the pre-kill process table: once a pass has killed the
+/// obsolete gateways, the evidence for which app spawned them is gone. Any
+/// caller that asks afterwards necessarily reads an emptier table than the one
+/// that produced the advice, which is how #542 shipped a panel that erased
+/// itself (see [`RestartAdvice`](../desktop/struct.RestartAdvice.html) for the
+/// merge that keeps it).
 #[derive(Debug, Clone, Default)]
 pub struct ReapReport {
     pub killed: Vec<String>,
     pub kept: Vec<String>,
     pub failed: Vec<String>,
+    /// Apps still launching an obsolete gateway, from this pass's pre-kill snapshot.
+    pub needs_restart: Vec<ClientNeedingRestart>,
 }
 
 impl ReapReport {
     pub fn killed_labels(&self) -> Vec<String> {
         self.killed.clone()
     }
+}
+
+/// An application that keeps relaunching an obsolete gateway and therefore has to
+/// be restarted by hand.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ClientNeedingRestart {
+    /// Basename of the client application, e.g. `claude.exe`.
+    pub client: String,
+    /// Pid of that application. Carried so stored advice can be revalidated and
+    /// expired: without it the advice can never be cleared once the user complies,
+    /// because absence of a respawned gateway is indistinguishable from a client
+    /// that simply has not made a tool call yet (#542 review).
+    pub client_pid: u32,
+    /// The obsolete gateway image it relaunched, e.g. `toolport-gateway-1.9.4.exe`.
+    pub gateway: String,
 }
 
 /// Build keep-paths known to this crate without calling into `clients` (avoids a
@@ -441,6 +479,156 @@ pub fn decide_reap(proc: &GatewayProcess, ctx: &ReapContext) -> ReapDecision {
     ReapDecision::Keep
 }
 
+/// Is `basename` one of our own processes rather than a third-party MCP client?
+///
+/// The supervised HTTP bridge is spawned by the Toolport app itself, so it would
+/// otherwise be reported as a client the user must restart.
+fn is_our_own_process(basename: &str) -> bool {
+    let lower = basename.to_ascii_lowercase();
+    lower.starts_with("toolport") || lower.starts_with("conduit")
+}
+
+/// Is this "parent" the init system or the kernel rather than an application?
+///
+/// An orphaned gateway is reparented to pid 1 on Unix, and Windows reports pid 0 /
+/// pid 4 for its kernel processes. None of them is something a user can restart,
+/// and each platform previously guarded a different subset of these, so the same
+/// orphan produced "restart systemd" on Linux and nothing on macOS. Name-matched
+/// as well as pid-matched because a systemd *user* session is a child subreaper
+/// with a pid of its own (#542 review).
+fn is_init_like(parent: &ParentProcess) -> bool {
+    if parent.pid <= 1 || parent.pid == 4 {
+        return true;
+    }
+    let lower = parent.basename.to_ascii_lowercase();
+    matches!(
+        lower.as_str(),
+        "systemd" | "init" | "launchd" | "system" | "[system process]"
+    )
+}
+
+/// Will the path this client cached start yielding new code by itself?
+///
+/// Only one case self-heals, and the ` (deleted)` marker alone does not identify
+/// it. On Linux `/proc/<pid>/exe` gains that marker whenever the file was
+/// *unlinked*, which covers two opposite outcomes:
+///
+/// * **Replaced in place** (a package upgrade wrote a new file at the same path):
+///   the cached path now resolves to the new binary, so the next spawn picks it up
+///   and there is nothing to advise.
+/// * **Moved or removed** (a stale install location that an upgrade abandoned):
+///   the cached path resolves to nothing, so the client cannot spawn a gateway at
+///   all. That is worse, not better, and the user still has to restart the app.
+///
+/// Treating the marker itself as "self-heals" silently dropped the second case.
+/// The test that was supposed to cover it passed only because it ran on macOS,
+/// where no marker appears and the entry survives for unrelated reasons; on Linux,
+/// the platform where the marker is real, it was silent (#542 review). Probing the
+/// stripped path tells the two apart. A path with no marker is unchanged on disk
+/// and never self-heals, which is why non-Linux platforms fall through to `false`.
+fn cached_path_self_heals(proc: &GatewayProcess) -> bool {
+    let Some(path) = proc.path.as_ref().and_then(|p| p.to_str()) else {
+        return false;
+    };
+    match path.strip_suffix(" (deleted)") {
+        Some(stripped) => Path::new(stripped).exists(),
+        None => false,
+    }
+}
+
+/// Applications running an obsolete gateway they will relaunch from a cached path.
+///
+/// An MCP client reads its config once at its own startup and caches the spawn
+/// command; see [`cached_path_self_heals`] for when that traps it on old code.
+///
+/// Deduplicated per (client pid, gateway) so one entry per app the user has to act
+/// on, not one per respawn. Pure so the grouping is testable without a process table.
+fn clients_needing_restart(
+    procs: &[GatewayProcess],
+    ctx: &ReapContext,
+) -> Vec<ClientNeedingRestart> {
+    // The updater kills every gateway including the current one, so every process
+    // reaches a Kill verdict and "obsolete" stops meaning anything. Computing advice
+    // there yields a list of apps to restart because they are running the CURRENT
+    // gateway, which is nonsense the user would act on (#542 review).
+    if ctx.kill_all {
+        return Vec::new();
+    }
+    let mut out: Vec<ClientNeedingRestart> = Vec::new();
+    for proc in procs {
+        if decide_reap(proc, ctx) != ReapDecision::Kill {
+            continue;
+        }
+        // A path we could not read means a process we could not inspect - a
+        // foreign user's session, or one whose ACL denied us. `decide_reap` still
+        // reaches Kill there via the basename-only fallback, but that path skips
+        // the `path_looks_like_our_install` guard, and we cannot stop the process
+        // either. Advising a restart for someone else's app is worse than silence.
+        if proc.path.is_none() {
+            // Logged rather than dropped silently: this is the one branch that
+            // withholds advice for a reason the user cannot see, so a support case
+            // ("why does it keep coming back and say nothing?") is otherwise
+            // untraceable (#542 review).
+            eprintln!(
+                "toolport: {} (pid {}) looks obsolete but its path could not be read, \
+                 so it is not attributed to an app",
+                proc.basename, proc.pid
+            );
+            continue;
+        }
+        if cached_path_self_heals(proc) {
+            continue;
+        }
+        // No parent means no name to show. Staying silent beats telling someone to
+        // restart "something".
+        let Some(parent) = proc.parent.as_ref() else {
+            continue;
+        };
+        if is_our_own_process(&parent.basename) || is_init_like(parent) {
+            continue;
+        }
+        let advice = ClientNeedingRestart {
+            client: parent.basename.clone(),
+            client_pid: parent.pid,
+            gateway: proc.basename.clone(),
+        };
+        if !out.contains(&advice) {
+            out.push(advice);
+        }
+    }
+    out
+}
+
+/// What a reaper pass will do, decided before it does any of it.
+#[derive(Debug, Clone, Default)]
+pub struct ReapPlan {
+    pub to_kill: Vec<GatewayProcess>,
+    pub kept: Vec<String>,
+    pub needs_restart: Vec<ClientNeedingRestart>,
+}
+
+/// Pure planner: classify a process table, and derive restart advice from that same
+/// pre-kill snapshot.
+///
+/// Exists so the "advice must be computed before anything is killed" requirement
+/// holds *by construction* rather than by where a line sits in the reaping loop.
+/// Three review rounds of #542 each moved that requirement somewhere new instead of
+/// removing it, and each move looked correct in isolation. Here the snapshot is an
+/// argument, so there is no later table to accidentally read.
+pub fn plan_reap(procs: &[GatewayProcess], ctx: &ReapContext) -> ReapPlan {
+    let mut plan = ReapPlan {
+        needs_restart: clients_needing_restart(procs, ctx),
+        ..Default::default()
+    };
+    for proc in procs {
+        match decide_reap(proc, ctx) {
+            ReapDecision::Keep => plan.kept.push(label_process(proc)),
+            ReapDecision::Kill => plan.to_kill.push(proc.clone()),
+        }
+    }
+    plan
+}
+
 fn label_process(proc: &GatewayProcess) -> String {
     match &proc.path {
         Some(p) => format!("{} (pid {} @ {})", proc.basename, proc.pid, p.display()),
@@ -450,15 +638,10 @@ fn label_process(proc: &GatewayProcess) -> String {
 
 fn reap_with_context(ctx: &ReapContext) -> ReapReport {
     let mut report = ReapReport::default();
-    let procs = list_gateway_processes();
-    let mut to_kill: Vec<GatewayProcess> = Vec::new();
-    for proc in procs {
-        match decide_reap(&proc, ctx) {
-            ReapDecision::Keep => report.kept.push(label_process(&proc)),
-            ReapDecision::Kill => to_kill.push(proc),
-        }
-    }
-    for proc in to_kill {
+    let plan = plan_reap(&list_gateway_processes(), ctx);
+    report.kept = plan.kept;
+    report.needs_restart = plan.needs_restart;
+    for proc in plan.to_kill {
         let label = label_process(&proc);
         if kill_gateway_process(&proc) {
             report.killed.push(label);
@@ -529,6 +712,15 @@ pub fn stop_stale_gateways() -> Vec<String> {
 /// Like [`stop_stale_gateways`], with extra keep-paths (e.g. nested macOS helper
 /// from `clients::resolve_gateway_path`).
 pub fn stop_stale_gateways_with_keep(extra_keep: &[PathBuf]) -> Vec<String> {
+    reap_stale(extra_keep).killed_labels()
+}
+
+/// Full-report variant of [`stop_stale_gateways_with_keep`].
+///
+/// Callers that surface anything beyond the killed list want this: the restart
+/// advice cannot be recovered after the fact, and `failed` is the difference
+/// between "nothing was stale" and "something is stale and we could not stop it".
+pub fn reap_stale(extra_keep: &[PathBuf]) -> ReapReport {
     let mut keep = default_keep_paths();
     for p in extra_keep {
         if !keep.iter().any(|e| paths_equal(e, p)) {
@@ -543,7 +735,68 @@ pub fn stop_stale_gateways_with_keep(extra_keep: &[PathBuf]) -> Vec<String> {
     };
     let report = reap_with_context(&ctx);
     log_reap_report("stale reaper", &report);
-    report.killed_labels()
+    report
+}
+
+/// Is this pid still running?
+///
+/// Used to expire stored restart advice once the user actually restarts the app.
+/// Fails *safe* by returning true on an inconclusive answer: keeping stale advice
+/// visible one pass longer is recoverable, dropping live advice is the failure that
+/// leaves a user pinned to an obsolete gateway with the UI saying nothing.
+pub fn pid_is_running(pid: u32) -> bool {
+    #[cfg(windows)]
+    {
+        use windows_sys::Win32::Foundation::{CloseHandle, ERROR_INVALID_PARAMETER};
+        use windows_sys::Win32::System::Threading::{
+            OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION,
+        };
+        unsafe {
+            let handle = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, pid);
+            if !handle.is_null() {
+                CloseHandle(handle);
+                return true;
+            }
+            // Only ERROR_INVALID_PARAMETER positively means "no such pid". Access
+            // denied means it exists and we cannot see it.
+            windows_sys::Win32::Foundation::GetLastError() != ERROR_INVALID_PARAMETER
+        }
+    }
+    #[cfg(unix)]
+    {
+        // Linux exposes a definitive answer without spawning anything.
+        #[cfg(not(target_os = "macos"))]
+        {
+            return Path::new(&format!("/proc/{pid}")).exists();
+        }
+        // macOS has no /proc, so `kill -0` it is: the existence/permission check
+        // without delivering a signal. Shelled out rather than via libc to match
+        // `unix_kill_pid`, which does the same deliberately so this module needs no
+        // libc dependency.
+        //
+        // A non-zero exit means either "no such process" or "not permitted", and
+        // only the first means gone. They are told apart by stderr because the exit
+        // code alone cannot: treating EPERM as gone would expire advice for a live
+        // app, the exact direction this function must not fail in.
+        #[cfg(target_os = "macos")]
+        {
+            match std::process::Command::new("kill")
+                .args(["-0", &pid.to_string()])
+                .output()
+            {
+                Ok(out) if out.status.success() => true,
+                Ok(out) => String::from_utf8_lossy(&out.stderr)
+                    .to_ascii_lowercase()
+                    .contains("permitted"),
+                Err(_) => true,
+            }
+        }
+    }
+    #[cfg(not(any(windows, unix)))]
+    {
+        let _ = pid;
+        true
+    }
 }
 
 // ----- OS process list / kill ------------------------------------------------
@@ -588,18 +841,26 @@ fn windows_list_gateway_processes() -> Vec<GatewayProcess> {
         }
         let mut entry: PROCESSENTRY32W = zeroed();
         entry.dwSize = size_of::<PROCESSENTRY32W>() as u32;
-        let mut out = Vec::new();
+        let mut out: Vec<(GatewayProcess, u32)> = Vec::new();
+        // Every pid in the snapshot, so a gateway's parent can be named even though
+        // the walk may reach the parent after the child.
+        let mut names: std::collections::HashMap<u32, String> = std::collections::HashMap::new();
         if Process32FirstW(snap, &mut entry) != 0 {
             loop {
                 let basename = widestr_to_string(&entry.szExeFile);
+                names.insert(entry.th32ProcessID, basename.clone());
                 if is_gateway_basename(&basename) {
                     let pid = entry.th32ProcessID;
                     let path = windows_process_path(pid);
-                    out.push(GatewayProcess {
-                        pid,
-                        path,
-                        basename,
-                    });
+                    out.push((
+                        GatewayProcess {
+                            pid,
+                            path,
+                            basename,
+                            parent: None,
+                        },
+                        entry.th32ParentProcessID,
+                    ));
                 }
                 if Process32NextW(snap, &mut entry) == 0 {
                     break;
@@ -607,7 +868,68 @@ fn windows_list_gateway_processes() -> Vec<GatewayProcess> {
             }
         }
         CloseHandle(snap);
-        out
+        // Resolve after the walk: a parent can appear later in the snapshot than
+        // its child, so this cannot be done inline.
+        out.into_iter()
+            .map(|(mut proc, ppid)| {
+                proc.parent = names
+                    .get(&ppid)
+                    .filter(|_| windows_parent_predates_child(ppid, proc.pid))
+                    .map(|basename| ParentProcess {
+                        pid: ppid,
+                        basename: basename.clone(),
+                    });
+                proc
+            })
+            .collect()
+    }
+}
+
+/// Guard against a recycled parent pid naming an unrelated application.
+///
+/// Unlike Unix, Windows never reparents an orphan and never clears the dead
+/// parent's pid from the child, so `th32ParentProcessID` dangles once the parent
+/// exits - and orphaned gateways are exactly the population the reaper exists to
+/// clean up. Windows then recycles pids freely, so the dangling value can point at
+/// something started later, and the user is told to restart an app that never
+/// spawned a gateway (#542 review).
+///
+/// A real parent always starts before its child. Fails closed: if either creation
+/// time is unreadable we drop the attribution rather than guess, because a wrong
+/// app name is worse than none.
+#[cfg(windows)]
+fn windows_parent_predates_child(ppid: u32, child_pid: u32) -> bool {
+    match (
+        windows_process_start_time(ppid),
+        windows_process_start_time(child_pid),
+    ) {
+        (Some(parent), Some(child)) => parent <= child,
+        _ => false,
+    }
+}
+
+/// Process creation time as a raw FILETIME tick count, for ordering only.
+#[cfg(windows)]
+fn windows_process_start_time(pid: u32) -> Option<u64> {
+    use windows_sys::Win32::Foundation::{CloseHandle, FILETIME};
+    use windows_sys::Win32::System::Threading::{
+        GetProcessTimes, OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION,
+    };
+    unsafe {
+        let handle = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, pid);
+        if handle.is_null() {
+            return None;
+        }
+        let mut created: FILETIME = std::mem::zeroed();
+        let mut exited: FILETIME = std::mem::zeroed();
+        let mut kernel: FILETIME = std::mem::zeroed();
+        let mut user: FILETIME = std::mem::zeroed();
+        let ok = GetProcessTimes(handle, &mut created, &mut exited, &mut kernel, &mut user);
+        CloseHandle(handle);
+        if ok == 0 {
+            return None;
+        }
+        Some(((created.dwHighDateTime as u64) << 32) | created.dwLowDateTime as u64)
     }
 }
 
@@ -712,6 +1034,7 @@ fn linux_list_gateway_processes() -> Vec<GatewayProcess> {
                 pid,
                 path: exe,
                 basename: exe_base,
+                parent: linux_parent_of(pid),
             });
             continue;
         }
@@ -720,9 +1043,38 @@ fn linux_list_gateway_processes() -> Vec<GatewayProcess> {
             pid,
             path,
             basename,
+            parent: linux_parent_of(pid),
         });
     }
     out
+}
+
+/// Parent application of a pid, from `/proc/<pid>/status`.
+#[cfg(all(unix, not(target_os = "macos")))]
+fn linux_parent_of(pid: u32) -> Option<ParentProcess> {
+    let status = std::fs::read_to_string(format!("/proc/{pid}/status")).ok()?;
+    let ppid: u32 = status
+        .lines()
+        .find_map(|line| line.strip_prefix("PPid:"))?
+        .trim()
+        .parse()
+        .ok()?;
+    // pid 0 is the kernel scheduler, never an application to restart.
+    if ppid == 0 {
+        return None;
+    }
+    // `comm` is truncated to 15 chars, which is fine for a display name.
+    let basename = std::fs::read_to_string(format!("/proc/{ppid}/comm"))
+        .ok()?
+        .trim()
+        .to_string();
+    if basename.is_empty() {
+        return None;
+    }
+    Some(ParentProcess {
+        pid: ppid,
+        basename,
+    })
 }
 
 /// macOS: `ps` for pid + accounting name (`ucomm`), then `proc_pidpath` for the
@@ -732,7 +1084,7 @@ fn linux_list_gateway_processes() -> Vec<GatewayProcess> {
 #[cfg(target_os = "macos")]
 fn macos_list_gateway_processes() -> Vec<GatewayProcess> {
     let Ok(out) = std::process::Command::new("ps")
-        .args(["-ax", "-o", "pid=", "-o", "ucomm="])
+        .args(["-ax", "-o", "pid=", "-o", "ppid=", "-o", "ucomm="])
         .output()
     else {
         return Vec::new();
@@ -748,31 +1100,69 @@ fn macos_list_gateway_processes() -> Vec<GatewayProcess> {
         return Vec::new();
     }
     let text = String::from_utf8_lossy(&out.stdout);
+    // One pass over the whole table: `-ax` already lists every process, so the
+    // parent's name is here and needs no second `ps` (SOU-435).
+    let rows: Vec<(u32, u32, String)> = text
+        .lines()
+        .filter_map(parse_ps_pid_ppid_name_line)
+        .collect();
+    let names: std::collections::HashMap<u32, &str> = rows
+        .iter()
+        .map(|(pid, _, ucomm)| (*pid, ucomm.as_str()))
+        .collect();
+
     let mut procs = Vec::new();
-    for line in text.lines() {
-        let Some((pid, ucomm)) = parse_ps_pid_name_line(line) else {
-            continue;
-        };
+    for (pid, ppid, ucomm) in &rows {
         // ucomm is the accounting basename; filter before the more expensive path lookup.
-        if !is_gateway_basename(&ucomm) {
+        if !is_gateway_basename(ucomm) {
             continue;
         }
-        let path = macos_proc_pidpath(pid);
+        let path = macos_proc_pidpath(*pid);
         let basename = path
             .as_ref()
             .and_then(|p| p.file_name())
             .map(|s| s.to_string_lossy().into_owned())
-            .unwrap_or(ucomm);
+            .unwrap_or_else(|| ucomm.clone());
         if !is_gateway_basename(&basename) {
             continue;
         }
+        // pid 1 is launchd, never an application a user can restart.
+        let parent = (*ppid > 1)
+            .then(|| names.get(ppid))
+            .flatten()
+            .map(|name| ParentProcess {
+                pid: *ppid,
+                basename: (*name).to_string(),
+            });
         procs.push(GatewayProcess {
-            pid,
+            pid: *pid,
             path,
             basename,
+            parent,
         });
     }
     procs
+}
+
+/// Parse one `ps -o pid= -o ppid= -o ucomm=` row.
+///
+/// Both leading columns are required. A row missing the ppid column must fail
+/// rather than slide the name left, which is how a wrong `-o` argv would quietly
+/// produce nonsense parent attributions instead of an empty list (SOU-435).
+#[cfg(target_os = "macos")]
+fn parse_ps_pid_ppid_name_line(line: &str) -> Option<(u32, u32, String)> {
+    let line = line.trim();
+    if line.is_empty() {
+        return None;
+    }
+    let mut parts = line.split_whitespace();
+    let pid = parts.next()?.parse().ok()?;
+    let ppid = parts.next()?.parse().ok()?;
+    let name = parts.collect::<Vec<_>>().join(" ");
+    if name.is_empty() {
+        return None;
+    }
+    Some((pid, ppid, name))
 }
 
 /// Full executable path for a pid via libproc (handles spaces and symlinks).
@@ -877,6 +1267,24 @@ mod tests {
             pid,
             basename: basename.into(),
             path: path.map(PathBuf::from),
+            parent: None,
+        }
+    }
+
+    /// Same, with an attributed parent application.
+    fn proc_with_parent(
+        pid: u32,
+        basename: &str,
+        path: Option<&str>,
+        parent_pid: u32,
+        parent_name: &str,
+    ) -> GatewayProcess {
+        GatewayProcess {
+            parent: Some(ParentProcess {
+                pid: parent_pid,
+                basename: parent_name.into(),
+            }),
+            ..proc(pid, basename, path)
         }
     }
 
@@ -1217,6 +1625,7 @@ mod tests {
                     pid: 1,
                     path: Some(keep),
                     basename: "toolport-gateway".into(),
+                    parent: None,
                 },
                 &c
             ),
@@ -1229,6 +1638,7 @@ mod tests {
                     pid: 2,
                     path: Some(deleted),
                     basename: "toolport-gateway".into(),
+                    parent: None,
                 },
                 &c
             ),
@@ -1377,5 +1787,284 @@ mod tests {
         );
 
         drop(guard);
+    }
+
+    // ----- SOU-435: restart advice -------------------------------------------
+
+    /// Unique temp dir for a test that needs real files on disk.
+    ///
+    /// Ends in a literal `Toolport` segment because `decide_reap` only kills a
+    /// versioned gateway under a path `path_looks_like_our_install` recognizes; a
+    /// bare temp dir is treated as a stranger's binary and kept.
+    fn advice_temp_dir(tag: &str) -> std::path::PathBuf {
+        let dir = std::env::temp_dir()
+            .join(format!(
+                "toolport-advice-{tag}-{}-{:?}",
+                std::process::id(),
+                std::thread::current().id()
+            ))
+            .join("Toolport");
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    /// A context where anything not at `keep` and not current-version is obsolete.
+    fn advice_ctx(keep: &Path) -> ReapContext {
+        ReapContext {
+            current_version: "9.9.9".into(),
+            keep_paths: vec![keep.to_path_buf()],
+            keep_pids: Vec::new(),
+            kill_all: false,
+        }
+    }
+
+    #[test]
+    fn advice_names_the_parent_app_and_carries_its_pid() {
+        let dir = advice_temp_dir("names-parent");
+        let keep = dir.join("toolport-gateway-9.9.9.exe");
+        let stale = dir.join("toolport-gateway-1.9.4.exe");
+        let ctx = advice_ctx(&keep);
+
+        let advice = clients_needing_restart(
+            &[proc_with_parent(
+                10,
+                "toolport-gateway-1.9.4.exe",
+                stale.to_str(),
+                77,
+                "claude.exe",
+            )],
+            &ctx,
+        );
+
+        assert_eq!(
+            advice,
+            vec![ClientNeedingRestart {
+                client: "claude.exe".into(),
+                client_pid: 77,
+                gateway: "toolport-gateway-1.9.4.exe".into(),
+            }],
+            "an obsolete gateway with a named parent must be attributed to that app"
+        );
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn advice_is_empty_for_the_updater_kill_all_pass() {
+        let dir = advice_temp_dir("kill-all");
+        let keep = dir.join("toolport-gateway-9.9.9.exe");
+        let mut ctx = advice_ctx(&keep);
+        ctx.kill_all = true;
+
+        // The CURRENT gateway, which kill_all also reaps so the installer can
+        // replace it. Advising a restart because an app runs the current binary is
+        // nonsense the user would act on.
+        let procs = [proc_with_parent(
+            10,
+            "toolport-gateway-9.9.9.exe",
+            keep.to_str(),
+            77,
+            "claude.exe",
+        )];
+        assert_eq!(decide_reap(&procs[0], &ctx), ReapDecision::Kill);
+        assert!(
+            clients_needing_restart(&procs, &ctx).is_empty(),
+            "kill_all gives every process a Kill verdict, so obsolescence means nothing there"
+        );
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// The case #542 got backwards. ` (deleted)` means *unlinked*, which covers an
+    /// in-place replacement (self-heals, stay silent) and an abandoned install
+    /// location (does not self-heal, must advise). The old check treated the marker
+    /// alone as self-healing and so was silent for the second, and its test only
+    /// passed because it ran on macOS where no marker appears at all.
+    #[test]
+    fn deleted_marker_advises_only_when_the_path_is_really_gone() {
+        let dir = advice_temp_dir("deleted-marker");
+        let keep = dir.join("toolport-gateway-9.9.9");
+        let ctx = advice_ctx(&keep);
+
+        // Replaced in place: the file at the stripped path exists again, so the
+        // cached spawn command already resolves to the new binary.
+        let replaced = dir.join("toolport-gateway-1.9.4");
+        std::fs::write(&replaced, b"new code").unwrap();
+        let replaced_marked = format!("{} (deleted)", replaced.display());
+        let replaced_proc = proc_with_parent(
+            11,
+            "toolport-gateway-1.9.4",
+            Some(&replaced_marked),
+            77,
+            "claude.exe",
+        );
+        assert_eq!(
+            decide_reap(&replaced_proc, &ctx),
+            ReapDecision::Kill,
+            "the marked path must still miss keep-paths so the old inode is reaped"
+        );
+        assert!(
+            cached_path_self_heals(&replaced_proc),
+            "a replaced-in-place binary self-heals on the next spawn"
+        );
+        assert!(
+            clients_needing_restart(&[replaced_proc], &ctx).is_empty(),
+            "nothing to advise when the cached path already yields new code"
+        );
+
+        // Moved or removed: nothing at the stripped path. The client cannot spawn a
+        // gateway at all, which is worse than running an old one.
+        let removed = dir.join("toolport-gateway-1.9.5");
+        let removed_marked = format!("{} (deleted)", removed.display());
+        assert!(!removed.exists());
+        let removed_proc = proc_with_parent(
+            12,
+            "toolport-gateway-1.9.5",
+            Some(&removed_marked),
+            78,
+            "grok.exe",
+        );
+        assert!(
+            !cached_path_self_heals(&removed_proc),
+            "an abandoned install location never starts yielding new code"
+        );
+        assert_eq!(
+            clients_needing_restart(&[removed_proc], &ctx),
+            vec![ClientNeedingRestart {
+                client: "grok.exe".into(),
+                client_pid: 78,
+                gateway: "toolport-gateway-1.9.5".into(),
+            }],
+            "the stale-install-location case must be reported, on every platform"
+        );
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn advice_skips_unattributable_and_non_app_parents() {
+        let dir = advice_temp_dir("skips");
+        let keep = dir.join("toolport-gateway-9.9.9.exe");
+        let stale = dir.join("toolport-gateway-1.9.4.exe");
+        let ctx = advice_ctx(&keep);
+        let stale_str = stale.to_str();
+
+        // No parent at all: nothing to name.
+        assert!(clients_needing_restart(
+            &[proc(10, "toolport-gateway-1.9.4.exe", stale_str)],
+            &ctx
+        )
+        .is_empty());
+
+        // Our own supervised HTTP bridge is not a client the user restarts.
+        assert!(clients_needing_restart(
+            &[proc_with_parent(
+                10,
+                "toolport-gateway-1.9.4.exe",
+                stale_str,
+                5,
+                "toolport.exe"
+            )],
+            &ctx
+        )
+        .is_empty());
+
+        // Init/kernel parents are not restartable applications. Both pid- and
+        // name-matched, so a systemd *user* session with its own pid is caught too.
+        for (ppid, name) in [
+            (1u32, "launchd"),
+            (4, "System"),
+            (900, "systemd"),
+            (0, "kernel"),
+        ] {
+            assert!(
+                clients_needing_restart(
+                    &[proc_with_parent(
+                        10,
+                        "toolport-gateway-1.9.4.exe",
+                        stale_str,
+                        ppid,
+                        name
+                    )],
+                    &ctx
+                )
+                .is_empty(),
+                "parent {name} (pid {ppid}) is not an app a user can restart"
+            );
+        }
+
+        // Unreadable path: decide_reap still reaches Kill via the basename fallback,
+        // but that skips the install-location guard and we cannot stop it either, so
+        // it may be a foreign user's process. Silence beats naming someone else's app.
+        assert!(clients_needing_restart(
+            &[proc_with_parent(
+                10,
+                "toolport-gateway-1.9.4.exe",
+                None,
+                77,
+                "claude.exe"
+            )],
+            &ctx
+        )
+        .is_empty());
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn advice_dedupes_repeat_respawns_of_the_same_app() {
+        let dir = advice_temp_dir("dedupe");
+        let keep = dir.join("toolport-gateway-9.9.9.exe");
+        let stale = dir.join("toolport-gateway-1.9.4.exe");
+        let ctx = advice_ctx(&keep);
+        let stale_str = stale.to_str();
+
+        // One app that respawned the same gateway three times is one thing to do.
+        let advice = clients_needing_restart(
+            &[
+                proc_with_parent(10, "toolport-gateway-1.9.4.exe", stale_str, 77, "claude.exe"),
+                proc_with_parent(11, "toolport-gateway-1.9.4.exe", stale_str, 77, "claude.exe"),
+                proc_with_parent(12, "toolport-gateway-1.9.4.exe", stale_str, 77, "claude.exe"),
+            ],
+            &ctx,
+        );
+        assert_eq!(advice.len(), 1, "one entry per app to act on, not per respawn");
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// The ordering requirement that three review rounds kept relocating: advice is
+    /// derived from the same snapshot the kill list is, so it cannot be read from a
+    /// table a previous pass already cleared.
+    #[test]
+    fn plan_reap_derives_advice_from_the_same_prekill_snapshot() {
+        let dir = advice_temp_dir("plan");
+        let keep = dir.join("toolport-gateway-9.9.9.exe");
+        let stale = dir.join("toolport-gateway-1.9.4.exe");
+        let ctx = advice_ctx(&keep);
+
+        let procs = vec![
+            proc_with_parent(10, "toolport-gateway-1.9.4.exe", stale.to_str(), 77, "claude.exe"),
+            proc_with_parent(11, "toolport-gateway-9.9.9.exe", keep.to_str(), 78, "cursor.exe"),
+        ];
+        let plan = plan_reap(&procs, &ctx);
+
+        assert_eq!(plan.to_kill.len(), 1, "only the obsolete gateway is killed");
+        assert_eq!(plan.to_kill[0].pid, 10);
+        assert_eq!(plan.kept.len(), 1, "the current gateway is kept");
+        assert_eq!(
+            plan.needs_restart,
+            vec![ClientNeedingRestart {
+                client: "claude.exe".into(),
+                client_pid: 77,
+                gateway: "toolport-gateway-1.9.4.exe".into(),
+            }],
+            "advice comes from the pre-kill snapshot, alongside the kill list"
+        );
+
+        // The post-kill table: the obsolete process is gone and its client has not
+        // respawned yet. Planning against it yields nothing, which is exactly why
+        // the advice must not be recomputed after a reap.
+        let after = plan_reap(&procs[1..], &ctx);
+        assert!(
+            after.needs_restart.is_empty(),
+            "a post-kill table cannot produce the advice, so it must never be the source"
+        );
+        std::fs::remove_dir_all(&dir).ok();
     }
 }

--- a/src-tauri/src/gateway_publish.rs
+++ b/src-tauri/src/gateway_publish.rs
@@ -342,23 +342,34 @@ fn basename_from_exe_link(path: &Path) -> String {
         .unwrap_or_else(|| cleaned.to_string())
 }
 
-/// Parse one line of `ps -ax -o pid= -o ucomm=` (or `comm=`) into `(pid, name)`.
+/// Parse one line of `ps -ax -o pid= -o ppid= -o ucomm=` into `(pid, ppid, name)`.
+///
 /// Pure helper for the macOS enumerator line format. Does **not** prove the `ps`
 /// argv itself is correct — a broken `-axo pid= comm=` still needs a macOS
 /// smoke / CI job (WS4-1 / WS4-8).
+///
+/// Both leading columns are required. A row missing the ppid column must fail
+/// rather than slide the name left, which is how a wrong `-o` argv would quietly
+/// produce nonsense parent attributions instead of an empty list (SOU-435).
+///
+/// Compiled under `test` on every platform, not just macOS, so the parser is
+/// covered on the machines that actually run the suite. Gating it to macOS alone
+/// is how the previous attempt ended up with a test that only ran where the bug
+/// could not appear.
 #[cfg(any(target_os = "macos", test))]
-fn parse_ps_pid_name_line(line: &str) -> Option<(u32, String)> {
+fn parse_ps_pid_ppid_name_line(line: &str) -> Option<(u32, u32, String)> {
     let line = line.trim();
     if line.is_empty() {
         return None;
     }
     let mut parts = line.split_whitespace();
     let pid = parts.next()?.parse().ok()?;
+    let ppid = parts.next()?.parse().ok()?;
     let name = parts.collect::<Vec<_>>().join(" ");
     if name.is_empty() {
         return None;
     }
-    Some((pid, name))
+    Some((pid, ppid, name))
 }
 
 /// True only for names like `toolport-gateway-1.9.4`, not `toolport-gateway-shim`.
@@ -778,10 +789,15 @@ pub fn pid_is_running(pid: u32) -> bool {
         // only the first means gone. They are told apart by stderr because the exit
         // code alone cannot: treating EPERM as gone would expire advice for a live
         // app, the exact direction this function must not fail in.
+        //
+        // LC_ALL=C pins that stderr to English. Without it a non-English locale
+        // makes the match fail, which reports a live app as gone and silently drops
+        // its restart advice - the same failure the stderr check exists to avoid.
         #[cfg(target_os = "macos")]
         {
             match std::process::Command::new("kill")
                 .args(["-0", &pid.to_string()])
+                .env("LC_ALL", "C")
                 .output()
             {
                 Ok(out) if out.status.success() => true,
@@ -1144,26 +1160,6 @@ fn macos_list_gateway_processes() -> Vec<GatewayProcess> {
     procs
 }
 
-/// Parse one `ps -o pid= -o ppid= -o ucomm=` row.
-///
-/// Both leading columns are required. A row missing the ppid column must fail
-/// rather than slide the name left, which is how a wrong `-o` argv would quietly
-/// produce nonsense parent attributions instead of an empty list (SOU-435).
-#[cfg(target_os = "macos")]
-fn parse_ps_pid_ppid_name_line(line: &str) -> Option<(u32, u32, String)> {
-    let line = line.trim();
-    if line.is_empty() {
-        return None;
-    }
-    let mut parts = line.split_whitespace();
-    let pid = parts.next()?.parse().ok()?;
-    let ppid = parts.next()?.parse().ok()?;
-    let name = parts.collect::<Vec<_>>().join(" ");
-    if name.is_empty() {
-        return None;
-    }
-    Some((pid, ppid, name))
-}
 
 /// Full executable path for a pid via libproc (handles spaces and symlinks).
 #[cfg(target_os = "macos")]
@@ -1646,28 +1642,40 @@ mod tests {
         );
     }
 
-    /// WS4-1 / WS4-8: pure parse of `ps -o pid= -o ucomm=` lines (including padded pid).
-    /// Does not prove the `ps` argv itself — that still needs a macOS smoke.
+    /// WS4-1 / WS4-8: pure parse of `ps -o pid= -o ppid= -o ucomm=` rows.
+    /// Does not prove the `ps` argv itself - that still needs a macOS smoke.
     #[test]
-    fn parse_ps_pid_name_line_accepts_padded_pid_and_ucomm() {
+    fn parse_ps_pid_ppid_name_line_accepts_padded_columns_and_ucomm() {
         assert_eq!(
-            parse_ps_pid_name_line("  123 toolport-gateway"),
-            Some((123, "toolport-gateway".into()))
+            parse_ps_pid_ppid_name_line("  123   1 toolport-gateway"),
+            Some((123, 1, "toolport-gateway".into()))
         );
         assert_eq!(
-            parse_ps_pid_name_line("45678 toolport-gateway-1.9.4"),
-            Some((45678, "toolport-gateway-1.9.4".into()))
+            parse_ps_pid_ppid_name_line("45678 4321 toolport-gateway-1.9.4"),
+            Some((45678, 4321, "toolport-gateway-1.9.4".into()))
         );
-        assert_eq!(parse_ps_pid_name_line(""), None);
-        assert_eq!(parse_ps_pid_name_line("not-a-pid toolport-gateway"), None);
-        assert_eq!(parse_ps_pid_name_line("99"), None);
+        assert_eq!(parse_ps_pid_ppid_name_line(""), None);
+        assert_eq!(parse_ps_pid_ppid_name_line("not-a-pid 1 toolport-gateway"), None);
+        // A missing ppid column must not be read as the name, which is how a wrong
+        // `-o` argv would silently produce nonsense parents rather than nothing.
+        assert_eq!(parse_ps_pid_ppid_name_line("99 toolport-gateway"), None);
+        assert_eq!(parse_ps_pid_ppid_name_line("99 1"), None);
+        assert_eq!(parse_ps_pid_ppid_name_line("99"), None);
         // Full-path comm= style still parses; basename filter is applied by the caller.
         assert_eq!(
-            parse_ps_pid_name_line("  42 /Applications/Toolport.app/Contents/MacOS/toolport-gateway"),
+            parse_ps_pid_ppid_name_line(
+                "  42 7 /Applications/Toolport.app/Contents/MacOS/toolport-gateway"
+            ),
             Some((
                 42,
+                7,
                 "/Applications/Toolport.app/Contents/MacOS/toolport-gateway".into()
             ))
+        );
+        // A name with spaces survives, since only the first two columns are positional.
+        assert_eq!(
+            parse_ps_pid_ppid_name_line("5 2 Some App Helper"),
+            Some((5, 2, "Some App Helper".into()))
         );
     }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -35,6 +35,7 @@ import {
   setAllEnabled,
   setServerEnabled,
   teamSyncWait,
+  type ClientNeedingRestart,
 } from "@/lib/api";
 import {
   importableServers,
@@ -287,6 +288,31 @@ function App() {
     const unlisten = listen<ProbeResult>("server-probed", (e) => {
       setHealth((h) => ({ ...h, [e.payload.serverId]: e.payload }));
       setBackendReachable(true);
+    });
+    return () => {
+      void unlisten.then((f) => f());
+    };
+  }, []);
+
+  // The launch reaper stops obsolete gateways, but an app that was already running
+  // cached the old spawn command and just launches it again. Only restarting that
+  // app fixes it, and nothing else in the UI would say so (SOU-435). Settings keeps
+  // the durable list; this is the nudge for someone who never opens it.
+  useEffect(() => {
+    const unlisten = listen<ClientNeedingRestart[]>("gateway-restart-needed", (e) => {
+      const apps = e.payload;
+      if (apps.length === 0) return;
+      const names = [...new Set(apps.map((a) => a.client))].join(", ");
+      toast.warning(
+        apps.length === 1
+          ? `${names} is still starting an old gateway`
+          : `${names} are still starting an old gateway`,
+        {
+          description:
+            "They cached the old path at startup, so restarting them is the only way to pick up the current gateway. Settings keeps the list.",
+          duration: 10000,
+        },
+      );
     });
     return () => {
       void unlisten.then((f) => f());

--- a/src/components/SettingsView.tsx
+++ b/src/components/SettingsView.tsx
@@ -58,6 +58,8 @@ import {
   startHttpBridge,
   stopHttpBridge,
   stopStaleGateways,
+  clientsNeedingRestart,
+  type ClientNeedingRestart,
   type HttpBridgeStatus,
   type QuarantinedTool,
 } from "@/lib/api";
@@ -572,6 +574,15 @@ export function SettingsView({ registry, onRegistryChange }: Props) {
   const [clientBusy, setClientBusy] = useState(false);
   const [reapBusy, setReapBusy] = useState(false);
   const [reapResult, setReapResult] = useState<string | null>(null);
+  // Apps still launching an obsolete gateway. Seeded from stored state because the
+  // launch reaper already found them before this view existed; refreshed from the
+  // button's own outcome, which merges rather than replaces (SOU-435).
+  const [needsRestart, setNeedsRestart] = useState<ClientNeedingRestart[]>([]);
+  useEffect(() => {
+    clientsNeedingRestart()
+      .then(setNeedsRestart)
+      .catch(() => {});
+  }, []);
   const [autostartOn, setAutostartOn] = useState(false);
 
   const httpClients = registry?.httpClients ?? [];
@@ -1286,11 +1297,28 @@ export function SettingsView({ registry, onRegistryChange }: Props) {
                 setReapBusy(true);
                 setReapResult(null);
                 try {
-                  const stopped = await stopStaleGateways();
+                  const outcome = await stopStaleGateways();
+                  // Always from the outcome: it carries the merged advice, so
+                  // clicking Run before a client has respawned cannot blank the
+                  // panel below (SOU-435).
+                  setNeedsRestart(outcome.needsRestart);
+                  const parts: string[] = [];
+                  if (outcome.killed.length > 0) {
+                    parts.push(
+                      `Stopped ${outcome.killed.length}: ${outcome.killed.join("; ")}`,
+                    );
+                  }
+                  // Reporting "found nothing" while a process is still running would
+                  // be the same lie the panel exists to prevent.
+                  if (outcome.failed.length > 0) {
+                    parts.push(
+                      `Could not stop ${outcome.failed.length}: ${outcome.failed.join("; ")}`,
+                    );
+                  }
                   setReapResult(
-                    stopped.length === 0
+                    parts.length === 0
                       ? "No old gateway processes found."
-                      : `Stopped ${stopped.length}: ${stopped.join("; ")}`,
+                      : parts.join(". "),
                   );
                 } catch (e) {
                   toastError(`Couldn't stop old gateways: ${e}`);
@@ -1304,6 +1332,28 @@ export function SettingsView({ registry, onRegistryChange }: Props) {
             </button>
           </div>
           {reapResult && <p className="text-xs text-muted-foreground">{reapResult}</p>}
+          {needsRestart.length > 0 && (
+            <div className="rounded-md border border-warning/40 bg-warning/5 p-3">
+              <p className="text-xs font-medium text-warning">
+                {needsRestart.length === 1
+                  ? "1 app is still launching an old gateway"
+                  : `${needsRestart.length} apps are still launching an old gateway`}
+              </p>
+              <ul className="mt-1.5 space-y-1">
+                {needsRestart.map((c) => (
+                  <li key={c.clientPid} className="text-xs text-muted-foreground">
+                    <span className="font-medium text-foreground">{c.client}</span> keeps
+                    starting <code className="font-mono">{c.gateway}</code>
+                  </li>
+                ))}
+              </ul>
+              <p className="mt-2 text-xs text-muted-foreground">
+                These apps cached the old gateway path when they started, so stopping the
+                process only makes them launch it again. Restart each one to pick up the
+                current gateway. This list clears itself as you do.
+              </p>
+            </div>
+          )}
         </div>
       </section>
     </div>

--- a/src/components/SettingsView.tsx
+++ b/src/components/SettingsView.tsx
@@ -1316,9 +1316,15 @@ export function SettingsView({ registry, onRegistryChange }: Props) {
                     );
                   }
                   setReapResult(
-                    parts.length === 0
-                      ? "No old gateway processes found."
-                      : parts.join(". "),
+                    parts.length > 0
+                      ? parts.join(". ")
+                      : outcome.needsRestart.length > 0
+                        ? // Saying "found nothing" while the panel below names an
+                          // app still launching an old gateway would be the same
+                          // self-contradiction this panel exists to prevent. None
+                          // are running *now*; the panel explains they come back.
+                          "No old gateway processes are running right now."
+                        : "No old gateway processes found.",
                   );
                 } catch (e) {
                   toastError(`Couldn't stop old gateways: ${e}`);

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -363,13 +363,51 @@ export function httpBridgeStatus(): Promise<HttpBridgeStatus> {
 }
 
 /**
+ * An application that keeps relaunching an obsolete gateway, so only restarting
+ * that application delivers the new gateway code (SOU-435).
+ */
+export type ClientNeedingRestart = {
+  /** Application basename, e.g. `claude.exe`. */
+  client: string;
+  /** Its pid. The entry disappears once that process is gone. */
+  clientPid: number;
+  /** The obsolete gateway image it relaunched. */
+  gateway: string;
+};
+
+/** What a reaper run did, and what the user still has to do about it. */
+export type ReapOutcome = {
+  /** Human-readable labels of processes that were stopped. */
+  killed: string[];
+  /** Matched but could not be stopped. Distinct from "nothing was stale". */
+  failed: string[];
+  /** Apps needing a manual restart, accumulated across passes this session. */
+  needsRestart: ClientNeedingRestart[];
+};
+
+/**
  * Stop obsolete Toolport gateway processes (older versions / stale paths).
  * Keeps the current resolved binary and the supervised HTTP bridge when they
- * match. Clients that auto-respawn MCP pick up the current binary on the next
- * tool call. Returns human-readable labels of processes that were stopped.
+ * match.
+ *
+ * Reaping alone does not always deliver new gateway code: a client caches its
+ * spawn command at its own startup, so one pinned to a path an upgrade never
+ * rewrites relaunches the same obsolete binary. Those apps come back in
+ * `needsRestart`, which is why this returns an outcome rather than a killed list.
  */
-export function stopStaleGateways(): Promise<string[]> {
-  return invoke<string[]>("stop_stale_gateways");
+export function stopStaleGateways(): Promise<ReapOutcome> {
+  return invoke<ReapOutcome>("stop_stale_gateways");
+}
+
+/**
+ * Apps needing a restart, without running a reaper pass.
+ *
+ * Read from stored state rather than recomputed: the advice is only visible in a
+ * pre-kill process table, so asking after a reap would always come back emptier
+ * than the truth.
+ */
+export function clientsNeedingRestart(): Promise<ClientNeedingRestart[]> {
+  return invoke<ClientNeedingRestart[]>("clients_needing_restart");
 }
 
 /**


### PR DESCRIPTION
Rebuilds the surfacing half of SOU-435. Closes the gap left when #542 was closed unmerged.

## Why #542 could not land

Three review rounds, each finding the previous round's fix defective the same way: every fix **moved** the "must happen at the right moment" requirement instead of removing it. Round 3 left the advice written unconditionally by `stop_stale_gateways`, so clicking **Run** in Settings before a client had respawned overwrote correct advice with an empty snapshot. The panel vanished and the UI reported "No old gateway processes found" while a client was still pinned to an obsolete binary, for the rest of the session.

## What is structurally different here

Each item is one of the design notes from that review, and each has a test.

- **`plan_reap(procs, ctx) -> ReapPlan` is pure** and takes the snapshot as an argument, so "advice is derived before anything is killed" holds by construction rather than by where a line sits in the reaping loop. `plan_reap_derives_advice_from_the_same_prekill_snapshot` also asserts the negative: planning against a post-kill table yields nothing, which is why that table must never be the source.
- **`RestartAdvice` merges as a union keyed by client pid, never a replace.** `an_empty_later_pass_does_not_erase_earlier_advice` is the #542 failure written as a test.
- **`ClientNeedingRestart` carries the client pid**, so entries expire on the only evidence of compliance that exists: the process being gone. Absence of a respawned gateway is not evidence, since a client that has not yet made a tool call looks identical.
- **Advice is skipped on the updater's `kill_all` pass**, where every gateway including the current one gets a Kill verdict and "obsolete" stops meaning anything.
- **Killed labels and advice travel in one IPC payload**, so they cannot describe different moments.
- **`ReapReport.failed` is no longer dropped.** "Found nothing" and "found something and could not stop it" now read differently in Settings and in the log.

## The platform-lucky test is fixed

The old `cached_path_self_heals` treated the Linux ` (deleted)` marker as self-healing. That marker means *unlinked*, which covers two opposite outcomes: replaced-in-place (self-heals, stay silent) and moved-or-removed (does not self-heal, and the client cannot spawn a gateway at all). The second case was silently dropped, and the test meant to cover it passed only because it ran on macOS, where no marker appears.

Probing the stripped path tells them apart. `deleted_marker_advises_only_when_the_path_is_really_gone` covers both directions with real files on disk and passes on every platform, including the Linux case that was previously silent.

## Salvaged unchanged

Parent resolution on all three platforms, the `windows_parent_predates_child` creation-time guard against recycled parent pids, and the `is_init_like` guard. All were independently verified during the #542 review and are carried over as-is.

## Testing

- 10 new tests: 6 in `gateway_publish` (attribution, pid carriage, `kill_all`, the `(deleted)` split, non-app parent and unreadable-path skips, dedup, the pre-kill snapshot property) and 4 in `desktop` (the clobber case, union keying, expiry, per-entry expiry).
- Full suites green: 687 lib + 219 gateway bin Rust tests, 211 frontend tests, `npm run build` and `npm run lint` clean (0 errors).
- Not exercised on a real install. The panel only appears with genuinely stale gateway processes, so the Windows/macOS/Linux behaviour belongs to the SOU-418 smoke rows.

Closes SOU-435 (surfacing half). The wording half shipped separately in #554.