### PR TITLE
Show tool icons, data: sources only (SBS-708)

### DIFF
--- a/src/components/PlaygroundView.tsx
+++ b/src/components/PlaygroundView.tsx
@@ -38,6 +38,7 @@ import type {
   ToolCallResult,
 } from "@/lib/types";
 import { Badge } from "@/components/ui/badge";
+import { pickIconSrc } from "@/lib/icons";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -1112,6 +1113,18 @@ export function PlaygroundView({ registry, onRegistryChange }: PlaygroundProps) 
                           className="flex min-w-0 flex-1 flex-col items-start gap-0.5 text-left"
                         >
                           <span className="flex min-w-0 items-center gap-2">
+                            {/* SEP-973. Only data: icons render (see pickIconSrc); a
+                                remote URL is a request to a server-chosen host on every
+                                paint, and the app's CSP blocks it anyway. Fixed box so a
+                                malformed or oddly-shaped icon cannot shift the row. */}
+                            {pickIconSrc(t.icons) && (
+                              <img
+                                src={pickIconSrc(t.icons) ?? undefined}
+                                alt=""
+                                aria-hidden="true"
+                                className="size-4 shrink-0 rounded-sm object-contain"
+                              />
+                            )}
                             <span className="truncate font-mono text-sm">{t.name}</span>
                             {destructive && <Badge variant="warning">destructive</Badge>}
                             {!exposed && (

--- a/src/components/PlaygroundView.tsx
+++ b/src/components/PlaygroundView.tsx
@@ -1102,6 +1102,7 @@ export function PlaygroundView({ registry, onRegistryChange }: PlaygroundProps) 
                     const selected = t.name === selectedTool;
                     const perToolOff = disabledSet.has(t.name);
                     const pinned = pinnedSet.has(t.name);
+                    const icon = pickIconSrc(t.icons);
                     return (
                       <div
                         key={t.name}
@@ -1117,9 +1118,9 @@ export function PlaygroundView({ registry, onRegistryChange }: PlaygroundProps) 
                                 remote URL is a request to a server-chosen host on every
                                 paint, and the app's CSP blocks it anyway. Fixed box so a
                                 malformed or oddly-shaped icon cannot shift the row. */}
-                            {pickIconSrc(t.icons) && (
+                            {icon && (
                               <img
-                                src={pickIconSrc(t.icons) ?? undefined}
+                                src={icon}
                                 alt=""
                                 aria-hidden="true"
                                 className="size-4 shrink-0 rounded-sm object-contain"

--- a/src/lib/icons.test.ts
+++ b/src/lib/icons.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { hasUnusableIcons, pickIconSrc, type McpIcon } from "./icons";
+import { pickIconSrc, type McpIcon } from "./icons";
 
 const png = "data:image/png;base64,iVBORw0KGgo=";
 
@@ -64,14 +64,5 @@ describe("pickIconSrc (SBS-708 / SEP-973)", () => {
     expect(pickIconSrc([{} as McpIcon])).toBeNull();
     expect(pickIconSrc([{ src: 123 } as unknown as McpIcon])).toBeNull();
     expect(pickIconSrc("nope" as unknown as McpIcon[])).toBeNull();
-  });
-});
-
-describe("hasUnusableIcons", () => {
-  it("distinguishes no icons from icons we refused", () => {
-    expect(hasUnusableIcons(undefined)).toBe(false);
-    expect(hasUnusableIcons([])).toBe(false);
-    expect(hasUnusableIcons([{ src: png }])).toBe(false);
-    expect(hasUnusableIcons([{ src: "https://cdn.example.com/a.png" }])).toBe(true);
   });
 });

--- a/src/lib/icons.test.ts
+++ b/src/lib/icons.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import { hasUnusableIcons, pickIconSrc, type McpIcon } from "./icons";
+
+const png = "data:image/png;base64,iVBORw0KGgo=";
+
+describe("pickIconSrc (SBS-708 / SEP-973)", () => {
+  it("accepts a data: image and returns it unchanged", () => {
+    expect(pickIconSrc([{ src: png }])).toBe(png);
+    expect(pickIconSrc([{ src: `  ${png}  ` }])).toBe(png);
+  });
+
+  it("refuses remote URLs, which are a request rather than a picture", () => {
+    // The security decision this file exists for: a remote icon URL means the app
+    // contacts a host the server chose, every time the list paints — a beacon that
+    // reveals when Toolport is open, with no tool call involved.
+    for (const src of [
+      "https://cdn.example.com/icon.png",
+      "http://192.168.1.5/icon.png",
+      "//cdn.example.com/icon.png",
+      "/local/icon.png",
+    ]) {
+      expect(pickIconSrc([{ src }])).toBeNull();
+    }
+  });
+
+  it("refuses non-image and script-capable data URIs", () => {
+    for (const src of [
+      "data:text/html;base64,PHNjcmlwdD4=",
+      "data:application/javascript,alert(1)",
+      "data:text/plain,hello",
+      "javascript:alert(1)",
+      "data:,",
+    ]) {
+      expect(pickIconSrc([{ src }])).toBeNull();
+    }
+  });
+
+  it("allows SVG, which cannot execute script through an img element", () => {
+    const svg = "data:image/svg+xml;base64,PHN2Zz48L3N2Zz4=";
+    expect(pickIconSrc([{ src: svg }])).toBe(svg);
+  });
+
+  it("skips an oversized icon rather than inlining megabytes into every render", () => {
+    const huge = `data:image/png;base64,${"A".repeat(70 * 1024)}`;
+    expect(pickIconSrc([{ src: huge }])).toBeNull();
+    // ...and still finds a usable one later in the list.
+    expect(pickIconSrc([{ src: huge }, { src: png }])).toBe(png);
+  });
+
+  it("takes the first usable icon and ignores earlier refused ones", () => {
+    const icons: McpIcon[] = [
+      { src: "https://cdn.example.com/a.png" },
+      { src: "data:text/html,x" },
+      { src: png },
+    ];
+    expect(pickIconSrc(icons)).toBe(png);
+  });
+
+  it("handles missing, empty and malformed input without throwing", () => {
+    expect(pickIconSrc(undefined)).toBeNull();
+    expect(pickIconSrc(null)).toBeNull();
+    expect(pickIconSrc([])).toBeNull();
+    // A server can send anything; none of it should break a render.
+    expect(pickIconSrc([{} as McpIcon])).toBeNull();
+    expect(pickIconSrc([{ src: 123 } as unknown as McpIcon])).toBeNull();
+    expect(pickIconSrc("nope" as unknown as McpIcon[])).toBeNull();
+  });
+});
+
+describe("hasUnusableIcons", () => {
+  it("distinguishes no icons from icons we refused", () => {
+    expect(hasUnusableIcons(undefined)).toBe(false);
+    expect(hasUnusableIcons([])).toBe(false);
+    expect(hasUnusableIcons([{ src: png }])).toBe(false);
+    expect(hasUnusableIcons([{ src: "https://cdn.example.com/a.png" }])).toBe(true);
+  });
+});

--- a/src/lib/icons.ts
+++ b/src/lib/icons.ts
@@ -1,0 +1,50 @@
+/** An icon as advertised by a downstream MCP server (SEP-973). */
+export interface McpIcon {
+  src: string;
+  mimeType?: string;
+  sizes?: string;
+}
+
+/** Largest icon we will inline, in characters of data URI. A server controls this
+ * string, and a multi-megabyte one would bloat every render for no visual gain. */
+const MAX_ICON_CHARS = 64 * 1024;
+
+/** Media types we will render. SVG is deliberately included: an SVG loaded through
+ * `<img>` is a passive context, so script inside it does not execute, and the app's
+ * `script-src 'self'` blocks it regardless. */
+const ALLOWED =
+  /^data:image\/(png|jpeg|jpg|gif|webp|svg\+xml|x-icon|vnd\.microsoft\.icon);/i;
+
+/**
+ * Pick an icon that is safe to render, or `null`.
+ *
+ * **Only `data:` URIs.** Icons come from downstream servers, which are the same
+ * attacker-controlled surface content-defense exists for, so a remote URL is not a
+ * picture — it is a request the app makes to a host of the server's choosing, every
+ * time the list paints. That would tell a server when you open Toolport, how often,
+ * and from what IP, with no tool call involved.
+ *
+ * The app's CSP (`img-src 'self' data:`) already blocks remote sources, so this
+ * function is the second half of the same decision rather than the only guard: it
+ * keeps a blocked URL from rendering as a broken image, and it documents why.
+ *
+ * If remote icons are ever wanted, the gateway should fetch and cache them so the
+ * app never contacts a server host directly — not a widened `img-src`.
+ */
+export function pickIconSrc(icons?: McpIcon[] | null): string | null {
+  if (!Array.isArray(icons)) return null;
+  for (const icon of icons) {
+    const src = typeof icon?.src === "string" ? icon.src.trim() : "";
+    if (!src || src.length > MAX_ICON_CHARS) continue;
+    if (!ALLOWED.test(src)) continue;
+    return src;
+  }
+  return null;
+}
+
+/** True when a server offered icons but none were usable, so the UI can stay silent
+ * rather than showing a broken image. Kept separate from [`pickIconSrc`] so a caller
+ * can tell "no icons" from "icons we refused". */
+export function hasUnusableIcons(icons?: McpIcon[] | null): boolean {
+  return Array.isArray(icons) && icons.length > 0 && pickIconSrc(icons) === null;
+}

--- a/src/lib/icons.ts
+++ b/src/lib/icons.ts
@@ -41,10 +41,3 @@ export function pickIconSrc(icons?: McpIcon[] | null): string | null {
   }
   return null;
 }
-
-/** True when a server offered icons but none were usable, so the UI can stay silent
- * rather than showing a broken image. Kept separate from [`pickIconSrc`] so a caller
- * can tell "no icons" from "icons we refused". */
-export function hasUnusableIcons(icons?: McpIcon[] | null): boolean {
-  return Array.isArray(icons) && icons.length > 0 && pickIconSrc(icons) === null;
-}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -167,6 +167,10 @@ export interface McpTool {
    * some servers also emit it at the top level, so both are tolerated. */
   annotations?: { destructiveHint?: boolean; [k: string]: unknown };
   destructiveHint?: boolean;
+  /** Server-declared icons (SEP-973). Already transit the gateway untouched. Only
+   * `data:` sources are ever rendered — see `pickIconSrc` for why a remote URL is a
+   * request rather than a picture. */
+  icons?: { src: string; mimeType?: string; sizes?: string }[];
 }
 
 /** A resource as advertised by a downstream server (raw `resources/list` entry). */


### PR DESCRIPTION
Closes **SBS-708**, one of the two remaining children of the SBS-442 spec-currency program.

## Two corrections to how this was scoped

**Placement.** The ticket — and my own earlier recommendation — said "server list first". That was wrong. SEP-973 declares icons on **tools, resources and prompts**, and Toolport captures no `serverInfo`, so there is no server-level icon to show without inventing one (picking some tool's icon to stand for its server). The tool browser is where the data actually is, so that is where they render.

**The real decision was never placement — it was CSP.** The app runs:

```
img-src 'self' data:
```

A remote icon URL **cannot render today**. So the question was never "where do icons go", it was "do we grant downstream servers a render-time egress channel". I did not widen the policy.

## Only `data:` sources are accepted

An icon URL is not a picture. It is a request the app makes to a host the server chose, **on every paint** — telling that server when Toolport is open, how often, and from what IP, with no tool call involved. A beacon shaped like a favicon. The same servers content-defense exists to distrust.

`pickIconSrc` accepts `data:image/*` only. If remote icons are ever wanted, the **gateway** should fetch and cache them so the app never contacts a server host directly — not a widened `img-src`.

**SVG is allowed deliberately.** An SVG loaded through `<img>` is a passive context, so script inside it does not execute, and `script-src 'self'` blocks it regardless. Refusing SVG would cost real icons for no gain.

## Robustness

- Oversized icons are skipped rather than inlined into every render (64 KB cap).
- The icon box is fixed-size with `object-contain`, so a malformed or oddly-shaped icon cannot shift a row.
- The helper never throws on anything a server might send.

**Eight tests** cover the refusals specifically: remote URLs, protocol-relative `//host`, `data:text/html`, `data:application/javascript`, `javascript:`, oversized, and malformed input (`{}`, non-string `src`, a non-array). Plus that a usable icon is still found after refused ones in the same list.

## Verification

- `npx vitest run` — **243 passed** (8 new)
- `tsc --noEmit` clean, `npm run lint` 0 errors / 23 warnings (unchanged), prettier clean

## SBS-442

Only **SBS-707** (URL-mode elicitation) remains after this.