### PR TITLE
Keyboard shortcuts and remembered window geometry

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -811,6 +811,7 @@ dependencies = [
  "tauri-plugin-process",
  "tauri-plugin-single-instance",
  "tauri-plugin-updater",
+ "tauri-plugin-window-state",
  "tiny_http",
  "toml 0.8.2",
  "ureq",
@@ -4981,6 +4982,21 @@ dependencies = [
  "url",
  "windows-sys 0.60.2",
  "zip",
+]
+
+[[package]]
+name = "tauri-plugin-window-state"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73736611e14142408d15353e21e3cca2f12a3cfb523ad0ce85999b6d2ef1a704"
+dependencies = [
+ "bitflags 2.13.0",
+ "log",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -21,6 +21,7 @@ desktop = [
     "dep:tauri-plugin-autostart",
     "dep:tauri-plugin-deep-link",
     "dep:tauri-plugin-single-instance",
+    "dep:tauri-plugin-window-state",
 ]
 
 [lib]
@@ -41,6 +42,7 @@ tauri-plugin-process = { version = "2", optional = true }
 tauri-plugin-dialog = { version = "2", optional = true }
 tauri-plugin-notification = { version = "2", optional = true }
 tauri-plugin-autostart = { version = "2", optional = true }
+tauri-plugin-window-state = { version = "2", optional = true }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 json5 = "0.4"

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -12,6 +12,7 @@
     "dialog:allow-open",
     "deep-link:default",
     "notification:default",
-    "autostart:default"
+    "autostart:default",
+    "window-state:default"
   ]
 }

--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -3582,6 +3582,22 @@ pub fn run() {
             tauri_plugin_autostart::MacosLauncher::LaunchAgent,
             Some(vec!["--hidden"]),
         ))
+        // Remember where the user put the window (SBS-144). Without this every cold
+        // start reopens at the fixed 1240x820 centered geometry from tauri.conf.json,
+        // undoing a resize or a move on every quit, reboot, and update relaunch.
+        //
+        // VISIBLE is skipped deliberately: the window is configured `visible: false` and
+        // shown by `setup()` (or kept hidden for a `--hidden` autostart into the tray).
+        // Letting the plugin restore visibility would fight that and flash a window on
+        // every launch-at-login.
+        .plugin(
+            tauri_plugin_window_state::Builder::new()
+                .with_state_flags(
+                    tauri_plugin_window_state::StateFlags::all()
+                        - tauri_plugin_window_state::StateFlags::VISIBLE,
+                )
+                .build(),
+        )
         .manage(Mutex::new(registry))
         .manage(Mutex::new(HttpBridge::default()))
         .manage(PendingShare::default())

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -449,6 +449,24 @@ function App() {
     setView(v);
   }
 
+  /** Focus the search box once it exists.
+   *
+   * Coming from another view the input is not mounted yet, and the view it replaces
+   * may be lazy-loaded behind Suspense, so a single frame is not reliably enough.
+   * Retry for a few frames, then give up rather than spin.
+   */
+  function focusSearchWhenMounted() {
+    let frames = 0;
+    const tick = () => {
+      if (searchRef.current) {
+        searchRef.current.select();
+        return;
+      }
+      if (frames++ < 15) requestAnimationFrame(tick);
+    };
+    requestAnimationFrame(tick);
+  }
+
   // One global keydown listener rather than per-control handlers, so a shortcut works
   // wherever focus happens to be. The decision of what a keystroke means lives in
   // `resolveShortcut` and is unit-tested there; this only performs the effect.
