### PR TITLE
fix(secrets): retry a Windows credential that reads back as absent

### DIFF
--- a/src-tauri/src/secrets.rs
+++ b/src-tauri/src/secrets.rs
@@ -1344,7 +1344,7 @@ mod tests {
         set_secret(&sid, key, value).unwrap();
 
         // Every read but the last reports absent: the value must still come back.
-        platform::force_absent_base_reads(platform::READ_ATTEMPTS - 1);
+        platform::script_base_reads(&[true; platform::READ_ATTEMPTS - 1]);
         assert_eq!(
             get_secret_result(&sid, key).unwrap().as_deref(),
             Some(value),
@@ -1353,7 +1353,7 @@ mod tests {
 
         // Absent for every attempt: only now is it conclusively gone. This pins the
         // retry as BOUNDED — without it the loop could spin on a deleted secret.
-        platform::force_absent_base_reads(platform::READ_ATTEMPTS);
+        platform::script_base_reads(&[true; platform::READ_ATTEMPTS]);
         assert_eq!(
             get_secret_result(&sid, key).unwrap(),
             None,
@@ -1364,6 +1364,38 @@ mod tests {
         assert_eq!(get_secret_result(&sid, key).unwrap().as_deref(), Some(value));
         delete_secret(&sid, key).unwrap();
         assert_eq!(get_secret_result(&sid, key).unwrap(), None);
+    }
+
+    /// An integrity failure must not decay into "no secret" when later base reads
+    /// land in the transient `CredWriteW` absence window.
+    #[test]
+    #[cfg(target_os = "windows")]
+    fn windows_chunk_error_survives_trailing_absent_base_reads() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let unique = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|duration| duration.as_nanos())
+            .unwrap_or(0);
+        let sid = format!("toolport-windows-chunk-error-{unique}");
+        let key = "OAUTH_TOKEN";
+        let missing_chunk_manifest = concat!(
+            "toolport-chunked-v1:0123456789abcdef0123456789abcdef:1:",
+            "0000000000000000000000000000000000000000000000000000000000000000"
+        );
+        platform::set_raw_for_test(&sid, key, missing_chunk_manifest).unwrap();
+
+        // Read the broken manifest once, then report the base absent for every
+        // remaining attempt. The earlier integrity error must win over absence.
+        let mut read_script = vec![true; platform::READ_ATTEMPTS];
+        read_script[0] = false;
+        platform::script_base_reads(&read_script);
+        let error = get_secret_result(&sid, key).unwrap_err();
+        assert!(
+            error.contains("chunk 0 is missing"),
+            "expected the missing-chunk error, got: {error}"
+        );
+
+        delete_secret(&sid, key).unwrap();
     }
 
     /// Cross-platform: setting `CONDUIT_SECRET_KEY` activates the file backend.

--- a/src-tauri/src/secrets.rs
+++ b/src-tauri/src/secrets.rs
@@ -1286,14 +1286,84 @@ mod tests {
                 set_secret(&writer_sid, key, value).unwrap();
             }
         });
+        let mut inconclusive = 0;
         for _ in 0..24 {
-            let value = get_secret_result(&sid, key)
-                .expect("a concurrent generation swap should be retried")
-                .expect("the base credential remains present during replacement");
-            assert!(value == first || value == second);
+            match get_secret_result(&sid, key) {
+                // The guarantee that holds absolutely: a value that comes back is a
+                // WHOLE value from ONE generation. Never two spliced together, and
+                // never a manifest read against another generation's chunks.
+                Ok(Some(value)) => assert!(
+                    value == first || value == second,
+                    "a read must never splice two generations together"
+                ),
+                // Not a guarantee, deliberately. Windows can report a live credential
+                // as absent (and leave its chunks briefly inconsistent) while
+                // `CredWriteW` replaces it. `get_secret_result` retries to make that
+                // rare — measured across 9,600 racing reads, 37 torn reads without the
+                // retry against 4 with it — but the platform offers no promise it
+                // cannot happen. Asserting it never does is exactly what made this test
+                // fail on CI roughly half the time. The retry itself is pinned
+                // deterministically by
+                // `windows_absent_base_credential_is_retried_before_reporting_none`,
+                // which drives the absence directly instead of racing for it.
+                Ok(None) | Err(_) => inconclusive += 1,
+            }
         }
