### PR TITLE
feat(oauth): client credentials for headless MCP servers (SBS-524)

### DIFF
--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -14192,6 +14192,7 @@ mod tests {
                 source: None,
                 disabled_tools: vec![],
                 cwd: None,
+                client_credentials: None,
                 unknown_fields: serde_json::Map::new(),
             });
         }
@@ -14228,6 +14229,7 @@ mod tests {
                 source: None,
                 disabled_tools: vec![],
                 cwd: None,
+                client_credentials: None,
                 unknown_fields: serde_json::Map::new(),
             });
             reg.set_server_enabled("default", id, true).unwrap();
@@ -14263,6 +14265,7 @@ mod tests {
             source: None,
             disabled_tools: vec![],
             cwd: None,
+            client_credentials: None,
             unknown_fields: serde_json::Map::new(),
         });
         reg.set_server_enabled("default", "github", true).unwrap();
@@ -17572,6 +17575,7 @@ mod tests {
             source: None,
             disabled_tools: vec![],
             cwd: None,
+            client_credentials: None,
             unknown_fields: serde_json::Map::new(),
         });
         reg.set_server_enabled("default", &id, true).unwrap();

--- a/src-tauri/src/clients.rs
+++ b/src-tauri/src/clients.rs
@@ -3931,6 +3931,7 @@ fn gateway_entry(profile: Option<&str>, client_id: &str) -> Result<ServerEntry, 
         source: Some("toolport".to_string()),
         disabled_tools: Vec::new(),
         cwd: None,
+        client_credentials: None,
         unknown_fields: serde_json::Map::new(),
     })
 }
@@ -3995,6 +3996,7 @@ pub fn gateway_entry_shared_http(
             source: Some("toolport".into()),
             disabled_tools: Vec::new(),
             cwd: None,
+            client_credentials: None,
             unknown_fields: serde_json::Map::new(),
         }
     } else {
@@ -4027,6 +4029,7 @@ pub fn gateway_entry_shared_http(
             source: Some("toolport".into()),
             disabled_tools: Vec::new(),
             cwd: None,
+            client_credentials: None,
             unknown_fields: serde_json::Map::new(),
         }
     }
@@ -4616,6 +4619,7 @@ mod tests {
             source: Some("toolport".into()),
             disabled_tools: Vec::new(),
             cwd: None,
+            client_credentials: None,
             unknown_fields: serde_json::Map::new(),
         }
     }
@@ -4713,6 +4717,7 @@ mod tests {
             source: None,
             disabled_tools: vec![],
             cwd: None,
+            client_credentials: None,
             unknown_fields: serde_json::Map::new(),
         }
     }
@@ -4733,6 +4738,7 @@ mod tests {
             source: None,
             disabled_tools: vec![],
             cwd: None,
+            client_credentials: None,
             unknown_fields: serde_json::Map::new(),
         }
     }

--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -1114,7 +1114,20 @@ fn set_client_credentials(
             ));
         }
     }
