### PR TITLE
fix: stop the agent plugin preferring a stale gateway, and unbreak tsc -b

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,8 @@ Entries before the rename below shipped under the project's former name, Conduit
 
 - **Agent plugin.** Toolport now ships as an [Agent Plugins 1.0](https://agent-plugins.org)
   package (`toolport-agent-plugin.zip` on each release): one install connects VS Code,
-  GitHub Copilot CLI, the Copilot app, and other conformant clients — plus Claude Code
-  via the bundled dual layout — to the local gateway, with a skill teaching the agent
+  GitHub Copilot CLI, the Copilot app, and other conformant clients (plus Claude Code,
+  via the bundled dual layout) to the local gateway, with a skill teaching the agent
   the search → call workflow. The plugin launches the gateway the desktop app already
   installed, so plugin installs share your existing servers, credentials, and profiles.
 

--- a/README.md
+++ b/README.md
@@ -236,9 +236,10 @@ Code plugin layout. It launches the gateway already installed by the desktop
 app, so every plugin install shares your existing servers, credentials, and
 profiles.
 
-If the Toolport app already manages that client's MCP config (VS Code and Claude
-Code both), remove or disable the app-managed entry first. Otherwise the client
-connects to the gateway twice and every meta-tool shows up in duplicate. Details
+If you already connected that client in the app's Clients view, disconnect it
+there first. VS Code, Claude Code, and GitHub Copilot CLI are all managed there,
+and leaving both in place connects the gateway twice and shows every meta-tool
+in duplicate. Details
 in [packaging/agent-plugin/toolport/README.md](packaging/agent-plugin/toolport/README.md).
 
 ### Headless / container / MCP over the network

