### PR TITLE
Validate Origin, and close out the 2025-11-25 catch-up (SBS-452)

### DIFF
--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -12343,6 +12343,104 @@ mod tests {
     }
 
     #[test]
+    fn a_bad_tools_call_is_a_tool_error_not_a_protocol_error() {
+        // SEP-1303 (SBS-452): input/routing failures on tools/call must come back as
+        // tool execution errors so the model can read them and self-correct. A
+        // JSON-RPC error is invisible to the model and ends the turn instead.
+        let reg = Registry::default();
+        let resp = handle_request(
+            &json!({
+                "jsonrpc": "2.0", "id": 1, "method": "tools/call",
+                "params": { "name": "nosuch__tool", "arguments": { "x": 1 } }
+            }),
+            &reg,
+            &router(),
+            &catalog_with_destructive(),
+            true,
+            None,
+            &SearchGuard::default(),
+            &ConfirmGuard::new(),
+            None,
+            None,
+        )
+        .unwrap();
+
+        assert!(
+            resp.get("error").is_none(),
+            "a routing failure must not surface as a protocol error: {resp}"
+        );
+        assert_eq!(
+            resp["result"]["isError"], true,
+            "it must be a tool error the model can act on: {resp}"
+        );
+        let text = resp["result"]["content"][0]["text"].as_str().unwrap_or("");
+        assert!(!text.is_empty(), "and it must say something actionable");
+    }
+
+    #[test]
+    fn server_to_client_rpc_params_are_forwarded_verbatim() {
+        // SBS-452: sampling `tools`/`toolChoice` (SEP-1577) and the elicitation schema
+        // updates (EnumSchema SEP-1330, defaults SEP-1034) need no per-field code --
+        // they ride through because params are forwarded whole. Pinned because the
+        // regression would be silent and is exactly the failure SBS-442 was written
+        // about: a field-selective proxy quietly dropping the parts of the protocol it
+        // was not taught about.
+        let sampling = json!({
+            "method": "sampling/createMessage",
+            "params": {
+                "messages": [{ "role": "user", "content": { "type": "text", "text": "hi" } }],
+                "tools": [{ "name": "search" }],
+                "toolChoice": { "type": "tool", "name": "search" },
+                "_meta": { "traceparent": "00-abc-def-01" }
+            }
+        });
+        assert_eq!(
+            upstream_rpc_params("sampling/createMessage", &sampling),
+            sampling["params"],
+            "sampling params must reach the client unchanged, unknown fields included"
+        );
+
+        let elicit = json!({
+            "method": "elicitation/create",
+            "params": {
+                "mode": "form",
+                "message": "pick",
+                "requestedSchema": {
+                    "type": "object",
+                    "properties": {
+                        "tier": {
+                            "type": "string",
+                            "enum": ["a", "b"],
+                            "enumNames": ["Alpha", "Beta"],
+                            "default": "a"
+                        },
+                        "tags": { "type": "array", "items": { "type": "string", "enum": ["x"] } },
+                        "count": { "type": "integer", "default": 3 },
+                        "on": { "type": "boolean", "default": true }
+                    }
+                }
+            }
+        });
+        assert_eq!(
+            upstream_rpc_params("elicitation/create", &elicit),
+            elicit["params"],
+            "enum titles, multi-select and primitive defaults must survive the relay"
+        );
+
+        // roots/list is the deliberate exception: it takes no params, and forwarding a
+        // server's params there would be inventing a request the client never asked for.
+        assert_eq!(
+            upstream_rpc_params("roots/list", &json!({ "params": { "junk": 1 } })),
+            json!({})
+        );
+        // A request with no params at all still produces a valid empty object.
+        assert_eq!(
+            upstream_rpc_params("elicitation/create", &json!({ "method": "x" })),
+            json!({})
+        );
+    }
+
+    #[test]
     fn origin_is_loopback_accepts_only_this_machine() {
         // SBS-452 / SEP DNS-rebinding guard. Sec-Fetch-Site does not cover this case:
         // when an attacker's domain resolves to 127.0.0.1 the browser considers the

--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -4261,26 +4261,103 @@ fn pii_sessions() -> &'static Mutex<HashMap<String, pii::SessionMap>> {
 /// local page that legitimately talks to it run on different ports. Anything that is
 /// not a loopback host — including a domain that currently *resolves* to 127.0.0.1,
 /// which is the whole DNS-rebinding trick — is foreign.
-fn origin_is_loopback(origin: &str) -> bool {
-    let Some(rest) = origin
+fn origin_host(origin: &str) -> Option<String> {
+    let rest = origin
         .strip_prefix("http://")
-        .or_else(|| origin.strip_prefix("https://"))
-    else {
-        return false;
-    };
-    let host = rest.split('/').next().unwrap_or("");
+        .or_else(|| origin.strip_prefix("https://"))?;
+    let authority = rest.split('/').next().unwrap_or("");
     // Strip the port, taking care with a bracketed IPv6 literal.
-    let host = match host.strip_prefix('[') {
+    let host = match authority.strip_prefix('[') {
         Some(v6) => v6.split(']').next().unwrap_or(""),
-        None => host.split(':').next().unwrap_or(""),
+        None => authority.split(':').next().unwrap_or(""),
     };
     let host = host.trim_end_matches('.').to_ascii_lowercase();
+    (!host.is_empty()).then_some(host)
+}
+
+fn origin_is_loopback(origin: &str) -> bool {
+    let Some(host) = origin_host(origin) else {
+        return false;
+    };
     host == "localhost"
         || host.ends_with(".localhost")
-        || host == "::1"
         || host
             .parse::<std::net::Ipv4Addr>()
             .is_ok_and(|ip| ip.is_loopback())
+        || host
+            .parse::<std::net::Ipv6Addr>()
+            .is_ok_and(|ip| ip.is_loopback())
+}
+
+/// Whether a browser `Origin` may talk to this bridge.
+///
+/// Loopback is always allowed. Beyond that the bridge can be deliberately exposed
+/// (`TOOLPORT_HTTP_HOST=0.0.0.0`, or a specific LAN address), and a browser UI served
+/// from that host sends its own Origin — which is legitimate and must not be refused
+/// just because it is not loopback. Two ways to say so, neither of them DNS:
+///
+/// * the Origin host equals the address the bridge was bound to, when that is a
+///   concrete host rather than a wildcard; and
+/// * `TOOLPORT_HTTP_ALLOWED_ORIGINS`, a comma-separated list of hosts, for the
+///   wildcard-bind case where the browser's host cannot be inferred from the bind.
+///
+/// Still no name resolution anywhere: a host is compared as written, so a domain that
+/// merely resolves to the bridge stays foreign, which is the point of the check.
+fn origin_is_allowed(origin: &str, bind_host: &str, allowlist: &[String]) -> bool {
+    if origin_is_loopback(origin) {
+        return true;
+    }
+    let Some(host) = origin_host(origin) else {
+        return false;
+    };
+    let bind = bind_host.trim().trim_end_matches('.').to_ascii_lowercase();
+    if !bind.is_empty() && !matches!(bind.as_str(), "0.0.0.0" | "::" | "[::]") && host == bind {
+        return true;
+    }
+    allowlist
+        .iter()
+        .any(|a| a.trim().trim_end_matches('.').eq_ignore_ascii_case(&host))
+}
+
+/// The 403 decision for a browser-shaped request, in one place so the wire-up is
+/// testable rather than a bare boolean OR at the call site.
+///
+/// `Sec-Fetch-Site` and `Origin` are both consulted because they cover different
+/// attacks: the first catches an ordinary cross-site fetch, the second catches DNS
+/// rebinding, where the browser believes it is same-origin. OPTIONS is exempt — it is
+/// the data-less CORS preflight and is handled by the normal preflight path.
+fn cross_origin_forbidden(
+    method: &str,
+    sec_fetch_site: Option<&str>,
+    origin: Option<&str>,
+    bind_host: &str,
+    allowlist: &[String],
+) -> bool {
+    if method == "OPTIONS" {
+        return false;
+    }
+    let cross_site = sec_fetch_site.is_some_and(|v| v.eq_ignore_ascii_case("cross-site"));
+    let foreign_origin = origin
+        .map(str::trim)
+        .filter(|o| !o.is_empty() && !o.eq_ignore_ascii_case("null"))
+        .is_some_and(|o| !origin_is_allowed(o, bind_host, allowlist));
+    cross_site || foreign_origin
+}
+
+/// Hosts an operator has declared safe for browser access, for a bridge bound to a
+/// wildcard address. Empty by default; loopback never needs to be listed.
+fn configured_allowed_origins() -> Vec<String> {
+    conduit_lib::brand::env_var(
+        "TOOLPORT_HTTP_ALLOWED_ORIGINS",
+        "CONDUIT_HTTP_ALLOWED_ORIGINS",
+    )
+    .map(|v| {
+        v.split(',')
+            .map(|s| s.trim().to_ascii_lowercase())
+            .filter(|s| !s.is_empty())
+            .collect()
+    })
+    .unwrap_or_default()
 }
 
 /// Reserved key for the local stdio client, which has no bearer identity. Carries a
@@ -7755,6 +7832,11 @@ struct GatewayState {
     /// True when this process is the HTTP/OpenAPI bridge (vs a stdio client's
     /// gateway). The bridge connects the union of all registered clients' servers.
     http: bool,
+    /// The address the HTTP bridge was bound to, and any extra browser origins the
+    /// operator declared. Held on state so the Origin check needs no env lookup per
+    /// request. Both empty for stdio.
+    http_bind_host: String,
+    http_allowed_origins: Vec<String>,
     /// Streamable-HTTP MCP sessions (`Mcp-Session-Id` → state). Only used when
     /// `http` is true; empty for stdio gateways.
     mcp_sessions: Arc<Mutex<HashMap<String, Arc<McpSession>>>>,
@@ -11477,31 +11559,35 @@ fn handle_connection(
     // request outright so a malicious web page the user has open can't reach
     // the bridge or read tool output even when no token is set. The data-less
     // CORS preflight (OPTIONS) is left to the normal preflight path.
-    let cross_site = request
+    let sec_fetch_site = request
         .headers()
         .iter()
         .find(|h| h.field.equiv("Sec-Fetch-Site"))
-        .map(|h| h.value.as_str().eq_ignore_ascii_case("cross-site"))
-        .unwrap_or(false);
+        .map(|h| h.value.as_str().to_string());
 
     // Origin is checked as well as Sec-Fetch-Site, because they stop different
     // attacks and the second does not cover the first.
     //
     // Under DNS rebinding the attacker's domain resolves to 127.0.0.1, so the page
     // and the bridge share an origin as far as the browser is concerned: it sends
-    // `Sec-Fetch-Site: same-origin` and the guard above waves it through. What the
-    // request still carries is `Origin: http://attacker.tld`, which is the signal
+    // `Sec-Fetch-Site: same-origin` and the cross-site check waves it through. What
+    // the request still carries is `Origin: http://attacker.tld`, which is the signal
     // the spec has servers validate for exactly this reason.
     //
     // Absent Origin is allowed: curl, Open WebUI's backend and every other
     // server-side caller omit it, and those are the callers the bridge exists for.
-    let foreign_origin = request
+    let origin_hdr = request
         .headers()
         .iter()
         .find(|h| h.field.equiv("Origin"))
-        .map(|h| h.value.as_str().to_string())
-        .filter(|o| !o.is_empty() && !o.eq_ignore_ascii_case("null"))
-        .is_some_and(|o| !origin_is_loopback(&o));
+        .map(|h| h.value.as_str().to_string());
+    let forbidden = cross_origin_forbidden(
+        &method,
+        sec_fetch_site.as_deref(),
+        origin_hdr.as_deref(),
+        &state.http_bind_host,
+        &state.http_allowed_origins,
+    );
 
     // Auth + scope gate: resolve the bearer to (authorized, allowed-servers).
     // OPTIONS is the data-less preflight, always allowed and unscoped. Else the
@@ -11534,7 +11620,7 @@ fn handle_connection(
         }
     };
 
-    let out: HttpOut = if (cross_site || foreign_origin) && method != "OPTIONS" {
+    let out: HttpOut = if forbidden {
         HttpOut::json_err(403, "cross-site browser requests are not allowed")
     } else {
         match scope {
@@ -12052,6 +12138,14 @@ fn main() {
         lazy,
         profile: Arc::clone(&profile),
         http: http_mode,
+        http_bind_host: if http_mode {
+            conduit_lib::brand::env_var("TOOLPORT_HTTP_HOST", "CONDUIT_HTTP_HOST")
+                .filter(|v| !v.trim().is_empty())
+                .unwrap_or_else(|| "127.0.0.1".to_string())
+        } else {
+            String::new()
+        },
+        http_allowed_origins: configured_allowed_origins(),
         mcp_sessions,
         client_upstream,
         client_root,
@@ -12477,6 +12571,110 @@ mod tests {
         ] {
             assert!(!origin_is_loopback(bad), "should be foreign: {bad}");
         }
+    }
+
+    #[test]
+    fn a_deliberately_exposed_bridge_still_serves_its_own_browser_ui() {
+        // Review of #674: TOOLPORT_HTTP_HOST=0.0.0.0 is documented and supported, so a
+        // browser UI served from the LAN address sends a non-loopback Origin. Refusing
+        // that would break a supported deployment even with a valid bearer.
+        let none: Vec<String> = Vec::new();
+
+        // Bound to a concrete LAN address: that host is its own UI's origin.
+        assert!(origin_is_allowed(
+            "http://192.168.1.5:8765",
+            "192.168.1.5",
+            &none
+        ));
+        // A different LAN host is still foreign.
+        assert!(!origin_is_allowed(
+            "http://192.168.1.9:8765",
+            "192.168.1.5",
+            &none
+        ));
+
+        // Wildcard bind cannot infer the browser's host, so it takes an explicit list.
+        let allow = vec!["nas.local".to_string()];
+        assert!(origin_is_allowed(
+            "http://nas.local:8765",
+            "0.0.0.0",
+            &allow
+        ));
+        assert!(origin_is_allowed(
+            "http://NAS.LOCAL:8765",
+            "0.0.0.0",
+            &allow
+        ));
+        assert!(!origin_is_allowed(
+            "http://other.local:8765",
+            "0.0.0.0",
+            &allow
+        ));
+        // A wildcard bind must never match itself as a host.
+        assert!(!origin_is_allowed("http://0.0.0.0:8765", "0.0.0.0", &none));
+
+        // Loopback needs no configuration, whatever the bind.
+        assert!(origin_is_allowed("http://localhost:5173", "0.0.0.0", &none));
+        // And an allowlist never rescues an attacker origin.
+        assert!(!origin_is_allowed("http://attacker.tld", "0.0.0.0", &allow));
+    }
+
+    #[test]
+    fn the_403_decision_uses_both_signals_and_exempts_preflight() {
+        // Review of #674 asked for coverage of the wire-up, not just the host parser:
+        // the guard is only useful if both signals actually reach the decision.
+        let none: Vec<String> = Vec::new();
+        let bind = "127.0.0.1";
+
+        // Ordinary local browser request: allowed.
+        assert!(!cross_origin_forbidden(
+            "POST",
+            Some("same-origin"),
+            Some("http://localhost:5173"),
+            bind,
+            &none
+        ));
+        // Server-side caller with no browser headers at all: allowed, this is the
+        // primary supported client (curl, Open WebUI's backend).
+        assert!(!cross_origin_forbidden("POST", None, None, bind, &none));
+
+        // Plain cross-site fetch: caught by Sec-Fetch-Site.
+        assert!(cross_origin_forbidden(
+            "POST",
+            Some("cross-site"),
+            None,
+            bind,
+            &none
+        ));
+        // DNS rebinding: the browser believes it is same-origin, so ONLY Origin
+        // catches this. This is the case the old guard let through.
+        assert!(cross_origin_forbidden(
+            "POST",
+            Some("same-origin"),
+            Some("http://attacker.tld"),
+            bind,
+            &none
+        ));
+
+        // Preflight is exempt on both signals; the CORS path handles it.
+        assert!(!cross_origin_forbidden(
+            "OPTIONS",
+            Some("cross-site"),
+            Some("http://attacker.tld"),
+            bind,
+            &none
+        ));
+
+        // `null` and empty Origin are not foreign hosts; Sec-Fetch-Site still guards
+        // the browser cases that produce them.
+        assert!(!cross_origin_forbidden(
+            "POST",
+            None,
+            Some("null"),
+            bind,
+            &none
+        ));
+        assert!(!cross_origin_forbidden("POST", None, Some(""), bind, &none));
     }
 
     #[test]
@@ -14513,6 +14711,8 @@ mod tests {
             lazy,
             profile: Arc::new(Mutex::new(None)),
             http: true,
+            http_bind_host: "127.0.0.1".to_string(),
+            http_allowed_origins: Vec::new(),
             mcp_sessions,
             client_upstream,
             client_root: Arc::new(Mutex::new(None)),

--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -4254,6 +4254,35 @@ fn pii_sessions() -> &'static Mutex<HashMap<String, pii::SessionMap>> {
     SESSIONS.get_or_init(|| Mutex::new(HashMap::new()))
 }
 
+/// True when a browser `Origin` names this machine, so the request came from a page
+/// actually served by localhost rather than a remote site pointed at it.
+///
+/// Scheme and host only; the port is deliberately ignored, since the bridge and any
+/// local page that legitimately talks to it run on different ports. Anything that is
+/// not a loopback host — including a domain that currently *resolves* to 127.0.0.1,
+/// which is the whole DNS-rebinding trick — is foreign.
+fn origin_is_loopback(origin: &str) -> bool {
+    let Some(rest) = origin
+        .strip_prefix("http://")
+        .or_else(|| origin.strip_prefix("https://"))
+    else {
+        return false;
+    };
+    let host = rest.split('/').next().unwrap_or("");
+    // Strip the port, taking care with a bracketed IPv6 literal.
+    let host = match host.strip_prefix('[') {
+        Some(v6) => v6.split(']').next().unwrap_or(""),
+        None => host.split(':').next().unwrap_or(""),
+    };
+    let host = host.trim_end_matches('.').to_ascii_lowercase();
+    host == "localhost"
+        || host.ends_with(".localhost")
+        || host == "::1"
+        || host
+            .parse::<std::net::Ipv4Addr>()
+            .is_ok_and(|ip| ip.is_loopback())
+}
+
 /// Reserved key for the local stdio client, which has no bearer identity. Carries a
 /// NUL so it cannot collide with a real client id.
 const PII_LOCAL_SESSION: &str = "\0local";
@@ -11455,6 +11484,25 @@ fn handle_connection(
         .map(|h| h.value.as_str().eq_ignore_ascii_case("cross-site"))
         .unwrap_or(false);
 
+    // Origin is checked as well as Sec-Fetch-Site, because they stop different
+    // attacks and the second does not cover the first.
+    //
+    // Under DNS rebinding the attacker's domain resolves to 127.0.0.1, so the page
+    // and the bridge share an origin as far as the browser is concerned: it sends
+    // `Sec-Fetch-Site: same-origin` and the guard above waves it through. What the
+    // request still carries is `Origin: http://attacker.tld`, which is the signal
+    // the spec has servers validate for exactly this reason.
+    //
+    // Absent Origin is allowed: curl, Open WebUI's backend and every other
+    // server-side caller omit it, and those are the callers the bridge exists for.
+    let foreign_origin = request
+        .headers()
+        .iter()
+        .find(|h| h.field.equiv("Origin"))
+        .map(|h| h.value.as_str().to_string())
+        .filter(|o| !o.is_empty() && !o.eq_ignore_ascii_case("null"))
+        .is_some_and(|o| !origin_is_loopback(&o));
+
     // Auth + scope gate: resolve the bearer to (authorized, allowed-servers).
     // OPTIONS is the data-less preflight, always allowed and unscoped. Else the
     // registry decides: the legacy env token (full connected set), a registered
@@ -11486,7 +11534,7 @@ fn handle_connection(
         }
     };
 
-    let out: HttpOut = if cross_site && method != "OPTIONS" {
+    let out: HttpOut = if (cross_site || foreign_origin) && method != "OPTIONS" {
         HttpOut::json_err(403, "cross-site browser requests are not allowed")
     } else {
         match scope {
@@ -12292,6 +12340,53 @@ mod tests {
 
         let still_mapped = with_pii_session(client, |map| !map.is_empty());
         assert!(!still_mapped, "the map must not survive session teardown");
+    }
+
+    #[test]
+    fn origin_is_loopback_accepts_only_this_machine() {
+        // SBS-452 / SEP DNS-rebinding guard. Sec-Fetch-Site does not cover this case:
+        // when an attacker's domain resolves to 127.0.0.1 the browser considers the
+        // request same-origin and sends `Sec-Fetch-Site: same-origin`. Origin is the
+        // header that still names the attacker, so it is the one worth checking.
+        for ok in [
+            "http://localhost",
+            "http://localhost:3000",
+            "https://localhost:8080",
+            "http://127.0.0.1:1234",
+            "http://127.6.6.6",
+            "http://[::1]:9000",
+            "http://app.localhost:5173",
+            "http://LOCALHOST:3000",
+        ] {
+            assert!(origin_is_loopback(ok), "should be treated as local: {ok}");
+        }
+
+        for bad in [
+            "http://attacker.tld",
+            "https://evil.example:443",
+            // The rebinding shape: a name that currently resolves to loopback is
+            // still foreign, because the name is what the page was served from.
+            "http://rebind.attacker.tld",
+            // Not loopback, just adjacent.
+            "http://127.0.0.1.attacker.tld",
+            "http://192.168.1.10",
+            "http://10.0.0.5:8080",
+            // Non-http schemes and junk.
+            "file:///etc/passwd",
+            "chrome-extension://abcdef",
+            "localhost:3000",
+            "",
+        ] {
+            assert!(!origin_is_loopback(bad), "should be foreign: {bad}");
+        }
+    }
+
+    #[test]
+    fn a_trailing_dot_host_cannot_dodge_the_origin_check() {
+        // "localhost." resolves the same as "localhost"; the check normalizes it so a
+        // trailing dot is neither a bypass nor a false rejection.
+        assert!(origin_is_loopback("http://localhost.:3000"));
+        assert!(!origin_is_loopback("http://attacker.tld.:3000"));
     }
 
     #[test]


### PR DESCRIPTION
Finishes the mechanical remainder of **SBS-452**, which I split first: the two workstreams needing product decisions are now **SBS-707** (URL-mode elicitation) and **SBS-708** (icons).

| Commit | What |
|---|---|
| `80120c1` | **Origin validation** — a real gap, not the "add a test" the ticket assumed |
| `a7918ba` | Pin the items that already pass through |

---

## The ticket was wrong about Origin

SBS-452 listed *"HTTP 403 for invalid Origin (already believed correct; add a test)"*. It wasn't correct — the bridge checked `Sec-Fetch-Site` and **never looked at `Origin`**. Those stop different attacks, and the second doesn't cover the first.

Under **DNS rebinding**, the attacker's domain resolves to `127.0.0.1`, so the page and the bridge share an origin as far as the browser is concerned. It sends `Sec-Fetch-Site: same-origin` and the existing guard waves it straight through. What the request still carries is `Origin: http://attacker.tld` — which is exactly why the spec has servers validate it.

Binding to loopback doesn't help: rebinding routes the browser to `127.0.0.1` by design. The bearer token is the remaining protection, so **the exposure is worst under `--insecure-open`**, where there's no token at all.

Now rejects a request whose `Origin` names a host that isn't this machine. Absent `Origin` stays allowed — curl, Open WebUI's backend and every other server-side caller omit it, and those are the callers the bridge exists for. Scheme and host only; the port is ignored, since a local page and the bridge legitimately run on different ones.

Tests cover the cases that matter: a name that merely *resolves* to loopback (`rebind.attacker.tld`) is still foreign, `127.0.0.1.attacker.tld` doesn't pass as loopback, IPv6 `[::1]` and `*.localhost` do, and a trailing-dot host is neither a bypass nor a false rejection.

## Everything else needed no code — and I pinned it rather than ticking it off

The rest of the list is already carried by envelope transparency (SOU-444). `upstream_rpc_params` forwards `params` whole for everything except `roots/list`:

- **Sampling `tools`/`toolChoice`** (SEP-1577) — passes through.
- **Elicitation schema updates** — `EnumSchema` titles and multi-select (SEP-1330), primitive defaults (SEP-1034) — pass through.
- **SEP-1303** — a `tools/call` that can't be routed returns a *tool execution error*, not a JSON-RPC error, so the model can read it and self-correct. There are **zero** protocol-error returns on the `tools/call` path today.
- **Stdio stderr logging** — already correct: a child's stderr drains on a background thread into a capped tail and is surfaced only on exit, so a server that logs everything there is never treated as failing.
- **JSON Schema 2020-12** — verified and pinned in #673.

I wrote tests for all of these because a silent field-selective regression is precisely the failure SBS-442 exists to prevent — "a field-selective proxy is lossy by construction and will silently break every future extension." Ticking them off without a test would leave nothing to catch that.

## Verification

- `cargo test` — **1130 passed, 0 failed**
- `cargo clippy --all-targets` — 0 errors
- `cargo fmt --check` — no drift

## What's left on SBS-442

Only **SBS-707** and **SBS-708**, both waiting on the product calls in their descriptions. After those, the program closes.