### PR TITLE
fix: honor HTTP cancellation and fail closed on incomplete update shutdown

### DIFF
--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -16057,8 +16057,11 @@ mod tests {
             response.starts_with("HTTP/1.1 408 Request Timeout"),
             "slow header response was: {response}"
         );
+        // Absolute deadline is 180ms. A per-read reset would take ~560ms
+        // (14 dripped bytes * 40ms). macOS CI can land just over 350ms
+        // from scheduling; 500ms still fails a reset-on-drip implementation.
         assert!(
-            elapsed < Duration::from_millis(350),
+            elapsed < Duration::from_millis(500),
             "header timeout reset after each drip ({elapsed:?}) instead of enforcing an absolute deadline"
         );
 

--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -351,6 +351,69 @@ struct HttpBridge {
 }
 type HttpBridgeState = Mutex<HttpBridge>;
 
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct UpdateHttpBridgeIntent {
+    port: u16,
+    token: String,
+}
+
+fn update_http_bridge_intent_path() -> Option<std::path::PathBuf> {
+    registry::resolved_path()?
+        .parent()
+        .map(|dir| dir.join("http-bridge-update-resume.json"))
+}
+
+fn save_update_http_bridge_intent(intent: &UpdateHttpBridgeIntent) -> Result<(), String> {
+    let path = update_http_bridge_intent_path()
+        .ok_or_else(|| "could not resolve the HTTP bridge update state path".to_string())?;
+    save_update_http_bridge_intent_to(&path, intent)
+}
+
+fn save_update_http_bridge_intent_to(
+    path: &std::path::Path,
+    intent: &UpdateHttpBridgeIntent,
+) -> Result<(), String> {
+    let json = serde_json::to_string(intent).map_err(|error| error.to_string())?;
+    registry::atomic_write(path, &json)
+}
+
+fn load_update_http_bridge_intent() -> Result<Option<UpdateHttpBridgeIntent>, String> {
+    let Some(path) = update_http_bridge_intent_path() else {
+        return Ok(None);
+    };
+    load_update_http_bridge_intent_from(&path)
+}
+
+fn load_update_http_bridge_intent_from(
+    path: &std::path::Path,
+) -> Result<Option<UpdateHttpBridgeIntent>, String> {
+    match std::fs::read_to_string(path) {
+        Ok(raw) => serde_json::from_str(&raw).map(Some).map_err(|error| {
+            format!("could not read the HTTP bridge update state: {error}")
+        }),
+        Err(error) if error.kind() == ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(format!("could not read the HTTP bridge update state: {error}")),
+    }
+}
+
+fn clear_update_http_bridge_intent() -> Result<(), String> {
+    let Some(path) = update_http_bridge_intent_path() else {
+        return Ok(());
+    };
+    clear_update_http_bridge_intent_at(&path)
+}
+
+fn clear_update_http_bridge_intent_at(path: &std::path::Path) -> Result<(), String> {
+    match std::fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(format!(
+            "could not clear the HTTP bridge update state: {error}"
+        )),
+    }
+}
+
 #[derive(serde::Serialize)]
 #[serde(rename_all = "camelCase")]
 struct HttpBridgeStatus {
@@ -3178,9 +3241,153 @@ fn http_bridge_alive(bridge: &mut HttpBridge) -> bool {
 
 /// Stop client-spawned gateway processes before an in-app update (all platforms).
 /// MCP clients stay open; only `toolport-gateway` / `conduit-gateway` children exit.
+///
+/// The supervised HTTP endpoint is the one gateway Toolport can recreate itself.
+/// Capture its port before reaping so a failed install can explicitly recover it;
+/// client-owned stdio gateways must be recreated by their owning applications.
+#[derive(Debug, Clone, Default, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct UpdateShutdownReport {
+    #[serde(flatten)]
+    reaper: crate::gateway_publish::ReapReport,
+    http_bridge_port: Option<u16>,
+    /// Failures managing Toolport's owned HTTP child or its durable recovery
+    /// marker. Kept separate from `ReapReport::failed`, whose entries are
+    /// external process labels and drive different user guidance.
+    lifecycle_errors: Vec<String>,
+}
+
 #[tauri::command]
-fn stop_spawned_gateways() -> u32 {
-    crate::gateway_publish::stop_spawned_gateways()
+fn stop_spawned_gateways(bridge: State<HttpBridgeState>) -> UpdateShutdownReport {
+    enum OwnedBridgeStop {
+        Absent,
+        Stopped(u16),
+        FailedWithIntent { port: u16, error: String },
+        FailedBeforeIntent(String),
+    }
+
+    let owned_bridge = {
+        let mut bridge = bridge
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if http_bridge_alive(&mut bridge) {
+            match (bridge.port, bridge.token.clone()) {
+                (Some(port), Some(token)) => {
+                    let intent = UpdateHttpBridgeIntent { port, token };
+                    match save_update_http_bridge_intent(&intent) {
+                        Ok(()) => {
+                            let mut child = bridge.child.take().expect("live bridge has a child");
+                            let stopped = match child.kill() {
+                                Ok(()) => child.wait().map(|_| ()),
+                                Err(kill_error) => match child.try_wait() {
+                                    Ok(Some(_)) => Ok(()),
+                                    Ok(None) => Err(kill_error),
+                                    Err(wait_error) => Err(wait_error),
+                                },
+                            };
+                            match stopped {
+                                Ok(()) => {
+                                    bridge.port = None;
+                                    bridge.token = None;
+                                    OwnedBridgeStop::Stopped(port)
+                                }
+                                Err(error) => {
+                                    bridge.child = Some(child);
+                                    OwnedBridgeStop::FailedWithIntent {
+                                        port,
+                                        error: format!(
+                                            "Toolport HTTP endpoint on port {port}: {error}"
+                                        ),
+                                    }
+                                }
+                            }
+                        }
+                        Err(error) => OwnedBridgeStop::FailedBeforeIntent(error),
+                    }
+                }
+                _ => OwnedBridgeStop::FailedBeforeIntent(
+                    "live HTTP endpoint is missing its port or token".to_string(),
+                ),
+            }
+        } else {
+            OwnedBridgeStop::Absent
+        }
+    };
+
+    // Never launch the kill-all pass when Toolport could not first persist the
+    // exact recovery identity for its owned endpoint. The global enumerator can
+    // see and kill that child too; proceeding would destroy connectivity without
+    // a trustworthy port/token from which to recover it.
+    if let OwnedBridgeStop::FailedBeforeIntent(error) = &owned_bridge {
+        return UpdateShutdownReport {
+            reaper: crate::gateway_publish::ReapReport {
+                ..Default::default()
+            },
+            http_bridge_port: None,
+            lifecycle_errors: vec![error.clone()],
+        };
+    }
+
+    let reaper = crate::gateway_publish::stop_spawned_gateways();
+    let mut lifecycle_errors = Vec::new();
+    let http_bridge_port = match owned_bridge {
+        OwnedBridgeStop::Absent => None,
+        OwnedBridgeStop::Stopped(port) => Some(port),
+        OwnedBridgeStop::FailedWithIntent { port, error } => {
+            lifecycle_errors.push(error);
+            // The durable intent was written before touching the owned child.
+            // Keep it on a partial shutdown failure: the global reaper may still
+            // stop that process, and recovery must then restore the exact port
+            // and bearer token. If it stayed live, recovery verifies the same
+            // endpoint and can safely clear the intent.
+            Some(port)
+        }
+        OwnedBridgeStop::FailedBeforeIntent(_) => unreachable!("returned before global reaper"),
+    };
+    UpdateShutdownReport {
+        reaper,
+        http_bridge_port,
+        lifecycle_errors,
+    }
+}
+
+#[derive(Debug, Clone, Default, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct UpdateRecoveryReport {
+    /// True only when an HTTP endpoint existed before shutdown and is available
+    /// again. External stdio clients are deliberately not represented as restored.
+    http_bridge_recovered: bool,
+    /// Endpoint availability and marker cleanup are separate facts. A failed
+    /// delete must not turn a verified live endpoint into a false "not restored"
+    /// message, but the retained marker still needs to be surfaced.
+    cleanup_warning: Option<String>,
+}
+
+/// Restore the transport Toolport owns after an update aborts. External clients
+/// own their gateway stdin/stdout pipes, so fabricating replacement children here
+/// would create disconnected processes and a false recovery claim.
+#[tauri::command]
+fn recover_update_gateways(
+    bridge: State<HttpBridgeState>,
+    http_bridge_port: Option<u16>,
+) -> Result<UpdateRecoveryReport, String> {
+    let Some(port) = http_bridge_port else {
+        return Ok(UpdateRecoveryReport::default());
+    };
+    let intent = load_update_http_bridge_intent()?
+        .ok_or_else(|| "HTTP bridge update state is missing; start it again from Settings".to_string())?;
+    if intent.port != port {
+        return Err(format!(
+            "HTTP bridge update state expected port {}, not {port}",
+            intent.port
+        ));
+    }
+    ensure_http_bridge_at(bridge.inner(), port, Some(intent.token))?;
+    let cleanup_warning = clear_update_http_bridge_intent().err();
+    Ok(UpdateRecoveryReport {
+        http_bridge_recovered: true,
+        cleanup_warning,
+    })
 }
 
 /// Apps still launching an obsolete gateway, accumulated across reaper passes.
@@ -3344,50 +3551,111 @@ fn reap_stale_and_restore_bridge(
     // to restore and the reaper's outcome is final.
     let was_serving = {
         let mut b = bridge.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
-        http_bridge_alive(&mut b).then(|| b.port).flatten()
+        http_bridge_alive(&mut b).then(|| (b.port, b.token.clone()))
     };
     let report = crate::gateway_publish::reap_stale(&extra_keep);
     // Merged from this pass's pre-kill snapshot, which is the only moment it can be
     // known. Union, not replace: see `RestartAdvice`.
+    let mut failed = report.failed.clone();
+    for remaining in &report.remaining {
+        if !failed.contains(remaining) {
+            failed.push(remaining.clone());
+        }
+    }
     let outcome = ReapOutcome {
         killed: report.killed.clone(),
-        failed: report.failed.clone(),
+        // Include the final alive set in the existing failure surface so Settings
+        // cannot report success merely because the OS accepted a termination request.
+        failed,
         needs_restart: advice.merge(report.needs_restart),
     };
-    if let Some(port) = was_serving {
+    if let Some((Some(port), token)) = was_serving {
         let still_serving = {
             let mut b = bridge.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
             http_bridge_alive(&mut b)
         };
         if !still_serving {
-            // The just-killed child may not have released the port yet, and
-            // `start_http_bridge_at` deliberately fails fast on a taken port (a
-            // user-initiated start must not report success against someone else's
-            // listener). Retry briefly so a teardown race does not turn into a
-            // spurious "could not be restarted".
-            let mut last = String::new();
-            for attempt in 0..5 {
-                match start_http_bridge_at(bridge, Some(port)) {
-                    Ok(_) => {
-                        eprintln!(
-                            "toolport: restarted the HTTP endpoint on port {port} after the stale \
-                             reaper stopped its previous (replaced) binary"
-                        );
-                        return outcome;
-                    }
-                    Err(e) => last = e,
-                }
-                if attempt < 4 {
-                    std::thread::sleep(Duration::from_millis(200));
-                }
+            match ensure_http_bridge_at(bridge, port, token) {
+                Ok(()) => eprintln!(
+                    "toolport: restarted the HTTP endpoint on port {port} after the stale \
+                     reaper stopped its previous (replaced) binary"
+                ),
+                Err(last) => eprintln!(
+                    "toolport: the stale reaper stopped the HTTP endpoint on port {port} and it \
+                     could not be restarted: {last}. Start it again from Settings."
+                ),
             }
-            eprintln!(
-                "toolport: the stale reaper stopped the HTTP endpoint on port {port} and it could \
-                 not be restarted: {last}. Start it again from Settings."
-            );
         }
     }
     outcome
+}
+
+/// Ensure the supervised HTTP bridge is available on its previous port. The
+/// just-stopped child may need a moment to release the listener, so retry within a
+/// short, deterministic bound. Idempotent when the tracked bridge is already alive.
+fn ensure_http_bridge_at(
+    state: &HttpBridgeState,
+    port: u16,
+    token: Option<String>,
+) -> Result<(), String> {
+    let tracked_live = {
+        let mut bridge = state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if http_bridge_alive(&mut bridge) {
+            if bridge.port == Some(port)
+                && token
+                    .as_ref()
+                    .is_none_or(|expected| bridge.token.as_ref() == Some(expected))
+            {
+                true
+            } else {
+                return Err(format!(
+                    "another Toolport HTTP endpoint is already running on port {}",
+                    bridge.port.unwrap_or_default()
+                ));
+            }
+        } else {
+            false
+        }
+    };
+    if tracked_live {
+        let expected = token.as_deref().ok_or_else(|| {
+            "could not verify the tracked HTTP endpoint without its bearer token".to_string()
+        })?;
+        return http_bridge_identity_ready(port, expected)
+            .then_some(())
+            .ok_or_else(|| {
+                format!(
+                    "the tracked Toolport HTTP endpoint on port {port} did not pass authenticated readiness"
+                )
+            });
+    }
+
+    let mut last = String::new();
+    for attempt in 0..5 {
+        match start_http_bridge_with_token_at(state, Some(port), token.clone()) {
+            Ok(status)
+                if status.port == Some(port)
+                    && token
+                        .as_ref()
+                        .is_none_or(|expected| status.token.as_ref() == Some(expected)) =>
+            {
+                return Ok(());
+            }
+            Ok(status) => {
+                return Err(format!(
+                    "another Toolport HTTP endpoint is already running on port {}",
+                    status.port.unwrap_or_default()
+                ));
+            }
+            Err(error) => last = error,
+        }
+        if attempt < 4 {
+            std::thread::sleep(Duration::from_millis(200));
+        }
+    }
+    Err(last)
 }
 
 /// Start `toolport-gateway --http <port>` as a supervised child so HTTP/OpenAPI
@@ -3406,6 +3674,38 @@ fn start_http_bridge(
 fn start_http_bridge_at(
     state: &HttpBridgeState,
     port: Option<u16>,
+) -> Result<HttpBridgeStatus, String> {
+    // Every ordinary/user-initiated start supersedes an interrupted-update
+    // marker, including install/migration paths that call this helper directly.
+    // Recovery paths use the token-preserving lower-level function instead.
+    clear_update_http_bridge_intent()?;
+    start_http_bridge_with_token_at(state, port, None)
+}
+
+fn http_bridge_identity_ready(port: u16, token: &str) -> bool {
+    use std::io::Read as _;
+
+    let response = match ureq::get(&format!("http://127.0.0.1:{port}/"))
+        .timeout(Duration::from_millis(300))
+        .set("Authorization", &format!("Bearer {token}"))
+        .call()
+    {
+        Ok(response) if response.status() == 200 => response,
+        _ => return false,
+    };
+    let mut body = String::new();
+    response
+        .into_reader()
+        .take(4 * 1024)
+        .read_to_string(&mut body)
+        .is_ok()
+        && body.starts_with("Toolport gateway (HTTP mode).")
+}
+
+fn start_http_bridge_with_token_at(
+    state: &HttpBridgeState,
+    port: Option<u16>,
+    token: Option<String>,
 ) -> Result<HttpBridgeStatus, String> {
     let port = port.unwrap_or(8765);
     let mut bridge = state.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
@@ -3426,9 +3726,15 @@ fn start_http_bridge_at(
     // Auto-generate a bearer token the client must send on every request.
     // Without it, any local process (including a web page open in the user's
     // browser) could POST to the port and run their tools.
-    let mut tok = [0u8; 24];
-    getrandom::getrandom(&mut tok).map_err(|e| format!("could not generate a token: {e}"))?;
-    let token: String = tok.iter().map(|b| format!("{b:02x}")).collect();
+    let token = match token {
+        Some(token) => token,
+        None => {
+            let mut tok = [0u8; 24];
+            getrandom::getrandom(&mut tok)
+                .map_err(|e| format!("could not generate a token: {e}"))?;
+            tok.iter().map(|b| format!("{b:02x}")).collect()
+        }
+    };
     let mut cmd = std::process::Command::new(&bin);
     cmd.arg("--http")
         .arg(port.to_string())
@@ -3448,9 +3754,10 @@ fn start_http_bridge_at(
     let mut child = cmd
         .spawn()
         .map_err(|e| format!("could not start the HTTP bridge: {e}"))?;
-    // Confirm it actually came up rather than dying on startup (bind race,
-    // bad binary, etc.). Poll the port; if the child exits or never answers,
-    // surface a real error instead of a false success.
+    // Confirm the spawned process is the authenticated Toolport gateway, not
+    // merely that some listener won a bind race on this port. The preserved
+    // bearer is high-entropy identity evidence and the fixed root response proves
+    // the peer completed Toolport's auth and routing path.
     let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
     loop {
         if let Ok(Some(status)) = child.try_wait() {
@@ -3458,11 +3765,12 @@ fn start_http_bridge_at(
                 "The HTTP endpoint exited on startup ({status}). Is port {port} already in use?"
             ));
         }
-        if std::net::TcpStream::connect(("127.0.0.1", port)).is_ok() {
-            break; // it's listening
+        if http_bridge_identity_ready(port, &token) {
+            break;
         }
         if std::time::Instant::now() >= deadline {
             let _ = child.kill();
+            let _ = child.wait();
             return Err(format!(
                 "The HTTP endpoint did not come up on port {port} within 5s."
             ));
@@ -3479,6 +3787,10 @@ fn start_http_bridge_at(
 #[tauri::command]
 fn stop_http_bridge(state: State<HttpBridgeState>) -> Result<HttpBridgeStatus, String> {
     let mut bridge = state.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+    // Clear the resume marker before stopping the live endpoint. If cleanup is
+    // denied, leave the endpoint running and report the error; otherwise a later
+    // launch could silently resurrect something the user explicitly disabled.
+    clear_update_http_bridge_intent()?;
     if let Some(mut child) = bridge.child.take() {
         let _ = child.kill();
         let _ = child.wait();
@@ -3486,6 +3798,19 @@ fn stop_http_bridge(state: State<HttpBridgeState>) -> Result<HttpBridgeStatus, S
     bridge.port = None;
     bridge.token = None;
     Ok(HttpBridgeStatus::new(None, None))
+}
+
+fn resume_http_bridge_after_update(state: &HttpBridgeState) -> Result<bool, String> {
+    let Some(intent) = load_update_http_bridge_intent()? else {
+        return Ok(false);
+    };
+    ensure_http_bridge_at(state, intent.port, Some(intent.token))?;
+    if let Err(error) = clear_update_http_bridge_intent() {
+        eprintln!(
+            "toolport: restored the HTTP endpoint, but could not clear its update resume state: {error}"
+        );
+    }
+    Ok(true)
 }
 
 /// Report whether the HTTP bridge is running, reaping it if it has exited.
@@ -3876,6 +4201,7 @@ pub fn run() {
             stop_http_bridge,
             http_bridge_status,
             stop_spawned_gateways,
+            recover_update_gateways,
             stop_stale_gateways,
             clients_needing_restart,
         ])
@@ -3951,6 +4277,21 @@ pub fn run() {
                         "toolport: published client gateway at {}",
                         published.display()
                     );
+                }
+                // An in-app update deliberately stops the supervised HTTP child
+                // before replacing files. The durable intent carries its exact
+                // port and bearer across relaunch, so the newly installed app
+                // restores connectivity without rotating credentials.
+                match resume_http_bridge_after_update(
+                    migrate_handle.state::<HttpBridgeState>().inner(),
+                ) {
+                    Ok(true) => eprintln!(
+                        "toolport: restored the HTTP endpoint after the in-app update"
+                    ),
+                    Ok(false) => {}
+                    Err(error) => eprintln!(
+                        "toolport: could not restore the HTTP endpoint after the in-app update: {error}"
+                    ),
                 }
                 // Ownership map from disk (this launch thread has no RegistryState handle).
                 let managed_snapshot = registry::load()
@@ -4183,6 +4524,69 @@ mod tests {
     use super::*;
     use crate::{arg_looks_secret, redact_url_userinfo};
     use registry::EnvVar;
+
+    fn unique_update_test_dir(label: &str) -> std::path::PathBuf {
+        std::env::temp_dir().join(format!(
+            "toolport-{label}-{}-{}",
+            std::process::id(),
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ))
+    }
+
+    #[test]
+    fn update_http_bridge_intent_round_trips_exact_token_and_clear_failures_surface() {
+        let dir = unique_update_test_dir("update-bridge-intent");
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("resume.json");
+        let intent = UpdateHttpBridgeIntent {
+            port: 9876,
+            token: "preserved-secret-token".to_string(),
+        };
+
+        save_update_http_bridge_intent_to(&path, &intent).unwrap();
+        let loaded = load_update_http_bridge_intent_from(&path)
+            .unwrap()
+            .expect("intent exists");
+        assert_eq!(loaded.port, intent.port);
+        assert_eq!(loaded.token, intent.token);
+        clear_update_http_bridge_intent_at(&path).unwrap();
+        assert!(load_update_http_bridge_intent_from(&path).unwrap().is_none());
+
+        let directory_marker = dir.join("not-a-file");
+        std::fs::create_dir(&directory_marker).unwrap();
+        assert!(clear_update_http_bridge_intent_at(&directory_marker).is_err());
+        std::fs::remove_dir(&directory_marker).unwrap();
+        std::fs::remove_dir(&dir).unwrap();
+    }
+
+    #[test]
+    fn update_http_bridge_readiness_requires_the_exact_bearer_and_identity() {
+        let server = tiny_http::Server::http("127.0.0.1:0").unwrap();
+        let port = server.server_addr().to_ip().unwrap().port();
+        let handle = std::thread::spawn(move || {
+            for _ in 0..2 {
+                let request = server.recv().unwrap();
+                let authorized = request.headers().iter().any(|header| {
+                    header.field.equiv("Authorization")
+                        && header.value.as_str() == "Bearer exact-secret"
+                });
+                let response = if authorized {
+                    tiny_http::Response::from_string("Toolport gateway (HTTP mode).\n")
+                        .with_status_code(200)
+                } else {
+                    tiny_http::Response::from_string("not authorized").with_status_code(401)
+                };
+                request.respond(response).unwrap();
+            }
+        });
+
+        assert!(!http_bridge_identity_ready(port, "wrong-secret"));
+        assert!(http_bridge_identity_ready(port, "exact-secret"));
+        handle.join().unwrap();
+    }
 
     #[test]
     fn tray_approvals_requests_choose_exactly_one_delivery_mode() {

--- a/src-tauri/src/downstream.rs
+++ b/src-tauri/src/downstream.rs
@@ -851,6 +851,16 @@ pub(crate) const HTTP_MAX_RETRIES: u32 = 2;
 /// Base backoff between retries; doubles each attempt, capped at HTTP_RETRY_CAP.
 pub(crate) const HTTP_RETRY_BASE: Duration = Duration::from_millis(250);
 pub(crate) const HTTP_RETRY_CAP: Duration = Duration::from_secs(10);
+/// Cancellation is observed at this cadence while a blocking HTTP attempt drains on
+/// its bounded worker. The router slot is released within one tick; the wire attempt
+/// remains owned by that single worker until ureq's 30s request timeout closes it.
+const HTTP_CANCEL_POLL: Duration = Duration::from_millis(25);
+/// A cancellation notification is best-effort and must never replace one blocked
+/// request with another. Its independent connection has this much total time.
+const HTTP_CANCEL_FORWARD_TIMEOUT: Duration = Duration::from_secs(1);
+const MAX_HTTP_CANCEL_THREADS: usize = 64;
+static HTTP_CANCEL_THREADS_INFLIGHT: std::sync::atomic::AtomicUsize =
+    std::sync::atomic::AtomicUsize::new(0);
 
 /// Error from a single transport request attempt. The caller (Router) owns the
 /// retry loop so it can release the per-server Mutex during the backoff sleep,
@@ -879,6 +889,12 @@ pub enum TransportError {
         retry_after: Option<Duration>,
         message: String,
     },
+    /// The upstream caller abandoned this operation. It is deliberately not a
+    /// health failure: pressing Stop says nothing about the downstream server.
+    Cancelled(String),
+    /// A prior cancelled HTTP wire attempt is still draining on its one bounded
+    /// worker. Followers fail promptly instead of spawning more request threads.
+    Busy(String),
 }
 
 /// Tracks client-side JSON-RPC request ids that are currently proxied to a
@@ -924,6 +940,16 @@ impl CancelContext {
     /// normal forwarding path still sends `notifications/cancelled` to that server.
     pub fn is_cancelled(&self) -> bool {
         self.registry.is_cancelled(&self.client_request_id)
+    }
+
+    fn reason(&self) -> Option<String> {
+        self.registry
+            .inner
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .cancelled
+            .get(&self.client_request_id)
+            .and_then(|cancelled| cancelled.reason.clone())
     }
 }
 
@@ -1182,6 +1208,9 @@ impl std::fmt::Display for TransportError {
             TransportError::Rpc(err) => write!(f, "{err}"),
             TransportError::Unavailable(msg) => write!(f, "{msg}"),
             TransportError::Retry { message, .. } => write!(f, "{message}"),
+            TransportError::Cancelled(message) | TransportError::Busy(message) => {
+                write!(f, "{message}")
+            }
         }
     }
 }
@@ -1825,6 +1854,18 @@ pub trait Transport: Send {
             ));
         }
         self.request(method, params)
+    }
+    /// Cancel and retire a server request suspended for this exact multi-round
+    /// continuation. Implementations must validate the requestState/method/base
+    /// params before touching pending state; an unrelated cancelled request may
+    /// share the same downstream server.
+    fn cancel_matching_pending_request(
+        &mut self,
+        _method: &str,
+        _params: &Value,
+        _cancel: &CancelContext,
+    ) -> bool {
+        false
     }
     /// Send a request with transport-level routing headers. Only modern
     /// Streamable HTTP consumes these; stdio and legacy transports deliberately
@@ -3125,6 +3166,16 @@ impl Transport for StdioTransport {
         params: Value,
         cancel: Option<CancelContext>,
     ) -> Result<Value, TransportError> {
+        if self.pending_mrtr.is_some()
+            && cancel.as_ref().is_some_and(CancelContext::is_cancelled)
+        {
+            if let Some(cancel) = cancel.as_ref() {
+                self.cancel_matching_pending_request(method, &params, cancel);
+            }
+            return Err(TransportError::Cancelled(
+                "request cancelled before it reached the downstream server".to_string(),
+            ));
+        }
         let mut params = params;
         if let Some(protocol) = &self.protocol_meta {
             merge_protocol_meta(&mut params, protocol);
@@ -3273,6 +3324,27 @@ impl Transport for StdioTransport {
                 return Ok(value.get("result").cloned().unwrap_or(Value::Null));
             }
         }
+    }
+
+    fn cancel_matching_pending_request(
+        &mut self,
+        method: &str,
+        params: &Value,
+        cancel: &CancelContext,
+    ) -> bool {
+        let Some(pending) = self.pending_mrtr.as_ref() else {
+            return false;
+        };
+        if pending.response_for_retry(method, params).is_err() {
+            return false;
+        }
+        let pending = self.pending_mrtr.take().expect("matching pending request exists");
+        CancelEntry {
+            stdin: Arc::clone(&self.stdin),
+            downstream_id: pending.downstream_request_id,
+        }
+        .send_cancel_async(cancel.reason());
+        true
     }
 
     fn notify(&mut self, method: &str, params: Value) -> Result<(), TransportError> {
@@ -3606,6 +3678,80 @@ pub struct HttpTransport {
     /// `protocol_meta` because that is replaced wholesale after version
     /// negotiation; see `merge_declared_extensions`.
     declared_extensions: serde_json::Map<String, Value>,
+    /// Retained so a cancellation notification can use an independent guarded
+    /// connection with the same SSRF policy as the request it is cancelling.
+    block_private: bool,
+    /// The temporary draining shell shares the live generation but must not stop
+    /// the listener when it is replaced by the worker-owned transport.
+    owns_listener_generation: bool,
+    /// Set only after the caller cancels a blocking ureq attempt. The receiver
+    /// owns the sole route back to that attempt's transport state; until it is
+    /// ready, followers fail fast and no second worker can be started.
+    draining: Option<Receiver<HttpAttemptOutcome>>,
+}
+
+struct HttpAttemptOutcome {
+    transport: HttpTransport,
+    result: Result<Value, TransportError>,
+}
+
+/// Per-wire-attempt cancellation state. Unlike CancelRegistry, this survives the
+/// gateway finishing the upstream request immediately after returning Cancelled.
+/// State: 0 = no POST started, 1 = POST started, 2 = durably cancelled.
+#[derive(Clone)]
+struct HttpCancelSignal {
+    context: CancelContext,
+    state: Arc<AtomicU8>,
+}
+
+impl HttpCancelSignal {
+    fn new(context: CancelContext, request_already_live: bool) -> Self {
+        Self {
+            context,
+            state: Arc::new(AtomicU8::new(u8::from(request_already_live))),
+        }
+    }
+
+    fn is_cancelled(&self) -> bool {
+        self.state.load(Ordering::SeqCst) == 2 || self.context.is_cancelled()
+    }
+
+    /// Atomically claim the right to send. If cancellation wins from state 0,
+    /// the worker never emits the first POST. Once any POST started, subsequent
+    /// auth retries retain state 1 but still observe a later state 2.
+    fn mark_sending(&self) -> bool {
+        loop {
+            if self.context.is_cancelled() {
+                // State 1 can mean this connection already has a live MRTR
+                // request even though this continuation POST has not started.
+                // Preserve that fact so the caller can still claim and forward
+                // notifications/cancelled for the original downstream id.
+                if self
+                    .state
+                    .compare_exchange(0, 2, Ordering::SeqCst, Ordering::SeqCst)
+                    .is_err()
+                {
+                    // A concurrent outer cancellation may already have moved
+                    // state 1 to 2 and forwarded it; either way, do not send.
+                }
+                return false;
+            }
+            match self
+                .state
+                .compare_exchange(0, 1, Ordering::SeqCst, Ordering::SeqCst)
+            {
+                Ok(_) | Err(1) => return true,
+                Err(2) => return false,
+                Err(_) => continue,
+            }
+        }
+    }
+
+    /// Latch cancellation independently of CancelRegistry teardown. Returns true
+    /// only when a POST had already started and needs a downstream notification.
+    fn cancel(&self) -> bool {
+        self.state.swap(2, Ordering::SeqCst) == 1
+    }
 }
 
 struct PendingHttpMrtr {
@@ -3666,6 +3812,9 @@ impl HttpTransport {
             listener_generation: Arc::new(AtomicU64::new(0)),
             subscription_listener_id: None,
             declared_extensions: serde_json::Map::new(),
+            block_private,
+            owns_listener_generation: true,
+            draining: None,
         }
     }
 
@@ -3728,12 +3877,142 @@ impl HttpTransport {
         self.protocol_meta.is_some()
     }
 
+    fn draining_shell(&self, receiver: Receiver<HttpAttemptOutcome>) -> Self {
+        Self {
+            url: self.url.clone(),
+            agent: self.agent.clone(),
+            inline_agent: self.inline_agent.clone(),
+            session_id: self.session_id.clone(),
+            next_id: self.next_id,
+            auth: Arc::clone(&self.auth),
+            refresh: self.refresh.clone(),
+            scope_reauthorize: self.scope_reauthorize.clone(),
+            scope_upgrade_attempts: Arc::clone(&self.scope_upgrade_attempts),
+            forced_refresh_token: self.forced_refresh_token.clone(),
+            server_handler: self.server_handler.clone(),
+            pending_mrtr: None,
+            resource_updated: self.resource_updated.clone(),
+            progress: self.progress.clone(),
+            protocol_meta: self.protocol_meta.clone(),
+            change_dirty: self.change_dirty.clone(),
+            listener_generation: Arc::clone(&self.listener_generation),
+            subscription_listener_id: self.subscription_listener_id,
+            declared_extensions: self.declared_extensions.clone(),
+            block_private: self.block_private,
+            owns_listener_generation: false,
+            draining: Some(receiver),
+        }
+    }
+
+    /// Restore transport-owned protocol/session state after a cancelled wire attempt
+    /// finishes. A pending attempt is a prompt non-health failure: this keeps the
+    /// per-server slot available without permitting another worker to pile up.
+    fn restore_drained(&mut self) -> Result<(), TransportError> {
+        let Some(receiver) = self.draining.take() else {
+            return Ok(());
+        };
+        match receiver.try_recv() {
+            Ok(outcome) => {
+                *self = outcome.transport;
+                // The abandoned response is intentionally ignored. Its state updates
+                // (session/token/request id) survive in the restored transport.
+                let _ = outcome.result;
+                Ok(())
+            }
+            Err(std::sync::mpsc::TryRecvError::Empty) => {
+                self.draining = Some(receiver);
+                Err(TransportError::Busy(
+                    "previous cancelled HTTP request is still draining".to_string(),
+                ))
+            }
+            Err(std::sync::mpsc::TryRecvError::Disconnected) => Err(TransportError::Fatal(
+                "cancelled HTTP request worker exited before restoring transport state".to_string(),
+            )),
+        }
+    }
+
+    fn downstream_request_id(&self) -> Value {
+        self.pending_mrtr
+            .as_ref()
+            .map(|pending| pending.common.downstream_request_id.clone())
+            .unwrap_or_else(|| json!(self.next_id))
+    }
+
+    fn forward_cancel_async(&self, downstream_id: Value, cancel: &CancelContext) {
+        if HTTP_CANCEL_THREADS_INFLIGHT.fetch_add(1, Ordering::SeqCst) >= MAX_HTTP_CANCEL_THREADS {
+            HTTP_CANCEL_THREADS_INFLIGHT.fetch_sub(1, Ordering::SeqCst);
+            downstream_trace("dropping HTTP cancellation forward: worker cap reached");
+            return;
+        }
+        let agent = guarded_agent_with_timeout(self.block_private, HTTP_CANCEL_FORWARD_TIMEOUT);
+        let url = self.url.clone();
+        let auth = Arc::clone(&self.auth);
+        let session_id = self.session_id.clone();
+        let protocol_meta = self.protocol_meta.clone();
+        let wire_version = self.wire_protocol_version();
+        let reason = cancel.reason();
+        std::thread::spawn(move || {
+            let mut params = json!({ "requestId": downstream_id });
+            if let Some(reason) = reason {
+                params["reason"] = json!(reason);
+            }
+            if let Some(protocol) = &protocol_meta {
+                merge_protocol_meta(&mut params, protocol);
+            }
+            let body = json!({
+                "jsonrpc": "2.0",
+                "method": "notifications/cancelled",
+                "params": params,
+            });
+            let mut request = agent
+                .post(&url)
+                .set("Content-Type", "application/json")
+                .set("Accept", "application/json, text/event-stream")
+                .set("MCP-Protocol-Version", &wire_version);
+            if protocol_meta.is_none() {
+                if let Some(session_id) = session_id.as_deref() {
+                    request = request.set("Mcp-Session-Id", session_id);
+                }
+            } else if let Ok(headers) = modern_standard_headers(&body) {
+                for (name, value) in headers {
+                    request = request.set(&name, &value);
+                }
+            }
+            let token = auth
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .clone();
+            if let Some(token) = token.as_deref() {
+                request = request.set("Authorization", &bearer_header(token));
+            }
+            if let Err(error) = request.send_string(&body.to_string()) {
+                downstream_trace(&format!("HTTP cancellation forward failed: {error}"));
+            }
+            HTTP_CANCEL_THREADS_INFLIGHT.fetch_sub(1, Ordering::SeqCst);
+        });
+    }
+
     fn request_inner(
         &mut self,
         method: &str,
         params: Value,
         headers: &[(String, String)],
     ) -> Result<Value, TransportError> {
+        self.request_inner_with_cancel(method, params, headers, None)
+    }
+
+    fn request_inner_with_cancel(
+        &mut self,
+        method: &str,
+        params: Value,
+        headers: &[(String, String)],
+        cancel: Option<&HttpCancelSignal>,
+    ) -> Result<Value, TransportError> {
+        if cancel.is_some_and(HttpCancelSignal::is_cancelled) {
+            return Err(TransportError::Cancelled(
+                "request cancelled before it reached the HTTP server".to_string(),
+            ));
+        }
         let mut params = params;
         if let Some(protocol) = &self.protocol_meta {
             merge_protocol_meta(&mut params, protocol);
@@ -3751,7 +4030,16 @@ impl HttpTransport {
                     return Ok(input_required);
                 }
             };
-            self.send_post_no_response(&response)?;
+            if cancel.is_some_and(HttpCancelSignal::is_cancelled) {
+                self.pending_mrtr = Some(pending);
+                return Err(TransportError::Cancelled(
+                    "request cancelled before it reached the HTTP server".to_string(),
+                ));
+            }
+            // This inline response resumes an already-live downstream request.
+            // Mark it as sent before the blocking POST so outer cancellation
+            // forwards notifications/cancelled with that original request id.
+            self.send_post_no_response_cancel(&response, cancel)?;
             let resp = self.read_sse_stream(
                 pending.reader,
                 pending.common.downstream_request_id.clone(),
@@ -3771,7 +4059,7 @@ impl HttpTransport {
         self.next_id += 1;
         let body = json!({ "jsonrpc": "2.0", "id": id, "method": method, "params": params });
         let resp = self
-            .post_with_headers(&body, true, headers)?
+            .post_with_headers_cancel(&body, true, headers, cancel)?
             .ok_or_else(|| TransportError::Fatal("empty response".to_string()))?;
         if let Some(err) = resp.get("error") {
             return Err(TransportError::Rpc(err.clone()));
@@ -3893,11 +4181,24 @@ impl HttpTransport {
 
     /// POST JSON-RPC without waiting for a response body (inline replies mid-SSE).
     fn send_post_no_response(&mut self, body: &Value) -> Result<(), TransportError> {
+        self.send_post_no_response_cancel(body, None)
+    }
+
+    fn send_post_no_response_cancel(
+        &mut self,
+        body: &Value,
+        cancel: Option<&HttpCancelSignal>,
+    ) -> Result<(), TransportError> {
         let payload = body.to_string();
         self.refresh_before_send();
         let mut refreshed = self.forced_refresh_spent();
         let wire_version = self.wire_protocol_version();
         let resp = loop {
+            if cancel.is_some_and(HttpCancelSignal::is_cancelled) {
+                return Err(TransportError::Cancelled(
+                    "HTTP request cancelled by upstream client".to_string(),
+                ));
+            }
             let mut req = self
                 .inline_agent
                 .post(&self.url)
@@ -3922,7 +4223,18 @@ impl HttpTransport {
             if let Some(token) = auth.as_deref() {
                 req = req.set("Authorization", &bearer_header(token));
             }
-            match req.send_string(&payload) {
+            if cancel.is_some_and(|signal| !signal.mark_sending()) {
+                return Err(TransportError::Cancelled(
+                    "HTTP request cancelled by upstream client".to_string(),
+                ));
+            }
+            let response = req.send_string(&payload);
+            if cancel.is_some_and(HttpCancelSignal::is_cancelled) {
+                return Err(TransportError::Cancelled(
+                    "HTTP request cancelled by upstream client".to_string(),
+                ));
+            }
+            match response {
                 Ok(resp) => break resp,
                 Err(ureq::Error::Status(code, resp))
                     if (code == 401 || code == 403)
@@ -4076,6 +4388,16 @@ impl HttpTransport {
         expect_response: bool,
         extra_headers: &[(String, String)],
     ) -> Result<Option<Value>, TransportError> {
+        self.post_with_headers_cancel(body, expect_response, extra_headers, None)
+    }
+
+    fn post_with_headers_cancel(
+        &mut self,
+        body: &Value,
+        expect_response: bool,
+        extra_headers: &[(String, String)],
+        cancel: Option<&HttpCancelSignal>,
+    ) -> Result<Option<Value>, TransportError> {
         let payload = body.to_string();
 
         // Refresh shortly before the known expiry, including before initialize.
@@ -4092,6 +4414,11 @@ impl HttpTransport {
         let mut refreshed = self.forced_refresh_spent();
         let wire_version = self.wire_protocol_version();
         let resp = loop {
+            if cancel.is_some_and(HttpCancelSignal::is_cancelled) {
+                return Err(TransportError::Cancelled(
+                    "request cancelled before it reached the HTTP server".to_string(),
+                ));
+            }
             let mut req = self
                 .agent
                 .post(&self.url)
@@ -4120,7 +4447,21 @@ impl HttpTransport {
                 req = req.set("Authorization", &bearer_header(token));
             }
 
-            match req.send_string(&payload) {
+            if cancel.is_some_and(|signal| !signal.mark_sending()) {
+                return Err(TransportError::Cancelled(
+                    "request cancelled before it reached the HTTP server".to_string(),
+                ));
+            }
+            let response = req.send_string(&payload);
+            // Cancellation wins even when the socket becomes readable at the same
+            // instant. In particular, never launch scope reauthorization or rotate
+            // an OAuth token for a request whose caller already abandoned it.
+            if cancel.is_some_and(HttpCancelSignal::is_cancelled) {
+                return Err(TransportError::Cancelled(
+                    "HTTP request cancelled by upstream client".to_string(),
+                ));
+            }
+            match response {
                 Ok(r) => break r,
                 // Rate limited: return a Retry signal so the Router sleeps
                 // *outside* the per-server Mutex.
@@ -4218,7 +4559,17 @@ impl HttpTransport {
 
 impl Transport for HttpTransport {
     fn request(&mut self, method: &str, params: Value) -> Result<Value, TransportError> {
+        self.restore_drained()?;
         self.request_inner(method, params, &[])
+    }
+
+    fn request_with_cancel(
+        &mut self,
+        method: &str,
+        params: Value,
+        cancel: Option<CancelContext>,
+    ) -> Result<Value, TransportError> {
+        self.request_with_cancel_and_headers(method, params, cancel, &[])
     }
 
     fn request_with_cancel_and_headers(
@@ -4228,12 +4579,95 @@ impl Transport for HttpTransport {
         cancel: Option<CancelContext>,
         headers: &[(String, String)],
     ) -> Result<Value, TransportError> {
-        if cancel.is_some() {
-            downstream_trace(&format!(
-                "cancellation closes the modern HTTP response stream for method {method}"
+        self.restore_drained()?;
+        let Some(cancel) = cancel else {
+            return self.request_inner(method, params, headers);
+        };
+        if cancel.is_cancelled() {
+            self.cancel_matching_pending_request(method, &params, &cancel);
+            return Err(TransportError::Cancelled(
+                "request cancelled before it reached the HTTP server".to_string(),
             ));
         }
-        self.request_inner(method, params, headers)
+
+        // ureq 2.x has no request abort handle. Move the complete mutable transport
+        // state to exactly one bounded wire worker, leaving this slot with only a
+        // receiver and immutable cancellation context. On cancellation the caller
+        // returns within HTTP_CANCEL_POLL; the worker owns no Router/ServerSlot borrow
+        // and drains for at most the agent's 30s request timeout.
+        let downstream_id = self.downstream_request_id();
+        let request_already_live = self.pending_mrtr.is_some();
+        let (sender, receiver) = std::sync::mpsc::sync_channel(1);
+        let shell = self.draining_shell(receiver);
+        let mut owned = std::mem::replace(self, shell);
+        let method = method.to_string();
+        let headers = headers.to_vec();
+        let cancel_signal = HttpCancelSignal::new(cancel.clone(), request_already_live);
+        let worker_cancel = cancel_signal.clone();
+        std::thread::spawn(move || {
+            let result =
+                owned.request_inner_with_cancel(&method, params, &headers, Some(&worker_cancel));
+            owned.draining = None;
+            let _ = sender.send(HttpAttemptOutcome {
+                transport: owned,
+                result,
+            });
+        });
+
+        loop {
+            let result = self
+                .draining
+                .as_ref()
+                .expect("draining receiver installed before HTTP worker started")
+                .recv_timeout(HTTP_CANCEL_POLL);
+            match result {
+                Ok(outcome) => {
+                    let result = outcome.result;
+                    *self = outcome.transport;
+                    if cancel.is_cancelled() {
+                        if cancel_signal.cancel() {
+                            self.forward_cancel_async(downstream_id, &cancel);
+                        }
+                        return Err(TransportError::Cancelled(
+                            "HTTP request cancelled by upstream client".to_string(),
+                        ));
+                    }
+                    return result;
+                }
+                Err(RecvTimeoutError::Timeout) if cancel.is_cancelled() => {
+                    if cancel_signal.cancel() {
+                        self.forward_cancel_async(downstream_id, &cancel);
+                    }
+                    return Err(TransportError::Cancelled(
+                        "HTTP request cancelled by upstream client".to_string(),
+                    ));
+                }
+                Err(RecvTimeoutError::Timeout) => {}
+                Err(RecvTimeoutError::Disconnected) => {
+                    self.draining = None;
+                    return Err(TransportError::Fatal(
+                        "HTTP request worker exited without returning transport state".to_string(),
+                    ));
+                }
+            }
+        }
+    }
+
+    fn cancel_matching_pending_request(
+        &mut self,
+        method: &str,
+        params: &Value,
+        cancel: &CancelContext,
+    ) -> bool {
+        let Some(pending) = self.pending_mrtr.as_ref() else {
+            return false;
+        };
+        if pending.common.response_for_retry(method, params).is_err() {
+            return false;
+        }
+        let pending = self.pending_mrtr.take().expect("matching pending request exists");
+        self.forward_cancel_async(pending.common.downstream_request_id, cancel);
+        true
     }
 
     fn supports_request_headers(&self) -> bool {
@@ -4241,6 +4675,7 @@ impl Transport for HttpTransport {
     }
 
     fn notify(&mut self, method: &str, params: Value) -> Result<(), TransportError> {
+        self.restore_drained()?;
         // Notifications carry the connection's protocol metadata too, so a modern
         // server sees a consistent story on every message rather than only on
         // requests. (The revision leaves notification headers undefined, so this
@@ -4272,6 +4707,7 @@ impl Transport for HttpTransport {
         &mut self,
         filter: SubscriptionFilter,
     ) -> Result<(), TransportError> {
+        self.restore_drained()?;
         let id = self.next_id;
         self.next_id += 1;
         let mut params = filter.params();
@@ -4504,7 +4940,9 @@ impl Transport for HttpTransport {
 
 impl Drop for HttpTransport {
     fn drop(&mut self) {
-        self.listener_generation.fetch_add(1, Ordering::SeqCst);
+        if self.owns_listener_generation {
+            self.listener_generation.fetch_add(1, Ordering::SeqCst);
+        }
     }
 }
 
@@ -10440,6 +10878,351 @@ mod tests {
         assert_eq!(hits.load(Ordering::SeqCst), 2);
 
         handle.join().unwrap();
+    }
+
+    #[test]
+    fn stalled_http_cancellation_returns_promptly_and_forwards_exact_request_id() {
+        use super::{CancelRegistry, HttpTransport, Transport, TransportError};
+        use std::sync::mpsc;
+        use std::time::{Duration, Instant};
+
+        let server = tiny_http::Server::http("127.0.0.1:0").unwrap();
+        let port = server.server_addr().to_ip().unwrap().port();
+        let (stalled_tx, stalled_rx) = mpsc::channel();
+        let (cancel_tx, cancel_rx) = mpsc::channel();
+        let (release_tx, release_rx) = mpsc::channel();
+        let handle = std::thread::spawn(move || {
+            let mut stalled = server.recv().expect("receive original HTTP request");
+            let mut original_body = String::new();
+            stalled
+                .as_reader()
+                .read_to_string(&mut original_body)
+                .unwrap();
+            let original: Value = serde_json::from_str(&original_body).unwrap();
+            stalled_tx.send(original["id"].clone()).unwrap();
+
+            let mut cancellation = server.recv().expect("receive cancellation POST");
+            let mut cancel_body = String::new();
+            cancellation
+                .as_reader()
+                .read_to_string(&mut cancel_body)
+                .unwrap();
+            let cancel: Value = serde_json::from_str(&cancel_body).unwrap();
+            cancel_tx.send(cancel).unwrap();
+            let _ = cancellation.respond(tiny_http::Response::empty(202));
+
+            // Keep the original request genuinely stalled until the caller has
+            // proved a follower cannot create a second wire attempt.
+            release_rx.recv().expect("test releases stalled response");
+
+            let ct = tiny_http::Header::from_bytes(&b"Content-Type"[..], &b"application/json"[..])
+                .unwrap();
+            let id = original["id"].clone();
+            let body = json!({ "jsonrpc": "2.0", "id": id, "result": { "ok": true } });
+            let _ =
+                stalled.respond(tiny_http::Response::from_string(body.to_string()).with_header(ct));
+        });
+
+        let cancellations = CancelRegistry::new();
+        assert!(cancellations.begin_client_request("http-stall".to_string()));
+        let cancel_context = cancellations.context("http-stall".to_string());
+        let url = format!("http://127.0.0.1:{port}/");
+        let worker = std::thread::spawn(move || {
+            let mut transport = HttpTransport::new(&url);
+            let started = Instant::now();
+            // Exercise the headerless trait path used by completion/complete too;
+            // HttpTransport must override it rather than inheriting the default
+            // cancellation-ignoring implementation.
+            let result = transport.request_with_cancel(
+                "completion/complete",
+                json!({ "name": "slow" }),
+                Some(cancel_context),
+            );
+            (transport, result, started.elapsed())
+        });
+
+        let original_id = stalled_rx.recv_timeout(Duration::from_secs(1)).unwrap();
+        assert!(cancellations.cancel("http-stall", Some("user pressed stop")));
+        let (mut transport, result, elapsed) = worker.join().unwrap();
+        assert!(matches!(result, Err(TransportError::Cancelled(_))));
+        assert!(
+            elapsed < Duration::from_millis(500),
+            "the caller/slot must be released within the 25ms poll bound, got {elapsed:?}"
+        );
+
+        let cancel = cancel_rx.recv_timeout(Duration::from_secs(2)).unwrap();
+        assert_eq!(cancel["method"], "notifications/cancelled");
+        assert_eq!(cancel["params"]["requestId"], original_id);
+        assert_eq!(cancel["params"]["reason"], "user pressed stop");
+
+        // A follower is not queued behind the dead wire request: it fails promptly
+        // while the sole worker drains, and cannot spawn a second attempt.
+        let follower_started = Instant::now();
+        let follower = transport.request("tools/call", json!({ "name": "other" }));
+        assert!(matches!(follower, Err(TransportError::Busy(_))));
+        assert!(follower_started.elapsed() < Duration::from_millis(100));
+
+        release_tx.send(()).unwrap();
+        cancellations.finish_client_request("http-stall");
+        handle.join().unwrap();
+
+        // Once the sole worker has drained, its full protocol state is restored
+        // and the transport can accept a fresh request instead of staying Busy.
+        let recovery_server = tiny_http::Server::http("127.0.0.1:0").unwrap();
+        let recovery_port = recovery_server.server_addr().to_ip().unwrap().port();
+        let recovery_handle = std::thread::spawn(move || {
+            let mut request = recovery_server.recv().expect("receive recovery request");
+            let mut raw = String::new();
+            request.as_reader().read_to_string(&mut raw).unwrap();
+            let body: Value = serde_json::from_str(&raw).unwrap();
+            let response = json!({
+                "jsonrpc": "2.0",
+                "id": body["id"],
+                "result": { "recovered": true }
+            });
+            let content_type = tiny_http::Header::from_bytes(
+                &b"Content-Type"[..],
+                &b"application/json"[..],
+            )
+            .unwrap();
+            request
+                .respond(
+                    tiny_http::Response::from_string(response.to_string())
+                        .with_header(content_type),
+                )
+                .unwrap();
+        });
+        // Wait only for the bounded worker to hand its owned protocol state back.
+        // No second wire request is allowed while the shell reports Busy.
+        let deadline = Instant::now() + Duration::from_secs(1);
+        loop {
+            match transport.restore_drained() {
+                Err(TransportError::Busy(_)) if Instant::now() < deadline => {
+                    std::thread::yield_now();
+                }
+                result => break result.unwrap(),
+            }
+        }
+        transport.url = format!("http://127.0.0.1:{recovery_port}/");
+        transport.agent = super::guarded_agent(false);
+        transport.inline_agent = super::guarded_agent(false);
+        let result = transport
+            .request("tools/call", json!({ "name": "after-cancel" }))
+            .expect("restored transport accepts a fresh request");
+        assert_eq!(result["recovered"], true);
+        recovery_handle.join().unwrap();
+    }
+
+    #[test]
+    fn pending_mrtr_cancellation_forwards_the_original_request_id() {
+        use super::{
+            CancelRegistry, HttpTransport, PendingHttpMrtr, PendingLegacyMrtr, Transport,
+            TransportError,
+        };
+        use std::io::Cursor;
+        use std::sync::mpsc;
+        use std::time::Duration;
+
+        let server = tiny_http::Server::http("127.0.0.1:0").unwrap();
+        let port = server.server_addr().to_ip().unwrap().port();
+        let (inline_tx, inline_rx) = mpsc::channel();
+        let (cancel_tx, cancel_rx) = mpsc::channel();
+        let (release_tx, release_rx) = mpsc::channel();
+        let handle = std::thread::spawn(move || {
+            let mut inline = server.recv().expect("receive MRTR inline response");
+            let mut inline_body = String::new();
+            inline.as_reader().read_to_string(&mut inline_body).unwrap();
+            inline_tx.send(inline_body).unwrap();
+
+            let mut cancellation = server.recv().expect("receive MRTR cancellation");
+            let mut cancel_body = String::new();
+            cancellation.as_reader().read_to_string(&mut cancel_body).unwrap();
+            cancel_tx
+                .send(serde_json::from_str::<Value>(&cancel_body).unwrap())
+                .unwrap();
+            cancellation
+                .respond(tiny_http::Response::empty(202))
+                .unwrap();
+
+            release_rx.recv().expect("release MRTR inline response");
+            inline.respond(tiny_http::Response::empty(202)).unwrap();
+        });
+
+        let base_params = json!({ "name": "interactive", "arguments": {} });
+        let common = PendingLegacyMrtr::new(
+            json!({
+                "jsonrpc": "2.0",
+                "id": 99,
+                "method": "elicitation/create",
+                "params": { "message": "Continue?" }
+            }),
+            json!(41),
+            "tools/call",
+            &base_params,
+        )
+        .unwrap();
+        let mut retry_params = base_params;
+        retry_params["requestState"] = json!(common.token.clone());
+        retry_params["inputResponses"] = json!({
+            common.input_key.clone(): { "action": "accept" }
+        });
+        let final_frame = b"data: {\"jsonrpc\":\"2.0\",\"id\":41,\"result\":{\"ok\":true}}\n\n";
+        let mut transport = HttpTransport::new(&format!("http://127.0.0.1:{port}/"));
+        transport.pending_mrtr = Some(PendingHttpMrtr {
+            common,
+            reader: Box::new(Cursor::new(final_frame.to_vec())),
+            bytes_read: 0,
+        });
+
+        let cancellations = CancelRegistry::new();
+        assert!(cancellations.begin_client_request("mrtr-cancel".to_string()));
+        let cancel_context = cancellations.context("mrtr-cancel".to_string());
+        let worker = std::thread::spawn(move || {
+            transport.request_with_cancel("tools/call", retry_params, Some(cancel_context))
+        });
+
+        let inline_body = inline_rx.recv_timeout(Duration::from_secs(1)).unwrap();
+        assert!(inline_body.contains("\"id\":99"));
+        assert!(cancellations.cancel("mrtr-cancel", Some("user pressed stop")));
+        let result = worker.join().unwrap();
+        assert!(matches!(result, Err(TransportError::Cancelled(_))));
+        let cancel = cancel_rx.recv_timeout(Duration::from_secs(2)).unwrap();
+        assert_eq!(cancel["method"], "notifications/cancelled");
+        assert_eq!(cancel["params"]["requestId"], 41);
+
+        release_tx.send(()).unwrap();
+        cancellations.finish_client_request("mrtr-cancel");
+        handle.join().unwrap();
+    }
+
+    #[test]
+    fn pending_mrtr_cancelled_before_inline_send_retains_forward_claim() {
+        use super::{CancelRegistry, HttpCancelSignal};
+
+        let cancellations = CancelRegistry::new();
+        assert!(cancellations.begin_client_request("mrtr-pre-send".to_string()));
+        let context = cancellations.context("mrtr-pre-send".to_string());
+        let signal = HttpCancelSignal::new(context, true);
+
+        assert!(cancellations.cancel("mrtr-pre-send", Some("user pressed stop")));
+        assert!(
+            !signal.mark_sending(),
+            "the continuation POST must not start after cancellation"
+        );
+        assert!(
+            signal.cancel(),
+            "the already-live original MRTR request still needs cancellation forwarded"
+        );
+        assert!(
+            !signal.cancel(),
+            "only one caller may claim the cancellation notification"
+        );
+        cancellations.finish_client_request("mrtr-pre-send");
+    }
+
+    #[test]
+    fn precancelled_pending_mrtr_forwards_original_id_without_continuation_post() {
+        use super::{
+            CancelRegistry, HttpTransport, PendingHttpMrtr, PendingLegacyMrtr, Transport,
+            TransportError,
+        };
+        use std::io::Cursor;
+        use std::time::Duration;
+
+        let server = tiny_http::Server::http("127.0.0.1:0").unwrap();
+        let port = server.server_addr().to_ip().unwrap().port();
+        let handle = std::thread::spawn(move || {
+            let mut request = server.recv().expect("receive cancellation");
+            let mut body = String::new();
+            request.as_reader().read_to_string(&mut body).unwrap();
+            request.respond(tiny_http::Response::empty(202)).unwrap();
+            let value: Value = serde_json::from_str(&body).unwrap();
+            assert_eq!(value["method"], "notifications/cancelled");
+            assert_eq!(value["params"]["requestId"], 41);
+            assert!(
+                server.recv_timeout(Duration::from_millis(150)).unwrap().is_none(),
+                "pre-cancellation must not send the inline continuation POST"
+            );
+        });
+
+        let base_params = json!({ "name": "interactive", "arguments": {} });
+        let common = PendingLegacyMrtr::new(
+            json!({
+                "jsonrpc": "2.0",
+                "id": 99,
+                "method": "elicitation/create",
+                "params": { "message": "Continue?" }
+            }),
+            json!(41),
+            "tools/call",
+            &base_params,
+        )
+        .unwrap();
+        let mut retry_params = base_params.clone();
+        retry_params["requestState"] = json!(common.token.clone());
+        retry_params["inputResponses"] = json!({
+            common.input_key.clone(): { "action": "accept" }
+        });
+        let mut transport = HttpTransport::new(&format!("http://127.0.0.1:{port}/"));
+        transport.pending_mrtr = Some(PendingHttpMrtr {
+            common,
+            reader: Box::new(Cursor::new(Vec::<u8>::new())),
+            bytes_read: 0,
+        });
+        let cancellations = CancelRegistry::new();
+        assert!(cancellations.begin_client_request("already-cancelled".to_string()));
+        let context = cancellations.context("already-cancelled".to_string());
+        assert!(cancellations.cancel("already-cancelled", Some("user pressed stop")));
+
+        let result = transport.request_with_cancel("tools/call", retry_params, Some(context));
+        assert!(matches!(result, Err(TransportError::Cancelled(_))));
+        assert!(transport.pending_mrtr.is_none());
+        handle.join().unwrap();
+        cancellations.finish_client_request("already-cancelled");
+    }
+
+    #[test]
+    fn unrelated_precancelled_request_cannot_retire_pending_mrtr() {
+        use super::{
+            CancelRegistry, HttpTransport, PendingHttpMrtr, PendingLegacyMrtr, Transport,
+            TransportError,
+        };
+        use std::io::Cursor;
+
+        let base_params = json!({ "name": "interactive", "arguments": {} });
+        let common = PendingLegacyMrtr::new(
+            json!({
+                "jsonrpc": "2.0",
+                "id": 99,
+                "method": "elicitation/create",
+                "params": { "message": "Continue?" }
+            }),
+            json!(41),
+            "tools/call",
+            &base_params,
+        )
+        .unwrap();
+        let mut unrelated = base_params.clone();
+        unrelated["requestState"] = json!("another-request-token");
+        unrelated["inputResponses"] = json!({ "other": { "action": "accept" } });
+        let mut transport = HttpTransport::new("http://127.0.0.1:9/");
+        transport.pending_mrtr = Some(PendingHttpMrtr {
+            common,
+            reader: Box::new(Cursor::new(Vec::<u8>::new())),
+            bytes_read: 0,
+        });
+        let cancellations = CancelRegistry::new();
+        assert!(cancellations.begin_client_request("unrelated-cancel".to_string()));
+        let context = cancellations.context("unrelated-cancel".to_string());
+        assert!(cancellations.cancel("unrelated-cancel", Some("user pressed stop")));
+
+        let result = transport.request_with_cancel("tools/call", unrelated, Some(context));
+        assert!(matches!(result, Err(TransportError::Cancelled(_))));
+        assert!(
+            transport.pending_mrtr.is_some(),
+            "an unrelated requestState must not consume another request's pending MRTR"
+        );
+        cancellations.finish_client_request("unrelated-cancel");
     }
 
     #[test]

--- a/src-tauri/src/gateway_publish.rs
+++ b/src-tauri/src/gateway_publish.rs
@@ -286,13 +286,28 @@ pub enum ReapDecision {
 /// that produced the advice, which is how #542 shipped a panel that erased
 /// itself (see [`RestartAdvice`](../desktop/struct.RestartAdvice.html) for the
 /// merge that keeps it).
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ReapReport {
     pub killed: Vec<String>,
     pub kept: Vec<String>,
     pub failed: Vec<String>,
+    /// Processes that still matched the kill plan after both termination passes.
+    /// A successful OS kill call is not proof that the process exited, so updater
+    /// callers must gate installation on this final observation too.
+    pub remaining: Vec<String>,
     /// Apps still launching an obsolete gateway, from this pass's pre-kill snapshot.
     pub needs_restart: Vec<ClientNeedingRestart>,
+    /// External client applications whose gateway accepted a stop request. When an
+    /// update later aborts, these apps may need restarting to recreate their stdio
+    /// connection. Toolport itself cannot safely recreate a client-owned pipe.
+    pub restart_clients: Vec<ClientNeedingRestart>,
+    /// Stopped gateways whose parent is provably an external application but
+    /// whose executable identity was not readable enough to safely name that
+    /// application. Orphans, init-owned helpers, and Toolport-owned processes do
+    /// not belong here; updater guidance must not infer external ownership from
+    /// the broad `killed` list.
+    pub unattributed_external_stopped: Vec<String>,
 }
 
 impl ReapReport {
@@ -714,6 +729,52 @@ fn label_process(proc: &GatewayProcess) -> String {
     }
 }
 
+/// Recovery target for a gateway stopped on behalf of the updater.
+///
+/// Only attribute a process when both its executable and parent were inspectable.
+/// That is the same trust boundary as stale-gateway restart advice: an unreadable
+/// process may belong to another user session, and naming its parent would turn
+/// weak basename evidence into confident recovery guidance.
+fn restart_client_for(proc: &GatewayProcess) -> Option<ClientNeedingRestart> {
+    proc.path.as_ref()?;
+    let parent = proc.parent.as_ref()?;
+    if is_our_own_process(&parent.basename) || is_init_like(parent) {
+        return None;
+    }
+    Some(ClientNeedingRestart {
+        client: parent.basename.clone(),
+        client_pid: parent.pid,
+        gateway: proc.basename.clone(),
+    })
+}
+
+fn record_restart_client(report: &mut ReapReport, proc: &GatewayProcess) {
+    let Some(client) = restart_client_for(proc) else {
+        let provably_external = proc
+            .parent
+            .as_ref()
+            .is_some_and(|parent| !is_our_own_process(&parent.basename) && !is_init_like(parent));
+        if provably_external {
+            let label = label_process(proc);
+            if !report
+                .unattributed_external_stopped
+                .iter()
+                .any(|existing| existing == &label)
+            {
+                report.unattributed_external_stopped.push(label);
+            }
+        }
+        return;
+    };
+    if !report
+        .restart_clients
+        .iter()
+        .any(|existing| existing.client_pid == client.client_pid)
+    {
+        report.restart_clients.push(client);
+    }
+}
+
 fn reap_with_context(ctx: &ReapContext) -> ReapReport {
     reap_listed(ctx, list_gateway_processes)
 }
@@ -737,6 +798,9 @@ fn reap_listed(ctx: &ReapContext, list: impl Fn() -> Vec<GatewayProcess>) -> Rea
         let label = label_process(&proc);
         if kill_gateway_process(&proc) {
             report.killed.push(label);
+            if ctx.kill_all {
+                record_restart_client(&mut report, &proc);
+            }
         } else {
             report.failed.push(label);
         }
@@ -749,14 +813,37 @@ fn reap_listed(ctx: &ReapContext, list: impl Fn() -> Vec<GatewayProcess>) -> Rea
             if decide_reap(&proc, ctx) == ReapDecision::Kill {
                 let label = label_process(&proc);
                 if kill_gateway_process(&proc) {
+                    // A first termination attempt may fail transiently. Once the
+                    // retry is accepted, do not leave a stale failure that would
+                    // incorrectly block the updater; the final observation below
+                    // is authoritative about whether the process actually exited.
+                    report.failed.retain(|failed| failed != &label);
                     if !report.killed.iter().any(|k| k == &label) {
                         report.killed.push(format!("{label} [retry]"));
                     }
+                    if ctx.kill_all {
+                        record_restart_client(&mut report, &proc);
+                    }
                 } else if !report.failed.iter().any(|f| f == &label) {
-                    report.failed.push(format!("{label} [still running]"));
+                    report.failed.push(label);
                 }
             }
         }
+
+        // A kill API reporting success only means the signal/request was accepted.
+        // Re-enumerate once more so update installation never races a process that
+        // still has the gateway binary open.
+        std::thread::sleep(std::time::Duration::from_millis(150));
+        report.remaining = list()
+            .into_iter()
+            .filter(|proc| decide_reap(proc, ctx) == ReapDecision::Kill)
+            .map(|proc| label_process(&proc))
+            .collect();
+
+        // Keep failed termination attempts even when the final enumerator no longer
+        // sees the pid. Enumeration is best-effort on every platform; only a later
+        // successful kill is strong enough evidence to clear a failure. Updaters
+        // must fail closed rather than replace files after an ambiguous shutdown.
     }
     report
 }
@@ -776,12 +863,20 @@ fn log_reap_report(kind: &str, report: &ReapReport) {
             report.failed.join("; ")
         );
     }
+    if !report.remaining.is_empty() {
+        eprintln!(
+            "toolport: {kind} still sees {} gateway process(es) alive: {}",
+            report.remaining.len(),
+            report.remaining.join("; ")
+        );
+    }
 }
 
 /// Terminate every Toolport/Conduit gateway process (all platforms). Used before
 /// in-app update so locked binaries can be replaced. Does not touch parent apps.
-/// Returns how many processes were successfully killed.
-pub fn stop_spawned_gateways() -> u32 {
+/// Returns the complete shutdown report. The updater must refuse installation
+/// while either `failed` or `remaining` is non-empty.
+pub fn stop_spawned_gateways() -> ReapReport {
     let ctx = ReapContext {
         current_version: env!("CARGO_PKG_VERSION").to_string(),
         keep_paths: Vec::new(),
@@ -791,7 +886,7 @@ pub fn stop_spawned_gateways() -> u32 {
     };
     let report = reap_with_context(&ctx);
     log_reap_report("updater reaper", &report);
-    report.killed.len() as u32
+    report
 }
 
 /// Terminate gateway processes that are not the current install. Safe on every
@@ -1609,6 +1704,78 @@ mod tests {
             }),
             ..proc(pid, basename, path)
         }
+    }
+
+    #[test]
+    fn updater_report_serializes_complete_shutdown_and_recovery_evidence() {
+        let client = ClientNeedingRestart {
+            client: "Cursor.exe".into(),
+            client_pid: 77,
+            gateway: "toolport-gateway.exe".into(),
+        };
+        let report = ReapReport {
+            killed: vec!["toolport-gateway.exe (pid 10)".into()],
+            kept: vec![],
+            failed: vec!["toolport-gateway.exe (pid 11)".into()],
+            remaining: vec!["toolport-gateway.exe (pid 11)".into()],
+            needs_restart: vec![],
+            restart_clients: vec![client],
+            unattributed_external_stopped: vec!["toolport-gateway.exe (pid 12)".into()],
+        };
+
+        let value = serde_json::to_value(report).expect("serialize updater reaper report");
+        assert_eq!(value["killed"][0], "toolport-gateway.exe (pid 10)");
+        assert_eq!(value["failed"][0], "toolport-gateway.exe (pid 11)");
+        assert_eq!(value["remaining"][0], "toolport-gateway.exe (pid 11)");
+        assert_eq!(value["restartClients"][0]["client"], "Cursor.exe");
+        assert_eq!(value["restartClients"][0]["clientPid"], 77);
+        assert_eq!(
+            value["unattributedExternalStopped"][0],
+            "toolport-gateway.exe (pid 12)"
+        );
+    }
+
+    #[test]
+    fn updater_recovery_names_only_safely_attributed_external_clients() {
+        let external = proc_with_parent(
+            10,
+            "toolport-gateway.exe",
+            Some(r"C:\Toolport\toolport-gateway.exe"),
+            77,
+            "Cursor.exe",
+        );
+        assert_eq!(
+            restart_client_for(&external),
+            Some(ClientNeedingRestart {
+                client: "Cursor.exe".into(),
+                client_pid: 77,
+                gateway: "toolport-gateway.exe".into(),
+            })
+        );
+
+        let unreadable = proc_with_parent(11, "toolport-gateway.exe", None, 78, "Claude.exe");
+        assert!(restart_client_for(&unreadable).is_none());
+        let mut report = ReapReport::default();
+        record_restart_client(&mut report, &unreadable);
+        assert_eq!(
+            report.unattributed_external_stopped,
+            vec!["toolport-gateway.exe (pid 11)"]
+        );
+
+        let supervised = proc_with_parent(
+            12,
+            "toolport-gateway.exe",
+            Some(r"C:\Toolport\toolport-gateway.exe"),
+            79,
+            "toolport.exe",
+        );
+        assert!(restart_client_for(&supervised).is_none());
+        record_restart_client(&mut report, &supervised);
+        assert_eq!(report.unattributed_external_stopped.len(), 1);
+
+        let orphan = proc(13, "toolport-gateway.exe", None);
+        record_restart_client(&mut report, &orphan);
+        assert_eq!(report.unattributed_external_stopped.len(), 1);
     }
 
     #[test]

--- a/src-tauri/src/router.rs
+++ b/src-tauri/src/router.rs
@@ -31,6 +31,27 @@ const TASK_HANDLE_PREFIX: &str = "toolport-task:v1:";
 const TASK_HANDLE_NONCE_LEN: usize = 24;
 const MCP_APPS_EXTENSION: &str = "io.modelcontextprotocol/ui";
 const MCP_APP_HTML_MIME: &str = "text/html;profile=mcp-app";
+/// Retry-After waits observe upstream cancellation within this bound.
+const RETRY_CANCEL_POLL: Duration = Duration::from_millis(25);
+
+fn wait_for_retry_or_cancel(
+    wait: Duration,
+    cancel: Option<&CancelContext>,
+) -> Result<(), TransportError> {
+    let deadline = Instant::now() + wait;
+    loop {
+        if cancel.is_some_and(CancelContext::is_cancelled) {
+            return Err(TransportError::Cancelled(
+                "request cancelled during downstream retry wait".to_string(),
+            ));
+        }
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            return Ok(());
+        }
+        std::thread::park_timeout(remaining.min(RETRY_CANCEL_POLL));
+    }
+}
 
 fn supports_mcp_app_html(extensions: &serde_json::Map<String, Value>) -> bool {
     extensions
@@ -1124,10 +1145,21 @@ impl Router {
     /// Retry wrapper that releases the per-server Mutex during the backoff sleep
     /// so concurrent calls to the same server aren't blocked while one call waits
     /// for a rate-limit or connection-retry delay.
-    fn call_with_retry<T, F>(&self, slot: &Arc<ServerSlot>, mut f: F) -> Result<T, String>
+    fn call_with_retry<T, F>(
+        &self,
+        slot: &Arc<ServerSlot>,
+        cancel: Option<&CancelContext>,
+        dispatch_cancelled_continuation: bool,
+        mut f: F,
+    ) -> Result<T, String>
     where
         F: FnMut(&mut DownstreamServer) -> Result<T, TransportError>,
     {
+        if !dispatch_cancelled_continuation
+            && cancel.is_some_and(CancelContext::is_cancelled)
+        {
+            return Err("request cancelled before downstream attempt".to_string());
+        }
         // Circuit breaker: a server that just failed repeatedly is fast-failed here,
         // BEFORE taking its `inner` lock, so a dead/hung server neither pays its full
         // read timeout again nor queues callers behind an in-flight timing-out call.
@@ -1152,6 +1184,11 @@ impl Router {
         };
         let mut attempt = 0u32;
         loop {
+            if !dispatch_cancelled_continuation
+                && cancel.is_some_and(CancelContext::is_cancelled)
+            {
+                return Err("request cancelled before downstream attempt".to_string());
+            }
             let result = {
                 let mut server = slot.inner.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
                 f(&mut server)
@@ -1167,7 +1204,7 @@ impl Router {
                 Err(TransportError::Retry { retry_after, message }) if attempt < HTTP_MAX_RETRIES => {
                     let wait = retry_wait(retry_after, attempt);
                     eprintln!("conduit: retrying downstream call after {wait:?}: {message}");
-                    std::thread::sleep(wait);
+                    wait_for_retry_or_cancel(wait, cancel).map_err(|error| error.to_string())?;
                     attempt += 1;
                 }
                 Err(e) => {
@@ -1182,7 +1219,10 @@ impl Router {
                         // self-heal only fires when EVERY server is dead). Gated on the
                         // probe so a live server is never re-spawned on a transient blip.
                         if is_probe {
-                            if let Some(v) = self.reconnect_and_retry(slot, &mut f) {
+                            if cancel.is_some_and(CancelContext::is_cancelled) {
+                                return Err("request cancelled before downstream reconnect".to_string());
+                            }
+                            if let Some(v) = self.reconnect_and_retry(slot, cancel, &mut f) {
                                 return v;
                             }
                         }
@@ -1202,7 +1242,12 @@ impl Router {
     /// stops), or `None` when the slot has no reconnect factory (fall through to the
     /// normal breaker-failure path). The spawn runs without holding the `inner` lock so
     /// a slow re-spawn doesn't wedge other callers to the same server.
-    fn reconnect_and_retry<T, F>(&self, slot: &Arc<ServerSlot>, f: &mut F) -> Option<Result<T, String>>
+    fn reconnect_and_retry<T, F>(
+        &self,
+        slot: &Arc<ServerSlot>,
+        cancel: Option<&CancelContext>,
+        f: &mut F,
+    ) -> Option<Result<T, String>>
     where
         F: FnMut(&mut DownstreamServer) -> Result<T, TransportError>,
     {
@@ -1212,6 +1257,11 @@ impl Router {
             eprintln!("conduit: re-spawn of '{}' failed; leaving it fast-failed", slot.id);
             return None; // still unreachable: fall through to record_failure
         };
+        if cancel.is_some_and(CancelContext::is_cancelled) {
+            return Some(Err(
+                "request cancelled before retrying the reconnected downstream".to_string(),
+            ));
+        }
         let retry = {
             let mut server = slot.inner.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
             *server = fresh; // swap the live child/connection for the fresh one
@@ -1228,7 +1278,9 @@ impl Router {
                 Ok(v)
             }
             Err(e) => {
-                breaker.record_failure(Instant::now());
+                if e.is_health_failure() {
+                    breaker.record_failure(Instant::now());
+                }
                 Err(e.to_string())
             }
         })
@@ -1271,7 +1323,11 @@ impl Router {
             .get(exposed_name)
             .ok_or_else(|| format!("no route for tool '{exposed_name}'"))?;
         let slot = self.slot_for(server_id)?;
-        let (result, downstream_supports_tasks) = self.call_with_retry(&slot, |server| {
+        let (result, downstream_supports_tasks) = self.call_with_retry(
+            &slot,
+            cancel.as_ref(),
+            mrtr.is_some_and(|request| !request.is_empty()),
+            |server| {
             let supports_tasks = server
                 .extensions()
                 .contains_key("io.modelcontextprotocol/tasks");
@@ -1284,7 +1340,8 @@ impl Router {
                     mrtr,
                 )
                 .map(|result| (result, supports_tasks))
-        })?;
+            },
+        )?;
         if result.get("resultType").and_then(Value::as_str) == Some("task") {
             if !client_supports_tasks(meta) {
                 return Err(
@@ -1336,7 +1393,7 @@ impl Router {
         let slot = self.slot_for(&server_id)?;
         let mut forwarded = params;
         forwarded["taskId"] = json!(native_task_id);
-        let result = self.call_with_retry(&slot, |server| {
+        let result = self.call_with_retry(&slot, cancel.as_ref(), false, |server| {
             server.task_request(method, forwarded.clone(), cancel.clone(), meta)
         })?;
         let mut result = result;
@@ -1497,9 +1554,14 @@ impl Router {
             .ok_or_else(|| format!("no server owns resource '{uri}'"))?
             .to_string();
         let slot = self.slot_for(&server_id)?;
-        self.call_with_retry(&slot, |server| {
+        self.call_with_retry(
+            &slot,
+            cancel.as_ref(),
+            mrtr.is_some_and(|request| !request.is_empty()),
+            |server| {
             server.read_resource_with_cancel_and_mrtr(uri, cancel.clone(), meta, mrtr)
-        })
+            },
+        )
     }
 
     /// Subscribe to resource-updated notifications on the owning downstream
@@ -1511,7 +1573,7 @@ impl Router {
             .ok_or_else(|| format!("no server owns resource '{uri}'"))?
             .to_string();
         let slot = self.slot_for(&server_id)?;
-        self.call_with_retry(&slot, |server| server.subscribe_resource(uri))
+        self.call_with_retry(&slot, None, false, |server| server.subscribe_resource(uri))
     }
 
     /// Unsubscribe from resource-updated notifications on the owning downstream
@@ -1536,7 +1598,7 @@ impl Router {
         uri: &str,
     ) -> Result<Value, String> {
         let slot = self.slot_for(server_id)?;
-        self.call_with_retry(&slot, |server| server.unsubscribe_resource(uri))
+        self.call_with_retry(&slot, None, false, |server| server.unsubscribe_resource(uri))
     }
 
     /// Get a prompt by its exposed name, forwarding the server's real name.
@@ -1569,7 +1631,11 @@ impl Router {
             .cloned()
             .ok_or_else(|| format!("no route for prompt '{exposed_name}'"))?;
         let slot = self.slot_for(&server_id)?;
-        self.call_with_retry(&slot, |server| {
+        self.call_with_retry(
+            &slot,
+            cancel.as_ref(),
+            mrtr.is_some_and(|request| !request.is_empty()),
+            |server| {
             server.get_prompt_with_cancel_and_mrtr(
                 &name,
                 arguments.clone(),
@@ -1577,7 +1643,8 @@ impl Router {
                 meta,
                 mrtr,
             )
-        })
+            },
+        )
     }
 
     /// Forward `completion/complete` to the owning downstream server, remapping
@@ -1593,7 +1660,7 @@ impl Router {
     ) -> Result<Value, String> {
         let (server_id, forwarded) = self.resolve_completion(&params)?;
         let slot = self.slot_for(&server_id)?;
-        self.call_with_retry(&slot, |server| {
+        self.call_with_retry(&slot, cancel.as_ref(), false, |server| {
             server.complete_with_cancel(forwarded.clone(), cancel.clone())
         })
     }
@@ -2316,7 +2383,7 @@ mod tests {
         let router = Router::new();
         // Factory hands back a healthy connection, mirroring a re-spawn that succeeds.
         let slot = dead_slot(Some(Box::new(|| Some(mock_server("s")))));
-        let out = router.reconnect_and_retry(&slot, &mut |ds| ds.call("echo", json!({})));
+        let out = router.reconnect_and_retry(&slot, None, &mut |ds| ds.call("echo", json!({})));
         // The probe re-spawned the server and the retried call went through.
         let value = out.expect("reconnect attempted").expect("call recovered");
         assert!(serde_json::to_string(&value).unwrap().contains("s:echo"));
@@ -2333,8 +2400,68 @@ mod tests {
         // caller must fall through to record the failure.
         let slot = dead_slot(Some(Box::new(|| None)));
         let out: Option<Result<Value, String>> =
-            router.reconnect_and_retry(&slot, &mut |ds| ds.call("echo", json!({})));
+            router.reconnect_and_retry(&slot, None, &mut |ds| ds.call("echo", json!({})));
         assert!(out.is_none(), "a failed re-spawn falls through to the breaker");
+    }
+
+    #[test]
+    fn cancellation_during_reconnect_prevents_the_retried_call() {
+        let router = Router::new();
+        let cancellations = CancelRegistry::new();
+        assert!(cancellations.begin_client_request("reconnect-cancel".to_string()));
+        let cancel = cancellations.context("reconnect-cancel".to_string());
+        let cancel_from_factory = cancellations.clone();
+        let slot = dead_slot(Some(Box::new(move || {
+            assert!(cancel_from_factory.cancel("reconnect-cancel", Some("user pressed stop")));
+            Some(mock_server("s"))
+        })));
+        let retried_calls = Arc::new(AtomicU32::new(0));
+        let calls = Arc::clone(&retried_calls);
+
+        let result = router
+            .reconnect_and_retry(&slot, Some(&cancel), &mut move |ds| {
+                calls.fetch_add(1, Ordering::SeqCst);
+                ds.call("echo", json!({}))
+            })
+            .expect("reconnect was attempted")
+            .unwrap_err();
+
+        assert!(result.contains("cancelled"), "unexpected error: {result}");
+        assert_eq!(
+            retried_calls.load(Ordering::SeqCst),
+            0,
+            "a reconnect that races cancellation must not emit the retry"
+        );
+        cancellations.finish_client_request("reconnect-cancel");
+    }
+
+    #[test]
+    fn cancellation_from_reconnected_attempt_does_not_penalize_breaker() {
+        let router = Router::new();
+        let cancellations = CancelRegistry::new();
+        assert!(cancellations.begin_client_request("retry-cancel".to_string()));
+        let cancel = cancellations.context("retry-cancel".to_string());
+        let cancel_from_retry = cancellations.clone();
+        let slot = dead_slot(Some(Box::new(|| Some(mock_server("s")))));
+
+        let result: Result<Value, String> = router
+            .reconnect_and_retry(&slot, Some(&cancel), &mut move |_server| {
+                assert!(cancel_from_retry.cancel("retry-cancel", Some("user pressed stop")));
+                Err(TransportError::Cancelled(
+                    "request cancelled during reconnected call".to_string(),
+                ))
+            })
+            .expect("reconnect was attempted");
+
+        assert!(result.unwrap_err().contains("cancelled"));
+        let mut breaker = slot
+            .breaker
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        assert_eq!(breaker.consecutive_failures, 0);
+        assert!(breaker.open_remaining(Instant::now()).is_none());
+        drop(breaker);
+        cancellations.finish_client_request("retry-cancel");
     }
 
     #[test]
@@ -2344,7 +2471,7 @@ mod tests {
         // reconnect is skipped and the breaker path handles the failure.
         let slot = dead_slot(None);
         let out: Option<Result<Value, String>> =
-            router.reconnect_and_retry(&slot, &mut |ds| ds.call("echo", json!({})));
+            router.reconnect_and_retry(&slot, None, &mut |ds| ds.call("echo", json!({})));
         assert!(out.is_none());
     }
 
@@ -3460,5 +3587,47 @@ mod tests {
             entries.load(Ordering::SeqCst) >= 3,
             "expected >=3 tool/call lock acquisitions"
         );
+    }
+
+    #[test]
+    fn cancellation_during_backoff_prevents_the_retry_attempt() {
+        let (server, entries) = retry_server_inspectable("cancel-retry", 1);
+        let mut router = Router::new();
+        router.add(server);
+        let router = Arc::new(router);
+        let cancellations = CancelRegistry::new();
+        assert!(cancellations.begin_client_request("cancel-retry-1".to_string()));
+        let cancel = cancellations.context("cancel-retry-1".to_string());
+
+        let worker_router = Arc::clone(&router);
+        let handle = std::thread::spawn(move || {
+            worker_router.route_call_with_cancel(
+                "cancel_retry__flaky",
+                json!({}),
+                Some(cancel),
+                None,
+            )
+        });
+        let deadline = Instant::now() + Duration::from_secs(1);
+        while entries.load(Ordering::SeqCst) == 0 && Instant::now() < deadline {
+            std::thread::yield_now();
+        }
+        assert_eq!(entries.load(Ordering::SeqCst), 1, "first attempt must run once");
+        assert!(cancellations.cancel("cancel-retry-1", Some("user pressed stop")));
+
+        let error = handle.join().unwrap().unwrap_err();
+        assert!(error.contains("cancelled"), "unexpected error: {error}");
+        assert_eq!(
+            entries.load(Ordering::SeqCst),
+            1,
+            "no downstream attempt may be emitted after cancellation"
+        );
+        let breaker = router.servers[0].breaker.lock().unwrap();
+        assert_eq!(
+            breaker.consecutive_failures, 0,
+            "upstream cancellation must not count as a downstream health failure"
+        );
+        assert!(breaker.open_until.is_none(), "cancellation must leave the breaker closed");
+        cancellations.finish_client_request("cancel-retry-1");
     }
 }

--- a/src/components/AppSidebar.test.tsx
+++ b/src/components/AppSidebar.test.tsx
@@ -12,6 +12,7 @@ const listQuarantined = vi.fn();
 const checkForUpdate = vi.fn();
 const installUpdate = vi.fn();
 const toastInfo = vi.fn();
+const toastError = vi.fn();
 const eventListeners = new Map<string, (event: { payload: unknown }) => void>();
 
 vi.mock("sonner", () => ({
@@ -19,6 +20,10 @@ vi.mock("sonner", () => ({
     info: (...args: unknown[]) => toastInfo(...args),
     success: vi.fn(),
   },
+}));
+
+vi.mock("@/lib/toast", () => ({
+  toastError: (...args: unknown[]) => toastError(...args),
 }));
 
 vi.mock("@/lib/api", () => ({
@@ -71,6 +76,7 @@ beforeEach(() => {
   checkForUpdate.mockReset();
   installUpdate.mockReset();
   toastInfo.mockReset();
+  toastError.mockReset();
   eventListeners.clear();
   checkForUpdate.mockResolvedValue({ kind: "current" });
   getSavingsSummary.mockResolvedValue({
@@ -223,6 +229,48 @@ describe("AppSidebar accessibility", () => {
     await userEvent.click(screen.getByRole("button", { name: /install and restart/i }));
 
     expect((await screen.findAllByText("Downloading 50%")).length).toBeGreaterThan(0);
+  });
+
+  it("shows updater recovery guidance without losing the install error", async () => {
+    const update = { version: "1.1.0", body: "Release notes" };
+    checkForUpdate.mockResolvedValue({ kind: "update", update });
+    installUpdate.mockRejectedValue(
+      Object.assign(new Error("package signature rejected"), {
+        recoveryAdvice:
+          "Restart Cursor.exe to recreate its Toolport connection. Toolport restored its HTTP endpoint on port 8765.",
+      }),
+    );
+
+    render(
+      <TooltipProvider>
+        <AppSidebar
+          clients={[client()]}
+          registry={null}
+          onRegistryChange={vi.fn()}
+          selectedClientId={null}
+          onSelectClient={vi.fn()}
+          view="servers"
+          onSelectView={vi.fn()}
+          onReplayOnboarding={vi.fn()}
+        />
+      </TooltipProvider>,
+    );
+
+    await userEvent.click(
+      await screen.findByRole("button", { name: /update to v1.1.0/i }),
+    );
+    await userEvent.click(screen.getByRole("button", { name: /install and restart/i }));
+
+    await waitFor(() =>
+      expect(toastError).toHaveBeenCalledWith(
+        "Update failed: package signature rejected",
+        expect.objectContaining({
+          description: expect.stringContaining(
+            "Restart Cursor.exe to recreate its Toolport connection",
+          ),
+        }),
+      ),
+    );
   });
 
   it("turns an in-flight quiet check into an announced tray result", async () => {

--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -190,8 +190,17 @@ function VersionFooter({
       installingRef.current = false;
       setInstalling(false);
       setInstallProgress(null);
-      toastError(`Update failed: ${e}`, {
-        description: "You can download it manually from the releases page.",
+      const message = e instanceof Error ? e.message : String(e);
+      const recoveryAdvice =
+        e &&
+        typeof e === "object" &&
+        "recoveryAdvice" in e &&
+        typeof e.recoveryAdvice === "string"
+          ? e.recoveryAdvice
+          : null;
+      toastError(`Update failed: ${message}`, {
+        description:
+          recoveryAdvice || "You can download it manually from the releases page.",
         action: {
           label: "Open",
           onClick: () =>

--- a/src/lib/updater.test.ts
+++ b/src/lib/updater.test.ts
@@ -12,10 +12,22 @@ vi.mock("@tauri-apps/plugin-process", () => ({
   relaunch: (...args: unknown[]) => relaunch(...args),
 }));
 
-import { installUpdate, type UpdateProgress } from "./updater";
+import { installUpdate, UpdateInstallError, type UpdateProgress } from "./updater";
+
+const cleanShutdown = {
+  killed: ["toolport-gateway (pid 10)"],
+  kept: [],
+  failed: [],
+  remaining: [],
+  needsRestart: [],
+  restartClients: [],
+  unattributedExternalStopped: [],
+  httpBridgePort: null,
+  lifecycleErrors: [],
+};
 
 beforeEach(() => {
-  invoke.mockReset().mockResolvedValue(1);
+  invoke.mockReset().mockResolvedValue(cleanShutdown);
   relaunch.mockReset().mockResolvedValue(undefined);
 });
 
@@ -34,7 +46,7 @@ describe("installUpdate", () => {
     });
     invoke.mockImplementation(async () => {
       calls.push("stop");
-      return 1;
+      return cleanShutdown;
     });
     relaunch.mockImplementation(async () => {
       calls.push("relaunch");
@@ -53,5 +65,232 @@ describe("installUpdate", () => {
       { phase: "installing" },
     ]);
     expect(invoke).toHaveBeenCalledWith("stop_spawned_gateways");
+  });
+
+  it("refuses installation while a targeted gateway remains alive", async () => {
+    const download = vi.fn().mockResolvedValue(undefined);
+    const install = vi.fn().mockResolvedValue(undefined);
+    invoke.mockImplementation(async (command: string) => {
+      if (command === "stop_spawned_gateways") {
+        return {
+          ...cleanShutdown,
+          failed: ["toolport-gateway.exe (pid 42 @ C:\\Toolport\\toolport-gateway.exe)"],
+          remaining: [
+            "toolport-gateway.exe (pid 42 @ C:\\Toolport\\toolport-gateway.exe)",
+          ],
+          httpBridgePort: 8765,
+        };
+      }
+      if (command === "recover_update_gateways") {
+        return { httpBridgeRecovered: true };
+      }
+      throw new Error(`unexpected command ${command}`);
+    });
+
+    const failure = await installUpdate({ download, install } as unknown as Update).catch(
+      (error: unknown) => error,
+    );
+
+    expect(failure).toBeInstanceOf(UpdateInstallError);
+    expect(failure).toMatchObject({ phase: "shutdown" });
+    expect((failure as UpdateInstallError).recoveryAdvice).toContain(
+      "Close the client apps that own these gateway processes",
+    );
+    expect((failure as UpdateInstallError).recoveryAdvice).toContain(
+      "restored its HTTP endpoint on port 8765",
+    );
+    expect(install).not.toHaveBeenCalled();
+    expect(relaunch).not.toHaveBeenCalled();
+    expect(invoke).toHaveBeenCalledWith("recover_update_gateways", {
+      httpBridgePort: 8765,
+    });
+  });
+
+  it("blocks on an owned-endpoint lifecycle error without blaming an external client", async () => {
+    const download = vi.fn().mockResolvedValue(undefined);
+    const install = vi.fn().mockResolvedValue(undefined);
+    invoke.mockImplementation(async (command: string) => {
+      if (command === "stop_spawned_gateways") {
+        return {
+          ...cleanShutdown,
+          lifecycleErrors: ["could not persist the HTTP bridge recovery state"],
+        };
+      }
+      if (command === "recover_update_gateways") {
+        return { httpBridgeRecovered: false };
+      }
+      throw new Error(`unexpected command ${command}`);
+    });
+
+    const failure = await installUpdate({ download, install } as unknown as Update).catch(
+      (error: unknown) => error,
+    );
+
+    expect(failure).toBeInstanceOf(UpdateInstallError);
+    expect(failure).toMatchObject({ phase: "shutdown" });
+    expect((failure as UpdateInstallError).recoveryAdvice).toContain(
+      "could not safely prepare its managed HTTP endpoint",
+    );
+    expect((failure as UpdateInstallError).recoveryAdvice).not.toContain(
+      "Close the client apps",
+    );
+    expect((failure as UpdateInstallError).recoveryAdvice).not.toContain(
+      "Restart any MCP client",
+    );
+    expect(install).not.toHaveBeenCalled();
+  });
+
+  it("reports exact client restart guidance when install rejects after shutdown", async () => {
+    const download = vi.fn().mockResolvedValue(undefined);
+    const install = vi.fn().mockRejectedValue(new Error("package signature rejected"));
+    invoke.mockImplementation(async (command: string) => {
+      if (command === "stop_spawned_gateways") {
+        return {
+          ...cleanShutdown,
+          restartClients: [
+            {
+              client: "Cursor.exe",
+              clientPid: 77,
+              gateway: "toolport-gateway.exe",
+            },
+          ],
+          httpBridgePort: 8765,
+        };
+      }
+      if (command === "recover_update_gateways") {
+        return { httpBridgeRecovered: true };
+      }
+      throw new Error(`unexpected command ${command}`);
+    });
+
+    const failure = await installUpdate({ download, install } as unknown as Update).catch(
+      (error: unknown) => error,
+    );
+
+    expect(failure).toBeInstanceOf(UpdateInstallError);
+    expect(failure).toMatchObject({
+      phase: "install",
+      message: "package signature rejected",
+    });
+    expect((failure as UpdateInstallError).recoveryAdvice).toContain(
+      "Restart Cursor.exe to recreate its Toolport connection.",
+    );
+    expect((failure as UpdateInstallError).recoveryAdvice).toContain(
+      "Toolport restored its HTTP endpoint",
+    );
+    expect((failure as UpdateInstallError).recoveryAdvice).not.toContain(
+      "Toolport restored Cursor.exe",
+    );
+    expect(relaunch).not.toHaveBeenCalled();
+  });
+
+  it("reports both named and proven unnamed external clients", async () => {
+    const download = vi.fn().mockResolvedValue(undefined);
+    const install = vi.fn().mockRejectedValue(new Error("installer rejected"));
+    invoke.mockImplementation(async (command: string) => {
+      if (command === "stop_spawned_gateways") {
+        return {
+          ...cleanShutdown,
+          restartClients: [
+            { client: "Cursor.exe", clientPid: 77, gateway: "toolport-gateway.exe" },
+          ],
+          unattributedExternalStopped: ["toolport-gateway.exe (pid 11)"],
+        };
+      }
+      if (command === "recover_update_gateways") {
+        return { httpBridgeRecovered: false, cleanupWarning: null };
+      }
+      throw new Error(`unexpected command ${command}`);
+    });
+
+    const failure = await installUpdate({ download, install } as unknown as Update).catch(
+      (error: unknown) => error,
+    );
+    const advice = (failure as UpdateInstallError).recoveryAdvice;
+    expect(advice).toContain("Restart Cursor.exe");
+    expect(advice).toContain("Restart any MCP client that disconnected");
+  });
+
+  it("reports a restored endpoint separately from resume-marker cleanup failure", async () => {
+    const download = vi.fn().mockResolvedValue(undefined);
+    const install = vi.fn().mockRejectedValue(new Error("installer rejected"));
+    invoke.mockImplementation(async (command: string) => {
+      if (command === "stop_spawned_gateways") {
+        return { ...cleanShutdown, httpBridgePort: 8765 };
+      }
+      if (command === "recover_update_gateways") {
+        return {
+          httpBridgeRecovered: true,
+          cleanupWarning: "access denied",
+        };
+      }
+      throw new Error(`unexpected command ${command}`);
+    });
+
+    const failure = await installUpdate({ download, install } as unknown as Update).catch(
+      (error: unknown) => error,
+    );
+    const advice = (failure as UpdateInstallError).recoveryAdvice;
+    expect(advice).toContain("restored its HTTP endpoint on port 8765");
+    expect(advice).toContain("endpoint is available");
+    expect(advice).toContain("access denied");
+    expect(advice).not.toContain("could not restore its HTTP endpoint");
+  });
+
+  it("gives generic restart guidance only for a proven but unnamed external client", async () => {
+    const download = vi.fn().mockResolvedValue(undefined);
+    const install = vi.fn().mockRejectedValue(new Error("installer rejected"));
+    invoke.mockImplementation(async (command: string) => {
+      if (command === "stop_spawned_gateways") {
+        return {
+          ...cleanShutdown,
+          unattributedExternalStopped: ["toolport-gateway.exe (pid 10)"],
+        };
+      }
+      if (command === "recover_update_gateways") {
+        return { httpBridgeRecovered: false };
+      }
+      throw new Error(`unexpected command ${command}`);
+    });
+
+    const failure = await installUpdate({ download, install } as unknown as Update).catch(
+      (error: unknown) => error,
+    );
+
+    expect(failure).toBeInstanceOf(UpdateInstallError);
+    expect(failure).toMatchObject({ message: "installer rejected" });
+    expect((failure as UpdateInstallError).recoveryAdvice).toBe(
+      "Restart any MCP client that disconnected during the update, then retry.",
+    );
+  });
+
+  it("does not republish the old helper when installation succeeds but relaunch fails", async () => {
+    const download = vi.fn().mockResolvedValue(undefined);
+    const install = vi.fn().mockResolvedValue(undefined);
+    invoke.mockResolvedValue({
+      ...cleanShutdown,
+      unattributedExternalStopped: ["toolport-gateway.exe (pid 10)"],
+      httpBridgePort: 8765,
+    });
+    relaunch.mockRejectedValue(new Error("relaunch denied"));
+
+    const failure = await installUpdate({ download, install } as unknown as Update).catch(
+      (error: unknown) => error,
+    );
+
+    expect(failure).toBeInstanceOf(UpdateInstallError);
+    expect(failure).toMatchObject({ phase: "relaunch", message: "relaunch denied" });
+    expect((failure as UpdateInstallError).recoveryAdvice).toContain(
+      "Quit and restart Toolport to finish applying the installed update.",
+    );
+    expect((failure as UpdateInstallError).recoveryAdvice).toContain(
+      "Restart any MCP client that disconnected during the update.",
+    );
+    expect((failure as UpdateInstallError).recoveryAdvice).not.toContain("then retry");
+    expect((failure as UpdateInstallError).recoveryAdvice).not.toContain(
+      "restored its HTTP endpoint",
+    );
+    expect(invoke).toHaveBeenCalledTimes(1);
+    expect(invoke).not.toHaveBeenCalledWith("recover_update_gateways", expect.anything());
   });
 });

--- a/src/lib/updater.ts
+++ b/src/lib/updater.ts
@@ -13,6 +13,136 @@ export type UpdateProgress =
   | { phase: "downloading"; downloadedBytes: number; totalBytes?: number }
   | { phase: "installing" };
 
+export interface RestartClient {
+  client: string;
+  clientPid: number;
+  gateway: string;
+}
+
+export interface UpdateShutdownReport {
+  killed: string[];
+  kept: string[];
+  failed: string[];
+  remaining: string[];
+  needsRestart: RestartClient[];
+  restartClients: RestartClient[];
+  unattributedExternalStopped: string[];
+  httpBridgePort: number | null;
+  lifecycleErrors: string[];
+}
+
+interface UpdateRecoveryReport {
+  httpBridgeRecovered: boolean;
+  cleanupWarning: string | null;
+}
+
+type UpdateFailurePhase = "shutdown" | "install" | "relaunch";
+
+/** An update error after gateways may have been stopped. The UI gets explicit,
+ * truthful recovery guidance without pretending relaunching Toolport recreates
+ * stdio pipes owned by external MCP clients. */
+export class UpdateInstallError extends Error {
+  readonly recoveryAdvice: string;
+
+  constructor(
+    readonly phase: UpdateFailurePhase,
+    cause: unknown,
+    readonly shutdown: UpdateShutdownReport,
+    recovery: UpdateRecoveryReport | null,
+    recoveryError: string | null,
+  ) {
+    const detail = cause instanceof Error ? cause.message : String(cause);
+    super(detail);
+    this.name = "UpdateInstallError";
+    this.recoveryAdvice = recoveryAdvice(phase, shutdown, recovery, recoveryError);
+  }
+}
+
+function unique(values: string[]): string[] {
+  return [...new Set(values)];
+}
+
+function recoveryAdvice(
+  phase: UpdateFailurePhase,
+  shutdown: UpdateShutdownReport,
+  recovery: UpdateRecoveryReport | null,
+  recoveryError: string | null,
+): string {
+  const advice: string[] = [];
+  if (phase === "relaunch") {
+    // Installation already succeeded, so this process and its bundled helper are
+    // now the old version. It must not republish/restart that helper; only starting
+    // the newly installed Toolport can finish the update safely.
+    advice.push("Quit and restart Toolport to finish applying the installed update.");
+  }
+  const blocked = unique([...shutdown.failed, ...shutdown.remaining]);
+  if (blocked.length > 0) {
+    advice.push(
+      `Close the client apps that own these gateway processes, then retry: ${blocked.join("; ")}.`,
+    );
+  }
+  if (shutdown.lifecycleErrors.length > 0) {
+    advice.push(
+      `Toolport could not safely prepare its managed HTTP endpoint: ${unique(shutdown.lifecycleErrors).join("; ")}. Resolve that error, then retry.`,
+    );
+  }
+
+  const clients = unique(shutdown.restartClients.map((client) => client.client));
+  if (clients.length > 0) {
+    advice.push(
+      `Restart ${clients.join(", ")} to recreate ${clients.length === 1 ? "its" : "their"} Toolport connection.`,
+    );
+  }
+  if (shutdown.unattributedExternalStopped.length > 0) {
+    // Parent attribution is best-effort and deliberately omitted for unreadable
+    // processes. The Rust report separately proves these had external parents;
+    // never infer that from the broad killed list, which also includes orphans and
+    // Toolport-owned helpers.
+    advice.push(
+      phase === "relaunch"
+        ? "Restart any MCP client that disconnected during the update."
+        : "Restart any MCP client that disconnected during the update, then retry.",
+    );
+  }
+
+  if (phase !== "relaunch" && shutdown.httpBridgePort != null) {
+    if (recovery?.httpBridgeRecovered) {
+      advice.push(
+        `Toolport restored its HTTP endpoint on port ${shutdown.httpBridgePort}.`,
+      );
+      if (recovery.cleanupWarning) {
+        advice.push(
+          `The endpoint is available, but Toolport could not clear its update recovery marker: ${recovery.cleanupWarning}.`,
+        );
+      }
+    } else if (recoveryError) {
+      advice.push(
+        `Toolport could not restore its HTTP endpoint on port ${shutdown.httpBridgePort}: ${recoveryError}. Start it again from Settings.`,
+      );
+    }
+  }
+  return advice.join(" ");
+}
+
+async function recoverAfterFailure(shutdown: UpdateShutdownReport): Promise<{
+  recovery: UpdateRecoveryReport | null;
+  error: string | null;
+}> {
+  try {
+    return {
+      recovery: await invoke<UpdateRecoveryReport>("recover_update_gateways", {
+        httpBridgePort: shutdown.httpBridgePort,
+      }),
+      error: null,
+    };
+  } catch (error) {
+    return {
+      recovery: null,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
 /** Check for a newer release via the Tauri updater. Never throws; failures
  * (dev build, offline, or no manifest published yet) come back as `error`. */
 export async function checkForUpdate(): Promise<UpdateCheck> {
@@ -45,7 +175,39 @@ export async function installUpdate(
   // gateways once the package is local and the installer is ready to replace files.
   await update.download(report);
   onProgress?.({ phase: "installing" });
-  await invoke<number>("stop_spawned_gateways");
-  await update.install();
-  await relaunch();
+  const shutdown = await invoke<UpdateShutdownReport>("stop_spawned_gateways");
+  const blocked = unique([
+    ...shutdown.failed,
+    ...shutdown.remaining,
+    ...shutdown.lifecycleErrors,
+  ]);
+  if (blocked.length > 0) {
+    const recovered = await recoverAfterFailure(shutdown);
+    throw new UpdateInstallError(
+      "shutdown",
+      `Could not safely prepare gateway shutdown (${blocked.length} ${blocked.length === 1 ? "issue" : "issues"}); installation did not start.`,
+      shutdown,
+      recovered.recovery,
+      recovered.error,
+    );
+  }
+
+  try {
+    await update.install();
+  } catch (error) {
+    const recovered = await recoverAfterFailure(shutdown);
+    throw new UpdateInstallError(
+      "install",
+      error,
+      shutdown,
+      recovered.recovery,
+      recovered.error,
+    );
+  }
+
+  try {
+    await relaunch();
+  } catch (error) {
+    throw new UpdateInstallError("relaunch", error, shutdown, null, null);
+  }
 }


### PR DESCRIPTION
## What and why

Closes the two in-progress items from the 2026-08-11 audit that users actually feel.

**SBS-716.** HTTP cancellation was a log line. The transport now moves the blocking ureq attempt onto one worker, returns `Cancelled` within 25ms, and forwards `notifications/cancelled` with the original downstream request id. Router retry/backoff observes the same cancel context, so a 429 wait cannot emit another POST after the caller is gone. Cancellation is not a circuit-breaker failure. Cancelled work releases the per-server slot; a follower sees `Busy` only while that one worker drains.

**SBS-717.** `stop_spawned_gateways` now returns the full reaper report (`failed`, `remaining`, attributed restart clients). The updater refuses to install while any targeted gateway is still alive or a Toolport-owned HTTP lifecycle step failed. If install fails after shutdown, Toolport restores the HTTP endpoint it owns and tells the user which external clients must be restarted. It does not pretend relaunching Toolport recreates client-owned stdio pipes. A successful install that then fails to relaunch does not republish the old helper.

## Testing

- [x] `npx prettier --check` on the changed frontend files
- [x] `npx eslint` on the changed frontend files
- [x] `npx vitest run src/lib/updater.test.ts src/components/AppSidebar.test.tsx` (16 passed)
- [x] Targeted Rust: HTTP stall cancel, MRTR cancel, retry-backoff cancel, reconnect-cancel, updater report/recovery, HTTP-bridge intent (all passed)
- [x] `cargo test --lib -- gateway_publish:: router:: desktop::tests::update` (96 passed)
- [x] Rebased onto current `main` (includes #698 catalog shrink). `#698` catalog tests still pass.
- [ ] `npm run build` / full `npm run test` / `npm run test:rust` (CI)
- [ ] Hand-ran `tauri dev` update + cancel (not run here)

## Notes

Linear: SBS-716, SBS-717. Do not treat GitHub issues as source of truth for these.

The branch is the previously uncommitted worktree at `toolport-sbs-716-717`, rebased onto `origin/main`.