### PR TITLE
refactor: isolate gateway request context for shared host (SBS-551)

### DIFF
--- a/docs/design/one-gateway-per-host.md
+++ b/docs/design/one-gateway-per-host.md
@@ -1,0 +1,301 @@
+# Design: One heavy gateway per host
+
+Status: PROPOSED for SBS-551. This document is the design pass requested before an
+implementation estimate. It does not change the current gateway topology.
+
+## Goal
+
+Stop every stdio AI-client session from starting its own router and copy of every
+downstream MCP server. A machine with many agent sessions should normally have one
+Toolport host daemon and one instance of each compatible downstream launch, plus a tiny
+stdio adapter for each client connection that requires stdio.
+
+"One gateway per host" therefore means **one heavy gateway runtime per compatible
+Toolport version and data directory**, not literally one operating-system process. A
+stdio client owns its child process's stdin and stdout, so a lightweight adapter process
+at that boundary is both necessary and desirable. The adapter must not load the registry,
+build a router, or spawn downstream servers.
+
+## Current architecture
+
+The existing code already proves most of the shared-runtime model, but the pieces are
+owned at the wrong boundaries:
+
+- Normal integration entries execute `toolport-gateway` directly and pass
+  `TOOLPORT_CLIENT_ID` plus an optional bootstrap profile (`clients.rs`,
+  `gateway_entry`). Every client launch therefore builds a complete gateway.
+- Shared HTTP mode builds the union of registered clients' servers and serves multiple
+  authenticated, scoped callers through one `GatewayState` (`toolport-gateway.rs`,
+  `resolve_http_caller`, `serve_http`). This proves that one router can safely filter
+  catalogs and calls per caller.
+- Clients without a native remote-MCP configuration use `npx -y mcp-remote` in today's
+  opt-in Shared HTTP mode (`clients.rs`, `client_uses_mcp_remote_bridge`). Making that
+  optional path the default would trade the Toolport process explosion for per-session
+  Node bridge processes and a third-party runtime dependency.
+- The desktop app owns one fixed-port `toolport-gateway --http` child and kills it on app
+  exit (`desktop.rs`, `start_http_bridge_at`). It fails when the port is occupied rather
+  than discovering an existing compatible process, so it is not a host daemon.
+- `GatewayState` mixes host state (registry, router, catalog, rebuild lock) with
+  connection state (stdout, profile, root, upstream capabilities and server-request
+  routing). Process globals also encode single-client assumptions: discovery/code mode,
+  stdio presence and era, progress dispatch, PII maps, result stash, and pending modern
+  HITL approvals.
+- Streamable HTTP already has useful session primitives: authenticated owner and scope,
+  client capabilities, outbound queues, upstream request correlation, subscriptions,
+  expiry, and cleanup.
+
+The measured failure mode is therefore structural, not a missing lock: N client sessions
+currently create N routers and approximately N copies of every enabled stdio server.
+Cross-process file locks protect individual shared files, but cannot remove that duplicated
+work or make in-memory state coherent.
+
+## Decision
+
+Use the existing gateway binary in two explicit roles:
+
+1. **Host daemon (`--daemon`)**: owns registry watching, the router pool, downstream
+   transports, caches, policy, audit, and all session tables. It listens only on an
+   authenticated loopback endpoint selected during rendezvous.
+2. **Stdio adapter (`--stdio-adapter`, eventually the default no-argument role)**: owns
+   exactly one client's stdin/stdout. It discovers or starts the compatible daemon,
+   establishes one daemon session, and translates JSON-RPC in both directions. It contains
+   no router and spawns no downstream MCP servers.
+
+Native remote-MCP clients may connect directly to the same daemon protocol once desktop
+bridge convergence lands. Stdio-only clients use the Toolport adapter, never
+`mcp-remote`. The existing standalone stdio gateway remains available during rollout as
+an escape hatch.
+
+Use authenticated loopback TCP and the gateway's Streamable HTTP semantics for the first
+implementation. This reuses code that already handles concurrent requests, legacy SSE,
+modern requests, server-to-client RPC, cancellation, session expiry, and scoped callers.
+Named pipes / Unix-domain sockets would reduce the network surface, but would require a
+second framing and transport implementation before topology risk is retired. The endpoint
+is loopback-only, requires a random bearer secret, rejects foreign browser origins, and is
+not exposed as the user-configured HTTP endpoint.
+
+## Runtime boundaries
+
+### Host state
+
+Owned once by the daemon:
+
+- loaded registry and registry watcher;
+- downstream pool and reconnect/circuit-breaker state;
+- catalog snapshots and persistent cache writes;
+- router rebuild coordination;
+- integrity/quarantine and shared rate-limit state;
+- audit, metrics, savings, and activity emission;
+- daemon session registry, progress routes, resource ownership, and subscription fanout.
+
+### Session state
+
+Owned once per adapter/native connection and removed on disconnect or TTL:
+
+- opaque daemon session id;
+- stable client principal (`client:{id}`) and audit label;
+- effective profile/server scope, recomputed from the registry;
+- MCP protocol version and declared capabilities;
+- project roots and the resolved `${ROOT}` context;
+- upstream request correlation and outbound queue;
+- cancellation registry, modern subscription filters, and resource subscriptions;
+- search-thrash guard and pending destructive confirmations;
+- connection-local notification eligibility and stdio/HTTP transport kind.
+
+PII maps and shaped-result cursors remain keyed by stable client principal to preserve the
+current policy across reconnects. Ending one of two concurrent sessions with the same
+principal may clear their shared PII map; the existing deliberate over-clear policy remains
+safer than retaining PII. Entries still need explicit TTL/cap cleanup because the daemon is
+long-lived.
+
+### Request context
+
+Protocol version, modern capabilities, active session, caller identity, effective scope,
+root context, and notification target must travel as an explicit request context. The
+current thread-local/process-global shortcuts are not safe once requests from different
+clients share workers. Temporary thread-local adapters are acceptable inside a synchronous
+call stack only if they are populated from, and cannot outlive, the explicit context.
+
+Downstream server-initiated requests must be correlated to the client request that caused
+them. The daemon records `downstream request id -> upstream session id` before forwarding.
+If no live originating session exists, Toolport refuses the request clearly; it must never
+guess a recipient or broadcast elicitation/sampling/roots requests.
+
+## Downstream pooling and `${ROOT}`
+
+Most downstream connections can be shared across all profiles because authorization is
+enforced when catalogs and calls are exposed. Profile membership does not by itself change
+how a server is launched.
+
+`${ROOT}` is the important exception. Two sessions can resolve the same server's cwd to
+different projects, and one child process cannot have two working directories. The daemon
+therefore pools downstream launches by a **launch key**:
+
+`server id + launch-affecting config fingerprint + resolved root context`
+
+The fingerprint includes transport, command/args, cwd, URL/auth mode, environment and any
+other value that changes the child or connection. Secrets contribute a keyed digest or
+generation marker, never plaintext. A registry or secret change retires the old launch key
+after its in-flight calls finish and creates the new one. Servers without root-dependent
+configuration converge to one instance; root-dependent servers converge per distinct root.
+This is the honest boundary for sharing and avoids silently running a tool in the wrong
+project.
+
+## Rendezvous and startup
+
+Each daemon compatibility domain has a rendezvous key derived from:
+
+- canonical Toolport data-directory path;
+- daemon protocol generation;
+- exact gateway version/build identity.
+
+Exact-version isolation makes upgrades safe: existing sessions keep using their old daemon,
+while a new adapter starts or joins the new daemon. Old daemons exit after becoming idle.
+No new binary talks to an older daemon merely because both understand HTTP.
+
+The data directory contains a version-keyed descriptor with only endpoint, bearer token,
+PID, protocol/build identity, and creation time. It is written atomically and inherits the
+data directory's user-only permissions. Startup is:
+
+1. Read the descriptor and perform an authenticated handshake that verifies the complete
+   compatibility identity. Never trust PID existence or an open port alone.
+2. If unavailable, acquire a version-keyed cross-process election lock using the existing
+   registry file-lock primitive.
+3. Recheck after acquiring the lock. Exactly one contender spawns `--daemon`; all others
+   wait for its bounded readiness handshake.
+4. The daemon binds an ephemeral loopback port, atomically publishes the descriptor, and
+   keeps running independently of the adapter and desktop app.
+5. A stale descriptor may be replaced only while holding the election lock and only after
+   its authenticated endpoint cannot be reached. Never kill a process solely because a PID
+   or port appears in a stale file.
+
+Client identity is asserted in the authenticated session-open request and resolved against
+the daemon's registry; the adapter does not supply an authoritative server allowlist. The
+bearer token protects against browser/local-port access. This follows Toolport's existing
+same-user data-directory trust boundary and does not claim to isolate hostile processes
+running as the same OS user.
+
+## Lifecycle and failure semantics
+
+- Every connected adapter/native client holds a session lease. The desktop app may later
+  hold a service lease for the user-facing shared HTTP endpoint.
+- The daemon exits after a conservative idle grace period only when it has no live leases,
+  in-flight calls, pending approvals/server requests, or active subscriptions. Start with
+  five minutes and make the constant testable; this is an operational default, not a user
+  setting in the first release.
+- Adapter EOF closes its daemon session immediately. Daemon TTL reaping handles crashed
+  adapters and performs the same subscription, PII, confirmation, and pending-request
+  cleanup as an explicit close.
+- If the daemon dies, adapters stay attached to their clients, fail the affected in-flight
+  request with a clear Toolport error, and perform rendezvous again before the next request.
+  They never replay an ambiguous tool call automatically. Initialize, ping, and list reads
+  may be retried only before the daemon accepted them.
+- One daemon crash affects more clients than one legacy gateway crash. Bounded startup,
+  panic containment at request workers, downstream circuit breakers, and no automatic
+  write replay are required mitigations. The legacy topology flag is the rollback path.
+- The app updater/reaper must understand daemon compatibility domains. It may retire an old
+  idle daemon, but must not kill a live shared daemon merely because the app is exiting.
+
+## Desktop HTTP convergence
+
+Do not combine daemon rollout with changing the public Shared HTTP contract.
+
+Initially, the internal daemon endpoint is private rendezvous infrastructure and the
+existing opt-in desktop HTTP bridge remains unchanged. After stdio sharing is stable, the
+desktop app can acquire a service lease and publish the configured port/token through the
+same host runtime. At that point `start_http_bridge_at` discovers/adopts the daemon and app
+exit releases its lease instead of killing the process.
+
+This sequencing keeps fixed-port behavior, registered client tokens, LAN exposure options,
+and user expectations out of the first migration. It also avoids accidentally exposing the
+internal host bearer as a copyable integration credential.
+
+## Implementation sequence
+
+### Phase 0: measurement and invariants
+
+- Add a diagnostic snapshot for gateway role, daemon compatibility key, session count,
+  downstream launch count, and launch keys without secret material.
+- Add an integration fixture that starts multiple logical clients and measures peak daemon,
+  adapter, and downstream child counts.
+- Record current cold-start, first-list, first-call, steady memory, and process counts as a
+  baseline. The ticket's real multi-session machine is the acceptance scenario.
+
+### Phase 1: make session ownership explicit without changing topology
+
+- Introduce `HostState`, `SessionState`, and `RequestContext` types.
+- Move discovery/code mode, root, capabilities, search guard, confirm guard, cancellation,
+  progress target, and notification routing off process-global/single-stdio assumptions.
+- Key long-lived PII, shaping, and modern-approval stores explicitly and add TTL/cap tests.
+- Keep normal stdio and HTTP behavior unchanged. This phase should be independently
+  reviewable and establishes isolation before any process sharing.
+
+### Phase 2: daemon rendezvous and native adapter, behind a flag
+
+- Add versioned descriptor, election lock, authenticated health/identity handshake,
+  `--daemon`, and `--stdio-adapter`.
+- Implement the adapter with Toolport's Streamable HTTP/SSE protocol; do not invoke Node or
+  `mcp-remote`.
+- Keep the existing in-process stdio gateway as automatic startup fallback during dogfood,
+  but never fall back after a request may have reached the daemon.
+- Cover simultaneous cold starts, stale descriptor, wrong token/version, daemon crash,
+  adapter EOF, oversized frames, cancellation, and server-initiated RPC.
+
+### Phase 3: downstream launch pooling
+
+- Build the union catalog once and enforce the session's allowed server set on every list,
+  call, prompt, resource, subscription, and server-initiated path.
+- Pool by launch key, including `${ROOT}` sharding and registry/secret generations.
+- Add concurrent clients with different identities, profiles, protocol eras, capabilities,
+  roots, and overlapping request ids. Assertions must prove both sharing and isolation.
+
+### Phase 4: dogfood, default, and desktop convergence
+
+- Ship opt-in telemetry/diagnostics and dogfood under a registry feature flag.
+- Make the adapter topology default only after process/memory reduction and parity suites
+  pass on Windows, macOS, and Linux.
+- Converge the desktop Shared HTTP supervisor onto a daemon service lease in a later PR.
+- Retain a documented legacy-topology kill switch for at least one release cycle.
+
+## Verification matrix
+
+The change is not complete on unit coverage alone. Required tests include:
+
+- 20 simultaneous adapters cold-start exactly one compatible daemon;
+- exact-version/data-dir mismatch creates separate daemons without cross-talk;
+- N clients using the same ordinary stdio server create one downstream child;
+- two `${ROOT}` values create two children, while equal roots share one;
+- profiles cannot list/call/subscribe to servers outside their scope;
+- identical JSON-RPC ids from different sessions never collide;
+- confirmations, shaped cursors, PII tokens, cancellation, progress, subscriptions,
+  sampling, roots, and both elicitation modes route only to the originating principal and
+  session as appropriate;
+- adapter/daemon/client crashes clean every session-owned resource after close or TTL;
+- registry edits rebuild once and preserve in-flight calls on the retired pool;
+- no request that may have executed is automatically replayed after a transport failure;
+- standalone/headless startup never waits indefinitely when rendezvous fails;
+- existing stdio, native HTTP, and Shared HTTP protocol suites remain green.
+
+Acceptance metrics should report heavy gateway processes, adapter processes, downstream
+children, total descendant count, steady private memory, cold-start latency, and first-call
+latency. The primary success criterion is that adding another ordinary client session does
+not add another router or another copy of root-independent downstream servers.
+
+## Risks and non-goals
+
+- This design reduces process duplication; it does not promise one downstream instance
+  when launch-affecting context differs.
+- It does not isolate mutually hostile processes running as the same OS user.
+- It does not make in-flight tool calls replayable or durable across daemon crashes.
+- It does not replace the approval broker, public Shared HTTP configuration, or remote
+  headless deployment in the first implementation.
+- A shared daemon increases blast radius and makes state-isolation bugs more serious. That
+  is why explicit session context lands before pooling and why the rollout is reversible.
+
+## Estimate after design
+
+This is a multi-PR architecture change, not a single large gateway edit. A reasonable
+delivery shape is four implementation phases plus dogfood, with Phase 1 carrying most of
+the correctness refactor and Phases 2-3 carrying most of the process/lifecycle risk. The
+work should not be estimated as complete until the cross-session isolation matrix and
+real-machine process-count acceptance run exist.