@@ -468,8 +486,7 @@ function App() {
           // Search only exists on the servers list; go there first so the shortcut
           // is not a silent no-op from another view.
           selectView("servers");
-          // After the view switch has painted, or the input is not mounted yet.
-          requestAnimationFrame(() => searchRef.current?.select());
+          focusSearchWhenMounted();
           break;
         case "addServer":
           e.preventDefault();
@@ -824,7 +841,7 @@ function App() {
                 size="icon"
                 className="size-8"
                 aria-label="Refresh"
-                title="Reload servers, clients, and health"
+                title={`Reload servers, clients, and health (${isMac ? "⌘" : "Ctrl"}R)`}
                 onClick={() => load(true)}
                 disabled={loading}
               >
@@ -1007,7 +1024,14 @@ function App() {
         <ServerDialog
           autoOpen
           onClose={() => setAddServerOpen(false)}
-          onSaved={setRegistry}
+          onSaved={(reg) => {
+            setRegistry(reg);
+            // A successful save closes the dialog internally without going through
+            // onOpenChange, so `onClose` never fires and this stays mounted-but-open.
+            // Without clearing it here the next Ctrl+N is a silent no-op. Same pattern
+            // CatalogView already uses for its autoOpen dialog.
+            setAddServerOpen(false);
+          }}
           existingNames={servers.map((s) => s.name)}
         />
       )}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -91,12 +91,14 @@ import { Callout } from "@/components/Callout";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
 import { ConfirmDialog } from "@/components/ConfirmDialog";
 import { Input } from "@/components/ui/input";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Skeleton } from "@/components/ui/skeleton";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { Toaster } from "@/components/ui/sonner";
 import { useTheme } from "@/lib/theme";
 import { fmtTs } from "@/lib/utils";
+import { resolveShortcut, shortcutHelp } from "@/lib/shortcuts";
 
 /** Above this many servers, "Disable all" asks for confirmation first. */
 const BULK_DISABLE_CONFIRM_MIN = 3;
