### PR TITLE
fix: distinguish a failed quarantine poll from a confirmed zero (#741)

### DIFF
--- a/src/components/AppSidebar.test.tsx
+++ b/src/components/AppSidebar.test.tsx
@@ -343,3 +343,87 @@ describe("AppSidebar accessibility", () => {
     expect(checkForUpdate).toHaveBeenCalledTimes(1);
   });
 });
+
+describe("AppSidebar quarantine badge", () => {
+  function renderSidebar() {
+    return render(
+      <TooltipProvider>
+        <AppSidebar
+          clients={[client()]}
+          registry={null}
+          onRegistryChange={vi.fn()}
+          selectedClientId={null}
+          onSelectClient={vi.fn()}
+          view="servers"
+          onSelectView={vi.fn()}
+          onReplayOnboarding={vi.fn()}
+        />
+      </TooltipProvider>,
+    );
+  }
+
+  function quarantinedTool(over: Partial<import("@/lib/api").QuarantinedTool> = {}) {
+    return {
+      server: "linear",
+      tool: "linear__save_issue",
+      reason: "a destructive tool's definition changed",
+      ts: Date.now(),
+      profile: "",
+      ...over,
+    };
+  }
+
+  it("shows the blocked-tool count once the poll confirms a count", async () => {
+    listQuarantined.mockResolvedValue([
+      quarantinedTool({ tool: "a" }),
+      quarantinedTool({ tool: "b" }),
+    ]);
+
+    renderSidebar();
+
+    expect(await screen.findByLabelText("2 tools blocked")).toBeInTheDocument();
+    expect(screen.queryByLabelText("Quarantine status unknown")).not.toBeInTheDocument();
+  });
+
+  it("shows no badge on a confirmed clean state", async () => {
+    listQuarantined.mockResolvedValue([]);
+
+    renderSidebar();
+
+    await waitFor(() => expect(listQuarantined).toHaveBeenCalled());
+    expect(screen.queryByLabelText("Quarantine status unknown")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText(/tool\s?blocked/)).not.toBeInTheDocument();
+  });
+
+  it("does not present a failed poll as an all-clear (#741)", async () => {
+    listQuarantined.mockRejectedValue(new Error("gateway not reachable"));
+
+    renderSidebar();
+
+    expect(await screen.findByLabelText("Quarantine status unknown")).toBeInTheDocument();
+    expect(screen.queryByLabelText(/tool\s?blocked/)).not.toBeInTheDocument();
+  });
+
+  it("keeps surfacing the unknown state across repeated failures (#741)", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    try {
+      listQuarantined.mockRejectedValue(new Error("gateway not reachable"));
+
+      renderSidebar();
+
+      expect(
+        await screen.findByLabelText("Quarantine status unknown"),
+      ).toBeInTheDocument();
+
+      const callsBeforeNextTick = listQuarantined.mock.calls.length;
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(10_000);
+      });
+
+      expect(listQuarantined.mock.calls.length).toBeGreaterThan(callsBeforeNextTick);
+      expect(screen.getByLabelText("Quarantine status unknown")).toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/src/components/AppSidebar.test.tsx
+++ b/src/components/AppSidebar.test.tsx
@@ -426,4 +426,44 @@ describe("AppSidebar quarantine badge", () => {
       vi.useRealTimers();
     }
   });
+
+  it("keeps a confirmed count on a failed poll and marks it stale (#742)", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    try {
+      listQuarantined
+        .mockResolvedValueOnce([
+          quarantinedTool({ tool: "a" }),
+          quarantinedTool({ tool: "b" }),
+          quarantinedTool({ tool: "c" }),
+        ])
+        .mockRejectedValueOnce(new Error("gateway not reachable"));
+
+      renderSidebar();
+
+      const badge = await screen.findByLabelText("3 tools blocked");
+      expect(badge).toBeInTheDocument();
+      expect(
+        screen.queryByLabelText("Quarantine status unknown"),
+      ).not.toBeInTheDocument();
+
+      const callsBeforeNextTick = listQuarantined.mock.calls.length;
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(10_000);
+      });
+
+      expect(listQuarantined.mock.calls.length).toBeGreaterThan(callsBeforeNextTick);
+      // The confirmed count survives the failed poll instead of degrading to "?".
+      expect(screen.getByLabelText("3 tools blocked")).toBeInTheDocument();
+      expect(
+        screen.queryByLabelText("Quarantine status unknown"),
+      ).not.toBeInTheDocument();
+      // ...but the badge says the number may be stale.
+      expect(screen.getByLabelText("3 tools blocked")).toHaveAttribute(
+        "title",
+        expect.stringContaining("stale"),
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/src/components/AppSidebar.test.tsx
+++ b/src/components/AppSidebar.test.tsx
@@ -395,6 +395,27 @@ describe("AppSidebar quarantine badge", () => {
     expect(screen.queryByLabelText(/tool\s?blocked/)).not.toBeInTheDocument();
   });
 
+  it("shows no badge before the first poll answers (#742)", async () => {
+    let resolvePoll!: (q: import("@/lib/api").QuarantinedTool[]) => void;
+    listQuarantined.mockReturnValue(
+      new Promise((resolve) => {
+        resolvePoll = resolve;
+      }),
+    );
+
+    renderSidebar();
+
+    await waitFor(() => expect(listQuarantined).toHaveBeenCalled());
+    expect(screen.queryByLabelText("Quarantine status unknown")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText(/tool\s?blocked/)).not.toBeInTheDocument();
+
+    await act(async () => {
+      resolvePoll([quarantinedTool({ tool: "a" })]);
+    });
+
+    expect(await screen.findByLabelText("1 tool blocked")).toBeInTheDocument();
+  });
+
   it("does not present a failed poll as an all-clear (#741)", async () => {
     listQuarantined.mockRejectedValue(new Error("gateway not reachable"));
 

--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -497,7 +497,10 @@ export function AppSidebar({
 }: Props) {
   const [showMissing, setShowMissing] = useState(false);
   const [savings, setSavings] = useState<SavingsSummary | null>(null);
-  const [quarantinedCount, setQuarantinedCount] = useState(0);
+  // `null` means "no confirmed count": the first poll hasn't answered yet or
+  // the last poll failed. It must render distinctly from a confirmed zero so
+  // a gateway that never answered never reads as "all clear" (#741).
+  const [quarantinedCount, setQuarantinedCount] = useState<number | null>(null);
   const sorted = sortClients(clients);
   const detectedClients = sorted.filter((c) => statusOf(c) !== "missing");
   const missingClients = sorted.filter((c) => statusOf(c) === "missing");
@@ -533,7 +536,11 @@ export function AppSidebar({
         .then((q) => {
           if (alive && id === latest) setQuarantinedCount(q.length);
         })
-        .catch(() => {});
+        .catch(() => {
+          // A failed poll must not read as a confirmed zero: surface the
+          // unknown state so the badge never claims "all clear" (#741).
+          if (alive && id === latest) setQuarantinedCount(null);
+        });
     };
     load();
     const id = setInterval(load, 10_000);
@@ -550,7 +557,7 @@ export function AppSidebar({
     label: string,
     active: boolean,
     onClick: () => void,
-    badge?: number,
+    badge?: number | null,
   ) => (
     <button
       onClick={onClick}
@@ -561,12 +568,21 @@ export function AppSidebar({
         className={`size-4 shrink-0 ${active ? "text-primary" : "text-muted-foreground"}`}
       />
       <span>{label}</span>
-      {badge !== undefined && badge > 0 && (
+      {badge !== undefined && badge !== null && badge > 0 && (
         <span
           className="ml-auto inline-flex shrink-0 items-center rounded-full bg-warning/15 px-1.5 text-[10px] font-medium text-warning"
           aria-label={`${badge} tool${badge === 1 ? "" : "s"} blocked`}
         >
           {badge}
+        </span>
+      )}
+      {badge === null && (
+        <span
+          className="ml-auto inline-flex shrink-0 items-center rounded-full bg-warning/15 px-1.5 text-[10px] font-medium text-warning"
+          aria-label="Quarantine status unknown"
+          title="Could not reach the gateway — quarantine status unknown"
+        >
+          ?
         </span>
       )}
     </button>

--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -503,7 +503,9 @@ export function AppSidebar({
   const [quarantinedCount, setQuarantinedCount] = useState<number | null>(null);
   // A failed poll keeps the last confirmed count and flags it stale instead of
   // dropping back to `null`, so one transient blip never erases a real number.
-  // Mirrors SettingsView's list+error shape (keep the value, add a flag) (#742).
+  // Before the first poll answers (`null`, not stale) no badge renders at all —
+  // the "?" glyph and its "Could not reach the gateway" tooltip must only appear
+  // once a poll has actually failed, not on every app start (#742).
   const [quarantineStale, setQuarantineStale] = useState(false);
   const sorted = sortClients(clients);
   const detectedClients = sorted.filter((c) => statusOf(c) !== "missing");
@@ -591,7 +593,7 @@ export function AppSidebar({
           {badge}
         </span>
       )}
-      {badge === null && (
+      {badge === null && stale && (
         <span
           className="ml-auto inline-flex shrink-0 items-center rounded-full bg-warning/15 px-1.5 text-[10px] font-medium text-warning"
           aria-label="Quarantine status unknown"

--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -497,10 +497,14 @@ export function AppSidebar({
 }: Props) {
   const [showMissing, setShowMissing] = useState(false);
   const [savings, setSavings] = useState<SavingsSummary | null>(null);
-  // `null` means "no confirmed count": the first poll hasn't answered yet or
-  // the last poll failed. It must render distinctly from a confirmed zero so
-  // a gateway that never answered never reads as "all clear" (#741).
+  // `null` means "no confirmed count": the first poll hasn't answered yet. It
+  // must render distinctly from a confirmed zero so a gateway that never
+  // answered never reads as "all clear" (#741).
   const [quarantinedCount, setQuarantinedCount] = useState<number | null>(null);
+  // A failed poll keeps the last confirmed count and flags it stale instead of
+  // dropping back to `null`, so one transient blip never erases a real number.
+  // Mirrors SettingsView's list+error shape (keep the value, add a flag) (#742).
+  const [quarantineStale, setQuarantineStale] = useState(false);
   const sorted = sortClients(clients);
   const detectedClients = sorted.filter((c) => statusOf(c) !== "missing");
   const missingClients = sorted.filter((c) => statusOf(c) === "missing");
@@ -534,12 +538,17 @@ export function AppSidebar({
       const id = ++latest;
       return listQuarantined()
         .then((q) => {
-          if (alive && id === latest) setQuarantinedCount(q.length);
+          if (alive && id === latest) {
+            setQuarantinedCount(q.length);
+            setQuarantineStale(false);
+          }
         })
         .catch(() => {
-          // A failed poll must not read as a confirmed zero: surface the
-          // unknown state so the badge never claims "all clear" (#741).
-          if (alive && id === latest) setQuarantinedCount(null);
+          // A failed poll must not read as a confirmed zero, but it must not
+          // erase a confirmed count either: keep the last answer and mark it
+          // stale so the badge never claims "all clear" and never loses a
+          // real number over one blip (#741, #742).
+          if (alive && id === latest) setQuarantineStale(true);
         });
     };
     load();
@@ -558,6 +567,7 @@ export function AppSidebar({
     active: boolean,
     onClick: () => void,
     badge?: number | null,
+    stale?: boolean,
   ) => (
     <button
       onClick={onClick}
@@ -572,6 +582,11 @@ export function AppSidebar({
         <span
           className="ml-auto inline-flex shrink-0 items-center rounded-full bg-warning/15 px-1.5 text-[10px] font-medium text-warning"
           aria-label={`${badge} tool${badge === 1 ? "" : "s"} blocked`}
+          title={
+            stale
+              ? "Could not reach the gateway — quarantine count may be stale"
+              : undefined
+          }
         >
           {badge}
         </span>
@@ -654,6 +669,7 @@ export function AppSidebar({
             view === "settings",
             () => onSelectView("settings"),
             quarantinedCount,
+            quarantineStale,
           )}
         </nav>
 

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -5,7 +5,38 @@ import { afterEach } from "vitest";
 import { cleanup } from "@testing-library/react";
 import "@testing-library/jest-dom/vitest";
 
-afterEach(() => cleanup());
+afterEach(() => {
+  cleanup();
+  // Reset the in-memory storage so localStorage state never leaks across tests.
+  storageData.clear();
+});
+
+// Node 25+ ships `localStorage` on globalThis as a method-less placeholder for
+// the experimental Web Storage API (it only works with `--localstorage-file`).
+// Vitest's jsdom environment deliberately skips copying jsdom's own localStorage
+// because the key already exists on the Node global, so tests would otherwise
+// call into a dead stub (`localStorage.clear is not a function`). Install a
+// working in-memory Storage that matches jsdom's semantics.
+const storageData = new Map<string, string>();
+const memoryStorage: Storage = {
+  get length() {
+    return storageData.size;
+  },
+  clear: () => storageData.clear(),
+  getItem: (key: string) => storageData.get(key) ?? null,
+  key: (index: number) => [...storageData.keys()][index] ?? null,
+  removeItem: (key: string) => {
+    storageData.delete(key);
+  },
+  setItem: (key: string, value: string) => {
+    storageData.set(key, String(value));
+  },
+};
+Object.defineProperty(globalThis, "localStorage", {
+  value: memoryStorage,
+  configurable: true,
+  writable: true,
+});
 
 // jsdom is missing a few DOM APIs that Radix UI (Dialog/Select) calls at runtime.
 // Stub them so component tests can render those primitives without throwing.


### PR DESCRIPTION
## What

Fixes #741 — a failed quarantine poll rendered identically to a confirmed all-clear, so a user who had dismissed the `QuarantineAlert` card could believe nothing was blocked when Toolport never got an answer.

## Problem

`quarantinedCount` started at `useState(0)` and the polling `load()` swallowed rejections with `.catch(() => {})`. The Settings-row badge only renders for counts `> 0`, so a first-load failure (`0`) and a clean state were indistinguishable, and repeated failures were never surfaced.

## Fix

- Track the count as `number | null`, where `null` means "no confirmed count" (first poll hasn't answered, or the last poll failed).
- The poll's rejection handler now sets the count to `null`, so a failed poll can never claim an all-clear.
- The badge renders a distinct unknown-state indicator (`?`, `aria-label="Quarantine status unknown"`) when the count is `null`, and renders nothing only for a *confirmed* zero. Repeated failures keep the badge visible rather than only surfacing on the first load.
- The monotonic request-id guard still applies, so a slow stale response can't overwrite a newer one.

Also included: the pre-existing test-env failure `localStorage.clear is not a function` (Node 25 ships a method-less `localStorage` placeholder that shadows jsdom's under Vitest) is fixed with an in-memory Storage shim in the test setup, so `npm test` passes.

## Validation

- 4 new tests in `AppSidebar.test.tsx`: confirmed count → badge, confirmed clean → no badge, rejected poll → unknown badge (no false all-clear), and repeated failures keep the unknown badge visible across poll ticks. The two failure-path tests fail against the pre-fix code.
- `npm test` (361), `npm run lint` (0 errors), and `npm run build` all pass.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Distinguish a failed quarantine poll from a confirmed zero in the sidebar badge
> - Before this fix, a failed quarantine poll left `quarantinedCount` at its initial value of `0`, making it indistinguishable from a confirmed clean state.
> - `quarantinedCount` is now typed as `number|null` (null = unconfirmed) and a `quarantineStale` boolean is added to track poll failures.
> - On success, the count is set to the array length and stale is cleared. On failure, stale is set to `true` without resetting the last confirmed count.
> - The Settings nav badge now shows nothing before the first poll resolves, a `?` badge (aria-label: "Quarantine status unknown") if the first poll fails, the confirmed count when >0, or a stale tooltip if a subsequent poll fails after a confirmed count was established.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 69e5679.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->