### PR TITLE
docs: list gateway env vars in help

### DIFF
--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -11119,7 +11119,8 @@ fn usage() -> String {
          \n\
          ENV:\n\
          \x20   TOOLPORT_HTTP, TOOLPORT_HTTP_PORT, TOOLPORT_HTTP_HOST, TOOLPORT_HTTP_TOKEN,\n\
-         \x20   TOOLPORT_REGISTRY, TOOLPORT_DEBUG",
+         \x20   TOOLPORT_REGISTRY, TOOLPORT_DISCOVERY, TOOLPORT_CODE_MODE,\n\
+         \x20   TOOLPORT_DATA_DIR, TOOLPORT_DEBUG",
         version = env!("CARGO_PKG_VERSION"),
         insecure = INSECURE_LOOPBACK_FLAG,
     )


### PR DESCRIPTION
## Summary

Adds the missing user-facing gateway env vars to the `--help` ENV block: `TOOLPORT_DISCOVERY`, `TOOLPORT_CODE_MODE`, and `TOOLPORT_DATA_DIR`.

## Verification

- `cargo check --manifest-path src-tauri/Cargo.toml --bin toolport-gateway` passes.
- The existing warnings are pre-existing.

Closes #631