### PR TITLE
Make two locally-failing tests hermetic

### DIFF
--- a/src-tauri/src/downstream.rs
+++ b/src-tauri/src/downstream.rs
@@ -1172,6 +1172,28 @@ pub fn bearer_header(token: &str) -> String {
     }
 }
 
+/// Resolve a bare command against an explicit `;`-separated PATH and PATHEXT.
+/// Directories are the outer loop and extensions the inner one, so a hit in an
+/// earlier PATH entry beats an earlier PATHEXT extension in a later entry —
+/// which is what Windows itself does.
+///
+/// Split out from [`resolve_command`] so the precedence rule is testable against
+/// known stub files instead of against whatever the developer happens to have
+/// installed, and without mutating the process-wide PATH that every other test
+/// (and any process they spawn) is reading concurrently (#651).
+#[cfg(windows)]
+fn resolve_bare_in(path: &str, pathext: &str, command: &str) -> Option<String> {
+    for dir in path.split(';').filter(|d| !d.is_empty()) {
+        for ext in pathext.split(';').filter(|e| !e.is_empty()) {
+            let candidate = Path::new(dir).join(format!("{command}{ext}"));
+            if candidate.is_file() {
+                return Some(candidate.to_string_lossy().into_owned());
+            }
+        }
+    }
+    None
+}
+
 /// Resolve a bare command to a concrete executable.
 ///
 /// On Windows, Node tooling lives in `.cmd` shims (`npx` is really `npx.cmd`),
@@ -1184,17 +1206,10 @@ pub fn resolve_command(command: &str) -> String {
         return command.to_string();
     }
     let exts = std::env::var("PATHEXT").unwrap_or_else(|_| ".COM;.EXE;.BAT;.CMD".to_string());
-    if let Ok(path) = std::env::var("PATH") {
-        for dir in path.split(';').filter(|d| !d.is_empty()) {
-            for ext in exts.split(';').filter(|e| !e.is_empty()) {
-                let candidate = Path::new(dir).join(format!("{command}{ext}"));
-                if candidate.is_file() {
-                    return candidate.to_string_lossy().into_owned();
-                }
-            }
-        }
-    }
-    command.to_string()
+    let Ok(path) = std::env::var("PATH") else {
+        return command.to_string();
+    };
+    resolve_bare_in(&path, &exts, command).unwrap_or_else(|| command.to_string())
 }
 
 /// A PATH that includes the user's real shell PATH plus common install dirs.
