### PR TITLE
test: cover auth and trust-boundary regressions (SBS-656, 657, 658, 659, 615, 671)

### DIFF
--- a/src-tauri/src/approval_broker.rs
+++ b/src-tauri/src/approval_broker.rs
@@ -345,6 +345,50 @@ pub fn clear_endpoint() {
     }
 }
 
+/// What the broker can settle about a request before a human is involved.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Preflight {
+    /// Unauthenticated: answer `Denied` and hang up.
+    Deny,
+    /// Covered by a fingerprint-bound allow: answer `Approved` without prompting.
+    AutoApprove,
+    /// Park it and wait for the person (or the fail-closed timeout).
+    AskHuman,
+}
+
+/// The authentication + auto-approve decision for one request, with no I/O so it can be
+/// exercised without a Tauri `AppHandle`. `is_allowed` answers whether a
+/// fingerprint-bound allow key is on the session or registry allowlist; it is consulted
+/// only for a key this function builds, which is why a legacy broad `server/tool` entry
+/// can never match (see the comment below).
+fn preflight(
+    req: &ApprovalRequest,
+    broker_token: &str,
+    is_allowed: impl Fn(&str) -> bool,
+) -> Preflight {
+    // Authenticate: only a process holding our token may register an approval. The empty
+    // check is not redundant with `token_eq`: if getrandom failed at startup our own token
+    // is empty, and without it every tokenless caller would authenticate.
+    if req.token.is_empty() || !token_eq(&req.token, broker_token) {
+        return Preflight::Deny;
+    }
+
+    // Auto-approve only if the current tool definition matches a fingerprint-bound allow.
+    // Legacy broad `server/tool` entries are intentionally ignored: a tool definition that
+    // changed since approval should re-prompt instead of inheriting a stale bypass. A
+    // request with no fingerprint at all likewise never auto-approves.
+    if req.url_elicitation.is_none() {
+        if let Some(fp) = req.tool_fingerprint.as_deref() {
+            let key = crate::approval::fingerprint_allow_key(&req.server, &req.tool, fp);
+            if is_allowed(&key) {
+                return Preflight::AutoApprove;
+            }
+        }
+    }
+
+    Preflight::AskHuman
+}
+
 /// Serve one gateway connection: read the request, authenticate it, park it for a human
 /// decision (or a fail-closed timeout), and write the decision back.
 fn handle_conn(stream: TcpStream, broker: ApprovalBroker, app: AppHandle) {
@@ -373,28 +417,23 @@ fn handle_conn(stream: TcpStream, broker: ApprovalBroker, app: AppHandle) {
         );
     };
 
