### PR TITLE
fix: maintain every Claude Code config, not just the resolved one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,19 @@ Entries before the rename below shipped under the project's former name, Conduit
 - **winget package.** `winget install Toolport.Toolport` on Windows once the manifest is
   published, and each release submits its own update.
 
-## [1.13.0] - 2026-08-13
+### Fixed
+
+- **A second Claude Code profile no longer gets stuck on an old gateway.**
+  `CLAUDE_CONFIG_DIR` is usually set per shell or per launcher rather than exported, so a
+  machine often has several Claude configs (a personal `~/.claude` beside a work
+  `~/.claude-work`). Toolport resolved exactly one of them, and every other one it had
+  written kept pinning whichever gateway binary was current the day it was written.
+  Because pruning deliberately keeps recent binaries, that profile went on launching
+  superseded gateway code indefinitely and the reaper could not win: it stopped the
+  process and the config Toolport never updated started it again. Every Claude config is
+  now re-pointed on launch, and each one's gateway binary counts as referenced so pruning
+  cannot delete it. Strictly a repair: a profile with no Toolport entry does not get one,
+  and a hand-customized entry is still left alone.
 
 Toolport installs two new ways: as an agent plugin any conformant client can pick up,
 and on Windows through a one-line command instead of a trip to the Releases page.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ Entries before the rename below shipped under the project's former name, Conduit
   cannot delete it. Strictly a repair: a profile with no Toolport entry does not get one,
   and a hand-customized entry is still left alone.
 
+## [1.13.0] - 2026-08-13
+
 Toolport installs two new ways: as an agent plugin any conformant client can pick up,
 and on Windows through a one-line command instead of a trip to the Releases page.
 Pseudonymization gains the piece it was missing, a way for a human to release one

--- a/src-tauri/src/clients.rs
+++ b/src-tauri/src/clients.rs
@@ -387,6 +387,73 @@ fn claude_code_config_path(config_dir: &std::path::Path) -> PathBuf {
     config_dir.join(".claude.json")
 }
 
