### PR TITLE
feat: add URL-mode elicitation and harden session lifecycle

### DIFF
--- a/src-tauri/src/approval.rs
+++ b/src-tauri/src/approval.rs
@@ -69,6 +69,21 @@ pub struct ApprovalRequest {
     /// Allowlist entries include this so a tool definition change re-requires approval.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub tool_fingerprint: Option<String>,
+    /// A URL-mode elicitation that the desktop broker should present when the MCP client
+    /// cannot do so itself. Absent for ordinary tool approvals.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub url_elicitation: Option<UrlElicitationRequest>,
+}
+
+/// The already-screened browser interaction carried over the local broker. The gateway
+/// validates the URL and derives `origin`; the desktop renders that origin separately so a
+/// server-controlled message cannot disguise where the link goes.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UrlElicitationRequest {
+    pub url: String,
+    pub origin: String,
+    pub message: String,
 }
 
 /// The broker's answer to an [`ApprovalRequest`].
@@ -211,6 +226,7 @@ mod tests {
             reason: ApprovalReason::Destructive,
             arguments: serde_json::json!({ "table": "users" }),
             tool_fingerprint: Some("v2:abc".into()),
+            url_elicitation: None,
         };
         let round: ApprovalRequest =
             serde_json::from_str(&serde_json::to_string(&req).unwrap()).unwrap();

--- a/src-tauri/src/approval_broker.rs
+++ b/src-tauri/src/approval_broker.rs
@@ -27,8 +27,8 @@ use tauri::{AppHandle, Emitter, Manager};
 use tauri_plugin_notification::NotificationExt;
 
 use crate::approval::{
-    ApprovalDecision, ApprovalReason, ApprovalRequest, EndpointDescriptor, DEFAULT_TIMEOUT_SECS,
-    ENDPOINT_FILE,
+    ApprovalDecision, ApprovalReason, ApprovalRequest, EndpointDescriptor, UrlElicitationRequest,
+    DEFAULT_TIMEOUT_SECS, ENDPOINT_FILE,
 };
 
 /// A pending approval as the UI sees it. The auth token is deliberately NOT included.
