### PR TITLE
feat(install): short install URLs and a winget package

### DIFF
--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -1,0 +1,58 @@
+name: winget
+
+# Submits a manifest update to microsoft/winget-pkgs after a release is PUBLISHED.
+#
+# Not on the version tag, deliberately: release.yml builds into a DRAFT release,
+# and winget's validation downloads the installer URL, which 404s while the
+# release is still a draft. `released` fires when the draft is published, which
+# is also the first moment the asset is fetchable.
+on:
+  release:
+    types: [released]
+
+permissions:
+  contents: read
+
+jobs:
+  submit:
+    # Prereleases are not what `winget install` should hand people.
+    if: ${{ !github.event.release.prerelease }}
+    runs-on: windows-latest
+    env:
+      # A PAT with `public_repo`, because GITHUB_TOKEN cannot push to the
+      # winget-pkgs fork this submits from. Until the secret exists the step
+      # below no-ops, so adding this workflow cannot fail a release. Same
+      # gating style as the Azure signing steps in release.yml.
+      WINGET_TOKEN: ${{ secrets.WINGET_TOKEN }}
+      TAG: ${{ github.event.release.tag_name }}
+    steps:
+      - name: Submit the manifest update
+        if: ${{ env.WINGET_TOKEN != '' }}
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          $version = $env:TAG -replace '^v', ''
+          $url = "https://github.com/${{ github.repository }}/releases/download/$env:TAG/Toolport_${version}_x64-setup.exe"
+
+          # Fail before touching winget-pkgs if the asset is not actually there,
+          # so a rename in release.yml surfaces here rather than as a rejected
+          # upstream PR days later.
+          $head = Invoke-WebRequest -Uri $url -Method Head -MaximumRedirection 5 -SkipHttpErrorCheck
+          if ($head.StatusCode -ne 200) {
+            throw "Installer not downloadable ($($head.StatusCode)): $url"
+          }
+
+          # wingetcreate is Microsoft's own tool, so this adds no third-party
+          # action to a workflow that holds a push token.
+          Invoke-WebRequest -Uri https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe
+          .\wingetcreate.exe update Toolport.Toolport `
+            --version $version `
+            --urls "$url|x64|user" `
+            --submit `
+            --token $env:WINGET_TOKEN
+
+      - name: Say why nothing was submitted
+        if: ${{ env.WINGET_TOKEN == '' }}
+        shell: pwsh
+        run: |
+          Write-Output "::warning::WINGET_TOKEN is not set, so no winget manifest was submitted for $env:TAG. Add the secret (PAT with public_repo) to enable this, or submit by hand from packaging/winget."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ Entries before the rename below shipped under the project's former name, Conduit
 
 ## [Unreleased]
 
+### Added
+
+- **Short install commands.** `irm https://toolport.app/install.ps1 | iex` on Windows and
+  `curl -fsSL https://toolport.app/install.sh | bash` on macOS and Linux, replacing the
+  86-character raw.githubusercontent URLs. Both redirect to a pinned commit rather than
+  a branch: these are piped into a shell, so the content behind them should not be able
+  to change without a reviewed change on both sides.
+- **winget package.** `winget install Toolport.Toolport` on Windows once the manifest is
+  published, and each release submits its own update.
+
 ## [1.13.0] - 2026-08-13
 
 Toolport installs two new ways: as an agent plugin any conformant client can pick up,

--- a/README.md
+++ b/README.md
@@ -308,12 +308,15 @@ namespaced per server, so the two never collide even in the same profile.
 brew install --cask tsouth89/toolport/toolport
 
 # macOS or Linux (script: .deb via apt where available, else AppImage; Mac copies the app)
-curl -fsSL https://raw.githubusercontent.com/tsouth89/toolport/main/scripts/install.sh | bash
+curl -fsSL https://toolport.app/install.sh | bash
 ```
 
 ```powershell
+# Windows (winget, once the package is published)
+winget install Toolport.Toolport
+
 # Windows (PowerShell: downloads the signed installer, verifies its checksum, installs per-user)
