### PR TITLE
test: harden credential and subscription reliability

### DIFF
--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -18517,7 +18517,12 @@ mod tests {
         let request_id = "cancelled-listen-request".to_string();
         assert!(cancellations.begin_client_request(request_id.clone()));
         let cancel = cancellations.context(request_id.clone());
-        assert!(cancellations.cancel(&request_id, Some("client went away")));
+        let cancel_registry = cancellations.clone();
+        let cancel_id = request_id.clone();
+        let canceller = std::thread::spawn(move || {
+            std::thread::sleep(Duration::from_millis(20));
+            assert!(cancel_registry.cancel(&cancel_id, Some("client went away")));
+        });
         let req = modern_req(
             77,
             "subscriptions/listen",
@@ -18540,6 +18545,7 @@ mod tests {
             Err(response) => response,
             Ok(_) => panic!("cancelled registration must fail"),
         };
+        canceller.join().unwrap();
         assert!(response["error"]["message"]
             .as_str()
             .is_some_and(|message| message.contains("cancelled")));

--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -590,16 +590,35 @@ const OPEN_GATE_MARGIN: Duration = Duration::from_secs(30);
 /// hardcoded, so raising the launcher budget can never silently make waiters give
 /// up before the leader they are waiting on (SOU-434).
 ///
-/// Note this is longer than any client request timeout, so a waiter can outlive the
-/// caller that queued it; bounding parked waiters is the remaining half of SOU-434.
+/// This can outlive a caller's deadline because MCP does not carry a portable deadline.
+/// Followers therefore also honor explicit cancellation and are bounded per gate (SBS-434).
 const OPEN_GATE_WAIT: Duration =
     Duration::from_secs(downstream::LEADER_OPEN_BUDGET.as_secs() + OPEN_GATE_MARGIN.as_secs());
+/// Maximum followers allowed to park behind one in-flight downstream subscribe. A real client
+/// needs one waiter; a storm must not turn a single slow server into an unbounded pile of blocked
+/// request workers (SBS-434).
+const MAX_OPEN_GATE_WAITERS_PER_URI: usize = 32;
+/// Cancellation has no Condvar notification, so a cancel-aware waiter checks at this cadence.
+const OPEN_GATE_CANCEL_POLL: Duration = Duration::from_millis(100);
 
 /// Coordinates concurrent first-subscriber races for one URI.
 struct OpenGate {
     /// `None` while the leader's downstream subscribe is in flight.
     result: Mutex<Option<Result<(), String>>>,
     cv: Condvar,
+    waiters: AtomicUsize,
+}
+
+/// One bounded follower slot. Releasing it in `Drop` covers success, timeout, cancellation, and
+/// unwinding without a second cleanup path.
+struct OpenGateWaiter<'a> {
+    gate: &'a OpenGate,
+}
+
+impl Drop for OpenGateWaiter<'_> {
+    fn drop(&mut self) {
+        self.gate.waiters.fetch_sub(1, Ordering::AcqRel);
+    }
 }
 
 impl OpenGate {
@@ -607,6 +626,7 @@ impl OpenGate {
         Arc::new(Self {
             result: Mutex::new(None),
             cv: Condvar::new(),
+            waiters: AtomicUsize::new(0),
         })
     }
 
@@ -619,30 +639,71 @@ impl OpenGate {
         self.cv.notify_all();
     }
 
-    fn wait(&self) -> Result<(), String> {
-        self.wait_for(OPEN_GATE_WAIT)
+    fn acquire_waiter(&self) -> Result<OpenGateWaiter<'_>, String> {
+        self.waiters
+            .fetch_update(Ordering::AcqRel, Ordering::Acquire, |current| {
+                (current < MAX_OPEN_GATE_WAITERS_PER_URI).then_some(current + 1)
+            })
+            .map_err(|_| {
+                format!(
+                    "too many clients are waiting for this resource subscription (limit {MAX_OPEN_GATE_WAITERS_PER_URI})"
+                )
+            })?;
+        Ok(OpenGateWaiter { gate: self })
+    }
+
+    fn wait(&self, cancel: Option<&downstream::CancelContext>) -> Result<(), String> {
+        self.wait_for_cancelable(OPEN_GATE_WAIT, cancel)
     }
 
     /// Wait for the leader with an explicit timeout (unit tests use a short one).
+    #[cfg(test)]
     fn wait_for(&self, timeout: Duration) -> Result<(), String> {
+        self.wait_for_cancelable(timeout, None)
+    }
+
+    fn wait_for_cancelable(
+        &self,
+        timeout: Duration,
+        cancel: Option<&downstream::CancelContext>,
+    ) -> Result<(), String> {
         let mut guard = self
             .result
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if let Some(outcome) = guard.as_ref() {
+            return outcome.clone();
+        }
+        // Count only callers that will actually park. A follower can observe the gate in the
+        // table just before the leader finishes; by the time it gets here the result may already
+        // be ready, and that fast path must neither consume a slot nor fail at the cap.
+        let _waiter = self.acquire_waiter()?;
         let deadline = Instant::now() + timeout;
         while guard.is_none() {
+            if cancel.is_some_and(downstream::CancelContext::is_cancelled) {
+                return Err(
+                    "resource subscription request was cancelled while waiting for another client"
+                        .into(),
+                );
+            }
             let now = Instant::now();
             if now >= deadline {
                 return Err(
                     "timed out waiting for another client to open the resource subscription".into(),
                 );
             }
+            let remaining = deadline.saturating_duration_since(now);
+            let wait_for = if cancel.is_some() {
+                remaining.min(OPEN_GATE_CANCEL_POLL)
+            } else {
+                remaining
+            };
             let (next, wait_result) = self
                 .cv
-                .wait_timeout(guard, deadline.saturating_duration_since(now))
+                .wait_timeout(guard, wait_for)
                 .unwrap_or_else(std::sync::PoisonError::into_inner);
             guard = next;
-            if wait_result.timed_out() && guard.is_none() {
+            if wait_result.timed_out() && guard.is_none() && Instant::now() >= deadline {
                 return Err(
                     "timed out waiting for another client to open the resource subscription".into(),
                 );
@@ -7113,6 +7174,7 @@ fn handle_resource_subscription(
     router: &Router,
     req: &Value,
     allowed: Option<&std::collections::HashSet<String>>,
+    cancel: Option<&downstream::CancelContext>,
     method: &str,
 ) -> Option<Value> {
     let id = match req.get("id") {
@@ -7208,7 +7270,7 @@ fn handle_resource_subscription(
                         }
                     }
                 }
-                BeginSubscribe::Wait(gate) => match gate.wait() {
+                BeginSubscribe::Wait(gate) => match gate.wait(cancel) {
                     Ok(()) => {
                         let mut table = state
                             .resource_subs
@@ -8350,6 +8412,7 @@ fn register_modern_subscription(
     router: &Router,
     req: &Value,
     allowed: Option<&std::collections::HashSet<String>>,
+    cancel: Option<&downstream::CancelContext>,
     owner: Option<&McpSessionOwner>,
     transport: ModernSubscriptionTransport,
 ) -> Result<(String, Arc<McpSession>), Value> {
@@ -8407,8 +8470,14 @@ fn register_modern_subscription(
             "params": { "uri": uri }
         });
         let _session = McpSessionGuard::enter(Some(key.clone()));
-        let response =
-            handle_resource_subscription(state, router, &subscribe, allowed, "resources/subscribe");
+        let response = handle_resource_subscription(
+            state,
+            router,
+            &subscribe,
+            allowed,
+            cancel,
+            "resources/subscribe",
+        );
         if response
             .as_ref()
             .is_some_and(|response| response.get("result").is_some())
@@ -9862,6 +9931,7 @@ fn process_request(
             &router,
             req,
             allowed,
+            cancel.as_ref(),
             None,
             ModernSubscriptionTransport::Stdio,
         ) {
@@ -9896,7 +9966,7 @@ fn process_request(
         }
         let _era =
             UpstreamEraGuard::enter(declared.filter(|v| v.as_str() == MODERN_PROTOCOL_VERSION));
-        return handle_resource_subscription(state, &router, req, allowed, method);
+        return handle_resource_subscription(state, &router, req, allowed, cancel.as_ref(), method);
     }
     handle_request_with_cancel(
         req,
@@ -10727,6 +10797,7 @@ fn handle_mcp_http(
                     &router,
                     &req,
                     allowed,
+                    None,
                     session_owner,
                     ModernSubscriptionTransport::Http,
                 ) {
@@ -18276,7 +18347,12 @@ mod tests {
         };
         table2.finish_open_err("file://y", &lead2, "downstream refused".into());
         assert!(table2.sessions_for_uri("file://y").is_empty());
-        assert_eq!(wait_gate.wait().unwrap_err(), "downstream refused");
+        assert_eq!(wait_gate.wait(None).unwrap_err(), "downstream refused");
+        assert_eq!(
+            wait_gate.waiters.load(Ordering::Acquire),
+            0,
+            "a completed gate returns immediately without consuming a waiter slot"
+        );
     }
 
     /// WS1-4: waiters must not park forever when the leader never finishes.
@@ -18287,6 +18363,54 @@ mod tests {
             .wait_for(Duration::from_millis(40))
             .expect_err("must time out");
         assert!(err.contains("timed out"), "got: {err}");
+    }
+
+    #[test]
+    fn open_gate_bounds_concurrent_waiters_per_uri() {
+        let gate = OpenGate::new();
+        let slots = (0..MAX_OPEN_GATE_WAITERS_PER_URI)
+            .map(|_| gate.acquire_waiter().expect("within the waiter limit"))
+            .collect::<Vec<_>>();
+
+        let err = match gate.acquire_waiter() {
+            Ok(_) => panic!("one gate must reject followers beyond its bounded capacity"),
+            Err(err) => err,
+        };
+        assert!(err.contains("too many clients"), "got: {err}");
+
+        drop(slots);
+        assert_eq!(
+            gate.waiters.load(Ordering::Acquire),
+            0,
+            "every exit path must return its waiter slot"
+        );
+    }
+
+    #[test]
+    fn open_gate_stops_waiting_when_the_upstream_request_is_cancelled() {
+        let gate = OpenGate::new();
+        let cancellations = downstream::CancelRegistry::new();
+        let request_id = "resource-sub-waiter".to_string();
+        assert!(cancellations.begin_client_request(request_id.clone()));
+        let cancel = cancellations.context(request_id.clone());
+        let cancel_registry = cancellations.clone();
+        let cancel_id = request_id.clone();
+        let canceller = std::thread::spawn(move || {
+            std::thread::sleep(Duration::from_millis(20));
+            assert!(cancel_registry.cancel(&cancel_id, Some("client deadline elapsed")));
+        });
+
+        let started = Instant::now();
+        let err = gate
+            .wait_for_cancelable(Duration::from_secs(1), Some(&cancel))
+            .expect_err("a cancelled caller must stop waiting");
+        canceller.join().unwrap();
+        assert!(err.contains("cancelled"), "got: {err}");
+        assert!(
+            started.elapsed() < Duration::from_millis(500),
+            "a cancelled request should not park for the one-second leader timeout"
+        );
+        assert_eq!(gate.waiters.load(Ordering::Acquire), 0);
     }
 
     /// WS1-1: mint_mcp_session must release resource subs held by reaped sessions.

--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -671,6 +671,12 @@ impl OpenGate {
             .result
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if cancel.is_some_and(downstream::CancelContext::is_cancelled) {
+            return Err(
+                "resource subscription request was cancelled while waiting for another client"
+                    .into(),
+            );
+        }
         if let Some(outcome) = guard.as_ref() {
             return outcome.clone();
         }
@@ -708,6 +714,15 @@ impl OpenGate {
                     "timed out waiting for another client to open the resource subscription".into(),
                 );
             }
+        }
+        // Cancellation wins the finish/cancel race. A caller that stopped caring
+        // must not join the just-opened subscription merely because the leader
+        // published its result between our final poll and this wake-up.
+        if cancel.is_some_and(downstream::CancelContext::is_cancelled) {
+            return Err(
+                "resource subscription request was cancelled while waiting for another client"
+                    .into(),
+            );
         }
         match guard.as_ref() {
             Some(Ok(())) => Ok(()),
@@ -8478,6 +8493,17 @@ fn register_modern_subscription(
             cancel,
             "resources/subscribe",
         );
+        if cancel.is_some_and(downstream::CancelContext::is_cancelled) {
+            // Earlier URIs in this same listen request may already have joined
+            // downstream subscriptions. Roll them all back before returning so a
+            // cancelled request cannot leave holders behind or publish a session.
+            cleanup_resource_subs_for_session(state, &key);
+            return Err(error(
+                response_id,
+                -32602,
+                "Toolport: resource subscription request was cancelled",
+            ));
+        }
         if response
             .as_ref()
             .is_some_and(|response| response.get("result").is_some())
@@ -10797,6 +10823,10 @@ fn handle_mcp_http(
                     &router,
                     &req,
                     allowed,
+                    // The blocking HTTP parser has no request-lifetime cancellation
+                    // token: client disconnect becomes observable only when the
+                    // returned response body is written/read. Stdio requests do
+                    // carry their CancelContext through this same helper.
                     None,
                     session_owner,
                     ModernSubscriptionTransport::Http,
@@ -18411,6 +18441,124 @@ mod tests {
             "a cancelled request should not park for the one-second leader timeout"
         );
         assert_eq!(gate.waiters.load(Ordering::Acquire), 0);
+    }
+
+    #[test]
+    fn open_gate_rejects_an_already_cancelled_waiter_without_taking_a_slot() {
+        let gate = OpenGate::new();
+        let cancellations = downstream::CancelRegistry::new();
+        let request_id = "resource-sub-already-cancelled".to_string();
+        assert!(cancellations.begin_client_request(request_id.clone()));
+        let cancel = cancellations.context(request_id.clone());
+        assert!(cancellations.cancel(&request_id, Some("client went away")));
+
+        let err = gate
+            .wait_for_cancelable(Duration::from_secs(1), Some(&cancel))
+            .expect_err("an already-cancelled caller must not park");
+        assert!(err.contains("cancelled"), "got: {err}");
+        assert_eq!(
+            gate.waiters.load(Ordering::Acquire),
+            0,
+            "an already-cancelled caller must not consume waiter capacity"
+        );
+    }
+
+    #[test]
+    fn open_gate_cancellation_wins_a_completed_leader_race() {
+        let gate = OpenGate::new();
+        let cancellations = downstream::CancelRegistry::new();
+        let request_id = "resource-sub-finish-cancel-race".to_string();
+        assert!(cancellations.begin_client_request(request_id.clone()));
+        let cancel = cancellations.context(request_id.clone());
+        gate.finish(Ok(()));
+        assert!(cancellations.cancel(&request_id, Some("client went away")));
+
+        let err = gate
+            .wait_for_cancelable(Duration::from_secs(1), Some(&cancel))
+            .expect_err("cancellation must win even when the leader just finished");
+        assert!(err.contains("cancelled"), "got: {err}");
+        assert_eq!(gate.waiters.load(Ordering::Acquire), 0);
+    }
+
+    #[test]
+    fn cancelled_modern_registration_rolls_back_earlier_resource_joins() {
+        let state = http_state(false);
+        let router = cache_router();
+        let id = json!(77);
+        let key = modern_subscription_key(None, &id, ModernSubscriptionTransport::Stdio);
+
+        // The first URI is already held by this request. The second is opening for
+        // another session, which forces register_modern_subscription through the
+        // cancellation-aware waiter path after one successful URI.
+        state
+            .resource_subs
+            .lock()
+            .unwrap()
+            .add("anchor", "fixture://cached", "cache")
+            .unwrap();
+        state
+            .resource_subs
+            .lock()
+            .unwrap()
+            .add(&key, "fixture://cached", "cache")
+            .unwrap();
+        let opening = {
+            let mut table = state.resource_subs.lock().unwrap();
+            match table
+                .begin_subscribe("leader", "fixture://waiting", "cache")
+                .unwrap()
+            {
+                BeginSubscribe::Lead(gate) => gate,
+                _ => panic!("fixture must own the opening subscription"),
+            }
+        };
+
+        let cancellations = downstream::CancelRegistry::new();
+        let request_id = "cancelled-listen-request".to_string();
+        assert!(cancellations.begin_client_request(request_id.clone()));
+        let cancel = cancellations.context(request_id.clone());
+        assert!(cancellations.cancel(&request_id, Some("client went away")));
+        let req = modern_req(
+            77,
+            "subscriptions/listen",
+            json!({
+                "notifications": {
+                    "resourceSubscriptions": ["fixture://cached", "fixture://waiting"]
+                }
+            }),
+        );
+
+        let response = match register_modern_subscription(
+            &state,
+            &router,
+            &req,
+            None,
+            Some(&cancel),
+            None,
+            ModernSubscriptionTransport::Stdio,
+        ) {
+            Err(response) => response,
+            Ok(_) => panic!("cancelled registration must fail"),
+        };
+        assert!(response["error"]["message"]
+            .as_str()
+            .is_some_and(|message| message.contains("cancelled")));
+        assert!(state.mcp_sessions.lock().unwrap().is_empty());
+        assert_eq!(
+            state
+                .resource_subs
+                .lock()
+                .unwrap()
+                .sessions_for_uri("fixture://cached"),
+            vec!["anchor".to_string()],
+            "the earlier successful URI must be rolled back without disturbing other holders"
+        );
+
+        state.resource_subs.lock().unwrap().finish_open_err(
+            "fixture://waiting",
+            &opening,
+            "fixture cleanup".into(),
+        );
     }
 
     /// WS1-1: mint_mcp_session must release resource subs held by reaped sessions.

--- a/src-tauri/src/downstream.rs
+++ b/src-tauri/src/downstream.rs
@@ -888,6 +888,18 @@ pub struct CancelContext {
     registry: CancelRegistry,
 }
 
+impl CancelContext {
+    /// Whether the upstream client has cancelled this request.
+    ///
+    /// Request handlers that are waiting before a downstream request is registered (for
+    /// example, a resource-subscription single-flight follower) use this to stop occupying a
+    /// worker as soon as the caller gives up. Once a downstream request exists, the registry's
+    /// normal forwarding path still sends `notifications/cancelled` to that server.
+    pub fn is_cancelled(&self) -> bool {
+        self.registry.is_cancelled(&self.client_request_id)
+    }
+}
+
 struct CancelGuard {
     client_request_id: String,
     registry: CancelRegistry,

--- a/src-tauri/src/secrets.rs
+++ b/src-tauri/src/secrets.rs
@@ -1171,7 +1171,12 @@ mod tests {
 
     impl Drop for SecretCleanupGuard<'_> {
         fn drop(&mut self) {
-            let _ = delete_secret(self.server_id, self.key);
+            if let Err(error) = delete_secret(self.server_id, self.key) {
+                eprintln!(
+                    "toolport: test credential cleanup failed for {}/{}: {error}",
+                    self.server_id, self.key
+                );
+            }
         }
     }
 
@@ -1299,47 +1304,42 @@ mod tests {
         let second = "b".repeat(4_000);
         set_secret(&sid, key, &first).unwrap();
 
-        let writer_sid = sid.clone();
-        let writer_first = first.clone();
-        let writer_second = second.clone();
-        let writer = std::thread::spawn(move || {
-            for index in 0..6 {
-                let value = if index % 2 == 0 {
-                    &writer_second
-                } else {
-                    &writer_first
-                };
-                set_secret(&writer_sid, key, value).unwrap();
+        std::thread::scope(|scope| {
+            let writer = scope.spawn(|| {
+                for index in 0..6 {
+                    let value = if index % 2 == 0 { &second } else { &first };
+                    set_secret(&sid, key, value).unwrap();
+                }
+            });
+            let mut inconclusive = 0;
+            for _ in 0..24 {
+                match get_secret_result(&sid, key) {
+                    // The guarantee that holds absolutely: a value that comes back is a
+                    // WHOLE value from ONE generation. Never two spliced together, and
+                    // never a manifest read against another generation's chunks.
+                    Ok(Some(value)) => assert!(
+                        value == first || value == second,
+                        "a read must never splice two generations together"
+                    ),
+                    // Not a guarantee, deliberately. Windows can report a live credential
+                    // as absent (and leave its chunks briefly inconsistent) while
+                    // `CredWriteW` replaces it. `get_secret_result` retries to make that
+                    // rare — measured across 9,600 racing reads, 37 torn reads without the
+                    // retry against 4 with it — but the platform offers no promise it
+                    // cannot happen. Asserting it never does is exactly what made this test
+                    // fail on CI roughly half the time. The retry itself is pinned
+                    // deterministically by
+                    // `windows_absent_base_credential_is_retried_before_reporting_none`,
+                    // which drives the absence directly instead of racing for it.
+                    Ok(None) | Err(_) => inconclusive += 1,
+                }
             }
+            assert!(
+                inconclusive < 24,
+                "every read was inconclusive - the retry is not working at all"
+            );
+            writer.join().unwrap();
         });
-        let mut inconclusive = 0;
-        for _ in 0..24 {
-            match get_secret_result(&sid, key) {
-                // The guarantee that holds absolutely: a value that comes back is a
-                // WHOLE value from ONE generation. Never two spliced together, and
-                // never a manifest read against another generation's chunks.
-                Ok(Some(value)) => assert!(
-                    value == first || value == second,
-                    "a read must never splice two generations together"
-                ),
-                // Not a guarantee, deliberately. Windows can report a live credential
-                // as absent (and leave its chunks briefly inconsistent) while
-                // `CredWriteW` replaces it. `get_secret_result` retries to make that
-                // rare — measured across 9,600 racing reads, 37 torn reads without the
-                // retry against 4 with it — but the platform offers no promise it
-                // cannot happen. Asserting it never does is exactly what made this test
-                // fail on CI roughly half the time. The retry itself is pinned
-                // deterministically by
-                // `windows_absent_base_credential_is_retried_before_reporting_none`,
-                // which drives the absence directly instead of racing for it.
-                Ok(None) | Err(_) => inconclusive += 1,
-            }
-        }
-        assert!(
-            inconclusive < 24,
-            "every read was inconclusive - the retry is not working at all"
-        );
-        writer.join().unwrap();
         delete_secret(&sid, key).unwrap();
     }
 
@@ -1437,18 +1437,32 @@ mod tests {
         let sid = format!("toolport-windows-cleanup-unwind-{unique}");
         let key = "OAUTH_TOKEN";
 
+        let cleanup = SecretCleanupGuard::new(&sid, key);
+        set_secret(&sid, key, &"x".repeat(5_000)).unwrap();
+        let raw_entries = platform::raw_entries_for_test(&sid, key).unwrap();
+        assert!(raw_entries.len() > 1, "fixture must create chunk credentials");
+
         let unwound = std::panic::catch_unwind(|| {
-            let _cleanup = SecretCleanupGuard::new(&sid, key);
-            set_secret(&sid, key, &"x".repeat(5_000)).unwrap();
+            let _cleanup = cleanup;
             panic!("exercise panic-safe credential cleanup");
         });
 
-        assert!(unwound.is_err(), "the fixture must actually unwind");
+        let payload = unwound.expect_err("the fixture must actually unwind");
+        assert_eq!(
+            payload.downcast_ref::<&str>(),
+            Some(&"exercise panic-safe credential cleanup")
+        );
         assert_eq!(
             get_secret_result(&sid, key).unwrap(),
             None,
             "the drop guard must remove the credential and its chunks during unwind"
         );
+        for account in raw_entries {
+            assert!(
+                !platform::raw_entry_exists_for_test(&account).unwrap(),
+                "cleanup left Windows credential entry {account} behind"
+            );
+        }
     }
 
     /// Cross-platform: setting `CONDUIT_SECRET_KEY` activates the file backend.

--- a/src-tauri/src/secrets.rs
+++ b/src-tauri/src/secrets.rs
@@ -1152,6 +1152,29 @@ mod tests {
     /// failures under the default multi-threaded test runner.
     static ENV_LOCK: Mutex<()> = Mutex::new(());
 
+    /// Deletes a real keychain credential even when a test assertion unwinds.
+    ///
+    /// The Windows integration tests intentionally exercise Credential Manager rather than a
+    /// mock. A trailing `delete_secret` is skipped when an assertion panics, and accumulated
+    /// chunk credentials eventually make later test setup fail. Keep cleanup in `Drop` so every
+    /// exit path removes the base credential and all generation chunks (SBS-711).
+    struct SecretCleanupGuard<'a> {
+        server_id: &'a str,
+        key: &'a str,
+    }
+
+    impl<'a> SecretCleanupGuard<'a> {
+        fn new(server_id: &'a str, key: &'a str) -> Self {
+            Self { server_id, key }
+        }
+    }
+
+    impl Drop for SecretCleanupGuard<'_> {
+        fn drop(&mut self) {
+            let _ = delete_secret(self.server_id, self.key);
+        }
+    }
+
     #[test]
     fn macos_secret_replacement_never_deletes_before_writing() {
         // This source-contract test runs on Windows/Linux CI even though the
@@ -1213,6 +1236,7 @@ mod tests {
         let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let sid = "conduit-test-server";
         let key = "CONDUIT_TEST_KEY";
+        let _cleanup = SecretCleanupGuard::new(sid, key);
         set_secret(sid, key, "s3cr3t").unwrap();
         assert_eq!(get_secret(sid, key).as_deref(), Some("s3cr3t"));
         delete_secret(sid, key).unwrap();
@@ -1229,6 +1253,7 @@ mod tests {
             .unwrap_or(0);
         let sid = format!("toolport-windows-large-secret-{unique}");
         let key = "OAUTH_TOKEN";
+        let _cleanup = SecretCleanupGuard::new(&sid, key);
         let first = format!("{}{}", "a".repeat(3_500), "🔒".repeat(300));
         let second = format!("{}{}", "b".repeat(6_100), "🚀".repeat(100));
 
@@ -1269,6 +1294,7 @@ mod tests {
             .unwrap_or(0);
         let sid = format!("toolport-windows-concurrent-secret-{unique}");
         let key = "OAUTH_TOKEN";
+        let _cleanup = SecretCleanupGuard::new(&sid, key);
         let first = "a".repeat(4_000);
         let second = "b".repeat(4_000);
         set_secret(&sid, key, &first).unwrap();
@@ -1340,6 +1366,7 @@ mod tests {
             .unwrap_or(0);
         let sid = format!("toolport-windows-absent-base-{unique}");
         let key = "OAUTH_TOKEN";
+        let _cleanup = SecretCleanupGuard::new(&sid, key);
         let value = "a-live-oauth-token";
         set_secret(&sid, key, value).unwrap();
 
@@ -1378,6 +1405,7 @@ mod tests {
             .unwrap_or(0);
         let sid = format!("toolport-windows-chunk-error-{unique}");
         let key = "OAUTH_TOKEN";
+        let _cleanup = SecretCleanupGuard::new(&sid, key);
         let missing_chunk_manifest = concat!(
             "toolport-chunked-v1:0123456789abcdef0123456789abcdef:1:",
             "0000000000000000000000000000000000000000000000000000000000000000"
@@ -1396,6 +1424,31 @@ mod tests {
         );
 
         delete_secret(&sid, key).unwrap();
+    }
+
+    #[test]
+    #[cfg(target_os = "windows")]
+    fn windows_secret_cleanup_guard_deletes_on_unwind() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let unique = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|duration| duration.as_nanos())
+            .unwrap_or(0);
+        let sid = format!("toolport-windows-cleanup-unwind-{unique}");
+        let key = "OAUTH_TOKEN";
+
+        let unwound = std::panic::catch_unwind(|| {
+            let _cleanup = SecretCleanupGuard::new(&sid, key);
+            set_secret(&sid, key, &"x".repeat(5_000)).unwrap();
+            panic!("exercise panic-safe credential cleanup");
+        });
+
+        assert!(unwound.is_err(), "the fixture must actually unwind");
+        assert_eq!(
+            get_secret_result(&sid, key).unwrap(),
+            None,
+            "the drop guard must remove the credential and its chunks during unwind"
+        );
     }
 
     /// Cross-platform: setting `CONDUIT_SECRET_KEY` activates the file backend.

--- a/src-tauri/src/windows_keyring.rs
+++ b/src-tauri/src/windows_keyring.rs
@@ -365,3 +365,23 @@ pub fn set_raw_for_test(server_id: &str, key: &str, value: &str) -> Result<(), S
         .set_password(value)
         .map_err(|error| error.to_string())
 }
+
+#[cfg(test)]
+pub fn raw_entries_for_test(server_id: &str, key: &str) -> Result<Vec<String>, String> {
+    let base = account(server_id, key);
+    let mut accounts = vec![base.clone()];
+    if let Some(raw) = read_entry(&base)? {
+        if let Some(manifest) = parse_manifest(&raw)? {
+            accounts.extend(
+                (0..manifest.count)
+                    .map(|index| chunk_account(&base, &manifest.generation, index)),
+            );
+        }
+    }
+    Ok(accounts)
+}
+
+#[cfg(test)]
+pub fn raw_entry_exists_for_test(account: &str) -> Result<bool, String> {
+    Ok(read_entry(account)?.is_some())
+}


### PR DESCRIPTION
## Summary

- add a drop guard to real keychain tests so Windows Credential Manager entries and chunk generations are removed even when assertions unwind
- cap resource-subscription single-flight followers at 32 per URI
- stop parked followers promptly when the upstream request is explicitly cancelled
- preserve the completed-gate fast path without consuming a waiter slot

## Validation

- `cargo test --manifest-path src-tauri/Cargo.toml --lib --no-default-features secrets::tests::windows_ -- --test-threads=1`
- `cargo test --manifest-path src-tauri/Cargo.toml --bin toolport-gateway --no-default-features open_gate_`
- `cargo test --manifest-path src-tauri/Cargo.toml --bin toolport-gateway --no-default-features resource_subscription_begin_subscribe_single_flights_first_open`
- `powershell -ExecutionPolicy Bypass -File scripts/test-rust-windows.ps1 -NoDefaultFeatures`
- `cargo clippy --manifest-path src-tauri/Cargo.toml --no-default-features --lib --bins --tests` (passes with existing baseline warnings)

Closes SBS-711
Closes SBS-434