### PR TITLE
fix: stop treating failed security, share, and health reads as all-clear

### DIFF
--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -2751,14 +2751,14 @@ fn export_config(
     state: State<RegistryState>,
     name: Option<String>,
     description: Option<String>,
-    server_names: Option<Vec<String>>,
+    server_ids: Option<Vec<String>>,
 ) -> Result<String, String> {
     let reg = state.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
     serde_json::to_string_pretty(&build_export(
         &reg,
         name.as_deref(),
         description.as_deref(),
-        server_names.as_deref(),
+        server_ids.as_deref(),
     ))
     .map_err(|e| e.to_string())
 }
@@ -2771,7 +2771,7 @@ fn export_config_to_path(
     path: String,
     name: Option<String>,
     description: Option<String>,
-    server_names: Option<Vec<String>>,
+    server_ids: Option<Vec<String>>,
 ) -> Result<(), String> {
     let json = {
         let reg = state.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
@@ -2779,7 +2779,7 @@ fn export_config_to_path(
             &reg,
             name.as_deref(),
             description.as_deref(),
-            server_names.as_deref(),
+            server_ids.as_deref(),
         ))
         .map_err(|e| e.to_string())?
     };
@@ -3046,12 +3046,12 @@ fn build_export(
     reg: &Registry,
     name: Option<&str>,
     description: Option<&str>,
-    server_names: Option<&[String]>,
+    server_ids: Option<&[String]>,
 ) -> serde_json::Value {
-    // When a selection is given, share only those servers (by name); otherwise
+    // When a selection is given, share only those servers (by stable id); otherwise
     // share them all. Lets a user share a focused "stack" instead of everything.
     let include: Option<std::collections::HashSet<&str>> =
-        server_names.map(|names| names.iter().map(String::as_str).collect());
+        server_ids.map(|ids| ids.iter().map(String::as_str).collect());
     let servers: Vec<ServerEntry> = reg
         .servers
         .iter()
@@ -3059,7 +3059,7 @@ fn build_export(
         .filter(|s| {
             include
                 .as_ref()
-                .map(|set| set.contains(s.name.as_str()))
+                .map(|set| set.contains(s.id.as_str()))
                 .unwrap_or(true)
         })
         .map(|s| {
@@ -4666,13 +4666,55 @@ mod tests {
         assert_eq!(doc["name"], "Team setup");
         assert_eq!(doc["description"], "Our shared servers");
 
-        // Selective share: a name filter includes only the matching servers, so a
+        // Selective share: an id filter includes only the matching servers, so a
         // user can share a focused stack instead of their whole setup.
-        let shared_name = servers[0]["name"].as_str().unwrap().to_string();
-        let subset = build_export(&reg, None, None, Some(&[shared_name]));
+        let shared_id = reg
+            .servers
+            .iter()
+            .find(|server| server.name == "GitHub")
+            .unwrap()
+            .id
+            .clone();
+        let subset = build_export(&reg, None, None, Some(&[shared_id]));
         assert_eq!(subset["servers"].as_array().unwrap().len(), 1);
         let empty = build_export(&reg, None, None, Some(&["does-not-exist".to_string()]));
         assert_eq!(empty["servers"].as_array().unwrap().len(), 0);
+    }
+
+    #[test]
+    fn export_selection_uses_stable_ids_and_an_explicit_snapshot() {
+        let mut reg = Registry::default();
+        let mut first = github_with_secret();
+        first.name = "Duplicate".into();
+        first.command = Some("first-command".into());
+        reg.add_server(first);
+        let mut second = github_with_secret();
+        second.name = "Duplicate".into();
+        second.command = Some("second-command".into());
+        reg.add_server(second);
+
+        let first_id = reg
+            .servers
+            .iter()
+            .find(|server| server.command.as_deref() == Some("first-command"))
+            .unwrap()
+            .id
+            .clone();
+        let snapshot = vec![first_id];
+
+        // A same-name server is not accidentally selected, and a later registry
+        // addition cannot widen the explicit snapshot.
+        let mut later = github_with_secret();
+        later.name = "Added later".into();
+        later.command = Some("later-command".into());
+        reg.add_server(later);
+        let doc = build_export(&reg, None, None, Some(&snapshot));
+        let exported = doc["servers"].as_array().unwrap();
+        assert_eq!(exported.len(), 1);
+        assert_eq!(exported[0]["command"], "first-command");
+
+        let empty = build_export(&reg, None, None, Some(&[]));
+        assert!(empty["servers"].as_array().unwrap().is_empty());
     }
 
     #[test]

--- a/src/App.probe.test.tsx
+++ b/src/App.probe.test.tsx
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { act, render, waitFor } from "@testing-library/react";
+import App from "./App";
+import type { ProbeResult } from "@/lib/types";
+
+const probeServers = vi.fn();
+const getRegistry = vi.fn();
+const detectClients = vi.fn();
+const takeRegistryRecoveryNotice = vi.fn();
+
+// Captures the props App hands to the (mocked) Onboarding wizard so the test can
+// invoke onProbe exactly the way the Done step does.
+const captured: { onProbe: (() => Promise<ProbeResult[]>) | null } = { onProbe: null };
+
+vi.mock("@/lib/api", () => ({
+  addServer: vi.fn(),
+  detectClients: (...a: unknown[]) => detectClients(...a),
+  getRegistry: (...a: unknown[]) => getRegistry(...a),
+  importServers: vi.fn(),
+  mainWindowVisible: vi.fn(() => Promise.resolve(true)),
+  parseServerSnippet: vi.fn(),
+  previewImportServers: vi.fn(),
+  probeServers: (...a: unknown[]) => probeServers(...a),
+  removeServer: vi.fn(),
+  setAllEnabled: vi.fn(),
+  setSecret: vi.fn(),
+  setServerEnabled: vi.fn(),
+  takeRegistryRecoveryNotice: (...a: unknown[]) => takeRegistryRecoveryNotice(...a),
+  teamSyncWait: vi.fn(),
+  testServer: vi.fn(),
+  updateServer: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: vi.fn(() => Promise.resolve(() => {})),
+}));
+
+vi.mock("@/lib/trayApprovals", () => ({
+  subscribeToTrayApprovals: vi.fn(() => Promise.resolve(() => {})),
+}));
+
+vi.mock("@/lib/theme", () => ({
+  useTheme: () => ({ resolved: "light" }),
+}));
+
+vi.mock("@/components/AppSidebar", () => ({ AppSidebar: () => null }));
+vi.mock("@/components/PendingApprovals", () => ({ PendingApprovals: () => null }));
+vi.mock("@/components/QuarantineAlert", () => ({ QuarantineAlert: () => null }));
+
+vi.mock("@/components/Onboarding", () => ({
+  Onboarding: (props: { onProbe: () => Promise<ProbeResult[]> }) => {
+    captured.onProbe = props.onProbe;
+    return null;
+  },
+}));
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  localStorage.clear();
+  captured.onProbe = null;
+  getRegistry.mockResolvedValue({
+    version: 1,
+    servers: [],
+    profiles: [],
+    activeProfileId: null,
+  });
+  detectClients.mockResolvedValue([]);
+  takeRegistryRecoveryNotice.mockResolvedValue(null);
+});
+
+describe("App onboarding probe wiring", () => {
+  // SBS-720 / CodeRev: after Connect, load() already kicked off a probe. The Done
+  // step's verification must JOIN that in-flight probe (reprobe), not queue a second
+  // full probeServers pass behind it (reprobeAfterMutation) — each pass is bounded
+  // at 90s per server, so stacking two can hold "Checking" for minutes.
+  it("joins the in-flight health probe instead of starting a second one", async () => {
+    const results: ProbeResult[] = [
+      { serverId: "s1", ok: true, toolCount: 3, error: null, authRequired: false },
+    ];
+    const inFlight = deferred<ProbeResult[]>();
+    probeServers.mockReturnValueOnce(inFlight.promise).mockResolvedValue([]);
+
+    render(<App />);
+
+    // Fresh install (no servers, no connected clients) opens onboarding, and the
+    // initial load has already started a silent health probe that is still pending.
+    await waitFor(() => expect(captured.onProbe).not.toBeNull());
+    await waitFor(() => expect(probeServers).toHaveBeenCalledTimes(1));
+
+    let probePromise!: Promise<ProbeResult[]>;
+    act(() => {
+      probePromise = captured.onProbe!();
+    });
+
+    await act(async () => {
+      inFlight.resolve(results);
+    });
+
+    // The Done step gets the authoritative in-flight result...
+    await expect(probePromise).resolves.toEqual(results);
+    // ...and no trailing probeServers pass was queued behind it.
+    await act(async () => {});
+    expect(probeServers).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1032,7 +1032,7 @@ function App() {
               setResumeAtConnect(true);
               selectView("catalog");
             }}
-            onProbe={reprobeAfterMutation}
+            onProbe={reprobe}
             onOpenPlayground={() => {
               setShowOnboarding(false);
               selectView("playground");

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -98,6 +98,7 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 import { Toaster } from "@/components/ui/sonner";
 import { useTheme } from "@/lib/theme";
 import { fmtTs } from "@/lib/utils";
+import { createSingleFlight } from "@/lib/singleFlight";
 import { resolveShortcut, shortcutHelp } from "@/lib/shortcuts";
 import { subscribeToTrayApprovals } from "@/lib/trayApprovals";
 
@@ -151,48 +152,60 @@ function App() {
   const [resumeAtConnect, setResumeAtConnect] = useState(false);
 
   const lastProbeRef = useRef(0);
-  const probingRef = useRef(false);
-  // Whether the most recent probe threw (vs. returned results or was skipped). Lets
-  // the manual Refresh distinguish "health check failed" from "nothing to report" so
-  // a thrown probe doesn't masquerade as a green success toast.
-  const probeErroredRef = useRef(false);
+  const probeFlightRef = useRef(createSingleFlight<ProbeResult[]>());
   const loadedOnce = useRef(false);
 
   // Probe health quietly (no toast). Used on load and after authenticating, so
   // each server's status badge reflects reality without the user clicking around.
-  const reprobe = useCallback(async (): Promise<ProbeResult[]> => {
-    probeErroredRef.current = false;
-    // Never stack probes. A probe spawns/reads every server (and on macOS can
-    // trigger keychain prompts); overlapping runs amplify that into a storm,
-    // especially since each dismissed prompt returns focus and could re-trigger.
-    if (probingRef.current) return [];
-    probingRef.current = true;
-    lastProbeRef.current = Date.now();
-    setProbing(true);
-    try {
-      const results = await probeServers();
-      setHealth(Object.fromEntries(results.map((r) => [r.serverId, r])));
-      setBackendReachable(true);
-      return results;
-    } catch {
-      // Non-fatal: badges just stay in "checking". Record that it threw so a manual
-      // refresh reports the failure instead of a false success (both return []), and
-      // surface a persistent banner so the stale badges aren't read as real status.
-      probeErroredRef.current = true;
-      setBackendReachable(false);
-      return [];
-    } finally {
-      setProbing(false);
-      probingRef.current = false;
-    }
+  const reprobe = useCallback((): Promise<ProbeResult[]> => {
+    // A second caller receives the SAME promise, not an invented empty result.
+    // This prevents onboarding, enablement, and refresh from treating in-flight
+    // work as an authoritative "zero problems" response (SBS-720).
+    return probeFlightRef.current.run(async () => {
+      lastProbeRef.current = Date.now();
+      setProbing(true);
+      try {
+        const results = await probeServers();
+        setHealth(Object.fromEntries(results.map((r) => [r.serverId, r])));
+        setBackendReachable(true);
+        return results;
+      } catch (error) {
+        setBackendReachable(false);
+        throw error;
+      } finally {
+        setProbing(false);
+      }
+    });
   }, []);
+
+  // Registry/auth mutations need a probe that starts after any older snapshot.
+  // Multiple mutations during one active probe share a single trailing run.
+  const reprobeAfterMutation = useCallback(
+    (): Promise<ProbeResult[]> =>
+      probeFlightRef.current.runAfterCurrent(async () => {
+        lastProbeRef.current = Date.now();
+        setProbing(true);
+        try {
+          const results = await probeServers();
+          setHealth(Object.fromEntries(results.map((r) => [r.serverId, r])));
+          setBackendReachable(true);
+          return results;
+        } catch (error) {
+          setBackendReachable(false);
+          throw error;
+        } finally {
+          setProbing(false);
+        }
+      }),
+    [],
+  );
 
   // Refresh statuses when the user returns to the window, so a server that came
   // up (or went down) while they were away reflects reality without a manual
   // refresh. Guarded so rapid alt-tabbing doesn't re-spawn every server.
   useEffect(() => {
     const onFocus = () => {
-      if (Date.now() - lastProbeRef.current > 20_000) void reprobe();
+      if (Date.now() - lastProbeRef.current > 20_000) void reprobe().catch(() => {});
     };
     window.addEventListener("focus", onFocus);
     return () => window.removeEventListener("focus", onFocus);
@@ -229,21 +242,19 @@ function App() {
         loadedOnce.current = true;
         setActivityKey((k) => k + 1);
         if (announce) {
-          const results = await reprobe();
-          if (results.length > 0) {
-            const up = results.filter((r) => r.ok).length;
-            toast.success(`${up} of ${results.length} servers healthy`);
-          } else if (probeErroredRef.current) {
-            // The registry/clients reloaded, but the health probe itself threw.
-            // Don't dress that up as a green success.
+          try {
+            const results = await reprobeAfterMutation();
+            if (results.length > 0) {
+              const up = results.filter((r) => r.ok).length;
+              toast.success(`${up} of ${results.length} servers healthy`);
+            } else {
+              toast.success("Refreshed");
+            }
+          } catch {
             toast.warning("Refreshed, but couldn't check server health");
-          } else {
-            // Registry/clients still reloaded; give feedback even when the probe
-            // was skipped (already in flight) or there are no servers to report.
-            toast.success("Refreshed");
           }
         } else {
-          void reprobe();
+          void reprobe().catch(() => {});
         }
       } catch (e) {
         // After the first successful load, a refresh failure shouldn't blow away a
@@ -257,7 +268,7 @@ function App() {
         setLoading(false);
       }
     },
-    [reprobe],
+    [reprobe, reprobeAfterMutation],
   );
 
   useEffect(() => {
@@ -632,7 +643,7 @@ function App() {
       // Enabling adds a server with no health entry yet, so its card would sit on
       // "Checking…" until a manual refresh. Probe now to resolve it. (Disabling
       // moves it to the disabled group, no probe needed.)
-      if (enabled) void reprobe();
+      if (enabled) void reprobeAfterMutation().catch(() => {});
     } catch (e) {
       toastError(`Couldn't toggle: ${e}`);
     } finally {
@@ -658,7 +669,7 @@ function App() {
     setTogglingAll(true);
     try {
       setRegistry(await setAllEnabled(profileId, enable));
-      if (enable) void reprobe();
+      if (enable) void reprobeAfterMutation().catch(() => {});
       toast.success(enable ? "Enabled all servers" : "Disabled all servers");
     } catch (e) {
       toastError(`Couldn't update servers: ${e}`);
@@ -714,7 +725,7 @@ function App() {
       onToggle={(en) => handleToggle(server.id, en)}
       onRemove={() => handleRemove(server.id, server.name)}
       onRegistryChange={setRegistry}
-      onReprobe={reprobe}
+      onReprobe={() => void reprobeAfterMutation().catch(() => {})}
     />
   );
 
@@ -892,7 +903,7 @@ function App() {
                 variant="outline"
                 size="sm"
                 className="shrink-0"
-                onClick={() => void reprobe()}
+                onClick={() => void reprobe().catch(() => {})}
                 disabled={probing}
               >
                 Retry
@@ -1021,7 +1032,7 @@ function App() {
               setResumeAtConnect(true);
               selectView("catalog");
             }}
-            onProbe={reprobe}
+            onProbe={reprobeAfterMutation}
             onOpenPlayground={() => {
               setShowOnboarding(false);
               selectView("playground");

--- a/src/components/ActivityView.test.tsx
+++ b/src/components/ActivityView.test.tsx
@@ -162,6 +162,42 @@ describe("ActivityView trust-state loading", () => {
     ).toBeInTheDocument();
   });
 
+  it("ignores an audit read that started before the clear and resolved after it", async () => {
+    const { toast } = await import("sonner");
+    clearActivityLogs.mockResolvedValue(undefined);
+    let resolveStale!: (rows: AuditEntry[]) => void;
+    getAuditLog
+      .mockResolvedValueOnce(initialLog)
+      .mockReturnValueOnce(
+        new Promise<AuditEntry[]>((res) => {
+          resolveStale = res;
+        }),
+      )
+      .mockRejectedValueOnce(new Error("locked"));
+
+    render(<ActivityView refreshKey={0} registry={null} />);
+    await act(async () => {});
+    expect(screen.getByText(/last 2/)).toBeInTheDocument();
+
+    // A live tick starts a refetch that is still in flight when the user clears.
+    await act(async () => {
+      vi.advanceTimersByTime(3000);
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Clear" }));
+    fireEvent.click(screen.getByRole("button", { name: "Clear activity" }));
+    // The pre-clear read resolves with the deleted rows in the same flush as the
+    // clear finishing, before its effect's cleanup has run.
+    resolveStale(initialLog);
+    await act(async () => {});
+
+    expect(toast.success).toHaveBeenCalledWith("Cleared retained activity");
+    expect(screen.queryByText(/last 2/)).not.toBeInTheDocument();
+    expect(
+      screen.getByText(/can't verify that the log is still empty/i),
+    ).toBeInTheDocument();
+  });
+
   it("does not turn a last-known empty audit log into a current all-clear", async () => {
     getAuditLog.mockResolvedValueOnce([]).mockRejectedValueOnce(new Error("locked"));
 

--- a/src/components/ActivityView.test.tsx
+++ b/src/components/ActivityView.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { render, screen, act } from "@testing-library/react";
+import { render, screen, act, fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { ActivityView } from "./ActivityView";
 import type { AuditEntry, SearchTrace } from "@/lib/types";
@@ -8,8 +8,10 @@ const getAuditLog = vi.fn();
 const getSearchTraces = vi.fn();
 const getSecurityEvents = vi.fn();
 
+const clearActivityLogs = vi.fn();
+
 vi.mock("@/lib/api", () => ({
-  clearActivityLogs: vi.fn(),
+  clearActivityLogs: (...a: unknown[]) => clearActivityLogs(...a),
   exportAuditToPath: vi.fn(),
   getAuditLog: (...a: unknown[]) => getAuditLog(...a),
   getAuditStats: vi.fn(() => Promise.resolve(null)),
@@ -135,6 +137,28 @@ describe("ActivityView trust-state loading", () => {
     expect(screen.queryByText("Protection active.")).not.toBeInTheDocument();
     expect(
       screen.getByRole("button", { name: "Retry protection status" }),
+    ).toBeInTheDocument();
+  });
+
+  it("does not restore cleared calls when the post-clear refetch fails", async () => {
+    const { toast } = await import("sonner");
+    clearActivityLogs.mockResolvedValue(undefined);
+    getAuditLog
+      .mockResolvedValueOnce(initialLog)
+      .mockRejectedValueOnce(new Error("locked"));
+
+    render(<ActivityView refreshKey={0} registry={null} />);
+    await act(async () => {});
+    expect(screen.getByText(/last 2/)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Clear" }));
+    fireEvent.click(screen.getByRole("button", { name: "Clear activity" }));
+    await act(async () => {});
+
+    expect(toast.success).toHaveBeenCalledWith("Cleared retained activity");
+    expect(screen.queryByText(/last 2/)).not.toBeInTheDocument();
+    expect(
+      screen.getByText(/can't verify that the log is still empty/i),
     ).toBeInTheDocument();
   });
 

--- a/src/components/ActivityView.test.tsx
+++ b/src/components/ActivityView.test.tsx
@@ -6,6 +6,7 @@ import type { AuditEntry, SearchTrace } from "@/lib/types";
 
 const getAuditLog = vi.fn();
 const getSearchTraces = vi.fn();
+const getSecurityEvents = vi.fn();
 
 vi.mock("@/lib/api", () => ({
   clearActivityLogs: vi.fn(),
@@ -15,7 +16,7 @@ vi.mock("@/lib/api", () => ({
   getInspectLog: vi.fn(() => Promise.resolve([])),
   getSavingsSummary: vi.fn(() => Promise.resolve(null)),
   getSearchTraces: (...a: unknown[]) => getSearchTraces(...a),
-  getSecurityEvents: vi.fn(() => Promise.resolve([])),
+  getSecurityEvents: (...a: unknown[]) => getSecurityEvents(...a),
   getToolIdentities: vi.fn(() => Promise.resolve([])),
 }));
 
@@ -52,11 +53,150 @@ beforeEach(() => {
   vi.useFakeTimers({ shouldAdvanceTime: true });
   getAuditLog.mockResolvedValue(initialLog);
   getSearchTraces.mockResolvedValue([]);
+  getSecurityEvents.mockResolvedValue([]);
 });
 
 afterEach(() => {
   vi.useRealTimers();
   vi.clearAllMocks();
+});
+
+describe("ActivityView trust-state loading", () => {
+  it("shows initial loading without claiming protection is clear", () => {
+    getAuditLog.mockReturnValue(new Promise(() => {}));
+    getSecurityEvents.mockReturnValue(new Promise(() => {}));
+
+    render(<ActivityView refreshKey={0} registry={null} />);
+
+    expect(screen.getByText("Loading activity…")).toBeInTheDocument();
+    expect(screen.getByText("Checking protection status…")).toBeInTheDocument();
+    expect(screen.queryByText("Protection active.")).not.toBeInTheDocument();
+  });
+
+  it("treats a successful empty read as verified empty", async () => {
+    getAuditLog.mockResolvedValue([]);
+    getSecurityEvents.mockResolvedValue([]);
+
+    render(<ActivityView refreshKey={0} registry={null} />);
+    await act(async () => {});
+
+    expect(screen.getByText("No tool calls yet")).toBeInTheDocument();
+    expect(screen.getByText("Protection active.")).toBeInTheDocument();
+  });
+
+  it("shows an unknown security state with retry after the initial read fails", async () => {
+    const user = userEvent.setup({
+      advanceTimers: (ms) => vi.advanceTimersByTime(ms),
+    });
+    getAuditLog.mockResolvedValue([]);
+    getSecurityEvents
+      .mockRejectedValueOnce(new Error("unreadable"))
+      .mockResolvedValueOnce([]);
+
+    render(<ActivityView refreshKey={0} registry={null} />);
+    await act(async () => {});
+
+    expect(screen.getByText("Couldn't verify protection status.")).toBeInTheDocument();
+    expect(screen.getByText(/this is not an all-clear/i)).toBeInTheDocument();
+    expect(screen.queryByText("Protection active.")).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Retry protection status" }));
+    await act(async () => {});
+
+    expect(screen.getByText("Protection active.")).toBeInTheDocument();
+    expect(
+      screen.queryByText("Couldn't verify protection status."),
+    ).not.toBeInTheDocument();
+  });
+
+  it("preserves last-known security findings when a live refresh fails", async () => {
+    const finding = {
+      ts: 1700000000000,
+      type: "tool_poison_flag",
+      server: "github",
+      tool: "github__create_issue",
+      change: "poison",
+      severity: "high" as const,
+    };
+    getSecurityEvents
+      .mockResolvedValueOnce([finding])
+      .mockRejectedValueOnce(new Error("locked"));
+
+    render(<ActivityView refreshKey={0} registry={null} />);
+    await act(async () => {});
+    expect(screen.getByText("github__create_issue")).toBeInTheDocument();
+
+    await act(async () => {
+      vi.advanceTimersByTime(3000);
+    });
+
+    expect(screen.getByText("Security status may be out of date.")).toBeInTheDocument();
+    expect(screen.getByText("github__create_issue")).toBeInTheDocument();
+    expect(screen.queryByText("Protection active.")).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Retry protection status" }),
+    ).toBeInTheDocument();
+  });
+
+  it("does not turn a last-known empty audit log into a current all-clear", async () => {
+    getAuditLog.mockResolvedValueOnce([]).mockRejectedValueOnce(new Error("locked"));
+
+    render(<ActivityView refreshKey={0} registry={null} />);
+    await act(async () => {});
+    expect(screen.getByText("No tool calls yet")).toBeInTheDocument();
+
+    await act(async () => {
+      vi.advanceTimersByTime(3000);
+    });
+
+    expect(screen.getByText("Activity may be out of date.")).toBeInTheDocument();
+    expect(screen.getByText("No current activity status")).toBeInTheDocument();
+    expect(screen.queryByText("No tool calls yet")).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Retry activity log" }),
+    ).toBeInTheDocument();
+  });
+
+  it("preserves last-known calls and offers retry when a live refresh fails", async () => {
+    const user = userEvent.setup({
+      advanceTimers: (ms) => vi.advanceTimersByTime(ms),
+    });
+    getAuditLog
+      .mockResolvedValueOnce(initialLog)
+      .mockRejectedValueOnce(new Error("locked"));
+
+    render(<ActivityView refreshKey={0} registry={null} />);
+    await act(async () => {});
+    await user.click(screen.getByRole("button", { name: /recent calls/i }));
+
+    await act(async () => {
+      vi.advanceTimersByTime(3000);
+    });
+
+    expect(screen.getByText("Activity may be out of date.")).toBeInTheDocument();
+    expect(screen.getByText("merge_pr")).toBeInTheDocument();
+    expect(screen.queryByText("Couldn't load activity")).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Retry activity log" }),
+    ).toBeInTheDocument();
+  });
+
+  it("shows an initial audit error with retry instead of a false empty log", async () => {
+    const user = userEvent.setup({
+      advanceTimers: (ms) => vi.advanceTimersByTime(ms),
+    });
+    getAuditLog.mockRejectedValueOnce(new Error("offline")).mockResolvedValueOnce([]);
+
+    render(<ActivityView refreshKey={0} registry={null} />);
+    await act(async () => {});
+
+    expect(screen.getByText("Couldn't load activity")).toBeInTheDocument();
+    expect(screen.queryByText("No tool calls yet")).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Retry activity log" }));
+    await act(async () => {});
+    expect(screen.getByText("No tool calls yet")).toBeInTheDocument();
+  });
 });
 
 describe("ActivityView recent calls", () => {

--- a/src/components/ActivityView.tsx
+++ b/src/components/ActivityView.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import {
   Activity,
   AlertTriangle,
@@ -1496,6 +1496,12 @@ export function ActivityView({
   // refetch (they'd otherwise keep showing the just-deleted rows until the parent's
   // refreshKey next changes).
   const [reloadTick, setReloadTick] = useState(0);
+  // Invalidates audit reads that started BEFORE a successful clear: a live-tick
+  // getAuditLog can resolve after the file was wiped (its effect cleanup only runs
+  // at the next commit) and would restore the deleted rows — which a failed
+  // follow-up reload then preserves as "stale". Bumped on clear; both completion
+  // handlers ignore results from an older generation.
+  const auditGeneration = useRef(0);
 
   function retryLoads() {
     // Keep last-known rows visible while retrying. Only a never-successful load returns
@@ -1510,6 +1516,7 @@ export function ActivityView({
       await clearActivityLogs();
       // The next getAuditLog can fail (Windows file lock right after clear).
       // Do not keep the deleted rows as last-known after a successful wipe.
+      auditGeneration.current += 1;
       setEntries([]);
       setAuditLoadStatus("ready");
       toast.success("Cleared retained activity");
@@ -1539,14 +1546,15 @@ export function ActivityView({
 
   useEffect(() => {
     let alive = true;
+    const generation = auditGeneration.current;
     getAuditLog(200)
       .then((e) => {
-        if (!alive) return;
+        if (!alive || generation !== auditGeneration.current) return;
         setEntries(e);
         setAuditLoadStatus("ready");
       })
       .catch(() => {
-        if (!alive) return;
+        if (!alive || generation !== auditGeneration.current) return;
         // Never replace a last-known audit trail with a false empty state.
         setAuditLoadStatus((status) =>
           status === "ready" || status === "stale" ? "stale" : "error",

--- a/src/components/ActivityView.tsx
+++ b/src/components/ActivityView.tsx
@@ -261,6 +261,81 @@ function SecurityResting() {
   );
 }
 
+type LoadStatus = "loading" | "ready" | "error" | "stale";
+
+/** Security data is part of the trust boundary: a failed read is unknown, never an
+ * all-clear. Keep this state visible until a successful read verifies the current log. */
+function SecurityLoadNotice({
+  status,
+  onRetry,
+}: {
+  status: Exclude<LoadStatus, "ready">;
+  onRetry: () => void;
+}) {
+  if (status === "loading") {
+    return (
+      <div
+        role="status"
+        className="mb-4 flex items-center gap-2 rounded-lg border border-border/60 bg-muted/30 px-4 py-2.5 text-xs text-muted-foreground"
+      >
+        <ShieldCheck className="size-4 shrink-0" />
+        <span>Checking protection status…</span>
+      </div>
+    );
+  }
+
+  const stale = status === "stale";
+  return (
+    <div
+      role="alert"
+      className="mb-4 flex items-center gap-3 rounded-lg border border-warning/40 bg-warning/5 px-4 py-2.5 text-xs"
+    >
+      <AlertTriangle className="size-4 shrink-0 text-warning" />
+      <span className="text-muted-foreground">
+        <span className="font-medium text-foreground">
+          {stale
+            ? "Security status may be out of date."
+            : "Couldn't verify protection status."}
+        </span>{" "}
+        {stale
+          ? "Showing the last security events Toolport read successfully; the latest check failed."
+          : "Toolport couldn't read security events, so this is not an all-clear."}
+      </span>
+      <button
+        type="button"
+        onClick={onRetry}
+        aria-label="Retry protection status"
+        className="ml-auto shrink-0 rounded-md border px-2.5 py-1 font-medium text-foreground transition-colors hover:bg-accent focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none"
+      >
+        Retry
+      </button>
+    </div>
+  );
+}
+
+function AuditStaleNotice({ onRetry }: { onRetry: () => void }) {
+  return (
+    <div
+      role="alert"
+      className="mb-4 flex items-center gap-3 rounded-lg border border-warning/40 bg-warning/5 px-4 py-2.5 text-xs"
+    >
+      <AlertTriangle className="size-4 shrink-0 text-warning" />
+      <span className="text-muted-foreground">
+        <span className="font-medium text-foreground">Activity may be out of date.</span>{" "}
+        Showing the last calls Toolport read successfully; the latest refresh failed.
+      </span>
+      <button
+        type="button"
+        onClick={onRetry}
+        aria-label="Retry activity log"
+        className="ml-auto shrink-0 rounded-md border px-2.5 py-1 font-medium text-foreground transition-colors hover:bg-accent focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none"
+      >
+        Retry
+      </button>
+    </div>
+  );
+}
+
 /** Surfaces tool security events: a tool you approved changed (rug-pull signal),
  * a known server added one, a tool definition contains injection-like content
  * (poisoning), or a tool returned data that looks like injected instructions
@@ -1409,17 +1484,26 @@ export function ActivityView({
   // surfaces the true error rate, and the toggle is right there for triage.
   const [errorsOnly, setErrorsOnly] = useState(false);
   const [security, setSecurity] = useState<SecurityEvent[]>([]);
+  const [securityLoadStatus, setSecurityLoadStatus] = useState<LoadStatus>("loading");
   const [dismissed, setDismissed] = useState<Set<string>>(loadDismissed);
   const [logOpen, setLogOpen] = useState(false);
   // Distinguish a load FAILURE (gateway unreachable / audit log unreadable) from a
   // genuinely empty log: both leave `entries` empty, but only one is an error. Without
   // this, a first-run backend failure renders the friendly "No tool calls yet" state
   // and hides that anything is wrong.
-  const [loadError, setLoadError] = useState(false);
+  const [auditLoadStatus, setAuditLoadStatus] = useState<LoadStatus>("loading");
   // Local reload trigger: bumped after a "Clear retained activity" so the panels
   // refetch (they'd otherwise keep showing the just-deleted rows until the parent's
   // refreshKey next changes).
   const [reloadTick, setReloadTick] = useState(0);
+
+  function retryLoads() {
+    // Keep last-known rows visible while retrying. Only a never-successful load returns
+    // to the full loading state; stale data remains explicitly marked stale.
+    setAuditLoadStatus((status) => (status === "error" ? "loading" : status));
+    setSecurityLoadStatus((status) => (status === "error" ? "loading" : status));
+    setReloadTick((tick) => tick + 1);
+  }
 
   async function clearActivity() {
     try {
@@ -1455,12 +1539,14 @@ export function ActivityView({
       .then((e) => {
         if (!alive) return;
         setEntries(e);
-        setLoadError(false);
+        setAuditLoadStatus("ready");
       })
       .catch(() => {
         if (!alive) return;
-        setEntries([]);
-        setLoadError(true);
+        // Never replace a last-known audit trail with a false empty state.
+        setAuditLoadStatus((status) =>
+          status === "ready" || status === "stale" ? "stale" : "error",
+        );
       });
     getAuditStats()
       .then((s) => alive && setStats(s))
@@ -1469,8 +1555,19 @@ export function ActivityView({
       .then((s) => alive && setSavings(s))
       .catch(() => alive && setSavings(null));
     getSecurityEvents(50)
-      .then((s) => alive && setSecurity(s))
-      .catch(() => alive && setSecurity([]));
+      .then((s) => {
+        if (!alive) return;
+        setSecurity(s);
+        setSecurityLoadStatus("ready");
+      })
+      .catch(() => {
+        if (!alive) return;
+        // A failed refresh must preserve prior findings and must never produce the
+        // reassuring verified-empty state.
+        setSecurityLoadStatus((status) =>
+          status === "ready" || status === "stale" ? "stale" : "error",
+        );
+      });
     return () => {
       alive = false;
     };
@@ -1532,11 +1629,14 @@ export function ActivityView({
   const banner = (
     <>
       {/* Loud lane: the only thing here that may need a decision. */}
+      {securityLoadStatus !== "ready" ? (
+        <SecurityLoadNotice status={securityLoadStatus} onRetry={retryLoads} />
+      ) : null}
       {highSecurity.length > 0 ? (
         <SecurityNotices events={highSecurity} onDismiss={dismissSecurity} />
-      ) : (
+      ) : securityLoadStatus === "ready" ? (
         <SecurityResting />
-      )}
+      ) : null}
       {infoSecurity.length > 0 ? (
         <QuietDriftHistory
           events={infoSecurity}
@@ -1563,7 +1663,7 @@ export function ActivityView({
     (e) => (!serverFilter || e.server === serverFilter) && (!errorsOnly || !e.ok),
   );
 
-  if (entries === null) {
+  if (entries === null && auditLoadStatus === "loading") {
     return (
       <div>
         {banner}
@@ -1574,7 +1674,7 @@ export function ActivityView({
     );
   }
 
-  if (loadError && entries.length === 0) {
+  if (entries === null && auditLoadStatus === "error") {
     return (
       <div>
         {banner}
@@ -1585,6 +1685,46 @@ export function ActivityView({
             <p className="max-w-md text-sm text-muted-foreground">
               Toolport couldn't reach the gateway or read the audit log. This is not an
               empty log, if the gateway isn't running, start it and refresh.
+            </p>
+            <button
+              type="button"
+              onClick={retryLoads}
+              aria-label="Retry activity log"
+              className="mt-3 rounded-md border px-3 py-1.5 text-sm font-medium transition-colors hover:bg-accent focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none"
+            >
+              Retry
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // Defensive fallback for an impossible state transition: unknown audit data must
+  // still render as an error, never as a verified empty log.
+  if (entries === null) {
+    return (
+      <div>
+        {banner}
+        <div className="flex items-center justify-center py-24 text-sm text-destructive">
+          Activity status is unavailable. Retry the activity log.
+        </div>
+      </div>
+    );
+  }
+
+  if (entries.length === 0 && auditLoadStatus === "stale") {
+    return (
+      <div>
+        {banner}
+        <AuditStaleNotice onRetry={retryLoads} />
+        <div className="flex flex-col items-center justify-center gap-3 py-20 text-center">
+          <AlertTriangle className="size-10 text-warning/70" />
+          <div>
+            <p className="font-medium">No current activity status</p>
+            <p className="max-w-md text-sm text-muted-foreground">
+              The last successful read found no calls, but the latest refresh failed, so
+              Toolport can't verify that the log is still empty.
             </p>
           </div>
         </div>
@@ -1613,6 +1753,7 @@ export function ActivityView({
   return (
     <div>
       {banner}
+      {auditLoadStatus === "stale" && <AuditStaleNotice onRetry={retryLoads} />}
       {stats && <StatsPanel stats={stats} />}
 
       <div className="mb-2 flex items-center gap-2">

--- a/src/components/ActivityView.tsx
+++ b/src/components/ActivityView.tsx
@@ -1508,6 +1508,10 @@ export function ActivityView({
   async function clearActivity() {
     try {
       await clearActivityLogs();
+      // The next getAuditLog can fail (Windows file lock right after clear).
+      // Do not keep the deleted rows as last-known after a successful wipe.
+      setEntries([]);
+      setAuditLoadStatus("ready");
       toast.success("Cleared retained activity");
       setReloadTick((t) => t + 1);
     } catch (e) {

--- a/src/components/Onboarding.health.test.tsx
+++ b/src/components/Onboarding.health.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { Onboarding } from "./Onboarding";
 import type { DetectedClient, Registry } from "@/lib/types";
@@ -53,6 +53,31 @@ describe("Onboarding health verification", () => {
 
     probe.resolve([]);
     expect(await screen.findByText("You're set up")).toBeInTheDocument();
+  });
+
+  it("does not dress an unconfigured setup in verification language", async () => {
+    const probe = deferred<[]>();
+    const disconnected = { ...client, gatewayInstalled: false } as DetectedClient;
+    render(
+      <Onboarding {...props} clients={[disconnected]} onProbe={() => probe.promise} />,
+    );
+
+    // Servers exist but no client is connected: the step explains what's missing,
+    // so neither the probe's pending state nor its failure may relabel the finish
+    // button or show verification status blocks.
+    expect(await screen.findByText("Setup started")).toBeInTheDocument();
+    expect(screen.queryByText("Checking server health…")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Got it" })).toBeEnabled();
+
+    await act(async () => probe.reject(new Error("gateway not running")));
+
+    expect(screen.getByRole("button", { name: "Got it" })).toBeEnabled();
+    expect(
+      screen.queryByText(/couldn't verify your servers started/i),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Continue without verification" }),
+    ).not.toBeInTheDocument();
   });
 
   it("keeps a failed probe unavailable and offers an authoritative retry", async () => {

--- a/src/components/Onboarding.health.test.tsx
+++ b/src/components/Onboarding.health.test.tsx
@@ -46,7 +46,9 @@ describe("Onboarding health verification", () => {
     render(<Onboarding {...props} onProbe={() => probe.promise} />);
 
     expect(await screen.findByText("Checking server health…")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Checking…" })).toBeDisabled();
+    expect(
+      screen.getByRole("button", { name: "Continue without verification" }),
+    ).toBeEnabled();
     expect(screen.queryByText("You're set up")).not.toBeInTheDocument();
 
     probe.resolve([]);

--- a/src/components/Onboarding.health.test.tsx
+++ b/src/components/Onboarding.health.test.tsx
@@ -1,0 +1,80 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { Onboarding } from "./Onboarding";
+import type { DetectedClient, Registry } from "@/lib/types";
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+const registry = {
+  version: 1,
+  servers: [{ id: "server-1", name: "Server", transport: "stdio" }],
+  profiles: [{ id: "default", name: "Default", enabledServerIds: [] }],
+  activeProfileId: "default",
+} as unknown as Registry;
+
+const client = {
+  id: "cursor",
+  name: "Cursor",
+  appPresent: true,
+  gatewayInstalled: true,
+  servers: [],
+  pluginServers: [],
+} as unknown as DetectedClient;
+
+const props = {
+  initialStep: 3,
+  clients: [client],
+  registry,
+  onRegistryChange: vi.fn(),
+  onClientsRefresh: vi.fn(),
+  onBrowseCatalog: vi.fn(),
+  onOpenPlayground: vi.fn(),
+  onFinish: vi.fn(),
+};
+
+describe("Onboarding health verification", () => {
+  it("does not present setup as ready while the health probe is in flight", async () => {
+    const probe = deferred<[]>();
+    render(<Onboarding {...props} onProbe={() => probe.promise} />);
+
+    expect(await screen.findByText("Checking server health…")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Checking…" })).toBeDisabled();
+    expect(screen.queryByText("You're set up")).not.toBeInTheDocument();
+
+    probe.resolve([]);
+    expect(await screen.findByText("You're set up")).toBeInTheDocument();
+  });
+
+  it("keeps a failed probe unavailable and offers an authoritative retry", async () => {
+    const onProbe = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("backend unavailable"))
+      .mockResolvedValueOnce([]);
+
+    render(<Onboarding {...props} onProbe={onProbe} />);
+    expect(
+      await screen.findByText(/couldn't verify your servers started/i),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Setup couldn't be verified")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Continue without verification" }),
+    ).toBeEnabled();
+    expect(screen.queryByText(/server.*couldn't start/i)).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+    await waitFor(() => expect(onProbe).toHaveBeenCalledTimes(2));
+    await waitFor(() =>
+      expect(
+        screen.queryByText(/couldn't verify your servers started/i),
+      ).not.toBeInTheDocument(),
+    );
+  });
+});

--- a/src/components/Onboarding.tsx
+++ b/src/components/Onboarding.tsx
@@ -805,6 +805,7 @@ function Done({
   // servers healthy": swallowing it to health=[] would show a confident "you're
   // set up" over servers we never actually checked, so track it separately.
   const [probeFailed, setProbeFailed] = useState(false);
+  const [probeAttempt, setProbeAttempt] = useState(0);
   useEffect(() => {
     if (serverCount === 0) {
       setHealth([]);
@@ -812,6 +813,8 @@ function Done({
       return;
     }
     let alive = true;
+    setHealth(null);
+    setProbeFailed(false);
     onProbe()
       .then((r) => {
         if (!alive) return;
@@ -820,18 +823,19 @@ function Done({
       })
       .catch(() => {
         if (!alive) return;
-        setHealth([]);
         setProbeFailed(true);
       });
     return () => {
       alive = false;
     };
-  }, [serverCount, onProbe]);
+  }, [serverCount, onProbe, probeAttempt]);
 
   const nameFor = (id: string) => registry.servers.find((s) => s.id === id)?.name ?? id;
   const broken = (health ?? []).filter((r) => !r.ok && !r.authRequired);
 
-  const ready = serverCount > 0 && connectedCount > 0;
+  const configured = serverCount > 0 && connectedCount > 0;
+  const checkingHealth = serverCount > 0 && health === null && !probeFailed;
+  const ready = configured && health !== null && !probeFailed;
   // The client to verify against: the first one Toolport is actually wired into.
   const verifyClient = clients.find((c) => c.gatewayInstalled) ?? null;
   const missing = [
@@ -844,7 +848,15 @@ function Done({
     <>
       <StepHeader
         icon={<Check className="size-5" />}
-        title={ready ? "You're set up" : "Setup started"}
+        title={
+          ready
+            ? "You're set up"
+            : configured && checkingHealth
+              ? "Checking your setup"
+              : configured && probeFailed
+                ? "Setup couldn't be verified"
+                : "Setup started"
+        }
       >
         {ready ? (
           <>
@@ -856,6 +868,15 @@ function Done({
             success. And Toolport watches every server for tampering and prompt injection,
             see Activity.
           </>
+        ) : configured && checkingHealth ? (
+          <>
+            Toolport is checking that your servers can start before marking setup ready.
+          </>
+        ) : configured && probeFailed ? (
+          <>
+            Your servers and client are connected, but Toolport could not verify server
+            health. Retry the check below or continue without verification.
+          </>
         ) : (
           <>
             You haven't {missing} yet. You can do both any time from the main screen: add
@@ -863,6 +884,16 @@ function Done({
           </>
         )}
       </StepHeader>
+
+      {checkingHealth && (
+        <div
+          role="status"
+          className="flex items-center gap-2 rounded-md bg-muted/40 px-3 py-2 text-xs text-muted-foreground"
+        >
+          <Loader2 className="size-3.5 animate-spin" aria-hidden="true" />
+          Checking server health…
+        </div>
+      )}
 
       {broken.length > 0 && (
         <div className="flex flex-col gap-2 rounded-md bg-warning/10 px-3 py-2 text-sm">
@@ -892,9 +923,18 @@ function Done({
       )}
 
       {probeFailed && (
-        <div className="rounded-md bg-muted/40 px-3 py-2 text-xs text-muted-foreground">
-          Couldn&apos;t verify your servers started, the health check didn&apos;t run.
-          Open the main screen to see each server&apos;s live status.
+        <div className="flex items-center gap-2 rounded-md bg-muted/40 px-3 py-2 text-xs text-muted-foreground">
+          <span>
+            Couldn&apos;t verify your servers started, the health check didn&apos;t run.
+          </span>
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            onClick={() => setProbeAttempt((attempt) => attempt + 1)}
+          >
+            Retry
+          </Button>
         </div>
       )}
 
@@ -902,8 +942,14 @@ function Done({
         <VerifyCall client={verifyClient} onOpenPlayground={onOpenPlayground} />
       )}
 
-      <Button onClick={onFinish} className="self-start">
-        {ready ? "Start using Toolport" : "Got it"}
+      <Button onClick={onFinish} className="self-start" disabled={checkingHealth}>
+        {checkingHealth
+          ? "Checking…"
+          : ready
+            ? "Start using Toolport"
+            : configured && probeFailed
+              ? "Continue without verification"
+              : "Got it"}
         <ArrowRight className="size-4" />
       </Button>
     </>

--- a/src/components/Onboarding.tsx
+++ b/src/components/Onboarding.tsx
@@ -942,14 +942,12 @@ function Done({
         <VerifyCall client={verifyClient} onOpenPlayground={onOpenPlayground} />
       )}
 
-      <Button onClick={onFinish} className="self-start" disabled={checkingHealth}>
-        {checkingHealth
-          ? "Checking…"
+      <Button onClick={onFinish} className="self-start">
+        {checkingHealth || (configured && probeFailed)
+          ? "Continue without verification"
           : ready
             ? "Start using Toolport"
-            : configured && probeFailed
-              ? "Continue without verification"
-              : "Got it"}
+            : "Got it"}
         <ArrowRight className="size-4" />
       </Button>
     </>

--- a/src/components/Onboarding.tsx
+++ b/src/components/Onboarding.tsx
@@ -834,7 +834,11 @@ function Done({
   const broken = (health ?? []).filter((r) => !r.ok && !r.authRequired);
 
   const configured = serverCount > 0 && connectedCount > 0;
-  const checkingHealth = serverCount > 0 && health === null && !probeFailed;
+  // Verification states only apply once setup is actually complete: with no client
+  // connected the step reports what's missing, and must not dress the finish button
+  // or the status blocks in "Checking…" / "couldn't verify" language.
+  const checkingHealth = configured && health === null && !probeFailed;
+  const verificationFailed = configured && probeFailed;
   const ready = configured && health !== null && !probeFailed;
   // The client to verify against: the first one Toolport is actually wired into.
   const verifyClient = clients.find((c) => c.gatewayInstalled) ?? null;
@@ -922,7 +926,7 @@ function Done({
         </div>
       )}
 
-      {probeFailed && (
+      {verificationFailed && (
         <div className="flex items-center gap-2 rounded-md bg-muted/40 px-3 py-2 text-xs text-muted-foreground">
           <span>
             Couldn&apos;t verify your servers started, the health check didn&apos;t run.
@@ -943,7 +947,7 @@ function Done({
       )}
 
       <Button onClick={onFinish} className="self-start">
-        {checkingHealth || (configured && probeFailed)
+        {checkingHealth || verificationFailed
           ? "Continue without verification"
           : ready
             ? "Start using Toolport"

--- a/src/components/ShareDialog.test.tsx
+++ b/src/components/ShareDialog.test.tsx
@@ -1,10 +1,14 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 const mocks = vi.hoisted(() => ({
   exportConfig: vi.fn(),
+  fetchSharedSetup: vi.fn(),
   getRegistry: vi.fn(),
+  importConfig: vi.fn(),
+  importSharedHandler: null as null | ((event: { payload: string }) => void),
+  previewImport: vi.fn(),
   shareStack: vi.fn(),
   success: vi.fn(),
   toastError: vi.fn(),
@@ -15,10 +19,10 @@ vi.mock("@/lib/toast", () => ({ toastError: mocks.toastError }));
 vi.mock("@/lib/api", () => ({
   exportConfig: mocks.exportConfig,
   exportConfigToPath: vi.fn(),
-  fetchSharedSetup: vi.fn(),
+  fetchSharedSetup: mocks.fetchSharedSetup,
   getRegistry: mocks.getRegistry,
-  importConfig: vi.fn(),
-  previewImport: vi.fn(),
+  importConfig: mocks.importConfig,
+  previewImport: mocks.previewImport,
   readSetupFile: vi.fn(),
   shareStack: mocks.shareStack,
   takePendingShared: vi.fn().mockResolvedValue(null),
@@ -28,16 +32,37 @@ vi.mock("@tauri-apps/plugin-dialog", () => ({
   save: vi.fn(),
 }));
 vi.mock("@tauri-apps/api/event", () => ({
-  listen: vi.fn().mockResolvedValue(() => {}),
+  listen: vi
+    .fn()
+    .mockImplementation(
+      (_event: string, handler: (event: { payload: string }) => void) => {
+        mocks.importSharedHandler = handler;
+        return Promise.resolve(() => {});
+      },
+    ),
 }));
 
 import { ShareDialog } from "./ShareDialog";
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, reject, resolve };
+}
 
 describe("ShareDialog share links", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.exportConfig.mockResolvedValue('{"servers":[]}');
     mocks.getRegistry.mockResolvedValue({ servers: [] });
+    mocks.previewImport.mockResolvedValue([]);
+    mocks.fetchSharedSetup.mockResolvedValue('{"servers":[]}');
+    mocks.importConfig.mockResolvedValue({ servers: [] });
+    mocks.importSharedHandler = null;
     mocks.shareStack.mockResolvedValue("https://toolport.app/s/example");
   });
 
@@ -89,5 +114,252 @@ describe("ShareDialog share links", () => {
     expect(mocks.toastError).not.toHaveBeenCalledWith(
       expect.stringContaining("Couldn't create a link"),
     );
+  });
+
+  it("does not export or enable share actions until the registry is loaded", async () => {
+    const registry = deferred<{ servers: never[] }>();
+    mocks.getRegistry.mockReturnValue(registry.promise);
+
+    render(<ShareDialog trigger={<button>Share</button>} onImported={vi.fn()} />);
+    await userEvent.click(screen.getByRole("button", { name: "Share" }));
+
+    expect(await screen.findByText("Loading servers…")).toBeVisible();
+    expect(screen.getByRole("button", { name: /create share link/i })).toBeDisabled();
+    expect(screen.getByRole("button", { name: /^copy$/i })).toBeDisabled();
+    expect(screen.getByRole("button", { name: /save to file/i })).toBeDisabled();
+    expect(mocks.exportConfig).not.toHaveBeenCalled();
+
+    await act(async () => registry.resolve({ servers: [] }));
+
+    await waitFor(() => expect(mocks.exportConfig).toHaveBeenCalledTimes(1));
+    expect(mocks.exportConfig).toHaveBeenLastCalledWith("", "", []);
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /create share link/i })).toBeEnabled(),
+    );
+  });
+
+  it("surfaces registry load errors and keeps every share action disabled", async () => {
+    mocks.getRegistry.mockRejectedValueOnce(new Error("registry unavailable"));
+
+    render(<ShareDialog trigger={<button>Share</button>} onImported={vi.fn()} />);
+    await userEvent.click(screen.getByRole("button", { name: "Share" }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent("registry unavailable");
+    expect(screen.getByRole("button", { name: /create share link/i })).toBeDisabled();
+    expect(screen.getByRole("button", { name: /^copy$/i })).toBeDisabled();
+    expect(screen.getByRole("button", { name: /save to file/i })).toBeDisabled();
+    expect(mocks.exportConfig).not.toHaveBeenCalled();
+  });
+
+  it("clears stale export and link output as soon as the setup changes", async () => {
+    const nextExport = deferred<string>();
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText: vi.fn().mockResolvedValue(undefined) },
+    });
+
+    render(<ShareDialog trigger={<button>Share</button>} onImported={vi.fn()} />);
+    await userEvent.click(screen.getByRole("button", { name: "Share" }));
+    const create = await screen.findByRole("button", { name: /create share link/i });
+    await waitFor(() => expect(create).toBeEnabled());
+    await userEvent.click(create);
+    expect(await screen.findByText("https://toolport.app/s/example")).toBeVisible();
+
+    mocks.exportConfig.mockReturnValueOnce(nextExport.promise);
+    await userEvent.type(screen.getByPlaceholderText("Name (optional)"), "Updated");
+
+    expect(screen.queryByText("https://toolport.app/s/example")).not.toBeInTheDocument();
+    expect(screen.getByLabelText("Exported setup")).toHaveValue("");
+    expect(create).toBeDisabled();
+
+    await waitFor(() => expect(mocks.exportConfig).toHaveBeenCalledTimes(2));
+    await act(async () => nextExport.resolve('{"name":"Updated"}'));
+    await waitFor(() => expect(create).toBeEnabled());
+  });
+
+  it("lets only the latest export request publish its result", async () => {
+    const first = deferred<string>();
+    const second = deferred<string>();
+
+    render(<ShareDialog trigger={<button>Share</button>} onImported={vi.fn()} />);
+    await userEvent.click(screen.getByRole("button", { name: "Share" }));
+    const create = await screen.findByRole("button", { name: /create share link/i });
+    await waitFor(() => expect(create).toBeEnabled());
+
+    mocks.exportConfig
+      .mockReturnValueOnce(first.promise)
+      .mockReturnValueOnce(second.promise);
+    const name = screen.getByPlaceholderText("Name (optional)");
+    await userEvent.type(name, "A");
+    await waitFor(() => expect(mocks.exportConfig).toHaveBeenCalledTimes(2));
+    await userEvent.type(name, "B");
+    await waitFor(() => expect(mocks.exportConfig).toHaveBeenCalledTimes(3));
+
+    await act(async () => second.resolve('{"name":"AB"}'));
+    await waitFor(() =>
+      expect(screen.getByLabelText("Exported setup")).toHaveValue('{"name":"AB"}'),
+    );
+    await act(async () => first.resolve('{"name":"A"}'));
+    expect(screen.getByLabelText("Exported setup")).toHaveValue('{"name":"AB"}');
+  });
+
+  it("ignores a link response after the exported setup was invalidated", async () => {
+    const link = deferred<string>();
+    mocks.shareStack.mockReturnValueOnce(link.promise);
+
+    render(<ShareDialog trigger={<button>Share</button>} onImported={vi.fn()} />);
+    await userEvent.click(screen.getByRole("button", { name: "Share" }));
+    const create = await screen.findByRole("button", { name: /create share link/i });
+    await waitFor(() => expect(create).toBeEnabled());
+    await userEvent.click(create);
+    await userEvent.type(
+      screen.getByPlaceholderText("Description (optional)"),
+      "Changed",
+    );
+
+    await act(async () => link.resolve("https://toolport.app/s/stale"));
+    expect(screen.queryByText("https://toolport.app/s/stale")).not.toBeInTheDocument();
+  });
+
+  it("keeps share actions disabled when export generation fails", async () => {
+    mocks.exportConfig.mockRejectedValueOnce(new Error("export unavailable"));
+
+    render(<ShareDialog trigger={<button>Share</button>} onImported={vi.fn()} />);
+    await userEvent.click(screen.getByRole("button", { name: "Share" }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent("export unavailable");
+    expect(screen.getByRole("button", { name: /create share link/i })).toBeDisabled();
+    expect(screen.getByRole("button", { name: /^copy$/i })).toBeDisabled();
+    expect(screen.getByRole("button", { name: /save to file/i })).toBeDisabled();
+  });
+
+  it("selects duplicate display names independently by stable server id", async () => {
+    mocks.getRegistry.mockResolvedValue({
+      servers: [
+        { id: "duplicate-a", name: "Duplicate", transport: "stdio" },
+        { id: "duplicate-b", name: "Duplicate", transport: "http" },
+      ],
+    });
+
+    render(<ShareDialog trigger={<button>Share</button>} onImported={vi.fn()} />);
+    await userEvent.click(screen.getByRole("button", { name: "Share" }));
+    await waitFor(() =>
+      expect(mocks.exportConfig).toHaveBeenLastCalledWith("", "", [
+        "duplicate-a",
+        "duplicate-b",
+      ]),
+    );
+
+    const duplicateButtons = screen.getAllByRole("button", { name: "Duplicate" });
+    await userEvent.click(duplicateButtons[0]);
+    await waitFor(() =>
+      expect(mocks.exportConfig).toHaveBeenLastCalledWith("", "", ["duplicate-b"]),
+    );
+  });
+
+  it("does not let a preview from a closed dialog enter a later session", async () => {
+    const preview = deferred<never[]>();
+    mocks.previewImport.mockReturnValueOnce(preview.promise);
+
+    render(<ShareDialog trigger={<button>Share</button>} onImported={vi.fn()} />);
+    await userEvent.click(screen.getByRole("button", { name: "Share" }));
+    fireEvent.change(screen.getByLabelText("Paste a shared setup"), {
+      target: { value: '{"servers":[]}' },
+    });
+    await userEvent.click(screen.getByRole("button", { name: /review and import/i }));
+    await userEvent.click(screen.getByRole("button", { name: "Close" }));
+    await userEvent.click(screen.getByRole("button", { name: "Share" }));
+
+    await act(async () => preview.resolve([]));
+    expect(screen.getByText("Share setup")).toBeInTheDocument();
+    expect(screen.queryByText("Review this setup")).not.toBeInTheDocument();
+  });
+
+  it("lets only the newest deep link publish an import review", async () => {
+    const first = deferred<string>();
+    const second = deferred<string>();
+    mocks.fetchSharedSetup
+      .mockReturnValueOnce(first.promise)
+      .mockReturnValueOnce(second.promise);
+
+    render(<ShareDialog trigger={<button>Share</button>} onImported={vi.fn()} />);
+    await waitFor(() => expect(mocks.importSharedHandler).not.toBeNull());
+    act(() => mocks.importSharedHandler?.({ payload: "first" }));
+    act(() => mocks.importSharedHandler?.({ payload: "second" }));
+
+    await act(async () => second.resolve('{"name":"newest","servers":[]}'));
+    await waitFor(() => expect(mocks.previewImport).toHaveBeenCalledTimes(1));
+    expect(mocks.previewImport).toHaveBeenLastCalledWith(
+      '{"name":"newest","servers":[]}',
+    );
+
+    await act(async () => first.resolve('{"name":"stale","servers":[]}'));
+    expect(mocks.previewImport).toHaveBeenCalledTimes(1);
+  });
+
+  it("invalidates a visible review as soon as a newer deep link arrives", async () => {
+    const item = {
+      name: "Reviewed A",
+      transport: "stdio" as const,
+      command: "npx",
+      args: [],
+      url: null,
+      isNew: true,
+    };
+    const newer = deferred<string>();
+    mocks.previewImport.mockResolvedValueOnce([item]);
+
+    render(<ShareDialog trigger={<button>Share</button>} onImported={vi.fn()} />);
+    await userEvent.click(screen.getByRole("button", { name: "Share" }));
+    fireEvent.change(screen.getByLabelText("Paste a shared setup"), {
+      target: { value: '{"name":"a","servers":[]}' },
+    });
+    await userEvent.click(screen.getByRole("button", { name: /review and import/i }));
+    expect(await screen.findByRole("button", { name: "Import 1 server" })).toBeEnabled();
+
+    mocks.fetchSharedSetup.mockReturnValueOnce(newer.promise);
+    act(() => mocks.importSharedHandler?.({ payload: "newer" }));
+
+    expect(
+      screen.queryByRole("button", { name: "Import 1 server" }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText("Share setup")).toBeInTheDocument();
+
+    await act(async () => newer.reject(new Error("fetch failed")));
+    await waitFor(() =>
+      expect(mocks.toastError).toHaveBeenCalledWith(
+        expect.stringContaining("fetch failed"),
+      ),
+    );
+    expect(screen.getByRole("button", { name: /review and import/i })).toBeDisabled();
+  });
+
+  it("does not let an older import completion close a newer review", async () => {
+    const item = {
+      name: "Reviewed server",
+      transport: "stdio" as const,
+      command: "npx",
+      args: [],
+      url: null,
+      isNew: true,
+    };
+    const importing = deferred<{ servers: [] }>();
+    mocks.previewImport.mockResolvedValue([item]);
+    mocks.importConfig.mockReturnValueOnce(importing.promise);
+
+    render(<ShareDialog trigger={<button>Share</button>} onImported={vi.fn()} />);
+    await userEvent.click(screen.getByRole("button", { name: "Share" }));
+    fireEvent.change(screen.getByLabelText("Paste a shared setup"), {
+      target: { value: '{"name":"a","servers":[]}' },
+    });
+    await userEvent.click(screen.getByRole("button", { name: /review and import/i }));
+    await userEvent.click(await screen.findByRole("button", { name: "Import 1 server" }));
+
+    act(() => mocks.importSharedHandler?.({ payload: "newer" }));
+    expect(await screen.findByText("Review this setup")).toBeInTheDocument();
+
+    await act(async () => importing.resolve({ servers: [] }));
+    expect(screen.getByText("Review this setup")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Import 1 server" })).toBeEnabled();
   });
 });

--- a/src/components/ShareDialog.test.tsx
+++ b/src/components/ShareDialog.test.tsx
@@ -347,7 +347,8 @@ describe("ShareDialog share links", () => {
     mocks.previewImport.mockResolvedValue([item]);
     mocks.importConfig.mockReturnValueOnce(importing.promise);
 
-    render(<ShareDialog trigger={<button>Share</button>} onImported={vi.fn()} />);
+    const onImported = vi.fn();
+    render(<ShareDialog trigger={<button>Share</button>} onImported={onImported} />);
     await userEvent.click(screen.getByRole("button", { name: "Share" }));
     fireEvent.change(screen.getByLabelText("Paste a shared setup"), {
       target: { value: '{"name":"a","servers":[]}' },
@@ -361,5 +362,9 @@ describe("ShareDialog share links", () => {
     await act(async () => importing.resolve({ servers: [] }));
     expect(screen.getByText("Review this setup")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Import 1 server" })).toBeEnabled();
+    expect(onImported).toHaveBeenCalledWith({ servers: [] });
+    expect(mocks.success).toHaveBeenCalledWith(
+      "Imported the setup you already confirmed",
+    );
   });
 });

--- a/src/components/ShareDialog.test.tsx
+++ b/src/components/ShareDialog.test.tsx
@@ -331,7 +331,13 @@ describe("ShareDialog share links", () => {
         expect.stringContaining("fetch failed"),
       ),
     );
-    expect(screen.getByRole("button", { name: /review and import/i })).toBeDisabled();
+    // The failed fetch must leave no review to act on: no review view, no
+    // "Reviewing…" spinner stuck on, and nothing staged in the paste field.
+    // (The review-and-import button being disabled alone would also hold for the
+    // unrelated reason that opening the dialog cleared the paste field.)
+    expect(screen.queryByText("Review this setup")).not.toBeInTheDocument();
+    expect(screen.queryByText("Reviewing…")).not.toBeInTheDocument();
+    expect(screen.getByLabelText("Paste a shared setup")).toHaveValue("");
   });
 
   it("does not let an older import completion close a newer review", async () => {

--- a/src/components/ShareDialog.tsx
+++ b/src/components/ShareDialog.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, type ReactNode } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import {
   ArrowLeft,
   Check,
@@ -43,6 +43,8 @@ interface Props {
   onImported: (registry: Registry) => void;
 }
 
+type LoadState = "idle" | "loading" | "ready" | "error";
+
 /** Share a curated server set with a teammate (and import theirs). Secret values
  * are never included - each person vaults their own keys after importing. This is
  * the no-backend version of "push a setup to your team".
@@ -66,32 +68,65 @@ export function ShareDialog({ trigger, onImported }: Props) {
   const [preview, setPreview] = useState<ImportItem[] | null>(null);
   const [pendingJson, setPendingJson] = useState("");
   // The user's servers and which to include in the shared stack (default all).
-  const [servers, setServers] = useState<{ name: string; transport: string }[]>([]);
+  const [servers, setServers] = useState<
+    { id: string; name: string; transport: string }[]
+  >([]);
   const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [registryState, setRegistryState] = useState<LoadState>("idle");
+  const [registryError, setRegistryError] = useState("");
+  const [exportState, setExportState] = useState<LoadState>("idle");
+  const [exportError, setExportError] = useState("");
+  const [exportRetry, setExportRetry] = useState(0);
   // A generated share link (toolport.app/s/...), cleared when the export changes.
   const [shareLink, setShareLink] = useState("");
   const [linkCopied, setLinkCopied] = useState(false);
   const [linking, setLinking] = useState(false);
+  const [saving, setSaving] = useState(false);
+  // Request generations make close/reopen, retry, and out-of-order completions inert.
+  const registryRequest = useRef(0);
+  const exportRequest = useRef(0);
+  const linkRequest = useRef(0);
+  const previewRequest = useRef(0);
 
-  // Load the server list on open so the user can choose a subset to share.
-  useEffect(() => {
-    if (!open) return;
-    getRegistry()
-      .then((reg) => {
-        const list = reg.servers
-          .filter((s) => !isGatewayServer(s))
-          .map((s) => ({ name: s.name, transport: s.transport }));
-        setServers(list);
-        setSelected(new Set(list.map((s) => s.name)));
-      })
-      .catch(() => {});
-  }, [open]);
+  const invalidateShareOutput = useCallback((nextState: LoadState = "loading") => {
+    exportRequest.current += 1;
+    linkRequest.current += 1;
+    setExported("");
+    setExportState(nextState);
+    setExportError("");
+    setShareLink("");
+    setLinkCopied(false);
+    setLinking(false);
+    setCopied(false);
+  }, []);
 
-  // Selection passed to the backend: undefined = share everything (also the
-  // pre-load state), otherwise just the chosen subset.
-  const allSelected = servers.length > 0 && selected.size === servers.length;
-  const shareFilter =
-    servers.length === 0 || allSelected ? undefined : Array.from(selected);
+  const loadServers = useCallback(async () => {
+    const request = ++registryRequest.current;
+    invalidateShareOutput("idle");
+    setRegistryState("loading");
+    setRegistryError("");
+    setServers([]);
+    setSelected(new Set());
+    try {
+      const reg = await getRegistry();
+      if (request !== registryRequest.current) return;
+      const list = reg.servers
+        .filter((s) => !isGatewayServer(s))
+        .map((s) => ({ id: s.id, name: s.name, transport: s.transport }));
+      invalidateShareOutput();
+      setServers(list);
+      setSelected(new Set(list.map((s) => s.id)));
+      setRegistryState("ready");
+    } catch (e) {
+      if (request !== registryRequest.current) return;
+      setRegistryState("error");
+      setRegistryError(String(e));
+    }
+  }, [invalidateShareOutput]);
+
+  // Always pass the exact stable-ID snapshot, including for All and verified empty.
+  // This prevents duplicate names or a server added after load from widening a share.
+  const shareFilter = useMemo(() => Array.from(selected), [selected]);
 
   useEffect(() => {
     const timer = setTimeout(() => {
@@ -103,52 +138,76 @@ export function ShareDialog({ trigger, onImported }: Props) {
   }, [name, description]);
 
   useEffect(() => {
-    if (!open) return;
-    setShareLink(""); // the export changed, so any prior link is stale
-    // Guard against out-of-order responses: this effect re-fires on every keystroke
-    // of name/description, and two in-flight exportConfig calls can resolve in either
-    // order. Without this, a slower earlier response could overwrite the preview with
-    // stale content. Only the latest effect run is allowed to commit its result.
-    let cancelled = false;
+    if (!open || registryState !== "ready") return;
+    const request = ++exportRequest.current;
+    linkRequest.current += 1;
     exportConfig(debouncedName, debouncedDescription, shareFilter)
       .then((v) => {
-        if (!cancelled) setExported(v);
+        if (request !== exportRequest.current) return;
+        setExported(v);
+        setExportState("ready");
       })
-      .catch(() => {
-        if (!cancelled) setExported("");
+      .catch((e) => {
+        if (request !== exportRequest.current) return;
+        setExported("");
+        setExportState("error");
+        setExportError(String(e));
       });
     return () => {
-      cancelled = true;
+      if (request === exportRequest.current) exportRequest.current += 1;
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [open, debouncedName, debouncedDescription, selected, servers]);
+  }, [
+    debouncedDescription,
+    debouncedName,
+    exportRetry,
+    open,
+    registryState,
+    shareFilter,
+  ]);
 
-  function onOpenChange(next: boolean) {
-    setOpen(next);
-    if (next) {
-      setPaste("");
-      setCopied(false);
-      setPreview(null);
-      setPendingJson("");
-    }
-  }
+  const onOpenChange = useCallback(
+    (next: boolean) => {
+      setOpen(next);
+      previewRequest.current += 1;
+      setBusyAction(null);
+      if (next) {
+        setPaste("");
+        setCopied(false);
+        setPreview(null);
+        setPendingJson("");
+        void loadServers();
+      } else {
+        registryRequest.current += 1;
+        setRegistryState("idle");
+        setRegistryError("");
+        invalidateShareOutput("idle");
+      }
+    },
+    [invalidateShareOutput, loadServers],
+  );
 
   async function createLink() {
+    const request = ++linkRequest.current;
+    const setup = exported;
     setLinking(true);
     try {
-      const url = await shareStack(exported);
+      const url = await shareStack(setup);
+      if (request !== linkRequest.current) return;
       setShareLink(url);
       try {
         await navigator.clipboard.writeText(url);
+        if (request !== linkRequest.current) return;
         toast.success("Share link created and copied");
       } catch {
+        if (request !== linkRequest.current) return;
         toast.success("Share link created");
         toastError("Couldn't copy automatically. Select the link and copy it.");
       }
     } catch (e) {
+      if (request !== linkRequest.current) return;
       toastError(`Couldn't create a link: ${e}`);
     } finally {
-      setLinking(false);
+      if (request === linkRequest.current) setLinking(false);
     }
   }
 
@@ -173,6 +232,7 @@ export function ShareDialog({ trigger, onImported }: Props) {
   }
 
   async function saveToFile() {
+    setSaving(true);
     try {
       const path = await save({
         title: "Save Toolport setup",
@@ -184,24 +244,35 @@ export function ShareDialog({ trigger, onImported }: Props) {
       toast.success("Saved setup to file");
     } catch (e) {
       toastError(`Couldn't save: ${e}`);
+    } finally {
+      setSaving(false);
     }
   }
 
   // Parse + preview a candidate setup (paste or file) before importing anything.
-  async function startPreview(json: string, source: "preview-paste" | "preview-file") {
+  async function startPreview(
+    json: string,
+    source: "preview-paste" | "preview-file",
+    existingRequest?: number,
+  ) {
+    const request = existingRequest ?? ++previewRequest.current;
     setBusyAction(source);
     try {
       const items = await previewImport(json);
+      if (request !== previewRequest.current) return;
       setPendingJson(json);
       setPreview(items);
     } catch (e) {
+      if (request !== previewRequest.current) return;
       toastError(`Couldn't read that setup: ${e}`);
     } finally {
-      setBusyAction(null);
+      if (request === previewRequest.current) setBusyAction(null);
     }
   }
 
   async function loadFromFile() {
+    const request = ++previewRequest.current;
+    setBusyAction("preview-file");
     try {
       const path = await openFile({
         title: "Open a Toolport setup",
@@ -209,26 +280,34 @@ export function ShareDialog({ trigger, onImported }: Props) {
         directory: false,
         filters: [{ name: "Toolport setup", extensions: ["json"] }],
       });
-      if (!path || typeof path !== "string") return;
+      if (request !== previewRequest.current || !path || typeof path !== "string") return;
       const json = await readSetupFile(path);
-      await startPreview(json, "preview-file");
+      if (request !== previewRequest.current) return;
+      await startPreview(json, "preview-file", request);
     } catch (e) {
+      if (request !== previewRequest.current) return;
       toastError(`Couldn't open that file: ${e}`);
+    } finally {
+      if (request === previewRequest.current) setBusyAction(null);
     }
   }
 
   async function confirmImport() {
+    const request = previewRequest.current;
+    const json = pendingJson;
     setBusyAction("import");
     try {
-      onImported(await importConfig(pendingJson));
+      onImported(await importConfig(json));
+      if (request !== previewRequest.current) return;
       toast.success("Imported shared setup", {
         description: "Add any API keys each server needs, then enable them.",
       });
-      setOpen(false);
+      onOpenChange(false);
     } catch (e) {
+      if (request !== previewRequest.current) return;
       toastError(`Couldn't import: ${e}`);
     } finally {
-      setBusyAction(null);
+      if (request === previewRequest.current) setBusyAction(null);
     }
   }
 
@@ -238,13 +317,20 @@ export function ShareDialog({ trigger, onImported }: Props) {
     let cancelled = false;
     let unlisten: (() => void) | undefined;
     async function openShared(id: string) {
+      // Immediately invalidate and hide any older command-bearing review. The
+      // incoming setup is a new review session even while its payload is fetching.
+      onOpenChange(true);
+      const request = ++previewRequest.current;
+      setBusyAction("preview-paste");
       try {
         const json = await fetchSharedSetup(id);
-        if (cancelled) return;
-        setOpen(true);
-        await startPreview(json, "preview-paste");
+        if (cancelled || request !== previewRequest.current) return;
+        await startPreview(json, "preview-paste", request);
       } catch (e) {
+        if (cancelled || request !== previewRequest.current) return;
         toastError(`Couldn't open that shared stack: ${e}`);
+      } finally {
+        if (!cancelled && request === previewRequest.current) setBusyAction(null);
       }
     }
     takePendingShared()
@@ -264,9 +350,16 @@ export function ShareDialog({ trigger, onImported }: Props) {
       cancelled = true;
       unlisten?.();
     };
-  }, []);
+  }, [onOpenChange]);
 
   const newCount = preview?.filter((i) => i.isNew).length ?? 0;
+  const hasSelection = selected.size > 0 || servers.length === 0;
+  const shareReady =
+    registryState === "ready" &&
+    exportState === "ready" &&
+    exported.length > 0 &&
+    hasSelection;
+  const shareActionDisabled = !shareReady || linking || saving;
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -327,13 +420,19 @@ export function ShareDialog({ trigger, onImported }: Props) {
               <div className="grid grid-cols-2 gap-2">
                 <Input
                   value={name}
-                  onChange={(e) => setName(e.target.value)}
+                  onChange={(e) => {
+                    invalidateShareOutput();
+                    setName(e.target.value);
+                  }}
                   placeholder="Name (optional)"
                   className="h-8 text-sm"
                 />
                 <Input
                   value={description}
-                  onChange={(e) => setDescription(e.target.value)}
+                  onChange={(e) => {
+                    invalidateShareOutput();
+                    setDescription(e.target.value);
+                  }}
                   placeholder="Description (optional)"
                   className="h-8 text-sm"
                 />
@@ -349,14 +448,20 @@ export function ShareDialog({ trigger, onImported }: Props) {
                       <button
                         type="button"
                         className="text-muted-foreground hover:text-foreground"
-                        onClick={() => setSelected(new Set(servers.map((s) => s.name)))}
+                        onClick={() => {
+                          invalidateShareOutput();
+                          setSelected(new Set(servers.map((s) => s.id)));
+                        }}
                       >
                         All
                       </button>
                       <button
                         type="button"
                         className="text-muted-foreground hover:text-foreground"
-                        onClick={() => setSelected(new Set())}
+                        onClick={() => {
+                          invalidateShareOutput();
+                          setSelected(new Set());
+                        }}
                       >
                         None
                       </button>
@@ -364,19 +469,20 @@ export function ShareDialog({ trigger, onImported }: Props) {
                   </div>
                   <div className="flex flex-wrap gap-1.5">
                     {servers.map((s) => {
-                      const on = selected.has(s.name);
+                      const on = selected.has(s.id);
                       return (
                         <button
-                          key={s.name}
+                          key={s.id}
                           type="button"
-                          onClick={() =>
+                          onClick={() => {
+                            invalidateShareOutput();
                             setSelected((prev) => {
                               const next = new Set(prev);
-                              if (on) next.delete(s.name);
-                              else next.add(s.name);
+                              if (on) next.delete(s.id);
+                              else next.add(s.id);
                               return next;
-                            })
-                          }
+                            });
+                          }}
                           className={`rounded-full border px-2.5 py-1 text-xs transition-colors ${
                             on
                               ? "border-success/50 bg-success/10 text-success"
@@ -388,6 +494,46 @@ export function ShareDialog({ trigger, onImported }: Props) {
                       );
                     })}
                   </div>
+                </div>
+              )}
+
+              {registryState === "loading" && (
+                <p role="status" className="text-xs text-muted-foreground">
+                  Loading servers…
+                </p>
+              )}
+              {registryState === "error" && (
+                <div
+                  role="alert"
+                  className="flex items-center justify-between gap-2 rounded-md border border-destructive/30 bg-destructive/5 px-2.5 py-2 text-xs text-destructive"
+                >
+                  <span>Couldn&apos;t load your servers: {registryError}</span>
+                  <Button size="sm" variant="outline" onClick={() => void loadServers()}>
+                    Retry
+                  </Button>
+                </div>
+              )}
+              {registryState === "ready" && exportState === "loading" && (
+                <p role="status" className="text-xs text-muted-foreground">
+                  Updating setup…
+                </p>
+              )}
+              {registryState === "ready" && exportState === "error" && (
+                <div
+                  role="alert"
+                  className="flex items-center justify-between gap-2 rounded-md border border-destructive/30 bg-destructive/5 px-2.5 py-2 text-xs text-destructive"
+                >
+                  <span>Couldn&apos;t build this setup: {exportError}</span>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    onClick={() => {
+                      invalidateShareOutput();
+                      setExportRetry((value) => value + 1);
+                    }}
+                  >
+                    Retry
+                  </Button>
                 </div>
               )}
 
@@ -403,9 +549,7 @@ export function ShareDialog({ trigger, onImported }: Props) {
                   size="sm"
                   className="h-8"
                   onClick={createLink}
-                  disabled={
-                    linking || !exported || (servers.length > 0 && selected.size === 0)
-                  }
+                  disabled={shareActionDisabled}
                 >
                   {linking ? (
                     <>
@@ -422,7 +566,7 @@ export function ShareDialog({ trigger, onImported }: Props) {
                   variant="outline"
                   className="h-8"
                   onClick={copy}
-                  disabled={!exported || (servers.length > 0 && selected.size === 0)}
+                  disabled={shareActionDisabled}
                 >
                   {copied ? (
                     <>
@@ -439,9 +583,17 @@ export function ShareDialog({ trigger, onImported }: Props) {
                   variant="outline"
                   className="h-8"
                   onClick={saveToFile}
-                  disabled={!exported || (servers.length > 0 && selected.size === 0)}
+                  disabled={shareActionDisabled}
                 >
-                  <FileDown className="size-3.5" /> Save to file
+                  {saving ? (
+                    <>
+                      <Loader2 className="size-3.5 animate-spin" /> Saving…
+                    </>
+                  ) : (
+                    <>
+                      <FileDown className="size-3.5" /> Save to file
+                    </>
+                  )}
                 </Button>
               </div>
               {shareLink && (

--- a/src/components/ShareDialog.tsx
+++ b/src/components/ShareDialog.tsx
@@ -297,8 +297,13 @@ export function ShareDialog({ trigger, onImported }: Props) {
     const json = pendingJson;
     setBusyAction("import");
     try {
-      onImported(await importConfig(json));
-      if (request !== previewRequest.current) return;
+      const imported = await importConfig(json);
+      // The write already happened. Always update the parent registry.
+      onImported(imported);
+      if (request !== previewRequest.current) {
+        toast.success("Imported the setup you already confirmed");
+        return;
+      }
       toast.success("Imported shared setup", {
         description: "Add any API keys each server needs, then enable them.",
       });

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -654,8 +654,8 @@ export function openDataDir(): Promise<void> {
 /** Serialize the user's servers into a shareable setup (no secret values),
  * optionally labelled with a name + description. */
 export function exportConfig(
-  name?: string,
-  description?: string,
+  name: string | undefined,
+  description: string | undefined,
   // Required snapshot. `[]` means share nothing; never omit this or default it
   // to empty, or a caller would silently export zero servers.
   serverIds: string[],
@@ -670,8 +670,8 @@ export function exportConfig(
 /** Write the shareable setup to a file on disk (path from a save dialog). */
 export function exportConfigToPath(
   path: string,
-  name?: string,
-  description?: string,
+  name: string | undefined,
+  description: string | undefined,
   serverIds: string[],
 ): Promise<void> {
   return invoke<void>("export_config_to_path", {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -656,12 +656,14 @@ export function openDataDir(): Promise<void> {
 export function exportConfig(
   name?: string,
   description?: string,
-  serverNames?: string[],
+  // Required snapshot. `[]` means share nothing; never omit this or default it
+  // to empty, or a caller would silently export zero servers.
+  serverIds: string[],
 ): Promise<string> {
   return invoke<string>("export_config", {
     name: name ?? null,
     description: description ?? null,
-    serverNames: serverNames ?? null,
+    serverIds,
   });
 }
 
@@ -670,13 +672,13 @@ export function exportConfigToPath(
   path: string,
   name?: string,
   description?: string,
-  serverNames?: string[],
+  serverIds: string[],
 ): Promise<void> {
   return invoke<void>("export_config_to_path", {
     path,
     name: name ?? null,
     description: description ?? null,
-    serverNames: serverNames ?? null,
+    serverIds,
   });
 }
 

--- a/src/lib/singleFlight.test.ts
+++ b/src/lib/singleFlight.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it, vi } from "vitest";
+import { createSingleFlight } from "./singleFlight";
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe("createSingleFlight", () => {
+  it("returns the authoritative in-flight result to every concurrent caller", async () => {
+    const flight = createSingleFlight<string[]>();
+    const first = deferred<string[]>();
+    const start = vi.fn(() => first.promise);
+
+    const a = flight.run(start);
+    const b = flight.run(start);
+    expect(start).toHaveBeenCalledTimes(0);
+
+    await Promise.resolve();
+    expect(start).toHaveBeenCalledTimes(1);
+    first.resolve(["healthy"]);
+    await expect(a).resolves.toEqual(["healthy"]);
+    await expect(b).resolves.toEqual(["healthy"]);
+  });
+
+  it("shares failures and permits a fresh probe afterward", async () => {
+    const flight = createSingleFlight<string[]>();
+    const first = deferred<string[]>();
+    const start = vi
+      .fn<() => Promise<string[]>>()
+      .mockReturnValueOnce(first.promise)
+      .mockResolvedValueOnce([]);
+
+    const a = flight.run(start);
+    const b = flight.run(start);
+    await Promise.resolve();
+    first.reject(new Error("backend unavailable"));
+    await expect(a).rejects.toThrow("backend unavailable");
+    await expect(b).rejects.toThrow("backend unavailable");
+
+    await expect(flight.run(start)).resolves.toEqual([]);
+    expect(start).toHaveBeenCalledTimes(2);
+  });
+
+  it("coalesces mutation-sensitive callers onto one trailing fresh run", async () => {
+    const flight = createSingleFlight<string[]>();
+    const beforeMutation = deferred<string[]>();
+    const afterMutation = deferred<string[]>();
+    const start = vi
+      .fn<() => Promise<string[]>>()
+      .mockReturnValueOnce(beforeMutation.promise)
+      .mockReturnValueOnce(afterMutation.promise);
+
+    const oldSnapshot = flight.run(start);
+    await Promise.resolve();
+    const freshA = flight.runAfterCurrent(start);
+    const freshB = flight.runAfterCurrent(start);
+
+    beforeMutation.resolve(["server-a"]);
+    await expect(oldSnapshot).resolves.toEqual(["server-a"]);
+    await Promise.resolve();
+    expect(start).toHaveBeenCalledTimes(2);
+
+    afterMutation.resolve(["server-a", "server-b"]);
+    await expect(freshA).resolves.toEqual(["server-a", "server-b"]);
+    await expect(freshB).resolves.toEqual(["server-a", "server-b"]);
+  });
+
+  it("queues another fresh run for a mutation during the trailing flight", async () => {
+    const flight = createSingleFlight<string[]>();
+    const first = deferred<string[]>();
+    const second = deferred<string[]>();
+    const third = deferred<string[]>();
+    const start = vi
+      .fn<() => Promise<string[]>>()
+      .mockReturnValueOnce(first.promise)
+      .mockReturnValueOnce(second.promise)
+      .mockReturnValueOnce(third.promise);
+
+    const initial = flight.run(start);
+    await Promise.resolve();
+    const afterFirstMutation = flight.runAfterCurrent(start);
+    first.resolve(["server-a"]);
+    await initial;
+    await vi.waitFor(() => expect(start).toHaveBeenCalledTimes(2));
+
+    const afterSecondMutation = flight.runAfterCurrent(start);
+    second.resolve(["server-a", "server-b"]);
+    await expect(afterFirstMutation).resolves.toEqual(["server-a", "server-b"]);
+    await vi.waitFor(() => expect(start).toHaveBeenCalledTimes(3));
+
+    third.resolve(["server-a", "server-b", "server-c"]);
+    await expect(afterSecondMutation).resolves.toEqual([
+      "server-a",
+      "server-b",
+      "server-c",
+    ]);
+  });
+});

--- a/src/lib/singleFlight.ts
+++ b/src/lib/singleFlight.ts
@@ -1,0 +1,43 @@
+/** Coalesce concurrent callers onto one authoritative asynchronous result.
+ * The slot clears after success or failure so the next caller starts fresh. */
+export function createSingleFlight<T>() {
+  let current: Promise<T> | null = null;
+  let trailing: Promise<T> | null = null;
+
+  function startFlight(start: () => Promise<T>): Promise<T> {
+    const pending = Promise.resolve()
+      .then(start)
+      .finally(() => {
+        if (current === pending) current = null;
+      });
+    current = pending;
+    return pending;
+  }
+
+  return {
+    run(start: () => Promise<T>): Promise<T> {
+      if (current) return current;
+      if (trailing) return trailing;
+      return startFlight(start);
+    },
+
+    /** Mutation-sensitive callers need a snapshot that starts after any current
+     * flight. Coalesce all of them onto one trailing run. */
+    runAfterCurrent(start: () => Promise<T>): Promise<T> {
+      if (trailing) return trailing;
+      if (!current) return startFlight(start);
+      const active = current;
+      const queued = active
+        .catch(() => undefined)
+        .then(() => {
+          // This request is no longer merely queued: it is taking its snapshot now.
+          // Clear the queue marker first so a mutation during this flight can request
+          // one additional coalesced run behind it.
+          if (trailing === queued) trailing = null;
+          return startFlight(start);
+        });
+      trailing = queued;
+      return queued;
+    },
+  };
+}


### PR DESCRIPTION
## What and why

The other half of the 2026-08-11 trust-state batch. Three places treated a failed or in-flight read as an authoritative empty/success result.

**SBS-718.** ShareDialog kept the previous export while a replacement `exportConfig()` was pending, so Copy / Save / Create link could publish a stale all-server setup after you deselected one. Selection and metadata changes now invalidate `exported` and `shareLink` immediately. Actions stay disabled until the latest export for the current snapshot resolves. Registry load failure is an error state, not "share everything". Export filters by stable server ids, so duplicate names or a later registry add cannot widen the snapshot.

**SBS-719.** A rejected `getSecurityEvents()` became `[]`, so Activity rendered "Protection active / No issues right now." Loading, error, stale-last-known, and verified-empty are now separate. Transient failures keep the last successful events and never show the all-clear until a successful read.

**SBS-720.** `reprobe()` swallowed backend failures as `[]` and a second caller during an active probe also got `[]`. Concurrent callers now share one promise; mutations queue one trailing probe. Onboarding stays in checking/unavailable until an authoritative result exists.

## Testing

- [x] `npx vitest run` ShareDialog, ActivityView, Onboarding.health, singleFlight (29 passed)
- [x] `cargo test --lib -- desktop::tests::export` (4 passed)
- [x] Rebased onto current `main`
- [ ] Full `npm run test` / `npm run test:rust` (CI)
- [ ] Hand-checked ShareDialog deselect + Activity load failure (`tauri dev`)

## Notes

Linear: SBS-718, SBS-719, SBS-720.

Independent of #701 (SBS-716/717). Both touch `desktop.rs` in different regions (export vs updater). If GitHub reports a conflict after #701 merges, it should be tests-module only.

I made `exportConfig` / `exportConfigToPath` require an explicit `serverIds` snapshot. `[]` means share nothing. Omitting the argument is a type error, so a caller cannot silently export zero servers by accident.