--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -48,21 +48,42 @@ use conduit_lib::semantic;
 use conduit_lib::shaping;
 use conduit_lib::{audit, usage_report};
 
+/// Context that belongs to the request currently executing on this worker.
+///
+/// These fields used to live in three independent thread-locals. That made it
+/// possible to install an MCP session without its era/capabilities (or restore
+/// one field but not the others) as nested code-mode calls crossed worker
+/// threads. Keeping one record is the first boundary needed by the shared host
+/// daemon: a later transport can install a complete session-derived context
+/// without relying on process-wide single-client state (SBS-551).
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+enum UpstreamTransport {
+    #[default]
+    Stdio,
+    Http,
+}
+
+#[derive(Clone, Debug, Default, PartialEq)]
+struct ActiveRequestContext {
+    /// Protocol version when the active client is modern (2026-07-28+).
+    upstream_version: Option<String>,
+    /// Per-request modern client capabilities used for MRTR/server RPC gating.
+    upstream_capabilities: Option<Value>,
+    /// Legacy HTTP session or modern subscription key used for upstream routing.
+    mcp_session: Option<String>,
+    /// Transport carrying the originating request. Progress and notifications
+    /// must never infer this from process topology in a multi-client daemon.
+    upstream_transport: UpstreamTransport,
+}
+
 thread_local! {
-    /// Protocol version of the request currently being served, when the client is
-    /// modern (2026-07-28+). `None` means a legacy client.
-    ///
-    /// Request-scoped rather than connection-scoped on purpose: a modern client
-    /// declares its version on every request, so there is no connection-level
-    /// negotiation to cache. Mirrors `ACTIVE_MCP_SESSION` so [`success`] can
-    /// decorate every result without threading the era through each of the two
-    /// dozen dispatch arms - including the ones that return early (SOU-446).
-    static ACTIVE_UPSTREAM_VERSION: std::cell::RefCell<Option<String>> =
-        const { std::cell::RefCell::new(None) };
-    /// Per-request capabilities of a modern upstream client. These decide
-    /// whether a legacy downstream server request can be surfaced as MRTR.
-    static ACTIVE_UPSTREAM_CAPABILITIES: std::cell::RefCell<Option<Value>> =
-        const { std::cell::RefCell::new(None) };
+    static ACTIVE_REQUEST_CONTEXT: std::cell::RefCell<ActiveRequestContext> =
+        const { std::cell::RefCell::new(ActiveRequestContext {
+            upstream_version: None,
+            upstream_capabilities: None,
+            mcp_session: None,
+            upstream_transport: UpstreamTransport::Stdio,
+        }) };
 }
 
 /// Sets the serving era for one request and restores the previous value on drop,