-    // Authenticate: only a process holding our token may register an approval.
-    if req.token.is_empty() || !token_eq(&req.token, &broker.inner.token) {
-        deny(&mut out);
-        return;
-    }
-
-    // Auto-approve only if the current tool definition matches a fingerprint-bound allow.
-    // Legacy broad `server/tool` entries are intentionally ignored: a tool definition that
-    // changed since approval should re-prompt instead of inheriting a stale bypass.
-    if req.url_elicitation.is_none() {
-        if let Some(fp) = req.tool_fingerprint.as_deref() {
-            let key = crate::approval::fingerprint_allow_key(&req.server, &req.tool, fp);
-            if broker.session_contains(&key) || registry_allows(&app, &key) {
-                let _ = out.set_write_timeout(Some(Duration::from_secs(10)));
-                let _ = writeln!(
-                    out,
-                    "{}",
-                    serde_json::to_string(&ApprovalDecision::Approved).unwrap_or_default()
-                );
-                return;
-            }
+    match preflight(&req, &broker.inner.token, |key| {
+        broker.session_contains(key) || registry_allows(&app, key)
+    }) {
+        Preflight::Deny => {
+            deny(&mut out);
+            return;
         }
+        Preflight::AutoApprove => {
+            let _ = out.set_write_timeout(Some(Duration::from_secs(10)));
+            let _ = writeln!(
+                out,
+                "{}",
+                serde_json::to_string(&ApprovalDecision::Approved).unwrap_or_default()
+            );
+            return;
+        }
+        Preflight::AskHuman => {}
     }
 
     let view = PendingView {
@@ -635,6 +674,92 @@ mod tests {
         permits.push(try_acquire_connection(&active).expect("released permit is reusable"));
         drop(permits);
         assert_eq!(active.load(Ordering::Acquire), 0);
+    }
+
+    /// A fingerprinted request as a gateway sends it, carrying `token`.
+    fn request(token: &str, fingerprint: Option<&str>) -> ApprovalRequest {
+        ApprovalRequest {
+            token: token.into(),
+            id: "req-1".into(),
+            client: None,
+            server: "db".into(),
+            tool: "drop_table".into(),
+            reason: ApprovalReason::Destructive,
+            arguments: serde_json::json!({}),
+            tool_fingerprint: fingerprint.map(str::to_string),
+            url_elicitation: None,
+        }
+    }
+
+    /// The allowlist probe `handle_conn` passes to `preflight`, backed by a fixed key set.
+    fn allowing(keys: &[String]) -> impl Fn(&str) -> bool + '_ {
+        move |key: &str| keys.iter().any(|k| k == key)
+    }
+
+    #[test]
+    fn preflight_denies_a_wrong_or_empty_token() {
+        let allow_nothing = allowing(&[]);
+        assert_eq!(
+            preflight(&request("nope", Some("v2:abc")), "tok", &allow_nothing),
+            Preflight::Deny
+        );
+        assert_eq!(
+            preflight(&request("", Some("v2:abc")), "tok", &allow_nothing),
+            Preflight::Deny
+        );
+        // Fail closed when getrandom failed at startup and our own token is empty: an
+        // empty-vs-empty compare would otherwise authenticate every caller.
+        assert_eq!(
+            preflight(&request("", Some("v2:abc")), "", &allow_nothing),
+            Preflight::Deny
+        );
+        // Sanity: the same request with the right token gets past auth.
+        assert_eq!(
+            preflight(&request("tok", Some("v2:abc")), "tok", &allow_nothing),
+            Preflight::AskHuman
+        );
+    }
+
+    #[test]
+    fn preflight_auto_approves_only_a_fingerprint_allow() {
+        let fp_key = crate::approval::fingerprint_allow_key("db", "drop_table", "v2:abc");
+        let allowed = [fp_key];
+        assert_eq!(
+            preflight(&request("tok", Some("v2:abc")), "tok", allowing(&allowed)),
+            Preflight::AutoApprove
+        );
+        // A different tool definition is a different key, so it re-prompts.
+        assert_eq!(
+            preflight(&request("tok", Some("v2:xyz")), "tok", allowing(&allowed)),
+            Preflight::AskHuman
+        );
+    }
+
+    #[test]
+    fn preflight_ignores_a_legacy_server_tool_allow() {
+        // The pre-fingerprint broad key must NOT grant a bypass to a fingerprinted call:
+        // a tool definition that changed since approval has to be re-approved.
+        let legacy = [crate::approval::allow_key("db", "drop_table")];
+        assert_eq!(
+            preflight(&request("tok", Some("v2:abc")), "tok", allowing(&legacy)),
+            Preflight::AskHuman
+        );
+    }
+
+    #[test]
+    fn preflight_never_auto_approves_an_unfingerprinted_request() {
+        // No fingerprint means we cannot prove the definition is the approved one, so no
+        // allowlist entry of any shape may bypass the human.
+        let every_key = |_: &str| true;
+        assert_eq!(
+            preflight(&request("tok", None), "tok", every_key),
+            Preflight::AskHuman
+        );
+        // Still denied first on a bad token.
+        assert_eq!(
+            preflight(&request("bad", None), "tok", every_key),
+            Preflight::Deny
+        );
     }
 
     #[test]

--- a/src-tauri/src/clients.rs
+++ b/src-tauri/src/clients.rs
@@ -4609,8 +4609,14 @@ fn read_gateway_profile(client_id: &str) -> Option<String> {
 /// never be re-pointed onto a current binary. Deleting one out from under a plugin
 /// entry leaves a reference nothing will ever repair.
 pub fn referenced_gateway_paths() -> Option<Vec<PathBuf>> {
+    referenced_gateway_paths_in(&detect_clients())
+}
+
+/// The pure half of [`referenced_gateway_paths`], over an already-probed client list so
+/// the fail-closed and plugin-reference rules are testable without touching real configs.
+fn referenced_gateway_paths_in(clients: &[DetectedClient]) -> Option<Vec<PathBuf>> {
     let mut out: Vec<PathBuf> = Vec::new();
-    for client in detect_clients() {
+    for client in clients {
         if client.error.is_some() {
             return None;
         }
@@ -5785,6 +5791,103 @@ bad = "not-a-table"
             assert!(slot.get("env").is_none());
             std::fs::remove_file(&path).ok();
         }
+    }
+
+    /// A detected client with no servers, no error, and a config file present.
+    fn detected(id: &str) -> DetectedClient {
+        DetectedClient {
+            id: id.into(),
+            name: id.into(),
+            uses_connectors: false,
+            config_path: format!("/tmp/{id}.json"),
+            config_exists: true,
+            app_present: true,
+            servers: Vec::new(),
+            plugin_servers: Vec::new(),
+            gateway_installed: true,
+            entry_state: GatewayEntryState::Managed,
+            error: None,
+        }
+    }
+
+    fn gateway_server(name: &str, command: &str) -> McpServer {
+        McpServer {
+            name: name.into(),
+            transport: "stdio".into(),
+            command: Some(command.into()),
+            args: vec![],
+            env_keys: vec![],
+            url: None,
+        }
+    }
+
+    #[test]
+    fn referenced_gateway_paths_fails_closed_on_an_unreadable_client() {
+        // An unreadable config means that client's references are UNKNOWN, and an unknown
+        // reference must never be read as an absent one - the caller skips the whole prune.
+        let mut broken = detected("claude-desktop");
+        broken.error = Some("permission denied".into());
+        assert_eq!(referenced_gateway_paths_in(&[broken.clone()]), None);
+
+        // ...and it still fails closed alongside a client we CAN read, rather than
+        // handing back a partial list that would make the other binary look unreferenced.
+        let mut healthy = detected("cursor");
+        healthy.servers = vec![gateway_server(
+            GATEWAY_ENTRY_NAME,
+            r"C:\Users\me\AppData\Roaming\Toolport\bin\toolport-gateway-1.9.5.exe",
+        )];
+        assert_eq!(
+            referenced_gateway_paths_in(&[healthy.clone(), broken.clone()]),
+            None,
+            "one unreadable client must veto the whole set, not yield a partial list"
+        );
+        assert_eq!(referenced_gateway_paths_in(&[broken, healthy]), None);
+    }
+
+    #[test]
+    fn referenced_gateway_paths_includes_plugin_and_customized_entries() {
+        let plugin_path = r"C:\Users\me\AppData\Roaming\Toolport\bin\toolport-gateway-1.8.0.exe";
+        // Plugin servers live outside the main config and can never be re-pointed, so a
+        // binary only they name must still survive the prune.
+        let mut plugin_only = detected("cursor");
+        plugin_only.plugin_servers = vec![gateway_server(GATEWAY_ENTRY_NAME, plugin_path)];
+        assert_eq!(
+            referenced_gateway_paths_in(&[plugin_only.clone()]),
+            Some(vec![PathBuf::from(plugin_path)])
+        );
+
+        // A customized entry (repoint leaves it alone) still names a binary the client
+        // will spawn, so it is included too.
+        let customized_path = r"C:\Users\me\custom\toolport-gateway-1.7.0.exe";
+        let mut customized = detected("windsurf");
+        customized.entry_state = GatewayEntryState::Customized;
+        customized.servers = vec![gateway_server(GATEWAY_ENTRY_NAME, customized_path)];
+        assert_eq!(
+            referenced_gateway_paths_in(&[customized.clone()]),
+            Some(vec![PathBuf::from(customized_path)])
+        );
+
+        // Both together, de-duplicated, and unrelated servers ignored.
+        let mut noise = detected("cline");
+        noise.servers = vec![gateway_server("github", "npx")];
+        let mut dupe = detected("claude-code");
+        dupe.servers = vec![gateway_server(GATEWAY_ENTRY_NAME, plugin_path)];
+        assert_eq!(
+            referenced_gateway_paths_in(&[plugin_only, customized, noise, dupe]),
+            Some(vec![
+                PathBuf::from(plugin_path),
+                PathBuf::from(customized_path),
+            ])
+        );
+    }
+
+    #[test]
+    fn referenced_gateway_paths_skips_clients_without_a_config() {
+        // No config file is a KNOWN-empty reference set, unlike an error: keep going.
+        let mut absent = detected("zed");
+        absent.config_exists = false;
+        absent.servers = vec![gateway_server(GATEWAY_ENTRY_NAME, "toolport-gateway-9.9.9")];
+        assert_eq!(referenced_gateway_paths_in(&[absent]), Some(vec![]));
     }
 
     #[test]

--- a/src-tauri/src/oauth.rs
+++ b/src-tauri/src/oauth.rs
@@ -1958,6 +1958,58 @@ mod tests {
         assert_eq!(code, "good-code");
     }
 
+    /// SBS-659: browsers hit the loopback redirect with /favicon.ico and other
+    /// stray requests. Treating the first connection as the authorization response
+    /// would fail the sign-in with "empty authorization code" while the real
+    /// redirect was still in flight right behind it.
+    #[test]
+    fn callback_ignores_stray_requests_and_waits_for_the_real_redirect() {
+        let result = callback_result(
+            &[
+                "/favicon.ico",
+                "/callback",
+                "/?utm_source=browser",
+                "/callback?code=good-code&state=expected",
+            ],
+            "expected",
+        );
+
+        match result {
+            Ok(code) => assert_eq!(code, "good-code"),
+            Err(e) => panic!("a stray request must not end the wait: {e}"),
+        }
+    }
+
+    /// A stray request must not be mistaken for a state mismatch either: it carries
+    /// no state, and rejecting it would abort the flow before the real redirect.
+    #[test]
+    fn callback_stray_request_is_not_treated_as_a_csrf_failure() {
+        let result = callback_result(
+            &["/favicon.ico?v=2", "/callback?code=good-code&state=expected"],
+            "expected",
+        );
+        match result {
+            Ok(code) => assert_eq!(code, "good-code"),
+            Err(e) => panic!("a stray request must not be read as a CSRF failure: {e}"),
+        }
+    }
+
+    /// An `error` response is still acted on once state checks out - the stray-request
+    /// skip must not swallow a genuine denial and leave the user waiting.
+    #[test]
+    fn callback_surfaces_an_authorization_error_after_a_stray_request() {
+        let error = callback_result(
+            &[
+                "/favicon.ico",
+                "/callback?error=access_denied&error_description=nope&state=expected",
+            ],
+            "expected",
+        )
+        .expect_err("a denial must end the wait");
+        assert!(error.contains("access_denied"), "{error}");
+        assert!(error.contains("nope"), "{error}");
+    }
+
     #[test]
     fn metadata_issuer_must_match_the_selected_authorization_server() {
         assert!(validate_metadata_issuer(

--- a/src-tauri/src/oauth.rs
+++ b/src-tauri/src/oauth.rs
@@ -1245,31 +1245,13 @@ pub fn client_credentials_token(
     // `agent_no_redirect`: a 302 on a credential-bearing POST could hand the
     // client secret to a host named by an attacker-influenceable metadata
     // document. Same reasoning as the code exchange and refresh.
-    let request = agent_no_redirect(block_private).post(token_endpoint);
-    let response = match method {
-        ClientAuthMethod::ClientSecretBasic => {
-            // RFC 6749 §2.3.1: client_id and secret are form-urlencoded before
-            // base64, not sent raw. Skipping that corrupts any secret containing
-            // a `+`, `:` or `/`, which is common in generated credentials.
-            let credentials = format!(
-                "{}:{}",
-                urlencoding::encode(client_id),
-                urlencoding::encode(client_secret)
-            );
-            let header = format!(
-                "Basic {}",
-                base64::engine::general_purpose::STANDARD.encode(credentials.as_bytes())
-            );
-            request.set("Authorization", &header).send_form(&form)
-        }
-        ClientAuthMethod::ClientSecretPost => {
-            let mut form = form.clone();
-            form.push(("client_id", client_id));
-            form.push(("client_secret", client_secret));
-            request.send_form(&form)
-        }
-        ClientAuthMethod::PrivateKeyJwt => unreachable!("rejected above"),
-    };
+    let mut request = agent_no_redirect(block_private).post(token_endpoint);
+    let authentication = client_authentication(method, client_id, client_secret);
+    if let Some(header) = &authentication.authorization {
+        request = request.set("Authorization", header);
+    }
+    form.extend_from_slice(&authentication.form_fields);
+    let response = request.send_form(&form);
 
     let resp: TokenResponse = response
         .map_err(|e| redact_secret(&e.to_string(), client_secret))?
@@ -1288,6 +1270,55 @@ pub fn client_credentials_token(
     // this flow is that re-authentication is cheap and non-interactive.
     tokens.refresh_token = None;
     Ok(tokens)
+}
+
+/// How the client proves its identity on a client-credentials token request:
+/// an `Authorization` header, extra form fields, or (per method) exactly one.
+struct ClientAuthentication<'a> {
+    authorization: Option<String>,
+    form_fields: Vec<(&'a str, &'a str)>,
+}
+
+/// Split out of [`client_credentials_token`] so the encoding rules are checkable
+/// without a network round trip: the credential encoding is the part that silently
+/// corrupts real secrets, and a live token endpoint is the worst possible place to
+/// discover that.
+fn client_authentication<'a>(
+    method: ClientAuthMethod,
+    client_id: &'a str,
+    client_secret: &'a str,
+) -> ClientAuthentication<'a> {
+    match method {
+        ClientAuthMethod::ClientSecretBasic => ClientAuthentication {
+            authorization: Some(client_secret_basic_header(client_id, client_secret)),
+            form_fields: Vec::new(),
+        },
+        // The secret rides in the body for this method, which is why the transport
+        // error path redacts it: it is quotable in a way the Basic header is not.
+        ClientAuthMethod::ClientSecretPost => ClientAuthentication {
+            authorization: None,
+            form_fields: vec![("client_id", client_id), ("client_secret", client_secret)],
+        },
+        ClientAuthMethod::PrivateKeyJwt => unreachable!("rejected above"),
+    }
+}
+
+/// Build the `client_secret_basic` credential header.
+///
+/// RFC 6749 §2.3.1: client_id and secret are form-urlencoded before base64, not
+/// sent raw. Skipping that corrupts any secret containing a `+`, `:` or `/`, which
+/// is common in generated credentials — and a `:` in the id would additionally
+/// move the field boundary the server splits on.
+fn client_secret_basic_header(client_id: &str, client_secret: &str) -> String {
+    let credentials = format!(
+        "{}:{}",
+        urlencoding::encode(client_id),
+        urlencoding::encode(client_secret)
+    );
+    format!(
+        "Basic {}",
+        base64::engine::general_purpose::STANDARD.encode(credentials.as_bytes())
+    )
 }
 
 /// Strip a credential out of text that is about to be surfaced or logged.
@@ -2675,6 +2706,78 @@ mod tests {
             Ok(_) => panic!("private_key_jwt must be refused before any request"),
         };
         assert!(err.contains("SBS-599"), "{err}");
+    }
+
+    /// Decode a `Basic <b64>` header back to the credential string the server sees.
+    fn decode_basic(header: &str) -> String {
+        let encoded = header
+            .strip_prefix("Basic ")
+            .unwrap_or_else(|| panic!("not a Basic header: {header}"));
+        let raw = base64::engine::general_purpose::STANDARD
+            .decode(encoded)
+            .expect("a Basic header must be valid base64");
+        String::from_utf8(raw).expect("credentials are ASCII once encoded")
+    }
+
+    /// RFC 6749 §2.3.1. Generated secrets routinely contain `+`, `:` and `/`, and
+    /// sending the raw pair is the failure this encoding exists to prevent: a `:`
+    /// moves the field boundary the server splits on, and `+` decodes back to a
+    /// space at any server that form-decodes the halves.
+    #[test]
+    fn client_secret_basic_form_encodes_the_credential_pair() {
+        let header = client_secret_basic_header("client:id", "s+cr:et/1");
+
+        // Written out literally rather than via `urlencoding::encode`, which would
+        // just restate the implementation and pass for any encoding at all.
+        assert_eq!(decode_basic(&header), "client%3Aid:s%2Bcr%3Aet%2F1");
+        // The only unescaped `:` is the field separator RFC 6749 defines.
+        assert_eq!(decode_basic(&header).matches(':').count(), 1);
+        assert_ne!(
+            decode_basic(&header),
+            "client:id:s+cr:et/1",
+            "the raw pair must never be what the server receives"
+        );
+    }
+
+    /// Credentials with no reserved characters must survive untouched, or the
+    /// encoding would break the common case to fix the rare one.
+    #[test]
+    fn client_secret_basic_leaves_unreserved_credentials_alone() {
+        assert_eq!(
+            decode_basic(&client_secret_basic_header("client-abc", "s3cret_value.1~x")),
+            "client-abc:s3cret_value.1~x"
+        );
+    }
+
+    /// `client_secret_post` puts the secret in the body, not the header. If it ever
+    /// grew an Authorization header too, the secret would be sent twice and the
+    /// redaction in the error path would no longer cover every copy.
+    #[test]
+    fn client_secret_post_sends_the_secret_in_the_form_body_only() {
+        let auth = client_authentication(
+            ClientAuthMethod::ClientSecretPost,
+            "client:id",
+            "s+cr:et/1",
+        );
+
+        assert!(
+            auth.authorization.is_none(),
+            "client_secret_post must not also send a Basic header"
+        );
+        assert_eq!(
+            auth.form_fields,
+            vec![("client_id", "client:id"), ("client_secret", "s+cr:et/1")],
+            "form fields are urlencoded by the form encoder, so they ride verbatim"
+        );
+
+        // And the Basic method is the mirror image: header only, nothing in the body.
+        let basic =
+            client_authentication(ClientAuthMethod::ClientSecretBasic, "client:id", "s+cr:et/1");
+        assert!(basic.form_fields.is_empty(), "the secret must not ride twice");
+        assert_eq!(
+            basic.authorization.as_deref(),
+            Some(client_secret_basic_header("client:id", "s+cr:et/1").as_str())
+        );
     }
 
     /// A secret can appear in a transport error that quotes the request body.

--- a/src-tauri/src/oauth.rs
+++ b/src-tauri/src/oauth.rs
@@ -1882,6 +1882,82 @@ mod tests {
         assert!(error.contains("empty authorization code"));
     }
 
+    /// Drive `wait_for_code` against a real loopback listener, feeding it the
+    /// given request targets one connection at a time.
+    ///
+    /// Each request is fully written and its response read to EOF before the next
+    /// connection opens, so the order `wait_for_code` sees is the order given here
+    /// and no test needs a sleep to synchronize.
+    fn callback_result(targets: &[&str], expected_state: &str) -> Result<String, String> {
+        use std::io::Write;
+
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        listener.set_nonblocking(true).unwrap();
+        let address = listener.local_addr().unwrap();
+        let requests: Vec<String> = targets.iter().map(|t| (*t).to_string()).collect();
+        let client = std::thread::spawn(move || {
+            for target in requests {
+                // `wait_for_code` may return before consuming every request (that is
+                // the point of some of these cases), so nothing here may block
+                // forever waiting for a reply that is never coming.
+                let Ok(mut stream) = std::net::TcpStream::connect(address) else {
+                    break;
+                };
+                stream.set_read_timeout(Some(Duration::from_secs(5))).unwrap();
+                if stream
+                    .write_all(format!("GET {target} HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n").as_bytes())
+                    .is_err()
+                {
+                    break;
+                }
+                // The server closes after replying, so this returns once the request
+                // has been handled - the handoff that keeps the ordering exact
+                // without a sleep.
+                let mut response = String::new();
+                let _ = stream.read_to_string(&mut response);
+            }
+        });
+
+        let result = wait_for_code(&listener, expected_state, "https://auth.example.com", false);
+        client.join().unwrap();
+        result
+    }
+
+    /// SBS-657: the `state` parameter is the only thing standing between the user
+    /// and an attacker-injected authorization code being redeemed against their
+    /// session, so a mismatch must abort rather than exchange the code.
+    #[test]
+    fn callback_rejects_a_code_carrying_the_wrong_state() {
+        let error = callback_result(&["/callback?code=attacker-code&state=wrong"], "expected")
+            .expect_err("a code arriving with the wrong state must not be redeemed");
+
+        assert!(
+            error.contains("state mismatch") && error.contains("CSRF"),
+            "the refusal has to name the reason: {error}"
+        );
+        assert!(
+            !error.contains("attacker-code"),
+            "the rejected code must not be echoed back: {error}"
+        );
+    }
+
+    /// A callback with no `state` at all is the same attack without the guesswork.
+    #[test]
+    fn callback_rejects_a_code_with_no_state_at_all() {
+        let error = callback_result(&["/callback?code=attacker-code"], "expected")
+            .expect_err("a missing state is not a matching state");
+        assert!(error.contains("state mismatch"), "{error}");
+    }
+
+    /// The happy path, so the callback suite is not failure-only: a matching state
+    /// and a non-empty code still complete the flow.
+    #[test]
+    fn callback_accepts_a_code_with_the_matching_state() {
+        let code = callback_result(&["/callback?code=good-code&state=expected"], "expected")
+            .expect("a matching state and a real code must complete the flow");
+        assert_eq!(code, "good-code");
+    }
+
     #[test]
     fn metadata_issuer_must_match_the_selected_authorization_server() {
         assert!(validate_metadata_issuer(

--- a/src-tauri/src/remote.rs
+++ b/src-tauri/src/remote.rs
@@ -319,7 +319,26 @@ fn client_credentials_resource_changed(server_id: &str, url: &str) -> bool {
     else {
         return false;
     };
-    state.resource.trim() != url.trim()
+    resource_binding_changed(&state.resource, url)
+}
+
+/// The comparison [`client_credentials_resource_changed`] is built on, split out so
+/// the case-sensitivity rule is checkable without a vault round trip.
+///
+/// Deliberately NOT `eq_ignore_ascii_case`: see the doc comment above.
+fn resource_binding_changed(vaulted_resource: &str, url: &str) -> bool {
+    vaulted_resource.trim() != url.trim()
+}
+
+/// Is the vaulted client-credentials state stale for the entry being connected?
+///
+/// Split out of [`connect_remote_with_handler`] so the decision is reachable
+/// without a live connect. Two ways state goes stale, both reached by editing the
+/// server outside `set_client_credentials`: the config was removed, or the URL
+/// changed out from under an RFC 8707 resource binding.
+fn client_credentials_state_is_stale(server: &ServerEntry, server_id: &str, url: &str) -> bool {
+    secrets::get_secret(server_id, CC_STATE_KEY).is_some()
+        && (!uses_client_credentials(server) || client_credentials_resource_changed(server_id, url))
 }
 
 /// Expiry of the vaulted client-credentials token, if this server uses that flow.
@@ -863,9 +882,7 @@ pub fn connect_remote_with_handler(
     //
     // Handled here because this is the only place that sees both the current entry
     // and the vault; the reacquire seam takes just a server id by design.
-    if secrets::get_secret(server_id, CC_STATE_KEY).is_some()
-        && (!uses_client_credentials(server) || client_credentials_resource_changed(server_id, url))
-    {
+    if client_credentials_state_is_stale(server, server_id, url) {
         // Not ignored: leaving stale state would silently keep using the wrong
         // flow, or the wrong resource binding, for the rest of the session.
         reset_client_credentials(server_id)?;
@@ -1399,5 +1416,183 @@ mod tests {
         .unwrap();
         assert_eq!(minimal.expires_at, None);
         assert_eq!(minimal.scope, None);
+    }
+
+    // ----- SBS-615: exact resource rebinding after a URL edit ------------------
+
+    /// The comparison is EXACT, and that is the whole point: RFC 8707 binds the
+    /// token to the resource string, and a URL path is case-sensitive, so
+    /// `/MCP` and `/mcp` are different resources. Folding case here would keep a
+    /// token minted for the old one and the user's edit would appear to do nothing.
+    #[test]
+    fn resource_rebinding_compares_the_url_exactly() {
+        let vaulted = "https://mcp.example.com/MCP";
+
+        assert!(
+            !resource_binding_changed(vaulted, "https://mcp.example.com/MCP"),
+            "the same URL must not force a pointless re-acquisition"
+        );
+        assert!(
+            resource_binding_changed(vaulted, "https://mcp.example.com/mcp"),
+            "a path differing only in case is a different resource"
+        );
+        // Case anywhere else counts as changed too. Over-reporting is the safe
+        // direction: re-acquiring is cheap and non-interactive by construction.
+        assert!(resource_binding_changed(vaulted, "https://MCP.example.com/MCP"));
+        assert!(resource_binding_changed(vaulted, "https://mcp.example.com/MCP/v2"));
+    }
+
+    /// Surrounding whitespace is not a resource change: a URL pasted with a
+    /// trailing newline would otherwise re-acquire on every single connect.
+    #[test]
+    fn resource_rebinding_ignores_surrounding_whitespace_only() {
+        assert!(!resource_binding_changed(
+            "  https://mcp.example.com/MCP\n",
+            "https://mcp.example.com/MCP"
+        ));
+        assert!(!resource_binding_changed(
+            "https://mcp.example.com/MCP",
+            "\thttps://mcp.example.com/MCP  "
+        ));
+        // Trimming must not reach inside the URL and mask a real edit.
+        assert!(resource_binding_changed(
+            "  https://mcp.example.com/MCP  ",
+            "  https://mcp.example.com/mcp  "
+        ));
+    }
+
+    /// Points the vault at a scratch dir and the file backend at a known key, so a
+    /// test can write real `ClientCredentialsState` and read it back.
+    ///
+    /// Holds `data_dir_test_lock` for the whole test: the data-dir override and the
+    /// backend-selecting env var are both process-global.
+    struct VaultFixture {
+        _data_dir_lock: std::sync::MutexGuard<'static, ()>,
+        _override: crate::registry::DataDirOverride,
+        dir: std::path::PathBuf,
+        previous_key: Option<String>,
+    }
+
+    impl VaultFixture {
+        fn new(name: &str) -> Self {
+            let lock = crate::registry::data_dir_test_lock();
+            let dir = std::env::temp_dir().join(format!(
+                "toolport-sbs615-{name}-{}-{}",
+                std::process::id(),
+                now_epoch_seconds()
+            ));
+            std::fs::create_dir_all(&dir).expect("scratch data dir");
+            let over = crate::registry::DataDirOverride::set(&dir);
+            let previous_key = std::env::var("TOOLPORT_SECRET_KEY").ok();
+            std::env::set_var("TOOLPORT_SECRET_KEY", "sbs-615-unit-test-passphrase");
+            Self {
+                _data_dir_lock: lock,
+                _override: over,
+                dir,
+                previous_key,
+            }
+        }
+
+        fn vault_state(&self, server_id: &str, resource: &str) {
+            let state = ClientCredentialsState {
+                issuer: "https://auth.example.com".into(),
+                token_endpoint: "https://auth.example.com/token".into(),
+                client_id: "client-abc".into(),
+                method: "client_secret_basic".into(),
+                scope: None,
+                resource: resource.into(),
+                expires_at: Some(9_999_999_999),
+            };
+            secrets::set_secret(
+                server_id,
+                CC_STATE_KEY,
+                &serde_json::to_string(&state).expect("state serializes"),
+            )
+            .expect("scratch vault write");
+        }
+    }
+
+    impl Drop for VaultFixture {
+        fn drop(&mut self) {
+            match self.previous_key.take() {
+                Some(v) => std::env::set_var("TOOLPORT_SECRET_KEY", v),
+                None => std::env::remove_var("TOOLPORT_SECRET_KEY"),
+            }
+            let _ = std::fs::remove_dir_all(&self.dir);
+        }
+    }
+
+    /// End to end over the real vault: state pinned to `/MCP`, entry edited to
+    /// `/mcp`. The connect path must call this stale and reset, or the next
+    /// acquisition would keep presenting a token bound to the old resource.
+    #[test]
+    fn a_url_edit_that_only_changes_path_case_rebinds_the_credential() {
+        let vault = VaultFixture::new("rebind");
+        let mut server = http_server("sbs615-rebind", Some(cc("client-abc")));
+        server.url = Some("https://mcp.example.com/MCP".into());
+        let server_id = server.id.clone();
+        vault.vault_state(&server_id, "https://mcp.example.com/MCP");
+
+        // Unchanged URL: nothing to reset, or every connect would re-acquire.
+        assert!(!client_credentials_resource_changed(
+            &server_id,
+            "https://mcp.example.com/MCP"
+        ));
+        assert!(!client_credentials_state_is_stale(
+            &server,
+            &server_id,
+            "https://mcp.example.com/MCP"
+        ));
+
+        // The edit: same host, same everything but the path case.
+        let edited = "https://mcp.example.com/mcp";
+        server.url = Some(edited.into());
+        assert!(client_credentials_resource_changed(&server_id, edited));
+        assert!(
+            client_credentials_state_is_stale(&server, &server_id, edited),
+            "the connect path must treat the vaulted state as stale"
+        );
+
+        // What the connect path then does. After it, nothing is left to reuse, so
+        // the next acquisition binds to the URL actually being contacted.
+        reset_client_credentials(&server_id).expect("reset");
+        assert!(secrets::get_secret(&server_id, CC_STATE_KEY).is_none());
+        assert!(secrets::get_secret(&server_id, secrets::HTTP_AUTH_KEY).is_none());
+    }
+
+    /// Removing the config is the other way state goes stale, and it must not
+    /// depend on the URL having changed.
+    #[test]
+    fn vaulted_state_without_a_configured_flow_is_stale_at_the_same_url() {
+        let vault = VaultFixture::new("deconfigured");
+        let url = "https://mcp.example.com/MCP";
+        let server = http_server("sbs615-deconfigured", None);
+        let server_id = server.id.clone();
+        vault.vault_state(&server_id, url);
+
+        assert!(!client_credentials_resource_changed(&server_id, url));
+        assert!(
+            client_credentials_state_is_stale(&server, &server_id, url),
+            "state for a server no longer configured for the flow must be discarded"
+        );
+    }
+
+    /// No vaulted state means nothing to rebind: a server being configured for the
+    /// first time must not report a change and must not attempt a reset.
+    #[test]
+    fn an_empty_vault_reports_no_resource_change() {
+        let _vault = VaultFixture::new("empty");
+        let server = http_server("sbs615-empty", Some(cc("client-abc")));
+        let server_id = server.id.clone();
+
+        assert!(!client_credentials_resource_changed(
+            &server_id,
+            "https://mcp.example.com/mcp"
+        ));
+        assert!(!client_credentials_state_is_stale(
+            &server,
+            &server_id,
+            "https://mcp.example.com/mcp"
+        ));
     }
 }


### PR DESCRIPTION
Backfills regression coverage for six trust boundaries that shipped recently with no tests guarding them. **Tests only** — plus four behavior-identical extractions made purely to get the decision logic out from under I/O so it is reachable without a Tauri `AppHandle`, a live network, or a real client config.

One commit per ticket, one file per commit.

## Tickets

| Commit | Ticket | What is now guarded |
|---|---|---|
| `dd44a75` | SBS-658 | `client_secret_basic` form-encodes the credential pair before base64 (RFC 6749 §2.3.1) |
| `bdb3b1b` | SBS-656 | HITL broker token auth + fingerprint-only auto-approve |
| `fd93827` | SBS-671 | `referenced_gateway_paths` fail-closed, and plugin-only references |
| `b95a515` | SBS-657 | OAuth callback rejects a code carrying the wrong state (CSRF) |
| `522163b` | SBS-659 | OAuth callback ignores stray loopback requests (favicon etc.) |
| `8811609` | SBS-615 | Client-credentials resource rebinding compares the URL exactly |

21 new tests, none `#[ignore]`.

## Extractions (behavior-identical)

- `approval_broker.rs` — auth/auto-approve decision moved out of `handle_conn` into a pure `preflight()`. Same I/O, same short-circuit order (`session_contains` then `registry_allows`, preserved through a closure).
- `clients.rs` — `referenced_gateway_paths()` is now a wrapper over `referenced_gateway_paths_in(&[DetectedClient])`; loop body unchanged.
- `oauth.rs` — `client_authentication()` + `client_secret_basic_header()` split out of `client_credentials_token`. Same header, same form fields, same order.
- `remote.rs` — `resource_binding_changed()` and `client_credentials_state_is_stale()` split out; the connect-time condition is unchanged.

## Every test was proven load-bearing

Each one was validated by applying the exact regression its ticket describes, confirming red, then reverting:

- Drop `req.token.is_empty()` → empty-token request becomes `AskHuman` instead of `Denied` (the getrandom-failure fail-open).
- Fall back to the legacy `server/tool` allow key → a changed tool definition auto-approves without re-prompting (the rug-pull bypass).
- `return None` → `Some(vec![])` on an unreadable client config, and drop the `plugin_servers` chain → prune would delete a live binary.
- `if false` on the state guard → an attacker-supplied code is redeemed.
- Delete the stray-request `continue` → a browser favicon hit kills the OAuth flow.
- `!=` → `eq_ignore_ascii_case` → a token minted for `/MCP` survives an edit to `/mcp`.

Assertions avoid being self-fulfilling where it matters — e.g. the expected Basic payload is written as the literal `client%3Aid:s%2Bcr%3Aet%2F1` rather than being recomputed with `urlencoding::encode`.

## Verification

`npm run test:rust` (exactly what CI runs): **857 lib + 257 bin + all integration suites, 0 failed, 0 ignored.**

Loopback tests bind to port 0, drive a real listener, read each response to EOF before the next connect, and use a 5s socket timeout — no sleeps as synchronization. Vault-backed tests use a scratch data dir under `registry::data_dir_test_lock` and restore the environment on drop.

## Scope note

SBS-615's connect-path criterion is covered via the extracted decision plus the `reset_client_credentials` effect, not `connect_remote_with_handler` end to end — that function does live discovery and a TCP connect, so it is not testable without network. This is the "mutation-friendly helper test" alternative the ticket allows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)