@@ -42,6 +42,8 @@ pub struct PendingView {
     pub tool_fingerprint: Option<String>,
     pub reason: ApprovalReason,
     pub arguments: serde_json::Value,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub url_elicitation: Option<UrlElicitationRequest>,
     /// Wall-clock epoch-millis when this call auto-denies (park time + the fail-closed
     /// timeout). The UI counts down to this exactly, instead of approximating from when
     /// it first saw the request. App and broker share one clock, so it's accurate.
@@ -380,16 +382,18 @@ fn handle_conn(stream: TcpStream, broker: ApprovalBroker, app: AppHandle) {
     // Auto-approve only if the current tool definition matches a fingerprint-bound allow.
     // Legacy broad `server/tool` entries are intentionally ignored: a tool definition that
     // changed since approval should re-prompt instead of inheriting a stale bypass.
-    if let Some(fp) = req.tool_fingerprint.as_deref() {
-        let key = crate::approval::fingerprint_allow_key(&req.server, &req.tool, fp);
-        if broker.session_contains(&key) || registry_allows(&app, &key) {
-            let _ = out.set_write_timeout(Some(Duration::from_secs(10)));
-            let _ = writeln!(
-                out,
-                "{}",
-                serde_json::to_string(&ApprovalDecision::Approved).unwrap_or_default()
-            );
-            return;
+    if req.url_elicitation.is_none() {
+        if let Some(fp) = req.tool_fingerprint.as_deref() {
+            let key = crate::approval::fingerprint_allow_key(&req.server, &req.tool, fp);
+            if broker.session_contains(&key) || registry_allows(&app, &key) {
+                let _ = out.set_write_timeout(Some(Duration::from_secs(10)));
+                let _ = writeln!(
+                    out,
+                    "{}",
+                    serde_json::to_string(&ApprovalDecision::Approved).unwrap_or_default()
+                );
+                return;
+            }
         }
     }
 
@@ -401,6 +405,7 @@ fn handle_conn(stream: TcpStream, broker: ApprovalBroker, app: AppHandle) {
         tool_fingerprint: req.tool_fingerprint.clone(),
         reason: req.reason,
         arguments: req.arguments.clone(),
+        url_elicitation: req.url_elicitation.clone(),
         // Stamp the deadline now, right before we park on `recv_timeout` below.
         deadline_ms: deadline_ms_from_now(),
     };
@@ -470,12 +475,33 @@ fn registry_allows(app: &AppHandle, key: &str) -> bool {
 /// off, no window) the in-app overlay is still the source of truth. We flash rather than
 /// force-focus so we don't yank the user out of what they're doing.
 fn notify_pending(app: &AppHandle, view: &PendingView) {
-    let who = view.client.as_deref().map(|c| format!("{c} wants to run ")).unwrap_or_default();
+    let who = view
+        .client
+        .as_deref()
+        .map(|c| format!("{c} wants to run "))
+        .unwrap_or_default();
+    let (title, body) = if let Some(elicitation) = &view.url_elicitation {
+        (
+            "Toolport: browser action required",
+            format!(
+                "{} requested an external browser interaction. Review it in Toolport.",
+                elicitation.origin
+            ),
+        )
+    } else {
+        (
+            "Toolport: approval required",
+            format!(
+                "{who}{}/{} - approve or deny it in Toolport.",
+                view.server, view.tool
+            ),
+        )
+    };
     let _ = app
         .notification()
         .builder()
-        .title("Toolport: approval required")
-        .body(format!("{who}{}/{} - approve or deny it in Toolport.", view.server, view.tool))
+        .title(title)
+        .body(body)
         .show();
     if let Some(win) = app.get_webview_window("main") {
         let _ = win.request_user_attention(Some(tauri::UserAttentionType::Critical));
@@ -506,6 +532,7 @@ mod tests {
             tool_fingerprint: Some("v2:abc".into()),
             reason: ApprovalReason::Destructive,
             arguments: serde_json::json!({}),
+            url_elicitation: None,
             deadline_ms: deadline_ms_from_now(),
         };
         b.inner

--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -120,6 +120,40 @@ fn modern_client_supports_server_rpc(method: &str) -> bool {
     })
 }
 
+fn elicitation_mode_supported(capability: Option<&Value>, mode: &str) -> bool {
+    let Some(capability) = capability.and_then(Value::as_object) else {
+        return false;
+    };
+    match mode {
+        "url" => capability.get("url").is_some(),
+        // The pre-SEP empty declaration remains form-only for backwards compatibility.
+        "form" => capability.is_empty() || capability.get("form").is_some(),
+        _ => false,
+    }
+}
+
+fn modern_client_supports_server_request(request: &Value) -> bool {
+    let Some(method) = request.get("method").and_then(Value::as_str) else {
+        return false;
+    };
+    if method != "elicitation/create" {
+        return modern_client_supports_server_rpc(method);
+    }
+    let mode = request
+        .get("params")
+        .and_then(|params| params.get("mode"))
+        .and_then(Value::as_str)
+        .unwrap_or("form");
+    ACTIVE_UPSTREAM_CAPABILITIES.with(|cell| {
+        elicitation_mode_supported(
+            cell.borrow()
+                .as_ref()
+                .and_then(|caps| caps.get("elicitation")),
+            mode,
+        )
+    })
+}
+
 fn modern_client_supports_extension(identifier: &str) -> bool {
     ACTIVE_UPSTREAM_CAPABILITIES.with(|cell| {
         cell.borrow()
@@ -3787,6 +3821,7 @@ fn execute_call(
                 // the pseudonyms.
                 arguments: rehydrated_for_local_approver(reg, client, srv, &arguments),
                 tool_fingerprint: current_fp.clone(),
+                url_elicitation: None,
             };
             let mut approval_reason = reason;
             let (decision, held_ms, approved_fp, audit_approval) = if modern_direct_call {
@@ -4122,6 +4157,9 @@ fn execute_call(
                 if let Some(token) = active_modern_hitl.as_deref() {
                     update_modern_hitl_downstream(token, &mut result);
                 }
+                return result;
+            }
+            if result.get("_toolportProtocolError").is_some() {
                 return result;
             }
             finish_modern_hitl(active_modern_hitl.as_deref());
@@ -7870,7 +7908,8 @@ struct GatewayState {
 struct ClientUpstreamCaps {
     roots: ClientRootsState,
     sampling: bool,
-    elicitation: bool,
+    elicitation_form: bool,
+    elicitation_url: bool,
 }
 
 /// Roots the upstream MCP client exposed at `initialize`.
@@ -8751,7 +8790,9 @@ fn capture_client_upstream_from_init(state: &mut ClientUpstreamCaps, params: Opt
         state.roots.roots = roots.clone();
     }
     state.sampling = caps.and_then(|c| c.get("sampling")).is_some();
-    state.elicitation = caps.and_then(|c| c.get("elicitation")).is_some();
+    let elicitation = caps.and_then(|c| c.get("elicitation"));
+    state.elicitation_form = elicitation_mode_supported(elicitation, "form");
+    state.elicitation_url = elicitation_mode_supported(elicitation, "url");
 }
 
 const UPSTREAM_RPC_TIMEOUT: Duration = Duration::from_secs(30);
@@ -8768,8 +8809,74 @@ fn client_supports_server_rpc(caps: &ClientUpstreamCaps, method: &str) -> bool {
     match method {
         "roots/list" => caps.roots.supported,
         "sampling/createMessage" => caps.sampling,
-        "elicitation/create" => caps.elicitation,
+        "elicitation/create" => caps.elicitation_form,
         _ => false,
+    }
+}
+
+fn client_supports_server_request(caps: &ClientUpstreamCaps, request: &Value) -> bool {
+    if request.get("method").and_then(Value::as_str) != Some("elicitation/create") {
+        return request
+            .get("method")
+            .and_then(Value::as_str)
+            .is_some_and(|method| client_supports_server_rpc(caps, method));
+    }
+    match request
+        .get("params")
+        .and_then(|params| params.get("mode"))
+        .and_then(Value::as_str)
+        .unwrap_or("form")
+    {
+        "url" => caps.elicitation_url,
+        "form" => caps.elicitation_form,
+        _ => false,
+    }
+}
+
+fn broker_url_elicitation(
+    id: Value,
+    screened: downstream::ScreenedUrlElicitation,
+) -> ServerRequestAction {
+    let decision = request_human_decision(approval::ApprovalRequest {
+        token: String::new(),
+        id: format!("toolport-url-{}", new_correlation_id()),
+        client: None,
+        server: screened.origin.clone(),
+        tool: "browser interaction".to_string(),
+        reason: approval::ApprovalReason::UntrustedSource,
+        arguments: Value::Null,
+        tool_fingerprint: None,
+        url_elicitation: Some(approval::UrlElicitationRequest {
+            url: screened.url,
+            origin: screened.origin,
+            message: screened.message,
+        }),
+    });
+    match decision {
+        approval::ApprovalDecision::Approved => {
+            ServerRequestAction::Respond(upstream_json_rpc_response(
+                id,
+                Ok(json!({ "action": "accept" })),
+            ))
+        }
+        approval::ApprovalDecision::Denied => {
+            ServerRequestAction::Respond(upstream_json_rpc_response(
+                id,
+                Ok(json!({ "action": "decline" })),
+            ))
+        }
+        approval::ApprovalDecision::Timeout => {
+            ServerRequestAction::Respond(upstream_json_rpc_response(
+                id,
+                Ok(json!({ "action": "cancel" })),
+            ))
+        }
+        approval::ApprovalDecision::Unreachable | approval::ApprovalDecision::StaleState => {
+            ServerRequestAction::Respond(missing_modern_client_capability(
+                id,
+                "elicitation/create (url mode); Toolport's desktop broker is not running",
+            ))
+        }
     }
 }
 
@@ -9040,14 +9147,28 @@ fn make_server_request_handler(
             return None;
         }
         let id = req.get("id")?.clone();
+        let mut screened_request = req.clone();
+        let url_elicitation = match downstream::screen_url_elicitation_request(&mut screened_request)
+        {
+            Ok(value) => value,
+            Err(message) => {
+                return Some(ServerRequestAction::Respond(json!({
+                    "jsonrpc": "2.0",
+                    "id": id,
+                    "error": { "code": -32602, "message": format!("Toolport refused unsafe URL elicitation: {message}") }
+                })))
+            }
+        };
         if serving_modern_client() {
-            return Some(if modern_client_supports_server_rpc(method) {
+            return Some(if modern_client_supports_server_request(&screened_request) {
                 ServerRequestAction::InputRequired
+            } else if let Some(screened) = url_elicitation {
+                broker_url_elicitation(id, screened)
             } else {
                 ServerRequestAction::Respond(missing_modern_client_capability(id, method))
             });
         }
-        let params = upstream_rpc_params(method, req);
+        let params = upstream_rpc_params(method, &screened_request);
         let timeout = upstream_rpc_timeout(method);
         let result = if http {
             let sid = ACTIVE_MCP_SESSION.with(|cell| cell.borrow().clone())?;
@@ -9058,9 +9179,12 @@ fn make_server_request_handler(
             let supported = session
                 .client_upstream
                 .lock()
-                .map(|caps| client_supports_server_rpc(&caps, method))
+                .map(|caps| client_supports_server_request(&caps, &screened_request))
                 .unwrap_or(false);
             if !supported {
+                if let Some(screened) = url_elicitation {
+                    return Some(broker_url_elicitation(id, screened));
+                }
                 return Some(ServerRequestAction::Respond(upstream_client_unsupported(
                     id, method,
                 )));
@@ -9069,9 +9193,12 @@ fn make_server_request_handler(
         } else {
             let supported = client_upstream
                 .lock()
-                .map(|caps| client_supports_server_rpc(&caps, method))
+                .map(|caps| client_supports_server_request(&caps, &screened_request))
                 .unwrap_or(false);
             if !supported {
+                if let Some(screened) = url_elicitation {
+                    return Some(broker_url_elicitation(id, screened));
+                }
                 return Some(ServerRequestAction::Respond(upstream_client_unsupported(
                     id, method,
                 )));
@@ -13066,7 +13193,8 @@ mod tests {
         assert!(state.roots.supported);
         assert!(state.roots.list_changed);
         assert!(state.sampling);
-        assert!(state.elicitation);
+        assert!(state.elicitation_form);
+        assert!(!state.elicitation_url);
         assert_eq!(state.roots.roots.len(), 1);
         assert_eq!(state.roots.roots[0]["uri"], "file:///tmp");
     }
@@ -13075,12 +13203,14 @@ mod tests {
     fn capture_client_upstream_resets_stale_capabilities_on_reinitialize() {
         let mut state = ClientUpstreamCaps {
             sampling: true,
-            elicitation: true,
+            elicitation_form: true,
+            elicitation_url: true,
             ..Default::default()
         };
         capture_client_upstream_from_init(&mut state, Some(&json!({"capabilities": {}})));
         assert!(!state.sampling);
-        assert!(!state.elicitation);
+        assert!(!state.elicitation_form);
+        assert!(!state.elicitation_url);
     }
 
     #[test]
@@ -13091,11 +13221,26 @@ mod tests {
                 ..Default::default()
             },
             sampling: true,
-            elicitation: false,
+            elicitation_form: false,
+            elicitation_url: false,
         };
         assert!(client_supports_server_rpc(&caps, "roots/list"));
         assert!(client_supports_server_rpc(&caps, "sampling/createMessage"));
         assert!(!client_supports_server_rpc(&caps, "elicitation/create"));
+    }
+
+    #[test]
+    fn elicitation_capability_distinguishes_form_and_url_modes() {
+        assert!(elicitation_mode_supported(Some(&json!({})), "form"));
+        assert!(!elicitation_mode_supported(Some(&json!({})), "url"));
+        assert!(elicitation_mode_supported(
+            Some(&json!({ "form": {}, "url": {} })),
+            "form"
+        ));
+        assert!(elicitation_mode_supported(
+            Some(&json!({ "form": {}, "url": {} })),
+            "url"
+        ));
     }
 
     #[test]
@@ -13123,6 +13268,36 @@ mod tests {
             "params": { "message": "Continue?" }
         });
         assert_eq!(handler(&request), Some(ServerRequestAction::InputRequired));
+    }
+
+    #[test]
+    fn modern_url_elicitation_relays_only_with_url_mode_capability() {
+        let request = json!({
+            "method": "elicitation/create",
+            "params": {
+                "mode": "url",
+                "message": "Sign in",
+                "url": "https://93.184.216.34/authorize"
+            }
+        });
+        let capable = json!({
+            "params": { "_meta": {
+                "io.modelcontextprotocol/clientCapabilities": {
+                    "elicitation": { "form": {}, "url": {} }
+                }
+            }}
+        });
+        let _caps = UpstreamCapabilitiesGuard::enter(&capable);
+        assert!(modern_client_supports_server_request(&request));
+
+        drop(_caps);
+        let form_only = json!({
+            "params": { "_meta": {
+                "io.modelcontextprotocol/clientCapabilities": { "elicitation": {} }
+            }}
+        });
+        let _caps = UpstreamCapabilitiesGuard::enter(&form_only);
+        assert!(!modern_client_supports_server_request(&request));
     }
 
     #[test]
@@ -13371,6 +13546,7 @@ mod tests {
             reason: approval::ApprovalReason::Destructive,
             arguments: serde_json::json!({}),
             tool_fingerprint: Some("v2:abc".into()),
+            url_elicitation: None,
         };
         // No endpoint descriptor (Toolport app not running) -> Unreachable (fail-closed),
         // distinct from a human Timeout so the caller can explain *why* it was blocked.

--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -8645,6 +8645,7 @@ impl Drop for McpSseReader {
                 .unwrap_or_else(std::sync::PoisonError::into_inner)
                 .remove(&key);
             cleanup_resource_subs_for_session(&state, &key);
+            clear_pii_session(self.session.owner.as_ref().map(|owner| owner.identity.as_str()));
         }
     }
 }
@@ -8666,6 +8667,33 @@ fn new_mcp_session_id() -> String {
     buf.iter().map(|b| format!("{b:02x}")).collect()
 }
 
+/// Remove expired/closed MCP sessions and all conversation-scoped state they own.
+fn reap_stale_mcp_sessions(state: &GatewayState) {
+    // Collect first so we do not hold the sessions lock across cleanup that may
+    // call the router.
+    let stale: Vec<(String, Arc<McpSession>)> = {
+        let mut sessions = state
+            .mcp_sessions
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let stale: Vec<(String, Arc<McpSession>)> = sessions
+            .iter()
+            .filter(|(_, session)| {
+                session.is_expired() || session.closed.load(Ordering::SeqCst)
+            })
+            .map(|(id, session)| (id.clone(), Arc::clone(session)))
+            .collect();
+        for (id, _) in &stale {
+            sessions.remove(id);
+        }
+        stale
+    };
+    for (id, session) in stale {
+        cleanup_resource_subs_for_session(state, &id);
+        clear_pii_session(session.owner.as_ref().map(|owner| owner.identity.as_str()));
+    }
+}
+
 /// Mint a new MCP session after TTL cleanup. Returns 503 when at capacity.
 ///
 /// Expired/closed sessions are removed and their resource subscriptions cleaned
@@ -8678,26 +8706,7 @@ fn mint_mcp_session(
 ) -> Result<String, HttpOut> {
     let sid = new_mcp_session_id();
     let session = Arc::new(McpSession::new(owner.cloned()));
-    // Collect first so we do not hold the sessions lock across cleanup that may
-    // call the router (same ordering as resolve_mcp_session).
-    let stale: Vec<String> = {
-        let mut sessions = state
-            .mcp_sessions
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
-        let stale: Vec<String> = sessions
-            .iter()
-            .filter(|(_, s)| s.is_expired() || s.closed.load(Ordering::SeqCst))
-            .map(|(id, _)| id.clone())
-            .collect();
-        for id in &stale {
-            sessions.remove(id);
-        }
-        stale
-    };
-    for id in &stale {
-        cleanup_resource_subs_for_session(state, id);
-    }
+    reap_stale_mcp_sessions(state);
     let mut sessions = state
         .mcp_sessions
         .lock()
@@ -10114,25 +10123,9 @@ fn mcp_require_session(
     if !valid_mcp_session_id(sid) {
         return Err(HttpOut::json_err(400, "invalid Mcp-Session-Id"));
     }
-    let mut sessions = state
-        .mcp_sessions
-        .lock()
-        .unwrap_or_else(std::sync::PoisonError::into_inner);
     // Drop expired/closed sessions and release any last-holder resource subs
-    // they held (SOU-394). Collect first so we do not hold the sessions lock
-    // across cleanup that may call the router.
-    let stale: Vec<String> = sessions
-        .iter()
-        .filter(|(_, s)| s.is_expired() || s.closed.load(Ordering::SeqCst))
-        .map(|(id, _)| id.clone())
-        .collect();
-    for id in &stale {
-        sessions.remove(id);
-    }
-    drop(sessions);
-    for id in &stale {
-        cleanup_resource_subs_for_session(state, id);
-    }
+    // they held (SOU-394), plus their conversation-scoped PII maps (SBS-704).
+    reap_stale_mcp_sessions(state);
     let sessions = state
         .mcp_sessions
         .lock()
@@ -16899,6 +16892,11 @@ mod tests {
             44
         );
 
+        let pii_client = Some(caller.session_owner.identity.as_str());
+        with_pii_session(pii_client, |map| {
+            *map = pii::SessionMap::new();
+            map.pseudonymize("crm", "ada@example.com");
+        });
         let listen = out.mcp_listen.take().unwrap();
         let (cleanup_state, cleanup_key) = listen.cleanup.unwrap();
         let reader = McpSseReader::with_cleanup(listen.session, cleanup_state, cleanup_key);
@@ -16906,6 +16904,10 @@ mod tests {
         assert!(
             state.mcp_sessions.lock().unwrap().is_empty(),
             "closing the POST response removes the listener"
+        );
+        assert!(
+            !with_pii_session(pii_client, |map| !map.is_empty()),
+            "closing the SSE conversation must drop its PII map"
         );
     }
 
@@ -17596,10 +17598,19 @@ mod tests {
     #[test]
     fn mint_mcp_session_cleans_resource_subs_of_closed_sessions() {
         let state = http_state(false);
-        let s1 = match mint_mcp_session(&state, None) {
+        let owner = McpSessionOwner {
+            identity: "client:reaped-pii".into(),
+            scope: None,
+        };
+        let pii_client = Some(owner.identity.as_str());
+        let s1 = match mint_mcp_session(&state, Some(&owner)) {
             Ok(s) => s,
             Err(_) => panic!("mint s1 failed"),
         };
+        with_pii_session(pii_client, |map| {
+            *map = pii::SessionMap::new();
+            map.pseudonymize("crm", "ada@example.com");
+        });
         {
             let mut table = state.resource_subs.lock().unwrap();
             table.add(&s1, "file://orphan", "srv").unwrap();
@@ -17628,6 +17639,10 @@ mod tests {
             "reaped session must not leave subscription orphans"
         );
         assert!(table.sessions_for_uri("file://orphan").is_empty());
+        assert!(
+            !with_pii_session(pii_client, |map| !map.is_empty()),
+            "reaped session must not leave its PII map behind"
+        );
     }
 
     #[test]

--- a/src-tauri/src/codemode.rs
+++ b/src-tauri/src/codemode.rs
@@ -1562,11 +1562,22 @@ mod tests {
     }
 
     #[test]
-    fn parallel_host_calls_overlap_in_wall_clock() {
-        // Each call sleeps ~80ms. Three sequential would be ~240ms; with max_parallel >= 3
-        // the batch should finish near one sleep (+ overhead).
-        let call: CallBinding = Arc::new(|name: &str, _: Value| {
+    fn parallel_host_calls_overlap() {
+        // Measure overlap directly instead of inferring it from wall-clock timing. The
+        // latter flakes on loaded runners even when all three workers are concurrent.
+        let in_flight = Arc::new(Mutex::new(0usize));
+        let peak = Arc::new(Mutex::new(0usize));
+        let in_flight2 = in_flight.clone();
+        let peak2 = peak.clone();
+        let call: CallBinding = Arc::new(move |name: &str, _: Value| {
+            {
+                let mut current = in_flight2.lock().unwrap();
+                *current += 1;
+                let mut observed_peak = peak2.lock().unwrap();
+                *observed_peak = (*observed_peak).max(*current);
+            }
             thread::sleep(StdDuration::from_millis(80));
+            *in_flight2.lock().unwrap() -= 1;
             json!({ "echo": name })
         });
         let limits = Limits {
@@ -1574,7 +1585,6 @@ mod tests {
             wall_clock: StdDuration::from_secs(10),
             ..Limits::default()
         };
-        let started = Instant::now();
         let out = run(
             r#"
                 return await Promise.all([
@@ -1587,14 +1597,9 @@ mod tests {
             call,
             limits,
         );
-        let elapsed = started.elapsed();
         assert_eq!(out.error, None, "unexpected error: {:?}", out.error);
         assert_eq!(out.calls, 3);
-        // Three 80ms sequential would be ~240ms; allow headroom for scheduler noise.
-        assert!(
-            elapsed < StdDuration::from_millis(220),
-            "expected overlapping host calls, took {elapsed:?}"
-        );
+        assert_eq!(*peak.lock().unwrap(), 3, "all host calls should overlap");
     }
 
     #[test]

--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -1655,7 +1655,7 @@ fn decide_approval(
     scope: String,
 ) -> Result<(), String> {
     let view = broker.decide(&id, approved)?;
-    if approved && scope != "once" {
+    if approved && scope != "once" && view.url_elicitation.is_none() {
         // Persist only when we can bind the allow to the current definition
         // fingerprint. If it's unavailable (the tool is no longer resolvable),
         // the call itself already went through via `decide` above; we simply
@@ -3419,7 +3419,7 @@ fn update_tray_tooltip(app: &AppHandle) {
     if let Some(tray) = app.tray_by_id("main") {
         let tip = if pending > 0 {
             format!(
-                "Toolport - {pending} tool call{} awaiting approval",
+                "Toolport - {pending} request{} awaiting action",
                 if pending == 1 { "" } else { "s" }
             )
         } else {

--- a/src-tauri/src/downstream.rs
+++ b/src-tauri/src/downstream.rs
@@ -561,24 +561,30 @@ fn with_meta(mut params: Value, meta: Option<&Value>) -> Value {
     params
 }
 
-/// Copy only extension declarations from the upstream client's per-request
-/// capabilities onto a modern downstream hop.
+/// Declare the upstream input capabilities Toolport can service on this downstream hop,
+/// plus opaque extension declarations that are intentionally transparent.
 ///
 /// Core client capabilities remain per-hop: Toolport may only advertise roots,
 /// sampling, or elicitation when it can service those callbacks itself. Unknown
 /// extension declarations are different. Their negotiation and payloads are
 /// intentionally opaque to a transparent gateway, so preserving the settings
 /// object is the only future-compatible behavior (SOU-453).
-fn attach_client_extensions(params: &mut Value, meta: Option<&Value>) {
-    let Some(extensions) = meta
+fn attach_serviceable_client_capabilities(params: &mut Value, meta: Option<&Value>) {
+    let Some(upstream) = meta
         .and_then(|meta| meta.get("io.modelcontextprotocol/clientCapabilities"))
-        .and_then(|capabilities| capabilities.get("extensions"))
         .and_then(Value::as_object)
-        .filter(|extensions| !extensions.is_empty())
-        .cloned()
     else {
         return;
     };
+    let mut serviceable = serde_json::Map::new();
+    for key in ["roots", "sampling", "elicitation", "extensions"] {
+        if let Some(value) = upstream.get(key) {
+            serviceable.insert(key.to_string(), value.clone());
+        }
+    }
+    if serviceable.is_empty() {
+        return;
+    }
     let Some(params) = params.as_object_mut() else {
         return;
     };
@@ -588,9 +594,7 @@ fn attach_client_extensions(params: &mut Value, meta: Option<&Value>) {
     if !meta.is_object() {
         *meta = Value::Object(serde_json::Map::new());
     }
-    meta["io.modelcontextprotocol/clientCapabilities"] = json!({
-        "extensions": Value::Object(extensions)
-    });
+    meta["io.modelcontextprotocol/clientCapabilities"] = Value::Object(serviceable);
 }
 
 /// Wire-only fields used when a 2026-07-28 client retries an incomplete request.
@@ -666,20 +670,16 @@ fn merge_protocol_meta(params: &mut Value, protocol: &Value) {
     }
     if let Some(meta) = slot.as_object_mut() {
         for (key, value) in protocol {
-            // `clientCapabilities` is still owned by this hop, but extension
-            // negotiation is the one intentionally transparent part. The
-            // request builder copied only the upstream extension map here; keep
-            // it while replacing every core capability with Toolport's own.
+            // `clientCapabilities` is owned by this hop. The request builder has already
+            // copied only capabilities Toolport can service, so merge those explicit
+            // declarations with Toolport's connection-level declarations.
             let mut value = value.clone();
             if key == "io.modelcontextprotocol/clientCapabilities" {
-                if let Some(extensions) = meta
-                    .get(key)
-                    .and_then(|capabilities| capabilities.get("extensions"))
-                    .and_then(Value::as_object)
-                    .filter(|extensions| !extensions.is_empty())
-                    .cloned()
-                {
-                    value["extensions"] = Value::Object(extensions);
+                if let (Some(target), Some(serviceable)) = (
+                    value.as_object_mut(),
+                    meta.get(key).and_then(Value::as_object),
+                ) {
+                    target.extend(serviceable.clone());
                 }
             }
             meta.insert(key.clone(), value);
@@ -695,9 +695,8 @@ fn protocol_meta_for(version: &str) -> Value {
             "name": "toolport-gateway",
             "version": env!("CARGO_PKG_VERSION")
         },
-        // Toolport speaks for itself on this hop. It advertises no client
-        // capabilities of its own yet; SOU-449 fills these in once MRTR lets the
-        // gateway service sampling/elicitation on a client's behalf.
+        // Toolport speaks for itself on this hop. Request-scoped capabilities are added
+        // only when the active upstream client declared input Toolport can relay.
         "io.modelcontextprotocol/clientCapabilities": {}
     })
 }
@@ -1520,6 +1519,125 @@ pub fn resolve_command(command: &str) -> String {
 pub enum ServerRequestAction {
     Respond(Value),
     InputRequired,
+}
+
+/// A URL elicitation after Toolport has applied the same public-host boundary used by its
+/// existing SSRF defenses. The origin is derived from the parsed URL, never from server text.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ScreenedUrlElicitation {
+    pub url: String,
+    pub origin: String,
+    pub message: String,
+}
+
+/// Validate a URL-mode elicitation before it can reach either the MCP host or Toolport's
+/// desktop broker. A server-provided browser link is an internal-network and phishing
+/// primitive, so unlike ordinary envelope relay Toolport permits only credential-free HTTPS
+/// URLs resolving exclusively to public addresses. The verified origin is appended to the
+/// user-visible message rather than trusting the server to identify itself honestly.
+pub fn screen_url_elicitation_request(
+    request: &mut Value,
+) -> Result<Option<ScreenedUrlElicitation>, String> {
+    if request.get("method").and_then(Value::as_str) != Some("elicitation/create") {
+        return Ok(None);
+    }
+    let Some(params) = request.get_mut("params").and_then(Value::as_object_mut) else {
+        return Err("URL elicitation is missing params".to_string());
+    };
+    if params.get("mode").and_then(Value::as_str) != Some("url") {
+        return Ok(None);
+    }
+    let raw_url = params
+        .get("url")
+        .and_then(Value::as_str)
+        .ok_or_else(|| "URL elicitation is missing a URL".to_string())?
+        .to_string();
+    let parsed = url::Url::parse(&raw_url)
+        .map_err(|_| "URL elicitation contains an invalid URL".to_string())?;
+    if parsed.scheme() != "https" {
+        return Err("URL elicitation must use HTTPS".to_string());
+    }
+    if !parsed.username().is_empty() || parsed.password().is_some() {
+        return Err("URL elicitation must not contain embedded credentials".to_string());
+    }
+    let host = parsed
+        .host_str()
+        .ok_or_else(|| "URL elicitation URL has no host".to_string())?;
+    if crate::oauth::host_is_private(host) {
+        return Err(format!(
+            "URL elicitation points at a private, loopback, or unresolvable host ({host})"
+        ));
+    }
+    let origin = parsed.origin().ascii_serialization();
+    let message = params
+        .get("message")
+        .and_then(Value::as_str)
+        .ok_or_else(|| "URL elicitation is missing a message".to_string())?
+        .to_string();
+    let origin_line = format!("Toolport destination: {origin}");
+    if !message.lines().any(|line| line == origin_line) {
+        params.insert(
+            "message".to_string(),
+            Value::String(format!("{message}\n\n{origin_line}")),
+        );
+    }
+    Ok(Some(ScreenedUrlElicitation {
+        url: raw_url,
+        origin,
+        message,
+    }))
+}
+
+fn screen_input_required(result: &mut Value) -> Result<(), TransportError> {
+    let Some(requests) = result.get_mut("inputRequests").and_then(Value::as_object_mut) else {
+        return Ok(());
+    };
+    for request in requests.values_mut() {
+        screen_url_elicitation_request(request).map_err(|message| {
+            TransportError::Fatal(format!("Toolport refused unsafe URL elicitation: {message}"))
+        })?;
+    }
+    Ok(())
+}
+
+fn modern_client_supports_input_request(meta: Option<&Value>, request: &Value) -> bool {
+    let capabilities = meta
+        .and_then(|meta| meta.get("io.modelcontextprotocol/clientCapabilities"));
+    match request.get("method").and_then(Value::as_str) {
+        Some("roots/list") => capabilities.and_then(|caps| caps.get("roots")).is_some(),
+        Some("sampling/createMessage") => {
+            capabilities.and_then(|caps| caps.get("sampling")).is_some()
+        }
+        Some("elicitation/create") => {
+            let Some(elicitation) = capabilities
+                .and_then(|caps| caps.get("elicitation"))
+                .and_then(Value::as_object)
+            else {
+                return false;
+            };
+            match request
+                .get("params")
+                .and_then(|params| params.get("mode"))
+                .and_then(Value::as_str)
+                .unwrap_or("form")
+            {
+                "url" => elicitation.get("url").is_some(),
+                "form" => elicitation.is_empty() || elicitation.get("form").is_some(),
+                _ => false,
+            }
+        }
+        _ => false,
+    }
+}
+
+fn modern_client_supports_input_required(meta: Option<&Value>, result: &Value) -> bool {
+    let Some(requests) = result.get("inputRequests").and_then(Value::as_object) else {
+        return false;
+    };
+    !requests.is_empty()
+        && requests
+            .values()
+            .all(|request| modern_client_supports_input_request(meta, request))
 }
 
 /// A bidirectional JSON-RPC channel to one downstream server.
@@ -3069,11 +3187,16 @@ impl Transport for StdioTransport {
             if trimmed.is_empty() {
                 continue;
             }
-            let value: Value = match serde_json::from_str(trimmed) {
+            let mut value: Value = match serde_json::from_str(trimmed) {
                 Ok(v) => v,
                 Err(_) => continue,
             };
             if is_server_initiated_request(&value) {
+                screen_url_elicitation_request(&mut value).map_err(|message| {
+                    TransportError::Fatal(format!(
+                        "Toolport refused unsafe URL elicitation: {message}"
+                    ))
+                })?;
                 if let Some(handler) = &self.server_handler {
                     match handler(&value) {
                         Some(ServerRequestAction::Respond(response)) => {
@@ -3840,7 +3963,7 @@ impl HttpTransport {
                 if data.is_empty() {
                     continue;
                 }
-                let Ok(v) = serde_json::from_str::<Value>(data) else {
+                let Ok(mut v) = serde_json::from_str::<Value>(data) else {
                     continue;
                 };
                 // Resource updates may arrive mid-stream alongside the response
@@ -3859,6 +3982,13 @@ impl HttpTransport {
                         sink(note);
                         continue;
                     }
+                }
+                if is_server_initiated_request(&v) {
+                    screen_url_elicitation_request(&mut v).map_err(|message| {
+                        TransportError::Fatal(format!(
+                            "Toolport refused unsafe URL elicitation: {message}"
+                        ))
+                    })?;
                 }
                 match self.inline_server_action(&v) {
                     Some(ServerRequestAction::Respond(response)) => {
@@ -4617,7 +4747,10 @@ impl DownstreamServer {
         self.server_handler = Some(handler);
     }
 
-    fn fulfill_input_required(&self, result: &Value) -> Result<MrtrRequest, TransportError> {
+    fn fulfill_input_required(
+        &self,
+        result: &Value,
+    ) -> Result<Option<MrtrRequest>, TransportError> {
         let requests = match result.get("inputRequests") {
             None => None,
             Some(Value::Object(requests)) => Some(requests),
@@ -4651,6 +4784,12 @@ impl DownstreamServer {
                 )
             })?;
             for (key, input) in requests {
+                let mut input = input.clone();
+                screen_url_elicitation_request(&mut input).map_err(|message| {
+                    TransportError::Fatal(format!(
+                        "Toolport refused unsafe URL elicitation: {message}"
+                    ))
+                })?;
                 let method = input.get("method").and_then(Value::as_str).ok_or_else(|| {
                     TransportError::Fatal(format!("input request '{key}' is missing a method"))
                 })?;
@@ -4675,9 +4814,7 @@ impl DownstreamServer {
                 let response = match handler(&request) {
                     Some(ServerRequestAction::Respond(response)) => response,
                     Some(ServerRequestAction::InputRequired) => {
-                        return Err(TransportError::Fatal(
-                            "cannot nest an input_required bridge while fulfilling one".to_string(),
-                        ))
+                        return Ok(None)
                     }
                     None => {
                         return Err(TransportError::Fatal(format!(
@@ -4700,10 +4837,10 @@ impl DownstreamServer {
         if input_responses.is_empty() {
             std::thread::sleep(MRTR_STATE_ONLY_DELAY);
         }
-        Ok(MrtrRequest {
+        Ok(Some(MrtrRequest {
             input_responses: (!input_responses.is_empty()).then(|| Value::Object(input_responses)),
             request_state,
-        })
+        }))
     }
 
     fn request_with_mrtr(
@@ -4721,17 +4858,21 @@ impl DownstreamServer {
         for round in 0..=MRTR_LEGACY_MAX_ROUNDS {
             let mut params = with_meta_and_mrtr(params.clone(), meta, Some(&retry));
             if modern_downstream {
-                attach_client_extensions(&mut params, meta);
+                attach_serviceable_client_capabilities(&mut params, meta);
             }
-            let result = self.transport.request_with_cancel_and_headers(
+            let mut result = self.transport.request_with_cancel_and_headers(
                 method,
                 params,
                 cancel.clone(),
                 headers,
             )?;
-            if result.get("resultType").and_then(Value::as_str) != Some("input_required")
-                || modern_upstream
-            {
+            if result.get("resultType").and_then(Value::as_str) == Some("input_required") {
+                screen_input_required(&mut result)?;
+            }
+            if result.get("resultType").and_then(Value::as_str) != Some("input_required") {
+                return Ok(result);
+            }
+            if modern_upstream && modern_client_supports_input_required(meta, &result) {
                 return Ok(result);
             }
             if round == MRTR_LEGACY_MAX_ROUNDS {
@@ -4739,7 +4880,29 @@ impl DownstreamServer {
                     "modern server exceeded the {MRTR_LEGACY_MAX_ROUNDS}-round input_required limit"
                 )));
             }
-            retry = self.fulfill_input_required(&result)?;
+            match self.fulfill_input_required(&result) {
+                Ok(Some(next)) => retry = next,
+                Ok(None) if modern_upstream => return Ok(result),
+                Ok(None) => {
+                    return Err(TransportError::Fatal(
+                        "cannot nest an input_required bridge while fulfilling one".to_string(),
+                    ))
+                }
+                Err(TransportError::Rpc(error))
+                    if modern_upstream
+                        && error.get("code").and_then(Value::as_i64)
+                            == Some(MISSING_REQUIRED_CLIENT_CAPABILITY) =>
+                {
+                    return Ok(json!({
+                        "_toolportProtocolError": {
+                            "code": MISSING_REQUIRED_CLIENT_CAPABILITY,
+                            "message": error.get("message").cloned().unwrap_or_else(|| json!("URL elicitation requires client support or a running Toolport desktop broker")),
+                            "requiredCapability": "elicitation"
+                        }
+                    }));
+                }
+                Err(error) => return Err(error),
+            }
         }
         unreachable!("bounded MRTR loop always returns")
     }
@@ -5231,7 +5394,7 @@ impl DownstreamServer {
         let original_meta = params.get("_meta").cloned();
         sanitize_forwarded_meta(&mut params);
         if matches!(self.era, Era::Modern { .. }) {
-            attach_client_extensions(&mut params, original_meta.as_ref());
+            attach_serviceable_client_capabilities(&mut params, original_meta.as_ref());
         }
         self.transport
             .request_with_cancel("completion/complete", params, cancel)
@@ -6582,6 +6745,48 @@ mod tests {
     }
 
     #[test]
+    fn url_elicitation_is_screened_and_shows_the_verified_origin() {
+        let mut request = json!({
+            "method": "elicitation/create",
+            "params": {
+                "mode": "url",
+                "message": "Connect your account",
+                "url": "https://93.184.216.34:8443/authorize?state=opaque"
+            }
+        });
+        let screened = super::screen_url_elicitation_request(&mut request)
+            .unwrap()
+            .expect("URL mode");
+        assert_eq!(screened.origin, "https://93.184.216.34:8443");
+        assert_eq!(screened.message, "Connect your account");
+        assert_eq!(
+            request["params"]["message"],
+            "Connect your account\n\nToolport destination: https://93.184.216.34:8443"
+        );
+        assert!(request["params"].get("elicitationId").is_none());
+    }
+
+    #[test]
+    fn url_elicitation_refuses_non_https_credentials_and_private_hosts() {
+        for (url, expected) in [
+            ("http://93.184.216.34/connect", "must use HTTPS"),
+            (
+                "https://user:secret@93.184.216.34/connect",
+                "embedded credentials",
+            ),
+            ("https://127.0.0.1/connect", "private, loopback"),
+            ("https://169.254.169.254/latest", "private, loopback"),
+        ] {
+            let mut request = json!({
+                "method": "elicitation/create",
+                "params": { "mode": "url", "message": "Continue", "url": url }
+            });
+            let error = super::screen_url_elicitation_request(&mut request).unwrap_err();
+            assert!(error.contains(expected), "{url}: {error}");
+        }
+    }
+
+    #[test]
     fn legacy_client_auto_fulfills_modern_input_required() {
         let (transport, requests) = MrtrTransport::modern(vec![
             Ok(json!({
@@ -6681,7 +6886,8 @@ mod tests {
             None
         }));
         let meta = json!({
-            "io.modelcontextprotocol/protocolVersion": MODERN_PROTOCOL_VERSION
+            "io.modelcontextprotocol/protocolVersion": MODERN_PROTOCOL_VERSION,
+            "io.modelcontextprotocol/clientCapabilities": { "elicitation": {} }
         });
 
         let incomplete = server
@@ -6714,6 +6920,131 @@ mod tests {
         assert_eq!(calls.len(), 2);
         assert_eq!(calls[1]["requestState"], "byte-exact-state");
         assert_eq!(calls[1]["inputResponses"], retry.input_responses.unwrap());
+    }
+
+    #[test]
+    fn modern_url_elicitation_relays_screened_request_to_capable_client() {
+        let (transport, _) = MrtrTransport::modern(vec![Ok(json!({
+            "resultType": "input_required",
+            "inputRequests": {
+                "auth": {
+                    "method": "elicitation/create",
+                    "params": {
+                        "mode": "url",
+                        "message": "Sign in",
+                        "url": "https://93.184.216.34/authorize"
+                    }
+                }
+            }
+        }))]);
+        let mut server = DownstreamServer::connect("modern".into(), Box::new(transport)).unwrap();
+        server.set_server_request_handler(Arc::new(|_| {
+            Some(ServerRequestAction::InputRequired)
+        }));
+        let meta = json!({
+            "io.modelcontextprotocol/protocolVersion": MODERN_PROTOCOL_VERSION,
+            "io.modelcontextprotocol/clientCapabilities": { "elicitation": { "url": {} } }
+        });
+
+        let result = server
+            .call_with_cancel_and_mrtr("echo", json!({}), None, Some(&meta), None)
+            .unwrap();
+        assert_eq!(result["resultType"], "input_required");
+        assert_eq!(
+            result["inputRequests"]["auth"]["params"]["message"],
+            "Sign in\n\nToolport destination: https://93.184.216.34"
+        );
+    }
+
+    #[test]
+    fn modern_url_elicitation_can_use_desktop_broker_fallback() {
+        let (transport, requests) = MrtrTransport::modern(vec![
+            Ok(json!({
+                "resultType": "input_required",
+                "inputRequests": {
+                    "auth": {
+                        "method": "elicitation/create",
+                        "params": {
+                            "mode": "url",
+                            "message": "Sign in",
+                            "url": "https://93.184.216.34/authorize"
+                        }
+                    }
+                },
+                "requestState": "out-of-band-state"
+            })),
+            Ok(json!({ "resultType": "complete", "content": [] })),
+        ]);
+        let mut server = DownstreamServer::connect("modern".into(), Box::new(transport)).unwrap();
+        server.set_server_request_handler(Arc::new(|request| {
+            Some(ServerRequestAction::Respond(json!({
+                "jsonrpc": "2.0",
+                "id": request["id"].clone(),
+                "result": { "action": "accept" }
+            })))
+        }));
+        let meta = json!({
+            "io.modelcontextprotocol/protocolVersion": MODERN_PROTOCOL_VERSION,
+            "io.modelcontextprotocol/clientCapabilities": {}
+        });
+
+        let result = server
+            .call_with_cancel_and_mrtr("echo", json!({}), None, Some(&meta), None)
+            .unwrap();
+        assert_eq!(result["resultType"], "complete");
+        let requests = requests.lock().unwrap();
+        let calls: Vec<&Value> = requests
+            .iter()
+            .filter(|(method, _)| method == "tools/call")
+            .map(|(_, params)| params)
+            .collect();
+        assert_eq!(calls.len(), 2);
+        assert_eq!(calls[1]["requestState"], "out-of-band-state");
+        assert_eq!(calls[1]["inputResponses"]["auth"]["action"], "accept");
+    }
+
+    #[test]
+    fn modern_url_elicitation_refuses_clearly_without_client_or_broker() {
+        let (transport, _) = MrtrTransport::modern(vec![Ok(json!({
+            "resultType": "input_required",
+            "inputRequests": {
+                "auth": {
+                    "method": "elicitation/create",
+                    "params": {
+                        "mode": "url",
+                        "message": "Sign in",
+                        "url": "https://93.184.216.34/authorize"
+                    }
+                }
+            }
+        }))]);
+        let mut server = DownstreamServer::connect("modern".into(), Box::new(transport)).unwrap();
+        server.set_server_request_handler(Arc::new(|request| {
+            Some(ServerRequestAction::Respond(json!({
+                "jsonrpc": "2.0",
+                "id": request["id"].clone(),
+                "error": {
+                    "code": super::MISSING_REQUIRED_CLIENT_CAPABILITY,
+                    "message": "URL elicitation requires client support or a running Toolport desktop broker"
+                }
+            })))
+        }));
+        let meta = json!({
+            "io.modelcontextprotocol/protocolVersion": MODERN_PROTOCOL_VERSION,
+            "io.modelcontextprotocol/clientCapabilities": {}
+        });
+
+        let result = server
+            .call_with_cancel_and_mrtr("echo", json!({}), None, Some(&meta), None)
+            .unwrap();
+        assert_eq!(
+            result["_toolportProtocolError"]["code"],
+            super::MISSING_REQUIRED_CLIENT_CAPABILITY
+        );
+        assert!(result["_toolportProtocolError"]["message"]
+            .as_str()
+            .unwrap()
+            .contains("desktop broker"));
     }
 
     #[test]
@@ -8130,10 +8461,9 @@ mod tests {
                 ["com.example/opaque"]["mode"],
             "strict"
         );
-        assert!(
-            params["_meta"]["io.modelcontextprotocol/clientCapabilities"]
-                .get("sampling")
-                .is_none()
+        assert_eq!(
+            params["_meta"]["io.modelcontextprotocol/clientCapabilities"]["sampling"],
+            json!({})
         );
 
         // A non-object `_meta` is rebuilt rather than panicking or being ignored.
@@ -8143,7 +8473,7 @@ mod tests {
     }
 
     #[test]
-    fn modern_requests_forward_only_client_extension_capabilities() {
+    fn modern_requests_declare_only_serviceable_client_capabilities() {
         use super::{DownstreamServer, Transport, TransportError, MODERN_PROTOCOL_VERSION};
         use std::sync::{Arc, Mutex};
 
@@ -8194,6 +8524,7 @@ mod tests {
             "io.modelcontextprotocol/protocolVersion": MODERN_PROTOCOL_VERSION,
             "io.modelcontextprotocol/clientCapabilities": {
                 "sampling": {},
+                "elicitation": { "url": {} },
                 "extensions": {
                     "com.example/opaque": { "mimeTypes": ["text/html"] },
                     "io.modelcontextprotocol/tasks": {}
@@ -8212,7 +8543,8 @@ mod tests {
             capabilities["extensions"]["com.example/opaque"]["mimeTypes"][0],
             "text/html"
         );
-        assert!(capabilities.get("sampling").is_none());
+        assert_eq!(capabilities["sampling"], json!({}));
+        assert_eq!(capabilities["elicitation"]["url"], json!({}));
         assert_eq!(
             capabilities["extensions"]["io.modelcontextprotocol/tasks"],
             json!({})

--- a/src-tauri/src/registry.rs
+++ b/src-tauri/src/registry.rs
@@ -1919,7 +1919,7 @@ fn load_from_inner(path: &Path) -> Result<Registry, String> {
 /// read/recovery path. Recovery can rewrite the primary from a backup, so even a caller
 /// that only intends to read must serialize with writers (SOU-330).
 pub fn load_from(path: &Path) -> Result<Registry, String> {
-    let lock = lock_for(path)?;
+    let lock = lock_for(path, REGISTRY_LOCK_TIMEOUT)?;
     load_from_locked(path, &lock)
 }
 
@@ -2020,7 +2020,9 @@ fn lock_path(path: &Path) -> PathBuf {
 /// Acquire the exclusive registry lock, retrying briefly under contention. Registry writes
 /// are sub-millisecond, so a real conflict clears at once; a holder stuck past the deadline
 /// surfaces as an error rather than hanging the caller indefinitely.
-fn lock_for(path: &Path) -> Result<FileLock, String> {
+const REGISTRY_LOCK_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+
+fn lock_for(path: &Path, timeout: std::time::Duration) -> Result<FileLock, String> {
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
     }
@@ -2029,7 +2031,7 @@ fn lock_for(path: &Path) -> Result<FileLock, String> {
         .write(true)
         .open(lock_path(path))
         .map_err(|e| format!("Could not open the registry lock: {e}"))?;
-    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+    let deadline = std::time::Instant::now() + timeout;
     loop {
         match file.try_lock_exclusive() {
             Ok(()) => return Ok(FileLock(file)),
@@ -2056,7 +2058,7 @@ fn lock_for(path: &Path) -> Result<FileLock, String> {
 /// through this or [`update_at`] — that is what makes the lock effective.
 pub fn update<T>(f: impl FnOnce(&mut Registry) -> Result<T, String>) -> Result<(Registry, T), String> {
     let path = resolved_path().ok_or("Could not resolve registry path")?;
-    let lock = lock_for(&path)?;
+    let lock = lock_for(&path, REGISTRY_LOCK_TIMEOUT)?;
     let mut reg = load_from_locked(&path, &lock)?;
     let out = f(&mut reg)?;
     // Save to the exact path we locked and loaded. Re-resolving after `f` would let a
@@ -2070,7 +2072,17 @@ pub fn update<T>(f: impl FnOnce(&mut Registry) -> Result<T, String>) -> Result<(
 /// agent toggle (which interleaves audit + early returns), and the integrity pins/quarantine
 /// stores (SOU-165). Hold the returned guard across the entire read-decide-write.
 pub fn lock_at(path: &Path) -> Result<FileLock, String> {
-    lock_for(path)
+    lock_for(path, REGISTRY_LOCK_TIMEOUT)
+}
+
+/// Acquire an explicit-path lock with a caller-appropriate contention deadline.
+/// Registry operations use the short default above; operations that deliberately
+/// hold a lock across network I/O need to cover that I/O's timeout instead.
+pub(crate) fn lock_at_for(
+    path: &Path,
+    timeout: std::time::Duration,
+) -> Result<FileLock, String> {
+    lock_for(path, timeout)
 }
 
 /// Like [`update`] but for a caller that already resolved an explicit path (the gateway
@@ -2079,7 +2091,7 @@ pub fn update_at<T>(
     path: &Path,
     f: impl FnOnce(&mut Registry) -> Result<T, String>,
 ) -> Result<(Registry, T), String> {
-    let lock = lock_for(path)?;
+    let lock = lock_for(path, REGISTRY_LOCK_TIMEOUT)?;
     let mut reg = load_from_locked(path, &lock)?;
     let out = f(&mut reg)?;
     save_to(path, &reg)?;

--- a/src-tauri/src/remote.rs
+++ b/src-tauri/src/remote.rs
@@ -351,16 +351,36 @@ fn uses_client_credentials(server: &ServerEntry) -> bool {
 /// covers only the interactive browser flow.
 ///
 /// Best-effort by design: with no resolvable data dir there is nowhere to put a lock, and
-/// refusing to refresh at all would be worse than the race it prevents. `lock_at` is
-/// bounded-blocking (retries for a few seconds), so a slow winner delays the loser rather
-/// than failing it.
-fn lock_oauth_refresh(server_id: &str) -> Option<crate::registry::FileLock> {
-    let dir = crate::registry::conduit_dir()?;
+/// refusing to refresh at all would be worse than the race it prevents. Contention waits long
+/// enough to cover the OAuth client's 30-second request timeout and metadata refresh before
+/// failing open visibly rather than silently dropping back to the original race (SBS-705).
+const OAUTH_REFRESH_LOCK_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(65);
+
+fn lock_oauth_refresh_for(
+    server_id: &str,
+    timeout: std::time::Duration,
+) -> Result<Option<crate::registry::FileLock>, String> {
+    let Some(dir) = crate::registry::conduit_dir() else {
+        return Ok(None);
+    };
     let leaf = format!(
         "oauth-refresh-{}.lock",
         crate::router::sanitize_segment(server_id)
     );
-    crate::registry::lock_at(&dir.join(leaf)).ok()
+    crate::registry::lock_at_for(&dir.join(leaf), timeout).map(Some)
+}
+
+fn lock_oauth_refresh(server_id: &str) -> Option<crate::registry::FileLock> {
+    match lock_oauth_refresh_for(server_id, OAUTH_REFRESH_LOCK_TIMEOUT) {
+        Ok(lock) => lock,
+        Err(error) => {
+            eprintln!(
+                "toolport: OAuth refresh for {server_id:?} is proceeding without the cross-process lock after waiting {}s: {error}",
+                OAUTH_REFRESH_LOCK_TIMEOUT.as_secs()
+            );
+            None
+        }
+    }
 }
 
 /// After winning the refresh lock, decide whether another process already did the work.
@@ -1042,6 +1062,18 @@ mod tests {
 
         let a = lock_oauth_refresh("server-a").expect("a data dir is set, so a lock exists");
         let b = lock_oauth_refresh("server-b").expect("a different server must not block");
+        let contention = match lock_oauth_refresh_for(
+            "server-a",
+            std::time::Duration::from_millis(40),
+        ) {
+            Err(error) => error,
+            Ok(_) => panic!("contention must remain distinguishable from a missing data dir"),
+        };
+        assert!(contention.contains("locked by another Toolport process"));
+        assert!(
+            OAUTH_REFRESH_LOCK_TIMEOUT >= std::time::Duration::from_secs(30),
+            "the production wait must cover the token client's request timeout"
+        );
         drop((a, b));
 
         assert!(

--- a/src-tauri/tests/spec_conformance.rs
+++ b/src-tauri/tests/spec_conformance.rs
@@ -636,7 +636,10 @@ fn modern_client_controls_native_mrtr_retry_fields() {
         .expect("spawn fixture");
     let mut server =
         DownstreamServer::connect("mock".to_string(), Box::new(transport)).expect("connect");
-    let meta = json!({ "io.modelcontextprotocol/protocolVersion": MODERN });
+    let meta = json!({
+        "io.modelcontextprotocol/protocolVersion": MODERN,
+        "io.modelcontextprotocol/clientCapabilities": { "elicitation": {} }
+    });
 
     let incomplete = server
         .call_with_cancel_and_mrtr("mrtr_confirm", json!({}), None, Some(&meta), None)

--- a/src/components/PendingApprovals.tsx
+++ b/src/components/PendingApprovals.tsx
@@ -5,6 +5,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { decideApproval, listPendingApprovals, type ApprovalScope } from "@/lib/api";
 import type { PendingApproval } from "@/lib/types";
+import { openExternal } from "@/lib/openUrl";
 import { toastError } from "@/lib/toast";
 
 /** Fail-closed window (must match approval::DEFAULT_TIMEOUT_SECS on the gateway). A
@@ -34,8 +35,8 @@ const REASON: Record<Reason, { label: string; className: string; Icon: typeof Tr
   };
 
 /**
- * The human-in-the-loop approval queue: tool calls the gateway is holding until you
- * approve or deny them. The call BLOCKS on your decision, so this is mounted globally
+ * The human-in-the-loop queue: tool calls and URL elicitations the gateway is holding
+ * until you act. The call BLOCKS on your decision, so this is mounted globally
  * (actionable from any view) and renders nothing when the queue is empty. It polls as a
  * safety net and refreshes immediately on the gateway's `approval-pending` /
  * `approval-resolved` events.
@@ -146,18 +147,18 @@ export function PendingApprovals() {
         {/* Announce count changes to screen readers without re-announcing on every countdown
          * tick (the visible timer lives elsewhere; this text only changes when the count does). */}
         <div aria-live="assertive" className="sr-only">
-          {pending.length} tool call{pending.length > 1 ? "s" : ""} awaiting your
-          approval. Press Escape to deny.
+          {pending.length} request{pending.length > 1 ? "s" : ""} awaiting your action.
+          Press Escape to cancel.
         </div>
         <header className="flex items-center gap-3 border-b border-border/60 px-4 py-3">
           <span className="flex size-8 shrink-0 items-center justify-center rounded-full bg-warning/15 text-warning">
             <ShieldAlert className="size-4" />
           </span>
           <div className="min-w-0">
-            <div className="text-sm font-semibold leading-tight">Approval required</div>
+            <div className="text-sm font-semibold leading-tight">Action required</div>
             <div className="text-xs text-muted-foreground">
-              {pending.length} tool call{pending.length > 1 ? "s" : ""} held — no decision
-              auto-denies
+              {pending.length} request{pending.length > 1 ? "s" : ""} held — no action
+              cancels it
             </div>
           </div>
         </header>
@@ -165,6 +166,7 @@ export function PendingApprovals() {
         <ul className="max-h-[70vh] divide-y divide-border/60 overflow-auto">
           {pending.map((a) => {
             const reason = REASON[a.reason];
+            const urlElicitation = a.urlElicitation;
             // Count down to the broker's authoritative deadline; fall back to
             // first-sighting + timeout only if deadlineMs is somehow absent, so the
             // timer is never blank.
@@ -183,11 +185,21 @@ export function PendingApprovals() {
                 <div className="mb-2 flex items-start justify-between gap-3">
                   <div className="min-w-0">
                     <div className="flex items-center gap-1.5 font-mono text-sm">
-                      <span className="truncate text-muted-foreground">{a.server}</span>
-                      <span className="text-muted-foreground/50">/</span>
-                      <span className="truncate font-medium text-foreground">
-                        {a.tool}
-                      </span>
+                      {urlElicitation ? (
+                        <span className="truncate font-medium text-foreground">
+                          {urlElicitation.origin}
+                        </span>
+                      ) : (
+                        <>
+                          <span className="truncate text-muted-foreground">
+                            {a.server}
+                          </span>
+                          <span className="text-muted-foreground/50">/</span>
+                          <span className="truncate font-medium text-foreground">
+                            {a.tool}
+                          </span>
+                        </>
+                      )}
                     </div>
                     {a.client && (
                       <div className="mt-1 flex items-center gap-1.5 text-xs text-muted-foreground">
@@ -196,19 +208,32 @@ export function PendingApprovals() {
                       </div>
                     )}
                   </div>
-                  <Badge className={reason.className}>
-                    <reason.Icon className="size-3" />
-                    {reason.label}
-                  </Badge>
+                  {urlElicitation ? (
+                    <Badge className="bg-warning/15 text-warning">
+                      <Globe className="size-3" />
+                      External link
+                    </Badge>
+                  ) : (
+                    <Badge className={reason.className}>
+                      <reason.Icon className="size-3" />
+                      {reason.label}
+                    </Badge>
+                  )}
                 </div>
 
                 <div className="mb-3">
                   <div className="mb-1 text-[0.7rem] font-medium uppercase tracking-wide text-muted-foreground">
-                    Arguments
+                    {urlElicitation ? "Why this is needed" : "Arguments"}
                   </div>
-                  <pre className="max-h-36 overflow-auto rounded-md border border-border/60 bg-muted/40 p-2.5 font-mono text-xs leading-relaxed">
-                    {JSON.stringify(a.arguments, null, 2)}
-                  </pre>
+                  {urlElicitation ? (
+                    <div className="rounded-md border border-border/60 bg-muted/40 p-2.5 text-sm leading-relaxed">
+                      {urlElicitation.message}
+                    </div>
+                  ) : (
+                    <pre className="max-h-36 overflow-auto rounded-md border border-border/60 bg-muted/40 p-2.5 font-mono text-xs leading-relaxed">
+                      {JSON.stringify(a.arguments, null, 2)}
+                    </pre>
+                  )}
                 </div>
 
                 <div className="flex items-center justify-between gap-3">
@@ -240,8 +265,19 @@ export function PendingApprovals() {
                       onClick={() => void decide(a.id, false)}
                     >
                       {isBusy ? <Loader2 className="animate-spin" /> : <X />}
-                      Deny
+                      {urlElicitation ? "Cancel" : "Deny"}
                     </Button>
+                    {urlElicitation && (
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        disabled={isBusy}
+                        onClick={() => void openExternal(urlElicitation.url)}
+                      >
+                        <Globe />
+                        Open link
+                      </Button>
+                    )}
                     <Button
                       size="sm"
                       disabled={isBusy}
@@ -249,30 +285,32 @@ export function PendingApprovals() {
                       className="bg-[color-mix(in_oklch,var(--success),black_16%)] text-white shadow-sm hover:bg-[color-mix(in_oklch,var(--success),black_26%)]"
                     >
                       {isBusy ? <Loader2 className="animate-spin" /> : <Check />}
-                      Approve
+                      {urlElicitation ? "Continue" : "Approve"}
                     </Button>
                   </div>
                 </div>
 
                 {/* Skip the prompt for this tool next time - curbs approval fatigue. */}
-                <div className="mt-2 flex flex-wrap items-center gap-x-2.5 gap-y-1 text-xs text-muted-foreground">
-                  <span>Skip next time?</span>
-                  <button
-                    disabled={isBusy}
-                    onClick={() => void decide(a.id, true, "session")}
-                    className="font-medium text-foreground/80 underline-offset-2 hover:text-foreground hover:underline disabled:opacity-50"
-                  >
-                    Allow for this session
-                  </button>
-                  <span className="text-muted-foreground/40">·</span>
-                  <button
-                    disabled={isBusy}
-                    onClick={() => void decide(a.id, true, "always")}
-                    className="font-medium text-foreground/80 underline-offset-2 hover:text-foreground hover:underline disabled:opacity-50"
-                  >
-                    Always allow this tool
-                  </button>
-                </div>
+                {!urlElicitation && (
+                  <div className="mt-2 flex flex-wrap items-center gap-x-2.5 gap-y-1 text-xs text-muted-foreground">
+                    <span>Skip next time?</span>
+                    <button
+                      disabled={isBusy}
+                      onClick={() => void decide(a.id, true, "session")}
+                      className="font-medium text-foreground/80 underline-offset-2 hover:text-foreground hover:underline disabled:opacity-50"
+                    >
+                      Allow for this session
+                    </button>
+                    <span className="text-muted-foreground/40">·</span>
+                    <button
+                      disabled={isBusy}
+                      onClick={() => void decide(a.id, true, "always")}
+                      className="font-medium text-foreground/80 underline-offset-2 hover:text-foreground hover:underline disabled:opacity-50"
+                    >
+                      Always allow this tool
+                    </button>
+                  </div>
+                )}
               </li>
             );
           })}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -366,6 +366,13 @@ export interface PendingApproval {
   toolFingerprint?: string | null;
   reason: "destructive" | "untrusted_source" | "destructive_and_untrusted";
   arguments: unknown;
+  /** A screened URL-mode elicitation brokered by the desktop because the MCP host
+   * did not declare URL elicitation support. */
+  urlElicitation?: {
+    url: string;
+    origin: string;
+    message: string;
+  } | null;
   /** Wall-clock epoch-ms when this call auto-denies; the overlay counts down to it. */
   deadlineMs: number;
 }


### PR DESCRIPTION
## Summary
- add MRTR-shaped URL-mode elicitation with capable-client relay, desktop fallback, clear headless refusal, and screened HTTPS origins
- clear conversation-scoped PII maps when SSE sessions drop or stale sessions are reaped
- extend OAuth refresh lock contention waits to cover network I/O and log the remaining fail-open path
- replace a flaky wall-clock concurrency assertion with a direct peak-overlap assertion after reproducing it twice on macOS CI

## Verification
- `cargo build --lib`
- `cargo test`
- `cargo clippy`
- `npm test` (242 passed)
- `npx tsc --noEmit`
- `npm run lint` (0 errors; 23 pre-existing warnings)
- GitHub CI: Windows, macOS, Ubuntu, CodeQL, gateway smoke, and image build all pass

SBS-707
SBS-704
SBS-705