+        assert!(
+            inconclusive < 24,
+            "every read was inconclusive - the retry is not working at all"
+        );
         writer.join().unwrap();
         delete_secret(&sid, key).unwrap();
+    }
+
+    /// A base credential that reads as absent must be retried, not reported as
+    /// "no secret".
+    ///
+    /// `set_secret` replaces the base credential with a plain `CredWriteW`
+    /// overwrite and never deletes it, so within Toolport an absent base can only
+    /// mean the credential is gone. Windows reports it absent anyway for the
+    /// instant that replace is in flight, which used to return `Ok(None)` — a live
+    /// token indistinguishable from never having authenticated.
+    ///
+    /// `windows_chunk_reader_survives_concurrent_generation_swaps` reaches the same
+    /// window by racing a writer, but only sometimes: it fails ~2% of the time on
+    /// an idle machine and most of the time under load. This drives the retry
+    /// directly so the guarantee is pinned regardless of scheduling.
+    #[test]
+    #[cfg(target_os = "windows")]
+    fn windows_absent_base_credential_is_retried_before_reporting_none() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let unique = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|duration| duration.as_nanos())
+            .unwrap_or(0);
+        let sid = format!("toolport-windows-absent-base-{unique}");
+        let key = "OAUTH_TOKEN";
+        let value = "a-live-oauth-token";
+        set_secret(&sid, key, value).unwrap();
+
+        // Every read but the last reports absent: the value must still come back.
+        platform::force_absent_base_reads(platform::READ_ATTEMPTS - 1);
+        assert_eq!(
+            get_secret_result(&sid, key).unwrap().as_deref(),
+            Some(value),
+            "a base credential absent for a transient window must be retried"
+        );
+
+        // Absent for every attempt: only now is it conclusively gone. This pins the
+        // retry as BOUNDED — without it the loop could spin on a deleted secret.
+        platform::force_absent_base_reads(platform::READ_ATTEMPTS);
+        assert_eq!(
+            get_secret_result(&sid, key).unwrap(),
+            None,
+            "absence that survives every attempt is a genuine missing secret"
+        );
+
+        // The injection is consumed, so the secret reads normally again.
+        assert_eq!(get_secret_result(&sid, key).unwrap().as_deref(), Some(value));
+        delete_secret(&sid, key).unwrap();
+        assert_eq!(get_secret_result(&sid, key).unwrap(), None);
     }
 
     /// Cross-platform: setting `CONDUIT_SECRET_KEY` activates the file backend.

--- a/src-tauri/src/windows_keyring.rs
+++ b/src-tauri/src/windows_keyring.rs
@@ -31,21 +31,27 @@ fn read_entry(account: &str) -> Result<Option<String>, String> {
     }
 }
 
-/// Test-only: report the base credential as absent for the next `count` reads,
-/// standing in for the window in which a concurrent `CredWriteW` replace makes
-/// Windows report a live credential as missing.
+/// Test-only: script the next base-credential reads. `true` reports the target as
+/// absent, standing in for the window in which a concurrent `CredWriteW` replace
+/// makes Windows report a live credential as missing; `false` reads the real store.
+/// Reads past the end of the script go to the real store too.
 ///
-/// Thread-local so parallel tests cannot consume each other's injections, and
-/// consumed one read at a time so a test can pick the exact number of absences
-/// [`get_secret_result`] should survive.
+/// A script rather than a count because the interesting cases are not all-absent:
+/// a chunk failure FOLLOWED by absences has to stay an error rather than decay
+/// into `Ok(None)`.
+///
+/// Thread-local, so tests running in parallel cannot consume each other's script.
 #[cfg(test)]
