### PR TITLE
feat: ship Toolport as an Agent Plugins 1.0 package (with Claude Code layout)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -223,14 +223,6 @@ jobs:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
 
-      # The agent plugin is plain files (manifests, a Node launcher, a skill), so
-      # one job zips it; Linux is the cheapest. `cd` first so the zip root is the
-      # `toolport/` plugin folder itself. zip -r includes the dotfile layout
-      # (.claude-plugin/, .mcp.json) that a shell glob would drop.
-      - name: Package the agent plugin
-        if: matrix.os == 'ubuntu-22.04'
-        run: cd packaging/agent-plugin && zip -r toolport-agent-plugin.zip toolport
-
       # Use the changelog entry we actually wrote. `generate_release_notes` produces a
       # flat list of every PR title with no grouping and no explanation, which for a
       # release like 1.12.0 buried a privacy feature and a migration note under 48
@@ -282,7 +274,26 @@ jobs:
             src-tauri/target/release/bundle/deb/*.deb
             src-tauri/target/release/bundle/appimage/*.AppImage
             src-tauri/target/release/bundle/appimage/*.AppImage.sig
-            packaging/agent-plugin/toolport-agent-plugin.zip
+
+  # The plugin is plain files and should still ship if a native installer build
+  # fails. Keep this job independent of the build matrix and upload its asset to
+  # the same draft release.
+  agent-plugin:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+
+      - name: Package the agent plugin
+        run: cd packaging/agent-plugin && zip -r toolport-agent-plugin.zip toolport
+
+      - name: Upload the agent plugin
+        uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3
+        with:
+          draft: true
+          name: Toolport ${{ github.ref_name }}
+          files: packaging/agent-plugin/toolport-agent-plugin.zip
 
   # Assemble the updater manifest from every platform's signature, after all
   # installers are uploaded to the draft. If this job fails the draft still has

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -223,6 +223,14 @@ jobs:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
 
+      # The agent plugin is plain files (manifests, a Node launcher, a skill), so
+      # one job zips it; Linux is the cheapest. `cd` first so the zip root is the
+      # `toolport/` plugin folder itself. zip -r includes the dotfile layout
+      # (.claude-plugin/, .mcp.json) that a shell glob would drop.
+      - name: Package the agent plugin
+        if: matrix.os == 'ubuntu-22.04'
+        run: cd packaging/agent-plugin && zip -r toolport-agent-plugin.zip toolport
+
       # Use the changelog entry we actually wrote. `generate_release_notes` produces a
       # flat list of every PR title with no grouping and no explanation, which for a
       # release like 1.12.0 buried a privacy feature and a migration note under 48
@@ -274,6 +282,7 @@ jobs:
             src-tauri/target/release/bundle/deb/*.deb
             src-tauri/target/release/bundle/appimage/*.AppImage
             src-tauri/target/release/bundle/appimage/*.AppImage.sig
+            packaging/agent-plugin/toolport-agent-plugin.zip
 
   # Assemble the updater manifest from every platform's signature, after all
   # installers are uploaded to the draft. If this job fails the draft still has

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to Toolport are documented here. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/); versions match the GitHub releases.
 Entries before the rename below shipped under the project's former name, Conduit.
 
+## [Unreleased]
+
+### Added
+
+- **Agent plugin.** Toolport now ships as an [Agent Plugins 1.0](https://agent-plugins.org)
+  package (`toolport-agent-plugin.zip` on each release): one install connects VS Code,
+  GitHub Copilot CLI, the Copilot app, and other conformant clients — plus Claude Code
+  via the bundled dual layout — to the local gateway, with a skill teaching the agent
+  the search → call workflow. The plugin launches the gateway the desktop app already
+  installed, so plugin installs share your existing servers, credentials, and profiles.
+
 ## [1.12.0] - 2026-08-09
 
 Two features ship for the first time. PII pseudonymization replaces personal data in

--- a/README.md
+++ b/README.md
@@ -227,7 +227,8 @@ Clients that install [Agent Plugins 1.0](https://agent-plugins.org) packages
 connect to Toolport by installing one plugin instead of editing MCP config:
 download `toolport-agent-plugin.zip` from the
 [latest release](https://github.com/tsouth89/toolport/releases/latest) and point
-your client's plugin install flow at the unzipped folder. The plugin bundles the
+your client's plugin install flow at the unzipped `toolport/` directory—the folder
+that contains `plugin.json`. The plugin bundles the
 gateway's MCP server entry plus a skill that teaches the agent Toolport's
 search → call workflow, and the same folder also carries the Claude Code plugin
 layout. It launches the gateway already installed by the desktop app, so every

--- a/README.md
+++ b/README.md
@@ -220,6 +220,20 @@ Integrations -> Open WebUI / HTTP endpoint** in the app (or run
 [docs/openwebui.md](docs/openwebui.md). The same endpoint serves
 any HTTP/OpenAPI MCP consumer (n8n, LibreChat, custom agents).
 
+### Agent plugin (Agent Plugins 1.0 and Claude Code)
+
+Clients that install [Agent Plugins 1.0](https://agent-plugins.org) packages
+(VS Code, GitHub Copilot CLI, the Copilot app, and other conformant agents) can
+connect to Toolport by installing one plugin instead of editing MCP config:
+download `toolport-agent-plugin.zip` from the
+[latest release](https://github.com/tsouth89/toolport/releases/latest) and point
+your client's plugin install flow at the unzipped folder. The plugin bundles the
+gateway's MCP server entry plus a skill that teaches the agent Toolport's
+search → call workflow, and the same folder also carries the Claude Code plugin
+layout. It launches the gateway already installed by the desktop app, so every
+plugin install shares your existing servers, credentials, and profiles. Details
+in [packaging/agent-plugin/toolport/README.md](packaging/agent-plugin/toolport/README.md).
+
 ### Headless / container / MCP over the network
 
 The same `--http` process also serves **MCP streamable-HTTP** at `POST /mcp`, including

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -9,6 +9,10 @@ Releases are built by CI on a version tag (`.github/workflows/release.yml`).
    - `package-lock.json` (root `version` fields)
    - `src-tauri/Cargo.lock` (the Cargo package is still named `conduit` for history;
      update that package's `version` entry)
+   - `packaging/agent-plugin/toolport/plugin.json` and
+     `packaging/agent-plugin/toolport/.claude-plugin/plugin.json` (`version`) —
+     a vitest check (`src/test/agent-plugin.test.ts`) fails CI if these drift
+     from `package.json`
    - `CHANGELOG.md` — move `[Unreleased]` entries into a dated section
    - `server.json` only when publishing a matching standalone gateway package
 2. Draft user-facing notes in `docs/release-notes/vX.Y.Z.md` (paste into the GitHub

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
+        "@types/node": "^20.0.0",
         "@types/react": "^19.1.8",
         "@types/react-dom": "^19.1.6",
         "@vitejs/plugin-react": "^4.6.0",
@@ -4054,6 +4055,16 @@
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
     },
     "node_modules/@types/react": {
       "version": "19.2.17",
@@ -10873,6 +10884,13 @@
       "engines": {
         "node": ">=20.18.1"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/unicorn-magic": {
       "version": "0.3.0",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",
+    "@types/node": "^20.0.0",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
     "@vitejs/plugin-react": "^4.6.0",

--- a/packaging/agent-plugin/toolport/.claude-plugin/plugin.json
+++ b/packaging/agent-plugin/toolport/.claude-plugin/plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "toolport",
+  "version": "1.12.0",
+  "description": "Every tool. One port. Connects this agent to your local Toolport gateway: every MCP server you set up in Toolport, exposed through a handful of compact meta-tools instead of hundreds of tool definitions (~90% fewer tokens, measured).",
+  "author": { "name": "Toolport", "url": "https://toolport.app" },
+  "homepage": "https://toolport.app",
+  "repository": "https://github.com/tsouth89/toolport",
+  "license": "MIT",
+  "keywords": ["mcp", "gateway", "tools", "lazy-discovery", "toolport"]
+}

--- a/packaging/agent-plugin/toolport/.mcp.json
+++ b/packaging/agent-plugin/toolport/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "toolport": {
+      "command": "node",
+      "args": ["${CLAUDE_PLUGIN_ROOT}/bin/launch-gateway.mjs"]
+    }
+  }
+}

--- a/packaging/agent-plugin/toolport/README.md
+++ b/packaging/agent-plugin/toolport/README.md
@@ -1,0 +1,49 @@
+# Toolport agent plugin
+
+Connect any [Agent Plugins 1.0](https://agent-plugins.org) client — VS Code,
+GitHub Copilot CLI, the Copilot app, and other conformant agents — or Claude
+Code to your local [Toolport](https://toolport.app) gateway with one install.
+
+The plugin bundles:
+
+- **An MCP server entry** (`mcp.json` / `.mcp.json`) that launches the
+  `toolport-gateway` binary already installed on this machine, wherever the
+  Toolport app put it (see `bin/launch-gateway.mjs` for the search order).
+- **A skill** (`skills/toolport/`) teaching the agent Toolport's
+  search → call workflow, code mode, shaped results, and the approval flow.
+
+Both manifest layouts ship in this one folder: `plugin.json` + `mcp.json` at
+the root (Agent Plugins 1.0) and `.claude-plugin/plugin.json` + `.mcp.json`
+(Claude Code), so the same directory installs into either ecosystem.
+
+## Requirements
+
+- The [Toolport desktop app](https://toolport.app) installed and opened at
+  least once (it publishes the gateway binary the plugin launches).
+- Node.js on PATH (the launcher is a small Node script; the clients this
+  plugin targets already run on Node or assume a dev machine).
+
+## Install
+
+Download `toolport-agent-plugin.zip` from the
+[latest release](https://github.com/tsouth89/toolport/releases/latest) and
+unzip it, or use this directory straight from a checkout.
+
+- **VS Code / Copilot CLI / Copilot app:** follow your client's "install a
+  local agent plugin" flow and point it at the unzipped `toolport/` folder.
+- **Claude Code:** `claude plugin install` from a marketplace listing this
+  repo, or add the folder as a local plugin.
+
+Every client you install the plugin into shares the same gateway, servers,
+credentials, and profiles — that's the point of Toolport.
+
+## Configuration
+
+None required here. Servers, credentials, profiles, discovery mode, and
+security settings are all managed in the Toolport app and apply to every
+connected client. Advanced per-client overrides (`TOOLPORT_PROFILE`,
+`TOOLPORT_DISCOVERY`, …) can be set as `env` on the server entry in
+`mcp.json`; see the [Toolport README](https://github.com/tsouth89/toolport#configuration).
+
+To point the plugin at a non-standard gateway location, set the
+`TOOLPORT_GATEWAY` environment variable to the binary's absolute path.

--- a/packaging/agent-plugin/toolport/bin/launch-gateway.d.mts
+++ b/packaging/agent-plugin/toolport/bin/launch-gateway.d.mts
@@ -1,0 +1,31 @@
+import type { ChildProcess, SpawnOptions } from "node:child_process";
+
+interface FsOps {
+  readFileSync(path: string, encoding: "utf8"): string;
+  readdirSync(path: string): string[];
+  statSync(path: string): { mtimeMs: number };
+}
+
+export function gatewayCandidates(options?: {
+  platform?: NodeJS.Platform;
+  env?: NodeJS.ProcessEnv;
+  home?: string;
+  fsOps?: FsOps;
+  version?: string;
+}): string[];
+
+export function spawnFirst(
+  binaries: string[],
+  options?: {
+    args?: string[];
+    spawnImpl?: (
+      command: string,
+      args: readonly string[],
+      options: SpawnOptions,
+    ) => ChildProcess;
+    stdio?: SpawnOptions["stdio"];
+    windowsHide?: boolean;
+  },
+): Promise<number>;
+
+export function validateGatewayOverride(override?: string): string | null;

--- a/packaging/agent-plugin/toolport/bin/launch-gateway.mjs
+++ b/packaging/agent-plugin/toolport/bin/launch-gateway.mjs
@@ -1,0 +1,183 @@
+#!/usr/bin/env node
+// Locates the installed toolport-gateway binary and runs it over stdio.
+//
+// Agent-plugin clients spawn `node <this file>` from mcp.json. The gateway
+// itself is installed by the Toolport desktop app, whose location differs per
+// OS and install method, so this launcher mirrors the same search order the
+// app uses when it writes client configs (clients.rs::resolve_gateway_path /
+// gateway_publish.rs), newest-first:
+//
+//   any OS   $TOOLPORT_GATEWAY (explicit override, absolute path)
+//   Windows  %APPDATA%\Toolport\bin\gateway-manifest.json -> recorded path,
+//            else the newest toolport-gateway-*.exe in that bin dir,
+//            else the NSIS install dir %LOCALAPPDATA%\Toolport
+//   macOS    Toolport.app helper bundle (Contents/Helpers/ToolportGateway.app),
+//            else the Contents/MacOS symlink, in /Applications then ~/Applications
+//   Linux    /usr/bin, /usr/local/bin (deb), else <config>/Toolport/bin (the
+//            AppImage stable copy)
+//   any OS   bare `toolport-gateway` on PATH
+//
+// The legacy `Conduit` data-dir leaf and `conduit-gateway` names are checked as
+// fallbacks so an install updated in place keeps working. If nothing is found,
+// the launcher answers the client's first JSON-RPC request with a clear error
+// instead of dying silently.
+
+import { spawn } from "node:child_process";
+import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import process from "node:process";
+
+const GATEWAY = "toolport-gateway";
+const LEGACY_GATEWAY = "conduit-gateway";
+const EXE = process.platform === "win32" ? ".exe" : "";
+
+/** Newest gateway binary in a published bin dir, by modification time.
+ *  Matches both plain versioned (`toolport-gateway-1.12.0.exe`) and
+ *  content-addressed (`...-1.12.0-<digest>.exe`) names. */
+function newestPublished(binDir) {
+  let best = null;
+  let bestMtime = 0;
+  let entries;
+  try {
+    entries = readdirSync(binDir);
+  } catch {
+    return null;
+  }
+  for (const name of entries) {
+    if (!name.startsWith(`${GATEWAY}-`) || !name.endsWith(EXE || ".exe")) continue;
+    const full = join(binDir, name);
+    try {
+      const mtime = statSync(full).mtimeMs;
+      if (mtime > bestMtime) {
+        best = full;
+        bestMtime = mtime;
+      }
+    } catch {
+      /* unreadable entry: skip */
+    }
+  }
+  return best;
+}
+
+/** The path recorded by the app in gateway-manifest.json, when still present. */
+function manifestPath(binDir) {
+  try {
+    const manifest = JSON.parse(
+      readFileSync(join(binDir, "gateway-manifest.json"), "utf8"),
+    );
+    if (typeof manifest.path === "string" && existsSync(manifest.path))
+      return manifest.path;
+  } catch {
+    /* no manifest, or unreadable: fall through to scanning */
+  }
+  return null;
+}
+
+function candidates() {
+  const home = homedir();
+  const found = [];
+  if (process.platform === "win32") {
+    const roaming = process.env.APPDATA || join(home, "AppData", "Roaming");
+    const local = process.env.LOCALAPPDATA || join(home, "AppData", "Local");
+    for (const leaf of ["Toolport", "Conduit"]) {
+      const binDir = join(roaming, leaf, "bin");
+      const fromManifest = manifestPath(binDir);
+      if (fromManifest) found.push(fromManifest);
+      const published = newestPublished(binDir);
+      if (published) found.push(published);
+    }
+    for (const leaf of ["Toolport", "Conduit"]) {
+      for (const name of [GATEWAY, LEGACY_GATEWAY]) {
+        found.push(join(local, leaf, `${name}${EXE}`));
+      }
+    }
+  } else if (process.platform === "darwin") {
+    for (const appsDir of ["/Applications", join(home, "Applications")]) {
+      const contents = join(appsDir, "Toolport.app", "Contents");
+      found.push(
+        join(contents, "Helpers", "ToolportGateway.app", "Contents", "MacOS", GATEWAY),
+        join(
+          contents,
+          "Helpers",
+          "ConduitGateway.app",
+          "Contents",
+          "MacOS",
+          LEGACY_GATEWAY,
+        ),
+        join(contents, "MacOS", GATEWAY),
+      );
+    }
+  } else {
+    found.push(join("/usr/bin", GATEWAY), join("/usr/local/bin", GATEWAY));
+    const configBase = process.env.XDG_CONFIG_HOME || join(home, ".config");
+    for (const leaf of ["Toolport", "Conduit"]) {
+      found.push(join(configBase, leaf, "bin", GATEWAY));
+    }
+  }
+  return found;
+}
+
+/** Speak just enough JSON-RPC to surface a useful error in the client's UI,
+ *  then exit. Clients treat a silent instant exit as a broken server. */
+function failNotInstalled(detail) {
+  const message =
+    `Toolport is not installed on this machine (the ${GATEWAY} binary was not found` +
+    (detail ? `: ${detail}` : "") +
+    "). Install Toolport from https://toolport.app and open it once, then restart this MCP server.";
+  process.stderr.write(`${message}\n`);
+  let buffered = "";
+  process.stdin.setEncoding("utf8");
+  process.stdin.on("data", (chunk) => {
+    buffered += chunk;
+    let newline;
+    while ((newline = buffered.indexOf("\n")) >= 0) {
+      const line = buffered.slice(0, newline).trim();
+      buffered = buffered.slice(newline + 1);
+      if (!line) continue;
+      try {
+        const request = JSON.parse(line);
+        if (request.id !== undefined && request.id !== null) {
+          process.stdout.write(
+            `${JSON.stringify({ jsonrpc: "2.0", id: request.id, error: { code: -32603, message } })}\n`,
+          );
+          process.exit(1);
+        }
+      } catch {
+        /* not a full JSON line yet */
+      }
+    }
+  });
+  process.stdin.on("end", () => process.exit(1));
+  // A client that never sends a request would otherwise keep us alive forever.
+  setTimeout(() => process.exit(1), 30_000);
+}
+
+function run(binary, isLastResort) {
+  const child = spawn(binary, process.argv.slice(2), {
+    stdio: "inherit",
+    windowsHide: true,
+  });
+  child.on("error", (err) => {
+    if (isLastResort)
+      failNotInstalled(err.code === "ENOENT" ? "not on PATH either" : err.message);
+    else failNotInstalled(err.message);
+  });
+  child.on("exit", (code, signal) => process.exit(signal ? 1 : (code ?? 1)));
+  for (const signal of ["SIGINT", "SIGTERM"]) {
+    process.on(signal, () => child.kill(signal));
+  }
+}
+
+const override = process.env.TOOLPORT_GATEWAY;
+if (override) {
+  // An explicit override is used as-is, never silently substituted: if it is
+  // wrong, the spawn error surfaces through failNotInstalled.
+  run(override, false);
+} else {
+  const resolved = candidates().find((p) => existsSync(p));
+  if (resolved) run(resolved, false);
+  // Last resort: let the OS search PATH (covers a from-source `cargo install`
+  // or a user who added the binary to PATH themselves).
+  else run(GATEWAY, true);
+}

