### PR TITLE
Improve tray and update lifecycle (SBS-146)

### DIFF
--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -2835,22 +2835,36 @@ type PendingShare = Mutex<Option<String>>;
 
 /// Remembers an approvals tray request that arrived before the frontend listener.
 #[derive(Default)]
-struct PendingTrayApprovals(Mutex<bool>);
+struct PendingTrayApprovals(Mutex<TrayApprovalsDelivery>);
 
-fn mark_pending_tray_approvals(state: &PendingTrayApprovals) {
-    *state
+#[derive(Default)]
+struct TrayApprovalsDelivery {
+    frontend_ready: bool,
+    pending: bool,
+}
+
+/// Queue a request until the frontend is ready, or tell the caller it is safe
+/// to emit live. The decision and state change are atomic with the readiness claim.
+fn should_emit_tray_approvals(state: &PendingTrayApprovals) -> bool {
+    let mut delivery = state
         .0
         .lock()
-        .unwrap_or_else(std::sync::PoisonError::into_inner) = true;
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    if delivery.frontend_ready {
+        true
+    } else {
+        delivery.pending = true;
+        false
+    }
 }
 
 fn claim_pending_tray_approvals(state: &PendingTrayApprovals) -> bool {
-    std::mem::take(
-        &mut *state
-            .0
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner),
-    )
+    let mut delivery = state
+        .0
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    delivery.frontend_ready = true;
+    std::mem::take(&mut delivery.pending)
 }
 
 /// Parse a `toolport://import?s=<id>` (or legacy `conduit://…`) deep link into its