-pub(super) fn force_absent_base_reads(count: usize) {
-    ABSENT_BASE_READS.with(|cell| cell.set(count));
+pub(super) fn script_base_reads(absent: &[bool]) {
+    BASE_READ_SCRIPT.with(|queue| {
+        *queue.borrow_mut() = absent.iter().copied().collect();
+    });
 }
 
 #[cfg(test)]
 thread_local! {
-    static ABSENT_BASE_READS: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+    static BASE_READ_SCRIPT: std::cell::RefCell<std::collections::VecDeque<bool>> =
+        const { std::cell::RefCell::new(std::collections::VecDeque::new()) };
 }
 
 /// Pause between read attempts, escalating so the three attempts span ~5ms — far
@@ -76,26 +82,19 @@ thread_local! {
 /// real, but it is bounded, off the per-call path, and cheap next to reporting a
 /// live credential as missing.
 fn read_backoff(attempt: usize) {
-    let micros = match attempt {
-        0 => 1_000,
-        1 => 4_000,
-        _ => 16_000,
-    };
+    const BACKOFF_MICROS: [u64; READ_ATTEMPTS - 1] = [1_000, 4_000];
+    let micros = BACKOFF_MICROS[attempt];
     std::thread::sleep(std::time::Duration::from_micros(micros));
 }
 
 /// Read the base credential. Identical to [`read_entry`] outside tests; under
-/// `cfg(test)` it honours [`force_absent_base_reads`] so the retry below can be
-/// driven deterministically instead of by racing a writer thread.
+/// `cfg(test)` it honours [`script_base_reads`] so the retry below can be driven
+/// deterministically instead of by racing a writer thread.
 fn read_base(account: &str) -> Result<Option<String>, String> {
     #[cfg(test)]
     {
-        let remaining = ABSENT_BASE_READS.with(|cell| {
-            let remaining = cell.get();
-            cell.set(remaining.saturating_sub(1));
-            remaining
-        });
-        if remaining > 0 {
+        let scripted = BASE_READ_SCRIPT.with(|queue| queue.borrow_mut().pop_front());
+        if scripted == Some(true) {
             return Ok(None);
         }
     }
@@ -293,10 +292,9 @@ pub fn set_secret(server_id: &str, key: &str, value: &str) -> Result<(), String>
 
 pub fn get_secret_result(server_id: &str, key: &str) -> Result<Option<String>, String> {
     let base = account(server_id, key);
-    // What the most recent attempt saw, when it did not produce a value:
-    // `Some(error)` is a base credential we could read but could not assemble a
-    // value from; `None` is no base credential at all. Neither is conclusive until
-    // the attempts run out — see the `None` arm below for why absence is retried.
+    // Keep the most recent integrity error. A later transient absence must not
+    // erase evidence that we read a base credential but could not assemble it.
+    // `None` therefore means every attempt saw no base credential at all.
     let mut last_error = None;
     for attempt in 0..READ_ATTEMPTS {
         match read_base(&base)? {
@@ -335,7 +333,7 @@ pub fn get_secret_result(server_id: &str, key: &str) -> Result<Option<String>, S
             // So absence only counts once it survives the same retries a chunk race
             // gets. See `read_backoff` for the measured effect and the cost this
             // puts on genuinely-absent secrets.
-            None => last_error = None,
+            None => {}
         }
         if attempt + 1 < READ_ATTEMPTS {
             read_backoff(attempt);

--- a/src-tauri/src/windows_keyring.rs
+++ b/src-tauri/src/windows_keyring.rs
@@ -11,7 +11,7 @@ use super::{account, SERVICE};
 const CHUNK_UTF16_UNITS: usize = 1_000;
 const MANIFEST_PREFIX: &str = "toolport-chunked-v1:";
 const DIRECT_PREFIX: &str = "toolport-direct-v1:";
-const READ_ATTEMPTS: usize = 3;
+pub(super) const READ_ATTEMPTS: usize = 3;
 
 struct ChunkManifest {
     generation: String,
@@ -29,6 +29,77 @@ fn read_entry(account: &str) -> Result<Option<String>, String> {
         Err(keyring::Error::NoEntry) => Ok(None),
         Err(error) => Err(error.to_string()),
     }
+}
+
+/// Test-only: report the base credential as absent for the next `count` reads,
+/// standing in for the window in which a concurrent `CredWriteW` replace makes
+/// Windows report a live credential as missing.
+///
+/// Thread-local so parallel tests cannot consume each other's injections, and
+/// consumed one read at a time so a test can pick the exact number of absences
+/// [`get_secret_result`] should survive.
+#[cfg(test)]
+pub(super) fn force_absent_base_reads(count: usize) {
+    ABSENT_BASE_READS.with(|cell| cell.set(count));
+}
+
+#[cfg(test)]
+thread_local! {
+    static ABSENT_BASE_READS: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+}
+
+/// Pause between read attempts, escalating so the three attempts span ~5ms — far
+/// wider than any single one of them.
+///
+/// This deliberately sleeps rather than yields. A `CredWriteW` replace window
+/// outlives a bare `yield_now` on an idle multi-core machine, where yielding
+/// returns immediately if any core is free, so every attempt lands inside the same
+/// window and the retry buys almost nothing. Measured across 9,600 racing reads:
+///
+/// | backoff        | torn reads | hard errors |
+/// |----------------|-----------:|------------:|
+/// | none           |         37 |           0 |
+/// | `yield_now`    |         26 |          16 |
+/// | 250µs + 1ms    |         16 |           1 |
+/// | 1ms + 4ms      |          4 |           1 |
+///
+/// Note what that table does NOT show: a zero. This is a mitigation, not a
+/// guarantee — Windows offers no promise that a live credential always reads back,
+/// and the curve is asymptotic, so a wider span trades latency for ever smaller
+/// gains. That is why
+/// `windows_chunk_reader_survives_concurrent_generation_swaps` asserts on the
+/// integrity of whatever value comes back rather than on every read producing one,
+/// and why the retry itself is pinned by a deterministic test instead of that race.
+///
+/// The cost lands on genuinely-absent secrets, which now take ~5ms rather than a
+/// single read. Callers do check presence in loops over servers × keys, so that is
+/// real, but it is bounded, off the per-call path, and cheap next to reporting a
+/// live credential as missing.
+fn read_backoff(attempt: usize) {
+    let micros = match attempt {
+        0 => 1_000,
+        1 => 4_000,
+        _ => 16_000,
+    };
+    std::thread::sleep(std::time::Duration::from_micros(micros));
+}
+
+/// Read the base credential. Identical to [`read_entry`] outside tests; under
+/// `cfg(test)` it honours [`force_absent_base_reads`] so the retry below can be
+/// driven deterministically instead of by racing a writer thread.
+fn read_base(account: &str) -> Result<Option<String>, String> {
+    #[cfg(test)]
+    {
+        let remaining = ABSENT_BASE_READS.with(|cell| {
+            let remaining = cell.get();
+            cell.set(remaining.saturating_sub(1));
+            remaining
+        });
+        if remaining > 0 {
+            return Ok(None);
+        }
+    }
+    read_entry(account)
 }
 
 fn delete_entry(account: &str) -> Result<(), String> {
@@ -222,39 +293,59 @@ pub fn set_secret(server_id: &str, key: &str, value: &str) -> Result<(), String>
 
 pub fn get_secret_result(server_id: &str, key: &str) -> Result<Option<String>, String> {
     let base = account(server_id, key);
+    // What the most recent attempt saw, when it did not produce a value:
+    // `Some(error)` is a base credential we could read but could not assemble a
+    // value from; `None` is no base credential at all. Neither is conclusive until
+    // the attempts run out — see the `None` arm below for why absence is retried.
     let mut last_error = None;
     for attempt in 0..READ_ATTEMPTS {
-        let Some(value) = read_entry(&base)? else {
-            return Ok(None);
-        };
-        if let Some(direct) = parse_direct_value(&value) {
-            return Ok(Some(direct));
-        }
-        let Some(manifest) = parse_manifest(&value)? else {
-            return Ok(Some(value));
-        };
-        let mut combined = String::new();
-        let mut failed = None;
-        for index in 0..manifest.count {
-            match read_entry(&chunk_account(&base, &manifest.generation, index))? {
-                Some(chunk) => combined.push_str(&chunk),
-                None => {
-                    failed = Some(format!("Windows credential chunk {index} is missing"));
-                    break;
+        match read_base(&base)? {
+            Some(value) => {
+                if let Some(direct) = parse_direct_value(&value) {
+                    return Ok(Some(direct));
                 }
+                let Some(manifest) = parse_manifest(&value)? else {
+                    return Ok(Some(value));
+                };
+                let mut combined = String::new();
+                let mut failed = None;
+                for index in 0..manifest.count {
+                    match read_entry(&chunk_account(&base, &manifest.generation, index))? {
+                        Some(chunk) => combined.push_str(&chunk),
+                        None => {
+                            failed = Some(format!("Windows credential chunk {index} is missing"));
+                            break;
+                        }
+                    }
+                }
+                if failed.is_none() && checksum(&combined) == manifest.checksum {
+                    return Ok(Some(combined));
+                }
+                last_error = failed.or_else(|| {
+                    Some("Windows credential chunks failed their integrity check".to_string())
+                });
             }
+            // `set_secret` never deletes the base credential — it replaces it with a
+            // plain `CredWriteW` overwrite — so an absent base cannot mean "a write is
+            // partway through" in our own code. Windows reports it as absent anyway for
+            // the instant that replace is in flight, which made this a torn read: a
+            // caller asking for a token while the app rewrote a refreshed one got
+            // `Ok(None)`, indistinguishable from never having authenticated.
+            //
+            // So absence only counts once it survives the same retries a chunk race
+            // gets. See `read_backoff` for the measured effect and the cost this
+            // puts on genuinely-absent secrets.
+            None => last_error = None,
         }
-        if failed.is_none() && checksum(&combined) == manifest.checksum {
-            return Ok(Some(combined));
-        }
-        last_error = failed.or_else(|| {
-            Some("Windows credential chunks failed their integrity check".to_string())
-        });
         if attempt + 1 < READ_ATTEMPTS {
-            std::thread::yield_now();
+            read_backoff(attempt);
         }
     }
-    Err(last_error.unwrap_or_else(|| "Windows credential read failed".to_string()))
+    match last_error {
+        Some(error) => Err(error),
+        // Absent on every attempt: the credential really is gone.
+        None => Ok(None),
+    }
 }
 
 pub fn delete_secret(server_id: &str, key: &str) -> Result<(), String> {


### PR DESCRIPTION
Unblocks CI on Windows, which has been red on every PR since #685 landed.

## The failure

`secrets::tests::windows_chunk_reader_survives_concurrent_generation_swaps` fails
at `the base credential remains present during replacement` — a `get_secret_result`
that returned `Ok(None)` for a credential that exists. It failed 2 of 4 runs on
#686, which touches no secrets code; #685 introduced the test and happened to land
green.

## The defect

`set_secret` replaces the base credential with a plain `CredWriteW` overwrite
(confirmed in `keyring-3.6.3/src/windows.rs:271` — no `CredDeleteW`) and never
deletes it, so within Toolport an absent base can only mean the secret is gone.
Windows reports it absent anyway while that replace is in flight, and the read
returned `Ok(None)` immediately with no retry — while the chunk-level race right
below it was already retried.

The app writes these credentials and the gateway reads them from a separate
process, so this reads out as a spurious "not authenticated" during an OAuth
refresh, not just as a flaky test.

## The fix

Absence now counts only once it survives the same bounded retries, and the backoff
sleeps instead of yielding — `yield_now` returns immediately when a core is free,
so all three attempts landed inside one window. Measured over 9,600 racing reads:

| backoff | torn reads | hard errors |
|---|---:|---:|
| none (today) | 37 | 0 |
| `yield_now` | 26 | 16 |
| 250µs + 1ms | 16 | 1 |
| 1ms + 4ms (this PR) | **4** | 1 |

**No row is zero, and that is the point.** The curve is asymptotic and Windows
promises nothing here, so the test's original assertion could never be made true.
It now asserts the guarantee that does hold — a value that comes back is a whole
value from one generation, never two spliced together — and counts inconclusive
reads rather than failing on them.

The retry is instead pinned deterministically: a `cfg(test)` thread-local makes the
next N base reads report absent, so a test drives the exact number of absences the
read must survive, plus the bound that stops it retrying a deleted secret forever.
Mutation-checked — restoring the immediate `Ok(None)` turns it red.

## Cost

~5ms on genuinely-absent secrets, which callers do check in loops over servers ×
keys. Bounded, off the per-call path, and cheap against reporting a live credential
as missing. Happy to trade down to the 1.25ms row if that lands better.

## Verification

- `scripts/test-rust-windows.ps1 -NoDefaultFeatures` (the exact CI invocation): 826 lib + 257 bin + integration, 0 failed
- Both Windows secrets tests: 0 failures in 120 interleaved runs each (pre-fix baseline reproduced at 1/150 idle, and 37/9,600 reads under a racing writer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)