### PR TITLE
fix(a11y): name the onboarding dialog from the step heading and expose role choice state

### DIFF
--- a/src/components/Onboarding.a11y.test.tsx
+++ b/src/components/Onboarding.a11y.test.tsx
@@ -1,0 +1,114 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { Onboarding } from "./Onboarding";
+import { listStacks } from "@/lib/api";
+import type { DetectedClient, Registry } from "@/lib/types";
+
+vi.mock("@/lib/api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/api")>();
+  return {
+    ...actual,
+    listStacks: vi.fn().mockResolvedValue([]),
+  };
+});
+vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+vi.mock("@/lib/toast", () => ({ toastError: vi.fn() }));
+// ClientLogo loads vendored SVGs via import.meta.glob; stub it so the test stays focused.
+vi.mock("@/components/ClientLogo", () => ({ ClientLogo: () => null }));
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+const registry = {
+  version: 1,
+  servers: [{ id: "server-1", name: "Server", transport: "stdio" }],
+  profiles: [{ id: "default", name: "Default", enabledServerIds: [] }],
+  activeProfileId: "default",
+} as unknown as Registry;
+
+const client = {
+  id: "cursor",
+  name: "Cursor",
+  appPresent: true,
+  gatewayInstalled: true,
+  servers: [],
+  pluginServers: [],
+} as unknown as DetectedClient;
+
+const props = {
+  clients: [client],
+  registry,
+  onRegistryChange: vi.fn(),
+  onClientsRefresh: vi.fn(),
+  onBrowseCatalog: vi.fn(),
+  onOpenPlayground: vi.fn(),
+  onFinish: vi.fn(),
+};
+
+describe("Onboarding dialog accessibility", () => {
+  it("names the dialog after the current step and updates as steps advance", async () => {
+    const probe = deferred<[]>();
+    const user = userEvent.setup();
+    render(<Onboarding {...props} onProbe={() => probe.promise} />);
+
+    // Welcome
+    expect(screen.getByRole("dialog")).toHaveAccessibleName("Welcome to Toolport");
+
+    await user.click(screen.getByRole("button", { name: /Get started/ }));
+    expect(screen.getByRole("dialog")).toHaveAccessibleName("Add your first servers");
+
+    await user.click(screen.getByRole("button", { name: /I'll add servers later/ }));
+    expect(screen.getByRole("dialog")).toHaveAccessibleName("Connect a client");
+
+    // Done: the name tracks the live verification state, then settles on success.
+    await user.click(screen.getByRole("button", { name: /Skip for now/ }));
+    expect(screen.getByRole("dialog")).toHaveAccessibleName("Checking your setup");
+
+    probe.resolve([]);
+    await waitFor(() =>
+      expect(screen.getByRole("dialog")).toHaveAccessibleName("You're set up"),
+    );
+  });
+
+  it("names the dialog for the Join Team step", async () => {
+    const user = userEvent.setup();
+    render(<Onboarding {...props} onProbe={vi.fn().mockResolvedValue([])} />);
+
+    await user.click(
+      screen.getByRole("button", { name: /Joining a team\? Enter your invite code/ }),
+    );
+    expect(screen.getByRole("dialog")).toHaveAccessibleName("Join your team");
+  });
+
+  it("exposes the selected state of the role/stack choice buttons", async () => {
+    vi.mocked(listStacks).mockResolvedValue([
+      { id: "dev", name: "Developer", description: "A dev stack", servers: [] },
+      { id: "ops", name: "Operations", description: "An ops stack", servers: [] },
+    ]);
+    const user = userEvent.setup();
+    render(
+      <Onboarding {...props} initialStep={1} onProbe={vi.fn().mockResolvedValue([])} />,
+    );
+
+    const dev = await screen.findByRole("button", { name: "Developer" });
+    const ops = screen.getByRole("button", { name: "Operations" });
+    // Neither is selected initially.
+    expect(dev).toHaveAttribute("aria-pressed", "false");
+    expect(ops).toHaveAttribute("aria-pressed", "false");
+
+    // Selecting a role presses only that button.
+    await user.click(dev);
+    expect(dev).toHaveAttribute("aria-pressed", "true");
+    expect(ops).toHaveAttribute("aria-pressed", "false");
+
+    // Clicking again toggles it back off (deselect).
+    await user.click(dev);
+    expect(dev).toHaveAttribute("aria-pressed", "false");
+  });
+});

--- a/src/components/Onboarding.health.test.tsx
+++ b/src/components/Onboarding.health.test.tsx
@@ -49,10 +49,16 @@ describe("Onboarding health verification", () => {
     expect(
       screen.getByRole("button", { name: "Continue without verification" }),
     ).toBeEnabled();
-    expect(screen.queryByText("You're set up")).not.toBeInTheDocument();
+    // The visible step heading (the dialog is also named from it via the
+    // sr-only DialogTitle, so target the heading to avoid the duplicate copy).
+    expect(
+      screen.queryByRole("heading", { name: "You're set up" }),
+    ).not.toBeInTheDocument();
 
     probe.resolve([]);
-    expect(await screen.findByText("You're set up")).toBeInTheDocument();
+    expect(
+      await screen.findByRole("heading", { name: "You're set up" }),
+    ).toBeInTheDocument();
   });
 
   it("does not dress an unconfigured setup in verification language", async () => {
@@ -65,7 +71,9 @@ describe("Onboarding health verification", () => {
     // Servers exist but no client is connected: the step explains what's missing,
     // so neither the probe's pending state nor its failure may relabel the finish
     // button or show verification status blocks.
-    expect(await screen.findByText("Setup started")).toBeInTheDocument();
+    expect(
+      await screen.findByRole("heading", { name: "Setup started" }),
+    ).toBeInTheDocument();
     expect(screen.queryByText("Checking server health…")).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Got it" })).toBeEnabled();
 
@@ -90,7 +98,9 @@ describe("Onboarding health verification", () => {
     expect(
       await screen.findByText(/couldn't verify your servers started/i),
     ).toBeInTheDocument();
-    expect(screen.getByText("Setup couldn't be verified")).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "Setup couldn't be verified" }),
+    ).toBeInTheDocument();
     expect(
       screen.getByRole("button", { name: "Continue without verification" }),
     ).toBeEnabled();

--- a/src/components/Onboarding.tsx
+++ b/src/components/Onboarding.tsx
@@ -44,7 +44,7 @@ import {
 } from "@/lib/types";
 import { openExternal } from "@/lib/openUrl";
 import { Button } from "@/components/ui/button";
-import { Dialog, DialogContent } from "@/components/ui/dialog";
+import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
 import { ImportReviewDialog } from "@/components/ImportReviewDialog";
 
 interface Props {
@@ -192,6 +192,14 @@ function StepHeader({
 }) {
   return (
     <div className="flex flex-col gap-2">
+      {/* Name the dialog from the visible step heading. Radix wires
+       * aria-labelledby from DialogTitle, so the dialog is announced with the
+       * current step's title (and Done's live state) instead of as an unnamed
+       * dialog. asChild + span keeps the visible h2 the only heading; the
+       * sr-only copy is purely the dialog's accessible name. */}
+      <DialogTitle asChild className="sr-only">
+        <span>{title}</span>
+      </DialogTitle>
       <div className="flex size-10 items-center justify-center rounded-xl bg-success/10 text-success">
         {icon}
       </div>
@@ -596,6 +604,8 @@ function AddServers({
               {stacks.map((s) => (
                 <button
                   key={s.id}
+                  type="button"
+                  aria-pressed={s.id === selected}
                   onClick={() => setSelected(s.id === selected ? null : s.id)}
                   className={`rounded-full border px-2.5 py-1 text-xs transition-colors ${
                     s.id === selected

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -7,6 +7,33 @@ import "@testing-library/jest-dom/vitest";
 
 afterEach(() => cleanup());
 
+// Node 25+ ships `localStorage` on globalThis as a method-less placeholder for
+// the experimental Web Storage API (it only works with `--localstorage-file`).
+// Vitest's jsdom environment deliberately skips copying jsdom's own localStorage
+// because the key already exists on the Node global, so tests would otherwise
+// call into a dead stub (`localStorage.clear is not a function`). Install a
+// working in-memory Storage that matches jsdom's semantics.
+const storageData = new Map<string, string>();
+const memoryStorage: Storage = {
+  get length() {
+    return storageData.size;
+  },
+  clear: () => storageData.clear(),
+  getItem: (key: string) => storageData.get(key) ?? null,
+  key: (index: number) => [...storageData.keys()][index] ?? null,
+  removeItem: (key: string) => {
+    storageData.delete(key);
+  },
+  setItem: (key: string, value: string) => {
+    storageData.set(key, String(value));
+  },
+};
+Object.defineProperty(globalThis, "localStorage", {
+  value: memoryStorage,
+  configurable: true,
+  writable: true,
+});
+
 // jsdom is missing a few DOM APIs that Radix UI (Dialog/Select) calls at runtime.
 // Stub them so component tests can render those primitives without throwing.
 if (typeof globalThis.ResizeObserver === "undefined") {

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -5,7 +5,11 @@ import { afterEach } from "vitest";
 import { cleanup } from "@testing-library/react";
 import "@testing-library/jest-dom/vitest";
 
-afterEach(() => cleanup());
+afterEach(() => {
+  cleanup();
+  // Reset the in-memory storage so localStorage state never leaks across tests.
+  storageData.clear();
+});
 
 // Node 25+ ships `localStorage` on globalThis as a method-less placeholder for
 // the experimental Web Storage API (it only works with `--localstorage-file`).


### PR DESCRIPTION
## Fix: onboarding dialog accessible name + role choice selected state

Closes #693

### Problem

The onboarding flow is a Radix dialog with no `DialogTitle`, so the visible
`<h2>` headings never populate the dialog's `aria-labelledby` and a screen
reader encounters an unnamed dialog. The role/stack choice buttons also
exposed no selected state — they relied on visual styling alone.

### Changes

- **Dialog naming** (`src/components/Onboarding.tsx`): each step renders a
  `sr-only` `DialogTitle` (via `asChild` + `<span>` so the visible `<h2>`
  remains the only heading in the tree) whose text mirrors the step title.
  Because the title lives in `StepHeader`, the accessible name automatically
  tracks every step — Welcome, Add, Connect, Done (including its live
  "Checking your setup" → "You're set up" transition), and Join Team.
- **Selected state**: the role/stack choice buttons now carry
  `aria-pressed`, toggling with selection.
- **Test-env fix** (`src/test/setup.ts`): pre-existing break where App tests
  failed with `localStorage.clear is not a function` on Node 25+ — Node ships
  a method-less `localStorage` placeholder on `globalThis` that shadows
  jsdom's real one under Vitest. The setup now installs an in-memory Storage
  with jsdom semantics.

### Validation

- New `Onboarding.a11y.test.tsx`: dialog name across Welcome/Add/Connect/
  Done/Join Team + `aria-pressed` toggle semantics — **all 3 fail on the
  pre-fix code**.
- Existing health tests updated to query the visible heading (the sr-only
  title duplicates the text).
- `npm test`: 356 passed (previously 2 failures on main due to the
  localStorage issue), `npm run lint`: 0 errors, `npm run build`: clean.
- Keyboard behavior and visible design unchanged.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Name the onboarding dialog from its step heading and expose role choice `aria-pressed` state
> - Adds a visually hidden `DialogTitle` (sr-only span) inside `StepHeader` that mirrors the visible step title, wiring the dialog's accessible name via `aria-labelledby` so screen readers announce the current step.
> - Updates role/stack selection buttons in `AddServers` to include `type="button"` and `aria-pressed` reflecting the current selection.
> - Adds a new accessibility test suite in [Onboarding.a11y.test.tsx](https://github.com/tsouth89/toolport/pull/726/files#diff-2ad311cecb11973a2df990b50615f211db1807ba2b4f516df239344e297d34de) covering dialog naming across steps and `aria-pressed` state.
> - Polyfills `localStorage` in [test/setup.ts](https://github.com/tsouth89/toolport/pull/726/files#diff-b38f1f15eee087a5b4a28827bab8f9cdcc2569a63018b1c53a56cc90a5d8df61) for compatibility with Node 25+, which ships a method-less placeholder.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 42de829.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->