### PR TITLE
chore: check out all text files as LF on every platform

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,17 @@
+# Check every text file out as LF, on every platform.
+#
+# Without this, a Windows clone with core.autocrlf=true gets CRLF working files
+# while Prettier is configured `endOfLine: "lf"`. `npm run format:check` then
+# reports nearly every file in the repo as unformatted, which buries the one or
+# two files that are genuinely wrong and trains contributors to ignore the
+# check. Worse, the obvious fix (`prettier --write`) rewrites the tree with CRLF
+# and still fails CI on Linux.
+#
+# Every blob in this repo is already stored LF, so this changes no file content
+# -- only how Git materializes the working tree.
+* text=auto eol=lf
+
 # Shell scripts must stay LF, or they fail to run on the macOS/Linux CI runners
-# (a CRLF in the shebang line gives "bad interpreter"). This pins them regardless
-# of a contributor's core.autocrlf setting.
+# (a CRLF in the shebang line gives "bad interpreter"). Kept explicit so the
+# guarantee survives any future narrowing of the rule above.
 *.sh text eol=lf


### PR DESCRIPTION
## Problem

Prettier is configured `endOfLine: "lf"`, but `.gitattributes` only pinned `*.sh`. A Windows clone with `core.autocrlf=true` therefore materializes CRLF working files, and `npm run format:check` reports **134 files** as unformatted when only one is genuinely wrong.

That is not just noise:

- It hides real failures. During the #643 investigation, the single genuinely misformatted file was indistinguishable from 133 false positives.
- The obvious fix is actively harmful. `prettier --write` rewrites the whole tree with CRLF, producing an enormous line-ending diff **and still failing CI on Linux**.

## Change

Adds `* text=auto eol=lf`, so every text file is checked out LF on every platform. The explicit `*.sh` rule is kept so that guarantee survives any future narrowing.

## Verification

- Every blob in the repo is already stored LF, so `git add --renormalize .` reports **only `.gitattributes`** as modified — zero content churn.
- After re-materializing the working tree, `git status` is clean and `npm run format:check` reports *"All matched files use Prettier code style!"* — down from 134 failures.
- `text=auto` auto-detects binaries, so `*.png` / `*.ico` are unaffected.

## Note for existing clones

Contributors with an existing checkout will see files re-materialize on their next pull. If anything looks odd locally, `git add --renormalize .` is a no-op safety net.

🤖 Generated with [Claude Code](https://claude.com/claude-code)