--- a/README.md
+++ b/README.md
@@ -224,15 +224,21 @@ any HTTP/OpenAPI MCP consumer (n8n, LibreChat, custom agents).
 
 Clients that install [Agent Plugins 1.0](https://agent-plugins.org) packages
 (VS Code, GitHub Copilot CLI, the Copilot app, and other conformant agents) can
-connect to Toolport by installing one plugin instead of editing MCP config:
-download `toolport-agent-plugin.zip` from the
-[latest release](https://github.com/tsouth89/toolport/releases/latest) and point
-your client's plugin install flow at the unzipped `toolport/` directory—the folder
-that contains `plugin.json`. The plugin bundles the
-gateway's MCP server entry plus a skill that teaches the agent Toolport's
-search → call workflow, and the same folder also carries the Claude Code plugin
-layout. It launches the gateway already installed by the desktop app, so every
-plugin install shares your existing servers, credentials, and profiles. Details
+connect to Toolport by installing one plugin instead of editing MCP config.
+Point your client's plugin install flow at
+[packaging/agent-plugin/toolport/](packaging/agent-plugin/toolport) from a
+checkout (the folder that contains `plugin.json`). From the first release tagged
+after this lands, the same folder also ships as `toolport-agent-plugin.zip` on
+the [releases page](https://github.com/tsouth89/toolport/releases). The plugin
+bundles the gateway's MCP server entry plus a skill that teaches the agent
+Toolport's search → call workflow, and the same folder also carries the Claude
+Code plugin layout. It launches the gateway already installed by the desktop
+app, so every plugin install shares your existing servers, credentials, and
+profiles.
+
+If the Toolport app already manages that client's MCP config (VS Code and Claude
+Code both), remove or disable the app-managed entry first. Otherwise the client
+connects to the gateway twice and every meta-tool shows up in duplicate. Details
 in [packaging/agent-plugin/toolport/README.md](packaging/agent-plugin/toolport/README.md).
 
 ### Headless / container / MCP over the network

--- a/packaging/agent-plugin/toolport/README.md
+++ b/packaging/agent-plugin/toolport/README.md
@@ -40,12 +40,13 @@ credentials, and profiles. That's the point of Toolport.
 
 ### Don't install it twice into one client
 
-The Toolport app writes MCP config directly for VS Code and Claude Code. If you
-install this plugin into a client the app already manages, that client gets two
+The Toolport app writes MCP config directly for most of the clients above, VS
+Code, Claude Code, and GitHub Copilot CLI included. If you install the plugin
+into a client the app already connected, that client gets two
 `toolport` server entries, spawns two gateway processes, and shows every
-meta-tool twice. Pick one: either turn the client off in the Toolport app's
-Clients view before installing the plugin, or skip the plugin for that client.
-Clients the app does not manage have nothing to disable.
+meta-tool twice. Pick one: either disconnect the client in the Toolport app's
+Clients view before installing the plugin, or skip the plugin for that client
+and let the app keep managing it.
 
 ## Configuration
 

--- a/packaging/agent-plugin/toolport/README.md
+++ b/packaging/agent-plugin/toolport/README.md
@@ -1,8 +1,8 @@
 # Toolport agent plugin
 
-Connect any [Agent Plugins 1.0](https://agent-plugins.org) client — VS Code,
-GitHub Copilot CLI, the Copilot app, and other conformant agents — or Claude
-Code to your local [Toolport](https://toolport.app) gateway with one install.
+Connect any [Agent Plugins 1.0](https://agent-plugins.org) client (VS Code,
+GitHub Copilot CLI, the Copilot app, and other conformant agents), or Claude
+Code, to your local [Toolport](https://toolport.app) gateway with one install.
 
 The plugin bundles:
 
@@ -12,9 +12,9 @@ The plugin bundles:
 - **A skill** (`skills/toolport/`) teaching the agent Toolport's
   search → call workflow, code mode, shaped results, and the approval flow.
 
-Both manifest layouts ship in this one folder: `plugin.json` + `mcp.json` at
-the root (Agent Plugins 1.0) and `.claude-plugin/plugin.json` + `.mcp.json`
-(Claude Code), so the same directory installs into either ecosystem.
+Both manifest layouts ship in this one folder (`plugin.json` + `mcp.json` at
+the root for Agent Plugins 1.0, `.claude-plugin/plugin.json` + `.mcp.json` for
+Claude Code), so the same directory installs into either ecosystem.
 
 ## Requirements
 
@@ -25,9 +25,10 @@ the root (Agent Plugins 1.0) and `.claude-plugin/plugin.json` + `.mcp.json`
 
 ## Install
 
-Download `toolport-agent-plugin.zip` from the
-[latest release](https://github.com/tsouth89/toolport/releases/latest) and
-unzip it, or use this directory straight from a checkout.
+Use this directory straight from a checkout, or download
+`toolport-agent-plugin.zip` and unzip it. That asset is attached to every
+release tagged after the packaging job shipped, so on older releases the
+checkout is the only source.
 
 - **VS Code / Copilot CLI / Copilot app:** follow your client's "install a
   local agent plugin" flow and point it at the unzipped `toolport/` folder.
@@ -35,7 +36,16 @@ unzip it, or use this directory straight from a checkout.
   repo, or add the folder as a local plugin.
 
 Every client you install the plugin into shares the same gateway, servers,
-credentials, and profiles — that's the point of Toolport.
+credentials, and profiles. That's the point of Toolport.
+
+### Don't install it twice into one client
+
+The Toolport app writes MCP config directly for VS Code and Claude Code. If you
+install this plugin into a client the app already manages, that client gets two
+`toolport` server entries, spawns two gateway processes, and shows every
+meta-tool twice. Pick one: either turn the client off in the Toolport app's
+Clients view before installing the plugin, or skip the plugin for that client.
+Clients the app does not manage have nothing to disable.
 
 ## Configuration
 

--- a/packaging/agent-plugin/toolport/bin/launch-gateway.mjs
+++ b/packaging/agent-plugin/toolport/bin/launch-gateway.mjs
@@ -58,11 +58,15 @@ function newestPublished(binDir, fsOps, pathImpl, exe) {
   }
   for (const name of entries) {
     const prefix = [GATEWAY, LEGACY_GATEWAY].find((p) => name.startsWith(`${p}-`));
-    // Published leaves are `<gateway>-<version>[-<digest>]<exe>`. Require a digit
-    // after the prefix so sidecars (a `.sig`, a manifest) can never win, and test
-    // `exe` as a plain suffix: it is "" off Windows, not ".exe".
-    if (!prefix || !/^\d/.test(name.slice(prefix.length + 1)) || !name.endsWith(exe))
-      continue;
+    if (!prefix || !name.endsWith(exe)) continue;
+    // Mirror the publisher's own rule (gateway_publish.rs::looks_like_version_suffix)
+    // rather than a looser one: leading digit, contains a dot, version-ish chars
+    // only. A copy Explorer made ("...-1.12.0 - Copy.exe", "...-1.12.0 (1).exe")
+    // can never be something we published, and would otherwise win on mtime and
+    // hide the real newest binary, since only one scanned path is returned.
+    // `exe` is a plain suffix here: it is "" off Windows, not ".exe".
+    const version = name.slice(prefix.length + 1, name.length - exe.length);
+    if (!/^\d[A-Za-z0-9._+-]*$/.test(version) || !version.includes(".")) continue;
     const full = pathImpl.join(binDir, name);
     try {
       const mtime = fsOps.statSync(full).mtimeMs;

--- a/packaging/agent-plugin/toolport/bin/launch-gateway.mjs
+++ b/packaging/agent-plugin/toolport/bin/launch-gateway.mjs
@@ -57,10 +57,11 @@ function newestPublished(binDir, fsOps, pathImpl, exe) {
     return null;
   }
   for (const name of entries) {
-    if (
-      ![GATEWAY, LEGACY_GATEWAY].some((prefix) => name.startsWith(`${prefix}-`)) ||
-      !name.endsWith(exe || ".exe")
-    )
+    const prefix = [GATEWAY, LEGACY_GATEWAY].find((p) => name.startsWith(`${p}-`));
+    // Published leaves are `<gateway>-<version>[-<digest>]<exe>`. Require a digit
+    // after the prefix so sidecars (a `.sig`, a manifest) can never win, and test
+    // `exe` as a plain suffix: it is "" off Windows, not ".exe".
+    if (!prefix || !/^\d/.test(name.slice(prefix.length + 1)) || !name.endsWith(exe))
       continue;
     const full = pathImpl.join(binDir, name);
     try {
@@ -108,8 +109,17 @@ export function gatewayCandidates({
       const binDir = pathImpl.join(roaming, leaf, "bin");
       const fromManifest = manifestPath(binDir, fsOps, pathImpl);
       if (fromManifest) found.push(fromManifest);
-      // The normal published filename can be constructed from this plugin's
-      // lockstep version even when MSIX hides the directory and manifest.
+      // Scan before guessing. This plugin is installed from a release zip and is
+      // never auto-updated, so its version pins to whatever shipped, while the
+      // desktop app updates underneath it. The app's prune keeps recent and
+      // still-referenced old images (gateway_publish.rs::decide_prune), so
+      // guessing first would spawn a stale gateway with the newer one sitting in
+      // the same directory.
+      const published = newestPublished(binDir, fsOps, pathImpl, exe);
+      if (published) found.push(published);
+      // Tried only after the scanned path fails to spawn: the normal published
+      // filename can still be constructed from this plugin's lockstep version
+      // when MSIX hides the directory and the manifest from readdir/read.
       const candidateVersion = version ?? pluginVersion(fsOps);
       if (candidateVersion) {
         found.push(
@@ -117,8 +127,6 @@ export function gatewayCandidates({
           pathImpl.join(binDir, `${LEGACY_GATEWAY}-${candidateVersion}${exe}`),
         );
       }
-      const published = newestPublished(binDir, fsOps, pathImpl, exe);
-      if (published) found.push(published);
     }
     for (const leaf of ["Toolport", "Conduit"]) {
       for (const name of [GATEWAY, LEGACY_GATEWAY]) {

--- a/packaging/agent-plugin/toolport/skills/toolport/SKILL.md
+++ b/packaging/agent-plugin/toolport/skills/toolport/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: toolport
-description: Use when the user asks for any external action or data — email, payments, deployments, databases, repos, issues, files, web search, messaging, or any connected service. Toolport is the front door to every MCP server on this machine; search it before concluding a capability is unavailable.
+description: Use when the user asks for any external action or data: email, payments, deployments, databases, repos, issues, files, web search, messaging, or any connected service. Toolport is the front door to every MCP server on this machine; search it before concluding a capability is unavailable.
 ---
 
 # Working through Toolport
@@ -13,12 +13,12 @@ discover the real tools on demand.
 
 1. **Search first.** For any external action, call `toolport_search_tools` with
    keywords describing the capability (`"list emails"`, `"create payment"`,
-   `"recent deployments"`). If the service is connected, its tool is here — do
+   `"recent deployments"`). If the service is connected, its tool is here, so do
    not tell the user a capability is unavailable until you have searched.
 2. **Call it.** The first matching result includes its exact name and full input
    schema and is ready to use: call `toolport_call_tool` with that `name` and
    all parameters inside the `arguments` object. Don't keep searching for a
-   better match, and never invent identifiers (teamId, projectId, …) — fetch
+   better match, and never invent identifiers (teamId, projectId, and so on). Fetch
    them with a list/get tool on the same server first.
 3. **Orient when needed.** `toolport_status` lists every connected server, its
    tool count, and the tokens Toolport has saved. Pass `server` to
@@ -42,7 +42,7 @@ stay full-sized inside the script; only your returned value is shaped for
 context. Pass `validate: true` for a dry run that compiles the script and
 returns the plan without executing. If a script fails partway,
 `structuredContent.toolportScript.progress` lists which calls already ran
-(their side effects are committed) — resume by index, not tool name.
+(their side effects are committed), so resume by index, not tool name.
 
 ## Results, approvals, and errors
 
@@ -53,9 +53,9 @@ returns the plan without executing. If a script fails partway,
 - **Destructive calls:** Toolport may intercept a destructive call and return a
   preview with a `token`. Confirm with `toolport_confirm` within 60 seconds to
   execute it unchanged, or a human approves it in the Toolport app. A denied
-  call is a decision, not an error — don't retry it verbatim.
+  call is a decision, not an error, so don't retry it verbatim.
 - **Server management:** when the user has allowed agent control,
   `toolport_enable_server` / `toolport_disable_server` turn servers on or off
   by id or name (see `toolport_status` for the list).
 - **Gateway not found:** if the Toolport server itself fails to start, the
-  desktop app isn't installed — the user can get it at https://toolport.app.
+  desktop app isn't installed. The user can get it at https://toolport.app.

--- a/src/test/agent-plugin.test.ts
+++ b/src/test/agent-plugin.test.ts
@@ -237,6 +237,61 @@ describe("agent plugin gateway launcher", () => {
     ).toContain(win32.join(legacyBin, "conduit-gateway-1.11.0.exe"));
   });
 
+  it("prefers the newest published gateway over its own pinned version", () => {
+    // The zip is never auto-updated, so an installed plugin's version goes stale
+    // while the app publishes newer gateways. Guessing the pinned filename ahead
+    // of a real directory scan would spawn old gateway code that the app's prune
+    // deliberately kept (referenced by another client, or recent enough).
+    const binDir = win32.join("R:\\Roaming", "Toolport", "bin");
+    const newer = win32.join(binDir, "toolport-gateway-1.13.0.exe");
+    const pinned = win32.join(binDir, "toolport-gateway-1.12.0.exe");
+    const candidates = gatewayCandidates({
+      platform: "win32",
+      home: "C:\\Users\\me",
+      env: { APPDATA: "R:\\Roaming", LOCALAPPDATA: "L:\\Local" },
+      fsOps: {
+        // No manifest, so the fallbacks are all that is left to order.
+        readFileSync: () => {
+          throw new Error("unreadable manifest");
+        },
+        readdirSync: (path: string) =>
+          path === binDir
+            ? ["toolport-gateway-1.12.0.exe", "toolport-gateway-1.13.0.exe"]
+            : [],
+        statSync: (path: string) => ({ mtimeMs: path === newer ? 2 : 1 }),
+      },
+      version: "1.12.0",
+    });
+    expect(candidates).toContain(newer);
+    expect(candidates.indexOf(newer)).toBeLessThan(candidates.indexOf(pinned));
+  });
+
+  it("only scans versioned gateway images, not lookalike neighbours", () => {
+    // A hand-made backup next to the real images must not outrank them just by
+    // being newer: only `<gateway>-<version>...` leaves are ours to spawn.
+    const binDir = win32.join("R:\\Roaming", "Toolport", "bin");
+    const candidates = gatewayCandidates({
+      platform: "win32",
+      home: "C:\\Users\\me",
+      env: { APPDATA: "R:\\Roaming", LOCALAPPDATA: "L:\\Local" },
+      fsOps: {
+        readFileSync: () => {
+          throw new Error("unreadable manifest");
+        },
+        readdirSync: (path: string) =>
+          path === binDir
+            ? ["toolport-gateway-backup.exe", "toolport-gateway-1.13.0.exe"]
+            : [],
+        statSync: (path: string) => ({
+          mtimeMs: path.endsWith("backup.exe") ? 9 : 1,
+        }),
+      },
+      version: "1.12.0",
+    });
+    expect(candidates).not.toContain(win32.join(binDir, "toolport-gateway-backup.exe"));
+    expect(candidates).toContain(win32.join(binDir, "toolport-gateway-1.13.0.exe"));
+  });
+
   it("falls through an unspawnable candidate to a working binary", async () => {
     await expect(
       spawnFirst([join(repoRoot, "missing-gateway"), process.execPath], {

--- a/src/test/agent-plugin.test.ts
+++ b/src/test/agent-plugin.test.ts
@@ -267,9 +267,18 @@ describe("agent plugin gateway launcher", () => {
   });
 
   it("only scans versioned gateway images, not lookalike neighbours", () => {
-    // A hand-made backup next to the real images must not outrank them just by
-    // being newer: only `<gateway>-<version>...` leaves are ours to spawn.
+    // Explorer's duplicate names and hand-made backups sit in the same directory
+    // and usually have the newest mtime. Only one scanned path is returned, so
+    // letting one of these win would hide the real newest binary entirely. The
+    // publisher cannot produce these names (gateway_publish.rs's version suffix
+    // is digit-led, dotted, and `[A-Za-z0-9._+-]` only).
     const binDir = win32.join("R:\\Roaming", "Toolport", "bin");
+    const impostors = [
+      "toolport-gateway-1.12.0 - Copy.exe",
+      "toolport-gateway-1.12.0 (1).exe",
+      "toolport-gateway-backup.exe",
+      "toolport-gateway-1.13.0.exe.sig",
+    ];
     const candidates = gatewayCandidates({
       platform: "win32",
       home: "C:\\Users\\me",
@@ -279,17 +288,42 @@ describe("agent plugin gateway launcher", () => {
           throw new Error("unreadable manifest");
         },
         readdirSync: (path: string) =>
-          path === binDir
-            ? ["toolport-gateway-backup.exe", "toolport-gateway-1.13.0.exe"]
-            : [],
+          path === binDir ? [...impostors, "toolport-gateway-1.13.0.exe"] : [],
+        // Every impostor is newer than the real image.
         statSync: (path: string) => ({
-          mtimeMs: path.endsWith("backup.exe") ? 9 : 1,
+          mtimeMs: path.endsWith("toolport-gateway-1.13.0.exe") ? 1 : 9,
         }),
       },
       version: "1.12.0",
     });
-    expect(candidates).not.toContain(win32.join(binDir, "toolport-gateway-backup.exe"));
-    expect(candidates).toContain(win32.join(binDir, "toolport-gateway-1.13.0.exe"));
+    for (const impostor of impostors) {
+      expect(candidates, impostor).not.toContain(win32.join(binDir, impostor));
+    }
+    // The real image still beats this plugin's own pinned guess.
+    expect(
+      candidates.indexOf(win32.join(binDir, "toolport-gateway-1.13.0.exe")),
+    ).toBeLessThan(candidates.indexOf(win32.join(binDir, "toolport-gateway-1.12.0.exe")));
+  });
+
+  it("still accepts content-addressed published names", () => {
+    // `<gateway>-<version>-<digest><exe>` is a real publisher output and must
+    // survive the stricter scan.
+    const binDir = win32.join("R:\\Roaming", "Toolport", "bin");
+    const addressed = "toolport-gateway-1.13.0-a1b2c3d4e5f6.exe";
+    const candidates = gatewayCandidates({
+      platform: "win32",
+      home: "C:\\Users\\me",
+      env: { APPDATA: "R:\\Roaming", LOCALAPPDATA: "L:\\Local" },
+      fsOps: {
+        readFileSync: () => {
+          throw new Error("unreadable manifest");
+        },
+        readdirSync: (path: string) => (path === binDir ? [addressed] : []),
+        statSync: () => ({ mtimeMs: 1 }),
+      },
+      version: "1.12.0",
+    });
+    expect(candidates).toContain(win32.join(binDir, addressed));
   });
 
   it("falls through an unspawnable candidate to a working binary", async () => {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,7 +3,6 @@ import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
 import { fileURLToPath, URL } from "node:url";
 
-// @ts-expect-error process is a nodejs global
 const host = process.env.TAURI_DEV_HOST;
 
 // https://vite.dev/config/


### PR DESCRIPTION
Follow-ups to tsouth89/toolport#705, found reviewing the merged feature. Four fixes, one file of tests.

### The launcher could spawn an old gateway

`gatewayCandidates()` pushed the version-constructed filename *before* scanning the published bin dir, so a plugin pinned at 1.12.0 would pick `toolport-gateway-1.12.0.exe` over a newer image sitting in the same directory whenever the manifest read failed.

That combination is not exotic. The plugin installs from a release zip and is never auto-updated, so its version goes stale the moment the desktop app updates, and the app's prune deliberately keeps old images that are recent or still referenced by another client config (`gateway_publish.rs::decide_prune`). This is the "silently runs old gateway code" class the gateway code already treats as a real bug ([SBS-435](https://linear.app/southboundsoftware/issue/SBS-435/reaper-does-not-deliver-new-gateway-code-to-already-running-clients)).

Scanning first costs nothing: the constructed name only ever helps when `readdir` is hidden, in which case the scan returns null and we fall through to it anyway. The scan now also requires a version digit after the prefix, so a `.sig` sidecar or a hand-made `toolport-gateway-backup.exe` can never outrank a real image.

Both behaviours are covered by new tests that fail without the launcher change (verified by stashing it).

### `tsc -b` is broken on main

Adding `@types/node` as a direct devDependency typed `process`, which made the `@ts-expect-error` in `vite.config.ts` unused, and that is a hard `TS2578` error:

\`\`\`<br>vite.config.ts(6,1): error TS2578: Unused '@ts-expect-error' directive.<br>\`\`\`

CI is green only by accident: `npm run build` runs plain `tsc`, which does not compile referenced projects, and `tsconfig.node.json` is a reference. It shows up in VS Code for anyone on main. Fixed by deleting the now-unused directive.

### Docs pointed at an asset that does not exist

Both READMEs told users to download `toolport-agent-plugin.zip` from the *latest* release. The packaging job only runs on the next tag, so that download 404s until then. Reworded to lead with the checkout and describe the zip as arriving with the next tag.

### Nothing warned about double registration

The app writes MCP config directly for VS Code and Claude Code (`clients.rs`), which are also the clients that accept plugins. Installing the plugin into a client the app already manages gives you two `toolport` entries, two gateway processes, and every meta-tool twice. Both READMEs now say to pick one.

### Also

Drops the em dashes from the copy this feature added (plugin README, SKILL.md, and the new README/CHANGELOG lines). Older CHANGELOG entries left alone.

### Verification

`npm run test` (315 passed, 33 files), `npm run lint` (0 errors, 24 warnings = unchanged baseline), `npm run format:check`, `npx tsc --noEmit`, and `npx tsc -b` all clean.