### PR TITLE
docs: stop pointing contributors at keyboard shortcuts

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -182,7 +182,7 @@ Keep comments at the density of the file you're editing.
 - New curated catalog entries (real, verified MCP servers) in `catalog.rs`.
 - New curated stacks (role-based server bundles) in `stacks.rs`.
 - Additional client support in `clients.rs` (a new AI tool's config format).
-- Frontend polish: empty states, error messages, keyboard shortcuts.
+- Frontend polish: empty states and error messages.
 - Tests for any of the above.
 
 ## Adding a curated catalog entry


### PR DESCRIPTION
"Good places to start" in CONTRIBUTING listed keyboard shortcuts alongside empty states and error messages. Shortcuts (view switch, focus search, add server, refresh) are already scoped as maintainer work, so recommending them sends a contributor at something in progress.

Drops that item and leaves the two that are actually open.

Found during the issue audit that produced #630-#636.