-irm https://raw.githubusercontent.com/tsouth89/toolport/main/scripts/install.ps1 | iex
+irm https://toolport.app/install.ps1 | iex
 ```
 
 The Windows script installs **silently** and needs no administrator rights. It

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -15,6 +15,10 @@ Releases are built by CI on a version tag (`.github/workflows/release.yml`).
      from `package.json`
    - `CHANGELOG.md` — move `[Unreleased]` entries into a dated section
    - `server.json` only when publishing a matching standalone gateway package
+   - `scripts/install.ps1` / `scripts/install.sh` only if you changed them, in which
+     case also move `INSTALL_SCRIPTS_REF` in the site repo's `worker/index.js`, since
+     `toolport.app/install.*` redirects to a pinned commit and will otherwise keep
+     serving the old script
 2. The `CHANGELOG.md` section from step 1 becomes the release body: CI extracts the
    lines under `## [X.Y.Z]` and falls back to generated notes if that heading is
    missing or empty. Write it there rather than anywhere else. (`docs/release-notes/`
@@ -32,6 +36,13 @@ CI builds installers for **Windows** (NSIS), **macOS** (dmg), and **Linux**
 (deb + AppImage), each with the gateway bundled, plus `toolport-agent-plugin.zip`,
 and attaches them to a **draft** release titled `Toolport vX.Y.Z` whose body is the
 changelog section. Review the draft, then click **Publish**.
+
+Publishing is also what triggers **winget** (`winget.yml`): it submits a manifest
+update to `microsoft/winget-pkgs` for the new version. It runs on publish rather
+than on the tag because winget's validation downloads the installer URL, which 404s
+while the release is still a draft. It no-ops with a warning unless the
+`WINGET_TOKEN` secret (a PAT with `public_repo`) is set, so it can never fail a
+release. To submit by hand instead, the manifests are in `packaging/winget`.
 
 The **gateway container image** (`ghcr.io/tsouth89/toolport-gateway`) publishes
 separately on every push to `main` via `docker-publish.yml` — no tag required.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -42,7 +42,16 @@ update to `microsoft/winget-pkgs` for the new version. It runs on publish rather
 than on the tag because winget's validation downloads the installer URL, which 404s
 while the release is still a draft. It no-ops with a warning unless the
 `WINGET_TOKEN` secret (a PAT with `public_repo`) is set, so it can never fail a
-release. To submit by hand instead, the manifests are in `packaging/winget`.
+release.
+
+To submit by hand instead, copy `packaging/winget` to a new
+`manifests/t/Toolport/Toolport/<version>/` directory in a fork of
+`microsoft/winget-pkgs` and update it for the release first: `PackageVersion`
+in all three files, plus `InstallerUrl`, `InstallerSha256`, `ReleaseDate` and
+`ReleaseNotesUrl`. The copy in this repo stays pinned to whatever version last
+shipped, so submitting it unchanged re-submits that version's metadata and the new
+release never reaches winget. Check it with `winget validate --manifest <dir>`
+before opening the PR.
 
 The **gateway container image** (`ghcr.io/tsouth89/toolport-gateway`) publishes
 separately on every push to `main` via `docker-publish.yml` — no tag required.

--- a/packaging/winget/Toolport.Toolport.installer.yaml
+++ b/packaging/winget/Toolport.Toolport.installer.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Toolport.Toolport
+PackageVersion: 1.13.0
+InstallerLocale: en-US
+InstallerType: nullsoft
+# Tauri's NSIS bundle installs per-user, so the uninstall entry lives under
+# HKCU and no elevation is needed. Scope must say so or winget will try to
+# install it machine-wide and mis-detect the installed version on upgrade.
+Scope: user
+UpgradeBehavior: install
+ReleaseDate: 2026-08-13
+# NSIS has no MSI ProductCode; winget matches the uninstall registry key name,
+# which Tauri writes as the product name.
+ProductCode: Toolport
+AppsAndFeaturesEntries:
+  - DisplayName: Toolport
+    ProductCode: Toolport
+    Publisher: tsout
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/tsouth89/toolport/releases/download/v1.13.0/Toolport_1.13.0_x64-setup.exe
+    InstallerSha256: 29E98D43D356829A3AFC79912D844264192168C68C2F860E34C4205FAE934EE4
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/packaging/winget/Toolport.Toolport.locale.en-US.yaml
+++ b/packaging/winget/Toolport.Toolport.locale.en-US.yaml
@@ -1,0 +1,48 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Toolport.Toolport
+PackageVersion: 1.13.0
+PackageLocale: en-US
+Publisher: Toolport
+PublisherUrl: https://toolport.app
+PublisherSupportUrl: https://github.com/tsouth89/toolport/issues
+PackageName: Toolport
+PackageUrl: https://toolport.app
+License: MIT
+LicenseUrl: https://github.com/tsouth89/toolport/blob/main/LICENSE
+Copyright: Copyright (c) Brandon South
+ShortDescription: Local-first MCP gateway. One port for every tool and every AI client.
+Description: |-
+  Toolport is a local gateway that aggregates every MCP server on your machine and
+  shares them with every AI client you use, so a server is configured once rather
+  than once per client.
+
+  Instead of loading hundreds of tool definitions into the model's context, clients
+  see a handful of meta-tools and discover the real ones on demand, which cuts tool
+  tokens by roughly 90%. Servers, credentials, and profiles are managed in one app:
+  secrets live in the OS keychain, tool definitions are pinned and re-checked so a
+  silently changed tool is quarantined rather than called, and destructive calls can
+  require human approval.
+
+  Runs entirely on your machine. There is no account, and no tool traffic leaves the
+  device unless a server you configured sends it.
+Moniker: toolport
+Tags:
+  - agent
+  - ai
+  - claude
+  - cli
+  - copilot
+  - cursor
+  - developer-tools
+  - gateway
+  - llm
+  - local-first
+  - mcp
+  - model-context-protocol
+ReleaseNotesUrl: https://github.com/tsouth89/toolport/releases/tag/v1.13.0
+Documentations:
+  - DocumentLabel: README
+    DocumentUrl: https://github.com/tsouth89/toolport#readme
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/packaging/winget/Toolport.Toolport.yaml
+++ b/packaging/winget/Toolport.Toolport.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Toolport.Toolport
+PackageVersion: 1.13.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,5 +1,12 @@
 # Toolport installer for Windows. One-liner:
-#   irm https://raw.githubusercontent.com/tsouth89/toolport/main/scripts/install.ps1 | iex
+#   irm https://toolport.app/install.ps1 | iex
+#
+# HEADS UP, IF YOU EDIT THIS FILE: toolport.app/install.ps1 redirects to a PINNED
+# COMMIT of this script, not to main, because it is piped into `iex` and a movable
+# URL there means anything that lands on main runs on users' machines. A change
+# here does NOT reach that URL until INSTALL_SCRIPTS_REF in the site repo's
+# worker/index.js is moved to the commit containing it. Ship both, or the fix you
+# just made will not reach anyone using the short URL.
 #
 # Downloads the NSIS installer for the latest release, verifies it against the
 # SHA-256 GitHub publishes for that asset, and runs it silently (per-user, no
@@ -12,7 +19,7 @@
 #   -AllowUnverified     TOOLPORT_ALLOW_UNVERIFIED=1  install even with no published checksum
 #
 # To pass parameters through the one-liner:
-#   & ([scriptblock]::Create((irm https://raw.githubusercontent.com/tsouth89/toolport/main/scripts/install.ps1))) -Version 1.12.0
+#   & ([scriptblock]::Create((irm https://toolport.app/install.ps1))) -Version 1.13.0
 
 param(
     [string]$Version,

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,7 +1,14 @@
 #!/usr/bin/env bash
 #
 # Toolport installer. One-liner:
-#   curl -fsSL https://raw.githubusercontent.com/tsouth89/toolport/main/scripts/install.sh | bash
+#   curl -fsSL https://toolport.app/install.sh | bash
+#
+# HEADS UP, IF YOU EDIT THIS FILE: toolport.app/install.sh redirects to a PINNED
+# COMMIT of this script, not to main, because it is piped into a shell and a movable
+# URL there means anything that lands on main runs on users' machines. A change here
+# does NOT reach that URL until INSTALL_SCRIPTS_REF in the site repo's
+# worker/index.js is moved to the commit containing it. Ship both, or the fix you
+# just made will not reach anyone using the short URL.
 #
 # Installs the latest signed release for your OS/arch:
 #   - Linux (x86_64): the .deb via apt where available, else the portable AppImage


### PR DESCRIPTION
Windows had the worst install story of the three platforms: a 76-character `raw.githubusercontent` URL, or a trip to the Releases page. This fixes both halves.

```powershell
winget install Toolport.Toolport
irm https://toolport.app/install.ps1 | iex
```

```sh
curl -fsSL https://toolport.app/install.sh | bash
```

## Short URLs

No DNS record was needed. The apex already resolves to the site Worker, and `/install.ps1` was a 404, so this is one route: tsouth89/toolport-site#44, already merged and live. Verified in production that `/install.ps1` and `/install.sh` 302 to the pinned commit with `cache-control: no-store`, that `/install`, `/INSTALL.PS1` and traversal still 404, that `POST` returns 405 with `Allow: GET, HEAD`, and that following the redirect returns this repo's script byte-for-byte as `text/plain`.

**They point at a pinned commit, not `main`.** These URLs are piped into a shell, so whoever controls the content controls what runs on a user's machine, and `main` changes on every merge. A commit SHA cannot be repointed, so changing what those users execute takes a reviewed change in both repos.

That coupling cuts the other way, and silently: a fix to `install.ps1` here would not reach the short URL. So both scripts now open with a header saying exactly that, and `RELEASING.md` step 1 repeats it. That is the failure mode most likely to bite months from now.

## winget

`packaging/winget` holds the three manifests, `winget validate` passes, and they are submitted upstream as microsoft/winget-pkgs#417106.

- `Toolport.Toolport`, per your choice of a brand-first identifier.
- `Scope: user`, because the Tauri NSIS bundle installs per-user with the uninstall entry under `HKCU`. Getting this wrong makes winget attempt a machine-wide install and mis-detect the installed version on upgrade.
- `ProductCode` and `AppsAndFeaturesEntries` keyed to the `Toolport` uninstall registry key, since NSIS has no MSI ProductCode. This is what lets `winget upgrade` correlate an already-installed copy.
- Installer SHA-256 taken from the published v1.13.0 asset, whose signature I confirmed as `Valid` (`CN=Brandon South`, Azure Trusted Signing).

`.github/workflows/winget.yml` keeps it current on each release:

- Runs on `released`, not on the tag. winget validation downloads the installer URL, which 404s while the release is still a draft, and publishing is the first moment the asset is fetchable.
- `HEAD`s that URL before touching winget-pkgs, so a filename change in `release.yml` fails loudly here rather than as a rejected upstream PR days later.
- Uses Microsoft's own `wingetcreate` rather than a third-party action, keeping a workflow that holds a push token free of third-party code.
- No-ops with a warning until `WINGET_TOKEN` exists, so merging this cannot fail a release.

**Needs from you:** a `WINGET_TOKEN` repo secret (PAT with `public_repo`) for the automation. Without it, releases still work and just log a warning.

## Context worth recording

While testing, Windows Defender flagged `Trojan:Win32/ClickFix.FFQ!MTB` on a shell command of mine that merely *contained* the `irm ... | iex` text inside a PR body. Nothing was downloaded or executed and no file was touched, but it is a reminder that this pattern is exactly what ClickFix detection targets, and Microsoft is tightening on it. That is the strongest argument for winget being the primary Windows path and the one-liner the fallback, which is the order the README now lists them in.

## Verification

316 tests, `winget validate`, `format:check`, YAML parse of the new workflow, and the live production checks listed above.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add short install URLs via toolport.app and a winget package for Windows
> - Replaces raw GitHub URLs in README install instructions with short `https://toolport.app/install.sh` and `https://toolport.app/install.ps1` redirects, which pin to a specific commit via `INSTALL_SCRIPTS_REF` in the site repo.
> - Adds winget manifests under [`packaging/winget/`](https://github.com/tsouth89/toolport/pull/712/files#diff-97778c999b3fa8c8668e6bc0b2d216df3c2cf28327b40ec08d5b683a8e36a521) for `Toolport.Toolport` version 1.13.0 and a `winget install Toolport.Toolport` example to the README.
> - Adds a [`.github/workflows/winget.yml`](https://github.com/tsouth89/toolport/pull/712/files#diff-3dff7c7e5f08f6f3163d130bec2c030f16b50bddf8d11a6b1d930592d7bd2434) workflow that, on non-prerelease GitHub releases, validates the installer asset and submits an updated manifest to `microsoft/winget-pkgs` via `wingetcreate` when `WINGET_TOKEN` is set.
> - Updates [`docs/RELEASING.md`](https://github.com/tsouth89/toolport/pull/712/files#diff-8936340d2e7844f9c8b77f67065f4e0c66c738ea4dd3844727002289f6d381cb) with guidance on updating install scripts, moving `INSTALL_SCRIPTS_REF`, and manual winget submission steps.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 07ff7f1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->