### PR TITLE
fix: stop Teams bearer redirects and enforce team-server review

### DIFF
--- a/src-tauri/src/catalog.rs
+++ b/src-tauri/src/catalog.rs
@@ -372,6 +372,51 @@ fn is_remote_package_spec(spec: &str) -> bool {
         || lower.starts_with("https:")
 }
 
+/// npm-only: specs that make `npx -y` fetch code from somewhere other than the named
+/// registry, in the spellings npm accepts BEYOND a leading protocol.
+///
+/// [`is_remote_package_spec`] only inspects the start of the combined
+/// `identifier@version` string, so every form here reached `npx -y` from a malicious or
+/// MITM'd registry entry: `attacker/payload` (npm reads an unscoped slash name as
+/// GitHub shorthand), `lodash@github:attacker/payload` (a hosted-git alias as the
+/// version range), `github.com/attacker/payload`, and `git@github.com:attacker/x.git`.
+///
+/// Applied on the npm path only. `user/image:tag` is a normal Docker reference, so the
+/// slash rule cannot be global without dropping valid OCI entries.
+fn npm_spec_escapes_registry(spec: &str) -> bool {
+    let lower = spec.to_ascii_lowercase();
+    // SCP-style git, which carries no `://` for is_remote_package_spec to catch.
+    if lower.starts_with("git@") {
+        return true;
+    }
+    // A hosted-git alias ANYWHERE, not just as a prefix: npm resolves it from the
+    // version half too.
+    if ["github:", "gitlab:", "bitbucket:", "gist:", "git+"]
+        .iter()
+        .any(|alias| lower.contains(alias))
+    {
+        return true;
+    }
+    // Hosted URLs with the scheme left off.
+    if ["github.com/", "gitlab.com/", "bitbucket.org/"]
+        .iter()
+        .any(|host| lower.starts_with(host) || lower.contains(&format!("@{host}")))
+    {
+        return true;
+    }
+    // An unscoped `user/repo` is GitHub shorthand to npm, while `@scope/name` is a
+    // real package. Judge the NAME half: a scoped name's own `@` must not be mistaken
+    // for the version separator.
+    let name = match lower.strip_prefix('@') {
+        Some(rest) => match rest.find('@') {
+            Some(i) => &lower[..=i],
+            None => lower.as_str(),
+        },
+        None => lower.split('@').next().unwrap_or(&lower),
+    };
+    !name.starts_with('@') && name.contains('/')
+}
+
 /// A registry package spec safe to pass as an npx/uvx/docker argument: non-empty, no
 /// leading dash (flag injection), bounded length, and only the characters real
 /// package names use. Nothing that could become a separate flag, a shell token,
@@ -488,7 +533,15 @@ fn map_server(server: &Value) -> Option<CatalogEntry> {
                     spec,
                 ],
             ),
-            _ => ("npx".to_string(), vec!["-y".to_string(), spec]),
+            _ => {
+                // npm-only, and deliberately here rather than in is_safe_package_id:
+                // `user/image:tag` is an ordinary Docker reference, so the slash rule
+                // below would drop legitimate OCI entries if applied globally.
+                if npm_spec_escapes_registry(&spec) {
+                    return None;
+                }
+                ("npx".to_string(), vec!["-y".to_string(), spec])
+            }
         };
         let env_keys = pkg
             .get("environmentVariables")
@@ -822,6 +875,58 @@ mod tests {
                 "{registry_type}: empty identifier must be dropped"
             );
         }
+    }
+
+    /// npm accepts several spellings of "fetch this from a git host" that carry no
+    /// `://` and no leading alias, so a prefix-only check let a malicious or MITM'd
+    /// registry entry one-click-install code from outside the named registry.
+    #[test]
+    fn map_server_rejects_npm_specs_that_escape_the_registry() {
+        let npm = |identifier: &str, version: Option<&str>| {
+            let mut pkg = json!({ "registryType": "npm", "identifier": identifier });
+            if let Some(v) = version {
+                pkg["version"] = json!(v);
+            }
+            json!({ "name": "io.x/y", "title": "Y", "packages": [pkg] })
+        };
+        for (identifier, version) in [
+            // Unscoped slash name: GitHub shorthand to npm.
+            ("attacker/payload", None),
+            // Hosted-git alias smuggled in as the version range.
+            ("lodash", Some("github:attacker/payload")),
+            ("lodash", Some("gitlab:attacker/payload")),
+            // Hosted URL with the scheme left off.
+            ("github.com/attacker/payload", None),
+            // SCP-style git, which has no `://` to catch.
+            ("git@github.com:attacker/payload.git", None),
+        ] {
+            assert!(
+                map_server(&npm(identifier, version)).is_none(),
+                "npm spec {identifier}@{version:?} must not reach npx -y"
+            );
+        }
+
+        // Real npm packages still install, including scoped names whose own `@` must
+        // not be read as the version separator.
+        for (identifier, version) in [
+            ("@scope/name", None),
+            ("@scope/name", Some("1.2.3")),
+            ("express", Some("4.18.0")),
+        ] {
+            let entry = map_server(&npm(identifier, version));
+            assert!(
+                entry.is_some(),
+                "npm spec {identifier}@{version:?} is legitimate and must still map"
+            );
+        }
+
+        // The slash rule is npm-only: a Docker reference is not GitHub shorthand.
+        let docker = json!({ "name": "io.x/d", "title": "D", "packages": [
+            { "registryType": "oci", "identifier": "user/image", "version": "tag" }] });
+        assert!(
+            map_server(&docker).is_some(),
+            "a docker user/image:tag reference must still map"
+        );
     }
 
     #[test]

--- a/src-tauri/src/catalog.rs
+++ b/src-tauri/src/catalog.rs
@@ -355,11 +355,27 @@ pub fn search(query: &str) -> Result<Vec<CatalogEntry>, String> {
     Ok(out)
 }
 
-/// Turn one registry `server` object into a catalog entry. Prefers a hosted
-/// remote (simplest to connect), else the first installable package.
+/// npm/yarn/pnpm remote specs that `npx -y` will fetch outside the registry.
+/// `:` itself stays allowed so docker `host:port/image` and OCI `image:tag` work.
+fn is_remote_package_spec(spec: &str) -> bool {
+    let lower = spec.to_ascii_lowercase();
+    lower.contains("://")
+        || lower.starts_with("github:")
+        || lower.starts_with("gitlab:")
+        || lower.starts_with("bitbucket:")
+        || lower.starts_with("gist:")
+        || lower.starts_with("git+")
+        || lower.starts_with("npm:")
+        || lower.starts_with("jsr:")
+        || lower.starts_with("file:")
+        || lower.starts_with("http:")
+        || lower.starts_with("https:")
+}
+
 /// A registry package spec safe to pass as an npx/uvx/docker argument: non-empty, no
 /// leading dash (flag injection), bounded length, and only the characters real
-/// package names use. Nothing that could become a separate flag or a shell token.
+/// package names use. Nothing that could become a separate flag, a shell token,
+/// or a github:/URL install that bypasses the named registry.
 fn is_safe_package_id(spec: &str) -> bool {
     !spec.is_empty()
         && !spec.starts_with('-')
@@ -367,8 +383,11 @@ fn is_safe_package_id(spec: &str) -> bool {
         && spec.chars().all(|c| {
             c.is_ascii_alphanumeric() || matches!(c, '@' | '/' | '-' | '_' | '.' | '+' | ':')
         })
+        && !is_remote_package_spec(spec)
 }
 
+/// Turn one registry `server` object into a catalog entry. Prefers a hosted
+/// remote (simplest to connect), else the first installable package.
 fn map_server(server: &Value) -> Option<CatalogEntry> {
     let id = server.get("name").and_then(|v| v.as_str()).unwrap_or("");
     // Friendly title when present; fall back to the namespaced id.
@@ -836,6 +855,22 @@ mod tests {
             map_server(&scheme).is_none(),
             "non-http remote must be dropped"
         );
+        // github:/URL/git+ specs would make npx fetch outside npm. Colon stays
+        // allowed for docker host:port and OCI tags (see maps_container_packages).
+        for identifier in [
+            "github:attacker/payload",
+            "https://evil.example/pkg.tgz",
+            "http://evil.example/pkg.tgz",
+            "git+https://github.com/attacker/payload.git",
+            "npm:evil",
+        ] {
+            let remote = json!({ "name": "io.x/r", "title": "R",
+                "packages": [{ "registryType": "npm", "identifier": identifier }] });
+            assert!(
+                map_server(&remote).is_none(),
+                "{identifier}: remote package spec must be dropped"
+            );
+        }
     }
 
     // Self-hosted catalog coverage (url_hint / setup_hint invariants), contributed by

--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -740,13 +740,35 @@ fn remove_server(state: State<RegistryState>, id: String) -> Result<Registry, St
     Ok(reg)
 }
 
