### PR TITLE
test(reaper): cover the Linux (deleted) policy and keep-path survival for real

### DIFF
--- a/src-tauri/src/gateway_publish.rs
+++ b/src-tauri/src/gateway_publish.rs
@@ -648,8 +648,22 @@ fn label_process(proc: &GatewayProcess) -> String {
 }
 
 fn reap_with_context(ctx: &ReapContext) -> ReapReport {
+    reap_listed(ctx, list_gateway_processes)
+}
+
+/// Body of [`reap_with_context`], taking the enumerator so a caller can bound which
+/// processes the pass may consider.
+///
+/// Production always passes [`list_gateway_processes`]. Tests pass an enumerator
+/// scoped to their own fixtures: driving the real plan/kill/verify path against the
+/// *global* process table would otherwise mean a real gateway that starts during the
+/// pass (including inside the 150ms verify window below, which re-enumerates) is not
+/// in `keep_pids` and gets killed. Pinning pids before the pass narrows that window
+/// but cannot close it, because the verify re-enumeration happens later than any
+/// snapshot the caller can take. Scoping the enumerator closes it by construction.
+fn reap_listed(ctx: &ReapContext, list: impl Fn() -> Vec<GatewayProcess>) -> ReapReport {
     let mut report = ReapReport::default();
-    let plan = plan_reap(&list_gateway_processes(), ctx);
+    let plan = plan_reap(&list(), ctx);
     report.kept = plan.kept;
     report.needs_restart = plan.needs_restart;
     for proc in plan.to_kill {
@@ -663,7 +677,7 @@ fn reap_with_context(ctx: &ReapContext) -> ReapReport {
     // Verify: anything still present that should be gone?
     if !report.killed.is_empty() || !report.failed.is_empty() {
         std::thread::sleep(std::time::Duration::from_millis(150));
-        let still = list_gateway_processes();
+        let still = list();
         for proc in still {
             if decide_reap(&proc, ctx) == ReapDecision::Kill {
                 let label = label_process(&proc);
@@ -1937,19 +1951,21 @@ mod tests {
         assert_eq!(m, back);
     }
 
-    /// Serializes every test that spawns real gateways and walks the process table.
+    /// Serializes copy-then-exec of a stand-in binary across tests.
     ///
-    /// Each of them puts its fixtures under a literal `Toolport` path segment
-    /// (`decide_reap` will not kill anything else), so two running concurrently
-    /// would let one test's reap pass kill the other's processes. Poison is
-    /// ignored: one failing test should not cascade into the rest.
-    #[cfg(all(unix, not(target_os = "macos")))]
-    static PROCESS_TABLE: std::sync::Mutex<()> = std::sync::Mutex::new(());
-
-    #[cfg(all(unix, not(target_os = "macos")))]
-    fn lock_process_table() -> std::sync::MutexGuard<'static, ()> {
-        PROCESS_TABLE.lock().unwrap_or_else(|e| e.into_inner())
-    }
+    /// Not for reaper reasons -- `reap_listed` bounds what a pass may touch, so tests
+    /// cannot reach each other's processes. This is the POSIX `ETXTBSY` race: while
+    /// one thread holds a write fd to the file it just copied, another thread's
+    /// `Command::spawn` forks and the child inherits that fd. The descriptor is
+    /// `O_CLOEXEC`, but it stays open across the window between the child's fork and
+    /// its exec, and a file any process holds open for writing cannot be exec'd. The
+    /// first thread's exec then fails with "Text file busy".
+    ///
+    /// Without this the three tests fail intermittently -- 3 runs in 8 while this was
+    /// being written. The critical section has to run from opening the destination
+    /// through exec actually completing, which is why it wraps the readiness poll and
+    /// not just the copy. Poison is ignored so one failing test does not cascade.
+    static SPAWN_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
     /// A small, long-running binary to stand in for a gateway image.
     #[cfg(all(unix, not(target_os = "macos")))]
@@ -1990,14 +2006,23 @@ mod tests {
                 std::thread::current().id()
             ));
             let _ = std::fs::remove_dir_all(&root);
+            std::fs::create_dir_all(&root).expect("create scratch root");
+            // Canonicalize the ROOT and derive everything else from it, so `root`,
+            // `dir` and every path handed to a test are in one form.
+            //
+            // It has to be canonical because `/proc/<pid>/exe` reports the kernel's
+            // own resolved path: where TMPDIR resolves through a symlink (a container
+            // layout, or a custom TMPDIR) an uncanonical path makes every
+            // `read_link(...) == exe` comparison fail despite a successful exec.
+            //
+            // Canonicalizing only `dir` and falling back to the uncanonical path on
+            // error was worse than not trying: it left `dir` and `root` in different
+            // forms, and a failure surfaced 3s later as an unexplained readiness-poll
+            // panic. The directory was just created, so failure here means a broken
+            // environment and should say so.
+            let root = std::fs::canonicalize(&root).expect("canonicalize scratch root");
             let dir = root.join("Toolport");
             std::fs::create_dir_all(&dir).expect("create scratch dir");
-            // Canonicalize, because `/proc/<pid>/exe` reports the kernel's own
-            // resolved path. Where TMPDIR is a symlink (a container layout, or a
-            // custom TMPDIR pointing through one) an uncanonicalized path would make
-            // every `read_link(...) == exe` comparison fail even though the exec
-            // succeeded, turning a portability quirk into a spurious test failure.
-            let dir = std::fs::canonicalize(&dir).unwrap_or(dir);
             Self { dir, root }
         }
     }
@@ -2039,6 +2064,7 @@ mod tests {
         fn at(exe: PathBuf) -> Self {
             use std::os::unix::fs::PermissionsExt as _;
 
+            let _spawn = SPAWN_LOCK.lock().unwrap_or_else(|e| e.into_inner());
             if let Some(parent) = exe.parent() {
                 std::fs::create_dir_all(parent).expect("create gateway dir");
             }
@@ -2122,8 +2148,6 @@ mod tests {
     #[cfg(all(unix, not(target_os = "macos")))]
     #[test]
     fn linux_enumeration_finds_a_versioned_gateway_via_the_exe_fallback() {
-        let _serial = lock_process_table();
-
         let dir = ScratchDir::new("reaper-enum");
         // Deliberately longer than comm's 15-char window so the truncation this
         // test exists for actually happens.
@@ -2190,8 +2214,6 @@ mod tests {
     #[cfg(all(unix, not(target_os = "macos")))]
     #[test]
     fn linux_deleted_image_is_enumerated_but_misses_its_own_keep_path() {
-        let _serial = lock_process_table();
-
         let dir = ScratchDir::new("reaper-deleted");
         let exe = dir.join("bin/toolport-gateway");
         let gw = SpawnedGateway::at(exe.clone());
@@ -2274,8 +2296,6 @@ mod tests {
     #[cfg(all(unix, not(target_os = "macos")))]
     #[test]
     fn linux_reap_keeps_the_live_keep_path_and_kills_stale_and_unlinked_images() {
-        let _serial = lock_process_table();
-
         let dir = ScratchDir::new("reaper-reap");
         let keep_exe = dir.join("bin/toolport-gateway");
         let stale_exe = dir.join("old/toolport-gateway");
@@ -2289,25 +2309,26 @@ mod tests {
         // replaced, so this process now holds an unlinked inode.
         upgraded.unlink_image();
 
-        // Snapshot immediately before the pass and pin everything that is not one of
-        // this test's three fixtures, so a real Toolport gateway on a developer's
-        // machine cannot be reaped by the suite. Snapshotting before the fixtures
-        // spawn would instead leave the whole spawn sequence as a window in which a
-        // real gateway could start, miss the snapshot, and be killed.
+        // Real enumeration, scoped to this test's own processes. Everything the pass
+        // sees is therefore something this test spawned, so it cannot reap a real
+        // Toolport gateway on a developer's machine no matter when one starts. A
+        // `keep_pids` snapshot cannot achieve that: the verify pass re-enumerates
+        // 150ms later, after any snapshot the caller could have taken.
         let mine = [keep.pid(), stale.pid(), upgraded.pid()];
-        let mut keep_pids: Vec<u32> = linux_list_gateway_processes()
-            .into_iter()
-            .map(|p| p.pid)
-            .filter(|pid| !mine.contains(pid))
-            .collect();
-        keep_pids.push(std::process::id());
-
-        let report = reap_with_context(&ReapContext {
-            current_version: "9.9.9".into(),
-            keep_paths: vec![keep_exe.clone(), upgraded_exe.clone()],
-            keep_pids,
-            kill_all: false,
-        });
+        let report = reap_listed(
+            &ReapContext {
+                current_version: "9.9.9".into(),
+                keep_paths: vec![keep_exe.clone(), upgraded_exe.clone()],
+                keep_pids: vec![std::process::id()],
+                kill_all: false,
+            },
+            || {
+                linux_list_gateway_processes()
+                    .into_iter()
+                    .filter(|p| mine.contains(&p.pid))
+                    .collect()
+            },
+        );
 
         let budget = std::time::Duration::from_secs(5);
         assert!(
@@ -2332,22 +2353,18 @@ mod tests {
             "the reaper could not stop processes it planned to kill: {:?}",
             report.failed
         );
-        // The pid snapshot above is the only thing standing between this pass and a
-        // real gateway that started in the window before it was taken. Assert the
-        // blast radius directly, so such a miss fails the suite loudly instead of
-        // silently killing a developer's gateway.
-        assert_eq!(
-            report.killed.len(),
-            2,
-            "expected exactly the stale and unlinked fixtures to be killed: {:?}",
+        // The keep-path process must not appear in the killed list under any label,
+        // including the verify pass's `[retry]` form. Asserting a count instead would
+        // be both weaker and flaky: a fixture the kernel has not finished reaping
+        // within the 150ms verify window legitimately adds a `[retry]` entry.
+        assert!(
+            !report
+                .killed
+                .iter()
+                .any(|label| label.contains(&keep_exe.display().to_string())),
+            "the keep-path gateway appears in the killed list: {:?}",
             report.killed
         );
-        for label in &report.killed {
-            assert!(
-                label.contains("toolport-reaper-reap-"),
-                "the reap pass killed a process outside this test's scratch tree: {label}"
-            );
-        }
     }
 
     // ----- SOU-435: restart advice -------------------------------------------

--- a/src-tauri/src/gateway_publish.rs
+++ b/src-tauri/src/gateway_publish.rs
@@ -1937,17 +1937,146 @@ mod tests {
         assert_eq!(m, back);
     }
 
-    /// Kills the child and removes the scratch directory even if an assertion
-    /// panics, so a failing run cannot leave a stray `sleep` behind.
+    /// Serializes every test that spawns real gateways and walks the process table.
+    ///
+    /// Each of them puts its fixtures under a literal `Toolport` path segment
+    /// (`decide_reap` will not kill anything else), so two running concurrently
+    /// would let one test's reap pass kill the other's processes. Poison is
+    /// ignored: one failing test should not cascade into the rest.
     #[cfg(all(unix, not(target_os = "macos")))]
-    struct SpawnedGateway(std::process::Child, PathBuf);
+    static PROCESS_TABLE: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    #[cfg(all(unix, not(target_os = "macos")))]
+    fn lock_process_table() -> std::sync::MutexGuard<'static, ()> {
+        PROCESS_TABLE.lock().unwrap_or_else(|e| e.into_inner())
+    }
+
+    /// A small, long-running binary to stand in for a gateway image.
+    #[cfg(all(unix, not(target_os = "macos")))]
+    fn stand_in_binary_source() -> &'static str {
+        // into_iter, not iter().map(Path::new): the latter returns a &Path borrowed
+        // from the temporary array, which does not outlive the statement.
+        ["/bin/sleep", "/usr/bin/sleep"]
+            .into_iter()
+            .find(|p| Path::new(p).exists())
+            .expect("no sleep binary available to stand in for a gateway")
+    }
+
+    /// Scratch tree removed on drop, shared by every gateway one test spawns.
+    #[cfg(all(unix, not(target_os = "macos")))]
+    struct ScratchDir(PathBuf);
+
+    #[cfg(all(unix, not(target_os = "macos")))]
+    impl ScratchDir {
+        /// Ends in a literal `Toolport` segment on purpose: `decide_reap` only kills
+        /// an image under a path `path_looks_like_our_install` recognizes, so a bare
+        /// temp dir would be treated as a stranger's binary and kept.
+        fn new(tag: &str) -> Self {
+            let dir = std::env::temp_dir()
+                .join(format!("toolport-reaper-{tag}-{}", std::process::id()))
+                .join("Toolport");
+            let _ = std::fs::remove_dir_all(&dir);
+            std::fs::create_dir_all(&dir).expect("create scratch dir");
+            Self(dir)
+        }
+
+        fn join(&self, rel: &str) -> PathBuf {
+            self.0.join(rel)
+        }
+    }
+
+    #[cfg(all(unix, not(target_os = "macos")))]
+    impl Drop for ScratchDir {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
+
+    /// A stand-in gateway process running from a scratch path.
+    ///
+    /// Kills and reaps the child on drop, so a failing assertion cannot leave a
+    /// stray `sleep` behind.
+    #[cfg(all(unix, not(target_os = "macos")))]
+    struct SpawnedGateway {
+        child: std::process::Child,
+        exe: PathBuf,
+    }
+
+    #[cfg(all(unix, not(target_os = "macos")))]
+    impl SpawnedGateway {
+        /// Copy the stand-in binary to `exe`, run it, and block until the exec has
+        /// actually happened.
+        ///
+        /// `spawn()` returns before exec completes, so `/proc/<pid>` is not populated
+        /// yet; polling the exe symlink is what makes the enumeration assertions
+        /// deterministic rather than racy.
+        fn at(exe: PathBuf) -> Self {
+            use std::os::unix::fs::PermissionsExt as _;
+
+            if let Some(parent) = exe.parent() {
+                std::fs::create_dir_all(parent).expect("create gateway dir");
+            }
+            std::fs::copy(stand_in_binary_source(), &exe).expect("copy stand-in binary");
+            std::fs::set_permissions(&exe, std::fs::Permissions::from_mode(0o755))
+                .expect("chmod +x");
+
+            let child = std::process::Command::new(&exe)
+                .arg("300")
+                .spawn()
+                .expect("spawn stand-in gateway");
+            let me = Self { child, exe };
+
+            let link = PathBuf::from(format!("/proc/{}/exe", me.pid()));
+            for _ in 0..300 {
+                if std::fs::read_link(&link)
+                    .map(|p| p == me.exe)
+                    .unwrap_or(false)
+                {
+                    return me;
+                }
+                std::thread::sleep(std::time::Duration::from_millis(10));
+            }
+            panic!("child never exec'd into {}", me.exe.display());
+        }
+
+        fn pid(&self) -> u32 {
+            self.child.id()
+        }
+
+        /// Unlink the running image, which is what an in-place binary replacement
+        /// (package upgrade, installer overwrite) does. `/proc/<pid>/exe` carries the
+        /// ` (deleted)` marker from here on.
+        fn unlink_image(&self) {
+            std::fs::remove_file(&self.exe).expect("unlink running image");
+        }
+
+        /// Did the process exit within `budget`? Reaps the zombie, so a later `/proc`
+        /// walk cannot see it.
+        fn exited_within(&mut self, budget: std::time::Duration) -> bool {
+            let deadline = std::time::Instant::now() + budget;
+            loop {
+                match self.child.try_wait() {
+                    Ok(Some(_)) => return true,
+                    Ok(None) => {}
+                    Err(_) => return false,
+                }
+                if std::time::Instant::now() >= deadline {
+                    return false;
+                }
+                std::thread::sleep(std::time::Duration::from_millis(20));
+            }
+        }
+
+        fn still_running(&mut self) -> bool {
+            matches!(self.child.try_wait(), Ok(None))
+        }
+    }
 
     #[cfg(all(unix, not(target_os = "macos")))]
     impl Drop for SpawnedGateway {
         fn drop(&mut self) {
-            let _ = self.0.kill();
-            let _ = self.0.wait();
-            let _ = std::fs::remove_dir_all(&self.1);
+            let _ = self.child.kill();
+            let _ = self.child.wait();
         }
     }
 
@@ -1967,44 +2096,14 @@ mod tests {
     #[cfg(all(unix, not(target_os = "macos")))]
     #[test]
     fn linux_enumeration_finds_a_versioned_gateway_via_the_exe_fallback() {
-        use std::os::unix::fs::PermissionsExt as _;
+        let _serial = lock_process_table();
 
-        // into_iter, not iter().map(Path::new): the latter returns a &Path borrowed
-        // from the temporary array, which does not outlive the statement.
-        let src = ["/bin/sleep", "/usr/bin/sleep"]
-            .into_iter()
-            .find(|p| Path::new(p).exists())
-            .expect("no sleep binary available to stand in for a gateway");
-
-        let dir = std::env::temp_dir().join(format!("toolport-reaper-enum-{}", std::process::id()));
-        let _ = std::fs::remove_dir_all(&dir);
-        std::fs::create_dir_all(&dir).expect("create scratch dir");
-
+        let dir = ScratchDir::new("enum");
         // Deliberately longer than comm's 15-char window so the truncation this
         // test exists for actually happens.
         let exe = dir.join("toolport-gateway-9.9.9");
-        std::fs::copy(src, &exe).expect("copy stand-in binary");
-        std::fs::set_permissions(&exe, std::fs::Permissions::from_mode(0o755)).expect("chmod +x");
-
-        let child = std::process::Command::new(&exe)
-            .arg("30")
-            .spawn()
-            .expect("spawn stand-in gateway");
-        let pid = child.id();
-        let guard = SpawnedGateway(child, dir.clone());
-
-        // spawn() returns before the exec completes, so /proc entries are not
-        // populated yet. Wait for the exe symlink to point at our copy.
-        let exe_link = PathBuf::from(format!("/proc/{pid}/exe"));
-        let mut execed = false;
-        for _ in 0..300 {
-            if std::fs::read_link(&exe_link).map(|p| p == exe).unwrap_or(false) {
-                execed = true;
-                break;
-            }
-            std::thread::sleep(std::time::Duration::from_millis(10));
-        }
-        assert!(execed, "child never exec'd into {}", exe.display());
+        let gw = SpawnedGateway::at(exe.clone());
+        let pid = gw.pid();
 
         // The premise: comm is truncated past recognition, so a hit below can only
         // have come from the exe fallback. If a future kernel widens comm this
@@ -2039,8 +2138,167 @@ mod tests {
             Some(exe.as_path()),
             "path must be the resolved exe so keep-path comparisons work"
         );
+    }
 
-        drop(guard);
+    /// SBS-418: the `(deleted)` policy from #505, against a real unlinked process.
+    ///
+    /// Two halves that pull in opposite directions and have to hold at once:
+    ///
+    /// * the marker is **stripped for basename matching**, so an unlinked image is
+    ///   still recognized as a gateway and enumerated at all;
+    /// * the marker is **kept on the stored path**, so that image misses keep-paths
+    ///   and is reaped even when the path it was launched from *is* the current
+    ///   keep-path.
+    ///
+    /// The second half is why this needs a real process. It reversed twice inside 16
+    /// minutes during development (e1242eb added a path strip, 2ba9f95 reverted it),
+    /// and until now only `decide_reap` fixtures covered it — which cannot catch the
+    /// enumerator handing `decide_reap` an already-stripped path, since the fixtures
+    /// build that path themselves.
+    ///
+    /// Uses the unversioned name deliberately. `toolport-gateway` is 16 chars and
+    /// `comm` caps at 15, so detection can only come from `/proc/<pid>/exe`, and the
+    /// verdict can only come from the unversioned path-identity branch. The legacy
+    /// `conduit-gateway` is exactly 15 and *does* match `comm`, which would mask a
+    /// broken fallback.
+    #[cfg(all(unix, not(target_os = "macos")))]
+    #[test]
+    fn linux_deleted_image_is_enumerated_but_misses_its_own_keep_path() {
+        let _serial = lock_process_table();
+
+        let dir = ScratchDir::new("deleted");
+        let exe = dir.join("bin/toolport-gateway");
+        let gw = SpawnedGateway::at(exe.clone());
+        gw.unlink_image();
+
+        let found = linux_list_gateway_processes();
+        let hit = found.iter().find(|p| p.pid == gw.pid()).unwrap_or_else(|| {
+            panic!(
+                "linux_list_gateway_processes() lost pid {} once its image was unlinked. \
+                 The ` (deleted)` marker must be stripped for basename matching, or an \
+                 in-place upgrade leaves the old inode running forever.",
+                gw.pid()
+            )
+        });
+
+        assert_eq!(
+            hit.basename, "toolport-gateway",
+            "basename must have the ` (deleted)` marker stripped"
+        );
+        let stored = hit
+            .path
+            .as_ref()
+            .expect("an unlinked image must still carry a path");
+        assert!(
+            stored.to_string_lossy().ends_with(" (deleted)"),
+            "path must KEEP the ` (deleted)` marker so the keep-path comparison misses; \
+             got {}",
+            stored.display()
+        );
+
+        // The launch path is the current keep-path and the process must still be
+        // killed. That is the entire point of leaving the marker on.
+        let ctx = ReapContext {
+            current_version: "9.9.9".into(),
+            keep_paths: vec![exe.clone()],
+            keep_pids: Vec::new(),
+            kill_all: false,
+        };
+        assert_eq!(
+            decide_reap(hit, &ctx),
+            ReapDecision::Kill,
+            "an unlinked image launched from the keep path {} must still be reaped, or \
+             an in-place upgrade keeps serving the old binary",
+            exe.display()
+        );
+
+        // Control: same name, same kind of path, image intact. The marker is the only
+        // difference between this and the case above, so it must flip the verdict.
+        let live_dir = ScratchDir::new("deleted-control");
+        let live_exe = live_dir.join("bin/toolport-gateway");
+        let live_gw = SpawnedGateway::at(live_exe.clone());
+        let live_hit = linux_list_gateway_processes()
+            .into_iter()
+            .find(|p| p.pid == live_gw.pid())
+            .expect("control gateway was not enumerated");
+        assert_eq!(
+            decide_reap(
+                &live_hit,
+                &ReapContext {
+                    keep_paths: vec![live_exe],
+                    ..ctx
+                }
+            ),
+            ReapDecision::Keep,
+            "an intact image at its keep path must survive"
+        );
+    }
+
+    /// SBS-418: a real `reap_with_context` pass over real processes.
+    ///
+    /// The decision tests are pure. This one proves the whole path — enumerate, plan,
+    /// signal — actually does what the plan says, including the row that matters most
+    /// operationally: **a live gateway at the keep path is still running afterwards.**
+    /// Every other test in this file could pass while the reaper killed the bridge it
+    /// had just started.
+    ///
+    /// Every gateway already running when the test starts is pinned into `keep_pids`,
+    /// so running the suite on a developer's Linux box cannot kill their real Toolport
+    /// gateway. Only the three processes spawned here are candidates.
+    #[cfg(all(unix, not(target_os = "macos")))]
+    #[test]
+    fn linux_reap_keeps_the_live_keep_path_and_kills_stale_and_unlinked_images() {
+        let _serial = lock_process_table();
+
+        let mut keep_pids: Vec<u32> = linux_list_gateway_processes()
+            .into_iter()
+            .map(|p| p.pid)
+            .collect();
+        keep_pids.push(std::process::id());
+
+        let dir = ScratchDir::new("reap");
+        let keep_exe = dir.join("bin/toolport-gateway");
+        let stale_exe = dir.join("old/toolport-gateway");
+        let upgraded_exe = dir.join("upgraded/toolport-gateway");
+
+        let mut keep = SpawnedGateway::at(keep_exe.clone());
+        let mut stale = SpawnedGateway::at(stale_exe.clone());
+        let mut upgraded = SpawnedGateway::at(upgraded_exe.clone());
+
+        // An in-place upgrade: the file at a path we still consider current was
+        // replaced, so this process now holds an unlinked inode.
+        upgraded.unlink_image();
+
+        let report = reap_with_context(&ReapContext {
+            current_version: "9.9.9".into(),
+            keep_paths: vec![keep_exe.clone(), upgraded_exe.clone()],
+            keep_pids,
+            kill_all: false,
+        });
+
+        let budget = std::time::Duration::from_secs(5);
+        assert!(
+            stale.exited_within(budget),
+            "a gateway at {} is not at any keep path and must be reaped; report: {report:?}",
+            stale_exe.display()
+        );
+        assert!(
+            upgraded.exited_within(budget),
+            "the unlinked image must be reaped even though it was launched from the keep \
+             path {}, otherwise an in-place upgrade keeps the old inode serving traffic; \
+             report: {report:?}",
+            upgraded_exe.display()
+        );
+        assert!(
+            keep.still_running(),
+            "the live gateway at the keep path {} must survive the reap; report: {report:?}",
+            keep_exe.display()
+        );
+        assert!(
+            report.failed.is_empty(),
+            "the reaper could not stop processes it planned to kill: {:?}",
+            report.failed
+        );
     }
 
     // ----- SOU-435: restart advice -------------------------------------------

--- a/src-tauri/src/gateway_publish.rs
+++ b/src-tauri/src/gateway_publish.rs
@@ -1962,9 +1962,24 @@ mod tests {
     /// first thread's exec then fails with "Text file busy".
     ///
     /// Without this the three tests fail intermittently -- 3 runs in 8 while this was
-    /// being written. The critical section has to run from opening the destination
-    /// through exec actually completing, which is why it wraps the readiness poll and
-    /// not just the copy. Poison is ignored so one failing test does not cascade.
+    /// being written.
+    ///
+    /// The guard deliberately spans copy through *exec completing*, i.e. it wraps the
+    /// readiness poll too, not just the copy and fork.
+    ///
+    /// Narrowing it to copy-through-fork looks correct -- `fs::copy` drops its
+    /// destination handle before `spawn`, so a child forked afterwards has no write fd
+    /// to inherit -- and was tried. It reintroduces the failure at a lower rate: 1 run
+    /// in 25, panicking in `spawn` with ETXTBSY, versus 25 in 25 clean with the guard
+    /// held across the poll. A forked child holds *every* inherited descriptor until
+    /// its own exec lands, so releasing at fork still leaves a window in which another
+    /// thread's copy target is held open by a child that has not exec'd yet.
+    ///
+    /// The cost is bounded and small: the poll is an exec-completion wait that returns
+    /// in tens of milliseconds, and the 3s in the loop below is a failure timeout, not
+    /// a typical duration. The whole `gateway_publish` suite runs in 0.36s.
+    ///
+    /// Poison is ignored so one failing test does not cascade.
     static SPAWN_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
     /// A small, long-running binary to stand in for a gateway image.
@@ -2057,10 +2072,10 @@ mod tests {
         fn at(exe: PathBuf) -> Self {
             use std::os::unix::fs::PermissionsExt as _;
 
-            let _spawn = SPAWN_LOCK.lock().unwrap_or_else(|e| e.into_inner());
             if let Some(parent) = exe.parent() {
                 std::fs::create_dir_all(parent).expect("create gateway dir");
             }
+            let _spawn = SPAWN_LOCK.lock().unwrap_or_else(|e| e.into_inner());
             std::fs::copy(stand_in_binary_source(), &exe).expect("copy stand-in binary");
             std::fs::set_permissions(&exe, std::fs::Permissions::from_mode(0o755))
                 .expect("chmod +x");

--- a/src-tauri/src/gateway_publish.rs
+++ b/src-tauri/src/gateway_publish.rs
@@ -1962,33 +1962,59 @@ mod tests {
             .expect("no sleep binary available to stand in for a gateway")
     }
 
-    /// Scratch tree removed on drop, shared by every gateway one test spawns.
-    #[cfg(all(unix, not(target_os = "macos")))]
-    struct ScratchDir(PathBuf);
+    /// Scratch tree removed on drop.
+    ///
+    /// Every test in this file that needs real files on disk goes through this, so
+    /// cleanup happens even when an assertion panics and the whole unique root is
+    /// removed rather than just its `Toolport` leaf. Doing it by hand at the end of
+    /// each test got both of those wrong: a failing test leaked its tree, and a
+    /// passing one still leaked the tree's parent, once per test per run.
+    struct ScratchDir {
+        /// Handed to tests. Ends in a literal `Toolport` segment on purpose:
+        /// `decide_reap` only kills an image under a path
+        /// `path_looks_like_our_install` recognizes, so a bare temp dir would be
+        /// treated as a stranger's binary and kept.
+        dir: PathBuf,
+        /// The unique root actually removed on drop. Dropping only `dir` would leave
+        /// its parent behind, leaking one empty directory per tag per run.
+        root: PathBuf,
+    }
 
-    #[cfg(all(unix, not(target_os = "macos")))]
     impl ScratchDir {
-        /// Ends in a literal `Toolport` segment on purpose: `decide_reap` only kills
-        /// an image under a path `path_looks_like_our_install` recognizes, so a bare
-        /// temp dir would be treated as a stranger's binary and kept.
+        /// Thread id as well as pid: the advice/prune tests run in parallel and each
+        /// needs its own tree.
         fn new(tag: &str) -> Self {
-            let dir = std::env::temp_dir()
-                .join(format!("toolport-reaper-{tag}-{}", std::process::id()))
-                .join("Toolport");
-            let _ = std::fs::remove_dir_all(&dir);
+            let root = std::env::temp_dir().join(format!(
+                "toolport-{tag}-{}-{:?}",
+                std::process::id(),
+                std::thread::current().id()
+            ));
+            let _ = std::fs::remove_dir_all(&root);
+            let dir = root.join("Toolport");
             std::fs::create_dir_all(&dir).expect("create scratch dir");
-            Self(dir)
-        }
-
-        fn join(&self, rel: &str) -> PathBuf {
-            self.0.join(rel)
+            // Canonicalize, because `/proc/<pid>/exe` reports the kernel's own
+            // resolved path. Where TMPDIR is a symlink (a container layout, or a
+            // custom TMPDIR pointing through one) an uncanonicalized path would make
+            // every `read_link(...) == exe` comparison fail even though the exec
+            // succeeded, turning a portability quirk into a spurious test failure.
+            let dir = std::fs::canonicalize(&dir).unwrap_or(dir);
+            Self { dir, root }
         }
     }
 
-    #[cfg(all(unix, not(target_os = "macos")))]
+    /// So a `ScratchDir` can be used anywhere the old `PathBuf` helper was, without
+    /// rewriting every call site.
+    impl std::ops::Deref for ScratchDir {
+        type Target = Path;
+
+        fn deref(&self) -> &Path {
+            &self.dir
+        }
+    }
+
     impl Drop for ScratchDir {
         fn drop(&mut self) {
-            let _ = std::fs::remove_dir_all(&self.0);
+            let _ = std::fs::remove_dir_all(&self.root);
         }
     }
 
@@ -2098,7 +2124,7 @@ mod tests {
     fn linux_enumeration_finds_a_versioned_gateway_via_the_exe_fallback() {
         let _serial = lock_process_table();
 
-        let dir = ScratchDir::new("enum");
+        let dir = ScratchDir::new("reaper-enum");
         // Deliberately longer than comm's 15-char window so the truncation this
         // test exists for actually happens.
         let exe = dir.join("toolport-gateway-9.9.9");
@@ -2166,7 +2192,7 @@ mod tests {
     fn linux_deleted_image_is_enumerated_but_misses_its_own_keep_path() {
         let _serial = lock_process_table();
 
-        let dir = ScratchDir::new("deleted");
+        let dir = ScratchDir::new("reaper-deleted");
         let exe = dir.join("bin/toolport-gateway");
         let gw = SpawnedGateway::at(exe.clone());
         gw.unlink_image();
@@ -2214,7 +2240,7 @@ mod tests {
 
         // Control: same name, same kind of path, image intact. The marker is the only
         // difference between this and the case above, so it must flip the verdict.
-        let live_dir = ScratchDir::new("deleted-control");
+        let live_dir = ScratchDir::new("reaper-deleted-control");
         let live_exe = live_dir.join("bin/toolport-gateway");
         let live_gw = SpawnedGateway::at(live_exe.clone());
         let live_hit = linux_list_gateway_processes()
@@ -2250,13 +2276,7 @@ mod tests {
     fn linux_reap_keeps_the_live_keep_path_and_kills_stale_and_unlinked_images() {
         let _serial = lock_process_table();
 
-        let mut keep_pids: Vec<u32> = linux_list_gateway_processes()
-            .into_iter()
-            .map(|p| p.pid)
-            .collect();
-        keep_pids.push(std::process::id());
-
-        let dir = ScratchDir::new("reap");
+        let dir = ScratchDir::new("reaper-reap");
         let keep_exe = dir.join("bin/toolport-gateway");
         let stale_exe = dir.join("old/toolport-gateway");
         let upgraded_exe = dir.join("upgraded/toolport-gateway");
@@ -2268,6 +2288,19 @@ mod tests {
         // An in-place upgrade: the file at a path we still consider current was
         // replaced, so this process now holds an unlinked inode.
         upgraded.unlink_image();
+
+        // Snapshot immediately before the pass and pin everything that is not one of
+        // this test's three fixtures, so a real Toolport gateway on a developer's
+        // machine cannot be reaped by the suite. Snapshotting before the fixtures
+        // spawn would instead leave the whole spawn sequence as a window in which a
+        // real gateway could start, miss the snapshot, and be killed.
+        let mine = [keep.pid(), stale.pid(), upgraded.pid()];
+        let mut keep_pids: Vec<u32> = linux_list_gateway_processes()
+            .into_iter()
+            .map(|p| p.pid)
+            .filter(|pid| !mine.contains(pid))
+            .collect();
+        keep_pids.push(std::process::id());
 
         let report = reap_with_context(&ReapContext {
             current_version: "9.9.9".into(),
@@ -2299,26 +2332,25 @@ mod tests {
             "the reaper could not stop processes it planned to kill: {:?}",
             report.failed
         );
+        // The pid snapshot above is the only thing standing between this pass and a
+        // real gateway that started in the window before it was taken. Assert the
+        // blast radius directly, so such a miss fails the suite loudly instead of
+        // silently killing a developer's gateway.
+        assert_eq!(
+            report.killed.len(),
+            2,
+            "expected exactly the stale and unlinked fixtures to be killed: {:?}",
+            report.killed
+        );
+        for label in &report.killed {
+            assert!(
+                label.contains("toolport-reaper-reap-"),
+                "the reap pass killed a process outside this test's scratch tree: {label}"
+            );
+        }
     }
 
     // ----- SOU-435: restart advice -------------------------------------------
-
-    /// Unique temp dir for a test that needs real files on disk.
-    ///
-    /// Ends in a literal `Toolport` segment because `decide_reap` only kills a
-    /// versioned gateway under a path `path_looks_like_our_install` recognizes; a
-    /// bare temp dir is treated as a stranger's binary and kept.
-    fn advice_temp_dir(tag: &str) -> std::path::PathBuf {
-        let dir = std::env::temp_dir()
-            .join(format!(
-                "toolport-advice-{tag}-{}-{:?}",
-                std::process::id(),
-                std::thread::current().id()
-            ))
-            .join("Toolport");
-        std::fs::create_dir_all(&dir).unwrap();
-        dir
-    }
 
     /// A context where anything not at `keep` and not current-version is obsolete.
     fn advice_ctx(keep: &Path) -> ReapContext {
@@ -2332,7 +2364,7 @@ mod tests {
 
     #[test]
     fn advice_names_the_parent_app_and_carries_its_pid() {
-        let dir = advice_temp_dir("names-parent");
+        let dir = ScratchDir::new("advice-names-parent");
         let keep = dir.join("toolport-gateway-9.9.9.exe");
         let stale = dir.join("toolport-gateway-1.9.4.exe");
         let ctx = advice_ctx(&keep);
@@ -2357,12 +2389,11 @@ mod tests {
             }],
             "an obsolete gateway with a named parent must be attributed to that app"
         );
-        std::fs::remove_dir_all(&dir).ok();
     }
 
     #[test]
     fn advice_is_empty_for_the_updater_kill_all_pass() {
-        let dir = advice_temp_dir("kill-all");
+        let dir = ScratchDir::new("advice-kill-all");
         let keep = dir.join("toolport-gateway-9.9.9.exe");
         let mut ctx = advice_ctx(&keep);
         ctx.kill_all = true;
@@ -2382,7 +2413,6 @@ mod tests {
             clients_needing_restart(&procs, &ctx).is_empty(),
             "kill_all gives every process a Kill verdict, so obsolescence means nothing there"
         );
-        std::fs::remove_dir_all(&dir).ok();
     }
 
     /// The case #542 got backwards. ` (deleted)` means *unlinked*, which covers an
@@ -2392,7 +2422,7 @@ mod tests {
     /// passed because it ran on macOS where no marker appears at all.
     #[test]
     fn deleted_marker_advises_only_when_the_path_is_really_gone() {
-        let dir = advice_temp_dir("deleted-marker");
+        let dir = ScratchDir::new("advice-deleted-marker");
         let keep = dir.join("toolport-gateway-9.9.9");
         let ctx = advice_ctx(&keep);
 
@@ -2447,12 +2477,11 @@ mod tests {
             }],
             "the stale-install-location case must be reported, on every platform"
         );
-        std::fs::remove_dir_all(&dir).ok();
     }
 
     #[test]
     fn advice_skips_unattributable_and_non_app_parents() {
-        let dir = advice_temp_dir("skips");
+        let dir = ScratchDir::new("advice-skips");
         let keep = dir.join("toolport-gateway-9.9.9.exe");
         let stale = dir.join("toolport-gateway-1.9.4.exe");
         let ctx = advice_ctx(&keep);
@@ -2516,12 +2545,11 @@ mod tests {
             &ctx
         )
         .is_empty());
-        std::fs::remove_dir_all(&dir).ok();
     }
 
     #[test]
     fn advice_dedupes_repeat_respawns_of_the_same_app() {
-        let dir = advice_temp_dir("dedupe");
+        let dir = ScratchDir::new("advice-dedupe");
         let keep = dir.join("toolport-gateway-9.9.9.exe");
         let stale = dir.join("toolport-gateway-1.9.4.exe");
         let ctx = advice_ctx(&keep);
@@ -2537,7 +2565,6 @@ mod tests {
             &ctx,
         );
         assert_eq!(advice.len(), 1, "one entry per app to act on, not per respawn");
-        std::fs::remove_dir_all(&dir).ok();
     }
 
     /// The ordering requirement that three review rounds kept relocating: advice is
@@ -2545,7 +2572,7 @@ mod tests {
     /// table a previous pass already cleared.
     #[test]
     fn plan_reap_derives_advice_from_the_same_prekill_snapshot() {
-        let dir = advice_temp_dir("plan");
+        let dir = ScratchDir::new("advice-plan");
         let keep = dir.join("toolport-gateway-9.9.9.exe");
         let stale = dir.join("toolport-gateway-1.9.4.exe");
         let ctx = advice_ctx(&keep);
@@ -2577,7 +2604,6 @@ mod tests {
             after.needs_restart.is_empty(),
             "a post-kill table cannot produce the advice, so it must never be the source"
         );
-        std::fs::remove_dir_all(&dir).ok();
     }
 
     // ----- SOU-484: pruning published gateway binaries ------------------------
@@ -2597,7 +2623,7 @@ mod tests {
 
     #[test]
     fn prune_deletes_only_old_versioned_images() {
-        let dir = advice_temp_dir("prune-basic");
+        let dir = ScratchDir::new("advice-prune-basic");
         let ctx = prune_ctx("1.10.0");
 
         assert_eq!(
@@ -2629,7 +2655,6 @@ mod tests {
             decide_prune(&bin(&dir, "toolport-gateway-1.10.0.exe"), &ctx),
             PruneDecision::Keep(_)
         ));
-        std::fs::remove_dir_all(&dir).ok();
     }
 
     /// The exact situation from the SOU-484 report: on the machine where this was
@@ -2638,7 +2663,7 @@ mod tests {
     /// Deleting it there would have broken Claude Code rather than updated it.
     #[test]
     fn prune_keeps_a_binary_a_live_process_is_running() {
-        let dir = advice_temp_dir("prune-live");
+        let dir = ScratchDir::new("advice-prune-live");
         let rc = bin(&dir, "toolport-gateway-1.9.7-rc.1.exe");
         let mut ctx = prune_ctx("1.10.0");
         // No config references it; only the live process speaks for it.
@@ -2648,12 +2673,11 @@ mod tests {
             decide_prune(&rc, &ctx),
             PruneDecision::Keep("backing a running process")
         );
-        std::fs::remove_dir_all(&dir).ok();
     }
 
     #[test]
     fn prune_keeps_a_binary_a_client_config_still_names() {
-        let dir = advice_temp_dir("prune-referenced");
+        let dir = ScratchDir::new("advice-prune-referenced");
         let old = bin(&dir, "toolport-gateway-1.8.0.exe");
         let mut ctx = prune_ctx("1.10.0");
         // Nothing is running it, but a client will spawn exactly this path.
@@ -2663,7 +2687,6 @@ mod tests {
             decide_prune(&old, &ctx),
             PruneDecision::Keep("named by a client config")
         );
-        std::fs::remove_dir_all(&dir).ok();
     }
 
     /// The window evidence alone misses: the client was reaped, has not respawned
@@ -2673,7 +2696,7 @@ mod tests {
     /// safe to do only after SOU-435.
     #[test]
     fn prune_keeps_a_binary_a_client_is_still_relaunching() {
-        let dir = advice_temp_dir("prune-advised");
+        let dir = ScratchDir::new("advice-prune-advised");
         let old = bin(&dir, "toolport-gateway-1.9.6.exe");
         let mut ctx = prune_ctx("1.10.0");
         assert_eq!(
@@ -2688,12 +2711,11 @@ mod tests {
             PruneDecision::Keep("a client is still relaunching it"),
             "restart advice must veto deletion even with no process and no config"
         );
-        std::fs::remove_dir_all(&dir).ok();
     }
 
     #[test]
     fn prune_keeps_the_two_newest_non_current_versions() {
-        let dir = advice_temp_dir("prune-recent");
+        let dir = ScratchDir::new("advice-prune-recent");
         let all: Vec<PathBuf> = [
             "toolport-gateway-1.6.2.exe",
             "toolport-gateway-1.9.0.exe",
@@ -2735,7 +2757,6 @@ mod tests {
             decide_prune(&bin(&dir, "toolport-gateway-1.6.2.exe"), &ctx),
             PruneDecision::Delete
         );
-        std::fs::remove_dir_all(&dir).ok();
     }
 
     /// `1.10.0` must sort above `1.9.6`, which a lexical compare gets backwards and
@@ -2772,7 +2793,7 @@ mod tests {
     /// listing happened to yield first.
     #[test]
     fn recency_floor_picks_the_newest_of_two_candidates() {
-        let dir = advice_temp_dir("prune-two-rcs");
+        let dir = ScratchDir::new("advice-prune-two-rcs");
         // Deliberately listed oldest-first, the order that hid this.
         let all: Vec<PathBuf> = [
             "toolport-gateway-1.9.6.exe",
@@ -2795,14 +2816,13 @@ mod tests {
             ],
             "the two newest are both candidates of 1.9.7, newest first"
         );
-        std::fs::remove_dir_all(&dir).ok();
     }
 
     /// The whole reported directory, end to end: 14 binaries, one current, one held
     /// by a live client, and the rest reclaimable.
     #[test]
     fn prune_plan_over_the_reported_directory() {
-        let dir = advice_temp_dir("prune-whole");
+        let dir = ScratchDir::new("advice-prune-whole");
         let names = [
             "toolport-gateway-1.6.2.exe",
             "toolport-gateway-1.7.0.exe",
@@ -2840,6 +2860,5 @@ mod tests {
             ],
             "current, the live rc, and the recency floor survive; the other 11 go"
         );
-        std::fs::remove_dir_all(&dir).ok();
     }
 }

--- a/src-tauri/src/gateway_publish.rs
+++ b/src-tauri/src/gateway_publish.rs
@@ -1983,14 +1983,26 @@ mod tests {
     static SPAWN_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
     /// A small, long-running binary to stand in for a gateway image.
+    ///
+    /// Searches `PATH` rather than assuming `/bin/sleep`, so the tests still run on
+    /// layouts that put it elsewhere (NixOS, busybox images, minimal containers).
     #[cfg(all(unix, not(target_os = "macos")))]
-    fn stand_in_binary_source() -> &'static str {
+    fn stand_in_binary_source() -> PathBuf {
+        if let Some(path) = std::env::var_os("PATH") {
+            for dir in std::env::split_paths(&path) {
+                let candidate = dir.join("sleep");
+                if candidate.is_file() {
+                    return candidate;
+                }
+            }
+        }
         // into_iter, not iter().map(Path::new): the latter returns a &Path borrowed
         // from the temporary array, which does not outlive the statement.
         ["/bin/sleep", "/usr/bin/sleep"]
             .into_iter()
-            .find(|p| Path::new(p).exists())
-            .expect("no sleep binary available to stand in for a gateway")
+            .map(PathBuf::from)
+            .find(|p| p.is_file())
+            .expect("no sleep binary on PATH to stand in for a gateway")
     }
 
     /// Scratch tree removed on drop, shared by every gateway one test spawns.
@@ -2033,7 +2045,15 @@ mod tests {
             // forms, and a failure surfaced 3s later as an unexplained readiness-poll
             // panic. The directory was just created, so failure here means a broken
             // environment and should say so.
-            let root = std::fs::canonicalize(&root).expect("canonicalize scratch root");
+            let root = match std::fs::canonicalize(&root) {
+                Ok(canonical) => canonical,
+                Err(e) => {
+                    // `Self` does not exist yet, so `Drop` cannot clean up the
+                    // directory just created. Remove it before unwinding.
+                    let _ = std::fs::remove_dir_all(&root);
+                    panic!("canonicalize scratch root {}: {e}", root.display());
+                }
+            };
             let dir = root.join("Toolport");
             std::fs::create_dir_all(&dir).expect("create scratch dir");
             Self { dir, root }
@@ -2134,9 +2154,18 @@ mod tests {
 
     #[cfg(all(unix, not(target_os = "macos")))]
     impl Drop for SpawnedGateway {
+        /// Only signals a child that has not already been reaped.
+        ///
+        /// `exited_within` reaps via `try_wait`, which frees the pid for reuse. A
+        /// bare `kill()` afterwards would signal whatever now holds that number.
+        /// `std` does not save us here: reaping with `try_wait` and then calling
+        /// `Child::kill()` returns `Ok(())` rather than refusing, so the guard has to
+        /// be explicit.
         fn drop(&mut self) {
-            let _ = self.child.kill();
-            let _ = self.child.wait();
+            if matches!(self.child.try_wait(), Ok(None)) {
+                let _ = self.child.kill();
+                let _ = self.child.wait();
+            }
         }
     }
 
@@ -2287,6 +2316,44 @@ mod tests {
             ),
             ReapDecision::Keep,
             "an intact image at its keep path must survive"
+        );
+    }
+
+    /// `ScratchDir` removes its whole root, including when a test panics.
+    ///
+    /// The panic half is the point: cleanup used to be a `remove_dir_all` on the last
+    /// line of each test, which is exactly the line an assertion failure skips, so a
+    /// failing test leaked its tree and the binaries in it.
+    #[cfg(all(unix, not(target_os = "macos")))]
+    #[test]
+    fn scratch_dir_removes_its_root_on_drop_and_on_panic() {
+        let root = {
+            let dir = ScratchDir::new("reaper-cleanup");
+            std::fs::write(dir.join("file"), b"x").expect("write into scratch dir");
+            dir.root.clone()
+        };
+        assert!(
+            !root.exists(),
+            "scratch root {} survived a normal drop",
+            root.display()
+        );
+
+        // The parent, not just the `Toolport` leaf: removing only the leaf is what
+        // leaked one directory per test per run.
+        let leaked = std::panic::catch_unwind(|| {
+            let dir = ScratchDir::new("reaper-cleanup-panic");
+            let root = dir.root.clone();
+            std::fs::write(dir.join("file"), b"x").expect("write into scratch dir");
+            std::panic::panic_any(root);
+        })
+        .expect_err("the closure must panic");
+        let root = leaked
+            .downcast::<PathBuf>()
+            .expect("panic payload is the scratch root");
+        assert!(
+            !root.exists(),
+            "scratch root {} survived a panicking test",
+            root.display()
         );
     }
 

--- a/src-tauri/src/gateway_publish.rs
+++ b/src-tauri/src/gateway_publish.rs
@@ -1978,13 +1978,11 @@ mod tests {
             .expect("no sleep binary available to stand in for a gateway")
     }
 
-    /// Scratch tree removed on drop.
+    /// Scratch tree removed on drop, shared by every gateway one test spawns.
     ///
-    /// Every test in this file that needs real files on disk goes through this, so
-    /// cleanup happens even when an assertion panics and the whole unique root is
-    /// removed rather than just its `Toolport` leaf. Doing it by hand at the end of
-    /// each test got both of those wrong: a failing test leaked its tree, and a
-    /// passing one still leaked the tree's parent, once per test per run.
+    /// Cleanup runs even when an assertion panics, and removes the whole unique root
+    /// rather than just its `Toolport` leaf.
+    #[cfg(all(unix, not(target_os = "macos")))]
     struct ScratchDir {
         /// Handed to tests. Ends in a literal `Toolport` segment on purpose:
         /// `decide_reap` only kills an image under a path
@@ -1996,9 +1994,9 @@ mod tests {
         root: PathBuf,
     }
 
+    #[cfg(all(unix, not(target_os = "macos")))]
     impl ScratchDir {
-        /// Thread id as well as pid: the advice/prune tests run in parallel and each
-        /// needs its own tree.
+        /// Thread id as well as pid, so parallel tests each get their own tree.
         fn new(tag: &str) -> Self {
             let root = std::env::temp_dir().join(format!(
                 "toolport-{tag}-{}-{:?}",
@@ -2025,18 +2023,13 @@ mod tests {
             std::fs::create_dir_all(&dir).expect("create scratch dir");
             Self { dir, root }
         }
-    }
 
-    /// So a `ScratchDir` can be used anywhere the old `PathBuf` helper was, without
-    /// rewriting every call site.
-    impl std::ops::Deref for ScratchDir {
-        type Target = Path;
-
-        fn deref(&self) -> &Path {
-            &self.dir
+        fn join(&self, rel: &str) -> PathBuf {
+            self.dir.join(rel)
         }
     }
 
+    #[cfg(all(unix, not(target_os = "macos")))]
     impl Drop for ScratchDir {
         fn drop(&mut self) {
             let _ = std::fs::remove_dir_all(&self.root);
@@ -2369,6 +2362,23 @@ mod tests {
 
     // ----- SOU-435: restart advice -------------------------------------------
 
+    /// Unique temp dir for a test that needs real files on disk.
+    ///
+    /// Ends in a literal `Toolport` segment because `decide_reap` only kills a
+    /// versioned gateway under a path `path_looks_like_our_install` recognizes; a
+    /// bare temp dir is treated as a stranger's binary and kept.
+    fn advice_temp_dir(tag: &str) -> std::path::PathBuf {
+        let dir = std::env::temp_dir()
+            .join(format!(
+                "toolport-advice-{tag}-{}-{:?}",
+                std::process::id(),
+                std::thread::current().id()
+            ))
+            .join("Toolport");
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
     /// A context where anything not at `keep` and not current-version is obsolete.
     fn advice_ctx(keep: &Path) -> ReapContext {
         ReapContext {
@@ -2381,7 +2391,7 @@ mod tests {
 
     #[test]
     fn advice_names_the_parent_app_and_carries_its_pid() {
-        let dir = ScratchDir::new("advice-names-parent");
+        let dir = advice_temp_dir("names-parent");
         let keep = dir.join("toolport-gateway-9.9.9.exe");
         let stale = dir.join("toolport-gateway-1.9.4.exe");
         let ctx = advice_ctx(&keep);
@@ -2406,11 +2416,12 @@ mod tests {
             }],
             "an obsolete gateway with a named parent must be attributed to that app"
         );
+        std::fs::remove_dir_all(&dir).ok();
     }
 
     #[test]
     fn advice_is_empty_for_the_updater_kill_all_pass() {
-        let dir = ScratchDir::new("advice-kill-all");
+        let dir = advice_temp_dir("kill-all");
         let keep = dir.join("toolport-gateway-9.9.9.exe");
         let mut ctx = advice_ctx(&keep);
         ctx.kill_all = true;
@@ -2430,6 +2441,7 @@ mod tests {
             clients_needing_restart(&procs, &ctx).is_empty(),
             "kill_all gives every process a Kill verdict, so obsolescence means nothing there"
         );
+        std::fs::remove_dir_all(&dir).ok();
     }
 
     /// The case #542 got backwards. ` (deleted)` means *unlinked*, which covers an
@@ -2439,7 +2451,7 @@ mod tests {
     /// passed because it ran on macOS where no marker appears at all.
     #[test]
     fn deleted_marker_advises_only_when_the_path_is_really_gone() {
-        let dir = ScratchDir::new("advice-deleted-marker");
+        let dir = advice_temp_dir("deleted-marker");
         let keep = dir.join("toolport-gateway-9.9.9");
         let ctx = advice_ctx(&keep);
 
@@ -2494,11 +2506,12 @@ mod tests {
             }],
             "the stale-install-location case must be reported, on every platform"
         );
+        std::fs::remove_dir_all(&dir).ok();
     }
 
     #[test]
     fn advice_skips_unattributable_and_non_app_parents() {
-        let dir = ScratchDir::new("advice-skips");
+        let dir = advice_temp_dir("skips");
         let keep = dir.join("toolport-gateway-9.9.9.exe");
         let stale = dir.join("toolport-gateway-1.9.4.exe");
         let ctx = advice_ctx(&keep);
@@ -2562,11 +2575,12 @@ mod tests {
             &ctx
         )
         .is_empty());
+        std::fs::remove_dir_all(&dir).ok();
     }
 
     #[test]
     fn advice_dedupes_repeat_respawns_of_the_same_app() {
-        let dir = ScratchDir::new("advice-dedupe");
+        let dir = advice_temp_dir("dedupe");
         let keep = dir.join("toolport-gateway-9.9.9.exe");
         let stale = dir.join("toolport-gateway-1.9.4.exe");
         let ctx = advice_ctx(&keep);
@@ -2582,6 +2596,7 @@ mod tests {
             &ctx,
         );
         assert_eq!(advice.len(), 1, "one entry per app to act on, not per respawn");
+        std::fs::remove_dir_all(&dir).ok();
     }
 
     /// The ordering requirement that three review rounds kept relocating: advice is
@@ -2589,7 +2604,7 @@ mod tests {
     /// table a previous pass already cleared.
     #[test]
     fn plan_reap_derives_advice_from_the_same_prekill_snapshot() {
-        let dir = ScratchDir::new("advice-plan");
+        let dir = advice_temp_dir("plan");
         let keep = dir.join("toolport-gateway-9.9.9.exe");
         let stale = dir.join("toolport-gateway-1.9.4.exe");
         let ctx = advice_ctx(&keep);
@@ -2621,6 +2636,7 @@ mod tests {
             after.needs_restart.is_empty(),
             "a post-kill table cannot produce the advice, so it must never be the source"
         );
+        std::fs::remove_dir_all(&dir).ok();
     }
 
     // ----- SOU-484: pruning published gateway binaries ------------------------
@@ -2640,7 +2656,7 @@ mod tests {
 
     #[test]
     fn prune_deletes_only_old_versioned_images() {
-        let dir = ScratchDir::new("advice-prune-basic");
+        let dir = advice_temp_dir("prune-basic");
         let ctx = prune_ctx("1.10.0");
 
         assert_eq!(
@@ -2672,6 +2688,7 @@ mod tests {
             decide_prune(&bin(&dir, "toolport-gateway-1.10.0.exe"), &ctx),
             PruneDecision::Keep(_)
         ));
+        std::fs::remove_dir_all(&dir).ok();
     }
 
     /// The exact situation from the SOU-484 report: on the machine where this was
@@ -2680,7 +2697,7 @@ mod tests {
     /// Deleting it there would have broken Claude Code rather than updated it.
     #[test]
     fn prune_keeps_a_binary_a_live_process_is_running() {
-        let dir = ScratchDir::new("advice-prune-live");
+        let dir = advice_temp_dir("prune-live");
         let rc = bin(&dir, "toolport-gateway-1.9.7-rc.1.exe");
         let mut ctx = prune_ctx("1.10.0");
         // No config references it; only the live process speaks for it.
@@ -2690,11 +2707,12 @@ mod tests {
             decide_prune(&rc, &ctx),
             PruneDecision::Keep("backing a running process")
         );
+        std::fs::remove_dir_all(&dir).ok();
     }
 
     #[test]
     fn prune_keeps_a_binary_a_client_config_still_names() {
-        let dir = ScratchDir::new("advice-prune-referenced");
+        let dir = advice_temp_dir("prune-referenced");
         let old = bin(&dir, "toolport-gateway-1.8.0.exe");
         let mut ctx = prune_ctx("1.10.0");
         // Nothing is running it, but a client will spawn exactly this path.
@@ -2704,6 +2722,7 @@ mod tests {
             decide_prune(&old, &ctx),
             PruneDecision::Keep("named by a client config")
         );
+        std::fs::remove_dir_all(&dir).ok();
     }
 
     /// The window evidence alone misses: the client was reaped, has not respawned
@@ -2713,7 +2732,7 @@ mod tests {
     /// safe to do only after SOU-435.
     #[test]
     fn prune_keeps_a_binary_a_client_is_still_relaunching() {
-        let dir = ScratchDir::new("advice-prune-advised");
+        let dir = advice_temp_dir("prune-advised");
         let old = bin(&dir, "toolport-gateway-1.9.6.exe");
         let mut ctx = prune_ctx("1.10.0");
         assert_eq!(
@@ -2728,11 +2747,12 @@ mod tests {
             PruneDecision::Keep("a client is still relaunching it"),
             "restart advice must veto deletion even with no process and no config"
         );
+        std::fs::remove_dir_all(&dir).ok();
     }
 
     #[test]
     fn prune_keeps_the_two_newest_non_current_versions() {
-        let dir = ScratchDir::new("advice-prune-recent");
+        let dir = advice_temp_dir("prune-recent");
         let all: Vec<PathBuf> = [
             "toolport-gateway-1.6.2.exe",
             "toolport-gateway-1.9.0.exe",
@@ -2774,6 +2794,7 @@ mod tests {
             decide_prune(&bin(&dir, "toolport-gateway-1.6.2.exe"), &ctx),
             PruneDecision::Delete
         );
+        std::fs::remove_dir_all(&dir).ok();
     }
 
     /// `1.10.0` must sort above `1.9.6`, which a lexical compare gets backwards and
@@ -2810,7 +2831,7 @@ mod tests {
     /// listing happened to yield first.
     #[test]
     fn recency_floor_picks_the_newest_of_two_candidates() {
-        let dir = ScratchDir::new("advice-prune-two-rcs");
+        let dir = advice_temp_dir("prune-two-rcs");
         // Deliberately listed oldest-first, the order that hid this.
         let all: Vec<PathBuf> = [
             "toolport-gateway-1.9.6.exe",
@@ -2833,13 +2854,14 @@ mod tests {
             ],
             "the two newest are both candidates of 1.9.7, newest first"
         );
+        std::fs::remove_dir_all(&dir).ok();
     }
 
     /// The whole reported directory, end to end: 14 binaries, one current, one held
     /// by a live client, and the rest reclaimable.
     #[test]
     fn prune_plan_over_the_reported_directory() {
-        let dir = ScratchDir::new("advice-prune-whole");
+        let dir = advice_temp_dir("prune-whole");
         let names = [
             "toolport-gateway-1.6.2.exe",
             "toolport-gateway-1.7.0.exe",
@@ -2877,5 +2899,6 @@ mod tests {
             ],
             "current, the live rc, and the recency floor survive; the other 11 go"
         );
+        std::fs::remove_dir_all(&dir).ok();
     }
 }


### PR DESCRIPTION
Closes the two Linux rows of SBS-418.

## Why

The `(deleted)` policy reversed twice inside 16 minutes during development (e1242eb added a path strip, 2ba9f95 reverted it), and only `decide_reap` fixtures covered it. Fixtures construct the path themselves, so they cannot catch the enumerator handing `decide_reap` an already-stripped path — which is the regression that keeps recurring. #561 covered Linux *enumeration*, not the reap decision.

## What

Two tests driving real processes against a real `/proc`:

- **`linux_deleted_image_is_enumerated_but_misses_its_own_keep_path`** unlinks a running image and asserts both halves of the policy at once: the marker is stripped for basename matching (so the process is still enumerated at all) and kept on the stored path (so it misses keep-paths and is reaped even though it was launched from the current keep path). An intact image at its keep path is the control, so the marker is provably the only difference between Keep and Kill.
- **`linux_reap_keeps_the_live_keep_path_and_kills_stale_and_unlinked_images`** runs an actual `reap_with_context` pass over three spawned gateways and checks the row that matters operationally: the live gateway at the keep path is still running afterwards. Every other test in the file could pass while the reaper killed the bridge it had just started.

Both use the unversioned `toolport-gateway` name deliberately. It is 16 chars and `comm` caps at 15, so detection can only come from the `/proc/<pid>/exe` fallback and the verdict only from the unversioned path-identity branch. Legacy `conduit-gateway` is exactly 15 and does match `comm`, which would mask a broken fallback.

## Verified by mutation, not just by going green

| Mutation | Result |
| -- | -- |
| Reintroduce the e1242eb path strip | both new tests FAIL, all 32 pre-existing tests stay green |
| Drop the ` (deleted)` basename strip | both new tests FAIL |
| Make `decide_reap` ignore `keep_paths` | both new tests FAIL, naming the keep-path process that was wrongly killed |

The first row is the point: the existing suite cannot see this regression.

Run on Ubuntu 24.04 (WSL2, real kernel `/proc`). Full CI Rust suite green there — 730 lib + 228 + 26 integration, 0 failed — and 8/8 repeat runs of the reaper tests with no flake. Windows also green (31 passed; the three Linux-only tests compile out).

## Supporting changes

- The one-off fixture from #561 becomes shared `ScratchDir` / `SpawnedGateway` helpers; the existing enumeration test moves onto them with its assertions unchanged.
- A mutex serializes the tests that walk the process table. All three put fixtures under a literal `Toolport` path segment (`decide_reap` will not kill anything else), so concurrent runs would let one test's reap pass kill another's processes.
- Every gateway already running when a test starts is pinned into `keep_pids`, so running the suite on a Linux dev box cannot kill a real Toolport gateway.

## Still open on SBS-418

Not addressed here, and not addressable in CI: the AppImage/.deb row, the macOS unversioned-path row, bridge continuity (#507), and the updater kill-all path. Those need real hardware or a real install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)