### PR TITLE
test: verify fixed Grok review runner

### DIFF
--- a/.github/coderev-grok-canary.md
+++ b/.github/coderev-grok-canary.md
@@ -1,0 +1,1 @@
+Temporary canary used to verify the subscription-backed Grok CLI completes on the self-hosted review runner.


### PR DESCRIPTION
Disposable live canary. This PR exists only to prove the newly pinned CodeRev action completes a subscription-backed Grok invocation on the self-hosted runner; it will be closed without merge after log verification.