+/// `reviewed` is the caller asserting the member saw the Teams review dialog for
+/// THIS definition. It defaults to false, which is the point: `set_all_enabled`
+/// already filters these out (`Registry::set_all_enabled`), but this single-server
+/// path had no gate at all, so the renderer's `needsTeamEnableReview` was the only
+/// thing standing between a team-pushed local command and a running process. That
+/// check cannot resolve DNS, so it missed a LAN URL written as a hostname, and any
+/// future caller of this command would have inherited the same hole. Deciding it
+/// here means the frontend heuristic is now an affordance rather than the boundary.
 #[tauri::command]
 fn set_server_enabled(
     state: State<RegistryState>,
     profile_id: String,
     server_id: String,
     enabled: bool,
+    reviewed: Option<bool>,
 ) -> Result<Registry, String> {
+    if enabled && !reviewed.unwrap_or(false) {
+        let reg = state.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+        if reg
+            .servers
+            .iter()
+            .any(|s| s.id == server_id && s.needs_team_enable_review())
+        {
+            return Err(
+                "this team server runs a local command or private address; enable it from Teams after review"
+                    .into(),
+            );
+        }
+    }
     let (reg, _) = write_registry(state.inner(), |reg| {
         reg.set_server_enabled(&profile_id, &server_id, enabled)
     })?;

--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -697,6 +697,9 @@ fn add_server(state: State<RegistryState>, entry: ServerEntry) -> Result<Registr
 /// then the package is already in the launcher's cache, which is the whole point.
 /// The connect result is deliberately ignored; the real probe reports health.
 fn prewarm_launcher(server: &ServerEntry) {
+    if server.needs_team_enable_review() {
+        return;
+    }
     let Some(command) = server.command.clone() else {
         return;
     };
@@ -1583,13 +1586,26 @@ async fn probe_servers(
 }
 
 /// Snapshot one server out of the registry by id (dropping the lock before I/O).
-fn server_by_id(state: &RegistryState, server_id: &str) -> Result<ServerEntry, String> {
+/// Playground connects must not spawn a team-review server the member has not
+/// enabled — the Teams confirm is otherwise frontend-only.
+fn playground_server(state: &RegistryState, server_id: &str) -> Result<ServerEntry, String> {
     let reg = state.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
-    reg.servers
+    let server = reg
+        .servers
         .iter()
         .find(|s| s.id == server_id)
         .cloned()
-        .ok_or_else(|| format!("server '{server_id}' not found"))
+        .ok_or_else(|| format!("server '{server_id}' not found"))?;
+    if server.needs_team_enable_review() {
+        let pid = reg.active_profile_id();
+        if !reg.is_enabled(&pid, &server.id) {
+            return Err(
+                "this team server runs a local command or private address; enable it from Teams after review"
+                    .into(),
+            );
+        }
+    }
+    Ok(server)
 }
 
 /// List the tools one server exposes (raw MCP tool objects: name, description,
@@ -1600,7 +1616,7 @@ async fn list_server_tools(
     state: State<'_, RegistryState>,
     server_id: String,
 ) -> Result<Vec<serde_json::Value>, String> {
-    let server = server_by_id(state.inner(), &server_id)?;
+    let server = playground_server(state.inner(), &server_id)?;
     tauri::async_runtime::spawn_blocking(move || connect_server(&server).map(|ds| ds.tools))
         .await
         .map_err(|e| e.to_string())?
@@ -1616,7 +1632,7 @@ async fn call_tool(
     tool: String,
     arguments: serde_json::Value,
 ) -> Result<serde_json::Value, String> {
-    let server = server_by_id(state.inner(), &server_id)?;
+    let server = playground_server(state.inner(), &server_id)?;
     tauri::async_runtime::spawn_blocking(move || {
         let mut ds = connect_server(&server)?;
         let started = std::time::Instant::now();
@@ -1648,7 +1664,7 @@ async fn list_server_resources(
     state: State<'_, RegistryState>,
     server_id: String,
 ) -> Result<Vec<serde_json::Value>, String> {
-    let server = server_by_id(state.inner(), &server_id)?;
+    let server = playground_server(state.inner(), &server_id)?;
     tauri::async_runtime::spawn_blocking(move || {
         connect_server(&server).map(|mut ds| {
             ds.load_resources_prompts();
@@ -1667,7 +1683,7 @@ async fn list_server_prompts(
     state: State<'_, RegistryState>,
     server_id: String,
 ) -> Result<Vec<serde_json::Value>, String> {
-    let server = server_by_id(state.inner(), &server_id)?;
+    let server = playground_server(state.inner(), &server_id)?;
     tauri::async_runtime::spawn_blocking(move || {
         connect_server(&server).map(|mut ds| {
             ds.load_resources_prompts();
@@ -1686,7 +1702,7 @@ async fn read_resource(
     server_id: String,
     uri: String,
 ) -> Result<serde_json::Value, String> {
-    let server = server_by_id(state.inner(), &server_id)?;
+    let server = playground_server(state.inner(), &server_id)?;
     tauri::async_runtime::spawn_blocking(move || {
         let mut ds = connect_server(&server)?;
         ds.read_resource(&uri).map_err(|e| e.to_string())
@@ -1704,7 +1720,7 @@ async fn get_prompt(
     name: String,
     arguments: serde_json::Value,
 ) -> Result<serde_json::Value, String> {
-    let server = server_by_id(state.inner(), &server_id)?;
+    let server = playground_server(state.inner(), &server_id)?;
     tauri::async_runtime::spawn_blocking(move || {
         let mut ds = connect_server(&server)?;
         ds.get_prompt(&name, arguments).map_err(|e| e.to_string())

--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -756,23 +756,38 @@ fn set_server_enabled(
     enabled: bool,
     reviewed: Option<bool>,
 ) -> Result<Registry, String> {
-    if enabled && !reviewed.unwrap_or(false) {
-        let reg = state.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
-        if reg
-            .servers
-            .iter()
-            .any(|s| s.id == server_id && s.needs_team_enable_review())
-        {
-            return Err(
-                "this team server runs a local command or private address; enable it from Teams after review"
-                    .into(),
-            );
-        }
-    }
+    let reviewed = reviewed.unwrap_or(false);
     let (reg, _) = write_registry(state.inner(), |reg| {
+        // Checked inside the write closure so it sees the registry that will be
+        // persisted: a team_sync_wait replace landing between a pre-lock check and
+        // this write could swap the entry for one that needs review.
+        refuse_unreviewed_team_enable(reg, &server_id, enabled, reviewed)?;
         reg.set_server_enabled(&profile_id, &server_id, enabled)
     })?;
     Ok(reg)
+}
+
+/// The gate half of `set_server_enabled`, split out so the write-closure behavior
+/// is unit-testable without a Tauri `State`.
+fn refuse_unreviewed_team_enable(
+    reg: &Registry,
+    server_id: &str,
+    enabled: bool,
+    reviewed: bool,
+) -> Result<(), String> {
+    if enabled
+        && !reviewed
+        && reg
+            .servers
+            .iter()
+            .any(|s| s.id == server_id && s.needs_team_enable_review())
+    {
+        return Err(
+            "this team server runs a local command or private address; enable it from Teams after review"
+                .into(),
+        );
+    }
+    Ok(())
 }
 
 #[tauri::command]
@@ -4701,6 +4716,23 @@ mod tests {
         );
         assert!(!r.ok);
         assert_eq!(r.server_id, "bogus");
+    }
+
+    #[test]
+    fn unreviewed_team_stdio_enable_is_refused_in_write_closure() {
+        let mut reg = Registry::default();
+        let mut s = plain_server("team-tool", "Team tool");
+        s.source = Some("team:acme".into());
+        reg.servers.push(s);
+
+        let err = refuse_unreviewed_team_enable(&reg, "team-tool", true, false)
+            .expect_err("stdio team server must not enable without review");
+        assert!(err.contains("enable it from Teams after review"), "{err}");
+        // The consent path (reviewed=true), disabling, and non-team servers pass.
+        assert!(refuse_unreviewed_team_enable(&reg, "team-tool", true, true).is_ok());
+        assert!(refuse_unreviewed_team_enable(&reg, "team-tool", false, false).is_ok());
+        reg.servers[0].source = None;
+        assert!(refuse_unreviewed_team_enable(&reg, "team-tool", true, false).is_ok());
     }
 
     fn plain_server(id: &str, name: &str) -> ServerEntry {

--- a/src-tauri/src/oauth.rs
+++ b/src-tauri/src/oauth.rs
@@ -428,13 +428,13 @@ fn screen_addrs(addrs: &[std::net::SocketAddr], block_private: bool) -> std::io:
         if ip_is_link_local(&sa.ip()) {
             return Err(std::io::Error::new(
                 std::io::ErrorKind::PermissionDenied,
-                format!("OAuth SSRF guard: refusing link-local / cloud-metadata address {}", sa.ip()),
+                format!("SSRF guard: refusing link-local / cloud-metadata address {}", sa.ip()),
             ));
         }
         if block_private && ip_is_private(&sa.ip()) {
             return Err(std::io::Error::new(
                 std::io::ErrorKind::PermissionDenied,
-                format!("OAuth SSRF guard: refusing private/loopback address {} for a public server", sa.ip()),
+                format!("SSRF guard: refusing private/loopback address {} for a public server", sa.ip()),
             ));
         }
     }
@@ -449,7 +449,7 @@ fn screen_addrs(addrs: &[std::net::SocketAddr], block_private: bool) -> std::io:
 /// that rebinds public->private between the pre-check and the connect is still refused here.
 /// The OAuth endpoints come from an attacker-influenceable metadata document, so this is the
 /// load-bearing SSRF guard.
-fn screened_resolve(netloc: &str, block_private: bool) -> std::io::Result<Vec<std::net::SocketAddr>> {
+pub(crate) fn screened_resolve(netloc: &str, block_private: bool) -> std::io::Result<Vec<std::net::SocketAddr>> {
     use std::net::ToSocketAddrs;
     let addrs: Vec<std::net::SocketAddr> = netloc.to_socket_addrs()?.collect();
     screen_addrs(&addrs, block_private)?;

--- a/src-tauri/src/registry.rs
+++ b/src-tauri/src/registry.rs
@@ -137,6 +137,26 @@ pub struct ServerEntry {
     pub unknown_fields: serde_json::Map<String, serde_json::Value>,
 }
 
+impl ServerEntry {
+    /// Team-synced local commands and LAN URLs stay off until the member enables
+    /// them after review. Enable-all and the playground must not skip that gate.
+    pub fn needs_team_enable_review(&self) -> bool {
+        let Some(src) = self.source.as_deref() else {
+            return false;
+        };
+        if !src.starts_with("team:") {
+            return false;
+        }
+        if self.transport == "stdio" || self.command.is_some() {
+            return true;
+        }
+        match self.url.as_deref().and_then(crate::oauth::host_of_url) {
+            Some(host) => crate::oauth::host_is_private(&host),
+            None => false,
+        }
+    }
+}
+
 /// Non-secret configuration for the OAuth client-credentials flow (SBS-524).
 ///
 /// Deliberately holds no secret. The client secret lives in the OS vault under
@@ -1199,14 +1219,34 @@ impl Registry {
     }
 
     /// Enable or disable every server in a profile at once.
+    ///
+    /// Enabling skips team-review servers (local command / LAN URL). Those stay
+    /// as they were so Enable all cannot bypass the Teams confirm, and so a
+    /// server the member already consented to is not wiped.
     pub fn set_all_enabled(&mut self, profile_id: &str, enabled: bool) -> Result<(), String> {
-        let ids: Vec<String> = self.servers.iter().map(|s| s.id.clone()).collect();
+        let ids: Vec<String> = if enabled {
+            self.servers
+                .iter()
+                .filter(|s| !s.needs_team_enable_review())
+                .map(|s| s.id.clone())
+                .collect()
+        } else {
+            Vec::new()
+        };
         let profile = self
             .profiles
             .iter_mut()
             .find(|p| p.id == profile_id)
             .ok_or_else(|| format!("No profile with id '{profile_id}'"))?;
-        profile.enabled_server_ids = if enabled { ids } else { Vec::new() };
+        if enabled {
+            for id in ids {
+                if !profile.enabled_server_ids.contains(&id) {
+                    profile.enabled_server_ids.push(id);
+                }
+            }
+        } else {
+            profile.enabled_server_ids = Vec::new();
+        }
         Ok(())
     }
 
@@ -2753,6 +2793,49 @@ mod tests {
         assert_eq!(r.enabled_servers().len(), 1);
         r.set_server_enabled(&profile, &id, false).unwrap();
         assert!(r.enabled_servers().is_empty());
+    }
+
+    #[test]
+    fn set_all_enabled_skips_unreviewed_team_servers() {
+        let mut r = Registry::default();
+        let own = r.add_server(sample_server("github"));
+        let mut team_cmd = sample_server("team-npx");
+        team_cmd.source = Some("team:t1".into());
+        let team_cmd_id = r.add_server(team_cmd);
+        let mut team_lan = sample_server("team-lan");
+        team_lan.transport = "http".into();
+        team_lan.command = None;
+        team_lan.args = vec![];
+        team_lan.url = Some("http://10.0.0.5:8080/mcp".into());
+        team_lan.source = Some("team:t1".into());
+        let team_lan_id = r.add_server(team_lan);
+        let mut team_public = sample_server("team-public");
+        team_public.transport = "http".into();
+        team_public.command = None;
+        team_public.args = vec![];
+        team_public.url = Some("https://1.2.3.4/mcp".into());
+        team_public.source = Some("team:t1".into());
+        let team_public_id = r.add_server(team_public);
+
+        r.set_all_enabled("default", true).unwrap();
+        assert!(r.is_enabled("default", &own));
+        assert!(r.is_enabled("default", &team_public_id));
+        assert!(
+            !r.is_enabled("default", &team_cmd_id),
+            "team stdio stays off until explicit enable"
+        );
+        assert!(
+            !r.is_enabled("default", &team_lan_id),
+            "team LAN URL stays off until explicit enable"
+        );
+
+        r.set_server_enabled("default", &team_cmd_id, true).unwrap();
+        r.set_all_enabled("default", true).unwrap();
+        assert!(
+            r.is_enabled("default", &team_cmd_id),
+            "consented review server stays on"
+        );
+        assert!(!r.is_enabled("default", &team_lan_id));
     }
 
     #[test]

--- a/src-tauri/src/teams.rs
+++ b/src-tauri/src/teams.rs
@@ -108,8 +108,10 @@ fn agent_with_timeout(server_url: &str, secs: u64) -> ureq::Agent {
 /// anything, so the caller persisted a receipt and suppressed the retry, and
 /// `post_call_events` advanced its cursor past events that were never sent. Silent
 /// data loss, not just a missed hop.
+/// 305/306 are deprecated but still 3xx-with-Location; 304 stays out because it
+/// carries no Location and means "unchanged", not "go elsewhere".
 fn is_redirect_status(status: u16) -> bool {
-    matches!(status, 300 | 301 | 302 | 303 | 307 | 308)
+    matches!(status, 300 | 301 | 302 | 303 | 305 | 306 | 307 | 308)
 }
 
 /// ureq with `redirects(0)` returns 3xx as a successful response. Treat those as
@@ -2770,7 +2772,7 @@ mod tests {
 
     #[test]
     fn redirect_statuses_are_refused() {
-        for status in [301u16, 302, 303, 307, 308] {
+        for status in [300u16, 301, 302, 303, 305, 306, 307, 308] {
             assert!(is_redirect_status(status), "{status} must be a redirect");
         }
         for status in [200u16, 204, 304, 400, 401, 404] {

--- a/src-tauri/src/teams.rs
+++ b/src-tauri/src/teams.rs
@@ -64,20 +64,48 @@ fn require_secure_team_url(server_url: &str) -> Result<(), String> {
     }
 }
 
+/// Public team hosts must not rebind onto the LAN; loopback/LAN team URLs (local
+/// `conduit-teams`) still connect. Link-local / cloud-metadata is always refused
+/// inside [`crate::oauth::screened_resolve`].
+fn block_private_for_team_url(server_url: &str) -> bool {
+    let host = crate::oauth::host_of_url(server_url).unwrap_or_default();
+    !crate::oauth::host_is_private(&host)
+}
+
 /// A ureq agent with a connect + read timeout. The team commands run on the Tauri
 /// command thread, so a slow or black-holed team server must not hang the UI: bare
 /// `ureq::get/post/put` have no timeout, this does.
-fn agent() -> ureq::Agent {
-    agent_with_timeout(30)
+///
+/// Redirects are refused: a 302 would replay `Authorization: Bearer` to a host of
+/// the redirector's choosing (the same control OAuth token POSTs and MCP HTTP use).
+fn agent(server_url: &str) -> ureq::Agent {
+    agent_with_timeout(server_url, 30)
 }
 
 /// A ureq agent with an explicit total timeout. A long-poll config pull needs a client
 /// timeout comfortably above the server's `wait` window, so the server (not the client)
 /// decides when to return.
-fn agent_with_timeout(secs: u64) -> ureq::Agent {
+fn agent_with_timeout(server_url: &str, secs: u64) -> ureq::Agent {
+    let block_private = block_private_for_team_url(server_url);
     ureq::AgentBuilder::new()
         .timeout(std::time::Duration::from_secs(secs))
+        .redirects(0)
+        .resolver(move |netloc: &str| crate::oauth::screened_resolve(netloc, block_private))
         .build()
+}
+
+fn is_redirect_status(status: u16) -> bool {
+    matches!(status, 301 | 302 | 303 | 307 | 308)
+}
+
+/// ureq with `redirects(0)` returns 3xx as a successful response. Treat those as
+/// errors so a team API never follows (or silently accepts) a bearer-bearing hop.
+fn require_no_redirect(resp: ureq::Response) -> Result<ureq::Response, String> {
+    if is_redirect_status(resp.status()) {
+        Err("team server redirected; Toolport does not follow redirects on team API calls".into())
+    } else {
+        Ok(resp)
+    }
 }
 
 // --- HTTP client (ureq) ---
@@ -118,7 +146,7 @@ pub fn join(server_url: &str, invite_code: &str, member_name: Option<&str>) -> R
     require_secure_team_url(server_url)?;
     let url = format!("{}/join", base(server_url));
     let body = serde_json::json!({ "invite_code": invite_code, "member_name": member_name });
-    let resp = agent().post(&url).send_json(body).map_err(stringify)?;
+    let resp = require_no_redirect(agent(server_url).post(&url).send_json(body).map_err(stringify)?)?;
     let v: Value = resp.into_json().map_err(|e| e.to_string())?;
     // An approval-gated link hands back a request token instead of a member token.
     if v["pending"].as_bool().unwrap_or(false) {
@@ -153,7 +181,7 @@ pub fn poll_join(
     require_secure_team_url(server_url)?;
     let url = format!("{}/join/status", base(server_url));
     let body = serde_json::json!({ "request_token": request_token });
-    let resp = agent().post(&url).send_json(body).map_err(stringify)?;
+    let resp = require_no_redirect(agent(server_url).post(&url).send_json(body).map_err(stringify)?)?;
     let v: Value = resp.into_json().map_err(|e| e.to_string())?;
     match v["status"].as_str().unwrap_or("") {
         "approved" => complete_join(server_url, member_name, joined_from(&v)?).map(JoinPoll::Connected),
@@ -181,9 +209,9 @@ pub fn pull_config(
     // when to return; a 304/200 the moment something changes.
     let ag = if wait_secs > 0 {
         url.push_str(&format!("?wait={wait_secs}"));
-        agent_with_timeout(wait_secs + 10)
+        agent_with_timeout(server_url, wait_secs + 10)
     } else {
-        agent()
+        agent(server_url)
     };
     // Echo the exact ETag the server last gave us. A restricted member's ETag carries a
     // per-member access suffix ("v{n}-m{hash}"), so a reconstructed "v{n}" would never
@@ -200,6 +228,7 @@ pub fn pull_config(
             if resp.status() == 304 {
                 return Ok(None);
             }
+            let resp = require_no_redirect(resp)?;
             // Capture the fresh ETag before the body consumes `resp`.
             let new_etag = resp.header("etag").map(str::to_string);
             let v: Value = resp.into_json().map_err(|e| e.to_string())?;
@@ -249,12 +278,13 @@ pub enum MembershipCheck {
 pub fn fetch_me(server_url: &str, team_id: &str, token: &str) -> Result<MembershipCheck, String> {
     require_secure_team_url(server_url)?;
     let url = format!("{}/teams/{}/me", base(server_url), team_id);
-    match agent()
+    match agent(server_url)
         .get(&url)
         .set("authorization", &format!("Bearer {token}"))
         .call()
     {
         Ok(resp) => {
+            let resp = require_no_redirect(resp)?;
             let v: Value = resp.into_json().map_err(|e| e.to_string())?;
             // Fail noisily on a malformed 200 rather than defaulting to "member": a
             // silent default would demote an admin's persisted role on a buggy response.
@@ -285,12 +315,13 @@ fn fetch_config_for_update(
 ) -> Result<(i64, Value), String> {
     require_secure_team_url(server_url)?;
     let url = format!("{}/teams/{}/config", base(server_url), team_id);
-    match agent()
+    match agent(server_url)
         .get(&url)
         .set("authorization", &format!("Bearer {token}"))
         .call()
     {
         Ok(resp) => {
+            let resp = require_no_redirect(resp)?;
             let v: Value = resp.into_json().map_err(|e| e.to_string())?;
             let version = v["version"]
                 .as_i64()
@@ -423,12 +454,12 @@ pub fn push_config(
     require_secure_team_url(server_url)?;
     let url = format!("{}/teams/{}/config", base(server_url), team_id);
     let body = push_body(config, base_version);
-    let resp = match agent()
+    let resp = match agent(server_url)
         .put(&url)
         .set("authorization", &format!("Bearer {token}"))
         .send_json(body)
     {
-        Ok(resp) => resp,
+        Ok(resp) => require_no_redirect(resp)?,
         Err(e @ ureq::Error::Status(status, _)) => {
             if let Some(message) = push_status_message(status) {
                 return Err(message.into());
@@ -469,12 +500,15 @@ fn post_usage_day(
     if let Some(status) = policy_status {
         body["policyStatus"] = status.clone();
     }
-    match agent()
+    match agent(server_url)
         .post(&url)
         .set("authorization", &format!("Bearer {token}"))
         .send_json(body)
     {
-        Ok(_) => Ok(true),
+        Ok(resp) => {
+            require_no_redirect(resp)?;
+            Ok(true)
+        }
         Err(ureq::Error::Status(404 | 405, _)) => Ok(false),
         Err(e) => Err(stringify(e)),
     }
@@ -1172,12 +1206,15 @@ fn post_call_events(
     require_secure_team_url(server_url)?;
     let url = format!("{}/teams/{}/call-events", base(server_url), team_id);
     let body = json!({ "events": events });
-    match agent()
+    match agent(server_url)
         .post(&url)
         .set("authorization", &format!("Bearer {token}"))
         .send_json(body)
     {
-        Ok(_) => Ok(true),
+        Ok(resp) => {
+            require_no_redirect(resp)?;
+            Ok(true)
+        }
         Err(ureq::Error::Status(404 | 405, _)) => Ok(false),
         Err(e) => Err(stringify(e)),
     }
@@ -2691,6 +2728,27 @@ mod tests {
         assert!(require_secure_team_url("http://192.168.1.10:8787").is_err());
         assert!(require_secure_team_url("http://teams.example.com").is_err());
         assert!(require_secure_team_url("teams.example.com").is_err());
+    }
+
+    #[test]
+    fn public_team_url_blocks_private_redirect_targets() {
+        // Literal public IPs so this does not depend on DNS (host_is_private
+        // fails closed on NXDOMAIN, which would invert the flag).
+        assert!(block_private_for_team_url("https://1.2.3.4"));
+        assert!(block_private_for_team_url("https://8.8.8.8"));
+        assert!(!block_private_for_team_url("http://127.0.0.1:8787"));
+        assert!(!block_private_for_team_url("http://localhost:8787"));
+        assert!(!block_private_for_team_url("http://[::1]:8787"));
+    }
+
+    #[test]
+    fn redirect_statuses_are_refused() {
+        for status in [301u16, 302, 303, 307, 308] {
+            assert!(is_redirect_status(status), "{status} must be a redirect");
+        }
+        for status in [200u16, 204, 304, 400, 401, 404] {
+            assert!(!is_redirect_status(status), "{status} must not be treated as a redirect");
+        }
     }
 
     #[test]

--- a/src-tauri/src/teams.rs
+++ b/src-tauri/src/teams.rs
@@ -67,9 +67,18 @@ fn require_secure_team_url(server_url: &str) -> Result<(), String> {
 /// Public team hosts must not rebind onto the LAN; loopback/LAN team URLs (local
 /// `conduit-teams`) still connect. Link-local / cloud-metadata is always refused
 /// inside [`crate::oauth::screened_resolve`].
+///
+/// Switching the rebind guard OFF is granting LAN trust, so it needs
+/// [`crate::oauth::host_is_definitely_private`], not the negation of
+/// [`crate::oauth::host_is_private`]. That is the issue #422 inversion `oauth.rs`
+/// documents: `host_is_private` fails CLOSED, returning true for an empty,
+/// unresolvable, or mixed-answer host, which is correct for refusing and backwards
+/// for granting. Negated, an attacker serving NXDOMAIN for their own name - or a
+/// public name whose first lookup merely fails - turned the guard off and let the
+/// connection land on RFC1918.
 fn block_private_for_team_url(server_url: &str) -> bool {
     let host = crate::oauth::host_of_url(server_url).unwrap_or_default();
-    !crate::oauth::host_is_private(&host)
+    !crate::oauth::host_is_definitely_private(&host)
 }
 
 /// A ureq agent with a connect + read timeout. The team commands run on the Tauri
@@ -2732,13 +2741,26 @@ mod tests {
 
     #[test]
     fn public_team_url_blocks_private_redirect_targets() {
-        // Literal public IPs so this does not depend on DNS (host_is_private
-        // fails closed on NXDOMAIN, which would invert the flag).
         assert!(block_private_for_team_url("https://1.2.3.4"));
         assert!(block_private_for_team_url("https://8.8.8.8"));
         assert!(!block_private_for_team_url("http://127.0.0.1:8787"));
         assert!(!block_private_for_team_url("http://localhost:8787"));
         assert!(!block_private_for_team_url("http://[::1]:8787"));
+    }
+
+    /// Issue #422, on the team path: switching the rebind guard off is GRANTING LAN
+    /// trust, so it needs positive confirmation. Under `!host_is_private` an
+    /// unresolvable host came back "private" (that function fails closed, which is
+    /// correct for refusing), the flag inverted, and the guard turned itself off for
+    /// exactly the host an attacker controls the DNS for.
+    #[test]
+    fn an_unresolvable_team_host_still_blocks_private_targets() {
+        // `.invalid` is reserved never to resolve (RFC 2606), so this is the NXDOMAIN
+        // case with no network dependency.
+        assert!(block_private_for_team_url("https://no-such-host-422.invalid"));
+        // An empty or unparseable host must not grant LAN trust either.
+        assert!(block_private_for_team_url("https://"));
+        assert!(block_private_for_team_url("not a url"));
     }
 
     #[test]

--- a/src-tauri/src/teams.rs
+++ b/src-tauri/src/teams.rs
@@ -103,8 +103,13 @@ fn agent_with_timeout(server_url: &str, secs: u64) -> ureq::Agent {
         .build()
 }
 
+/// `300 Multiple Choices` is a redirect too, and excluding it made it read as
+/// SUCCESS: `post_usage_day` returned `Ok(true)` without the server having recorded
+/// anything, so the caller persisted a receipt and suppressed the retry, and
+/// `post_call_events` advanced its cursor past events that were never sent. Silent
+/// data loss, not just a missed hop.
 fn is_redirect_status(status: u16) -> bool {
-    matches!(status, 301 | 302 | 303 | 307 | 308)
+    matches!(status, 300 | 301 | 302 | 303 | 307 | 308)
 }
 
 /// ureq with `redirects(0)` returns 3xx as a successful response. Treat those as

--- a/src/App.teamEnableReview.test.tsx
+++ b/src/App.teamEnableReview.test.tsx
@@ -1,0 +1,129 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { act, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import App from "./App";
+import type { Registry } from "@/lib/types";
+
+const getRegistry = vi.fn();
+const detectClients = vi.fn();
+const takeRegistryRecoveryNotice = vi.fn();
+const setServerEnabled = vi.fn();
+const teamSyncWait = vi.fn();
+
+vi.mock("@/lib/api", () => ({
+  addServer: vi.fn(),
+  detectClients: (...a: unknown[]) => detectClients(...a),
+  getRegistry: (...a: unknown[]) => getRegistry(...a),
+  importServers: vi.fn(),
+  mainWindowVisible: vi.fn(() => Promise.resolve(true)),
+  parseServerSnippet: vi.fn(),
+  previewImportServers: vi.fn(),
+  probeServers: vi.fn(() => Promise.resolve([])),
+  removeServer: vi.fn(),
+  setAllEnabled: vi.fn(),
+  setSecret: vi.fn(),
+  setServerEnabled: (...a: unknown[]) => setServerEnabled(...a),
+  takeRegistryRecoveryNotice: (...a: unknown[]) => takeRegistryRecoveryNotice(...a),
+  teamSyncWait: (...a: unknown[]) => teamSyncWait(...a),
+  testServer: vi.fn(),
+  updateServer: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: vi.fn(() => Promise.resolve(() => {})),
+}));
+
+vi.mock("@/lib/trayApprovals", () => ({
+  subscribeToTrayApprovals: vi.fn(() => Promise.resolve(() => {})),
+}));
+
+vi.mock("@/lib/theme", () => ({
+  useTheme: () => ({ resolved: "light" }),
+}));
+
+vi.mock("@/components/AppSidebar", () => ({ AppSidebar: () => null }));
+vi.mock("@/components/PendingApprovals", () => ({ PendingApprovals: () => null }));
+vi.mock("@/components/QuarantineAlert", () => ({ QuarantineAlert: () => null }));
+
+function registryWith(args: string[]): Registry {
+  return {
+    version: 1,
+    servers: [
+      {
+        id: "team-tool",
+        name: "Team tool",
+        transport: "stdio",
+        command: "npx",
+        args,
+        env: [],
+        url: null,
+        source: "team:team-1",
+      },
+    ],
+    profiles: [{ id: "default", name: "Default", enabledServerIds: [] }],
+    activeProfileId: "default",
+    team: {
+      serverUrl: "https://teams.toolport.app",
+      teamId: "team-1",
+      role: "member",
+      lastVersion: 1,
+    },
+  } as Registry;
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  localStorage.clear();
+  getRegistry.mockResolvedValue(registryWith(["-y", "old-tool"]));
+  detectClients.mockResolvedValue([]);
+  takeRegistryRecoveryNotice.mockResolvedValue(null);
+});
+
+describe("team enable review dialog", () => {
+  // CodeRev on SBS-786: a team push landing while the confirm is open swaps the
+  // definition. The handler re-opens review on the live entry, but a normal
+  // return let ConfirmDialog close and null it out, so the promised in-place
+  // re-review never appeared. The handler must reject to hold the dialog open.
+  it(
+    "stays open showing the new command when the definition changes mid-review",
+    { timeout: 20000 },
+    async () => {
+      const sync = deferred<Registry>();
+      // First long-poll delivers the mutated registry when we choose; later polls park.
+      teamSyncWait
+        .mockReturnValueOnce(sync.promise)
+        .mockReturnValue(new Promise(() => {}));
+
+      render(<App />);
+      // The (only) server is off, so it sits in the collapsed Disabled group.
+      await userEvent.click(
+        await screen.findByRole("button", { name: /Disabled/ }, { timeout: 3000 }),
+      );
+      const toggle = await screen.findByRole("switch", { name: "Toggle Team tool" });
+      await userEvent.click(toggle);
+      expect(await screen.findByText(/npx -y old-tool/)).toBeInTheDocument();
+
+      // The push lands while the member is reading the dialog.
+      await act(async () => {
+        sync.resolve(registryWith(["-y", "new-tool"]));
+      });
+
+      await userEvent.click(screen.getByRole("button", { name: "Enable" }));
+
+      // Nothing enabled, dialog still up, and it now shows the changed command.
+      expect(setServerEnabled).not.toHaveBeenCalled();
+      expect(screen.getByRole("dialog")).toBeInTheDocument();
+      await waitFor(() =>
+        expect(screen.getByText(/npx -y new-tool/)).toBeInTheDocument(),
+      );
+    },
+  );
+});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -63,6 +63,7 @@ import { ServerDialog } from "@/components/ServerDialog";
 import {
   ImportReviewDialog,
   needsTeamEnableReview,
+  sameReviewedDefinition,
 } from "@/components/ImportReviewDialog";
 
 // Secondary destinations are code-split so the initial bundle only carries the
@@ -639,11 +640,11 @@ function App() {
     setOnboardingStep(0);
   }
 
-  async function applyToggle(serverId: string, enabled: boolean) {
+  async function applyToggle(serverId: string, enabled: boolean, reviewed = false) {
     if (!profileId) return;
     setBusyId(serverId);
     try {
-      setRegistry(await setServerEnabled(profileId, serverId, enabled));
+      setRegistry(await setServerEnabled(profileId, serverId, enabled, reviewed));
       // Enabling adds a server with no health entry yet, so its card would sit on
       // "Checking…" until a manual refresh. Probe now to resolve it. (Disabling
       // moves it to the disabled group, no probe needed.)
@@ -1107,7 +1108,25 @@ function App() {
         confirmLabel="Enable"
         onConfirm={() => {
           if (!confirmEnableTeam) return;
-          return applyToggle(confirmEnableTeam.id, true);
+          // Re-check the definition against the one that was reviewed. Team sync runs
+          // on a timer, so a push landing while this dialog is open would otherwise
+          // enable a command or URL the member never saw - the confirmation carried
+          // only the id. If it changed under them, re-open review on the new one
+          // instead of enabling it.
+          const live = registry?.servers.find((s) => s.id === confirmEnableTeam.id);
+          if (!live) {
+            setConfirmEnableTeam(null);
+            toastError("That server is no longer in your registry.");
+            return;
+          }
+          if (!sameReviewedDefinition(confirmEnableTeam, live)) {
+            setConfirmEnableTeam(live);
+            toastError(
+              "This server changed while you were reviewing it. Check it again.",
+            );
+            return;
+          }
+          return applyToggle(confirmEnableTeam.id, true, true);
         }}
       />
       {/* Ctrl+N. Mounted only while open so `autoOpen` fires each time, and unmounted

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1124,7 +1124,10 @@ function App() {
             toastError(
               "This server changed while you were reviewing it. Check it again.",
             );
-            return;
+            // Reject so ConfirmDialog skips its setOpen(false) - a normal return
+            // would close the dialog and onOpenChange(false) would null out the
+            // `live` entry we just swapped in, so the re-review never appears.
+            throw new Error("definition changed");
           }
           return applyToggle(confirmEnableTeam.id, true, true);
         }}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -60,7 +60,10 @@ import { PendingApprovals } from "@/components/PendingApprovals";
 import { QuarantineAlert } from "@/components/QuarantineAlert";
 import { RegistryServerRow } from "@/components/RegistryServerRow";
 import { ServerDialog } from "@/components/ServerDialog";
-import { ImportReviewDialog } from "@/components/ImportReviewDialog";
+import {
+  ImportReviewDialog,
+  needsTeamEnableReview,
+} from "@/components/ImportReviewDialog";
 
 // Secondary destinations are code-split so the initial bundle only carries the
 // default Servers view and the app chrome. Each mounts behind a Suspense
@@ -118,6 +121,7 @@ function App() {
   // Gates the "Disable all" bulk action behind a confirm when it turns off more
   // than a couple of servers, so one menu click can't silently kill a big set.
   const [confirmDisableAll, setConfirmDisableAll] = useState(false);
+  const [confirmEnableTeam, setConfirmEnableTeam] = useState<ServerEntry | null>(null);
   const [selectedClientId, setSelectedClientId] = useState<string | null>(null);
   const [view, setView] = useState<View>("servers");
   const [activityKey, setActivityKey] = useState(0);
@@ -635,7 +639,7 @@ function App() {
     setOnboardingStep(0);
   }
 
-  async function handleToggle(serverId: string, enabled: boolean) {
+  async function applyToggle(serverId: string, enabled: boolean) {
     if (!profileId) return;
     setBusyId(serverId);
     try {
@@ -649,6 +653,17 @@ function App() {
     } finally {
       setBusyId(null);
     }
+  }
+
+  async function handleToggle(serverId: string, enabled: boolean) {
+    if (enabled) {
+      const server = servers.find((s) => s.id === serverId);
+      if (server && needsTeamEnableReview(server)) {
+        setConfirmEnableTeam(server);
+        return;
+      }
+    }
+    await applyToggle(serverId, enabled);
   }
 
   async function handleRemove(serverId: string, name: string) {
@@ -666,11 +681,31 @@ function App() {
   async function handleToggleAll() {
     if (!profileId || togglingAll) return;
     const enable = enabledCount < servers.length;
+    const pendingReview =
+      enable && registry
+        ? servers.filter((s) => needsTeamEnableReview(s) && !isEnabled(registry, s.id))
+            .length
+        : 0;
+    if (enable && pendingReview > 0 && pendingReview === servers.length - enabledCount) {
+      toast.message(
+        pendingReview === 1
+          ? "That team server still needs review in Teams."
+          : `${pendingReview} team servers still need review in Teams.`,
+      );
+      return;
+    }
     setTogglingAll(true);
     try {
       setRegistry(await setAllEnabled(profileId, enable));
       if (enable) void reprobeAfterMutation().catch(() => {});
-      toast.success(enable ? "Enabled all servers" : "Disabled all servers");
+      let message = enable ? "Enabled all servers" : "Disabled all servers";
+      if (enable && pendingReview > 0) {
+        message =
+          pendingReview === 1
+            ? "Enabled servers. 1 team server still needs review."
+            : `Enabled servers. ${pendingReview} team servers still need review.`;
+      }
+      toast.success(message);
     } catch (e) {
       toastError(`Couldn't update servers: ${e}`);
     } finally {
@@ -1053,6 +1088,27 @@ function App() {
         confirmLabel="Disable all"
         destructive
         onConfirm={handleToggleAll}
+      />
+      <ConfirmDialog
+        open={confirmEnableTeam !== null}
+        onOpenChange={(open) => {
+          if (!open) setConfirmEnableTeam(null);
+        }}
+        title={
+          confirmEnableTeam ? `Enable "${confirmEnableTeam.name}"?` : "Enable server?"
+        }
+        description={
+          confirmEnableTeam
+            ? confirmEnableTeam.transport === "stdio" || confirmEnableTeam.command
+              ? `This runs a local command on your machine: ${[confirmEnableTeam.command, ...(confirmEnableTeam.args ?? [])].join(" ")}. Only enable it if you trust your team and recognize this command.`
+              : `This connects Toolport to ${confirmEnableTeam.url ?? ""}, a private/LAN address. Only enable it if you trust your team.`
+            : undefined
+        }
+        confirmLabel="Enable"
+        onConfirm={() => {
+          if (!confirmEnableTeam) return;
+          return applyToggle(confirmEnableTeam.id, true);
+        }}
       />
       {/* Ctrl+N. Mounted only while open so `autoOpen` fires each time, and unmounted
           on close so the next press starts from a clean form. */}

--- a/src/components/ImportReviewDialog.test.tsx
+++ b/src/components/ImportReviewDialog.test.tsx
@@ -6,7 +6,9 @@ import {
   runsShell,
   isPrivateHostUrl,
   needsTeamEnableReview,
+  sameReviewedDefinition,
 } from "./ImportReviewDialog";
+import type { ReviewedFields } from "./ImportReviewDialog";
 import type { ImportItem } from "@/lib/types";
 
 function items(): ImportItem[] {
@@ -251,5 +253,64 @@ describe("needsTeamEnableReview", () => {
         url: "https://mcp.example.com/mcp",
       }),
     ).toBe(false);
+  });
+
+  // A renderer cannot resolve DNS, so a hostname that points at the LAN reads as
+  // public here. Rust's host_is_private resolves it and this dialog is the consent
+  // gate, so anything it cannot positively call public gets asked about.
+  it.each([
+    ["a bare intranet hostname", "http://internal-service/mcp"],
+    ["the same host over https", "https://internal-service/mcp"],
+    ["an mDNS name", "https://nas.local/mcp"],
+    ["a cloud-internal name", "https://svc.internal/mcp"],
+    ["plaintext http to a public name", "http://mcp.example.com/mcp"],
+    ["an unparseable url", "not-a-url"],
+  ])("flags %s", (_label, url) => {
+    expect(
+      needsTeamEnableReview({
+        source: "team:t1",
+        transport: "http",
+        command: null,
+        url,
+      }),
+    ).toBe(true);
+  });
+});
+
+// The confirmation carries only a server id, so a team push landing while the
+// dialog is open would otherwise enable a command the member never read.
+describe("sameReviewedDefinition", () => {
+  const reviewed: ReviewedFields = {
+    transport: "stdio",
+    command: "npx",
+    args: ["-y", "@team/mcp"],
+    url: null,
+  };
+
+  it("accepts the definition that was reviewed", () => {
+    expect(sameReviewedDefinition(reviewed, { ...reviewed })).toBe(true);
+    // Absent and empty args are the same definition, not a change.
+    expect(
+      sameReviewedDefinition(
+        { transport: "http", command: null, args: [], url: "https://a.example.com" },
+        {
+          transport: "http",
+          command: null,
+          args: undefined,
+          url: "https://a.example.com",
+        },
+      ),
+    ).toBe(true);
+  });
+
+  const swaps: [string, ReviewedFields][] = [
+    ["the command", { ...reviewed, command: "curl" }],
+    ["an argument", { ...reviewed, args: ["-y", "@attacker/mcp"] }],
+    ["an added argument", { ...reviewed, args: ["-y", "@team/mcp", "--evil"] }],
+    ["the transport", { ...reviewed, transport: "http" }],
+    ["the url", { ...reviewed, url: "https://attacker.example.com" }],
+  ];
+  it.each(swaps)("rejects a swap of %s", (_label, live) => {
+    expect(sameReviewedDefinition(reviewed, live)).toBe(false);
   });
 });

--- a/src/components/ImportReviewDialog.test.tsx
+++ b/src/components/ImportReviewDialog.test.tsx
@@ -1,7 +1,12 @@
 import { describe, it, expect, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { ImportReviewDialog, runsShell, isPrivateHostUrl } from "./ImportReviewDialog";
+import {
+  ImportReviewDialog,
+  runsShell,
+  isPrivateHostUrl,
+  needsTeamEnableReview,
+} from "./ImportReviewDialog";
 import type { ImportItem } from "@/lib/types";
 
 function items(): ImportItem[] {
@@ -200,5 +205,51 @@ describe("isPrivateHostUrl", () => {
     ["", false],
   ])("classifies %j as %s", (url, expected) => {
     expect(isPrivateHostUrl(url)).toBe(expected);
+  });
+});
+
+describe("needsTeamEnableReview", () => {
+  it("ignores personal servers even with a local command", () => {
+    expect(
+      needsTeamEnableReview({
+        source: "manual",
+        transport: "stdio",
+        command: "npx",
+        url: null,
+      }),
+    ).toBe(false);
+  });
+
+  it("flags a team stdio server", () => {
+    expect(
+      needsTeamEnableReview({
+        source: "team:t1",
+        transport: "stdio",
+        command: "npx",
+        url: null,
+      }),
+    ).toBe(true);
+  });
+
+  it("flags a team LAN URL", () => {
+    expect(
+      needsTeamEnableReview({
+        source: "team:t1",
+        transport: "http",
+        command: null,
+        url: "http://10.0.0.5:8080/mcp",
+      }),
+    ).toBe(true);
+  });
+
+  it("does not flag a team public HTTPS remote", () => {
+    expect(
+      needsTeamEnableReview({
+        source: "team:t1",
+        transport: "http",
+        command: null,
+        url: "https://mcp.example.com/mcp",
+      }),
+    ).toBe(false);
   });
 });

--- a/src/components/ImportReviewDialog.tsx
+++ b/src/components/ImportReviewDialog.tsx
@@ -216,13 +216,60 @@ export function isPrivateHostUrl(url: string | null | undefined): boolean {
 
 /** Team-synced local commands and LAN URLs stay off until the member confirms.
  * Mirrors `ServerEntry::needs_team_enable_review` so the Servers Switch and
- * Enable all cannot skip the Teams review dialog. */
+ * Enable all cannot skip the Teams review dialog.
+ *
+ * Deliberately an AFFORDANCE, not the security boundary. It cannot match the Rust
+ * check exactly: `host_is_private` resolves named hosts (and treats an unresolvable
+ * one as private), and a renderer cannot do DNS, so `http://internal-service/mcp`
+ * pointing at 10.0.0.5 reads as public here. `set_server_enabled` decides for real
+ * and refuses without an explicit reviewed flag, so a miss here costs a clear error
+ * rather than an unreviewed enable. */
 export function needsTeamEnableReview(
   server: Pick<ServerEntry, "source" | "transport" | "command" | "url">,
 ): boolean {
   if (!server.source?.startsWith("team:")) return false;
   if (server.transport === "stdio" || !!server.command) return true;
-  return isPrivateHostUrl(server.url);
+  // Anything that is not a plain https:// URL to a dotted public name is treated as
+  // needing review: a bare hostname is an intranet name far more often than not, and
+  // over-prompting is the safe direction for a dialog whose whole job is consent.
+  return isPrivateHostUrl(server.url) || !isPublicLookingHttpsUrl(server.url);
+}
+
+/** True only for `https://` URLs whose host is a dotted name or a public literal IP.
+ * A bare hostname (`https://internal-service/mcp`) and any plaintext `http://` fall
+ * to false, so [`needsTeamEnableReview`] asks. */
+function isPublicLookingHttpsUrl(url: string | null | undefined): boolean {
+  if (!url) return false;
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return false;
+  }
+  if (parsed.protocol !== "https:") return false;
+  const host = parsed.hostname.replace(/^\[|\]$/g, "");
+  if (isPrivateHostUrl(url)) return false;
+  return host.includes(".") && !host.endsWith(".local") && !host.endsWith(".internal");
+}
+
+/** The fields a member actually reviews before enabling a team server. `args` is
+ * optional so an entry that omits it compares equal to one with an empty list. */
+export type ReviewedFields = {
+  transport: ServerEntry["transport"];
+  command: ServerEntry["command"];
+  args?: ServerEntry["args"];
+  url: ServerEntry["url"];
+};
+
+/** Compared on confirm so a team push landing mid-dialog cannot swap the definition
+ * underneath the member (the confirmation carries only the server id). */
+export function sameReviewedDefinition(a: ReviewedFields, b: ReviewedFields): boolean {
+  return (
+    a.transport === b.transport &&
+    (a.command ?? "") === (b.command ?? "") &&
+    (a.url ?? "") === (b.url ?? "") &&
+    JSON.stringify(a.args ?? []) === JSON.stringify(b.args ?? [])
+  );
 }
 
 /** Mirror src-tauri/src/oauth.rs ip_is_private for IPv4. */

--- a/src/components/ImportReviewDialog.tsx
+++ b/src/components/ImportReviewDialog.tsx
@@ -3,7 +3,7 @@ import { Check, ShieldAlert } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { TransportPill } from "@/components/TransportPill";
-import type { ImportItem } from "@/lib/types";
+import type { ImportItem, ServerEntry } from "@/lib/types";
 
 interface Props {
   open: boolean;
@@ -212,6 +212,17 @@ export function isPrivateHostUrl(url: string | null | undefined): boolean {
     return false;
   }
   return isPrivateIpv4(host);
+}
+
+/** Team-synced local commands and LAN URLs stay off until the member confirms.
+ * Mirrors `ServerEntry::needs_team_enable_review` so the Servers Switch and
+ * Enable all cannot skip the Teams review dialog. */
+export function needsTeamEnableReview(
+  server: Pick<ServerEntry, "source" | "transport" | "command" | "url">,
+): boolean {
+  if (!server.source?.startsWith("team:")) return false;
+  if (server.transport === "stdio" || !!server.command) return true;
+  return isPrivateHostUrl(server.url);
 }
 
 /** Mirror src-tauri/src/oauth.rs ip_is_private for IPv4. */

--- a/src/components/TeamsView.test.tsx
+++ b/src/components/TeamsView.test.tsx
@@ -66,6 +66,47 @@ describe("TeamsView shared-server update", () => {
     expect(await screen.findByText(/now version 8/i)).toBeInTheDocument();
   });
 
+  it("passes reviewed=true when the member confirms enabling a review server", async () => {
+    const withReviewServer: Registry = {
+      ...registry,
+      servers: [
+        {
+          id: "team-tool",
+          name: "Team tool",
+          transport: "stdio",
+          command: "npx",
+          args: ["-y", "some-tool"],
+          env: [],
+          url: null,
+          source: "team:team-1",
+        },
+      ] as Registry["servers"],
+    };
+    api.setServerEnabled.mockResolvedValue(withReviewServer);
+
+    render(<TeamsView registry={withReviewServer} onRegistryChange={vi.fn()} />);
+    await userEvent.click(screen.getByRole("button", { name: "Enable" }));
+    // The ConfirmDialog's confirm button carries the same label as the trigger;
+    // the dialog copy shows the exact command being consented to (the row also
+    // renders the command, so anchor on dialog-only copy).
+    expect(await screen.findByText(/recognize this command/)).toBeInTheDocument();
+    const confirm = screen
+      .getAllByRole("button", { name: "Enable" })
+      .at(-1) as HTMLElement;
+    await userEvent.click(confirm);
+
+    // The fourth arg is the backend's consent assertion: without it the gate
+    // in set_server_enabled refuses and Teams enable silently breaks.
+    await waitFor(() =>
+      expect(api.setServerEnabled).toHaveBeenCalledWith(
+        "default",
+        "team-tool",
+        true,
+        true,
+      ),
+    );
+  });
+
   it("discards a stale confirmation and requires a fresh preview", async () => {
     const preview = {
       baseVersion: 7,

--- a/src/components/TeamsView.tsx
+++ b/src/components/TeamsView.tsx
@@ -252,7 +252,9 @@ export function TeamsView({
     run("enable", async () => {
       const pid = registry ? activeProfile(registry)?.id : undefined;
       if (!pid) throw new Error("No active profile to enable into.");
-      onRegistryChange(await setServerEnabled(pid, serverId, true));
+      // reviewed=true: this runs only from the ConfirmDialog below, which showed
+      // the member the exact command/URL. The backend refuses without it.
+      onRegistryChange(await setServerEnabled(pid, serverId, true, true));
       setNotice("Enabled. That server now runs in your active profile.");
     });
 

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -785,12 +785,21 @@ export function removeServer(id: string): Promise<Registry> {
   return invoke<Registry>("remove_server", { id });
 }
 
+/// `reviewed` asserts the member saw the Teams review dialog for the definition
+/// being enabled. The backend refuses to enable a team server that needs review
+/// without it, so pass it ONLY from that dialog's confirm handler.
 export function setServerEnabled(
   profileId: string,
   serverId: string,
   enabled: boolean,
+  reviewed = false,
 ): Promise<Registry> {
-  return invoke<Registry>("set_server_enabled", { profileId, serverId, enabled });
+  return invoke<Registry>("set_server_enabled", {
+    profileId,
+    serverId,
+    enabled,
+    reviewed,
+  });
 }
 
 export function createProfile(name: string): Promise<Registry> {


### PR DESCRIPTION
## What and why

Closes the Medium findings from the 2026-08-13 audit:

- **SBS-786** — Teams HTTP uses `redirects(0)` plus the OAuth SSRF resolver, and treats 3xx as failure so a 302 cannot replay `Authorization: Bearer`.
- **SBS-787** — Team local-command / LAN servers stay off under Enable all. The Servers switch asks for the same confirm Teams does. Playground refuses to connect until the member enables them. `set_server_enabled` remains the explicit opt-in.
- **SBS-788** — Catalog package ids reject `github:`, `http(s):`, `git+`, and similar remote specs. Docker `host:port` and OCI `image:tag` still work.

Linear: https://linear.app/southboundsoftware/issue/SBS-786 https://linear.app/southboundsoftware/issue/SBS-787 https://linear.app/southboundsoftware/issue/SBS-788

## Testing

- [x] `cargo test --lib map_server_rejects_unsafe_specs` passes
- [x] `cargo test --lib set_all_enabled_skips_unreviewed_team_servers` passes
- [x] `cargo test --lib public_team_url_blocks_private_redirect_targets` passes
- [x] `cargo test --lib redirect_statuses_are_refused` passes
- [x] `npx vitest run src/components/ImportReviewDialog.test.tsx` passes (68 tests)
- [ ] `npm run build` passes
- [ ] `npm run test` passes
- [ ] `npm run audit:prod` passes
- [ ] `npm run test:rust` passes
- [ ] Ran the app (`npm run tauri dev`) and checked the change by hand

## Notes

Follow-up to https://github.com/tsouth89/toolport/pull/711. No secrets in the diff.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Block bearer token redirect leaks and enforce team-server enable review
> - All HTTP clients in [teams.rs](https://github.com/tsouth89/toolport/pull/713/files#diff-cd8712bc1a5c6c56e55e867d15f3fb7aaf0c25b20186b10e164686e8f9926526) now disable redirects and use SSRF-screened DNS resolution; any 3xx response is treated as an error to prevent bearer tokens from being replayed to attacker-controlled hosts.
> - Enabling a team server that runs a local command or resolves to a private/LAN address now requires an explicit `reviewed=true` flag, enforced in both the backend `set_server_enabled` command and the frontend consent dialog in [App.tsx](https://github.com/tsouth89/toolport/pull/713/files#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2).
> - Bulk "enable all" in [registry.rs](https://github.com/tsouth89/toolport/pull/713/files#diff-8187fea44e15daa4059544c5fcff94f80f39fa1ec39c67eccccc153a98b39349) skips team servers requiring review and preserves already-consented ones.
> - npm package specs that escape the registry (git shortcuts, schemeless hosted URLs, `git@` SCP syntax) are now rejected in [catalog.rs](https://github.com/tsouth89/toolport/pull/713/files#diff-b56dca4e76e9db5b234989e4a8ff5de0ec51bb049bd61cad28777ffdf0839161) before constructing an `npx` invocation.
> - Risk: `set_server_enabled` signature changed — callers that do not pass `reviewed: true` will be refused for team servers needing review, and background prewarming is skipped for such servers.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0435cea.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->