### PR TITLE
Stop stale gateway/catalog state from silently becoming permanent

### DIFF
--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -3132,6 +3132,80 @@ fn server_of_tool(name: &str) -> &str {
     name.split_once("__").map(|(s, _)| s).unwrap_or(name)
 }
 
+/// Count a flat aggregated catalog by owning server.
+fn tools_per_server(tools: &[Value]) -> HashMap<String, usize> {
+    let mut counts: HashMap<String, usize> = HashMap::new();
+    for tool in tools {
+        if let Some(name) = tool.get("name").and_then(Value::as_str) {
+            *counts.entry(server_of_tool(name).to_string()).or_default() += 1;
+        }
+    }
+    counts
+}
+
+/// Keep a server's previous catalog when a rebuild produced an implausibly
+/// smaller one for it.
+///
+/// A router rebuild replaces catalogs from *fresh connects*, which never consult
+/// [`conduit_lib::downstream::is_implausible_shrink`] - that guard only sits on
+/// the in-place refresh path. So a downstream that answers `tools/list`
+/// successfully but with a degraded subset (Atlassian returns 3 of its 40 tools
+/// when its token loses scope) gets that subset published to clients AND written
+/// to `tool-cache.json`, where every gateway that starts next inherits it. This
+/// is the rebuild-path half of the same policy.
+///
+/// Deliberately only guards servers that came back with at least one tool. A
+/// server that is absent, or returned nothing at all, is indistinguishable here
+/// from one the user just disabled - and resurrecting a disabled server's tools
+/// from cache would be a far worse failure than briefly under-reporting one.
+fn preserve_collapsed_servers(new_tools: Vec<Value>, previous: &[Value]) -> Vec<Value> {
+    if previous.is_empty() {
+        return new_tools;
+    }
+    let before = tools_per_server(previous);
+    let after = tools_per_server(&new_tools);
+    let collapsed: Vec<String> = after
+        .iter()
+        .filter(|(server, &now)| {
+            now > 0
+                && before
+                    .get(*server)
+                    .is_some_and(|&was| conduit_lib::downstream::is_implausible_shrink(was, now))
+        })
+        .map(|(server, _)| server.clone())
+        .collect();
+    if collapsed.is_empty() {
+        return new_tools;
+    }
+    let mut guarded: Vec<Value> = new_tools
+        .into_iter()
+        .filter(|tool| {
+            tool.get("name")
+                .and_then(Value::as_str)
+                .is_none_or(|name| !collapsed.iter().any(|s| s == server_of_tool(name)))
+        })
+        .collect();
+    for server in &collapsed {
+        glog(&format!(
+            "toolport: server '{}' rebuilt with {} tool(s) but was {}; keeping the previous catalog for it",
+            server,
+            after.get(server).copied().unwrap_or(0),
+            before.get(server).copied().unwrap_or(0),
+        ));
+        guarded.extend(
+            previous
+                .iter()
+                .filter(|tool| {
+                    tool.get("name")
+                        .and_then(Value::as_str)
+                        .is_some_and(|name| server_of_tool(name) == server.as_str())
+                })
+                .cloned(),
+        );
+    }
+    guarded
+}
+
 /// Whether the exposed tool `name` is destructive, for the HITL / confirm gate. Resolves
 /// from the cached catalog first, then the LIVE router if the cache doesn't list it (a
 /// cold or stale cache, or a tool whose `destructiveHint` was just added by drift). If
@@ -7731,7 +7805,14 @@ fn persist_and_emit_with_sessions(
 ) {
     if !tools.is_empty() {
         let started = Instant::now();
-        let next = Arc::new(CatalogSnapshot::new(tools.to_vec()));
+        let tools = {
+            let current = cached_tools
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .clone();
+            preserve_collapsed_servers(tools.to_vec(), &current.tools)
+        };
+        let next = Arc::new(CatalogSnapshot::new(tools.clone()));
         let index_bytes = next.search.estimated_auxiliary_bytes();
         *cached_tools
             .lock()
@@ -7742,33 +7823,20 @@ fn persist_and_emit_with_sessions(
             index_bytes.div_ceil(1024),
             started.elapsed().as_secs_f64() * 1000.0
         ));
-        save_tool_cache(tools, profile);
+        save_tool_cache(&tools, profile);
     }
     notify_tools_changed(stdout, mcp_sessions);
 }
 
-/// Keep the always-on gateway log bounded; trimmed to roughly the back half once
-/// it grows past this, so a long-running client can't let it grow without limit.
-const GATEWAY_LOG_CAP: u64 = 256 * 1024;
-
 /// Append a line to the always-on gateway log (connection lifecycle: starts,
 /// connect successes and failures). This is what `gather_diagnostics` bundles
 /// into a bug report, so it stays on regardless of `CONDUIT_DEBUG`.
+///
+/// The implementation lives in the library so `downstream` can reach the same
+/// file: a truncated catalog is only visible there, and stderr does not survive
+/// an MCP client.
 fn glog(msg: &str) {
-    let Some(path) = registry::gateway_log_path() else {
-        return;
-    };
-    if let Some(parent) = path.parent() {
-        let _ = std::fs::create_dir_all(parent);
-    }
-    if let Ok(mut f) = std::fs::OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(&path)
-    {
-        let _ = f.write_all(format!("{msg}\n").as_bytes());
-    }
-    trim_log_if_large(&path);
+    conduit_lib::gatewaylog::append(msg);
 }
 
 /// Per-request trace, gated behind `TOOLPORT_DEBUG` / `CONDUIT_DEBUG` so the
@@ -7778,28 +7846,6 @@ fn gtrace(msg: &str) {
     if conduit_lib::brand::env_var_os("TOOLPORT_DEBUG", "CONDUIT_DEBUG").is_some() {
         glog(msg);
     }
-}
-
-/// Trim the log to its back half (on a line boundary) once it exceeds the cap.
-/// Best-effort: a read/rewrite race between concurrent gateways at worst drops a
-/// few diagnostic lines, which is fine for a log.
-fn trim_log_if_large(path: &Path) {
-    let over = std::fs::metadata(path)
-        .map(|m| m.len() > GATEWAY_LOG_CAP)
-        .unwrap_or(false);
-    if !over {
-        return;
-    }
-    let Ok(data) = std::fs::read(path) else {
-        return;
-    };
-    let keep_from = data.len().saturating_sub((GATEWAY_LOG_CAP / 2) as usize);
-    let start = data[keep_from..]
-        .iter()
-        .position(|&b| b == b'\n')
-        .map(|i| keep_from + i + 1)
-        .unwrap_or(keep_from);
-    let _ = std::fs::write(path, &data[start..]);
 }
 
 /// Cache file for a given profile. Scoped clients get their own file
