### PR TITLE
fix(gateway): route every tool the collapse guard keeps advertising

### DIFF
--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -9733,6 +9733,8 @@ fn reconcile_to(
 fn persist_and_emit_with_sessions(
     tools: &[Value],
     cached_tools: &SharedCatalog,
+    router: &Arc<Mutex<Arc<Router>>>,
+    previous_router: Option<&Router>,
     stdout: &Arc<Mutex<std::io::Stdout>>,
     mcp_sessions: Option<&Arc<Mutex<HashMap<String, Arc<McpSession>>>>>,
     profile: Option<&str>,
@@ -9746,6 +9748,19 @@ fn persist_and_emit_with_sessions(
                 .clone();
             preserve_collapsed_servers_guarded(tools.to_vec(), &current.tools)
         };
+        // A guarded rebuild keeps the previous catalog for a collapsed server in
+        // the cache, but the router was already published from the degraded
+        // connect, so its routes map misses every restored tool while the cache
+        // still advertises it. Re-adopt those routes from the pre-rebuild router
+        // (authoritative (server, original) mapping -- never re-derived by
+        // splitting the exposed name) so route_of resolves what tools/list
+        // advertises (issue #700).
+        if let Some(prev) = previous_router {
+            let mut guard = router
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            Arc::make_mut(&mut guard).adopt_restored_routes(prev, &tools);
+        }
         let next = Arc::new(CatalogSnapshot::new(tools.clone()));
         let index_bytes = next.search.estimated_auxiliary_bytes();
         *cached_tools
@@ -10158,6 +10173,15 @@ fn watch_tick(
         }
         let server_count = new_router.server_count();
         let tools = new_router.aggregated_tools();
+        // Snapshot the pre-rebuild router BEFORE publishing the new one: its
+        // routes map is the authoritative (server, original) source for tools a
+        // guarded rebuild keeps from the previous catalog (issue #700).
+        let previous_router = {
+            let guard = router
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            (**guard).clone()
+        };
         *registry
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner) = new_reg;
@@ -10168,6 +10192,8 @@ fn watch_tick(
         persist_and_emit_with_sessions(
             &tools,
             cached_tools,
+            router,
+            Some(&previous_router),
             stdout,
             mcp_sessions,
             resolved.as_deref(),
@@ -10227,6 +10253,11 @@ fn watch_tick(
             persist_and_emit_with_sessions(
                 &tools,
                 cached_tools,
+                router,
+                // In-place refresh keeps the previous catalog per slot when a
+                // list implausibly shrinks, so the refreshed router routes what
+                // the cache advertises -- nothing to re-adopt.
+                None,
                 stdout,
                 mcp_sessions,
                 resolved.as_deref(),
@@ -11739,6 +11770,15 @@ fn rebuild_router_for_root(state: &GatewayState) {
     );
     reestablish_all_resource_subscriptions(&new_router, &state.resource_subs);
     let tools = new_router.aggregated_tools();
+    // Snapshot the pre-rebuild router before publishing: authoritative routes
+    // for tools a guarded rebuild keeps from the previous catalog (issue #700).
+    let previous_router = {
+        let guard = state
+            .router
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        (**guard).clone()
+    };
     *state
         .router
         .lock()
@@ -11747,6 +11787,8 @@ fn rebuild_router_for_root(state: &GatewayState) {
     persist_and_emit_with_sessions(
         &tools,
         &state.cached_tools,
+        &state.router,
+        Some(&previous_router),
         &state.stdout,
         Some(&state.mcp_sessions),
         profile.as_deref(),
@@ -12004,6 +12046,15 @@ fn process_request(
             if built.server_count() > 0 {
                 reestablish_all_resource_subscriptions(&built, &state.resource_subs);
                 let tools = built.aggregated_tools();
+                // Snapshot the pre-rebuild router before publishing: authoritative
+                // routes for tools the guard keeps from the previous catalog.
+                let previous_router = {
+                    let guard = state
+                        .router
+                        .lock()
+                        .unwrap_or_else(std::sync::PoisonError::into_inner);
+                    (**guard).clone()
+                };
                 *state
                     .router
                     .lock()
@@ -12018,6 +12069,15 @@ fn process_request(
                         .clone();
                     preserve_collapsed_servers_guarded(tools, &current.tools)
                 };
+                // Re-adopt routes the guard kept from the previous catalog so the
+                // published router routes what the cache advertises (issue #700).
+                {
+                    let mut guard = state
+                        .router
+                        .lock()
+                        .unwrap_or_else(std::sync::PoisonError::into_inner);
+                    Arc::make_mut(&mut guard).adopt_restored_routes(&previous_router, &tools);
+                }
                 if !tools.is_empty() {
                     *state
                         .cached_tools
@@ -14680,6 +14740,14 @@ fn main() {
                 tools.len(),
                 built.server_count()
             ));
+            // Snapshot the pre-rebuild router before publishing: authoritative
+            // routes for tools the guard keeps from the previous catalog.
+            let previous_router = {
+                let guard = router
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner);
+                (**guard).clone()
+            };
             *router
                 .lock()
                 .unwrap_or_else(std::sync::PoisonError::into_inner) = Arc::new(built);
@@ -14697,6 +14765,14 @@ fn main() {
                         .clone();
                     preserve_collapsed_servers_guarded(tools, &current.tools)
                 };
+                // Re-adopt routes the guard kept from the previous catalog so the
+                // published router routes what the cache advertises (issue #700).
+                {
+                    let mut guard = router
+                        .lock()
+                        .unwrap_or_else(std::sync::PoisonError::into_inner);
+                    Arc::make_mut(&mut guard).adopt_restored_routes(&previous_router, &tools);
+                }
                 *cached_tools
                     .lock()
                     .unwrap_or_else(std::sync::PoisonError::into_inner) =

--- a/src-tauri/src/router.rs
+++ b/src-tauri/src/router.rs
@@ -2962,14 +2962,35 @@ mod tests {
     fn adopt_restored_routes_never_touches_an_already_routed_tool() {
         // A tool the rebuilt router already routes (one of the 3 the degraded
         // connect returned) must keep its live mapping, not be overwritten.
-        let previous = router_with_catalogs(&[("atlassian", 40)]);
+        // The previous router carries an override renaming one of those same
+        // tools (t1 -> renamed-t1), so its catalog disagrees with the rebuilt
+        // router's live routes; adoption must leave every live name alone and
+        // adopt the renamed slot under its renamed exposure.
+        let mut previous = Router::new();
+        previous.set_overrides(HashMap::from([(
+            "atlassian".to_string(),
+            HashMap::from([(
+                "t1".to_string(),
+                ToolOverride {
+                    name: Some("renamed-t1".into()),
+                    description: None,
+                },
+            )]),
+        )]));
+        previous.add(catalog_server("atlassian", 40));
         let mut rebuilt = router_with_catalogs(&[("atlassian", 3)]);
         let guarded = previous.aggregated_tools();
         rebuilt.adopt_restored_routes(&previous, &guarded);
 
+        // Live routes for tools the degraded connect still advertises are kept,
+        // even though the previous catalog disagrees about one of them.
         assert_eq!(rebuilt.route_of("atlassian__t0"), Some(("atlassian", "t0")));
         assert_eq!(rebuilt.route_of("atlassian__t1"), Some(("atlassian", "t1")));
         assert_eq!(rebuilt.route_of("atlassian__t2"), Some(("atlassian", "t2")));
+        // The renamed slot from the previous catalog is adopted under its
+        // renamed (sanitized) exposure — never re-derived by splitting on `__`
+        // — pointing at the same downstream tool.
+        assert_eq!(rebuilt.route_of("renamed_t1"), Some(("atlassian", "t1")));
     }
 
     #[test]

--- a/src-tauri/src/router.rs
+++ b/src-tauri/src/router.rs
@@ -1087,6 +1087,44 @@ impl Router {
         self.blocked.get(exposed_name).map(String::as_str)
     }
 
+    /// Re-adopt the routes (and exposed tool entries) for tools that came back
+    /// from a previous catalog during a guarded rebuild. The rebuild guard
+    /// keeps the previous catalog for a server whose fresh connect implausibly
+    /// shrank, but the rebuilt router was indexed from that degraded connect,
+    /// so `route_of` would miss every restored tool while the cache still
+    /// advertises it. `previous` is the pre-rebuild router, whose `routes` map
+    /// is the authoritative `(server id, original downstream name)` source --
+    /// never re-derive the original name by splitting the exposed name on `__`
+    /// (overrides and `_2` collision suffixes make that split wrong, see
+    /// [`Self::route_of`]). Only exposed names this router does not already
+    /// route are adopted, so a healthy server is never touched.
+    pub fn adopt_restored_routes(&mut self, previous: &Router, catalog: &[Value]) {
+        for tool in catalog {
+            let Some(exposed) = tool.get("name").and_then(Value::as_str) else {
+                continue;
+            };
+            if self.routes.contains_key(exposed) || self.blocked.contains_key(exposed) {
+                continue;
+            }
+            // The previous router indexed the same exposed name; reuse its
+            // (server, original) pair verbatim instead of re-deriving it.
+            let Some((server_id, original)) = previous.route_of(exposed) else {
+                continue;
+            };
+            self.routes
+                .insert(exposed.to_string(), (server_id.to_string(), original.to_string()));
+            // Re-adopt the exposed tool entry so aggregated_tools() and the
+            // quarantine/fingerprint paths see the restored tool, matching what
+            // the cache advertises.
+            if !self.tools.iter().any(|t| {
+                t.get("name").and_then(Value::as_str) == Some(exposed)
+            }) {
+                self.tools.push(tool.clone());
+            }
+            self.seen.insert(exposed.to_string());
+        }
+    }
+
     /// Re-derive the exposed tool/resource/template/prompt aggregation from the
     /// current servers' (possibly refreshed) lists, in the original add order so
     /// exposed names and their `_2` collision suffixes stay stable. The server
@@ -2819,6 +2857,119 @@ mod tests {
         assert_eq!(router.route_of("say"), Some(("srv", "echo")), "renamed tool resolves to origin");
         assert_eq!(router.route_of("srv__add"), Some(("srv", "add")), "normal tool resolves");
         assert_eq!(router.route_of("nope"), None, "unknown name resolves to nothing");
+    }
+
+    /// A transport that advertises `n` tools (`t0`..`t(n-1)`) and echoes calls
+    /// back as `server:tool`, like MockTransport but with a configurable catalog.
+    struct CatalogTransport {
+        label: String,
+        n: usize,
+    }
+
+    impl Transport for CatalogTransport {
+        fn request(&mut self, method: &str, params: Value) -> Result<Value, TransportError> {
+            match method {
+                "initialize" => Ok(json!({
+                    "protocolVersion": "2025-06-18",
+                    "capabilities": { "resources": {}, "prompts": {}, "completions": {} }
+                })),
+                "tools/list" => Ok(json!({
+                    "tools": (0..self.n)
+                        .map(|i| json!({ "name": format!("t{i}"), "description": "" }))
+                        .collect::<Vec<_>>()
+                })),
+                "tools/call" => {
+                    let name = params.get("name").and_then(|n| n.as_str()).unwrap_or("");
+                    Ok(json!({
+                        "content": [{ "type": "text", "text": format!("{}:{}", self.label, name) }],
+                        "isError": false
+                    }))
+                }
+                "resources/list" => Ok(json!({ "resources": [] })),
+                "prompts/list" => Ok(json!({ "prompts": [] })),
+                other => Err(TransportError::Fatal(format!("unexpected method {other}"))),
+            }
+        }
+
+        fn notify(&mut self, _method: &str, _params: Value) -> Result<(), TransportError> {
+            Ok(())
+        }
+    }
+
+    fn catalog_server(id: &str, n: usize) -> DownstreamServer {
+        let mut ds = DownstreamServer::connect(
+            id.to_string(),
+            Box::new(CatalogTransport {
+                label: id.to_string(),
+                n,
+            }),
+        )
+        .unwrap();
+        ds.load_resources_prompts();
+        ds
+    }
+
+    fn router_with_catalogs(specs: &[(&str, usize)]) -> Router {
+        let mut router = Router::new();
+        for (id, n) in specs {
+            router.add(catalog_server(id, *n));
+        }
+        router
+    }
+
+    #[test]
+    fn adopt_restored_routes_reroutes_a_guarded_rebuild() {
+        // A rebuild guard keeps the previous catalog for a server whose fresh
+        // connect implausibly shrank (40 -> 3). The rebuilt router was indexed
+        // from the degraded connect, so route_of misses the 37 restored tools
+        // while the cache still advertises them (issue #700).
+        let previous = router_with_catalogs(&[("atlassian", 40), ("github", 5)]);
+        let mut rebuilt = router_with_catalogs(&[("atlassian", 3), ("github", 5)]);
+
+        // Simulate the gateway guard: the guarded catalog keeps atlassian's
+        // previous 40 tools and github's fresh 5.
+        let guarded = previous.aggregated_tools();
+        rebuilt.adopt_restored_routes(&previous, &guarded);
+
+        // Every advertised tool now routes, to the ORIGINAL downstream name.
+        assert_eq!(rebuilt.route_of("atlassian__t39"), Some(("atlassian", "t39")));
+        assert_eq!(rebuilt.route_of("atlassian__t37"), Some(("atlassian", "t37")));
+        assert_eq!(
+            rebuilt.route_of("github__t4"),
+            Some(("github", "t4")),
+            "healthy server's own routes are untouched"
+        );
+        // A call to one of the 37 restored tools reaches the downstream server.
+        let result = rebuilt
+            .route_call("atlassian__t39", json!({}))
+            .unwrap();
+        assert_eq!(
+            result["content"][0]["text"].as_str().unwrap(),
+            "atlassian:t39",
+            "the call reaches the downstream under its original name"
+        );
+        // aggregated_tools() now matches what the cache advertises.
+        let names: std::collections::HashSet<String> = rebuilt
+            .aggregated_tools()
+            .iter()
+            .filter_map(|t| t["name"].as_str().map(|s| s.to_string()))
+            .collect();
+        assert!(names.contains("atlassian__t39"));
+        assert_eq!(names.len(), 45, "40 restored + 5 healthy");
+    }
+
+    #[test]
+    fn adopt_restored_routes_never_touches_an_already_routed_tool() {
+        // A tool the rebuilt router already routes (one of the 3 the degraded
+        // connect returned) must keep its live mapping, not be overwritten.
+        let previous = router_with_catalogs(&[("atlassian", 40)]);
+        let mut rebuilt = router_with_catalogs(&[("atlassian", 3)]);
+        let guarded = previous.aggregated_tools();
+        rebuilt.adopt_restored_routes(&previous, &guarded);
+
+        assert_eq!(rebuilt.route_of("atlassian__t0"), Some(("atlassian", "t0")));
+        assert_eq!(rebuilt.route_of("atlassian__t1"), Some(("atlassian", "t1")));
+        assert_eq!(rebuilt.route_of("atlassian__t2"), Some(("atlassian", "t2")));
     }
 
     #[test]

--- a/src-tauri/src/router.rs
+++ b/src-tauri/src/router.rs
@@ -1097,7 +1097,11 @@ impl Router {
     /// never re-derive the original name by splitting the exposed name on `__`
     /// (overrides and `_2` collision suffixes make that split wrong, see
     /// [`Self::route_of`]). Only exposed names this router does not already
-    /// route are adopted, so a healthy server is never touched.
+    /// route are adopted, so a healthy server is never touched. Policy is
+    /// re-evaluated per restored tool before adoption: the rebuilt router only
+    /// indexed the degraded connect, so tools quarantined or disabled since the
+    /// previous build are absent from its `blocked` map and must not slip back
+    /// in through the guarded catalog (which still carries them from the cache).
     pub fn adopt_restored_routes(&mut self, previous: &Router, catalog: &[Value]) {
         for tool in catalog {
             let Some(exposed) = tool.get("name").and_then(Value::as_str) else {
@@ -1111,6 +1115,19 @@ impl Router {
             let Some((server_id, original)) = previous.route_of(exposed) else {
                 continue;
             };
+            // Re-evaluate policy before adopting. The rebuilt router only indexed
+            // the degraded connect, so a tool quarantined / disabled / scoped out
+            // since the previous build has no entry in `self.blocked` yet and the
+            // guarded catalog (from the disk cache) still carries it. Adopting it
+            // now would silently bypass the quarantine and scope guards while the
+            // cache keeps advertising it (review on #717).
+            if let Some(reason) = self
+                .policy
+                .blocked_reason(exposed, server_id, original, tool)
+            {
+                self.blocked.insert(exposed.to_string(), reason.to_string());
+                continue;
+            }
             self.routes
                 .insert(exposed.to_string(), (server_id.to_string(), original.to_string()));
             // Re-adopt the exposed tool entry so aggregated_tools() and the
@@ -2956,6 +2973,37 @@ mod tests {
             .collect();
         assert!(names.contains("atlassian__t39"));
         assert_eq!(names.len(), 45, "40 restored + 5 healthy");
+    }
+
+    #[test]
+    fn adopt_restored_routes_never_adopts_a_newly_quarantined_tool() {
+        // A tool quarantined since the previous build is absent from the degraded
+        // connect, so the rebuilt router's `blocked` map has no entry for it --
+        // but the guarded catalog (kept from the previous/cached catalog) still
+        // carries it. Adoption must re-check policy instead of blindly restoring
+        // the route, or quarantine would be silently bypassed (review on #717).
+        let previous = router_with_catalogs(&[("atlassian", 40)]);
+        let mut rebuilt = router_with_catalogs(&[("atlassian", 3)]);
+        // Quarantine a tool the degraded connect never returned, mirroring the
+        // live flow: requarantine re-indexes from the current (degraded) connect.
+        rebuilt.requarantine(BTreeSet::from(["atlassian__t30".to_string()]));
+        assert!(rebuilt.block_reason("atlassian__t30").is_none());
+
+        let guarded = previous.aggregated_tools();
+        rebuilt.adopt_restored_routes(&previous, &guarded);
+
+        // The quarantined tool must not be routed or advertised again.
+        assert!(rebuilt.block_reason("atlassian__t30").is_some());
+        assert!(rebuilt.route_of("atlassian__t30").is_none());
+        let names: std::collections::HashSet<String> = rebuilt
+            .aggregated_tools()
+            .iter()
+            .filter_map(|t| t["name"].as_str().map(|s| s.to_string()))
+            .collect();
+        assert!(!names.contains("atlassian__t30"));
+        // The other 39 restored tools are still adopted (3 degraded + 36 more).
+        assert!(names.contains("atlassian__t39"));
+        assert_eq!(names.len(), 39, "3 degraded + 36 restored, t30 quarantined");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes #700 — after a guarded rebuild, every tool `tools/list` advertises for a collapsed server now actually dispatches.

## Problem

`preserve_collapsed_servers` guards the **cache** from a degraded downstream catalog, but the **router** was published before the guard ran:

```rust
let tools = built.aggregated_tools();          // degraded: 3 tools
*state.router.lock()... = Arc::new(built);     // router published UNGUARDED
let tools = preserve_collapsed_servers(tools, &current.tools);  // cache guarded: 40 tools
```

So while a server is degraded, `tools/list` (served from `cached_tools`) advertises the full 40 tools, but the router's `routes` map only holds the 3 the degraded connect returned. Calling any of the other 37 misses `Router::route_of` and errors.

## Fix

- **`src-tauri/src/router.rs`**: new `Router::adopt_restored_routes(previous, catalog)` — for each tool the guard kept from the previous catalog that this router does not already route, re-adopt the route from the pre-rebuild router's authoritative `(server, original downstream name)` mapping. It never re-derives the original name by splitting the exposed name on `__` (overrides and `_2` collision suffixes make that split wrong, per the `route_of` note). The exposed tool entries are re-added too, so `aggregated_tools()` matches what the cache advertises.
- **`src-tauri/src/bin/toolport-gateway.rs`**: all three rebuild sites (full rebuild in `process_request`, `${ROOT}` rebuild, self-heal cold start, background build) now snapshot the pre-rebuild router before publishing and call `adopt_restored_routes` after the collapse guard runs. `persist_and_emit_with_sessions` gains a `router` + `previous_router` pair so the shared path does the same; the in-place refresh path passes `None` because its slot-level guard already keeps the router consistent.
- A server that returned nothing is never resurrected: the guard's existing `now == 0` rule (`a_rebuild_does_not_resurrect_a_server_that_returned_nothing`) is untouched, and adoption only ever adds routes that the guard itself decided to keep.

## Tests

- `adopt_restored_routes_reroutes_a_guarded_rebuild`: 40→3 rebuild keeps routing all 40 (including a call to one of the 37, which reaches the downstream under its original name), healthy servers untouched, `aggregated_tools()` matches the cache.
- `adopt_restored_routes_never_touches_an_already_routed_tool`: routes the degraded connect already produced are not overwritten.

## Validation

- `cargo test --lib --no-default-features`: 950 passed (incl. 61 router tests)
- `cargo test --bin toolport-gateway --features test-support --no-default-features`: 305 passed
- `cargo clippy --lib --no-default-features`: clean on changed files


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix routing gaps for tools preserved by the collapse guard after router rebuilds
> - Adds `Router.adopt_restored_routes` in [router.rs](https://github.com/tsouth89/toolport/pull/717/files#diff-b99219e3712fdc73489d504fabe0d86011d46c4c0b36493a118c90725ec67197), which restores routes and tool entries for tools kept by the collapse guard using authoritative mappings from the previous router, while respecting current policy and quarantine.
> - Calls `adopt_restored_routes` after every rebuild path (registry change, `${ROOT}` change, self-heal, and cold-start background build) in [toolport-gateway.rs](https://github.com/tsouth89/toolport/pull/717/files#diff-fe5f13c01103f5adf39c870989b67ecdb11c19b3ba86b88c4acb028a7374cc01) so the live router's routing table matches what the catalog advertises.
> - Adds three unit tests covering correct re-adoption, quarantine exclusion, and no-op behavior for already-routed tools.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5dc9498.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->