### PR TITLE
fix: a batch of Toolport correctness, data-loss, and security bugs

### DIFF
--- a/src-tauri/src/clients.rs
+++ b/src-tauri/src/clients.rs
@@ -1534,7 +1534,11 @@ pub fn parse_snippet(content: &str) -> Result<Vec<ParsedSnippetServer>, String> 
 fn launcher_base(command: &str) -> String {
     let file = command.rsplit(['/', '\\']).next().unwrap_or(command);
     let lower = file.to_ascii_lowercase();
-    for ext in [".exe", ".cmd", ".ps1"] {
+    // `.bat` belongs here too: a Node install can put `npx.bat` on PATH, and omitting it
+    // made launcher_package_arg return None, so two servers running different packages
+    // under one display name collapsed to a single import (and a bare paste got named
+    // "npx"). `launcher::command_base` already strips all four for the same role.
+    for ext in [".exe", ".cmd", ".bat", ".ps1"] {
         if let Some(stripped) = lower.strip_suffix(ext) {
             return stripped.to_string();
         }

--- a/src-tauri/src/codemode.rs
+++ b/src-tauri/src/codemode.rs
@@ -846,12 +846,12 @@ fn drive_to_completion(
         }
 
         let Some(obj) = top.as_object() else {
-            return Ok(top.to_json(context).ok().flatten().unwrap_or(Value::Null));
+            return json_from_js(context, &top);
         };
         let promise = match JsPromise::from_object(obj.clone()) {
             Ok(p) => p,
             Err(_) => {
-                return Ok(top.to_json(context).ok().flatten().unwrap_or(Value::Null));
+                return json_from_js(context, &top);
             }
         };
 
@@ -864,7 +864,7 @@ fn drive_to_completion(
                 )));
             }
             PromiseState::Fulfilled(value) => {
-                return Ok(value.to_json(context).ok().flatten().unwrap_or(Value::Null));
+                return json_from_js(context, &value);
             }
             PromiseState::Rejected(reason) => {
                 let msg = reason
@@ -881,6 +881,45 @@ fn drive_to_completion(
     Err(JsError::from_native(JsNativeError::error().with_message(
         "toolport script exceeded internal async drive budget",
     )))
+}
+
+/// Convert a script's return value to JSON through JS `JSON.stringify`, the same boundary
+/// the prelude already uses for tool arguments and results.
+///
+/// Not `JsValue::to_json`: that is a host-side walk of internal property slots, so it never
+/// runs `toJSON()` and never sees accessors. A `Date` has no own enumerable properties and
+/// came back as `{}`; a `BigInt` produced an `Err` that the old call sites discarded with
+/// `.ok().flatten().unwrap_or(Value::Null)`. Either way the script reported success with
+/// the data gone, which the agent cannot distinguish from a real `null` return.
+///
+/// Going through `JSON.stringify` gives `Date` its ISO-8601 string and turns values that
+/// genuinely cannot be represented (`BigInt`, cyclic structures) into a thrown `TypeError`
+/// we surface as a script error. `undefined` — a script that returned nothing — stays
+/// `null`, matching [`ScriptOutcome::value`]'s contract.
+fn json_from_js(context: &mut Context, value: &JsValue) -> Result<Value, JsError> {
+    let json = context.global_object().get(js_string!("JSON"), context)?;
+    let stringify = json
+        .as_object()
+        .ok_or_else(|| type_error("JSON is not an object"))?
+        .get(js_string!("stringify"), context)?
+        .as_callable()
+        .ok_or_else(|| type_error("JSON.stringify is not callable"))?;
+
+    let encoded = stringify.call(&JsValue::undefined(), &[value.clone()], context)?;
+    let Some(text) = encoded.as_string() else {
+        // `JSON.stringify(undefined)` is `undefined`: the script returned nothing.
+        return Ok(Value::Null);
+    };
+
+    serde_json::from_str(&text.to_std_string_escaped()).map_err(|e| {
+        JsError::from_native(JsNativeError::typ().with_message(format!(
+            "script return value could not be encoded as JSON: {e}"
+        )))
+    })
+}
+
+fn type_error(message: &str) -> JsError {
+    JsError::from_native(JsNativeError::typ().with_message(message.to_string()))
 }
 
 /// Take queued `callAsync` work, run it with bounded host-side parallelism, resolve each
@@ -1047,6 +1086,88 @@ mod tests {
         assert_eq!(progress_names(&out), vec!["first", "second"]);
         assert!(out.progress.iter().all(|c| c.ok));
         assert_eq!(out.calls, 2);
+    }
+
+    /// A binding no return-value test needs, since none of them call a tool.
+    fn no_calls() -> CallBinding {
+        Arc::new(|_name: &str, _args: Value| json!({}))
+    }
+
+    fn returns(script: &str) -> ScriptOutcome {
+        run(script, json!({}), no_calls(), Limits::default())
+    }
+
+    #[test]
+    fn a_returned_date_survives_as_its_instant() {
+        // SBS-631: boa's to_json walks internal slots, so it never ran Date's toJSON()
+        // and the instant arrived as {} under a successful outcome.
+        let out = returns("return new Date(0);");
+
+        assert_eq!(out.error, None, "unexpected error: {:?}", out.error);
+        assert_eq!(out.value, json!("1970-01-01T00:00:00.000Z"));
+    }
+
+    #[test]
+    fn a_returned_bigint_fails_closed_instead_of_reporting_null() {
+        // The old path produced `Err` here and then dropped it on the floor with
+        // `.ok().flatten().unwrap_or(Value::Null)`, so the agent saw a successful
+        // `null` id. A false success is worse than an error it can recover from.
+        let out = returns("return 9007199254740993n;");
+
+        let err = out.error.expect("BigInt cannot be represented in JSON");
+        assert!(
+            err.to_lowercase().contains("bigint"),
+            "error should name the unrepresentable type, got: {err}"
+        );
+    }
+
+    #[test]
+    fn dates_nested_in_a_returned_structure_survive_too() {
+        // Aggregation output is where this actually bit: the timestamp is a field on
+        // a row, not the whole return value.
+        let out = returns(r#"return { ranAt: new Date(0), rows: [{ at: new Date(0) }] };"#);
+
+        assert_eq!(out.error, None, "unexpected error: {:?}", out.error);
+        assert_eq!(
+            out.value,
+            json!({
+                "ranAt": "1970-01-01T00:00:00.000Z",
+                "rows": [{ "at": "1970-01-01T00:00:00.000Z" }],
+            })
+        );
+    }
+
+    #[test]
+    fn a_cyclic_return_value_is_an_error_not_an_empty_success() {
+        let out = returns("const a = {}; a.self = a; return a;");
+
+        let err = out.error.expect("a cycle cannot be encoded as JSON");
+        assert!(
+            err.to_lowercase().contains("circular") || err.to_lowercase().contains("cyclic"),
+            "error should explain the cycle, got: {err}"
+        );
+    }
+
+    #[test]
+    fn returning_nothing_is_still_a_successful_null() {
+        // `JSON.stringify(undefined)` is `undefined`, not a string. That has to stay a
+        // successful null rather than falling into the encode-failure branch.
+        let out = returns("return;");
+
+        assert_eq!(out.error, None, "unexpected error: {:?}", out.error);
+        assert_eq!(out.value, json!(null));
+    }
+
+    #[test]
+    fn ordinary_return_values_are_unchanged() {
+        // The conversion swap must not disturb the shapes scripts actually return.
+        let out = returns(r#"return { n: 1, s: "x", b: true, nil: null, arr: [1, 2] };"#);
+
+        assert_eq!(out.error, None, "unexpected error: {:?}", out.error);
+        assert_eq!(
+            out.value,
+            json!({ "n": 1, "s": "x", "b": true, "nil": null, "arr": [1, 2] })
+        );
     }
 
     #[test]

--- a/src-tauri/src/integrity.rs
+++ b/src-tauri/src/integrity.rs
@@ -634,7 +634,16 @@ fn load_quarantine(profile: Option<&str>) -> Result<Quarantine, String> {
 /// Parse quarantine JSON. Shared by disk load and the mtime-cached read path.
 fn parse_quarantine_raw(raw: &str, path: &Path) -> Result<Quarantine, String> {
     if raw.trim().is_empty() {
-        return Ok(Quarantine::new());
+        // An empty store is a LOST store, not a fresh start — the same reasoning
+        // `load_pins` already applies to an empty baseline. `atomic_write` (temp + fsync
+        // + rename) never leaves an empty file, and a release always writes at least
+        // `{}`, so emptiness means truncation or a wipe. Treating it as "nothing
+        // quarantined" silently re-exposes every tool held after high-risk drift or
+        // baseline tamper, which is exactly the fail-open SOU-320 closed for corrupt JSON.
+        return Err(format!(
+            "quarantine store at {path:?} is empty, which means it was truncated or wiped; \
+             refusing to treat that as an empty quarantine set"
+        ));
     }
     match serde_json::from_str::<Quarantine>(raw) {
         // A destructive tool APPEARING (first sight) is no longer quarantine-worthy: that

--- a/src-tauri/src/remote.rs
+++ b/src-tauri/src/remote.rs
@@ -511,8 +511,12 @@ fn require_secure_for_auth(url: &str) -> Result<(), String> {
     if oauth::host_is_definitely_private(&host) {
         return Ok(());
     }
+    // Redact before interpolating: this message reaches the activity UI, client error
+    // text, and any log that records the failure, and a URL of the form
+    // `http://user:hunter2@host/mcp` would carry the password into all three.
+    let shown = crate::registry::redact_url_userinfo(url);
     Err(format!(
-        "refusing to send the saved auth token to a non-HTTPS URL ({url}); \
+        "refusing to send the saved auth token to a non-HTTPS URL ({shown}); \
          use https for an authenticated remote server"
     ))
 }
@@ -822,6 +826,38 @@ mod tests {
         assert!(is_auth_error("HTTP 401"));
         assert!(is_auth_error("server said 403."));
         assert!(is_auth_error("(403)"));
+    }
+
+    #[test]
+    fn refusing_cleartext_auth_does_not_echo_url_credentials() {
+        // The refusal message reaches the activity UI, client error text, and logs. A
+        // password in the URL would ride along into all three, which is the leak this
+        // error was supposed to prevent in the first place.
+        let err = require_secure_for_auth("http://user:hunter2@8.8.8.8/mcp")
+            .expect_err("cleartext auth to a public host must be refused");
+
+        assert!(
+            !err.contains("hunter2"),
+            "credentials leaked into the error: {err}"
+        );
+        assert!(
+            err.contains("8.8.8.8"),
+            "the host has to survive or the error is unactionable: {err}"
+        );
+    }
+
+    #[test]
+    fn a_cleartext_url_without_credentials_is_reported_as_written() {
+        let err = require_secure_for_auth("http://8.8.8.8/mcp")
+            .expect_err("cleartext auth to a public host must be refused");
+        assert!(err.contains("http://8.8.8.8/mcp"), "got: {err}");
+    }
+
+    #[test]
+    fn private_and_https_hosts_are_still_allowed() {
+        // Redaction must not change which URLs are accepted.
+        assert!(require_secure_for_auth("https://mcp.example.com/mcp").is_ok());
+        assert!(require_secure_for_auth("http://127.0.0.1:4000/mcp").is_ok());
     }
 
     fn oauth_state(expires_at: Option<u64>, refresh_token: Option<&str>) -> OAuthState {

--- a/src-tauri/src/router.rs
+++ b/src-tauri/src/router.rs
@@ -190,6 +190,16 @@ fn regex_is_match(pattern: &str, text: &str) -> bool {
     match_simple_pattern(inner, text)
 }
 
+/// Byte offsets just past each char of `s`, longest prefix first — the lengths a greedy
+/// variable segment should try, in greedy order.
+///
+/// Backtracking used to count raw bytes (`(1..=end).rev()`), which slices mid-codepoint
+/// and panics on any multi-byte URI: matching `file://café` against `file://{name}é`
+/// took the router down. Only whole chars are valid stopping points.
+fn char_end_offsets(s: &str) -> impl Iterator<Item = usize> + '_ {
+    s.char_indices().map(|(i, c)| i + c.len_utf8()).rev()
+}
+
 fn match_simple_pattern(mut pattern: &str, mut text: &str) -> bool {
     // Iterative literal consumption keeps recursion depth proportional to the
     // number of placeholders, not the URI length. Variable branches still
@@ -204,7 +214,7 @@ fn match_simple_pattern(mut pattern: &str, mut text: &str) -> bool {
                 return false;
             }
             let end = text.find('/').unwrap_or(text.len());
-            for take in (1..=end).rev() {
+            for take in char_end_offsets(&text[..end]) {
                 if match_simple_pattern(rest, &text[take..]) {
                     return true;
                 }
@@ -215,7 +225,7 @@ fn match_simple_pattern(mut pattern: &str, mut text: &str) -> bool {
             if text.is_empty() {
                 return false;
             }
-            for take in (1..=text.len()).rev() {
+            for take in char_end_offsets(text) {
                 if match_simple_pattern(rest, &text[take..]) {
                     return true;
                 }

--- a/src-tauri/tests/audit_codemode_return_loss.rs
+++ b/src-tauri/tests/audit_codemode_return_loss.rs
@@ -1,0 +1,75 @@
+//! Repro from SBS-631: code mode silently corrupted Date/BigInt return values to `{}` or
+//! `null` and still reported success. Kept as the ticket filed it so the acceptance
+//! criteria stay checkable from outside the crate.
+use conduit_lib::codemode::{run_script, Limits};
+use serde_json::json;
+use std::sync::Arc;
+
+fn run(script: &str) -> conduit_lib::codemode::ScriptOutcome {
+    run_script(
+        script,
+        json!({}),
+        Arc::new(|_n, _a| json!({})),
+        None,
+        Limits::default(),
+        &[],
+    )
+}
+
+/// Code mode must not report success when the script's return value was
+/// silently replaced with null or {}.
+#[test]
+fn date_return_must_preserve_instant_or_error() {
+    let outcome = run("return new Date(0);");
+    // A successful Date return must carry the instant (ISO string or epoch),
+    // not an empty object that looks like success with no data.
+    assert!(
+        outcome.error.is_some()
+            || outcome.value.as_str().is_some()
+            || outcome.value.as_i64().is_some()
+            || outcome.value.as_f64().is_some()
+            || outcome.value.get("$date").is_some()
+            || (outcome.value.is_object()
+                && outcome
+                    .value
+                    .as_object()
+                    .map(|o| !o.is_empty())
+                    .unwrap_or(false)),
+        "Date(0) return was silently corrupted: value={:?} error={:?}",
+        outcome.value,
+        outcome.error
+    );
+}
+
+#[test]
+fn bigint_return_must_not_become_null_success() {
+    let outcome = run("return 9007199254740993n;");
+    assert!(
+        !(outcome.error.is_none() && outcome.value == json!(null)),
+        "BigInt became null success: value={:?} error={:?}",
+        outcome.value,
+        outcome.error
+    );
+}
+
+#[test]
+fn nested_date_in_array_must_not_become_empty_object() {
+    let outcome = run("return [new Date(0), 1];");
+    assert!(outcome.error.is_none() || outcome.value != json!(null));
+    if outcome.error.is_some() {
+        return; // fail-closed is acceptable
+    }
+    let arr = outcome
+        .value
+        .as_array()
+        .expect("successful return should be an array");
+    assert_eq!(arr.len(), 2);
+    assert!(
+        arr[0].as_str().is_some()
+            || arr[0].as_i64().is_some()
+            || arr[0].as_f64().is_some()
+            || (arr[0].is_object() && !arr[0].as_object().unwrap().is_empty()),
+        "Date in array corrupted to {:?}",
+        arr[0]
+    );
+}

--- a/src-tauri/tests/quarantine_empty_truncation.rs
+++ b/src-tauri/tests/quarantine_empty_truncation.rs
@@ -1,0 +1,132 @@
+//! Repro: an empty quarantine store file must fail closed, not silently unblock.
+//!
+//! Pin baselines treat a present-but-empty file as a lost/corrupt baseline
+//! (`PinsLoad::Corrupt`) because `atomic_write` never leaves an empty file.
+//! Quarantine currently treats empty as "nothing blocked" (`Ok(empty set)`), which
+//! drops every quarantine record and re-exposes tools that were deliberately held.
+
+use serde_json::json;
+
+/// `DataDirOverride` is process-global, so every test in this binary that resolves the
+/// data dir has to serialize against every other one — otherwise a test reads a sibling's
+/// scratch directory. The library's own `data_dir_test_lock` is `pub(crate)`, so an
+/// integration test has to bring its own.
+static DATA_DIR: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+fn data_dir_guard() -> std::sync::MutexGuard<'static, ()> {
+    DATA_DIR
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+}
+
+fn scratch_dir(tag: &str) -> std::path::PathBuf {
+    let dir = std::env::temp_dir().join(format!(
+        "toolport-q-{tag}-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0)
+    ));
+    std::fs::create_dir_all(&dir).expect("scratch data dir");
+    dir
+}
+
+fn quarantine_a_destructive_tool(profile: Option<&str>) {
+    let current = vec![json!({
+        "name": "srv__wipe",
+        "description": "Wipe everything.",
+        "inputSchema": { "type": "object" },
+        "annotations": { "destructiveHint": true }
+    })];
+    let events = vec![json!({
+        "ts": 1,
+        "type": "tool_drift",
+        "server": "srv",
+        "tool": "srv__wipe",
+        "change": "changed",
+        "severity": "high",
+    })];
+    assert!(
+        conduit_lib::integrity::apply_quarantine(profile, &current, &events),
+        "destructive change must quarantine"
+    );
+}
+
+#[test]
+fn empty_quarantine_file_must_not_silently_unblock() {
+    let dir = scratch_dir("empty-trunc");
+    let _lock = data_dir_guard();
+    let _data_dir = conduit_lib::registry::DataDirOverride::set(&dir);
+
+    let profile = Some("q-empty-trunc");
+    quarantine_a_destructive_tool(profile);
+    let blocked = conduit_lib::integrity::quarantined(profile).expect("readable store");
+    assert!(
+        blocked.contains("srv__wipe"),
+        "tool must be quarantined before truncation"
+    );
+
+    // Present-but-empty is not a legitimate first-run state: a clean install has no
+    // file at all, and a full release writes `{}`. Emptiness is truncation or wipe.
+    let path = dir.join("quarantine-q-empty-trunc.json");
+    assert!(
+        path.is_file(),
+        "quarantine store should exist at {}",
+        path.display()
+    );
+    std::fs::write(&path, "").expect("truncate quarantine store to empty");
+
+    // Fail closed: same class of failure as corrupt JSON (SOU-320). Returning Ok({})
+    // here permanently loses every quarantine record and unblocks the tool.
+    let after = conduit_lib::integrity::quarantined(profile);
+    assert!(
+        after.is_err(),
+        "empty quarantine file must fail closed like a corrupt store, got Ok({:?})",
+        after.ok()
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn a_missing_quarantine_file_is_still_an_empty_set() {
+    // First run has no file at all. That must stay a legitimate empty set, or every
+    // clean install would refuse to serve tools.
+    let dir = scratch_dir("absent");
+    let _lock = data_dir_guard();
+    let _data_dir = conduit_lib::registry::DataDirOverride::set(&dir);
+
+    let blocked = conduit_lib::integrity::quarantined(Some("q-absent"))
+        .expect("a missing store is a fresh start, not a failure");
+    assert!(blocked.is_empty());
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn an_empty_store_also_blocks_rewrites_that_would_erase_it() {
+    // `release` and `apply_quarantine` both refuse to act on a store they could not
+    // load, so an empty file must not become a `{}` write that makes the loss permanent.
+    let dir = scratch_dir("no-rewrite");
+    let _lock = data_dir_guard();
+    let _data_dir = conduit_lib::registry::DataDirOverride::set(&dir);
+
+    let profile = Some("q-no-rewrite");
+    quarantine_a_destructive_tool(profile);
+
+    let path = dir.join("quarantine-q-no-rewrite.json");
+    std::fs::write(&path, "").expect("truncate quarantine store to empty");
+
+    assert!(
+        !conduit_lib::integrity::release(profile, "srv__wipe"),
+        "release must refuse while the store is unreadable"
+    );
+    assert_eq!(
+        std::fs::read_to_string(&path).expect("store still present"),
+        "",
+        "the broken store must be left for inspection, not overwritten"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}

--- a/src-tauri/tests/repro_npx_bat_launcher_base.rs
+++ b/src-tauri/tests/repro_npx_bat_launcher_base.rs
@@ -28,7 +28,8 @@ fn npx_bat_must_dedupe_by_package_like_npx_cmd() {
 fn parse_snippet_names_package_for_npx_bat() {
     use conduit_lib::clients::parse_snippet;
 
-    let json = r#"{"command":"C:\\Program Files\\nodejs\\npx.bat","args":["-y","@acme/mcp-weather"]}"#;
+    let json =
+        r#"{"command":"C:\\Program Files\\nodejs\\npx.bat","args":["-y","@acme/mcp-weather"]}"#;
     let servers = parse_snippet(json).expect("parse");
     assert_eq!(servers.len(), 1);
     assert_eq!(

--- a/src-tauri/tests/repro_npx_bat_launcher_base.rs
+++ b/src-tauri/tests/repro_npx_bat_launcher_base.rs
@@ -1,0 +1,57 @@
+//! Repro: clients::launcher_base omits .bat, so npx.bat loses package identity.
+
+#[test]
+fn npx_bat_must_dedupe_by_package_like_npx_cmd() {
+    use conduit_lib::clients::import_dedupe_key;
+
+    let args_a = vec!["-y".into(), "@acme/mcp-weather".into()];
+    let args_b = vec!["-y".into(), "@other/mcp-weather".into()];
+    let cmd_bat = r"C:\Program Files\nodejs\npx.bat";
+    let cmd_cmd = r"C:\Program Files\nodejs\npx.cmd";
+
+    let k_cmd_a = import_dedupe_key("weather", Some(cmd_cmd), &args_a);
+    let k_cmd_b = import_dedupe_key("weather", Some(cmd_cmd), &args_b);
+    assert_ne!(
+        k_cmd_a, k_cmd_b,
+        "npx.cmd must distinguish packages (control); got {k_cmd_a} vs {k_cmd_b}"
+    );
+
+    let k_bat_a = import_dedupe_key("weather", Some(cmd_bat), &args_a);
+    let k_bat_b = import_dedupe_key("weather", Some(cmd_bat), &args_b);
+    assert_ne!(
+        k_bat_a, k_bat_b,
+        "npx.bat must distinguish packages the same way as npx.cmd; got {k_bat_a} vs {k_bat_b}"
+    );
+}
+
+#[test]
+fn parse_snippet_names_package_for_npx_bat() {
+    use conduit_lib::clients::parse_snippet;
+
+    let json = r#"{"command":"C:\\Program Files\\nodejs\\npx.bat","args":["-y","@acme/mcp-weather"]}"#;
+    let servers = parse_snippet(json).expect("parse");
+    assert_eq!(servers.len(), 1);
+    assert_eq!(
+        servers[0].name, "weather",
+        "npx.bat must resolve the package name like npx.cmd; got {}",
+        servers[0].name
+    );
+}
+
+#[test]
+fn a_plain_bat_program_is_still_its_own_identity() {
+    use conduit_lib::clients::import_dedupe_key;
+
+    // Stripping `.bat` must only affect the *runner* lookup. A normal batch program is
+    // not a package runner, so its identity stays the command itself and two servers
+    // with the same display name must not collapse on differing args.
+    let key = import_dedupe_key(
+        "weather",
+        Some(r"C:\tools\my-server.bat"),
+        &["--port".to_string(), "1".to_string()],
+    );
+    assert!(
+        !key.contains("package:"),
+        "a plain .bat program is not a package runner, got {key}"
+    );
+}

--- a/src-tauri/tests/uri_template_multibyte_panic.rs
+++ b/src-tauri/tests/uri_template_multibyte_panic.rs
@@ -1,0 +1,46 @@
+//! Reproduction: `uri_matches_template` panics on multi-byte path segments when
+//! the matcher must backtrack off a char boundary (router resource routing).
+
+use conduit_lib::router::uri_matches_template;
+
+#[test]
+fn uri_matches_template_multibyte_backtrack_does_not_panic() {
+    // "café" is 5 UTF-8 bytes (é is two bytes). The Level-1 matcher walks the
+    // variable segment with raw byte indices; when the trailing literal forces
+    // backtrack, a non-boundary index slices the string and panics.
+    //
+    // Expected: a bool (true if the URI is an expansion of the template).
+    // Actual on origin/main: panic "byte index is not a char boundary".
+    let uri = "file://café";
+    let template = "file://{name}é";
+    let matched = uri_matches_template(uri, template);
+    assert!(
+        matched,
+        "file://café should match Level-1 template file://{{name}}é"
+    );
+}
+
+#[test]
+fn ascii_template_matching_is_unchanged() {
+    // Guard the existing Level-1 and {+var} results while the backtrack walk changes
+    // from byte offsets to char offsets.
+    assert!(uri_matches_template(
+        "fixture://item/06",
+        "fixture://item/{id}"
+    ));
+    assert!(!uri_matches_template(
+        "fixture://item/06/extra",
+        "fixture://item/{id}"
+    ));
+    assert!(uri_matches_template(
+        "file:///a/b/c.txt",
+        "file:///{+path}"
+    ));
+}
+
+#[test]
+fn multibyte_reserved_expansion_also_survives() {
+    // `{+var}` uses the `.+` branch, which had the same raw-byte backtrack.
+    assert!(uri_matches_template("file:///naïve/päth.txt", "file:///{+path}"));
+    assert!(uri_matches_template("file:///日本語/x", "file:///{+path}"));
+}

--- a/src-tauri/tests/uri_template_multibyte_panic.rs
+++ b/src-tauri/tests/uri_template_multibyte_panic.rs
@@ -32,15 +32,15 @@ fn ascii_template_matching_is_unchanged() {
         "fixture://item/06/extra",
         "fixture://item/{id}"
     ));
-    assert!(uri_matches_template(
-        "file:///a/b/c.txt",
-        "file:///{+path}"
-    ));
+    assert!(uri_matches_template("file:///a/b/c.txt", "file:///{+path}"));
 }
 
 #[test]
 fn multibyte_reserved_expansion_also_survives() {
     // `{+var}` uses the `.+` branch, which had the same raw-byte backtrack.
-    assert!(uri_matches_template("file:///naïve/päth.txt", "file:///{+path}"));
+    assert!(uri_matches_template(
+        "file:///naïve/päth.txt",
+        "file:///{+path}"
+    ));
     assert!(uri_matches_template("file:///日本語/x", "file:///{+path}"));
 }


### PR DESCRIPTION
Five independent Toolport bugs, one commit each, all with the reproductions from their tickets.

| Commit | Ticket | What it fixes |
|---|---|---|
| `aa2cbbc` | SBS-631 | Code mode silently corrupted `Date`/`BigInt` script return values |
| `5953fdb` | SBS-620 | URI template matcher panicked on multi-byte segments |
| `ec97fcc` | SBS-654 | An empty quarantine store silently unblocked every held tool |
| `6931b42` | SBS-664 | `npx.bat` lost package identity on import and paste |
| `c1b6e72` | SBS-636 | Cleartext-auth refusal echoed URL-embedded credentials |

---

### SBS-631 — code mode return values

`drive_to_completion` used boa's `JsValue::to_json`, a host-side walk of internal property slots that never runs `toJSON()`. A `Date` has no own enumerable properties, so it arrived as `{}`. A `BigInt` *did* produce an `Err` — which the three call sites discarded with `.ok().flatten().unwrap_or(Value::Null)`. Both reported `error: None`, so the agent saw a successful outcome with the data gone and could not tell it from a real `null` return.

Route the value through JS `JSON.stringify`, the boundary the prelude already uses for tool arguments and results. `Date` keeps its instant; `BigInt` and cycles fail closed.

### SBS-620 — URI template panic

`match_simple_pattern` backtracked with raw byte indices (`(1..=end).rev()`) and sliced the URI at each. Any multi-byte character put that index mid-codepoint and panicked — `file://café` against `file://{name}é` took the router down, and `catch_unwind` turned it into a JSON-RPC internal error for a URI that was a valid expansion. Walks char end offsets now. Both the `[^/]+` and `.+` branches had it.

### SBS-654 — empty quarantine store

`parse_quarantine_raw` read a present-but-empty file as an empty quarantine set, silently re-exposing every tool held after high-risk drift or baseline tamper. `atomic_write` never leaves an empty file and a release always writes at least `{}`, so emptiness means truncation. `load_pins` already reaches that conclusion for an empty baseline, and SOU-320 closed the same fail-open for corrupt JSON — empty was just left behind. `release` and `apply_quarantine` already refuse to rewrite a store they could not load, so a truncated file is now left for inspection.

### SBS-664 — `npx.bat`

`launcher_base` stripped only `.exe`/`.cmd`/`.ps1`, so `launcher_package_arg` returned `None` for `.bat` and two servers running different packages under one display name collapsed to a single import. `launcher::command_base` already strips all four.

### SBS-636 — credential leak

`require_secure_for_auth` interpolated the raw URL, so `http://user:hunter2@host/mcp` put the password into the activity UI, client error text, and logs — leaking the credential the refusal exists to protect. Now goes through `registry::redact_url_userinfo`; the host still shows.

## Verification

- Each ticket's verbatim repro committed and passing (failing on `main` before)
- `cargo test --manifest-path src-tauri/Cargo.toml` — **808 library + 238 gateway + all integration/spec-conformance pass**
- `cargo fmt --check` — no new drift from any file in this PR (the repo's pre-existing drift is untouched)

## Note on the tests

The SBS-654 tests need a file-local mutex: `DataDirOverride` is process-global and the library's own `data_dir_test_lock` is `pub(crate)`, so integration tests in the same binary have to serialize themselves. The ticket's repro only worked because it was alone in its binary — worth knowing before adding a second data-dir test anywhere.