@@ -71,19 +92,24 @@ struct UpstreamEraGuard(Option<String>);
 
 impl UpstreamEraGuard {
     fn enter(version: Option<String>) -> Self {
-        UpstreamEraGuard(ACTIVE_UPSTREAM_VERSION.with(|cell| cell.replace(version)))
+        let previous = ACTIVE_REQUEST_CONTEXT.with(|cell| {
+            std::mem::replace(&mut cell.borrow_mut().upstream_version, version)
+        });
+        UpstreamEraGuard(previous)
     }
 }
 
 impl Drop for UpstreamEraGuard {
     fn drop(&mut self) {
-        ACTIVE_UPSTREAM_VERSION.with(|cell| *cell.borrow_mut() = self.0.take());
+        ACTIVE_REQUEST_CONTEXT.with(|cell| {
+            cell.borrow_mut().upstream_version = self.0.take();
+        });
     }
 }
 
 /// True when the request being served came from a modern client.
 fn serving_modern_client() -> bool {
-    ACTIVE_UPSTREAM_VERSION.with(|cell| cell.borrow().is_some())
+    ACTIVE_REQUEST_CONTEXT.with(|cell| cell.borrow().upstream_version.is_some())
 }
 
 struct UpstreamCapabilitiesGuard(Option<Value>);
