### PR TITLE
fix(desktop): move gateway install/uninstall off the GTK main loop, and test the Windows installer script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,3 +144,35 @@ jobs:
       - name: Headless gateway security smoke (Windows)
         if: matrix.os == 'windows-latest'
         run: powershell -ExecutionPolicy Bypass -File scripts/smoke-headless.ps1
+
+  # scripts/install.ps1 is piped into `iex` from a pinned commit, so a
+  # regression in asset selection, checksum enforcement, or the silent-install
+  # flag reaches users with no build step in between. Nothing else in CI runs
+  # it. Its own job because it needs neither Rust nor Node (SBS-713).
+  installer-script:
+    name: Installer script tests
+    runs-on: windows-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      # windows-latest ships Pester 5, but pin the major here so a runner-image
+      # change cannot silently move the test framework under these tests.
+      - name: Install Pester
+        shell: pwsh
+        run: |
+          if (-not (Get-Module -ListAvailable Pester |
+                Where-Object { $_.Version -ge [version]'5.5.0' -and $_.Version -lt [version]'6.0.0' })) {
+            Set-PSRepository PSGallery -InstallationPolicy Trusted
+            Install-Module Pester -MinimumVersion 5.5.0 -MaximumVersion 5.99.99 `
+              -Force -Scope CurrentUser -SkipPublisherCheck
+          }
+
+      - name: Pester tests for scripts/install.ps1
+        shell: pwsh
+        run: |
+          Import-Module Pester -MinimumVersion 5.5.0 -MaximumVersion 5.99.99
+          $result = Invoke-Pester -Path scripts/install.Tests.ps1 -Output Detailed -PassThru
+          if ($result.FailedCount -gt 0) { exit 1 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,6 +62,9 @@ powershell -ExecutionPolicy Bypass -File scripts/smoke-headless.ps1
 # Frontend unit tests (Vitest)
 npm run test
 
+# Windows installer script (Pester 5, Windows only)
+npm run test:install-script
+
 # Frontend type-check + build
 npx tsc --noEmit && npm run build
 ```
@@ -72,6 +75,21 @@ in `src-tauri/tests/`. Use the npm script above so your local target selection
 matches CI. Frontend tests use [Vitest](https://vitest.dev) and live alongside
 the code as `*.test.ts` or `*.test.tsx` files inside `src/`, depending on whether
 the test contains JSX.
+
+`scripts/install.ps1` is the `irm ... | iex` one-liner, so a regression in asset
+selection, checksum enforcement, or the silent-install flag reaches users with no
+build step in between. `scripts/install.Tests.ps1` drives the real script end to
+end with the GitHub API, the download, and the installer mocked. It needs
+[Pester](https://pester.dev) 5.5 or newer, which is not the version bundled with
+Windows PowerShell 5.1:
+
+```powershell
+Install-Module Pester -MinimumVersion 5.5.0 -Force -Scope CurrentUser -SkipPublisherCheck
+```
+
+`Get-FileHash` is deliberately left unmocked there: the download mock writes known
+bytes and the fake release advertises their real digest, so a checksum test fails
+if verification is ever skipped or inverted. Keep it that way when adding cases.
 
 ### Formatting
 

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:rust": "cargo test --manifest-path src-tauri/Cargo.toml --lib --bins --tests",
+    "test:install-script": "pwsh -NoProfile -Command \"Import-Module Pester -MinimumVersion 5.5.0; $r = Invoke-Pester -Path scripts/install.Tests.ps1 -Output Detailed -PassThru; if ($r.FailedCount -gt 0) { exit 1 }\"",
     "test:rust:windows": "powershell -ExecutionPolicy Bypass -File scripts/test-rust-windows.ps1",
     "smoke:headless": "node scripts/smoke-headless.mjs",
     "bench:latency": "node benchmark/latency.mjs",

--- a/scripts/install.Tests.ps1
+++ b/scripts/install.Tests.ps1
@@ -1,0 +1,570 @@
+# Pester tests for scripts/install.ps1 (SBS-713).
+#
+# The script is piped into `iex` from a pinned commit, so a regression in asset
+# selection, checksum enforcement, or the silent-install flag reaches users'
+# machines with no build step in between. Nothing else in CI executes it.
+#
+# These drive the real script end to end with the network and the installer
+# mocked, so the assertions are about the behaviour a user gets rather than
+# about extracted helpers. `Get-FileHash` is deliberately NOT mocked: the
+# download mock writes known bytes and the fake release carries their real
+# digest, so the checksum tests fail if verification is skipped or inverted.
+#
+# Run: pwsh -NoProfile -Command "Invoke-Pester -Path scripts/install.Tests.ps1"
+
+# Minimal stand-ins for the HTTP failure shape the script reads
+# (`$_.Exception.Response.StatusCode`). Classes must live at file scope.
+class FakeHttpResponse {
+    [int]$StatusCode
+    FakeHttpResponse([int]$status) { $this.StatusCode = $status }
+}
+class FakeHttpException : System.Exception {
+    [object]$Response
+    FakeHttpException([string]$message, [int]$status) : base($message) {
+        $this.Response = [FakeHttpResponse]::new($status)
+    }
+}
+
+BeforeAll {
+    # These fixtures are deliberately global, not $script:. A Pester mock body
+    # runs in the scope of the code that called the mocked command -- here, the
+    # scope of install.ps1 -- so a $script: variable declared in this file
+    # resolves to nothing inside the download and release mocks below.
+    $global:TpInstallScript = Join-Path $PSScriptRoot "install.ps1"
+
+    # 64 known bytes stand in for the downloaded installer. The fake release
+    # advertises this exact size and digest, so the size and checksum gates see
+    # a genuinely consistent asset unless a test deliberately breaks one.
+    $global:TpFakeBytes = [byte[]](1..64)
+    $sha = [System.Security.Cryptography.SHA256]::Create()
+    try {
+        $global:TpFakeSha256 = -join ($sha.ComputeHash($global:TpFakeBytes) | ForEach-Object { $_.ToString("x2") })
+    } finally {
+        $sha.Dispose()
+    }
+
+    function New-FakeAsset {
+        param(
+            [string]$Name,
+            [object]$Digest = $global:TpFakeSha256,
+            [object]$Size = 64,
+            [string]$Url
+        )
+        if (-not $Url) {
+            $Url = "https://github.com/tsouth89/toolport/releases/download/v1.13.0/$Name"
+        }
+        [pscustomobject]@{
+            name                 = $Name
+            browser_download_url = $Url
+            digest               = if ($null -eq $Digest) { $null } else { "sha256:$Digest" }
+            size                 = $Size
+        }
+    }
+
+    function New-FakeRelease {
+        param([object[]]$Assets, [string]$Tag = "v1.13.0")
+        [pscustomobject]@{ tag_name = $Tag; assets = @($Assets) }
+    }
+
+    # Invoke the script and return its console output plus the exit code it set.
+    # `exit` inside a script called with `&` ends that script only, so a refusal
+    # is observable here rather than tearing down the test run.
+    function Invoke-Installer {
+        param([hashtable]$Parameters = @{})
+        $global:LASTEXITCODE = 0
+        $output = & $global:TpInstallScript @Parameters 6>&1 | Out-String
+        [pscustomobject]@{
+            Output   = $output
+            ExitCode = $LASTEXITCODE
+        }
+    }
+}
+
+AfterAll {
+    Remove-Variable -Name TpInstallScript, TpFakeBytes, TpFakeSha256 -Scope Global -ErrorAction SilentlyContinue
+}
+
+Describe "install.ps1" {
+    BeforeEach {
+        # The script reads the machine architecture and four TOOLPORT_* env
+        # vars. Pin them per test so the developer's real environment cannot
+        # change the outcome, and restore them afterwards.
+        $script:SavedEnv = @{}
+        foreach ($name in @(
+                "PROCESSOR_ARCHITECTURE", "PROCESSOR_ARCHITEW6432",
+                "TOOLPORT_VERSION", "TOOLPORT_INTERACTIVE",
+                "TOOLPORT_DOWNLOAD_ONLY", "TOOLPORT_ALLOW_UNVERIFIED",
+                "GITHUB_TOKEN", "GH_TOKEN")) {
+            $script:SavedEnv[$name] = [Environment]::GetEnvironmentVariable($name)
+            Remove-Item "Env:\$name" -ErrorAction SilentlyContinue
+        }
+        $env:PROCESSOR_ARCHITECTURE = "AMD64"
+
+        Mock Invoke-RestMethod {
+            [pscustomobject]@{
+                tag_name = "v1.13.0"
+                assets   = @(New-FakeAsset -Name "Toolport_1.13.0_x64-setup.exe")
+            }
+        }
+        Mock Invoke-WebRequest { [IO.File]::WriteAllBytes($OutFile, $global:TpFakeBytes) }
+        Mock Get-AuthenticodeSignature { [pscustomobject]@{ Status = "NotSigned"; SignerCertificate = $null } }
+        Mock Start-Process { [pscustomobject]@{ ExitCode = 0 } }
+        # The post-install confirmation reads the uninstall registry key.
+        Mock Get-ItemProperty {
+            [pscustomobject]@{
+                DisplayName     = "Toolport"
+                DisplayVersion  = "1.13.0"
+                InstallLocation = '"C:\Users\test\AppData\Local\Toolport"'
+                MainBinaryName  = "conduit.exe"
+            }
+        }
+        # -DownloadOnly keeps the file; never touch the real Downloads folder.
+        Mock Move-Item { }
+    }
+
+    AfterEach {
+        foreach ($name in $script:SavedEnv.Keys) {
+            $value = $script:SavedEnv[$name]
+            if ($null -eq $value) {
+                Remove-Item "Env:\$name" -ErrorAction SilentlyContinue
+            } else {
+                Set-Item "Env:\$name" -Value $value
+            }
+        }
+    }
+
+    Context "release lookup" {
+        It "rejects a malformed -Version before making any network call" {
+            $result = Invoke-Installer @{ Version = "1.13; rm -rf /" }
+
+            $result.Output | Should -Match "doesn't look like a version"
+            $result.ExitCode | Should -Be 1
+            Should -Invoke Invoke-RestMethod -Times 0 -Exactly
+        }
+
+        It "accepts a bare version and asks for the v-prefixed tag" {
+            Invoke-Installer @{ Version = "1.13.0" } | Out-Null
+
+            Should -Invoke Invoke-RestMethod -Times 1 -Exactly -ParameterFilter {
+                $Uri -eq "https://api.github.com/repos/tsouth89/toolport/releases/tags/v1.13.0"
+            }
+        }
+
+        It "asks for the latest release when no version is given" {
+            Invoke-Installer | Out-Null
+
+            Should -Invoke Invoke-RestMethod -Times 1 -Exactly -ParameterFilter {
+                $Uri -eq "https://api.github.com/repos/tsouth89/toolport/releases/latest"
+            }
+        }
+
+        It "reads TOOLPORT_VERSION when the parameter is absent" {
+            $env:TOOLPORT_VERSION = "1.12.0"
+
+            Invoke-Installer | Out-Null
+
+            Should -Invoke Invoke-RestMethod -Times 1 -Exactly -ParameterFilter {
+                $Uri -eq "https://api.github.com/repos/tsouth89/toolport/releases/tags/v1.12.0"
+            }
+        }
+
+        It "explains a 404 on a specific tag" {
+            Mock Invoke-RestMethod { throw [FakeHttpException]::new("Not Found", 404) }
+
+            $result = Invoke-Installer @{ Version = "9.9.9" }
+
+            $result.Output | Should -Match "No release tagged v9\.9\.9"
+            $result.ExitCode | Should -Be 1
+        }
+
+        It "explains a 404 on the latest lookup as nothing being published yet" {
+            Mock Invoke-RestMethod { throw [FakeHttpException]::new("Not Found", 404) }
+
+            $result = Invoke-Installer
+
+            $result.Output | Should -Match "no published Toolport release yet"
+        }
+
+        It "explains a rate limit rather than reporting a generic failure" {
+            Mock Invoke-RestMethod { throw [FakeHttpException]::new("rate limited", 403) }
+
+            $result = Invoke-Installer
+
+            $result.Output | Should -Match "rate-limited this machine"
+        }
+
+        It "sends the token as a bearer when GITHUB_TOKEN is set" {
+            $env:GITHUB_TOKEN = "ghp_example"
+
+            Invoke-Installer | Out-Null
+
+            Should -Invoke Invoke-RestMethod -Times 1 -Exactly -ParameterFilter {
+                $Headers["Authorization"] -eq "Bearer ghp_example"
+            }
+        }
+    }
+
+    Context "asset selection" {
+        It "refuses an architecture Toolport does not ship" {
+            $env:PROCESSOR_ARCHITECTURE = "x86"
+
+            $result = Invoke-Installer
+
+            $result.Output | Should -Match "Unsupported architecture 'x86'"
+            Should -Invoke Invoke-RestMethod -Times 0 -Exactly
+        }
+
+        It "uses the real machine architecture from PROCESSOR_ARCHITEW6432" {
+            # A 32-bit PowerShell on 64-bit Windows reports x86 in
+            # PROCESSOR_ARCHITECTURE; the real arch is in the W6432 variable.
+            $env:PROCESSOR_ARCHITECTURE = "x86"
+            $env:PROCESSOR_ARCHITEW6432 = "AMD64"
+
+            $result = Invoke-Installer
+
+            $result.Output | Should -Not -Match "Unsupported architecture"
+            Should -Invoke Start-Process -Times 1 -Exactly
+        }
+
+        It "prefers the native arm64 build when the release has one" {
+            Mock Invoke-RestMethod {
+                [pscustomobject]@{
+                    tag_name = "v1.13.0"
+                    assets   = @(
+                        New-FakeAsset -Name "Toolport_1.13.0_x64-setup.exe"
+                        New-FakeAsset -Name "Toolport_1.13.0_arm64-setup.exe"
+                    )
+                }
+            }
+            $env:PROCESSOR_ARCHITECTURE = "ARM64"
+
+            $result = Invoke-Installer
+
+            $result.Output | Should -Match "Toolport_1\.13\.0_arm64-setup\.exe"
+            $result.Output | Should -Not -Match "using the x64 installer"
+        }
+
+        It "falls back to the x64 build on arm64 and says so" {
+            $env:PROCESSOR_ARCHITECTURE = "ARM64"
+
+            $result = Invoke-Installer
+
+            $result.Output | Should -Match "No native arm64 build in v1\.13\.0"
+            Should -Invoke Invoke-WebRequest -Times 1 -Exactly -ParameterFilter {
+                $Uri -like "*Toolport_1.13.0_x64-setup.exe"
+            }
+        }
+
+        It "never selects the updater signature asset" {
+            Mock Invoke-RestMethod {
+                [pscustomobject]@{
+                    tag_name = "v1.13.0"
+                    assets   = @(
+                        New-FakeAsset -Name "Toolport_1.13.0_x64-setup.exe.sig"
+                        New-FakeAsset -Name "Toolport_1.13.0_x64-setup.exe"
+                    )
+                }
+            }
+
+            Invoke-Installer | Out-Null
+
+            Should -Invoke Invoke-WebRequest -Times 1 -Exactly -ParameterFilter {
+                $Uri -like "*Toolport_1.13.0_x64-setup.exe"
+            }
+        }
+
+        It "reports a release that carries no Windows installer" {
+            Mock Invoke-RestMethod {
+                [pscustomobject]@{
+                    tag_name = "v1.13.0"
+                    assets   = @(New-FakeAsset -Name "Toolport_1.13.0_amd64.deb")
+                }
+            }
+
+            $result = Invoke-Installer
+
+            $result.Output | Should -Match "has no Windows installer"
+            Should -Invoke Invoke-WebRequest -Times 0 -Exactly
+        }
+
+        It "refuses a download URL that is not https" {
+            Mock Invoke-RestMethod {
+                [pscustomobject]@{
+                    tag_name = "v1.13.0"
+                    assets   = @(New-FakeAsset -Name "Toolport_1.13.0_x64-setup.exe" `
+                            -Url "http://example.invalid/Toolport_1.13.0_x64-setup.exe")
+                }
+            }
+
+            $result = Invoke-Installer
+
+            $result.Output | Should -Match "no https download URL"
+            Should -Invoke Invoke-WebRequest -Times 0 -Exactly
+        }
+    }
+
+    Context "checksum enforcement" {
+        It "refuses to install when the release publishes no checksum" {
+            Mock Invoke-RestMethod {
+                [pscustomobject]@{
+                    tag_name = "v1.13.0"
+                    assets   = @(New-FakeAsset -Name "Toolport_1.13.0_x64-setup.exe" -Digest $null)
+                }
+            }
+
+            $result = Invoke-Installer
+
+            $result.Output | Should -Match "publishes no checksum"
+            $result.ExitCode | Should -Be 1
+            Should -Invoke Invoke-WebRequest -Times 0 -Exactly
+            Should -Invoke Start-Process -Times 0 -Exactly
+        }
+
+        It "installs an unverified asset only when -AllowUnverified is passed" {
+            Mock Invoke-RestMethod {
+                [pscustomobject]@{
+                    tag_name = "v1.13.0"
+                    assets   = @(New-FakeAsset -Name "Toolport_1.13.0_x64-setup.exe" -Digest $null)
+                }
+            }
+
+            $result = Invoke-Installer @{ AllowUnverified = $true }
+
+            $result.Output | Should -Match "Installing an unverified binary"
+            Should -Invoke Start-Process -Times 1 -Exactly
+        }
+
+        It "treats TOOLPORT_ALLOW_UNVERIFIED=1 like the switch" {
+            Mock Invoke-RestMethod {
+                [pscustomobject]@{
+                    tag_name = "v1.13.0"
+                    assets   = @(New-FakeAsset -Name "Toolport_1.13.0_x64-setup.exe" -Digest $null)
+                }
+            }
+            $env:TOOLPORT_ALLOW_UNVERIFIED = "1"
+
+            Invoke-Installer | Out-Null
+
+            Should -Invoke Start-Process -Times 1 -Exactly
+        }
+
+        It "treats TOOLPORT_ALLOW_UNVERIFIED=0 as not set" {
+            Mock Invoke-RestMethod {
+                [pscustomobject]@{
+                    tag_name = "v1.13.0"
+                    assets   = @(New-FakeAsset -Name "Toolport_1.13.0_x64-setup.exe" -Digest $null)
+                }
+            }
+            $env:TOOLPORT_ALLOW_UNVERIFIED = "0"
+
+            $result = Invoke-Installer
+
+            $result.Output | Should -Match "publishes no checksum"
+            Should -Invoke Start-Process -Times 0 -Exactly
+        }
+
+        It "verifies a matching digest and reports it" {
+            $result = Invoke-Installer
+
+            $result.Output | Should -Match "SHA256 verified: $($global:TpFakeSha256)"
+            $result.ExitCode | Should -Be 0
+            Should -Invoke Start-Process -Times 1 -Exactly
+        }
+
+        It "stops on a digest that does not match the downloaded bytes" {
+            $wrong = "0" * 64
+            Mock Invoke-RestMethod {
+                [pscustomobject]@{
+                    tag_name = "v1.13.0"
+                    assets   = @(New-FakeAsset -Name "Toolport_1.13.0_x64-setup.exe" -Digest ("0" * 64))
+                }
+            }
+
+            $result = Invoke-Installer
+
+            $result.Output | Should -Match "SHA256 mismatch"
+            $result.Output | Should -Match "expected $wrong"
+            $result.ExitCode | Should -Be 1
+            Should -Invoke Start-Process -Times 0 -Exactly
+        }
+
+        It "treats a short download as truncated before hashing it" {
+            Mock Invoke-WebRequest { [IO.File]::WriteAllBytes($OutFile, [byte[]](1..8)) }
+
+            $result = Invoke-Installer
+
+            $result.Output | Should -Match "Treating it as truncated"
+            Should -Invoke Start-Process -Times 0 -Exactly
+        }
+
+        It "rejects an empty download" {
+            Mock Invoke-WebRequest { [IO.File]::WriteAllBytes($OutFile, [byte[]]@()) }
+
+            $result = Invoke-Installer
+
+            $result.Output | Should -Match "empty file"
+            Should -Invoke Start-Process -Times 0 -Exactly
+        }
+    }
+
+    Context "signature handling" {
+        It "refuses a file whose Authenticode signature does not match it" {
+            Mock Get-AuthenticodeSignature {
+                [pscustomobject]@{ Status = "HashMismatch"; SignerCertificate = $null }
+            }
+
+            $result = Invoke-Installer
+
+            $result.Output | Should -Match "doesn't match its contents"
+            $result.ExitCode | Should -Be 1
+            Should -Invoke Start-Process -Times 0 -Exactly
+        }
+
+        It "installs an unsigned build but warns about it" {
+            $result = Invoke-Installer
+
+            $result.Output | Should -Match "isn't code-signed"
+            Should -Invoke Start-Process -Times 1 -Exactly
+        }
+
+        It "reports the publisher from a quoted CN containing a comma" {
+            Mock Get-AuthenticodeSignature {
+                [pscustomobject]@{
+                    Status            = "Valid"
+                    SignerCertificate = [pscustomobject]@{ Subject = 'CN="South, Brandon", O=Southbound' }
+                }
+            }
+
+            $result = Invoke-Installer
+
+            $result.Output | Should -Match "signature valid: South, Brandon"
+        }
+
+        It "keeps installing when the signature status is only untrusted" {
+            Mock Get-AuthenticodeSignature {
+                [pscustomobject]@{ Status = "UnknownError"; SignerCertificate = $null }
+            }
+
+            $result = Invoke-Installer
+
+            $result.Output | Should -Match "Authenticode status: UnknownError"
+            Should -Invoke Start-Process -Times 1 -Exactly
+        }
+    }
+
+    Context "install invocation" {
+        It "installs silently by default" {
+            Invoke-Installer | Out-Null
+
+            Should -Invoke Start-Process -Times 1 -Exactly -ParameterFilter {
+                ($ArgumentList -join " ") -eq "/S"
+            }
+        }
+
+        It "runs the wizard with no silent flag under -Interactive" {
+            $result = Invoke-Installer @{ Interactive = $true }
+
+            $result.Output | Should -Match "Running the installer \(wizard\)"
+            Should -Invoke Start-Process -Times 1 -Exactly -ParameterFilter { -not $ArgumentList }
+        }
+
+        It "treats TOOLPORT_INTERACTIVE=1 like the switch" {
+            $env:TOOLPORT_INTERACTIVE = "1"
+
+            Invoke-Installer | Out-Null
+
+            Should -Invoke Start-Process -Times 1 -Exactly -ParameterFilter { -not $ArgumentList }
+        }
+
+        It "verifies but never installs under -DownloadOnly" {
+            $result = Invoke-Installer @{ DownloadOnly = $true }
+
+            $result.Output | Should -Match "Verified installer saved to"
+            $result.ExitCode | Should -Be 0
+            Should -Invoke Move-Item -Times 1 -Exactly
+            Should -Invoke Start-Process -Times 0 -Exactly
+        }
+
+        It "labels a -DownloadOnly file unverified when there was no checksum" {
+            Mock Invoke-RestMethod {
+                [pscustomobject]@{
+                    tag_name = "v1.13.0"
+                    assets   = @(New-FakeAsset -Name "Toolport_1.13.0_x64-setup.exe" -Digest $null)
+                }
+            }
+
+            $result = Invoke-Installer @{ DownloadOnly = $true; AllowUnverified = $true }
+
+            $result.Output | Should -Match "Unverified installer saved to"
+        }
+
+        It "reports a failing installer exit code" {
+            Mock Start-Process { [pscustomobject]@{ ExitCode = 2 } }
+
+            $result = Invoke-Installer
+
+            $result.Output | Should -Match "installer exited with code 2"
+            $result.ExitCode | Should -Be 1
+        }
+
+        It "explains a cancelled elevation prompt" {
+            Mock Start-Process { [pscustomobject]@{ ExitCode = 1223 } }
+
+            $result = Invoke-Installer
+
+            $result.Output | Should -Match "elevation prompt was cancelled"
+        }
+    }
+
+    Context "post-install confirmation" {
+        It "reports the installed version and location" {
+            $result = Invoke-Installer
+
+            $result.Output | Should -Match "Installed Toolport 1\.13\.0"
+            # The quotes NSIS writes around InstallLocation are stripped.
+            $result.Output | Should -Match "to C:\\Users\\test\\AppData\\Local\\Toolport"
+        }
+
+        It "warns when no uninstall entry appeared despite a zero exit code" {
+            Mock Get-ItemProperty { }
+
+            $result = Invoke-Installer
+
+            $result.Output | Should -Match "no 'Toolport' entry appeared"
+            $result.ExitCode | Should -Be 0
+        }
+
+        It "warns when an older install won over the version it downloaded" {
+            Mock Get-ItemProperty {
+                [pscustomobject]@{
+                    DisplayName     = "Toolport"
+                    DisplayVersion  = "1.20.0"
+                    InstallLocation = "C:\Toolport"
+                    MainBinaryName  = "conduit.exe"
+                }
+            }
+
+            $result = Invoke-Installer
+
+            $result.Output | Should -Match "an existing newer install may have won"
+        }
+    }
+
+    Context "session hygiene" {
+        It "leaves no Install-Toolport function behind in the caller's session" {
+            Invoke-Installer | Out-Null
+
+            Test-Path "Function:\Install-Toolport" | Should -BeFalse
+        }
+
+        It "restores ErrorActionPreference and ProgressPreference" {
+            $ErrorActionPreference = "Continue"
+            $ProgressPreference = "Continue"
+
+            Invoke-Installer | Out-Null
+
+            $ErrorActionPreference | Should -Be "Continue"
+            $ProgressPreference | Should -Be "Continue"
+        }
+    }
+}

--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -918,59 +918,71 @@ fn refuse_if_customized(state: &RegistryState, client_id: &str, force: bool) -> 
 /// `transport` is `"stdio"` (default) or `"sharedHttp"` (SOU-407).
 /// When the live entry is user-customized, pass `force: true` after the UI confirms
 /// overwrite (SOU-406); otherwise the install is refused.
+///
+/// Runs on the blocking pool, not the GTK main loop (SBS-818): the shared-HTTP
+/// path reaches the vault through `ensure_client_http_token`, and a Secret
+/// Service call is a synchronous D-Bus round trip that stalls window controls
+/// and the tray menu on a slow or locked keyring (SBS-813, SBS-812). Reading the
+/// client's config in `refuse_if_customized` and writing it in `clients::*` are
+/// blocking file IO for the same reason.
 #[tauri::command]
-fn install_gateway(
-    state: State<RegistryState>,
-    bridge: State<HttpBridgeState>,
+async fn install_gateway(
+    app: AppHandle,
     client_id: String,
     profile: Option<String>,
     force: Option<bool>,
     transport: Option<String>,
 ) -> Result<clients::WriteOutcome, String> {
-    refuse_if_customized(state.inner(), &client_id, force.unwrap_or(false))?;
-    let transport = transport
-        .as_deref()
-        .map(str::trim)
-        .filter(|t| !t.is_empty())
-        .unwrap_or("stdio");
-    let outcome = if transport.eq_ignore_ascii_case("sharedHttp")
-        || transport.eq_ignore_ascii_case("shared_http")
-    {
-        // Ensure the supervised bridge is up, mint/reuse a per-client bearer, write
-        // native remote or mcp-remote into the client config (SOU-407).
-        let status = start_http_bridge_at(bridge.inner(), None)?;
-        let port = status.port.unwrap_or(8765);
-        let url = format!("http://127.0.0.1:{port}/mcp");
-        let token = ensure_client_http_token(state.inner(), &client_id, profile.as_deref())?;
-        let spec = clients::SharedHttpSpec { url, token };
-        clients::install_gateway_shared_http(&client_id, profile.as_deref(), &spec)?
-    } else {
-        clients::install_gateway(&client_id, profile.as_deref())?
-    };
-    // Record the scope we just wrote into the client's config, so the UI can show
-    // and re-apply this client's effective scope without re-reading the config.
-    // A concrete profile is stored by name; "no profile" is recorded as an
-    // explicit-unscoped marker (not a removal) so a running gateway drops its old
-    // scope live instead of falling back to its boot-time CONDUIT_PROFILE. The client
-    // config was already written above (outside the lock); only the registry record
-    // goes through the locked load-modify-save.
-    let scope: Option<String> = profile
-        .as_deref()
-        .map(str::trim)
-        .filter(|p| !p.is_empty())
-        .map(str::to_string);
-    let managed = outcome.managed.clone();
-    write_registry(state.inner(), |reg| {
-        match scope.as_deref() {
-            Some(p) => reg.set_client_scope(&client_id, Some(p)),
-            None => reg.set_client_unscoped(&client_id),
-        }
-        if let Some(m) = managed {
-            reg.set_client_managed_entry(&client_id, m);
-        }
-        Ok(())
-    })?;
-    Ok(outcome)
+    tauri::async_runtime::spawn_blocking(move || {
+        let state = app.state::<RegistryState>();
+        let bridge = app.state::<HttpBridgeState>();
+        refuse_if_customized(state.inner(), &client_id, force.unwrap_or(false))?;
+        let transport = transport
+            .as_deref()
+            .map(str::trim)
+            .filter(|t| !t.is_empty())
+            .unwrap_or("stdio");
+        let outcome = if transport.eq_ignore_ascii_case("sharedHttp")
+            || transport.eq_ignore_ascii_case("shared_http")
+        {
+            // Ensure the supervised bridge is up, mint/reuse a per-client bearer, write
+            // native remote or mcp-remote into the client config (SOU-407).
+            let status = start_http_bridge_at(bridge.inner(), None)?;
+            let port = status.port.unwrap_or(8765);
+            let url = format!("http://127.0.0.1:{port}/mcp");
+            let token = ensure_client_http_token(state.inner(), &client_id, profile.as_deref())?;
+            let spec = clients::SharedHttpSpec { url, token };
+            clients::install_gateway_shared_http(&client_id, profile.as_deref(), &spec)?
+        } else {
+            clients::install_gateway(&client_id, profile.as_deref())?
+        };
+        // Record the scope we just wrote into the client's config, so the UI can show
+        // and re-apply this client's effective scope without re-reading the config.
+        // A concrete profile is stored by name; "no profile" is recorded as an
+        // explicit-unscoped marker (not a removal) so a running gateway drops its old
+        // scope live instead of falling back to its boot-time CONDUIT_PROFILE. The client
+        // config was already written above (outside the lock); only the registry record
+        // goes through the locked load-modify-save.
+        let scope: Option<String> = profile
+            .as_deref()
+            .map(str::trim)
+            .filter(|p| !p.is_empty())
+            .map(str::to_string);
+        let managed = outcome.managed.clone();
+        write_registry(state.inner(), |reg| {
+            match scope.as_deref() {
+                Some(p) => reg.set_client_scope(&client_id, Some(p)),
+                None => reg.set_client_unscoped(&client_id),
+            }
+            if let Some(m) = managed {
+                reg.set_client_managed_entry(&client_id, m);
+            }
+            Ok(())
+        })?;
+        Ok(outcome)
+    })
+    .await
+    .map_err(|e| format!("install task join failed: {e}"))?
 }
 
 /// Mint or reuse a bearer token for a managed shared-HTTP client install.
@@ -1049,21 +1061,30 @@ fn revoke_client_http_token(state: &RegistryState, client_id: &str) {
 }
 
 /// Remove the Toolport gateway from a client.
+///
+/// Runs on the blocking pool for the same reason as [`install_gateway`]
+/// (SBS-818): `revoke_client_http_token` deletes the vaulted bearer, which is a
+/// synchronous Secret Service round trip on Linux.
 #[tauri::command]
-fn uninstall_gateway(
-    state: State<RegistryState>,
+async fn uninstall_gateway(
+    app: AppHandle,
     client_id: String,
 ) -> Result<clients::WriteOutcome, String> {
-    let outcome = clients::uninstall_gateway(&client_id)?;
-    // Config entry is gone; also revoke the bridge bearer so a leftover backup or
-    // stale token cannot keep authenticating (WS3-4).
-    revoke_client_http_token(state.inner(), &client_id);
-    write_registry(state.inner(), |reg| {
-        reg.set_client_scope(&client_id, None);
-        reg.clear_client_managed_entry(&client_id);
-        Ok(())
-    })?;
-    Ok(outcome)
+    tauri::async_runtime::spawn_blocking(move || {
+        let state = app.state::<RegistryState>();
+        let outcome = clients::uninstall_gateway(&client_id)?;
+        // Config entry is gone; also revoke the bridge bearer so a leftover backup or
+        // stale token cannot keep authenticating (WS3-4).
+        revoke_client_http_token(state.inner(), &client_id);
+        write_registry(state.inner(), |reg| {
+            reg.set_client_scope(&client_id, None);
+            reg.clear_client_managed_entry(&client_id);
+            Ok(())
+        })?;
+        Ok(outcome)
+    })
+    .await
+    .map_err(|e| format!("uninstall task join failed: {e}"))?
 }
 
 /// 24 random bytes (192 bits) as hex, for a bearer token or a unique id.


### PR DESCRIPTION
Two backlog items: SBS-818 and SBS-713. One commit each.

## SBS-818 - install/uninstall reach the vault on the GTK main loop

SBS-813 (#716) moved 17 blocking commands onto the blocking pool but missed
`install_gateway` and `uninstall_gateway`. Both are plain sync `#[tauri::command] fn`,
so they run on the GTK main loop, and both reach the vault:

- `install_gateway` -> `ensure_client_http_token` -> `secrets::get_secret` / `set_secret`
  (shared-HTTP path)
- `uninstall_gateway` -> `revoke_client_http_token` -> `secrets::delete_secret`

A Secret Service call is a synchronous D-Bus round trip. On a slow, locked or crashing
keyring it blocks, and on the main loop that freezes window controls and the tray menu,
which is the symptom pair of SBS-813 and SBS-812. SBS-815 (#720) bounded the worst case
with a 2.5s lock deadline and no retry on a locked keyring, but a bounded main-loop stall
is still a main-loop stall.

Both become `async fn` + `spawn_blocking`, taking `AppHandle` and resolving the managed
state inside the closure (the shape #716 used, since `State<'_, T>` cannot move into the
closure). Their blocking client-config reads and writes go off the main loop with them.
Command names and arguments are unchanged, so `src/lib/api.ts` needs no edit.

**Sweep for the rest of the class.** These two were the only remaining sync commands that
reach `secrets::`. Every other call site is already off the main loop:

| call site | why it is already safe |
| --- | --- |
| `missing_secret`, `connect_server` | only reachable via `probe_one` and the async playground commands, all under `spawn_blocking` |
| `prewarm_launcher` | does its vault read inside its own `std::thread::spawn` |
| `set_secret` ... `secret_status` | already converted by #716 |

One thing I did **not** change: `migrate_client` is already `async`, but it calls
`ensure_client_http_token` directly in the async body rather than inside `spawn_blocking`,
so it blocks a tokio worker rather than the GTK main loop. Not a UI freeze, out of scope
here. Happy to file it separately if you want it tidied.

## SBS-713 - install.ps1 had no test coverage and CI never ran it

`scripts/install.ps1` is the `irm ... | iex` one-liner, so a regression in asset selection,
checksum enforcement, or the `/S` flag ships silently. #691 deferred this because the repo
had no PowerShell test infrastructure.

`scripts/install.Tests.ps1` adds 39 Pester cases that drive the real script end to end
with `Invoke-RestMethod`, `Invoke-WebRequest`, `Start-Process`, `Get-AuthenticodeSignature`,
`Get-ItemProperty` and `Move-Item` mocked. **The script itself is byte-for-byte unchanged.**
It is piped into `iex` from a pinned commit, so refactoring it for testability would have
been the riskier half of this change.

`Get-FileHash` is deliberately **not** mocked. The download mock writes 64 known bytes and
the fake release advertises their real SHA-256, so verification runs for real.

Covered: version validation, tag vs latest lookup, 404/403 branches, the token header,
architecture detection including `PROCESSOR_ARCHITEW6432`, native vs x64-fallback asset
choice, `.sig` exclusion, https-only download URLs, the no-checksum refusal and its
`-AllowUnverified` escape, digest mismatch, truncated and empty downloads, Authenticode
`HashMismatch`, `/S` vs `-Interactive`, `-DownloadOnly`, installer exit codes (including
the 1223 hint), the post-install registry read, and the `TOOLPORT_*` env fallbacks
including that `"0"` reads as off.

**Verified load-bearing by mutation.** Each of these was applied to `install.ps1`, run,
and reverted:

| mutation | tests that went red |
| --- | --- |
| drop the no-checksum refusal | 2 |
| `/S` -> `/VERYSILENT` | 1 |
| remove the arm64-to-x64 fallback | 1 |
| neuter the hash comparison | 1 |

CI runs it as its own `windows-latest` job, which needs neither Rust nor Node. Pester is
pinned to the 5.x major so a runner-image change cannot move the framework underneath the
tests. Locally: `npm run test:install-script`.

## Verification

- `cargo test --lib` with default features (desktop on): 1012 passed, 0 failed
- `cargo check --lib --tests`: clean, no new warnings
- Pester suite: 39/39 on both 5.7.1 and 6.1.0
- `prettier --check` clean on the edited files

## Not in this batch

- **SBS-712** (Windows torn credential reads) left alone on purpose. The ticket exists to
  record the decision, not to push the work: "Revisit if torn reads are ever observed in
  the wild."
- **SBS-709** (gateway-side icon caching) is not a small item. It needs SSRF screening, a
  bounded cache, and an opt-in-vs-default call that the ticket leaves open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Move gateway install/uninstall off the GTK main loop and add Pester tests for the Windows installer script
> - Converts `install_gateway` and `uninstall_gateway` Tauri commands to `async`, moving their blocking work into `tauri::async_runtime::spawn_blocking` to avoid blocking the GTK main loop.
> - Adds a Pester 5 test suite in [scripts/install.Tests.ps1](https://github.com/tsouth89/toolport/pull/725/files#diff-f8248c81187205f66faccab276671a8a535634f3d5686c297c8288827247823a) covering release lookup, asset selection, checksum enforcement, Authenticode handling, install invocation, and session hygiene.
> - A new CI job runs the Pester suite on Windows and fails the workflow if any test fails; developers can also run it locally via `npm run test:install-script`.
> - Behavioral Change: join failures in the install/uninstall commands now surface as string errors prefixed with `install task join failed:` or `uninstall task join failed:`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fb956a7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->