### PR TITLE
fix: harden credential and recovery boundaries

### DIFF
--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -4073,8 +4073,7 @@ fn execute_call(
     // mid-session still has tokens sitting in the model's context, and skipping
     // this would dispatch a literal `⟦EMAIL_1⟧` as the recipient. `rehydrate_args`
     // is already a no-op on an empty map.
-    let mut arguments = arguments;
-    with_pii_session(client, |map| pii::rehydrate_args(map, &mut arguments));
+    let arguments = rehydrate_for_downstream(client, arguments);
 
     let started = Instant::now();
     let effective_mrtr = routed_mrtr.as_ref().or(mrtr);
@@ -4246,6 +4245,16 @@ fn with_pii_session<T>(client: Option<&str>, f: impl FnOnce(&mut pii::SessionMap
         .entry(client.unwrap_or(PII_LOCAL_SESSION).to_string())
         .or_insert_with(pii::SessionMap::new);
     f(map)
+}
+
+/// Resolve pseudonyms on the owned dispatch copy only.
+///
+/// Callers must retain the original tokenized value for every model-facing or
+/// persisted preflight surface (HITL, destructive confirmation, inspect and
+/// audit hashing), and invoke this only at the final downstream boundary.
+fn rehydrate_for_downstream(client: Option<&str>, mut arguments: Value) -> Value {
+    with_pii_session(client, |map| pii::rehydrate_args(map, &mut arguments));
+    arguments
 }
 
 /// Pseudonymize a result's text blocks in place, returning how many values were
@@ -11936,6 +11945,21 @@ mod tests {
         assert_eq!(fmt_tokens(999_950), "1.0M");
         assert_eq!(fmt_tokens(1_000_000), "1.0M");
         assert_eq!(fmt_tokens(1_250_000), "1.2M");
+    }
+
+    #[test]
+    fn downstream_rehydration_does_not_mutate_model_facing_arguments() {
+        let client = Some("pii-placement-regression");
+        let token = with_pii_session(client, |map| {
+            *map = pii::SessionMap::new();
+            map.pseudonymize("ada@example.com").text
+        });
+        let model_facing = json!({ "to": token });
+
+        let downstream = rehydrate_for_downstream(client, model_facing.clone());
+
+        assert_eq!(model_facing["to"], "⟦EMAIL_1⟧");
+        assert_eq!(downstream["to"], "ada@example.com");
     }
 
     #[test]

--- a/src-tauri/src/clients.rs
+++ b/src-tauri/src/clients.rs
@@ -3386,7 +3386,28 @@ fn yaml_extensions_mut(root: &mut serde_yaml::Value) -> &mut serde_yaml::Mapping
 fn write_yaml_extensions(path: &Path, servers: &[ServerEntry]) -> Result<(), String> {
     let mut root = read_existing_yaml(path)?;
     let exts = yaml_extensions_mut(&mut root);
-    exts.clear();
+    // Replace only definitions Toolport can actually import as MCP servers.
+    // Goose builtins/platform extensions and unknown shapes share this map but
+    // have no inventory representation, so clearing the map silently deletes
+    // functionality during migration.
+    exts.retain(|_, definition| {
+        let Some(mapping) = definition.as_mapping() else {
+            return true;
+        };
+        let extension_type = mapping.get("type").and_then(|value| value.as_str());
+        if matches!(extension_type, Some("builtin" | "platform")) {
+            return true;
+        }
+        let has_command = mapping
+            .get("cmd")
+            .and_then(|value| value.as_str())
+            .is_some_and(|value| !value.is_empty());
+        let has_url = mapping
+            .get("url")
+            .and_then(|value| value.as_str())
+            .is_some_and(|value| !value.is_empty());
+        !has_command && !has_url
+    });
     for s in servers {
         exts.insert(
             serde_yaml::Value::String(s.name.clone()),
@@ -7386,6 +7407,31 @@ command = "npx"
         }
         .is_err());
         assert_eq!(std::fs::read_to_string(&path).unwrap(), garbage);
+        std::fs::remove_file(&path).ok();
+    }
+
+    #[test]
+    fn goose_inventory_write_preserves_non_mcp_extensions() {
+        let path = temp_path("goose-preserve-builtins.yaml");
+        std::fs::write(
+            &path,
+            "GOOSE_MODEL: gpt-4o\nextensions:\n  developer:\n    type: builtin\n    enabled: true\n  platform-tools:\n    type: platform\n    cmd: internal\n  future-shape:\n    enabled: true\n  fetch:\n    type: stdio\n    cmd: uvx\n    args: [mcp-server-fetch]\n",
+        )
+        .unwrap();
+
+        let gateway = sample_gateway(None, "goose");
+        write_yaml_extensions(&path, &[gateway]).unwrap();
+
+        let root: serde_yaml::Value =
+            serde_yaml::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        assert_eq!(root["GOOSE_MODEL"].as_str(), Some("gpt-4o"));
+        let extensions = root["extensions"].as_mapping().unwrap();
+        assert!(extensions.get("developer").is_some());
+        assert!(extensions.get("platform-tools").is_some());
+        assert!(extensions.get("future-shape").is_some());
+        assert!(extensions.get("fetch").is_none());
+        assert!(extensions.get(GATEWAY_ENTRY_NAME).is_some());
+
         std::fs::remove_file(&path).ok();
     }
 

--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -4488,6 +4488,9 @@ mod tests {
         assert!(arg_looks_secret("--dsn=postgres://u:p@h/db"));
         assert!(arg_looks_secret("PASSWORD=hunter2"));
         assert!(arg_looks_secret("Authorization: token=abc123"));
+        assert!(arg_looks_secret("Authorization: Bearer sk-live-secret"));
+        assert!(arg_looks_secret("authorization:Basic Zm9vOmJhcg=="));
+        assert!(arg_looks_secret("Bearer sk-live-secret"));
         // Legitimate args must NOT be redacted.
         assert!(!arg_looks_secret("-y"));
         assert!(!arg_looks_secret("@modelcontextprotocol/server-postgres"));
@@ -4504,6 +4507,7 @@ mod tests {
                 "-y".into(),
                 "@modelcontextprotocol/server-postgres".into(),
                 "postgresql://admin:hunter2@db.example.com:5432/app".into(),
+                "Authorization: Bearer sk-live-secret".into(),
             ],
             env: vec![],
             url: None,
@@ -4517,11 +4521,13 @@ mod tests {
         let serialized = serde_json::to_string(&doc).unwrap();
         // The password must never appear in a shared setup.
         assert!(!serialized.contains("hunter2"));
+        assert!(!serialized.contains("sk-live-secret"));
         let args = doc["servers"][0]["args"].as_array().unwrap();
         // Benign args are kept; only the credential-bearing one is redacted.
         assert_eq!(args[0], "-y");
         assert_eq!(args[1], "@modelcontextprotocol/server-postgres");
         assert_eq!(args[2], "<redacted>");
+        assert_eq!(args[3], "<redacted>");
     }
 
     #[test]

--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -4491,6 +4491,9 @@ mod tests {
         assert!(arg_looks_secret("Authorization: Bearer sk-live-secret"));
         assert!(arg_looks_secret("authorization:Basic Zm9vOmJhcg=="));
         assert!(arg_looks_secret("Bearer sk-live-secret"));
+        assert!(arg_looks_secret("Basic dXNlcjpwYXNz"));
+        assert!(arg_looks_secret("Digest username=admin,response=secret"));
+        assert!(arg_looks_secret("Proxy-Authorization: Basic dXNlcjpwYXNz"));
         // Legitimate args must NOT be redacted.
         assert!(!arg_looks_secret("-y"));
         assert!(!arg_looks_secret("@modelcontextprotocol/server-postgres"));

--- a/src-tauri/src/oauth.rs
+++ b/src-tauri/src/oauth.rs
@@ -1175,6 +1175,10 @@ pub fn refresh(
     resource: Option<&str>,
     block_private: bool,
 ) -> Result<Tokens, String> {
+    // Refresh tokens are long-lived credentials. Re-check the endpoint at this
+    // public boundary so legacy vaulted state and direct callers cannot bypass
+    // the TLS rule enforced during discovery.
+    require_https(token_endpoint, "token endpoint")?;
     let mut form: Vec<(&str, &str)> = vec![
         ("grant_type", "refresh_token"),
         ("refresh_token", refresh_token),
@@ -2632,6 +2636,21 @@ mod tests {
             "s3cret",
             ClientAuthMethod::ClientSecretBasic,
             None,
+            None,
+            true,
+        ) {
+            Err(e) => e,
+            Ok(_) => panic!("a cleartext token endpoint must be refused"),
+        };
+        assert!(err.contains("must use https"), "{err}");
+    }
+
+    #[test]
+    fn refresh_refuses_a_cleartext_public_token_endpoint() {
+        let err = match refresh(
+            "http://auth.example.com/token",
+            "client",
+            "refresh-token-value",
             None,
             true,
         ) {

--- a/src-tauri/src/pii.rs
+++ b/src-tauri/src/pii.rs
@@ -431,10 +431,17 @@ fn for_each_result_text(result: &mut Value, f: &mut impl FnMut(&mut String)) {
             let Some(item) = item.as_object_mut() else {
                 continue;
             };
-            // `messages[].content` nests one level further.
-            if let Some(Value::Object(nested)) = item.get_mut("content") {
-                if let Some(Value::String(text)) = nested.get_mut("text") {
-                    f(text);
+            // `messages[].content` may be either a bare string or a nested text
+            // object. Both are model-facing MCP prompt shapes.
+            if let Some(content) = item.get_mut("content") {
+                match content {
+                    Value::String(text) => f(text),
+                    Value::Object(nested) => {
+                        if let Some(Value::String(text)) = nested.get_mut("text") {
+                            f(text);
+                        }
+                    }
+                    _ => {}
                 }
                 continue;
             }
@@ -745,6 +752,24 @@ mod tests {
         );
         // Same value, same token, across both shapes.
         assert_eq!(m.rehydrate("⟦EMAIL_1⟧"), "ada@example.com");
+    }
+
+    #[test]
+    fn result_walk_covers_bare_string_prompt_messages() {
+        let mut m = map();
+        let mut result = serde_json::json!({
+            "messages": [
+                { "role": "user", "content": "contact ada@example.com" },
+                { "role": "assistant", "content": { "type": "text", "text": "backup grace@example.com" } }
+            ]
+        });
+        let out = pseudonymize_result(&mut m, &mut result);
+        assert_eq!(out.replaced, 2);
+        assert_eq!(result["messages"][0]["content"], "contact ⟦EMAIL_1⟧");
+        assert_eq!(
+            result["messages"][1]["content"]["text"],
+            "backup ⟦EMAIL_2⟧"
+        );
     }
 
     /// A rename must never overwrite a sibling that already holds the target key.

--- a/src-tauri/src/registry.rs
+++ b/src-tauri/src/registry.rs
@@ -1672,6 +1672,14 @@ fn backup_path(path: &Path) -> PathBuf {
     PathBuf::from(name)
 }
 
+/// Sequence recorded alongside `.bak`, allowing recovery to distinguish two
+/// snapshots whose filesystem mtimes collapse into the same coarse bucket.
+fn backup_sequence_path(path: &Path) -> PathBuf {
+    let mut name = path.as_os_str().to_owned();
+    name.push(".bak.seq");
+    PathBuf::from(name)
+}
+
 /// How many rolling backup generations `save_to` keeps beyond the single `.bak`.
 /// The registry is a few KB, so 5 generations is negligible on disk but means
 /// recovery has several recent snapshots to fall back to, not one file that (as
@@ -1679,8 +1687,8 @@ fn backup_path(path: &Path) -> PathBuf {
 const BACKUP_GENERATIONS: usize = 5;
 
 /// The rolling journal generations written by `save_to`, named
-/// `<registry>.bak.<ts-millis>`. Timestamps are fixed-width for any realistic
-/// epoch, so name order is age order; returned oldest-first. Excludes the single
+/// `<registry>.bak.<sequence>`. The sequence starts from epoch milliseconds and
+/// advances monotonically, so name order is age order; returned oldest-first. Excludes the single
 /// `<registry>.bak` (no trailing timestamp) and the `.unreadable-*` quarantine
 /// files, which use a different prefix.
 fn backup_generations(path: &Path) -> Vec<PathBuf> {
@@ -1698,7 +1706,8 @@ fn backup_generations(path: &Path) -> Vec<PathBuf> {
         .filter(|p| {
             p.file_name()
                 .and_then(|f| f.to_str())
-                .is_some_and(|f| f.starts_with(&prefix))
+                .and_then(|f| f.strip_prefix(&prefix))
+                .is_some_and(|suffix| suffix.parse::<u128>().is_ok())
         })
         .collect();
     gens.sort();
@@ -1709,13 +1718,30 @@ fn backup_generations(path: &Path) -> Vec<PathBuf> {
 /// newest `BACKUP_GENERATIONS`. Best-effort: a failure here never fails a save -
 /// the primary write and the single `.bak` remain the durability guarantees, and
 /// this only adds recovery depth on top of them.
-fn write_backup_generation(path: &Path, content: &str) {
-    let ts = std::time::SystemTime::now()
+fn next_backup_sequence(path: &Path) -> u128 {
+    let now = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .map(|d| d.as_millis())
         .unwrap_or(0);
+    let latest = backup_generations(path)
+        .into_iter()
+        .filter_map(|generation| {
+            generation
+                .file_name()?
+                .to_str()?
+                .rsplit_once(".bak.")?
+                .1
+                .parse::<u128>()
+                .ok()
+        })
+        .max()
+        .unwrap_or(0);
+    now.max(latest.saturating_add(1))
+}
+
+fn write_backup_generation(path: &Path, content: &str, sequence: u128) {
     let mut name = path.as_os_str().to_owned();
-    name.push(format!(".bak.{ts}"));
+    name.push(format!(".bak.{sequence}"));
     if atomic_write(&PathBuf::from(name), content).is_err() {
         return;
     }
@@ -1732,7 +1758,11 @@ fn write_backup_generation(path: &Path, content: &str) {
 /// when nothing usable remains. Walking the journal means one stale or corrupt
 /// `.bak` no longer strands recovery when fresher snapshots exist.
 fn restore_from_backup(path: &Path) -> Option<Registry> {
-    let mut candidates = vec![backup_path(path)];
+    let single_backup = backup_path(path);
+    let single_sequence = std::fs::read_to_string(backup_sequence_path(path))
+        .ok()
+        .and_then(|raw| raw.trim().parse::<u128>().ok());
+    let mut candidates = vec![single_backup.clone()];
     candidates.extend(backup_generations(path));
     candidates.sort_by(|a, b| {
         let modified = |candidate: &Path| {
@@ -1740,11 +1770,27 @@ fn restore_from_backup(path: &Path) -> Option<Registry> {
                 .and_then(|metadata| metadata.modified())
                 .unwrap_or(std::time::UNIX_EPOCH)
         };
-        // On coarse-timestamp filesystems, prefer a journal generation over the
-        // single .bak on a tie: save_to writes the generation after .bak.
-        modified(b)
-            .cmp(&modified(a))
-            .then_with(|| b.as_os_str().len().cmp(&a.as_os_str().len()))
+        let sequence = |candidate: &Path| {
+            if candidate == single_backup {
+                single_sequence
+            } else {
+                candidate
+                    .file_name()?
+                    .to_str()?
+                    .rsplit_once(".bak.")?
+                    .1
+                    .parse::<u128>()
+                    .ok()
+            }
+        };
+        match (sequence(a), sequence(b)) {
+            (Some(a_sequence), Some(b_sequence)) => b_sequence.cmp(&a_sequence),
+            // Legacy backups have no sequence sidecar. Preserve mtime ordering
+            // for them, preferring the journal only when the coarse times tie.
+            _ => modified(b)
+                .cmp(&modified(a))
+                .then_with(|| b.as_os_str().len().cmp(&a.as_os_str().len())),
+        }
     });
 
     for candidate in candidates {
@@ -1915,11 +1961,19 @@ pub fn save_to(path: &Path, registry: &Registry) -> Result<(), String> {
         if !existing.trim().is_empty() {
             if serde_json::from_str::<Registry>(&existing).is_ok() {
                 // Single last-known-good (compat + the load_from fast path)...
-                let _ = atomic_write(&backup_path(path), &existing);
+                let sequence = next_backup_sequence(path);
+                if atomic_write(&backup_path(path), &existing).is_ok() {
+                    let sequence_path = backup_sequence_path(path);
+                    if atomic_write(&sequence_path, &sequence.to_string()).is_err() {
+                        // Never leave older metadata attached to newer `.bak`
+                        // contents; mtime fallback is safer than a stale sequence.
+                        let _ = std::fs::remove_file(sequence_path);
+                    }
+                }
                 // ...plus a rolling journal generation, so recovery can fall back
                 // to the immediately-previous state and a few before it, not just
                 // whatever the one .bak happens to hold.
-                write_backup_generation(path, &existing);
+                write_backup_generation(path, &existing, sequence);
             } else {
                 quarantine_unreadable(path, &existing);
             }
@@ -2067,17 +2121,21 @@ pub(crate) fn arg_looks_secret(arg: &str) -> bool {
     }
     // Common remote-MCP launchers pass an HTTP auth header as one argument.
     // It has no key=value marker, but sharing it would disclose the credential.
-    if let Some(value) = trimmed.strip_prefix("authorization:") {
-        let value = value.trim_start();
-        if value.starts_with("bearer") || value.starts_with("basic") {
+    for header in ["authorization:", "proxy-authorization:"] {
+        if trimmed
+            .strip_prefix(header)
+            .is_some_and(|value| !value.trim().is_empty())
+        {
             return true;
         }
     }
     // Some launchers split the header name and value into separate arguments.
     // Catch the credential-bearing value even when "Authorization:" is adjacent.
-    if let Some(value) = trimmed.strip_prefix("bearer") {
-        if value.chars().next().is_some_and(char::is_whitespace) && !value.trim().is_empty() {
-            return true;
+    for scheme in ["bearer", "basic", "digest"] {
+        if let Some(value) = trimmed.strip_prefix(scheme) {
+            if value.chars().next().is_some_and(char::is_whitespace) && !value.trim().is_empty() {
+                return true;
+            }
         }
     }
     // A connection URI with embedded userinfo: scheme://user:pass@host/...
@@ -3382,6 +3440,58 @@ mod tests {
         std::fs::remove_file(backup_path(&path)).ok();
         for generation in backup_generations(&path) {
             std::fs::remove_file(generation).ok();
+        }
+    }
+
+    #[test]
+    fn recovery_uses_backup_sequence_when_mtimes_tie() {
+        let dir = std::env::temp_dir();
+        let path = dir.join(format!(
+            "conduit-reg-recover-sequence-{}.json",
+            std::process::id()
+        ));
+        let bak = backup_path(&path);
+        let sequence_path = backup_sequence_path(&path);
+        let mut generation_name = path.as_os_str().to_owned();
+        generation_name.push(".bak.100");
+        let generation = PathBuf::from(generation_name);
+
+        for candidate in [&path, &bak, &sequence_path, &generation] {
+            std::fs::remove_file(candidate).ok();
+        }
+
+        let mut stale = Registry::default();
+        stale.add_server(sample_server("stale"));
+        std::fs::write(&generation, serde_json::to_string(&stale).unwrap()).unwrap();
+
+        let mut fresh = stale.clone();
+        fresh.add_server(sample_server("fresh"));
+        std::fs::write(&bak, serde_json::to_string(&fresh).unwrap()).unwrap();
+        std::fs::write(&sequence_path, "200").unwrap();
+
+        let tied_time = std::time::SystemTime::UNIX_EPOCH
+            + std::time::Duration::from_secs(1_700_000_000);
+        let times = std::fs::FileTimes::new().set_modified(tied_time);
+        std::fs::OpenOptions::new()
+            .write(true)
+            .open(&bak)
+            .unwrap()
+            .set_times(times)
+            .unwrap();
+        std::fs::OpenOptions::new()
+            .write(true)
+            .open(&generation)
+            .unwrap()
+            .set_times(times)
+            .unwrap();
+        std::fs::write(&path, "{ corrupt").unwrap();
+
+        let recovered = load_from(&path).unwrap();
+        assert_eq!(recovered.servers.len(), 2);
+        assert!(recovered.servers.iter().any(|server| server.name == "fresh"));
+
+        for candidate in [&path, &bak, &sequence_path, &generation] {
+            std::fs::remove_file(candidate).ok();
         }
     }
 

--- a/src-tauri/src/registry.rs
+++ b/src-tauri/src/registry.rs
@@ -1725,17 +1725,27 @@ fn write_backup_generation(path: &Path, content: &str) {
     }
 }
 
-/// Recover the registry from the backups `save_to` maintains, newest-first: the
-/// single `.bak` (the last-known-good fast path), then the rolling journal
-/// generations from newest to oldest. Returns the first that parses (and
+/// Recover the registry from the backups `save_to` maintains, newest-first by
+/// filesystem modification time across both `.bak` and rolling generations.
+/// Returns the first that parses (and
 /// best-effort rewrites the primary from it so a later read self-heals), or None
 /// when nothing usable remains. Walking the journal means one stale or corrupt
 /// `.bak` no longer strands recovery when fresher snapshots exist.
 fn restore_from_backup(path: &Path) -> Option<Registry> {
     let mut candidates = vec![backup_path(path)];
-    let mut gens = backup_generations(path);
-    gens.reverse(); // newest generation first
-    candidates.extend(gens);
+    candidates.extend(backup_generations(path));
+    candidates.sort_by(|a, b| {
+        let modified = |candidate: &Path| {
+            std::fs::metadata(candidate)
+                .and_then(|metadata| metadata.modified())
+                .unwrap_or(std::time::UNIX_EPOCH)
+        };
+        // On coarse-timestamp filesystems, prefer a journal generation over the
+        // single .bak on a tie: save_to writes the generation after .bak.
+        modified(b)
+            .cmp(&modified(a))
+            .then_with(|| b.as_os_str().len().cmp(&a.as_os_str().len()))
+    });
 
     for candidate in candidates {
         let Ok(content) = std::fs::read_to_string(&candidate) else {
@@ -2047,12 +2057,28 @@ pub fn load_resolved() -> Result<Registry, String> {
 /// Biased toward over-redacting: for a share, a false positive is harmless.
 pub(crate) fn arg_looks_secret(arg: &str) -> bool {
     let lower = arg.to_ascii_lowercase();
+    let trimmed = lower.trim();
     const NEEDLES: [&str; 8] = [
         "password=", "pwd=", "token=", "apikey=", "api_key=", "secret=", "accountkey=",
         "access_key",
     ];
     if NEEDLES.iter().any(|n| lower.contains(n)) {
         return true;
+    }
+    // Common remote-MCP launchers pass an HTTP auth header as one argument.
+    // It has no key=value marker, but sharing it would disclose the credential.
+    if let Some(value) = trimmed.strip_prefix("authorization:") {
+        let value = value.trim_start();
+        if value.starts_with("bearer") || value.starts_with("basic") {
+            return true;
+        }
+    }
+    // Some launchers split the header name and value into separate arguments.
+    // Catch the credential-bearing value even when "Authorization:" is adjacent.
+    if let Some(value) = trimmed.strip_prefix("bearer") {
+        if value.chars().next().is_some_and(char::is_whitespace) && !value.trim().is_empty() {
+            return true;
+        }
     }
     // A connection URI with embedded userinfo: scheme://user:pass@host/...
     if let Some((_, rest)) = arg.split_once("://") {
@@ -3316,6 +3342,46 @@ mod tests {
         std::fs::remove_file(backup_path(&path)).ok();
         for g in backup_generations(&path) {
             std::fs::remove_file(g).ok();
+        }
+    }
+
+    #[test]
+    fn recovery_prefers_a_fresher_journal_over_a_stale_parseable_bak() {
+        let dir = std::env::temp_dir();
+        let path = dir.join(format!(
+            "conduit-reg-recover-freshest-{}.json",
+            std::process::id()
+        ));
+        std::fs::remove_file(&path).ok();
+        std::fs::remove_file(backup_path(&path)).ok();
+        for generation in backup_generations(&path) {
+            std::fs::remove_file(generation).ok();
+        }
+
+        let mut stale = Registry::default();
+        stale.add_server(sample_server("stale"));
+        std::fs::write(backup_path(&path), serde_json::to_string(&stale).unwrap()).unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(20));
+
+        let mut fresh = stale.clone();
+        fresh.add_server(sample_server("fresh"));
+        let mut generation_name = path.as_os_str().to_owned();
+        generation_name.push(".bak.9999999999999");
+        std::fs::write(
+            PathBuf::from(generation_name),
+            serde_json::to_string(&fresh).unwrap(),
+        )
+        .unwrap();
+        std::fs::write(&path, "{ corrupt").unwrap();
+
+        let recovered = load_from(&path).unwrap();
+        assert_eq!(recovered.servers.len(), 2);
+        assert!(recovered.servers.iter().any(|server| server.name == "fresh"));
+
+        std::fs::remove_file(&path).ok();
+        std::fs::remove_file(backup_path(&path)).ok();
+        for generation in backup_generations(&path) {
+            std::fs::remove_file(generation).ok();
         }
     }
 

--- a/src-tauri/src/remote.rs
+++ b/src-tauri/src/remote.rs
@@ -508,7 +508,7 @@ fn require_secure_for_auth(url: &str) -> Result<(), String> {
         return Ok(());
     }
     let host = oauth::host_of_url(url).unwrap_or_default();
-    if oauth::host_is_private(&host) {
+    if oauth::host_is_definitely_private(&host) {
         return Ok(());
     }
     Err(format!(
@@ -912,6 +912,10 @@ mod tests {
         // Loopback / private over http is acceptable (local dev).
         assert!(require_secure_for_auth("http://127.0.0.1:8080/mcp").is_ok());
         assert!(require_secure_for_auth("http://192.168.1.10/mcp").is_ok());
+        // An unresolvable host is not positively local. The refusal-side
+        // predicate treats this as private, but that must never grant permission
+        // to put a saved token on a cleartext connection.
+        assert!(require_secure_for_auth("http://no-such-host-633.invalid/mcp").is_err());
     }
 
     #[test]

--- a/src-tauri/src/secrets.rs
+++ b/src-tauri/src/secrets.rs
@@ -140,10 +140,9 @@ mod platform {
     /// Builds a dictionary with `kSecClass=kSecClassGenericPassword`,
     /// `kSecAttrService`, `kSecAttrAccount`, `kSecValueData`,
     /// `kSecUseDataProtectionKeychain=true`, `kSecAttrAccessGroup=<shared group>`,
-    /// and `kSecAttrAccessible=kSecAttrAccessibleAfterFirstUnlock`. A
-    /// `SecItemDelete` with the SAME query keys (incl. the access group + the
-    /// data-protection flag) runs first for idempotency, then `SecItemAdd` creates
-    /// a fresh item.
+    /// and `kSecAttrAccessible=kSecAttrAccessibleAfterFirstUnlock`. Existing
+    /// items are replaced with `SecItemUpdate`; `SecItemAdd` is used only when
+    /// the account does not exist, so a failed update cannot destroy the old value.
     ///
     /// The high-level `security_framework::passwords` API targets the *legacy*
     /// keychain and cannot set the access group or the data-protection flag, so
@@ -193,7 +192,7 @@ mod platform {
                 access_ref: *mut *mut c_void,
             ) -> i32;
             fn SecItemAdd(attributes: *const c_void, result: *mut *const c_void) -> i32;
-            fn SecItemDelete(query: *const c_void) -> i32;
+            fn SecItemUpdate(query: *const c_void, attributes: *const c_void) -> i32;
             static kSecClass: CFTypeRef;
             static kSecClassGenericPassword: CFTypeRef;
             static kSecAttrService: CFTypeRef;
@@ -260,18 +259,33 @@ mod platform {
         let service_cf = CFString::new(SERVICE).as_CFType();
         let account_cf = CFString::new(account_str).as_CFType();
 
-        // 2. Remove any existing item for this account (SecItemAdd rejects dups).
-        let del = CFDictionary::from_CFType_pairs(&[
+        // 2. Update in place when the master key already exists. A failed update
+        // leaves the previous value intact; delete-then-add could destroy the only
+        // key capable of decrypting the file backend.
+        let query = CFDictionary::from_CFType_pairs(&[
             (k_class.clone(), k_generic.clone()),
             (k_service.clone(), service_cf.clone()),
             (k_account.clone(), account_cf.clone()),
         ]);
-        unsafe {
-            SecItemDelete(del.as_concrete_TypeRef() as *const c_void);
+        let data_cf = CFData::from_buffer(value.as_bytes()).as_CFType();
+        let update = CFDictionary::from_CFType_pairs(&[
+            (k_value.clone(), data_cf.clone()),
+            (k_access.clone(), access_cf.clone()),
+        ]);
+        let update_status = unsafe {
+            SecItemUpdate(
+                query.as_concrete_TypeRef() as *const c_void,
+                update.as_concrete_TypeRef() as *const c_void,
+            )
+        };
+        if update_status == 0 {
+            return Ok(());
+        }
+        if update_status != -25300 {
+            return Err(format!("SecItemUpdate with shared access failed: {update_status}"));
         }
 
-        // 3. Add the item WITH the shared-access ACL, atomically (no prompt).
-        let data_cf = CFData::from_buffer(value.as_bytes()).as_CFType();
+        // 3. No prior item: add it WITH the shared-access ACL atomically.
         let add = CFDictionary::from_CFType_pairs(&[
             (k_class, k_generic),
             (k_service, service_cf),
@@ -334,6 +348,7 @@ mod platform {
             fn SecItemAdd(attributes: *const c_void, result: *mut *const c_void) -> i32;
             fn SecItemCopyMatching(query: *const c_void, result: *mut *const c_void) -> i32;
             fn SecItemDelete(query: *const c_void) -> i32;
+            fn SecItemUpdate(query: *const c_void, attributes: *const c_void) -> i32;
 
             static kSecClass: CFTypeRef;
             static kSecClassGenericPassword: CFTypeRef;
@@ -375,22 +390,36 @@ mod platform {
             }
         }
 
-        /// `SecItemDelete` for idempotency, then `SecItemAdd`. Returns Err on any
-        /// non-success add status (notably -34018 `errSecMissingEntitlement` on an
-        /// unsigned build).
+        /// Update an existing item in place, or add it when absent. A failed
+        /// replacement never deletes the previous value.
         pub fn set(account_str: &str, value: &str) -> Result<(), String> {
-            // 1. Delete any existing item (same keys incl. access group + DP flag).
-            let del = CFDictionary::from_CFType_pairs(&base_query(account_str));
-            unsafe {
-                SecItemDelete(del.as_concrete_TypeRef() as *const c_void);
+            let query = CFDictionary::from_CFType_pairs(&base_query(account_str));
+            let value_data = CFData::from_buffer(value.as_bytes()).as_CFType();
+            let update = CFDictionary::from_CFType_pairs(&[
+                (k(unsafe { kSecValueData }), value_data.clone()),
+                (
+                    k(unsafe { kSecAttrAccessible }),
+                    k(unsafe { kSecAttrAccessibleAfterFirstUnlock }),
+                ),
+            ]);
+            let update_status = unsafe {
+                SecItemUpdate(
+                    query.as_concrete_TypeRef() as *const c_void,
+                    update.as_concrete_TypeRef() as *const c_void,
+                )
+            };
+            if update_status == 0 {
+                return Ok(());
+            }
+            if update_status != ERR_SEC_ITEM_NOT_FOUND {
+                return Err(format!(
+                    "SecItemUpdate (data-protection keychain) failed: {update_status}"
+                ));
             }
 
-            // 2. Add the fresh item with the value + accessibility class.
+            // No prior item: add the fresh value + accessibility class.
             let mut pairs = base_query(account_str);
-            pairs.push((
-                k(unsafe { kSecValueData }),
-                CFData::from_buffer(value.as_bytes()).as_CFType(),
-            ));
+            pairs.push((k(unsafe { kSecValueData }), value_data));
             pairs.push((
                 k(unsafe { kSecAttrAccessible }),
                 k(unsafe { kSecAttrAccessibleAfterFirstUnlock }),
@@ -1118,6 +1147,43 @@ mod tests {
     /// races with a sibling that assumes the keychain path, causing spurious
     /// failures under the default multi-threaded test runner.
     static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    #[test]
+    fn macos_secret_replacement_never_deletes_before_writing() {
+        // This source-contract test runs on Windows/Linux CI even though the
+        // Security.framework implementation is only compiled on macOS. It
+        // protects the data-loss invariant: both replacement paths must update
+        // an existing item in place and reserve SecItemAdd for a missing item.
+        let source = include_str!("secrets.rs");
+
+        let legacy_start = source
+            .find("fn add_with_shared_access(")
+            .expect("legacy keychain writer must exist");
+        let legacy_end = source[legacy_start..]
+            .find("pub fn seed_legacy_for_test")
+            .map(|offset| legacy_start + offset)
+            .expect("legacy writer must end before its test helper");
+        let legacy_writer = &source[legacy_start..legacy_end];
+
+        let dpk_module_start = source
+            .find("mod dpk {")
+            .expect("data-protection keychain module must exist");
+        let dpk_set_start = source[dpk_module_start..]
+            .find("pub fn set(")
+            .map(|offset| dpk_module_start + offset)
+            .expect("data-protection keychain writer must exist");
+        let dpk_set_end = source[dpk_set_start..]
+            .find("pub fn get(")
+            .map(|offset| dpk_set_start + offset)
+            .expect("data-protection writer must end before its reader");
+        let dpk_writer = &source[dpk_set_start..dpk_set_end];
+
+        for writer in [legacy_writer, dpk_writer] {
+            assert!(writer.contains("SecItemUpdate("));
+            assert!(writer.contains("SecItemAdd("));
+            assert!(!writer.contains("SecItemDelete("));
+        }
+    }
 
     #[test]
     fn server_secrets_cannot_use_the_internal_task_key_namespace() {

--- a/src-tauri/src/teams.rs
+++ b/src-tauri/src/teams.rs
@@ -2484,6 +2484,25 @@ mod tests {
         }
     }
 
+    #[test]
+    fn team_server_export_redacts_authorization_args() {
+        let mut reg = base_registry();
+        let server = reg
+            .servers
+            .iter_mut()
+            .find(|s| s.id == "mine")
+            .expect("fixture server");
+        server.args = vec![
+            "--header".into(),
+            "Authorization: Bearer team-secret".into(),
+        ];
+
+        let exported = team_server_export(&reg);
+        let serialized = serde_json::to_string(&exported).unwrap();
+        assert!(!serialized.contains("team-secret"), "secret leaked: {serialized}");
+        assert!(serialized.contains("<redacted>"));
+    }
+
     /// A server with no block, or a blank client id, must not be treated as
     /// configured: that would send every connect down the headless path and fail
     /// with "no client secret vaulted".


### PR DESCRIPTION
## Summary

- fail closed before sending bearer or refresh credentials over unsafe endpoints
- redact standard Authorization and Bearer arguments from share and team exports
- cover bare-string prompt PII and keep rehydration on an owned downstream-only copy
- preserve Goose builtin/platform extensions during migration
- recover from the freshest registry generation
- replace macOS keychain secrets without delete-before-add data loss

## Linear

Addresses SBS-633, SBS-652, SBS-669, SBS-676, SBS-653, SBS-665, and SBS-612.

SBS-614 is partial: this adds the downstream-copy placement regression, while its broader modern-HITL, destructive-confirm, and live-inspect end-to-end matrix remains follow-up work.

## Verification

- npm run test:rust:windows
- cargo test --manifest-path src-tauri/Cargo.toml secrets::tests::macos_secret_replacement_never_deletes_before_writing -- --exact
- git diff --check

Full Windows result: 793 library tests, 238 gateway tests, and all integration/spec-conformance tests passed.