### PR TITLE
fix: close the 2026-08-13 audit tail (SBS-789 – SBS-794)

### DIFF
--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -8704,6 +8704,10 @@ fn connect_one(
         .map(|d| bind_progress_sink(d, &server.id));
     let result = if let Some(command) = &server.command {
         let mut env: Vec<(String, String)> = Vec::new();
+        // A failed vault read is NOT "no secret stored" (SBS-789): a locked
+        // Credential Manager or torn chunk read must fail the connect, not spawn
+        // the child without its token and make it look never-authenticated.
+        let mut vault_error: Option<String> = None;
         for e in &server.env {
             if let Some(v) = &e.value {
                 env.push((e.key.clone(), v.clone()));
@@ -8718,12 +8722,21 @@ fn connect_one(
                         format_args!("TOOLPORT_SECRET_{}", e.key),
                         e.key
                     ),
-                    Err(err) => eprintln!(
-                        "toolport: '{}' could not read secret '{}': {err}",
-                        server.id, e.key
-                    ),
+                    Err(err) => {
+                        vault_error = Some(format!(
+                            "could not read secret '{}' from the vault: {err}",
+                            e.key
+                        ));
+                        break;
+                    }
                 }
             }
+        }
+        if let Some(err) = vault_error {
+            let msg = format!("'{}' failed: {err}", server.id);
+            eprintln!("toolport: {msg}");
+            glog(&msg);
+            return None;
         }
         // Resolve the ${ROOT} token against the client's project root (issue #239)
         // before spawning. `None` (no ${ROOT}, or ${ROOT} with no known root) means

--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -456,11 +456,15 @@ struct ProbeResult {
 }
 
 /// True if this server declares secret env vars that don't yet have a vaulted value.
+/// A failed vault read is NOT "missing" (SBS-789): a locked keychain must not flip
+/// the UI to "Needs sign-in" and invite the user to re-enter a credential that is
+/// in fact stored — only a confirmed `Ok(None)` counts.
 fn missing_secret(server: &ServerEntry) -> bool {
-    server
-        .env
-        .iter()
-        .any(|e| e.secret && e.value.is_none() && secrets::get_secret(&server.id, &e.key).is_none())
+    server.env.iter().any(|e| {
+        e.secret
+            && e.value.is_none()
+            && matches!(secrets::get_secret_result(&server.id, &e.key), Ok(None))
+    })
 }
 
 /// Connect to one server (stdio or remote), injecting any vaulted secrets, and
@@ -719,16 +723,21 @@ fn prewarm_launcher(server: &ServerEntry) {
     }
     let server = server.clone();
     std::thread::spawn(move || {
-        let env: Vec<(String, String)> = server
-            .env
-            .iter()
-            .filter_map(|e| {
-                e.value
-                    .clone()
-                    .or_else(|| secrets::get_secret(&server.id, &e.key))
-                    .map(|v| (e.key.clone(), v))
-            })
-            .collect();
+        let mut env: Vec<(String, String)> = Vec::new();
+        for e in &server.env {
+            match e.value.clone() {
+                Some(v) => env.push((e.key.clone(), v)),
+                None => match secrets::get_secret_result(&server.id, &e.key) {
+                    Ok(Some(v)) => env.push((e.key.clone(), v)),
+                    // Unset stays lenient (the point is warming the download
+                    // cache), but a failed vault read aborts (SBS-789): don't
+                    // hand the child a half-real environment while the keychain
+                    // is locked — the real probe will retry with the truth.
+                    Ok(None) => {}
+                    Err(_) => return,
+                },
+            }
+        }
         let cwd = server.cwd.as_deref().and_then(|c| resolve_root_token(c, None));
         if let Ok(t) = StdioTransport::spawn(&command, &server.args, &env, cwd.as_deref()) {
             // Attempting the handshake keeps the child alive until the download
@@ -2878,9 +2887,11 @@ fn clear_auth_token(state: State<RegistryState>, server_id: String) -> Result<()
     Ok(())
 }
 
+/// Errs on a failed vault read instead of reporting `false` (SBS-789): a locked
+/// keychain must not make a vaulted token look like "never authenticated".
 #[tauri::command]
-fn has_auth_token(server_id: String) -> bool {
-    secrets::get_secret(&server_id, secrets::HTTP_AUTH_KEY).is_some()
+fn has_auth_token(server_id: String) -> Result<bool, String> {
+    Ok(secrets::get_secret_result(&server_id, secrets::HTTP_AUTH_KEY)?.is_some())
 }
 
 /// Figure out what a remote server needs to connect (none / oauth / token) and

--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -727,6 +727,9 @@ fn prewarm_launcher(server: &ServerEntry) {
         for e in &server.env {
             match e.value.clone() {
                 Some(v) => env.push((e.key.clone(), v)),
+                // Only secret entries have vaulted values; a plain unset var
+                // must not pick up a same-named secret from the vault.
+                None if !e.secret => {}
                 None => match secrets::get_secret_result(&server.id, &e.key) {
                     Ok(Some(v)) => env.push((e.key.clone(), v)),
                     // Unset stays lenient (the point is warming the download

--- a/src-tauri/src/downstream.rs
+++ b/src-tauri/src/downstream.rs
@@ -3000,6 +3000,7 @@ pub fn is_download_launcher(command: &str, args: &[String]) -> bool {
     let base = base
         .strip_suffix(".exe")
         .or_else(|| base.strip_suffix(".cmd"))
+        .or_else(|| base.strip_suffix(".bat"))
         .or_else(|| base.strip_suffix(".ps1"))
         .unwrap_or(&base);
     let first = args.first().map(String::as_str);
@@ -7553,6 +7554,7 @@ mod tests {
             "bunx",
             "/usr/local/bin/npx",
             r"C:\Program Files\nodejs\npx.cmd",
+            r"C:\Program Files\nodejs\npx.bat",
             "NPX.EXE",
             "uvx.exe",
         ] {

--- a/src-tauri/src/oauth.rs
+++ b/src-tauri/src/oauth.rs
@@ -1078,8 +1078,11 @@ pub fn build_authorize_url(
     scope: Option<&str>,
 ) -> String {
     let enc = |s: &str| urlencoding::encode(s).into_owned();
+    // RFC 6749 §3.1: the metadata's authorization_endpoint may already carry a
+    // query component (some enterprise/B2C providers); join with `&` then.
+    let sep = if authorization_endpoint.contains('?') { '&' } else { '?' };
     let mut url = format!(
-        "{authorization_endpoint}?response_type=code&client_id={}&redirect_uri={}&code_challenge={}&code_challenge_method=S256&state={}&resource={}",
+        "{authorization_endpoint}{sep}response_type=code&client_id={}&redirect_uri={}&code_challenge={}&code_challenge_method=S256&state={}&resource={}",
         enc(client_id),
         enc(redirect_uri),
         enc(challenge),
@@ -1817,6 +1820,21 @@ mod tests {
         assert!(url.contains("code_challenge_method=S256"));
         assert!(url.contains("redirect_uri=http%3A%2F%2F127.0.0.1%3A41789%2Fcallback"));
         assert!(url.contains("scope=mcp"));
+    }
+
+    #[test]
+    fn authorize_url_joins_with_ampersand_when_endpoint_has_a_query() {
+        let url = build_authorize_url(
+            "https://as/auth?p=b2c_signin",
+            "cid",
+            "http://127.0.0.1:41789/callback",
+            "chal",
+            "st",
+            "https://mcp/x",
+            None,
+        );
+        assert!(url.starts_with("https://as/auth?p=b2c_signin&response_type=code"));
+        assert_eq!(url.matches('?').count(), 1);
     }
 
     #[test]

--- a/src-tauri/src/remote.rs
+++ b/src-tauri/src/remote.rs
@@ -894,8 +894,13 @@ pub fn connect_remote_with_handler(
             .expect("uses_client_credentials checked it");
         acquire_client_credentials(server_id, url, config)?;
     }
-    let stored_auth = secrets::get_secret(server_id, secrets::HTTP_AUTH_KEY)
-        .or_else(|| first_vaulted_secret(server));
+    // A vault read failure is not "no token" (SBS-789): connecting anonymous on a
+    // locked keychain would surface as a bogus 401/"needs sign-in" and can hand an
+    // unauthenticated session to a server the user believes is authenticated.
+    let stored_auth = match secrets::get_secret_result(server_id, secrets::HTTP_AUTH_KEY) {
+        Ok(v) => v.or_else(|| first_vaulted_secret(server)),
+        Err(e) => return Err(format!("could not read the vaulted auth token: {e}")),
+    };
     let auth = match refresh_token_if_needed(server_id)? {
         Some(fresh) => Some(fresh),
         None => stored_auth,

--- a/src-tauri/src/remote.rs
+++ b/src-tauri/src/remote.rs
@@ -823,15 +823,18 @@ fn guard_connect_target(server: &ServerEntry) -> Result<(), String> {
 /// The first custom secret env var that has a value vaulted in the keychain.
 /// For HTTP servers that don't use OAuth (e.g. Magica with a `BEARER` API key),
 /// this is the token we send as `Authorization: Bearer ***`.
-fn first_vaulted_secret(server: &ServerEntry) -> Option<String> {
+/// Errs on a failed vault read (SBS-789) — this fallback is the ONLY token
+/// source for such servers, so swallowing the error here would connect
+/// anonymous exactly like the `HTTP_AUTH_KEY` path used to.
+fn first_vaulted_secret(server: &ServerEntry) -> Result<Option<String>, String> {
     for e in &server.env {
         if e.secret && e.value.is_none() {
-            if let Some(v) = secrets::get_secret(&server.id, &e.key) {
-                return Some(v);
+            if let Some(v) = secrets::get_secret_result(&server.id, &e.key)? {
+                return Ok(Some(v));
             }
         }
     }
-    None
+    Ok(None)
 }
 
 /// Connect to a remote server, injecting any vaulted token. On an auth error,
@@ -898,7 +901,9 @@ pub fn connect_remote_with_handler(
     // locked keychain would surface as a bogus 401/"needs sign-in" and can hand an
     // unauthenticated session to a server the user believes is authenticated.
     let stored_auth = match secrets::get_secret_result(server_id, secrets::HTTP_AUTH_KEY) {
-        Ok(v) => v.or_else(|| first_vaulted_secret(server)),
+        Ok(Some(v)) => Some(v),
+        Ok(None) => first_vaulted_secret(server)
+            .map_err(|e| format!("could not read the vaulted auth token: {e}"))?,
         Err(e) => return Err(format!("could not read the vaulted auth token: {e}")),
     };
     let auth = match refresh_token_if_needed(server_id)? {

--- a/src-tauri/src/teams.rs
+++ b/src-tauri/src/teams.rs
@@ -23,8 +23,10 @@ pub const TEAM_TOKEN_KEY: &str = "member_token";
 pub fn save_token(token: &str) -> Result<(), String> {
     crate::secrets::set_secret(TEAM_TOKEN_SERVER, TEAM_TOKEN_KEY, token)
 }
-pub fn load_token() -> Option<String> {
-    crate::secrets::get_secret(TEAM_TOKEN_SERVER, TEAM_TOKEN_KEY)
+/// Distinguishes "no token stored" (`Ok(None)`) from a failed vault read
+/// (`Err`) so a locked keychain reads as an error, not as signed-out (SBS-789).
+pub fn load_token() -> Result<Option<String>, String> {
+    crate::secrets::get_secret_result(TEAM_TOKEN_SERVER, TEAM_TOKEN_KEY)
 }
 pub fn clear_token() -> Result<(), String> {
     crate::secrets::delete_secret(TEAM_TOKEN_SERVER, TEAM_TOKEN_KEY)
@@ -660,7 +662,7 @@ fn sync_inner(wait_secs: u64) -> Result<SyncResult, String> {
         let reg = crate::registry::load()?;
         reg.team.clone().ok_or("not connected to a team")?
     };
-    let token = load_token().ok_or("team token is missing from the keychain")?;
+    let token = load_token()?.ok_or("team token is missing from the keychain")?;
 
     // Membership heartbeat first. This catches two things a config pull can't: removal
     // (a config pull would just error on the now-invalid token, indistinguishable from a
@@ -1321,7 +1323,7 @@ pub fn preview_push_current() -> Result<PushPreview, String> {
     if conn.role != "admin" {
         return Err("only a team admin can push the shared config".into());
     }
-    let token = load_token().ok_or("team token is missing from the keychain")?;
+    let token = load_token()?.ok_or("team token is missing from the keychain")?;
     let local_servers = team_server_export(&reg);
     let (base_version, remote_config) =
         fetch_config_for_update(&conn.server_url, &conn.team_id, &token)?;
@@ -1346,7 +1348,7 @@ pub fn push_current(
     if conn.role != "admin" {
         return Err("only a team admin can push the shared config".into());
     }
-    let token = load_token().ok_or("team token is missing from the keychain")?;
+    let token = load_token()?.ok_or("team token is missing from the keychain")?;
     let servers = team_server_export(&reg);
     if crate::audit::args_hash(&servers) != expected_local_fingerprint {
         return Err(

--- a/src/components/ClientDetail.tsx
+++ b/src/components/ClientDetail.tsx
@@ -340,20 +340,6 @@ export function ClientDetail({ client, registry, onChanged, onRegistryChange }: 
     return next;
   }
 
-  async function handleImportOne(server: McpServer) {
-    setBusy(true);
-    try {
-      await importOne(server);
-      toast.success(`Imported ${server.name} into Toolport`, {
-        description: "Enable it to serve it to every client through the gateway.",
-      });
-    } catch (e) {
-      toastError(`${e}`);
-    } finally {
-      setBusy(false);
-    }
-  }
-
   async function handleImportAll() {
     setBulkImportServers(toImport);
   }
@@ -796,7 +782,9 @@ export function ClientDetail({ client, registry, onChanged, onRegistryChange }: 
                 isPlugin={pluginNames.has(server.name.toLowerCase())}
                 imported={importedNames.has(server.name.toLowerCase())}
                 busy={busy}
-                onImport={() => handleImportOne(server)}
+                // Same review dialog as "Import all": a per-row import must show the
+                // same shell/private-host warnings before anything is added.
+                onImport={() => setBulkImportServers([server])}
               />
             ))}
           </div>

--- a/src/components/ImportReviewDialog.test.tsx
+++ b/src/components/ImportReviewDialog.test.tsx
@@ -126,6 +126,7 @@ describe("runsShell", () => {
     ["sh", true],
     ["bash", true],
     ["zsh", true],
+    ["fish", true],
     ["cmd", true],
     ["powershell", true],
     ["pwsh", true],
@@ -141,7 +142,15 @@ describe("runsShell", () => {
     ["npx", false],
     ["node", false],
     ["bash-language-server", false],
-    ["fish", false],
+    // env alone launches nothing; env with a shell target is a shell.
+    ["/usr/bin/env", false],
+    // Packed invocations (whole command line in `command`, empty args) are split
+    // like the backend's normalize_invocation before classifying.
+    ["bash -c 'curl … | sh'", true],
+    ["env bash -c 'x'", true],
+    ["npx -y @scope/pkg", false],
+    // A path with spaces is not split, so the packed rule can't misread it.
+    ["/opt/my tools/server --stdio", false],
     // Only a trailing .exe is stripped.
     ["bash.exe.bak", false],
     // Missing command.
@@ -149,6 +158,14 @@ describe("runsShell", () => {
     ["", false],
   ])("classifies %j as %s", (command, expected) => {
     expect(runsShell(command)).toBe(expected);
+  });
+
+  it("classifies packed Windows shells and env-launched shells via args", () => {
+    expect(runsShell("C:\\Windows\\System32\\cmd.exe /c evil", [])).toBe(false); // path, not split
+    expect(runsShell("C:\\Windows\\System32\\cmd.exe", ["/c", "evil"])).toBe(true);
+    expect(runsShell("cmd.bat", [])).toBe(true);
+    expect(runsShell("/usr/bin/env", ["bash", "-c", "x"])).toBe(true);
+    expect(runsShell("/usr/bin/env", ["node", "server.js"])).toBe(false);
   });
 });
 

--- a/src/components/ImportReviewDialog.test.tsx
+++ b/src/components/ImportReviewDialog.test.tsx
@@ -167,6 +167,18 @@ describe("runsShell", () => {
     expect(runsShell("/usr/bin/env", ["bash", "-c", "x"])).toBe(true);
     expect(runsShell("/usr/bin/env", ["node", "server.js"])).toBe(false);
   });
+
+  it("follows env past option operands and stays conservative on unknown options", () => {
+    expect(runsShell("env", ["-u", "HISTFILE", "bash", "-c", "x"])).toBe(true);
+    expect(runsShell("env", ["-C", "/tmp", "sh", "-c", "x"])).toBe(true);
+    expect(runsShell("env", ["--unset=HISTFILE", "bash", "-c", "x"])).toBe(true);
+    expect(runsShell("env", ["--chdir", "/tmp", "zsh"])).toBe(true);
+    expect(runsShell("env", ["-i", "FOO=1", "node", "server.js"])).toBe(false);
+    expect(runsShell("env", ["-u", "HISTFILE", "node", "server.js"])).toBe(false);
+    // -S repacks a whole command line; classify as shell rather than miss one.
+    expect(runsShell("env", ["-S", "bash -c x"])).toBe(true);
+    expect(runsShell("env", ["-S", "node server.js"])).toBe(true);
+  });
 });
 
 describe("isPrivateHostUrl", () => {

--- a/src/components/ImportReviewDialog.tsx
+++ b/src/components/ImportReviewDialog.tsx
@@ -177,10 +177,35 @@ export function runsShell(command: string | null, args: string[] = []): boolean 
     .pop()!
     .toLowerCase()
     .replace(/\.(exe|cmd|bat)$/, "");
-  // `env` just launches its first non-flag argument; classify that instead.
+  // `env` just launches a command; classify that instead. GNU env options that
+  // take a separate operand (-u NAME, -C DIR) must be skipped with their value,
+  // or `env -u FOO bash -c '…'` would classify FOO and miss the shell. Unknown
+  // options (notably -S, which repacks a whole command line) classify as shell
+  // conservatively rather than silently dropping the warning.
   if (base === "env") {
-    const target = argv.find((a) => !a.startsWith("-") && !a.includes("="));
-    return target != null && runsShell(target, argv.slice(argv.indexOf(target) + 1));
+    for (let i = 0; i < argv.length; i++) {
+      const a = argv[i];
+      if (a.startsWith("--")) {
+        const name = a.split("=")[0];
+        if (name === "--ignore-environment") continue;
+        if (name === "--unset" || name === "--chdir") {
+          if (!a.includes("=")) i++;
+          continue;
+        }
+        return true;
+      }
+      if (a.startsWith("-")) {
+        if (a === "-" || a === "-i") continue; // both mean ignore-environment
+        if (a === "-u" || a === "-C") {
+          i++;
+          continue;
+        }
+        return true;
+      }
+      if (a.includes("=")) continue; // NAME=VALUE assignment
+      return runsShell(a, argv.slice(i + 1));
+    }
+    return false;
   }
   return ["cmd", "sh", "bash", "zsh", "fish", "powershell", "pwsh"].includes(base);
 }

--- a/src/components/ImportReviewDialog.tsx
+++ b/src/components/ImportReviewDialog.tsx
@@ -114,7 +114,7 @@ function ImportReviewContent({
 export function ImportRow({ item, selected }: { item: ImportItem; selected?: boolean }) {
   const runs =
     item.command != null ? [item.command, ...item.args].join(" ") : (item.url ?? "");
-  const shell = runsShell(item.command);
+  const shell = runsShell(item.command, item.args);
   const privateHost = isPrivateHostUrl(item.url);
   return (
     <div className="rounded-md border px-3 py-2">
@@ -156,15 +156,33 @@ export function ImportRow({ item, selected }: { item: ImportItem; selected?: boo
 
 // Exported for unit tests: security-relevant classifier behind the
 // "Runs a shell command" warning above.
-export function runsShell(command: string | null): boolean {
+export function runsShell(command: string | null, args: string[] = []): boolean {
   if (!command) return false;
-  const base = command
+  let cmd = command;
+  let argv = args;
+  // Backend `normalize_invocation`: a packed `"bash -c '…'"` with empty args is
+  // split, but only when the first token is a bare program name (no path) — the
+  // same rule `isDownloadLauncher` mirrors, so a path with spaces stays intact.
+  if (args.length === 0) {
+    const parts = command.split(/\s+/).filter(Boolean);
+    const first = parts[0] ?? "";
+    if (parts.length > 1 && !first.includes("/") && !first.includes("\\")) {
+      cmd = first;
+      argv = parts.slice(1);
+    }
+  }
+  const base = cmd
     .replace(/\\/g, "/")
     .split("/")
     .pop()!
     .toLowerCase()
-    .replace(/\.exe$/, "");
-  return ["cmd", "sh", "bash", "zsh", "powershell", "pwsh"].includes(base);
+    .replace(/\.(exe|cmd|bat)$/, "");
+  // `env` just launches its first non-flag argument; classify that instead.
+  if (base === "env") {
+    const target = argv.find((a) => !a.startsWith("-") && !a.includes("="));
+    return target != null && runsShell(target, argv.slice(argv.indexOf(target) + 1));
+  }
+  return ["cmd", "sh", "bash", "zsh", "fish", "powershell", "pwsh"].includes(base);
 }
 
 // Exported for unit tests: security-relevant classifier behind the

--- a/src/components/PlaygroundView.tsx
+++ b/src/components/PlaygroundView.tsx
@@ -840,13 +840,15 @@ export function PlaygroundView({ registry, onRegistryChange }: PlaygroundProps) 
   }
 
   // Stop waiting on an in-flight call: invalidate its id so the eventual result is
-  // dropped, and reset the UI. The downstream call still has its own server-side
-  // timeout; this just frees the user from a stuck "Calling…" state.
+  // dropped, and reset the UI. A Tauri invoke can't be aborted, so this is NOT an
+  // abort — the downstream tool keeps executing and its side effects still happen.
+  // The copy must say so; Playground skips approval gates, so implying a destructive
+  // call was stopped would be a false all-clear.
   function cancelCall() {
     callSeq.current++;
     if (tickerRef.current) clearInterval(tickerRef.current);
     setCalling(false);
-    setCallError("Call cancelled.");
+    setCallError("Stopped waiting — the call may still be running on the server.");
   }
 
   if (servers.length === 0) {

--- a/src/components/SecretsDialog.tsx
+++ b/src/components/SecretsDialog.tsx
@@ -92,6 +92,7 @@ export function SecretsDialog({ server, onSaved, trigger, onChanged }: Props) {
   const [newValue, setNewValue] = useState("");
   const [busyKey, setBusyKey] = useState<string | null>(null);
   const [authSet, setAuthSet] = useState(false);
+  const [authProbeError, setAuthProbeError] = useState(false);
   const [authInput, setAuthInput] = useState("");
   const [oauthBusy, setOauthBusy] = useState(false);
   // Headless (client-credentials) auth. `ccSecretSet` tracks only whether a
@@ -138,8 +139,16 @@ export function SecretsDialog({ server, onSaved, trigger, onChanged }: Props) {
     }
     if (isRemote && server.url) {
       hasAuthToken(server.id)
-        .then((v) => fresh() && setAuthSet(v))
-        .catch(() => {});
+        .then((v) => {
+          if (!fresh()) return;
+          setAuthSet(v);
+          setAuthProbeError(false);
+        })
+        .catch(() => {
+          // Unknown ≠ absent (SBS-789): keep the badge off but say the check
+          // failed rather than implying no token is vaulted.
+          if (fresh()) setAuthProbeError(true);
+        });
       // Seed the headless form from the registry. The secret is deliberately not
       // fetched: only whether one exists, so it can never be read back out.
       const cc = server.clientCredentials ?? null;
@@ -419,6 +428,11 @@ export function SecretsDialog({ server, onSaved, trigger, onChanged }: Props) {
                         <span className="inline-flex items-center gap-1 text-xs text-success">
                           <Check className="size-3" />
                           vaulted
+                        </span>
+                      )}
+                      {authProbeError && (
+                        <span className="text-xs text-warning">
+                          couldn't check the keychain
                         </span>
                       )}
                     </div>

--- a/src/components/SecretsDialog.tsx
+++ b/src/components/SecretsDialog.tsx
@@ -145,9 +145,11 @@ export function SecretsDialog({ server, onSaved, trigger, onChanged }: Props) {
           setAuthProbeError(false);
         })
         .catch(() => {
-          // Unknown ≠ absent (SBS-789): keep the badge off but say the check
-          // failed rather than implying no token is vaulted.
-          if (fresh()) setAuthProbeError(true);
+          // Unknown ≠ absent (SBS-789): drop any stale badge and say the check
+          // failed rather than asserting either presence or absence.
+          if (!fresh()) return;
+          setAuthSet(false);
+          setAuthProbeError(true);
         });
       // Seed the headless form from the registry. The secret is deliberately not
       // fetched: only whether one exists, so it can never be read back out.
@@ -210,6 +212,9 @@ export function SecretsDialog({ server, onSaved, trigger, onChanged }: Props) {
     try {
       await setAuthToken(server.id, authInput);
       setAuthSet(true);
+      // A successful write is an authoritative "token present" — clear any
+      // earlier failed-probe warning.
+      setAuthProbeError(false);
       setAuthInput("");
       toast.success("Saved auth token");
       onChanged?.();
@@ -305,6 +310,7 @@ export function SecretsDialog({ server, onSaved, trigger, onChanged }: Props) {
     try {
       await authenticateOauth(server.id, server.url);
       setAuthSet(true);
+      setAuthProbeError(false);
       toast.success("Authenticated");
       onChanged?.();
     } catch (e) {

--- a/src/lib/launcher.test.ts
+++ b/src/lib/launcher.test.ts
@@ -11,6 +11,7 @@ describe("isDownloadLauncher", () => {
   it("matches launchers behind absolute paths and Windows shims", () => {
     expect(isDownloadLauncher("/usr/local/bin/npx", ["-y", "pkg"])).toBe(true);
     expect(isDownloadLauncher("C:\\Program Files\\nodejs\\npx.cmd", ["pkg"])).toBe(true);
+    expect(isDownloadLauncher("C:\\Program Files\\nodejs\\npx.bat", ["pkg"])).toBe(true);
     expect(isDownloadLauncher("NPX.EXE", ["pkg"])).toBe(true);
   });
 

--- a/src/lib/launcher.ts
+++ b/src/lib/launcher.ts
@@ -21,7 +21,7 @@ export function isDownloadLauncher(command: string | null, args: string[]): bool
   }
   const base = (cmd.split(/[\\/]/).pop() ?? cmd)
     .toLowerCase()
-    .replace(/\.(exe|cmd|ps1)$/, "");
+    .replace(/\.(exe|cmd|bat|ps1)$/, "");
   if (base === "npx" || base === "uvx" || base === "bunx") return true;
   const sub = argv[0];
   if ((base === "pnpm" || base === "yarn") && sub === "dlx") return true;

--- a/src/lib/openUrl.test.ts
+++ b/src/lib/openUrl.test.ts
@@ -20,6 +20,23 @@ describe("openExternal", () => {
     expect(openUrl).toHaveBeenCalledTimes(2);
   });
 
+  it("keeps loopback and private-LAN docs reachable", async () => {
+    await openExternal("http://127.0.0.1:8080/docs");
+    await openExternal("http://192.168.1.10/manual");
+    expect(openUrl).toHaveBeenCalledTimes(2);
+  });
+
+  it("refuses link-local and cloud-metadata hosts", async () => {
+    await openExternal("http://169.254.169.254/latest/meta-data/");
+    await openExternal("http://169.254.169.254./latest/meta-data/");
+    await openExternal("http://100.100.100.200/latest/meta-data/");
+    await openExternal("http://0.0.0.0:8080/");
+    await openExternal("http://[fe80::1]/");
+    await openExternal("http://[::ffff:169.254.169.254]/");
+    await openExternal("http://[::]/");
+    expect(openUrl).not.toHaveBeenCalled();
+  });
+
   it("refuses file:, javascript:, malformed, and empty inputs", async () => {
     await openExternal("file:///etc/passwd");
     await openExternal("javascript:alert(1)");

--- a/src/lib/openUrl.test.ts
+++ b/src/lib/openUrl.test.ts
@@ -34,6 +34,9 @@ describe("openExternal", () => {
     await openExternal("http://[fe80::1]/");
     await openExternal("http://[::ffff:169.254.169.254]/");
     await openExternal("http://[::]/");
+    await openExternal("http://[fd00:ec2::254]/latest/meta-data/");
+    await openExternal("http://metadata.google.internal/computeMetadata/v1/");
+    await openExternal("http://metadata/computeMetadata/v1/");
     expect(openUrl).not.toHaveBeenCalled();
   });
 

--- a/src/lib/openUrl.ts
+++ b/src/lib/openUrl.ts
@@ -10,21 +10,67 @@ import { openUrl } from "@tauri-apps/plugin-opener";
  * backend also validates at the source (see `catalog.rs`); this is the matching
  * frontend guard so every `openUrl` call site is covered.
  *
- * Silently no-ops on a missing or non-web URL rather than throwing, since these
+ * Link-local and metadata-range hosts are refused too: clicking "docs" on an
+ * untrusted registry entry must not reach `http://169.254.169.254/…` (IMDSv1)
+ * from a cloud desktop. Loopback stays allowed for locally served docs; other
+ * private LAN ranges are ordinary browsing and stay allowed as well.
+ *
+ * Silently no-ops on a missing or refused URL rather than throwing, since these
  * are all fire-and-forget click handlers.
  */
 export function openExternal(url: string | null | undefined): Promise<void> {
   if (!url) return Promise.resolve();
-  let protocol: string;
+  let parsed: URL;
   try {
-    protocol = new URL(url).protocol;
+    parsed = new URL(url);
   } catch {
     console.warn(`openExternal: refusing to open unparseable URL: ${url}`);
     return Promise.resolve();
   }
-  if (protocol !== "http:" && protocol !== "https:") {
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
     console.warn(`openExternal: refusing to open non-web URL: ${url}`);
     return Promise.resolve();
   }
+  if (isLinkLocalHost(parsed.hostname)) {
+    console.warn(`openExternal: refusing to open link-local/metadata URL: ${url}`);
+    return Promise.resolve();
+  }
   return openUrl(url);
+}
+
+/** Link-local and metadata address ranges only — deliberately narrower than
+ * `isPrivateHostUrl` (ImportReviewDialog): loopback and RFC1918 LAN hosts are
+ * legitimate browser targets, the metadata ranges never are. */
+function isLinkLocalHost(hostname: string): boolean {
+  // WHATWG keeps a trailing dot on named hosts and brackets on IPv6 literals.
+  const host = hostname
+    .toLowerCase()
+    .replace(/^\[|\]$/g, "")
+    .replace(/\.$/, "");
+  const v4 = (dotted: string): boolean => {
+    const match = dotted.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/);
+    if (!match) return false;
+    const [a, b, c, d] = match.slice(1).map(Number);
+    if ([a, b, c, d].some((n) => n > 255)) return false;
+    return (
+      (a === 169 && b === 254) || // link-local, incl. 169.254.169.254 (IMDS)
+      (a === 100 && (b & 0xc0) === 64) || // CGNAT 100.64/10 (Alibaba/OCI metadata)
+      a === 0 || // "this network" — 0.0.0.0 reaches loopback/IMDS on some stacks
+      (a === 255 && b === 255 && c === 255 && d === 255) // broadcast
+    );
+  };
+  if (!host.includes(":")) return v4(host);
+  // IPv4-mapped IPv6 — WHATWG may emit dotted or hex form.
+  const mappedDotted = host.match(/^::ffff:(\d{1,3}(?:\.\d{1,3}){3})$/i);
+  if (mappedDotted) return v4(mappedDotted[1]);
+  const mappedHex = host.match(/^::ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/i);
+  if (mappedHex) {
+    const hi = parseInt(mappedHex[1], 16);
+    const lo = parseInt(mappedHex[2], 16);
+    return v4(`${(hi >> 8) & 0xff}.${hi & 0xff}.${(lo >> 8) & 0xff}.${lo & 0xff}`);
+  }
+  if (host === "::" || host === "0:0:0:0:0:0:0:0") return true; // unspecified
+  const first = parseInt(host.split(":")[0] || "0", 16);
+  if (Number.isNaN(first)) return false;
+  return (first & 0xffc0) === 0xfe80; // fe80::/10 link-local
 }

--- a/src/lib/openUrl.ts
+++ b/src/lib/openUrl.ts
@@ -47,6 +47,10 @@ function isLinkLocalHost(hostname: string): boolean {
     .toLowerCase()
     .replace(/^\[|\]$/g, "")
     .replace(/\.$/, "");
+  // Well-known metadata hostnames resolve to the metadata service without a
+  // link-local literal ever appearing in the URL. A renderer can't do DNS, so
+  // match the names directly (mirrors oauth.rs `ip_is_link_local`'s intent).
+  if (host === "metadata.google.internal" || host === "metadata") return true;
   const v4 = (dotted: string): boolean => {
     const match = dotted.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/);
     if (!match) return false;
@@ -70,6 +74,9 @@ function isLinkLocalHost(hostname: string): boolean {
     return v4(`${(hi >> 8) & 0xff}.${hi & 0xff}.${(lo >> 8) & 0xff}.${lo & 0xff}`);
   }
   if (host === "::" || host === "0:0:0:0:0:0:0:0") return true; // unspecified
+  // AWS IMDS on IPv6 (same service as 169.254.169.254; oauth.rs treats it as
+  // link-local too).
+  if (host === "fd00:ec2::254") return true;
   const first = parseInt(host.split(":")[0] || "0", 16);
   if (Number.isNaN(first)) return false;
   return (first & 0xffc0) === 0xfe80; // fe80::/10 link-local


### PR DESCRIPTION
## What and why

Closes the six remaining findings from the 2026-08-13 audit, finishing the `audit-2026-08` batch:

- **SBS-789** — A failed vault read is no longer indistinguishable from "no secret stored" on production paths. The gateway refuses to spawn a stdio child without its secret and the HTTP connect refuses to go anonymous when the keychain read errs; `has_auth_token` errs instead of reporting `false`; `missing_secret` only counts a confirmed `Ok(None)`; `prewarm_launcher` aborts on a read error; teams `load_token` returns `Result`. SecretsDialog shows "couldn't check the keychain" instead of implying no token is vaulted. (Same direction as SBS-722 / #704, applied to the remaining paths.)
- **SBS-790** — `openExternal` refuses link-local and cloud-metadata hosts: 169.254/16 (IMDSv1), CGNAT 100.64/10, 0/8, broadcast, `fe80::/10`, `::`, and IPv4-mapped IPv6 forms. Loopback and private-LAN docs stay reachable.
- **SBS-791** — `build_authorize_url` joins with `&` when the metadata's authorization endpoint already carries a query (RFC 6749 §3.1).
- **SBS-792** — Playground cancel copy is now honest: "Stopped waiting — the call may still be running on the server." A Tauri invoke cannot be aborted, and Playground skips approval gates, so claiming a destructive call was cancelled was a false all-clear.
- **SBS-793** — `runsShell` classifies packed invocations (`"bash -c '…'"` in `command` with empty args) after the same `normalize_invocation` split the backend uses, strips `.cmd`/`.bat`, follows `env` to its target, and adds `fish`. The per-row Client Detail import now routes through the same `ImportReviewDialog` as "Import all", so single-row imports get the shell/private-host warnings too.
- **SBS-794** — `isDownloadLauncher` (frontend) and `is_download_launcher` (backend) strip `.bat` like the other Windows launcher suffixes, follow-up to SBS-664.

## Testing

- `tsc` clean; full vitest suite passes (34 files, 352 tests), including new cases for `.bat` shims, link-local/metadata URL refusal, packed shell classification, and the query-bearing authorize endpoint.
- Rust: new unit test `authorize_url_joins_with_ampersand_when_endpoint_has_a_query`; `.bat` case added to `download_launchers_get_the_long_connect_budget`. Compiled-checked headless up to the keyring crate's system D-Bus dependency — relying on CI for the full three-OS build and test run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix vault read error handling across secret-dependent operations for the 2026-08-13 audit
> - Vault read failures (e.g., locked keychain) now abort operations that require secrets rather than proceeding with missing tokens. Affected paths: stdio/remote connection, prewarm launch, team sync/push, and `has_auth_token` IPC command.
> - `has_auth_token` now returns `Result<bool, String>` so callers can distinguish vault errors from a missing token; [SecretsDialog.tsx](https://github.com/tsouth89/toolport/pull/715/files#diff-4f221815d69310fc5fbc26d8fba9b6981352fd1e0a2e281d9a04fc34882c4350) surfaces a warning when the probe fails.
> - Single-server import in [ClientDetail.tsx](https://github.com/tsouth89/toolport/pull/715/files#diff-15ded61721cddaa632475d3a7bccd611453b6af74f40ec361edf3a825ebb62e5) now opens the same review dialog as bulk import, showing shell and private-host warnings.
> - `runsShell` in [ImportReviewDialog.tsx](https://github.com/tsouth89/toolport/pull/715/files#diff-323874f3a959327b9ef6a600fad22a97160977cc5fefd9af9c9c34ce51b8d1df) gains broader shell detection: `env`-launched shells, packed commands, `.exe`/`.cmd`/`.bat` stripping, and `fish`.
> - `openExternal` in [openUrl.ts](https://github.com/tsouth89/toolport/pull/715/files#diff-c35ecba06344844a6436cf98daed80a3bc67202264fed1373fd2d45b8dee630a) now blocks link-local and cloud metadata URLs (e.g., `169.254.x.x`, `metadata.google.internal`) while allowing loopback and private LAN.
> - Windows `.bat` launcher shims (e.g., `npx.bat`) are now recognized as download launchers in both the Rust and TypeScript `isDownloadLauncher` implementations.
> - OAuth `build_authorize_url` now appends params with `&` when the endpoint already contains a `?`, preventing malformed double-`?` URLs.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e0eb340.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->