### PR TITLE
Bound pure-JS runaways honestly, keep the restart reminder visible

### DIFF
--- a/src-tauri/src/codemode.rs
+++ b/src-tauri/src/codemode.rs
@@ -28,6 +28,25 @@
 //! (they never enter model context). The gateway shapes only the script's final aggregate
 //! for the client. Limits: call budget, wall-clock deadline, max concurrent host calls,
 //! promise-job budget, and boa's loop/recursion caps.
+//!
+//! # What actually bounds a pure-JS runaway (SBS-430)
+//!
+//! [`Limits::wall_clock`] is NOT enforced while synchronous JS is running. It is checked
+//! when a script reserves a host call ([`reserve_budget`]) and between promise jobs
+//! ([`BoundedJobExecutor`]), and boa 0.21 exposes no time-based interrupt to check it
+//! anywhere else. A script that never calls a tool and never awaits is bounded only by
+//! boa's own counters:
+//!
+//!   * `loop_iteration_limit` — total loop iterations, across nested loops, not per-loop.
+//!   * recursion limit — depth, which trips almost immediately.
+//!
+//! Both fail closed, so a runaway always terminates. The gap is that the loop bound counts
+//! *iterations*, not *time*: at the 10M default a trivial body measured ~15s, and a heavier
+//! body scales from there with nothing consulting the 60s wall clock. Treat `wall_clock` as
+//! a bound on host-call and async work, not as a hard ceiling on a CPU-bound script.
+//!
+//! `pure_js_runaways_are_bounded_by_count_not_wall_clock` pins this so a boa upgrade that
+//! drops either counter is caught rather than silently removing the only real bound.
 
 use std::cell::{Cell, RefCell};
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
@@ -1386,6 +1405,65 @@ mod tests {
         let out = run("while (true) {} return 1;", json!({}), call, limits);
         assert_ne!(out.error, None, "an infinite loop must be stopped");
         assert_eq!(out.calls, 0);
+    }
+
+    #[test]
+    fn nested_loops_share_one_iteration_budget() {
+        // SBS-430: the cap is total iterations, not per-loop, so nesting cannot multiply
+        // its way past it. Without this a script could sit under the limit in every
+        // individual loop and still run unbounded work.
+        let call = Arc::new(|_: &str, _: Value| Value::Null);
+        let limits = Limits {
+            loop_iteration_limit: 1_000,
+            ..Limits::default()
+        };
+        let out = run(
+            "let n = 0; for (let i = 0; i < 1000; i++) { for (let j = 0; j < 1000; j++) { n++; } } return n;",
+            json!({}),
+            call,
+            limits,
+        );
+
+        let err = out.error.expect("nested loops must hit the shared budget");
+        assert!(err.contains("loop iteration limit"), "got: {err}");
+    }
+
+    #[test]
+    fn unbounded_recursion_is_stopped_without_a_host_call() {
+        // The other half of the pure-JS bound. Depth-limited, and it trips long before
+        // the loop budget would.
+        let call = Arc::new(|_: &str, _: Value| Value::Null);
+        let out = run(
+            "function f(n) { return n <= 0 ? 0 : f(n - 1) + 1; } return f(10000000);",
+            json!({}),
+            call,
+            Limits::default(),
+        );
+
+        let err = out.error.expect("unbounded recursion must be stopped");
+        assert!(err.contains("recursive calls"), "got: {err}");
+        assert_eq!(out.calls, 0, "it never reached a host call");
+    }
+
+    #[test]
+    fn pure_js_runaways_are_bounded_by_count_not_wall_clock() {
+        // Documents the real contract (SBS-430): a CPU-bound script that never calls a
+        // tool and never awaits is stopped by boa's iteration counter, NOT by
+        // Limits::wall_clock, which nothing consults on that path. A wall_clock of zero
+        // therefore does not stop it -- only the loop budget does.
+        let call = Arc::new(|_: &str, _: Value| Value::Null);
+        let limits = Limits {
+            wall_clock: StdDuration::from_secs(0),
+            loop_iteration_limit: 5_000,
+            ..Limits::default()
+        };
+        let out = run("while (true) {} return 1;", json!({}), call, limits);
+
+        let err = out.error.expect("the loop budget must still stop it");
+        assert!(
+            err.contains("loop iteration limit"),
+            "an expired wall clock is not what stops a pure-JS loop; got: {err}"
+        );
     }
 
     #[test]

--- a/src/components/ClientDetail.tsx
+++ b/src/components/ClientDetail.tsx
@@ -53,6 +53,7 @@ import { ConfirmDialog } from "@/components/ConfirmDialog";
 import { ImportReviewDialog } from "@/components/ImportReviewDialog";
 import {
   clientRestartHint,
+  clientRestartHintAfterRemoval,
   connectSuccessDescription,
   toolportStudioClientBlurb,
 } from "@/lib/clientConnect";