@@ -3612,11 +3626,13 @@ fn build_tray(app: &AppHandle) -> tauri::Result<()> {
         .on_menu_event(|app, event| match event.id.as_ref() {
             "tray_open" => show_main_window(app),
             "tray_approvals" => {
-                if let Some(state) = app.try_state::<PendingTrayApprovals>() {
-                    mark_pending_tray_approvals(state.inner());
-                }
+                let should_emit = app
+                    .try_state::<PendingTrayApprovals>()
+                    .is_none_or(|state| should_emit_tray_approvals(state.inner()));
                 show_main_window(app);
-                let _ = app.emit("tray-open-approvals", ());
+                if should_emit {
+                    let _ = app.emit("tray-open-approvals", ());
+                }
             }
             "tray_check_updates" => {
                 show_main_window(app);
@@ -4150,12 +4166,16 @@ mod tests {
     use registry::EnvVar;
 
     #[test]
-    fn pending_tray_approvals_request_is_claimed_once() {
+    fn tray_approvals_requests_choose_exactly_one_delivery_mode() {
         let pending = PendingTrayApprovals::default();
+
+        // Before the frontend claims readiness, queue without emitting.
+        assert!(!should_emit_tray_approvals(&pending));
+        assert!(claim_pending_tray_approvals(&pending));
         assert!(!claim_pending_tray_approvals(&pending));
 
-        mark_pending_tray_approvals(&pending);
-        assert!(claim_pending_tray_approvals(&pending));
+        // Once ready, deliver live without leaving a queued duplicate.
+        assert!(should_emit_tray_approvals(&pending));
         assert!(!claim_pending_tray_approvals(&pending));
     }
 

--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -35,6 +35,10 @@ use crate::vendors;
 
 type RegistryState = Mutex<Registry>;
 
+struct TrayMenuState {
+    pending_approvals: MenuItem<tauri::Wry>,
+}
+
 const OAUTH_LOCK_LEASE_SECS: u64 = 180;
 const OAUTH_LOCK_WAIT_SECS: u64 = 30;
 const OAUTH_LOCK_POLL_MS: u64 = 250;
@@ -2884,15 +2888,14 @@ fn take_pending_shared(state: State<PendingShare>) -> Option<String> {
 }
 
 /// Deliver a shared-stack id from a deep link to the UI: stash it so a cold start
-/// can claim it on mount, focus the window, and emit the live event for a running
-/// app. Idempotent enough that delivering the same id twice just re-opens it.
+/// can claim it on mount, reveal the window from every tray/minimized state, and
+/// emit the live event for a running app. Idempotent enough that delivering the
+/// same id twice just re-opens it.
 fn deliver_shared_import(handle: &tauri::AppHandle, id: String) {
     if let Some(st) = handle.try_state::<PendingShare>() {
         *st.lock().unwrap_or_else(std::sync::PoisonError::into_inner) = Some(id.clone());
     }
-    if let Some(w) = handle.get_webview_window("main") {
-        let _ = w.set_focus();
-    }
+    show_main_window(handle);
     let _ = handle.emit("import-shared", id);
 }
 
@@ -3504,6 +3507,11 @@ fn update_tray_tooltip(app: &AppHandle) {
         .try_state::<approval_broker::ApprovalBroker>()
         .map(|b| b.list().len())
         .unwrap_or(0);
+    if let Some(menu) = app.try_state::<TrayMenuState>() {
+        let _ = menu
+            .pending_approvals
+            .set_text(format!("Pending approvals ({pending})"));
+    }
     if let Some(tray) = app.tray_by_id("main") {
         let tip = if pending > 0 {
             format!(
@@ -3540,15 +3548,36 @@ fn maybe_show_tray_hint(app: &AppHandle) {
         .show();
 }
 
-/// Build the system-tray (Windows) / menu-bar (macOS) icon: left-click opens the app,
-/// right-click shows an Open/Quit menu. Quit fully exits (the run-loop's Exit handler
-/// tears down the HTTP bridge); closing the window only hides it (see the window-event
+/// Build the system-tray (Windows) / menu-bar (macOS) icon. The menu exposes the two
+/// background actions users need without hunting through a hidden window: pending
+/// approvals and update checks. Quit fully exits (the run-loop's Exit handler tears
+/// down the HTTP bridge); closing the window only hides it (see the window-event
 /// handler), so the gateway/broker keep running and HITL stays live.
 fn build_tray(app: &AppHandle) -> tauri::Result<()> {
     let open = MenuItem::with_id(app, "tray_open", "Open Toolport", true, None::<&str>)?;
+    let approvals = MenuItem::with_id(
+        app,
+        "tray_approvals",
+        "Pending approvals (0)",
+        true,
+        None::<&str>,
+    )?;
+    let check_updates = MenuItem::with_id(
+        app,
+        "tray_check_updates",
+        "Check for updates",
+        true,
+        None::<&str>,
+    )?;
     let sep = PredefinedMenuItem::separator(app)?;
     let quit = MenuItem::with_id(app, "tray_quit", "Quit Toolport", true, None::<&str>)?;
-    let menu = Menu::with_items(app, &[&open, &sep, &quit])?;
+    let menu = Menu::with_items(
+        app,
+        &[&open, &approvals, &check_updates, &sep, &quit],
+    )?;
+    app.manage(TrayMenuState {
+        pending_approvals: approvals,
+    });
 
     let mut builder = TrayIconBuilder::with_id("main")
         .tooltip("Toolport")
@@ -3556,6 +3585,14 @@ fn build_tray(app: &AppHandle) -> tauri::Result<()> {
         .show_menu_on_left_click(false)
         .on_menu_event(|app, event| match event.id.as_ref() {
             "tray_open" => show_main_window(app),
+            "tray_approvals" => {
+                show_main_window(app);
+                let _ = app.emit("tray-open-approvals", ());
+            }
+            "tray_check_updates" => {
+                show_main_window(app);
+                let _ = app.emit("tray-check-updates", ());
+            }
             "tray_quit" => app.exit(0),
             _ => {}
         })

--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -2833,6 +2833,26 @@ async fn share_stack(setup_json: String) -> Result<String, String> {
 /// that arrived before the UI was ready (cold start). The frontend claims it on mount.
 type PendingShare = Mutex<Option<String>>;
 
+/// Remembers an approvals tray request that arrived before the frontend listener.
+#[derive(Default)]
+struct PendingTrayApprovals(Mutex<bool>);
+
+fn mark_pending_tray_approvals(state: &PendingTrayApprovals) {
+    *state
+        .0
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner) = true;
+}
+
+fn claim_pending_tray_approvals(state: &PendingTrayApprovals) -> bool {
+    std::mem::take(
+        &mut *state
+            .0
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner),
+    )
+}
+
 /// Parse a `toolport://import?s=<id>` (or legacy `conduit://…`) deep link into its
 /// share id. Tolerates an optional trailing slash after the host; the id must look
 /// like a share id.
@@ -2885,6 +2905,12 @@ fn take_pending_shared(state: State<PendingShare>) -> Option<String> {
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner)
         .take()
+}
+
+/// Claim an approvals tray request captured before the UI was listening.
+#[tauri::command]
+fn take_pending_tray_approvals(state: State<PendingTrayApprovals>) -> bool {
+    claim_pending_tray_approvals(state.inner())
 }
 
 /// Deliver a shared-stack id from a deep link to the UI: stash it so a cold start
@@ -3586,6 +3612,9 @@ fn build_tray(app: &AppHandle) -> tauri::Result<()> {
         .on_menu_event(|app, event| match event.id.as_ref() {
             "tray_open" => show_main_window(app),
             "tray_approvals" => {
+                if let Some(state) = app.try_state::<PendingTrayApprovals>() {
+                    mark_pending_tray_approvals(state.inner());
+                }
                 show_main_window(app);
                 let _ = app.emit("tray-open-approvals", ());
             }
@@ -3726,6 +3755,7 @@ pub fn run() {
         .manage(Mutex::new(registry))
         .manage(Mutex::new(HttpBridge::default()))
         .manage(PendingShare::default())
+        .manage(PendingTrayApprovals::default())
         .manage(RestartAdvice::default())
         .invoke_handler(tauri::generate_handler![
             detect_clients,
@@ -3820,6 +3850,7 @@ pub fn run() {
             share_stack,
             fetch_shared_setup,
             take_pending_shared,
+            take_pending_tray_approvals,
             import_config,
             read_setup_file,
             preview_import,
@@ -4117,6 +4148,16 @@ mod tests {
     use super::*;
     use crate::{arg_looks_secret, redact_url_userinfo};
     use registry::EnvVar;
+
+    #[test]
+    fn pending_tray_approvals_request_is_claimed_once() {
+        let pending = PendingTrayApprovals::default();
+        assert!(!claim_pending_tray_approvals(&pending));
+
+        mark_pending_tray_approvals(&pending);
+        assert!(claim_pending_tray_approvals(&pending));
+        assert!(!claim_pending_tray_approvals(&pending));
+    }
 
     #[test]
     fn registry_startup_failure_is_blocking_and_preserves_the_real_path_and_error() {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -276,6 +276,20 @@ function App() {
     };
   }, []);
 
+  // The tray remains available while the window is hidden. Its approvals entry
+  // should reveal the app at the exact place where the waiting calls can be
+  // inspected, rather than merely opening whichever screen was last visible.
+  useEffect(() => {
+    const unlisten = listen("tray-open-approvals", () => {
+      setSelectedClientId(null);
+      setView("activity");
+      setActivityKey((key) => key + 1);
+    });
+    return () => {
+      void unlisten.then((remove) => remove());
+    };
+  }, []);
+
   // The backend signals an authoritative removal from a team (a 401/403 on the
   // membership heartbeat) so we can tell the member plainly rather than leaving them
   // to wonder why the team's servers vanished. The registry (team already cleared) is

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -99,6 +99,7 @@ import { Toaster } from "@/components/ui/sonner";
 import { useTheme } from "@/lib/theme";
 import { fmtTs } from "@/lib/utils";
 import { resolveShortcut, shortcutHelp } from "@/lib/shortcuts";
+import { subscribeToTrayApprovals } from "@/lib/trayApprovals";
 
 /** Above this many servers, "Disable all" asks for confirmation first. */
 const BULK_DISABLE_CONFIRM_MIN = 3;
@@ -280,13 +281,23 @@ function App() {
   // should reveal the app at the exact place where the waiting calls can be
   // inspected, rather than merely opening whichever screen was last visible.
   useEffect(() => {
-    const unlisten = listen("tray-open-approvals", () => {
+    let cancelled = false;
+    let unlisten: (() => void) | undefined;
+    const openApprovals = () => {
+      if (cancelled) return;
       setSelectedClientId(null);
       setView("activity");
       setActivityKey((key) => key + 1);
-    });
+    };
+    subscribeToTrayApprovals(openApprovals)
+      .then((remove) => {
+        if (cancelled) remove();
+        else unlisten = remove;
+      })
+      .catch(() => {});
     return () => {
-      void unlisten.then((remove) => remove());
+      cancelled = true;
+      unlisten?.();
     };
   }, []);
 

--- a/src/components/AppSidebar.test.tsx
+++ b/src/components/AppSidebar.test.tsx
@@ -1,5 +1,5 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
 
@@ -9,6 +9,9 @@ import { AppSidebar } from "./AppSidebar";
 
 const getSavingsSummary = vi.fn();
 const listQuarantined = vi.fn();
+const checkForUpdate = vi.fn();
+const installUpdate = vi.fn();
+const eventListeners = new Map<string, (event: { payload: unknown }) => void>();
 
 vi.mock("@/lib/api", () => ({
   gatherDiagnostics: vi.fn(),
@@ -21,9 +24,16 @@ vi.mock("@tauri-apps/api/app", () => ({
   getVersion: vi.fn().mockResolvedValue("1.0.0"),
 }));
 
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: vi.fn((event: string, handler: (event: { payload: unknown }) => void) => {
+    eventListeners.set(event, handler);
+    return Promise.resolve(() => eventListeners.delete(event));
+  }),
+}));
+
 vi.mock("@/lib/updater", () => ({
-  checkForUpdate: vi.fn().mockResolvedValue({ kind: "current" }),
-  installUpdate: vi.fn(),
+  checkForUpdate: (...args: unknown[]) => checkForUpdate(...args),
+  installUpdate: (...args: unknown[]) => installUpdate(...args),
 }));
 
 vi.mock("@/components/ShareDialog", () => ({
@@ -50,6 +60,10 @@ function client(overrides: Partial<DetectedClient> = {}): DetectedClient {
 beforeEach(() => {
   getSavingsSummary.mockReset();
   listQuarantined.mockReset();
+  checkForUpdate.mockReset();
+  installUpdate.mockReset();
+  eventListeners.clear();
+  checkForUpdate.mockResolvedValue({ kind: "current" });
   getSavingsSummary.mockResolvedValue({
     tokensSaved: 0,
     listLoads: 0,
@@ -57,6 +71,10 @@ beforeEach(() => {
     sinceTs: 0,
   });
   listQuarantined.mockResolvedValue([]);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
 });
 
 describe("AppSidebar accessibility", () => {
@@ -106,5 +124,106 @@ describe("AppSidebar accessibility", () => {
     await userEvent.click(toggle);
     expect(toggle).toHaveAttribute("aria-expanded", "true");
     expect(screen.getByRole("button", { name: /zed/i })).toBeInTheDocument();
+  });
+
+  it("rechecks updates when a stale tray-hidden window is shown", async () => {
+    let now = 1_000;
+    vi.spyOn(Date, "now").mockImplementation(() => now);
+
+    render(
+      <TooltipProvider>
+        <AppSidebar
+          clients={[client()]}
+          registry={null}
+          onRegistryChange={vi.fn()}
+          selectedClientId={null}
+          onSelectClient={vi.fn()}
+          view="servers"
+          onSelectView={vi.fn()}
+          onReplayOnboarding={vi.fn()}
+        />
+      </TooltipProvider>,
+    );
+
+    await waitFor(() => expect(checkForUpdate).toHaveBeenCalledTimes(1));
+    now += 24 * 60 * 60 * 1000;
+    act(() => {
+      eventListeners.get("team-window-visible")?.({ payload: true });
+    });
+    await waitFor(() => expect(checkForUpdate).toHaveBeenCalledTimes(2));
+  });
+
+  it("shows byte-based download progress while installing", async () => {
+    const update = { version: "1.1.0", body: "Release notes" };
+    checkForUpdate.mockResolvedValue({ kind: "update", update });
+    installUpdate.mockImplementation(
+      async (_update: unknown, onProgress: (progress: unknown) => void) => {
+        onProgress({
+          phase: "downloading",
+          downloadedBytes: 5,
+          totalBytes: 10,
+        });
+        await new Promise(() => {});
+      },
+    );
+
+    render(
+      <TooltipProvider>
+        <AppSidebar
+          clients={[client()]}
+          registry={null}
+          onRegistryChange={vi.fn()}
+          selectedClientId={null}
+          onSelectClient={vi.fn()}
+          view="servers"
+          onSelectView={vi.fn()}
+          onReplayOnboarding={vi.fn()}
+        />
+      </TooltipProvider>,
+    );
+
+    const updateButton = await screen.findByRole("button", { name: /update to v1.1.0/i });
+    await userEvent.click(updateButton);
+    await userEvent.click(screen.getByRole("button", { name: /install and restart/i }));
+
+    expect((await screen.findAllByText("Downloading 50%")).length).toBeGreaterThan(0);
+  });
+
+  it("turns an in-flight quiet check into an announced tray result", async () => {
+    const update = { version: "1.1.0", body: "Release notes" };
+    let resolveCheck!: (result: unknown) => void;
+    checkForUpdate.mockReturnValue(
+      new Promise((resolve) => {
+        resolveCheck = resolve;
+      }),
+    );
+
+    render(
+      <TooltipProvider>
+        <AppSidebar
+          clients={[client()]}
+          registry={null}
+          onRegistryChange={vi.fn()}
+          selectedClientId={null}
+          onSelectClient={vi.fn()}
+          view="servers"
+          onSelectView={vi.fn()}
+          onReplayOnboarding={vi.fn()}
+        />
+      </TooltipProvider>,
+    );
+
+    await waitFor(() => expect(checkForUpdate).toHaveBeenCalledTimes(1));
+    act(() => {
+      eventListeners.get("tray-check-updates")?.({ payload: undefined });
+    });
+    await act(async () => {
+      resolveCheck({ kind: "update", update });
+    });
+
+    expect(checkForUpdate).toHaveBeenCalledTimes(1);
+    expect(
+      await screen.findByRole("heading", { name: "Update available: v1.1.0" }),
+    ).toBeInTheDocument();
   });
 });

--- a/src/components/AppSidebar.test.tsx
+++ b/src/components/AppSidebar.test.tsx
@@ -11,7 +11,15 @@ const getSavingsSummary = vi.fn();
 const listQuarantined = vi.fn();
 const checkForUpdate = vi.fn();
 const installUpdate = vi.fn();
+const toastInfo = vi.fn();
 const eventListeners = new Map<string, (event: { payload: unknown }) => void>();
+
+vi.mock("sonner", () => ({
+  toast: {
+    info: (...args: unknown[]) => toastInfo(...args),
+    success: vi.fn(),
+  },
+}));
 
 vi.mock("@/lib/api", () => ({
   gatherDiagnostics: vi.fn(),
@@ -62,6 +70,7 @@ beforeEach(() => {
   listQuarantined.mockReset();
   checkForUpdate.mockReset();
   installUpdate.mockReset();
+  toastInfo.mockReset();
   eventListeners.clear();
   checkForUpdate.mockResolvedValue({ kind: "current" });
   getSavingsSummary.mockResolvedValue({
@@ -153,6 +162,33 @@ describe("AppSidebar accessibility", () => {
     await waitFor(() => expect(checkForUpdate).toHaveBeenCalledTimes(2));
   });
 
+  it("retries a quiet update check after a transient error", async () => {
+    checkForUpdate
+      .mockResolvedValueOnce({ kind: "error", message: "offline" })
+      .mockResolvedValueOnce({ kind: "current" });
+
+    render(
+      <TooltipProvider>
+        <AppSidebar
+          clients={[client()]}
+          registry={null}
+          onRegistryChange={vi.fn()}
+          selectedClientId={null}
+          onSelectClient={vi.fn()}
+          view="servers"
+          onSelectView={vi.fn()}
+          onReplayOnboarding={vi.fn()}
+        />
+      </TooltipProvider>,
+    );
+
+    await waitFor(() => expect(checkForUpdate).toHaveBeenCalledTimes(1));
+    act(() => {
+      eventListeners.get("team-window-visible")?.({ payload: true });
+    });
+    await waitFor(() => expect(checkForUpdate).toHaveBeenCalledTimes(2));
+  });
+
   it("shows byte-based download progress while installing", async () => {
     const update = { version: "1.1.0", body: "Release notes" };
     checkForUpdate.mockResolvedValue({ kind: "update", update });
@@ -225,5 +261,37 @@ describe("AppSidebar accessibility", () => {
     expect(
       await screen.findByRole("heading", { name: "Update available: v1.1.0" }),
     ).toBeInTheDocument();
+  });
+
+  it("acknowledges an explicit tray check while an update is installing", async () => {
+    const update = { version: "1.1.0", body: "Release notes" };
+    checkForUpdate.mockResolvedValue({ kind: "update", update });
+    installUpdate.mockReturnValue(new Promise(() => {}));
+
+    render(
+      <TooltipProvider>
+        <AppSidebar
+          clients={[client()]}
+          registry={null}
+          onRegistryChange={vi.fn()}
+          selectedClientId={null}
+          onSelectClient={vi.fn()}
+          view="servers"
+          onSelectView={vi.fn()}
+          onReplayOnboarding={vi.fn()}
+        />
+      </TooltipProvider>,
+    );
+
+    await userEvent.click(
+      await screen.findByRole("button", { name: /update to v1.1.0/i }),
+    );
+    await userEvent.click(screen.getByRole("button", { name: /install and restart/i }));
+    act(() => {
+      eventListeners.get("tray-check-updates")?.({ payload: undefined });
+    });
+
+    expect(toastInfo).toHaveBeenCalledWith("An update is already in progress");
+    expect(checkForUpdate).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -114,11 +114,14 @@ function VersionFooter({
       if (announce) announceCheckRef.current = true;
       return;
     }
+    if (installingRef.current) {
+      if (announce) toast.info("An update is already in progress");
+      return;
+    }
     if (
-      installingRef.current ||
-      (!force &&
-        lastCheckRef.current !== 0 &&
-        now - lastCheckRef.current < UPDATE_CHECK_INTERVAL_MS)
+      !force &&
+      lastCheckRef.current !== 0 &&
+      now - lastCheckRef.current < UPDATE_CHECK_INTERVAL_MS
     ) {
       return;
     }
@@ -126,7 +129,7 @@ function VersionFooter({
     if (mountedRef.current) setChecking(true);
     try {
       const result = await checkForUpdate();
-      lastCheckRef.current = Date.now();
+      if (result.kind !== "error") lastCheckRef.current = Date.now();
       if (!mountedRef.current) return;
       const shouldAnnounce = announce || announceCheckRef.current;
       announceCheckRef.current = false;

--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { listen } from "@tauri-apps/api/event";
 import {
   ArrowUpCircle,
   ChevronRight,
@@ -37,7 +38,7 @@ import {
   openDataDir,
 } from "@/lib/api";
 import { fmtTokens } from "@/lib/utils";
-import { checkForUpdate, installUpdate } from "@/lib/updater";
+import { checkForUpdate, installUpdate, type UpdateProgress } from "@/lib/updater";
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
@@ -48,6 +49,23 @@ const FOCUS_RING =
   "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring";
 const NAV_ITEM = `flex w-full items-center gap-2.5 rounded-md px-2.5 py-2 text-left text-sm transition-colors hover:bg-accent ${FOCUS_RING}`;
 const ICON_BTN = `rounded text-muted-foreground transition hover:text-foreground ${FOCUS_RING}`;
+const UPDATE_CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000;
+
+function updateProgressLabel(progress: UpdateProgress | null): string {
+  if (!progress) return "Preparing update…";
+  if (progress.phase === "installing") return "Installing…";
+  if (progress.totalBytes && progress.totalBytes > 0) {
+    const percent = Math.min(
+      100,
+      Math.round((progress.downloadedBytes / progress.totalBytes) * 100),
+    );
+    return `Downloading ${percent}%`;
+  }
+  const megabytes = progress.downloadedBytes / (1024 * 1024);
+  return megabytes > 0
+    ? `Downloading ${megabytes.toFixed(megabytes >= 10 ? 0 : 1)} MB…`
+    : "Downloading…";
+}
 
 /** Footer showing the running version, and an in-app update button when a newer
  * release is published. The check is best-effort: any failure (dev build,
@@ -63,60 +81,112 @@ function VersionFooter({
   const [version, setVersion] = useState("");
   const [update, setUpdate] = useState<Update | null>(null);
   const [installing, setInstalling] = useState(false);
+  const [installProgress, setInstallProgress] = useState<UpdateProgress | null>(null);
   const [checking, setChecking] = useState(false);
   const [showNotes, setShowNotes] = useState(false);
+  const mountedRef = useRef(false);
+  const checkingRef = useRef(false);
+  const announceCheckRef = useRef(false);
+  const installingRef = useRef(false);
+  const lastCheckRef = useRef(0);
 
   useEffect(() => {
-    let alive = true;
+    mountedRef.current = true;
     getVersion()
       .then((v) => {
-        if (alive) setVersion(v);
+        if (mountedRef.current) setVersion(v);
       })
       .catch(() => {
         // Never let a failed version lookup hide the whole footer toolbar.
-        if (alive) setVersion("?");
+        if (mountedRef.current) setVersion("?");
       });
-    checkForUpdate()
-      .then((r) => {
-        if (alive && r.kind === "update") setUpdate(r.update);
-      })
-      .catch(() => {});
     return () => {
-      alive = false;
+      mountedRef.current = false;
     };
   }, []);
 
-  async function manualCheck() {
-    if (checking || installing) return;
-    setChecking(true);
+  const runUpdateCheck = useCallback(async (announce: boolean, force = false) => {
+    const now = Date.now();
+    if (checkingRef.current) {
+      // A tray/manual request can arrive while the quiet startup/visibility check
+      // is already in flight. Upgrade that request to an announced result instead
+      // of dropping the user's explicit action or starting a duplicate request.
+      if (announce) announceCheckRef.current = true;
+      return;
+    }
+    if (
+      installingRef.current ||
+      (!force &&
+        lastCheckRef.current !== 0 &&
+        now - lastCheckRef.current < UPDATE_CHECK_INTERVAL_MS)
+    ) {
+      return;
+    }
+    checkingRef.current = true;
+    if (mountedRef.current) setChecking(true);
     try {
-      const r = await checkForUpdate();
-      if (r.kind === "update") {
-        setUpdate(r.update);
-        setShowNotes(true);
-      } else if (r.kind === "current") {
-        toast.success("You're on the latest version");
-      } else {
+      const result = await checkForUpdate();
+      lastCheckRef.current = Date.now();
+      if (!mountedRef.current) return;
+      const shouldAnnounce = announce || announceCheckRef.current;
+      announceCheckRef.current = false;
+      if (result.kind === "update") {
+        setUpdate(result.update);
+        if (shouldAnnounce) setShowNotes(true);
+      } else if (result.kind === "current") {
+        setUpdate(null);
+        if (shouldAnnounce) toast.success("You're on the latest version");
+      } else if (shouldAnnounce) {
         toastError("Couldn't check for updates", {
           description: "You may be offline. Try again in a moment.",
         });
       }
     } finally {
-      setChecking(false);
+      checkingRef.current = false;
+      if (mountedRef.current) setChecking(false);
     }
+  }, []);
+
+  useEffect(() => {
+    void runUpdateCheck(false);
+    const interval = window.setInterval(
+      () => void runUpdateCheck(false),
+      UPDATE_CHECK_INTERVAL_MS,
+    );
+    const visibleUnlisten = listen<boolean>("team-window-visible", (event) => {
+      if (event.payload) void runUpdateCheck(false);
+    });
+    const trayUnlisten = listen("tray-check-updates", () => {
+      void runUpdateCheck(true, true);
+    });
+    return () => {
+      window.clearInterval(interval);
+      void visibleUnlisten.then((unlisten) => unlisten());
+      void trayUnlisten.then((unlisten) => unlisten());
+    };
+  }, [runUpdateCheck]);
+
+  async function manualCheck() {
+    await runUpdateCheck(true, true);
   }
 
   async function applyUpdate() {
     if (!update) return;
+    installingRef.current = true;
     setInstalling(true);
+    setInstallProgress(null);
     toast.info(`Updating to v${update.version}…`, {
       description:
-        "Stopping gateway processes so the installer can replace files. MCP clients may disconnect briefly; your editors can stay open.",
+        "Downloading first; MCP clients stay connected until the installer is ready to replace files.",
     });
     try {
-      await installUpdate(update);
+      await installUpdate(update, (progress) => {
+        if (mountedRef.current) setInstallProgress(progress);
+      });
     } catch (e) {
+      installingRef.current = false;
       setInstalling(false);
+      setInstallProgress(null);
       toastError(`Update failed: ${e}`, {
         description: "You can download it manually from the releases page.",
         action: {
@@ -127,6 +197,8 @@ function VersionFooter({
       });
     }
   }
+
+  const progressLabel = updateProgressLabel(installProgress);
 
   if (!version) return null;
   return (
@@ -143,7 +215,7 @@ function VersionFooter({
             <ArrowUpCircle className="size-3.5 shrink-0" />
           )}
           <span className="truncate">
-            {installing ? "Updating…" : `Update to v${update.version}`}
+            {installing ? progressLabel : `Update to v${update.version}`}
           </span>
         </button>
       ) : (
@@ -162,6 +234,7 @@ function VersionFooter({
         onOpenChange={setShowNotes}
         update={update}
         installing={installing}
+        progressLabel={progressLabel}
         onInstall={applyUpdate}
       />
       <div className="flex shrink-0 items-center gap-2">
@@ -220,12 +293,14 @@ function UpdateNotes({
   onOpenChange,
   update,
   installing,
+  progressLabel,
   onInstall,
 }: {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   update: Update | null;
   installing: boolean;
+  progressLabel: string;
   onInstall: () => void;
 }) {
   if (!update) return null;
@@ -252,7 +327,7 @@ function UpdateNotes({
             <Button onClick={onInstall} disabled={installing}>
               {installing ? (
                 <>
-                  <Loader2 className="size-4 animate-spin" /> Installing…
+                  <Loader2 className="size-4 animate-spin" /> {progressLabel}
                 </>
               ) : (
                 <>

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -700,6 +700,11 @@ export function takePendingShared(): Promise<string | null> {
   return invoke<string | null>("take_pending_shared");
 }
 
+/** Claim a tray approvals request captured before the frontend was listening. */
+export function takePendingTrayApprovals(): Promise<boolean> {
+  return invoke<boolean>("take_pending_tray_approvals");
+}
+
 /** Import a shared setup, adding servers not already present. */
 export function importConfig(json: string): Promise<Registry> {
   return invoke<Registry>("import_config", { json });

--- a/src/lib/trayApprovals.test.ts
+++ b/src/lib/trayApprovals.test.ts
@@ -37,4 +37,19 @@ describe("tray approvals navigation", () => {
     );
     expect(openApprovals).toHaveBeenCalledTimes(1);
   });
+
+  it("opens once when a ready frontend receives the live event", async () => {
+    let handler!: () => void;
+    mocks.listen.mockImplementation(async (_event: string, callback: () => void) => {
+      handler = callback;
+      return vi.fn();
+    });
+    const openApprovals = vi.fn();
+
+    await subscribeToTrayApprovals(openApprovals);
+    handler();
+
+    expect(mocks.takePendingTrayApprovals).toHaveBeenCalledTimes(1);
+    expect(openApprovals).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/lib/trayApprovals.test.ts
+++ b/src/lib/trayApprovals.test.ts
@@ -1,0 +1,40 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  listen: vi.fn(),
+  takePendingTrayApprovals: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: (...args: unknown[]) => mocks.listen(...args),
+}));
+vi.mock("@/lib/api", () => ({
+  takePendingTrayApprovals: (...args: unknown[]) =>
+    mocks.takePendingTrayApprovals(...args),
+}));
+
+import { subscribeToTrayApprovals } from "./trayApprovals";
+
+describe("tray approvals navigation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.listen.mockResolvedValue(vi.fn());
+    mocks.takePendingTrayApprovals.mockResolvedValue(false);
+  });
+
+  it("replays an approvals request captured before the frontend mounted", async () => {
+    mocks.takePendingTrayApprovals.mockResolvedValue(true);
+    const openApprovals = vi.fn();
+
+    await subscribeToTrayApprovals(openApprovals);
+
+    expect(mocks.listen).toHaveBeenCalledWith(
+      "tray-open-approvals",
+      expect.any(Function),
+    );
+    expect(mocks.listen.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.takePendingTrayApprovals.mock.invocationCallOrder[0],
+    );
+    expect(openApprovals).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/lib/trayApprovals.ts
+++ b/src/lib/trayApprovals.ts
@@ -1,0 +1,25 @@
+import { listen, type UnlistenFn } from "@tauri-apps/api/event";
+import { takePendingTrayApprovals } from "@/lib/api";
+
+/**
+ * Subscribe before claiming the persisted request so a tray click cannot fall
+ * into the gap between checking backend state and installing the live listener.
+ */
+export async function subscribeToTrayApprovals(
+  openApprovals: () => void,
+): Promise<UnlistenFn> {
+  let handledLiveRequest = false;
+  const unlisten = await listen("tray-open-approvals", () => {
+    handledLiveRequest = true;
+    openApprovals();
+  });
+
+  try {
+    const pending = await takePendingTrayApprovals();
+    if (pending && !handledLiveRequest) openApprovals();
+  } catch {
+    // A live listener still works against an older backend without the command.
+  }
+
+  return unlisten;
+}

--- a/src/lib/updater.test.ts
+++ b/src/lib/updater.test.ts
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Update } from "@tauri-apps/plugin-updater";
+
+const invoke = vi.fn();
+const relaunch = vi.fn();
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: (...args: unknown[]) => invoke(...args),
+}));
+vi.mock("@tauri-apps/plugin-updater", () => ({ check: vi.fn() }));
+vi.mock("@tauri-apps/plugin-process", () => ({
+  relaunch: (...args: unknown[]) => relaunch(...args),
+}));
+
+import { installUpdate, type UpdateProgress } from "./updater";
+
+beforeEach(() => {
+  invoke.mockReset().mockResolvedValue(1);
+  relaunch.mockReset().mockResolvedValue(undefined);
+});
+
+describe("installUpdate", () => {
+  it("downloads with progress before disconnecting gateways and installing", async () => {
+    const calls: string[] = [];
+    const download = vi.fn(async (onEvent: (event: unknown) => void) => {
+      calls.push("download");
+      onEvent({ event: "Started", data: { contentLength: 10 } });
+      onEvent({ event: "Progress", data: { chunkLength: 4 } });
+      onEvent({ event: "Progress", data: { chunkLength: 6 } });
+      onEvent({ event: "Finished" });
+    });
+    const install = vi.fn(async () => {
+      calls.push("install");
+    });
+    invoke.mockImplementation(async () => {
+      calls.push("stop");
+      return 1;
+    });
+    relaunch.mockImplementation(async () => {
+      calls.push("relaunch");
+    });
+    const progress: UpdateProgress[] = [];
+
+    await installUpdate({ download, install } as unknown as Update, (event) => {
+      progress.push(event);
+    });
+
+    expect(calls).toEqual(["download", "stop", "install", "relaunch"]);
+    expect(progress).toEqual([
+      { phase: "downloading", downloadedBytes: 0, totalBytes: 10 },
+      { phase: "downloading", downloadedBytes: 4, totalBytes: 10 },
+      { phase: "downloading", downloadedBytes: 10, totalBytes: 10 },
+      { phase: "installing" },
+    ]);
+    expect(invoke).toHaveBeenCalledWith("stop_spawned_gateways");
+  });
+});

--- a/src/lib/updater.ts
+++ b/src/lib/updater.ts
@@ -1,5 +1,5 @@
 import { invoke } from "@tauri-apps/api/core";
-import { check, type Update } from "@tauri-apps/plugin-updater";
+import { check, type DownloadEvent, type Update } from "@tauri-apps/plugin-updater";
 import { relaunch } from "@tauri-apps/plugin-process";
 
 /** Outcome of an update check. `error` is distinct from `current` so the UI can
@@ -8,6 +8,10 @@ export type UpdateCheck =
   | { kind: "update"; update: Update }
   | { kind: "current" }
   | { kind: "error"; message: string };
+
+export type UpdateProgress =
+  | { phase: "downloading"; downloadedBytes: number; totalBytes?: number }
+  | { phase: "installing" };
 
 /** Check for a newer release via the Tauri updater. Never throws; failures
  * (dev build, offline, or no manifest published yet) come back as `error`. */
@@ -20,9 +24,28 @@ export async function checkForUpdate(): Promise<UpdateCheck> {
   }
 }
 
-/** Download + install the update, then relaunch into the new version. */
-export async function installUpdate(update: Update): Promise<void> {
+/** Download + install the update, reporting real byte progress before relaunch. */
+export async function installUpdate(
+  update: Update,
+  onProgress?: (progress: UpdateProgress) => void,
+): Promise<void> {
+  let downloadedBytes = 0;
+  let totalBytes: number | undefined;
+  const report = (event: DownloadEvent) => {
+    if (event.event === "Started") {
+      downloadedBytes = 0;
+      totalBytes = event.data.contentLength;
+      onProgress?.({ phase: "downloading", downloadedBytes, totalBytes });
+    } else if (event.event === "Progress") {
+      downloadedBytes += event.data.chunkLength;
+      onProgress?.({ phase: "downloading", downloadedBytes, totalBytes });
+    }
+  };
+  // Keep MCP clients connected during the potentially slow download. Only stop
+  // gateways once the package is local and the installer is ready to replace files.
+  await update.download(report);
+  onProgress?.({ phase: "installing" });
   await invoke<number>("stop_spawned_gateways");
-  await update.downloadAndInstall();
+  await update.install();
   await relaunch();
 }


### PR DESCRIPTION
## Summary

- reveal and focus the main window when a shared-setup deep link arrives from the tray
- add tray actions for pending approvals and update checks, including a live approval count
- recheck updates daily and when a stale hidden window is shown
- show real download progress and keep MCP gateways connected until installation begins
- add focused coverage for update ordering, progress, stale-window checks, and tray/manual check races

## Validation

- `npm test` (249 tests passed)
- `npm run build`
- `npm run lint` (0 errors; existing warnings only)
- `cargo check --manifest-path src-tauri/Cargo.toml`
- `git diff --check`

Linear: https://linear.app/southboundsoftware/issue/SBS-146/tray-resident-lifecycle-show-hidden-window-on-deep-link-update