### PR TITLE
test: cover result-shaping, cancel-forward, and install-shape regressions (SBS-644, 649, 650, 672, 673)

### DIFF
--- a/src-tauri/src/catalog.rs
+++ b/src-tauri/src/catalog.rs
@@ -699,6 +699,101 @@ mod tests {
     }
 
     #[test]
+    fn maps_a_pypi_package_to_uvx() {
+        let server = json!({
+            "name": "io.github.acme/pytool",
+            "description": "A python server.",
+            "packages": [{
+                "registryType": "pypi",
+                "identifier": "acme-mcp",
+                "version": "0.4.2"
+            }]
+        });
+        let e = map_server(&server).unwrap();
+        assert_eq!(e.transport, "stdio");
+        assert_eq!(e.command.as_deref(), Some("uvx"));
+        // uvx takes the spec alone — no `-y`-style prefix.
+        assert_eq!(e.args, vec!["acme-mcp@0.4.2"]);
+
+        // `latest` is a dist-tag, not a version, so the bare identifier is used.
+        let latest = json!({ "name": "io.github.acme/pytool", "title": "Pytool",
+            "packages": [{ "registryType": "pypi", "identifier": "acme-mcp", "version": "latest" }] });
+        let e = map_server(&latest).unwrap();
+        assert_eq!(e.command.as_deref(), Some("uvx"));
+        assert_eq!(e.args, vec!["acme-mcp"]);
+
+        // Same for a missing version.
+        let bare = json!({ "name": "io.github.acme/pytool", "title": "Pytool",
+            "packages": [{ "registryType": "pypi", "identifier": "acme-mcp" }] });
+        assert_eq!(map_server(&bare).unwrap().args, vec!["acme-mcp"]);
+    }
+
+    #[test]
+    fn maps_container_packages_to_a_docker_run() {
+        // "oci" and "docker" are the two spellings the registry uses for the same thing.
+        for registry_type in ["oci", "docker"] {
+            let server = json!({
+                "name": "io.github.acme/boxed",
+                "description": "A containerized server.",
+                "packages": [{
+                    "registryType": registry_type,
+                    "identifier": "ghcr.io/acme/boxed-mcp",
+                    "version": "1.2.3",
+                    "environmentVariables": [{ "name": "ACME_API_KEY" }]
+                }]
+            });
+            let e = map_server(&server).unwrap();
+            assert_eq!(e.transport, "stdio");
+            assert_eq!(e.command.as_deref(), Some("docker"), "{registry_type}");
+            // stdio needs the container's stdin held open and the container reaped,
+            // so `-i --rm` must precede the image spec.
+            assert_eq!(
+                e.args,
+                vec!["run", "-i", "--rm", "ghcr.io/acme/boxed-mcp@1.2.3"],
+                "{registry_type}"
+            );
+            assert_eq!(e.env_keys, vec!["ACME_API_KEY"], "{registry_type}");
+        }
+
+        // No version: the image spec is the bare identifier.
+        let bare = json!({ "name": "io.github.acme/boxed", "title": "Boxed",
+            "packages": [{ "registryType": "oci", "identifier": "ghcr.io/acme/boxed-mcp" }] });
+        assert_eq!(
+            map_server(&bare).unwrap().args,
+            vec!["run", "-i", "--rm", "ghcr.io/acme/boxed-mcp"]
+        );
+    }
+
+    #[test]
+    fn map_server_rejects_unsafe_specs_for_every_registry_type() {
+        // The safety gate runs before the registry_type match, so uvx and docker get
+        // the same treatment npx does.
+        for registry_type in ["pypi", "oci", "docker"] {
+            // Leading-dash identifier (flag injection into uvx/docker) is dropped.
+            let flag = json!({ "name": "io.x/y", "title": "Y",
+                "packages": [{ "registryType": registry_type, "identifier": "--unsafe-flag" }] });
+            assert!(
+                map_server(&flag).is_none(),
+                "{registry_type}: flag-injection identifier must be dropped"
+            );
+            // Shell metacharacters in the version are dropped.
+            let meta = json!({ "name": "io.x/z", "title": "Z",
+                "packages": [{ "registryType": registry_type, "identifier": "pkg", "version": "1; rm -rf /" }] });
+            assert!(
+                map_server(&meta).is_none(),
+                "{registry_type}: shell metachars must be dropped"
+            );
+            // An empty identifier has nothing to install.
+            let empty = json!({ "name": "io.x/w", "title": "W",
+                "packages": [{ "registryType": registry_type, "identifier": "" }] });
+            assert!(
+                map_server(&empty).is_none(),
+                "{registry_type}: empty identifier must be dropped"
+            );
+        }
+    }
+
+    #[test]
     fn skips_isnt_latest() {
         let old = json!({ "_meta": { "io.modelcontextprotocol.registry/official": { "isLatest": false } } });
         let cur = json!({ "_meta": { "io.modelcontextprotocol.registry/official": { "isLatest": true } } });

--- a/src-tauri/src/downstream.rs
+++ b/src-tauri/src/downstream.rs
@@ -7352,6 +7352,321 @@ mod tests {
         assert!(!cancelled.forwarded);
     }
 
+    /// A real child process that records everything written to its stdin, so a
+    /// cancellation test can read back the exact bytes the production write path
+    /// produced. A genuine child is used rather than an in-process pipe because
+    /// `CancelEntry` holds a `ChildStdin`, and on Windows a `ChildStdin` adopted
+    /// from `std::io::pipe` swallows writes (that pipe is opened in overlapped
+    /// mode; the child-stdio writer is not).
+    struct StdinRecorder {
+        child: std::process::Child,
+        stdin: Arc<Mutex<std::process::ChildStdin>>,
+        output: std::path::PathBuf,
+        script: Option<std::path::PathBuf>,
+    }
+
+    impl StdinRecorder {
+        fn new(tag: &str) -> Self {
+            use std::process::{Command, Stdio};
+            use std::time::{SystemTime, UNIX_EPOCH};
+
+            let nonce = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos();
+            let output = std::env::temp_dir().join(format!(
+                "toolport-cancel-{tag}-{}-{nonce}.jsonl",
+                std::process::id()
+            ));
+            let sink = std::fs::File::create(&output).expect("create the recorder's output file");
+            // The child copies stdin to stdout, and stdout is the file above, so
+            // nothing has to be interpolated into the script itself.
+            let mut script = None;
+            let mut cmd = if cfg!(windows) {
+                let path = output.with_extension("ps1");
+                std::fs::write(
+                    &path,
+                    "$in = [Console]::OpenStandardInput()\n\
+                     $out = [Console]::OpenStandardOutput()\n\
+                     $in.CopyTo($out)\n\
+                     $out.Flush()\n",
+                )
+                .expect("write the recorder script");
+                let mut c = Command::new("powershell.exe");
+                c.args([
+                    "-NoLogo",
+                    "-NoProfile",
+                    "-NonInteractive",
+                    "-ExecutionPolicy",
+                    "Bypass",
+                    "-File",
+                ])
+                .arg(&path);
+                script = Some(path);
+                c
+            } else {
+                Command::new("cat")
+            };
+            let mut child = cmd
+                .stdin(Stdio::piped())
+                .stdout(Stdio::from(sink))
+                .stderr(Stdio::null())
+                .spawn()
+                .expect("spawn the stdin recorder");
+            let stdin = Arc::new(Mutex::new(child.stdin.take().expect("piped stdin")));
+            Self {
+                child,
+                stdin,
+                output,
+                script,
+            }
+        }
+
+        /// Drop this side's handle to the child's stdin, wait for the child to
+        /// exit, then parse what it recorded.
+        ///
+        /// The wait is what makes these tests deterministic rather than timed: a
+        /// cancellation forward runs on a detached thread that owns a clone of
+        /// the stdin handle, so the child cannot reach EOF - and cannot exit -
+        /// until that thread has finished writing. Waiting therefore observes
+        /// every forward that will ever happen, and equally proves the absence of
+        /// one, with no sleep and no poll loop. Every other clone of the handle
+        /// must already be dropped.
+        fn finish(self) -> Vec<Value> {
+            let StdinRecorder {
+                mut child,
+                stdin,
+                output,
+                script,
+            } = self;
+            drop(stdin);
+            let status = child
+                .wait()
+                .expect("the recorder should exit once its stdin closes");
+            assert!(status.success(), "recorder exited with {status}");
+            let raw = std::fs::read_to_string(&output).expect("read the recorded stdin");
+            let _ = std::fs::remove_file(&output);
+            if let Some(script) = script {
+                let _ = std::fs::remove_file(script);
+            }
+            raw.lines()
+                .filter(|l| !l.trim().is_empty())
+                .map(|l| serde_json::from_str(l).unwrap_or_else(|e| panic!("bad frame {l:?}: {e}")))
+                .collect()
+        }
+    }
+
+    /// Any short-lived process will do: `StdioTransport` owns a `Child` it never
+    /// speaks to in these tests (stdin is the recorder's pipe and stdout is a
+    /// pre-loaded channel), it just has to hold one. The recorder's own child is
+    /// deliberately NOT used here - dropping the transport kills its child, which
+    /// on unix would cut the recording short.
+    fn placeholder_child() -> std::process::Child {
+        use std::process::{Command, Stdio};
+        let mut cmd = if cfg!(windows) {
+            let mut c = Command::new("cmd");
+            c.args(["/C", "exit"]);
+            c
+        } else {
+            let mut c = Command::new("sh");
+            c.args(["-c", "exit 0"]);
+            c
+        };
+        cmd.stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn a placeholder child")
+    }
+
+    /// A `StdioTransport` whose stdin is `stdin` and whose only stdout line is
+    /// `response`, queued before the call so the read never depends on timing.
+    fn stdio_transport_fixture(
+        stdin: Arc<Mutex<std::process::ChildStdin>>,
+        response: &Value,
+    ) -> super::StdioTransport {
+        use std::sync::atomic::AtomicBool;
+        let (tx, rx) = std::sync::mpsc::channel();
+        tx.send(response.to_string()).expect("queue the response");
+        drop(tx);
+        super::StdioTransport {
+            child: placeholder_child(),
+            #[cfg(windows)]
+            job: None,
+            stdin,
+            rx,
+            stderr: Arc::new(Mutex::new(String::new())),
+            next_id: 1,
+            read_timeout: std::time::Duration::from_secs(30),
+            armed: Arc::new(AtomicBool::new(false)),
+            launcher: false,
+            server_handler: None,
+            pending_mrtr: None,
+            progress: Arc::new(Mutex::new(None)),
+            protocol_meta: None,
+            subscription_listener_id: None,
+        }
+    }
+
+    /// SBS-644. The cancel-before-registration race: the client cancels while the
+    /// request is still on its way to the child, so `cancel` finds nothing in
+    /// flight and can only record the mark. The `notifications/cancelled` write
+    /// has to happen afterwards, from the request path itself, once the
+    /// downstream id exists. Driven through the real `request_with_cancel` and
+    /// asserted on the bytes that reached stdin - the registry agreeing with
+    /// itself was never the claim, the frame on the wire is.
+    ///
+    /// The interleaving is forced, not raced: the cancel is issued before the
+    /// request begins, which is exactly the ordering that produces the bug.
+    #[test]
+    fn cancel_before_registration_is_forwarded_once_the_request_is_written() {
+        let registry = CancelRegistry::new();
+        assert!(registry.begin_client_request("c-1".to_string()));
+        // Nothing is in flight yet, so this can only leave the mark behind.
+        assert!(registry.cancel("c-1", Some("user pressed stop")));
+
+        let recorder = StdinRecorder::new("deferred");
+        let mut transport = stdio_transport_fixture(
+            Arc::clone(&recorder.stdin),
+            &json!({ "jsonrpc": "2.0", "id": 1, "result": { "ok": true } }),
+        );
+
+        transport
+            .request_with_cancel(
+                "tools/call",
+                json!({ "name": "echo" }),
+                Some(registry.context("c-1".to_string())),
+            )
+            .expect("the queued response should complete the request");
+
+        registry.finish_client_request("c-1");
+        drop(transport);
+
+        let frames = recorder.finish();
+        assert_eq!(
+            frames.len(),
+            2,
+            "expected the request then its deferred cancellation, got {frames:?}"
+        );
+        assert_eq!(frames[0]["method"], "tools/call");
+        let downstream_id = frames[0]["id"].clone();
+        assert!(
+            !downstream_id.is_null(),
+            "the request must carry a downstream id, got {:?}",
+            frames[0]
+        );
+
+        let cancel = &frames[1];
+        assert_eq!(
+            cancel["method"], "notifications/cancelled",
+            "the deferred forward must actually be written, got {cancel:?}"
+        );
+        assert_eq!(
+            cancel["params"]["requestId"], downstream_id,
+            "the forward must name the DOWNSTREAM id, got {cancel:?}"
+        );
+        assert_eq!(
+            cancel["params"]["reason"], "user pressed stop",
+            "the reason recorded before registration must survive the deferral, got {cancel:?}"
+        );
+    }
+
+    /// The `forwarded` latch: once a cancellation has reached the downstream
+    /// server, a repeat `notifications/cancelled` from the client must not put a
+    /// second one on the wire for the same in-flight request.
+    #[test]
+    fn a_forwarded_cancel_is_not_written_a_second_time() {
+        use super::CancelEntry;
+
+        let registry = CancelRegistry::new();
+        assert!(registry.begin_client_request("c-2".to_string()));
+
+        let recorder = StdinRecorder::new("latch");
+        let guard = registry.register(
+            "c-2".to_string(),
+            CancelEntry {
+                stdin: Arc::clone(&recorder.stdin),
+                downstream_id: json!(41),
+            },
+        );
+
+        assert!(registry.cancel("c-2", Some("user pressed stop")));
+        // Clients that hold down the stop key send this more than once.
+        assert!(registry.cancel("c-2", Some("user pressed stop")));
+        assert!(registry.cancel("c-2", None));
+
+        drop(guard);
+        registry.finish_client_request("c-2");
+
+        let frames = recorder.finish();
+        assert_eq!(
+            frames.len(),
+            1,
+            "three cancels of one in-flight request must forward exactly once, got {frames:?}"
+        );
+        assert_eq!(frames[0]["method"], "notifications/cancelled");
+        assert_eq!(frames[0]["params"]["requestId"], 41);
+        assert_eq!(frames[0]["params"]["reason"], "user pressed stop");
+    }
+
+    /// The latch is per in-flight registration, not for the life of the client
+    /// request: when a cancelled request is re-issued downstream (a retry lands
+    /// on a fresh downstream id), `register` clears `forwarded` so the new child
+    /// request is cancelled too. Each registration writes to its own recorder, so
+    /// the two forwards can never interleave mid-line.
+    #[test]
+    fn re_registering_a_cancelled_request_forwards_to_the_new_downstream_id() {
+        use super::CancelEntry;
+
+        let registry = CancelRegistry::new();
+        assert!(registry.begin_client_request("c-3".to_string()));
+
+        let first_recorder = StdinRecorder::new("retry-first");
+        let first_guard = registry.register(
+            "c-3".to_string(),
+            CancelEntry {
+                stdin: Arc::clone(&first_recorder.stdin),
+                downstream_id: json!(41),
+            },
+        );
+        assert!(registry.cancel("c-3", Some("user pressed stop")));
+        // The first attempt is over before the retry registers, so its guard
+        // cannot evict the replacement entry on drop.
+        drop(first_guard);
+
+        let second_recorder = StdinRecorder::new("retry-second");
+        let second_guard = registry.register(
+            "c-3".to_string(),
+            CancelEntry {
+                stdin: Arc::clone(&second_recorder.stdin),
+                downstream_id: json!(42),
+            },
+        );
+        // Same post-write step the stdio request path runs.
+        assert!(registry.is_cancelled("c-3"));
+        registry.forward_cancel_if_ready("c-3");
+        drop(second_guard);
+        registry.finish_client_request("c-3");
+
+        let first = first_recorder.finish();
+        assert_eq!(first.len(), 1, "the first attempt was cancelled: {first:?}");
+        assert_eq!(first[0]["params"]["requestId"], 41);
+
+        let second = second_recorder.finish();
+        assert_eq!(
+            second.len(),
+            1,
+            "the retry's downstream request must be cancelled too, got {second:?}"
+        );
+        assert_eq!(second[0]["method"], "notifications/cancelled");
+        assert_eq!(
+            second[0]["params"]["requestId"], 42,
+            "the forward must follow the new downstream id, got {:?}",
+            second[0]
+        );
+        assert_eq!(second[0]["params"]["reason"], "user pressed stop");
+    }
+
     fn argv(parts: &[&str]) -> Vec<String> {
         parts.iter().map(|s| s.to_string()).collect()
     }

--- a/src-tauri/src/launcher.rs
+++ b/src-tauri/src/launcher.rs
@@ -820,6 +820,41 @@ mod tests {
         );
     }
 
