### PR TITLE
chore: ignore local marketing assets and captured design notes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,9 @@ dist-ssr
 # kept local; the README's demo.mp4/.gif/.srt stay tracked.
 /docs/conduit-llmstudio-demo*.mp4
 /captions.srt
+# Standalone HTML animations rendered for individual posts/videos.
+/mcp-usb-animation.html
+/toolport-cta-end-card.html
 
 # Stray test artifacts (e.g. share/export test exports)
 /src-tauri/test.json
@@ -96,6 +99,8 @@ license-signing.keycd
 /docs/SITE-MESSAGING.md
 /docs/specs/
 /docs/drafts/
+# Captured design direction, explicitly "not a committed spec".
+/docs/HIL-TEAMS-MOBILE.md
 
 # Agent/session scratch (never commit)
 _poll_pr.py


### PR DESCRIPTION
Three files have been sitting untracked in the working tree, showing up in every `git status` and triggering the "uncommitted changes" warning on every PR:

```
docs/HIL-TEAMS-MOBILE.md
mcp-usb-animation.html
toolport-cta-end-card.html
```

None belong in the repo, and each already has a matching section in `.gitignore`, so they went into the existing blocks rather than a new one:

- **`mcp-usb-animation.html`, `toolport-cta-end-card.html`** — standalone HTML animations rendered for individual posts. Filed with the existing per-post video/caption entries.
- **`docs/HIL-TEAMS-MOBILE.md`** — a captured working discussion that states on its second line that it is "a design direction, not a committed spec". Same category as `SITE-MESSAGING` / `specs/` / `drafts/`.

Verified with `git check-ignore -v`; `git status` is clean afterwards. The files stay on disk — this only stops Git tracking them.

Note these are ignored by **exact path**. If you later decide any of them should be in the repo, the `.gitignore` line has to come out first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
