### PR TITLE
fix: correctness batch — audit paging, receipt hash, clippy blocker, OAuth refresh race

### DIFF
--- a/src-tauri/src/audit.rs
+++ b/src-tauri/src/audit.rs
@@ -406,14 +406,17 @@ pub fn read_recent(limit: usize) -> Vec<Value> {
         Ok(c) => c,
         Err(_) => return Vec::new(),
     };
-    let mut entries: Vec<Value> = content
+    // Filter BEFORE take, matching `inspect::read_recent` and `searchtrace`. Taking
+    // first let an unparseable line consume a slot, so one corrupt row among the
+    // newest entries returned a short page and dropped older valid history that
+    // should have filled it.
+    let entries: Vec<Value> = content
         .lines()
         .rev()
-        .take(limit)
         .filter_map(|line| serde_json::from_str(line).ok())
+        .take(limit)
         .collect();
-    // `rev().take()` gives newest-first already.
-    entries.truncate(limit);
+    // `rev()` gives newest-first already.
     entries
 }
 

--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -6590,78 +6590,84 @@ fn handle_resource_subscription(
     let session = active_resource_session_id();
     match method {
         "resources/subscribe" => {
-            // Single-flight loop: leaders open downstream; waiters re-enter after
-            // the gate resolves so they either join or see a fail-closed error.
-            loop {
-                let begin = {
-                    let mut table = state
-                        .resource_subs
-                        .lock()
-                        .unwrap_or_else(std::sync::PoisonError::into_inner);
-                    match table.begin_subscribe(&session, uri, &owner) {
-                        Ok(b) => b,
-                        Err(e) => {
-                            return Some(error(id, -32602, &format!("Toolport: {e}")));
-                        }
+            // Single-flight: the first caller opens downstream, the rest wait on the
+            // gate and then either join the open subscription or inherit the leader's
+            // error. Deliberately fail-closed -- a waiter does NOT retry as a new leader,
+            // so one failed open cannot turn N parked waiters into N retries against a
+            // server that just failed.
+            //
+            // This was a `loop` whose every arm returned, so it never iterated. The comment
+            // described a waiter re-entry the code never performed (SBS-434 item 4), and
+            // clippy's deny-by-default never_loop was the one hard error blocking a
+            // -D warnings gate in CI.
+            let begin = {
+                let mut table = state
+                    .resource_subs
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner);
+                match table.begin_subscribe(&session, uri, &owner) {
+                    Ok(b) => b,
+                    Err(e) => {
+                        return Some(error(id, -32602, &format!("Toolport: {e}")));
                     }
-                };
-                match begin {
-                    BeginSubscribe::AlreadyLocal | BeginSubscribe::Joined => {
-                        return Some(success(id, json!({})));
-                    }
-                    BeginSubscribe::Lead(gate) => {
-                        // If subscribe_resource panics, Drop clears `opening` and
-                        // fails waiters instead of parking them forever (WS1-4).
-                        let mut lead_guard = LeadOpenGuard {
-                            state,
-                            uri: uri.to_string(),
-                            gate: Arc::clone(&gate),
-                            armed: true,
-                        };
-                        match router.subscribe_resource(uri) {
-                            Ok(_) => {
-                                let mut table = state
-                                    .resource_subs
-                                    .lock()
-                                    .unwrap_or_else(std::sync::PoisonError::into_inner);
-                                table.finish_open_ok(uri, &gate);
-                                lead_guard.disarm();
-                                return Some(success(id, json!({})));
-                            }
-                            Err(e) => {
-                                let msg = integrity::defend_error_text(uri, &e);
-                                let mut table = state
-                                    .resource_subs
-                                    .lock()
-                                    .unwrap_or_else(std::sync::PoisonError::into_inner);
-                                table.finish_open_err(uri, &gate, msg.clone());
-                                lead_guard.disarm();
-                                return Some(error(
-                                    id,
-                                    -32602,
-                                    &format!("Toolport: {msg}"),
-                                ));
-                            }
-                        }
-                    }
-                    BeginSubscribe::Wait(gate) => match gate.wait() {
-                        Ok(()) => {
+                }
+            };
+            match begin {
+                BeginSubscribe::AlreadyLocal | BeginSubscribe::Joined => {
+                    return Some(success(id, json!({})));
+                }
+                BeginSubscribe::Lead(gate) => {
+                    // If subscribe_resource panics, Drop clears `opening` and
+                    // fails waiters instead of parking them forever (WS1-4).
+                    let mut lead_guard = LeadOpenGuard {
+                        state,
+                        uri: uri.to_string(),
+                        gate: Arc::clone(&gate),
+                        armed: true,
+                    };
+                    match router.subscribe_resource(uri) {
+                        Ok(_) => {
                             let mut table = state
                                 .resource_subs
                                 .lock()
                                 .unwrap_or_else(std::sync::PoisonError::into_inner);
-                            match table.join_open(&session, uri, &owner) {
-                                Ok(()) => return Some(success(id, json!({}))),
-                                Err(e) => {
-                                    return Some(error(id, -32602, &format!("Toolport: {e}")));
-                                }
-                            }
+                            table.finish_open_ok(uri, &gate);
+                            lead_guard.disarm();
+                            return Some(success(id, json!({})));
                         }
                         Err(e) => {
-                            return Some(error(id, -32602, &format!("Toolport: {e}")));
+                            let msg = integrity::defend_error_text(uri, &e);
+                            let mut table = state
+                                .resource_subs
+                                .lock()
+                                .unwrap_or_else(std::sync::PoisonError::into_inner);
+                            table.finish_open_err(uri, &gate, msg.clone());
+                            lead_guard.disarm();
+                            return Some(error(
+                                id,
+                                -32602,
+                                &format!("Toolport: {msg}"),
+                            ));
                         }
-                    },
+                    }
                 }
+                BeginSubscribe::Wait(gate) => match gate.wait() {
+                    Ok(()) => {
+                        let mut table = state
+                            .resource_subs
+                            .lock()
+                            .unwrap_or_else(std::sync::PoisonError::into_inner);
+                        match table.join_open(&session, uri, &owner) {
+                            Ok(()) => return Some(success(id, json!({}))),
+                            Err(e) => {
+                                return Some(error(id, -32602, &format!("Toolport: {e}")));
+                            }
+                        }
+                    }
+                    Err(e) => {
+                        return Some(error(id, -32602, &format!("Toolport: {e}")));
+                    }
+                },
             }
         }
         "resources/unsubscribe" => {

--- a/src-tauri/src/instructions.rs
+++ b/src-tauri/src/instructions.rs
@@ -19,9 +19,6 @@
 //! a remove takes the managed span back out, so a full join→edit→leave cycle returns the
 //! user's own content unchanged.
 
-use std::collections::hash_map::DefaultHasher;
-use std::hash::{Hash, Hasher};
-
 /// How a client's rules file is written.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Strategy {
@@ -110,10 +107,20 @@ fn start_marker(team_id: &str, version: i64) -> String {
 /// Stable content hash reported to the server as the "effective rules receipt": it identifies
 /// exactly the org content a client wrote to disk. Not cryptographic — only needs to detect
 /// change and let the dashboard prove on-disk == the pushed version.
+///
+/// SHA-256 truncated to 16 hex chars, NOT `DefaultHasher`. "Stable" here means stable across
+/// toolchains, not just within one build: this value is reported to the org server and used
+/// as a dedupe fingerprint, and `DefaultHasher`'s algorithm carries no cross-release
+/// guarantee. A Rust bump would silently change every member's reported hash and light up the
+/// coverage dashboard with drift that never happened (SBS-460). Width is unchanged, so the
+/// server sees the same shape.
 pub fn content_hash(content: &str) -> String {
-    let mut h = DefaultHasher::new();
-    content.hash(&mut h);
-    format!("{:016x}", h.finish())
+    use sha2::{Digest, Sha256};
+    let mut hasher = Sha256::new();
+    hasher.update(content.as_bytes());
+    let digest = hasher.finalize();
+    // 8 bytes -> the same 16 hex chars DefaultHasher's u64 produced.
+    digest[..8].iter().map(|b| format!("{b:02x}")).collect()
 }
 
 /// Render the full body of an [`Strategy::OwnedFile`] file (header + a blank line + content).

--- a/src-tauri/src/remote.rs
+++ b/src-tauri/src/remote.rs
@@ -343,7 +343,78 @@ fn uses_client_credentials(server: &ServerEntry) -> bool {
 
 /// Use the stored refresh token to mint a fresh access token, vault it, and
 /// return it.
+/// Cross-process lock serializing programmatic refresh for one server.
+///
+/// The desktop app's health probe and the gateway are separate processes sharing one
+/// keychain. Both could read RT0, both POST `/token`, and a provider with refresh-token
+/// reuse detection revokes the whole family — the exact failure the in-process guard was
+/// added to prevent, reached by another route (SBS-479). The app's existing OAuth lock
+/// covers only the interactive browser flow.
+///
+/// Best-effort by design: with no resolvable data dir there is nowhere to put a lock, and
+/// refusing to refresh at all would be worse than the race it prevents. `lock_at` is
+/// bounded-blocking (retries for a few seconds), so a slow winner delays the loser rather
+/// than failing it.
+fn lock_oauth_refresh(server_id: &str) -> Option<crate::registry::FileLock> {
+    let dir = crate::registry::conduit_dir()?;
+    let leaf = format!(
+        "oauth-refresh-{}.lock",
+        crate::router::sanitize_segment(server_id)
+    );
+    crate::registry::lock_at(&dir.join(leaf)).ok()
+}
+
+/// After winning the refresh lock, decide whether another process already did the work.
+///
+/// Compares the vaulted access token against the snapshot taken BEFORE the lock. Unchanged
+/// means the refresh is still ours to do. Changed means someone rotated it while we were
+/// parked, so we use theirs rather than spending a second exchange on a refresh token they
+/// have already invalidated.
+///
+/// A rotated-but-already-expired token is not reusable, so that falls through and refreshes
+/// normally.
+fn refreshed_while_waiting(server_id: &str, before: Option<&str>) -> Option<RefreshedToken> {
+    let current = secrets::get_secret(server_id, secrets::HTTP_AUTH_KEY);
+    let state = load_state(server_id);
+    reuse_racing_refresh(before, current, state.as_ref(), now_epoch_seconds())
+}
+
+/// The decision half of [`refreshed_while_waiting`], with the vault reads lifted out so
+/// it is testable without writing to the developer's keychain.
+///
+/// Reuses the racing process's token only when it is both *different* from what we saw
+/// before the lock and *usable* — the same `refresh_decision` the proactive path uses, so
+/// the two cannot disagree about what "still good" means.
+fn reuse_racing_refresh(
+    before: Option<&str>,
+    current: Option<String>,
+    state: Option<&OAuthState>,
+    now: u64,
+) -> Option<RefreshedToken> {
+    let current = current?;
+    if Some(current.as_str()) == before {
+        return None;
+    }
+    let state = state?;
+    if refresh_decision(state, now) != RefreshDecision::NotNeeded {
+        return None;
+    }
+    Some(RefreshedToken {
+        access_token: current,
+        expires_at: state.expires_at,
+    })
+}
+
 fn refresh_token_with_expiry(server_id: &str) -> Result<RefreshedToken, String> {
+    // Snapshot before locking: the comparison after we win is what tells us whether a
+    // racing process rotated the credential while we waited.
+    let before_access = secrets::get_secret(server_id, secrets::HTTP_AUTH_KEY);
+    // Held for the whole function, including the client-credentials branch, so two
+    // processes cannot mint two tokens for the same server.
+    let _refresh_lock = lock_oauth_refresh(server_id);
+    if let Some(winner) = refreshed_while_waiting(server_id, before_access.as_deref()) {
+        return Ok(winner);
+    }
     // Client-credentials servers have no refresh token by construction, so they
     // reacquire instead. Checked first because this is the seam BOTH the proactive
     // pre-expiry path and the reactive 401/403 retry go through; branching here
@@ -826,6 +897,92 @@ mod tests {
         assert!(is_auth_error("HTTP 401"));
         assert!(is_auth_error("server said 403."));
         assert!(is_auth_error("(403)"));
+    }
+
+    fn racing_state(expires_at: Option<u64>) -> OAuthState {
+        OAuthState {
+            issuer: Some("https://auth.example.com".into()),
+            token_endpoint: "https://auth.example.com/token".into(),
+            client_id: "client".into(),
+            refresh_token: Some("rt-1".into()),
+            resource: Some("https://mcp.example.com".into()),
+            scope: None,
+            issued_at: Some(1_000),
+            expires_at,
+        }
+    }
+
+    #[test]
+    fn an_unchanged_vaulted_token_leaves_the_refresh_to_us() {
+        // Nobody rotated it while we waited for the lock, so the caller must go on and
+        // do the exchange rather than handing back a token it already knows is stale.
+        let state = racing_state(Some(10_000));
+        assert!(
+            reuse_racing_refresh(Some("token-0"), Some("token-0".into()), Some(&state), 1_000)
+                .is_none(),
+            "an unchanged token is not somebody else's win"
+        );
+    }
+
+    #[test]
+    fn a_token_rotated_while_waiting_is_reused_instead_of_refreshed_again() {
+        // The SBS-479 race: we parked on the lock and the other process refreshed.
+        // Spending our own exchange now burns a refresh token it already invalidated,
+        // which is what trips a provider's reuse detection.
+        let state = racing_state(Some(10_000));
+        let winner =
+            reuse_racing_refresh(Some("token-0"), Some("token-1".into()), Some(&state), 1_000)
+                .expect("a rotated, still-valid token must be reused");
+        assert_eq!(winner.access_token, "token-1");
+        assert_eq!(winner.expires_at, Some(10_000));
+    }
+
+    #[test]
+    fn a_rotated_but_expired_token_still_triggers_a_refresh() {
+        // Reusing it would hand the caller a credential that is already dead. Uses the
+        // same refresh_decision as the proactive path, so the skew window agrees.
+        let state = racing_state(Some(1_030));
+        assert!(
+            reuse_racing_refresh(Some("token-0"), Some("token-1".into()), Some(&state), 1_000)
+                .is_none(),
+            "inside the pre-expiry skew window this is not a usable win"
+        );
+    }
+
+    #[test]
+    fn a_rotation_without_vaulted_state_is_not_reused() {
+        // No state means no expiry to judge it by; refreshing is the safe read.
+        assert!(
+            reuse_racing_refresh(Some("token-0"), Some("token-1".into()), None, 1_000).is_none()
+        );
+        // And an empty vault is not a win either.
+        let state = racing_state(Some(10_000));
+        assert!(reuse_racing_refresh(Some("token-0"), None, Some(&state), 1_000).is_none());
+    }
+
+    #[test]
+    fn the_refresh_lock_is_per_server_and_released_on_drop() {
+        // Two servers must not serialize against each other, or one slow provider
+        // stalls refresh for every other server in the registry.
+        let _guard = crate::registry::data_dir_test_lock();
+        let dir = std::env::temp_dir().join(format!(
+            "toolport-oauth-refresh-lock-{}-{}",
+            std::process::id(),
+            now_epoch_seconds()
+        ));
+        std::fs::create_dir_all(&dir).expect("scratch data dir");
+        let _override = crate::registry::DataDirOverride::set(&dir);
+
+        let a = lock_oauth_refresh("server-a").expect("a data dir is set, so a lock exists");
+        let b = lock_oauth_refresh("server-b").expect("a different server must not block");
+        drop((a, b));
+
+        assert!(
+            lock_oauth_refresh("server-a").is_some(),
+            "the lock must be reacquirable once released"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]

--- a/src-tauri/src/remote.rs
+++ b/src-tauri/src/remote.rs
@@ -114,8 +114,7 @@ pub fn store_oauth_state(
 }
 
 fn load_state(server_id: &str) -> Option<OAuthState> {
-    secrets::get_secret(server_id, STATE_KEY)
-        .and_then(|s| serde_json::from_str(&s).ok())
+    secrets::get_secret(server_id, STATE_KEY).and_then(|s| serde_json::from_str(&s).ok())
 }
 
 fn issuer_bound_token_endpoint<'a>(
@@ -325,8 +324,8 @@ fn client_credentials_resource_changed(server_id: &str, url: &str) -> bool {
 
 /// Expiry of the vaulted client-credentials token, if this server uses that flow.
 fn client_credentials_expiry(server_id: &str) -> Option<u64> {
-    let state: ClientCredentialsState = secrets::get_secret(server_id, CC_STATE_KEY)
-        .and_then(|s| serde_json::from_str(&s).ok())?;
+    let state: ClientCredentialsState =
+        secrets::get_secret(server_id, CC_STATE_KEY).and_then(|s| serde_json::from_str(&s).ok())?;
     // A server that reports no lifetime keeps the reactive 401/403 behaviour,
     // matching the interactive flow. Returning 0 here would reacquire on every
     // single connect.
@@ -375,8 +374,39 @@ fn lock_oauth_refresh(server_id: &str) -> Option<crate::registry::FileLock> {
 /// normally.
 fn refreshed_while_waiting(server_id: &str, before: Option<&str>) -> Option<RefreshedToken> {
     let current = secrets::get_secret(server_id, secrets::HTTP_AUTH_KEY);
-    let state = load_state(server_id);
-    reuse_racing_refresh(before, current, state.as_ref(), now_epoch_seconds())
+    let now = now_epoch_seconds();
+    // Client-credentials servers keep their expiry under their own key and have no
+    // OAuthState, so they need their own read. Without this a CC waiter would win the
+    // lock and mint a second grant it did not need — serialized, so not a race, but a
+    // redundant round trip to the token endpoint on every contended connect.
+    if let Some(expires_at) = client_credentials_expiry(server_id) {
+        return reuse_racing_client_credentials(before, current, expires_at, now);
+    }
+    reuse_racing_refresh(before, current, load_state(server_id).as_ref(), now)
+}
+
+/// [`reuse_racing_refresh`] for the client-credentials flow.
+///
+/// Same rule, different source of truth for expiry, and deliberately the same skew the
+/// proactive CC path uses to decide a token is too close to its deadline — otherwise a
+/// waiter could accept a token the very next connect would immediately replace.
+fn reuse_racing_client_credentials(
+    before: Option<&str>,
+    current: Option<String>,
+    expires_at: u64,
+    now: u64,
+) -> Option<RefreshedToken> {
+    let current = current?;
+    if Some(current.as_str()) == before {
+        return None;
+    }
+    if now.saturating_add(PROACTIVE_REFRESH_SKEW_SECS) >= expires_at {
+        return None;
+    }
+    Some(RefreshedToken {
+        access_token: current,
+        expires_at: Some(expires_at),
+    })
 }
 
 /// The decision half of [`refreshed_while_waiting`], with the vault reads lifted out so
@@ -529,9 +559,12 @@ fn refresh_token_if_needed(server_id: &str) -> Result<Option<String>, String> {
     // simply replaced rather than surfaced as "needs sign-in".
     if let Some(expires_at) = client_credentials_expiry(server_id) {
         if now_epoch_seconds().saturating_add(PROACTIVE_REFRESH_SKEW_SECS) >= expires_at {
-            return Ok(reacquire_client_credentials(server_id)
-                .ok()
-                .map(|t| t.access_token));
+            // Through `refresh_token`, not `reacquire_client_credentials` directly: that
+            // seam is where the cross-process lock lives, and calling the reacquire
+            // straight from here left the proactive headless path as the one arm of the
+            // call graph still able to mint concurrently (SBS-479). Matches the shape of
+            // the refresh-token arm below.
+            return Ok(refresh_token(server_id).ok());
         }
         return Ok(None);
     }
@@ -660,27 +693,28 @@ fn authed_transport(
     } else {
         None
     };
-    let scope_reauthorize: Option<ScopeReauthorizeFn> = if token.is_some() && load_state(server_id).is_some() {
-        let sid = server_id.to_string();
-        let resource = url.to_string();
-        let next_refresh_at = Arc::clone(&next_refresh_at);
-        let credential_update = Arc::clone(&credential_update);
-        Some(Box::new(move |scope| {
-            let _update = credential_update
-                .lock()
-                .map_err(|_| "OAuth credential-update lock poisoned".to_string())?;
-            let token = reauthorize_for_scope(&sid, &resource, scope)?;
-            let deadline = token
-                .expires_at
-                .map(|expires_at| expires_at.saturating_sub(PROACTIVE_REFRESH_SKEW_SECS));
-            *next_refresh_at
-                .lock()
-                .map_err(|_| "OAuth refresh deadline lock poisoned".to_string())? = deadline;
-            Ok(token.access_token)
-        }))
-    } else {
-        None
-    };
+    let scope_reauthorize: Option<ScopeReauthorizeFn> =
+        if token.is_some() && load_state(server_id).is_some() {
+            let sid = server_id.to_string();
+            let resource = url.to_string();
+            let next_refresh_at = Arc::clone(&next_refresh_at);
+            let credential_update = Arc::clone(&credential_update);
+            Some(Box::new(move |scope| {
+                let _update = credential_update
+                    .lock()
+                    .map_err(|_| "OAuth credential-update lock poisoned".to_string())?;
+                let token = reauthorize_for_scope(&sid, &resource, scope)?;
+                let deadline = token
+                    .expires_at
+                    .map(|expires_at| expires_at.saturating_sub(PROACTIVE_REFRESH_SKEW_SECS));
+                *next_refresh_at
+                    .lock()
+                    .map_err(|_| "OAuth refresh deadline lock poisoned".to_string())? = deadline;
+                Ok(token.access_token)
+            }))
+        } else {
+            None
+        };
     // The resolver enforces the SSRF policy at connect time (DNS-rebind safe); it
     // mirrors `guard_connect_target`: link-local/metadata blocked for all, private
     // blocked only for untrusted-provenance servers.
@@ -961,6 +995,39 @@ mod tests {
     }
 
     #[test]
+    fn a_client_credentials_token_minted_while_waiting_is_reused() {
+        // A CC waiter that wins the lock after the other process already minted must not
+        // spend a second grant. Serialization alone would prevent the race but not the
+        // redundant round trip.
+        let winner =
+            reuse_racing_client_credentials(Some("token-0"), Some("token-1".into()), 10_000, 1_000)
+                .expect("a freshly minted, still-valid CC token must be reused");
+        assert_eq!(winner.access_token, "token-1");
+        assert_eq!(winner.expires_at, Some(10_000));
+    }
+
+    #[test]
+    fn client_credentials_reuse_honours_the_same_skew_as_the_proactive_path() {
+        // Inside the pre-expiry window the proactive path would replace this token on the
+        // very next connect, so accepting it here just defers the work by one call.
+        assert!(reuse_racing_client_credentials(
+            Some("token-0"),
+            Some("token-1".into()),
+            1_030,
+            1_000
+        )
+        .is_none());
+        // And an unchanged token still means the mint is ours to do.
+        assert!(reuse_racing_client_credentials(
+            Some("token-0"),
+            Some("token-0".into()),
+            10_000,
+            1_000
+        )
+        .is_none());
+    }
+
+    #[test]
     fn the_refresh_lock_is_per_server_and_released_on_drop() {
         // Two servers must not serialize against each other, or one slow provider
         // stalls refresh for every other server in the registry.
@@ -1085,13 +1152,19 @@ mod tests {
             token_endpoint_auth_methods_supported: None,
         };
 
-        let rotated = endpoints("https://auth.example.com", "https://auth.example.com/token-v2");
+        let rotated = endpoints(
+            "https://auth.example.com",
+            "https://auth.example.com/token-v2",
+        );
         assert_eq!(
             issuer_bound_token_endpoint("https://auth.example.com", &rotated).unwrap(),
             "https://auth.example.com/token-v2"
         );
 
-        let changed = endpoints("https://other.example.com", "https://other.example.com/token");
+        let changed = endpoints(
+            "https://other.example.com",
+            "https://other.example.com/token",
+        );
         assert!(issuer_bound_token_endpoint("https://auth.example.com", &changed).is_err());
     }
 
@@ -1232,7 +1305,10 @@ mod tests {
     /// headless path and fail with "no client secret vaulted".
     #[test]
     fn client_credentials_flow_requires_a_non_empty_client_id() {
-        assert!(uses_client_credentials(&http_server("a", Some(cc("client-abc")))));
+        assert!(uses_client_credentials(&http_server(
+            "a",
+            Some(cc("client-abc"))
+        )));
         assert!(!uses_client_credentials(&http_server("b", Some(cc("   ")))));
         assert!(!uses_client_credentials(&http_server("c", Some(cc("")))));
         assert!(!uses_client_credentials(&http_server("d", None)));

--- a/src-tauri/tests/repro_audit_read_recent_corrupt.rs
+++ b/src-tauri/tests/repro_audit_read_recent_corrupt.rs
@@ -1,0 +1,100 @@
+//! Repro: audit::read_recent takes `limit` lines before skipping unparseable ones,
+//! so a corrupt line inside the window shrinks the returned page. inspect::read_recent
+//! was already fixed to filter first; audit still takes first.
+
+use conduit_lib::audit::{audit_path, read_recent};
+use conduit_lib::registry::DataDirOverride;
+use std::fs;
+use std::path::PathBuf;
+
+/// `DataDirOverride` is process-global, so tests in this binary must serialize.
+static DATA_DIR: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+fn data_dir_guard() -> std::sync::MutexGuard<'static, ()> {
+    DATA_DIR
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+}
+
+#[test]
+fn read_recent_skips_corrupt_lines_without_shrinking_page() {
+    let dir = unique_temp_dir("audit-read-recent-corrupt");
+    let _lock = data_dir_guard();
+    let _override = DataDirOverride::set(&dir);
+
+    let path = audit_path().expect("audit path under override");
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).expect("create data dir");
+    }
+
+    // Four valid entries and one corrupt line near the end (newest side when reversed).
+    // Requesting limit=3 should still yield 3 valid newest entries (4,3,2), not 2.
+    fs::write(
+        &path,
+        r#"{"server":"s","tool":"t","ok":true,"i":1}
+{"server":"s","tool":"t","ok":true,"i":2}
+{"server":"s","tool":"t","ok":true,"i":3}
+not json
+{"server":"s","tool":"t","ok":true,"i":4}
+"#,
+    )
+    .expect("write fixture audit log");
+
+    let recent = read_recent(3);
+    assert_eq!(
+        recent.len(),
+        3,
+        "corrupt lines must not shrink the page; got {recent:?}"
+    );
+    assert_eq!(recent[0].get("i").and_then(|v| v.as_u64()), Some(4));
+    assert_eq!(recent[1].get("i").and_then(|v| v.as_u64()), Some(3));
+    assert_eq!(recent[2].get("i").and_then(|v| v.as_u64()), Some(2));
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn a_fully_valid_log_is_unchanged() {
+    // Filtering before taking must not disturb ordering or counts on the ordinary path.
+    let dir = unique_temp_dir("audit-read-recent-valid");
+    let _lock = data_dir_guard();
+    let _override = DataDirOverride::set(&dir);
+
+    let path = audit_path().expect("audit path under override");
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).expect("create data dir");
+    }
+    fs::write(
+        &path,
+        r#"{"i":1}
+{"i":2}
+{"i":3}
+"#,
+    )
+    .expect("write fixture audit log");
+
+    let recent = read_recent(2);
+    assert_eq!(recent.len(), 2);
+    assert_eq!(recent[0].get("i").and_then(|v| v.as_u64()), Some(3));
+    assert_eq!(recent[1].get("i").and_then(|v| v.as_u64()), Some(2));
+
+    // A limit past the end returns everything, newest first.
+    let all = read_recent(99);
+    assert_eq!(all.len(), 3);
+    assert_eq!(all[0].get("i").and_then(|v| v.as_u64()), Some(3));
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+fn unique_temp_dir(label: &str) -> PathBuf {
+    let path = std::env::temp_dir().join(format!(
+        "toolport-{label}-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0)
+    ));
+    fs::create_dir_all(&path).expect("temp dir");
+    path
+}

--- a/src/components/Onboarding.tsx
+++ b/src/components/Onboarding.tsx
@@ -30,7 +30,7 @@ import {
 } from "@/lib/api";
 import { ClientLogo } from "@/components/ClientLogo";
 import { clientRestartHint } from "@/lib/clientConnect";
-import { teamUrlError } from "@/lib/teamUrl";
+import { HOSTED_TEAMS_URL, TEAMS_MARKETING_URL, teamUrlError } from "@/lib/teamUrl";
 import { Input } from "@/components/ui/input";
 import {
   importableServers,
@@ -267,7 +267,7 @@ function Welcome({
         </button>
         <button
           type="button"
-          onClick={() => openExternal("https://toolport.app/teams")}
+          onClick={() => openExternal(TEAMS_MARKETING_URL)}
           className="self-start text-2xs text-muted-foreground transition hover:text-foreground"
         >
           What is Toolport for Teams? →
@@ -276,8 +276,6 @@ function Welcome({
     </>
   );
 }
-
-const HOSTED_TEAMS_URL = "https://teams.toolport.app";
 
 /** The team-member on-ramp. A person handed an invite code lands here from the
  * Welcome step, pastes it, and the team's shared servers arrive locally. The

--- a/src/components/TeamsView.tsx
+++ b/src/components/TeamsView.tsx
@@ -30,7 +30,7 @@ import {
   teamInstructionsStatus,
   setServerEnabled,
 } from "@/lib/api";
-import { teamUrlError } from "@/lib/teamUrl";
+import { HOSTED_TEAMS_URL, teamUrlError } from "@/lib/teamUrl";
 import { isEnabled, activeProfile } from "@/lib/types";
 import type { TeamPushPreview } from "@/lib/api";
 import type {
@@ -63,10 +63,6 @@ const INSTR_STATE_META: Record<
   },
   error: { label: "Write error", className: "text-destructive", Icon: AlertTriangle },
 };
-
-/** The hosted Toolport Teams instance, prefilled as the default. Self-hosters replace
- * it with their own server URL. */
-const HOSTED_TEAMS_URL = "https://teams.toolport.app";
 
 /**
  * Toolport Teams: join a team and have its shared MCP server set appear locally. The

--- a/src/lib/teamUrl.ts
+++ b/src/lib/teamUrl.ts
@@ -1,3 +1,15 @@
+/** The hosted Toolport Teams **app**, prefilled as the default server URL. Self-hosters
+ * replace it with their own server. */
+export const HOSTED_TEAMS_URL = "https://teams.toolport.app";
+
+/** The public **explainer** page — deliberately not [`HOSTED_TEAMS_URL`].
+ *
+ * Onboarding's "What is Toolport for Teams?" link targets this: someone reading it has
+ * no team and no invite code yet, so sending them to the app would land them on a sign-in
+ * for something they have not been told about. The two lived as three separate string
+ * literals across two components, which is how they drifted (SBS-461). */
+export const TEAMS_MARKETING_URL = "https://toolport.app/teams";
+
 export function teamUrlError(raw: string): string | null {
   const value = raw.trim();
   if (!value) return "Server URL is required.";


### PR DESCRIPTION
Five Toolport tickets, one commit each. Skips the `test-coverage` backlog per direction — these are the remaining real bugs.

| Commit | Ticket | What |
|---|---|---|
| `1bb14cf` | SBS-677 | Corrupt audit lines shrank the Activity page |
| `e778ff3` | SBS-460 | Instructions receipt hash was `DefaultHasher` |
| `fbb4298` | SBS-434 (4) | Subscribe `loop` that never looped — **unblocks the clippy gate** |
| `e5333f1` | SBS-461 | Three team-URL literals, two names |
| `bc9f584` | SBS-479 | OAuth refresh not serialized across processes |

---

### SBS-677 — audit paging

`read_recent` did `.lines().rev().take(limit).filter_map(parse)`, so an unparseable line consumed a slot in the take window. One corrupt row among the newest entries returned a short page and dropped older valid history that should have filled it. `inspect::read_recent` and `searchtrace` already filter before taking; audit now matches.

### SBS-460 — receipt hash stability

`content_hash` is documented as the stable receipt hash, reported to the org server and used as a dedupe fingerprint — built on `DefaultHasher`, whose algorithm has no cross-release guarantee. A toolchain bump would silently change every member's hash and show phantom drift on the coverage dashboard. Now SHA-256 truncated to the same 16 hex chars, so the wire shape is unchanged.

**Rollout:** this changes every member's hash once. Wants a release note and one reconvergence pass on the dashboard side.

### SBS-434 item 4 — the clippy blocker

The `resources/subscribe` single-flight block opened with `loop {`, but every arm returns — there is no `continue` in the body, so it always exited on the first pass. The comment described a waiter re-entering as a new leader; the code never did that.

I kept the shipping behaviour rather than adding the re-entry: a waiter inheriting the leader's error means one failed open cannot turn N parked waiters into N retries against a server that just failed. The comment now says that.

**`cargo clippy --all-targets` is error-free after this** — `never_loop` is deny-by-default and was the one hard error blocking a `-D warnings` gate, so this unblocks GitHub #635 (assigned to @Vermitrude).

### SBS-461 — team URLs

Both components declared their own `HOSTED_TEAMS_URL`, and Onboarding opened a third hardcoded URL (the marketing page) a few lines above its own copy. Both now live in `src/lib/teamUrl.ts`.

**The product call in the ticket:** the onboarding "What is Toolport for Teams?" link keeps pointing at the marketing page, now named `TEAMS_MARKETING_URL` with the reasoning recorded — a reader there has no team and no invite code, so the app would land them on a sign-in for something nobody has told them about. One-line flip if you want it the other way.

### SBS-479 — OAuth refresh race

`refresh_token_with_expiry` read the refresh token, POSTed, and wrote back the rotated one with no cross-process lock. The desktop health probe and the gateway are separate processes on the same keychain, so both could read RT0, both POST `/token`, and a provider with reuse detection revokes the whole family. The in-process guard only covered one process; the app's existing OAuth lock covers only the interactive browser flow.

Now takes a per-server file lock around the whole refresh (including the client-credentials branch) and re-reads the vaulted token after winning it, so the loser uses the winner's token instead of burning an exchange on an already-invalidated refresh token.

Two things worth a look in review:

- The reuse decision goes through the same `refresh_decision` as the proactive path, so a rotated-but-already-stale token still refreshes rather than being handed back dead.
- **Best-effort by design.** With no resolvable data dir there is nowhere to put a lock, and refusing to refresh at all would be worse than the race it prevents.

The decision half is a pure function (`reuse_racing_refresh`) specifically so it is testable without writing to the developer's keychain — `secrets` goes to the OS keychain, not the data dir, so a vault-writing unit test would leak real items.

## Not addressed

SBS-479 also names two narrower effects I left alone, both worth their own change rather than riding along here: the `connect_remote_with_handler` guard can still read `vaulted != sent_auth` mid-race and report "Needs sign-in" for a server that now holds a good token (transient, clears on the next connect), and `get_secret_result` resolving `TOOLPORT_SECRET___http_auth__` from the environment before the keychain. Say the word and I'll file them.

## Verification

- `cargo test` — **813 library + 238 gateway + all integration/spec-conformance pass**
- `cargo clippy --all-targets` — **0 errors** (was 1, the `never_loop`)
- `npm run lint` (0 errors) and `tsc --noEmit` clean
- `cargo fmt --check` — no new drift from any file in this PR