### PR TITLE
fix: isolate profile cache, pins, and quarantine by stable id

### DIFF
--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -8192,7 +8192,13 @@ fn watch_tick(
         // client's configured profile. So editing folder_profiles (a registry change)
         // re-applies routing live for a client already sitting in a mapped folder.
         let env_owned = env_profile.map(|s| s.to_string());
-        let resolved = effective_profile(&new_reg, client_id, &env_owned, root.as_deref());
+        // HTTP serves a union catalog. Never persist that into a profile namespace
+        // after a later registry reload (SBS-715).
+        let resolved = if http_mode {
+            None
+        } else {
+            effective_profile(&new_reg, client_id, &env_owned, root.as_deref())
+        };
         // Capture the profile we were serving before this reload so the log can
         // show the transition - the single most useful line when diagnosing
         // "why can't this client see server X": it pins down which profile is
@@ -21253,6 +21259,58 @@ mod tests {
 
         drop(_data_dir);
         std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn watch_tick_http_mode_keeps_profile_none_after_registry_reload() {
+        let _env = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let dir = std::env::temp_dir().join(format!(
+            "toolport-http-profile-none-{}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let _data_dir = conduit_lib::registry::DataDirOverride::set(&dir);
+
+        let registry = Arc::new(Mutex::new(Registry::default()));
+        let router = Arc::new(Mutex::new(Arc::new(Router::new())));
+        let stdout = Arc::new(Mutex::new(std::io::stdout()));
+        let cached_tools = Arc::new(Mutex::new(Arc::new(CatalogSnapshot::default())));
+        let profile_slot = Arc::new(Mutex::new(None));
+        let downstream_dirty = Arc::new(AtomicU8::new(0));
+        let client_root = Arc::new(Mutex::new(None));
+        let server_handler: ServerRequestHandler = Arc::new(|_| None);
+        let rebuild_lock = Arc::new(Mutex::new(()));
+        let reg_path = dir.join("registry.json");
+        conduit_lib::registry::save_to(&reg_path, &Registry::default()).unwrap();
+        let mut state = WatchLoopState {
+            last_mtime: None,
+            last_relevant: json!({}),
+        };
+
+        let _ = watch_tick(
+            &reg_path,
+            &registry,
+            &router,
+            &stdout,
+            &cached_tools,
+            &profile_slot,
+            None,
+            Some("Default"),
+            true,
+            &downstream_dirty,
+            &server_handler,
+            &client_root,
+            None,
+            None,
+            None,
+            &rebuild_lock,
+            &mut state,
+        );
+        assert!(
+            profile_slot.lock().unwrap().is_none(),
+            "HTTP mode must not adopt the active profile after a registry reload"
+        );
+        let _ = std::fs::remove_dir_all(dir);
     }
 
     #[test]

--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -14095,39 +14095,41 @@ mod tests {
         // client, it must win - that's what makes a profile switch apply without
         // restarting the client.
         let mut reg = Registry::default();
+        let billing = reg.add_profile("Billing");
         reg.set_client_scope("cursor", Some("Billing"));
         let env_profile = Some("Default".to_string());
         assert_eq!(
             resolve_live_profile(&reg, Some("cursor"), &env_profile),
-            Some("Billing".to_string())
+            Some(billing)
         );
     }
 
     #[test]
     fn resolve_live_profile_falls_back_to_env_var_when_scope_unset() {
         // A client_id with no client_scopes entry yet (e.g. installed before
-        // CONDUIT_CLIENT_ID existed, or never re-scoped) keeps the bootstrap value.
+        // CONDUIT_CLIENT_ID existed, or never re-scoped) keeps the bootstrap value,
+        // resolved to the stable profile id so cache/pins/quarantine stay isolated.
         let reg = Registry::default();
         let env_profile = Some("Default".to_string());
         assert_eq!(
             resolve_live_profile(&reg, Some("cursor"), &env_profile),
-            Some("Default".to_string())
+            Some(reg.active_profile_id())
         );
     }
 
     #[test]
     fn resolve_live_profile_explicit_unscope_overrides_frozen_env_var() {
         // Re-scoping a client to "all servers" records an explicit-unscoped marker
-        // (empty string), which must resolve to None (follow the active profile)
-        // rather than falling back to the CONDUIT_PROFILE this process booted with.
-        // Without this, switching from a named profile to unscoped wouldn't apply
-        // until the client restarted.
+        // (empty string), which must follow the live active profile rather than the
+        // CONDUIT_PROFILE this process booted with. Returning that id (not None)
+        // keeps the client's cache/pins on the active profile's isolated store
+        // instead of the shared HTTP-union fallback files.
         let mut reg = Registry::default();
         reg.set_client_unscoped("cursor");
         let env_profile = Some("Billing".to_string());
         assert_eq!(
             resolve_live_profile(&reg, Some("cursor"), &env_profile),
-            None
+            Some(reg.active_profile_id())
         );
     }
 
@@ -14138,18 +14140,21 @@ mod tests {
         let env_profile = Some("Default".to_string());
         assert_eq!(
             resolve_live_profile(&reg, Some("cursor"), &env_profile),
-            Some("Default".to_string())
+            Some(reg.active_profile_id())
         );
     }
 
     #[test]
     fn resolve_live_profile_unscoped_client_always_uses_env_profile() {
         // No client_id at all (unscoped install): never consult client_scopes.
-        // This path already resolves the active profile live elsewhere, via
-        // Registry::enabled_servers().
+        // Without a boot profile, isolate onto the active profile rather than
+        // the shared fallback files the HTTP union uses.
         let mut reg = Registry::default();
         reg.set_client_scope("cursor", Some("Billing"));
-        assert_eq!(resolve_live_profile(&reg, None, &None), None);
+        assert_eq!(
+            resolve_live_profile(&reg, None, &None),
+            Some(reg.active_profile_id())
+        );
     }
 
     #[test]
@@ -14157,15 +14162,17 @@ mod tests {
         // Simulates a profile switch mid-session: same client_id, registry
         // mutated in place (as the watcher would see across two poll ticks).
         let mut reg = Registry::default();
+        let billing = reg.add_profile("Billing");
+        let engineering = reg.add_profile("Engineering");
         reg.set_client_scope("cursor", Some("Billing"));
         assert_eq!(
             resolve_live_profile(&reg, Some("cursor"), &None),
-            Some("Billing".to_string())
+            Some(billing)
         );
         reg.set_client_scope("cursor", Some("Engineering"));
         assert_eq!(
             resolve_live_profile(&reg, Some("cursor"), &None),
-            Some("Engineering".to_string())
+            Some(engineering)
         );
     }
 

--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -7888,24 +7888,14 @@ fn gtrace(msg: &str) {
     }
 }
 
-/// Cache file for a given profile. Scoped clients get their own file
-/// (`tool-cache-<profile>.json`) so a billing-scoped client never reads a
+/// Cache file for a given stable profile id. Scoped clients get their own file
+/// (`tool-cache-v2-<profile-id>.json`) so a billing-scoped client never reads a
 /// coding-scoped client's catalog - which would defeat the scoping.
 fn tool_cache_path(profile: Option<&str>) -> Option<PathBuf> {
     let dir = registry::conduit_dir()?;
     let file = match profile {
         Some(p) if !p.is_empty() => {
-            let slug: String = p
-                .chars()
-                .map(|c| {
-                    if c.is_ascii_alphanumeric() {
-                        c.to_ascii_lowercase()
-                    } else {
-                        '-'
-                    }
-                })
-                .collect();
-            format!("tool-cache-{slug}.json")
+            format!("tool-cache-v2-{}.json", registry::profile_store_key(p))
         }
         _ => "tool-cache.json".to_string(),
     };
@@ -7943,9 +7933,9 @@ fn save_tool_cache(tools: &[Value], profile: Option<&str>) {
 
 /// Resolve this client's live profile from `registry.client_scopes[client_id]`
 /// (kept current by `watch_registry` on every reload). Three cases:
-/// - a non-empty entry: this client is scoped to that named profile;
+/// - a non-empty entry: this client is scoped to that stable profile id;
 /// - an empty-string entry: this client is *explicitly* unscoped (follow the
-///   active profile now), so return `None` and do NOT fall back to the boot env
+///   active profile now), so return its id and do NOT fall back to the boot env
 ///   var - that's what makes a live re-scope to "all servers" take effect
 ///   without restarting the client (see `Registry::set_client_unscoped`);
 /// - no entry at all: fall back to the `CONDUIT_PROFILE` this process started
@@ -7959,11 +7949,16 @@ fn resolve_live_profile(
     client_id: Option<&str>,
     env_profile: &Option<String>,
 ) -> Option<String> {
-    match client_id.and_then(|id| reg.client_scopes.get(id)) {
-        Some(p) if p.trim().is_empty() => None,
-        Some(p) => Some(p.clone()),
-        None => env_profile.clone(),
-    }
+    let profile_ref = match client_id.and_then(|id| reg.client_scopes.get(id)) {
+        Some(p) if p.trim().is_empty() => return Some(reg.active_profile_id()),
+        Some(p) => Some(p.as_str()),
+        None => env_profile.as_deref(),
+    };
+    Some(
+        profile_ref
+            .map(|profile| reg.resolve_profile_id(profile))
+            .unwrap_or_else(|| reg.active_profile_id()),
+    )
 }
 
 /// The profile that actually governs a client's scope right now: a folder-scoped override
@@ -12626,7 +12621,13 @@ fn main() {
     // Resolve the live profile immediately from what's already on disk, rather than
     // waiting for the watcher's first tick: a scoped client re-launched after being
     // re-scoped should see the new profile from its very first request.
-    let resolved_profile = resolve_live_profile(&loaded, client_id.as_deref(), &env_profile);
+    // The HTTP bridge serves a union of several profiles and must never persist
+    // that union under the active profile's cache/pins/quarantine namespace.
+    let resolved_profile = if http_mode {
+        None
+    } else {
+        resolve_live_profile(&loaded, client_id.as_deref(), &env_profile)
+    };
     let registry = Arc::new(Mutex::new(loaded));
     // Empty router + cached catalog: the handshake and tools/list answer instantly
     // (from cache), while downstream servers connect in the background for the

--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -21116,7 +21116,10 @@ mod tests {
         let _data_dir = conduit_lib::registry::DataDirOverride::set(&dir);
         let profile = Some("corrupt-pins-live-q");
         std::fs::write(
-            dir.join("tool-pins-corrupt-pins-live-q.json"),
+            dir.join(format!(
+                "tool-pins-v2-{}.json",
+                conduit_lib::registry::profile_store_key("corrupt-pins-live-q")
+            )),
             "{ corrupt trust root",
         )
         .unwrap();
@@ -21154,7 +21157,10 @@ mod tests {
 
         let profile = Some("baseline-tamper");
         std::fs::write(
-            dir.join("tool-pins-baseline-tamper.json"),
+            dir.join(format!(
+                "tool-pins-v2-{}.json",
+                conduit_lib::registry::profile_store_key("baseline-tamper")
+            )),
             "{ corrupt baseline",
         )
         .unwrap();
@@ -21217,7 +21223,10 @@ mod tests {
         assert!(router.lock().unwrap().quarantined().contains("srv__wipe"));
 
         // Corrupt the store underneath the running gateway.
-        let path = dir.join("quarantine-corrupt-q.json");
+        let path = dir.join(format!(
+            "quarantine-v2-{}.json",
+            conduit_lib::registry::profile_store_key("corrupt-q")
+        ));
         assert!(path.exists(), "fixture wrote where expected: {path:?}");
         std::fs::write(&path, "{ not json at all").unwrap();
 

--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -2030,18 +2030,18 @@ fn build_tool_identities(
 /// pins by the CONDUIT_PROFILE it ran under (often None -> tool-pins.json), which need
 /// not equal the app's active profile. Empty until the gateway has pinned a baseline.
 #[tauri::command]
-fn list_tool_identities(state: State<RegistryState>) -> Vec<ToolIdentity> {
+fn list_tool_identities(state: State<RegistryState>) -> Result<Vec<ToolIdentity>, String> {
     let reg = state
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner);
     let mut ids = build_tool_identities(
-        &integrity::all_baselines(),
-        &integrity::all_quarantined_names(),
+        &integrity::all_baselines()?,
+        &integrity::all_quarantined_names()?,
         &reg.servers,
         &reg.profiles,
     );
     ids.sort_by(|a, b| b.last_changed.cmp(&a.last_changed).then(a.alias.cmp(&b.alias)));
-    ids
+    Ok(ids)
 }
 
 /// Toggle quarantine-on-drift. When enabled, the gateway hides and blocks a high-risk
@@ -2087,10 +2087,10 @@ fn set_pii_redaction(state: State<RegistryState>, on: bool) -> Result<Registry, 
 /// running" path. First call only seeds the seen-set so restarting the app with an
 /// already-quarantined tool does not re-notify.
 #[tauri::command]
-fn list_quarantined(app: AppHandle) -> Vec<serde_json::Value> {
-    let list = integrity::all_quarantined();
+fn list_quarantined(app: AppHandle) -> Result<Vec<serde_json::Value>, String> {
+    let list = integrity::all_quarantined()?;
     notify_new_quarantines(&app, &list);
-    list
+    Ok(list)
 }
 
 /// Keys of quarantine entries we have already observed this process. `None` = not

--- a/src-tauri/src/integrity.rs
+++ b/src-tauri/src/integrity.rs
@@ -280,6 +280,9 @@ fn load_pins(profile: Option<&str>) -> PinsLoad {
         return PinsLoad::Fresh;
     };
     if !path.exists() {
+        if profile.is_some_and(|id| crate::registry::unmigrated_legacy_profile_store(id, true)) {
+            return PinsLoad::Corrupt;
+        }
         return PinsLoad::Fresh;
     }
     // Every connected client spawns its own gateway, and they all share this one pins file.
@@ -809,7 +812,16 @@ fn load_quarantine(profile: Option<&str>) -> Result<Quarantine, String> {
     };
     let raw = match std::fs::read_to_string(&path) {
         Ok(s) => s,
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(Quarantine::new()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            if profile
+                .is_some_and(|id| crate::registry::unmigrated_legacy_profile_store(id, false))
+            {
+                return Err(format!(
+                    "quarantine store at {path:?} was not migrated from a legacy file; refusing to treat that as empty"
+                ));
+            }
+            return Ok(Quarantine::new());
+        }
         Err(e) => {
             return Err(format!("quarantine store at {path:?} is unreadable: {e}"))
         }
@@ -2972,6 +2984,18 @@ mod tests {
         let still_blocked = mandatory_quarantined(profile).unwrap();
         assert!(!still_blocked.contains("alpha__read"));
         assert!(still_blocked.contains("beta__write"));
+    }
+
+    #[test]
+    fn load_pins_fails_closed_when_a_legacy_file_was_not_migrated() {
+        let _data_dir_lock = crate::registry::data_dir_test_lock();
+        let data_dir = TestDataDir::new("legacy-pins-unmigrated");
+        std::fs::write(data_dir.path.join("tool-pins-billing.json"), r#"{"x":{}}"#)
+            .unwrap();
+        assert!(
+            matches!(load_pins(Some("billing")), PinsLoad::Corrupt),
+            "a leftover name-slug pin file is not a first run"
+        );
     }
 
     #[test]

--- a/src-tauri/src/integrity.rs
+++ b/src-tauri/src/integrity.rs
@@ -245,25 +245,20 @@ fn server_of(namespaced: &str) -> &str {
 }
 
 fn pins_path(profile: Option<&str>) -> Option<PathBuf> {
-    profile_file(profile, "tool-pins-", "tool-pins.json")
+    profile_file(profile, "tool-pins-v2-", "tool-pins.json")
 }
 
 fn quarantine_path(profile: Option<&str>) -> Option<PathBuf> {
-    profile_file(profile, "quarantine-", "quarantine.json")
+    profile_file(profile, "quarantine-v2-", "quarantine.json")
 }
 
-/// Per-profile store file in the conduit dir. The profile name is slugged to
-/// `[a-z0-9-]` so it can't escape the directory; the no-profile case uses `fallback`.
+/// Per-profile store file in the conduit dir. Profile references are canonical
+/// stable ids before they reach this module; imported non-canonical ids receive a
+/// collision-resistant key. The no-profile case uses `fallback`.
 fn profile_file(profile: Option<&str>, prefix: &str, fallback: &str) -> Option<PathBuf> {
     let dir = crate::registry::conduit_dir()?;
     let file = match profile {
-        Some(p) if !p.is_empty() => {
-            let slug: String = p
-                .chars()
-                .map(|c| if c.is_ascii_alphanumeric() { c.to_ascii_lowercase() } else { '-' })
-                .collect();
-            format!("{prefix}{slug}.json")
-        }
+        Some(p) if !p.is_empty() => format!("{prefix}{}.json", crate::registry::profile_store_key(p)),
         _ => fallback.to_string(),
     };
     Some(dir.join(file))
@@ -711,9 +706,9 @@ pub fn baselines(profile: Option<&str>) -> BTreeMap<String, ToolBaseline> {
     }
 }
 
-/// Aggregate baselines across ALL profile pin files (`tool-pins.json` +
-/// `tool-pins-<slug>.json`), merged by tool name. The gateway keys pins by the
-/// `CONDUIT_PROFILE` it ran under (often None -> `tool-pins.json`), so the identity view
+/// Aggregate baselines across current stable-id pin files, merged by tool name.
+/// The legacy fallback is also included for the distinct HTTP-union namespace, but retained
+/// pre-v2 name-derived files are migration evidence and must not affect live identity state.
 /// must union every profile's pins rather than guess a single one. For a tool seen in
 /// several profiles: earliest first_seen, latest last_changed, and the fingerprint from
 /// the most recent change.
@@ -722,16 +717,11 @@ pub fn all_baselines() -> BTreeMap<String, ToolBaseline> {
     let Some(dir) = crate::registry::conduit_dir() else {
         return merged;
     };
-    let Ok(entries) = std::fs::read_dir(&dir) else {
-        return merged;
-    };
-    for entry in entries.flatten() {
-        let fname = entry.file_name();
-        let Some(name) = fname.to_str() else { continue };
-        if !(name.starts_with("tool-pins") && name.ends_with(".json")) {
-            continue;
-        }
-        let Ok(s) = std::fs::read_to_string(entry.path()) else {
+    let registry = crate::registry::load_resolved().unwrap_or_default();
+    let mut paths = vec![dir.join("tool-pins.json")];
+    paths.extend(registry.profiles.iter().filter_map(|profile| pins_path(Some(&profile.id))));
+    for path in paths {
+        let Ok(s) = std::fs::read_to_string(path) else {
             continue;
         };
         let Ok(pins) = serde_json::from_str::<BTreeMap<String, PinRepr>>(&s) else {
@@ -779,20 +769,11 @@ pub fn all_quarantined_names() -> BTreeSet<String> {
     let Some(dir) = crate::registry::conduit_dir() else {
         return out;
     };
-    let Ok(entries) = std::fs::read_dir(&dir) else {
-        return out;
-    };
-    for entry in entries.flatten() {
-        let fname = entry.file_name();
-        let Some(name) = fname.to_str() else { continue };
-        let is_q = name
-            .strip_prefix("quarantine")
-            .and_then(|r| r.strip_suffix(".json"))
-            .is_some();
-        if !is_q {
-            continue;
-        }
-        if let Ok(s) = std::fs::read_to_string(entry.path()) {
+    let registry = crate::registry::load_resolved().unwrap_or_default();
+    let mut paths = vec![dir.join("quarantine.json")];
+    paths.extend(registry.profiles.iter().filter_map(|profile| quarantine_path(Some(&profile.id))));
+    for path in paths {
+        if let Ok(s) = std::fs::read_to_string(path) {
             if let Ok(q) = serde_json::from_str::<Quarantine>(&s) {
                 for (name, rec) in q {
                     if !is_legacy_added(&rec) {
@@ -1021,35 +1002,27 @@ pub fn quarantine_list(profile: Option<&str>) -> Vec<Value> {
     }
 }
 
-/// Every quarantined tool across all profiles, each record tagged with its profile
-/// slug (`""` for the no-profile store), for the app UI which spans profiles. The
+/// Every quarantined tool across all current stable-id profiles, each record tagged with its
+/// exact profile id (`""` for the distinct HTTP-union store), for the app UI. The
 /// `profile` tag is what `release` takes back to clear the right store.
 pub fn all_quarantined() -> Vec<Value> {
     let Some(dir) = crate::registry::conduit_dir() else {
         return Vec::new();
     };
     let mut out = Vec::new();
-    let Ok(entries) = std::fs::read_dir(&dir) else {
-        return out;
-    };
-    for entry in entries.flatten() {
-        let fname = entry.file_name();
-        let Some(name) = fname.to_str() else { continue };
-        // "quarantine.json" -> slug ""; "quarantine-<slug>.json" -> "<slug>".
-        let Some(rest) = name
-            .strip_prefix("quarantine")
-            .and_then(|r| r.strip_suffix(".json"))
-        else {
-            continue;
-        };
-        let slug = rest.strip_prefix('-').unwrap_or("");
-        if let Ok(s) = std::fs::read_to_string(entry.path()) {
+    let registry = crate::registry::load_resolved().unwrap_or_default();
+    let mut stores = vec![(String::new(), dir.join("quarantine.json"))];
+    stores.extend(registry.profiles.iter().filter_map(|profile| {
+        quarantine_path(Some(&profile.id)).map(|path| (profile.id.clone(), path))
+    }));
+    for (profile, path) in stores {
+        if let Ok(s) = std::fs::read_to_string(path) {
             if let Ok(q) = serde_json::from_str::<Quarantine>(&s) {
                 for mut rec in q.into_values() {
                     if is_legacy_added(&rec) {
                         continue;
                     }
-                    rec["profile"] = json!(slug);
+                    rec["profile"] = json!(profile);
                     out.push(rec);
                 }
             }

--- a/src-tauri/src/integrity.rs
+++ b/src-tauri/src/integrity.rs
@@ -889,6 +889,14 @@ pub fn quarantined_checked(profile: Option<&str>) -> Result<BTreeSet<String>, St
         // place, so an empty set is the truth here rather than a failure.
         return Ok(BTreeSet::new());
     };
+    // A missing v2 store with a leftover legacy slug file means migration failed;
+    // reporting "empty" would let the watcher reconcile the live set down to nothing
+    // and re-expose previously quarantined tools (SBS-715).
+    if profile.is_some_and(|id| crate::registry::unmigrated_legacy_profile_store(id, false)) {
+        return Err(format!(
+            "quarantine store at {path:?} was not migrated from a legacy file; refusing to treat that as empty"
+        ));
+    }
     quarantined_checked_at(&path)
 }
 
@@ -913,6 +921,13 @@ pub fn mandatory_quarantined_checked(profile: Option<&str>) -> Result<BTreeSet<S
     let Some(path) = quarantine_path(profile) else {
         return Ok(BTreeSet::new());
     };
+    // Same unmigrated-legacy guard as `quarantined_checked`: a failed migration must
+    // not read as "no mandatory quarantine" (SBS-715).
+    if profile.is_some_and(|id| crate::registry::unmigrated_legacy_profile_store(id, false)) {
+        return Err(format!(
+            "quarantine store at {path:?} was not migrated from a legacy file; refusing to treat that as empty"
+        ));
+    }
     Ok(quarantined_sets_checked_at(&path)?.1)
 }
 
@@ -2996,6 +3011,27 @@ mod tests {
             matches!(load_pins(Some("billing")), PinsLoad::Corrupt),
             "a leftover name-slug pin file is not a first run"
         );
+    }
+
+    #[test]
+    fn quarantine_reads_fail_closed_when_a_legacy_file_was_not_migrated() {
+        let _data_dir_lock = crate::registry::data_dir_test_lock();
+        let data_dir = TestDataDir::new("legacy-quarantine-unmigrated");
+        let record = r#"{"srv__wipe":{"server":"srv","tool":"wipe","change":"tamper"}}"#;
+        std::fs::write(data_dir.path.join("quarantine-billing.json"), record).unwrap();
+        assert!(
+            load_quarantine(Some("billing")).is_err(),
+            "a leftover name-slug quarantine file is not a first run"
+        );
+        // The watcher's cached reads must also refuse: `Ok(empty)` would reconcile
+        // the router's live quarantine set down to nothing.
+        assert!(quarantined_checked(Some("billing")).is_err());
+        assert!(mandatory_quarantined_checked(Some("billing")).is_err());
+        // Once the v2 store exists the same reads recover.
+        let v2 = quarantine_path(Some("billing")).expect("data dir override is set");
+        std::fs::write(&v2, record).unwrap();
+        assert_eq!(quarantined_checked(Some("billing")).unwrap().len(), 1);
+        assert_eq!(mandatory_quarantined_checked(Some("billing")).unwrap().len(), 1);
     }
 
     #[test]

--- a/src-tauri/src/integrity.rs
+++ b/src-tauri/src/integrity.rs
@@ -715,12 +715,12 @@ pub fn baselines(profile: Option<&str>) -> BTreeMap<String, ToolBaseline> {
 /// must union every profile's pins rather than guess a single one. For a tool seen in
 /// several profiles: earliest first_seen, latest last_changed, and the fingerprint from
 /// the most recent change.
-pub fn all_baselines() -> BTreeMap<String, ToolBaseline> {
+pub fn all_baselines() -> Result<BTreeMap<String, ToolBaseline>, String> {
     let mut merged: BTreeMap<String, ToolBaseline> = BTreeMap::new();
     let Some(dir) = crate::registry::conduit_dir() else {
-        return merged;
+        return Ok(merged);
     };
-    let registry = crate::registry::load_resolved().unwrap_or_default();
+    let registry = crate::registry::load_resolved()?;
     let mut paths = vec![dir.join("tool-pins.json")];
     paths.extend(registry.profiles.iter().filter_map(|profile| pins_path(Some(&profile.id))));
     for path in paths {
@@ -753,7 +753,7 @@ pub fn all_baselines() -> BTreeMap<String, ToolBaseline> {
                 .or_insert(base);
         }
     }
-    merged
+    Ok(merged)
 }
 
 /// The set of quarantined tool names across ALL profiles, for the identity view's badge.
@@ -767,12 +767,12 @@ fn is_legacy_added(rec: &Value) -> bool {
     rec.get("change").and_then(Value::as_str) == Some("added")
 }
 
-pub fn all_quarantined_names() -> BTreeSet<String> {
+pub fn all_quarantined_names() -> Result<BTreeSet<String>, String> {
     let mut out = BTreeSet::new();
     let Some(dir) = crate::registry::conduit_dir() else {
-        return out;
+        return Ok(out);
     };
-    let registry = crate::registry::load_resolved().unwrap_or_default();
+    let registry = crate::registry::load_resolved()?;
     let mut paths = vec![dir.join("quarantine.json")];
     paths.extend(registry.profiles.iter().filter_map(|profile| quarantine_path(Some(&profile.id))));
     for path in paths {
@@ -786,7 +786,7 @@ pub fn all_quarantined_names() -> BTreeSet<String> {
             }
         }
     }
-    out
+    Ok(out)
 }
 
 // ===== Quarantine: block high-risk tools after a drift until re-approved =====
@@ -1032,12 +1032,12 @@ pub fn quarantine_list(profile: Option<&str>) -> Vec<Value> {
 /// Every quarantined tool across all current stable-id profiles, each record tagged with its
 /// exact profile id (`""` for the distinct HTTP-union store), for the app UI. The
 /// `profile` tag is what `release` takes back to clear the right store.
-pub fn all_quarantined() -> Vec<Value> {
+pub fn all_quarantined() -> Result<Vec<Value>, String> {
     let Some(dir) = crate::registry::conduit_dir() else {
-        return Vec::new();
+        return Ok(Vec::new());
     };
     let mut out = Vec::new();
-    let registry = crate::registry::load_resolved().unwrap_or_default();
+    let registry = crate::registry::load_resolved()?;
     let mut stores = vec![(String::new(), dir.join("quarantine.json"))];
     stores.extend(registry.profiles.iter().filter_map(|profile| {
         quarantine_path(Some(&profile.id)).map(|path| (profile.id.clone(), path))
@@ -1055,7 +1055,7 @@ pub fn all_quarantined() -> Vec<Value> {
             }
         }
     }
-    out
+    Ok(out)
 }
 
 /// Re-approve a quarantined tool: drop it so the gateway re-exposes it on the next
@@ -2816,11 +2816,12 @@ mod tests {
         // filter or the UI keeps showing tools the gateway no longer blocks (the bug the
         // user hit: dozens of first-sight destructive tools still listed as quarantined).
         assert!(
-            !all_quarantined_names().contains(probe),
+            !all_quarantined_names().unwrap().contains(probe),
             "legacy added entry is dropped from the cross-profile enforcement set"
         );
         assert!(
             !all_quarantined()
+                .unwrap()
                 .iter()
                 .any(|r| r.get("tool").and_then(Value::as_str) == Some(probe)),
             "legacy added entry is dropped from the cross-profile display list"
@@ -3032,6 +3033,17 @@ mod tests {
         std::fs::write(&v2, record).unwrap();
         assert_eq!(quarantined_checked(Some("billing")).unwrap().len(), 1);
         assert_eq!(mandatory_quarantined_checked(Some("billing")).unwrap().len(), 1);
+    }
+
+    #[test]
+    fn cross_profile_quarantine_view_surfaces_a_registry_load_failure() {
+        let _data_dir_lock = crate::registry::data_dir_test_lock();
+        let data_dir = TestDataDir::new("aggregate-corrupt-registry");
+        std::fs::write(data_dir.path.join("registry.json"), "{ corrupt registry").unwrap();
+        assert!(
+            all_quarantined().is_err(),
+            "a corrupt registry must not become an authoritative empty cross-profile view"
+        );
     }
 
     #[test]

--- a/src-tauri/src/metrics.rs
+++ b/src-tauri/src/metrics.rs
@@ -20,7 +20,10 @@ pub fn render() -> String {
         .get("tokensSaved")
         .and_then(Value::as_u64)
         .unwrap_or(0);
-    let quarantined = crate::integrity::all_quarantined().len() as u64;
+    let quarantined = match crate::integrity::all_quarantined() {
+        Ok(entries) => entries.len() as u64,
+        Err(error) => return format!("# Toolport metrics unavailable: {error}\n"),
+    };
     render_from_parts(&entries, tokens_saved, quarantined)
 }
 

--- a/src-tauri/src/registry.rs
+++ b/src-tauri/src/registry.rs
@@ -800,15 +800,44 @@ pub fn unmigrated_legacy_profile_store(profile: &str, pins: bool) -> bool {
     if v2.exists() {
         return false;
     }
-    let slug = legacy_profile_store_slug(profile);
-    if slug.is_empty() {
-        return false;
+    let mut slugs = BTreeSet::from([legacy_profile_store_slug(profile)]);
+    // Live callers use stable ids, while pre-v2 files were usually named from the
+    // profile's display name. Read the registry without invoking migration again so
+    // both historical references are checked (SBS-715 / CodeRabbit).
+    let registry = resolved_path().map(|path| load_from(&path));
+    match registry {
+        Some(Ok(registry)) => {
+            if let Some(record) = registry.profiles.iter().find(|record| record.id == profile) {
+                slugs.insert(legacy_profile_store_slug(&record.name));
+            }
+        }
+        Some(Err(_)) => {
+            // If the registry itself cannot be read, we cannot prove which legacy
+            // name belongs to this id. Any leftover store is therefore evidence of
+            // an incomplete migration, and the trust read must fail closed.
+            let prefix = if pins { "tool-pins-" } else { "quarantine-" };
+            return std::fs::read_dir(&dir).is_ok_and(|entries| {
+                entries.flatten().any(|entry| {
+                    entry.file_name().to_str().is_some_and(|name| {
+                        name.starts_with(prefix)
+                            && !name.starts_with(&format!("{prefix}v2-"))
+                            && name.ends_with(".json")
+                    })
+                })
+            });
+        }
+        None => {}
     }
-    dir.join(format!(
-        "{}{slug}.json",
-        if pins { "tool-pins-" } else { "quarantine-" }
-    ))
-    .exists()
+    slugs
+        .into_iter()
+        .filter(|slug| !slug.is_empty())
+        .any(|slug| {
+            dir.join(format!(
+                "{}{slug}.json",
+                if pins { "tool-pins-" } else { "quarantine-" }
+            ))
+            .exists()
+        })
 }
 
 /// The lossy filename mapping used before profile stores were keyed by stable ids.
@@ -1066,7 +1095,10 @@ impl Registry {
             })
         };
         if let Some(active) = self.active_profile_id.clone() {
-            self.active_profile_id = Some(normalize(&active));
+            // A stale active profile is global state. Clear it so the existing
+            // first-profile fallback applies instead of persisting an invalid marker
+            // that empties every unscoped client's catalog.
+            self.active_profile_id = resolve(&active);
         }
         for scope in self.client_scopes.values_mut() {
             *scope = normalize(scope);
@@ -2408,9 +2440,7 @@ pub fn load_resolved() -> Result<Registry, String> {
         Some(path) => load_from(&path),
         None => Ok(Registry::default()),
     }?;
-    if let Err(error) = migrate_profile_stores(&registry) {
-        eprintln!("toolport: profile-store migration failed: {error}");
-    }
+    migrate_profile_stores(&registry)?;
     Ok(registry)
 }
 
@@ -3860,6 +3890,15 @@ mod tests {
     }
 
     #[test]
+    fn normalize_clears_a_stale_active_profile_for_first_profile_fallback() {
+        let mut registry = Registry::default();
+        registry.active_profile_id = Some("deleted-profile".into());
+        registry.normalize_profile_references();
+        assert_eq!(registry.active_profile_id, None);
+        assert_eq!(registry.active_profile_id(), DEFAULT_PROFILE_ID);
+    }
+
+    #[test]
     fn migrate_copies_unambiguous_legacy_files_and_fails_closed_on_slug_collisions() {
         let _lock = data_dir_test_lock();
         let dir = std::env::temp_dir().join(format!(
@@ -3963,15 +4002,22 @@ mod tests {
         let _ = std::fs::remove_dir_all(&dir);
         std::fs::create_dir_all(&dir).unwrap();
         let _override = DataDirOverride::set(&dir);
-        std::fs::write(dir.join("tool-pins-billing.json"), r#"{"x":{}}"#).unwrap();
-        assert!(unmigrated_legacy_profile_store("billing", true));
-        assert!(!unmigrated_legacy_profile_store("billing", false));
+        let mut registry = Registry::default();
+        let billing = registry.add_profile("Customer Billing");
+        save_to(&dir.join("registry.json"), &registry).unwrap();
+        std::fs::write(
+            dir.join("tool-pins-customer-billing.json"),
+            r#"{"x":{}}"#,
+        )
+        .unwrap();
+        assert!(unmigrated_legacy_profile_store(&billing, true));
+        assert!(!unmigrated_legacy_profile_store(&billing, false));
         let v2 = dir.join(format!(
             "tool-pins-v2-{}.json",
-            profile_store_key("billing")
+            profile_store_key(&billing)
         ));
         std::fs::write(&v2, "{}").unwrap();
-        assert!(!unmigrated_legacy_profile_store("billing", true));
+        assert!(!unmigrated_legacy_profile_store(&billing, true));
         let _ = std::fs::remove_dir_all(&dir);
     }
 

--- a/src-tauri/src/registry.rs
+++ b/src-tauri/src/registry.rs
@@ -8,7 +8,7 @@
 //! Secrets are never stored here. Env vars marked `secret` keep their value in
 //! the OS keychain; this file only records that a secret exists.
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 
@@ -73,6 +73,7 @@ pub fn atomic_write(path: &Path, contents: &str) -> Result<(), String> {
     Ok(())
 }
 const DEFAULT_PROFILE_ID: &str = "default";
+const INVALID_PROFILE_REF_PREFIX: &str = "__toolport_invalid_profile_ref__:";
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
@@ -773,6 +774,195 @@ fn slugify(s: &str) -> String {
     out.trim_matches('-').to_string()
 }
 
+/// A filesystem-safe, collision-resistant key for a stable profile id.
+/// Every id uses the same SHA-256 domain so no readable/non-readable branch can
+/// collide with another id's literal text (SBS-715).
+pub fn profile_store_key(profile_id: &str) -> String {
+    sha256_hex(&format!("toolport-profile-id-v1:{profile_id}"))
+}
+
+/// The lossy filename mapping used before profile stores were keyed by stable ids.
+fn legacy_profile_store_slug(profile_ref: &str) -> String {
+    profile_ref
+        .chars()
+        .map(|c| if c.is_ascii_alphanumeric() { c.to_ascii_lowercase() } else { '-' })
+        .collect()
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum ProfileStoreKind {
+    Cache,
+    Pins,
+    Quarantine,
+}
+
+impl ProfileStoreKind {
+    fn legacy_prefix(self) -> &'static str {
+        match self {
+            Self::Cache => "tool-cache-",
+            Self::Pins => "tool-pins-",
+            Self::Quarantine => "quarantine-",
+        }
+    }
+
+    fn stable_prefix(self) -> &'static str {
+        match self {
+            Self::Cache => "tool-cache-v2-",
+            Self::Pins => "tool-pins-v2-",
+            Self::Quarantine => "quarantine-v2-",
+        }
+    }
+
+    fn fallback_file(self) -> &'static str {
+        match self {
+            Self::Cache => "tool-cache.json",
+            Self::Pins => "tool-pins.json",
+            Self::Quarantine => "quarantine.json",
+        }
+    }
+}
+
+fn write_new_profile_store(path: &Path, contents: &str) -> Result<(), String> {
+    let _lock = lock_at(path)
+        .map_err(|e| format!("could not lock profile store {} for migration: {e}", path.display()))?;
+    if path.exists() {
+        return Ok(());
+    }
+    atomic_write(path, contents)
+        .map_err(|e| format!("could not migrate profile store {}: {e}", path.display()))
+}
+
+fn merge_legacy_quarantines(paths: &[PathBuf]) -> Result<String, String> {
+    let mut merged = serde_json::Map::new();
+    for path in paths {
+        let raw = std::fs::read_to_string(path)
+            .map_err(|e| format!("could not read legacy quarantine {}: {e}", path.display()))?;
+        let value: serde_json::Value = serde_json::from_str(&raw).map_err(|e| {
+            format!("could not parse legacy quarantine {} during migration: {e}", path.display())
+        })?;
+        let object = value.as_object().ok_or_else(|| {
+            format!("legacy quarantine {} is not an object", path.display())
+        })?;
+        for (tool, record) in object {
+            // Every record blocks the same namespaced tool. Keeping the first
+            // record is conservative; ambiguity is resolved by the corrupt-pin
+            // marker, which forces a fresh tamper quarantine before trust resumes.
+            merged.entry(tool.clone()).or_insert_with(|| record.clone());
+        }
+    }
+    serde_json::to_string_pretty(&serde_json::Value::Object(merged)).map_err(|e| e.to_string())
+}
+
+/// Copy legacy name-derived profile stores into stable-id-derived files.
+///
+/// Legacy files are retained as recovery evidence. A source filename claimed by
+/// more than one profile is never trusted as a cache or pin baseline: caches are
+/// rebuilt, pin stores receive an intentionally invalid marker (so integrity
+/// fails closed), and quarantine records are unioned into every claimant.
+pub fn migrate_profile_stores(registry: &Registry) -> Result<(), String> {
+    let Some(dir) = conduit_dir() else { return Ok(()) };
+    if !dir.exists() {
+        return Ok(());
+    }
+
+    let mut claims: BTreeMap<String, BTreeSet<String>> = BTreeMap::new();
+    let mut profile_slugs: BTreeMap<String, BTreeSet<String>> = BTreeMap::new();
+    for profile in &registry.profiles {
+        let slugs = [
+            legacy_profile_store_slug(&profile.name),
+            legacy_profile_store_slug(&profile.id),
+        ]
+        .into_iter()
+        .filter(|slug| !slug.is_empty())
+        .collect::<BTreeSet<_>>();
+        for slug in &slugs {
+            claims.entry(slug.clone()).or_default().insert(profile.id.clone());
+        }
+        profile_slugs.insert(profile.id.clone(), slugs);
+    }
+
+    for profile in &registry.profiles {
+        let Some(slugs) = profile_slugs.get(&profile.id) else { continue };
+        for kind in [ProfileStoreKind::Cache, ProfileStoreKind::Pins, ProfileStoreKind::Quarantine]
+        {
+            let target = dir.join(format!(
+                "{}{}.json",
+                kind.stable_prefix(),
+                profile_store_key(&profile.id)
+            ));
+            if target.exists() {
+                continue;
+            }
+            let mut sources = slugs
+                .iter()
+                .map(|slug| {
+                    (Some(slug), dir.join(format!("{}{slug}.json", kind.legacy_prefix())))
+                })
+                .filter(|(_, path)| path.exists())
+                .collect::<Vec<_>>();
+            let fallback = dir.join(kind.fallback_file());
+            if fallback.exists() {
+                // The fallback followed whichever profile was active. With more
+                // than one profile its ownership is unknowable, so every profile
+                // treats it as an ambiguous legacy source and fails closed.
+                sources.push((None, fallback));
+            }
+            if sources.is_empty() {
+                continue;
+            }
+            let mut source_paths = sources.iter().map(|(_, path)| path.clone()).collect::<Vec<_>>();
+            source_paths.sort();
+            source_paths.dedup();
+            let _source_locks = if kind == ProfileStoreKind::Cache {
+                Vec::new()
+            } else {
+                source_paths
+                    .iter()
+                    .map(|path| {
+                        lock_at(path).map_err(|e| {
+                            format!(
+                                "could not lock legacy profile store {} for migration: {e}",
+                                path.display()
+                            )
+                        })
+                    })
+                    .collect::<Result<Vec<_>, _>>()?
+            };
+            let unambiguous = sources.len() == 1
+                && match sources[0].0 {
+                    Some(slug) => claims.get(slug).is_some_and(|owners| owners.len() == 1),
+                    None => registry.profiles.len() == 1,
+                };
+            if unambiguous {
+                let raw = std::fs::read_to_string(&sources[0].1).map_err(|e| {
+                    format!("could not read legacy profile store {}: {e}", sources[0].1.display())
+                })?;
+                write_new_profile_store(&target, &raw)?;
+                continue;
+            }
+
+            match kind {
+                ProfileStoreKind::Cache => {
+                    // A cache can be rebuilt. Copying an ambiguous catalog could
+                    // disclose another profile's tools during cold startup.
+                }
+                ProfileStoreKind::Pins => {
+                    write_new_profile_store(
+                        &target,
+                        "ambiguous legacy profile pin store; re-approval required",
+                    )?;
+                }
+                ProfileStoreKind::Quarantine => {
+                    let paths = sources.into_iter().map(|(_, path)| path).collect::<Vec<_>>();
+                    let merged = merge_legacy_quarantines(&paths)?;
+                    write_new_profile_store(&target, &merged)?;
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
 pub(crate) fn unique_id(base: &str, existing: &[String]) -> String {
     let base = if base.is_empty() { "item" } else { base };
     if !existing.iter().any(|e| e == base) {
@@ -789,6 +979,76 @@ pub(crate) fn unique_id(base: &str, existing: &[String]) -> String {
 }
 
 impl Registry {
+    fn profile_id_for_ref(&self, profile_ref: &str) -> Option<String> {
+        let profile_ref = profile_ref.trim();
+        if profile_ref.is_empty() {
+            return None;
+        }
+        if let Some(profile) = self.profiles.iter().find(|p| p.id == profile_ref) {
+            return Some(profile.id.clone());
+        }
+        let mut matches = self
+            .profiles
+            .iter()
+            .filter(|p| p.name.eq_ignore_ascii_case(profile_ref));
+        let first = matches.next()?;
+        if matches.next().is_some() {
+            // A legacy name reference shared by multiple profiles cannot be
+            // resolved safely. Leave it dangling so server scope fails closed.
+            return None;
+        }
+        Some(first.id.clone())
+    }
+
+    /// Resolve a user/API supplied profile reference to a stable id, rejecting
+    /// stale and ambiguous names instead of creating another name-keyed binding.
+    pub fn canonical_profile_id(&self, profile_ref: &str) -> Result<String, String> {
+        self.profile_id_for_ref(profile_ref)
+            .ok_or_else(|| format!("No unique profile matches '{profile_ref}'"))
+    }
+
+    /// Rewrite every persisted profile reference to the stable profile id when
+    /// it resolves unambiguously. Unknown or ambiguous legacy references remain
+    /// dangling and therefore fail closed.
+    fn normalize_profile_references(&mut self) {
+        let profiles = self.profiles.clone();
+        let resolve = |profile_ref: &str| {
+            let profile_ref = profile_ref.trim();
+            if profile_ref.is_empty() {
+                return None;
+            }
+            if let Some(profile) = profiles.iter().find(|p| p.id == profile_ref) {
+                return Some(profile.id.clone());
+            }
+            let mut matches = profiles
+                .iter()
+                .filter(|p| p.name.eq_ignore_ascii_case(profile_ref));
+            let first = matches.next()?;
+            matches.next().is_none().then(|| first.id.clone())
+        };
+
+        let normalize = |profile_ref: &str| {
+            if profile_ref.trim().is_empty() {
+                return String::new();
+            }
+            resolve(profile_ref).unwrap_or_else(|| {
+                format!("{INVALID_PROFILE_REF_PREFIX}{}", sha256_hex(profile_ref.trim()))
+            })
+        };
+        if let Some(active) = self.active_profile_id.clone() {
+            self.active_profile_id = Some(normalize(&active));
+        }
+        for scope in self.client_scopes.values_mut() {
+            *scope = normalize(scope);
+        }
+        for mapping in &mut self.folder_profiles {
+            mapping.profile = normalize(&mapping.profile);
+        }
+        for client in &mut self.http_clients {
+            client.profile = normalize(&client.profile);
+        }
+    }
+
     fn server_ids(&self) -> Vec<String> {
         self.servers.iter().map(|s| s.id.clone()).collect()
     }
@@ -1181,10 +1441,7 @@ impl Registry {
         if profile_ref.trim().is_empty() {
             return self.active_profile_id();
         }
-        self.profiles
-            .iter()
-            .find(|p| p.id == profile_ref || p.name.eq_ignore_ascii_case(profile_ref))
-            .map(|p| p.id.clone())
+        self.profile_id_for_ref(profile_ref)
             .unwrap_or_else(|| profile_ref.to_string())
     }
 
@@ -1218,7 +1475,7 @@ impl Registry {
                 path_is_within(&base, &root).then_some((base.len(), fp.profile.clone()))
             })
             .max_by_key(|(len, _)| *len)
-            .map(|(_, profile)| profile)
+            .map(|(_, profile)| self.resolve_profile_id(&profile))
     }
 
     /// Replace the folder -> profile routing mappings (the UI edits the list wholesale). Drops
@@ -1228,6 +1485,10 @@ impl Registry {
         self.folder_profiles = mappings
             .into_iter()
             .filter(|m| !m.path.trim().is_empty() && !m.profile.trim().is_empty())
+            .map(|mut mapping| {
+                mapping.profile = self.resolve_profile_id(&mapping.profile);
+                mapping
+            })
             .collect();
     }
 
@@ -1274,7 +1535,8 @@ impl Registry {
     pub fn set_client_scope(&mut self, client_id: &str, profile: Option<&str>) {
         match profile.map(str::trim).filter(|p| !p.is_empty()) {
             Some(p) => {
-                self.client_scopes.insert(client_id.to_string(), p.to_string());
+                self.client_scopes
+                    .insert(client_id.to_string(), self.resolve_profile_id(p));
             }
             None => {
                 self.client_scopes.remove(client_id);
@@ -1884,7 +2146,7 @@ fn quarantine_unreadable(path: &Path, content: &str) -> Option<PathBuf> {
 }
 
 fn load_from_inner(path: &Path) -> Result<Registry, String> {
-    match read_registry_file(path) {
+    let mut registry = match read_registry_file(path) {
         // Genuinely missing or empty (not a rename race - read_registry_file
         // already waited that out): recover the last-known-good from the .bak
         // sibling if one survived, else this is a first run.
@@ -1912,7 +2174,9 @@ fn load_from_inner(path: &Path) -> Result<Registry, String> {
                 }
             }
         },
-    }
+    }?;
+    registry.normalize_profile_references();
+    Ok(registry)
 }
 
 /// Load an explicit registry while holding its cross-process lock across the full
@@ -2110,10 +2374,14 @@ pub fn resolved_path() -> Option<PathBuf> {
 /// Load honoring the `TOOLPORT_REGISTRY` / `CONDUIT_REGISTRY` env override (used
 /// by the gateway and tests), falling back to the default path.
 pub fn load_resolved() -> Result<Registry, String> {
-    match resolved_path() {
+    let registry = match resolved_path() {
         Some(path) => load_from(&path),
         None => Ok(Registry::default()),
+    }?;
+    if let Err(error) = migrate_profile_stores(&registry) {
+        eprintln!("toolport: profile-store migration failed: {error}");
     }
+    Ok(registry)
 }
 
 /// True when a command argument looks like it carries a secret: an inline

--- a/src-tauri/src/registry.rs
+++ b/src-tauri/src/registry.rs
@@ -781,6 +781,36 @@ pub fn profile_store_key(profile_id: &str) -> String {
     sha256_hex(&format!("toolport-profile-id-v1:{profile_id}"))
 }
 
+/// True when a v2 store is missing but a pre-migration name-slug file still exists
+/// for this profile. Live reads must fail closed rather than treat that as a
+/// first run (SBS-715).
+pub fn unmigrated_legacy_profile_store(profile: &str, pins: bool) -> bool {
+    let Some(dir) = conduit_dir() else {
+        return false;
+    };
+    let v2 = dir.join(format!(
+        "{}{}.json",
+        if pins {
+            "tool-pins-v2-"
+        } else {
+            "quarantine-v2-"
+        },
+        profile_store_key(profile)
+    ));
+    if v2.exists() {
+        return false;
+    }
+    let slug = legacy_profile_store_slug(profile);
+    if slug.is_empty() {
+        return false;
+    }
+    dir.join(format!(
+        "{}{slug}.json",
+        if pins { "tool-pins-" } else { "quarantine-" }
+    ))
+    .exists()
+}
+
 /// The lossy filename mapping used before profile stores were keyed by stable ids.
 fn legacy_profile_store_slug(profile_ref: &str) -> String {
     profile_ref
@@ -3916,6 +3946,32 @@ mod tests {
         // Legacy files stay as recovery evidence.
         assert!(dir.join("tool-cache-work-prod.json").exists());
 
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn unmigrated_legacy_pin_store_is_detected() {
+        let _lock = data_dir_test_lock();
+        let dir = std::env::temp_dir().join(format!(
+            "toolport-sbs-715-unmigrated-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let _override = DataDirOverride::set(&dir);
+        std::fs::write(dir.join("tool-pins-billing.json"), r#"{"x":{}}"#).unwrap();
+        assert!(unmigrated_legacy_profile_store("billing", true));
+        assert!(!unmigrated_legacy_profile_store("billing", false));
+        let v2 = dir.join(format!(
+            "tool-pins-v2-{}.json",
+            profile_store_key("billing")
+        ));
+        std::fs::write(&v2, "{}").unwrap();
+        assert!(!unmigrated_legacy_profile_store("billing", true));
         let _ = std::fs::remove_dir_all(&dir);
     }
 

--- a/src-tauri/src/registry.rs
+++ b/src-tauri/src/registry.rs
@@ -3776,6 +3776,150 @@ mod tests {
     }
 
     #[test]
+    fn profile_store_keys_do_not_collide_for_slug_equivalent_names() {
+        let work_prod = profile_store_key("work-prod");
+        let work_slash = profile_store_key("work/prod");
+        let work_space = profile_store_key("Work Prod");
+        assert_ne!(work_prod, work_slash);
+        assert_ne!(work_prod, work_space);
+        assert_ne!(work_slash, work_space);
+        assert_eq!(
+            legacy_profile_store_slug("Work Prod"),
+            legacy_profile_store_slug("Work/Prod")
+        );
+        assert_eq!(legacy_profile_store_slug("Work Prod"), "work-prod");
+    }
+
+    #[test]
+    fn canonical_profile_id_rejects_ambiguous_display_names() {
+        let mut registry = Registry::default();
+        let first = registry.add_profile("Work Prod");
+        let second = registry.add_profile("Work/Prod");
+        assert_eq!(registry.canonical_profile_id(&first).unwrap(), first);
+        assert_eq!(registry.canonical_profile_id("default").unwrap(), "default");
+        assert!(registry.canonical_profile_id("Work Prod").is_ok());
+        registry.profiles[1].name = "Work Prod".into();
+        registry.profiles[2].name = "Work Prod".into();
+        assert!(
+            registry.canonical_profile_id("Work Prod").is_err(),
+            "duplicate case-insensitive names must not resolve"
+        );
+        assert_eq!(registry.canonical_profile_id(&second).unwrap(), second);
+    }
+
+    #[test]
+    fn normalize_rewrites_unique_name_scope_and_leaves_ambiguous_dangling() {
+        let mut registry = Registry::default();
+        let work = registry.add_profile("Work");
+        registry
+            .client_scopes
+            .insert("cursor".into(), "work".into());
+        registry
+            .client_scopes
+            .insert("zed".into(), "Missing".into());
+        registry.normalize_profile_references();
+        assert_eq!(registry.client_scopes.get("cursor").unwrap(), &work);
+        assert!(
+            registry
+                .client_scopes
+                .get("zed")
+                .unwrap()
+                .starts_with(INVALID_PROFILE_REF_PREFIX),
+            "unknown names stay dangling instead of widening to the active profile"
+        );
+    }
+
+    #[test]
+    fn migrate_copies_unambiguous_legacy_files_and_fails_closed_on_slug_collisions() {
+        let _lock = data_dir_test_lock();
+        let dir = std::env::temp_dir().join(format!(
+            "toolport-sbs-715-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let _override = DataDirOverride::set(&dir);
+
+        let mut registry = Registry::default();
+        let work_space = registry.add_profile("Work Prod");
+        let work_slash = registry.add_profile("Work/Prod");
+        let solo = registry.add_profile("Solo");
+
+        std::fs::write(dir.join("tool-cache-work-prod.json"), r#"{"owner":"collided"}"#).unwrap();
+        std::fs::write(dir.join("tool-pins-work-prod.json"), r#"{"shared":{"fp":"x"}}"#).unwrap();
+        std::fs::write(
+            dir.join("quarantine-work-prod.json"),
+            r#"{"alpha__tool":{"tool":"alpha__tool","reason":"a"},"beta__tool":{"tool":"beta__tool","reason":"b"}}"#,
+        )
+        .unwrap();
+        std::fs::write(dir.join("tool-cache-solo.json"), r#"{"owner":"solo"}"#).unwrap();
+        std::fs::write(dir.join("tool-pins-solo.json"), r#"{"solo":{"fp":"y"}}"#).unwrap();
+
+        migrate_profile_stores(&registry).unwrap();
+
+        let space_cache = dir.join(format!(
+            "tool-cache-v2-{}.json",
+            profile_store_key(&work_space)
+        ));
+        let slash_cache = dir.join(format!(
+            "tool-cache-v2-{}.json",
+            profile_store_key(&work_slash)
+        ));
+        let space_pins = dir.join(format!(
+            "tool-pins-v2-{}.json",
+            profile_store_key(&work_space)
+        ));
+        let slash_pins = dir.join(format!(
+            "tool-pins-v2-{}.json",
+            profile_store_key(&work_slash)
+        ));
+        let space_q = dir.join(format!(
+            "quarantine-v2-{}.json",
+            profile_store_key(&work_space)
+        ));
+        let slash_q = dir.join(format!(
+            "quarantine-v2-{}.json",
+            profile_store_key(&work_slash)
+        ));
+        let solo_cache = dir.join(format!("tool-cache-v2-{}.json", profile_store_key(&solo)));
+        let solo_pins = dir.join(format!("tool-pins-v2-{}.json", profile_store_key(&solo)));
+
+        assert!(!space_cache.exists(), "collided cache must not be copied");
+        assert!(!slash_cache.exists(), "collided cache must not be copied");
+        assert_eq!(
+            std::fs::read_to_string(&space_pins).unwrap(),
+            "ambiguous legacy profile pin store; re-approval required"
+        );
+        assert_eq!(
+            std::fs::read_to_string(&slash_pins).unwrap(),
+            "ambiguous legacy profile pin store; re-approval required"
+        );
+        let space_quarantine: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&space_q).unwrap()).unwrap();
+        let slash_quarantine: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&slash_q).unwrap()).unwrap();
+        assert!(space_quarantine.get("alpha__tool").is_some());
+        assert!(space_quarantine.get("beta__tool").is_some());
+        assert_eq!(space_quarantine, slash_quarantine);
+        assert_eq!(
+            std::fs::read_to_string(&solo_cache).unwrap(),
+            r#"{"owner":"solo"}"#
+        );
+        assert_eq!(
+            std::fs::read_to_string(&solo_pins).unwrap(),
+            r#"{"solo":{"fp":"y"}}"#
+        );
+        // Legacy files stay as recovery evidence.
+        assert!(dir.join("tool-cache-work-prod.json").exists());
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
     fn data_dir_leaf_is_dev_in_debug_builds() {
         assert_eq!(
             crate::brand::data_dir_leaf_name(),

--- a/src-tauri/tests/quarantine_empty_truncation.rs
+++ b/src-tauri/tests/quarantine_empty_truncation.rs
@@ -69,7 +69,10 @@ fn empty_quarantine_file_must_not_silently_unblock() {
 
     // Present-but-empty is not a legitimate first-run state: a clean install has no
     // file at all, and a full release writes `{}`. Emptiness is truncation or wipe.
-    let path = dir.join("quarantine-q-empty-trunc.json");
+    let path = dir.join(format!(
+        "quarantine-v2-{}.json",
+        conduit_lib::registry::profile_store_key("q-empty-trunc")
+    ));
     assert!(
         path.is_file(),
         "quarantine store should exist at {}",
@@ -115,7 +118,10 @@ fn an_empty_store_also_blocks_rewrites_that_would_erase_it() {
     let profile = Some("q-no-rewrite");
     quarantine_a_destructive_tool(profile);
 
-    let path = dir.join("quarantine-q-no-rewrite.json");
+    let path = dir.join(format!(
+        "quarantine-v2-{}.json",
+        conduit_lib::registry::profile_store_key("q-no-rewrite")
+    ));
     std::fs::write(&path, "").expect("truncate quarantine store to empty");
 
     assert!(

--- a/src/components/ClientDetail.test.tsx
+++ b/src/components/ClientDetail.test.tsx
@@ -276,12 +276,7 @@ describe("ClientDetail connect toast (SOU-317)", () => {
     await userEvent.click(screen.getByRole("button", { name: /connect to toolport/i }));
 
     await waitFor(() =>
-      expect(installGateway).toHaveBeenCalledWith(
-        "claude-desktop",
-        "p1",
-        false,
-        "stdio",
-      ),
+      expect(installGateway).toHaveBeenCalledWith("claude-desktop", "p1", false, "stdio"),
     );
     expect(toastSuccess).toHaveBeenCalledWith(
       "Connected Toolport to Claude Desktop",

--- a/src/components/ClientDetail.test.tsx
+++ b/src/components/ClientDetail.test.tsx
@@ -6,13 +6,14 @@ import type { DetectedClient, Registry } from "@/lib/types";
 
 const installGateway = vi.fn();
 const uninstallGateway = vi.fn();
+const migrateClient = vi.fn();
 const toastSuccess = vi.fn();
 const toastError = vi.fn();
 
 vi.mock("@/lib/api", () => ({
   installGateway: (...a: unknown[]) => installGateway(...a),
   uninstallGateway: (...a: unknown[]) => uninstallGateway(...a),
-  migrateClient: vi.fn(),
+  migrateClient: (...a: unknown[]) => migrateClient(...a),
   setClientDiscovery: vi.fn(),
   addServer: vi.fn(),
 }));
@@ -59,6 +60,7 @@ function emptyRegistry(): Registry {
 beforeEach(() => {
   installGateway.mockReset();
   uninstallGateway.mockReset();
+  migrateClient.mockReset();
   toastSuccess.mockReset();
   toastError.mockReset();
 });
@@ -220,6 +222,51 @@ describe("ClientDetail customized entry (SOU-406)", () => {
       />,
     );
     expect(screen.getAllByRole("combobox")[0]).toHaveTextContent("Only: Work");
+  });
+
+  it("passes a stable profile id from the migrate dialog", async () => {
+    const reg = emptyRegistry();
+    reg.profiles = [
+      { id: "p1", name: "Work", enabledServerIds: [] },
+      { id: "p2", name: "Home", enabledServerIds: [] },
+    ];
+    migrateClient.mockResolvedValue({ registry: reg, moved: ["calendar"] });
+    render(
+      <ClientDetail
+        client={client({
+          servers: [
+            {
+              name: "calendar",
+              transport: "stdio",
+              command: "calendar-mcp",
+              args: [],
+              envKeys: [],
+              url: null,
+            },
+          ],
+        })}
+        registry={reg}
+        onChanged={() => {}}
+        onRegistryChange={() => {}}
+      />,
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: /move into gateway/i }));
+    const dialog = screen.getByRole("dialog");
+    const scopeSelect = dialog.querySelector('[role="combobox"]');
+    expect(scopeSelect).not.toBeNull();
+    await userEvent.click(scopeSelect!);
+    await userEvent.click(await screen.findByRole("option", { name: /Only: Home/i }));
+    await userEvent.click(screen.getByRole("button", { name: /move 1 into toolport/i }));
+
+    await waitFor(() =>
+      expect(migrateClient).toHaveBeenCalledWith(
+        "claude-desktop",
+        "p2",
+        undefined,
+        "stdio",
+      ),
+    );
   });
 });
 

--- a/src/components/ClientDetail.test.tsx
+++ b/src/components/ClientDetail.test.tsx
@@ -192,11 +192,34 @@ describe("ClientDetail customized entry (SOU-406)", () => {
     await waitFor(() =>
       expect(installGateway).toHaveBeenCalledWith(
         "claude-desktop",
-        "Home",
+        "p2",
         false,
         "sharedHttp",
       ),
     );
+  });
+
+  it("selects a scope stored as a profile id", async () => {
+    const reg = emptyRegistry();
+    reg.profiles = [
+      { id: "p1", name: "Work", enabledServerIds: [] },
+      { id: "p2", name: "Home", enabledServerIds: [] },
+    ];
+    reg.clientScopes = { "claude-desktop": "p1" };
+    const connected = {
+      ...client(),
+      gatewayInstalled: true,
+      entryState: "managed" as const,
+    };
+    render(
+      <ClientDetail
+        client={connected}
+        registry={reg}
+        onChanged={() => {}}
+        onRegistryChange={() => {}}
+      />,
+    );
+    expect(screen.getAllByRole("combobox")[0]).toHaveTextContent("Only: Work");
   });
 });
 
@@ -255,7 +278,7 @@ describe("ClientDetail connect toast (SOU-317)", () => {
     await waitFor(() =>
       expect(installGateway).toHaveBeenCalledWith(
         "claude-desktop",
-        "Work",
+        "p1",
         false,
         "stdio",
       ),

--- a/src/components/ClientDetail.tsx
+++ b/src/components/ClientDetail.tsx
@@ -184,9 +184,11 @@ export function ClientDetail({ client, registry, onChanged, onRegistryChange }: 
 
   /** How many servers a given scope ("" = active profile, else a named profile)
    * resolves to, for the "scoped to X · N servers" summary. */
-  function scopeServerCount(scopeName: string): number {
-    const target = scopeName
-      ? profiles.find((p) => p.name.toLowerCase() === scopeName.toLowerCase())
+  function scopeServerCount(scopeRef: string): number {
+    const target = scopeRef
+      ? profiles.find(
+          (p) => p.id === scopeRef || p.name.toLowerCase() === scopeRef.toLowerCase(),
+        )
       : (profiles.find((p) => p.id === registry?.activeProfileId) ?? profiles[0]);
     if (!target) return 0;
     // Exclude Toolport's own gateway entry so the count matches the Servers list (which
@@ -199,9 +201,11 @@ export function ClientDetail({ client, registry, onChanged, onRegistryChange }: 
 
   /** The actual servers a scope resolves to, so a connected client shows WHAT it can
    * reach, not just a count. */
-  function scopeServers(scopeName: string): { id: string; name: string }[] {
-    const target = scopeName
-      ? profiles.find((p) => p.name.toLowerCase() === scopeName.toLowerCase())
+  function scopeServers(scopeRef: string): { id: string; name: string }[] {
+    const target = scopeRef
+      ? profiles.find(
+          (p) => p.id === scopeRef || p.name.toLowerCase() === scopeRef.toLowerCase(),
+        )
       : (profiles.find((p) => p.id === registry?.activeProfileId) ?? profiles[0]);
     if (!target) return [];
     const enabled = new Set(target.enabledServerIds);
@@ -864,7 +868,7 @@ export function ClientDetail({ client, registry, onChanged, onRegistryChange }: 
                   <SelectContent>
                     <SelectItem value="__all__">Follow active profile</SelectItem>
                     {profiles.map((p) => (
-                      <SelectItem key={p.id} value={p.name}>
+                      <SelectItem key={p.id} value={p.id}>
                         Only: {p.name}
                       </SelectItem>
                     ))}

--- a/src/components/ClientDetail.tsx
+++ b/src/components/ClientDetail.tsx
@@ -115,8 +115,13 @@ export function ClientDetail({ client, registry, onChanged, onRegistryChange }: 
   // profile). Keep the picker in sync with it as the selected client changes.
   const currentScope = registry?.clientScopes?.[client.id] ?? "";
   useEffect(() => {
-    setProfile(currentScope);
-  }, [currentScope, client.id]);
+    if (!currentScope) {
+      setProfile("");
+      return;
+    }
+    const match = profiles.find((p) => p.id === currentScope || p.name === currentScope);
+    setProfile(match?.id ?? currentScope);
+  }, [currentScope, client.id, registry?.profiles]);
   useEffect(() => {
     setTransport(managedTransport);
   }, [managedTransport, client.id]);
@@ -220,9 +225,10 @@ export function ClientDetail({ client, registry, onChanged, onRegistryChange }: 
       await installGateway(client.id, profile || undefined, false, transport);
       // Rescope rewrites the client's MCP config the same way Connect does; without a
       // restart hint the change is invisible until the next cold start (SOU-317).
+      const scopeName = profiles.find((p) => p.id === profile)?.name ?? profile;
       toast.success(
         profile
-          ? `${client.name} scoped to "${profile}".`
+          ? `${client.name} scoped to "${scopeName}".`
           : `${client.name} now follows the active profile.`,
         { description: clientRestartHint(client.name, client.id) },
       );
@@ -407,7 +413,9 @@ export function ClientDetail({ client, registry, onChanged, onRegistryChange }: 
               transport === "sharedHttp"
                 ? "Uses the shared HTTP bridge (one gateway process)."
                 : null,
-              profile ? `Scoped to the "${profile}" profile.` : null,
+              profile
+                ? `Scoped to the "${profiles.find((p) => p.id === profile)?.name ?? profile}" profile.`
+                : null,
               !profile && outcome.backup ? "Previous config backed up." : null,
             ],
             client.id,
@@ -507,7 +515,7 @@ export function ClientDetail({ client, registry, onChanged, onRegistryChange }: 
               <SelectContent>
                 <SelectItem value="__all__">Follow active profile</SelectItem>
                 {profiles.map((p) => (
-                  <SelectItem key={p.id} value={p.name}>
+                  <SelectItem key={p.id} value={p.id}>
                     Only: {p.name}
                   </SelectItem>
                 ))}


### PR DESCRIPTION
## What and why

**SBS-715.** Per-profile tool cache, pins, and quarantine files were named by a lossy slug of the display name. `Work Prod` and `Work/Prod` both mapped to `tool-cache-work-prod.json` (and the same pins/quarantine files). A cold gateway could serve another profile's catalog; pin/quarantine apply/release could cross the boundary.

Stores are now keyed by `v2-<sha256(toolport-profile-id-v1:{id})>`. Client scopes, folder mappings, and HTTP client profiles normalize to the stable id on load. Ambiguous legacy name refs stay dangling and fail closed instead of widening to the active profile.

Migration keeps legacy files as evidence:
- Unambiguous name-derived files are copied to the new path.
- Slug collisions skip cache (rebuild), write a corrupt-pin marker so integrity fails closed (SBS-714), and union quarantine records into every claimant.
- The HTTP bridge still uses the unscoped fallback files so a union catalog cannot land in one profile's store.

## Testing

- [x] New registry tests: colliding slugs, canonical-id rejection, scope normalize, fail-closed migration
- [x] `resolve_live_profile*` updated for id-based isolation (6 passed)
- [x] `integrity::tests` (57 passed)
- [x] Rebased onto current `main` (resolved #698 `glog` move vs cache-path comment)
- [ ] Full `npm run test:rust` (CI)

## Notes

Linear: SBS-715.

Independent of #701 and #702. Does not touch the updater or ShareDialog surfaces.

After this lands, a colliding-name install needs one gateway/app start so `load_resolved` can migrate. Ambiguous pin stores require re-approval; that is intentional.