### PR TITLE
fix: do not treat failed audit and secret probes as success

### DIFF
--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -4208,6 +4208,21 @@ mod tests {
         assert!(message.contains("Your registry was not replaced"));
     }
 
+    /// A failed keychain read must surface as an error, never as "no secret
+    /// stored": `Ok(false)` sends the UI down the first-time path and blocks a
+    /// user whose secret really is vaulted (SBS-722). The reserved internal
+    /// namespace is the one deterministic way to make `get_secret_result` fail
+    /// on every platform, and `secrets::get_secret` swallows exactly that error
+    /// into `None` -- which is the regression this pins against.
+    #[test]
+    fn has_client_secret_reports_a_failed_read_as_an_error_not_missing() {
+        let result = has_client_secret("__toolport_internal__".to_string());
+        assert!(
+            result.is_err(),
+            "a failed secret read must propagate, not resolve to a boolean: {result:?}"
+        );
+    }
+
     fn github_with_secret() -> ServerEntry {
         ServerEntry {
             id: "gh".into(),

--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -1231,7 +1231,7 @@ fn set_client_credentials(
     // require re-entering the credential. Resolve it here but do not write yet.
     let secret_to_store = supplied_secret(client_secret);
     if secret_to_store.is_none()
-        && secrets::get_secret(&server_id, secrets::CLIENT_SECRET_KEY).is_none()
+        && secrets::get_secret_result(&server_id, secrets::CLIENT_SECRET_KEY)?.is_none()
     {
         return Err("no client secret is stored for this server yet; enter one".into());
     }
@@ -1304,8 +1304,8 @@ fn clear_client_credentials(
 /// Whether a client secret is vaulted for this server, so the UI can show
 /// "configured" without ever reading the value back.
 #[tauri::command]
-fn has_client_secret(server_id: String) -> bool {
-    secrets::get_secret(&server_id, secrets::CLIENT_SECRET_KEY).is_some()
+fn has_client_secret(server_id: String) -> Result<bool, String> {
+    Ok(secrets::get_secret_result(&server_id, secrets::CLIENT_SECRET_KEY)?.is_some())
 }
 
 /// The most recent tool-call audit entries (newest first).

--- a/src/components/Onboarding.tsx
+++ b/src/components/Onboarding.tsx
@@ -926,23 +926,32 @@ export function VerifyCall({
   timeoutMs?: number;
 }) {
   const prompt = "List the tools you can use through Toolport.";
-  const [status, setStatus] = useState<"waiting" | "success" | "timeout">("waiting");
+  const [status, setStatus] = useState<
+    "snapshot" | "waiting" | "success" | "timeout" | "snapshot-failed"
+  >("snapshot");
   const [hit, setHit] = useState<AuditEntry | null>(null);
+  const [snapshotAttempt, setSnapshotAttempt] = useState(0);
 
   useEffect(() => {
     let alive = true;
     let timer: ReturnType<typeof setTimeout> | undefined;
     const deadline = Date.now() + timeoutMs;
+    setHit(null);
+    setStatus("snapshot");
     void (async () => {
-      // Snapshot the newest existing call so only a call made from here on counts. Compare
-      // audit ts to audit ts (unit-agnostic); the deadline uses wall-clock independently.
+      // Snapshot must succeed before anything can count. A failed read used to
+      // leave since=0, so the next poll could celebrate retained history.
       let since = 0;
       try {
         const recent = await getAuditLog(1);
+        if (!alive) return;
         if (recent[0]) since = recent[0].ts;
       } catch {
-        // No log yet is fine: `since` stays 0, so the first-ever call still counts.
+        if (alive) setStatus("snapshot-failed");
+        return;
       }
+      if (!alive) return;
+      setStatus("waiting");
       const poll = async () => {
         if (!alive) return;
         try {
@@ -954,7 +963,7 @@ export function VerifyCall({
             return;
           }
         } catch {
-          // Transient read error: keep polling until the deadline.
+          // Transient read error after a good baseline: keep polling.
         }
         if (Date.now() > deadline) {
           setStatus("timeout");
@@ -968,7 +977,7 @@ export function VerifyCall({
       alive = false;
       if (timer) clearTimeout(timer);
     };
-  }, [pollMs, timeoutMs]);
+  }, [pollMs, timeoutMs, snapshotAttempt]);
 
   async function copyPrompt() {
     try {
@@ -990,15 +999,16 @@ export function VerifyCall({
         <div className="flex items-start gap-2 rounded-md bg-success/10 px-3 py-2 text-sm">
           <Check className="mt-0.5 size-4 shrink-0 text-success" />
           <span>
-            <span className="font-medium text-success">It works.</span> A call just
-            reached Toolport: <code className="text-xs">{hit.tool}</code>
+            <span className="font-medium text-success">It works.</span> A call reached
+            Toolport after this check started: <code className="text-xs">{hit.tool}</code>
             {hit.server ? (
               <>
                 {" "}
                 on <code className="text-xs">{hit.server}</code>
               </>
             ) : null}
-            .
+            . Local stdio calls are not tagged with a client, so this is not proof it came
+            from {client.name}.
           </span>
         </div>
       ) : (
@@ -1019,13 +1029,31 @@ export function VerifyCall({
             </button>
           </div>
 
-          {status === "waiting" ? (
+          {status === "snapshot" || status === "waiting" ? (
             <div className="flex items-start gap-2 text-xs text-muted-foreground">
               <Loader2 className="mt-0.5 size-3.5 shrink-0 animate-spin" />
               <span>
-                Waiting for the first call from {client.name}. Just connected it?{" "}
-                {clientRestartHint(client.name, client.id)}
+                {status === "snapshot"
+                  ? "Reading the audit log so older calls cannot count as proof."
+                  : `Waiting for a new call after this check started. Just connected ${client.name}? ${clientRestartHint(client.name, client.id)}`}
               </span>
+            </div>
+          ) : status === "snapshot-failed" ? (
+            <div className="flex flex-col gap-1.5 rounded-md bg-warning/10 px-3 py-2 text-xs">
+              <span className="font-medium text-warning">
+                Couldn&apos;t read the audit log, so this check did not start.
+              </span>
+              <span className="text-muted-foreground">
+                An older or unrelated call will not be treated as proof. Retry when the
+                log is available, or use the Playground.
+              </span>
+              <button
+                type="button"
+                onClick={() => setSnapshotAttempt((n) => n + 1)}
+                className="self-start font-medium text-primary hover:underline"
+              >
+                Retry the check
+              </button>
             </div>
           ) : (
             <div className="flex flex-col gap-1.5 rounded-md bg-warning/10 px-3 py-2 text-xs">

--- a/src/components/Onboarding.tsx
+++ b/src/components/Onboarding.tsx
@@ -1013,21 +1013,25 @@ export function VerifyCall({
         </div>
       ) : (
         <>
-          <p className="text-xs text-muted-foreground">
-            In {client.name}, ask your agent to run this. It's read-only, it just lists
-            your tools through Toolport.
-          </p>
-          <div className="flex items-center gap-2 rounded border bg-background px-2 py-1.5">
-            <code className="min-w-0 flex-1 truncate text-xs">{prompt}</code>
-            <button
-              type="button"
-              onClick={() => void copyPrompt()}
-              aria-label="Copy the prompt"
-              className="shrink-0 rounded p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-            >
-              <Copy className="size-3.5" />
-            </button>
-          </div>
+          {status === "waiting" && (
+            <>
+              <p className="text-xs text-muted-foreground">
+                In {client.name}, ask your agent to run this. It's read-only, it just
+                lists your tools through Toolport.
+              </p>
+              <div className="flex items-center gap-2 rounded border bg-background px-2 py-1.5">
+                <code className="min-w-0 flex-1 truncate text-xs">{prompt}</code>
+                <button
+                  type="button"
+                  onClick={() => void copyPrompt()}
+                  aria-label="Copy the prompt"
+                  className="shrink-0 rounded p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+                >
+                  <Copy className="size-3.5" />
+                </button>
+              </div>
+            </>
+          )}
 
           {status === "snapshot" || status === "waiting" ? (
             <div className="flex items-start gap-2 text-xs text-muted-foreground">

--- a/src/components/Onboarding.verify.test.tsx
+++ b/src/components/Onboarding.verify.test.tsx
@@ -38,9 +38,42 @@ describe("VerifyCall", () => {
     render(<VerifyCall client={client} onOpenPlayground={vi.fn()} pollMs={5} />);
 
     await waitFor(() => expect(screen.getByText(/It works/)).toBeInTheDocument());
-    // Names the tool + server that succeeded.
+    // Names the tool + server that succeeded, without claiming Cursor sent it.
     expect(screen.getByText("get_me")).toBeInTheDocument();
     expect(screen.getByText("GitHub")).toBeInTheDocument();
+    expect(screen.getByText(/after this check started/)).toBeInTheDocument();
+    expect(screen.getByText(/not proof it came from Cursor/)).toBeInTheDocument();
+  });
+
+  it("does not celebrate historical traffic when the baseline read fails", async () => {
+    getAuditLog
+      .mockRejectedValueOnce(new Error("audit unavailable"))
+      .mockResolvedValue([{ ts: 50, server: "GitHub", tool: "old", ok: true }]);
+
+    render(<VerifyCall client={client} onOpenPlayground={vi.fn()} pollMs={5} />);
+
+    await waitFor(() =>
+      expect(screen.getByText(/Couldn't read the audit log/)).toBeInTheDocument(),
+    );
+    expect(screen.queryByText(/It works/)).not.toBeInTheDocument();
+    expect(screen.queryByText("old")).not.toBeInTheDocument();
+  });
+
+  it("ignores unrelated traffic that is not newer than the baseline", async () => {
+    getAuditLog
+      .mockResolvedValueOnce([{ ts: 100, server: "GitHub", tool: "baseline", ok: true }])
+      .mockResolvedValue([
+        { ts: 100, server: "GitHub", tool: "baseline", ok: true },
+        { ts: 40, server: "Other", tool: "older", ok: true },
+      ]);
+
+    render(
+      <VerifyCall client={client} onOpenPlayground={vi.fn()} pollMs={5} timeoutMs={40} />,
+    );
+
+    await waitFor(() => expect(screen.getByText(/No call yet/)).toBeInTheDocument());
+    expect(screen.queryByText(/It works/)).not.toBeInTheDocument();
+    expect(screen.queryByText("older")).not.toBeInTheDocument();
   });
 
   it("shows recovery guidance when no call arrives before the deadline", async () => {

--- a/src/components/Onboarding.verify.test.tsx
+++ b/src/components/Onboarding.verify.test.tsx
@@ -57,6 +57,9 @@ describe("VerifyCall", () => {
     );
     expect(screen.queryByText(/It works/)).not.toBeInTheDocument();
     expect(screen.queryByText("old")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("List the tools you can use through Toolport."),
+    ).not.toBeInTheDocument();
   });
 
   it("ignores unrelated traffic that is not newer than the baseline", async () => {

--- a/src/components/Onboarding.verify.test.tsx
+++ b/src/components/Onboarding.verify.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import type { DetectedClient } from "@/lib/types";
 
 // Poll target: watch the local audit log for the first new call.
@@ -60,6 +61,42 @@ describe("VerifyCall", () => {
     expect(
       screen.queryByText("List the tools you can use through Toolport."),
     ).not.toBeInTheDocument();
+  });
+
+  /// The prompt is hidden until a baseline exists, so a user cannot paste it
+  /// early and have Retry's snapshot absorb that very call as the baseline with
+  /// nothing newer ever arriving. After Retry, only calls newer than the fresh
+  /// baseline count.
+  it("retries the snapshot and celebrates only calls newer than the retry baseline", async () => {
+    getAuditLog
+      .mockRejectedValueOnce(new Error("audit unavailable"))
+      // Retry's snapshot: the newest row is an interim call (e.g. the prompt
+      // pasted while the check was down). It becomes the baseline, not proof.
+      .mockResolvedValueOnce([{ ts: 150, server: "GitHub", tool: "interim", ok: true }])
+      .mockResolvedValueOnce([{ ts: 150, server: "GitHub", tool: "interim", ok: true }])
+      .mockResolvedValue([
+        { ts: 200, server: "GitHub", tool: "fresh", ok: true },
+        { ts: 150, server: "GitHub", tool: "interim", ok: true },
+      ]);
+    const user = userEvent.setup();
+
+    render(<VerifyCall client={client} onOpenPlayground={vi.fn()} pollMs={5} />);
+
+    await waitFor(() =>
+      expect(screen.getByText(/Couldn't read the audit log/)).toBeInTheDocument(),
+    );
+    await user.click(screen.getByRole("button", { name: /Retry the check/ }));
+
+    // A working baseline brings the copy-paste prompt back.
+    await waitFor(() =>
+      expect(
+        screen.getByText("List the tools you can use through Toolport."),
+      ).toBeInTheDocument(),
+    );
+    await waitFor(() => expect(screen.getByText(/It works/)).toBeInTheDocument());
+    // The celebrated call is the one after the retry baseline, not the interim row.
+    expect(screen.getByText("fresh")).toBeInTheDocument();
+    expect(screen.queryByText("interim")).not.toBeInTheDocument();
   });
 
   it("ignores unrelated traffic that is not newer than the baseline", async () => {

--- a/src/components/SecretsDialog.clientCredentials.test.tsx
+++ b/src/components/SecretsDialog.clientCredentials.test.tsx
@@ -216,6 +216,40 @@ describe("SecretsDialog client credentials (SBS-524)", () => {
     ).not.toBeInTheDocument();
   });
 
+  /// Reopening the dialog for a different server must not show the previous
+  /// server's "secret stored" badge while the new probe is still in flight.
+  it("does not carry the stored badge across servers while the probe is pending", async () => {
+    hasClientSecret.mockResolvedValueOnce(true);
+    const user = userEvent.setup();
+    const { rerender } = render(
+      <SecretsDialog
+        server={server({ clientCredentials: { clientId: "a-id" } })}
+        onSaved={vi.fn()}
+      />,
+    );
+    await user.click(screen.getByRole("button"));
+    await waitFor(() => expect(screen.getByText(/secret stored/i)).toBeInTheDocument());
+    await user.keyboard("{Escape}");
+
+    // Server B's probe never settles inside this test.
+    hasClientSecret.mockImplementation(() => new Promise(() => {}));
+    rerender(
+      <SecretsDialog
+        server={server({
+          id: "srv-2",
+          name: "Other MCP",
+          clientCredentials: { clientId: "b-id" },
+        })}
+        onSaved={vi.fn()}
+      />,
+    );
+    await user.click(screen.getByRole("button", { name: /Other MCP/ }));
+    await waitFor(() =>
+      expect(screen.getByPlaceholderText("Client ID")).toHaveValue("b-id"),
+    );
+    expect(screen.queryByText(/secret stored/i)).not.toBeInTheDocument();
+  });
+
   it("refuses to save without a client id instead of calling the backend", async () => {
     const user = await openDialog(server());
     await user.click(

--- a/src/components/SecretsDialog.clientCredentials.test.tsx
+++ b/src/components/SecretsDialog.clientCredentials.test.tsx
@@ -165,6 +165,33 @@ describe("SecretsDialog client credentials (SBS-524)", () => {
     await waitFor(() => expect(clearClientCredentials).toHaveBeenCalledWith("srv-1"));
   });
 
+  it("does not treat a failed secret probe as a missing secret", async () => {
+    hasClientSecret.mockRejectedValue(new Error("keychain unavailable"));
+    const user = await openDialog(
+      server({ clientCredentials: { clientId: "client-abc" } }),
+    );
+    await waitFor(() => expect(hasClientSecret).toHaveBeenCalled());
+    await waitFor(() =>
+      expect(screen.getByText(/Couldn't check the stored secret/)).toBeInTheDocument(),
+    );
+
+    await user.type(screen.getByPlaceholderText(/Scopes \(optional/i), "mcp:read");
+    await user.click(screen.getByRole("button", { name: "Save client credentials" }));
+
+    await waitFor(() =>
+      expect(setClientCredentials).toHaveBeenCalledWith(
+        "srv-1",
+        "client-abc",
+        "",
+        null,
+        "mcp:read",
+      ),
+    );
+    expect(toastError).not.toHaveBeenCalledWith(
+      "Enter the client secret issued by your authorization server.",
+    );
+  });
+
   it("refuses to save without a client id instead of calling the backend", async () => {
     const user = await openDialog(server());
     await user.click(

--- a/src/components/SecretsDialog.clientCredentials.test.tsx
+++ b/src/components/SecretsDialog.clientCredentials.test.tsx
@@ -190,6 +190,30 @@ describe("SecretsDialog client credentials (SBS-524)", () => {
     expect(toastError).not.toHaveBeenCalledWith(
       "Enter the client secret issued by your authorization server.",
     );
+    await waitFor(() => expect(screen.getByText(/secret stored/i)).toBeInTheDocument());
+    expect(
+      screen.queryByText(/Couldn't check the stored secret/),
+    ).not.toBeInTheDocument();
+  });
+
+  it("retries the secret probe without wiping typed fields", async () => {
+    hasClientSecret
+      .mockRejectedValueOnce(new Error("keychain unavailable"))
+      .mockResolvedValueOnce(false);
+    const user = await openDialog(server());
+    await user.click(
+      screen.getByText(/No browser available\? Use a client id and secret/i),
+    );
+    await waitFor(() =>
+      expect(screen.getByText(/Couldn't check the stored secret/)).toBeInTheDocument(),
+    );
+    await user.type(screen.getByPlaceholderText("Client ID"), "typed-id");
+    await user.click(screen.getByRole("button", { name: "Retry the secret check" }));
+    await waitFor(() => expect(hasClientSecret).toHaveBeenCalledTimes(2));
+    expect(screen.getByPlaceholderText("Client ID")).toHaveValue("typed-id");
+    expect(
+      screen.queryByText(/Couldn't check the stored secret/),
+    ).not.toBeInTheDocument();
   });
 
   it("refuses to save without a client id instead of calling the backend", async () => {

--- a/src/components/SecretsDialog.tsx
+++ b/src/components/SecretsDialog.tsx
@@ -99,10 +99,11 @@ export function SecretsDialog({ server, onSaved, trigger, onChanged }: Props) {
   const [ccOpen, setCcOpen] = useState(false);
   const [ccBusy, setCcBusy] = useState(false);
   const [ccSecretSet, setCcSecretSet] = useState(false);
-  // Whether the `hasClientSecret` probe has settled. The "secret required" guard
-  // below must not fire while this is unknown, or a fast click after opening
-  // would demand a credential that is already vaulted.
+  // Whether the `hasClientSecret` probe succeeded. Failure must stay unknown:
+  // treating it as "not stored" blocks a real vaulted secret with a first-time
+  // prompt (SBS-722).
   const [ccSecretKnown, setCcSecretKnown] = useState(false);
+  const [ccSecretProbeError, setCcSecretProbeError] = useState(false);
   const [ccClientId, setCcClientId] = useState("");
   const [ccSecret, setCcSecret] = useState("");
   const [ccScope, setCcScope] = useState("");
@@ -148,11 +149,20 @@ export function SecretsDialog({ server, onSaved, trigger, onChanged }: Props) {
       setCcSecret("");
       setCcOpen(cc != null);
       setCcSecretKnown(false);
+      setCcSecretProbeError(false);
       hasClientSecret(server.id)
-        .then((v) => fresh() && setCcSecretSet(v))
-        .catch(() => {})
-        // Settled either way: on failure the backend stays authoritative.
-        .finally(() => fresh() && setCcSecretKnown(true));
+        .then((v) => {
+          if (!fresh()) return;
+          setCcSecretSet(v);
+          setCcSecretKnown(true);
+          setCcSecretProbeError(false);
+        })
+        .catch(() => {
+          if (!fresh()) return;
+          setCcSecretSet(false);
+          setCcSecretKnown(false);
+          setCcSecretProbeError(true);
+        });
       setProbing(true);
       setAuthInfo(null);
       probeAuth(server.url)
@@ -510,6 +520,11 @@ export function SecretsDialog({ server, onSaved, trigger, onChanged }: Props) {
                               <Check className="size-3" /> secret stored
                             </span>
                           )}
+                          {ccSecretProbeError && (
+                            <span className="text-[11px] text-warning">
+                              Couldn&apos;t check the stored secret
+                            </span>
+                          )}
                         </div>
                         <p className="text-[11px] text-muted-foreground">
                           For servers that authenticate the application rather than a
@@ -546,7 +561,19 @@ export function SecretsDialog({ server, onSaved, trigger, onChanged }: Props) {
                           {ccSecretSet
                             ? " It cannot be shown again; leave the field blank to keep it."
                             : ""}
+                          {ccSecretProbeError
+                            ? " Toolport couldn't check whether one is already stored, so it will not assume the field is empty. Retry or save and let the backend decide."
+                            : ""}
                         </p>
+                        {ccSecretProbeError && (
+                          <button
+                            type="button"
+                            className="text-[11px] font-medium text-primary hover:underline"
+                            onClick={() => void refreshStatus()}
+                          >
+                            Retry the secret check
+                          </button>
+                        )}
                         <div className="flex gap-2">
                           <Button
                             size="sm"

--- a/src/components/SecretsDialog.tsx
+++ b/src/components/SecretsDialog.tsx
@@ -148,6 +148,7 @@ export function SecretsDialog({ server, onSaved, trigger, onChanged }: Props) {
       setCcMethod(cc?.tokenEndpointAuthMethod ?? "");
       setCcSecret("");
       setCcOpen(cc != null);
+      setCcSecretSet(false);
       setCcSecretKnown(false);
       setCcSecretProbeError(false);
       hasClientSecret(server.id)
@@ -169,6 +170,23 @@ export function SecretsDialog({ server, onSaved, trigger, onChanged }: Props) {
         .then((v) => fresh() && setAuthInfo(v))
         .catch(() => {})
         .finally(() => fresh() && setProbing(false));
+    }
+  }
+
+  async function retrySecretProbe() {
+    const runId = ++runIdRef.current;
+    setCcSecretKnown(false);
+    setCcSecretProbeError(false);
+    try {
+      const present = await hasClientSecret(server.id);
+      if (runId !== runIdRef.current) return;
+      setCcSecretSet(present);
+      setCcSecretKnown(true);
+    } catch {
+      if (runId !== runIdRef.current) return;
+      setCcSecretSet(false);
+      setCcSecretKnown(false);
+      setCcSecretProbeError(true);
     }
   }
 
@@ -233,6 +251,8 @@ export function SecretsDialog({ server, onSaved, trigger, onChanged }: Props) {
         ),
       );
       setCcSecretSet(true);
+      setCcSecretKnown(true);
+      setCcSecretProbeError(false);
       setCcSecret("");
       toast.success("Saved client credentials", {
         description: "The next connection will request a token. No browser needed.",
@@ -250,6 +270,8 @@ export function SecretsDialog({ server, onSaved, trigger, onChanged }: Props) {
     try {
       onSaved(await clearClientCredentials(server.id));
       setCcSecretSet(false);
+      setCcSecretKnown(true);
+      setCcSecretProbeError(false);
       setCcClientId("");
       setCcSecret("");
       setCcScope("");
@@ -569,7 +591,7 @@ export function SecretsDialog({ server, onSaved, trigger, onChanged }: Props) {
                           <button
                             type="button"
                             className="text-[11px] font-medium text-primary hover:underline"
-                            onClick={() => void refreshStatus()}
+                            onClick={() => void retrySecretProbe()}
                           >
                             Retry the secret check
                           </button>


### PR DESCRIPTION
## What and why

The last two fail-open UI items from the 2026-08-11 audit.

**SBS-721.** First-run "Prove it works in Cursor" treated a failed audit snapshot as `since = 0`, so the next successful poll could celebrate retained history. Any new entry also counted, including one from another client, and stdio audit rows have no client tag. The check now refuses to start until the baseline read succeeds. Success copy says a call arrived after the check started and explicitly does not claim it came from the named client.

**SBS-722.** When `hasClientSecret()` rejected, the dialog still marked the probe as known while `ccSecretSet` stayed false. Editing scopes for an already-vaulted secret was then blocked with "Enter the client secret." A failed probe now stays unknown, the first-time guard does not fire, and the UI offers retry plus a note that the backend remains authoritative.

## Testing

- [x] `npx vitest run` Onboarding.verify + SecretsDialog.clientCredentials (13 passed)
- [ ] Full `npm run test` (CI)

## Notes

Linear: SBS-721, SBS-722.

Touches `Onboarding.tsx`, which #702 also edits (health probe). Different functions (`VerifyCall` vs Done-step health). Independent of #701 and #703.