### PR TITLE
docs: complete client format table

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -308,11 +308,15 @@ Check the client's config file and match it to a `Format` variant:
 | Format               | Config shape                                       | Existing clients                 |
 | -------------------- | -------------------------------------------------- | -------------------------------- |
 | `JsonMcpServers`     | `{"mcpServers": {...}}`                            | Claude Desktop, Cursor, Windsurf |
+| `JsonCopilotMcpServers` | `{"mcpServers": {...}}` entries require a `tools` allowlist | GitHub Copilot CLI |
+| `JsonDroidMcpServers` | `{"mcpServers": {...}}` every entry requires a `"type"` field | Factory Droid |
+| `JsonAmpMcpServers`  | dotted top-level key `amp.mcpServers` (not a nested object) | Amp |
+| `JsonMcp`            | top-level `mcp` object                              | Crush                           |
 | `JsonQwenMcpServers` | `{"mcpServers": {"name": {"httpUrl": "..."}}}`     | Qwen Code                        |
 | `JsonServers`        | `{"servers": {...}}`                               | VS Code                          |
 | `JsonOpenCodeMcp`    | `{"mcp": {"name": {"command": [...]}}}`            | OpenCode, Kilo Code              |
 | `JsonContextServers` | `{"context_servers": {...}}` (JSONC)               | Zed                              |
-| `TomlMcpServers`     | `[mcp_servers.name]`                               | Codex, Grok Build                |
+| `TomlMcpServers`     | `[mcp_servers.name]`                               | Codex CLI                        |
 | `YamlExtensions`     | `extensions:` map (Goose shape: `cmd`/`envs`)      | Goose                            |
 | `YamlMcpServers`     | `mcp_servers:` map (Hermes shape: `command`/`env`) | Hermes                           |
 | `YamlMcpServersList` | `mcpServers:` list                                 | Continue                         |


### PR DESCRIPTION
## Summary

Adds the four missing `Format` variants to the CONTRIBUTING table and reconciles the client names with the enum doc comments.

## Changes

- Adds `JsonCopilotMcpServers`, `JsonDroidMcpServers`, `JsonAmpMcpServers`, and `JsonMcp` rows.
- Changes the `TomlMcpServers` client list to Codex CLI.

Closes #630