### PR TITLE
fix: render rich ConfirmDialog descriptions without invalid DOM nesting (#692)

### DIFF
--- a/src/components/ConfirmDialog.test.tsx
+++ b/src/components/ConfirmDialog.test.tsx
@@ -87,4 +87,37 @@ describe("ConfirmDialog", () => {
     expect(screen.getByRole("dialog")).toBeInTheDocument();
     expect(screen.getByText("Delete item?")).toBeInTheDocument();
   });
+
+  it("renders rich descriptions in a block container without invalid-DOM errors", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      renderControlledDialog({
+        description: (
+          <div>
+            <p>Only the server list changes.</p>
+            <ul>
+              <li>Alpha</li>
+            </ul>
+          </div>
+        ),
+      });
+
+      expect(screen.getByText("Only the server list changes.")).toBeInTheDocument();
+      expect(screen.getByText("Alpha")).toBeInTheDocument();
+
+      // aria-describedby still points at the complete explanation container.
+      const dialog = screen.getByRole("dialog");
+      const describedBy = dialog.getAttribute("aria-describedby");
+      expect(describedBy).toBeTruthy();
+      const described = document.getElementById(describedBy!);
+      expect(described).not.toBeNull();
+      expect(described!.tagName).toBe("DIV");
+      expect(described!.querySelector("ul")).not.toBeNull();
+      expect(described!.querySelector("ul li")).toHaveTextContent("Alpha");
+    } finally {
+      errorSpy.mockRestore();
+    }
+
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
 });

--- a/src/components/ConfirmDialog.tsx
+++ b/src/components/ConfirmDialog.tsx
@@ -1,4 +1,4 @@
-import { useState, type ReactNode } from "react";
+import { useId, useState, type ReactNode } from "react";
 import {
   Dialog,
   DialogContent,
@@ -43,6 +43,12 @@ export function ConfirmDialog({
 }: Props) {
   const [openState, setOpenState] = useState(false);
   const [busy, setBusy] = useState(false);
+  // Rich (element) descriptions contain block elements (div/p/ul), which are
+  // invalid inside Radix DialogDescription's <p> root. Render those in a plain
+  // block container and wire aria-describedby by hand; string descriptions keep
+  // using DialogDescription exactly as before (#692).
+  const descriptionId = useId();
+  const richDescription = description !== undefined && typeof description !== "string";
   // Controlled when an `open` prop is supplied (e.g. opened from a menu item),
   // otherwise self-managed by the trigger.
   const isControlled = openProp !== undefined;
@@ -69,10 +75,24 @@ export function ConfirmDialog({
   return (
     <Dialog open={open} onOpenChange={setOpen}>
       {trigger && <DialogTrigger asChild>{trigger}</DialogTrigger>}
-      <DialogContent className="sm:max-w-sm" onClick={(e) => e.stopPropagation()}>
+      <DialogContent
+        className="sm:max-w-sm"
+        onClick={(e) => e.stopPropagation()}
+        aria-describedby={richDescription ? descriptionId : undefined}
+      >
         <DialogHeader>
           <DialogTitle>{title}</DialogTitle>
-          {description && <DialogDescription>{description}</DialogDescription>}
+          {description &&
+            (richDescription ? (
+              <div
+                id={descriptionId}
+                className="text-sm text-muted-foreground *:[a]:underline *:[a]:underline-offset-3 *:[a]:hover:text-foreground"
+              >
+                {description}
+              </div>
+            ) : (
+              <DialogDescription>{description}</DialogDescription>
+            ))}
         </DialogHeader>
         <DialogFooter>
           <Button variant="ghost" onClick={() => setOpen(false)} disabled={busy}>


### PR DESCRIPTION
## Summary

Fixes #692 — `ConfirmDialog` passed element (JSX) descriptions straight into Radix `DialogDescription`, whose root is a `<p>`. When the description contained block elements (`<div>`, `<p>`, `<ul>`), React emitted invalid nested HTML like `<p><div>…</div></p>`, which the DOM parser mangles (block boundaries get moved outside the `<p>`).

## Change

- When `description` is an element (non-string), render it in a plain block `div` and wire `aria-describedby` to it by hand.
- String descriptions continue to use `DialogDescription` exactly as before — zero behavior change for the common case.
- Added a regression test that renders a rich description, asserts the text is present, confirms `aria-describedby` still points at the full explanation container, and verifies no React invalid-DOM warnings are emitted.

## Validation

- `vitest run src/components/ConfirmDialog.test.tsx src/components/TeamsView.test.tsx` — 8/8 pass (TeamsView is the consumer with the rich description)
- Full suite: 353 pass, only the 2 pre-existing `localStorage.clear` jsdom failures (confirmed identical on clean `main`)
- `tsc --noEmit` clean, ESLint clean, `npm run build` succeeds


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix invalid DOM nesting in `ConfirmDialog` when rendering rich descriptions
> When `ConfirmDialog` receives a non-string description, wrapping it in `DialogDescription` (a `<p>`) causes invalid DOM nesting if the content includes block elements. The fix renders rich descriptions inside a plain `<div>` referenced via `aria-describedby` on `DialogContent`, preserving accessibility while avoiding the nesting violation. String descriptions continue to use `DialogDescription` unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized eb4c62f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->