-    // Keychain first, outside the registry lock, matching `set_secret`. An empty
+    // Validate the id BEFORE touching the keychain. Writing first and erroring
+    // afterwards would leave an orphaned secret with nothing referencing it and
+    // no path to clean it up. The closure below re-checks under the lock, which
+    // is what actually guarantees consistency; this is purely so the common
+    // typo case cannot leave a credential behind.
+    {
+        let reg = state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if !reg.servers.iter().any(|s| s.id == server_id) {
+            return Err(format!("no server with id {server_id:?}"));
+        }
+    }
+    // Keychain next, outside the registry lock, matching `set_secret`. An empty
     // secret means "keep the vaulted one", so editing scopes does not require
     // re-entering the credential.
     if let Some(secret) = client_secret.as_deref().map(str::trim).filter(|s| !s.is_empty()) {

--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -1095,6 +1095,15 @@ fn set_client_credentials(
     if client_id.is_empty() {
         return Err("a client id is required for client-credentials auth".into());
     }
+    // Trim at the boundary, not just in the UI. `ClientAuthMethod::parse` trims
+    // before matching, so an untrimmed method would validate here and then be
+    // persisted with the whitespace still on it; scope is sent to the token
+    // endpoint verbatim, where padding can be rejected.
+    let blank_to_none = |v: Option<String>| {
+        v.map(|s| s.trim().to_string()).filter(|s| !s.is_empty())
+    };
+    let token_endpoint_auth_method = blank_to_none(token_endpoint_auth_method);
+    let scope = blank_to_none(scope);
     // Reject an unknown method here rather than at connect time, so a typo is a
     // dialog error instead of a failed connection later.
     if let Some(method) = token_endpoint_auth_method.as_deref() {
@@ -1117,16 +1126,20 @@ fn set_client_credentials(
     remote::reset_client_credentials(&server_id)?;
 
     let (reg, _) = write_registry(state.inner(), |reg| {
-        if let Some(server) = reg.servers.iter_mut().find(|s| s.id == server_id) {
-            let existing = server.client_credentials.take().unwrap_or_default();
-            server.client_credentials = Some(registry::ClientCredentials {
-                client_id: client_id.clone(),
-                token_endpoint_auth_method: token_endpoint_auth_method.clone(),
-                scope: scope.clone(),
-                // Preserve fields a newer build wrote, same contract as elsewhere.
-                unknown_fields: existing.unknown_fields,
-            });
-        }
+        // Fail loudly on an unknown id. The keychain write above already happened,
+        // so silently skipping the registry half would leave a stored secret with
+        // no configuration pointing at it, and report success.
+        let Some(server) = reg.servers.iter_mut().find(|s| s.id == server_id) else {
+            return Err(format!("no server with id {server_id:?}"));
+        };
+        let existing = server.client_credentials.take().unwrap_or_default();
+        server.client_credentials = Some(registry::ClientCredentials {
+            client_id: client_id.clone(),
+            token_endpoint_auth_method: token_endpoint_auth_method.clone(),
+            scope: scope.clone(),
+            // Preserve fields a newer build wrote, same contract as elsewhere.
+            unknown_fields: existing.unknown_fields,
+        });
         reg.secrets_generation = reg.secrets_generation.wrapping_add(1);
         Ok(())
     })?;
@@ -1143,9 +1156,10 @@ fn clear_client_credentials(
     let _ = secrets::delete_secret(&server_id, secrets::CLIENT_SECRET_KEY);
     remote::reset_client_credentials(&server_id)?;
     let (reg, _) = write_registry(state.inner(), |reg| {
-        if let Some(server) = reg.servers.iter_mut().find(|s| s.id == server_id) {
-            server.client_credentials = None;
-        }
+        let Some(server) = reg.servers.iter_mut().find(|s| s.id == server_id) else {
+            return Err(format!("no server with id {server_id:?}"));
+        };
+        server.client_credentials = None;
         reg.secrets_generation = reg.secrets_generation.wrapping_add(1);
         Ok(())
     })?;

--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -1118,10 +1118,13 @@ fn set_client_credentials(
     // Reject an unknown method here rather than at connect time, so a typo is a
     // dialog error instead of a failed connection later.
     if let Some(method) = token_endpoint_auth_method.as_deref() {
-        if oauth::ClientAuthMethod::parse(method).is_none() {
+        // Unusable as well as unrecognised. `private_key_jwt` parses but is not
+        // implemented, so persisting it produces a server that fails closed at
+        // every connect. Team import already refuses it; this is the same rule at
+        // the other entry point.
+        if !oauth::ClientAuthMethod::parse(method).is_some_and(|m| m.is_implemented()) {
             return Err(format!(
-                "unknown token endpoint auth method {method:?}; expected \
-                 client_secret_basic, client_secret_post, or private_key_jwt"
+                "unsupported token endpoint auth method {method:?}; expected                  client_secret_basic or client_secret_post (private_key_jwt is                  not implemented yet, see SBS-599)"
             ));
         }
     }

--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -1127,12 +1127,16 @@ fn set_client_credentials(
             return Err(format!("no server with id {server_id:?}"));
         }
     }
-    // Keychain next, outside the registry lock, matching `set_secret`. An empty
-    // secret means "keep the vaulted one", so editing scopes does not require
-    // re-entering the credential.
-    if let Some(secret) = client_secret.as_deref().map(str::trim).filter(|s| !s.is_empty()) {
-        secrets::set_secret(&server_id, secrets::CLIENT_SECRET_KEY, secret)?;
-    } else if secrets::get_secret(&server_id, secrets::CLIENT_SECRET_KEY).is_none() {
+    // An empty secret means "keep the vaulted one", so editing scopes does not
+    // require re-entering the credential. Resolve it here but do not write yet.
+    let secret_to_store = client_secret
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string);
+    if secret_to_store.is_none()
+        && secrets::get_secret(&server_id, secrets::CLIENT_SECRET_KEY).is_none()
+    {
         return Err("no client secret is stored for this server yet; enter one".into());
     }
     // Any config change invalidates a token minted under the old settings.
@@ -1156,6 +1160,14 @@ fn set_client_credentials(
         reg.secrets_generation = reg.secrets_generation.wrapping_add(1);
         Ok(())
     })?;
+    // Secret LAST, so no earlier failure can leave one vaulted with nothing
+    // referencing it and no way to reach it from the UI. If this write is the
+    // thing that fails, the config exists without a secret, which surfaces at
+    // connect as "no client secret is vaulted" and can simply be retried -- a
+    // visible, recoverable state rather than an invisible orphan.
+    if let Some(secret) = secret_to_store {
+        secrets::set_secret(&server_id, secrets::CLIENT_SECRET_KEY, &secret)?;
+    }
     Ok(reg)
 }
 
@@ -1166,8 +1178,11 @@ fn clear_client_credentials(
     state: State<RegistryState>,
     server_id: String,
 ) -> Result<Registry, String> {
-    let _ = secrets::delete_secret(&server_id, secrets::CLIENT_SECRET_KEY);
+    // Reset first. If it fails the secret is still there and the user can retry;
+    // deleting the credential first would destroy it on a half-completed removal,
+    // leaving a server configured for a flow whose secret is gone.
     remote::reset_client_credentials(&server_id)?;
+    secrets::delete_secret(&server_id, secrets::CLIENT_SECRET_KEY)?;
     let (reg, _) = write_registry(state.inner(), |reg| {
         let Some(server) = reg.servers.iter_mut().find(|s| s.id == server_id) else {
             return Err(format!("no server with id {server_id:?}"));

--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -1075,6 +1075,17 @@ fn delete_secret(
     Ok(reg)
 }
 
+/// Did the user supply a new client secret, and what exactly should be stored?
+///
+/// Whitespace decides only whether the field was left blank ("keep the stored
+/// one"). The value itself is stored VERBATIM: generated secrets are opaque, and
+/// one that legitimately begins or ends with whitespace would otherwise be
+/// silently altered, rejected by the token endpoint as `invalid_client`, and
+/// impossible to correct through the UI since the field cannot be read back.
+fn supplied_secret(input: Option<String>) -> Option<String> {
+    input.filter(|s| !s.trim().is_empty())
+}
+
 /// Configure the headless OAuth client-credentials flow for an HTTP server
 /// (SBS-524).
 ///
@@ -1129,11 +1140,7 @@ fn set_client_credentials(
     }
     // An empty secret means "keep the vaulted one", so editing scopes does not
     // require re-entering the credential. Resolve it here but do not write yet.
-    let secret_to_store = client_secret
-        .as_deref()
-        .map(str::trim)
-        .filter(|s| !s.is_empty())
-        .map(str::to_string);
+    let secret_to_store = supplied_secret(client_secret);
     if secret_to_store.is_none()
         && secrets::get_secret(&server_id, secrets::CLIENT_SECRET_KEY).is_none()
     {
@@ -4984,5 +4991,24 @@ mod tests {
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
         assert_eq!(only_server(&guard), "first");
+    }
+
+    /// SBS-524: whitespace decides only whether the field was blank; the value
+    /// itself must reach the keychain byte-for-byte. Trimming it would corrupt an
+    /// opaque secret that legitimately carries edge whitespace, and the resulting
+    /// `invalid_client` would be uncorrectable from a field that cannot be read back.
+    #[test]
+    fn supplied_secret_keeps_the_value_verbatim() {
+        assert_eq!(
+            supplied_secret(Some("  s3cret  ".into())).as_deref(),
+            Some("  s3cret  ")
+        );
+        assert_eq!(supplied_secret(Some("s3cret".into())).as_deref(), Some("s3cret"));
+        // Blank in any form means "keep the vaulted one".
+        assert_eq!(supplied_secret(Some(String::new())), None);
+        assert_eq!(supplied_secret(Some("   ".into())), None);
+        assert_eq!(supplied_secret(Some("	
+".into())), None);
+        assert_eq!(supplied_secret(None), None);
     }
 }

--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -1075,6 +1075,90 @@ fn delete_secret(
     Ok(reg)
 }
 
+/// Configure the headless OAuth client-credentials flow for an HTTP server
+/// (SBS-524).
+///
+/// The secret goes to the keychain; only the non-secret client id, auth method
+/// and scopes are written to the registry. Deliberately not routed through
+/// [`set_secret`], which records an env var: this credential is not an env var,
+/// and surfacing it as one would put it in the server's environment listing.
+#[tauri::command]
+fn set_client_credentials(
+    state: State<RegistryState>,
+    server_id: String,
+    client_id: String,
+    client_secret: Option<String>,
+    token_endpoint_auth_method: Option<String>,
+    scope: Option<String>,
+) -> Result<Registry, String> {
+    let client_id = client_id.trim().to_string();
+    if client_id.is_empty() {
+        return Err("a client id is required for client-credentials auth".into());
+    }
+    // Reject an unknown method here rather than at connect time, so a typo is a
+    // dialog error instead of a failed connection later.
+    if let Some(method) = token_endpoint_auth_method.as_deref() {
+        if oauth::ClientAuthMethod::parse(method).is_none() {
+            return Err(format!(
+                "unknown token endpoint auth method {method:?}; expected \
+                 client_secret_basic, client_secret_post, or private_key_jwt"
+            ));
+        }
+    }
+    // Keychain first, outside the registry lock, matching `set_secret`. An empty
+    // secret means "keep the vaulted one", so editing scopes does not require
+    // re-entering the credential.
+    if let Some(secret) = client_secret.as_deref().map(str::trim).filter(|s| !s.is_empty()) {
+        secrets::set_secret(&server_id, secrets::CLIENT_SECRET_KEY, secret)?;
+    } else if secrets::get_secret(&server_id, secrets::CLIENT_SECRET_KEY).is_none() {
+        return Err("no client secret is stored for this server yet; enter one".into());
+    }
+    // Any config change invalidates a token minted under the old settings.
+    remote::reset_client_credentials(&server_id)?;
+
+    let (reg, _) = write_registry(state.inner(), |reg| {
+        if let Some(server) = reg.servers.iter_mut().find(|s| s.id == server_id) {
+            let existing = server.client_credentials.take().unwrap_or_default();
+            server.client_credentials = Some(registry::ClientCredentials {
+                client_id: client_id.clone(),
+                token_endpoint_auth_method: token_endpoint_auth_method.clone(),
+                scope: scope.clone(),
+                // Preserve fields a newer build wrote, same contract as elsewhere.
+                unknown_fields: existing.unknown_fields,
+            });
+        }
+        reg.secrets_generation = reg.secrets_generation.wrapping_add(1);
+        Ok(())
+    })?;
+    Ok(reg)
+}
+
+/// Remove client-credentials auth from a server: the vaulted secret, the minted
+/// access token, and the registry config.
+#[tauri::command]
+fn clear_client_credentials(
+    state: State<RegistryState>,
+    server_id: String,
+) -> Result<Registry, String> {
+    let _ = secrets::delete_secret(&server_id, secrets::CLIENT_SECRET_KEY);
+    remote::reset_client_credentials(&server_id)?;
+    let (reg, _) = write_registry(state.inner(), |reg| {
+        if let Some(server) = reg.servers.iter_mut().find(|s| s.id == server_id) {
+            server.client_credentials = None;
+        }
+        reg.secrets_generation = reg.secrets_generation.wrapping_add(1);
+        Ok(())
+    })?;
+    Ok(reg)
+}
+
+/// Whether a client secret is vaulted for this server, so the UI can show
+/// "configured" without ever reading the value back.
+#[tauri::command]
+fn has_client_secret(server_id: String) -> bool {
+    secrets::get_secret(&server_id, secrets::CLIENT_SECRET_KEY).is_some()
+}
+
 /// The most recent tool-call audit entries (newest first).
 #[tauri::command]
 fn get_audit_log(limit: usize) -> Vec<serde_json::Value> {
@@ -3446,6 +3530,9 @@ pub fn run() {
             migrate_client,
             set_secret,
             delete_secret,
+            set_client_credentials,
+            clear_client_credentials,
+            has_client_secret,
             secret_status,
             get_audit_log,
             audit_stats,

--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -1159,12 +1159,15 @@ fn set_client_credentials(
         let Some(server) = reg.servers.iter_mut().find(|s| s.id == server_id) else {
             return Err(format!("no server with id {server_id:?}"));
         };
-        let existing = server.client_credentials.take().unwrap_or_default();
+        let mut existing = server.client_credentials.take().unwrap_or_default();
+        // Preserve a newer build's fields, but never a credential smuggled in
+        // through them -- e.g. a `clientSecret` hand-written into registry.json,
+        // which saving here would otherwise re-persist and hand to team export.
+        existing.strip_secret_fields();
         server.client_credentials = Some(registry::ClientCredentials {
             client_id: client_id.clone(),
             token_endpoint_auth_method: token_endpoint_auth_method.clone(),
             scope: scope.clone(),
-            // Preserve fields a newer build wrote, same contract as elsewhere.
             unknown_fields: existing.unknown_fields,
         });
         reg.secrets_generation = reg.secrets_generation.wrapping_add(1);

--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -1178,11 +1178,18 @@ fn clear_client_credentials(
     state: State<RegistryState>,
     server_id: String,
 ) -> Result<Registry, String> {
-    // Reset first. If it fails the secret is still there and the user can retry;
-    // deleting the credential first would destroy it on a half-completed removal,
-    // leaving a server configured for a flow whose secret is gone.
+    // Reset first, so a failure here preserves the credential and the removal can
+    // be retried.
     remote::reset_client_credentials(&server_id)?;
-    secrets::delete_secret(&server_id, secrets::CLIENT_SECRET_KEY)?;
+    // Then the config, and only then the secret. This is the OPPOSITE order to
+    // `set_client_credentials`, deliberately: there, a stranded secret is one the
+    // user still has in hand, so failing visibly is the better trade. Here the
+    // secret may be unrecoverable -- it is never shown again and may have to be
+    // re-issued by the authorization server -- so it must not be destroyed until
+    // the config is durably gone. If the delete is what fails, the result is a
+    // stale keychain entry with nothing pointing at it, and Remove can be run
+    // again; that is strictly better than losing a credential the user cannot get
+    // back.
     let (reg, _) = write_registry(state.inner(), |reg| {
         let Some(server) = reg.servers.iter_mut().find(|s| s.id == server_id) else {
             return Err(format!("no server with id {server_id:?}"));
@@ -1191,6 +1198,7 @@ fn clear_client_credentials(
         reg.secrets_generation = reg.secrets_generation.wrapping_add(1);
         Ok(())
     })?;
+    secrets::delete_secret(&server_id, secrets::CLIENT_SECRET_KEY)?;
     Ok(reg)
 }
 

--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -431,6 +431,7 @@ fn server_from_detected(server: &clients::McpServer, client_id: &str) -> ServerE
         source: Some(format!("imported:{client_id}")),
         disabled_tools: vec![],
         cwd: None,
+        client_credentials: None,
         unknown_fields: serde_json::Map::new(),
     }
 }
@@ -3836,6 +3837,7 @@ mod tests {
             source: None,
             disabled_tools: vec![],
             cwd: None,
+            client_credentials: None,
             unknown_fields: serde_json::Map::new(),
         }
     }
@@ -3869,6 +3871,7 @@ mod tests {
             source: None,
             disabled_tools: vec![],
             cwd: None,
+            client_credentials: None,
             unknown_fields: serde_json::Map::new(),
         }
     }
@@ -4236,6 +4239,7 @@ mod tests {
             source: None,
             disabled_tools: vec![],
             cwd: None,
+            client_credentials: None,
             unknown_fields: serde_json::Map::new(),
         });
 
@@ -4299,6 +4303,7 @@ mod tests {
             source: None,
             disabled_tools: vec![],
             cwd: None,
+            client_credentials: None,
             unknown_fields: serde_json::Map::new(),
         });
         let doc = build_export(&reg, None, None, None);
@@ -4339,6 +4344,7 @@ mod tests {
             source: None,
             disabled_tools: vec![],
             cwd: None,
+            client_credentials: None,
             unknown_fields: serde_json::Map::new(),
         });
         let doc = build_export(&reg, None, None, None);
@@ -4371,6 +4377,7 @@ mod tests {
             source: None,
             disabled_tools: vec![],
             cwd: None,
+            client_credentials: None,
             unknown_fields: serde_json::Map::new(),
         });
         let json = serde_json::to_string(&build_export(&reg, None, None, None)).unwrap();
@@ -4484,6 +4491,7 @@ mod tests {
             source: None,
             disabled_tools: vec![],
             cwd: None,
+            client_credentials: None,
             unknown_fields: serde_json::Map::new(),
         });
         reg.add_server(ServerEntry {
@@ -4497,6 +4505,7 @@ mod tests {
             source: None,
             disabled_tools: vec![],
             cwd: None,
+            client_credentials: None,
             unknown_fields: serde_json::Map::new(),
         });
 

--- a/src-tauri/src/downstream.rs
+++ b/src-tauri/src/downstream.rs
@@ -701,6 +701,40 @@ fn protocol_meta_for(version: &str) -> Value {
     })
 }
 
+/// Extension identifier for the headless OAuth flow (SBS-524).
+pub const OAUTH_CLIENT_CREDENTIALS_EXTENSION: &str =
+    "io.modelcontextprotocol/oauth-client-credentials";
+
+/// Merge Toolport's own extension declarations into a per-request `_meta`.
+///
+/// Kept separate from `protocol_meta` because [`Transport::set_protocol_meta`]
+/// replaces that wholesale after version negotiation, which would otherwise
+/// silently drop a declaration made at connect time. Re-merging on every set is
+/// what makes the declaration survive.
+fn merge_declared_extensions(meta: &mut Value, declared: &serde_json::Map<String, Value>) {
+    if declared.is_empty() {
+        return;
+    }
+    let Some(obj) = meta.as_object_mut() else {
+        return;
+    };
+    let capabilities = obj
+        .entry("io.modelcontextprotocol/clientCapabilities")
+        .or_insert_with(|| json!({}));
+    let Some(capabilities) = capabilities.as_object_mut() else {
+        return;
+    };
+    let extensions = capabilities
+        .entry("extensions")
+        .or_insert_with(|| json!({}));
+    let Some(extensions) = extensions.as_object_mut() else {
+        return;
+    };
+    for (name, settings) in declared {
+        extensions.insert(name.clone(), settings.clone());
+    }
+}
+
 const MCP_APPS_EXTENSION: &str = "io.modelcontextprotocol/ui";
 const MCP_APP_HTML_MIME: &str = "text/html;profile=mcp-app";
 
@@ -3190,6 +3224,10 @@ pub struct HttpTransport {
     /// drops its response on the next frame/keepalive, closing the old POST.
     listener_generation: Arc<AtomicU64>,
     subscription_listener_id: Option<i64>,
+    /// Extensions Toolport declares on this connection. Held apart from
+    /// `protocol_meta` because that is replaced wholesale after version
+    /// negotiation; see `merge_declared_extensions`.
+    declared_extensions: serde_json::Map<String, Value>,
 }
 
 struct PendingHttpMrtr {
@@ -3249,11 +3287,29 @@ impl HttpTransport {
             change_dirty: None,
             listener_generation: Arc::new(AtomicU64::new(0)),
             subscription_listener_id: None,
+            declared_extensions: serde_json::Map::new(),
         }
     }
 
     pub fn set_scope_reauthorize(&mut self, callback: Option<ScopeReauthorizeFn>) {
         self.scope_reauthorize = callback.map(|callback| Arc::new(Mutex::new(callback)));
+    }
+
+    /// Declare an extension Toolport supports on this connection.
+    ///
+    /// Declared per connection rather than globally: an extension is a statement
+    /// about *this* server, and claiming one on a server that does not use it
+    /// invites callbacks or semantics the gateway cannot service. Same reasoning
+    /// as the MCP Apps declaration on catalog fetches.
+    ///
+    /// A legacy (pre-2026-07-28) connection has no per-request `_meta`, so there
+    /// is nowhere to put this. The declaration is recorded and applied if the
+    /// connection is later negotiated up; the flow itself does not depend on it.
+    pub fn declare_extension(&mut self, name: &str, settings: Value) {
+        self.declared_extensions.insert(name.to_string(), settings);
+        if let Some(meta) = self.protocol_meta.as_mut() {
+            merge_declared_extensions(meta, &self.declared_extensions);
+        }
     }
 
     /// Wire the gateway sink for `notifications/resources/updated` seen on SSE
@@ -3817,6 +3873,9 @@ impl Transport for HttpTransport {
 
     fn set_protocol_meta(&mut self, meta: Option<Value>) {
         self.protocol_meta = meta;
+        if let Some(meta) = self.protocol_meta.as_mut() {
+            merge_declared_extensions(meta, &self.declared_extensions);
+        }
         if self.protocol_meta.is_some() {
             self.session_id = None;
         }
@@ -5078,7 +5137,8 @@ mod tests {
         resolve_root_token, screen_resolved_addrs, screen_spawn_command, screen_spawn_env,
         validate_cwd, CacheHint, CancelRegistry, DownstreamServer, MrtrRequest, ServerRequestAction,
         ServerRequestHandler, Transport, TransportError, MODERN_PROTOCOL_VERSION,
-        fetch_paginated_list,
+        fetch_paginated_list, protocol_meta_for, HttpTransport,
+        OAUTH_CLIENT_CREDENTIALS_EXTENSION,
     };
     use serde_json::{json, Value};
     use std::collections::{HashMap, VecDeque};
@@ -8639,5 +8699,56 @@ mod tests {
             }
             other => panic!("expected Retry or Fatal, got {other:?}"),
         }
+    }
+
+    /// SBS-524: a declared extension must survive `set_protocol_meta`.
+    ///
+    /// Version negotiation replaces `protocol_meta` wholesale, and the declaration
+    /// is made at connect time, before negotiation. Storing it only inside
+    /// `protocol_meta` would drop it on the first modern handshake and the server
+    /// would never learn the flow was in use -- with nothing failing to say so.
+    #[test]
+    fn declared_extensions_survive_protocol_meta_replacement() {
+        let mut transport = HttpTransport::guarded("https://mcp.example.com/mcp", None, None, true);
+        transport.declare_extension(OAUTH_CLIENT_CREDENTIALS_EXTENSION, json!({}));
+
+        // Declared before there is any protocol meta: nothing to merge into yet.
+        assert!(transport.protocol_meta.is_none());
+
+        transport.set_protocol_meta(Some(protocol_meta_for("2026-07-28")));
+        let extensions = transport
+            .protocol_meta
+            .as_ref()
+            .and_then(|m| m.get("io.modelcontextprotocol/clientCapabilities"))
+            .and_then(|c| c.get("extensions"))
+            .and_then(Value::as_object)
+            .expect("modern meta must carry a clientCapabilities.extensions map");
+        assert!(
+            extensions.contains_key(OAUTH_CLIENT_CREDENTIALS_EXTENSION),
+            "the declaration was dropped by version negotiation: {extensions:?}"
+        );
+
+        // Re-negotiating (a second handshake on the same transport) keeps it.
+        transport.set_protocol_meta(Some(protocol_meta_for("2026-07-28")));
+        assert!(transport
+            .protocol_meta
+            .as_ref()
+            .and_then(|m| m.get("io.modelcontextprotocol/clientCapabilities"))
+            .and_then(|c| c.get("extensions"))
+            .and_then(Value::as_object)
+            .is_some_and(|e| e.contains_key(OAUTH_CLIENT_CREDENTIALS_EXTENSION)));
+    }
+
+    /// A connection that never declares anything must send exactly what it always
+    /// did, so this cannot leak an empty `extensions` map onto every server.
+    #[test]
+    fn undeclared_connections_send_unchanged_meta() {
+        let mut transport = HttpTransport::guarded("https://mcp.example.com/mcp", None, None, true);
+        transport.set_protocol_meta(Some(protocol_meta_for("2026-07-28")));
+        assert_eq!(
+            transport.protocol_meta.as_ref().unwrap(),
+            &protocol_meta_for("2026-07-28"),
+            "declaring nothing must not alter the standard per-request meta"
+        );
     }
 }

--- a/src-tauri/src/oauth.rs
+++ b/src-tauri/src/oauth.rs
@@ -55,6 +55,121 @@ pub struct Endpoints {
     pub scope: Option<String>,
     pub authorization_response_iss_parameter_supported: bool,
     pub client_id_metadata_document_supported: bool,
+    /// RFC 8414 `token_endpoint_auth_methods_supported`. `None` when the server
+    /// omits it, which per RFC 8414 means `client_secret_basic` only.
+    pub token_endpoint_auth_methods_supported: Option<Vec<String>>,
+}
+
+/// How the client authenticates itself to the token endpoint.
+///
+/// Only relevant to the headless client-credentials flow (SBS-524). The
+/// interactive authorization-code flow uses a public client with PKCE and sends
+/// no client secret at all.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ClientAuthMethod {
+    /// Credentials in the form body (RFC 6749 §2.3.1, the `client_secret_post`
+    /// alternative).
+    ClientSecretPost,
+    /// Credentials in an HTTP Basic header (RFC 6749 §2.3.1, the default that
+    /// RFC 8414 assumes when a server advertises nothing).
+    ClientSecretBasic,
+    /// RFC 7523 private-key JWT assertion. Recognized and configurable, but not
+    /// implemented: it needs an asymmetric signing dependency the crate does not
+    /// have. Tracked in SBS-599. Selecting it fails closed rather than silently
+    /// downgrading to a shared secret, which would be a security regression.
+    PrivateKeyJwt,
+}
+
+impl ClientAuthMethod {
+    /// The RFC 8414 `token_endpoint_auth_method` identifier.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::ClientSecretPost => "client_secret_post",
+            Self::ClientSecretBasic => "client_secret_basic",
+            Self::PrivateKeyJwt => "private_key_jwt",
+        }
+    }
+
+    pub fn parse(s: &str) -> Option<Self> {
+        match s.trim() {
+            "client_secret_post" => Some(Self::ClientSecretPost),
+            "client_secret_basic" => Some(Self::ClientSecretBasic),
+            "private_key_jwt" => Some(Self::PrivateKeyJwt),
+            _ => None,
+        }
+    }
+
+    /// Does this method authenticate with a shared secret Toolport can send today?
+    fn is_implemented(self) -> bool {
+        matches!(self, Self::ClientSecretPost | Self::ClientSecretBasic)
+    }
+}
+
+/// Choose the token-endpoint auth method for a client-credentials connection.
+///
+/// `configured` is the user's explicit choice, if any. `advertised` is the
+/// server's `token_endpoint_auth_methods_supported`.
+///
+/// Fails closed in every ambiguous case rather than guessing. Sending a client
+/// secret by a method the server did not advertise leaks it to an endpoint that
+/// may log or reject it, and silently substituting a different method than the
+/// user configured is exactly the kind of downgrade this flow exists to avoid.
+pub fn select_client_auth_method(
+    configured: Option<ClientAuthMethod>,
+    advertised: Option<&[String]>,
+) -> Result<ClientAuthMethod, String> {
+    // RFC 8414: when the server omits the field, `client_secret_basic` is the
+    // assumed default. Treat an empty list the same way rather than concluding
+    // that nothing is supported.
+    let supported: Option<Vec<ClientAuthMethod>> = advertised
+        .filter(|list| !list.is_empty())
+        .map(|list| list.iter().filter_map(|m| ClientAuthMethod::parse(m)).collect());
+
+    if let Some(method) = configured {
+        if !method.is_implemented() {
+            return Err(format!(
+                "{} is not supported yet (it needs asymmetric signing; tracked in \
+                 SBS-599). Configure client_secret_post or client_secret_basic.",
+                method.as_str()
+            ));
+        }
+        if let Some(ref supported) = supported {
+            if !supported.contains(&method) {
+                return Err(format!(
+                    "the authorization server does not accept {}; it advertises: {}",
+                    method.as_str(),
+                    advertised.map(|l| l.join(", ")).unwrap_or_default()
+                ));
+            }
+        }
+        return Ok(method);
+    }
+
+    let Some(supported) = supported else {
+        // Nothing advertised: RFC 8414's default.
+        return Ok(ClientAuthMethod::ClientSecretBasic);
+    };
+    // Prefer basic, then post, among what we can actually do. `private_key_jwt`
+    // is deliberately not auto-selected: it is unimplemented, and picking it
+    // here would fail every connection on servers that advertise it alongside a
+    // secret-based method we can use.
+    supported
+        .iter()
+        .copied()
+        .find(|m| *m == ClientAuthMethod::ClientSecretBasic)
+        .or_else(|| {
+            supported
+                .iter()
+                .copied()
+                .find(|m| *m == ClientAuthMethod::ClientSecretPost)
+        })
+        .ok_or_else(|| {
+            format!(
+                "the authorization server advertises no token-endpoint auth method \
+                 Toolport can use ({}). private_key_jwt is tracked in SBS-599.",
+                advertised.map(|l| l.join(", ")).unwrap_or_default()
+            )
+        })
 }
 
 fn base64url(data: &[u8]) -> String {
@@ -247,6 +362,10 @@ struct AsMeta {
     authorization_response_iss_parameter_supported: bool,
     #[serde(default)]
     client_id_metadata_document_supported: bool,
+    /// RFC 8414. Absent means `client_secret_basic` per the spec, so this stays
+    /// `Option` rather than defaulting to an empty list, which would instead read
+    /// as "the server supports nothing".
+    token_endpoint_auth_methods_supported: Option<Vec<String>>,
 }
 
 enum ClientRegistration<'a> {
@@ -878,6 +997,8 @@ pub fn discover(mcp_url: &str) -> Result<Endpoints, String> {
                     .authorization_response_iss_parameter_supported,
                 client_id_metadata_document_supported: meta
                     .client_id_metadata_document_supported,
+                token_endpoint_auth_methods_supported: meta
+                    .token_endpoint_auth_methods_supported,
             });
         }
     }
