### PR TITLE
fix(release): credit contributors and stop the plugin job creating a bodyless draft

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -288,11 +288,38 @@ jobs:
       - name: Package the agent plugin
         run: cd packaging/agent-plugin && zip -r toolport-agent-plugin.zip toolport
 
+      # Deliberately duplicated from the build job rather than shared. This job is
+      # seconds long while a native build is tens of minutes, so it always creates
+      # the draft first - and the release action only applies `body_path` to a
+      # release it created, so whichever job gets there first is the only one whose
+      # notes ever land. v1.13.0 published with an empty body for exactly this
+      # reason. Both jobs must carry the notes; do not "clean this up" into one.
+      - name: Extract this version's changelog entry
+        id: notes
+        shell: bash
+        run: |
+          version="${GITHUB_REF_NAME#v}"
+          awk -v v="$version" '
+            index($0, "## [" v "]") == 1 { found = 1; next }
+            found && index($0, "## [") == 1 { exit }
+            found { print }
+          ' CHANGELOG.md > release-notes.md
+          if grep -q '[^[:space:]]' release-notes.md; then
+            printf '\n---\n\n**Full changelog:** https://github.com/%s/blob/%s/CHANGELOG.md\n' \
+              "$GITHUB_REPOSITORY" "$GITHUB_REF_NAME" >> release-notes.md
+            echo "have_notes=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "have_notes=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::No CHANGELOG section for $version; falling back to generated notes."
+          fi
+
       - name: Upload the agent plugin
         uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3
         with:
           draft: true
           name: Toolport ${{ github.ref_name }}
+          body_path: ${{ steps.notes.outputs.have_notes == 'true' && 'release-notes.md' || '' }}
+          generate_release_notes: ${{ steps.notes.outputs.have_notes != 'true' }}
           files: packaging/agent-plugin/toolport-agent-plugin.zip
 
   # Assemble the updater manifest from every platform's signature, after all

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,6 +120,19 @@ app act on it. Each one now fails closed.
 - **Tray and update lifecycle**, including approval requests being delivered once rather
   than repeatedly. (SBS-146)
 
+### Thanks
+
+Two patches this cycle, one of them a code-mode feature listed above:
+
+- **[Vermitrude](https://github.com/Vermitrude)** - `toolport.checkpoint()`, the
+  script-declared resume marker a code-mode script sets alongside the automatic call
+  ledger (#689).
+- **[rohankumardubey](https://github.com/rohankumardubey)** - ran the headless Rust
+  suite across macOS, Linux and Windows in CI, where the no-desktop build had only been
+  exercised on one platform (#671).
+
+If we missed you, open an issue.
+
 ## [1.12.0] - 2026-08-09
 
 Two features ship for the first time. PII pseudonymization replaces personal data in

--- a/src/test/agent-plugin.test.ts
+++ b/src/test/agent-plugin.test.ts
@@ -353,4 +353,17 @@ describe("agent plugin gateway launcher", () => {
     expect(job).toContain("toolport-agent-plugin.zip");
     expect(job).toContain("Upload the agent plugin");
   });
+
+  it("carries the changelog notes, since it always creates the draft first", () => {
+    // This job runs in seconds against a native build's tens of minutes, so it wins
+    // the race to create the release, and the release action only applies body_path
+    // to a release it created. Without its own notes step the published body is
+    // empty, which is how v1.13.0 shipped before it was set by hand.
+    const job = releaseWorkflow
+      .split("\n  agent-plugin:\n")[1]
+      ?.split("\n  updater-manifest:\n")[0];
+    expect(job).toContain("Extract this version's changelog entry");
+    expect(job).toContain("body_path:");
+    expect(job).toContain("CHANGELOG.md");
+  });
 });


### PR DESCRIPTION
v1.13.0 shipped with an empty release body, and its notes omitted the two external patches in the cycle. Both were corrected on the draft before publishing, so **the live release is right**. This PR lands the same content in the repo and fixes the mechanism so it does not recur.

## The bug

The `agent-plugin` job runs in seconds; a native build takes tens of minutes. So the plugin job always wins the race to create the draft release, and it passed no `body_path`. `softprops/action-gh-release` only applies `body_path` to a release **it created**, so all four build jobs uploaded their assets to the existing draft and left the body empty.

This was not a changelog extraction failure. The ubuntu job logged `body_path: release-notes.md` with no fallback warning, meaning the awk found the section and handed it over, and the release still read `body_length: 0` after three successful uploads.

I reviewed this race in #705 and waved it through on the reasoning that a build job would fill the body in later. It doesn't.

## The fix

Both jobs now carry the notes step, so whichever creates the draft sets the body.

It is duplicated rather than shared, with a comment saying why: the two jobs must each be able to create a complete release on their own, and factoring this back into one place is precisely what reintroduces the bug. Keeping the plugin job independent of the build matrix was the deliberate design in #705, so the plugin still ships if a native build fails.

A test in `src/test/agent-plugin.test.ts` pins it, verified load-bearing by stashing the workflow change.

## Thanks section

The 1.13.0 notes had no `### Thanks`, though two external contributions landed:

- **Vermitrude** (#689) `toolport.checkpoint()`, which is already listed under Added as a feature
- **rohankumardubey** (#671) the headless Rust matrix across macOS, Linux and Windows

Written in the same style as the 1.11.0 and earlier sections.

## Known cosmetic gap

The `v1.13.0` tag points at `1ed50ff`, which predates this commit, so the **Full changelog** link in the published body resolves to a `CHANGELOG.md` at that tag without the Thanks section. The published release body itself is correct and complete. Re-tagging would mean a full 40-minute rebuild and re-verification of signed artifacts to fix a link target, which is not worth it.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix release workflow to attach changelog notes and credit contributors in draft releases
> - The `agent-plugin` job in [release.yml](.github/workflows/release.yml) now extracts the current version's changelog entry using `awk` and writes it to `release-notes.md`, attaching it as the release body when present.
> - Falls back to GitHub-generated release notes when no changelog entry is found, preventing bodyless draft releases.
> - Adds a `Thanks` section to [CHANGELOG.md](CHANGELOG.md) crediting contributors before the 1.12.0 section.
> - A new test in [agent-plugin.test.ts](src/test/agent-plugin.test.ts) asserts the workflow includes the changelog extraction step and `body_path` configuration.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e9aa2bf.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->