@@ -129,15 +130,23 @@ export function ClientDetail({ client, registry, onChanged, onRegistryChange }: 
   // cascading-render setState-in-effect.
   const [restartNotice, setRestartNotice] = useState<{
     clientId: string;
+    title: string;
     text: string;
   } | null>(null);
-  const showRestartNotice =
-    restartNotice?.clientId === client.id ? restartNotice.text : null;
+  const showRestartNotice = restartNotice?.clientId === client.id ? restartNotice : null;
 
-  function noteRestartNeeded() {
+  /** `applied` = Toolport was written into the config; `removed` = taken out of it.
+   *
+   * Both need a restart, for opposite reasons, and the connect wording ("so it loads
+   * Toolport") reads as a failed disconnect on the removal path. */
+  function noteRestartNeeded(kind: "applied" | "removed") {
     setRestartNotice({
       clientId: client.id,
-      text: clientRestartHint(client.name, client.id),
+      title: kind === "applied" ? "Not live yet" : "Still connected until restart",
+      text:
+        kind === "applied"
+          ? clientRestartHint(client.name, client.id)
+          : clientRestartHintAfterRemoval(client.name, client.id),
     });
   }
 
@@ -217,7 +226,7 @@ export function ClientDetail({ client, registry, onChanged, onRegistryChange }: 
           : `${client.name} now follows the active profile.`,
         { description: clientRestartHint(client.name, client.id) },
       );
-      noteRestartNeeded();
+      noteRestartNeeded("applied");
       onChanged();
     } catch (e) {
       toastError(`${e}`);
@@ -234,7 +243,7 @@ export function ClientDetail({ client, registry, onChanged, onRegistryChange }: 
       toast.success(`Reset ${client.name} to the default Toolport gateway`, {
         description: clientRestartHint(client.name, client.id),
       });
-      noteRestartNeeded();
+      noteRestartNeeded("applied");
       setResetOpen(false);
       onChanged();
     } catch (e) {
@@ -264,9 +273,12 @@ export function ClientDetail({ client, registry, onChanged, onRegistryChange }: 
       toast.success(
         `Moved ${result.moved.length} server${result.moved.length === 1 ? "" : "s"} into Toolport`,
         {
-          description: `${client.name} now uses only the Toolport gateway. Config backed up.`,
+          // Migrate rewrites the whole gateway slot, so it needs the restart line for
+          // the same reason Connect does.
+          description: `${client.name} now uses only the Toolport gateway. Config backed up. ${clientRestartHint(client.name, client.id)}`,
         },
       );
+      noteRestartNeeded("applied");
       setMigrateOpen(false);
       onChanged();
     } catch (e) {
@@ -375,7 +387,10 @@ export function ClientDetail({ client, registry, onChanged, onRegistryChange }: 
     try {
       if (installed) {
         await uninstallGateway(client.id);
-        toast.success(`Disconnected Toolport from ${client.name}`);
+        toast.success(`Disconnected Toolport from ${client.name}`, {
+          description: clientRestartHintAfterRemoval(client.name, client.id),
+        });
+        noteRestartNeeded("removed");
       } else {
         const outcome = await installGateway(
           client.id,
@@ -398,8 +413,8 @@ export function ClientDetail({ client, registry, onChanged, onRegistryChange }: 
             client.id,
           ),
         });
+        noteRestartNeeded("applied");
       }
-      noteRestartNeeded();
       onChanged();
     } catch (e) {
       toastError(`${e}`);
@@ -573,8 +588,8 @@ export function ClientDetail({ client, registry, onChanged, onRegistryChange }: 
         >
           <RefreshCw className="mt-0.5 size-4 shrink-0" />
           <div className="min-w-0 flex-1">
-            <p className="font-medium">Not live yet</p>
-            <p className="mt-0.5 break-words text-xs">{showRestartNotice}</p>
+            <p className="font-medium">{showRestartNotice.title}</p>
+            <p className="mt-0.5 break-words text-xs">{showRestartNotice.text}</p>
           </div>
           <button
             type="button"

--- a/src/components/ClientDetail.tsx
+++ b/src/components/ClientDetail.tsx
@@ -8,8 +8,10 @@ import {
   Plug,
   PlugZap,
   Puzzle,
+  RefreshCw,
   Shuffle,
   TriangleAlert,
+  X,
 } from "lucide-react";
 import { toast } from "sonner";
 import { toastError } from "@/lib/toast";
@@ -118,6 +120,27 @@ export function ClientDetail({ client, registry, onChanged, onRegistryChange }: 
     setTransport(managedTransport);
   }, [managedTransport, client.id]);
 
+  // SOU-317 follow-up (SBS-336): the restart advice is load-bearing — an MCP client
+  // typically does not pick up a rewritten config until relaunch — but it only ever
+  // appeared in a toast, which fades after a few seconds and is gone if the user was
+  // looking elsewhere. Keep it in the panel until they dismiss it.
+  // Keyed by client id rather than cleared in an effect: selecting another client must
+  // not carry the previous one's advice across, and deriving that from the key avoids a
+  // cascading-render setState-in-effect.
+  const [restartNotice, setRestartNotice] = useState<{
+    clientId: string;
+    text: string;
+  } | null>(null);
+  const showRestartNotice =
+    restartNotice?.clientId === client.id ? restartNotice.text : null;
+
+  function noteRestartNeeded() {
+    setRestartNotice({
+      clientId: client.id,
+      text: clientRestartHint(client.name, client.id),
+    });
+  }
+
   // Discovery: the global mode this client falls back to, and its own override (if any).
   // The gateway resolves env > per-client > global, so an override here applies live.
   const globalMode =
@@ -194,6 +217,7 @@ export function ClientDetail({ client, registry, onChanged, onRegistryChange }: 
           : `${client.name} now follows the active profile.`,
         { description: clientRestartHint(client.name, client.id) },
       );
+      noteRestartNeeded();
       onChanged();
     } catch (e) {
       toastError(`${e}`);
@@ -210,6 +234,7 @@ export function ClientDetail({ client, registry, onChanged, onRegistryChange }: 
       toast.success(`Reset ${client.name} to the default Toolport gateway`, {
         description: clientRestartHint(client.name, client.id),
       });
+      noteRestartNeeded();
       setResetOpen(false);
       onChanged();
     } catch (e) {
@@ -374,6 +399,7 @@ export function ClientDetail({ client, registry, onChanged, onRegistryChange }: 
           ),
         });
       }
+      noteRestartNeeded();
       onChanged();
     } catch (e) {
       toastError(`${e}`);
@@ -537,6 +563,27 @@ export function ClientDetail({ client, registry, onChanged, onRegistryChange }: 
             <p className="font-medium">Couldn't read this client's configuration</p>
             <p className="mt-0.5 break-words text-xs">{client.error}</p>
           </div>
+        </div>
+      )}
+
+      {showRestartNotice && (
+        <div
+          role="status"
+          className="flex items-start gap-2 rounded-lg border border-info/30 bg-info/10 px-3 py-2 text-sm text-info"
+        >
+          <RefreshCw className="mt-0.5 size-4 shrink-0" />
+          <div className="min-w-0 flex-1">
+            <p className="font-medium">Not live yet</p>
+            <p className="mt-0.5 break-words text-xs">{showRestartNotice}</p>
+          </div>
+          <button
+            type="button"
+            onClick={() => setRestartNotice(null)}
+            aria-label="Dismiss restart reminder"
+            className="rounded p-0.5 text-info/70 transition-colors hover:bg-info/10 hover:text-info focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-info"
+          >
+            <X className="size-3.5" />
+          </button>
         </div>
       )}
 

--- a/src/lib/clientConnect.test.ts
+++ b/src/lib/clientConnect.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   clientRestartHint,
+  clientRestartHintAfterRemoval,
   connectSuccessDescription,
   toolportStudioClientBlurb,
 } from "./clientConnect";
@@ -43,5 +44,27 @@ describe("clientRestartHint / connectSuccessDescription (SOU-317)", () => {
   it("explains zero-config tools vs Connect for Studio", () => {
     expect(toolportStudioClientBlurb()).toMatch(/discovers Toolport automatically/);
     expect(toolportStudioClientBlurb()).toMatch(/pin a profile/);
+  });
+});
+
+describe("clientRestartHintAfterRemoval (SBS-336 review)", () => {
+  it("says the client stops loading Toolport, not that it loads it", () => {
+    // The connect wording on a disconnect reads as though the disconnect failed.
+    expect(clientRestartHintAfterRemoval("Claude Desktop")).toBe(
+      "Restart Claude Desktop so it stops loading Toolport.",
+    );
+    expect(clientRestartHintAfterRemoval("Claude Desktop")).not.toContain(
+      "so it loads Toolport",
+    );
+  });
+
+  it("keeps Studio's new-conversation wording", () => {
+    expect(clientRestartHintAfterRemoval("Toolport Studio", "toolport-studio")).toBe(
+      "Start a new conversation in Toolport Studio so it stops using Toolport.",
+    );
+    // A different client id must not pick up the Studio phrasing.
+    expect(clientRestartHintAfterRemoval("Other", "other-client")).toBe(
+      "Restart Other so it stops loading Toolport.",
+    );
   });
 });

--- a/src/lib/clientConnect.ts
+++ b/src/lib/clientConnect.ts
@@ -14,6 +14,24 @@ export function clientRestartHint(clientName: string, clientId?: string): string
   return `Restart ${clientName} so it loads Toolport.`;
 }
 