@@ -1048,6 +1169,107 @@ pub fn refresh(
         resp.expires_in
     ));
     Ok(resp.into_tokens(now_epoch_seconds()))
+}
+
+/// Mint an access token with the RFC 6749 client-credentials grant (SBS-524).
+///
+/// This is the headless path: no browser, no user consent, no refresh token. The
+/// authorization server issues a token to the *client* rather than on behalf of a
+/// user, so when it expires the correct move is to ask for another one, not to
+/// redeem a refresh token. Servers are told not to issue one for this grant.
+///
+/// Deliberately fails closed rather than falling back to the interactive flow. A
+/// headless connection that silently opened a browser would be a surprising and
+/// unusable behaviour on a server, which is the environment this exists for.
+///
+/// `resource` rides as the RFC 8707 resource indicator so the token stays bound to
+/// the MCP server it was minted for, matching [`exchange_code`] and [`refresh`].
+pub fn client_credentials_token(
+    token_endpoint: &str,
+    client_id: &str,
+    client_secret: &str,
+    method: ClientAuthMethod,
+    scope: Option<&str>,
+    resource: Option<&str>,
+    block_private: bool,
+) -> Result<Tokens, String> {
+    if !method.is_implemented() {
+        return Err(format!(
+            "{} is not supported yet (tracked in SBS-599)",
+            method.as_str()
+        ));
+    }
+    // The secret rides in this request, so the transport must be encrypted. Same
+    // rule as every other credential-bearing call here; loopback is exempt for
+    // local development only.
+    require_https(token_endpoint, "token endpoint")?;
+
+    let mut form: Vec<(&str, &str)> = vec![("grant_type", "client_credentials")];
+    if let Some(s) = scope {
+        form.push(("scope", s));
+    }
+    if let Some(r) = resource {
+        form.push(("resource", r));
+    }
+
+    // `agent_no_redirect`: a 302 on a credential-bearing POST could hand the
+    // client secret to a host named by an attacker-influenceable metadata
+    // document. Same reasoning as the code exchange and refresh.
+    let request = agent_no_redirect(block_private).post(token_endpoint);
+    let response = match method {
+        ClientAuthMethod::ClientSecretBasic => {
+            // RFC 6749 §2.3.1: client_id and secret are form-urlencoded before
+            // base64, not sent raw. Skipping that corrupts any secret containing
+            // a `+`, `:` or `/`, which is common in generated credentials.
+            let credentials = format!(
+                "{}:{}",
+                urlencoding::encode(client_id),
+                urlencoding::encode(client_secret)
+            );
+            let header = format!(
+                "Basic {}",
+                base64::engine::general_purpose::STANDARD.encode(credentials.as_bytes())
+            );
+            request.set("Authorization", &header).send_form(&form)
+        }
+        ClientAuthMethod::ClientSecretPost => {
+            let mut form = form.clone();
+            form.push(("client_id", client_id));
+            form.push(("client_secret", client_secret));
+            request.send_form(&form)
+        }
+        ClientAuthMethod::PrivateKeyJwt => unreachable!("rejected above"),
+    };
+
+    let resp: TokenResponse = response
+        .map_err(|e| redact_secret(&e.to_string(), client_secret))?
+        .into_json()
+        .map_err(|e| redact_secret(&e.to_string(), client_secret))?;
+    debug_log(&format!(
+        "client_credentials response: method={} expires_in={:?} refresh_token={}",
+        method.as_str(),
+        resp.expires_in,
+        resp.refresh_token.is_some()
+    ));
+    let mut tokens = resp.into_tokens(now_epoch_seconds());
+    // RFC 6749 §4.4.3: a refresh token SHOULD NOT be issued for this grant. If a
+    // server sends one anyway, drop it rather than vault it: keeping it would let
+    // the reacquire path silently become a refresh path, and the whole point of
+    // this flow is that re-authentication is cheap and non-interactive.
+    tokens.refresh_token = None;
+    Ok(tokens)
+}
+
+/// Strip a credential out of text that is about to be surfaced or logged.
+///
+/// Transport errors can quote the request, and this flow puts the secret in the
+/// body for `client_secret_post`. Redacting at the boundary is cheaper to keep
+/// right than auditing every downstream sink.
+fn redact_secret(text: &str, secret: &str) -> String {
+    if secret.is_empty() {
+        return text.to_string();
+    }
+    text.replace(secret, "***")
 }
 
 fn open_browser(url: &str) {
@@ -2186,6 +2408,7 @@ mod tests {
             scope: None,
             authorization_response_iss_parameter_supported: false,
             client_id_metadata_document_supported: cimd,
+            token_endpoint_auth_methods_supported: None,
         };
 
         assert!(matches!(
@@ -2223,5 +2446,162 @@ mod tests {
         }))
         .unwrap();
         assert!(metadata.client_id_metadata_document_supported);
+    }
+
+    // ----- SBS-524: client-credentials auth-method selection ------------------
+
+    fn methods(list: &[&str]) -> Vec<String> {
+        list.iter().map(|s| s.to_string()).collect()
+    }
+
+    /// RFC 8414: a server that omits `token_endpoint_auth_methods_supported` is
+    /// declaring `client_secret_basic`, not declaring nothing.
+    #[test]
+    fn absent_or_empty_advertisement_means_client_secret_basic() {
+        assert_eq!(
+            select_client_auth_method(None, None).unwrap(),
+            ClientAuthMethod::ClientSecretBasic
+        );
+        // An empty list is treated the same rather than as "supports nothing",
+        // which would make such a server unusable for no good reason.
+        assert_eq!(
+            select_client_auth_method(None, Some(&[])).unwrap(),
+            ClientAuthMethod::ClientSecretBasic
+        );
+    }
+
+    #[test]
+    fn auto_selection_picks_a_method_we_can_actually_perform() {
+        assert_eq!(
+            select_client_auth_method(None, Some(&methods(&["client_secret_post"]))).unwrap(),
+            ClientAuthMethod::ClientSecretPost
+        );
+        assert_eq!(
+            select_client_auth_method(
+                None,
+                Some(&methods(&["client_secret_post", "client_secret_basic"]))
+            )
+            .unwrap(),
+            ClientAuthMethod::ClientSecretBasic
+        );
+    }
+
+    /// `private_key_jwt` must never be auto-selected while it is unimplemented:
+    /// picking it would fail every connection to a server that also offers a
+    /// secret-based method we can use.
+    #[test]
+    fn auto_selection_skips_private_key_jwt_but_uses_a_usable_sibling() {
+        assert_eq!(
+            select_client_auth_method(
+                None,
+                Some(&methods(&["private_key_jwt", "client_secret_post"]))
+            )
+            .unwrap(),
+            ClientAuthMethod::ClientSecretPost
+        );
+    }
+
+    #[test]
+    fn auto_selection_fails_closed_when_nothing_is_usable() {
+        let err = select_client_auth_method(
+            None,
+            Some(&methods(&["private_key_jwt", "tls_client_auth"])),
+        )
+        .unwrap_err();
+        assert!(err.contains("SBS-599"), "error should point at the follow-up: {err}");
+    }
+
+    /// Configuring an unimplemented method fails rather than quietly downgrading
+    /// to a shared secret, which would be a security regression.
+    #[test]
+    fn configured_private_key_jwt_fails_closed_rather_than_downgrading() {
+        let err = select_client_auth_method(
+            Some(ClientAuthMethod::PrivateKeyJwt),
+            Some(&methods(&["private_key_jwt", "client_secret_basic"])),
+        )
+        .unwrap_err();
+        assert!(err.contains("not supported yet"), "{err}");
+        assert!(err.contains("SBS-599"), "{err}");
+    }
+
+    /// Never send a secret by a method the server did not advertise.
+    #[test]
+    fn configured_method_must_be_advertised() {
+        let err = select_client_auth_method(
+            Some(ClientAuthMethod::ClientSecretPost),
+            Some(&methods(&["client_secret_basic"])),
+        )
+        .unwrap_err();
+        assert!(err.contains("does not accept client_secret_post"), "{err}");
+
+        // But an explicit choice is honoured when the server says nothing, since
+        // there is no advertisement to contradict it.
+        assert_eq!(
+            select_client_auth_method(Some(ClientAuthMethod::ClientSecretPost), None).unwrap(),
+            ClientAuthMethod::ClientSecretPost
+        );
+    }
+
+    #[test]
+    fn auth_method_identifiers_round_trip() {
+        for m in [
+            ClientAuthMethod::ClientSecretPost,
+            ClientAuthMethod::ClientSecretBasic,
+            ClientAuthMethod::PrivateKeyJwt,
+        ] {
+            assert_eq!(ClientAuthMethod::parse(m.as_str()), Some(m));
+        }
+        assert_eq!(ClientAuthMethod::parse("none"), None);
+        assert_eq!(ClientAuthMethod::parse("tls_client_auth"), None);
+    }
+
+    /// The token endpoint receives the secret, so cleartext is refused outright
+    /// before any request is made.
+    #[test]
+    fn client_credentials_refuses_a_cleartext_token_endpoint() {
+        // `unwrap_err` would require `Tokens: Debug`, and `Tokens` deliberately
+        // does not derive it: a Debug impl on a struct holding an access token is
+        // one stray `{:?}` away from logging the credential.
+        let err = match client_credentials_token(
+            "http://auth.example.com/token",
+            "client",
+            "s3cret",
+            ClientAuthMethod::ClientSecretBasic,
+            None,
+            None,
+            true,
+        ) {
+            Err(e) => e,
+            Ok(_) => panic!("a cleartext token endpoint must be refused"),
+        };
+        assert!(err.contains("must use https"), "{err}");
+    }
+
+    #[test]
+    fn client_credentials_rejects_private_key_jwt_before_any_request() {
+        let err = match client_credentials_token(
+            "https://auth.example.com/token",
+            "client",
+            "",
+            ClientAuthMethod::PrivateKeyJwt,
+            None,
+            None,
+            true,
+        ) {
+            Err(e) => e,
+            Ok(_) => panic!("private_key_jwt must be refused before any request"),
+        };
+        assert!(err.contains("SBS-599"), "{err}");
+    }
+
+    /// A secret can appear in a transport error that quotes the request body.
+    #[test]
+    fn secrets_are_redacted_from_surfaced_text() {
+        assert_eq!(
+            redact_secret("POST failed: client_secret=hunter2&x=1", "hunter2"),
+            "POST failed: client_secret=***&x=1"
+        );
+        // An empty secret must not turn every character into a redaction.
+        assert_eq!(redact_secret("nothing to hide", ""), "nothing to hide");
     }
 }

