### PR TITLE
chore(release): 1.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ Entries before the rename below shipped under the project's former name, Conduit
 
 ## [Unreleased]
 
+## [1.13.0] - 2026-08-13
+
+Toolport installs two new ways: as an agent plugin any conformant client can pick up,
+and on Windows through a one-line command instead of a trip to the Releases page.
+Pseudonymization gains the piece it was missing, a way for a human to release one
+value to one server, so the workflow it used to dead-end now has an answer.
+
+Most of the rest of this release is one defect wearing different faces: code that
+read a failed probe as good news. A failed audit baseline, health check, security
+read, integrity load, or Windows credential read could each come back looking like
+"all clear" and let the app act on it. Each one now fails closed.
+
 ### Added
 
 - **Agent plugin.** Toolport now ships as an [Agent Plugins 1.0](https://agent-plugins.org)
@@ -14,6 +26,93 @@ Entries before the rename below shipped under the project's former name, Conduit
   via the bundled dual layout) to the local gateway, with a skill teaching the agent
   the search → call workflow. The plugin launches the gateway the desktop app already
   installed, so plugin installs share your existing servers, credentials, and profiles.
+  If the app already manages that client, disconnect it there first or the gateway
+  connects twice.
+- **Windows one-line install.**
+  `irm https://raw.githubusercontent.com/tsouth89/toolport/main/scripts/install.ps1 | iex`,
+  matching the macOS and Linux one-liners. It resolves the release through the GitHub
+  API, picks the NSIS asset for the machine's architecture, and refuses to install
+  anything it cannot verify against the per-asset digest (`-AllowUnverified` is the
+  explicit override). A signature that disagrees with the file is fatal; a missing one
+  is a warning, since builds before Azure signing shipped unsigned. (#610)
+- **Release one pseudonymized value to one server.** Scoping rehydration to the minting
+  server closed a cross-server exfiltration channel but left a legitimate workflow with
+  no path at all: read a customer from a CRM, mail them through a different server, and
+  the call simply failed. Refusal is still the default, with a human decision as the
+  remedy. The prompt names the destination, each token, and its real value, and grants
+  that one value to that one server. There is deliberately no blanket per-server grant,
+  an "always allow" on a tool can never release a later value, and a headless gateway
+  with nobody to ask refuses exactly as before. Audited by hashing the arguments, so
+  released values never reach the log. (SBS-696)
+- **Pseudonymization counts in the audit log, CSV export, and Activity.** This path
+  fails open: a full session map or an over-cap result leaves values in the clear, and
+  a call where redaction quietly did not apply used to be indistinguishable from a clean
+  one. `piiReplaced` is absent when redaction was off and present-and-zero when it ran
+  and matched nothing, and `piiIncomplete` is written only when true, so the fail-open
+  case is greppable. Activity shows "N pseudonymized" with a warning badge when the pass
+  did not fully apply. Counts only; values never leave the session map. CSV columns are
+  appended at the end, so positional consumers keep working. (SBS-607)
+- **`toolport.checkpoint()` in code mode.** A last-write-wins resume marker a script
+  sets itself, alongside the automatic call ledger. Unlike `progress`, which is
+  positional, this holds author-chosen state (`{ lastInsertedId: row.id }`). Costs
+  nothing against `max_calls`, capped at 4096 bytes, and surfaces in the failure text
+  and in `structuredContent.toolportScript.checkpoint`. (#663)
+- **Server-declared tool icons** render in the tool browser. `data:` sources only: a
+  remote icon URL is not a picture but a request the app makes to a server-chosen host
+  on every paint, reporting when Toolport is open and from what IP with no tool call
+  involved. (SEP-973)
+- **URL-mode elicitation.** (SBS-707)
+
+### Fixed
+
+- **A failed read no longer looks like success.** Onboarding needs a successful audit
+  baseline before anything counts and stays in checking or unavailable until an
+  authoritative health result exists, with concurrent probes sharing one promise instead
+  of returning an empty list. Activity keeps the last known security events across a
+  failed refresh and never shows Protection active without an authoritative read. A
+  rejected client-secret probe stays unknown instead of reporting "no secret stored",
+  which was blocking scope edits for secrets that were already vaulted. Integrity-store
+  failures fail closed, and interrupted pin updates recover. (SBS-718, SBS-719, SBS-720,
+  SBS-721, SBS-722, #697)
+- **The HTTP bridge validates `Origin`, not just `Sec-Fetch-Site`.** Under DNS rebinding
+  the attacker's domain resolves to loopback, so the browser calls it same-origin and the
+  old guard waved it through, worst under `--insecure-open` where there is no token.
+  Absent `Origin` stays allowed, so curl and Open WebUI's backend are unaffected, and a
+  deliberately exposed bridge can still serve its own browser UI by matching the bound
+  address or listing hosts in `TOOLPORT_HTTP_ALLOWED_ORIGINS`. No name resolution is
+  involved, so a domain that merely resolves to the bridge stays foreign. (SBS-452)
+- **Folder scoping keeps working as Roots is deprecated.** Roots was the only input
+  folder-scoped auto-routing ever had, so a client that never sent it, or stopped
+  mid-session, silently dropped to the unscoped profile and reached more servers than
+  intended. The project root now resolves from `TOOLPORT_ROOT`, then the client's roots
+  for the whole deprecation window, then the gateway's working directory. (SEP-2577)
+- **Stale gateway and catalog state can no longer become permanent.** `CLAUDE_CONFIG_DIR`
+  is honored instead of hardcoding `~/.claude.json`. A downstream that answers
+  `tools/list` with a truncated catalog no longer becomes cached truth for every gateway
+  started afterwards. A republish under a content-addressed filename no longer flips a
+  managed client to Customized, which had pinned it to a superseded gateway permanently
+  (npx, docker, and wrapper scripts are still Customized). A confirmed rebuild collapse
+  can now land instead of being held forever. (#698)
+- **Profiles with similar names no longer share state.** Per-profile stores were named by
+  a lossy slug of the display name, so "Work Prod" and "Work/Prod" shared cache, pins,
+  and quarantine. Files are keyed by a hashed profile id now, unambiguous legacy files
+  migrate, and a slug collision fails closed rather than merging two profiles. (SBS-715)
+- **A Windows credential being replaced no longer reads as missing.** Windows reports the
+  base credential absent for the instant a replace is in flight, which surfaced as a
+  spurious "not authenticated" during OAuth refresh, since the app writes these and the
+  gateway reads them from another process. Absence now only counts once it survives
+  bounded retries with a real backoff. A mitigation rather than a guarantee: measured
+  over 9,600 racing reads, 37 torn reads became 4. (SBS-711)
+- **Atlassian OAuth on Windows**, plus a longer refresh-lock wait so a slow refresh is
+  not abandoned. (#685, SBS-705)
+- **Cancellation is honored end to end.** The HTTP transport aborts or forwards
+  cancellation and retry backoff observes it, so abandoned work releases its per-server
+  slot. The updater refuses to install while gateways are still running and recovers the
+  HTTP bridge if an install fails after shutdown. (SBS-716, SBS-717)
+- **PII session maps are cleared when sessions end.** (SBS-704)
+- **Requests with no transport fail closed** instead of proceeding. (SBS-551)
+- **Tray and update lifecycle**, including approval requests being delivered once rather
+  than repeatedly. (SBS-146)
 
 ## [1.12.0] - 2026-08-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,8 @@ value to one server, so the workflow it used to dead-end now has an answer.
 
 Most of the rest of this release is one defect wearing different faces: code that
 read a failed probe as good news. A failed audit baseline, health check, security
-read, integrity load, or Windows credential read could each come back looking like
-"all clear" and let the app act on it. Each one now fails closed.
+read, or integrity load could each come back looking like "all clear" and let the
+app act on it. Each one now fails closed.
 
 ### Added
 
@@ -61,7 +61,13 @@ read, integrity load, or Windows credential read could each come back looking li
   remote icon URL is not a picture but a request the app makes to a server-chosen host
   on every paint, reporting when Toolport is open and from what IP with no tool call
   involved. (SEP-973)
-- **URL-mode elicitation.** (SBS-707)
+- **URL-mode elicitation**, so a server that needs you to finish something in a browser
+  works even with a client that does not support it: Toolport brokers the prompt in the
+  desktop app instead of letting the call fail. A server-provided link is a phishing and
+  internal-network primitive, so only credential-free HTTPS URLs resolving exclusively to
+  public addresses are allowed, under the same host boundary as Toolport's SSRF defenses,
+  and the origin shown to you is derived from the parsed URL rather than from anything the
+  server says about itself. (SBS-707)
 
 ### Fixed
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -15,8 +15,10 @@ Releases are built by CI on a version tag (`.github/workflows/release.yml`).
      from `package.json`
    - `CHANGELOG.md` — move `[Unreleased]` entries into a dated section
    - `server.json` only when publishing a matching standalone gateway package
-2. Draft user-facing notes in `docs/release-notes/vX.Y.Z.md` (paste into the GitHub
-   release body when publishing the draft CI creates).
+2. The `CHANGELOG.md` section from step 1 becomes the release body: CI extracts the
+   lines under `## [X.Y.Z]` and falls back to generated notes if that heading is
+   missing or empty. Write it there rather than anywhere else. (`docs/release-notes/`
+   holds hand-written notes from before this was automated; nothing reads it.)
 3. Commit the bump (e.g. `chore(release): 1.6.0`).
 4. Merge to `main`, then tag and push:
 
@@ -27,9 +29,9 @@ Releases are built by CI on a version tag (`.github/workflows/release.yml`).
    ```
 
 CI builds installers for **Windows** (NSIS), **macOS** (dmg), and **Linux**
-(deb + AppImage), each with the gateway bundled, and attaches them to a **draft**
-release with auto-generated notes. Replace or augment the body with
-`docs/release-notes/vX.Y.Z.md`, then click **Publish**.
+(deb + AppImage), each with the gateway bundled, plus `toolport-agent-plugin.zip`,
+and attaches them to a **draft** release titled `Toolport vX.Y.Z` whose body is the
+changelog section. Review the draft, then click **Publish**.
 
 The **gateway container image** (`ghcr.io/tsouth89/toolport-gateway`) publishes
 separately on every push to `main` via `docker-publish.yml` — no tag required.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "toolport",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "toolport",
-      "version": "1.12.0",
+      "version": "1.13.0",
       "dependencies": {
         "@fontsource-variable/geist": "^5.2.9",
         "@tailwindcss/vite": "^4.3.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "toolport",
   "private": true,
-  "version": "1.12.0",
+  "version": "1.13.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/packaging/agent-plugin/toolport/.claude-plugin/plugin.json
+++ b/packaging/agent-plugin/toolport/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "toolport",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "description": "Every tool. One port. Connects this agent to your local Toolport gateway: every MCP server you set up in Toolport, exposed through a handful of compact meta-tools instead of hundreds of tool definitions (~90% fewer tokens, measured).",
   "author": { "name": "Toolport", "url": "https://toolport.app" },
   "homepage": "https://toolport.app",

--- a/packaging/agent-plugin/toolport/plugin.json
+++ b/packaging/agent-plugin/toolport/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "toolport",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "description": "Every tool. One port. Connects this agent to your local Toolport gateway: every MCP server you set up in Toolport, exposed through a handful of compact meta-tools instead of hundreds of tool definitions (~90% fewer tokens, measured).",
   "author": { "name": "Toolport", "url": "https://toolport.app" },
   "homepage": "https://toolport.app",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -780,7 +780,7 @@ dependencies = [
 
 [[package]]
 name = "conduit"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "base64 0.22.1",
  "boa_engine",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conduit"
-version = "1.12.0"
+version = "1.13.0"
 description = "Local MCP gateway: manage all your MCP servers in one place, set up once and shared by every AI client, with ~90% fewer tokens per request"
 authors = ["South Forge AI"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Toolport",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "identifier": "com.tsout.conduit",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
Prepares the 1.13.0 release. **No tag is pushed by this PR** - merging it just puts the version bump and changelog on `main` so the tag can be cut.

## Why now

58 commits have landed since `v1.12.0` (tagged 2026-08-09), 22 of them user-facing: 6 features and 16 fixes. The strongest argument for cutting is a cluster of six fail-closed fixes, where a failed audit probe, health check, security read, integrity load, credential read, or missing transport could each come back looking like "all clear" and let the app act on it.

Also, both READMEs now tell users to download `toolport-agent-plugin.zip`, and that asset does not exist until a tag is pushed, since the packaging job only runs on `v*`.

Minor rather than patch, because there are six features.

## Version bumps

All seven surfaces from RELEASING.md step 1, `1.12.0` to `1.13.0`:

- `package.json`, `package-lock.json` (both root fields)
- `src-tauri/tauri.conf.json` (drives the installer filename)
- `src-tauri/Cargo.toml` and `src-tauri/Cargo.lock` (package still named `conduit`)
- `packaging/agent-plugin/toolport/plugin.json` and `.claude-plugin/plugin.json`

`cargo metadata --locked` confirms the lock still matches the manifest, and the vitest lockstep check covers the two plugin manifests.

`server.json` is deliberately left at `0.4.2`. It tracks the standalone gateway package, which RELEASING.md says to bump only when publishing that package.

## Changelog

Written from the diffs rather than the commit subjects. Several commits are follow-ups to features that already shipped in 1.12.0 and would read as new if transcribed literally, so the PII release-binding fix (SBS-696) folds into the release-one-value entry, and the agent plugin's launcher hardening folds into the plugin entry. The 17 `test:` and 8 `ci:` commits are not user-facing and are not listed.

Since `ad84b5e`, CI extracts the release body from the `## [1.13.0]` heading. I ran that exact awk against this section: 107 lines, stopping cleanly before the 1.12.0 heading, nothing leaked.

## Also

`RELEASING.md` step 2 was stale. It still told the releaser to hand-write `docs/release-notes/vX.Y.Z.md` and paste it into the draft, which nothing has read since the changelog extraction landed. Corrected, along with the draft description, which now mentions the plugin zip and the auto-set title.

## After merging

```
git checkout main && git pull
git tag v1.13.0
git push origin v1.13.0
```

Then review the draft release CI creates and publish it.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Release Toolport v1.13.0
> Bumps version to 1.13.0 across [package.json](https://github.com/tsouth89/toolport/pull/709/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519), [Cargo.toml](https://github.com/tsouth89/toolport/pull/709/files#diff-fe4c6a80a21e81339e2e0faeb9134d0f9636c168987df13c8abf1927a1caee39), [tauri.conf.json](https://github.com/tsouth89/toolport/pull/709/files#diff-fa09f1dac39604a735cd6a53957d3c35e0c3298cca9cf4829180f167abbd69b7), and the agent plugin manifests. Updates [CHANGELOG.md](https://github.com/tsouth89/toolport/pull/709/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed) with the full 1.13.0 release notes covering bug fixes and new features including agent plugin packaging, pseudonymization workflow updates, code-mode checkpoint API, server-declared tool icons, and various stability fixes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6f655ad.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->