@@ -126,6 +128,15 @@ function App() {
   // only appears after a real failure.
   const [backendReachable, setBackendReachable] = useState(true);
   const [query, setQuery] = useState("");
+  // Keyboard shortcuts (SBS-143). The app had none, which for a developer tool means
+  // every interaction is mouse-only.
+  const searchRef = useRef<HTMLInputElement>(null);
+  const [shortcutsOpen, setShortcutsOpen] = useState(false);
+  // Ctrl+N mounts its own ServerDialog with `autoOpen` rather than reaching into the
+  // trigger-based one, so the shortcut needs no changes to ServerDialog's API.
+  const [addServerOpen, setAddServerOpen] = useState(false);
+  const isMac =
+    typeof navigator !== "undefined" && /Mac|iPhone|iPad/.test(navigator.platform ?? "");
   const [onboarded, setOnboarded] = useState(
     () =>
       localStorage.getItem("toolport.onboarded") === "1" ||
@@ -438,6 +449,51 @@ function App() {
     setView(v);
   }
 
+  // One global keydown listener rather than per-control handlers, so a shortcut works
+  // wherever focus happens to be. The decision of what a keystroke means lives in
+  // `resolveShortcut` and is unit-tested there; this only performs the effect.
+  useEffect(() => {
+    function onKeyDown(e: KeyboardEvent) {
+      const action = resolveShortcut(e, e.target as HTMLElement | null);
+      if (!action) return;
+      // Only claim the key once we know it is ours. Ctrl+R in particular would
+      // otherwise reload the webview and throw away in-flight state.
+      switch (action.kind) {
+        case "view":
+          e.preventDefault();
+          selectView(action.view);
+          break;
+        case "focusSearch":
+          e.preventDefault();
+          // Search only exists on the servers list; go there first so the shortcut
+          // is not a silent no-op from another view.
+          selectView("servers");
+          // After the view switch has painted, or the input is not mounted yet.
+          requestAnimationFrame(() => searchRef.current?.select());
+          break;
+        case "addServer":
+          e.preventDefault();
+          setAddServerOpen(true);
+          break;
+        case "refresh":
+          e.preventDefault();
+          void load(true);
+          break;
+        case "help":
+          e.preventDefault();
+          setShortcutsOpen(true);
+          break;
+        case "closeHelp":
+          // No preventDefault: Escape belongs to whatever dialog or menu is open, and
+          // this must not stop it closing. Only acts when the sheet is actually up.
+          setShortcutsOpen(false);
+          break;
+      }
+    }
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [load]);
+
   const profileId = registry
     ? (registry.activeProfileId ?? registry.profiles[0]?.id)
     : undefined;
@@ -693,9 +749,11 @@ function App() {
                   <div className="relative">
                     <Search className="pointer-events-none absolute top-1/2 left-2.5 size-3.5 -translate-y-1/2 text-muted-foreground" />
                     <Input
+                      ref={searchRef}
                       value={query}
                       onChange={(e) => setQuery(e.target.value)}
                       placeholder="Search servers"
+                      title={`Search servers (/ or ${isMac ? "⌘" : "Ctrl"}F)`}
                       className="h-9 w-44 pl-8"
                     />
                   </div>
@@ -703,7 +761,11 @@ function App() {
                     onSaved={setRegistry}
                     existingNames={servers.map((s) => s.name)}
                     trigger={
-                      <Button variant="outline" size="sm">
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        title={`Add server (${isMac ? "⌘" : "Ctrl"}N)`}
+                      >
                         <Plus className="size-4" />
                         Add server
                       </Button>
@@ -939,6 +1001,36 @@ function App() {
         destructive
         onConfirm={handleToggleAll}
       />
+      {/* Ctrl+N. Mounted only while open so `autoOpen` fires each time, and unmounted
+          on close so the next press starts from a clean form. */}
+      {addServerOpen && (
+        <ServerDialog
+          autoOpen
+          onClose={() => setAddServerOpen(false)}
+          onSaved={setRegistry}
+          existingNames={servers.map((s) => s.name)}
+        />
+      )}
+      {/* `?` cheat sheet: shortcuts nobody can see are shortcuts nobody uses. */}
+      <Dialog open={shortcutsOpen} onOpenChange={setShortcutsOpen}>
+        <DialogContent className="sm:max-w-sm">
+          <DialogHeader>
+            <DialogTitle>Keyboard shortcuts</DialogTitle>
+          </DialogHeader>
+          <dl className="grid grid-cols-[auto_1fr] items-center gap-x-4 gap-y-2 text-sm">
+            {shortcutHelp(isMac).map((row) => (
+              <div key={row.keys} className="contents">
+                <dt>
+                  <kbd className="rounded border border-border/60 bg-muted px-1.5 py-0.5 font-mono text-xs">
+                    {row.keys}
+                  </kbd>
+                </dt>
+                <dd className="text-muted-foreground">{row.what}</dd>
+              </div>
+            ))}
+          </dl>
+        </DialogContent>
+      </Dialog>
       <Toaster theme={resolvedTheme} position="bottom-right" />
     </TooltipProvider>
   );

--- a/src/components/ServerDialog.autoopen.test.tsx
+++ b/src/components/ServerDialog.autoopen.test.tsx
@@ -1,0 +1,95 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useState } from "react";
+import { ServerDialog } from "./ServerDialog";
+
+// The dialog talks to Tauri on save; stub the surface it touches.
+vi.mock("@/lib/api", () => ({
+  addServer: vi.fn(async () => ({ servers: [], profiles: [] })),
+  updateServer: vi.fn(async () => ({ servers: [], profiles: [] })),
+  setSecret: vi.fn(async () => undefined),
+  testServer: vi.fn(async () => ({ ok: true, toolCount: 1, error: null })),
+}));
+
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn(), warning: vi.fn(), message: vi.fn() },
+}));
+
+/**
+ * A parent that opens ServerDialog the way a keyboard shortcut does: mount-on-demand
+ * with `autoOpen`, unmount when it reports closed.
+ *
+ * The bug this pins (SBS-143 review): a successful save closes the dialog through its
+ * own `setOpen(false)` rather than `onOpenChange`, so `onClose` never fires. A parent
+ * that only clears its state in `onClose` stays stuck `true`, and the next press is a
+ * silent no-op because nothing remounts to re-trigger `autoOpen`.
+ */
+function ShortcutHost({ clearOnSaved }: { clearOnSaved: boolean }) {
+  const [open, setOpen] = useState(false);
+  return (
+    <div>
+      <button onClick={() => setOpen(true)}>shortcut</button>
+      <span data-testid="mounted">{open ? "yes" : "no"}</span>
+      {open && (
+        <ServerDialog
+          autoOpen
+          onClose={() => setOpen(false)}
+          onSaved={() => {
+            if (clearOnSaved) setOpen(false);
+          }}
+        />
+      )}
+    </div>
+  );
+}
+
+async function saveAServer(user: ReturnType<typeof userEvent.setup>) {
+  await user.type(screen.getByLabelText(/name/i), "demo");
+  await user.type(screen.getByLabelText(/command/i), "npx");
+  const save = screen.getByRole("button", { name: /^add$|^save$/i });
+  await waitFor(() => expect(save).toBeEnabled());
+  await user.click(save);
+}
+
+describe("ServerDialog opened by a shortcut (autoOpen)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("stays reopenable after a successful save", async () => {
+    const user = userEvent.setup();
+    render(<ShortcutHost clearOnSaved />);
+
+    await user.click(screen.getByText("shortcut"));
+    expect(screen.getByTestId("mounted")).toHaveTextContent("yes");
+    await saveAServer(user);
+
+    // The save must release the parent's state, or the dialog can never reopen.
+    await waitFor(() => expect(screen.getByTestId("mounted")).toHaveTextContent("no"));
+
+    await user.click(screen.getByText("shortcut"));
+    expect(screen.getByTestId("mounted")).toHaveTextContent("yes");
+  });
+
+  it("regression: a parent that clears only in onClose gets stuck after saving", async () => {
+    // Documents WHY App.tsx clears in onSaved as well. If ServerDialog is ever changed
+    // to route save through onOpenChange, this test flips and can be deleted.
+    const user = userEvent.setup();
+    render(<ShortcutHost clearOnSaved={false} />);
+
+    await user.click(screen.getByText("shortcut"));
+    await saveAServer(user);
+
+    // Still mounted: onClose never fired, because save bypasses onOpenChange.
+    expect(screen.getByTestId("mounted")).toHaveTextContent("yes");
+  });
+
+  it("cancelling does release the parent", async () => {
+    const user = userEvent.setup();
+    render(<ShortcutHost clearOnSaved />);
+
+    await user.click(screen.getByText("shortcut"));
+    await user.click(screen.getByRole("button", { name: /cancel/i }));
+
+    await waitFor(() => expect(screen.getByTestId("mounted")).toHaveTextContent("no"));
+  });
+});

