### PR TITLE
codemode: add toolport.checkpoint() for script-declared resume state

### DIFF
--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -14558,7 +14558,7 @@ mod tests {
         let reg = Registry::default();
         let router = Arc::new(routed_router("s", "tool"));
         let args = json!({
-            "script": "toolport.checkpoint({ resume: 'x'.repeat(4000) }); throw new Error('E'.repeat(20000));"
+            "script": "toolport.checkpoint({ resume: 'x'.repeat(1000) }); try { toolport.checkpoint({ resume: 'y'.repeat(4000) }); } catch (_) {} throw new Error('E'.repeat(20000));"
         });
         let result = run_script_dispatch(&reg, Some(&router), &[], None, None, None, &args, None);
 
@@ -14569,10 +14569,18 @@ mod tests {
 
         assert_eq!(result["isError"].as_bool(), Some(true));
         let text = result["content"][0]["text"].as_str().unwrap_or_default();
+        assert!(
+            text.contains("[Toolport shaped this result"),
+            "test needs an actually-shaped result to prove the budget is honored; got: {text}"
+        );
         assert!(text.contains("checkpoint:"), "missing checkpoint: {text}");
         assert!(
-            text.contains(&"x".repeat(4000)),
-            "a near-limit checkpoint must remain complete even when the configured shaping budget is smaller"
+            text.contains(&"x".repeat(1000)),
+            "the largest checkpoint accepted under a 2 KiB result budget must remain complete"
+        );
+        assert!(
+            !text.contains(&"y".repeat(4000)),
+            "a checkpoint too large for the active result budget must be rejected"
         );
     }
 

--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -5015,6 +5015,9 @@ fn run_script_dispatch(
         Some(v) => format!("checkpoint: {v}. "),
         None => String::new(),
     };
+    let protected_failure_prefix_bytes = outcome.checkpoint.as_ref().map_or(0, |checkpoint| {
+        format!("Toolport code mode: the script failed. checkpoint: {checkpoint}. ").len()
+    });
 
     let ledger_text = if outcome.progress.is_empty() {
         "no calls completed".to_string()
@@ -5066,7 +5069,12 @@ fn run_script_dispatch(
     if let Some(msg) = warning {
         eprintln!("{msg}");
     }
-    shaping::shape_result(&mut result, budget, client);
+    shaping::shape_result_preserving_prefix(
+        &mut result,
+        budget,
+        client,
+        protected_failure_prefix_bytes,
+    );
     result
 }
 
@@ -14550,7 +14558,7 @@ mod tests {
         let reg = Registry::default();
         let router = Arc::new(routed_router("s", "tool"));
         let args = json!({
-            "script": "toolport.checkpoint({ lastInsertedId: 99 }); throw new Error('E'.repeat(20000));"
+            "script": "toolport.checkpoint({ resume: 'x'.repeat(4000) }); throw new Error('E'.repeat(20000));"
         });
         let result = run_script_dispatch(&reg, Some(&router), &[], None, None, None, &args, None);
 
@@ -14561,13 +14569,10 @@ mod tests {
 
         assert_eq!(result["isError"].as_bool(), Some(true));
         let text = result["content"][0]["text"].as_str().unwrap_or_default();
+        assert!(text.contains("checkpoint:"), "missing checkpoint: {text}");
         assert!(
-            text.contains("[Toolport shaped this result"),
-            "test needs an actually-shaped result to be meaningful; got: {text}"
-        );
-        assert!(
-            text.contains("checkpoint:") && text.contains("lastInsertedId"),
-            "the checkpoint must survive head-first shaping in the text body; got: {text}"
+            text.contains(&"x".repeat(4000)),
+            "a near-limit checkpoint must remain complete even when the configured shaping budget is smaller"
         );
     }
 

--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -1217,8 +1217,11 @@ fn run_script_tool_def() -> Value {
             approval). If the script fails partway, `structuredContent.toolportScript.progress` lists \
             the calls that already ran, in order, as {index, name, ok} - those side effects are \
             committed. Resume by INDEX (entries 0..n ran, n onward did not); never skip by tool name, \
-            since the same tool appears once per call. Best when you already know the steps; explore \
-            with toolport_search_tools first.",
+            since the same tool appears once per call. Call `toolport.checkpoint(value)` to record \
+            your own resume state (e.g. the last id you processed) as you go; on failure it's \
+            returned as `structuredContent.toolportScript.checkpoint`, letting a retry pick up from \
+            where it actually left off instead of guessing from the index alone. Best when you \
+            already know the steps; explore with toolport_search_tools first.",
         "inputSchema": {
             "type": "object",
             "properties": {
@@ -5008,6 +5011,11 @@ fn run_script_dispatch(
     // error would otherwise lose its recovery data at exactly the moment that
     // data matters most. Leading with it means truncation eats the error text,
     // which is the more expendable half. Bounded by `max_calls` (64).
+    let checkpoint_text = match &outcome.checkpoint {
+        Some(v) => format!("checkpoint: {v}. "),
+        None => String::new(),
+    };
+
     let ledger_text = if outcome.progress.is_empty() {
         "no calls completed".to_string()
     } else {
@@ -5034,10 +5042,10 @@ fn run_script_dispatch(
         Some(err) => json!({
             "content": [{
                 "type": "text",
-                "text": format!("Toolport code mode: the script failed. {ledger_text}. Error: {err}")
+                "text": format!("Toolport code mode: the script failed. {checkpoint_text}{ledger_text}. Error: {err}")
             }],
             "isError": true,
-            "structuredContent": { "toolportScript": { "ok": false, "calls": outcome.calls, "progress": progress, "error": err } }
+            "structuredContent": { "toolportScript": { "ok": false, "calls": outcome.calls, "progress": progress, "checkpoint": outcome.checkpoint, "error": err } }
         }),
         None => {
             // One aggregated value; the intermediate call results stayed out of context.
@@ -14527,6 +14535,74 @@ mod tests {
         assert!(
             text.contains("do NOT skip by tool name"),
             "the ordinal contract must survive with it; got: {text}"
+        );
+    }
+
+    /// Mirrors `an_oversized_code_mode_failure_keeps_its_call_ledger_in_the_text`:
+    /// the checkpoint is rendered ahead of the ledger and the error, so head-first
+    /// shaping must never eat it either (#663).
+    #[test]
+    fn an_oversized_code_mode_failure_keeps_its_checkpoint_in_the_text() {
+        let _env = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let previous = std::env::var("TOOLPORT_RESULT_BUDGET").ok();
+        std::env::set_var("TOOLPORT_RESULT_BUDGET", "2048");
+
+        let reg = Registry::default();
+        let router = Arc::new(routed_router("s", "tool"));
+        let args = json!({
+            "script": "toolport.checkpoint({ lastInsertedId: 99 }); throw new Error('E'.repeat(20000));"
+        });
+        let result = run_script_dispatch(&reg, Some(&router), &[], None, None, None, &args, None);
+
+        match previous {
+            Some(value) => std::env::set_var("TOOLPORT_RESULT_BUDGET", value),
+            None => std::env::remove_var("TOOLPORT_RESULT_BUDGET"),
+        }
+
+        assert_eq!(result["isError"].as_bool(), Some(true));
+        let text = result["content"][0]["text"].as_str().unwrap_or_default();
+        assert!(
+            text.contains("[Toolport shaped this result"),
+            "test needs an actually-shaped result to be meaningful; got: {text}"
+        );
+        assert!(
+            text.contains("checkpoint:") && text.contains("lastInsertedId"),
+            "the checkpoint must survive head-first shaping in the text body; got: {text}"
+        );
+    }
+
+    #[test]
+    fn checkpoint_is_surfaced_in_structured_content_on_failure() {
+        let reg = Registry::default();
+        let router = Arc::new(routed_router("s", "tool"));
+        let args = json!({
+            "script": "toolport.checkpoint({ lastInsertedId: 7 }); throw new Error('boom');"
+        });
+        let result = run_script_dispatch(&reg, Some(&router), &[], None, None, None, &args, None);
+
+        assert_eq!(result["isError"].as_bool(), Some(true));
+        assert_eq!(
+            result["structuredContent"]["toolportScript"]["checkpoint"],
+            json!({ "lastInsertedId": 7 })
+        );
+    }
+
+    #[test]
+    fn checkpoint_absent_when_the_script_never_calls_it() {
+        let reg = Registry::default();
+        let router = Arc::new(routed_router("s", "tool"));
+        let args = json!({ "script": "throw new Error('boom');" });
+        let result = run_script_dispatch(&reg, Some(&router), &[], None, None, None, &args, None);
+
+        assert_eq!(result["isError"].as_bool(), Some(true));
+        let text = result["content"][0]["text"].as_str().unwrap_or_default();
+        assert!(
+            !text.contains("checkpoint:"),
+            "no checkpoint text should appear when the script never called it; got: {text}"
+        );
+        assert_eq!(
+            result["structuredContent"]["toolportScript"]["checkpoint"],
+            Value::Null
         );
     }
 

--- a/src-tauri/src/codemode.rs
+++ b/src-tauri/src/codemode.rs
@@ -338,6 +338,10 @@ struct HostState {
     /// Last checkpoint value the script recorded via `toolport.checkpoint(value)`.
     /// Last-write-wins — a fresh call overwrites, it doesn't append (#663).
     checkpoint: Rc<RefCell<Option<Value>>>,
+    /// Maximum serialized checkpoint size for this run. This is capped against
+    /// the active result budget so an accepted checkpoint can always be surfaced
+    /// immediately when the script fails.
+    max_checkpoint_bytes: usize,
     max_calls: usize,
     max_parallel: usize,
     deadline: Instant,
@@ -349,13 +353,29 @@ struct HostState {
 /// failure response can surface it without becoming an unbounded escape hatch.
 const MAX_CHECKPOINT_BYTES: usize = 4096;
 
+/// Space reserved for the failure prefix, shaping marker, and MCP result
+/// envelope. The remainder of the active result budget is available to the
+/// checkpoint itself.
+const CHECKPOINT_RESPONSE_RESERVE_BYTES: usize = 1024;
+
+fn checkpoint_limit_for_result_budget(result_budget: usize) -> usize {
+    if result_budget == 0 {
+        MAX_CHECKPOINT_BYTES
+    } else {
+        MAX_CHECKPOINT_BYTES.min(result_budget.saturating_sub(CHECKPOINT_RESPONSE_RESERVE_BYTES))
+    }
+}
+
 fn store_checkpoint(
     checkpoint: &RefCell<Option<Value>>,
     raw: &str,
+    max_bytes: usize,
 ) -> Result<(), JsError> {
-    if raw.len() > MAX_CHECKPOINT_BYTES {
+    if raw.len() > max_bytes {
         return Err(JsError::from_native(JsNativeError::error().with_message(
-            format!("toolport.checkpoint value exceeds {MAX_CHECKPOINT_BYTES} bytes"),
+            format!(
+                "toolport.checkpoint value exceeds {max_bytes} bytes for the active result budget"
+            ),
         )));
     }
     let parsed: Value = serde_json::from_str(raw).map_err(|error| {
@@ -392,6 +412,7 @@ impl Clone for HostState {
             calls_made: Rc::clone(&self.calls_made),
             executed: Rc::clone(&self.executed),
             checkpoint: Rc::clone(&self.checkpoint),
+            max_checkpoint_bytes: self.max_checkpoint_bytes,
             max_calls: self.max_calls,
             max_parallel: self.max_parallel,
             deadline: self.deadline,
@@ -659,6 +680,8 @@ pub fn run_script(
     let calls_made = Rc::new(Cell::new(0usize));
     let executed = Rc::new(RefCell::new(Vec::new()));
     let checkpoint = Rc::new(RefCell::new(None::<Value>));
+    let (result_budget, _warning) = crate::shaping::budget();
+    let max_checkpoint_bytes = checkpoint_limit_for_result_budget(result_budget);
     let pending = Rc::new(RefCell::new(VecDeque::new()));
     let deadline = Instant::now() + limits.wall_clock;
     let executor = Rc::new(BoundedJobExecutor::new(deadline, limits.max_promise_jobs));
@@ -688,6 +711,7 @@ pub fn run_script(
         calls_made: calls_made.clone(),
         executed: executed.clone(),
         checkpoint: checkpoint.clone(),
+        max_checkpoint_bytes,
         max_calls: limits.max_calls,
         max_parallel: limits.max_parallel.max(1),
         deadline,
@@ -742,7 +766,7 @@ pub fn run_script(
                 .and_then(JsValue::as_string)
                 .map(|s| s.to_std_string_escaped())
                 .unwrap_or_else(|| "null".to_string());
-            store_checkpoint(&state.checkpoint, &raw)?;
+            store_checkpoint(&state.checkpoint, &raw, state.max_checkpoint_bytes)?;
             Ok(JsValue::undefined())
         },
         state.clone(),
@@ -2075,15 +2099,24 @@ mod tests {
 
     #[test]
     fn malformed_checkpoint_json_is_rejected_without_dropping_the_prior_one() {
-        let checkpoint = RefCell::new(Some(json!({ "safe": true })));
-
-        let error = store_checkpoint(&checkpoint, "{not-json")
-            .expect_err("malformed checkpoint JSON must fail closed");
-        assert!(error.to_string().contains("invalid JSON"), "got: {error}");
+        let call = Arc::new(|_: &str, _: Value| Value::Null);
+        let out = run(
+            r#"
+                toolport.checkpoint({ safe: true });
+                try {
+                    __toolport_checkpoint('{not-json');
+                } catch (_) {}
+                return 'done';
+            "#,
+            json!({}),
+            call,
+            Limits::default(),
+        );
+        assert_eq!(out.error, None, "unexpected error: {:?}", out.error);
         assert_eq!(
-            checkpoint.into_inner(),
+            out.checkpoint,
             Some(json!({ "safe": true })),
-            "parsing must succeed before the last good checkpoint is replaced"
+            "malformed direct-binding input must not replace the last good checkpoint"
         );
     }
 

--- a/src-tauri/src/codemode.rs
+++ b/src-tauri/src/codemode.rs
@@ -281,6 +281,10 @@ pub struct ScriptOutcome {
     /// script whose call sequence depends on data returned mid-run, even that
     /// holds only if the re-run takes the same branches.
     pub progress: Vec<CallRecord>,
+    /// Last value the script passed to `toolport.checkpoint()`, if any. Author-chosen,
+    /// so unlike `progress` this can safely carry script-relevant state — the script
+    /// decides what's safe to surface. `None` if the script never called it. See #663.
+    pub checkpoint: Option<Value>,
     /// `Some(message)` if the script threw, hit a limit, or failed to compile. Fail-closed:
     /// the caller surfaces this to the agent as an error result.
     pub error: Option<String>,
@@ -331,6 +335,9 @@ struct HostState {
     /// `calls_made` is. Appended after the host binding returns, never before, so
     /// it records committed work rather than intent (#646).
     executed: Rc<RefCell<Vec<CallRecord>>>,
+    /// Last checkpoint value the script recorded via `toolport.checkpoint(value)`.
+    /// Last-write-wins — a fresh call overwrites, it doesn't append (#663).
+    checkpoint: Rc<RefCell<Option<Value>>>,
     max_calls: usize,
     max_parallel: usize,
     deadline: Instant,
@@ -361,6 +368,7 @@ impl Clone for HostState {
             call: Arc::clone(&self.call),
             calls_made: Rc::clone(&self.calls_made),
             executed: Rc::clone(&self.executed),
+            checkpoint: Rc::clone(&self.checkpoint),
             max_calls: self.max_calls,
             max_parallel: self.max_parallel,
             deadline: self.deadline,
@@ -413,6 +421,9 @@ globalThis.toolport = {
     call: function (name, args) {
         var payload = (args === undefined || args === null) ? {} : args;
         return JSON.parse(__toolport_call(String(name), JSON.stringify(payload)));
+    },
+    checkpoint: function (value) {
+        __toolport_checkpoint(JSON.stringify(value === undefined ? null : value));
     },
     callAsync: function (name, args) {
         var payload = (args === undefined || args === null) ? {} : args;
@@ -624,6 +635,7 @@ pub fn run_script(
 ) -> ScriptOutcome {
     let calls_made = Rc::new(Cell::new(0usize));
     let executed = Rc::new(RefCell::new(Vec::new()));
+    let checkpoint = Rc::new(RefCell::new(None::<Value>));
     let pending = Rc::new(RefCell::new(VecDeque::new()));
     let deadline = Instant::now() + limits.wall_clock;
     let executor = Rc::new(BoundedJobExecutor::new(deadline, limits.max_promise_jobs));
@@ -634,6 +646,7 @@ pub fn run_script(
                 value: json!(null),
                 calls: 0,
                 progress: Vec::new(),
+                checkpoint: None,
                 error: Some(format!("toolport code mode: failed to create JS context: {e}")),
             };
         }
@@ -651,6 +664,7 @@ pub fn run_script(
         call,
         calls_made: calls_made.clone(),
         executed: executed.clone(),
+        checkpoint: checkpoint.clone(),
         max_calls: limits.max_calls,
         max_parallel: limits.max_parallel.max(1),
         deadline,
@@ -696,14 +710,47 @@ pub fn run_script(
         state.clone(),
     );
 
+    /// A checkpoint is a resume marker, not a payload — bounded well below the
+    /// call-arg budget so a script cannot smuggle a large blob out through the
+    /// one path (the failure text) that isn't subject to `max_calls`.
+    const MAX_CHECKPOINT_BYTES: usize = 4096;
+
+    let checkpoint_native = NativeFunction::from_copy_closure_with_captures(
+        |_this: &JsValue, args: &[JsValue], state: &HostState, _ctx: &mut Context| {
+            // No reserve_call_slot: this makes no downstream call, so it costs
+            // nothing against max_calls or the wall clock (#663).
+            let raw = args
+                .first()
+                .and_then(JsValue::as_string)
+                .map(|s| s.to_std_string_escaped())
+                .unwrap_or_else(|| "null".to_string());
+            if raw.len() > MAX_CHECKPOINT_BYTES {
+                return Err(JsError::from_native(JsNativeError::error().with_message(
+                    format!("toolport.checkpoint value exceeds {MAX_CHECKPOINT_BYTES} bytes"),
+                )));
+            }
+            let parsed: Value = serde_json::from_str(&raw).unwrap_or(Value::Null);
+            *state.checkpoint.borrow_mut() = Some(parsed);
+            Ok(JsValue::undefined())
+        },
+        state.clone(),
+    );
+
     if let Err(e) = context.register_global_callable(js_string!("__toolport_call"), 2, sync_native)
     {
-        return fail(calls_made.get(), executed.take(), e);
+        return fail(calls_made.get(), executed.take(), checkpoint.take(), e);
     }
     if let Err(e) =
         context.register_global_callable(js_string!("__toolport_call_async"), 2, async_native)
     {
-        return fail(calls_made.get(), executed.take(), e);
+        return fail(calls_made.get(), executed.take(), checkpoint.take(), e);
+    }
+    if let Err(e) = context.register_global_callable(
+        js_string!("__toolport_checkpoint"),
+        1,
+        checkpoint_native,
+    ) {
+        return fail(calls_made.get(), executed.take(), checkpoint.take(), e);
     }
 
     // Fetch binding: pages shaped results by cursor. Absent binding fails closed.
@@ -766,7 +813,7 @@ pub fn run_script(
     if let Err(e) =
         context.register_global_callable(js_string!("__toolport_fetch_result"), 1, fetch_native)
     {
-        return fail(calls_made.get(), executed.take(), e);
+        return fail(calls_made.get(), executed.take(), checkpoint.take(), e);
     }
 
     // Inject `data` as a global before the prelude/script run.
@@ -775,27 +822,27 @@ pub fn run_script(
             if let Err(e) =
                 context.register_global_property(js_string!("data"), v, Attribute::all())
             {
-                return fail(calls_made.get(), executed.take(), e);
+                return fail(calls_made.get(), executed.take(), checkpoint.take(), e);
             }
         }
-        Err(e) => return fail(calls_made.get(), executed.take(), e),
+        Err(e) => return fail(calls_made.get(), executed.take(), checkpoint.take(), e),
     }
 
     if let Err(e) = context.eval(Source::from_bytes(PRELUDE)) {
-        return fail(calls_made.get(), executed.take(), e);
+        return fail(calls_made.get(), executed.take(), checkpoint.take(), e);
     }
 
     // Typed `servers.*` surface from the scoped catalog (after toolport bindings exist).
     let servers_js = build_servers_prelude(catalog);
     if let Err(e) = context.eval(Source::from_bytes(servers_js.as_bytes())) {
-        return fail(calls_made.get(), executed.take(), e);
+        return fail(calls_made.get(), executed.take(), checkpoint.take(), e);
     }
 
     // Async IIFE: top-level `return` and `await` both work; the result is always a Promise.
     let wrapped = format!("(async function () {{\n{script}\n}})()");
     let top = match context.eval(Source::from_bytes(wrapped.as_bytes())) {
         Ok(v) => v,
-        Err(e) => return fail(calls_made.get(), executed.take(), e),
+        Err(e) => return fail(calls_made.get(), executed.take(), checkpoint.take(), e),
     };
 
     match drive_to_completion(&mut context, &state, top) {
@@ -803,9 +850,10 @@ pub fn run_script(
             value,
             calls: calls_made.get(),
             progress: executed.take(),
+            checkpoint: checkpoint.take(),
             error: None,
         },
-        Err(e) => fail(calls_made.get(), executed.take(), e),
+        Err(e) => fail(calls_made.get(), executed.take(), checkpoint.take(), e),
     }
 }
 
@@ -1054,11 +1102,12 @@ fn run_calls_parallel(call: &CallBinding, items: Vec<(String, Value)>) -> Vec<Va
 /// runtime-limit errors (loop/recursion caps) panic when converted to an opaque JS value,
 /// and `Display` yields a usable message (`Uncaught Error: ...`, `RuntimeLimit: ...`) for
 /// every error kind.
-fn fail(calls: usize, progress: Vec<CallRecord>, err: JsError) -> ScriptOutcome {
+fn fail(calls: usize, progress: Vec<CallRecord>, checkpoint: Option<Value>, err: JsError) -> ScriptOutcome {
     ScriptOutcome {
         value: json!(null),
         calls,
         progress,
+        checkpoint,
         error: Some(err.to_string()),
     }
 }
@@ -1937,5 +1986,102 @@ mod tests {
             err.contains("promise-job budget") || err.contains("wall-clock"),
             "unexpected error: {err}"
         );
+    }
+
+    #[test]
+    fn checkpoint_is_last_write_wins() {
+        // #663: repeated calls overwrite, they don't accumulate a history.
+        let call = Arc::new(|_: &str, _: Value| Value::Null);
+        let out = run(
+            r#"
+                toolport.checkpoint({ step: 1 });
+                toolport.checkpoint({ step: 2 });
+                toolport.checkpoint({ step: 3 });
+                return 'done';
+            "#,
+            json!({}),
+            call,
+            Limits::default(),
+        );
+        assert_eq!(out.error, None, "unexpected error: {:?}", out.error);
+        assert_eq!(out.checkpoint, Some(json!({ "step": 3 })));
+    }
+
+    #[test]
+    fn checkpoint_survives_on_the_error_path() {
+        // The whole point of #663: a script that records progress and then dies
+        // must still report where it got to.
+        let call = Arc::new(|_: &str, _: Value| Value::Null);
+        let out = run(
+            r#"
+                toolport.checkpoint({ lastInsertedId: 41 });
+                throw new Error('boom');
+            "#,
+            json!({}),
+            call,
+            Limits::default(),
+        );
+        assert!(out.error.is_some(), "script was supposed to throw");
+        assert_eq!(out.checkpoint, Some(json!({ "lastInsertedId": 41 })));
+    }
+
+    #[test]
+    fn checkpoint_is_none_when_the_script_never_calls_it() {
+        let out = returns("return 'ok';");
+        assert_eq!(out.error, None, "unexpected error: {:?}", out.error);
+        assert_eq!(out.checkpoint, None);
+    }
+
+    #[test]
+    fn checkpoint_is_none_on_a_script_that_never_compiles() {
+        let call = Arc::new(|_: &str, _: Value| Value::Null);
+        let out = run("this is not ( valid javascript", json!({}), call, Limits::default());
+        assert!(out.error.is_some());
+        assert_eq!(out.checkpoint, None);
+    }
+
+    #[test]
+    fn checkpoint_oversized_value_is_rejected_without_dropping_the_prior_one() {
+        // A checkpoint is a resume marker, not a payload: a script cannot smuggle a
+        // large blob out through the one path (the failure text) that isn't subject
+        // to max_calls.
+        let call = Arc::new(|_: &str, _: Value| Value::Null);
+        let out = run(
+            r#"
+                toolport.checkpoint({ ok: true });
+                toolport.checkpoint({ blob: 'x'.repeat(5000) });
+            "#,
+            json!({}),
+            call,
+            Limits::default(),
+        );
+        let err = out.error.expect("an oversized checkpoint must fail closed");
+        assert!(err.contains("4096"), "error should name the byte cap: {err}");
+        // The prior good checkpoint is untouched by the rejected call.
+        assert_eq!(out.checkpoint, Some(json!({ "ok": true })));
+    }
+
+    #[test]
+    fn checkpoint_costs_nothing_against_the_call_budget() {
+        // Per #663: checkpoint makes no downstream call, so it must not be gated by
+        // reserve_call_slot / max_calls, unlike toolport.call.
+        let call = Arc::new(|_: &str, _: Value| Value::Null);
+        let limits = Limits {
+            max_calls: 0,
+            ..Limits::default()
+        };
+        let out = run(
+            r#"
+                toolport.checkpoint({ a: 1 });
+                toolport.checkpoint({ a: 2 });
+                return 'done';
+            "#,
+            json!({}),
+            call,
+            limits,
+        );
+        assert_eq!(out.error, None, "unexpected error: {:?}", out.error);
+        assert_eq!(out.calls, 0, "checkpoint must not count against max_calls");
+        assert_eq!(out.checkpoint, Some(json!({ "a": 2 })));
     }
 }

--- a/src-tauri/src/codemode.rs
+++ b/src-tauri/src/codemode.rs
@@ -345,6 +345,29 @@ struct HostState {
     pending: Rc<RefCell<VecDeque<PendingCall>>>,
 }
 
+/// A checkpoint is a resume marker, not a payload. Keep it bounded so even a
+/// failure response can surface it without becoming an unbounded escape hatch.
+const MAX_CHECKPOINT_BYTES: usize = 4096;
+
+fn store_checkpoint(
+    checkpoint: &RefCell<Option<Value>>,
+    raw: &str,
+) -> Result<(), JsError> {
+    if raw.len() > MAX_CHECKPOINT_BYTES {
+        return Err(JsError::from_native(JsNativeError::error().with_message(
+            format!("toolport.checkpoint value exceeds {MAX_CHECKPOINT_BYTES} bytes"),
+        )));
+    }
+    let parsed: Value = serde_json::from_str(raw).map_err(|error| {
+        JsError::from_native(
+            JsNativeError::error()
+                .with_message(format!("toolport.checkpoint received invalid JSON: {error}")),
+        )
+    })?;
+    *checkpoint.borrow_mut() = Some(parsed);
+    Ok(())
+}
+
 /// Capture for `__toolport_fetch_result` (no GC refs). Shares the same call
 /// budget and wall-clock deadline as `toolport.call` (WS2-2).
 struct FetchHost {
@@ -710,11 +733,6 @@ pub fn run_script(
         state.clone(),
     );
 
-    /// A checkpoint is a resume marker, not a payload — bounded well below the
-    /// call-arg budget so a script cannot smuggle a large blob out through the
-    /// one path (the failure text) that isn't subject to `max_calls`.
-    const MAX_CHECKPOINT_BYTES: usize = 4096;
-
     let checkpoint_native = NativeFunction::from_copy_closure_with_captures(
         |_this: &JsValue, args: &[JsValue], state: &HostState, _ctx: &mut Context| {
             // No reserve_call_slot: this makes no downstream call, so it costs
@@ -724,13 +742,7 @@ pub fn run_script(
                 .and_then(JsValue::as_string)
                 .map(|s| s.to_std_string_escaped())
                 .unwrap_or_else(|| "null".to_string());
-            if raw.len() > MAX_CHECKPOINT_BYTES {
-                return Err(JsError::from_native(JsNativeError::error().with_message(
-                    format!("toolport.checkpoint value exceeds {MAX_CHECKPOINT_BYTES} bytes"),
-                )));
-            }
-            let parsed: Value = serde_json::from_str(&raw).unwrap_or(Value::Null);
-            *state.checkpoint.borrow_mut() = Some(parsed);
+            store_checkpoint(&state.checkpoint, &raw)?;
             Ok(JsValue::undefined())
         },
         state.clone(),
@@ -2059,6 +2071,20 @@ mod tests {
         assert!(err.contains("4096"), "error should name the byte cap: {err}");
         // The prior good checkpoint is untouched by the rejected call.
         assert_eq!(out.checkpoint, Some(json!({ "ok": true })));
+    }
+
+    #[test]
+    fn malformed_checkpoint_json_is_rejected_without_dropping_the_prior_one() {
+        let checkpoint = RefCell::new(Some(json!({ "safe": true })));
+
+        let error = store_checkpoint(&checkpoint, "{not-json")
+            .expect_err("malformed checkpoint JSON must fail closed");
+        assert!(error.to_string().contains("invalid JSON"), "got: {error}");
+        assert_eq!(
+            checkpoint.into_inner(),
+            Some(json!({ "safe": true })),
+            "parsing must succeed before the last good checkpoint is replaced"
+        );
     }
 
     #[test]

--- a/src-tauri/src/shaping.rs
+++ b/src-tauri/src/shaping.rs
@@ -187,6 +187,18 @@ fn is_text_representable(result: &Value) -> bool {
 /// A `budget` of 0 disables shaping. Lossless: the full body stays fetchable via
 /// [`fetch_result`].
 pub fn shape_result(result: &mut Value, budget: usize, owner: Option<&str>) -> bool {
+    shape_result_preserving_prefix(result, budget, owner, 0)
+}
+
+/// Shape a result while retaining at least `min_head_bytes` from the start of
+/// its text projection. If the protected prefix and marker cannot fit, leave the
+/// result whole instead of silently truncating recovery-critical data.
+pub fn shape_result_preserving_prefix(
+    result: &mut Value,
+    budget: usize,
+    owner: Option<&str>,
+    min_head_bytes: usize,
+) -> bool {
     if budget == 0 {
         return false;
     }
@@ -233,7 +245,10 @@ pub fn shape_result(result: &mut Value, budget: usize, owner: Option<&str>) -> b
     // floor won whenever `budget - reserve - preserved` fell below it. The final
     // fit-check below is what actually enforces the contract; this is only the
     // starting estimate.
-    let mut head_byte_limit = budget.saturating_sub(512 + preserved_bytes);
+    let min_head_bytes = min_head_bytes.min(body.len());
+    let mut head_byte_limit = budget
+        .saturating_sub(512 + preserved_bytes)
+        .max(min_head_bytes);
     let head = head_within_bytes(&body, head_byte_limit).to_string();
     let is_error = result
         .get("isError")
@@ -288,7 +303,9 @@ pub fn shape_result(result: &mut Value, budget: usize, owner: Option<&str>) -> b
             break;
         }
         let overage = shaped_size - budget;
-        head_byte_limit = head_byte_limit.saturating_sub(overage.max(1));
+        head_byte_limit = head_byte_limit
+            .saturating_sub(overage.max(1))
+            .max(min_head_bytes);
         head = head_within_bytes(&body, head_byte_limit).to_string();
         shaped = build(&head);
     }


### PR DESCRIPTION
 ## Summary

Adds `toolport.checkpoint(value)`, letting a code-mode script record its own resume state as it runs — distinct from the automatic, positional call ledger added in #646.

The ledger (`structuredContent.toolportScript.progress`) tells you *how far* a script got (`entries 0..n ran`), but not *what state it left behind*. That's only a safe basis for resuming when the retry takes identical branches. For scripts whose call sequence depends on data returned mid-run, position `n` on the second run isn't guaranteed to be the same call as position `n` on the first.

`checkpoint` fixes that by letting the script itself declare what "progress" means, in its own terms:

```js
for (const row of data.rows) {
  await servers.db.insert_row(row);
  toolport.checkpoint({ lastInsertedId: row.id });
}
```

## Design notes (per the issue)

- **Author-chosen value** — the script decides what's safe to surface, so this doesn't force call arguments (which can hold credentials/PII) into model-facing context the way an automatic ledger would.
- **No budget cost** — doesn't call `reserve_call_slot`, since it makes no downstream call. Doesn't count against `max_calls`.
- **Size-capped at 4096 bytes** — a script can't use checkpoint to smuggle a large payload out through the one path (the failure text) that isn't otherwise budget-gated. Oversized calls fail closed and leave the last good checkpoint untouched.
- **Last-write-wins** — no history is kept; a full log is more state than a resume needs.
- **Survives shaping** — rendered ahead of the ledger in the failure text, so head-first truncation (same behavior the ledger got in #661) can't eat it. Also surfaced structurally at `structuredContent.toolportScript.checkpoint`.
- **Discoverable** — `toolport_run_script`'s tool description now documents `toolport.checkpoint()`, so a calling model can find and use it without out-of-band docs.

## Tests

`codemode.rs`:
- last-write-wins across repeated calls
- checkpoint present on the error path
- checkpoint absent when the script never calls it
- checkpoint absent when the script never compiles
- oversized value is rejected without dropping the prior good checkpoint
- costs nothing against `max_calls`

`toolport-gateway.rs`:
- checkpoint survives head-first truncation in an oversized failure
- checkpoint surfaced in `structuredContent` on failure
- checkpoint absent (in both text and structured content) when unused

All 882 lib tests + 260 gateway tests + integration suites pass locally.

Closes #663.