### PR TITLE
Test the Grok review canary

### DIFF
--- a/.github/coderev-grok-canary.md
+++ b/.github/coderev-grok-canary.md
@@ -1,0 +1,4 @@
+# CodeRev Grok canary
+
+This temporary documentation-only change verifies that an owner-authored
+Toolport pull request is reviewed through the dedicated local Grok runner.


### PR DESCRIPTION
Temporary documentation-only PR used to verify the owner-only local Grok review path. This PR will be closed without merging after the run is inspected.