+/// Every `.claude.json` on this machine that some Claude Code process may read.
+///
+/// [`claude_config_dir_override`] resolves the ONE config Toolport reads and writes,
+/// which is correct for connecting a client but wrong for maintaining one. A machine
+/// routinely has several: `CLAUDE_CONFIG_DIR` is usually exported per-shell or set by
+/// a launcher for one profile (a personal `~/.claude` beside a work `~/.claude-work`),
+/// so whichever one Toolport did not resolve today keeps pinning whatever gateway
+/// binary was current the day it was written. Pruning deliberately keeps recent
+/// binaries, so that client goes on respawning superseded gateway code indefinitely,
+/// and the reaper cannot win: it stops the process and the config Toolport never
+/// updated starts it again. That is the failure this list exists to close.
+///
+/// Discovery is deliberately narrow: the documented default, the override, and
+/// `.claude*` siblings directly under home. No recursion, nothing outside home.
+fn claude_code_config_paths() -> Vec<PathBuf> {
+    let Some(home) = home() else {
+        return Vec::new();
+    };
+    let dirs: Vec<String> = std::fs::read_dir(&home)
+        .map(|entries| {
+            entries
+                .flatten()
+                .filter(|e| e.file_type().map(|t| t.is_dir()).unwrap_or(false))
+                .map(|e| e.file_name().to_string_lossy().into_owned())
+                .collect()
+        })
+        .unwrap_or_default();
+    claude_code_config_paths_from(&home, claude_config_dir_override().as_deref(), &dirs)
+        .into_iter()
+        .filter(|p| p.is_file())
+        .collect()
+}
+
+/// The env- and filesystem-free half of [`claude_code_config_paths`], so ordering and
+/// de-duplication are testable without a home directory full of fixtures.
+///
+/// `home_dirs` is the set of directory names directly under `home`. Order matters: the
+/// resolved config comes first so a caller that only wants "the one we manage" can take
+/// the head, and the rest follow in a stable order.
+fn claude_code_config_paths_from(
+    home: &std::path::Path,
+    override_dir: Option<&std::path::Path>,
+    home_dirs: &[String],
+) -> Vec<PathBuf> {
+    let mut out: Vec<PathBuf> = Vec::new();
+    let push = |path: PathBuf, out: &mut Vec<PathBuf>| {
+        if !out.contains(&path) {
+            out.push(path);
+        }
+    };
+    if let Some(dir) = override_dir {
+        push(claude_code_config_path(dir), &mut out);
+    }
+    // The documented default is a FILE at the home root, not `.claude/.claude.json`.
+    push(home.join(".claude.json"), &mut out);
+    let mut siblings: Vec<&String> = home_dirs
+        .iter()
+        .filter(|name| *name == ".claude" || name.starts_with(".claude-"))
+        .collect();
+    // read_dir order is unspecified; sort so the log and any diagnostics are stable.
+    siblings.sort();
+    for name in siblings {
+        push(claude_code_config_path(&home.join(name)), &mut out);
+    }
+    out
+}
+
 fn client_config_path(client_id: &str) -> Option<PathBuf> {
     let home = home()?;
     if client_id == "claude-code" {
@@ -2652,6 +2719,14 @@ pub struct RepointOutcome {
     /// UI. Six clients on this developer's machine sat on a superseded gateway
     /// for days with nothing anywhere recording why.
     pub failed: Vec<(String, String)>,
+    /// Claude Code configs other than the one Toolport resolves, repaired by
+    /// [`repoint_other_claude_configs`]. Paths rather than client ids, because they
+    /// all belong to the same `claude-code` client and carry no ownership record of
+    /// their own - the registry keys ownership by client id, and a sibling must not
+    /// overwrite the resolved config's snapshot.
+    pub extra_claude_repointed: Vec<PathBuf>,
+    /// Sibling Claude configs that needed a repair and could not be written.
+    pub extra_claude_failed: Vec<(PathBuf, String)>,
 }
 
 fn find_def(client_id: &str) -> Option<ClientDef> {
@@ -4673,7 +4748,45 @@ fn read_gateway_profile(client_id: &str) -> Option<String> {
 /// never be re-pointed onto a current binary. Deleting one out from under a plugin
 /// entry leaves a reference nothing will ever repair.
 pub fn referenced_gateway_paths() -> Option<Vec<PathBuf>> {
-    referenced_gateway_paths_in(&detect_clients())
+    let mut out = referenced_gateway_paths_in(&detect_clients())?;
+    // Secondary Claude Code configs are invisible to detect_clients(), which probes
+    // one path per client. Their gateway commands are still live references: pruning
+    // a binary one of them names is what strands that profile on a missing gateway.
+    // Keep-paths must be a superset of what any config can spawn, not of what we
+    // happen to resolve today.
+    for path in extra_claude_gateway_references() {
+        if !out.contains(&path) {
+            out.push(path);
+        }
+    }
+    Some(out)
+}
+
+/// Gateway binaries named by Claude Code configs other than the resolved one.
+///
+/// Unreadable or unparseable files yield nothing rather than failing the whole scan:
+/// [`referenced_gateway_paths`] already fails closed on a client it could not probe,
+/// and these are best-effort extras discovered by directory scan, so one unreadable
+/// sibling must not suppress pruning across the machine forever.
+fn extra_claude_gateway_references() -> Vec<PathBuf> {
+    let primary = client_config_path("claude-code");
+    let mut out = Vec::new();
+    for path in claude_code_config_paths() {
+        if primary.as_deref() == Some(path.as_path()) {
+            continue;
+        }
+        let Ok(text) = read_config_file(&path) else {
+            continue;
+        };
+        let Some((_, command)) = claude_gateway_entry_in(&text) else {
+            continue;
+        };
+        let command = command.trim();
+        if !command.is_empty() {
+            out.push(PathBuf::from(command));
+        }
+    }
+    out
 }
 
 /// The pure half of [`referenced_gateway_paths`], over an already-probed client list so
@@ -4780,8 +4893,117 @@ pub fn repoint_stale_gateways(managed: &HashMap<String, ManagedEntry>) -> Repoin
             }
         }
     }
+    repoint_other_claude_configs(&current, &mut outcome);
     log_repoint_outcome(&current, &outcome);
     outcome
+}
+
+/// Repair Toolport's entry in every Claude Code config EXCEPT the one
+/// [`client_config_path`] resolves, which the pass above already handled.
+///
+/// Strictly a repair, never an install. A file is touched only when it already holds
+/// an entry of ours whose command is one of our gateway binaries
+/// ([`gateway_entry_needs_rewrite`] gates on [`command_is_gateway_binary`]). A Claude
+/// profile that deliberately has no Toolport keeps not having one, and a hand-written
+/// entry under our name stays the user's. That distinction is why this is separate
+/// from the connect path rather than folded into it: connecting is a decision the user
+/// makes per profile, but a config we already wrote going stale is our bug to fix.
+///
+/// The registry ownership record is deliberately not written here. It is keyed by
+/// client id, and all of these files are `claude-code`, so recording a sibling would
+/// overwrite the resolved config's snapshot and make the next pass read that one as
+/// Customized - i.e. we would stop maintaining the config we actually manage.
+fn repoint_other_claude_configs(current: &str, outcome: &mut RepointOutcome) {
+    let primary = client_config_path("claude-code");
+    let others: Vec<PathBuf> = claude_code_config_paths()
+        .into_iter()
+        .filter(|path| primary.as_deref() != Some(path.as_path()))
+        .collect();
+    for repair in claude_configs_needing_repair(&others, current) {
+        let ClaudeRepair {
+            path,
+            profile,
+            stored,
+        } = repair;
+        let write = gateway_entry(profile.as_deref(), "claude-code").and_then(|entry| {
+            backup_file("claude-code", &path)?;
+            edit_json_gateway(&path, "mcpServers", Some(&entry), true)
+        });
+        match write {
+            Ok(()) => {
+                let msg = format!(
+                    "toolport: re-pointed a secondary Claude Code config at {} from {stored} to {current}",
+                    path.display(),
+                );
+                eprintln!("{msg}");
+                crate::gatewaylog::append(&msg);
+                outcome.extra_claude_repointed.push(path);
+            }
+            Err(error) => {
+                let msg = format!(
+                    "toolport: could not re-point the secondary Claude Code config at {}: {error}",
+                    path.display(),
+                );
+                eprintln!("{msg}");
+                crate::gatewaylog::append(&msg);
+                outcome.extra_claude_failed.push((path, error));
+            }
+        }
+    }
+}
+
+/// One secondary Claude config that needs its gateway entry repaired.
+#[derive(Debug, PartialEq, Eq)]
+struct ClaudeRepair {
+    path: PathBuf,
+    /// This file's own `TOOLPORT_PROFILE`. These configs are scoped independently, so
+    /// the resolved config's profile is not necessarily this one's, and a repair that
+    /// dropped it would silently unscope a client.
+    profile: Option<String>,
+    /// What the entry pointed at before, for the log.
+    stored: String,
+}
+
+/// Decide which of `paths` need repair, reading but never writing.
+///
+/// Split out from [`repoint_other_claude_configs`] so the rules are testable against
+/// real files without a home directory, a `CLAUDE_CONFIG_DIR`, or an installed gateway
+/// binary to resolve. The caller does the writing.
+fn claude_configs_needing_repair(paths: &[PathBuf], current: &str) -> Vec<ClaudeRepair> {
+    let mut out = Vec::new();
+    for path in paths {
+        let Ok(text) = read_config_file(path) else {
+            continue;
+        };
+        let Some((entry_name, stored)) = claude_gateway_entry_in(&text) else {
+            continue;
+        };
+        if !gateway_entry_needs_rewrite(&entry_name, &stored, current, Some(&text)) {
+            continue;
+        }
+        out.push(ClaudeRepair {
+            path: path.clone(),
+            profile: profile_from_config_text(&text),
+            stored,
+        });
+    }
+    out
+}
+
+/// Our gateway entry's `(name, command)` in a `.claude.json`, by identity rather than
+/// by exact name, so a pre-rename `conduit` entry is found too.
+///
+/// Returns None on unparseable text rather than treating it as "no entry": these files
+/// hold Claude Code's entire application state, and a transient parse failure must not
+/// be read as an invitation to write.
+fn claude_gateway_entry_in(text: &str) -> Option<(String, String)> {
+    let value: serde_json::Value = serde_json::from_str(text).ok()?;
+    let servers = value.get("mcpServers")?.as_object()?;
+    servers.iter().find_map(|(name, entry)| {
+        let command = entry.get("command").and_then(|c| c.as_str());
+        gateway_identity_matches(name, name, command)
+            .then(|| (name.clone(), command.unwrap_or_default().to_string()))
+    })
 }
 
 /// Record a re-point pass in the gateway log.