@@ -95,14 +121,94 @@ impl UpstreamCapabilitiesGuard {
             .and_then(|params| params.get("_meta"))
             .and_then(|meta| meta.get("io.modelcontextprotocol/clientCapabilities"))
             .cloned();
-        Self(ACTIVE_UPSTREAM_CAPABILITIES.with(|cell| cell.replace(capabilities)))
+        let previous = ACTIVE_REQUEST_CONTEXT.with(|cell| {
+            std::mem::replace(&mut cell.borrow_mut().upstream_capabilities, capabilities)
+        });
+        Self(previous)
     }
 }
 
 impl Drop for UpstreamCapabilitiesGuard {
     fn drop(&mut self) {
-        ACTIVE_UPSTREAM_CAPABILITIES.with(|cell| *cell.borrow_mut() = self.0.take());
+        ACTIVE_REQUEST_CONTEXT.with(|cell| {
+            cell.borrow_mut().upstream_capabilities = self.0.take();
+        });
     }
+}
+
+/// Installs one upstream MCP session and restores the previous session on drop.
+/// Nested dispatch and early returns therefore cannot leak a caller into the
+/// next request served by the same worker thread.
+struct McpSessionGuard(Option<String>);
+
+impl McpSessionGuard {
+    fn enter(session: Option<String>) -> Self {
+        let previous = ACTIVE_REQUEST_CONTEXT.with(|cell| {
+            std::mem::replace(&mut cell.borrow_mut().mcp_session, session)
+        });
+        Self(previous)
+    }
+}
+
+impl Drop for McpSessionGuard {
+    fn drop(&mut self) {
+        ACTIVE_REQUEST_CONTEXT.with(|cell| {
+            cell.borrow_mut().mcp_session = self.0.take();
+        });
+    }
+}
+
+fn active_mcp_session() -> Option<String> {
+    ACTIVE_REQUEST_CONTEXT.with(|cell| cell.borrow().mcp_session.clone())
+}
+
+struct UpstreamTransportGuard(UpstreamTransport);
+
+impl UpstreamTransportGuard {
+    fn enter(transport: UpstreamTransport) -> Self {
+        let previous = ACTIVE_REQUEST_CONTEXT.with(|cell| {
+            std::mem::replace(&mut cell.borrow_mut().upstream_transport, transport)
+        });
+        Self(previous)
+    }
+}
+
+impl Drop for UpstreamTransportGuard {
+    fn drop(&mut self) {
+        ACTIVE_REQUEST_CONTEXT.with(|cell| {
+            cell.borrow_mut().upstream_transport = self.0;
+        });
+    }
+}
+
+fn active_upstream_is_stdio() -> bool {
+    ACTIVE_REQUEST_CONTEXT.with(|cell| {
+        cell.borrow().upstream_transport == UpstreamTransport::Stdio
+    })
+}
+
+/// Installs a complete request context on a worker that continues work for a
+/// request started on another thread (currently code-mode `callAsync`). Copying
+/// only the session id is insufficient: modern server-initiated RPC also needs
+/// the originating client's protocol era and capabilities.
+struct ActiveRequestContextGuard(ActiveRequestContext);
+
+impl ActiveRequestContextGuard {
+    fn enter(context: ActiveRequestContext) -> Self {
+        Self(ACTIVE_REQUEST_CONTEXT.with(|cell| cell.replace(context)))
+    }
+}
+
+impl Drop for ActiveRequestContextGuard {
+    fn drop(&mut self) {
+        ACTIVE_REQUEST_CONTEXT.with(|cell| {
+            cell.replace(std::mem::take(&mut self.0));
+        });
+    }
+}
+
+fn active_request_context() -> ActiveRequestContext {
+    ACTIVE_REQUEST_CONTEXT.with(|cell| cell.borrow().clone())
 }
 
 fn modern_client_supports_server_rpc(method: &str) -> bool {
@@ -112,8 +218,9 @@ fn modern_client_supports_server_rpc(method: &str) -> bool {
         "elicitation/create" => "elicitation",
         _ => return false,
     };
-    ACTIVE_UPSTREAM_CAPABILITIES.with(|cell| {
+    ACTIVE_REQUEST_CONTEXT.with(|cell| {
         cell.borrow()
+            .upstream_capabilities
             .as_ref()
             .and_then(|caps| caps.get(capability))
             .is_some()
@@ -144,9 +251,10 @@ fn modern_client_supports_server_request(request: &Value) -> bool {
         .and_then(|params| params.get("mode"))
         .and_then(Value::as_str)
         .unwrap_or("form");
-    ACTIVE_UPSTREAM_CAPABILITIES.with(|cell| {
+    ACTIVE_REQUEST_CONTEXT.with(|cell| {
         elicitation_mode_supported(
             cell.borrow()
+                .upstream_capabilities
                 .as_ref()
                 .and_then(|caps| caps.get("elicitation")),
             mode,
@@ -155,8 +263,9 @@ fn modern_client_supports_server_request(request: &Value) -> bool {
 }
 
 fn modern_client_supports_extension(identifier: &str) -> bool {
-    ACTIVE_UPSTREAM_CAPABILITIES.with(|cell| {
+    ACTIVE_REQUEST_CONTEXT.with(|cell| {
         cell.borrow()
+            .upstream_capabilities
             .as_ref()
             .and_then(|caps| caps.get("extensions"))
             .and_then(|extensions| extensions.get(identifier))
@@ -172,8 +281,9 @@ fn mcp_app_html_settings(settings: &Value) -> bool {
 }
 
 fn active_client_supports_mcp_app_html() -> bool {
-    ACTIVE_UPSTREAM_CAPABILITIES.with(|cell| {
+    ACTIVE_REQUEST_CONTEXT.with(|cell| {
         cell.borrow()
+            .upstream_capabilities
             .as_ref()
             .and_then(|caps| caps.get("extensions"))
             .and_then(|extensions| extensions.get(MCP_APPS_EXTENSION))
@@ -845,74 +955,10 @@ static PROGRESS_DISPATCH: std::sync::OnceLock<ProgressDispatch> = std::sync::Onc
 static PROGRESS_ROUTES: std::sync::OnceLock<Arc<Mutex<ProgressRoutes>>> =
     std::sync::OnceLock::new();
 
-/// Whether this process serves a stdio MCP client, i.e. whether writing a
-/// server-to-client message to stdout reaches anybody.
-///
-/// False in HTTP bridge mode. Defaults to true when unset so direct unit-test
-/// callers keep the stdio behaviour they were written against.
-///
-/// Tri-state (`0` unset, `1` no stdio client, `2` stdio client) rather than a
-/// `OnceLock`: a write-once cell cannot be set by a test without pinning the
-/// value for every other test in the binary, so no test ever set it and every
-/// one of them silently resolved to the stdio branch - including the ones whose
-/// whole point was an HTTP gateway (SOU-474 #9).
-static HAS_STDIO_CLIENT: std::sync::atomic::AtomicU8 = std::sync::atomic::AtomicU8::new(0);
 /// Once this stdio peer sends a 2026-07-28 request, unsolicited legacy
 /// notifications must stop. Modern notifications travel only through its
 /// explicit `subscriptions/listen` filter.
 static MODERN_STDIO_UPSTREAM: AtomicBool = AtomicBool::new(false);
-
-fn set_has_stdio_client(present: bool) {
-    HAS_STDIO_CLIENT.store(
-        if present { 2 } else { 1 },
-        std::sync::atomic::Ordering::SeqCst,
-    );
-}
-
-fn has_stdio_client() -> bool {
-    // Unset resolves to true: see the note above.
-    HAS_STDIO_CLIENT.load(std::sync::atomic::Ordering::SeqCst) != 1
-}
-
-/// Serializes tests that override [`HAS_STDIO_CLIENT`], which is process-global.
-///
-/// Only tests that take this lock are serialized. libtest runs tests on parallel
-/// threads, so a test that reaches `progress_target()` WITHOUT overriding can
-/// still observe another test's value. That is latent rather than live today
-/// (only the override-taking tests touch that path), but a new test on the
-/// progress path needs this guard even when it does not care about the value.
-#[cfg(test)]
-static STDIO_CLIENT_TEST_LOCK: Mutex<()> = Mutex::new(());
-
-/// Sets [`HAS_STDIO_CLIENT`] for the duration of a test and restores it on drop,
-/// holding the lock above for as long as the override is in effect.
-#[cfg(test)]
-struct StdioClientOverride {
-    _guard: std::sync::MutexGuard<'static, ()>,
-    previous: u8,
-}
-
-#[cfg(test)]
-impl StdioClientOverride {
-    fn set(present: bool) -> Self {
-        let guard = STDIO_CLIENT_TEST_LOCK
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
-        let previous = HAS_STDIO_CLIENT.load(std::sync::atomic::Ordering::SeqCst);
-        set_has_stdio_client(present);
-        Self {
-            _guard: guard,
-            previous,
-        }
-    }
-}
-
-#[cfg(test)]
-impl Drop for StdioClientOverride {
-    fn drop(&mut self) {
-        HAS_STDIO_CLIENT.store(self.previous, std::sync::atomic::Ordering::SeqCst);
-    }
-}
 
 /// Where progress for the request being served should be delivered, or `None`
 /// when there is no channel to deliver it on.
@@ -924,10 +970,7 @@ impl Drop for StdioClientOverride {
 /// traffic nobody is reading, so it returns `None` and the caller declines to ask
 /// the server for progress at all (SOU-447).
 fn progress_target() -> Option<String> {
-    progress_target_for(
-        ACTIVE_MCP_SESSION.with(|cell| cell.borrow().clone()),
-        has_stdio_client(),
-    )
+    progress_target_for(active_mcp_session(), active_upstream_is_stdio())
 }
 
 /// The decision behind [`progress_target`], separated from the globals it reads
@@ -4876,11 +4919,12 @@ fn run_script_dispatch(
     let allowed_owned = allowed.cloned();
     let cancel_owned = cancel;
 
-    // Capture the active MCP session id (if any) so callAsync workers on other
-    // threads reinstall it for the duration of each host call (WS2-3). Without
-    // this, HTTP-mode server-initiated RPC (sampling/elicitation/roots) during
-    // a fanned-out callAsync cannot resolve the upstream client.
-    let active_session = ACTIVE_MCP_SESSION.with(|cell| cell.borrow().clone());
+    // Capture the complete request context so callAsync workers on other threads
+    // reinstall the originating session, protocol era, and capabilities for the
+    // duration of each host call. Installing only the session id lets a modern
+    // request reach its HTTP client but then misclassifies it as legacy when a
+    // downstream asks for sampling/elicitation/roots (SBS-551, extending WS2-3).
+    let request_context = active_request_context();
 
     // Arc + Send + Sync so independent callAsync work can run on a small host thread pool.
     // shape=false: intermediate results stay full-sized in the sandbox (never enter model
@@ -4909,16 +4953,8 @@ fn run_script_dispatch(
                 live_owned.as_ref(),
             )
         };
-        match active_session.as_ref() {
-            Some(sid) => ACTIVE_MCP_SESSION.with(|cell| {
-                let previous = cell.borrow().clone();
-                *cell.borrow_mut() = Some(sid.clone());
-                let out = run();
-                *cell.borrow_mut() = previous;
-                out
-            }),
-            None => run(),
-        }
+        let _context = ActiveRequestContextGuard::enter(request_context.clone());
+        run()
     });
 
     // Cursor handoff for any already-shaped result (prior turn, or external cursor in data).
@@ -6836,11 +6872,7 @@ fn make_resource_updated_sink(
 /// Active MCP session key for resource subscription bookkeeping: real HTTP
 /// session id when set, otherwise the stdio sentinel.
 fn active_resource_session_id() -> String {
-    ACTIVE_MCP_SESSION.with(|cell| {
-        cell.borrow()
-            .clone()
-            .unwrap_or_else(|| RESOURCE_SUB_STDIO.to_string())
-    })
+    active_mcp_session().unwrap_or_else(|| RESOURCE_SUB_STDIO.to_string())
 }
 
 /// Handle `resources/subscribe` / `resources/unsubscribe` with ownership routing,
@@ -8006,10 +8038,6 @@ impl StdioUpstream {
     }
 }
 
-thread_local! {
-    static ACTIVE_MCP_SESSION: std::cell::RefCell<Option<String>> = const { std::cell::RefCell::new(None) };
-}
-
 fn should_write_legacy_stdio_resource_update(need_stdio: bool, modern_stdio: bool) -> bool {
     need_stdio && !modern_stdio
 }
@@ -8149,10 +8177,9 @@ fn register_modern_subscription(
             "method": "resources/subscribe",
             "params": { "uri": uri }
         });
-        ACTIVE_MCP_SESSION.with(|cell| *cell.borrow_mut() = Some(key.clone()));
+        let _session = McpSessionGuard::enter(Some(key.clone()));
         let response =
             handle_resource_subscription(state, router, &subscribe, allowed, "resources/subscribe");
-        ACTIVE_MCP_SESSION.with(|cell| *cell.borrow_mut() = None);
         if response
             .as_ref()
             .is_some_and(|response| response.get("result").is_some())
@@ -9180,7 +9207,7 @@ fn make_server_request_handler(
         let params = upstream_rpc_params(method, &screened_request);
         let timeout = upstream_rpc_timeout(method);
         let result = if http {
-            let sid = ACTIVE_MCP_SESSION.with(|cell| cell.borrow().clone())?;
+            let sid = active_mcp_session()?;
             let session = {
                 let sessions = mcp_sessions.lock().ok()?;
                 sessions.get(&sid).cloned()?
@@ -9441,6 +9468,11 @@ fn process_request(
     cancel: Option<downstream::CancelContext>,
     client: Option<&str>,
 ) -> Option<Value> {
+    let _transport = UpstreamTransportGuard::enter(if state.http {
+        UpstreamTransport::Http
+    } else {
+        UpstreamTransport::Stdio
+    });
     let method = req.get("method").and_then(|m| m.as_str()).unwrap_or("");
     if !state.http && upstream_declared_version(req) == Some(MODERN_PROTOCOL_VERSION) {
         MODERN_STDIO_UPSTREAM.store(true, Ordering::SeqCst);
@@ -10538,9 +10570,8 @@ fn handle_mcp_http(
 
             // Notifications / JSON-RPC responses: 202 with empty body.
             if !has_id {
-                ACTIVE_MCP_SESSION.with(|cell| *cell.borrow_mut() = session_id.clone());
+                let _session = McpSessionGuard::enter(session_id.clone());
                 let _ = process_request(state, &req, guard, confirm, allowed, None, client);
-                ACTIVE_MCP_SESSION.with(|cell| *cell.borrow_mut() = None);
                 let out = HttpOut::new(202, "text/plain", String::new());
                 return match session_id.as_deref() {
                     Some(sid) => out.with_header("Mcp-Session-Id", sid),
@@ -10548,12 +10579,8 @@ fn handle_mcp_http(
                 };
             }
 
-            let resp = ACTIVE_MCP_SESSION.with(|cell| {
-                *cell.borrow_mut() = session_id.clone();
-                let out = process_request(state, &req, guard, confirm, allowed, None, client);
-                *cell.borrow_mut() = None;
-                out
-            });
+            let _session = McpSessionGuard::enter(session_id.clone());
+            let resp = process_request(state, &req, guard, confirm, allowed, None, client);
             match resp {
                 Some(resp) => {
                     let status = if is_modern {
@@ -12117,9 +12144,6 @@ fn main() {
         Arc::clone(&mcp_sessions),
         Arc::clone(progress_routes()),
     ));
-    // In HTTP bridge mode nothing reads this process's stdout, so it is not a
-    // delivery channel for server-to-client messages (SOU-447).
-    set_has_stdio_client(!http_mode);
     // Single-flight for every router build/swap (startup, watcher self-heal, and
     // ${ROOT} rebuilds). Created up front so the startup build can share it.
     let rebuild_lock = Arc::new(Mutex::new(()));
@@ -18731,7 +18755,8 @@ mod tests {
         // Code mode re-enters dispatch while an outer request is being served, so
         // an inner modern request must restore the outer era on the way out
         // rather than leaving it set.
-        let outer_is_modern = ACTIVE_UPSTREAM_VERSION.with(|cell| cell.borrow().is_some());
+        let outer_is_modern =
+            ACTIVE_REQUEST_CONTEXT.with(|cell| cell.borrow().upstream_version.is_some());
         assert!(!outer_is_modern, "test starts with no era installed");
 
         // Simulate the outer legacy request holding the thread-local, then a
@@ -18756,6 +18781,86 @@ mod tests {
     }
 
     #[test]
+    fn mcp_session_guard_restores_nested_session_context() {
+        assert!(
+            active_mcp_session().is_none(),
+            "test starts without an installed session"
+        );
+        {
+            let _outer = McpSessionGuard::enter(Some("session-a".to_string()));
+            assert_eq!(active_mcp_session().as_deref(), Some("session-a"));
+            {
+                let _inner = McpSessionGuard::enter(Some("session-b".to_string()));
+                assert_eq!(active_mcp_session().as_deref(), Some("session-b"));
+            }
+            assert_eq!(
+                active_mcp_session().as_deref(),
+                Some("session-a"),
+                "dropping a nested guard restores its caller"
+            );
+        }
+        assert!(
+            active_mcp_session().is_none(),
+            "dropping the outer guard restores the worker default"
+        );
+    }
+
+    #[test]
+    fn active_request_context_is_isolated_between_worker_threads() {
+        assert_eq!(
+            ACTIVE_REQUEST_CONTEXT.with(|cell| cell.borrow().clone()),
+            ActiveRequestContext::default(),
+            "test starts with a clean worker context"
+        );
+        let _era = UpstreamEraGuard::enter(Some(MODERN_PROTOCOL_VERSION.to_string()));
+        let _session = McpSessionGuard::enter(Some("parent-session".to_string()));
+        let parent_caps = json!({
+            "params": {
+                "_meta": {
+                    "io.modelcontextprotocol/clientCapabilities": {
+                        "roots": {}
+                    }
+                }
+            }
+        });
+        let _capabilities = UpstreamCapabilitiesGuard::enter(&parent_caps);
+
+        let captured = active_request_context();
+        let child = std::thread::spawn(move || {
+            assert_eq!(
+                active_request_context(),
+                ActiveRequestContext::default(),
+                "a fresh worker must not inherit another request's context"
+            );
+            let installed = {
+                let _context = ActiveRequestContextGuard::enter(captured);
+                assert_eq!(active_mcp_session().as_deref(), Some("parent-session"));
+                assert!(serving_modern_client());
+                assert!(modern_client_supports_server_rpc("roots/list"));
+                active_request_context()
+            };
+            assert_eq!(
+                active_request_context(),
+                ActiveRequestContext::default(),
+                "dropping the cross-thread guard restores the worker default"
+            );
+            installed
+        })
+        .join()
+        .expect("worker completes");
+
+        assert_eq!(child.mcp_session.as_deref(), Some("parent-session"));
+        assert_eq!(
+            child.upstream_version.as_deref(),
+            Some(MODERN_PROTOCOL_VERSION)
+        );
+        assert!(child.upstream_capabilities.is_some());
+        assert_eq!(active_mcp_session().as_deref(), Some("parent-session"));
+        assert!(serving_modern_client());
+        assert!(modern_client_supports_server_rpc("roots/list"));
+    }
+
+    #[test]
     fn prepare_progress_withholds_the_token_when_nothing_can_deliver_it() {
         // The shipping function, not its pure helpers. `progress_target_for` was
         // unit-tested in every combination while `prepare_progress` - which reads
@@ -18765,11 +18870,13 @@ mod tests {
 
         // A modern HTTP client: no session, no stdio. Nothing can carry progress,
         // so the server must not be asked to produce it.
-        let _no_stdio = StdioClientOverride::set(false);
+        let _http = UpstreamTransportGuard::enter(UpstreamTransport::Http);
         // Thread-local, and libtest may reuse this thread for another test, so
         // assert the default rather than assuming it and leaving it changed.
-        ACTIVE_MCP_SESSION
-            .with(|cell| assert!(cell.borrow().is_none(), "no session on this thread"));
+        assert!(
+            active_mcp_session().is_none(),
+            "no session on this thread"
+        );
         assert_eq!(
             progress_target(),
             None,
@@ -18794,11 +18901,13 @@ mod tests {
     fn prepare_progress_registers_a_route_for_a_stdio_client() {
         // The other side of the same decision: a stdio client IS a delivery
         // channel, so the token is registered and rewritten rather than dropped.
-        let _stdio = StdioClientOverride::set(true);
+        let _stdio = UpstreamTransportGuard::enter(UpstreamTransport::Stdio);
         // Thread-local, and libtest may reuse this thread for another test, so
         // assert the default rather than assuming it and leaving it changed.
-        ACTIVE_MCP_SESSION
-            .with(|cell| assert!(cell.borrow().is_none(), "no session on this thread"));
+        assert!(
+            active_mcp_session().is_none(),
+            "no session on this thread"
+        );
         assert_eq!(
             progress_target().as_deref(),
             Some(RESOURCE_SUB_STDIO),

--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -58,7 +58,10 @@ use conduit_lib::{audit, usage_report};
 /// without relying on process-wide single-client state (SBS-551).
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 enum UpstreamTransport {
+    /// No transport was installed for this worker. Delivery decisions must fail
+    /// closed rather than guessing that process stdout belongs to the caller.
     #[default]
+    Unknown,
     Stdio,
     Http,
 }
@@ -68,7 +71,7 @@ struct ActiveRequestContext {
     /// Protocol version when the active client is modern (2026-07-28+).
     upstream_version: Option<String>,
     /// Per-request modern client capabilities used for MRTR/server RPC gating.
-    upstream_capabilities: Option<Value>,
+    upstream_capabilities: Option<Arc<Value>>,
     /// Legacy HTTP session or modern subscription key used for upstream routing.
     mcp_session: Option<String>,
     /// Transport carrying the originating request. Progress and notifications
@@ -82,7 +85,7 @@ thread_local! {
             upstream_version: None,
             upstream_capabilities: None,
             mcp_session: None,
-            upstream_transport: UpstreamTransport::Stdio,
+            upstream_transport: UpstreamTransport::Unknown,
         }) };
 }
 
@@ -112,7 +115,7 @@ fn serving_modern_client() -> bool {
     ACTIVE_REQUEST_CONTEXT.with(|cell| cell.borrow().upstream_version.is_some())
 }
 
-struct UpstreamCapabilitiesGuard(Option<Value>);
+struct UpstreamCapabilitiesGuard(Option<Arc<Value>>);
 
 impl UpstreamCapabilitiesGuard {
     fn enter(req: &Value) -> Self {
@@ -120,7 +123,8 @@ impl UpstreamCapabilitiesGuard {
             .get("params")
             .and_then(|params| params.get("_meta"))
             .and_then(|meta| meta.get("io.modelcontextprotocol/clientCapabilities"))
-            .cloned();
+            .cloned()
+            .map(Arc::new);
         let previous = ACTIVE_REQUEST_CONTEXT.with(|cell| {
             std::mem::replace(&mut cell.borrow_mut().upstream_capabilities, capabilities)
         });
@@ -18858,6 +18862,61 @@ mod tests {
         assert_eq!(active_mcp_session().as_deref(), Some("parent-session"));
         assert!(serving_modern_client());
         assert!(modern_client_supports_server_rpc("roots/list"));
+    }
+
+    #[test]
+    fn cloned_request_context_shares_large_capability_snapshot() {
+        let large = "x".repeat(256 * 1024);
+        let req = json!({
+            "params": {
+                "_meta": {
+                    "io.modelcontextprotocol/clientCapabilities": {
+                        "extensions": { "test/large": { "payload": large } }
+                    }
+                }
+            }
+        });
+        let _capabilities = UpstreamCapabilitiesGuard::enter(&req);
+        let original = active_request_context();
+        let original_caps = original
+            .upstream_capabilities
+            .as_ref()
+            .expect("capabilities installed");
+
+        for _ in 0..64 {
+            let worker = original.clone();
+            assert!(Arc::ptr_eq(
+                original_caps,
+                worker
+                    .upstream_capabilities
+                    .as_ref()
+                    .expect("worker retains capabilities")
+            ));
+        }
+    }
+
+    #[test]
+    fn missing_transport_fails_closed_for_progress() {
+        assert_eq!(
+            active_request_context().upstream_transport,
+            UpstreamTransport::Unknown,
+            "test starts without a transport installed"
+        );
+        assert_eq!(
+            progress_target(),
+            None,
+            "an unknown transport is not an implicit stdio delivery channel"
+        );
+
+        let meta = json!({ "progressToken": "must-not-route" });
+        let (registration, relayed) = prepare_progress(Some(&meta), "alpha");
+        assert!(registration.is_none());
+        assert!(
+            relayed
+                .expect("metadata is relayed without progress")
+                .get("progressToken")
+                .is_none()
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- document the one-heavy-gateway-per-host architecture, including native stdio adapters, versioned rendezvous, `${ROOT}` launch-key sharding, crash behavior, and phased rollout
- introduce one request-context record for protocol era, client capabilities, MCP session, and upstream transport
- replace manual MCP-session thread-local mutation with scoped RAII guards
- propagate the complete originating context into code-mode worker threads so server-initiated RPC keeps the correct client era, capabilities, and session
- remove the process-global stdio-presence flag and its serialized test lock

## Scope

This is the design and first isolation foundation for SBS-551. It deliberately does not introduce the shared daemon or change the installed client topology yet. The next slices move the remaining notification/discovery policy into session-owned state before daemon rendezvous and downstream pooling land.

## Validation

- `cargo test --bin toolport-gateway` — 255 passed
- `cargo clippy --bin toolport-gateway --tests` — completed successfully (pre-existing warnings only)
- `git diff --check origin/main...HEAD`

## Tracker

SBS-551