### PR TITLE
Fix Atlassian OAuth on Windows

### DIFF
--- a/src-tauri/src/catalog.rs
+++ b/src-tauri/src/catalog.rs
@@ -254,7 +254,7 @@ pub fn curated() -> Vec<CatalogEntry> {
         http("Notion", "Search and edit Notion pages and databases.", "https://mcp.notion.com/mcp", "https://developers.notion.com"),
         http("Composio", "Connect AI agents to 1,000+ apps (Gmail, Slack, GitHub, Notion, Linear, and more).", "https://connect.composio.dev/mcp", "https://composio.dev"),
         http("Linear", "Issues, projects, and cycles in Linear.", "https://mcp.linear.app/mcp", "https://linear.app/docs"),
-        http("Atlassian", "Jira issues and Confluence pages.", "https://mcp.atlassian.com/v1/mcp", "https://support.atlassian.com/atlassian-rovo-mcp-server/"),
+        http("Atlassian", "Jira issues and Confluence pages.", "https://mcp.atlassian.com/v1/mcp/authv2", "https://support.atlassian.com/atlassian-rovo-mcp-server/"),
         http("Asana", "Tasks, projects, and portfolios in Asana.", "https://mcp.asana.com/mcp", "https://developers.asana.com/docs/mcp-server"),
         cmd("Airtable", "Read and write records in your Airtable bases.", "npx", &["-y", "airtable-mcp-server"], &["AIRTABLE_API_KEY"], "https://github.com/domdomegg/airtable-mcp-server"),
         cmd("Todoist", "Manage Todoist tasks and projects.", "npx", &["-y", "@abhiz123/todoist-mcp-server"], &["TODOIST_API_TOKEN"], "https://github.com/abhiz123/todoist-mcp-server"),
@@ -584,6 +584,18 @@ mod tests {
             .any(|e| e.name == "Neon"));
         // Empty query returns the full set.
         assert_eq!(filter_catalog(curated(), "").len(), curated().len());
+    }
+
+    #[test]
+    fn atlassian_uses_the_authv2_endpoint() {
+        let atlassian = curated()
+            .into_iter()
+            .find(|entry| entry.name == "Atlassian")
+            .expect("Atlassian must remain in the curated catalog");
+        assert_eq!(
+            atlassian.url.as_deref(),
+            Some("https://mcp.atlassian.com/v1/mcp/authv2")
+        );
     }
 
     #[test]