--- a/src-tauri/src/oauth.rs
+++ b/src-tauri/src/oauth.rs
@@ -100,7 +100,11 @@ impl ClientAuthMethod {
     }
 
     /// Does this method authenticate with a shared secret Toolport can send today?
-    fn is_implemented(self) -> bool {
+    ///
+    /// Public because callers that persist a configuration need to refuse an
+    /// unimplemented method up front, rather than storing it and failing at every
+    /// later connect.
+    pub fn is_implemented(self) -> bool {
         matches!(self, Self::ClientSecretPost | Self::ClientSecretBasic)
     }
 }

--- a/src-tauri/src/oauth.rs
+++ b/src-tauri/src/oauth.rs
@@ -369,7 +369,29 @@ struct AsMeta {
     /// RFC 8414. Absent means `client_secret_basic` per the spec, so this stays
     /// `Option` rather than defaulting to an empty list, which would instead read
     /// as "the server supports nothing".
+    #[serde(default, deserialize_with = "lenient_string_list")]
     token_endpoint_auth_methods_supported: Option<Vec<String>>,
+}
+
+/// Parse a list-of-strings metadata field without letting a malformed value fail
+/// the whole document.
+///
+/// This field is new to `AsMeta`. Before it was read, a server that published it
+/// as a bare string (or any non-array) was simply ignored; typing it strictly
+/// would turn that into a hard discovery failure and break the interactive flow
+/// for servers that work today. A malformed value is treated as absent, and
+/// non-string entries are dropped rather than poisoning the list.
+fn lenient_string_list<'de, D>(deserializer: D) -> Result<Option<Vec<String>>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value = serde_json::Value::deserialize(deserializer)?;
+    Ok(value.as_array().map(|items| {
+        items
+            .iter()
+            .filter_map(|item| item.as_str().map(String::from))
+            .collect()
+    }))
 }
 
 enum ClientRegistration<'a> {
@@ -2450,6 +2472,44 @@ mod tests {
         }))
         .unwrap();
         assert!(metadata.client_id_metadata_document_supported);
+    }
+
+    /// A malformed `token_endpoint_auth_methods_supported` must not fail the whole
+    /// metadata document.
+    ///
+    /// This field is new. Before it was read, a server publishing it as a bare
+    /// string was simply ignored; typing it strictly would turn that into a hard
+    /// discovery failure and break the interactive flow for servers that work
+    /// today.
+    #[test]
+    fn malformed_token_endpoint_auth_methods_do_not_fail_discovery() {
+        let parse = |methods: serde_json::Value| {
+            serde_json::from_value::<AsMeta>(serde_json::json!({
+                "issuer": "https://auth.example.com",
+                "authorization_endpoint": "https://auth.example.com/authorize",
+                "token_endpoint": "https://auth.example.com/token",
+                "token_endpoint_auth_methods_supported": methods,
+            }))
+        };
+
+        // A bare string, an object, and null are all "absent", not fatal.
+        for bad in [
+            serde_json::json!("client_secret_basic"),
+            serde_json::json!({ "a": 1 }),
+            serde_json::Value::Null,
+        ] {
+            let meta = parse(bad.clone())
+                .unwrap_or_else(|e| panic!("{bad} must not fail the document: {e}"));
+            assert_eq!(meta.token_endpoint_auth_methods_supported, None);
+        }
+
+        // A well-formed list still parses, and non-string entries are dropped
+        // rather than poisoning it.
+        let meta = parse(serde_json::json!(["client_secret_basic", 7])).unwrap();
+        assert_eq!(
+            meta.token_endpoint_auth_methods_supported,
+            Some(vec!["client_secret_basic".to_string()])
+        );
     }
 
     // ----- SBS-524: client-credentials auth-method selection ------------------

--- a/src-tauri/src/registry.rs
+++ b/src-tauri/src/registry.rs
@@ -124,9 +124,39 @@ pub struct ServerEntry {
     /// an empty list means every tool the server advertises is exposed.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub disabled_tools: Vec<String>,
+    /// Headless outbound OAuth for an HTTP server (SBS-524). Presence of this
+    /// block is what selects the client-credentials flow; absence leaves
+    /// interactive OAuth and pasted-token behaviour exactly as before.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub client_credentials: Option<ClientCredentials>,
     /// Per-server fields written by a newer build that this binary doesn't know
     /// about. Captured on load and re-emitted on save so a mixed-version binary
     /// never strips them (same contract as `Registry::unknown_fields`).
+    #[serde(flatten)]
+    pub unknown_fields: serde_json::Map<String, serde_json::Value>,
+}
+
+/// Non-secret configuration for the OAuth client-credentials flow (SBS-524).
+///
+/// Deliberately holds no secret. The client secret lives in the OS vault under
+/// [`crate::secrets::CLIENT_SECRET_KEY`], because this struct is written to
+/// `registry.json`, copied into config backups, and included in exports. The
+/// client id, scopes and auth method are not credentials and are useful to see
+/// in the file.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct ClientCredentials {
+    /// OAuth client identifier issued by the authorization server.
+    pub client_id: String,
+    /// `client_secret_basic` | `client_secret_post` | `private_key_jwt`.
+    /// Unset means negotiate from the server's advertised methods.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub token_endpoint_auth_method: Option<String>,
+    /// Space-delimited scopes to request. Unset means use what discovery
+    /// advertises for the protected resource.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scope: Option<String>,
+    /// Forward-compat, same contract as `ServerEntry::unknown_fields`.
     #[serde(flatten)]
     pub unknown_fields: serde_json::Map<String, serde_json::Value>,
 }
@@ -2035,6 +2065,7 @@ mod tests {
             source: Some("manual".to_string()),
             disabled_tools: vec![],
             cwd: None,
+            client_credentials: None,
             unknown_fields: serde_json::Map::new(),
         }
     }
@@ -3064,6 +3095,7 @@ mod tests {
             source: None,
             disabled_tools: vec![],
             cwd: None,
+            client_credentials: None,
             unknown_fields: serde_json::Map::new(),
         });
         // Inject a per-server field this binary's ServerEntry doesn't define.