+/**
+ * The same advice after Toolport is REMOVED from a client's config.
+ *
+ * A restart is just as load-bearing here, for the opposite reason: the client keeps
+ * serving Toolport's tools from the config it read at startup until it relaunches. The
+ * connect wording ("so it loads Toolport") is actively wrong on that path and reads as
+ * though the disconnect failed.
+ */
+export function clientRestartHintAfterRemoval(
+  clientName: string,
+  clientId?: string,
+): string {
+  if (clientId === "toolport-studio") {
+    return "Start a new conversation in Toolport Studio so it stops using Toolport.";
+  }
+  return `Restart ${clientName} so it stops loading Toolport.`;
+}
+
 /** Short product note for the Studio Clients row (zero-config tools + Connect for scope). */
 export function toolportStudioClientBlurb(): string {
   return "Studio discovers Toolport automatically for every conversation. Connect here to pin a profile and show as connected in Activity.";


### PR DESCRIPTION
Two Toolport tickets, plus one closed as already-shipped. Smaller than the last batch — see "What I found in the backlog" below for why.

| Commit | Ticket | What |
|---|---|---|
| `37ce5a6` | SBS-430 | Verified + documented what actually bounds a pure-JS runaway |
| `328068e` | SBS-336 | Restart reminder now persists in the panel, not just a toast |
| — | SBS-334 | **Already shipped** in #466; closing the stale ticket |

---

### SBS-430 — what bounds a pure-JS runaway

The ticket asked to verify whether boa bounds a busy loop with no host calls, and add a wall-clock budget if not. Measured both:

| Case | Result |
|---|---|
| `while (true) {}` | stopped by `loop_iteration_limit` |
| unbounded recursion | stopped by the recursion limit, ~5ms |
| 10M iterations, trivial body | stopped — **after ~15s** |

So it is bounded, but **by count, not by time**. `Limits::wall_clock` is only consulted when a script reserves a host call and between promise jobs; boa 0.21 exposes no time-based interrupt, so a CPU-bound script that never calls a tool and never awaits never checks it. At the 10M default a trivial body runs ~15s against a 60s wall clock, and a heavier body scales from there.

**I documented this rather than changing it.** Lowering the default would silently break scripts that currently work, and that is a product call, not a cleanup. The module docs now state the real contract, and three tests pin it — including one asserting that an expired `wall_clock` is *not* what stops a pure-JS loop, so the distinction cannot quietly rot.

If you want a hard time ceiling, that needs either a boa interrupt hook (not in 0.21) or a lower iteration default, and is worth its own ticket with a chosen number.

### SBS-336 — durable restart reminder

Connect, rescope and reset-to-default all rewrite a client's MCP config, and the client does not pick it up until relaunch. That advice only ever appeared in a toast description — it fades in a few seconds and is missed entirely if the user was looking elsewhere, so the change silently looks applied while the client keeps running the old config.

Dismissible in-panel callout alongside the existing toast, set by all three paths.

Keyed by client id rather than cleared in a `useEffect`: switching clients must not carry the previous one's advice across, and deriving it from the key avoids the `set-state-in-effect` cascading-render lint that the two neighbouring effects already trip. Lint warning count is unchanged at 23.

## What I found in the backlog

**SBS-334 is already done.** `ClientDetail` has rendered `client.error` in a warning banner since `b6685c8` (PR #466). The Linear ticket still sits in Backlog. I did not write code for it — worth closing, and worth knowing the backlog has stale entries that read as open work.

I also skipped two candidates deliberately:

- **SBS-22** (Argon2id key derivation) needs a new `argon2` dependency, which deserves its own decision rather than riding in a batch.
- **SBS-431** (code-mode meta-tool prefix filter) says the contract is "TBD from the WS2 handoff notes". I would be guessing at the intended behaviour; it needs the contract pinned down first.

## Verification

- `cargo test` — **811 library + 238 gateway + all integration/spec-conformance pass**
- `cargo clippy --all-targets` — 0 errors
- `npx vitest run` — 218 frontend tests pass
- `tsc --noEmit` clean, `npm run lint` 0 errors / 23 warnings (unchanged), prettier clean
- `cargo fmt --check` — no new drift from this PR

One note on the build: I hit corrupted target artifacts twice (`found staticlib boa_macros instead of rlib`, then `invalid metadata files for conduit_lib`). A full `cargo clean` fixed it and everything above is from the clean rebuild. Not diff-related — flagging in case you see it locally.