--- a/src/components/ServerDialog.tsx
+++ b/src/components/ServerDialog.tsx
@@ -40,7 +40,9 @@ import {
 } from "@/components/ui/select";
 
 interface Props {
-  trigger: ReactNode;
+  /** The control that opens the dialog. Omit when opening it with `autoOpen` (a
+   * keyboard shortcut or a catalog flow), where there is no button to render. */
+  trigger?: ReactNode;
   onSaved: (registry: Registry) => void;
   /** When set, the dialog edits this server (vs. adding a new one). */
   editId?: string;
@@ -277,7 +279,7 @@ export function ServerDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogTrigger asChild>{trigger}</DialogTrigger>
+      {trigger && <DialogTrigger asChild>{trigger}</DialogTrigger>}
       <DialogContent className="sm:max-w-md">
         <DialogHeader>
           <DialogTitle>{editing ? "Edit server" : "Add MCP server"}</DialogTitle>

--- a/src/lib/shortcuts.test.ts
+++ b/src/lib/shortcuts.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest";
+import {
+  isTextEntry,
+  resolveShortcut,
+  shortcutHelp,
+  SHORTCUT_VIEWS,
+  type ShortcutEvent,
+} from "./shortcuts";
+
+function key(k: string, mods: Partial<ShortcutEvent> = {}): ShortcutEvent {
+  return {
+    key: k,
+    ctrlKey: false,
+    metaKey: false,
+    altKey: false,
+    shiftKey: false,
+    ...mods,
+  };
+}
+
+describe("resolveShortcut (SBS-143)", () => {
+  it("maps Ctrl+1..6 to the six views in order", () => {
+    SHORTCUT_VIEWS.forEach((view, i) => {
+      expect(resolveShortcut(key(String(i + 1), { ctrlKey: true }))).toEqual({
+        kind: "view",
+        view,
+      });
+    });
+  });
+
+  it("accepts Cmd as well as Ctrl", () => {
+    expect(resolveShortcut(key("1", { metaKey: true }))).toEqual({
+      kind: "view",
+      view: "servers",
+    });
+  });
+
+  it("does not claim a seventh number", () => {
+    expect(resolveShortcut(key("7", { ctrlKey: true }))).toBeNull();
+  });
+
+  it("focuses search on bare / only outside a text field", () => {
+    expect(resolveShortcut(key("/"))).toEqual({ kind: "focusSearch" });
+    // Typing "/" into a field must insert the character, not steal focus.
+    expect(resolveShortcut(key("/"), { tagName: "INPUT" })).toBeNull();
+    expect(resolveShortcut(key("/"), { isContentEditable: true })).toBeNull();
+  });
+
+  it("keeps modifier chords working while typing", () => {
+    // An explicit chord is never a character the user meant to enter.
+    expect(resolveShortcut(key("f", { ctrlKey: true }), { tagName: "INPUT" })).toEqual({
+      kind: "focusSearch",
+    });
+    expect(resolveShortcut(key("2", { ctrlKey: true }), { tagName: "TEXTAREA" })).toEqual(
+      {
+        kind: "view",
+        view: "activity",
+      },
+    );
+  });
+
+  it("maps the action chords", () => {
+    expect(resolveShortcut(key("n", { ctrlKey: true }))).toEqual({ kind: "addServer" });
+    expect(resolveShortcut(key("r", { ctrlKey: true }))).toEqual({ kind: "refresh" });
+    // Case-insensitive: Shift+Ctrl+N still reads as N.
+    expect(resolveShortcut(key("N", { ctrlKey: true, shiftKey: true }))).toEqual({
+      kind: "addServer",
+    });
+  });
+
+  it("opens help on ? and closes it on Escape even from a field", () => {
+    expect(resolveShortcut(key("?"))).toEqual({ kind: "help" });
+    expect(resolveShortcut(key("?"), { tagName: "INPUT" })).toBeNull();
+    // Escape means the same thing everywhere else in the app, so it works while typing.
+    expect(resolveShortcut(key("Escape"), { tagName: "INPUT" })).toEqual({
+      kind: "closeHelp",
+    });
+  });
+
+  it("leaves Alt chords to the OS", () => {
+    expect(resolveShortcut(key("1", { ctrlKey: true, altKey: true }))).toBeNull();
+    expect(resolveShortcut(key("/", { altKey: true }))).toBeNull();
+  });
+
+  it("ignores ordinary typing", () => {
+    for (const k of ["a", "Enter", "Tab", "ArrowDown", " "]) {
+      expect(resolveShortcut(key(k))).toBeNull();
+    }
+  });
+});
+
+describe("isTextEntry", () => {
+  it("treats inputs, textareas, selects and contenteditable as typing surfaces", () => {
+    expect(isTextEntry({ tagName: "INPUT" })).toBe(true);
+    expect(isTextEntry({ tagName: "textarea" })).toBe(true);
+    expect(isTextEntry({ tagName: "SELECT" })).toBe(true);
+    expect(isTextEntry({ isContentEditable: true })).toBe(true);
+    expect(isTextEntry({ tagName: "DIV" })).toBe(false);
+    expect(isTextEntry(null)).toBe(false);
+  });
+});
+
+describe("shortcutHelp", () => {
+  it("names the platform modifier so a Mac user is not told to press Ctrl", () => {
+    expect(shortcutHelp(true)[0].keys).toContain("⌘");
+    expect(shortcutHelp(false)[0].keys).toContain("Ctrl");
+  });
+
+  it("documents every action the resolver can produce", () => {
+    const rows = shortcutHelp(false);
+    expect(rows).toHaveLength(6);
+    expect(rows.every((r) => r.keys && r.what)).toBe(true);
+  });
+});

--- a/src/lib/shortcuts.ts
+++ b/src/lib/shortcuts.ts
@@ -1,0 +1,112 @@
+import type { View } from "./types";
+
+/** Views in the order their number key selects them (SBS-143). */
+export const SHORTCUT_VIEWS: View[] = [
+  "servers",
+  "activity",
+  "catalog",
+  "playground",
+  "teams",
+  "settings",
+];
+
+/** What a keystroke resolved to, or `null` when it is not a shortcut. */
+export type ShortcutAction =
+  | { kind: "view"; view: View }
+  | { kind: "focusSearch" }
+  | { kind: "addServer" }
+  | { kind: "refresh" }
+  | { kind: "help" }
+  | { kind: "closeHelp" };
+
+/** The subset of a keyboard event this needs, so it is testable without a DOM. */
+export interface ShortcutEvent {
+  key: string;
+  ctrlKey: boolean;
+  metaKey: boolean;
+  altKey: boolean;
+  shiftKey: boolean;
+}
+
+/** Where the keystroke landed. A bare `/` must reach the page, not steal a character
+ * from whatever the user is typing into. */
+export interface ShortcutTarget {
+  tagName?: string;
+  isContentEditable?: boolean;
+}
+
+const TEXT_ENTRY_TAGS = new Set(["INPUT", "TEXTAREA", "SELECT"]);
+
+/** True when the keystroke is being typed into a field, so bare-key shortcuts defer. */
+export function isTextEntry(target: ShortcutTarget | null | undefined): boolean {
+  if (!target) return false;
+  if (target.isContentEditable) return true;
+  return TEXT_ENTRY_TAGS.has((target.tagName ?? "").toUpperCase());
+}
+
+/**
+ * Resolve a keystroke to an action, or `null`.
+ *
+ * Pure and DOM-free on purpose: the interesting behaviour here is which keys are
+ * claimed and which are deliberately left alone, and that is worth testing directly
+ * rather than through a rendered tree.
+ *
+ * Rules:
+ *   * `Ctrl/Cmd+1..6` switch views, and work even while typing — an explicit modifier
+ *     chord is never something the user meant as text.
+ *   * `/` focuses search, but only outside a text field, or it eats the character.
+ *   * `Ctrl/Cmd+F` also focuses search, everywhere. `Ctrl/Cmd+N` adds a server,
+ *     `Ctrl/Cmd+R` refreshes.
+ *   * `?` opens the cheat sheet, `Escape` closes it.
+ *   * Anything with `Alt` is left alone: Alt chords are OS/menu territory.
+ */
+export function resolveShortcut(
+  event: ShortcutEvent,
+  target?: ShortcutTarget | null,
+): ShortcutAction | null {
+  if (event.altKey) return null;
+  const mod = event.ctrlKey || event.metaKey;
+  const typing = isTextEntry(target);
+
+  if (mod) {
+    const index = SHORTCUT_VIEWS.findIndex((_, i) => event.key === String(i + 1));
+    if (index >= 0) return { kind: "view", view: SHORTCUT_VIEWS[index] };
+    switch (event.key.toLowerCase()) {
+      case "f":
+        return { kind: "focusSearch" };
+      case "n":
+        return { kind: "addServer" };
+      case "r":
+        return { kind: "refresh" };
+      default:
+        return null;
+    }
+  }
+
+  // Bare keys. Escape closes the sheet even from a field, since that is what Escape
+  // means everywhere else in the app.
+  if (event.key === "Escape") return { kind: "closeHelp" };
+  if (typing) return null;
+  if (event.key === "/") return { kind: "focusSearch" };
+  if (event.key === "?") return { kind: "help" };
+  return null;
+}
+
+/** One row of the `?` cheat sheet. `keys` is already display-formatted. */
+export interface ShortcutHelpRow {
+  keys: string;
+  what: string;
+}
+
+/** The cheat sheet, built for the platform so a Mac user is not told to press Ctrl. */
+export function shortcutHelp(isMac: boolean): ShortcutHelpRow[] {
+  const mod = isMac ? "⌘" : "Ctrl";
+  return [
+    { keys: `${mod}1 – ${mod}6`, what: "Switch view" },
+    { keys: `/ or ${mod}F`, what: "Focus the server search" },
+    { keys: `${mod}N`, what: "Add a server" },
+    { keys: `${mod}R`, what: "Refresh servers and clients" },
+    { keys: "?", what: "Show this list" },
+    { keys: "Esc", what: "Close this list" },
+  ];
+}


### PR DESCRIPTION
Two tickets from the 2026-07-13 UX audit, both in the **Frontend & polish** milestone.

| Commit | Ticket | What |
|---|---|---|
| `5a5f8e7` | SBS-143 | Keyboard shortcuts + `?` cheat sheet |
| `806790a` | SBS-144 | Window size/position survives a restart |

---

### SBS-143 — keyboard shortcuts

There were none: no `ctrlKey`/`metaKey` handlers, no accelerators, only per-field Enter. For a developer tool every interaction was mouse-only, and the server search box could not be focused from the keyboard at all.

| Key | Action |
|---|---|
| `Ctrl/Cmd+1..6` | Switch view |
| `/` or `Ctrl/Cmd+F` | Focus server search |
| `Ctrl/Cmd+N` | Add a server |
| `Ctrl/Cmd+R` | Refresh servers and clients |
| `?` | Cheat sheet |
| `Esc` | Close it |

Three decisions worth reviewing:

- **A bare `/` is ignored while typing**, or it eats the character out of whatever field has focus. An explicit modifier chord still works there, since a chord is never text the user meant to enter.
- **`Esc` does not `preventDefault`.** It belongs to whatever dialog or menu is open and must not be stopped from closing it — it only clears the cheat sheet.
- **`Ctrl+R` is claimed**, because otherwise the webview reloads and discards in-flight state. But `preventDefault` happens only *after* the key resolves as ours, so every unclaimed key keeps its default behaviour.

Which key means what lives in a pure `resolveShortcut()` with **12 unit tests**, rather than being buried in a DOM handler. That matters here because the interesting part is which keys are deliberately *not* claimed (Alt chords, ordinary typing, `/` in a field), and that is exactly what is untestable through a rendered tree.

`ServerDialog`'s `trigger` prop becomes optional — `Ctrl+N` mounts one with `autoOpen` and no button to render.

### SBS-144 — window geometry

The window opened at the fixed 1240x820 centered geometry on every process start, undoing a resize or move on every quit, reboot and update relaunch. Adds `tauri-plugin-window-state`, which the ticket names as the fix.

**`VISIBLE` is excluded from the restored flags on purpose.** The window is configured `visible: false` and shown by `setup()`, or deliberately left hidden for a `--hidden` autostart into the tray. Letting the plugin restore visibility would fight that and flash a window on every launch-at-login.

This adds one dependency. It is the official Tauri plugin and the ticket's own prescribed fix, but flagging it since it is the only dep added across this batch of PRs.

## Verification

- `npx vitest run` — **230 frontend tests pass** (12 new)
- `cargo test` — 808 library + 238 gateway + all integration pass
- `tsc --noEmit` clean, `npm run lint` 0 errors / 23 warnings (unchanged), prettier clean
- `cargo fmt --check` — no new drift

`cargo clippy --all-targets` reports **1 error on this branch**, the pre-existing `never_loop` in `toolport-gateway.rs:6595`. That is not from this PR — it is fixed in #669, and this branch is off `main`.

## Note on the build

Adding the dependency triggered the same corrupted-artifact failures I have hit repeatedly today (`found staticlib pest_derive instead of rlib`, `can't find crate for conduit_lib`). A full `cargo clean` did **not** clear it; what did was building the lib alone first (`cargo build --lib`) and then running the suite. All numbers above are from that clean run. Worth knowing if CI ever interleaves clippy and test against a shared target dir.