--- a/src-tauri/src/registry.rs
+++ b/src-tauri/src/registry.rs
@@ -157,8 +157,31 @@ pub struct ClientCredentials {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub scope: Option<String>,
     /// Forward-compat, same contract as `ServerEntry::unknown_fields`.
+    ///
+    /// Sanitized by [`Self::strip_secret_fields`] wherever this crosses a trust
+    /// boundary: forward-compat must not become a smuggling channel for a
+    /// credential this type is specifically designed never to hold.
     #[serde(flatten)]
     pub unknown_fields: serde_json::Map<String, serde_json::Value>,
+}
+
+impl ClientCredentials {
+    /// Drop any forward-compat field whose name looks like a credential.
+    ///
+    /// `unknown_fields` exists so a newer build's additions survive a round trip
+    /// through an older one. That is the right default for configuration, and the
+    /// wrong one for secrets: a `clientSecret` key written by hand into
+    /// registry.json, or present in a team payload, would otherwise be preserved
+    /// and then pushed to the org control plane and every teammate by
+    /// `team_server_export` -- the exact leak this struct's shape is meant to make
+    /// impossible.
+    ///
+    /// Name-based and deliberately broad. A real forward-compat field is free to
+    /// avoid the word; a credential that slips through is not recoverable.
+    pub fn strip_secret_fields(&mut self) {
+        self.unknown_fields
+            .retain(|k, _| !k.to_ascii_lowercase().contains("secret"));
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/src-tauri/src/remote.rs
+++ b/src-tauri/src/remote.rs
@@ -700,6 +700,13 @@ pub fn connect_remote_with_handler(
     // registry config (client id, method, scopes); every later reacquisition runs
     // from the state vaulted here, which is why it can go through the shared seam
     // with just a server id.
+    // Config removed while vaulted state survived -- e.g. registry.json edited by
+    // hand with the app closed. Clear it here, at the one place that can see both,
+    // so the reacquire path cannot keep the headless flow alive for a server that
+    // is no longer configured for it.
+    if !uses_client_credentials(server) && secrets::get_secret(server_id, CC_STATE_KEY).is_some() {
+        let _ = reset_client_credentials(server_id);
+    }
     if uses_client_credentials(server) && secrets::get_secret(server_id, CC_STATE_KEY).is_none() {
         let config = server
             .client_credentials

--- a/src-tauri/src/remote.rs
+++ b/src-tauri/src/remote.rs
@@ -568,6 +568,16 @@ fn authed_transport(
     // blocked only for untrusted-provenance servers.
     let mut transport = HttpTransport::guarded(url, token, refresh, block_private);
     transport.set_scope_reauthorize(scope_reauthorize);
+    // Declared per request only while the flow is actually in use, which is what
+    // the extension requires. Keyed off vaulted state rather than registry config
+    // so it is true of the credential actually being sent: a server configured for
+    // the flow but not yet provisioned has nothing to declare.
+    if secrets::get_secret(server_id, CC_STATE_KEY).is_some() {
+        transport.declare_extension(
+            crate::downstream::OAUTH_CLIENT_CREDENTIALS_EXTENSION,
+            serde_json::json!({}),
+        );
+    }
     Ok(transport)
 }
 

--- a/src-tauri/src/remote.rs
+++ b/src-tauri/src/remote.rs
@@ -287,10 +287,14 @@ fn reacquire_client_credentials(server_id: &str) -> Result<RefreshedToken, Strin
 /// an edit would keep minting tokens against the OLD configuration and the user's
 /// change would appear to do nothing.
 pub fn reset_client_credentials(server_id: &str) -> Result<(), String> {
-    let _ = secrets::delete_secret(server_id, CC_STATE_KEY);
+    // Errors propagate. A failed delete leaves state that would keep minting
+    // tokens under the OLD configuration, so reporting success here would tell
+    // the user their change had taken effect when it had not. Deleting a key that
+    // is not there is already `Ok` in every backend, so this does not fail on a
+    // server being configured for the first time.
+    secrets::delete_secret(server_id, CC_STATE_KEY)?;
     // The access token was minted under the previous configuration too.
-    let _ = secrets::delete_secret(server_id, secrets::HTTP_AUTH_KEY);
-    Ok(())
+    secrets::delete_secret(server_id, secrets::HTTP_AUTH_KEY)
 }
 
 /// Expiry of the vaulted client-credentials token, if this server uses that flow.

--- a/src-tauri/src/remote.rs
+++ b/src-tauri/src/remote.rs
@@ -628,6 +628,7 @@ mod tests {
             scope: None,
             authorization_response_iss_parameter_supported: false,
             client_id_metadata_document_supported: false,
+            token_endpoint_auth_methods_supported: None,
         };
 
         let rotated = endpoints("https://auth.example.com", "https://auth.example.com/token-v2");

--- a/src-tauri/src/remote.rs
+++ b/src-tauri/src/remote.rs
@@ -304,17 +304,23 @@ pub fn reset_client_credentials(server_id: &str) -> Result<(), String> {
 
 /// Does the vaulted state name a different MCP URL than the one being connected?
 ///
-/// Compared case-insensitively on the trimmed string. An unreadable state counts
-/// as unchanged: the caller only uses this to decide whether to discard state,
-/// and discarding on a parse failure would loop a broken vault into re-acquiring
-/// on every connect.
+/// Compared EXACTLY on the trimmed string, not case-insensitively. A URL path and
+/// query are case-sensitive, so `/MCP` and `/mcp` are different resources; folding
+/// case would let an edit between them keep a token that RFC 8707 bound to the old
+/// one. Erring the other way is harmless: a comparison that reports "changed" when
+/// only the scheme or host case differs just re-acquires, which is cheap and
+/// non-interactive by construction.
+///
+/// An unreadable state counts as unchanged: the caller only uses this to decide
+/// whether to discard state, and discarding on a parse failure would loop a broken
+/// vault into re-acquiring on every connect.
 fn client_credentials_resource_changed(server_id: &str, url: &str) -> bool {
     let Some(state) = secrets::get_secret(server_id, CC_STATE_KEY)
         .and_then(|s| serde_json::from_str::<ClientCredentialsState>(&s).ok())
     else {
         return false;
     };
-    !state.resource.trim().eq_ignore_ascii_case(url.trim())
+    state.resource.trim() != url.trim()
 }
 
 /// Expiry of the vaulted client-credentials token, if this server uses that flow.

--- a/src-tauri/src/remote.rs
+++ b/src-tauri/src/remote.rs
@@ -136,8 +136,13 @@ fn issuer_bound_token_endpoint<'a>(
 /// manually pasted bearer token. Otherwise stale vaulted state could silently
 /// recreate a credential the user explicitly removed.
 pub fn clear_oauth_state(server_id: &str) -> Result<(), String> {
-    let _ = secrets::delete_secret(server_id, CC_STATE_KEY);
-    secrets::delete_secret(server_id, STATE_KEY)
+    // Attempt both, then surface the first failure. Swallowing the
+    // client-credentials delete would leave state that silently reacquires with
+    // the long-lived secret after the user believed they had cleared auth; only
+    // attempting the second on success would leave the other key behind.
+    let headless = secrets::delete_secret(server_id, CC_STATE_KEY);
+    let interactive = secrets::delete_secret(server_id, STATE_KEY);
+    headless.and(interactive)
 }
 
 // ── Client-credentials flow (SBS-524) ──────────────────────────────────────

--- a/src-tauri/src/remote.rs
+++ b/src-tauri/src/remote.rs
@@ -302,6 +302,21 @@ pub fn reset_client_credentials(server_id: &str) -> Result<(), String> {
     secrets::delete_secret(server_id, secrets::HTTP_AUTH_KEY)
 }
 
+/// Does the vaulted state name a different MCP URL than the one being connected?
+///
+/// Compared case-insensitively on the trimmed string. An unreadable state counts
+/// as unchanged: the caller only uses this to decide whether to discard state,
+/// and discarding on a parse failure would loop a broken vault into re-acquiring
+/// on every connect.
+fn client_credentials_resource_changed(server_id: &str, url: &str) -> bool {
+    let Some(state) = secrets::get_secret(server_id, CC_STATE_KEY)
+        .and_then(|s| serde_json::from_str::<ClientCredentialsState>(&s).ok())
+    else {
+        return false;
+    };
+    !state.resource.trim().eq_ignore_ascii_case(url.trim())
+}
+
 /// Expiry of the vaulted client-credentials token, if this server uses that flow.
 fn client_credentials_expiry(server_id: &str) -> Option<u64> {
     let state: ClientCredentialsState = secrets::get_secret(server_id, CC_STATE_KEY)
@@ -700,12 +715,25 @@ pub fn connect_remote_with_handler(
     // registry config (client id, method, scopes); every later reacquisition runs
     // from the state vaulted here, which is why it can go through the shared seam
     // with just a server id.
-    // Config removed while vaulted state survived -- e.g. registry.json edited by
-    // hand with the app closed. Clear it here, at the one place that can see both,
-    // so the reacquire path cannot keep the headless flow alive for a server that
-    // is no longer configured for it.
-    if !uses_client_credentials(server) && secrets::get_secret(server_id, CC_STATE_KEY).is_some() {
-        let _ = reset_client_credentials(server_id);
+    // Vaulted state that no longer matches the entry. Two cases, both reached by
+    // editing the server outside `set_client_credentials`:
+    //
+    //   * the config was removed (e.g. registry.json edited with the app closed),
+    //     which would otherwise keep the headless flow alive for a server no
+    //     longer configured for it;
+    //   * the URL changed, which matters more. The vaulted state pins `resource`,
+    //     and the token is bound to it via RFC 8707, so reusing it would present a
+    //     credential minted for the OLD resource to the new one. Reset instead, so
+    //     the next acquisition binds to the URL actually being contacted.
+    //
+    // Handled here because this is the only place that sees both the current entry
+    // and the vault; the reacquire seam takes just a server id by design.
+    if secrets::get_secret(server_id, CC_STATE_KEY).is_some()
+        && (!uses_client_credentials(server) || client_credentials_resource_changed(server_id, url))
+    {
+        // Not ignored: leaving stale state would silently keep using the wrong
+        // flow, or the wrong resource binding, for the rest of the session.
+        reset_client_credentials(server_id)?;
     }
     if uses_client_credentials(server) && secrets::get_secret(server_id, CC_STATE_KEY).is_none() {
         let config = server

--- a/src-tauri/src/remote.rs
+++ b/src-tauri/src/remote.rs
@@ -280,6 +280,19 @@ fn reacquire_client_credentials(server_id: &str) -> Result<RefreshedToken, Strin
     })
 }
 
+/// Drop vaulted client-credentials state so the next connect re-acquires.
+///
+/// Called whenever the configuration changes. The state records the issuer,
+/// method and scopes resolved at acquisition time, so leaving it in place after
+/// an edit would keep minting tokens against the OLD configuration and the user's
+/// change would appear to do nothing.
+pub fn reset_client_credentials(server_id: &str) -> Result<(), String> {
+    let _ = secrets::delete_secret(server_id, CC_STATE_KEY);
+    // The access token was minted under the previous configuration too.
+    let _ = secrets::delete_secret(server_id, secrets::HTTP_AUTH_KEY);
+    Ok(())
+}
+
 /// Expiry of the vaulted client-credentials token, if this server uses that flow.
 fn client_credentials_expiry(server_id: &str) -> Option<u64> {
     let state: ClientCredentialsState = secrets::get_secret(server_id, CC_STATE_KEY)

--- a/src-tauri/src/remote.rs
+++ b/src-tauri/src/remote.rs
@@ -136,12 +136,178 @@ fn issuer_bound_token_endpoint<'a>(
 /// manually pasted bearer token. Otherwise stale vaulted state could silently
 /// recreate a credential the user explicitly removed.
 pub fn clear_oauth_state(server_id: &str) -> Result<(), String> {
+    let _ = secrets::delete_secret(server_id, CC_STATE_KEY);
     secrets::delete_secret(server_id, STATE_KEY)
+}
+
+// ── Client-credentials flow (SBS-524) ──────────────────────────────────────
+
+const CC_STATE_KEY: &str = "__oauth_cc_state__";
+
+/// What a later reacquisition needs, resolved once at connect time.
+///
+/// The reacquire seam (`refresh_token_with_expiry`) is reached from the request
+/// path with only a server id, so everything needed to mint another token is
+/// captured here rather than looked up from the registry again. That also means a
+/// reacquisition uses the same issuer and method the first one did, instead of
+/// silently following a metadata document that changed underneath it.
+///
+/// Holds no secret: the client secret stays in the vault under its own key.
+#[derive(Serialize, Deserialize)]
+struct ClientCredentialsState {
+    issuer: String,
+    token_endpoint: String,
+    client_id: String,
+    /// The negotiated `token_endpoint_auth_method` identifier.
+    method: String,
+    #[serde(default)]
+    scope: Option<String>,
+    /// RFC 8707 resource indicator (the MCP server URL).
+    resource: String,
+    #[serde(default)]
+    expires_at: Option<u64>,
+}
+
+/// Discover, negotiate an auth method, and mint an access token for a headless
+/// server. Vaults the token and the state a later reacquisition needs.
+///
+/// Fails closed rather than falling back to the interactive flow: a server that
+/// silently opened a browser would be unusable in the environment this exists for.
+fn acquire_client_credentials(
+    server_id: &str,
+    resource: &str,
+    config: &crate::registry::ClientCredentials,
+) -> Result<RefreshedToken, String> {
+    let secret = secrets::get_secret(server_id, secrets::CLIENT_SECRET_KEY).ok_or(
+        "no client secret is vaulted for this server; add one before connecting \
+         (client-credentials auth never falls back to a browser sign-in)",
+    )?;
+    let configured = match config.token_endpoint_auth_method.as_deref() {
+        Some(raw) => Some(oauth::ClientAuthMethod::parse(raw).ok_or_else(|| {
+            format!("unknown token_endpoint_auth_method {raw:?} configured for this server")
+        })?),
+        None => None,
+    };
+
+    let endpoints = oauth::discover(resource)?;
+    let method = oauth::select_client_auth_method(
+        configured,
+        endpoints.token_endpoint_auth_methods_supported.as_deref(),
+    )?;
+    // Prefer the user's explicit scopes; otherwise take what discovery advertises
+    // for this protected resource, matching the interactive flow.
+    let scope = config.scope.clone().or_else(|| endpoints.scope.clone());
+
+    let block_private = oauth::host_of_url(&endpoints.token_endpoint)
+        .map(|h| !oauth::host_is_definitely_private(&h))
+        .unwrap_or(true);
+    let tokens = oauth::client_credentials_token(
+        &endpoints.token_endpoint,
+        &config.client_id,
+        &secret,
+        method,
+        scope.as_deref(),
+        Some(resource),
+        block_private,
+    )?;
+
+    // State first, then the access token: a failure between the two leaves the
+    // next attempt able to reacquire, where the reverse order could strand a
+    // token with no way to mint its successor. Same ordering as the refresh path.
+    let state = ClientCredentialsState {
+        issuer: endpoints.issuer,
+        token_endpoint: endpoints.token_endpoint,
+        client_id: config.client_id.clone(),
+        method: method.as_str().to_string(),
+        scope,
+        resource: resource.to_string(),
+        expires_at: tokens.expires_at,
+    };
+    let json = serde_json::to_string(&state).map_err(|e| e.to_string())?;
+    secrets::set_secret(server_id, CC_STATE_KEY, &json)?;
+    secrets::set_secret(server_id, secrets::HTTP_AUTH_KEY, &tokens.access_token)?;
+    Ok(RefreshedToken {
+        access_token: tokens.access_token,
+        expires_at: tokens.expires_at,
+    })
+}
+
+/// Mint a replacement token from vaulted client-credentials state.
+///
+/// There is no refresh token to redeem (RFC 6749 §4.4.3), so this re-runs the
+/// grant. It reuses the recorded token endpoint and method rather than
+/// rediscovering, and re-verifies the issuer when it does discover, so a resource
+/// that changed authorization server fails closed instead of sending the secret
+/// somewhere new.
+fn reacquire_client_credentials(server_id: &str) -> Result<RefreshedToken, String> {
+    let state: ClientCredentialsState = secrets::get_secret(server_id, CC_STATE_KEY)
+        .and_then(|s| serde_json::from_str(&s).ok())
+        .ok_or("no client-credentials state to reacquire from")?;
+    let secret = secrets::get_secret(server_id, secrets::CLIENT_SECRET_KEY)
+        .ok_or("the vaulted client secret is gone; re-add it for this server")?;
+    let method = oauth::ClientAuthMethod::parse(&state.method)
+        .ok_or_else(|| format!("vaulted auth method {:?} is not recognized", state.method))?;
+
+    let endpoints = oauth::discover(&state.resource).map_err(|e| {
+        format!("could not verify the stored OAuth issuer before reusing the client secret: {e}")
+    })?;
+    let token_endpoint = issuer_bound_token_endpoint(&state.issuer, &endpoints)?;
+
+    let block_private = oauth::host_of_url(token_endpoint)
+        .map(|h| !oauth::host_is_definitely_private(&h))
+        .unwrap_or(true);
+    let tokens = oauth::client_credentials_token(
+        token_endpoint,
+        &state.client_id,
+        &secret,
+        method,
+        state.scope.as_deref(),
+        Some(&state.resource),
+        block_private,
+    )?;
+
+    let next = ClientCredentialsState {
+        token_endpoint: token_endpoint.to_string(),
+        expires_at: tokens.expires_at,
+        ..state
+    };
+    let json = serde_json::to_string(&next).map_err(|e| e.to_string())?;
+    secrets::set_secret(server_id, CC_STATE_KEY, &json)?;
+    secrets::set_secret(server_id, secrets::HTTP_AUTH_KEY, &tokens.access_token)?;
+    Ok(RefreshedToken {
+        access_token: tokens.access_token,
+        expires_at: tokens.expires_at,
+    })
+}
+
+/// Expiry of the vaulted client-credentials token, if this server uses that flow.
+fn client_credentials_expiry(server_id: &str) -> Option<u64> {
+    let state: ClientCredentialsState = secrets::get_secret(server_id, CC_STATE_KEY)
+        .and_then(|s| serde_json::from_str(&s).ok())?;
+    // A server that reports no lifetime keeps the reactive 401/403 behaviour,
+    // matching the interactive flow. Returning 0 here would reacquire on every
+    // single connect.
+    state.expires_at
+}
+
+/// Is this server configured for the headless flow?
+fn uses_client_credentials(server: &ServerEntry) -> bool {
+    server
+        .client_credentials
+        .as_ref()
+        .is_some_and(|c| !c.client_id.trim().is_empty())
 }
 
 /// Use the stored refresh token to mint a fresh access token, vault it, and
 /// return it.
 fn refresh_token_with_expiry(server_id: &str) -> Result<RefreshedToken, String> {
+    // Client-credentials servers have no refresh token by construction, so they
+    // reacquire instead. Checked first because this is the seam BOTH the proactive
+    // pre-expiry path and the reactive 401/403 retry go through; branching here
+    // means neither has to know which flow a server uses.
+    if secrets::get_secret(server_id, CC_STATE_KEY).is_some() {
+        return reacquire_client_credentials(server_id);
+    }
     let state = load_state(server_id).ok_or("no stored OAuth state to refresh")?;
     let rt = state
         .refresh_token
@@ -244,6 +410,17 @@ pub fn refresh_token(server_id: &str) -> Result<String, String> {
 /// no refresh token exists, return an auth-classified error so the existing
 /// per-server "Needs sign-in" UI appears before a failed tool call.
 fn refresh_token_if_needed(server_id: &str) -> Result<Option<String>, String> {
+    // Same pre-expiry rule for the headless flow, minus the "no refresh token"
+    // branch: reacquiring needs no user interaction, so a near-deadline token is
+    // simply replaced rather than surfaced as "needs sign-in".
+    if let Some(expires_at) = client_credentials_expiry(server_id) {
+        if now_epoch_seconds().saturating_add(PROACTIVE_REFRESH_SKEW_SECS) >= expires_at {
+            return Ok(reacquire_client_credentials(server_id)
+                .ok()
+                .map(|t| t.access_token));
+        }
+        return Ok(None);
+    }
     let Some(state) = load_state(server_id) else {
         return Ok(None);
     };
@@ -487,6 +664,17 @@ pub fn connect_remote_with_handler(
     // Untrusted-provenance servers also get private/loopback refused at the resolver,
     // matching `guard_connect_target`'s pre-check but closing the DNS-rebind TOCTOU.
     let block_private = is_untrusted_source(server.source.as_deref());
+    // First connect for a headless server: mint a token now. Only this path has the
+    // registry config (client id, method, scopes); every later reacquisition runs
+    // from the state vaulted here, which is why it can go through the shared seam
+    // with just a server id.
+    if uses_client_credentials(server) && secrets::get_secret(server_id, CC_STATE_KEY).is_none() {
+        let config = server
+            .client_credentials
+            .as_ref()
+            .expect("uses_client_credentials checked it");
+        acquire_client_credentials(server_id, url, config)?;
+    }
     let stored_auth = secrets::get_secret(server_id, secrets::HTTP_AUTH_KEY)
         .or_else(|| first_vaulted_secret(server));
     let auth = match refresh_token_if_needed(server_id)? {
@@ -690,6 +878,7 @@ mod tests {
             source: source.map(String::from),
             disabled_tools: vec![],
             cwd: None,
+            client_credentials: None,
             unknown_fields: serde_json::Map::new(),
         }
     }
@@ -716,5 +905,121 @@ mod tests {
     fn guard_allows_public_host_for_any_source() {
         let s = remote_server("https://8.8.8.8/mcp", Some("shared"));
         assert!(guard_connect_target(&s).is_ok());
+    }
+
+    // ----- SBS-524: client-credentials wiring ---------------------------------
+
+    fn cc(client_id: &str) -> crate::registry::ClientCredentials {
+        crate::registry::ClientCredentials {
+            client_id: client_id.into(),
+            ..Default::default()
+        }
+    }
+
+    fn http_server(id: &str, cc: Option<crate::registry::ClientCredentials>) -> ServerEntry {
+        let mut s = remote_server("https://mcp.example.com/mcp", None);
+        s.id = id.into();
+        s.client_credentials = cc;
+        s
+    }
+
+    /// The registry file, its backups and its exports must never carry the client
+    /// secret. Only the vault does. This asserts the shape rather than trusting
+    /// that no one adds a `clientSecret` field later.
+    #[test]
+    fn client_credentials_config_serializes_without_any_secret() {
+        let mut config = cc("client-abc");
+        config.token_endpoint_auth_method = Some("client_secret_basic".into());
+        config.scope = Some("mcp:read mcp:write".into());
+
+        let json = serde_json::to_string(&config).unwrap();
+        assert!(json.contains("\"clientId\":\"client-abc\""), "{json}");
+        assert!(
+            json.contains("\"tokenEndpointAuthMethod\":\"client_secret_basic\""),
+            "{json}"
+        );
+        assert!(
+            !json.to_ascii_lowercase().contains("secret\":"),
+            "the registry must not carry a client secret: {json}"
+        );
+
+        let back: crate::registry::ClientCredentials = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, config);
+    }
+
+    /// A newer build's fields survive a round-trip through this one, same contract
+    /// as the rest of the registry.
+    #[test]
+    fn client_credentials_config_preserves_unknown_fields() {
+        let json = r#"{"clientId":"c","somethingNewer":{"a":1}}"#;
+        let parsed: crate::registry::ClientCredentials = serde_json::from_str(json).unwrap();
+        let out = serde_json::to_string(&parsed).unwrap();
+        assert!(out.contains("somethingNewer"), "{out}");
+    }
+
+    /// The flow is selected by configuration, and a blank client id does not
+    /// select it: an empty block would otherwise send every connect down the
+    /// headless path and fail with "no client secret vaulted".
+    #[test]
+    fn client_credentials_flow_requires_a_non_empty_client_id() {
+        assert!(uses_client_credentials(&http_server("a", Some(cc("client-abc")))));
+        assert!(!uses_client_credentials(&http_server("b", Some(cc("   ")))));
+        assert!(!uses_client_credentials(&http_server("c", Some(cc("")))));
+        assert!(!uses_client_credentials(&http_server("d", None)));
+    }
+
+    #[test]
+    fn client_credentials_state_round_trips_and_tolerates_older_vaulted_shapes() {
+        let state = ClientCredentialsState {
+            issuer: "https://auth.example.com".into(),
+            token_endpoint: "https://auth.example.com/token".into(),
+            client_id: "client-abc".into(),
+            method: "client_secret_basic".into(),
+            scope: Some("mcp:read".into()),
+            resource: "https://mcp.example.com/mcp".into(),
+            expires_at: Some(1_700_000_000),
+        };
+        let json = serde_json::to_string(&state).unwrap();
+        // Assert the exact key set rather than grepping for "secret": the auth
+        // METHOD is legitimately named `client_secret_basic`, so a substring check
+        // both false-positives here and would miss a field named anything else.
+        let keys: std::collections::BTreeSet<String> =
+            serde_json::from_str::<serde_json::Map<String, serde_json::Value>>(&json)
+                .unwrap()
+                .keys()
+                .cloned()
+                .collect();
+        assert_eq!(
+            keys,
+            [
+                "issuer",
+                "token_endpoint",
+                "client_id",
+                "method",
+                "scope",
+                "resource",
+                "expires_at"
+            ]
+            .iter()
+            .map(|k| k.to_string())
+            .collect::<std::collections::BTreeSet<_>>(),
+            "vaulted state grew a field; make sure it is not a credential: {json}"
+        );
+        let back: ClientCredentialsState = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.issuer, state.issuer);
+        assert_eq!(back.method, state.method);
+        assert_eq!(back.expires_at, state.expires_at);
+
+        // A provider that reports no lifetime keeps the reactive 401/403 path.
+        let minimal: ClientCredentialsState = serde_json::from_str(
+            r#"{"issuer":"https://a","tokenEndpoint":"https://a/t","clientId":"c",
+                "method":"client_secret_post","resource":"https://r"}"#
+                .replace("tokenEndpoint", "token_endpoint")
+                .replace("clientId", "client_id")
+                .as_str(),
+        )
+        .unwrap();
+        assert_eq!(minimal.expires_at, None);
+        assert_eq!(minimal.scope, None);
     }
 }

--- a/src-tauri/src/secrets.rs
+++ b/src-tauri/src/secrets.rs
@@ -12,6 +12,14 @@ const TASK_HANDLE_KEY: &str = "__task_handle_key__";
 /// the OAuth flow stores its access token).
 pub const HTTP_AUTH_KEY: &str = "__http_auth__";
 
+/// Reserved secret key for the OAuth client-credentials client secret (SBS-524).
+///
+/// Separate from [`HTTP_AUTH_KEY`], which holds the short-lived *access* token.
+/// This is the long-lived credential used to mint those, so it must never be
+/// written to `registry.json`, config backups, or exports; only the non-secret
+/// `clientId` / scopes / auth method live there.
+pub const CLIENT_SECRET_KEY: &str = "__oauth_client_secret__";
+
 fn account(server_id: &str, key: &str) -> String {
     format!("{server_id}::{key}")
 }

--- a/src-tauri/src/teams.rs
+++ b/src-tauri/src/teams.rs
@@ -1634,6 +1634,7 @@ fn classify_team_server(s: &Value, tag: &str) -> TeamClass {
         source: Some(tag.to_string()),
         disabled_tools: str_array("disabledTools"),
         cwd: None,
+        client_credentials: None,
         unknown_fields: serde_json::Map::new(),
     };
 
@@ -1769,6 +1770,7 @@ mod tests {
             source: Some("manual".into()),
             disabled_tools: vec![],
             cwd: None,
+            client_credentials: None,
             unknown_fields: serde_json::Map::new(),
         });
         let active = r.active_profile_id.clone().unwrap();
@@ -1919,6 +1921,7 @@ mod tests {
             source: Some("manual".into()),
             disabled_tools: vec![],
             cwd: None,
+            client_credentials: None,
             unknown_fields: serde_json::Map::new(),
         });
         let cfg = json!({ "servers": [
@@ -2043,6 +2046,7 @@ mod tests {
             source: Some("manual".into()),
             disabled_tools: vec![],
             cwd: None,
+            client_credentials: None,
             unknown_fields: serde_json::Map::new(),
         });
         apply_team_config(
@@ -2375,6 +2379,7 @@ mod tests {
             source: Some("manual".into()),
             disabled_tools: vec![],
             cwd: None,
+            client_credentials: None,
             unknown_fields: serde_json::Map::new(),
         });
         // A team-sourced server: excluded too (don't echo the team's own set back).
@@ -2389,6 +2394,7 @@ mod tests {
             source: Some("team:abc".into()),
             disabled_tools: vec![],
             cwd: None,
+            client_credentials: None,
             unknown_fields: serde_json::Map::new(),
         });
         let servers = team_server_export(&r);

--- a/src-tauri/src/teams.rs
+++ b/src-tauri/src/teams.rs
@@ -1637,6 +1637,17 @@ fn classify_team_server(s: &Value, tag: &str) -> TeamClass {
         Some(v) => match serde_json::from_value::<crate::registry::ClientCredentials>(v.clone()) {
             // A blank client id is "not configured", not malformed.
             Ok(c) if c.client_id.trim().is_empty() => None,
+            // An auth method this build cannot perform is refused at import for
+            // the same reason a malformed block is: importing it produces a
+            // server that fails at connect instead of one the member was told
+            // about.
+            Ok(c)
+                if c.token_endpoint_auth_method
+                    .as_deref()
+                    .is_some_and(|m| crate::oauth::ClientAuthMethod::parse(m).is_none()) =>
+            {
+                return TeamClass::Blocked
+            }
             Ok(c) => Some(c),
             Err(_) => return TeamClass::Blocked,
         },
@@ -2474,6 +2485,38 @@ mod tests {
                     "a blank client id must not count as configured"
                 )
             }
+            _ => panic!("expected import"),
+        }
+    }
+
+    /// An auth method this build cannot perform is refused at import, rather than
+    /// persisted and failing at connect.
+    #[test]
+    fn team_import_refuses_an_unknown_token_endpoint_auth_method() {
+        let mut bad = serde_json::json!({
+            "id": "s", "name": "S", "transport": "http",
+            "url": "https://mcp.example.com/mcp",
+        });
+        bad["clientCredentials"] = serde_json::json!({
+            "clientId": "c",
+            "tokenEndpointAuthMethod": "unknown_method",
+        });
+        assert!(matches!(
+            classify_team_server(&bad, "team:t1"),
+            TeamClass::Blocked
+        ));
+
+        // A method we DO support still imports.
+        bad["clientCredentials"] = serde_json::json!({
+            "clientId": "c",
+            "tokenEndpointAuthMethod": "client_secret_post",
+        });
+        match classify_team_server(&bad, "team:t1") {
+            TeamClass::Review(e) | TeamClass::Ready(e) => assert_eq!(
+                e.client_credentials
+                    .and_then(|c| c.token_endpoint_auth_method),
+                Some("client_secret_post".into())
+            ),
             _ => panic!("expected import"),
         }
     }

--- a/src-tauri/src/teams.rs
+++ b/src-tauri/src/teams.rs
@@ -1641,10 +1641,15 @@ fn classify_team_server(s: &Value, tag: &str) -> TeamClass {
             // the same reason a malformed block is: importing it produces a
             // server that fails at connect instead of one the member was told
             // about.
+            // Unrecognised OR recognised-but-unimplemented. `private_key_jwt`
+            // parses fine and would otherwise import, then fail closed at every
+            // connect with "not supported yet" -- a silently broken server, which
+            // is the outcome this guard exists to prevent.
             Ok(c)
-                if c.token_endpoint_auth_method
-                    .as_deref()
-                    .is_some_and(|m| crate::oauth::ClientAuthMethod::parse(m).is_none()) =>
+                if c.token_endpoint_auth_method.as_deref().is_some_and(|m| {
+                    crate::oauth::ClientAuthMethod::parse(m)
+                        .is_none_or(|parsed| !parsed.is_implemented())
+                }) =>
             {
                 return TeamClass::Blocked
             }
@@ -2500,6 +2505,17 @@ mod tests {
         bad["clientCredentials"] = serde_json::json!({
             "clientId": "c",
             "tokenEndpointAuthMethod": "unknown_method",
+        });
+        assert!(matches!(
+            classify_team_server(&bad, "team:t1"),
+            TeamClass::Blocked
+        ));
+
+        // Recognised but unimplemented counts too: importing it would produce a
+        // server that fails closed on every connect.
+        bad["clientCredentials"] = serde_json::json!({
+            "clientId": "c",
+            "tokenEndpointAuthMethod": "private_key_jwt",
         });
         assert!(matches!(
             classify_team_server(&bad, "team:t1"),

--- a/src-tauri/src/teams.rs
+++ b/src-tauri/src/teams.rs
@@ -1351,6 +1351,12 @@ fn team_server_export(reg: &Registry) -> Value {
                 "url": url,
                 "env": s.env.iter().map(|e| serde_json::json!({ "key": e.key, "secret": e.secret })).collect::<Vec<_>>(),
                 "disabledTools": s.disabled_tools,
+                // Non-secret by construction: client id, method and scopes only.
+                // The client SECRET is vaulted per member and is never in this
+                // payload, so a teammate importing this gets a server that tells
+                // them to add their own secret rather than one that silently falls
+                // back to an interactive browser flow they cannot complete.
+                "clientCredentials": s.client_credentials,
             })
         })
         .collect();
@@ -1634,7 +1640,14 @@ fn classify_team_server(s: &Value, tag: &str) -> TeamClass {
         source: Some(tag.to_string()),
         disabled_tools: str_array("disabledTools"),
         cwd: None,
-        client_credentials: None,
+        // Carried through so a shared headless server stays headless. Dropping it
+        // silently downgraded the member to interactive OAuth, which is exactly
+        // what this flow exists to avoid; the secret is still theirs to add.
+        client_credentials: s
+            .get("clientCredentials")
+            .filter(|v| !v.is_null())
+            .and_then(|v| serde_json::from_value(v.clone()).ok())
+            .filter(|c: &crate::registry::ClientCredentials| !c.client_id.trim().is_empty()),
         unknown_fields: serde_json::Map::new(),
     };
 
@@ -2362,6 +2375,95 @@ mod tests {
         assert!(message.contains("nothing was overwritten"));
         assert_eq!(push_status_message(401), None);
         assert_eq!(push_status_message(500), None);
+    }
+
+    #[test]
+    /// SBS-524: a shared headless server must stay headless.
+    ///
+    /// Dropping the block on either leg silently downgrades the member to the
+    /// interactive browser flow, which is the exact thing that flow exists to
+    /// avoid, and nothing would report an error.
+    #[test]
+    fn client_credentials_round_trip_through_team_import_and_export() {
+        let config = crate::registry::ClientCredentials {
+            client_id: "client-abc".into(),
+            token_endpoint_auth_method: Some("client_secret_basic".into()),
+            scope: Some("mcp:read".into()),
+            unknown_fields: serde_json::Map::new(),
+        };
+        let mut reg = base_registry();
+        let server = reg
+            .servers
+            .iter_mut()
+            .find(|s| s.id == "mine")
+            .expect("fixture server");
+        server.transport = "http".into();
+        server.command = None;
+        server.url = Some("https://mcp.example.com/mcp".into());
+        server.client_credentials = Some(config.clone());
+
+        let exported = team_server_export(&reg);
+        let entry = exported
+            .as_array()
+            .and_then(|a| a.iter().find(|s| s.get("id").and_then(Value::as_str) == Some("mine")))
+            .expect("the server must be exported");
+        assert_eq!(
+            entry.get("clientCredentials").and_then(|c| c.get("clientId")),
+            Some(&Value::String("client-abc".into())),
+            "export dropped the config: {entry}"
+        );
+        // The secret is per member and must never ride along.
+        assert!(
+            !serde_json::to_string(entry).unwrap().contains("clientSecret"),
+            "a client secret must never be pushed to the org: {entry}"
+        );
+
+        match classify_team_server(entry, "team:t1") {
+            TeamClass::Review(imported) | TeamClass::Ready(imported) => {
+                assert_eq!(
+                    imported.client_credentials.as_ref().map(|c| c.client_id.as_str()),
+                    Some("client-abc"),
+                    "import dropped the config"
+                );
+                assert_eq!(
+                    imported
+                        .client_credentials
+                        .as_ref()
+                        .and_then(|c| c.scope.as_deref()),
+                    Some("mcp:read")
+                );
+            }
+            _ => panic!("expected the http server to import"),
+        }
+    }
+
+    /// A server with no block, or a blank client id, must not be treated as
+    /// configured: that would send every connect down the headless path and fail
+    /// with "no client secret vaulted".
+    #[test]
+    fn team_import_ignores_absent_or_blank_client_credentials() {
+        let base = serde_json::json!({
+            "id": "s", "name": "S", "transport": "http",
+            "url": "https://mcp.example.com/mcp",
+        });
+        match classify_team_server(&base, "team:t1") {
+            TeamClass::Review(e) | TeamClass::Ready(e) => {
+                assert!(e.client_credentials.is_none())
+            }
+            _ => panic!("expected import"),
+        }
+
+        let mut blank = base.clone();
+        blank["clientCredentials"] = serde_json::json!({ "clientId": "   " });
+        match classify_team_server(&blank, "team:t1") {
+            TeamClass::Review(e) | TeamClass::Ready(e) => {
+                assert!(
+                    e.client_credentials.is_none(),
+                    "a blank client id must not count as configured"
+                )
+            }
+            _ => panic!("expected import"),
+        }
     }
 
     #[test]

--- a/src-tauri/src/teams.rs
+++ b/src-tauri/src/teams.rs
@@ -1356,7 +1356,10 @@ fn team_server_export(reg: &Registry) -> Value {
                 // payload, so a teammate importing this gets a server that tells
                 // them to add their own secret rather than one that silently falls
                 // back to an interactive browser flow they cannot complete.
-                "clientCredentials": s.client_credentials,
+                "clientCredentials": s.client_credentials.clone().map(|mut c| {
+                    c.strip_secret_fields();
+                    c
+                }),
             })
         })
         .collect();
@@ -1653,7 +1656,10 @@ fn classify_team_server(s: &Value, tag: &str) -> TeamClass {
             {
                 return TeamClass::Blocked
             }
-            Ok(c) => Some(c),
+            Ok(mut c) => {
+                c.strip_secret_fields();
+                Some(c)
+            }
             Err(_) => return TeamClass::Blocked,
         },
         None => None,
@@ -2492,6 +2498,55 @@ mod tests {
             }
             _ => panic!("expected import"),
         }
+    }
+
+    /// A `clientSecret` must never survive into the registry or back out to the
+    /// org. `unknown_fields` is forward-compat, not a smuggling channel.
+    #[test]
+    fn team_client_credentials_never_carry_a_secret_in_unknown_fields() {
+        let mut hostile = serde_json::json!({
+            "id": "s", "name": "S", "transport": "http",
+            "url": "https://mcp.example.com/mcp",
+        });
+        hostile["clientCredentials"] = serde_json::json!({
+            "clientId": "c",
+            "clientSecret": "leaked",
+            "somethingNewer": 1,
+        });
+
+        let imported = match classify_team_server(&hostile, "team:t1") {
+            TeamClass::Review(e) | TeamClass::Ready(e) => e,
+            _ => panic!("expected import"),
+        };
+        let cc = imported.client_credentials.expect("config imported");
+        assert!(
+            !cc.unknown_fields.contains_key("clientSecret"),
+            "a secret must not be persisted: {:?}",
+            cc.unknown_fields
+        );
+        // Genuine forward-compat still survives.
+        assert!(cc.unknown_fields.contains_key("somethingNewer"));
+
+        // And the export leg strips it too, for a registry that already has one.
+        let mut reg = base_registry();
+        let entry = reg.servers.iter_mut().find(|s| s.id == "mine").unwrap();
+        entry.transport = "http".into();
+        entry.command = None;
+        entry.url = Some("https://mcp.example.com/mcp".into());
+        let mut smuggled = crate::registry::ClientCredentials {
+            client_id: "c".into(),
+            ..Default::default()
+        };
+        smuggled
+            .unknown_fields
+            .insert("clientSecret".into(), Value::String("leaked".into()));
+        entry.client_credentials = Some(smuggled);
+
+        let json = serde_json::to_string(&team_server_export(&reg)).unwrap();
+        assert!(
+            !json.contains("leaked") && !json.contains("clientSecret"),
+            "a secret must never be pushed to the org: {json}"
+        );
     }
 
     /// An auth method this build cannot perform is refused at import, rather than

--- a/src-tauri/src/teams.rs
+++ b/src-tauri/src/teams.rs
@@ -1627,6 +1627,22 @@ fn classify_team_server(s: &Value, tag: &str) -> TeamClass {
         })
         .unwrap_or_default();
 