@@ -4792,7 +5014,12 @@ pub fn repoint_stale_gateways(managed: &HashMap<String, ManagedEntry>) -> Repoin
 /// what `gather_diagnostics` bundles, so a stale-gateway report can be answered
 /// from it instead of reconstructed from file mtimes.
 fn log_repoint_outcome(current: &str, outcome: &RepointOutcome) {
-    if outcome.repointed.is_empty() && outcome.customized.is_empty() && outcome.failed.is_empty() {
+    if outcome.repointed.is_empty()
+        && outcome.customized.is_empty()
+        && outcome.failed.is_empty()
+        && outcome.extra_claude_repointed.is_empty()
+        && outcome.extra_claude_failed.is_empty()
+    {
         return;
     }
     let ids = |pairs: &[(String, ManagedEntry)]| {
@@ -4802,8 +5029,15 @@ fn log_repoint_outcome(current: &str, outcome: &RepointOutcome) {
             .collect::<Vec<_>>()
             .join(", ")
     };
+    let paths = |items: &[PathBuf]| {
+        items
+            .iter()
+            .map(|p| p.display().to_string())
+            .collect::<Vec<_>>()
+            .join(", ")
+    };
     crate::gatewaylog::append(&format!(
-        "toolport: re-point pass against {current}: {} re-pointed [{}], {} customized [{}], {} failed [{}]",
+        "toolport: re-point pass against {current}: {} re-pointed [{}], {} customized [{}], {} failed [{}], {} secondary Claude configs re-pointed [{}], {} secondary failed [{}]",
         outcome.repointed.len(),
         ids(&outcome.repointed),
         outcome.customized.len(),
@@ -4813,6 +5047,15 @@ fn log_repoint_outcome(current: &str, outcome: &RepointOutcome) {
             .failed
             .iter()
             .map(|(id, why)| format!("{id}: {why}"))
+            .collect::<Vec<_>>()
+            .join("; "),
+        outcome.extra_claude_repointed.len(),
+        paths(&outcome.extra_claude_repointed),
+        outcome.extra_claude_failed.len(),
+        outcome
+            .extra_claude_failed
+            .iter()
+            .map(|(p, why)| format!("{}: {why}", p.display()))
             .collect::<Vec<_>>()
             .join("; "),
     ));
@@ -4842,6 +5085,205 @@ mod tests {
             claude_code_config_path(&relocated),
             relocated.join(".claude.json")
         );
+    }
+
+    #[test]
+    fn every_claude_profile_on_the_machine_is_discovered() {
+        // The resolved config is one of several. A personal `.claude` beside a work
+        // `.claude-work` is the ordinary shape, and the one Toolport did not resolve
+        // is exactly the one that rots.
+        let home = PathBuf::from(if cfg!(windows) {
+            r"C:\Users\someone"
+        } else {
+            "/home/someone"
+        });
+        let dirs = [
+            ".claude-work".to_string(),
+            ".claude".to_string(),
+            // These share the `.claude` prefix but are not profiles. A plain
+            // starts_with(".claude") would sweep them in and write a gateway entry
+            // into a backup directory or another tool's state.
+            ".claude.bak".to_string(),
+            ".claudesync".to_string(),
+            "Documents".to_string(),
+        ];
+        let paths = claude_code_config_paths_from(&home, Some(&home.join(".claude-work")), &dirs);
+        assert_eq!(
+            paths,
+            vec![
+                // The resolved config leads, so callers can take the head.
+                home.join(".claude-work").join(".claude.json"),
+                // The documented default is a file at the home root.
+                home.join(".claude.json"),
+                home.join(".claude").join(".claude.json"),
+            ],
+            "expected the override first, then the default, then sorted siblings"
+        );
+        for impostor in [".claude.bak", ".claudesync"] {
+            assert!(
+                !paths.iter().any(|p| p.starts_with(home.join(impostor))),
+                "{impostor} is not a Claude Code profile and must not be written"
+            );
+        }
+    }
+
+    #[test]
+    fn the_resolved_claude_config_is_never_listed_twice() {
+        // The override commonly IS one of the siblings. Listing it twice would make
+        // the repair pass rewrite the same file, and the resolved config is handled
+        // by the main loop, so a duplicate is a double write, not a harmless extra.
+        let home = PathBuf::from(if cfg!(windows) {
+            r"C:\Users\someone"
+        } else {
+            "/home/someone"
+        });
+        let dirs = [".claude".to_string()];
+        let paths = claude_code_config_paths_from(&home, Some(&home.join(".claude")), &dirs);
+        assert_eq!(
+            paths,
+            vec![
+                home.join(".claude").join(".claude.json"),
+                home.join(".claude.json"),
+            ]
+        );
+    }
+
+    #[test]
+    fn a_secondary_claude_config_yields_its_gateway_entry() {
+        // Found by identity, so the pre-rename `conduit` entry is repaired too.
+        let text = r#"{
+            "mcpServers": {
+                "conduit": {
+                    "type": "stdio",
+                    "command": "/opt/Toolport/bin/conduit-gateway-1.11.0",
+                    "env": { "CONDUIT_PROFILE": "work" }
+                }
+            },
+            "projects": {}
+        }"#;
+        assert_eq!(
+            claude_gateway_entry_in(text),
+            Some((
+                "conduit".to_string(),
+                "/opt/Toolport/bin/conduit-gateway-1.11.0".to_string()
+            ))
+        );
+        // Per-file profile: a sibling is scoped independently of the resolved config.
+        assert_eq!(profile_from_config_text(text).as_deref(), Some("work"));
+    }
+
+    #[test]
+    fn an_unreadable_secondary_config_is_not_read_as_having_no_entry() {
+        // `.claude.json` holds Claude Code's entire application state. Treating a
+        // parse failure as "no gateway entry here" is how a transient failure turns
+        // into a write that flattens the user's whole config.
+        assert_eq!(claude_gateway_entry_in("{ not json"), None);
+        assert_eq!(claude_gateway_entry_in("{}"), None);
+        assert_eq!(claude_gateway_entry_in(r#"{"mcpServers":{}}"#), None);
+        // A server that isn't ours is not ours, whatever it is called.
+        assert_eq!(
+            claude_gateway_entry_in(r#"{"mcpServers":{"sentry":{"command":"npx"}}}"#),
+            None
+        );
+    }
+
+    #[test]
+    fn a_secondary_config_is_repaired_only_when_the_entry_is_one_of_ours() {
+        // The repair pass gates on gateway_entry_needs_rewrite, whose provenance
+        // check is what keeps this a repair rather than a takeover: a hand-written
+        // entry under our name belongs to the user even in a config we also write.
+        let current = if cfg!(windows) {
+            r"C:\Users\someone\AppData\Roaming\Toolport\bin\toolport-gateway-1.13.0.exe"
+        } else {
+            "/home/someone/.config/Toolport/bin/toolport-gateway-1.13.0"
+        };
+        let stale = if cfg!(windows) {
+            r"C:\Users\someone\AppData\Roaming\Toolport\bin\toolport-gateway-1.12.0.exe"
+        } else {
+            "/home/someone/.config/Toolport/bin/toolport-gateway-1.12.0"
+        };
+        assert!(
+            gateway_entry_needs_rewrite("toolport", stale, current, None),
+            "a superseded gateway binary is exactly what this pass exists to fix"
+        );
+        assert!(
+            !gateway_entry_needs_rewrite("toolport", "npx", current, None),
+            "a custom command must survive a pass over a secondary config"
+        );
+        assert!(
+            !gateway_entry_needs_rewrite("toolport", "", current, None),
+            "an entry with no command is not ours to rewrite"
+        );
+        assert!(
+            !gateway_entry_needs_rewrite("toolport", current, current, None),
+            "an already-current entry must not be rewritten on every launch"
+        );
+    }
+
+    #[test]
+    fn only_the_stale_secondary_claude_configs_are_selected_for_repair() {
+        // The wiring, against real files: which of several Claude profiles actually
+        // get rewritten, and with which profile preserved. This is the step that was
+        // missing before - the resolved config was maintained and every other one
+        // silently kept respawning whatever gateway was current the day it was
+        // written.
+        let dir = temp_path("claude-secondary-repair");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let current = dir.join("toolport-gateway-1.13.0").to_string_lossy().into_owned();
+        std::fs::write(&current, b"binary").unwrap();
+
+        let write = |name: &str, body: &str| {
+            let path = dir.join(name);
+            std::fs::write(&path, body).unwrap();
+            path
+        };
+        let stale_command = dir.join("toolport-gateway-1.12.0");
+        let stale = write(
+            "stale.json",
+            &format!(
+                r#"{{"mcpServers":{{"toolport":{{"command":{},"env":{{"TOOLPORT_PROFILE":"work"}}}}}},"projects":{{}}}}"#,
+                serde_json::to_string(&stale_command.to_string_lossy().into_owned()).unwrap()
+            ),
+        );
+        let already_current = write(
+            "current.json",
+            &format!(
+                r#"{{"mcpServers":{{"toolport":{{"command":{}}}}}}}"#,
+                serde_json::to_string(&current).unwrap()
+            ),
+        );
+        let customized = write(
+            "custom.json",
+            r#"{"mcpServers":{"toolport":{"command":"npx","args":["-y","something"]}}}"#,
+        );
+        let no_gateway = write("none.json", r#"{"mcpServers":{"sentry":{"command":"npx"}}}"#);
+        let unparseable = write("broken.json", "{ this is not json");
+        let missing = dir.join("does-not-exist.json");
+
+        let repairs = claude_configs_needing_repair(
+            &[
+                stale.clone(),
+                already_current,
+                customized,
+                no_gateway,
+                unparseable,
+                missing,
+            ],
+            &current,
+        );
+
+        assert_eq!(
+            repairs,
+            vec![ClaudeRepair {
+                path: stale,
+                // Preserved per file: dropping it would silently unscope this client.
+                profile: Some("work".to_string()),
+                stored: stale_command.to_string_lossy().into_owned(),
+            }],
+            "only the config pinned to a superseded gateway of ours should be repaired"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]

--- a/src-tauri/src/clients.rs
+++ b/src-tauri/src/clients.rs
@@ -405,19 +405,34 @@ fn claude_code_config_paths() -> Vec<PathBuf> {
     let Some(home) = home() else {
         return Vec::new();
     };
-    let dirs: Vec<String> = std::fs::read_dir(&home)
-        .map(|entries| {
-            entries
-                .flatten()
-                .filter(|e| e.file_type().map(|t| t.is_dir()).unwrap_or(false))
-                .map(|e| e.file_name().to_string_lossy().into_owned())
-                .collect()
-        })
-        .unwrap_or_default();
+    let dirs = match claude_profile_dirs(&home) {
+        Ok(dirs) => dirs,
+        Err(error) => {
+            let msg = format!(
+                "toolport: could not scan {} for secondary Claude Code configs: {error}",
+                home.display()
+            );
+            eprintln!("{msg}");
+            crate::gatewaylog::append(&msg);
+            Vec::new()
+        }
+    };
     claude_code_config_paths_from(&home, claude_config_dir_override().as_deref(), &dirs)
         .into_iter()
         .filter(|p| p.is_file())
         .collect()
+}
+
+/// Directory names directly under home that may hold Claude Code profiles. `Path::is_dir`
+/// deliberately follows symlinks: keeping a work profile on another volume via
+/// `~/.claude-work -> /volume/work-claude` is a supported filesystem shape.
+fn claude_profile_dirs(home: &Path) -> Result<Vec<String>, String> {
+    let entries = std::fs::read_dir(home).map_err(|e| e.to_string())?;
+    Ok(entries
+        .filter_map(Result::ok)
+        .filter(|entry| entry.path().is_dir())
+        .map(|entry| entry.file_name().to_string_lossy().into_owned())
+        .collect())
 }
 
 /// The env- and filesystem-free half of [`claude_code_config_paths`], so ordering and
@@ -2791,6 +2806,18 @@ fn read_config_file(path: &Path) -> Result<String, String> {
 /// exist yet, or if it isn't a regular file / is over the size cap (we won't copy
 /// a device or a huge file into the backup dir).
 fn backup_file(client_id: &str, path: &Path) -> Result<Option<PathBuf>, String> {
+    let name = path
+        .file_name()
+        .and_then(|f| f.to_str())
+        .unwrap_or("config");
+    backup_file_named(client_id, path, name)
+}
+
+fn backup_file_named(
+    client_id: &str,
+    path: &Path,
+    backup_name: &str,
+) -> Result<Option<PathBuf>, String> {
     match std::fs::metadata(path) {
         Ok(meta) if meta.is_file() && meta.len() <= MAX_CONFIG_BYTES => {}
         // Missing, special file, or oversized: nothing safe to back up.
@@ -2798,14 +2825,29 @@ fn backup_file(client_id: &str, path: &Path) -> Result<Option<PathBuf>, String> 
     }
     let dir = backup_dir(client_id).ok_or("Could not resolve backup dir")?;
     std::fs::create_dir_all(&dir).map_err(|e| e.to_string())?;
-    let name = path
-        .file_name()
-        .and_then(|f| f.to_str())
-        .unwrap_or("config");
-    let dest = dir.join(format!("{}-{}", epoch_millis(), name));
+    let mut stamp = epoch_millis();
+    let dest = loop {
+        let candidate = dir.join(format!("{stamp}-{backup_name}"));
+        if !candidate.exists() {
+            break candidate;
+        }
+        stamp += 1;
+    };
     std::fs::copy(path, &dest).map_err(|e| e.to_string())?;
-    prune_backups(&dir, name);
+    prune_backups(&dir, backup_name);
     Ok(Some(dest))
+}
+
+/// Secondary Claude configs all share the `.claude.json` basename and client id.
+/// Give each full path a stable backup identity so profiles cannot overwrite or prune
+/// one another's recovery copies.
+fn backup_secondary_claude_file(path: &Path) -> Result<Option<PathBuf>, String> {
+    backup_file_named("claude-code", path, &secondary_claude_backup_name(path))
+}
+
+fn secondary_claude_backup_name(path: &Path) -> String {
+    let digest = crate::registry::sha256_hex(&path.to_string_lossy());
+    format!("claude-{}.json", &digest[..16])
 }
 
 /// How many backup generations to keep per client config file. Matches the
@@ -4175,6 +4217,15 @@ fn gateway_entry(profile: Option<&str>, client_id: &str) -> Result<ServerEntry, 
     })
 }
 
+/// A secondary Claude config has no distinct registry client id. Preserve its frozen
+/// profile and omit `TOOLPORT_CLIENT_ID`; otherwise every secondary resolves through
+/// the primary `claude-code` client scope and silently changes tool sets on repair.
+fn secondary_claude_gateway_entry(profile: Option<&str>) -> Result<ServerEntry, String> {
+    let mut entry = gateway_entry(profile, "claude-code")?;
+    entry.env.retain(|var| var.key != crate::brand::CLIENT_ID);
+    Ok(entry)
+}
+
 /// Parameters for installing a shared-HTTP gateway entry (SOU-407).
 #[derive(Debug, Clone)]
 pub struct SharedHttpSpec {
@@ -4925,8 +4976,8 @@ fn repoint_other_claude_configs(current: &str, outcome: &mut RepointOutcome) {
             profile,
             stored,
         } = repair;
-        let write = gateway_entry(profile.as_deref(), "claude-code").and_then(|entry| {
-            backup_file("claude-code", &path)?;
+        let write = secondary_claude_gateway_entry(profile.as_deref()).and_then(|entry| {
+            backup_secondary_claude_file(&path)?;
             edit_json_gateway(&path, "mcpServers", Some(&entry), true)
         });
         match write {
@@ -5145,6 +5196,49 @@ mod tests {
                 home.join(".claude").join(".claude.json"),
                 home.join(".claude.json"),
             ]
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn symlinked_claude_profile_directories_are_discovered() {
+        use std::os::unix::fs::symlink;
+
+        let root = temp_path("claude-symlink-profile");
+        let home = root.join("home");
+        let target = root.join("work-profile");
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(&home).unwrap();
+        std::fs::create_dir_all(&target).unwrap();
+        std::fs::write(target.join(".claude.json"), "{}").unwrap();
+        symlink(&target, home.join(".claude-work")).unwrap();
+
+        let dirs = claude_profile_dirs(&home).unwrap();
+        assert!(dirs.iter().any(|name| name == ".claude-work"));
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn claude_profile_scan_surfaces_read_errors() {
+        let missing = temp_path("missing-claude-profile-home");
+        let _ = std::fs::remove_dir_all(&missing);
+        assert!(claude_profile_dirs(&missing).is_err());
+    }
+
+    #[test]
+    fn secondary_claude_backups_have_per_path_identities() {
+        let home = PathBuf::from(if cfg!(windows) {
+            r"C:\Users\someone"
+        } else {
+            "/home/someone"
+        });
+        let personal = secondary_claude_backup_name(&home.join(".claude.json"));
+        let work = secondary_claude_backup_name(&home.join(".claude-work").join(".claude.json"));
+        assert_ne!(personal, work);
+        assert_eq!(
+            secondary_claude_backup_name(&home.join(".claude-work").join(".claude.json")),
+            work,
+            "the identity must stay stable across launches"
         );
     }
 
@@ -6975,6 +7069,24 @@ command = "npx"
             Some("cursor")
         );
         assert!(uenv.get(crate::brand::PROFILE).is_none());
+    }
+
+    #[test]
+    fn secondary_claude_repair_keeps_profile_without_primary_client_id() {
+        let entry = secondary_claude_gateway_entry(Some("work")).unwrap();
+        let env: std::collections::HashMap<_, _> = entry
+            .env
+            .iter()
+            .map(|e| (e.key.clone(), e.value.clone()))
+            .collect();
+        assert_eq!(
+            env.get(crate::brand::PROFILE).unwrap().as_deref(),
+            Some("work")
+        );
+        assert!(
+            !env.contains_key(crate::brand::CLIENT_ID),
+            "a secondary config must fall through to its own frozen profile"
+        );
     }
 
     // Informational (no assert): prints what the Cursor plugin scanner finds on


### PR DESCRIPTION
Toolport maintains exactly one Claude Code config. That is correct for connecting a client and wrong for maintaining one, and the gap is not theoretical: I found it on this machine tonight.

## The bug

`CLAUDE_CONFIG_DIR` relocates Claude Code's whole config tree, and it is normally set per shell or by a launcher rather than exported globally. So a machine routinely has several Claude configs, a personal `~/.claude` beside a work `~/.claude-work`. `client_config_path("claude-code")` resolves exactly one of them, so every other config Toolport has already written keeps pinning whichever gateway binary was current the day it was written.

Nothing recovers from that on its own:

- Pruning deliberately keeps recent and still-referenced binaries, so the pinned one stays on disk and keeps working.
- The reaper loses by construction. It stops the process, and the config Toolport never updated starts it again.

The doc comment on `claude_config_dir_override` already predicted exactly this and left it unhandled:

> It does NOT cover a launcher that sets the variable only for the child process it spawns - Toolport cannot see that, and such a config stays stale.

**Observed live:** the app auto-updated to 1.13.0 and repointed `~/.claude`, while `~/.claude-work` still named `toolport-gateway-1.12.0-140f0e8d8cfa.exe`.

## The fix

- `claude_code_config_paths` discovers the documented default, the `CLAUDE_CONFIG_DIR` override, and `.claude*` siblings directly under home. No recursion, nothing outside home. `.claude.bak` and `.claudesync` are not profiles and are not written.
- `repoint_stale_gateways` repairs the others after its normal pass.
- `referenced_gateway_paths` counts their gateway binaries, so pruning cannot delete a gateway a secondary profile still names.

**Strictly a repair, never an install.** It only touches a file that already holds an entry of ours whose command is one of our gateway binaries, via `gateway_entry_needs_rewrite`'s existing provenance gate. A Claude profile that deliberately has no Toolport keeps not having one, and a hand-written entry under our name stays the user's. Connecting is a per-profile decision the user makes; a config we already wrote going stale is our bug to fix. That is why this is separate from the connect path rather than folded into it.

Two details that are easy to get wrong:

- **Each file's own `TOOLPORT_PROFILE` is preserved.** These configs are scoped independently, so reusing the resolved config's profile would silently re-scope a client.
- **The registry ownership record is deliberately not written for secondaries.** It is keyed by client id and these are all `claude-code`, so recording one would overwrite the resolved config's snapshot and make the next pass read it as `Customized`, i.e. we would stop maintaining the one config we actually manage.

## Tests

Six, all in the pure/decision layer so they need no home directory, no env, and no installed gateway. Each was verified load-bearing by mutating the code under test:

| mutation | test that catches it |
| --- | --- |
| loosen the sibling rule to `starts_with(".claude")` | `every_claude_profile_on_the_machine_is_discovered` |
| drop the de-dup guard | `the_resolved_claude_config_is_never_listed_twice` |
| treat unparseable JSON as "no entry" | `an_unreadable_secondary_config_is_not_read_as_having_no_entry` |
| drop per-file profile preservation | `only_the_stale_secondary_claude_configs_are_selected_for_repair` |
| drop the provenance gate | `only_the_stale_secondary_claude_configs_are_selected_for_repair` |

Worth flagging: my first version of the discovery test was **not** load-bearing. Its `.claudia` fixture does not start with `.claude` (it is `.claudi`), so the loosened rule still passed and the test asserted nothing. Caught it by running the mutation rather than assuming, and replaced the fixture with `.claude.bak` and `.claudesync`, which do share the prefix.

884 lib tests pass. `cargo check` adds no new warnings.

## Not in scope

Multiple Claude profiles are still one `claude-code` client in the UI and share one profile/scope. Giving each config its own identity and scoping is a bigger change to the registry and Clients view, and this PR is the correctness half: stop shipping stale gateways to profiles we already wrote.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Claude Code config maintenance to repoint all profiles, not just the resolved one
> - On launch, the app now discovers all candidate `.claude.json` files (default, override, and `.claude`/`.claude-*` siblings under home) and repoints stale Toolport gateway entries in each, not just the primary resolved config.
> - Secondary configs are repaired in place while preserving their per-file profile; the written gateway entry omits `TOOLPORT_CLIENT_ID` to avoid profile resolution via registry scope.
> - Gateway binaries referenced by secondary Claude configs are included in the pruning keep-set, preventing deletion of binaries still named by those profiles.
> - Backup files for secondary configs use a stable SHA-256-derived name per path to avoid cross-profile collisions.
> - Behavioral Change: profiles without an existing Toolport gateway entry are left untouched; only stale Toolport-owned entries are rewritten.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 458aa5d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->