--- a/packaging/agent-plugin/toolport/bin/launch-gateway.mjs
+++ b/packaging/agent-plugin/toolport/bin/launch-gateway.mjs
@@ -23,32 +23,47 @@
 // instead of dying silently.
 
 import { spawn } from "node:child_process";
-import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
+import { readFileSync, readdirSync, statSync } from "node:fs";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { isAbsolute, posix, win32 } from "node:path";
 import process from "node:process";
+import { fileURLToPath } from "node:url";
 
 const GATEWAY = "toolport-gateway";
 const LEGACY_GATEWAY = "conduit-gateway";
-const EXE = process.platform === "win32" ? ".exe" : "";
+const defaultFs = { readFileSync, readdirSync, statSync };
+
+function pluginVersion(fsOps) {
+  try {
+    return JSON.parse(
+      fsOps.readFileSync(new URL("../plugin.json", import.meta.url), "utf8"),
+    ).version;
+  } catch {
+    return null;
+  }
+}
 
 /** Newest gateway binary in a published bin dir, by modification time.
  *  Matches both plain versioned (`toolport-gateway-1.12.0.exe`) and
  *  content-addressed (`...-1.12.0-<digest>.exe`) names. */
-function newestPublished(binDir) {
+function newestPublished(binDir, fsOps, pathImpl, exe) {
   let best = null;
   let bestMtime = 0;
   let entries;
   try {
-    entries = readdirSync(binDir);
+    entries = fsOps.readdirSync(binDir);
   } catch {
     return null;
   }
   for (const name of entries) {
-    if (!name.startsWith(`${GATEWAY}-`) || !name.endsWith(EXE || ".exe")) continue;
-    const full = join(binDir, name);
+    if (
+      ![GATEWAY, LEGACY_GATEWAY].some((prefix) => name.startsWith(`${prefix}-`)) ||
+      !name.endsWith(exe || ".exe")
+    )
+      continue;
+    const full = pathImpl.join(binDir, name);
     try {
-      const mtime = statSync(full).mtimeMs;
+      const mtime = fsOps.statSync(full).mtimeMs;
       if (mtime > bestMtime) {
         best = full;
         bestMtime = mtime;
@@ -61,61 +76,95 @@ function newestPublished(binDir) {
 }
 
 /** The path recorded by the app in gateway-manifest.json, when still present. */
-function manifestPath(binDir) {
+function manifestPath(binDir, fsOps, pathImpl) {
   try {
     const manifest = JSON.parse(
-      readFileSync(join(binDir, "gateway-manifest.json"), "utf8"),
+      fsOps.readFileSync(pathImpl.join(binDir, "gateway-manifest.json"), "utf8"),
     );
-    if (typeof manifest.path === "string" && existsSync(manifest.path))
-      return manifest.path;
+    // Do not preflight with existsSync: MSIX filesystem virtualization can hide a
+    // host path from stat/read APIs even though CreateProcess can launch it.
+    if (typeof manifest.path === "string") return manifest.path;
   } catch {
     /* no manifest, or unreadable: fall through to scanning */
   }
   return null;
 }
 
-function candidates() {
-  const home = homedir();
+export function gatewayCandidates({
+  platform = process.platform,
+  env = process.env,
+  home = homedir(),
+  fsOps = defaultFs,
+  version,
+} = {}) {
+  const pathImpl = platform === "win32" ? win32 : posix;
+  const exe = platform === "win32" ? ".exe" : "";
   const found = [];
-  if (process.platform === "win32") {
-    const roaming = process.env.APPDATA || join(home, "AppData", "Roaming");
-    const local = process.env.LOCALAPPDATA || join(home, "AppData", "Local");
+  if (platform === "win32") {
+    const roaming = env.APPDATA || pathImpl.join(home, "AppData", "Roaming");
+    const local = env.LOCALAPPDATA || pathImpl.join(home, "AppData", "Local");
     for (const leaf of ["Toolport", "Conduit"]) {
-      const binDir = join(roaming, leaf, "bin");
-      const fromManifest = manifestPath(binDir);
+      const binDir = pathImpl.join(roaming, leaf, "bin");
+      const fromManifest = manifestPath(binDir, fsOps, pathImpl);
       if (fromManifest) found.push(fromManifest);
-      const published = newestPublished(binDir);
+      // The normal published filename can be constructed from this plugin's
+      // lockstep version even when MSIX hides the directory and manifest.
+      const candidateVersion = version ?? pluginVersion(fsOps);
+      if (candidateVersion) {
+        found.push(
+          pathImpl.join(binDir, `${GATEWAY}-${candidateVersion}${exe}`),
+          pathImpl.join(binDir, `${LEGACY_GATEWAY}-${candidateVersion}${exe}`),
+        );
+      }
+      const published = newestPublished(binDir, fsOps, pathImpl, exe);
       if (published) found.push(published);
     }
     for (const leaf of ["Toolport", "Conduit"]) {
       for (const name of [GATEWAY, LEGACY_GATEWAY]) {
-        found.push(join(local, leaf, `${name}${EXE}`));
+        found.push(pathImpl.join(local, leaf, `${name}${exe}`));
       }
     }
-  } else if (process.platform === "darwin") {
-    for (const appsDir of ["/Applications", join(home, "Applications")]) {
-      const contents = join(appsDir, "Toolport.app", "Contents");
-      found.push(
-        join(contents, "Helpers", "ToolportGateway.app", "Contents", "MacOS", GATEWAY),
-        join(
-          contents,
-          "Helpers",
-          "ConduitGateway.app",
-          "Contents",
-          "MacOS",
-          LEGACY_GATEWAY,
-        ),
-        join(contents, "MacOS", GATEWAY),
-      );
+  } else if (platform === "darwin") {
+    for (const appsDir of ["/Applications", pathImpl.join(home, "Applications")]) {
+      for (const leaf of ["Toolport", "Conduit"]) {
+        const contents = pathImpl.join(appsDir, `${leaf}.app`, "Contents");
+        found.push(
+          pathImpl.join(
+            contents,
+            "Helpers",
+            "ToolportGateway.app",
+            "Contents",
+            "MacOS",
+            GATEWAY,
+          ),
+          pathImpl.join(
+            contents,
+            "Helpers",
+            "ConduitGateway.app",
+            "Contents",
+            "MacOS",
+            LEGACY_GATEWAY,
+          ),
+          pathImpl.join(contents, "MacOS", GATEWAY),
+          pathImpl.join(contents, "MacOS", LEGACY_GATEWAY),
+        );
+      }
     }
   } else {
-    found.push(join("/usr/bin", GATEWAY), join("/usr/local/bin", GATEWAY));
-    const configBase = process.env.XDG_CONFIG_HOME || join(home, ".config");
+    for (const dir of ["/usr/bin", "/usr/local/bin"]) {
+      found.push(pathImpl.join(dir, GATEWAY), pathImpl.join(dir, LEGACY_GATEWAY));
+    }
+    const configBase = env.XDG_CONFIG_HOME || pathImpl.join(home, ".config");
     for (const leaf of ["Toolport", "Conduit"]) {
-      found.push(join(configBase, leaf, "bin", GATEWAY));
+      found.push(
+        pathImpl.join(configBase, leaf, "bin", GATEWAY),
+        pathImpl.join(configBase, leaf, "bin", LEGACY_GATEWAY),
+      );
     }
   }
-  return found;
+  // Let the OS search PATH only after every absolute candidate has failed.
+  found.push(GATEWAY, LEGACY_GATEWAY);
+  return [...new Set(found)];
 }
 
 /** Speak just enough JSON-RPC to surface a useful error in the client's UI,
@@ -153,31 +202,65 @@ function failNotInstalled(detail) {
   setTimeout(() => process.exit(1), 30_000);
 }
 
-function run(binary, isLastResort) {
-  const child = spawn(binary, process.argv.slice(2), {
-    stdio: "inherit",
-    windowsHide: true,
+export function spawnFirst(
+  binaries,
+  {
+    args = process.argv.slice(2),
+    spawnImpl = spawn,
+    stdio = "inherit",
+    windowsHide = true,
+  } = {},
+) {
+  return new Promise((resolve, reject) => {
+    let lastError = null;
+    const attempt = (index) => {
+      if (index >= binaries.length) {
+        reject(lastError ?? new Error("no gateway candidates"));
+        return;
+      }
+      const child = spawnImpl(binaries[index], args, { stdio, windowsHide });
+      let started = false;
+      child.once("spawn", () => {
+        started = true;
+        for (const signal of ["SIGINT", "SIGTERM"]) {
+          process.once(signal, () => child.kill(signal));
+        }
+      });
+      child.once("error", (error) => {
+        if (started) reject(error);
+        else {
+          lastError = error;
+          attempt(index + 1);
+        }
+      });
+      child.once("exit", (code, signal) => resolve(signal ? 1 : (code ?? 1)));
+    };
+    attempt(0);
   });
-  child.on("error", (err) => {
-    if (isLastResort)
-      failNotInstalled(err.code === "ENOENT" ? "not on PATH either" : err.message);
-    else failNotInstalled(err.message);
-  });
-  child.on("exit", (code, signal) => process.exit(signal ? 1 : (code ?? 1)));
-  for (const signal of ["SIGINT", "SIGTERM"]) {
-    process.on(signal, () => child.kill(signal));
+}
+
+export function validateGatewayOverride(override) {
+  if (!override) return null;
+  if (!isAbsolute(override)) {
+    throw new Error("TOOLPORT_GATEWAY must be an absolute path");
+  }
+  return override;
+}
+
+async function main() {
+  let override;
+  try {
+    override = validateGatewayOverride(process.env.TOOLPORT_GATEWAY);
+  } catch (error) {
+    failNotInstalled(error.message);
+    return;
+  }
+  const binaries = override ? [override] : gatewayCandidates();
+  try {
+    process.exit(await spawnFirst(binaries));
+  } catch (error) {
+    failNotInstalled(error?.code === "ENOENT" ? "not on PATH either" : error?.message);
   }
 }
 
-const override = process.env.TOOLPORT_GATEWAY;
-if (override) {
-  // An explicit override is used as-is, never silently substituted: if it is
-  // wrong, the spawn error surfaces through failNotInstalled.
-  run(override, false);
-} else {
-  const resolved = candidates().find((p) => existsSync(p));
-  if (resolved) run(resolved, false);
-  // Last resort: let the OS search PATH (covers a from-source `cargo install`
-  // or a user who added the binary to PATH themselves).
-  else run(GATEWAY, true);
-}
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) void main();

--- a/packaging/agent-plugin/toolport/bin/launch-gateway.mjs
+++ b/packaging/agent-plugin/toolport/bin/launch-gateway.mjs
@@ -27,7 +27,8 @@ import { readFileSync, readdirSync, statSync } from "node:fs";
 import { homedir } from "node:os";
 import { isAbsolute, posix, win32 } from "node:path";
 import process from "node:process";
-import { fileURLToPath } from "node:url";
+import { setTimeout } from "node:timers";
+import { fileURLToPath, URL } from "node:url";
 
 const GATEWAY = "toolport-gateway";
 const LEGACY_GATEWAY = "conduit-gateway";

--- a/packaging/agent-plugin/toolport/mcp.json
+++ b/packaging/agent-plugin/toolport/mcp.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/mcp.schema.json",
+  "mcpServers": {
+    "toolport": {
+      "type": "stdio",
+      "command": "node",
+      "args": ["${PLUGIN_ROOT}/bin/launch-gateway.mjs"]
+    }
+  }
+}

--- a/packaging/agent-plugin/toolport/plugin.json
+++ b/packaging/agent-plugin/toolport/plugin.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+  "name": "toolport",
+  "version": "1.12.0",
+  "description": "Every tool. One port. Connects this agent to your local Toolport gateway: every MCP server you set up in Toolport, exposed through a handful of compact meta-tools instead of hundreds of tool definitions (~90% fewer tokens, measured).",
+  "author": { "name": "Toolport", "url": "https://toolport.app" },
+  "homepage": "https://toolport.app",
+  "repository": "https://github.com/tsouth89/toolport",
+  "license": "MIT",
+  "keywords": ["mcp", "gateway", "tools", "lazy-discovery", "toolport"]
+}

--- a/packaging/agent-plugin/toolport/skills/toolport/SKILL.md
+++ b/packaging/agent-plugin/toolport/skills/toolport/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: toolport
+description: Use when the user asks for any external action or data — email, payments, deployments, databases, repos, issues, files, web search, messaging, or any connected service. Toolport is the front door to every MCP server on this machine; search it before concluding a capability is unavailable.
+---
+
+# Working through Toolport
+
+Toolport is a local gateway that aggregates every MCP server the user has set
+up. Instead of hundreds of tool definitions, you see a few meta-tools and
+discover the real tools on demand.
+
+## Core workflow
+
+1. **Search first.** For any external action, call `toolport_search_tools` with
+   keywords describing the capability (`"list emails"`, `"create payment"`,
+   `"recent deployments"`). If the service is connected, its tool is here — do
+   not tell the user a capability is unavailable until you have searched.
+2. **Call it.** The first matching result includes its exact name and full input
+   schema and is ready to use: call `toolport_call_tool` with that `name` and
+   all parameters inside the `arguments` object. Don't keep searching for a
+   better match, and never invent identifiers (teamId, projectId, …) — fetch
+   them with a list/get tool on the same server first.
+3. **Orient when needed.** `toolport_status` lists every connected server, its
+   tool count, and the tokens Toolport has saved. Pass `server` to
+   `toolport_search_tools` (with an empty `query`) to list one server's full
+   tool set.
+
+## Search tips
+
+- Tool names are namespaced per server: `stripe__create_refund`.
+- If the result says more tools matched than were shown, narrow with `server`
+  or raise `limit` before concluding anything is missing.
+- Many servers expose a generic API bridge (one write/create tool), so search
+  by capability, not exact operation names.
+
+## Multi-step work: `toolport_run_script`
+
+When you already know the steps, run ONE JavaScript orchestration script
+server-side instead of many round-trips: `servers.stripe.create_refund({...})`
+(sync) or `.async({...})` with `Promise.all` to fan out. Intermediate results
+stay full-sized inside the script; only your returned value is shaped for
+context. Pass `validate: true` for a dry run that compiles the script and
+returns the plan without executing. If a script fails partway,
+`structuredContent.toolportScript.progress` lists which calls already ran
+(their side effects are committed) — resume by index, not tool name.
+
+## Results, approvals, and errors
+
+- **Truncated results:** a `[Toolport shaped this result]` marker means the
+  result was cut for context, not lost. Page the rest with
+  `toolport_fetch_result` using the marker's `cursor`/`offset`, or pass
+  `projection` (a dot path like `data.items.0.name`) to pull one field.
+- **Destructive calls:** Toolport may intercept a destructive call and return a
+  preview with a `token`. Confirm with `toolport_confirm` within 60 seconds to
+  execute it unchanged, or a human approves it in the Toolport app. A denied
+  call is a decision, not an error — don't retry it verbatim.
+- **Server management:** when the user has allowed agent control,
+  `toolport_enable_server` / `toolport_disable_server` turn servers on or off
+  by id or name (see `toolport_status` for the list).
+- **Gateway not found:** if the Toolport server itself fails to start, the
+  desktop app isn't installed — the user can get it at https://toolport.app.

--- a/src/test/agent-plugin.test.ts
+++ b/src/test/agent-plugin.test.ts
@@ -102,6 +102,7 @@ describe("agent plugin MCP config (mcp.json)", () => {
       // placeholders and no embedded arguments.
       expect(server.command).toBe("node");
       expect(server.command).not.toMatch(/[\s$]/);
+      expect(server.args).toContain("${PLUGIN_ROOT}/bin/launch-gateway.mjs");
       for (const arg of server.args ?? []) {
         const m = /^\$\{PLUGIN_ROOT\}\/(.+)$/.exec(arg);
         if (m) {
@@ -119,6 +120,7 @@ describe("agent plugin MCP config (mcp.json)", () => {
     const servers = Object.values(claudeMcp.mcpServers as Record<string, McpServerEntry>);
     expect(servers.length).toBeGreaterThan(0);
     for (const server of servers) {
+      expect(server.args).toContain("${CLAUDE_PLUGIN_ROOT}/bin/launch-gateway.mjs");
       const launcherArg = (server.args ?? []).find((a) =>
         a.startsWith("${CLAUDE_PLUGIN_ROOT}/"),
       );

--- a/src/test/agent-plugin.test.ts
+++ b/src/test/agent-plugin.test.ts
@@ -6,7 +6,12 @@
 import { describe, expect, it } from "vitest";
 import { execFileSync } from "node:child_process";
 import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
-import { join } from "node:path";
+import { join, posix, win32 } from "node:path";
+import {
+  gatewayCandidates,
+  spawnFirst,
+  validateGatewayOverride,
+} from "../../packaging/agent-plugin/toolport/bin/launch-gateway.mjs";
 
 // Not import.meta.url: under the jsdom environment vitest serves modules from
 // an http:// URL, so file-relative resolution breaks. Vitest's cwd is the repo
@@ -22,6 +27,10 @@ const mcp = readJson("mcp.json");
 const claudeManifest = readJson(".claude-plugin", "plugin.json");
 const claudeMcp = readJson(".mcp.json");
 const pkg = JSON.parse(readFileSync(join(repoRoot, "package.json"), "utf8"));
+const releaseWorkflow = readFileSync(
+  join(repoRoot, ".github", "workflows", "release.yml"),
+  "utf8",
+);
 
 // Spec 1.0.0: name is 1-64 chars of [a-z0-9.-], alphanumeric at both ends, no
 // consecutive hyphens or periods.
@@ -145,5 +154,112 @@ describe("agent plugin components", () => {
       "--check",
       join(pluginRoot, "bin", "launch-gateway.mjs"),
     ]);
+  });
+});
+
+describe("agent plugin gateway launcher", () => {
+  const blindFs = {
+    readFileSync: () => {
+      throw new Error("hidden");
+    },
+    readdirSync: () => {
+      throw new Error("hidden");
+    },
+    statSync: () => {
+      throw new Error("hidden");
+    },
+  };
+
+  it("tries constructed Windows paths even when filesystem probes are hidden", () => {
+    const candidates = gatewayCandidates({
+      platform: "win32",
+      home: "C:\\Users\\me",
+      env: { APPDATA: "R:\\Roaming", LOCALAPPDATA: "L:\\Local" },
+      fsOps: blindFs,
+      version: pkg.version,
+    });
+    expect(candidates).toContain(
+      win32.join("L:\\Local", "Toolport", "toolport-gateway.exe"),
+    );
+    expect(candidates).toContain(
+      win32.join("R:\\Roaming", "Toolport", "bin", `toolport-gateway-${pkg.version}.exe`),
+    );
+  });
+
+  it("keeps legacy Conduit gateway layouts on every desktop OS", () => {
+    expect(
+      gatewayCandidates({
+        platform: "win32",
+        home: "C:\\Users\\me",
+        env: { APPDATA: "R:\\Roaming", LOCALAPPDATA: "L:\\Local" },
+        fsOps: blindFs,
+      }),
+    ).toContain(win32.join("L:\\Local", "Conduit", "conduit-gateway.exe"));
+    expect(
+      gatewayCandidates({
+        platform: "darwin",
+        home: "/Users/me",
+        env: {},
+        fsOps: blindFs,
+      }),
+    ).toContain(
+      posix.join("/Applications", "Conduit.app", "Contents", "MacOS", "conduit-gateway"),
+    );
+    expect(
+      gatewayCandidates({
+        platform: "linux",
+        home: "/home/me",
+        env: {},
+        fsOps: blindFs,
+      }),
+    ).toContain(posix.join("/home/me", ".config", "Conduit", "bin", "conduit-gateway"));
+  });
+
+  it("finds an older versioned Conduit gateway when its manifest is unreadable", () => {
+    const legacyBin = win32.join("R:\\Roaming", "Conduit", "bin");
+    const fsOps = {
+      readFileSync: () => {
+        throw new Error("unreadable manifest");
+      },
+      readdirSync: (path: string) =>
+        path === legacyBin ? ["conduit-gateway-1.11.0.exe"] : [],
+      statSync: () => ({ mtimeMs: 1 }),
+    };
+    expect(
+      gatewayCandidates({
+        platform: "win32",
+        home: "C:\\Users\\me",
+        env: { APPDATA: "R:\\Roaming", LOCALAPPDATA: "L:\\Local" },
+        fsOps,
+      }),
+    ).toContain(win32.join(legacyBin, "conduit-gateway-1.11.0.exe"));
+  });
+
+  it("falls through an unspawnable candidate to a working binary", async () => {
+    await expect(
+      spawnFirst([join(repoRoot, "missing-gateway"), process.execPath], {
+        args: ["-e", "process.exit(0)"],
+        stdio: "ignore",
+      }),
+    ).resolves.toBe(0);
+  });
+
+  it("reports a missing candidate and rejects relative overrides", async () => {
+    await expect(
+      spawnFirst([join(repoRoot, "missing-gateway")], { stdio: "ignore" }),
+    ).rejects.toMatchObject({ code: "ENOENT" });
+    expect(() => validateGatewayOverride("./gateway")).toThrow(
+      "TOOLPORT_GATEWAY must be an absolute path",
+    );
+  });
+
+  it("packages and uploads the zip independently of native builds", () => {
+    const job = releaseWorkflow
+      .split("\n  agent-plugin:\n")[1]
+      ?.split("\n  updater-manifest:\n")[0];
+    expect(job).toBeDefined();
+    expect(job).not.toMatch(/^\s+needs:/m);
+    expect(job).toContain("toolport-agent-plugin.zip");
+    expect(job).toContain("Upload the agent plugin");
   });
 });

--- a/src/test/agent-plugin.test.ts
+++ b/src/test/agent-plugin.test.ts
@@ -1,0 +1,149 @@
+// Conformance checks for packaging/agent-plugin/toolport against the Agent
+// Plugins 1.0 spec (https://github.com/agentplugins/agent-plugins-spec) and
+// the Claude Code plugin layout. These are file-content assertions, not a
+// runtime test: they exist so a rename, a moved launcher, or a version bump
+// that skips the plugin manifest fails CI instead of shipping a broken zip.
+import { describe, expect, it } from "vitest";
+import { execFileSync } from "node:child_process";
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+// Not import.meta.url: under the jsdom environment vitest serves modules from
+// an http:// URL, so file-relative resolution breaks. Vitest's cwd is the repo
+// root (where vite.config.ts lives).
+const repoRoot = process.cwd();
+const pluginRoot = join(repoRoot, "packaging", "agent-plugin", "toolport");
+
+const readJson = (...segments: string[]) =>
+  JSON.parse(readFileSync(join(pluginRoot, ...segments), "utf8"));
+
+const manifest = readJson("plugin.json");
+const mcp = readJson("mcp.json");
+const claudeManifest = readJson(".claude-plugin", "plugin.json");
+const claudeMcp = readJson(".mcp.json");
+const pkg = JSON.parse(readFileSync(join(repoRoot, "package.json"), "utf8"));
+
+// Spec 1.0.0: name is 1-64 chars of [a-z0-9.-], alphanumeric at both ends, no
+// consecutive hyphens or periods.
+const NAME_PATTERN = /^(?!.*(?:--|\.\.))[a-z0-9](?:[a-z0-9.-]*[a-z0-9])?$/;
+
+interface McpServerEntry {
+  type?: string;
+  command?: string;
+  args?: string[];
+  env?: Record<string, string>;
+}
+
+describe("agent plugin manifest (plugin.json)", () => {
+  it("declares the 1.0.0 schema and a spec-valid name", () => {
+    expect(manifest.$schema).toBe(
+      "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+    );
+    expect(manifest.name).toBe("toolport");
+    expect(manifest.name).toMatch(NAME_PATTERN);
+    expect(manifest.name.length).toBeLessThanOrEqual(64);
+  });
+
+  it("only uses top-level fields the closed schema allows", () => {
+    const allowed = new Set([
+      "$schema",
+      "name",
+      "version",
+      "description",
+      "author",
+      "homepage",
+      "repository",
+      "license",
+      "keywords",
+      "extensions",
+    ]);
+    for (const key of Object.keys(manifest)) {
+      expect(allowed, `unexpected top-level field "${key}"`).toContain(key);
+    }
+    // Components live in fixed locations, never in the manifest.
+    expect(manifest.mcpServers).toBeUndefined();
+    expect(manifest.skills).toBeUndefined();
+  });
+
+  it("stays in version lockstep with package.json", () => {
+    // RELEASING.md step 1 bumps this file with the rest; this is the backstop.
+    expect(manifest.version).toBe(pkg.version);
+    expect(claudeManifest.version).toBe(pkg.version);
+  });
+
+  it("mirrors the Claude Code manifest", () => {
+    expect(claudeManifest.name).toBe(manifest.name);
+    expect(claudeManifest.description).toBe(manifest.description);
+  });
+});
+
+describe("agent plugin MCP config (mcp.json)", () => {
+  it("declares the matching 1.0.0 MCP schema", () => {
+    // A schema-version mismatch between plugin.json and mcp.json makes
+    // conformant clients skip MCP loading entirely.
+    expect(mcp.$schema).toBe("https://agent-plugins.org/schemas/1.0.0/mcp.schema.json");
+  });
+
+  it("defines a stdio server whose launcher exists inside the plugin", () => {
+    const servers = Object.entries(mcp.mcpServers as Record<string, McpServerEntry>);
+    expect(servers.length).toBeGreaterThan(0);
+    for (const [id, server] of servers) {
+      expect(server.type).toBe("stdio");
+      // The spec requires a single bare token or ./relative path — no
+      // placeholders and no embedded arguments.
+      expect(server.command).toBe("node");
+      expect(server.command).not.toMatch(/[\s$]/);
+      for (const arg of server.args ?? []) {
+        const m = /^\$\{PLUGIN_ROOT\}\/(.+)$/.exec(arg);
+        if (m) {
+          expect(existsSync(join(pluginRoot, m[1])), `${id}: missing ${m[1]}`).toBe(true);
+        }
+        expect(arg).not.toContain("${PLUGIN_DATA}"); // launcher takes no data-dir args
+      }
+      // Expansion never happens in env *keys*, and these two are reserved.
+      expect(Object.keys(server.env ?? {})).not.toContain("PLUGIN_ROOT");
+      expect(Object.keys(server.env ?? {})).not.toContain("PLUGIN_DATA");
+    }
+  });
+
+  it("keeps the Claude Code MCP config pointing at the same launcher", () => {
+    const servers = Object.values(claudeMcp.mcpServers as Record<string, McpServerEntry>);
+    expect(servers.length).toBeGreaterThan(0);
+    for (const server of servers) {
+      const launcherArg = (server.args ?? []).find((a) =>
+        a.startsWith("${CLAUDE_PLUGIN_ROOT}/"),
+      );
+      expect(launcherArg).toBeDefined();
+      const relative = launcherArg!.replace("${CLAUDE_PLUGIN_ROOT}/", "");
+      expect(existsSync(join(pluginRoot, relative))).toBe(true);
+    }
+  });
+});
+
+describe("agent plugin components", () => {
+  it("ships at least one skill with valid SKILL.md frontmatter", () => {
+    const skillsDir = join(pluginRoot, "skills");
+    const skillDirs = readdirSync(skillsDir).filter((entry) =>
+      statSync(join(skillsDir, entry)).isDirectory(),
+    );
+    expect(skillDirs.length).toBeGreaterThan(0);
+    for (const dir of skillDirs) {
+      const skillFile = join(skillsDir, dir, "SKILL.md");
+      expect(existsSync(skillFile), `${dir} has no SKILL.md`).toBe(true);
+      const text = readFileSync(skillFile, "utf8");
+      const frontmatter = /^---\n([\s\S]+?)\n---/.exec(text);
+      expect(frontmatter, `${dir}: SKILL.md has no frontmatter`).not.toBeNull();
+      expect(frontmatter![1]).toMatch(/^name:\s*\S+/m);
+      expect(frontmatter![1]).toMatch(/^description:\s*\S+/m);
+    }
+  });
+
+  it("has a syntactically valid launcher", () => {
+    // `node --check` parses without executing; catches a broken edit before
+    // the zip ships. process.execPath is the node running vitest.
+    execFileSync(process.execPath, [
+      "--check",
+      join(pluginRoot, "bin", "launch-gateway.mjs"),
+    ]);
+  });
+});


### PR DESCRIPTION
## What

Ships Toolport as an installable **[Agent Plugins 1.0](https://agent-plugins.org) package** — the packaging standard GitHub announced GA for VS Code, Copilot CLI, and the Copilot app on Aug 12 — with the **Claude Code plugin layout bundled in the same folder**. One plugin install connects a client to the local gateway and shares the user's existing servers, credentials, and profiles.

## Contents (`packaging/agent-plugin/toolport/`)

- `plugin.json` + `mcp.json` — spec layout (closed 1.0.0 manifest schema, `stdio` server via `${PLUGIN_ROOT}` launcher arg)
- `.claude-plugin/plugin.json` + `.mcp.json` — Claude Code layout pointing at the same launcher via `${CLAUDE_PLUGIN_ROOT}`
- `bin/launch-gateway.mjs` — zero-dependency Node launcher that resolves the installed gateway with the same search order the app uses when writing client configs (Windows `gateway-manifest.json` → published bin dir → NSIS install dir; macOS helper bundle → `Contents/MacOS` symlink; Linux `/usr/bin` → AppImage stable copy; `TOOLPORT_GATEWAY` override; PATH last). When nothing is found it answers the client's first JSON-RPC request with an install hint instead of dying silently.
- `skills/toolport/SKILL.md` — teaches the agent the search → call workflow, code mode, `toolport_fetch_result` paging, and the `toolport_confirm` approval flow, grounded in the gateway's actual tool descriptions
- `src/test/agent-plugin.test.ts` — CI conformance checks: schema URIs, closed-manifest fields, name pattern, launcher paths resolve inside the plugin root, reserved env keys absent, skill frontmatter, and version lockstep with `package.json` (RELEASING.md updated to match)
- `release.yml` — the Linux job zips the folder as `toolport-agent-plugin.zip` and attaches it to the draft release

## Verification

- New vitest suite passes (9 checks) and is proven load-bearing: pointing `mcp.json` at a renamed launcher goes red
- Full frontend suite: 30 files / 263 tests green
- **Real handshake:** the launcher resolved this machine's installed gateway and completed an MCP `initialize` (serverInfo `toolport-gateway 1.12.0`)
- Not-found path (`TOOLPORT_GATEWAY` pointed at a bogus file) returns a JSON-RPC `-32603` error with the install hint
- Zip layout verified to include the dotfile entries (`.claude-plugin/`, `.mcp.json`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)