### PR TITLE
fix(gateway): HITL owner flip, rebuild single-flight, empty catalog guard

### DIFF
--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -6890,6 +6890,8 @@ fn watch_registry(
     resource_updated: Option<ResourceUpdatedDispatch>,
     // Subscription table so rebuilds re-issue resources/subscribe.
     resource_subs: Option<Arc<Mutex<ResourceSubscriptionTable>>>,
+    // Single-flight with startup self-heal and ${ROOT} rebuilds (SOU-337).
+    rebuild_lock: Arc<Mutex<()>>,
 ) {
     eprintln!("toolport: watching registry at {}", path.display());
     let mut state = WatchLoopState {
@@ -6920,6 +6922,7 @@ fn watch_registry(
             Some(&mcp_sessions),
             resource_updated.as_ref(),
             resource_subs.as_ref(),
+            &rebuild_lock,
             &mut state,
         );
     }
@@ -6948,6 +6951,9 @@ fn watch_tick(
     mcp_sessions: Option<&Arc<Mutex<HashMap<String, Arc<McpSession>>>>>,
     resource_updated: Option<&ResourceUpdatedDispatch>,
     resource_subs: Option<&Arc<Mutex<ResourceSubscriptionTable>>>,
+    // Serializes full rebuilds with self-heal / ${ROOT} (SOU-337). Unused on the
+    // in-place list_changed refresh branch, which does not spawn.
+    rebuild_lock: &Arc<Mutex<()>>,
     state: &mut WatchLoopState,
 ) -> TickOutcome {
     // Re-approving a tool rewrites quarantine.json, which is NOT the registry file
@@ -7051,7 +7057,13 @@ fn watch_tick(
             *guard = resolved.clone();
             prev
         };
-        // Build the new router (spawns processes) before taking locks.
+        // Full rebuild spawns stdio children. Single-flight with startup self-heal
+        // and ${ROOT} rebuild so two concurrent build_router+swap paths cannot
+        // double-spawn and kill the loser's children on Drop (SOU-337).
+        let _rebuild = rebuild_lock
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        // Build the new router (spawns processes) before taking the router lock.
         let new_router = build_router(
             &new_reg,
             resolved.as_deref(),
@@ -7215,10 +7227,11 @@ struct GatewayState {
     stdout: Arc<Mutex<std::io::Stdout>>,
     ready: Arc<AtomicBool>,
     downstream_dirty: Arc<AtomicU8>,
-    /// Serializes the self-heal rebuild so a startup burst of concurrent tools/call
-    /// workers that all observe an empty router don't each spawn the full server set
-    /// (single-flight). The winner rebuilds; the others block here, then re-check
-    /// server_count under the router lock and skip.
+    /// Serializes every full `build_router` + router swap: startup background build,
+    /// empty-router self-heal, `${ROOT}` rebuild, and registry-watcher full rebuild
+    /// (SOU-337). Without this, overlapping builds double-spawn stdio children and
+    /// the loser's Drop kills mid-flight work. In-place tools/list_changed refresh
+    /// does not take it (no spawn).
     rebuild_lock: Arc<Mutex<()>>,
     lazy: bool,
     /// Live-updated: the registry watcher keeps this in sync with
@@ -11349,6 +11362,7 @@ fn main() {
         let mcp_sessions = Arc::clone(&mcp_sessions);
         let resource_updated = resource_updated_sink.clone();
         let resource_subs_watch = Arc::clone(&resource_subs);
+        let rebuild_lock = Arc::clone(&rebuild_lock);
         std::thread::spawn(move || {
             watch_registry(
                 path,
@@ -11366,6 +11380,7 @@ fn main() {
                 mcp_sessions,
                 resource_updated,
                 Some(resource_subs_watch),
+                rebuild_lock,
             )
         });
     }
@@ -17887,6 +17902,7 @@ mod tests {
         };
 
         // First tick: pick up the quarantined tool from disk.
+        let rebuild_lock = Arc::new(Mutex::new(()));
         let load = watch_tick(
             &reg_path,
             &registry,
@@ -17903,6 +17919,7 @@ mod tests {
             None,
             None,
             None,
+            &rebuild_lock,
             &mut state,
         );
         assert!(
@@ -17932,6 +17949,7 @@ mod tests {
             None,
             None,
             None,
+            &rebuild_lock,
             &mut state,
         );
         assert!(steady.idle_after_quarantine);
@@ -17955,6 +17973,7 @@ mod tests {
             None,
             None,
             None,
+            &rebuild_lock,
             &mut state,
         );
         assert!(

--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -3704,6 +3704,9 @@ fn execute_call(
     let mut exec_router_owned: Option<Arc<Router>> = None;
     let mut active_modern_hitl: Option<String> = None;
     let mut routed_mrtr: Option<MrtrRequest> = None;
+    // Defer the "approved" audit line until after the exec-route rebind so it names
+    // the same (server, tool) as route_call / defense / inspect (CodeRabbit on SOU-478).
+    let mut pending_approval_audit: Option<(&'static str, u64)> = None;
 
     // Human-in-the-loop approval: gate a destructive or untrusted call until a
     // person approves it in the Toolport app. Legacy clients hold this request;
@@ -3924,18 +3927,9 @@ fn execute_call(
                 }
                 exec_router_owned = Some(live);
             }
-            // Approved calls are audited too, so the trail shows what actually ran,
-            // not only what was blocked.
+            // Defer the approval audit until after the exec-route rebind below.
             if audit_approval {
-                audit::record_decision(
-                    srv,
-                    tool,
-                    client,
-                    reason_str,
-                    "approved",
-                    &arguments,
-                    Some(held_ms),
-                );
+                pending_approval_audit = Some((reason_str, held_ms));
             }
             // Skip the agent-confirm step and route the call.
             confirmed = true;
@@ -3964,6 +3958,20 @@ fn execute_call(
     let (server_id, tool) = exec_router.route_of(name).unwrap_or((server_id, tool));
     let srv_owned = sanitize_segment(server_id);
     let srv = srv_owned.as_str();
+
+    // Approval decision audit uses the rebound identity so the trail matches
+    // the server/tool that will actually run (and that content defense uses).
+    if let Some((reason_str, held_ms)) = pending_approval_audit {
+        audit::record_decision(
+            srv,
+            tool,
+            client,
+            reason_str,
+            "approved",
+            &arguments,
+            Some(held_ms),
+        );
+    }
 
     // Per-call confirmation for destructive tools: intercept the first
     // call with these arguments, store it, and return a preview. The

--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -3386,12 +3386,16 @@ fn content_binding_decision(
     }
 }
 
-/// Post-HITL revalidation against the *live* router (SOU-321 / SOU-322).
+/// Post-HITL revalidation against the *live* router (SOU-321 / SOU-322 / SOU-478).
 ///
 /// After a human approves, the world may have changed during the hold: quarantine may have
-/// forked a new `Arc<Router>` via `Arc::make_mut`, or the tool definition may have drifted.
+/// forked a new `Arc<Router>` via `Arc::make_mut`, the tool definition may have drifted, or
+/// a rebuild may have re-homed the exposed name onto a different owning server.
 /// The request-scoped snapshot used for the gate is intentionally kept for pre-HITL
 /// consistency, but execution must fail closed if:
+/// - the live route maps the exposed name to a different server than the human approved
+///   against (SOU-478: `integrity::fingerprint` does not hash the owner, so an identical
+///   tool definition on another server would otherwise pass),
 /// - the live definition fingerprint no longer matches what was approved (or is gone), or
 /// - the live router now blocks the exposed tool (quarantine / policy).
 ///
@@ -3404,8 +3408,20 @@ fn content_binding_decision(
 fn post_hitl_revalidation(
     approved_fingerprint: Option<&str>,
     name: &str,
+    gate_server_id: &str,
     live: &Router,
 ) -> Option<approval::ApprovalDecision> {
+    // SOU-478: owner identity is not in the definition fingerprint. Two server ids that
+    // sanitize to the same prefix (`gh-api` / `gh_api`) can flip who owns the bare exposed
+    // name after a mid-hold rebuild; refuse rather than run under the wrong policy/audit.
+    match live.route_of(name) {
+        Some((live_srv, _)) if live_srv == gate_server_id => {}
+        Some(_) => return Some(approval::ApprovalDecision::StaleState),
+        None if !gate_server_id.is_empty() => {
+            return Some(approval::ApprovalDecision::StaleState);
+        }
+        None => {}
+    }
     let live_fp = live
         .aggregated_tools()
         .iter()
@@ -3883,13 +3899,17 @@ fn execute_call(
                 );
                 return refused_call_result(name, stale, reason_str);
             }
-            // Rebind to the live router and re-check fingerprint + quarantine
-            // (SOU-321 / SOU-322). The request snapshot may predate a mid-hold
-            // `requarantine` that forked a new Arc via `make_mut`.
+            // Rebind to the live router and re-check owner + fingerprint + quarantine
+            // (SOU-321 / SOU-322 / SOU-478). The request snapshot may predate a mid-hold
+            // `requarantine` that forked a new Arc via `make_mut`, or a rebuild that
+            // re-homed the exposed name onto a different server.
             if let Some(live) = clone_live_router(live_router) {
-                if let Some(stale) =
-                    post_hitl_revalidation(approved_fp.as_deref(), name, &live)
-                {
+                if let Some(stale) = post_hitl_revalidation(
+                    approved_fp.as_deref(),
+                    name,
+                    server_id,
+                    &live,
+                ) {
                     finish_modern_hitl(active_modern_hitl.as_deref());
                     audit::record_decision(
                         srv,
@@ -3933,6 +3953,17 @@ fn execute_call(
     }
 
     let exec_router: &Router = exec_router_owned.as_deref().unwrap_or(router);
+
+    // SOU-478: bind every post-gate consumer (confirm, progress, audit, content
+    // defense, inspect) to the route identity on the router that will execute.
+    // After HITL, that is the live Arc revalidated above; otherwise it is the
+    // request snapshot and this rebind is a no-op. Owner flips during a hold are
+    // already refused by post_hitl_revalidation; rebinding still keeps audit and
+    // per-server defense policy aligned with the executing route if the original
+    // tool name changes under a rename/override rebuild.
+    let (server_id, tool) = exec_router.route_of(name).unwrap_or((server_id, tool));
+    let srv_owned = sanitize_segment(server_id);
+    let srv = srv_owned.as_str();
 
     // Per-call confirmation for destructive tools: intercept the first
     // call with these arguments, store it, and return a preview. The
@@ -4007,13 +4038,9 @@ fn execute_call(
     // spoof check compares like with like. Held in a named binding so the RAII
     // guard lives across the call rather than dropping immediately.
     //
-    // The producer must come from the router that will actually execute the call,
-    // not the request snapshot `server_id` was resolved from. A rebuild during a
-    // HITL hold can re-route the tool to a different server, and a route
-    // registered against the pre-hold producer fails the spoof check on every
-    // notification the new one sends - silently dropping the whole stream (SOU-474).
-    let exec_server_id = exec_router.route_of(name).map_or(server_id, |(srv, _)| srv);
-    let (_progress_route, relay_owned) = prepare_progress(client_meta, exec_server_id);
+    // Identity already comes from `exec_router` via the SOU-478 rebind above
+    // (SOU-474 originally fixed only this progress path).
+    let (_progress_route, relay_owned) = prepare_progress(client_meta, server_id);
     let client_meta = relay_owned.as_ref().or(client_meta);
 
     let started = Instant::now();
@@ -12225,6 +12252,7 @@ mod tests {
             post_hitl_revalidation(
                 approved_fp.as_deref(),
                 "s__wipe",
+                "s",
                 live.lock().unwrap().as_ref(),
             ),
             Some(approval::ApprovalDecision::StaleState),
@@ -12232,7 +12260,7 @@ mod tests {
         );
         // Control: revalidating the stale snapshot alone would wrongly pass.
         assert!(
-            post_hitl_revalidation(approved_fp.as_deref(), "s__wipe", &snapshot).is_none(),
+            post_hitl_revalidation(approved_fp.as_deref(), "s__wipe", "s", &snapshot).is_none(),
             "snapshot-only check would miss the bug this test guards"
         );
     }
@@ -12277,11 +12305,11 @@ mod tests {
             tool_fingerprint_for("s__wipe", &[], &after_drift).as_deref(),
         );
         assert_eq!(
-            post_hitl_revalidation(approved_fp.as_deref(), "s__wipe", &after_drift),
+            post_hitl_revalidation(approved_fp.as_deref(), "s__wipe", "s", &after_drift),
             Some(approval::ApprovalDecision::StaleState),
         );
         assert!(
-            post_hitl_revalidation(approved_fp.as_deref(), "s__wipe", &at_gate).is_none(),
+            post_hitl_revalidation(approved_fp.as_deref(), "s__wipe", "s", &at_gate).is_none(),
             "unchanged definition must still pass"
         );
     }
@@ -12296,6 +12324,7 @@ mod tests {
         assert!(post_hitl_revalidation(
             approved_fp.as_deref(),
             "s__wipe",
+            "s",
             live.lock().unwrap().as_ref(),
         )
         .is_none());
@@ -12314,7 +12343,7 @@ mod tests {
         // not use it — missing live definition is StaleState.
         let _stale_cache = snapshot.aggregated_tools();
         assert_eq!(
-            post_hitl_revalidation(approved_fp.as_deref(), "s__wipe", &live),
+            post_hitl_revalidation(approved_fp.as_deref(), "s__wipe", "s", &live),
             Some(approval::ApprovalDecision::StaleState),
         );
     }
@@ -12354,15 +12383,82 @@ mod tests {
             post_hitl_revalidation(
                 approved_fp.as_deref(),
                 "s__wipe",
+                "s",
                 live.lock().unwrap().as_ref(),
             )
             .is_none(),
             "a mid-hold release on the live Arc must clear the post-HITL block"
         );
         assert_eq!(
-            post_hitl_revalidation(approved_fp.as_deref(), "s__wipe", &snapshot),
+            post_hitl_revalidation(approved_fp.as_deref(), "s__wipe", "s", &snapshot),
             Some(approval::ApprovalDecision::StaleState),
             "the pre-hold snapshot would still wrongly block"
+        );
+    }
+
+    /// SOU-478: a mid-hold rebuild can re-home an exposed name onto a different owning
+    /// server when two ids sanitize to the same prefix (`gh-api` / `gh_api`). Definition
+    /// fingerprints match (identical tools), so only the owner check fails closed.
+    ///
+    /// Mutation check: drop the `gate_server_id` comparison in `post_hitl_revalidation`
+    /// and this test must fail (fingerprint alone would allow execute).
+    #[test]
+    fn post_hitl_revalidation_rejects_server_owner_flip() {
+        let tool_def = json!({ "name": "wipe", "description": "delete rows" });
+        let with_order = |first: &str, second: &str| {
+            let mut r = Router::new();
+            for id in [first, second] {
+                let ds = DownstreamServer::connect(
+                    id.into(),
+                    Box::new(MockRoute {
+                        tools: vec![tool_def.clone()],
+                    }),
+                )
+                .unwrap();
+                r.add(ds);
+            }
+            r
+        };
+        // First writer owns the bare `gh_api__wipe` name; second takes `_2`.
+        let at_gate = with_order("gh-api", "gh_api");
+        let after_flip = with_order("gh_api", "gh-api");
+        let exposed = "gh_api__wipe";
+        assert_eq!(at_gate.route_of(exposed), Some(("gh-api", "wipe")));
+        assert_eq!(after_flip.route_of(exposed), Some(("gh_api", "wipe")));
+        assert_ne!(
+            at_gate.route_of(exposed).map(|(s, _)| s),
+            after_flip.route_of(exposed).map(|(s, _)| s),
+            "fixture must actually flip the owner"
+        );
+
+        let approved_fp = tool_fingerprint_for(exposed, &[], &at_gate);
+        assert!(approved_fp.is_some());
+        assert_eq!(
+            approved_fp.as_deref(),
+            tool_fingerprint_for(exposed, &[], &after_flip).as_deref(),
+            "identical definitions: fingerprint alone cannot catch the owner flip"
+        );
+
+        assert_eq!(
+            post_hitl_revalidation(approved_fp.as_deref(), exposed, "gh-api", &after_flip),
+            Some(approval::ApprovalDecision::StaleState),
+            "owner flip must StaleState even when fingerprints match"
+        );
+        assert!(
+            post_hitl_revalidation(approved_fp.as_deref(), exposed, "gh-api", &at_gate).is_none(),
+            "unchanged owner must still pass"
+        );
+    }
+
+    /// SOU-478: missing live route for a tool that had a known owner at gate is StaleState.
+    #[test]
+    fn post_hitl_revalidation_rejects_missing_live_owner() {
+        let at_gate = routed_router("s", "wipe");
+        let approved_fp = tool_fingerprint_for("s__wipe", &[], &at_gate);
+        let live = Router::new();
+        assert_eq!(
+            post_hitl_revalidation(approved_fp.as_deref(), "s__wipe", "s", &live),
+            Some(approval::ApprovalDecision::StaleState),
         );
     }
 

--- a/src-tauri/src/downstream.rs
+++ b/src-tauri/src/downstream.rs
@@ -425,6 +425,53 @@ impl CacheHint {
     }
 }
 
+/// Consecutive successful empty list responses required before we accept a wipe
+/// of a previously non-empty catalog (SOU-338).
+///
+/// **Decision (CodeRev on #629):** a single empty success is treated as a
+/// transient glitch / list_changed race and is not applied. Two consecutive
+/// empty successes are treated as intentional (admin revoked tools, server
+/// emptied the catalog) and the wipe is accepted. A full router rebuild still
+/// replaces catalogs from a fresh connect regardless of this counter.
+const EMPTY_CATALOG_CONFIRMATIONS: u8 = 2;
+
+/// Apply a successful list refresh with SOU-338 empty-success handling.
+///
+/// - Non-empty `new_items` always replaces and clears the empty streak.
+/// - Empty `new_items` when `previous` is already empty is a no-op replace.
+/// - Empty `new_items` when `previous` is non-empty increments `empty_streak`;
+///   only at [`EMPTY_CATALOG_CONFIRMATIONS`] is the wipe accepted.
+fn apply_catalog_refresh(
+    previous: &mut Vec<Value>,
+    new_items: Vec<Value>,
+    empty_streak: &mut u8,
+    cache_hint: &mut CacheHint,
+    new_hint: CacheHint,
+    server_id: &str,
+    kind: &str,
+) {
+    if !previous.is_empty() && new_items.is_empty() {
+        *empty_streak = empty_streak.saturating_add(1);
+        if *empty_streak < EMPTY_CATALOG_CONFIRMATIONS {
+            cache_hint.mark_stale_and_defer();
+            eprintln!(
+                "toolport: keeping server '{server_id}' previous {kind} catalog after a successful empty refresh ({empty_streak}/{EMPTY_CATALOG_CONFIRMATIONS})"
+            );
+            return;
+        }
+        eprintln!(
+            "toolport: accepting empty {kind} catalog for server '{server_id}' after {EMPTY_CATALOG_CONFIRMATIONS} consecutive empty refreshes"
+        );
+        *empty_streak = 0;
+        *cache_hint = new_hint;
+        *previous = new_items;
+        return;
+    }
+    *empty_streak = 0;
+    *cache_hint = new_hint;
+    *previous = new_items;
+}
+
 /// Error codes the 2026-07-28 allocation policy reserves for the specification
 /// (`-32020`..`-32099`). Their presence in a response is what identifies a modern
 /// server during the backward-compatibility probe.
@@ -4035,6 +4082,12 @@ pub struct DownstreamServer {
     resource_cache_hint: CacheHint,
     resource_template_cache_hint: CacheHint,
     prompt_cache_hint: CacheHint,
+    /// Consecutive successful empty tools/list responses while tools were non-empty
+    /// (SOU-338). Reset on any non-empty refresh. See [`EMPTY_CATALOG_CONFIRMATIONS`].
+    empty_tools_streak: u8,
+    empty_resources_streak: u8,
+    empty_templates_streak: u8,
+    empty_prompts_streak: u8,
     /// Whether the server's `initialize` advertised resources / prompts. The
     /// actual lists are fetched lazily via `load_resources_prompts`.
     caps_resources: bool,
@@ -4266,6 +4319,10 @@ impl DownstreamServer {
             resource_cache_hint: CacheHint::default(),
             resource_template_cache_hint: CacheHint::default(),
             prompt_cache_hint: CacheHint::default(),
+            empty_tools_streak: 0,
+            empty_resources_streak: 0,
+            empty_templates_streak: 0,
+            empty_prompts_streak: 0,
             caps_resources,
             caps_prompts,
             caps_completions,
@@ -4460,18 +4517,15 @@ impl DownstreamServer {
                 } else {
                     listed.items
                 };
-                // SOU-338: a successful empty list can be a transient glitch (or a
-                // list_changed race). Never wipe a previously non-empty catalog.
-                if !self.tools.is_empty() && new_tools.is_empty() {
-                    self.tool_cache_hint.mark_stale_and_defer();
-                    eprintln!(
-                        "toolport: keeping server '{}' previous tool catalog after a successful empty refresh",
-                        self.id
-                    );
-                } else {
-                    self.tool_cache_hint = listed.cache_hint;
-                    self.tools = new_tools;
-                }
+                apply_catalog_refresh(
+                    &mut self.tools,
+                    new_tools,
+                    &mut self.empty_tools_streak,
+                    &mut self.tool_cache_hint,
+                    listed.cache_hint,
+                    &self.id,
+                    "tool",
+                );
             }
             Ok(listed) => {
                 self.tool_cache_hint.mark_stale_and_defer();
@@ -4519,17 +4573,15 @@ impl DownstreamServer {
         self.transport.set_read_timeout(STDIO_CONNECT_TIMEOUT);
         match fetch_paginated_list(&mut *self.transport, "resources/list", "resources") {
             Ok(listed) if listed.warning.is_none() => {
-                // SOU-338: same empty-success guard as tools (and prompts).
-                if !self.resources.is_empty() && listed.items.is_empty() {
-                    self.resource_cache_hint.mark_stale_and_defer();
-                    eprintln!(
-                        "toolport: keeping server '{}' previous resource catalog after a successful empty refresh",
-                        self.id
-                    );
-                } else {
-                    self.resource_cache_hint = listed.cache_hint;
-                    self.resources = listed.items;
-                }
+                apply_catalog_refresh(
+                    &mut self.resources,
+                    listed.items,
+                    &mut self.empty_resources_streak,
+                    &mut self.resource_cache_hint,
+                    listed.cache_hint,
+                    &self.id,
+                    "resource",
+                );
             }
             Ok(listed) => {
                 self.resource_cache_hint.mark_stale_and_defer();
@@ -4555,17 +4607,15 @@ impl DownstreamServer {
             "resourceTemplates",
         ) {
             Ok(listed) if listed.warning.is_none() => {
-                // SOU-338: empty-success guard (templates share the resources signal).
-                if !self.resource_templates.is_empty() && listed.items.is_empty() {
-                    self.resource_template_cache_hint.mark_stale_and_defer();
-                    eprintln!(
-                        "toolport: keeping server '{}' previous resource-template catalog after a successful empty refresh",
-                        self.id
-                    );
-                } else {
-                    self.resource_template_cache_hint = listed.cache_hint;
-                    self.resource_templates = listed.items;
-                }
+                apply_catalog_refresh(
+                    &mut self.resource_templates,
+                    listed.items,
+                    &mut self.empty_templates_streak,
+                    &mut self.resource_template_cache_hint,
+                    listed.cache_hint,
+                    &self.id,
+                    "resource-template",
+                );
             }
             Ok(listed) => {
                 self.resource_template_cache_hint.mark_stale_and_defer();
@@ -4606,17 +4656,15 @@ impl DownstreamServer {
         self.transport.set_read_timeout(STDIO_CONNECT_TIMEOUT);
         match fetch_paginated_list(&mut *self.transport, "prompts/list", "prompts") {
             Ok(listed) if listed.warning.is_none() => {
-                // SOU-338: same empty-success guard as tools/resources.
-                if !self.prompts.is_empty() && listed.items.is_empty() {
-                    self.prompt_cache_hint.mark_stale_and_defer();
-                    eprintln!(
-                        "toolport: keeping server '{}' previous prompt catalog after a successful empty refresh",
-                        self.id
-                    );
-                } else {
-                    self.prompt_cache_hint = listed.cache_hint;
-                    self.prompts = listed.items;
-                }
+                apply_catalog_refresh(
+                    &mut self.prompts,
+                    listed.items,
+                    &mut self.empty_prompts_streak,
+                    &mut self.prompt_cache_hint,
+                    listed.cache_hint,
+                    &self.id,
+                    "prompt",
+                );
             }
             Ok(listed) => {
                 self.prompt_cache_hint.mark_stale_and_defer();
@@ -5273,6 +5321,10 @@ mod tests {
             resource_cache_hint: CacheHint::default(),
             resource_template_cache_hint: CacheHint::default(),
             prompt_cache_hint: CacheHint::default(),
+            empty_tools_streak: 0,
+            empty_resources_streak: 0,
+            empty_templates_streak: 0,
+            empty_prompts_streak: 0,
             caps_resources: false,
             caps_prompts: false,
             caps_completions: false,
@@ -5286,7 +5338,7 @@ mod tests {
         assert_eq!(server.tools, vec![json!({"name":"stable"})]);
     }
 
-    /// SOU-338: a successful empty tools/list must not wipe a non-empty catalog.
+    /// SOU-338: a single successful empty tools/list must not wipe a non-empty catalog.
     /// Mutation check: remove the empty-success guard and this fails.
     #[test]
     fn empty_successful_tool_refresh_keeps_previous_catalog() {
@@ -5302,6 +5354,10 @@ mod tests {
             resource_cache_hint: CacheHint::default(),
             resource_template_cache_hint: CacheHint::default(),
             prompt_cache_hint: CacheHint::default(),
+            empty_tools_streak: 0,
+            empty_resources_streak: 0,
+            empty_templates_streak: 0,
+            empty_prompts_streak: 0,
             caps_resources: false,
             caps_prompts: false,
             caps_completions: false,
@@ -5317,8 +5373,53 @@ mod tests {
         assert_eq!(
             server.tools,
             vec![json!({"name":"stable"})],
-            "successful empty list must not wipe prior tools"
+            "first successful empty list must not wipe prior tools"
         );
+        assert_eq!(server.empty_tools_streak, 1);
+    }
+
+    /// CodeRev on #629 / SOU-338: two consecutive empty successes accept the wipe
+    /// so legitimate full revocation is not stuck forever behind the guard.
+    #[test]
+    fn two_consecutive_empty_tool_refreshes_accept_wipe() {
+        let transport = PaginationTransport::new(vec![
+            Ok(json!({ "tools": [] })),
+            Ok(json!({ "tools": [] })),
+        ]);
+        let mut server = DownstreamServer {
+            id: "fixture".to_string(),
+            transport: Box::new(transport),
+            tools: vec![json!({"name":"stable"})],
+            resources: Vec::new(),
+            resource_templates: Vec::new(),
+            prompts: Vec::new(),
+            tool_cache_hint: CacheHint::default(),
+            resource_cache_hint: CacheHint::default(),
+            resource_template_cache_hint: CacheHint::default(),
+            prompt_cache_hint: CacheHint::default(),
+            empty_tools_streak: 0,
+            empty_resources_streak: 0,
+            empty_templates_streak: 0,
+            empty_prompts_streak: 0,
+            caps_resources: false,
+            caps_prompts: false,
+            caps_completions: false,
+            caps_extensions: serde_json::Map::new(),
+            era: super::Era::Legacy {
+                version: super::PROTOCOL_VERSION.to_string(),
+            },
+            modern_http: false,
+            modern_resource_subscriptions: std::collections::HashSet::new(),
+            server_handler: None,
+        };
+        server.refresh_tools();
+        assert_eq!(server.tools, vec![json!({"name":"stable"})]);
+        server.refresh_tools();
+        assert!(
+            server.tools.is_empty(),
+            "second consecutive empty success must accept the wipe"
+        );
+        assert_eq!(server.empty_tools_streak, 0);
     }
 
     /// SOU-338: empty success is allowed when the catalog was already empty
@@ -5337,6 +5438,10 @@ mod tests {
             resource_cache_hint: CacheHint::default(),
             resource_template_cache_hint: CacheHint::default(),
             prompt_cache_hint: CacheHint::default(),
+            empty_tools_streak: 0,
+            empty_resources_streak: 0,
+            empty_templates_streak: 0,
+            empty_prompts_streak: 0,
             caps_resources: false,
             caps_prompts: false,
             caps_completions: false,
@@ -5371,6 +5476,10 @@ mod tests {
             resource_cache_hint: CacheHint::default(),
             resource_template_cache_hint: CacheHint::default(),
             prompt_cache_hint: CacheHint::default(),
+            empty_tools_streak: 0,
+            empty_resources_streak: 0,
+            empty_templates_streak: 0,
+            empty_prompts_streak: 0,
             caps_resources: true,
             caps_prompts: true,
             caps_completions: false,
@@ -5412,6 +5521,10 @@ mod tests {
             resource_cache_hint: CacheHint::default(),
             resource_template_cache_hint: CacheHint::default(),
             prompt_cache_hint: CacheHint::default(),
+            empty_tools_streak: 0,
+            empty_resources_streak: 0,
+            empty_templates_streak: 0,
+            empty_prompts_streak: 0,
             caps_resources: true,
             caps_prompts: false,
             caps_completions: false,

--- a/src-tauri/src/downstream.rs
+++ b/src-tauri/src/downstream.rs
@@ -4455,12 +4455,23 @@ impl DownstreamServer {
         }
         match listed {
             Ok(listed) if listed.warning.is_none() => {
-                self.tool_cache_hint = listed.cache_hint;
-                self.tools = if self.modern_http {
+                let new_tools = if self.modern_http {
                     filter_modern_http_tools(&self.id, listed.items)
                 } else {
                     listed.items
                 };
+                // SOU-338: a successful empty list can be a transient glitch (or a
+                // list_changed race). Never wipe a previously non-empty catalog.
+                if !self.tools.is_empty() && new_tools.is_empty() {
+                    self.tool_cache_hint.mark_stale_and_defer();
+                    eprintln!(
+                        "toolport: keeping server '{}' previous tool catalog after a successful empty refresh",
+                        self.id
+                    );
+                } else {
+                    self.tool_cache_hint = listed.cache_hint;
+                    self.tools = new_tools;
+                }
             }
             Ok(listed) => {
                 self.tool_cache_hint.mark_stale_and_defer();
@@ -4508,8 +4519,17 @@ impl DownstreamServer {
         self.transport.set_read_timeout(STDIO_CONNECT_TIMEOUT);
         match fetch_paginated_list(&mut *self.transport, "resources/list", "resources") {
             Ok(listed) if listed.warning.is_none() => {
-                self.resource_cache_hint = listed.cache_hint;
-                self.resources = listed.items;
+                // SOU-338: same empty-success guard as tools (and prompts).
+                if !self.resources.is_empty() && listed.items.is_empty() {
+                    self.resource_cache_hint.mark_stale_and_defer();
+                    eprintln!(
+                        "toolport: keeping server '{}' previous resource catalog after a successful empty refresh",
+                        self.id
+                    );
+                } else {
+                    self.resource_cache_hint = listed.cache_hint;
+                    self.resources = listed.items;
+                }
             }
             Ok(listed) => {
                 self.resource_cache_hint.mark_stale_and_defer();
@@ -4535,8 +4555,17 @@ impl DownstreamServer {
             "resourceTemplates",
         ) {
             Ok(listed) if listed.warning.is_none() => {
-                self.resource_template_cache_hint = listed.cache_hint;
-                self.resource_templates = listed.items;
+                // SOU-338: empty-success guard (templates share the resources signal).
+                if !self.resource_templates.is_empty() && listed.items.is_empty() {
+                    self.resource_template_cache_hint.mark_stale_and_defer();
+                    eprintln!(
+                        "toolport: keeping server '{}' previous resource-template catalog after a successful empty refresh",
+                        self.id
+                    );
+                } else {
+                    self.resource_template_cache_hint = listed.cache_hint;
+                    self.resource_templates = listed.items;
+                }
             }
             Ok(listed) => {
                 self.resource_template_cache_hint.mark_stale_and_defer();
@@ -4577,8 +4606,17 @@ impl DownstreamServer {
         self.transport.set_read_timeout(STDIO_CONNECT_TIMEOUT);
         match fetch_paginated_list(&mut *self.transport, "prompts/list", "prompts") {
             Ok(listed) if listed.warning.is_none() => {
-                self.prompt_cache_hint = listed.cache_hint;
-                self.prompts = listed.items;
+                // SOU-338: same empty-success guard as tools/resources.
+                if !self.prompts.is_empty() && listed.items.is_empty() {
+                    self.prompt_cache_hint.mark_stale_and_defer();
+                    eprintln!(
+                        "toolport: keeping server '{}' previous prompt catalog after a successful empty refresh",
+                        self.id
+                    );
+                } else {
+                    self.prompt_cache_hint = listed.cache_hint;
+                    self.prompts = listed.items;
+                }
             }
             Ok(listed) => {
                 self.prompt_cache_hint.mark_stale_and_defer();
@@ -5246,6 +5284,112 @@ mod tests {
         };
         server.refresh_tools();
         assert_eq!(server.tools, vec![json!({"name":"stable"})]);
+    }
+
+    /// SOU-338: a successful empty tools/list must not wipe a non-empty catalog.
+    /// Mutation check: remove the empty-success guard and this fails.
+    #[test]
+    fn empty_successful_tool_refresh_keeps_previous_catalog() {
+        let transport = PaginationTransport::new(vec![Ok(json!({ "tools": [] }))]);
+        let mut server = DownstreamServer {
+            id: "fixture".to_string(),
+            transport: Box::new(transport),
+            tools: vec![json!({"name":"stable"})],
+            resources: Vec::new(),
+            resource_templates: Vec::new(),
+            prompts: Vec::new(),
+            tool_cache_hint: CacheHint::default(),
+            resource_cache_hint: CacheHint::default(),
+            resource_template_cache_hint: CacheHint::default(),
+            prompt_cache_hint: CacheHint::default(),
+            caps_resources: false,
+            caps_prompts: false,
+            caps_completions: false,
+            caps_extensions: serde_json::Map::new(),
+            era: super::Era::Legacy {
+                version: super::PROTOCOL_VERSION.to_string(),
+            },
+            modern_http: false,
+            modern_resource_subscriptions: std::collections::HashSet::new(),
+            server_handler: None,
+        };
+        server.refresh_tools();
+        assert_eq!(
+            server.tools,
+            vec![json!({"name":"stable"})],
+            "successful empty list must not wipe prior tools"
+        );
+    }
+
+    /// SOU-338: empty success is allowed when the catalog was already empty
+    /// (first-time empty, or intentionally emptied after a real full wipe path).
+    #[test]
+    fn empty_successful_tool_refresh_ok_when_already_empty() {
+        let transport = PaginationTransport::new(vec![Ok(json!({ "tools": [] }))]);
+        let mut server = DownstreamServer {
+            id: "fixture".to_string(),
+            transport: Box::new(transport),
+            tools: Vec::new(),
+            resources: Vec::new(),
+            resource_templates: Vec::new(),
+            prompts: Vec::new(),
+            tool_cache_hint: CacheHint::default(),
+            resource_cache_hint: CacheHint::default(),
+            resource_template_cache_hint: CacheHint::default(),
+            prompt_cache_hint: CacheHint::default(),
+            caps_resources: false,
+            caps_prompts: false,
+            caps_completions: false,
+            caps_extensions: serde_json::Map::new(),
+            era: super::Era::Legacy {
+                version: super::PROTOCOL_VERSION.to_string(),
+            },
+            modern_http: false,
+            modern_resource_subscriptions: std::collections::HashSet::new(),
+            server_handler: None,
+        };
+        server.refresh_tools();
+        assert!(server.tools.is_empty());
+    }
+
+    /// SOU-338: resources and prompts share the empty-success guard.
+    #[test]
+    fn empty_successful_resource_and_prompt_refresh_keeps_previous() {
+        let transport = PaginationTransport::new(vec![
+            Ok(json!({ "resources": [] })),
+            Ok(json!({ "resourceTemplates": [] })),
+            Ok(json!({ "prompts": [] })),
+        ]);
+        let mut server = DownstreamServer {
+            id: "fixture".to_string(),
+            transport: Box::new(transport),
+            tools: Vec::new(),
+            resources: vec![json!({"uri":"stable-r:"})],
+            resource_templates: vec![json!({"uriTemplate":"stable://{id}"})],
+            prompts: vec![json!({"name":"stable-p"})],
+            tool_cache_hint: CacheHint::default(),
+            resource_cache_hint: CacheHint::default(),
+            resource_template_cache_hint: CacheHint::default(),
+            prompt_cache_hint: CacheHint::default(),
+            caps_resources: true,
+            caps_prompts: true,
+            caps_completions: false,
+            caps_extensions: serde_json::Map::new(),
+            era: super::Era::Legacy {
+                version: super::PROTOCOL_VERSION.to_string(),
+            },
+            modern_http: false,
+            modern_resource_subscriptions: std::collections::HashSet::new(),
+            server_handler: None,
+        };
+        server.refresh_resources();
+        server.refresh_prompts();
+        assert_eq!(server.resources, vec![json!({"uri":"stable-r:"})]);
+        assert_eq!(
+            server.resource_templates,
+            vec![json!({"uriTemplate":"stable://{id}"})]
+        );
+        assert_eq!(server.prompts, vec![json!({"name":"stable-p"})]);
     }
 
     #[test]

--- a/src-tauri/src/inspect.rs
+++ b/src-tauri/src/inspect.rs
@@ -261,6 +261,12 @@ mod tests {
         reset();
 
         let path = inspect_path().unwrap();
+        // Direct write (not via record/write_line) must ensure the data dir exists.
+        // On a fresh override / cold CI home the parent can be missing; write_line
+        // create_dir_all's it, so this test must match (CI flake: NotFound on write).
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
 
         std::fs::write(
             &path,


### PR DESCRIPTION
## Summary

Wave 1 correctness fixes from the Toolport board (no new audit; board-driven).

- **SOU-478**: `post_hitl_revalidation` fails closed when the live route's owning server differs from the gate-time owner (definition fingerprints do not hash the owner). Rebind post-gate audit / content defense / inspect identity from the exec router.
- **SOU-337**: Registry-watcher full rebuild now takes `rebuild_lock` so it single-flights with startup self-heal and `${ROOT}` rebuilds (no double-spawn).
- **SOU-338**: Successful empty `tools/list` / resources / prompts / templates refresh no longer wipes a non-empty prior catalog.

## Test plan

- [x] `cargo test --bin toolport-gateway post_hitl_revalidation` (7 tests, including owner-flip fixture)
- [x] `cargo test --bin toolport-gateway hitl`
- [x] `cargo test --lib empty_successful` (SOU-338)
- [x] `cargo test --bin toolport-gateway watch_tick`
- [ ] CI green on this PR