+    // A block that is present but unparseable refuses the whole server rather
+    // than importing it without one. Dropping it silently would hand the member a
+    // server that falls back to the interactive browser flow -- which is the exact
+    // thing this configuration exists to avoid, and on a headless machine it can
+    // never complete. `Blocked` is counted in the merge outcome, so the member
+    // sees that something was refused instead of getting a quietly broken server.
+    let client_credentials = match s.get("clientCredentials").filter(|v| !v.is_null()) {
+        Some(v) => match serde_json::from_value::<crate::registry::ClientCredentials>(v.clone()) {
+            // A blank client id is "not configured", not malformed.
+            Ok(c) if c.client_id.trim().is_empty() => None,
+            Ok(c) => Some(c),
+            Err(_) => return TeamClass::Blocked,
+        },
+        None => None,
+    };
+
     let transport = str_field("transport").unwrap_or("stdio").to_string();
     let command = str_field("command").map(String::from);
     let mut entry = ServerEntry {
@@ -1643,11 +1659,7 @@ fn classify_team_server(s: &Value, tag: &str) -> TeamClass {
         // Carried through so a shared headless server stays headless. Dropping it
         // silently downgraded the member to interactive OAuth, which is exactly
         // what this flow exists to avoid; the secret is still theirs to add.
-        client_credentials: s
-            .get("clientCredentials")
-            .filter(|v| !v.is_null())
-            .and_then(|v| serde_json::from_value(v.clone()).ok())
-            .filter(|c: &crate::registry::ClientCredentials| !c.client_id.trim().is_empty()),
+        client_credentials,
         unknown_fields: serde_json::Map::new(),
     };
 
@@ -2464,6 +2476,21 @@ mod tests {
             }
             _ => panic!("expected import"),
         }
