### PR TITLE
refactor: remove dead data dir shim

### DIFF
--- a/src-tauri/src/brand.rs
+++ b/src-tauri/src/brand.rs
@@ -56,7 +56,11 @@ pub fn env_flag(new_key: &str, legacy_key: &str) -> bool {
     }
 }
 
-/// Canonical data-dir leaf under the OS config root (`Toolport` / `Toolport-dev`).
+/// Leaf directory name under the OS config root (`Toolport` release,
+/// `Toolport-dev` for debug/`tauri dev` builds). Override the full path with
+/// `TOOLPORT_DATA_DIR` (legacy: `CONDUIT_DATA_DIR`). Existing `Conduit` /
+/// `Conduit-dev` dirs are migrated in place by [`resolve_data_dir_under`] when
+/// safe.
 pub fn data_dir_leaf_name() -> &'static str {
     if cfg!(debug_assertions) {
         "Toolport-dev"

--- a/src-tauri/src/registry.rs
+++ b/src-tauri/src/registry.rs
@@ -1277,14 +1277,6 @@ impl Registry {
     }
 }
 
-/// Leaf directory name under the OS config root (`Toolport` release, `Toolport-dev`
-/// for debug/`tauri dev` builds). Override the full path with `TOOLPORT_DATA_DIR`
-/// (legacy: `CONDUIT_DATA_DIR`). Existing `Conduit` / `Conduit-dev` dirs are migrated
-/// in place by [`crate::brand::resolve_data_dir_under`] when safe.
-pub(crate) fn data_dir_leaf_name() -> &'static str {
-    crate::brand::data_dir_leaf_name()
-}
-
 /// How [`conduit_dir`] was resolved, for startup diagnostics. Only Windows has
 /// interesting cases (MSIX app containers); everywhere else it is `Direct`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -2764,7 +2756,10 @@ mod tests {
         // Prefer Toolport; existing installs may still resolve under the legacy leaf
         // until desktop launch migrates it.
         assert!(
-            s.ends_with(&format!("AppData\\Roaming\\{}", data_dir_leaf_name()))
+            s.ends_with(&format!(
+                "AppData\\Roaming\\{}",
+                crate::brand::data_dir_leaf_name()
+            ))
                 || s.ends_with(&format!(
                     "AppData\\Roaming\\{}",
                     crate::brand::legacy_data_dir_leaf_name()
@@ -3225,7 +3220,7 @@ mod tests {
     #[test]
     fn data_dir_leaf_is_dev_in_debug_builds() {
         assert_eq!(
-            data_dir_leaf_name(),
+            crate::brand::data_dir_leaf_name(),
             if cfg!(debug_assertions) {
                 "Toolport-dev"
             } else {


### PR DESCRIPTION
## Summary

Removes the dead `registry::data_dir_leaf_name` forwarding shim and moves its explanation onto `brand::data_dir_leaf_name` so no documentation is lost. The two registry tests that used the shim now call the canonical brand function directly.

## Verification

- `cargo check --manifest-path src-tauri/Cargo.toml --lib` passes.
- `cargo test --manifest-path src-tauri/Cargo.toml --no-default-features -p conduit --lib data_dir_leaf` passes.

Closes #633