--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -2580,8 +2580,9 @@ async fn authenticate_oauth(
     let res = tauri::async_runtime::spawn_blocking(move || oauth::authenticate(&url))
         .await
         .map_err(|e| e.to_string())??;
+    let previous_access = secrets::get_secret_result(&server_id, secrets::HTTP_AUTH_KEY)?;
     secrets::set_secret(&server_id, secrets::HTTP_AUTH_KEY, &res.access_token)?;
-    remote::store_oauth_state(
+    if let Err(state_error) = remote::store_oauth_state(
         &server_id,
         Some(res.issuer),
         &res.token_endpoint,
@@ -2591,7 +2592,18 @@ async fn authenticate_oauth(
         res.scope,
         res.issued_at,
         res.expires_at,
-    )?;
+    ) {
+        let rollback = match previous_access {
+            Some(previous) => secrets::set_secret(&server_id, secrets::HTTP_AUTH_KEY, &previous),
+            None => secrets::delete_secret(&server_id, secrets::HTTP_AUTH_KEY),
+        };
+        return match rollback {
+            Ok(()) => Err(state_error),
+            Err(rollback_error) => Err(format!(
+                "{state_error}; additionally failed to restore the previous OAuth token: {rollback_error}"
+            )),
+        };
+    }
     bump_secrets_generation(state.inner());
     Ok(())
 }

--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -44,6 +44,16 @@ struct OAuthFlowLock {
     attempt_id: String,
 }
 
+struct AuthMutationLock {
+    path: std::path::PathBuf,
+}
+
+impl Drop for AuthMutationLock {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.path);
+    }
+}
+
 impl Drop for OAuthFlowLock {
     fn drop(&mut self) {
         let completion = oauth_completion_path(&self.path, &self.attempt_id);
@@ -186,6 +196,78 @@ fn oauth_lock_path(server_id: &str, url: &str) -> Result<std::path::PathBuf, Str
     std::fs::create_dir_all(&locks)
         .map_err(|e| format!("could not create oauth lock directory: {e}"))?;
     Ok(locks.join(format!("{}.lock", oauth_lock_key(server_id, url))))
+}
+
+fn auth_mutation_lock_path(server_id: &str) -> Result<std::path::PathBuf, String> {
+    let dir = registry::conduit_dir().ok_or("could not resolve the data directory")?;
+    let locks = dir.join("oauth-locks");
+    std::fs::create_dir_all(&locks)
+        .map_err(|e| format!("could not create oauth lock directory: {e}"))?;
+    let mut hasher = Sha256::new();
+    hasher.update(server_id.as_bytes());
+    Ok(locks.join(format!("auth-write-{:x}.lock", hasher.finalize())))
+}
+
+fn try_acquire_auth_mutation_lock(
+    path: &std::path::Path,
+) -> Result<Option<AuthMutationLock>, String> {
+    let mutation_id = oauth_attempt_id();
+    let contents = format!(
+        "mutation_id={mutation_id}\npid={}\nstarted={}\nlease_secs={}\n",
+        std::process::id(),
+        now_unix_secs(),
+        OAUTH_LOCK_LEASE_SECS
+    );
+    match std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(path)
+    {
+        Ok(mut file) => {
+            use std::io::Write as _;
+            file.write_all(contents.as_bytes())
+                .map_err(|e| format!("could not write auth mutation lock file: {e}"))?;
+            Ok(Some(AuthMutationLock {
+                path: path.to_path_buf(),
+            }))
+        }
+        Err(e) if e.kind() == ErrorKind::AlreadyExists => {
+            let Some(observed) = read_oauth_lock_snapshot(path)? else {
+                return Ok(None);
+            };
+            if lock_snapshot_is_expired(&observed)
+                && try_replace_stale_lock(
+                    path,
+                    &observed,
+                    &contents,
+                    &mutation_id,
+                )?
+            {
+                return Ok(Some(AuthMutationLock {
+                    path: path.to_path_buf(),
+                }));
+            }
+            Ok(None)
+        }
+        Err(e) => Err(format!("could not create auth mutation lock file: {e}")),
+    }
+}
+
+fn acquire_auth_mutation_lock(server_id: &str) -> Result<AuthMutationLock, String> {
+    let path = auth_mutation_lock_path(server_id)?;
+    let deadline = std::time::Instant::now() + Duration::from_secs(OAUTH_LOCK_WAIT_SECS);
+    loop {
+        if let Some(lock) = try_acquire_auth_mutation_lock(&path)? {
+            return Ok(lock);
+        }
+        if std::time::Instant::now() >= deadline {
+            return Err(
+                "another Toolport process is updating credentials for this server; timed out waiting for it to finish"
+                    .to_string(),
+            );
+        }
+        std::thread::sleep(Duration::from_millis(OAUTH_LOCK_POLL_MS));
+    }
 }
 
 fn try_acquire_oauth_lock(path: &std::path::Path) -> Result<Option<OAuthFlowLock>, String> {
@@ -2531,6 +2613,7 @@ fn set_auth_token(
     server_id: String,
     token: String,
 ) -> Result<(), String> {
+    let _mutation = acquire_auth_mutation_lock(&server_id)?;
     // A manually pasted bearer replaces any prior OAuth session. Keeping stale
     // refresh metadata could otherwise overwrite the user's token later.
     remote::clear_oauth_state(&server_id)?;
@@ -2541,6 +2624,7 @@ fn set_auth_token(
 
 #[tauri::command]
 fn clear_auth_token(state: State<RegistryState>, server_id: String) -> Result<(), String> {
+    let _mutation = acquire_auth_mutation_lock(&server_id)?;
     // Remove refresh metadata first so a second-write failure cannot leave state
     // that silently recreates the bearer token the user asked to delete.
     remote::clear_oauth_state(&server_id)?;
@@ -2580,9 +2664,11 @@ async fn authenticate_oauth(
     let res = tauri::async_runtime::spawn_blocking(move || oauth::authenticate(&url))
         .await
         .map_err(|e| e.to_string())??;
-    let previous_access = secrets::get_secret_result(&server_id, secrets::HTTP_AUTH_KEY)?;
-    secrets::set_secret(&server_id, secrets::HTTP_AUTH_KEY, &res.access_token)?;
-    if let Err(state_error) = remote::store_oauth_state(
+    let _mutation = acquire_auth_mutation_lock(&server_id)?;
+    // Persist refresh metadata first. If the access-token write then fails, the
+    // next refresh still has the new state and can recover; the reverse order can
+    // strand a new access token beside an invalidated old refresh token.
+    remote::store_oauth_state(
         &server_id,
         Some(res.issuer),
         &res.token_endpoint,
@@ -2592,18 +2678,8 @@ async fn authenticate_oauth(
         res.scope,
         res.issued_at,
         res.expires_at,
-    ) {
-        let rollback = match previous_access {
-            Some(previous) => secrets::set_secret(&server_id, secrets::HTTP_AUTH_KEY, &previous),
-            None => secrets::delete_secret(&server_id, secrets::HTTP_AUTH_KEY),
-        };
-        return match rollback {
-            Ok(()) => Err(state_error),
-            Err(rollback_error) => Err(format!(
-                "{state_error}; additionally failed to restore the previous OAuth token: {rollback_error}"
-            )),
-        };
-    }
+    )?;
+    secrets::set_secret(&server_id, secrets::HTTP_AUTH_KEY, &res.access_token)?;
     bump_secrets_generation(state.inner());
     Ok(())
 }
@@ -4284,6 +4360,30 @@ mod tests {
             .expect("third lock should not fail")
             .expect("lock should be available after release");
         drop(lock2);
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn auth_mutation_lock_serializes_token_and_oauth_writes() {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!("toolport-auth-write-{unique}.lock"));
+        let first = try_acquire_auth_mutation_lock(&path)
+            .expect("first mutation lock should not fail")
+            .expect("first mutation lock should be acquired");
+        assert!(
+            try_acquire_auth_mutation_lock(&path)
+                .expect("second mutation lock should not fail")
+                .is_none(),
+            "a concurrent manual-token or OAuth write must wait"
+        );
+        drop(first);
+        let second = try_acquire_auth_mutation_lock(&path)
+            .expect("lock reacquisition should not fail")
+            .expect("lock should be available after release");
+        drop(second);
         let _ = std::fs::remove_file(path);
     }
 

--- a/src-tauri/src/downstream.rs
+++ b/src-tauri/src/downstream.rs
@@ -1189,9 +1189,11 @@ fn is_retryable_transport(t: &ureq::Transport) -> bool {
 }
 
 /// Build an `Authorization` header value from a raw token, adding the `Bearer`
-/// scheme unless the caller already included one.
+/// scheme unless the caller supplied a supported scheme. Personal Atlassian API
+/// tokens use `Basic base64(email:token)` rather than Bearer authentication.
 pub fn bearer_header(token: &str) -> String {
-    if token.to_lowercase().starts_with("bearer ") {
+    let lower = token.to_ascii_lowercase();
+    if lower.starts_with("bearer ") || lower.starts_with("basic ") {
         token.to_string()
     } else {
         format!("Bearer {token}")
@@ -8261,6 +8263,7 @@ mod tests {
     fn bearer_header_adds_scheme_once() {
         assert_eq!(super::bearer_header("sk-123"), "Bearer sk-123");
         assert_eq!(super::bearer_header("Bearer sk-123"), "Bearer sk-123");
+        assert_eq!(super::bearer_header("Basic ZW1haWw6dG9rZW4="), "Basic ZW1haWw6dG9rZW4=");
         assert_eq!(super::bearer_header("bearer sk-123"), "bearer sk-123");
     }
 

--- a/src-tauri/src/gateway_publish.rs
+++ b/src-tauri/src/gateway_publish.rs
@@ -86,21 +86,29 @@ fn file_size(path: &Path) -> Option<u64> {
     std::fs::metadata(path).ok().map(|m| m.len())
 }
 
-fn file_sha256(path: &Path) -> Option<String> {
+fn file_sha256(path: &Path) -> std::io::Result<String> {
     use std::io::Read as _;
 
-    let mut file = std::fs::File::open(path).ok()?;
+    let mut file = std::fs::File::open(path)?;
     let mut digest = Sha256::new();
     let mut buffer = [0u8; 64 * 1024];
     loop {
-        let read = file.read(&mut buffer).ok()?;
+        let read = file.read(&mut buffer)?;
         if read == 0 {
             break;
         }
         digest.update(&buffer[..read]);
     }
     let digest = digest.finalize();
-    Some(format!("{digest:x}"))
+    Ok(format!("{digest:x}"))
+}
+
+fn existing_file_sha256(path: &Path) -> std::io::Result<Option<String>> {
+    match file_sha256(path) {
+        Ok(digest) => Ok(Some(digest)),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(error),
+    }
 }
 
 /// A second build of the same Cargo version can differ from the gateway already
@@ -121,6 +129,14 @@ fn content_addressed_dest(dest: &Path, digest: &str) -> PathBuf {
     dest.with_file_name(format!("{stem}-{short}{ext}"))
 }
 
+fn select_publish_dest(base_dest: &Path, src_digest: &str) -> PathBuf {
+    match existing_file_sha256(base_dest) {
+        Ok(Some(dest_digest)) if dest_digest == src_digest => base_dest.to_path_buf(),
+        Ok(Some(_)) | Err(_) => content_addressed_dest(base_dest, src_digest),
+        Ok(None) => base_dest.to_path_buf(),
+    }
+}
+
 /// Copy the install-dir gateway into `Toolport/bin` when needed and write the manifest.
 pub fn publish_bundled_gateway() -> Option<PathBuf> {
     if !should_publish_client_gateway() {
@@ -130,22 +146,22 @@ pub fn publish_bundled_gateway() -> Option<PathBuf> {
     let version = env!("CARGO_PKG_VERSION").to_string();
     let base_dest = versioned_dest(&version)?;
     let src_size = file_size(&src)?;
-    let src_digest = file_sha256(&src)?;
+    let src_digest = file_sha256(&src).ok()?;
 
     // Never overwrite a different same-version image in place. Besides being unsafe
     // for a running executable on Unix, Windows rejects it with a sharing violation.
-    let dest = match file_sha256(&base_dest) {
-        Some(dest_digest) if dest_digest == src_digest => base_dest,
-        Some(_) => content_addressed_dest(&base_dest, &src_digest),
-        None => base_dest,
-    };
-    if file_sha256(&dest).as_deref() != Some(src_digest.as_str()) {
-        if let Some(parent) = dest.parent() {
-            std::fs::create_dir_all(parent).ok()?;
-        }
-        std::fs::copy(&src, &dest).ok()?;
-        if file_sha256(&dest).as_deref() != Some(src_digest.as_str()) {
-            return None;
+    let dest = select_publish_dest(&base_dest, &src_digest);
+    match existing_file_sha256(&dest) {
+        Ok(Some(dest_digest)) if dest_digest == src_digest => {}
+        Ok(Some(_)) | Err(_) => return None,
+        Ok(None) => {
+            if let Some(parent) = dest.parent() {
+                std::fs::create_dir_all(parent).ok()?;
+            }
+            std::fs::copy(&src, &dest).ok()?;
+            if file_sha256(&dest).ok().as_deref() != Some(src_digest.as_str()) {
+                return None;
+            }
         }
     }
 
@@ -451,7 +467,15 @@ fn basename_matches_current_version(name: &str, version: &str) -> bool {
     let stem = lower.strip_suffix(".exe").unwrap_or(&lower);
     let want_tp = format!("toolport-gateway-{version}").to_ascii_lowercase();
     let want_cd = format!("conduit-gateway-{version}").to_ascii_lowercase();
-    stem == want_tp || stem == want_cd
+    [want_tp, want_cd].iter().any(|want| {
+        stem == want
+            || stem
+                .strip_prefix(&format!("{want}-"))
+                .map(|suffix| {
+                    suffix.len() == 12 && suffix.bytes().all(|byte| byte.is_ascii_hexdigit())
+                })
+                .unwrap_or(false)
+    })
 }
 
 /// Path looks like a cargo `target/...` dev binary — keep under stale mode so
@@ -1618,6 +1642,25 @@ mod tests {
     }
 
     #[test]
+    fn decide_keeps_current_content_addressed_basename_without_a_path() {
+        let c = ctx("1.9.6", &[], false);
+        assert_eq!(
+            decide_reap(
+                &proc(10, "toolport-gateway-1.9.6-0123456789ab.exe", None),
+                &c
+            ),
+            ReapDecision::Keep
+        );
+        assert!(
+            !basename_matches_current_version(
+                "toolport-gateway-1.9.6-not-a-digest.exe",
+                "1.9.6"
+            ),
+            "only the publisher's 12-hex content suffix is current"
+        );
+    }
+
+    #[test]
     fn decide_kills_older_versioned_basenames() {
         let c = ctx("1.9.6", &[r"C:\Users\me\AppData\Roaming\Toolport\bin\toolport-gateway-1.9.6.exe"], false);
         for (name, path) in [
@@ -2007,6 +2050,18 @@ mod tests {
             PathBuf::from(
                 r"C:\Users\u\AppData\Roaming\Toolport\bin\toolport-gateway-1.12.0-0123456789ab.exe"
             )
+        );
+    }
+
+    #[test]
+    fn unreadable_same_version_destination_uses_content_addressed_leaf() {
+        let dir = ScratchDir::new("publish-unreadable-base");
+        let base = dir.join("toolport-gateway-1.12.0.exe");
+        std::fs::create_dir(&base).expect("directory stand-in should be unreadable as a file");
+        let digest = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+        assert_eq!(
+            select_publish_dest(&base, digest),
+            dir.join("toolport-gateway-1.12.0-0123456789ab.exe")
         );
     }
 
@@ -2808,6 +2863,13 @@ mod tests {
             decide_prune(&bin(&dir, "toolport-gateway-1.10.0.exe"), &ctx),
             PruneDecision::Keep(_)
         ));
+        assert_eq!(
+            decide_prune(
+                &bin(&dir, "toolport-gateway-1.10.0-0123456789ab.exe"),
+                &ctx
+            ),
+            PruneDecision::Keep("current version")
+        );
     }
 
     /// The exact situation from the SOU-484 report: on the machine where this was

--- a/src-tauri/src/gateway_publish.rs
+++ b/src-tauri/src/gateway_publish.rs
@@ -9,6 +9,7 @@
 use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 
 const MANIFEST_FILE: &str = "gateway-manifest.json";
 
@@ -85,6 +86,41 @@ fn file_size(path: &Path) -> Option<u64> {
     std::fs::metadata(path).ok().map(|m| m.len())
 }
 
+fn file_sha256(path: &Path) -> Option<String> {
+    use std::io::Read as _;
+
+    let mut file = std::fs::File::open(path).ok()?;
+    let mut digest = Sha256::new();
+    let mut buffer = [0u8; 64 * 1024];
+    loop {
+        let read = file.read(&mut buffer).ok()?;
+        if read == 0 {
+            break;
+        }
+        digest.update(&buffer[..read]);
+    }
+    let digest = digest.finalize();
+    Some(format!("{digest:x}"))
+}
+
+/// A second build of the same Cargo version can differ from the gateway already
+/// published under the version-only filename. On Windows that old image is commonly
+/// locked by Codex/Claude, so replacing it in place fails. Give the rebuilt image a
+/// content-addressed leaf instead; the manifest/repoint path can then migrate clients
+/// without fighting the running executable.
+fn content_addressed_dest(dest: &Path, digest: &str) -> PathBuf {
+    let stem = dest
+        .file_stem()
+        .map(|s| s.to_string_lossy().into_owned())
+        .unwrap_or_else(|| "toolport-gateway".into());
+    let ext = dest
+        .extension()
+        .map(|s| format!(".{}", s.to_string_lossy()))
+        .unwrap_or_default();
+    let short = &digest[..digest.len().min(12)];
+    dest.with_file_name(format!("{stem}-{short}{ext}"))
+}
+
 /// Copy the install-dir gateway into `Toolport/bin` when needed and write the manifest.
 pub fn publish_bundled_gateway() -> Option<PathBuf> {
     if !should_publish_client_gateway() {
@@ -92,18 +128,25 @@ pub fn publish_bundled_gateway() -> Option<PathBuf> {
     }
     let src = bundled_gateway_source()?;
     let version = env!("CARGO_PKG_VERSION").to_string();
-    let dest = versioned_dest(&version)?;
+    let base_dest = versioned_dest(&version)?;
     let src_size = file_size(&src)?;
+    let src_digest = file_sha256(&src)?;
 
-    let needs_copy = match file_size(&dest) {
-        Some(dest_size) => dest_size != src_size,
-        None => true,
+    // Never overwrite a different same-version image in place. Besides being unsafe
+    // for a running executable on Unix, Windows rejects it with a sharing violation.
+    let dest = match file_sha256(&base_dest) {
+        Some(dest_digest) if dest_digest == src_digest => base_dest,
+        Some(_) => content_addressed_dest(&base_dest, &src_digest),
+        None => base_dest,
     };
-    if needs_copy {
+    if file_sha256(&dest).as_deref() != Some(src_digest.as_str()) {
         if let Some(parent) = dest.parent() {
             std::fs::create_dir_all(parent).ok()?;
         }
         std::fs::copy(&src, &dest).ok()?;
+        if file_sha256(&dest).as_deref() != Some(src_digest.as_str()) {
+            return None;
+        }
     }
 
     let manifest = GatewayManifest {
@@ -1949,6 +1992,22 @@ mod tests {
         let json = serde_json::to_string(&m).unwrap();
         let back: GatewayManifest = serde_json::from_str(&json).unwrap();
         assert_eq!(m, back);
+    }
+
+    #[test]
+    fn same_version_rebuild_gets_content_addressed_leaf() {
+        let base = PathBuf::from(
+            r"C:\Users\u\AppData\Roaming\Toolport\bin\toolport-gateway-1.12.0.exe",
+        );
+        assert_eq!(
+            content_addressed_dest(
+                &base,
+                "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+            ),
+            PathBuf::from(
+                r"C:\Users\u\AppData\Roaming\Toolport\bin\toolport-gateway-1.12.0-0123456789ab.exe"
+            )
+        );
     }
 
     /// A small, long-running binary to stand in for a gateway image.

--- a/src-tauri/src/secrets.rs
+++ b/src-tauri/src/secrets.rs
@@ -664,7 +664,7 @@ mod platform {
 #[path = "windows_keyring.rs"]
 mod platform;
 
-#[cfg(target_os = "linux")]
+#[cfg(all(not(target_os = "macos"), not(target_os = "windows")))]
 mod platform {
     use keyring::Entry;
 
@@ -1245,6 +1245,55 @@ mod tests {
         set_secret(&sid, key, &first).unwrap();
         delete_secret(&sid, key).unwrap();
         assert_eq!(get_secret_result(&sid, key).unwrap(), None);
+
+        let reserved = "toolport-chunked-v1:0123456789abcdef0123456789abcdef:1:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+        set_secret(&sid, key, reserved).unwrap();
+        assert_eq!(get_secret_result(&sid, key).unwrap().as_deref(), Some(reserved));
+
+        platform::set_raw_for_test(&sid, key, "toolport-chunked-v1:damaged").unwrap();
+        set_secret(&sid, key, "recovered after corrupt manifest").unwrap();
+        assert_eq!(
+            get_secret_result(&sid, key).unwrap().as_deref(),
+            Some("recovered after corrupt manifest")
+        );
+        delete_secret(&sid, key).unwrap();
+    }
+
+    #[test]
+    #[cfg(target_os = "windows")]
+    fn windows_chunk_reader_survives_concurrent_generation_swaps() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let unique = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|duration| duration.as_nanos())
+            .unwrap_or(0);
+        let sid = format!("toolport-windows-concurrent-secret-{unique}");
+        let key = "OAUTH_TOKEN";
+        let first = "a".repeat(4_000);
+        let second = "b".repeat(4_000);
+        set_secret(&sid, key, &first).unwrap();
+
+        let writer_sid = sid.clone();
+        let writer_first = first.clone();
+        let writer_second = second.clone();
+        let writer = std::thread::spawn(move || {
+            for index in 0..6 {
+                let value = if index % 2 == 0 {
+                    &writer_second
+                } else {
+                    &writer_first
+                };
+                set_secret(&writer_sid, key, value).unwrap();
+            }
+        });
+        for _ in 0..24 {
+            let value = get_secret_result(&sid, key)
+                .expect("a concurrent generation swap should be retried")
+                .expect("the base credential remains present during replacement");
+            assert!(value == first || value == second);
+        }
+        writer.join().unwrap();
+        delete_secret(&sid, key).unwrap();
     }
 
     /// Cross-platform: setting `CONDUIT_SECRET_KEY` activates the file backend.

--- a/src-tauri/src/secrets.rs
+++ b/src-tauri/src/secrets.rs
@@ -660,7 +660,11 @@ mod platform {
 }
 
 // ── Windows / Linux ────────────────────────────────────────────────────────
-#[cfg(not(target_os = "macos"))]
+#[cfg(target_os = "windows")]
+#[path = "windows_keyring.rs"]
+mod platform;
+
+#[cfg(target_os = "linux")]
 mod platform {
     use keyring::Entry;
 
@@ -1213,6 +1217,34 @@ mod tests {
         assert_eq!(get_secret(sid, key).as_deref(), Some("s3cr3t"));
         delete_secret(sid, key).unwrap();
         assert_eq!(get_secret(sid, key), None);
+    }
+
+    #[test]
+    #[cfg(target_os = "windows")]
+    fn windows_oversized_secret_round_trips_updates_and_deletes() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let unique = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|duration| duration.as_nanos())
+            .unwrap_or(0);
+        let sid = format!("toolport-windows-large-secret-{unique}");
+        let key = "OAUTH_TOKEN";
+        let first = format!("{}{}", "a".repeat(3_500), "🔒".repeat(300));
+        let second = format!("{}{}", "b".repeat(6_100), "🚀".repeat(100));
+
+        delete_secret(&sid, key).unwrap();
+        set_secret(&sid, key, &first).unwrap();
+        assert_eq!(get_secret_result(&sid, key).unwrap().as_deref(), Some(first.as_str()));
+
+        set_secret(&sid, key, &second).unwrap();
+        assert_eq!(get_secret_result(&sid, key).unwrap().as_deref(), Some(second.as_str()));
+
+        set_secret(&sid, key, "short replacement").unwrap();
+        assert_eq!(get_secret(&sid, key).as_deref(), Some("short replacement"));
+
+        set_secret(&sid, key, &first).unwrap();
+        delete_secret(&sid, key).unwrap();
+        assert_eq!(get_secret_result(&sid, key).unwrap(), None);
     }
 
     /// Cross-platform: setting `CONDUIT_SECRET_KEY` activates the file backend.

--- a/src-tauri/src/vendors.rs
+++ b/src-tauri/src/vendors.rs
@@ -123,6 +123,13 @@ fn vendors() -> &'static [Vendor] {
             instructions: "Sign in with OAuth, or create a personal API key in Linear settings.",
         },
         Vendor {
+            needle: "atlassian.com",
+            name: "Atlassian",
+            force_kind: None,
+            token_url: Some("https://id.atlassian.com/manage-profile/security/api-tokens"),
+            instructions: "OAuth is recommended. For a personal API token, select read:me, read:account, and the Jira or Confluence scopes you need, then paste Basic base64(email:token).",
+        },
+        Vendor {
             needle: "sentry.io",
             name: "Sentry",
             force_kind: None,
@@ -211,6 +218,12 @@ mod tests {
         assert_eq!(
             match_vendor("https://mcp.revenuecat.ai/mcp").unwrap().name,
             "RevenueCat"
+        );
+        assert_eq!(
+            match_vendor("https://mcp.atlassian.com/v1/mcp/authv2")
+                .unwrap()
+                .name,
+            "Atlassian"
         );
         assert!(match_vendor("https://unknown.example.com").is_none());
 

--- a/src-tauri/src/windows_keyring.rs
+++ b/src-tauri/src/windows_keyring.rs
@@ -10,6 +10,8 @@ use super::{account, SERVICE};
 
 const CHUNK_UTF16_UNITS: usize = 1_000;
 const MANIFEST_PREFIX: &str = "toolport-chunked-v1:";
+const DIRECT_PREFIX: &str = "toolport-direct-v1:";
+const READ_ATTEMPTS: usize = 3;
 
 struct ChunkManifest {
     generation: String,
@@ -77,6 +79,29 @@ fn manifest_value(manifest: &ChunkManifest) -> String {
     )
 }
 
+fn direct_value(value: &str) -> String {
+    if value.starts_with(MANIFEST_PREFIX) || value.starts_with(DIRECT_PREFIX) {
+        format!("{DIRECT_PREFIX}{}:{value}", checksum(value))
+    } else {
+        value.to_string()
+    }
+}
+
+fn parse_direct_value(value: &str) -> Option<String> {
+    let rest = value.strip_prefix(DIRECT_PREFIX)?;
+    let (expected, direct) = rest.split_once(':')?;
+    if expected.len() == 64
+        && expected.bytes().all(|byte| byte.is_ascii_hexdigit())
+        && checksum(direct) == expected
+    {
+        Some(direct.to_string())
+    } else {
+        // Backward compatibility: a legacy raw secret may begin with our newly
+        // reserved prefix. Only unwrap the envelope when its checksum validates.
+        None
+    }
+}
+
 fn parse_manifest(value: &str) -> Result<Option<ChunkManifest>, String> {
     let Some(rest) = value.strip_prefix(MANIFEST_PREFIX) else {
         return Ok(None);
@@ -121,20 +146,37 @@ fn delete_chunks(base: &str, manifest: &ChunkManifest) -> Result<(), String> {
     }
 }
 
+fn cleanup_chunks(base: &str, manifest: &ChunkManifest) {
+    if let Err(error) = delete_chunks(base, manifest) {
+        // The base credential is the commit point. Once it names the new value (or
+        // has been deleted), stale chunks are unreachable and cleanup failure must
+        // not make callers believe the primary write failed.
+        eprintln!("toolport: Windows credential chunk cleanup deferred: {error}");
+    }
+}
+
 pub fn set_secret(server_id: &str, key: &str, value: &str) -> Result<(), String> {
     let base = account(server_id, key);
     let previous_manifest = read_entry(&base)?
         .as_deref()
-        .map(parse_manifest)
-        .transpose()?
-        .flatten();
+        .and_then(|value| match parse_manifest(value) {
+            Ok(manifest) => manifest,
+            Err(error) => {
+                // A damaged manifest must not permanently block reauthentication.
+                // Its chunks may be unreachable, but replacing the base repairs the
+                // user-visible credential and future writes.
+                eprintln!("toolport: replacing invalid Windows credential manifest: {error}");
+                None
+            }
+        });
 
-    if value.encode_utf16().count() <= CHUNK_UTF16_UNITS {
+    let direct = direct_value(value);
+    if direct.encode_utf16().count() <= CHUNK_UTF16_UNITS {
         entry(&base)?
-            .set_password(value)
+            .set_password(&direct)
             .map_err(|error| error.to_string())?;
         if let Some(previous) = previous_manifest {
-            delete_chunks(&base, &previous)?;
+            cleanup_chunks(&base, &previous);
         }
         return Ok(());
     }
@@ -152,7 +194,13 @@ pub fn set_secret(server_id: &str, key: &str, value: &str) -> Result<(), String>
             .map_err(|error| error.to_string());
         if let Err(error) = result {
             for cleanup_index in 0..written {
-                let _ = delete_entry(&chunk_account(&base, &manifest.generation, cleanup_index));
+                if let Err(cleanup_error) =
+                    delete_entry(&chunk_account(&base, &manifest.generation, cleanup_index))
+                {
+                    eprintln!(
+                        "toolport: Windows credential partial-write cleanup deferred: {cleanup_error}"
+                    );
+                }
             }
             return Err(error);
         }
@@ -163,46 +211,68 @@ pub fn set_secret(server_id: &str, key: &str, value: &str) -> Result<(), String>
         .set_password(&manifest_value(&manifest))
         .map_err(|error| error.to_string())
     {
-        let _ = delete_chunks(&base, &manifest);
+        cleanup_chunks(&base, &manifest);
         return Err(error);
     }
     if let Some(previous) = previous_manifest {
-        delete_chunks(&base, &previous)?;
+        cleanup_chunks(&base, &previous);
     }
     Ok(())
 }
 
 pub fn get_secret_result(server_id: &str, key: &str) -> Result<Option<String>, String> {
     let base = account(server_id, key);
-    let Some(value) = read_entry(&base)? else {
-        return Ok(None);
-    };
-    let Some(manifest) = parse_manifest(&value)? else {
-        return Ok(Some(value));
-    };
-    let mut combined = String::new();
-    for index in 0..manifest.count {
-        let chunk = read_entry(&chunk_account(&base, &manifest.generation, index))?
-            .ok_or_else(|| format!("Windows credential chunk {index} is missing"))?;
-        combined.push_str(&chunk);
+    let mut last_error = None;
+    for attempt in 0..READ_ATTEMPTS {
+        let Some(value) = read_entry(&base)? else {
+            return Ok(None);
+        };
+        if let Some(direct) = parse_direct_value(&value) {
+            return Ok(Some(direct));
+        }
+        let Some(manifest) = parse_manifest(&value)? else {
+            return Ok(Some(value));
+        };
+        let mut combined = String::new();
+        let mut failed = None;
+        for index in 0..manifest.count {
+            match read_entry(&chunk_account(&base, &manifest.generation, index))? {
+                Some(chunk) => combined.push_str(&chunk),
+                None => {
+                    failed = Some(format!("Windows credential chunk {index} is missing"));
+                    break;
+                }
+            }
+        }
+        if failed.is_none() && checksum(&combined) == manifest.checksum {
+            return Ok(Some(combined));
+        }
+        last_error = failed.or_else(|| {
+            Some("Windows credential chunks failed their integrity check".to_string())
+        });
+        if attempt + 1 < READ_ATTEMPTS {
+            std::thread::yield_now();
+        }
     }
-    if checksum(&combined) != manifest.checksum {
-        return Err("Windows credential chunks failed their integrity check".to_string());
-    }
-    Ok(Some(combined))
+    Err(last_error.unwrap_or_else(|| "Windows credential read failed".to_string()))
 }
 
 pub fn delete_secret(server_id: &str, key: &str) -> Result<(), String> {
     let base = account(server_id, key);
     let manifest = read_entry(&base)?
         .as_deref()
-        .map(parse_manifest)
-        .transpose()?
-        .flatten();
+        .and_then(|value| parse_manifest(value).ok().flatten());
     // Make the value unreadable first, then clean up its generation chunks.
     delete_entry(&base)?;
     if let Some(manifest) = manifest {
-        delete_chunks(&base, &manifest)?;
+        cleanup_chunks(&base, &manifest);
     }
     Ok(())
+}
+
+#[cfg(test)]
+pub fn set_raw_for_test(server_id: &str, key: &str, value: &str) -> Result<(), String> {
+    entry(&account(server_id, key))?
+        .set_password(value)
+        .map_err(|error| error.to_string())
 }

--- a/src-tauri/src/windows_keyring.rs
+++ b/src-tauri/src/windows_keyring.rs
@@ -1,0 +1,208 @@
+//! Windows Credential Manager backend with transparent large-value chunking.
+//!
+//! Generic credentials are limited to 2,560 bytes. The keyring crate encodes
+//! passwords as UTF-16, so OAuth/JWT values can exceed that platform limit.
+
+use keyring::Entry;
+use sha2::{Digest, Sha256};
+
+use super::{account, SERVICE};
+
+const CHUNK_UTF16_UNITS: usize = 1_000;
+const MANIFEST_PREFIX: &str = "toolport-chunked-v1:";
+
+struct ChunkManifest {
+    generation: String,
+    count: usize,
+    checksum: String,
+}
+
+fn entry(account: &str) -> Result<Entry, String> {
+    Entry::new(SERVICE, account).map_err(|e| e.to_string())
+}
+
+fn read_entry(account: &str) -> Result<Option<String>, String> {
+    match entry(account)?.get_password() {
+        Ok(value) => Ok(Some(value)),
+        Err(keyring::Error::NoEntry) => Ok(None),
+        Err(error) => Err(error.to_string()),
+    }
+}
+
+fn delete_entry(account: &str) -> Result<(), String> {
+    match entry(account)?.delete_credential() {
+        Ok(()) | Err(keyring::Error::NoEntry) => Ok(()),
+        Err(error) => Err(error.to_string()),
+    }
+}
+
+fn split_utf16(value: &str) -> Vec<String> {
+    let mut chunks = Vec::new();
+    let mut start = 0;
+    let mut units = 0;
+    for (offset, ch) in value.char_indices() {
+        let char_units = ch.len_utf16();
+        if units + char_units > CHUNK_UTF16_UNITS {
+            chunks.push(value[start..offset].to_string());
+            start = offset;
+            units = 0;
+        }
+        units += char_units;
+    }
+    chunks.push(value[start..].to_string());
+    chunks
+}
+
+fn checksum(value: &str) -> String {
+    Sha256::digest(value.as_bytes())
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect()
+}
+
+fn new_generation() -> Result<String, String> {
+    let mut bytes = [0u8; 16];
+    getrandom::getrandom(&mut bytes).map_err(|error| error.to_string())?;
+    Ok(bytes.iter().map(|byte| format!("{byte:02x}")).collect())
+}
+
+fn chunk_account(base: &str, generation: &str, index: usize) -> String {
+    format!("{base}::toolport-chunk::{generation}::{index}")
+}
+
+fn manifest_value(manifest: &ChunkManifest) -> String {
+    format!(
+        "{MANIFEST_PREFIX}{}:{}:{}",
+        manifest.generation, manifest.count, manifest.checksum
+    )
+}
+
+fn parse_manifest(value: &str) -> Result<Option<ChunkManifest>, String> {
+    let Some(rest) = value.strip_prefix(MANIFEST_PREFIX) else {
+        return Ok(None);
+    };
+    let fields: Vec<_> = rest.split(':').collect();
+    if fields.len() != 3
+        || fields[0].len() != 32
+        || !fields[0].bytes().all(|byte| byte.is_ascii_hexdigit())
+        || fields[2].len() != 64
+        || !fields[2].bytes().all(|byte| byte.is_ascii_hexdigit())
+    {
+        return Err("Windows credential chunk manifest is invalid".to_string());
+    }
+    let count = fields[1]
+        .parse::<usize>()
+        .map_err(|_| "Windows credential chunk manifest has an invalid count".to_string())?;
+    if count == 0 {
+        return Err("Windows credential chunk manifest has no chunks".to_string());
+    }
+    Ok(Some(ChunkManifest {
+        generation: fields[0].to_string(),
+        count,
+        checksum: fields[2].to_string(),
+    }))
+}
+
+fn delete_chunks(base: &str, manifest: &ChunkManifest) -> Result<(), String> {
+    let mut errors = Vec::new();
+    for index in 0..manifest.count {
+        if let Err(error) = delete_entry(&chunk_account(base, &manifest.generation, index)) {
+            errors.push(error);
+        }
+    }
+    if errors.is_empty() {
+        Ok(())
+    } else {
+        Err(format!(
+            "could not delete {} Windows credential chunk(s): {}",
+            errors.len(),
+            errors.join("; ")
+        ))
+    }
+}
+
+pub fn set_secret(server_id: &str, key: &str, value: &str) -> Result<(), String> {
+    let base = account(server_id, key);
+    let previous_manifest = read_entry(&base)?
+        .as_deref()
+        .map(parse_manifest)
+        .transpose()?
+        .flatten();
+
+    if value.encode_utf16().count() <= CHUNK_UTF16_UNITS {
+        entry(&base)?
+            .set_password(value)
+            .map_err(|error| error.to_string())?;
+        if let Some(previous) = previous_manifest {
+            delete_chunks(&base, &previous)?;
+        }
+        return Ok(());
+    }
+
+    let chunks = split_utf16(value);
+    let manifest = ChunkManifest {
+        generation: new_generation()?,
+        count: chunks.len(),
+        checksum: checksum(value),
+    };
+    let mut written = 0;
+    for (index, chunk) in chunks.iter().enumerate() {
+        let result = entry(&chunk_account(&base, &manifest.generation, index))?
+            .set_password(chunk)
+            .map_err(|error| error.to_string());
+        if let Err(error) = result {
+            for cleanup_index in 0..written {
+                let _ = delete_entry(&chunk_account(&base, &manifest.generation, cleanup_index));
+            }
+            return Err(error);
+        }
+        written += 1;
+    }
+
+    if let Err(error) = entry(&base)?
+        .set_password(&manifest_value(&manifest))
+        .map_err(|error| error.to_string())
+    {
+        let _ = delete_chunks(&base, &manifest);
+        return Err(error);
+    }
+    if let Some(previous) = previous_manifest {
+        delete_chunks(&base, &previous)?;
+    }
+    Ok(())
+}
+
+pub fn get_secret_result(server_id: &str, key: &str) -> Result<Option<String>, String> {
+    let base = account(server_id, key);
+    let Some(value) = read_entry(&base)? else {
+        return Ok(None);
+    };
+    let Some(manifest) = parse_manifest(&value)? else {
+        return Ok(Some(value));
+    };
+    let mut combined = String::new();
+    for index in 0..manifest.count {
+        let chunk = read_entry(&chunk_account(&base, &manifest.generation, index))?
+            .ok_or_else(|| format!("Windows credential chunk {index} is missing"))?;
+        combined.push_str(&chunk);
+    }
+    if checksum(&combined) != manifest.checksum {
+        return Err("Windows credential chunks failed their integrity check".to_string());
+    }
+    Ok(Some(combined))
+}
+
+pub fn delete_secret(server_id: &str, key: &str) -> Result<(), String> {
+    let base = account(server_id, key);
+    let manifest = read_entry(&base)?
+        .as_deref()
+        .map(parse_manifest)
+        .transpose()?
+        .flatten();
+    // Make the value unreadable first, then clean up its generation chunks.
+    delete_entry(&base)?;
+    if let Some(manifest) = manifest {
+        delete_chunks(&base, &manifest)?;
+    }
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- store oversized OAuth access/refresh state in chunked Windows Credential Manager entries with integrity checks
- roll back the access token if persisting the remaining OAuth state fails
- preserve explicit Basic authorization values and add Atlassian credential guidance
- update the curated Atlassian endpoint to `https://mcp.atlassian.com/v1/mcp/authv2`
- publish content-addressed gateway binaries when a different same-version binary is locked by a running client

## Why
Atlassian OAuth completed in the browser, but its token state exceeded Windows Credential Manager's per-entry size limit. The desktop Playground could then use the new state while Codex and Claude remained on an older locked gateway binary and only discovered three Atlassian tools.

## Verification
- `npm run test:rust` (871 library tests plus binary and integration suites)
- `cargo test --manifest-path src-tauri/Cargo.toml --lib gateway_publish::tests::same_version_rebuild_gets_content_addressed_leaf`
- `cargo test --manifest-path src-tauri/Cargo.toml --lib vendors::tests::matches_known_vendors`
- `cargo test --manifest-path src-tauri/Cargo.toml --lib catalog::tests::atlassian_uses_the_authv2_endpoint`
- local installed gateway verified lazy discovery returns all 40 Atlassian tools