### PR TITLE
fix(settings): keep launch-at-login switch disabled until the OS state is known

### DIFF
--- a/src/components/SettingsView.test.tsx
+++ b/src/components/SettingsView.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import { ThemeProvider } from "@/lib/theme";
@@ -30,8 +30,16 @@ vi.mock("@/lib/api", async (importOriginal) => {
 vi.mock("@tauri-apps/api/event", () => ({
   listen: vi.fn().mockResolvedValue(() => {}),
 }));
+vi.mock("@tauri-apps/plugin-autostart", () => ({
+  isEnabled: vi.fn(),
+  enable: vi.fn().mockResolvedValue(undefined),
+  disable: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { isEnabled as isAutostartEnabled } from "@tauri-apps/plugin-autostart";
 
 const mockedListServerTools = vi.mocked(listServerTools);
+const mockedIsAutostartEnabled = vi.mocked(isAutostartEnabled);
 const mockedSetAllowRoutineWrites = vi.mocked(setAllowRoutineWrites);
 const mockedSetCodeMode = vi.mocked(setCodeMode);
 const mockedListRoutineSuggestions = vi.mocked(listRoutineSuggestions);
@@ -328,5 +336,60 @@ describe("SettingsView routine suggestions", () => {
     await waitFor(() =>
       expect(screen.queryByText("Suggested routines")).not.toBeInTheDocument(),
     );
+  });
+});
+
+describe("SettingsView launch at login", () => {
+  it("keeps the switch disabled until the OS autostart state is known", async () => {
+    const request = deferred<boolean>();
+    mockedIsAutostartEnabled.mockReturnValueOnce(request.promise);
+
+    renderSettings();
+
+    const control = screen.getByRole("switch", { name: /launch at login/i });
+    expect(control).toBeDisabled();
+    expect(screen.getByText(/checking the current os setting/i)).toBeInTheDocument();
+
+    request.resolve(true);
+    await waitFor(() => expect(control).toBeEnabled());
+    expect(control).toHaveAttribute("aria-checked", "true");
+    expect(
+      screen.queryByText(/checking the current os setting/i),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders a verified disabled state once the OS read succeeds with false", async () => {
+    mockedIsAutostartEnabled.mockResolvedValueOnce(false);
+
+    renderSettings();
+
+    const control = screen.getByRole("switch", { name: /launch at login/i });
+    await waitFor(() => expect(control).toBeEnabled());
+    expect(control).toHaveAttribute("aria-checked", "false");
+  });
+
+  it("shows unavailable/retry feedback on a failed read and restores the real state on retry", async () => {
+    const user = userEvent.setup();
+    mockedIsAutostartEnabled.mockRejectedValueOnce(new Error("boom"));
+
+    renderSettings();
+
+    const control = screen.getByRole("switch", { name: /launch at login/i });
+    await waitFor(() =>
+      expect(screen.getByText(/couldn't read the os setting/i)).toBeInTheDocument(),
+    );
+    // A failed read must never be presented as a verified Off state.
+    expect(control).toBeDisabled();
+    const row = screen.getByText("Launch at login").closest("label");
+    expect(row).not.toBeNull();
+    expect(within(row!).getByRole("button", { name: /retry/i })).toBeInTheDocument();
+
+    // A successful retry restores the real enabled/disabled state.
+    mockedIsAutostartEnabled.mockResolvedValueOnce(true);
+    await user.click(within(row!).getByRole("button", { name: /retry/i }));
+
+    await waitFor(() => expect(control).toBeEnabled());
+    expect(control).toHaveAttribute("aria-checked", "true");
+    expect(screen.queryByText(/couldn't read the os setting/i)).not.toBeInTheDocument();
   });
 });

--- a/src/components/SettingsView.tsx
+++ b/src/components/SettingsView.tsx
@@ -779,7 +779,12 @@ export function SettingsView({ registry, onRegistryChange }: Props) {
       .then(setNeedsRestart)
       .catch(() => {});
   }, []);
-  const [autostartOn, setAutostartOn] = useState(false);
+  // Launch-at-login is OS-level state owned by the autostart plugin. Model
+  // loading/ready/error explicitly so the switch is never presented as a
+  // verified Off while the real OS value is unknown or unreadable (#694).
+  const [autostart, setAutostart] = useState<
+    { status: "loading" } | { status: "error" } | { status: "ready"; enabled: boolean }
+  >({ status: "loading" });
 
   const httpClients = registry?.httpClients ?? [];
   const profiles = registry?.profiles ?? [];
@@ -791,18 +796,27 @@ export function SettingsView({ registry, onRegistryChange }: Props) {
   }, [registry?.servers]);
 
   // Launch-at-login is OS-level (managed by the autostart plugin), not registry state.
-  useEffect(() => {
-    isAutostartEnabled()
-      .then(setAutostartOn)
-      .catch(() => {});
+  // A failed read must not be rendered as "Off": keep the switch disabled and offer
+  // a retry until the OS value is actually known.
+  const loadAutostart = useCallback(async () => {
+    setAutostart({ status: "loading" });
+    try {
+      setAutostart({ status: "ready", enabled: await isAutostartEnabled() });
+    } catch {
+      setAutostart({ status: "error" });
+    }
   }, []);
+
+  useEffect(() => {
+    void loadAutostart();
+  }, [loadAutostart]);
 
   const toggleAutostart = async (on: boolean) => {
     setBusySettings((current) => new Set(current).add("autostart"));
     try {
       if (on) await enableAutostart();
       else await disableAutostart();
-      setAutostartOn(on);
+      setAutostart({ status: "ready", enabled: on });
     } catch (e) {
       toastError(`Couldn't ${on ? "enable" : "disable"} launch at login: ${e}`);
     } finally {
@@ -976,18 +990,41 @@ export function SettingsView({ registry, onRegistryChange }: Props) {
     desc: string,
     onChange: (v: boolean) => void,
     settingKey: SettingKey,
+    extra?: {
+      switchDisabled?: boolean;
+      hint?: string;
+      hintTone?: "muted" | "destructive";
+      onRetry?: () => void;
+    },
   ) => (
     <label className="flex items-center gap-2.5 rounded-md border px-3 py-2.5 text-sm">
       <Icon className={`size-4 shrink-0 ${on ? accent : "text-muted-foreground"}`} />
       <span className="flex min-w-0 flex-1 flex-col leading-tight">
         <span className="font-medium">{title}</span>
         <span className="text-xs text-muted-foreground">{desc}</span>
+        {extra?.hint && (
+          <span
+            className={
+              extra.hintTone === "destructive"
+                ? "text-xs text-destructive"
+                : "text-xs text-muted-foreground"
+            }
+          >
+            {extra.hint}
+          </span>
+        )}
       </span>
       <Switch
         checked={on}
         onCheckedChange={onChange}
-        disabled={busySettings.has(settingKey)}
+        disabled={busySettings.has(settingKey) || extra?.switchDisabled}
       />
+      {extra?.onRetry && (
+        <Button size="sm" variant="ghost" className="gap-1.5" onClick={extra.onRetry}>
+          <RefreshCw className="size-3.5" />
+          Retry
+        </Button>
+      )}
     </label>
   );
 
@@ -999,12 +1036,24 @@ export function SettingsView({ registry, onRegistryChange }: Props) {
         </h2>
         {toggle(
           Power,
-          autostartOn,
+          autostart.status === "ready" && autostart.enabled,
           "text-info",
           "Launch at login",
           "Start Toolport in the tray when you sign in, so it can hold tool calls for approval even before you open it",
           toggleAutostart,
           "autostart",
+          {
+            switchDisabled: autostart.status !== "ready",
+            hint:
+              autostart.status === "loading"
+                ? "Checking the current OS setting…"
+                : autostart.status === "error"
+                  ? "Couldn't read the OS setting — launch-at-login state is unknown."
+                  : undefined,
+            hintTone: autostart.status === "error" ? "destructive" : "muted",
+            onRetry:
+              autostart.status === "error" ? () => void loadAutostart() : undefined,
+          },
         )}
         <div className="flex items-center gap-2.5 rounded-md border px-3 py-2.5 text-sm">
           <Sun className="size-4 shrink-0 text-info" />


### PR DESCRIPTION
## Problem

Settings initialized the launch-at-login state to `false`, then loaded the
real OS value asynchronously with a swallowed catch. The UI presented an
actionable **Off** switch while the value was still loading, and permanently
presented **Off** after `isAutostartEnabled()` failed — even if launch at
login was actually enabled. Clicking during that window could also act from
a state the UI never verified.

## Fix

Model the autostart state explicitly as `loading | error | ready`:

- The switch is **disabled** until the OS read succeeds (loading shows a
  "Checking the current OS setting…" hint).
- A **failed read** keeps the switch disabled and shows destructive
  unavailable feedback with a **Retry** button — never a verified Off state.
- A **successful retry** restores the real enabled/disabled state.
- The generic `toggle` row helper gains an optional `extra` (switch
  disablement, hint, retry) used only by the autostart row; other rows are
  unchanged.

## Tests

- Deferred successful read: switch disabled while pending, then enabled and
  reflecting the resolved value.
- Verified-disabled read: switch enabled with `aria-checked=false` once the
  OS value is `false`.
- Rejected read: switch stays disabled, error hint + Retry appear; retry
  after the mock resolves restores the real state.

## Validation

- `npx vitest run src/components/SettingsView.test.tsx` — 10/10 passed
- `npm test` — 354 passed; the 2 `localStorage.clear is not a function`
  failures are pre-existing on clean main
- `npm run lint` — 0 errors
- `npm run build` — passes

Closes #694


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Keep launch-at-login switch disabled in `SettingsView` until OS autostart state is known
> - Replaces the simple `autostartOn` boolean state with a discriminated union (`loading | error | ready`) to model the OS autostart read lifecycle.
> - The switch is disabled and shows a "Checking the current OS setting…" hint while loading. On failure, it stays disabled, shows an error hint, and renders a Retry button to reattempt the read.
> - The `toggle` helper in [SettingsView.tsx](https://github.com/tsouth89/toolport/pull/721/files#diff-7df3701f815f17f65cca4085a374bd5c5b1c545381f096cd2b64498355a39209) now accepts optional metadata to force-disable the switch, show hint text, and render a Retry button.
> - Tests added in [SettingsView.test.tsx](https://github.com/tsouth89/toolport/pull/721/files#diff-bb26392a4412c125c4445e9997a58cff768508435f76e945d8501feb16fb0c89) covering the loading, success, and error+retry states.
> - Behavioral Change: the switch now shows as disabled (not falsely "off") on initial render until the OS state is confirmed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3b3b49d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->