+    /// npm publishes `1.4.0-rc.1` *before* `1.4.0`, so both can sit in the cache. A
+    /// plain numeric compare would call them equal and let the prerelease win by
+    /// arrival order.
+    #[test]
+    fn a_release_sorts_above_its_own_prereleases() {
+        let release = Version::parse("1.4.0");
+        for pre in ["1.4.0-rc.1", "1.4.0-rc.10", "1.4.0-beta", "1.4.0-alpha.0"] {
+            assert!(
+                release > Version::parse(pre),
+                "1.4.0 must outrank {pre}, got {release:?} vs {:?}",
+                Version::parse(pre)
+            );
+        }
+        // The numeric core still dominates: a later prerelease beats an earlier release.
+        assert!(Version::parse("1.5.0-rc.1") > Version::parse("1.4.0"));
+        // Build metadata is not a prerelease marker.
+        assert!(Version::parse("1.4.0+build.7") > Version::parse("1.4.0-rc.1"));
+    }
+
+    #[test]
+    fn a_cached_prerelease_never_beats_the_cached_release() {
+        let fx = Fixture::new("prerelease");
+        fx.package("rc", "srv", "1.4.0-rc.1", serde_json::json!("index.js"));
+        fx.package("rel", "srv", "1.4.0", serde_json::json!("index.js"));
+        let node = fx.node();
+
+        let direct =
+            resolve_in("npx", &s(&["srv"]), &fx.roots(), &node).expect("cached package resolves");
+        assert!(
+            direct.args[0].replace('\\', "/").contains("/rel/"),
+            "expected the 1.4.0 release copy, got {}",
+            direct.args[0]
+        );
+    }
+
     #[test]
     fn an_exact_version_request_must_match_the_cached_copy() {
         let fx = Fixture::new("version");

--- a/src-tauri/src/shaping.rs
+++ b/src-tauri/src/shaping.rs
@@ -85,6 +85,22 @@ fn sweep(map: &mut HashMap<String, Cached>) {
     map.retain(|_, c| c.at.elapsed() < CACHE_TTL);
 }
 
+/// Bound memory: evict oldest until the entry count and total bytes leave room for
+/// a `new_entry_size`-byte result (or the cache empties, keeping one over-cap
+/// result). Each entry's `size` is precomputed, so this sum is O(n) adds, not O(n)
+/// JSON re-serializations, on every iteration.
+fn evict_to_fit(map: &mut HashMap<String, Cached>, new_entry_size: usize) {
+    while !map.is_empty()
+        && (map.len() >= MAX_CACHE_ENTRIES
+            || map.values().map(|c| c.size).sum::<usize>() + new_entry_size > MAX_CACHE_BYTES)
+    {
+        let Some(oldest) = map.iter().min_by_key(|(_, c)| c.at).map(|(k, _)| k.clone()) else {
+            break;
+        };
+        map.remove(&oldest);
+    }
+}
+
 /// Concatenate the model-facing text of an MCP tool result's content blocks, then
 /// fold in `structuredContent` so nothing is lost when the structured payload is
 /// the bloat.
@@ -292,19 +308,7 @@ pub fn shape_result(result: &mut Value, budget: usize, owner: Option<&str>) -> b
         let mut map = cache().lock().unwrap_or_else(|e| e.into_inner());
         sweep(&mut map);
 
-        // Bound memory: evict oldest until the entry count and total bytes leave
-        // room for this cached result (or the cache empties, keeping one over-cap
-        // result). Each entry's `size` is precomputed, so this sum is O(n) adds, not
-        // O(n) JSON re-serializations, on every iteration.
-        while !map.is_empty()
-            && (map.len() >= MAX_CACHE_ENTRIES
-                || map.values().map(|c| c.size).sum::<usize>() + new_entry_size > MAX_CACHE_BYTES)
-        {
-            let Some(oldest) = map.iter().min_by_key(|(_, c)| c.at).map(|(k, _)| k.clone()) else {
-                break;
-            };
-            map.remove(&oldest);
-        }
+        evict_to_fit(&mut map, new_entry_size);
 
         map.insert(
             cursor.clone(),
@@ -816,6 +820,100 @@ mod tests {
             "cache grew to {} entries",
             map.len()
         );
+    }
+
+    // A cache entry with a given recorded `size` and age, without allocating a body
+    // of that size: the eviction loop reads `Cached.size`, never the body itself, so
+    // multi-megabyte entries cost a few bytes here. `secs_ago` fixes the insertion
+    // order deterministically rather than relying on clock resolution between calls.
+    fn cached_entry(size: usize, secs_ago: u64) -> Cached {
+        Cached {
+            body: String::new(),
+            structured: None,
+            size,
+            at: Instant::now() - Duration::from_secs(secs_ago),
+            owner: None,
+        }
+    }
+
+    #[test]
+    fn cache_byte_cap_evicts_oldest_first() {
+        // The ENTRY cap is covered by `cache_is_bounded`; this is the BYTE cap, which
+        // a burst of a few huge results hits long before 64 entries. Sizes are
+        // recorded, not allocated, so the 64 MiB path costs nothing to exercise.
+        // Three of these sum to 72 MiB, past the 64 MiB cap; dropping the oldest
+        // leaves 48 MiB, so exactly one eviction is required for a 1 MiB arrival.
+        const HUGE: usize = 24 * 1024 * 1024;
+        let mut map: HashMap<String, Cached> = HashMap::new();
+        map.insert("oldest".to_string(), cached_entry(HUGE, 60));
+        map.insert("middle".to_string(), cached_entry(HUGE, 40));
+        map.insert("newest".to_string(), cached_entry(HUGE, 20));
+        assert!(map.len() < MAX_CACHE_ENTRIES, "must exercise the byte cap, not the entry cap");
+
+        let new_entry_size = 1024 * 1024;
+        evict_to_fit(&mut map, new_entry_size);
+        map.insert("incoming".to_string(), cached_entry(new_entry_size, 0));
+
+        let total: usize = map.values().map(|c| c.size).sum();
+        assert!(
+            total <= MAX_CACHE_BYTES,
+            "cached bytes grew to {total}, past the {MAX_CACHE_BYTES} cap"
+        );
+        // Oldest-by-insertion-time goes first, and only as far as needed.
+        assert!(!map.contains_key("oldest"), "the oldest entry must be evicted first");
+        assert!(map.contains_key("middle"), "eviction must stop once the new body fits");
+        assert!(map.contains_key("newest"));
+        assert!(map.contains_key("incoming"));
+    }
+
+    #[test]
+    fn cache_keeps_one_over_cap_body_rather_than_dropping_it() {
+        // Documented behaviour (see MAX_CACHE_BYTES): evict until it fits OR the
+        // cache is empty, so a single body larger than the cap is still retained
+        // rather than dropping the result the caller just produced.
+        let mut map: HashMap<String, Cached> = HashMap::new();
+        map.insert("stale".to_string(), cached_entry(1024, 60));
+
+        evict_to_fit(&mut map, MAX_CACHE_BYTES + 1);
+        assert!(map.is_empty(), "everything older must be evicted to make room");
+
+        // Eviction stops at an empty cache, so the caller's own over-cap result is
+        // still inserted rather than discarded. It is over the cap by construction;
+        // the next oversized call is what evicts it.
+        map.insert("incoming".to_string(), cached_entry(MAX_CACHE_BYTES + 1, 0));
+        assert!(
+            map.contains_key("incoming"),
+            "an over-cap body is kept, not dropped, when it is the only entry"
+        );
+        let mut map2 = map;
+        evict_to_fit(&mut map2, 1);
+        assert!(
+            map2.is_empty(),
+            "the retained over-cap entry must be evicted by the next arrival"
+        );
+    }
+
+    #[test]
+    fn cached_size_records_body_plus_structured_bytes() {
+        // The eviction loop trusts `Cached.size` instead of re-serializing, so a
+        // size recorded as 0 (or body-only) would silently disable the byte cap.
+        let structured = json!({ "rows": ["y".repeat(3_000)] });
+        let mut r = json!({
+            "content": [{ "type": "text", "text": "x".repeat(5_000) }],
+            "structuredContent": structured,
+            "isError": false
+        });
+        assert!(shape_result(&mut r, 2048, None));
+        let cursor = cursor_of(&r);
+
+        let map = cache().lock().unwrap_or_else(|e| e.into_inner());
+        let entry = map.get(&cursor).expect("the shaped result is cached under its cursor");
+        assert_eq!(
+            entry.size,
+            entry.body.len() + entry.structured.as_ref().map(value_size).unwrap_or(0),
+            "recorded size must cover the body and the stashed structuredContent"
+        );
+        assert!(entry.size >= 8_000, "recorded size was {}", entry.size);
     }
 
     #[test]

--- a/src-tauri/src/shaping.rs
+++ b/src-tauri/src/shaping.rs
@@ -819,6 +819,30 @@ mod tests {
     }
 
     #[test]
+    fn shaping_preserves_is_error_on_oversized_failures() {
+        // A failure big enough to shape is still a failure. Dropping `isError` here
+        // would turn a downstream error into an apparent success for the model, and
+        // the marker must survive too so the failure detail stays pageable.
+        let mut r = json!({
+            "content": [{ "type": "text", "text": "boom: ".to_string() + &"e".repeat(10_000) }],
+            "isError": true
+        });
+        assert!(shape_result(&mut r, 2048, None));
+
+        // The JSON value itself, so a dropped or nulled field fails rather than
+        // silently reading as "not true".
+        assert_eq!(
+            r["isError"],
+            json!(true),
+            "shaped failure lost its isError flag: {}",
+            r
+        );
+        let text = r["content"][0]["text"].as_str().unwrap();
+        assert!(text.contains("Toolport shaped this result"));
+        assert!(text.contains("\"cursor\":\"r"), "the failure must stay pageable");
+    }
+
+    #[test]
     fn fetch_result_projection_returns_nested_field() {
         let mut r = json!({
             "content": [{


### PR DESCRIPTION
Second batch of test-gap backfill, independent of #683 (no overlapping files, so the two can merge in either order).

One commit per ticket, one file per commit. **Only one production change**, called out below.

## Tickets

| Commit | Ticket | What is now guarded |
|---|---|---|
| `b17aaef` | SBS-649 | `isError` survives shaping of an oversized failure |
| `323ce76` | SBS-650 | Shaped-result cache **byte** cap and `Cached.size` |
| `1443183` | SBS-672 | `map_server` pypi (`uvx`) and oci/docker (`docker run -i --rm`) shapes |
| `73f92d0` | SBS-673 | Launcher `Version` sorts releases above prereleases |
| `b8a8cb9` | SBS-644 | Deferred cancel-forward race (cancel before in-flight registration) |

12 new tests, none `#[ignore]`.

## The one production change

`shaping.rs` — the eviction loop is lifted verbatim out of `shape_result` into `evict_to_fit(map, new_entry_size)`. Same condition, same `min_by_key`, same `break`; the doc comment moved onto the function. Needed because the only alternative was asserting against the process-global cache while other tests insert into it concurrently, which is flaky by construction.

`catalog.rs`, `launcher.rs`, and `downstream.rs` are **test-only** additions — `downstream.rs` is +315/-0, entirely inside `mod tests`.

## Every test was proven load-bearing

Each validated by applying the exact regression, confirming red, then reverting:

- Pass `false` instead of `is_error` to `text_result` → shaped failures read as successes.
- Record `Cached.size` as `0`, and separately drop the byte clause from the eviction loop → cache grew to 76,546,048 bytes, past the 67,108,864 cap.
- Map pypi to `npx -y` → uvx test red while the other 17 catalog tests stay green (the old npm-only coverage never reached it). Drop `-i`/`--rm` → container test red.
- Invert the `!text.contains('-')` prerelease bit → both new launcher tests red, the existing 1.10.0-vs-1.9.0 test still green.
- Remove the post-write `forward_cancel_if_ready` → only the `tools/call` frame is written. Drop `register`'s `forwarded = false` reset → no second forward. Remove the latch → three identical notifications instead of one.

Each cancel-forward mutation failed exactly one test and left the other two green, so the three are independently load-bearing.

## Notes worth reviewing

**SBS-672 — the ticket's example was wrong.** Expectations are derived from the source, not the ticket text: the version is appended with `@`, so an OCI image maps to `image@1.2.3`, not `image:1.2.3`.

**SBS-644 is deterministic, not timing-based.** The interleaving is forced by call order (cancel strictly before register). The barrier is `Child::wait()`: the forward thread holds a clone of the `ChildStdin`, so the recorder child cannot observe EOF until that thread has finished writing — which proves the *absence* of a write as well as its presence. No sleeps, no polling. Assertions are on the bytes on the wire, not on registry bookkeeping, because bookkeeping would stay green while the notification never reached the child.

**Windows pipe gotcha, documented in the fixture.** `std::io::pipe()` + `ChildStdin::from(OwnedHandle)` silently discards writes on Windows — the stable pipe is opened in overlapped mode, the child-stdio writer is not. Hence the real-child stdin recorder; the comment exists so the "simpler" version is not re-attempted.

**SBS-650 costs CI nothing.** Entries carry a recorded `size` with empty bodies, so 72 MiB of accounted cache is a few bytes of real memory — no 64 MiB allocation.

## Verification

`npm run test:rust` (exactly what CI runs): **848 lib + 257 bin + all integration suites, 0 failed, 0 ignored.** The cancel-forward tests were additionally run 3× consecutively to check for flakes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)