+    }
+
+    /// A malformed block must refuse the server, not import it as interactive.
+    #[test]
+    fn team_import_refuses_a_server_with_a_malformed_client_credentials_block() {
+        let mut bad = serde_json::json!({
+            "id": "s", "name": "S", "transport": "http",
+            "url": "https://mcp.example.com/mcp",
+        });
+        // clientId as a number: parses as JSON, not as the struct.
+        bad["clientCredentials"] = serde_json::json!({ "clientId": 42 });
+        assert!(
+            matches!(classify_team_server(&bad, "team:t1"), TeamClass::Blocked),
+            "a malformed block must be refused, not silently downgraded"
+        );
     }
 
     #[test]

--- a/src-tauri/src/teams.rs
+++ b/src-tauri/src/teams.rs
@@ -1658,6 +1658,17 @@ fn classify_team_server(s: &Value, tag: &str) -> TeamClass {
             }
             Ok(mut c) => {
                 c.strip_secret_fields();
+                // Trim like the desktop command does: a padded client id or scope
+                // reaches the token endpoint verbatim and can be rejected there.
+                c.client_id = c.client_id.trim().to_string();
+                c.scope = c
+                    .scope
+                    .map(|s| s.trim().to_string())
+                    .filter(|s| !s.is_empty());
+                c.token_endpoint_auth_method = c
+                    .token_endpoint_auth_method
+                    .map(|m| m.trim().to_string())
+                    .filter(|m| !m.is_empty());
                 Some(c)
             }
             Err(_) => return TeamClass::Blocked,

