### PR TITLE
test: share one scratch-dir guard across the reaper test fixtures

### DIFF
--- a/src-tauri/src/gateway_publish.rs
+++ b/src-tauri/src/gateway_publish.rs
@@ -2005,11 +2005,13 @@ mod tests {
             .expect("no sleep binary on PATH to stand in for a gateway")
     }
 
-    /// Scratch tree removed on drop, shared by every gateway one test spawns.
+    /// Scratch tree removed on drop.
     ///
-    /// Cleanup runs even when an assertion panics, and removes the whole unique root
-    /// rather than just its `Toolport` leaf.
-    #[cfg(all(unix, not(target_os = "macos")))]
+    /// Every test in this file that needs real files on disk goes through this, so
+    /// cleanup happens even when an assertion panics and the whole unique root is
+    /// removed rather than just its `Toolport` leaf. Doing it by hand at the end of
+    /// each test got both of those wrong: a failing test leaked its tree, and a
+    /// passing one still leaked the tree's parent, once per test per run.
     struct ScratchDir {
         /// Handed to tests. Ends in a literal `Toolport` segment on purpose:
         /// `decide_reap` only kills an image under a path
@@ -2021,9 +2023,9 @@ mod tests {
         root: PathBuf,
     }
 
-    #[cfg(all(unix, not(target_os = "macos")))]
     impl ScratchDir {
-        /// Thread id as well as pid, so parallel tests each get their own tree.
+        /// Thread id as well as pid: the advice/prune tests run in parallel and each
+        /// needs its own tree.
         fn new(tag: &str) -> Self {
             let root = std::env::temp_dir().join(format!(
                 "toolport-{tag}-{}-{:?}",
@@ -2058,13 +2060,18 @@ mod tests {
             std::fs::create_dir_all(&dir).expect("create scratch dir");
             Self { dir, root }
         }
+    }
 
-        fn join(&self, rel: &str) -> PathBuf {
-            self.dir.join(rel)
+    /// So a `ScratchDir` can be used anywhere the old `PathBuf` helper was, without
+    /// rewriting every call site.
+    impl std::ops::Deref for ScratchDir {
+        type Target = Path;
+
+        fn deref(&self) -> &Path {
+            &self.dir
         }
     }
 
-    #[cfg(all(unix, not(target_os = "macos")))]
     impl Drop for ScratchDir {
         fn drop(&mut self) {
             let _ = std::fs::remove_dir_all(&self.root);
@@ -2444,23 +2451,6 @@ mod tests {
 
     // ----- SOU-435: restart advice -------------------------------------------
 
-    /// Unique temp dir for a test that needs real files on disk.
-    ///
-    /// Ends in a literal `Toolport` segment because `decide_reap` only kills a
-    /// versioned gateway under a path `path_looks_like_our_install` recognizes; a
-    /// bare temp dir is treated as a stranger's binary and kept.
-    fn advice_temp_dir(tag: &str) -> std::path::PathBuf {
-        let dir = std::env::temp_dir()
-            .join(format!(
-                "toolport-advice-{tag}-{}-{:?}",
-                std::process::id(),
-                std::thread::current().id()
-            ))
-            .join("Toolport");
-        std::fs::create_dir_all(&dir).unwrap();
-        dir
-    }
-
     /// A context where anything not at `keep` and not current-version is obsolete.
     fn advice_ctx(keep: &Path) -> ReapContext {
         ReapContext {
@@ -2473,7 +2463,7 @@ mod tests {
 
     #[test]
     fn advice_names_the_parent_app_and_carries_its_pid() {
-        let dir = advice_temp_dir("names-parent");
+        let dir = ScratchDir::new("advice-names-parent");
         let keep = dir.join("toolport-gateway-9.9.9.exe");
         let stale = dir.join("toolport-gateway-1.9.4.exe");
         let ctx = advice_ctx(&keep);
@@ -2498,12 +2488,11 @@ mod tests {
             }],
             "an obsolete gateway with a named parent must be attributed to that app"
         );
-        std::fs::remove_dir_all(&dir).ok();
     }
 
     #[test]
     fn advice_is_empty_for_the_updater_kill_all_pass() {
-        let dir = advice_temp_dir("kill-all");
+        let dir = ScratchDir::new("advice-kill-all");
         let keep = dir.join("toolport-gateway-9.9.9.exe");
         let mut ctx = advice_ctx(&keep);
         ctx.kill_all = true;
@@ -2523,7 +2512,6 @@ mod tests {
             clients_needing_restart(&procs, &ctx).is_empty(),
             "kill_all gives every process a Kill verdict, so obsolescence means nothing there"
         );
-        std::fs::remove_dir_all(&dir).ok();
     }
 
     /// The case #542 got backwards. ` (deleted)` means *unlinked*, which covers an
@@ -2533,7 +2521,7 @@ mod tests {
     /// passed because it ran on macOS where no marker appears at all.
     #[test]
     fn deleted_marker_advises_only_when_the_path_is_really_gone() {
-        let dir = advice_temp_dir("deleted-marker");
+        let dir = ScratchDir::new("advice-deleted-marker");
         let keep = dir.join("toolport-gateway-9.9.9");
         let ctx = advice_ctx(&keep);
 
@@ -2588,12 +2576,11 @@ mod tests {
             }],
             "the stale-install-location case must be reported, on every platform"
         );
-        std::fs::remove_dir_all(&dir).ok();
     }
 
     #[test]
     fn advice_skips_unattributable_and_non_app_parents() {
-        let dir = advice_temp_dir("skips");
+        let dir = ScratchDir::new("advice-skips");
         let keep = dir.join("toolport-gateway-9.9.9.exe");
         let stale = dir.join("toolport-gateway-1.9.4.exe");
         let ctx = advice_ctx(&keep);
@@ -2657,12 +2644,11 @@ mod tests {
             &ctx
         )
         .is_empty());
-        std::fs::remove_dir_all(&dir).ok();
     }
 
     #[test]
     fn advice_dedupes_repeat_respawns_of_the_same_app() {
-        let dir = advice_temp_dir("dedupe");
+        let dir = ScratchDir::new("advice-dedupe");
         let keep = dir.join("toolport-gateway-9.9.9.exe");
         let stale = dir.join("toolport-gateway-1.9.4.exe");
         let ctx = advice_ctx(&keep);
@@ -2678,7 +2664,6 @@ mod tests {
             &ctx,
         );
         assert_eq!(advice.len(), 1, "one entry per app to act on, not per respawn");
-        std::fs::remove_dir_all(&dir).ok();
     }
 
     /// The ordering requirement that three review rounds kept relocating: advice is
@@ -2686,7 +2671,7 @@ mod tests {
     /// table a previous pass already cleared.
     #[test]
     fn plan_reap_derives_advice_from_the_same_prekill_snapshot() {
-        let dir = advice_temp_dir("plan");
+        let dir = ScratchDir::new("advice-plan");
         let keep = dir.join("toolport-gateway-9.9.9.exe");
         let stale = dir.join("toolport-gateway-1.9.4.exe");
         let ctx = advice_ctx(&keep);
@@ -2718,7 +2703,6 @@ mod tests {
             after.needs_restart.is_empty(),
             "a post-kill table cannot produce the advice, so it must never be the source"
         );
-        std::fs::remove_dir_all(&dir).ok();
     }
 
     // ----- SOU-484: pruning published gateway binaries ------------------------
@@ -2738,7 +2722,7 @@ mod tests {
 
     #[test]
     fn prune_deletes_only_old_versioned_images() {
-        let dir = advice_temp_dir("prune-basic");
+        let dir = ScratchDir::new("advice-prune-basic");
         let ctx = prune_ctx("1.10.0");
 
         assert_eq!(
@@ -2770,7 +2754,6 @@ mod tests {
             decide_prune(&bin(&dir, "toolport-gateway-1.10.0.exe"), &ctx),
             PruneDecision::Keep(_)
         ));
-        std::fs::remove_dir_all(&dir).ok();
     }
 
     /// The exact situation from the SOU-484 report: on the machine where this was
@@ -2779,7 +2762,7 @@ mod tests {
     /// Deleting it there would have broken Claude Code rather than updated it.
     #[test]
     fn prune_keeps_a_binary_a_live_process_is_running() {
-        let dir = advice_temp_dir("prune-live");
+        let dir = ScratchDir::new("advice-prune-live");
         let rc = bin(&dir, "toolport-gateway-1.9.7-rc.1.exe");
         let mut ctx = prune_ctx("1.10.0");
         // No config references it; only the live process speaks for it.
@@ -2789,12 +2772,11 @@ mod tests {
             decide_prune(&rc, &ctx),
             PruneDecision::Keep("backing a running process")
         );
-        std::fs::remove_dir_all(&dir).ok();
     }
 
     #[test]
     fn prune_keeps_a_binary_a_client_config_still_names() {
-        let dir = advice_temp_dir("prune-referenced");
+        let dir = ScratchDir::new("advice-prune-referenced");
         let old = bin(&dir, "toolport-gateway-1.8.0.exe");
         let mut ctx = prune_ctx("1.10.0");
         // Nothing is running it, but a client will spawn exactly this path.
@@ -2804,7 +2786,6 @@ mod tests {
             decide_prune(&old, &ctx),
             PruneDecision::Keep("named by a client config")
         );
-        std::fs::remove_dir_all(&dir).ok();
     }
 
     /// The window evidence alone misses: the client was reaped, has not respawned
@@ -2814,7 +2795,7 @@ mod tests {
     /// safe to do only after SOU-435.
     #[test]
     fn prune_keeps_a_binary_a_client_is_still_relaunching() {
-        let dir = advice_temp_dir("prune-advised");
+        let dir = ScratchDir::new("advice-prune-advised");
         let old = bin(&dir, "toolport-gateway-1.9.6.exe");
         let mut ctx = prune_ctx("1.10.0");
         assert_eq!(
@@ -2829,12 +2810,11 @@ mod tests {
             PruneDecision::Keep("a client is still relaunching it"),
             "restart advice must veto deletion even with no process and no config"
         );
-        std::fs::remove_dir_all(&dir).ok();
     }
 
     #[test]
     fn prune_keeps_the_two_newest_non_current_versions() {
-        let dir = advice_temp_dir("prune-recent");
+        let dir = ScratchDir::new("advice-prune-recent");
         let all: Vec<PathBuf> = [
             "toolport-gateway-1.6.2.exe",
             "toolport-gateway-1.9.0.exe",
@@ -2876,7 +2856,6 @@ mod tests {
             decide_prune(&bin(&dir, "toolport-gateway-1.6.2.exe"), &ctx),
             PruneDecision::Delete
         );
-        std::fs::remove_dir_all(&dir).ok();
     }
 
     /// `1.10.0` must sort above `1.9.6`, which a lexical compare gets backwards and
@@ -2913,7 +2892,7 @@ mod tests {
     /// listing happened to yield first.
     #[test]
     fn recency_floor_picks_the_newest_of_two_candidates() {
-        let dir = advice_temp_dir("prune-two-rcs");
+        let dir = ScratchDir::new("advice-prune-two-rcs");
         // Deliberately listed oldest-first, the order that hid this.
         let all: Vec<PathBuf> = [
             "toolport-gateway-1.9.6.exe",
@@ -2936,14 +2915,13 @@ mod tests {
             ],
             "the two newest are both candidates of 1.9.7, newest first"
         );
-        std::fs::remove_dir_all(&dir).ok();
     }
 
     /// The whole reported directory, end to end: 14 binaries, one current, one held
     /// by a live client, and the rest reclaimable.
     #[test]
     fn prune_plan_over_the_reported_directory() {
-        let dir = advice_temp_dir("prune-whole");
+        let dir = ScratchDir::new("advice-prune-whole");
         let names = [
             "toolport-gateway-1.6.2.exe",
             "toolport-gateway-1.7.0.exe",
@@ -2981,6 +2959,5 @@ mod tests {
             ],
             "current, the live rc, and the recency floor survive; the other 11 go"
         );
-        std::fs::remove_dir_all(&dir).ok();
     }
 }


### PR DESCRIPTION
Stacked on #649 — review that first; this PR's diff is only the refactor.

Split out of #649 at review time. That PR needed a scratch-dir guard for its own fixtures, and building one exposed the same bug in the pre-existing `advice_temp_dir`. Keeping the two together buried the actual reaper work under 13 call sites of mechanical churn, so it lives here instead.

## The bug

`advice_temp_dir` built `<tmp>/toolport-advice-<tag>-<pid>-<tid>/Toolport` and returned the leaf. Its 13 call sites each cleaned up by hand, with a `remove_dir_all(&dir).ok()` as the last line of the test. That got two things wrong:

- it removed only the `Toolport` leaf, so the unique parent leaked on every run, once per test;
- being the last statement, it was skipped entirely whenever an assertion panicked — so a *failing* test leaked its whole tree, copied binaries and all.

A `Drop` guard fixes both, and can't be forgotten by the next test that needs real files on disk.

## Measured

The 13+ `toolport-advice-*` directories a full run used to leave in `/tmp` are now zero.

Not fixed here: a full-suite run still leaves two `toolport-*mandatory-q-*` directories, which come from `bin/toolport-gateway.rs`. Out of scope for this PR — happy to file it separately if you want.

## Changes

`ScratchDir` loses its unix-only cfg (it's pure filesystem) and gains `Deref<Target = Path>`, so the 13 call sites are unchanged apart from the constructor. It also canonicalizes, which the reaper tests need and these don't care about either way.

Behaviour of the tests themselves is untouched. Full Rust suite green on Linux (730 + 228 + 26).

🤖 Generated with [Claude Code](https://claude.com/claude-code)