@@ -6922,12 +6937,77 @@ mod tests {
     #[test]
     #[cfg(windows)]
     fn resolves_bare_command_via_pathext() {
-        // `cmd` is always on PATH on Windows; it should resolve to a real file.
-        let resolved = resolve_command("cmd");
-        assert!(
-            resolved.to_lowercase().ends_with("cmd.exe"),
-            "expected cmd.exe, got {resolved}"
+        // Hermetic on purpose. This used to resolve the real `cmd` and assert it
+        // ended in `cmd.exe`, which fails on any machine carrying a `cmd.CMD` in
+        // an earlier PATH entry (npm's global bin directory is a common one).
+        // That resolution is CORRECT — `.CMD` is in PATHEXT and the earlier
+        // directory legitimately wins — so the test was over-specified rather
+        // than the resolver wrong. Assert the rule against known stubs instead
+        // of against whatever is installed (#651).
+        use super::resolve_bare_in;
+
+        let root = std::env::temp_dir().join(format!(
+            "toolport-pathext-{}-{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        let first = root.join("first");
+        let second = root.join("second");
+        std::fs::create_dir_all(&first).unwrap();
+        std::fs::create_dir_all(&second).unwrap();
+        let stub = |dir: &std::path::Path, name: &str| {
+            let p = dir.join(name);
+            std::fs::write(&p, b"stub").unwrap();
+            p
+        };
+
+        let path = format!("{};{}", first.display(), second.display());
+
+        // PATH order beats PATHEXT order: `.EXE` sorts before `.CMD` in PATHEXT,
+        // but `second` is searched only after `first` has no candidate at all.
+        let early_cmd = stub(&first, "tool.CMD");
+        stub(&second, "tool.EXE");
+        assert_eq!(
+            resolve_bare_in(&path, ".COM;.EXE;.BAT;.CMD", "tool").as_deref(),
+            Some(early_cmd.to_string_lossy().as_ref()),
+            "an earlier PATH entry wins even with a later-ranked extension"
         );
+
+        // Within one directory, PATHEXT order decides.
+        let both_exe = stub(&first, "both.EXE");
+        stub(&first, "both.CMD");
+        assert_eq!(
+            resolve_bare_in(&path, ".COM;.EXE;.BAT;.CMD", "both").as_deref(),
+            Some(both_exe.to_string_lossy().as_ref()),
+            "PATHEXT order decides within a single directory"
+        );
+        // ... and reordering PATHEXT reorders the result, so the precedence is
+        // really coming from PATHEXT and not from directory enumeration order.
+        assert!(
+            resolve_bare_in(&path, ".CMD;.EXE", "both")
+                .unwrap()
+                .to_lowercase()
+                .ends_with("both.cmd"),
+            "PATHEXT is honored in the order given"
+        );
+
+        // Empty PATH/PATHEXT segments are skipped, not joined as "".
+        assert_eq!(
+            resolve_bare_in(&format!(";{path};"), ";.EXE;", "both").as_deref(),
+            Some(both_exe.to_string_lossy().as_ref())
+        );
+
+        // No candidate anywhere: the caller falls back to the bare command.
+        assert_eq!(resolve_bare_in(&path, ".EXE;.CMD", "absent"), None);
+        assert_eq!(resolve_command("toolport-definitely-not-installed"), "toolport-definitely-not-installed");
+
+        // An explicit extension or a path separator is passed through untouched,
+        // so PATH is never consulted for it.
+        assert_eq!(resolve_command("node.exe"), "node.exe");
+        assert_eq!(resolve_command(r"C:\tools\node"), r"C:\tools\node");
+        assert_eq!(resolve_command("tools/node"), "tools/node");
+
+        std::fs::remove_dir_all(&root).ok();
     }
 
     #[test]

--- a/src-tauri/src/downstream.rs
+++ b/src-tauri/src/downstream.rs
@@ -6991,15 +6991,37 @@ mod tests {
             "PATHEXT is honored in the order given"
         );
 
-        // Empty PATH/PATHEXT segments are skipped, not joined as "".
+        // PATHEXT is matched case-insensitively, as Windows does: every stub on
+        // disk here has an uppercase extension.
+        assert!(
+            resolve_bare_in(&path, ".exe", "both")
+                .unwrap()
+                .to_lowercase()
+                .ends_with("both.exe"),
+            "a lowercase PATHEXT entry matches an uppercase file on disk"
+        );
+
+        // An empty PATHEXT entry is skipped, NOT treated as "no extension".
+        // `both` exists without one, so a loop that failed to filter would
+        // return it in preference to `both.EXE`.
+        stub(&first, "both");
         assert_eq!(
-            resolve_bare_in(&format!(";{path};"), ";.EXE;", "both").as_deref(),
+            resolve_bare_in(&path, ";.EXE", "both").as_deref(),
+            Some(both_exe.to_string_lossy().as_ref()),
+            "an empty PATHEXT entry must not match the extensionless file"
+        );
+        // Empty PATH entries are tolerated the same way.
+        assert_eq!(
+            resolve_bare_in(&format!(";{path};"), ".EXE", "both").as_deref(),
             Some(both_exe.to_string_lossy().as_ref())
         );
 
         // No candidate anywhere: the caller falls back to the bare command.
         assert_eq!(resolve_bare_in(&path, ".EXE;.CMD", "absent"), None);
-        assert_eq!(resolve_command("toolport-definitely-not-installed"), "toolport-definitely-not-installed");
+        assert_eq!(
+            resolve_command("toolport-definitely-not-installed"),
+            "toolport-definitely-not-installed"
+        );
 
         // An explicit extension or a path separator is passed through untouched,
         // so PATH is never consulted for it.

--- a/src-tauri/src/registry.rs
+++ b/src-tauri/src/registry.rs
@@ -2146,6 +2146,43 @@ mod tests {
         std::fs::remove_dir_all(&dir).ok();
     }
 
+    /// One `secrets_generation` increment, retrying the way a real caller would.
+    ///
+    /// `lock_for` gives up after a bounded wait and returns "The registry is locked
+    /// by another Toolport process ...; try again." That is an expected outcome
+    /// under sustained contention, not a failure: every writer here holds the lock
+    /// across an fsync-ing `save_to`, so on a slow filesystem the queue can exceed
+    /// the acquisition deadline. Unwrapping it made the test assert "the lock is
+    /// always acquired within the deadline" on top of the property it actually
+    /// means to assert, which is "no update is lost" — and that is why it failed
+    /// under `cargo test --lib update_at_serializes_concurrent_writers` yet passed
+    /// in the full suite, where unrelated work spaced the writers out (#652).
+    ///
+    /// Only the contention error is retried; any other error still fails the test.
+    fn increment_with_retry(path: &Path) {
+        // Bound the retries by wall clock, not by a count: each attempt already
+        // spins inside `lock_for` for its own deadline, so a fixed attempt count
+        // would multiply out to minutes before the test admitted defeat.
+        let give_up_at = std::time::Instant::now() + std::time::Duration::from_secs(60);
+        loop {
+            match update_at(path, |r| {
+                r.secrets_generation += 1;
+                Ok(())
+            }) {
+                Ok(_) => return,
+                Err(e) if e.contains("is locked by another") => {
+                    assert!(
+                        std::time::Instant::now() < give_up_at,
+                        "registry lock stayed contended for 60s; this is a real hang, not scheduling"
+                    );
+                    // Let the current holder finish; `lock_for` already spun.
+                    std::thread::sleep(std::time::Duration::from_millis(10));
+                }
+                Err(e) => panic!("update_at failed for a reason other than contention: {e}"),
+            }
+        }
+    }
+
     #[test]
     fn update_at_serializes_concurrent_writers_with_no_lost_updates() {
         // The definitive lock check: many threads each read-increment-write via update_at.
@@ -2165,11 +2202,7 @@ mod tests {
                 let p = path.clone();
                 std::thread::spawn(move || {
                     for _ in 0..PER {
-                        update_at(&p, |r| {
-                            r.secrets_generation += 1;
-                            Ok(())
-                        })
-                        .unwrap();
+                        increment_with_retry(&p);
                     }
                 })
             })


### PR DESCRIPTION
Two tests that fail on `main` when run locally, both because they assert
something about the environment rather than about the code. Neither is caught
by CI, since CI only runs Linux and only runs the whole suite at once (#608).

Independent commits — either can be dropped without touching the other.

### #651 — `resolves_bare_command_via_pathext`

Resolved the real `cmd` and asserted it ended in `cmd.exe`. Fails on any
machine with a `cmd.CMD` in an earlier PATH entry (npm's global bin is a
common one), because `.CMD` is in PATHEXT and the earlier directory
legitimately wins. The resolution is correct — the test was over-specified.

Extracted the search into a pure `resolve_bare_in(path, pathext, command)` and
assert the real rule against stub files: PATH order beats PATHEXT order,
PATHEXT decides within a directory, empty segments are skipped, explicit
extensions and separators pass through. `resolve_command` behavior unchanged.

Pure rather than PATH-mutating deliberately: overwriting the process-wide PATH
would race every other test in the binary, including ones that spawn children
and need to find their own executables.

### #652 — `update_at_serializes_concurrent_writers_with_no_lost_updates`

Unwrapped every `update_at`. Under sustained contention `lock_for` gives up at
its deadline and returns "locked by another Toolport process ... try again",
which is an expected outcome — each writer holds the lock across an fsync-ing
`save_to`, so on a slow filesystem the queue outruns the deadline. Unwrapping
it made the test assert "the lock is always acquired within the deadline" on
top of the property it means to assert, which is "no update is lost". Hence
failing alone and passing in the full suite, where unrelated work spaced the
writers out.

Now retries only the contention error, the way a real caller would; any other
error still fails. Bounded by wall clock rather than attempt count, since each
attempt already spins inside `lock_for`.

## Testing

- [x] `npm run test:rust:windows` passes (773 lib + 228 gateway + 29 others)
- [x] `cargo test --lib update_at_serializes_concurrent_writers` in isolation, 3/3
- [x] `cargo test --lib resolves_bare_command_via_pathext` in isolation

For #652 I could not reproduce the original failure directly — it was reported
on WSL2 and I am on Windows, where the filesystem is fast enough that the
deadline is never reached. I verified the fix by temporarily collapsing the
`lock_for` deadline to zero, which forces the contention error on every
contended acquisition: the old test panics with exactly the reported message
(os error 33 rather than 11, same path), the new one passes 3/3. Both
temporary edits were reverted before committing.

Fixes #651
Fixes #652

🤖 Generated with [Claude Code](https://claude.com/claude-code)