--- a/src/components/SecretsDialog.clientCredentials.test.tsx
+++ b/src/components/SecretsDialog.clientCredentials.test.tsx
@@ -1,0 +1,147 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { SecretsDialog } from "./SecretsDialog";
+import type { Registry, ServerEntry } from "@/lib/types";
+
+const setClientCredentials = vi.fn();
+const clearClientCredentials = vi.fn();
+const hasClientSecret = vi.fn();
+const toastError = vi.fn();
+
+vi.mock("@/lib/api", () => ({
+  setClientCredentials: (...a: unknown[]) => setClientCredentials(...a),
+  clearClientCredentials: (...a: unknown[]) => clearClientCredentials(...a),
+  hasClientSecret: (...a: unknown[]) => hasClientSecret(...a),
+  secretStatus: vi.fn().mockResolvedValue([]),
+  hasAuthToken: vi.fn().mockResolvedValue(false),
+  probeAuth: vi.fn().mockResolvedValue({ kind: "oauth", guidance: null }),
+  setSecret: vi.fn(),
+  deleteSecret: vi.fn(),
+  setAuthToken: vi.fn(),
+  clearAuthToken: vi.fn(),
+  authenticateOauth: vi.fn(),
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+    warning: vi.fn(),
+    info: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/toast", () => ({
+  toastError: (...a: unknown[]) => toastError(...a),
+}));
+
+vi.mock("@/lib/openUrl", () => ({ openExternal: vi.fn() }));
+
+function server(over: Partial<ServerEntry> = {}): ServerEntry {
+  return {
+    id: "srv-1",
+    name: "Headless MCP",
+    transport: "http",
+    command: null,
+    args: [],
+    env: [],
+    url: "https://mcp.example.com/mcp",
+    source: "manual",
+    ...over,
+  };
+}
+
+const registry = {} as Registry;
+
+async function openDialog(entry: ServerEntry) {
+  const user = userEvent.setup();
+  render(<SecretsDialog server={entry} onSaved={vi.fn()} />);
+  await user.click(screen.getByRole("button"));
+  return user;
+}
+
+describe("SecretsDialog client credentials (SBS-524)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    hasClientSecret.mockResolvedValue(false);
+    setClientCredentials.mockResolvedValue(registry);
+    clearClientCredentials.mockResolvedValue(registry);
+  });
+
+  it("keeps headless auth behind a disclosure so browser sign-in stays primary", async () => {
+    const user = await openDialog(server());
+    expect(screen.queryByPlaceholderText("Client ID")).not.toBeInTheDocument();
+
+    await user.click(
+      screen.getByText(/No browser available\? Use a client id and secret/i),
+    );
+    expect(screen.getByPlaceholderText("Client ID")).toBeInTheDocument();
+  });
+
+  /// The secret must never be read back out of the keychain, only its existence.
+  it("asks only whether a secret exists, never for its value", async () => {
+    await openDialog(server({ clientCredentials: { clientId: "abc" } }));
+    await waitFor(() => expect(hasClientSecret).toHaveBeenCalledWith("srv-1"));
+    // There is no API that returns the secret, and the form must not be seeded
+    // with one.
+    await waitFor(() =>
+      expect(screen.getByPlaceholderText("Client ID")).toHaveValue("abc"),
+    );
+    const secretField = screen.getByPlaceholderText(/Client secret/i);
+    expect(secretField).toHaveValue("");
+  });
+
+  it("sends trimmed values and null for the optional fields left blank", async () => {
+    const user = await openDialog(server());
+    await user.click(
+      screen.getByText(/No browser available\? Use a client id and secret/i),
+    );
+    await user.type(screen.getByPlaceholderText("Client ID"), "  client-abc  ");
+    await user.type(screen.getByPlaceholderText(/^Client secret$/i), "s3cret");
+    await user.click(screen.getByRole("button", { name: "Save client credentials" }));
+
+    await waitFor(() =>
+      expect(setClientCredentials).toHaveBeenCalledWith(
+        "srv-1",
+        "client-abc",
+        "s3cret",
+        null,
+        null,
+      ),
+    );
+  });
+
+  /// Editing scopes must not force re-entering the credential.
+  it("submits a blank secret when one is already stored, to keep it", async () => {
+    hasClientSecret.mockResolvedValue(true);
+    const user = await openDialog(
+      server({ clientCredentials: { clientId: "client-abc" } }),
+    );
+    await waitFor(() => expect(hasClientSecret).toHaveBeenCalled());
+
+    await user.type(screen.getByPlaceholderText(/Scopes \(optional/i), "mcp:read");
+    await user.click(screen.getByRole("button", { name: "Save client credentials" }));
+
+    await waitFor(() =>
+      expect(setClientCredentials).toHaveBeenCalledWith(
+        "srv-1",
+        "client-abc",
+        "",
+        null,
+        "mcp:read",
+      ),
+    );
+  });
+
+  it("refuses to save without a client id instead of calling the backend", async () => {
+    const user = await openDialog(server());
+    await user.click(
+      screen.getByText(/No browser available\? Use a client id and secret/i),
+    );
+    await user.click(screen.getByRole("button", { name: "Save client credentials" }));
+
+    await waitFor(() => expect(toastError).toHaveBeenCalled());
+    expect(setClientCredentials).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/SecretsDialog.clientCredentials.test.tsx
+++ b/src/components/SecretsDialog.clientCredentials.test.tsx
@@ -149,6 +149,22 @@ describe("SecretsDialog client credentials (SBS-524)", () => {
     expect(setClientCredentials).not.toHaveBeenCalled();
   });
 
+  /// The secret is never shown again and may have to be re-issued, so a single
+  /// stray click must not destroy it.
+  it("does not remove credentials until the destructive action is confirmed", async () => {
+    hasClientSecret.mockResolvedValue(true);
+    const user = await openDialog(
+      server({ clientCredentials: { clientId: "client-abc" } }),
+    );
+    await waitFor(() => expect(hasClientSecret).toHaveBeenCalled());
+
+    await user.click(screen.getByRole("button", { name: "Remove client credentials" }));
+    expect(clearClientCredentials).not.toHaveBeenCalled();
+
+    await user.click(screen.getByRole("button", { name: "Remove" }));
+    await waitFor(() => expect(clearClientCredentials).toHaveBeenCalledWith("srv-1"));
+  });
+
   it("refuses to save without a client id instead of calling the backend", async () => {
     const user = await openDialog(server());
     await user.click(

--- a/src/components/SecretsDialog.clientCredentials.test.tsx
+++ b/src/components/SecretsDialog.clientCredentials.test.tsx
@@ -134,6 +134,21 @@ describe("SecretsDialog client credentials (SBS-524)", () => {
     );
   });
 
+  /// The backend also rejects this, but its message describes stored state; the
+  /// first-time user needs a direct instruction.
+  it("requires a secret the first time, before calling the backend", async () => {
+    hasClientSecret.mockResolvedValue(false);
+    const user = await openDialog(server());
+    await user.click(
+      screen.getByText(/No browser available\? Use a client id and secret/i),
+    );
+    await user.type(screen.getByPlaceholderText("Client ID"), "client-abc");
+    await user.click(screen.getByRole("button", { name: "Save client credentials" }));
+
+    await waitFor(() => expect(toastError).toHaveBeenCalled());
+    expect(setClientCredentials).not.toHaveBeenCalled();
+  });
+
   it("refuses to save without a client id instead of calling the backend", async () => {
     const user = await openDialog(server());
     await user.click(

--- a/src/components/SecretsDialog.tsx
+++ b/src/components/SecretsDialog.tsx
@@ -99,6 +99,10 @@ export function SecretsDialog({ server, onSaved, trigger, onChanged }: Props) {
   const [ccOpen, setCcOpen] = useState(false);
   const [ccBusy, setCcBusy] = useState(false);
   const [ccSecretSet, setCcSecretSet] = useState(false);
+  // Whether the `hasClientSecret` probe has settled. The "secret required" guard
+  // below must not fire while this is unknown, or a fast click after opening
+  // would demand a credential that is already vaulted.
+  const [ccSecretKnown, setCcSecretKnown] = useState(false);
   const [ccClientId, setCcClientId] = useState("");
   const [ccSecret, setCcSecret] = useState("");
   const [ccScope, setCcScope] = useState("");
@@ -143,9 +147,12 @@ export function SecretsDialog({ server, onSaved, trigger, onChanged }: Props) {
       setCcMethod(cc?.tokenEndpointAuthMethod ?? "");
       setCcSecret("");
       setCcOpen(cc != null);
+      setCcSecretKnown(false);
       hasClientSecret(server.id)
         .then((v) => fresh() && setCcSecretSet(v))
-        .catch(() => {});
+        .catch(() => {})
+        // Settled either way: on failure the backend stays authoritative.
+        .finally(() => fresh() && setCcSecretKnown(true));
       setProbing(true);
       setAuthInfo(null);
       probeAuth(server.url)
@@ -197,8 +204,10 @@ export function SecretsDialog({ server, onSaved, trigger, onChanged }: Props) {
     }
     // A blank secret means "keep the stored one", which is only meaningful when
     // one exists. Catch it here so the first-time case gets a direct instruction
-    // instead of a backend error describing internal state.
-    if (!ccSecretSet && !ccSecret.trim()) {
+    // instead of a backend error describing internal state. Skipped until the
+    // presence probe has settled: the backend knows authoritatively and returns a
+    // clear message, so deferring is always safe, while guessing is not.
+    if (ccSecretKnown && !ccSecretSet && !ccSecret.trim()) {
       toastError("Enter the client secret issued by your authorization server.");
       return;
     }
@@ -552,15 +561,23 @@ export function SecretsDialog({ server, onSaved, trigger, onChanged }: Props) {
                             )}
                           </Button>
                           {(ccSecretSet || server.clientCredentials) && (
-                            <Button
-                              size="sm"
-                              variant="ghost"
-                              disabled={ccBusy}
-                              onClick={removeClientCredentials}
-                              aria-label="Remove client credentials"
-                            >
-                              Remove
-                            </Button>
+                            <ConfirmDialog
+                              destructive
+                              title="Remove client credentials?"
+                              description="The client secret is deleted from your keychain and cannot be shown again. You'll need to get a new one from your authorization server to reconnect this way."
+                              confirmLabel="Remove"
+                              onConfirm={removeClientCredentials}
+                              trigger={
+                                <Button
+                                  size="sm"
+                                  variant="ghost"
+                                  disabled={ccBusy}
+                                  aria-label="Remove client credentials"
+                                >
+                                  Remove
+                                </Button>
+                              }
+                            />
                           )}
                         </div>
                       </div>

--- a/src/components/SecretsDialog.tsx
+++ b/src/components/SecretsDialog.tsx
@@ -195,6 +195,13 @@ export function SecretsDialog({ server, onSaved, trigger, onChanged }: Props) {
       toastError("Enter the client id issued by your authorization server.");
       return;
     }
+    // A blank secret means "keep the stored one", which is only meaningful when
+    // one exists. Catch it here so the first-time case gets a direct instruction
+    // instead of a backend error describing internal state.
+    if (!ccSecretSet && !ccSecret.trim()) {
+      toastError("Enter the client secret issued by your authorization server.");
+      return;
+    }
     setCcBusy(true);
     try {
       onSaved(
@@ -527,6 +534,9 @@ export function SecretsDialog({ server, onSaved, trigger, onChanged }: Props) {
                         <p className="text-[11px] text-muted-foreground">
                           The secret is stored in your OS keychain, never in
                           Toolport&rsquo;s config file, backups, or shared setups.
+                          {ccSecretSet
+                            ? " It cannot be shown again; leave the field blank to keep it."
+                            : ""}
                         </p>
                         <div className="flex gap-2">
                           <Button

--- a/src/components/SecretsDialog.tsx
+++ b/src/components/SecretsDialog.tsx
@@ -5,6 +5,9 @@ import { toastError } from "@/lib/toast";
 import { openExternal } from "@/lib/openUrl";
 import {
   authenticateOauth,
+  setClientCredentials,
+  clearClientCredentials,
+  hasClientSecret,
   clearAuthToken,
   deleteSecret,
   hasAuthToken,
@@ -91,6 +94,15 @@ export function SecretsDialog({ server, onSaved, trigger, onChanged }: Props) {
   const [authSet, setAuthSet] = useState(false);
   const [authInput, setAuthInput] = useState("");
   const [oauthBusy, setOauthBusy] = useState(false);
+  // Headless (client-credentials) auth. `ccSecretSet` tracks only whether a
+  // secret exists; the value is never read back out of the keychain.
+  const [ccOpen, setCcOpen] = useState(false);
+  const [ccBusy, setCcBusy] = useState(false);
+  const [ccSecretSet, setCcSecretSet] = useState(false);
+  const [ccClientId, setCcClientId] = useState("");
+  const [ccSecret, setCcSecret] = useState("");
+  const [ccScope, setCcScope] = useState("");
+  const [ccMethod, setCcMethod] = useState("");
   const [authInfo, setAuthInfo] = useState<AuthInfo | null>(null);
   const [probing, setProbing] = useState(false);
 
@@ -122,6 +134,17 @@ export function SecretsDialog({ server, onSaved, trigger, onChanged }: Props) {
     if (isRemote && server.url) {
       hasAuthToken(server.id)
         .then((v) => fresh() && setAuthSet(v))
+        .catch(() => {});
+      // Seed the headless form from the registry. The secret is deliberately not
+      // fetched: only whether one exists, so it can never be read back out.
+      const cc = server.clientCredentials ?? null;
+      setCcClientId(cc?.clientId ?? "");
+      setCcScope(cc?.scope ?? "");
+      setCcMethod(cc?.tokenEndpointAuthMethod ?? "");
+      setCcSecret("");
+      setCcOpen(cc != null);
+      hasClientSecret(server.id)
+        .then((v) => fresh() && setCcSecretSet(v))
         .catch(() => {});
       setProbing(true);
       setAuthInfo(null);
@@ -164,6 +187,54 @@ export function SecretsDialog({ server, onSaved, trigger, onChanged }: Props) {
       toastError(secretErrorMessage(e));
     } finally {
       setBusyKey(null);
+    }
+  }
+
+  async function saveClientCredentials() {
+    if (!ccClientId.trim()) {
+      toastError("Enter the client id issued by your authorization server.");
+      return;
+    }
+    setCcBusy(true);
+    try {
+      onSaved(
+        await setClientCredentials(
+          server.id,
+          ccClientId.trim(),
+          ccSecret,
+          ccMethod ? ccMethod : null,
+          ccScope.trim() ? ccScope.trim() : null,
+        ),
+      );
+      setCcSecretSet(true);
+      setCcSecret("");
+      toast.success("Saved client credentials", {
+        description: "The next connection will request a token. No browser needed.",
+      });
+      onChanged?.();
+    } catch (e) {
+      toastError(`${e}`);
+    } finally {
+      setCcBusy(false);
+    }
+  }
+
+  async function removeClientCredentials() {
+    setCcBusy(true);
+    try {
+      onSaved(await clearClientCredentials(server.id));
+      setCcSecretSet(false);
+      setCcClientId("");
+      setCcSecret("");
+      setCcScope("");
+      setCcMethod("");
+      setCcOpen(false);
+      toast.success("Removed client credentials");
+      onChanged?.();
+    } catch (e) {
+      toastError(`${e}`);
+    } finally {
+      setCcBusy(false);
     }
   }
 
@@ -397,6 +468,94 @@ export function SecretsDialog({ server, onSaved, trigger, onChanged }: Props) {
                       here.
                     </p>
                   )}
+
+                  {/* Headless auth. Kept behind a disclosure so the common case
+                      (browser sign-in) stays the obvious one, and deliberately
+                      worded to distinguish the two: the failure people hit is
+                      configuring this and then waiting for a browser prompt that
+                      never comes. */}
+                  <div className="mt-1 border-t border-border/60 pt-3">
+                    {!ccOpen ? (
+                      <button
+                        type="button"
+                        className="text-[11px] text-muted-foreground underline underline-offset-2 hover:text-foreground"
+                        onClick={() => setCcOpen(true)}
+                      >
+                        No browser available? Use a client id and secret instead
+                      </button>
+                    ) : (
+                      <div className="space-y-2">
+                        <div className="flex items-center justify-between gap-2">
+                          <p className="text-xs font-medium">
+                            Client credentials (no browser)
+                          </p>
+                          {ccSecretSet && (
+                            <span className="inline-flex items-center gap-1 text-[11px] text-muted-foreground">
+                              <Check className="size-3" /> secret stored
+                            </span>
+                          )}
+                        </div>
+                        <p className="text-[11px] text-muted-foreground">
+                          For servers that authenticate the application rather than a
+                          person, e.g. on a build machine. Toolport requests a token
+                          directly and renews it automatically; it never opens a browser
+                          for this server.
+                        </p>
+                        <Input
+                          value={ccClientId}
+                          onChange={(e) => setCcClientId(e.target.value)}
+                          placeholder="Client ID"
+                          autoComplete="off"
+                        />
+                        <Input
+                          type="password"
+                          value={ccSecret}
+                          onChange={(e) => setCcSecret(e.target.value)}
+                          placeholder={
+                            ccSecretSet
+                              ? "Client secret (leave blank to keep the stored one)"
+                              : "Client secret"
+                          }
+                          autoComplete="off"
+                        />
+                        <Input
+                          value={ccScope}
+                          onChange={(e) => setCcScope(e.target.value)}
+                          placeholder="Scopes (optional, space separated)"
+                          autoComplete="off"
+                        />
+                        <p className="text-[11px] text-muted-foreground">
+                          The secret is stored in your OS keychain, never in
+                          Toolport&rsquo;s config file, backups, or shared setups.
+                        </p>
+                        <div className="flex gap-2">
+                          <Button
+                            size="sm"
+                            disabled={ccBusy}
+                            onClick={saveClientCredentials}
+                            aria-label="Save client credentials"
+                          >
+                            {ccBusy ? (
+                              <Loader2 className="size-4 animate-spin" />
+                            ) : (
+                              "Save"
+                            )}
+                          </Button>
+                          {(ccSecretSet || server.clientCredentials) && (
+                            <Button
+                              size="sm"
+                              variant="ghost"
+                              disabled={ccBusy}
+                              onClick={removeClientCredentials}
+                              aria-label="Remove client credentials"
+                            >
+                              Remove
+                            </Button>
+                          )}
+                        </div>
+                      </div>
+                    )}
+                  </div>
                 </>
               )}
             </div>

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -599,6 +599,38 @@ export function authenticateOauth(serverId: string, url: string): Promise<void> 
   return invoke<void>("authenticate_oauth", { serverId, url });
 }
 
+/** Configure the headless OAuth client-credentials flow for an http server.
+ *
+ * The secret goes straight to the OS keychain; only the client id, auth method
+ * and scopes are written to the registry. Pass an empty `clientSecret` to keep
+ * the stored one, so editing scopes does not require re-entering it. */
+export function setClientCredentials(
+  serverId: string,
+  clientId: string,
+  clientSecret: string,
+  tokenEndpointAuthMethod: string | null,
+  scope: string | null,
+): Promise<Registry> {
+  return invoke<Registry>("set_client_credentials", {
+    serverId,
+    clientId,
+    clientSecret,
+    tokenEndpointAuthMethod,
+    scope,
+  });
+}
+
+/** Remove client-credentials auth: vaulted secret, minted token, and config. */
+export function clearClientCredentials(serverId: string): Promise<Registry> {
+  return invoke<Registry>("clear_client_credentials", { serverId });
+}
+
+/** Whether a client secret is vaulted, so the UI can show "configured" without
+ * ever reading the value back. */
+export function hasClientSecret(serverId: string): Promise<boolean> {
+  return invoke<boolean>("has_client_secret", { serverId });
+}
+
 /** Detect what a remote server needs to connect (none/oauth/token) + guidance. */
 export function probeAuth(url: string): Promise<AuthInfo> {
   return invoke<AuthInfo>("probe_auth", { url });

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -318,6 +318,21 @@ export interface ServerEntry {
   /** Working directory for a stdio server. Unset = inherit the gateway's cwd.
    * `~` and `${VAR}` are expanded. Lets a server run in a project dir (#239). */
   cwd?: string | null;
+  /** Headless outbound OAuth (SBS-524). Present = this server uses the
+   * client-credentials flow instead of the interactive browser one. */
+  clientCredentials?: ClientCredentials | null;
+}
+
+/** Non-secret client-credentials config. The client SECRET is never here: it
+ * lives in the OS keychain, because this object is written to registry.json and
+ * included in config backups and exports. */
+export interface ClientCredentials {
+  clientId: string;
+  /** `client_secret_basic` | `client_secret_post` | `private_key_jwt`.
+   * Unset = negotiate from what the authorization server advertises. */
+  tokenEndpointAuthMethod?: string | null;
+  /** Space-delimited scopes. Unset = use what discovery advertises. */
+  scope?: string | null;
 }
 
 export interface Profile {


### PR DESCRIPTION
Closes SBS-524, the last feature child of the MCP spec-currency program.

A headless MCP server has no human at a browser. The existing OAuth path opens one, waits on a loopback redirect and needs a click — fine on a laptop, useless on a build machine. This adds the client-credentials grant so Toolport can authenticate itself and connect unattended.

Four commits, each reviewable on its own.

## 1. Protocol layer (`d5d5b30`)

`client_credentials_token` performs RFC 6749 §4.4. Decisions worth a look:

- **https required before any request is made**, since the secret rides in this call. Loopback stays exempt for local dev, matching the rest of the module.
- **No-redirect agent**, so a hostile metadata document cannot 302 a credential-bearing POST to a host it names. Same reasoning as `exchange_code` and `refresh`.
- **Form-urlencodes id and secret before base64** for `client_secret_basic`, per §2.3.1. Skipping that corrupts any secret containing `+`, `:` or `/`, which generated credentials frequently do.
- **Discards a returned refresh token.** §4.4.3 says servers SHOULD NOT issue one; vaulting it would let the reacquire path quietly become a refresh path, when the whole point is that re-auth here is cheap and non-interactive.

`select_client_auth_method` fails closed everywhere it is unsure: absent or empty `token_endpoint_auth_methods_supported` means `client_secret_basic` per RFC 8414 (not "supports nothing"); a configured method the server does not advertise is refused rather than sent anyway; `private_key_jwt` is rejected rather than silently downgraded to a shared secret, and is never auto-selected, so a server offering it *alongside* a usable method still connects.

`private_key_jwt` itself is split to SBS-599 — it needs an asymmetric signing dependency the crate does not have, which is a supply-chain decision for the credential path rather than a code-shape one, and shouldn't ride along inside a feature PR.

## 2. Connection wiring (`9c66049`)

`ServerEntry` gains an optional `clientCredentials` block. **It holds no secret** — that struct goes into `registry.json`, config backups and exports, so only the client id, method and scopes live there; the secret gets its own keychain key, separate from the access token. A test asserts the serialized key set rather than trusting nobody adds a `clientSecret` field later.

Reacquisition hangs off `refresh_token_with_expiry`, the seam both the proactive pre-expiry check and the reactive 401/403 retry already go through, so neither caller needs to know which flow a server uses. There is no refresh token to redeem, so it re-runs the grant — and re-verifies the issuer first, so a resource that changed authorization server fails closed instead of sending the secret somewhere new.

## 3. Extension declaration (`8dc8b99`)

Declares `io.modelcontextprotocol/oauth-client-credentials` per connection, keyed off vaulted state so it is true of the credential actually being sent.

Held separately from `protocol_meta` because `set_protocol_meta` replaces that wholesale after version negotiation — and the declaration is made at connect time, before it. Storing it only there would drop it on the first modern handshake with **nothing failing to say so**. The mutation check covers exactly that.

## 4. Desktop UI (`5a731b0`)

Three commands plus a disclosure in the secrets dialog. Not routed through `set_secret`, which records an env var — this credential is not one, and surfacing it there would imply the downstream process receives it.

An empty secret field means "keep the stored one", so editing scopes does not force re-entering a credential you cannot read back. Any config change resets the vaulted state, since it records the issuer and scopes resolved at acquisition and would otherwise keep minting under the old settings.

## Verification

- Full Rust suite green: 747 lib + 228 + 26
- Frontend: 216 passed, lint/format/tsc/build clean
- Mutation-checked: removing the extension re-merge fails its test

Known unrelated flake: `registry::update_at_serializes_concurrent_writers_with_no_lost_updates` (#652), confirmed on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)