@@ -9998,6 +10044,16 @@ fn process_request(
                     .router
                     .lock()
                     .unwrap_or_else(std::sync::PoisonError::into_inner) = Arc::new(built);
+                let tools = if tools.is_empty() {
+                    tools
+                } else {
+                    let current = state
+                        .cached_tools
+                        .lock()
+                        .unwrap_or_else(std::sync::PoisonError::into_inner)
+                        .clone();
+                    preserve_collapsed_servers(tools, &current.tools)
+                };
                 if !tools.is_empty() {
                     *state
                         .cached_tools
@@ -12648,6 +12704,16 @@ fn main() {
             // every downstream momentarily unreachable) clobber a good catalog -
             // that's what leaves a client showing only toolport_status.
             if !tools.is_empty() {
+                // The disk cache loaded at startup is the baseline here, so a cold
+                // start that reaches a degraded downstream cannot overwrite a
+                // known-good catalog with its subset.
+                let tools = {
+                    let current = cached_tools
+                        .lock()
+                        .unwrap_or_else(std::sync::PoisonError::into_inner)
+                        .clone();
+                    preserve_collapsed_servers(tools, &current.tools)
+                };
                 *cached_tools
                     .lock()
                     .unwrap_or_else(std::sync::PoisonError::into_inner) =
@@ -16428,6 +16494,54 @@ mod tests {
         assert_eq!(server_of_tool("resend__send_email"), "resend");
         // A meta-tool has no namespace; the whole name is returned.
         assert_eq!(server_of_tool("toolport_status"), "toolport_status");
+    }
+
+    #[test]
+    fn a_rebuild_keeps_the_previous_catalog_for_a_collapsed_server() {
+        // A router rebuild replaces catalogs from fresh connects, so the in-place
+        // refresh guard never sees it. Without this, a degraded Atlassian answer
+        // lands in tool-cache.json and every gateway started afterwards inherits it.
+        let previous: Vec<Value> = (0..40)
+            .map(|i| json!({"name": format!("atlassian__t{i}")}))
+            .chain((0..5).map(|i| json!({"name": format!("github__g{i}")})))
+            .collect();
+        let rebuilt: Vec<Value> = (0..3)
+            .map(|i| json!({"name": format!("atlassian__t{i}")}))
+            .chain((0..5).map(|i| json!({"name": format!("github__g{i}")})))
+            .collect();
+
+        let guarded = preserve_collapsed_servers(rebuilt, &previous);
+        let counts = tools_per_server(&guarded);
+        assert_eq!(counts.get("atlassian").copied(), Some(40), "collapse held");
+        assert_eq!(counts.get("github").copied(), Some(5), "healthy untouched");
+    }
+
+    #[test]
+    fn a_rebuild_does_not_resurrect_a_server_that_returned_nothing() {
+        // Absent or empty is indistinguishable from "the user disabled it", and
+        // reviving a disabled server's tools from cache is worse than
+        // under-reporting one.
+        let previous: Vec<Value> = (0..40)
+            .map(|i| json!({"name": format!("atlassian__t{i}")}))
+            .collect();
+        let rebuilt = vec![json!({"name": "github__g0"})];
+
+        let guarded = preserve_collapsed_servers(rebuilt, &previous);
+        let counts = tools_per_server(&guarded);
+        assert_eq!(counts.get("atlassian").copied(), None, "stayed removed");
+        assert_eq!(counts.get("github").copied(), Some(1));
+    }
+
+    #[test]
+    fn a_rebuild_that_grows_or_holds_steady_is_passed_through() {
+        let previous: Vec<Value> = (0..10)
+            .map(|i| json!({"name": format!("linear__t{i}")}))
+            .collect();
+        let rebuilt: Vec<Value> = (0..12)
+            .map(|i| json!({"name": format!("linear__t{i}")}))
+            .collect();
+        let guarded = preserve_collapsed_servers(rebuilt, &previous);
+        assert_eq!(tools_per_server(&guarded).get("linear").copied(), Some(12));
     }
 
     #[test]
@@ -22400,6 +22514,7 @@ mod tests {
     fn trim_log_bounds_size_and_keeps_a_line_boundary() {
         // A file past the cap is trimmed to its back half, starting at a clean
         // line boundary, and the most recent line survives.
+        use conduit_lib::gatewaylog::{trim_log_if_large, GATEWAY_LOG_CAP};
         let path = std::env::temp_dir().join("conduit-trim-test.log");
         let filler = "x".repeat(GATEWAY_LOG_CAP as usize + 8192);
         std::fs::write(&path, format!("OLDEST\n{filler}\nNEWEST\n")).unwrap();

--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -3158,22 +3158,60 @@ fn tools_per_server(tools: &[Value]) -> HashMap<String, usize> {
 /// server that is absent, or returned nothing at all, is indistinguishable here
 /// from one the user just disabled - and resurrecting a disabled server's tools
 /// from cache would be a far worse failure than briefly under-reporting one.
-fn preserve_collapsed_servers(new_tools: Vec<Value>, previous: &[Value]) -> Vec<Value> {
+/// Consecutive guarded rebuilds per server, so the rebuild path can confirm-then-accept
+/// exactly as [`conduit_lib::downstream::apply_catalog_refresh`] does on the refresh path.
+///
+/// Process-global because the three rebuild call sites do not share a struct, and a
+/// gateway process serves one client. Tests drive the pure function with their own map.
+static REBUILD_SHRINK_STREAKS: std::sync::LazyLock<Mutex<HashMap<String, u8>>> =
+    std::sync::LazyLock::new(|| Mutex::new(HashMap::new()));
+
+/// [`preserve_collapsed_servers`] against the process-global streak map.
+fn preserve_collapsed_servers_guarded(new_tools: Vec<Value>, previous: &[Value]) -> Vec<Value> {
+    let mut streaks = REBUILD_SHRINK_STREAKS
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    preserve_collapsed_servers(new_tools, previous, &mut streaks)
+}
+
+fn preserve_collapsed_servers(
+    new_tools: Vec<Value>,
+    previous: &[Value],
+    streaks: &mut HashMap<String, u8>,
+) -> Vec<Value> {
     if previous.is_empty() {
         return new_tools;
     }
     let before = tools_per_server(previous);
     let after = tools_per_server(&new_tools);
-    let collapsed: Vec<String> = after
-        .iter()
-        .filter(|(server, &now)| {
-            now > 0
-                && before
-                    .get(*server)
-                    .is_some_and(|&was| conduit_lib::downstream::is_implausible_shrink(was, now))
-        })
-        .map(|(server, _)| server.clone())
-        .collect();
+    // Confirm-then-accept, mirroring the refresh path. Holding a collapse forever
+    // would pin a server whose catalog genuinely shrank (revoked scopes, an admin
+    // pruning tools) to a stale catalog with no way back, which is the failure the
+    // refresh guard's streak exists to avoid - the rebuild guard must not disagree.
+    let mut collapsed: Vec<String> = Vec::new();
+    for (server, &now) in &after {
+        let Some(&was) = before.get(server) else {
+            continue;
+        };
+        if now == 0 || !conduit_lib::downstream::is_implausible_shrink(was, now) {
+            streaks.remove(server);
+            continue;
+        }
+        let streak = streaks.entry(server.clone()).or_insert(0);
+        *streak = streak.saturating_add(1);
+        if *streak < conduit_lib::downstream::EMPTY_CATALOG_CONFIRMATIONS {
+            collapsed.push(server.clone());
+        } else {
+            glog(&format!(
+                "toolport: accepting rebuilt catalog collapse {was} -> {now} for server '{server}' after {} consecutive rebuilds",
+                conduit_lib::downstream::EMPTY_CATALOG_CONFIRMATIONS
+            ));
+            streaks.remove(server);
+        }
+    }
+    // A server that vanished from the rebuild is not evidence either way; drop its
+    // streak so a later genuine collapse starts counting from zero.
+    streaks.retain(|server, _| after.contains_key(server));
     if collapsed.is_empty() {
         return new_tools;
     }
@@ -3187,10 +3225,12 @@ fn preserve_collapsed_servers(new_tools: Vec<Value>, previous: &[Value]) -> Vec<
         .collect();
     for server in &collapsed {
         glog(&format!(
-            "toolport: server '{}' rebuilt with {} tool(s) but was {}; keeping the previous catalog for it",
+            "toolport: server '{}' rebuilt with {} tool(s) but was {}; keeping the previous catalog for it ({}/{})",
             server,
             after.get(server).copied().unwrap_or(0),
             before.get(server).copied().unwrap_or(0),
+            streaks.get(server).copied().unwrap_or(0),
+            conduit_lib::downstream::EMPTY_CATALOG_CONFIRMATIONS,
         ));
         guarded.extend(
             previous
@@ -7810,7 +7850,7 @@ fn persist_and_emit_with_sessions(
                 .lock()
                 .unwrap_or_else(std::sync::PoisonError::into_inner)
                 .clone();
-            preserve_collapsed_servers(tools.to_vec(), &current.tools)
+            preserve_collapsed_servers_guarded(tools.to_vec(), &current.tools)
         };
         let next = Arc::new(CatalogSnapshot::new(tools.clone()));
         let index_bytes = next.search.estimated_auxiliary_bytes();
@@ -10052,7 +10092,7 @@ fn process_request(
                         .lock()
                         .unwrap_or_else(std::sync::PoisonError::into_inner)
                         .clone();
-                    preserve_collapsed_servers(tools, &current.tools)
+                    preserve_collapsed_servers_guarded(tools, &current.tools)
                 };
                 if !tools.is_empty() {
                     *state
@@ -12712,7 +12752,7 @@ fn main() {
                         .lock()
                         .unwrap_or_else(std::sync::PoisonError::into_inner)
                         .clone();
-                    preserve_collapsed_servers(tools, &current.tools)
+                    preserve_collapsed_servers_guarded(tools, &current.tools)
                 };
                 *cached_tools
                     .lock()
@@ -16510,7 +16550,7 @@ mod tests {
             .chain((0..5).map(|i| json!({"name": format!("github__g{i}")})))
             .collect();
 
-        let guarded = preserve_collapsed_servers(rebuilt, &previous);
+        let guarded = preserve_collapsed_servers(rebuilt, &previous, &mut HashMap::new());
         let counts = tools_per_server(&guarded);
         assert_eq!(counts.get("atlassian").copied(), Some(40), "collapse held");
         assert_eq!(counts.get("github").copied(), Some(5), "healthy untouched");
@@ -16526,7 +16566,7 @@ mod tests {
             .collect();
         let rebuilt = vec![json!({"name": "github__g0"})];
 
-        let guarded = preserve_collapsed_servers(rebuilt, &previous);
+        let guarded = preserve_collapsed_servers(rebuilt, &previous, &mut HashMap::new());
         let counts = tools_per_server(&guarded);
         assert_eq!(counts.get("atlassian").copied(), None, "stayed removed");
         assert_eq!(counts.get("github").copied(), Some(1));
@@ -16540,8 +16580,57 @@ mod tests {
         let rebuilt: Vec<Value> = (0..12)
             .map(|i| json!({"name": format!("linear__t{i}")}))
             .collect();
-        let guarded = preserve_collapsed_servers(rebuilt, &previous);
+        let guarded = preserve_collapsed_servers(rebuilt, &previous, &mut HashMap::new());
         assert_eq!(tools_per_server(&guarded).get("linear").copied(), Some(12));
+    }
+
+    fn atlassian_catalog(n: usize) -> Vec<Value> {
+        (0..n)
+            .map(|i| json!({"name": format!("atlassian__t{i}")}))
+            .collect()
+    }
+
+    #[test]
+    fn a_confirmed_rebuild_collapse_is_accepted_on_the_second_pass() {
+        // The refresh path accepts a collapse after EMPTY_CATALOG_CONFIRMATIONS
+        // agreeing refreshes. The rebuild path must not disagree: holding forever
+        // pins a genuinely downsized server (revoked scopes, an admin pruning
+        // tools) to a stale catalog with no way back.
+        let previous = atlassian_catalog(40);
+        let rebuilt = atlassian_catalog(3);
+        let mut streaks = HashMap::new();
+
+        let first = preserve_collapsed_servers(rebuilt.clone(), &previous, &mut streaks);
+        assert_eq!(
+            tools_per_server(&first).get("atlassian").copied(),
+            Some(40),
+            "first collapse is held pending confirmation"
+        );
+        let second = preserve_collapsed_servers(rebuilt, &previous, &mut streaks);
+        assert_eq!(
+            tools_per_server(&second).get("atlassian").copied(),
+            Some(3),
+            "a second agreeing rebuild confirms the downsizing"
+        );
+    }
+
+    #[test]
+    fn a_recovered_rebuild_clears_the_collapse_streak() {
+        // A held collapse followed by a healthy rebuild must not leave the server one
+        // step from acceptance. Otherwise two unrelated blips, months apart, would
+        // combine into a "confirmation" and drop 37 tools on the strength of one.
+        let previous = atlassian_catalog(40);
+        let mut streaks = HashMap::new();
+
+        preserve_collapsed_servers(atlassian_catalog(3), &previous, &mut streaks);
+        preserve_collapsed_servers(atlassian_catalog(40), &previous, &mut streaks);
+        let after_recovery =
+            preserve_collapsed_servers(atlassian_catalog(3), &previous, &mut streaks);
+        assert_eq!(
+            tools_per_server(&after_recovery).get("atlassian").copied(),
+            Some(40),
+            "the recovery reset the streak, so this collapse is held again"
+        );
     }
 
     #[test]

--- a/src-tauri/src/clients.rs
+++ b/src-tauri/src/clients.rs
@@ -353,8 +353,47 @@ fn resolve_client_config_path(
     Some(path)
 }
 
+/// Claude Code relocates its whole config tree - `.claude.json` included - when
+/// `CLAUDE_CONFIG_DIR` is set, so the default `~/.claude.json` is not always the
+/// file it reads.
+///
+/// Resolving only the default is not a cosmetic miss: Toolport rewrites the
+/// gateway path in this file on every upgrade, so a relocated config keeps
+/// pinning whichever versioned binary was current when it was written. The
+/// client then respawns that obsolete gateway forever, and the "app is still
+/// launching an old gateway" reaper cannot win - it stops the process, and the
+/// config Toolport never updated starts it again.
+///
+/// Taken from Toolport's own environment, which covers a user who exports the
+/// variable. It does NOT cover a launcher that sets the variable only for the
+/// child process it spawns - Toolport cannot see that, and such a config stays
+/// stale. Kept split from the pure path table so tests stay env-free.
+fn claude_config_dir_override() -> Option<PathBuf> {
+    claude_config_dir_from(std::env::var_os("CLAUDE_CONFIG_DIR"))
+}
+
+/// The env-free half of [`claude_config_dir_override`], so the validation rules
+/// are testable without mutating process environment from a parallel test.
+fn claude_config_dir_from(raw: Option<std::ffi::OsString>) -> Option<PathBuf> {
+    let dir = PathBuf::from(raw?);
+    // An empty or relative value is a misconfiguration, not an instruction to
+    // write somewhere surprising: fall back to the documented default rather
+    // than resolving against whatever cwd Toolport happens to have.
+    dir.is_absolute().then_some(dir)
+}
+
+/// The `.claude.json` a Claude Code process reads, given its config dir.
+fn claude_code_config_path(config_dir: &std::path::Path) -> PathBuf {
+    config_dir.join(".claude.json")
+}
+
 fn client_config_path(client_id: &str) -> Option<PathBuf> {
     let home = home()?;
+    if client_id == "claude-code" {
+        if let Some(dir) = claude_config_dir_override() {
+            return Some(claude_code_config_path(&dir));
+        }
+    }
     #[cfg(all(unix, not(target_os = "macos")))]
     {
         return resolve_client_config_path_linux(client_id, &home);
@@ -4705,6 +4744,36 @@ mod tests {
     use super::*;
     use crate::registry::EnvVar;
 
+    #[test]
+    fn claude_code_config_follows_a_relocated_config_dir() {
+        // Claude Code moves `.claude.json` when CLAUDE_CONFIG_DIR is set. Resolving
+        // only `~/.claude.json` leaves the relocated copy pinned to whichever
+        // versioned gateway binary was current when it was last written, and the
+        // client then respawns that obsolete gateway indefinitely.
+        let relocated = if cfg!(windows) {
+            PathBuf::from(r"C:\Users\someone\.claude-work")
+        } else {
+            PathBuf::from("/home/someone/.claude-work")
+        };
+        assert_eq!(
+            claude_config_dir_from(Some(relocated.clone().into_os_string())),
+            Some(relocated.clone())
+        );
+        assert_eq!(
+            claude_code_config_path(&relocated),
+            relocated.join(".claude.json")
+        );
+    }
+
+    #[test]
+    fn an_unset_or_unusable_claude_config_dir_falls_back_to_the_default() {
+        assert_eq!(claude_config_dir_from(None), None);
+        assert_eq!(claude_config_dir_from(Some("".into())), None);
+        // Relative: resolving it would depend on Toolport's cwd, which has nothing
+        // to do with where the client reads its config.
+        assert_eq!(claude_config_dir_from(Some("relative/dir".into())), None);
+    }
+
     fn sample_gateway(profile: Option<&str>, client_id: &str) -> ServerEntry {
         let mut env = vec![EnvVar {
             key: crate::brand::CLIENT_ID.to_string(),
@@ -7999,6 +8068,12 @@ command = "npx"
         // kimi_code_path() honors KIMI_CODE_HOME; clear it so the wrapper matches
         // the static resolver used for the expected path.
         let _kimi_home = EnvRestore::set("KIMI_CODE_HOME", Path::new(""));
+        // This asserts the documented default table, so neutralize the Claude Code
+        // config-dir override the host may have exported (a Claude Code session
+        // running these tests has it set, which legitimately relocates
+        // `.claude.json`). The override itself is covered by
+        // `claude_code_config_follows_a_relocated_config_dir`.
+        let _claude_config_dir = EnvRestore::set("CLAUDE_CONFIG_DIR", Path::new(""));
         let home = home().expect("home dir should be available in tests");
         let platform = Platform::current();
         for client in defs() {

--- a/src-tauri/src/clients.rs
+++ b/src-tauri/src/clients.rs
@@ -2530,7 +2530,24 @@ pub fn detect_clients() -> Vec<DetectedClient> {
 /// still match without storing tokens on the registry (SOU-406/407).
 fn managed_matches_detected(server: &McpServer, rec: &ManagedEntry) -> bool {
     let cmd = server.command.as_deref().unwrap_or("");
-    if cmd != rec.command {
+    // A command that differs only by *which of our gateway binaries* it names is
+    // path drift, not a user taking the entry over.
+    //
+    // Requiring byte equality here made the ownership record a trap: anything that
+    // rewrote the path out from under it - a republish under a content-addressed
+    // filename, a data-dir move, a support fix applied by hand - silently
+    // reclassified the entry as Customized, and `repoint_stale_gateways` skips
+    // Customized entries. The client was then abandoned on whatever binary it
+    // happened to hold, permanently, and the only evidence was an eprintln the
+    // desktop app writes to a stderr nobody reads.
+    //
+    // Issue #487 is preserved exactly: an entry repointed at npx / docker / a
+    // wrapper script fails `command_is_gateway_binary` and is still Customized.
+    // Only the "still ours, different path" case is forgiven, and args/env/url
+    // below stay byte-strict so a genuine customization anywhere else still counts.
+    if cmd != rec.command
+        && !(command_is_gateway_binary(cmd) && command_is_gateway_binary(&rec.command))
+    {
         return false;
     }
     let server_args = crate::registry::strip_auth_header_args(&server.args);
@@ -2627,6 +2644,14 @@ pub struct RepointOutcome {
     pub repointed: Vec<(String, ManagedEntry)>,
     /// Client ids left alone because their entry is user-customized.
     pub customized: Vec<String>,
+    /// Clients that needed a re-point and could not be written, with the reason.
+    ///
+    /// Previously an `install_gateway` error here was dropped on the floor by an
+    /// `if let Ok(..)`, which made a client that failed to migrate look exactly
+    /// like one that never needed to - no log line, no retry, no surface in the
+    /// UI. Six clients on this developer's machine sat on a superseded gateway
+    /// for days with nothing anywhere recording why.
+    pub failed: Vec<(String, String)>,
 }
 
 fn find_def(client_id: &str) -> Option<ClientDef> {
@@ -4730,13 +4755,67 @@ pub fn repoint_stale_gateways(managed: &HashMap<String, ManagedEntry>) -> Repoin
             .as_deref()
             .and_then(profile_from_config_text)
             .or_else(|| read_gateway_profile(&client.id));
-        if let Ok(write) = install_gateway(&client.id, profile.as_deref()) {
-            if let Some(m) = write.managed {
-                outcome.repointed.push((client.id.clone(), m));
+        match install_gateway(&client.id, profile.as_deref()) {
+            Ok(write) => match write.managed {
+                Some(m) => outcome.repointed.push((client.id.clone(), m)),
+                // Written, but no ownership snapshot came back, so the registry
+                // would keep the superseded command and read this entry as
+                // Customized on the next pass - i.e. we would stop maintaining a
+                // client we just rewrote. Worth recording rather than assuming.
+                None => outcome.failed.push((
+                    client.id.clone(),
+                    "config was written but returned no ownership record".to_string(),
+                )),
+            },
+            Err(error) => {
+                let msg = format!(
+                    "toolport: could not re-point {}'s gateway entry from {} to {}: {error}",
+                    client.id,
+                    if stored.is_empty() { "none" } else { stored },
+                    current,
+                );
+                eprintln!("{msg}");
+                crate::gatewaylog::append(&msg);
+                outcome.failed.push((client.id.clone(), error.to_string()));
             }
         }
     }
+    log_repoint_outcome(&current, &outcome);
     outcome
+}
+
+/// Record a re-point pass in the gateway log.
+///
+/// This runs in the desktop app, whose stderr no one ever sees, so until now a
+/// re-point left no durable trace at all: a pass that migrated every client and a
+/// pass that silently skipped six of them produced identical evidence. The log is
+/// what `gather_diagnostics` bundles, so a stale-gateway report can be answered
+/// from it instead of reconstructed from file mtimes.
+fn log_repoint_outcome(current: &str, outcome: &RepointOutcome) {
+    if outcome.repointed.is_empty() && outcome.customized.is_empty() && outcome.failed.is_empty() {
+        return;
+    }
+    let ids = |pairs: &[(String, ManagedEntry)]| {
+        pairs
+            .iter()
+            .map(|(id, _)| id.clone())
+            .collect::<Vec<_>>()
+            .join(", ")
+    };
+    crate::gatewaylog::append(&format!(
+        "toolport: re-point pass against {current}: {} re-pointed [{}], {} customized [{}], {} failed [{}]",
+        outcome.repointed.len(),
+        ids(&outcome.repointed),
+        outcome.customized.len(),
+        outcome.customized.join(", "),
+        outcome.failed.len(),
+        outcome
+            .failed
+            .iter()
+            .map(|(id, why)| format!("{id}: {why}"))
+            .collect::<Vec<_>>()
+            .join("; "),
+    ));
 }
 
 #[cfg(test)]
@@ -6024,6 +6103,82 @@ bad = "not-a-table"
                 Some(&rec)
             ),
             GatewayEntryState::Absent
+        );
+    }
+
+    fn managed_record(command: &str) -> ManagedEntry {
+        ManagedEntry {
+            command: command.to_string(),
+            args: Vec::new(),
+            env: std::collections::BTreeMap::new(),
+            transport: "stdio".to_string(),
+            url: None,
+            updated_at: 0,
+        }
+    }
+
+    fn detected_server(command: &str) -> McpServer {
+        McpServer {
+            name: GATEWAY_ENTRY_NAME.to_string(),
+            transport: "stdio".to_string(),
+            command: Some(command.to_string()),
+            args: Vec::new(),
+            env_keys: Vec::new(),
+            url: None,
+        }
+    }
+
+    #[test]
+    fn a_drifted_gateway_path_stays_managed() {
+        // The ownership record must not become a trap. When a republish moves our
+        // binary to a content-addressed filename, the config and the record
+        // disagree on the path while both still name OUR gateway. Reading that as
+        // Customized makes repoint_stale_gateways skip the client forever, which
+        // is how six clients on a real machine sat on a superseded gateway.
+        let record = managed_record(
+            r"C:\Users\me\AppData\Roaming\Toolport\bin\toolport-gateway-1.12.0.exe",
+        );
+        let drifted = detected_server(
+            r"C:\Users\me\AppData\Roaming\Toolport\bin\toolport-gateway-1.12.0-140f0e8d8cfa.exe",
+        );
+        assert_eq!(
+            resolve_entry_state(&[drifted], Some(&record)),
+            GatewayEntryState::Managed,
+            "a path-only drift between two of our own binaries is not customization"
+        );
+    }
+
+    #[test]
+    fn a_user_owned_command_is_still_customized() {
+        // The other side of the same rule: #487 must keep working. A record exists,
+        // but the command now names something that is not our binary, so the user
+        // has taken the entry over and we stand down.
+        let record = managed_record(
+            r"C:\Users\me\AppData\Roaming\Toolport\bin\toolport-gateway-1.12.0.exe",
+        );
+        for taken_over in ["npx", "docker", r"C:\Users\me\bin\my-wrapper.cmd"] {
+            assert_eq!(
+                resolve_entry_state(&[detected_server(taken_over)], Some(&record)),
+                GatewayEntryState::Customized,
+                "{taken_over} is not ours and must stay customized"
+            );
+        }
+    }
+
+    #[test]
+    fn a_drifted_path_with_changed_args_is_still_customized() {
+        // Only the command path is forgiven. Anything else the user touched still
+        // counts as customization.
+        let record = managed_record(
+            r"C:\Users\me\AppData\Roaming\Toolport\bin\toolport-gateway-1.12.0.exe",
+        );
+        let mut server = detected_server(
+            r"C:\Users\me\AppData\Roaming\Toolport\bin\toolport-gateway-1.12.0-140f0e8d8cfa.exe",
+        );
+        server.args = vec!["--their-flag".to_string()];
+        assert_eq!(
+            resolve_entry_state(&[server], Some(&record)),
+            GatewayEntryState::Customized
         );
     }
 

--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -3983,6 +3983,23 @@ pub fn run() {
                         repoint.customized.join(", ")
                     );
                 }
+                if !repoint.failed.is_empty() {
+                    // A client that needed migrating and could not be written stays
+                    // on a superseded gateway until someone notices. Keep it
+                    // distinguishable from "nothing to do" at the call site too,
+                    // not just in the gateway log.
+                    eprintln!(
+                        "toolport: FAILED to re-point {} client config(s); they will keep \
+                         launching their previous gateway: {}",
+                        repoint.failed.len(),
+                        repoint
+                            .failed
+                            .iter()
+                            .map(|(id, why)| format!("{id} ({why})"))
+                            .collect::<Vec<_>>()
+                            .join(", ")
+                    );
+                }
                 // Stop obsolete gateway processes. Path-based identity on all OS
                 // (SOU-414); not gated on repoint (SOU-306).
                 //

--- a/src-tauri/src/downstream.rs
+++ b/src-tauri/src/downstream.rs
@@ -438,7 +438,7 @@ impl CacheHint {
 /// empty successes are treated as intentional (admin revoked tools, server
 /// emptied the catalog) and the wipe is accepted. A full router rebuild still
 /// replaces catalogs from a fresh connect regardless of this counter.
-const EMPTY_CATALOG_CONFIRMATIONS: u8 = 2;
+pub const EMPTY_CATALOG_CONFIRMATIONS: u8 = 2;
 
 /// True when a refresh returns so much less than the previous catalog that it is
 /// more likely a degraded answer than a real change.

--- a/src-tauri/src/downstream.rs
+++ b/src-tauri/src/downstream.rs
@@ -430,8 +430,8 @@ impl CacheHint {
     }
 }
 
-/// Consecutive successful empty list responses required before we accept a wipe
-/// of a previously non-empty catalog (SOU-338).
+/// Consecutive successful shrunken list responses required before we accept a
+/// collapse of a previously larger catalog (SOU-338, extended).
 ///
 /// **Decision (CodeRev on #629):** a single empty success is treated as a
 /// transient glitch / list_changed race and is not applied. Two consecutive
@@ -440,39 +440,66 @@ impl CacheHint {
 /// replaces catalogs from a fresh connect regardless of this counter.
 const EMPTY_CATALOG_CONFIRMATIONS: u8 = 2;
 
-/// Apply a successful list refresh with SOU-338 empty-success handling.
+/// True when a refresh returns so much less than the previous catalog that it is
+/// more likely a degraded answer than a real change.
 ///
-/// - Non-empty `new_items` always replaces and clears the empty streak.
-/// - Empty `new_items` when `previous` is already empty is a no-op replace.
-/// - Empty `new_items` when `previous` is non-empty increments `empty_streak`;
-///   only at [`EMPTY_CATALOG_CONFIRMATIONS`] is the wipe accepted.
+/// The original rule only caught a shrink all the way to zero, which let the
+/// interesting case straight through: a remote server that answers `tools/list`
+/// successfully but with a *subset* of its catalog. Atlassian does exactly this -
+/// it returns its 3 beta Teamwork Graph tools instead of the full 40 when the
+/// access token is degraded - and the response is a perfectly well-formed
+/// success, indistinguishable at the transport layer from the server genuinely
+/// having 3 tools. Nothing downstream can tell those apart; only the size of the
+/// drop can.
+///
+/// Losing more than half a catalog in one refresh is the signal. Empty is just
+/// this rule's degenerate case (`0 * 2 < previous` for any non-empty previous),
+/// so the two policies stay unified rather than drifting apart.
+pub fn is_implausible_shrink(previous: usize, new: usize) -> bool {
+    new * 2 < previous
+}
+
+/// Apply a successful list refresh, holding off on an implausible collapse.
+///
+/// - A refresh that keeps at least half the previous catalog always replaces it
+///   and clears the streak.
+/// - A refresh that loses more than half increments `shrink_streak`; only at
+///   [`EMPTY_CATALOG_CONFIRMATIONS`] consecutive confirmations is it accepted.
+///   Requiring confirmation rather than refusing outright keeps a genuine
+///   downsizing (revoked scopes, an admin pruning tools) from being pinned to a
+///   stale catalog forever.
 fn apply_catalog_refresh(
     previous: &mut Vec<Value>,
     new_items: Vec<Value>,
-    empty_streak: &mut u8,
+    shrink_streak: &mut u8,
     cache_hint: &mut CacheHint,
     new_hint: CacheHint,
     server_id: &str,
     kind: &str,
 ) {
-    if !previous.is_empty() && new_items.is_empty() {
-        *empty_streak = empty_streak.saturating_add(1);
-        if *empty_streak < EMPTY_CATALOG_CONFIRMATIONS {
+    if is_implausible_shrink(previous.len(), new_items.len()) {
+        *shrink_streak = shrink_streak.saturating_add(1);
+        let (before, after) = (previous.len(), new_items.len());
+        if *shrink_streak < EMPTY_CATALOG_CONFIRMATIONS {
             cache_hint.mark_stale_and_defer();
-            eprintln!(
-                "toolport: keeping server '{server_id}' previous {kind} catalog after a successful empty refresh ({empty_streak}/{EMPTY_CATALOG_CONFIRMATIONS})"
+            let msg = format!(
+                "toolport: keeping server '{server_id}' previous {kind} catalog after a successful refresh collapsed it {before} -> {after} ({shrink_streak}/{EMPTY_CATALOG_CONFIRMATIONS})"
             );
+            eprintln!("{msg}");
+            crate::gatewaylog::append(&msg);
             return;
         }
-        eprintln!(
-            "toolport: accepting empty {kind} catalog for server '{server_id}' after {EMPTY_CATALOG_CONFIRMATIONS} consecutive empty refreshes"
+        let msg = format!(
+            "toolport: accepting {kind} catalog collapse {before} -> {after} for server '{server_id}' after {EMPTY_CATALOG_CONFIRMATIONS} consecutive confirmations"
         );
-        *empty_streak = 0;
+        eprintln!("{msg}");
+        crate::gatewaylog::append(&msg);
+        *shrink_streak = 0;
         *cache_hint = new_hint;
         *previous = new_items;
         return;
     }
-    *empty_streak = 0;
+    *shrink_streak = 0;
     *cache_hint = new_hint;
     *previous = new_items;
 }
@@ -4497,12 +4524,13 @@ pub struct DownstreamServer {
     resource_cache_hint: CacheHint,
     resource_template_cache_hint: CacheHint,
     prompt_cache_hint: CacheHint,
-    /// Consecutive successful empty tools/list responses while tools were non-empty
-    /// (SOU-338). Reset on any non-empty refresh. See [`EMPTY_CATALOG_CONFIRMATIONS`].
-    empty_tools_streak: u8,
-    empty_resources_streak: u8,
-    empty_templates_streak: u8,
-    empty_prompts_streak: u8,
+    /// Consecutive successful tools/list responses that collapsed the catalog to
+    /// less than half its previous size (SOU-338, extended to partial collapses).
+    /// Reset on any plausible refresh. See [`EMPTY_CATALOG_CONFIRMATIONS`].
+    shrink_tools_streak: u8,
+    shrink_resources_streak: u8,
+    shrink_templates_streak: u8,
+    shrink_prompts_streak: u8,
     /// Whether the server's `initialize` advertised resources / prompts. The
     /// actual lists are fetched lazily via `load_resources_prompts`.
     caps_resources: bool,
@@ -4694,7 +4722,31 @@ impl DownstreamServer {
         let listed = fetch_paginated_list(&mut *transport, "tools/list", "tools")
             .map_err(|e| e.to_string())?;
         if let Some(warning) = &listed.warning {
-            eprintln!("toolport: server '{id}' returned a partial tool catalog: {warning}");
+            let msg = format!(
+                "server '{id}' returned a partial tool catalog ({} tool(s)): {warning}",
+                listed.items.len()
+            );
+            eprintln!("toolport: {msg}");
+            // To the gateway log, not just stderr: an MCP client swallows a
+            // gateway's stderr, so this was the one place a silent truncation
+            // could have been caught and wasn't.
+            crate::gatewaylog::append(&format!("toolport: {msg}"));
+        }
+        // Refuse to adopt a prefix that only exists because a page failed. The
+        // catalog captured here is what gets published to clients AND persisted to
+        // `tool-cache.json`, and every later refresh declines to overwrite it with
+        // a partial - so a truncated catalog accepted at connect is not a transient
+        // glitch, it is a wrong answer that outlives the process that cached it and
+        // is served to every client that starts against that cache. Failing the
+        // connect keeps the previous cache intact and leaves a retry to the
+        // existing rebuild/self-heal path. `Bounded` truncation is kept: retrying
+        // it returns the same prefix, so the prefix is the real answer.
+        if listed.truncation == Some(Truncation::Transient) {
+            return Err(format!(
+                "incomplete tool catalog for '{id}' ({} tool(s) before traversal stopped): {}",
+                listed.items.len(),
+                listed.warning.unwrap_or_default()
+            ));
         }
         let modern_http = matches!(era, Era::Modern { .. }) && transport.supports_request_headers();
         let tools = if modern_http {
@@ -4737,10 +4789,10 @@ impl DownstreamServer {
             resource_cache_hint: CacheHint::default(),
             resource_template_cache_hint: CacheHint::default(),
             prompt_cache_hint: CacheHint::default(),
-            empty_tools_streak: 0,
-            empty_resources_streak: 0,
-            empty_templates_streak: 0,
-            empty_prompts_streak: 0,
+            shrink_tools_streak: 0,
+            shrink_resources_streak: 0,
+            shrink_templates_streak: 0,
+            shrink_prompts_streak: 0,
             caps_resources,
             caps_prompts,
             caps_completions,
@@ -4966,7 +5018,7 @@ impl DownstreamServer {
                 apply_catalog_refresh(
                     &mut self.tools,
                     new_tools,
-                    &mut self.empty_tools_streak,
+                    &mut self.shrink_tools_streak,
                     &mut self.tool_cache_hint,
                     listed.cache_hint,
                     &self.id,
@@ -4975,11 +5027,14 @@ impl DownstreamServer {
             }
             Ok(listed) => {
                 self.tool_cache_hint.mark_stale_and_defer();
-                eprintln!(
-                    "toolport: keeping server '{}' previous tool catalog after an incomplete refresh: {}",
+                let msg = format!(
+                    "toolport: keeping server '{}' previous tool catalog after an incomplete refresh ({} tool(s) fetched): {}",
                     self.id,
+                    listed.items.len(),
                     listed.warning.unwrap_or_default()
                 );
+                eprintln!("{msg}");
+                crate::gatewaylog::append(&msg);
             }
             Err(error) => {
                 self.tool_cache_hint.mark_stale_and_defer();
@@ -5022,7 +5077,7 @@ impl DownstreamServer {
                 apply_catalog_refresh(
                     &mut self.resources,
                     listed.items,
-                    &mut self.empty_resources_streak,
+                    &mut self.shrink_resources_streak,
                     &mut self.resource_cache_hint,
                     listed.cache_hint,
                     &self.id,
@@ -5056,7 +5111,7 @@ impl DownstreamServer {
                 apply_catalog_refresh(
                     &mut self.resource_templates,
                     listed.items,
-                    &mut self.empty_templates_streak,
+                    &mut self.shrink_templates_streak,
                     &mut self.resource_template_cache_hint,
                     listed.cache_hint,
                     &self.id,
@@ -5105,7 +5160,7 @@ impl DownstreamServer {
                 apply_catalog_refresh(
                     &mut self.prompts,
                     listed.items,
-                    &mut self.empty_prompts_streak,
+                    &mut self.shrink_prompts_streak,
                     &mut self.prompt_cache_hint,
                     listed.cache_hint,
                     &self.id,
@@ -5429,6 +5484,23 @@ fn extract_array(result: &Value, key: &str) -> Vec<Value> {
         .unwrap_or_default()
 }
 
+/// Why a paginated traversal stopped before the server ran out of pages.
+///
+/// The distinction decides whether the prefix we did collect is an *answer* or an
+/// *accident*, and callers must treat those differently: re-running a `Bounded`
+/// traversal returns the same prefix, so the prefix is the best result available,
+/// while re-running a `Transient` one probably returns the whole catalog.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Truncation {
+    /// A page after the first failed, or the wall-clock cap tripped mid-chain.
+    /// The rest of the catalog still exists and another attempt can reach it, so
+    /// this prefix must never be mistaken for the server's real catalog.
+    Transient,
+    /// A defensive bound on catalog size was reached, or the server drove us into
+    /// a cursor loop. Deterministic: the prefix is all we will ever get.
+    Bounded,
+}
+
 struct PaginatedList {
     items: Vec<Value>,
     /// Minimum remaining TTL and most-private scope across every page. A partial
@@ -5438,6 +5510,32 @@ struct PaginatedList {
     /// Initial discovery may expose that useful prefix; refreshes keep the prior
     /// complete snapshot instead of replacing it with a partial catalog.
     warning: Option<String>,
+    /// Set whenever `warning` is. Kept in lockstep by the constructors below so
+    /// the two cannot drift into disagreeing about whether this list is complete.
+    truncation: Option<Truncation>,
+}
+
+impl PaginatedList {
+    /// Every page the server offered, traversed to the end.
+    fn complete(items: Vec<Value>, cache_hint: CacheHint) -> Self {
+        Self {
+            items,
+            cache_hint,
+            warning: None,
+            truncation: None,
+        }
+    }
+
+    /// A prefix. The cache hint collapses to the conservative default because a
+    /// partial traversal cannot vouch for the TTL or scope of the pages it missed.
+    fn truncated(items: Vec<Value>, truncation: Truncation, warning: String) -> Self {
+        Self {
+            items,
+            cache_hint: CacheHint::default(),
+            warning: Some(warning),
+            truncation: Some(truncation),
+        }
+    }
 }
 
 /// Traverse one MCP list operation using its opaque `nextCursor`. The first page
@@ -5457,14 +5555,16 @@ fn fetch_paginated_list(
 
     for page_index in 0..MAX_LIST_PAGES {
         if page_index > 0 && started.elapsed() >= MAX_LIST_DURATION {
-            return Ok(PaginatedList {
+            // A clock ran out, not a catalog. Whatever we are missing is still
+            // there to be fetched, so this is `Transient`.
+            return Ok(PaginatedList::truncated(
                 items,
-                cache_hint: CacheHint::default(),
-                warning: Some(format!(
+                Truncation::Transient,
+                format!(
                     "catalog traversal exceeded the {}-second safety cap",
                     MAX_LIST_DURATION.as_secs()
-                )),
-            });
+                ),
+            ));
         }
         let params = cursor
             .as_ref()
@@ -5472,11 +5572,11 @@ fn fetch_paginated_list(
         let result = match transport.request(method, params) {
             Ok(result) => result,
             Err(error) if page_index > 0 => {
-                return Ok(PaginatedList {
+                return Ok(PaginatedList::truncated(
                     items,
-                    cache_hint: CacheHint::default(),
-                    warning: Some(format!("page {} failed: {error}", page_index + 1)),
-                });
+                    Truncation::Transient,
+                    format!("page {} failed: {error}", page_index + 1),
+                ));
             }
             Err(error) => return Err(error),
         };
@@ -5488,16 +5588,26 @@ fn fetch_paginated_list(
         });
 
         let page = extract_array(&result, key);
+        // Per-page shape, behind the debug flag. Without this the only recorded
+        // fact is the final total, which cannot distinguish "the server owns a
+        // small catalog" from "we stopped reading a large one" - the ambiguity
+        // that made a truncated catalog impossible to diagnose after the fact.
+        if crate::brand::env_var_os("TOOLPORT_DEBUG", "CONDUIT_DEBUG").is_some() {
+            crate::gatewaylog::append(&format!(
+                "toolport: {method} page {} returned {} item(s), nextCursor={}",
+                page_index + 1,
+                page.len(),
+                result.get("nextCursor").and_then(Value::as_str).is_some()
+            ));
+        }
         let remaining = MAX_LIST_ITEMS.saturating_sub(items.len());
         if page.len() > remaining {
             items.extend(page.into_iter().take(remaining));
-            return Ok(PaginatedList {
+            return Ok(PaginatedList::truncated(
                 items,
-                cache_hint: CacheHint::default(),
-                warning: Some(format!(
-                    "catalog exceeded the {MAX_LIST_ITEMS}-item safety cap"
-                )),
-            });
+                Truncation::Bounded,
+                format!("catalog exceeded the {MAX_LIST_ITEMS}-item safety cap"),
+            ));
         }
         items.extend(page);
 
@@ -5506,29 +5616,26 @@ fn fetch_paginated_list(
             .and_then(Value::as_str)
             .map(str::to_string)
         else {
-            return Ok(PaginatedList {
+            return Ok(PaginatedList::complete(
                 items,
-                cache_hint: cache_hint.unwrap_or_default(),
-                warning: None,
-            });
+                cache_hint.unwrap_or_default(),
+            ));
         };
         if !seen_cursors.insert(next_cursor.clone()) {
-            return Ok(PaginatedList {
+            return Ok(PaginatedList::truncated(
                 items,
-                cache_hint: CacheHint::default(),
-                warning: Some("server repeated a pagination cursor".to_string()),
-            });
+                Truncation::Bounded,
+                "server repeated a pagination cursor".to_string(),
+            ));
         }
         cursor = Some(next_cursor);
     }
 
-    Ok(PaginatedList {
+    Ok(PaginatedList::truncated(
         items,
-        cache_hint: CacheHint::default(),
-        warning: Some(format!(
-            "catalog exceeded the {MAX_LIST_PAGES}-page safety cap"
-        )),
-    })
+        Truncation::Bounded,
+        format!("catalog exceeded the {MAX_LIST_PAGES}-page safety cap"),
+    ))
 }
 
 #[cfg(test)]
@@ -5538,8 +5645,9 @@ mod tests {
         file_uri_to_path, protocol_meta_for, resolve_command, resolve_project_root,
         resolve_root_token, screen_resolved_addrs, screen_spawn_command, screen_spawn_env,
         validate_cwd, CacheHint, CancelRegistry, DownstreamServer, HttpTransport, MrtrRequest,
-        RootSource, ServerRequestAction, ServerRequestHandler, Transport, TransportError,
-        MODERN_PROTOCOL_VERSION, OAUTH_CLIENT_CREDENTIALS_EXTENSION,
+        apply_catalog_refresh, is_implausible_shrink, RootSource, ServerRequestAction,
+        ServerRequestHandler, Transport, TransportError, Truncation, MODERN_PROTOCOL_VERSION,
+        OAUTH_CLIENT_CREDENTIALS_EXTENSION,
     };
     use serde_json::{json, Value};
     use std::collections::{HashMap, VecDeque};
@@ -5733,6 +5841,140 @@ mod tests {
     }
 
     #[test]
+    fn a_catalog_that_collapses_is_held_until_confirmed() {
+        // The Atlassian case: a *successful* tools/list that returns 3 of a
+        // server's 40 tools. Nothing about the response is malformed, so only the
+        // size of the drop can catch it.
+        let mut tools: Vec<Value> = (0..40).map(|i| json!({"name": format!("t{i}")})).collect();
+        let mut streak = 0u8;
+        let mut hint = CacheHint::default();
+        let degraded: Vec<Value> = (0..3).map(|i| json!({"name": format!("t{i}")})).collect();
+
+        apply_catalog_refresh(
+            &mut tools,
+            degraded.clone(),
+            &mut streak,
+            &mut hint,
+            CacheHint::default(),
+            "atlassian",
+            "tool",
+        );
+        assert_eq!(tools.len(), 40, "first collapse must not be applied");
+        assert_eq!(streak, 1);
+
+        // Confirmed twice: a real downsizing has to be able to land eventually.
+        apply_catalog_refresh(
+            &mut tools,
+            degraded,
+            &mut streak,
+            &mut hint,
+            CacheHint::default(),
+            "atlassian",
+            "tool",
+        );
+        assert_eq!(tools.len(), 3, "a confirmed collapse must be accepted");
+        assert_eq!(streak, 0);
+    }
+
+    #[test]
+    fn an_ordinary_catalog_change_is_applied_immediately() {
+        // The guard must not add latency to normal churn: losing a few tools, or
+        // holding steady, is applied on the first refresh.
+        for new_len in [40usize, 39, 20] {
+            let mut tools: Vec<Value> = (0..40).map(|i| json!({"name": format!("t{i}")})).collect();
+            let mut streak = 0u8;
+            let mut hint = CacheHint::default();
+            apply_catalog_refresh(
+                &mut tools,
+                (0..new_len).map(|i| json!({"name": format!("t{i}")})).collect(),
+                &mut streak,
+                &mut hint,
+                CacheHint::default(),
+                "server",
+                "tool",
+            );
+            assert_eq!(tools.len(), new_len, "{new_len} should apply immediately");
+            assert_eq!(streak, 0);
+        }
+    }
+
+    #[test]
+    fn shrink_rule_treats_empty_as_the_degenerate_collapse() {
+        assert!(is_implausible_shrink(40, 3));
+        assert!(is_implausible_shrink(40, 0), "empty is still guarded");
+        assert!(!is_implausible_shrink(40, 20), "exactly half is plausible");
+        assert!(!is_implausible_shrink(0, 0), "no previous, nothing to lose");
+        assert!(!is_implausible_shrink(3, 40), "growth is never a collapse");
+    }
+
+    #[test]
+    fn a_failed_page_is_transient_and_a_safety_cap_is_bounded() {
+        // The two truncation classes must not be conflated: one says "ask again",
+        // the other says "this is all there is".
+        let mut failed_page = PaginationTransport::new(vec![
+            Ok(json!({"tools":[{"name":"one"}],"nextCursor":"two"})),
+            Err(TransportError::Unavailable("page two died".to_string())),
+        ]);
+        let listed = fetch_paginated_list(&mut failed_page, "tools/list", "tools").unwrap();
+        assert_eq!(listed.truncation, Some(Truncation::Transient));
+
+        let mut looping_cursor = PaginationTransport::new(vec![
+            Ok(json!({"tools":[{"name":"one"}],"nextCursor":"same"})),
+            Ok(json!({"tools":[{"name":"two"}],"nextCursor":"same"})),
+        ]);
+        let listed = fetch_paginated_list(&mut looping_cursor, "tools/list", "tools").unwrap();
+        assert_eq!(listed.truncation, Some(Truncation::Bounded));
+
+        let mut whole = PaginationTransport::new(vec![Ok(json!({"tools":[{"name":"one"}]}))]);
+        let listed = fetch_paginated_list(&mut whole, "tools/list", "tools").unwrap();
+        assert_eq!(listed.truncation, None);
+        assert!(listed.warning.is_none());
+    }
+
+    #[test]
+    fn connect_refuses_a_catalog_truncated_by_a_failed_page() {
+        // The regression this exists for: a server whose first page holds 1 of its
+        // tools and whose second page fails must NOT connect advertising that one
+        // tool as its catalog. That prefix would be published to clients and
+        // persisted to the on-disk tool cache, where every later refresh declines
+        // to overwrite it - so accepting it here strands the server on a wrong
+        // catalog that outlives the process.
+        let transport = PaginationTransport::new(vec![
+            Ok(json!({ "capabilities": {} })),
+            Ok(json!({"tools":[{"name":"first-page-only"}],"nextCursor":"two"})),
+            Err(TransportError::Unavailable(
+                "page two timed out".to_string(),
+            )),
+        ]);
+        let Err(err) = DownstreamServer::connect("fixture".to_string(), Box::new(transport)) else {
+            panic!("a transiently truncated catalog must fail the connect");
+        };
+        assert!(
+            err.contains("incomplete tool catalog"),
+            "unexpected error: {err}"
+        );
+        assert!(
+            err.contains("page two timed out"),
+            "error should carry the underlying cause: {err}"
+        );
+    }
+
+    #[test]
+    fn connect_keeps_a_catalog_truncated_by_a_safety_cap() {
+        // Bounded truncation is deterministic - retrying returns the same prefix -
+        // so refusing it would make an oversized or cursor-looping server
+        // permanently unusable rather than partially usable.
+        let transport = PaginationTransport::new(vec![
+            Ok(json!({ "capabilities": {} })),
+            Ok(json!({"tools":[{"name":"one"}],"nextCursor":"same"})),
+            Ok(json!({"tools":[{"name":"two"}],"nextCursor":"same"})),
+        ]);
+        let server = DownstreamServer::connect("fixture".to_string(), Box::new(transport))
+            .expect("a bounded truncation should still connect");
+        assert_eq!(server.tools.len(), 2);
+    }
+
+    #[test]
     fn downstream_server_loads_all_tool_resource_and_prompt_pages() {
         let transport = PaginationTransport::new(vec![
             Ok(json!({
@@ -5782,10 +6024,10 @@ mod tests {
             resource_cache_hint: CacheHint::default(),
             resource_template_cache_hint: CacheHint::default(),
             prompt_cache_hint: CacheHint::default(),
-            empty_tools_streak: 0,
-            empty_resources_streak: 0,
-            empty_templates_streak: 0,
-            empty_prompts_streak: 0,
+            shrink_tools_streak: 0,
+            shrink_resources_streak: 0,
+            shrink_templates_streak: 0,
+            shrink_prompts_streak: 0,
             caps_resources: false,
             caps_prompts: false,
             caps_completions: false,
@@ -5817,10 +6059,10 @@ mod tests {
             resource_cache_hint: CacheHint::default(),
             resource_template_cache_hint: CacheHint::default(),
             prompt_cache_hint: CacheHint::default(),
-            empty_tools_streak: 0,
-            empty_resources_streak: 0,
-            empty_templates_streak: 0,
-            empty_prompts_streak: 0,
+            shrink_tools_streak: 0,
+            shrink_resources_streak: 0,
+            shrink_templates_streak: 0,
+            shrink_prompts_streak: 0,
             caps_resources: false,
             caps_prompts: false,
             caps_completions: false,
@@ -5838,7 +6080,7 @@ mod tests {
             vec![json!({"name":"stable"})],
             "first successful empty list must not wipe prior tools"
         );
-        assert_eq!(server.empty_tools_streak, 1);
+        assert_eq!(server.shrink_tools_streak, 1);
     }
 
     /// CodeRev on #629 / SOU-338: two consecutive empty successes accept the wipe
@@ -5858,10 +6100,10 @@ mod tests {
             resource_cache_hint: CacheHint::default(),
             resource_template_cache_hint: CacheHint::default(),
             prompt_cache_hint: CacheHint::default(),
-            empty_tools_streak: 0,
-            empty_resources_streak: 0,
-            empty_templates_streak: 0,
-            empty_prompts_streak: 0,
+            shrink_tools_streak: 0,
+            shrink_resources_streak: 0,
+            shrink_templates_streak: 0,
+            shrink_prompts_streak: 0,
             caps_resources: false,
             caps_prompts: false,
             caps_completions: false,
@@ -5880,7 +6122,7 @@ mod tests {
             server.tools.is_empty(),
             "second consecutive empty success must accept the wipe"
         );
-        assert_eq!(server.empty_tools_streak, 0);
+        assert_eq!(server.shrink_tools_streak, 0);
     }
 
     /// SOU-338: empty success is allowed when the catalog was already empty
@@ -5899,10 +6141,10 @@ mod tests {
             resource_cache_hint: CacheHint::default(),
             resource_template_cache_hint: CacheHint::default(),
             prompt_cache_hint: CacheHint::default(),
-            empty_tools_streak: 0,
-            empty_resources_streak: 0,
-            empty_templates_streak: 0,
-            empty_prompts_streak: 0,
+            shrink_tools_streak: 0,
+            shrink_resources_streak: 0,
+            shrink_templates_streak: 0,
+            shrink_prompts_streak: 0,
             caps_resources: false,
             caps_prompts: false,
             caps_completions: false,
@@ -5937,10 +6179,10 @@ mod tests {
             resource_cache_hint: CacheHint::default(),
             resource_template_cache_hint: CacheHint::default(),
             prompt_cache_hint: CacheHint::default(),
-            empty_tools_streak: 0,
-            empty_resources_streak: 0,
-            empty_templates_streak: 0,
-            empty_prompts_streak: 0,
+            shrink_tools_streak: 0,
+            shrink_resources_streak: 0,
+            shrink_templates_streak: 0,
+            shrink_prompts_streak: 0,
             caps_resources: true,
             caps_prompts: true,
             caps_completions: false,
@@ -5984,10 +6226,10 @@ mod tests {
             resource_cache_hint: CacheHint::default(),
             resource_template_cache_hint: CacheHint::default(),
             prompt_cache_hint: CacheHint::default(),
-            empty_tools_streak: 0,
-            empty_resources_streak: 0,
-            empty_templates_streak: 0,
-            empty_prompts_streak: 0,
+            shrink_tools_streak: 0,
+            shrink_resources_streak: 0,
+            shrink_templates_streak: 0,
+            shrink_prompts_streak: 0,
             caps_resources: true,
             caps_prompts: false,
             caps_completions: false,

--- a/src-tauri/src/gatewaylog.rs
+++ b/src-tauri/src/gatewaylog.rs
@@ -1,0 +1,61 @@
+//! The always-on gateway log (`gateway.log`).
+//!
+//! This is what `gather_diagnostics` bundles into a bug report, so it stays on
+//! regardless of `TOOLPORT_DEBUG` and holds connection-lifecycle facts only:
+//! starts, connect successes, connect failures, and catalogs that came back
+//! incomplete.
+//!
+//! It lives in the library rather than the gateway binary because the code that
+//! knows a catalog was truncated is [`crate::downstream`], and a warning only
+//! that module can see is worthless if it cannot reach the file a user actually
+//! sends us. MCP clients swallow a gateway's stderr, so `eprintln!` alone means
+//! a silent truncation is indistinguishable from a healthy connect in any
+//! after-the-fact diagnosis - which is exactly how a downstream server served a
+//! 3-tool prefix of its 40-tool catalog for days without leaving a trace.
+
+use std::io::Write;
+use std::path::Path;
+
+/// Keep the always-on gateway log bounded; trimmed to roughly the back half once
+/// it grows past this, so a long-running client can't let it grow without limit.
+pub const GATEWAY_LOG_CAP: u64 = 256 * 1024;
+
+/// Append one line to the gateway log. Best-effort: logging must never take down
+/// a connection, so every failure here is swallowed.
+pub fn append(msg: &str) {
+    let Some(path) = crate::registry::gateway_log_path() else {
+        return;
+    };
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    if let Ok(mut f) = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&path)
+    {
+        let _ = f.write_all(format!("{msg}\n").as_bytes());
+    }
+    trim_log_if_large(&path);
+}
+
+/// Trim the log to roughly its back half once it exceeds [`GATEWAY_LOG_CAP`],
+/// cutting at a line boundary so the survivor never starts mid-record.
+pub fn trim_log_if_large(path: &Path) {
+    let over = std::fs::metadata(path)
+        .map(|m| m.len() > GATEWAY_LOG_CAP)
+        .unwrap_or(false);
+    if !over {
+        return;
+    }
+    let Ok(data) = std::fs::read(path) else {
+        return;
+    };
+    let keep_from = data.len().saturating_sub((GATEWAY_LOG_CAP / 2) as usize);
+    let start = data[keep_from..]
+        .iter()
+        .position(|&b| b == b'\n')
+        .map(|i| keep_from + i + 1)
+        .unwrap_or(keep_from);
+    let _ = std::fs::write(path, &data[start..]);
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -10,6 +10,7 @@ pub mod clients;
 pub mod codemode;
 pub mod downstream;
 pub mod gateway_publish;
+pub mod gatewaylog;
 pub mod inspect;
 pub mod instructions;
 pub mod integrity;


### PR DESCRIPTION
Three related failures where Toolport quietly kept serving superseded state and left no evidence behind.

### 1. A degraded downstream catalog became cached truth
A downstream catalog that came back degraded (empty/partial) was written into the cache as if it were authoritative, so one bad fetch persisted past the condition that caused it.

### 2. `CLAUDE_CONFIG_DIR` was ignored when resolving Claude Code's config
We hardcoded `~/.claude.json`. Anyone who relocates their Claude Code config via `CLAUDE_CONFIG_DIR` had their real config missed and a second one written to the default path.

### 3. Path drift silently orphaned a managed client
A client's gateway entry counted as ours only if the config command was byte-identical to the ownership record. Any move of our binary out from under that record — a republish under a content-addressed filename, a data-dir move, a fix applied by hand — flipped the entry to `Customized`, and the launch-time re-point *skips* `Customized`. The client was then pinned to whatever gateway it held, permanently, with no path back.

A command that still names one of our own gateway binaries is now treated as path drift and stays `Managed`, so the next re-point adopts it.

Issue #487 is untouched and covered by tests: a command that is **not** our binary (`npx`, `docker`, a wrapper script) is still `Customized`, and args/env/url stay byte-strict, so a genuine customization anywhere else still stands us down.

**The re-point pass was also unfalsifiable.** `install_gateway` errors went into an `if let Ok(..)` and vanished — a client that *failed* to migrate looked exactly like one that never needed to: no log line, no retry, nothing in the UI. Failures are now captured in `RepointOutcome`, reported at the call site, and the whole pass (re-pointed / customized / failed) is written to the gateway log that `gather_diagnostics` already bundles.

### Testing
- 915 lib tests pass, including the existing #487 regression test.
- The new drift test was mutation-checked: reverting the one-line condition turns it red while the two customization-guard tests stay green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)