### PR TITLE
fix(pii): keep pseudonyms on every model-facing path

### DIFF
--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -3617,22 +3617,6 @@ fn execute_call(
     // `None` only in test wrappers that lack `GatewayState`.
     live_router: Option<&Arc<Mutex<Arc<Router>>>>,
 ) -> Value {
-    // Turn pseudonyms back into real values BEFORE anything inspects the arguments
-    // (SBS-346).
-    //
-    // Every gate downstream of here reads them: the human-approval prompt, the
-    // destructive-call confirmation preview, the content-binding hash, and the
-    // audit record. An approver asked to authorize a send to `⟦EMAIL_1⟧` cannot
-    // make an informed decision, and a hash taken over pseudonyms would not
-    // describe the call actually dispatched. Re-hydrating once, up front, keeps
-    // all of them consistent with what the downstream server receives.
-    //
-    // A no-op when the feature is off or nothing was ever tokenized.
-    let mut arguments = arguments;
-    if reg.pii_redaction_effective() {
-        with_pii_session(client, |map| pii::rehydrate_args(map, &mut arguments));
-    }
-
     let mut confirmed = opts.confirmed;
     let shape = opts.shape;
     if !opts.allow_app_only && !named_tool_is_model_visible(name, cached, router) {
@@ -3779,7 +3763,12 @@ fn execute_call(
                 server: srv.to_string(),
                 tool: tool.to_string(),
                 reason,
-                arguments: arguments.clone(),
+                // Real values, for THIS path only (SBS-346). The local broker is a
+                // loopback UI shown to the trusted human on this machine and is not
+                // persisted, so an approver sees the recipient they are actually
+                // authorizing rather than `⟦EMAIL_1⟧`. Everything model-facing keeps
+                // the pseudonyms.
+                arguments: rehydrated_for_local_approver(reg, client, &arguments),
                 tool_fingerprint: current_fp.clone(),
             };
             let mut approval_reason = reason;
@@ -4068,6 +4057,17 @@ fn execute_call(
     let (_progress_route, relay_owned) = prepare_progress(client_meta, server_id);
     let client_meta = relay_owned.as_ref().or(client_meta);
 
+    // Resolve pseudonyms LAST, immediately before the call leaves the machine, so
+    // the downstream server gets real data while every model-facing path above
+    // kept the tokens (SBS-346).
+    //
+    // Gated on the map rather than the setting: a user who turns PII off
+    // mid-session still has tokens sitting in the model's context, and skipping
+    // this would dispatch a literal `⟦EMAIL_1⟧` as the recipient. `rehydrate_args`
+    // is already a no-op on an empty map.
+    let mut arguments = arguments;
+    with_pii_session(client, |map| pii::rehydrate_args(map, &mut arguments));
+
     let started = Instant::now();
     let effective_mrtr = routed_mrtr.as_ref().or(mrtr);
     match exec_router.route_call_with_cancel_and_mrtr(
@@ -4246,6 +4246,24 @@ fn with_pii_session<T>(client: Option<&str>, f: impl FnOnce(&mut pii::SessionMap
 /// Runs BEFORE content-defense so the injection wrapper, which is Toolport's own
 /// text rather than untrusted content, is not scanned as if it were PII.
 ///
+/// A copy of `arguments` with pseudonyms resolved, for the LOCAL approval UI.
+///
+/// Deliberately not applied to `arguments` itself. Everything else that reads them
+/// before dispatch is model-facing -- the modern HITL elicitation is relayed back
+/// through the model host, the destructive-confirm preview is returned to the
+/// model as a tool result, and live inspect writes them to disk -- so resolving
+/// them in place would push real PII into exactly the places this feature exists
+/// to keep it out of. The local broker is loopback-only and unpersisted, which is
+/// the one audience that should see real values before the wire does.
+fn rehydrated_for_local_approver(reg: &Registry, client: Option<&str>, arguments: &Value) -> Value {
+    if !reg.pii_redaction_effective() {
+        return arguments.clone();
+    }
+    let mut copy = arguments.clone();
+    with_pii_session(client, |map| pii::rehydrate_args(map, &mut copy));
+    copy
+}
+
 /// An incomplete pass is logged. This path fails OPEN -- a full map or an over-cap
 /// result leaves values in the clear -- and the whole point of returning
 /// `complete` was so that could be noticed rather than assumed away.
@@ -4256,7 +4274,7 @@ fn pseudonymize_if_enabled(reg: &Registry, client: Option<&str>, result: &mut Va
     let out = with_pii_session(client, |map| pii::pseudonymize_result(map, result));
     if !out.complete {
         eprintln!(
-            "toolport: PII pseudonymization was incomplete for this result - some values              reached the model in the clear (the session map is full, or the result exceeded              the scan cap)."
+            "toolport: PII pseudonymization was incomplete for this result - some values reached the model in the clear (the session map is full, or the result exceeded the scan cap)."
         );
     }
     out.replaced

--- a/src-tauri/src/pii.rs
+++ b/src-tauri/src/pii.rs
@@ -414,6 +414,15 @@ fn for_each_result_text(result: &mut Value, f: &mut impl FnMut(&mut String)) {
     let Some(obj) = result.as_object_mut() else {
         return;
     };
+    // `structuredContent` is model-facing payload, not plumbing: modern hosts feed
+    // it straight to the model, and `shaping::shape_result` relays it verbatim.
+    // Leaving it out meant a structured-output server handed the model real PII
+    // while the feature reported it was redacting -- the headline claim was simply
+    // untrue for those servers. Walked in full, unlike `nextCursor` and friends,
+    // which stay untouched because a rewrite there breaks the NEXT call.
+    if let Some(structured) = obj.get_mut("structuredContent") {
+        walk_strings(structured, f);
+    }
     for key in ["content", "contents", "messages"] {
         let Some(items) = obj.get_mut(key).and_then(Value::as_array_mut) else {
             continue;
@@ -458,6 +467,15 @@ fn walk_strings(v: &mut Value, f: &mut impl FnMut(&mut String)) {
                 })
                 .collect();
             for (old, new) in renames {
+                // Never clobber. A model routinely mixes a value it read verbatim
+                // with one it echoed as a token, so `{"ada@example.com": "viewer",
+                // "⟦EMAIL_1⟧": "owner"}` is reachable -- and `Map::insert` would
+                // silently drop one of the two entries before dispatch. Leaving the
+                // token in place is visibly wrong; deleting a role assignment is
+                // not.
+                if map.contains_key(&new) {
+                    continue;
+                }
                 if let Some(value) = map.remove(&old) {
                     map.insert(new, value);
                 }
@@ -703,20 +721,44 @@ mod tests {
         assert_eq!(args["body"]["text"], "hi ada@example.com");
     }
 
-    /// Ids, cursors and URLs live outside the text blocks and a rewrite there
-    /// would break the next call.
+    /// Ids and cursors are plumbing: a rewrite there breaks the NEXT call, so they
+    /// stay untouched. `structuredContent` is the opposite -- model-facing payload
+    /// relayed verbatim by `shaping::shape_result` -- so leaving it raw handed the
+    /// model real PII while the feature claimed to be redacting.
     #[test]
-    fn result_walk_leaves_non_text_fields_alone() {
+    fn result_walk_covers_structured_content_but_not_plumbing() {
         let mut m = map();
         let mut result = serde_json::json!({
             "content": [{ "type": "text", "text": "ada@example.com" }],
             "nextCursor": "ada@example.com",
-            "structuredContent": { "email": "ada@example.com" }
+            "structuredContent": { "customer": { "email": "ada@example.com" } }
         });
         pseudonymize_result(&mut m, &mut result);
-        assert_eq!(result["nextCursor"], "ada@example.com");
-        assert_eq!(result["structuredContent"]["email"], "ada@example.com");
+        assert_eq!(
+            result["nextCursor"], "ada@example.com",
+            "a cursor rewrite would break the next call"
+        );
         assert_eq!(result["content"][0]["text"], "⟦EMAIL_1⟧");
+        assert_eq!(
+            result["structuredContent"]["customer"]["email"], "⟦EMAIL_1⟧",
+            "structured output reaches the model and must be pseudonymized too"
+        );
+        // Same value, same token, across both shapes.
+        assert_eq!(m.rehydrate("⟦EMAIL_1⟧"), "ada@example.com");
+    }
+
+    /// A rename must never overwrite a sibling that already holds the target key.
+    #[test]
+    fn rehydrate_does_not_drop_a_colliding_sibling_key() {
+        let mut m = map();
+        m.pseudonymize("ada@example.com");
+        let mut args = serde_json::json!({
+            "roles": { "ada@example.com": "viewer", "⟦EMAIL_1⟧": "owner" }
+        });
+        rehydrate_args(&m, &mut args);
+        let roles = args["roles"].as_object().unwrap();
+        assert_eq!(roles.len(), 2, "an entry was silently dropped: {roles:?}");
+        assert_eq!(roles["ada@example.com"], "viewer");
     }
 
     #[test]


### PR DESCRIPTION
Follow-up to #656. A fresh-eyes review found that moving re-hydration to the top of `execute_call` — which I did to satisfy an earlier review note — pushed real PII into three places it must never reach. That change was wrong and this reverses its premise.

## Three leaks, all caused by the same move

**Modern HITL elicitation → the model (high).** `start_modern_hitl` bakes the arguments into its elicitation message, and that request is relayed back through the model host. With arguments already re-hydrated, approving a call sent the real recipient into the model's conversation.

The comment justifying the early move — *"an approver asked to authorize a send to `⟦EMAIL_1⟧` cannot make an informed decision"* — is true only of the **local** broker, a loopback UI. It's false for the modern path, where the "approver" is reached *through* the model.

**Destructive-confirm preview → the model (high).** That path formats arguments into a message and returns it as a tool result via a bare `return`, so it never passes through `defend_and_shape` — the only place the inbound pass runs. Real arguments went straight back to the model.

**Live inspect → disk.** `inspect_args` is captured after the old re-hydration point, so the move turned a file of pseudonyms into a file of PII, contradicting the module's own "no PII reaches disk".

## The fix

Invert the rule. `arguments` stays pseudonymized through every model-facing path, and real values are produced in exactly two places: `rehydrated_for_local_approver` (a copy handed only to the loopback approval UI) and immediately before dispatch.

## Three more from the same review

- **Toggling PII off mid-session dispatched a literal `⟦EMAIL_1⟧`** as a recipient — the outbound leg was gated on the setting while tokens were still live in the model's context. Now gated on the map.
- **`structuredContent` was never pseudonymized.** It's model-facing payload, relayed verbatim by `shaping::shape_result`, so a structured-output server handed the model real PII while the feature reported it was redacting. Now walked; ids and cursors stay untouched since a rewrite there breaks the next call.
- **A key rename could clobber a sibling.** `{"ada@example.com": "viewer", "⟦EMAIL_1⟧": "owner"}` collapsed to one entry, silently dropping a role assignment. Collisions are skipped now: a stray token is visibly wrong, a deleted entry is not.

Rust 776 + 228 + 26.

## Filed separately, not fixed here

- Any server can re-hydrate any token, for the process lifetime — an injection-driven exfiltration channel worth a design decision, not a patch.
- MRTR `inputResponses` bypass re-hydration.
- The per-call count is computed and discarded; Activity surfacing is still unimplemented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)