### PR TITLE
fix(deps): pin nanoid >=3.3.17 to clear the prod audit gate

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8708,9 +8708,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,8 @@
     "eslint-plugin-jsx-a11y": {
       "eslint": "$eslint"
     },
-    "postcss": "8.5.23"
+    "postcss": "8.5.23",
+    "nanoid": "^3.3.17"
   },
   "lint-staged": {
     "*.{ts,tsx,css,mjs,json,md}": "prettier --write",


### PR DESCRIPTION
## Problem

CI is red on `main` (`8b1276c`). The failure is not from that commit — it is `npm run audit:prod` tripping on an advisory that landed after #645 was reviewed:

```
nanoid  <3.3.17
Severity: high
nanoid: custom generators can loop indefinitely when size is zero
https://github.com/advisories/GHSA-2v37-7h3g-55p8
```

#645's own checks were green because they ran before the advisory was published; the post-merge run on `main` hit it. Any PR opened from here would inherit the same red X.

## Fix

`nanoid` is not a direct dependency — it arrives transitively via the pinned `postcss` 8.5.23 under `vite`. Pin it through `overrides`, the same mechanism already used for `postcss`, `esbuild`, and `fast-uri`.

Resolves `nanoid` 3.3.16 → 3.3.18.

## Verification

- `npm audit --omit=dev` → `found 0 vulnerabilities` (was exit 1)
- `npm run build` → clean
- `npm test` → 22 files, 211 tests, all passing

Diff is 5 insertions / 4 deletions across `package.json` and `package-lock.json`. No source changes.
