### PR TITLE
fix: propagate a failed secrets-generation bump so revokes really take effect (#737)

### DIFF
--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -6811,6 +6811,13 @@ mod tests {
         let _env = registry::REGISTRY_ENV_LOCK
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
+        // TOOLPORT_REGISTRY is process-global and OUTRANKS the data-dir override,
+        // so while this test points it at a deliberately broken path, any
+        // concurrent test using DataDirOverride reads and writes the wrong
+        // registry and fails on state it just saved. Take the same lock those
+        // tests hold (as clear_auth_token_propagates_reload_failure... already
+        // does) so the two can never overlap.
+        let _data = registry::data_dir_test_lock();
         let dir = unique_update_test_dir("bump-failure");
         std::fs::create_dir_all(&dir).unwrap();
         std::fs::create_dir_all(dir.join("registry.json")).unwrap();
@@ -6848,6 +6855,9 @@ mod tests {
         let _env = registry::REGISTRY_ENV_LOCK
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
+        // Same reason as above: this sets the process-global TOOLPORT_REGISTRY,
+        // which outranks any concurrent test's data-dir override.
+        let _data = registry::data_dir_test_lock();
         let dir = unique_update_test_dir("bump-success");
         std::fs::create_dir_all(&dir).unwrap();
         let path = dir.join("registry.json");

--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -2986,14 +2986,37 @@ fn stored_sign_in_token_but_reload_failed(e: &str) -> String {
     format!("The sign-in token was stored in the keychain, but {e}")
 }
 
+/// Sentence wrappers for the pre-bump failures on the auth paths. Keychain and
+/// sign-in-state errors are bare fragments (e.g. an OS keychain error), so they
+/// are wrapped into complete sentences before the frontend shows them as-is;
+/// the frontend renders these messages verbatim, so a bare fragment would leave
+/// users staring at an untethered error (#743).
+fn could_not_finish_sign_in(e: &str) -> String {
+    format!("Could not finish sign-in: {e}")
+}
+
+fn could_not_store_token(e: &str) -> String {
+    format!("Could not store the token: {e}")
+}
+
+fn could_not_clear_sign_in_state(e: &str) -> String {
+    format!("Could not clear the previous sign-in state: {e}")
+}
+
+fn could_not_remove_token(e: &str) -> String {
+    format!("Could not remove the token: {e}")
+}
+
 /// The keychain half of `clear_auth_token`, extracted from the Tauri command so the
 /// whole clear-token path (not just the bump) is reachable from tests (#743).
 fn clear_auth_token_inner(server_id: &str, state: &RegistryState) -> Result<(), String> {
     let _mutation = acquire_auth_mutation_lock(server_id)?;
     // Remove refresh metadata first so a second-write failure cannot leave state
     // that silently recreates the bearer token the user asked to delete.
-    remote::clear_oauth_state(server_id)?;
-    secrets::delete_secret(server_id, secrets::HTTP_AUTH_KEY)?;
+    remote::clear_oauth_state(server_id)
+        .map_err(|e| could_not_clear_sign_in_state(&e))?;
+    secrets::delete_secret(server_id, secrets::HTTP_AUTH_KEY)
+        .map_err(|e| could_not_remove_token(&e))?;
     bump_secrets_generation(state).map_err(|e| removed_token_but_reload_failed(&e))?;
     Ok(())
 }
@@ -3010,8 +3033,10 @@ async fn set_auth_token(app: AppHandle, server_id: String, token: String) -> Res
         let _mutation = acquire_auth_mutation_lock(&server_id)?;
         // A manually pasted bearer replaces any prior OAuth session. Keeping stale
         // refresh metadata could otherwise overwrite the user's token later.
-        remote::clear_oauth_state(&server_id)?;
-        secrets::set_secret(&server_id, secrets::HTTP_AUTH_KEY, &token)?;
+        remote::clear_oauth_state(&server_id)
+            .map_err(|e| could_not_clear_sign_in_state(&e))?;
+        secrets::set_secret(&server_id, secrets::HTTP_AUTH_KEY, &token)
+            .map_err(|e| could_not_store_token(&e))?;
         bump_secrets_generation(app.state::<RegistryState>().inner()).map_err(|e| {
             // The vault half already succeeded; the user needs to know that and that the
             // gateway wasn't told (#737).
@@ -3083,8 +3108,10 @@ async fn authenticate_oauth(
         res.scope,
         res.issued_at,
         res.expires_at,
-    )?;
-    secrets::set_secret(&server_id, secrets::HTTP_AUTH_KEY, &res.access_token)?;
+    )
+    .map_err(|e| could_not_finish_sign_in(&e))?;
+    secrets::set_secret(&server_id, secrets::HTTP_AUTH_KEY, &res.access_token)
+        .map_err(|e| could_not_store_token(&e))?;
     bump_secrets_generation(state.inner()).map_err(|e| {
         // The vault half already succeeded; a fresh sign-in that never reaches the
         // gateway leaves the user staring at 401s from a server they just authenticated.
@@ -6388,6 +6415,24 @@ mod tests {
         assert_eq!(
             stored_sign_in_token_but_reload_failed("could not reload the running gateway"),
             "The sign-in token was stored in the keychain, but could not reload the running gateway"
+        );
+        // The pre-bump vault failures are wrapped into complete sentences so a bare
+        // keychain fragment never reaches the frontend verbatim (#743).
+        assert_eq!(
+            could_not_finish_sign_in("state mismatch (possible CSRF); try connecting again"),
+            "Could not finish sign-in: state mismatch (possible CSRF); try connecting again"
+        );
+        assert_eq!(
+            could_not_store_token("keychain is locked"),
+            "Could not store the token: keychain is locked"
+        );
+        assert_eq!(
+            could_not_clear_sign_in_state("keychain is locked"),
+            "Could not clear the previous sign-in state: keychain is locked"
+        );
+        assert_eq!(
+            could_not_remove_token("keychain is locked"),
+            "Could not remove the token: keychain is locked"
         );
     }
 

--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -2968,6 +2968,36 @@ fn bump_secrets_generation(state: &RegistryState) -> Result<(), String> {
     .map_err(|e| format!("could not reload the running gateway after the secret change: {e}"))
 }
 
+/// Copy for a secret change whose keychain half succeeded but whose gateway reload
+/// failed. Named helpers so the exact wording is reachable from tests; the frontend
+/// shows these messages as-is, so they must stand alone without a "failed" prefix
+/// (they would otherwise read as a sentence arguing with itself) (#743).
+fn stored_token_but_reload_failed(e: &str) -> String {
+    format!("The token was stored in the keychain, but {e}")
+}
+
+fn removed_token_but_reload_failed(e: &str) -> String {
+    format!(
+        "The token was removed from the keychain, but {e}; the running gateway may still serve it"
+    )
+}
+
+fn stored_sign_in_token_but_reload_failed(e: &str) -> String {
+    format!("The sign-in token was stored in the keychain, but {e}")
+}
+
+/// The keychain half of `clear_auth_token`, extracted from the Tauri command so the
+/// whole clear-token path (not just the bump) is reachable from tests (#743).
+fn clear_auth_token_inner(server_id: &str, state: &RegistryState) -> Result<(), String> {
+    let _mutation = acquire_auth_mutation_lock(server_id)?;
+    // Remove refresh metadata first so a second-write failure cannot leave state
+    // that silently recreates the bearer token the user asked to delete.
+    remote::clear_oauth_state(server_id)?;
+    secrets::delete_secret(server_id, secrets::HTTP_AUTH_KEY)?;
+    bump_secrets_generation(state).map_err(|e| removed_token_but_reload_failed(&e))?;
+    Ok(())
+}
+
 #[tauri::command]
 fn take_registry_recovery_notice() -> Option<registry::RegistryRecoveryNotice> {
     registry::take_recovery_notice()
@@ -2985,7 +3015,7 @@ async fn set_auth_token(app: AppHandle, server_id: String, token: String) -> Res
         bump_secrets_generation(app.state::<RegistryState>().inner()).map_err(|e| {
             // The vault half already succeeded; the user needs to know that and that the
             // gateway wasn't told (#737).
-            format!("The token was stored in the keychain, but {e}")
+            stored_token_but_reload_failed(&e)
         })?;
         Ok(())
     })
@@ -2996,19 +3026,7 @@ async fn set_auth_token(app: AppHandle, server_id: String, token: String) -> Res
 #[tauri::command]
 async fn clear_auth_token(app: AppHandle, server_id: String) -> Result<(), String> {
     tauri::async_runtime::spawn_blocking(move || {
-        let _mutation = acquire_auth_mutation_lock(&server_id)?;
-        // Remove refresh metadata first so a second-write failure cannot leave state
-        // that silently recreates the bearer token the user asked to delete.
-        remote::clear_oauth_state(&server_id)?;
-        secrets::delete_secret(&server_id, secrets::HTTP_AUTH_KEY)?;
-        bump_secrets_generation(app.state::<RegistryState>().inner()).map_err(|e| {
-            // The keychain half already succeeded; a token the user believes they just
-            // revoked must not read as cleanly removed when the gateway still serves it.
-            format!(
-                "The token was removed from the keychain, but {e}; the running gateway may still serve it"
-            )
-        })?;
-        Ok(())
+        clear_auth_token_inner(&server_id, app.state::<RegistryState>().inner())
     })
     .await
     .map_err(|e| format!("keychain task join failed: {e}"))?
@@ -3070,7 +3088,7 @@ async fn authenticate_oauth(
     bump_secrets_generation(state.inner()).map_err(|e| {
         // The vault half already succeeded; a fresh sign-in that never reaches the
         // gateway leaves the user staring at 401s from a server they just authenticated.
-        format!("Sign-in completed and the token was stored, but {e}")
+        stored_sign_in_token_but_reload_failed(&e)
     })?;
     Ok(())
 }
@@ -6349,6 +6367,90 @@ mod tests {
         bump_secrets_generation(&state).expect("bump should succeed");
         let persisted = registry::load_from(&path).expect("registry should exist");
         assert_eq!(persisted.secrets_generation, 1);
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// The three partial-failure messages are the exact copy users see (the frontend
+    /// shows them as-is, without an "OAuth failed:" prefix), so pin them here to keep
+    /// the wording deliberate and non-contradictory (#743).
+    #[test]
+    fn partial_secret_change_messages_state_the_outcome() {
+        assert_eq!(
+            stored_token_but_reload_failed("could not reload the running gateway"),
+            "The token was stored in the keychain, but could not reload the running gateway"
+        );
+        assert_eq!(
+            removed_token_but_reload_failed("could not reload the running gateway"),
+            "The token was removed from the keychain, but could not reload the running gateway; \
+             the running gateway may still serve it"
+        );
+        assert_eq!(
+            stored_sign_in_token_but_reload_failed("could not reload the running gateway"),
+            "The sign-in token was stored in the keychain, but could not reload the running gateway"
+        );
+    }
+
+    /// The clear-token path (not just the bump): with a file-backed keychain, a registry
+    /// write failure must surface the partial state — the token is gone from the keychain
+    /// but the running gateway was never told to reload (#737, #743).
+    #[test]
+    fn clear_auth_token_propagates_reload_failure_after_keychain_removal() {
+        let _serial = GEN_TEST_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let _env = registry::REGISTRY_ENV_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let _data = registry::data_dir_test_lock();
+        let dir = unique_update_test_dir("clear-auth-reload-fail");
+        std::fs::create_dir_all(&dir).unwrap();
+        // The registry "file" is an existing directory, so the atomic temp+rename
+        // save fails fast and `bump_secrets_generation` must propagate the failure.
+        std::fs::create_dir_all(dir.join("registry.json")).unwrap();
+        let _override = registry::DataDirOverride::set(&dir);
+
+        let previous_key = std::env::var_os("TOOLPORT_SECRET_KEY");
+        struct RestoreKey(Option<std::ffi::OsString>);
+        impl Drop for RestoreKey {
+            fn drop(&mut self) {
+                match &self.0 {
+                    Some(value) => std::env::set_var("TOOLPORT_SECRET_KEY", value),
+                    None => std::env::remove_var("TOOLPORT_SECRET_KEY"),
+                }
+            }
+        }
+        let _restore_key = RestoreKey(previous_key);
+        std::env::set_var("TOOLPORT_SECRET_KEY", "test-secret-key-for-clear-auth");
+
+        let previous = std::env::var_os("TOOLPORT_REGISTRY");
+        struct RestoreEnv(Option<std::ffi::OsString>);
+        impl Drop for RestoreEnv {
+            fn drop(&mut self) {
+                match &self.0 {
+                    Some(value) => std::env::set_var("TOOLPORT_REGISTRY", value),
+                    None => std::env::remove_var("TOOLPORT_REGISTRY"),
+                }
+            }
+        }
+        let _restore = RestoreEnv(previous);
+        std::env::set_var("TOOLPORT_REGISTRY", dir.join("registry.json"));
+
+        // A real vaulted token so the delete half has something to remove.
+        secrets::set_secret("srv-clear-auth", secrets::HTTP_AUTH_KEY, "tok-123").unwrap();
+        assert_eq!(
+            secrets::get_secret_result("srv-clear-auth", secrets::HTTP_AUTH_KEY).unwrap(),
+            Some("tok-123".to_string())
+        );
+
+        let state: RegistryState = Mutex::new(Registry::default());
+        let err = clear_auth_token_inner("srv-clear-auth", &state)
+            .expect_err("a failed bump must propagate on the clear path");
+        assert!(
+            err.contains("removed from the keychain"),
+            "unexpected error: {err}"
+        );
+        assert!(err.contains("may still serve it"), "unexpected error: {err}");
 
         std::fs::remove_dir_all(&dir).ok();
     }

--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -2957,12 +2957,15 @@ fn nudge_gateway(state: &RegistryState) {
 
 /// Bump [`Registry::secrets_generation`] and save under the lock so gateways reload even
 /// when only the keychain changed. Increments the FRESH on-disk value (not a stale `+1`) so
-/// a concurrent bump from another writer isn't lost.
-fn bump_secrets_generation(state: &RegistryState) {
-    let _ = write_registry(state, |reg| {
+/// a concurrent bump from another writer isn't lost. Propagates registry write failures:
+/// callers must not report success when the running gateway was never told to reload (#737).
+fn bump_secrets_generation(state: &RegistryState) -> Result<(), String> {
+    write_registry(state, |reg| {
         reg.secrets_generation = reg.secrets_generation.wrapping_add(1);
         Ok(())
-    });
+    })
+    .map(|_| ())
+    .map_err(|e| format!("could not reload the running gateway after the secret change: {e}"))
 }
 
 #[tauri::command]
@@ -2979,7 +2982,11 @@ async fn set_auth_token(app: AppHandle, server_id: String, token: String) -> Res
         // refresh metadata could otherwise overwrite the user's token later.
         remote::clear_oauth_state(&server_id)?;
         secrets::set_secret(&server_id, secrets::HTTP_AUTH_KEY, &token)?;
-        bump_secrets_generation(app.state::<RegistryState>().inner());
+        bump_secrets_generation(app.state::<RegistryState>().inner()).map_err(|e| {
+            // The vault half already succeeded; the user needs to know that and that the
+            // gateway wasn't told (#737).
+            format!("The token was stored in the keychain, but {e}")
+        })?;
         Ok(())
     })
     .await
@@ -2994,7 +3001,13 @@ async fn clear_auth_token(app: AppHandle, server_id: String) -> Result<(), Strin
         // that silently recreates the bearer token the user asked to delete.
         remote::clear_oauth_state(&server_id)?;
         secrets::delete_secret(&server_id, secrets::HTTP_AUTH_KEY)?;
-        bump_secrets_generation(app.state::<RegistryState>().inner());
+        bump_secrets_generation(app.state::<RegistryState>().inner()).map_err(|e| {
+            // The keychain half already succeeded; a token the user believes they just
+            // revoked must not read as cleanly removed when the gateway still serves it.
+            format!(
+                "The token was removed from the keychain, but {e}; the running gateway may still serve it"
+            )
+        })?;
         Ok(())
     })
     .await
@@ -3054,7 +3067,11 @@ async fn authenticate_oauth(
         res.expires_at,
     )?;
     secrets::set_secret(&server_id, secrets::HTTP_AUTH_KEY, &res.access_token)?;
-    bump_secrets_generation(state.inner());
+    bump_secrets_generation(state.inner()).map_err(|e| {
+        // The vault half already succeeded; a fresh sign-in that never reaches the
+        // gateway leaves the user staring at 401s from a server they just authenticated.
+        format!("Sign-in completed and the token was stored, but {e}")
+    })?;
     Ok(())
 }
 
@@ -6260,6 +6277,80 @@ mod tests {
             "fresh-B",
             "refresh_from_disk must not be able to restore stale cached state"
         );
+    }
+
+    /// A failed registry write must not be swallowed: `bump_secrets_generation` returns
+    /// the error so `clear_auth_token` (and friends) can tell the user the keychain half
+    /// succeeded but the running gateway was never told to reload (#737). The registry
+    /// "file" is an existing directory, so the atomic temp+rename save fails fast.
+    #[test]
+    fn bump_secrets_generation_propagates_registry_write_failure() {
+        let _serial = GEN_TEST_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let _env = registry::REGISTRY_ENV_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let dir = unique_update_test_dir("bump-failure");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::create_dir_all(dir.join("registry.json")).unwrap();
+
+        let previous = std::env::var_os("TOOLPORT_REGISTRY");
+        struct RestoreEnv(Option<std::ffi::OsString>);
+        impl Drop for RestoreEnv {
+            fn drop(&mut self) {
+                match &self.0 {
+                    Some(value) => std::env::set_var("TOOLPORT_REGISTRY", value),
+                    None => std::env::remove_var("TOOLPORT_REGISTRY"),
+                }
+            }
+        }
+        let _restore = RestoreEnv(previous);
+        std::env::set_var("TOOLPORT_REGISTRY", dir.join("registry.json"));
+
+        let state: RegistryState = Mutex::new(Registry::default());
+        let err = bump_secrets_generation(&state).expect_err("a failed bump must propagate");
+        assert!(
+            err.contains("could not reload the running gateway"),
+            "unexpected error: {err}"
+        );
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// The happy path: the bump persists the incremented generation so a running gateway
+    /// (which watches the file) reloads with the freshly vaulted credentials.
+    #[test]
+    fn bump_secrets_generation_increments_generation_on_disk() {
+        let _serial = GEN_TEST_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let _env = registry::REGISTRY_ENV_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let dir = unique_update_test_dir("bump-success");
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("registry.json");
+
+        let previous = std::env::var_os("TOOLPORT_REGISTRY");
+        struct RestoreEnv(Option<std::ffi::OsString>);
+        impl Drop for RestoreEnv {
+            fn drop(&mut self) {
+                match &self.0 {
+                    Some(value) => std::env::set_var("TOOLPORT_REGISTRY", value),
+                    None => std::env::remove_var("TOOLPORT_REGISTRY"),
+                }
+            }
+        }
+        let _restore = RestoreEnv(previous);
+        std::env::set_var("TOOLPORT_REGISTRY", &path);
+
+        let state: RegistryState = Mutex::new(Registry::default());
+        bump_secrets_generation(&state).expect("bump should succeed");
+        let persisted = registry::load_from(&path).expect("registry should exist");
+        assert_eq!(persisted.secrets_generation, 1);
+
+        std::fs::remove_dir_all(&dir).ok();
     }
 
     /// The uncontended reload: nothing touches the cache during the load, so the disk

--- a/src-tauri/src/registry.rs
+++ b/src-tauri/src/registry.rs
@@ -17,6 +17,12 @@ use crate::router::sanitize_segment;
 use fs2::FileExt;
 use serde::{Deserialize, Serialize};
 
+/// Serializes tests that read/write the `TOOLPORT_REGISTRY` env var (the env is
+/// process-global, so parallel tests in different modules would otherwise race).
+/// Declared outside the test module so desktop.rs tests can share it too.
+#[cfg(test)]
+pub(crate) static REGISTRY_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
 const REGISTRY_VERSION: u32 = 1;
 
 /// Per-process counter for unique atomic-write temp names.
@@ -2636,8 +2642,6 @@ pub(crate) fn redact_url_userinfo(url: &str) -> String {
 mod tests {
     use super::*;
     use crate::approval::fingerprint_allow_key;
-
-    static REGISTRY_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
     fn sample_server(name: &str) -> ServerEntry {
         ServerEntry {

--- a/src/components/SecretsDialog.tsx
+++ b/src/components/SecretsDialog.tsx
@@ -258,6 +258,10 @@ export function SecretsDialog({ server, onSaved, trigger, onChanged }: Props) {
       onChanged?.();
     } catch (e) {
       toastError(secretErrorMessage(e));
+      // A partial failure (keychain removed, gateway reload failed) must not leave
+      // the green "vaulted" badge up: re-probe the authoritative keychain state so
+      // the badge reflects what the backend actually holds (#743).
+      void refreshStatus();
     } finally {
       setBusyKey(null);
     }
@@ -343,7 +347,10 @@ export function SecretsDialog({ server, onSaved, trigger, onChanged }: Props) {
     } catch (e) {
       const msg = `${e}`;
       const blankHint = /state mismatch|timed out|closed/i.test(msg);
-      toastError(`OAuth failed: ${msg}`, {
+      // Backend messages are complete sentences and already name the failure
+      // (e.g. "The token was stored in the keychain, but could not reload..."), so
+      // prefixing "OAuth failed:" produced a toast that argued with itself (#743).
+      toastError(msg, {
         description: blankHint
           ? "If the sign-in page was blank, your default browser (e.g. Safari) may block the local redirect. Set Chrome or Brave as default and try once more, or paste an access token above instead."
           : undefined,


### PR DESCRIPTION
## What

Fixes #737 — a failed secrets-generation bump was invisible. `bump_secrets_generation` discarded the result of `write_registry`, so when the cross-process registry lock was held (or the disk was full), `clear_auth_token` / `set_auth_token` / `authenticate_oauth` returned `Ok` and the running gateway kept serving the credential the user believed they just revoked (or never picked up a fresh OAuth sign-in).

## Fix

- `bump_secrets_generation` now returns `Result<(), String>` and propagates the registry-write error.
- All three callers surface it with a message that states the exact state: the keychain half **succeeded**, the gateway reload **failed** — e.g. `"The token was removed from the keychain, but could not reload the running gateway after the secret change: <detail>; the running gateway may still serve it"`. The commands no longer report success when the running gateway was never told.
- The registry test env lock (`REGISTRY_ENV_LOCK`) moved out of the test module so the desktop tests can share it (the `TOOLPORT_REGISTRY` env var is process-global).

## Validation

- New test `bump_secrets_generation_propagates_registry_write_failure` covers the clear-token path's failed bump (registry save fails fast via a directory at the registry path) — **fails against the pre-fix swallow version**, passes now.
- New test `bump_secrets_generation_increments_generation_on_disk` covers the happy path (persisted generation increments, which is what triggers the gateway's file-watcher reload).
- `npm run test:rust` equivalent passes: lib **1020 passed / 0 failed** (incl. the 2 new tests), bins & integration **1375 passed / 0 failed**.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `bump_secrets_generation` to propagate registry write failures so token revokes take effect
> - `bump_secrets_generation` in [desktop.rs](https://github.com/tsouth89/toolport/pull/743/files#diff-fe6823673f9c91b7a17eb4b96e5bc54bc3c58e75d02ae0a2d2fae6f7ce03ecd5) previously swallowed registry write errors; it now returns `Result<(), String>` and propagates failures to callers.
> - `set_auth_token`, `clear_auth_token`, and `authenticate_oauth` Tauri commands now surface user-facing error messages when the gateway reload signal fails after a token change, instead of silently succeeding.
> - A new `clear_auth_token_inner` helper consolidates the clear-token flow with distinct error messages for keychain vs. reload failures.
> - The frontend [SecretsDialog.tsx](https://github.com/tsouth89/toolport/pull/743/files#diff-4f221815d69310fc5fbc26d8fba9b6981352fd1e0a2e281d9a04fc34882c4350) now calls `refreshStatus` after a failed `clearAuthToken` to re-sync the vaulted badge with actual keychain state.
> - Risk: callers that previously saw a success response when the registry write failed will now receive an error.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5e0ac32.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->