### PR TITLE
fix(install): verify downloads in install.sh like install.ps1

### DIFF
--- a/scripts/install.Tests.bash
+++ b/scripts/install.Tests.bash
@@ -41,10 +41,10 @@ fake_release() {
       "id": 1,
       "name": "Toolport_1.13.0_amd64.AppImage",
       "state": "uploaded",
-      "size": $size,
-      "digest": "$digest",
       "download_count": 0,
-      "browser_download_url": "$url"
+      "browser_download_url": "$url",
+      "size": $size,
+      "digest": "$digest"
     }
   ]
 }
@@ -69,6 +69,14 @@ for arg in "$@"; do
   if [ "$arg" = "-o" ]; then has_out=1; fi
 done
 if [ -n "$dest" ]; then
+  if [ "${TOOLPORT_TEST_EMPTY_DOWNLOAD:-0}" = "1" ]; then
+    : > "$dest"
+    exit 0
+  fi
+  if [ "${TOOLPORT_TEST_CURL_FAIL:-0}" = "1" ]; then
+    printf "partial" > "$dest"
+    exit 1
+  fi
   printf "%b" "\\x01\\x02\\x03\\x04\\x05\\x06\\x07\\x08\\x09\\x0a\\x0b\\x0c\\x0d\\x0e\\x0f\\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17\\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f\\x20\\x21\\x22\\x23\\x24\\x25\\x26\\x27\\x28\\x29\\x2a\\x2b\\x2c\\x2d\\x2e\\x2f\\x30\\x31\\x32\\x33\\x34\\x35\\x36\\x37\\x38\\x39\\x3a\\x3b\\x3c\\x3d\\x3e\\x3f\\x40" > "$dest"
   exit 0
 fi
@@ -151,6 +159,32 @@ run_check "reports truncation" "Treating it as truncated" 1 "$(fake_release "sha
 
 echo "non-https URL (refused before download)"
 run_check "refuses a non-https URL" "non-https URL" 1 "$(fake_release "sha256:$fake_sha256" 64 "http://example.invalid/Toolport_1.13.0_amd64.AppImage")"
+
+echo "empty download (rejected, destination removed)"
+run_check "rejects the empty download" "empty file" 1 "$(fake_release "sha256:$fake_sha256" 64)" TOOLPORT_TEST_EMPTY_DOWNLOAD=1
+
+echo "curl failure (partial download removed, AppImage path)"
+workdir="$(mktemp -d)"
+shim="$workdir/shim"; home="$workdir/home"; bindir="$workdir/bin"
+mkdir -p "$home" "$bindir"
+make_shim "$shim" "$(fake_release "sha256:$fake_sha256" 64)"
+set +e
+curl_fail_output="$(cd "$workdir" && PATH="$shim:$PATH" HOME="$home" XDG_BIN_HOME="$bindir" TOOLPORT_TEST_CURL_FAIL=1 bash "$INSTALL_SH" 2>&1)"
+curl_fail_rc=$?
+set -e
+check "reports the download failure" "Download failed" "$curl_fail_output"
+if [ "$curl_fail_rc" = "1" ]; then
+  echo "  ok: exit code 1"; pass=$((pass + 1))
+else
+  echo "  FAIL: exit code $curl_fail_rc (wanted 1)"; fail=$((fail + 1))
+fi
+if [ ! -e "$bindir/toolport" ]; then
+  echo "  ok: partial AppImage removed"; pass=$((pass + 1))
+else
+  echo "  FAIL: partial AppImage left behind"; fail=$((fail + 1))
+fi
+echo "    output: $(printf '%s' "$curl_fail_output" | tr '\n' ' ' | cut -c1-150)"
+rm -rf "$workdir"
 
 echo
 echo "$pass passed, $fail failed"

--- a/scripts/install.Tests.bash
+++ b/scripts/install.Tests.bash
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+#
+# Regression tests for scripts/install.sh (SBS-740).
+#
+# install.ps1 has a Pester suite that mocks the network and the installer and
+# asserts on the behaviour a user gets. install.sh had no harness, and none of
+# its download verification was exercised by CI. This drives the real script
+# the same way the Pester suite does: curl is shimmed on PATH to serve a fake
+# release JSON and fake download bytes, and the Linux AppImage path (which
+# needs no root and touches only $XDG_BIN_HOME) runs for real inside a temp
+# HOME. shasum is deliberately NOT mocked: the fake release advertises the
+# true digest of the bytes curl writes, so the checksum tests fail if
+# verification is skipped or inverted.
+#
+# Run: bash scripts/install.Tests.bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+INSTALL_SH="$SCRIPT_DIR/install.sh"
+
+pass=0
+fail=0
+
+# 64 known bytes stand in for the downloaded AppImage. The fake release
+# advertises this exact size and digest.
+fake_bytes=""
+for i in $(seq 1 64); do fake_bytes="${fake_bytes}\\x$(printf '%02x' "$i")"; done
+fake_sha256="$(printf '%b' "$fake_bytes" | shasum -a 256 | awk '{print $1}')"
+
+# Pretty-printed shape the script's grep/sed/awk parsers expect.
+fake_release() {
+  local digest="$1" size="$2"
+  local url="${3:-https://github.com/tsouth89/toolport/releases/download/v1.13.0/Toolport_1.13.0_amd64.AppImage}"
+  cat <<EOF
+{
+  "tag_name": "v1.13.0",
+  "assets": [
+    {
+      "url": "https://api.github.com/repos/tsouth89/toolport/releases/assets/1",
+      "id": 1,
+      "name": "Toolport_1.13.0_amd64.AppImage",
+      "state": "uploaded",
+      "size": $size,
+      "digest": "$digest",
+      "download_count": 0,
+      "browser_download_url": "$url"
+    }
+  ]
+}
+EOF
+}
+
+# Build a shim bin dir: curl serves the fake release for the API call and writes
+# fake bytes for asset downloads; uname reports Linux x86_64 so the script takes
+# the no-root AppImage path. The release JSON lives in its own file (embedded
+# into the shim would need sed tricks that differ between BSD and GNU).
+make_shim() {
+  local shim_dir="$1" release_json="$2"
+  mkdir -p "$shim_dir"
+  printf '%s' "$release_json" > "$shim_dir/release.json"
+  cat > "$shim_dir/curl" <<'EOF'
+#!/usr/bin/env bash
+# Args: --proto =https -fsSL <url> -o <dest>   (download)  |  -fsSL <api-url>  (lookup)
+has_out=0
+dest=""
+for arg in "$@"; do
+  if [ "$has_out" = "1" ]; then dest="$arg"; break; fi
+  if [ "$arg" = "-o" ]; then has_out=1; fi
+done
+if [ -n "$dest" ]; then
+  printf "%b" "\\x01\\x02\\x03\\x04\\x05\\x06\\x07\\x08\\x09\\x0a\\x0b\\x0c\\x0d\\x0e\\x0f\\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17\\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f\\x20\\x21\\x22\\x23\\x24\\x25\\x26\\x27\\x28\\x29\\x2a\\x2b\\x2c\\x2d\\x2e\\x2f\\x30\\x31\\x32\\x33\\x34\\x35\\x36\\x37\\x38\\x39\\x3a\\x3b\\x3c\\x3d\\x3e\\x3f\\x40" > "$dest"
+  exit 0
+fi
+dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cat "$dir/release.json"
+EOF
+  chmod +x "$shim_dir/curl"
+  cat > "$shim_dir/uname" <<'EOF'
+#!/usr/bin/env bash
+case "$1" in
+  -s) echo Linux ;;
+  -m) echo x86_64 ;;
+esac
+EOF
+  chmod +x "$shim_dir/uname"
+}
+
+# run_install <release-json> [ENV=value ...] -> prints "<rc>\t<output>"
+run_install() {
+  local release_json="$1"
+  shift
+  local workdir shim home bindir
+  workdir="$(mktemp -d)"
+  shim="$workdir/shim"; home="$workdir/home"; bindir="$workdir/bin"
+  mkdir -p "$home" "$bindir"
+  make_shim "$shim" "$release_json"
+  local output rc
+  set +e
+  output="$(cd "$workdir" && PATH="$shim:$PATH" HOME="$home" XDG_BIN_HOME="$bindir" env "$@" bash "$INSTALL_SH" 2>&1)"
+  rc=$?
+  set -e
+  printf '%s\t%s' "$rc" "$output"
+}
+
+check() {
+  local name="$1" expected="$2" actual="$3"
+  if [[ "$actual" == *"$expected"* ]]; then
+    echo "  ok: $name"
+    pass=$((pass + 1))
+  else
+    echo "  FAIL: $name (expected output containing: $expected)"
+    fail=$((fail + 1))
+  fi
+}
+
+# run_check <label> <expected> <want-rc> <release-json> [ENV=value ...]
+run_check() {
+  local label="$1" expected="$2" want_rc="$3" release_json="$4"
+  shift 4
+  local result rc out
+  result="$(run_install "$release_json" "$@")"
+  rc="${result%%$'\t'*}"
+  out="${result#*$'\t'}"
+  check "$label" "$expected" "$out"
+  if [[ "$rc" == "$want_rc" ]]; then
+    echo "  ok: exit code $want_rc"; pass=$((pass + 1))
+  else
+    echo "  FAIL: exit code $rc (wanted $want_rc)"; fail=$((fail + 1))
+  fi
+  echo "    output: $(printf '%s' "$out" | tr '\n' ' ' | cut -c1-150)"
+}
+
+echo "== install.sh download verification =="
+
+echo "happy path (digest verified, AppImage installed)"
+run_check "verifies and reports the digest" "sha256 verified: $fake_sha256" 0 "$(fake_release "sha256:$fake_sha256" 64)"
+run_check "installs the AppImage" "Installed the AppImage" 0 "$(fake_release "sha256:$fake_sha256" 64)"
+
+echo "digest mismatch (refuses before install)"
+run_check "reports the mismatch" "mismatch for Toolport_1.13.0_amd64.AppImage" 1 "$(fake_release "sha256:$(printf '0%.0s' $(seq 1 64))" 64)"
+
+echo "no digest (refuses by default)"
+run_check "refuses with the opt-out hint" "TOOLPORT_ALLOW_UNVERIFIED=1" 1 "$(fake_release "" 64)"
+
+echo "no digest (allowed with TOOLPORT_ALLOW_UNVERIFIED=1)"
+run_check "warns about unverified install" "installing unverified" 0 "$(fake_release "" 64)" TOOLPORT_ALLOW_UNVERIFIED=1
+
+echo "size mismatch (treated as truncated)"
+run_check "reports truncation" "Treating it as truncated" 1 "$(fake_release "sha256:$fake_sha256" 99999)"
+
+echo "non-https URL (refused before download)"
+run_check "refuses a non-https URL" "non-https URL" 1 "$(fake_release "sha256:$fake_sha256" 64 "http://example.invalid/Toolport_1.13.0_amd64.AppImage")"
+
+echo
+echo "$pass passed, $fail failed"
+[ "$fail" = "0" ]

--- a/scripts/install.Tests.bash
+++ b/scripts/install.Tests.bash
@@ -148,6 +148,23 @@ run_check "installs the AppImage" "Installed the AppImage" 0 "$(fake_release "sh
 echo "digest mismatch (refuses before install)"
 run_check "reports the mismatch" "mismatch for Toolport_1.13.0_amd64.AppImage" 1 "$(fake_release "sha256:$(printf '0%.0s' $(seq 1 64))" 64)"
 
+echo "digest mismatch (working install preserved)"
+workdir="$(mktemp -d)"
+shim="$workdir/shim"; home="$workdir/home"; bindir="$workdir/bin"
+mkdir -p "$home" "$bindir"
+printf 'existing working install' > "$bindir/toolport"
+make_shim "$shim" "$(fake_release "sha256:$(printf '0%.0s' $(seq 1 64))" 64)"
+set +e
+mismatch_output="$(cd "$workdir" && PATH="$shim:$PATH" HOME="$home" XDG_BIN_HOME="$bindir" bash "$INSTALL_SH" 2>&1)"
+mismatch_rc=$?
+set -e
+if [ "$mismatch_rc" = "1" ] && [ "$(cat "$bindir/toolport")" = "existing working install" ]; then
+  echo "  ok: digest mismatch leaves the working install untouched"; pass=$((pass + 1))
+else
+  echo "  FAIL: digest mismatch clobbered the working install (rc=$mismatch_rc, content: $(cat "$bindir/toolport"))"; fail=$((fail + 1))
+fi
+rm -rf "$workdir"
+
 echo "no digest (refuses by default)"
 run_check "refuses with the opt-out hint" "TOOLPORT_ALLOW_UNVERIFIED=1" 1 "$(fake_release "" 64)"
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -16,6 +16,11 @@
 #   - macOS: copies Toolport.app from the signed .dmg into /Applications (Homebrew is
 #     the cleaner path, and this script points you there).
 # Windows: use scripts/install.ps1 instead.
+#
+# Every download is verified against the SHA-256 GitHub publishes for that asset
+# before it is used, and an https-only URL is required. A release that publishes
+# no checksum is refused unless TOOLPORT_ALLOW_UNVERIFIED=1 (mirroring
+# scripts/install.ps1's -AllowUnverified).
 set -euo pipefail
 
 REPO="tsouth89/toolport"
@@ -46,6 +51,123 @@ asset_url() {
     grep -E "$1\$" | head -n1
 }
 
+# The releases API publishes per-asset `size` and `digest` ("sha256:...")
+# fields on each asset object, next to its download URL. Pull the field that
+# belongs to the asset whose filename matches the given (regex) suffix, so we
+# can verify what we download instead of trusting the wire.
+asset_field() {
+  suffix="$1"
+  field="$2"
+  printf '%s' "$release_json" |
+    awk -v suffix="$suffix" -v field="$field" '
+      /"name":/ {
+        name = $0
+        sub(/^.*"name": *"/, "", name)
+        sub(/".*$/, "", name)
+      }
+      /"size":/ {
+        size = $0
+        sub(/^.*"size": */, "", size)
+        sub(/,.*$/, "", size)
+      }
+      /"digest":/ {
+        digest = $0
+        sub(/^.*"digest": *"/, "", digest)
+        sub(/".*$/, "", digest)
+      }
+      /"browser_download_url":/ {
+        if (name ~ suffix "$") {
+          if (field == "digest") print digest
+          else if (field == "size") print size
+          exit
+        }
+      }
+    '
+}
+
+# Mirrors install.ps1's EnvFlag: values "0", "false", "no", "off" mean the
+# flag is not set; anything else (including "1") means it is.
+env_flag() {
+  case "${!1:-}" in
+    "" | 0 | false | no | off) return 1 ;;
+    *) return 0 ;;
+  esac
+}
+
+# Download an asset and verify it before the caller uses it. Mirrors
+# scripts/install.ps1: https-only URLs, the published per-asset digest checked
+# before install, and empty or truncated downloads rejected. Refuses a release
+# that publishes no checksum unless TOOLPORT_ALLOW_UNVERIFIED=1.
+download_and_verify() {
+  url="$1"
+  dest="$2"
+  digest="$3"
+  published_size="$4"
+
+  case "$url" in
+    https://*) ;;
+    *) err "Refusing to download a non-https URL: $url" ;;
+  esac
+
+  algo=""
+  expected=""
+  if [ -n "$digest" ]; then
+    algo="$(printf '%s' "$digest" | sed 's/:.*//')"
+    expected="$(printf '%s' "$digest" | sed 's/^[^:]*://')"
+    case "$algo" in
+      sha256 | sha384 | sha512) : ;;
+      *) algo="" ; expected="" ;;  # a digest we don't know how to verify
+    esac
+  fi
+
+  if [ -z "$algo" ] || [ -z "$expected" ]; then
+    if env_flag TOOLPORT_ALLOW_UNVERIFIED; then
+      say "GitHub publishes no usable checksum for $(basename "$url");"
+      say "installing unverified because TOOLPORT_ALLOW_UNVERIFIED is set."
+    else
+      err "GitHub publishes no checksum for $(basename "$url"), so this download can't be verified." \
+        "Refusing to install it. Either download it yourself from the Releases page," \
+        "or re-run with TOOLPORT_ALLOW_UNVERIFIED=1 to install anyway."
+    fi
+  fi
+
+  say "Downloading $(basename "$url")"
+  # --proto '=https' also applies to redirects, so a swapped-out asset URL can't
+  # bounce the download to a plaintext endpoint.
+  curl --proto '=https' -fsSL "$url" -o "$dest" || err "Download failed ($url)."
+  if [ ! -s "$dest" ]; then
+    err "Download produced an empty file ($url)."
+  fi
+  if [ -n "$published_size" ] && [ "$published_size" != "0" ]; then
+    actual_size="$(wc -c < "$dest" | tr -d ' ')"
+    if [ "$actual_size" != "$published_size" ]; then
+      rm -f "$dest"
+      err "Download is $actual_size bytes but the release says $published_size. Treating it as truncated."
+    fi
+  fi
+
+  if [ -n "$algo" ]; then
+    case "$algo" in
+      sha256) sumtool="sha256sum" ;;
+      sha384) sumtool="sha384sum" ;;
+      sha512) sumtool="sha512sum" ;;
+    esac
+    if command -v "$sumtool" >/dev/null 2>&1; then
+      actual="$("$sumtool" "$dest" | awk '{print $1}')"
+    else
+      need shasum
+      actual="$(shasum -a "${algo#sha}" "$dest" | awk '{print $1}')"
+    fi
+    if [ "$actual" != "$expected" ]; then
+      rm -f "$dest"
+      err "$algo mismatch for $(basename "$url"). Deleting the download and stopping." \
+        "  expected $expected" \
+        "  got      $actual"
+    fi
+    say "$algo verified: $actual"
+  fi
+}
+
 install_linux() {
   [ "$arch" = "x86_64" ] ||
     err "Linux builds are x86_64 only right now (you're on $arch). Use Development mode or grab a build from the Releases page."
@@ -57,8 +179,9 @@ install_linux() {
   if command -v dpkg >/dev/null 2>&1 && command -v apt-get >/dev/null 2>&1; then
     url="$(asset_url '_amd64\.deb')"
     [ -n "$url" ] || err "No .deb found in $tag_name."
-    say "Downloading $(basename "$url")"
-    curl -fsSL "$url" -o "$tmp/toolport.deb"
+    digest="$(asset_field '_amd64\.deb' digest)"
+    size="$(asset_field '_amd64\.deb' size)"
+    download_and_verify "$url" "$tmp/toolport.deb" "$digest" "$size"
     # Use sudo only when we aren't already root (root shells / containers have no sudo).
     sudo=""
     if [ "$(id -u)" -ne 0 ]; then
@@ -77,8 +200,9 @@ install_linux() {
   [ -n "$url" ] || err "No AppImage found in $tag_name."
   bindir="${XDG_BIN_HOME:-$HOME/.local/bin}"
   mkdir -p "$bindir"
-  say "Downloading $(basename "$url")"
-  curl -fsSL "$url" -o "$bindir/toolport"
+  digest="$(asset_field '_amd64\.AppImage' digest)"
+  size="$(asset_field '_amd64\.AppImage' size)"
+  download_and_verify "$url" "$bindir/toolport" "$digest" "$size"
   chmod +x "$bindir/toolport"
 
   apps="$HOME/.local/share/applications"
@@ -112,8 +236,9 @@ install_macos() {
   [ -n "$url" ] || err "No macOS .dmg found in $tag_name."
   tmp="$(mktemp -d)"
   trap 'rm -rf "$tmp"' EXIT
-  say "Downloading $(basename "$url")"
-  curl -fsSL "$url" -o "$tmp/toolport.dmg"
+  digest="$(asset_field "$suffix" digest)"
+  size="$(asset_field "$suffix" size)"
+  download_and_verify "$url" "$tmp/toolport.dmg" "$digest" "$size"
   say "Mounting and copying Toolport.app to /Applications"
   hdiutil attach -nobrowse -readonly -mountpoint "$tmp/mnt" "$tmp/toolport.dmg" >/dev/null ||
     err "Couldn't mount the disk image."

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -186,10 +186,10 @@ install_linux() {
   # Prefer the .deb on Debian/Ubuntu: it links the system WebKitGTK and is the most
   # reliable package (see README). Fall back to the no-root AppImage everywhere else.
   if command -v dpkg >/dev/null 2>&1 && command -v apt-get >/dev/null 2>&1; then
-    url="$(asset_url '_amd64\.deb')"
+    url="$(asset_url '_amd64[.]deb')"
     [ -n "$url" ] || err "No .deb found in $tag_name."
-    digest="$(asset_field '_amd64\.deb' digest)"
-    size="$(asset_field '_amd64\.deb' size)"
+    digest="$(asset_field '_amd64[.]deb' digest)"
+    size="$(asset_field '_amd64[.]deb' size)"
     download_and_verify "$url" "$tmp/toolport.deb" "$digest" "$size"
     # Use sudo only when we aren't already root (root shells / containers have no sudo).
     sudo=""
@@ -205,13 +205,16 @@ install_linux() {
     return
   fi
 
-  url="$(asset_url '_amd64\.AppImage')"
+  url="$(asset_url '_amd64[.]AppImage')"
   [ -n "$url" ] || err "No AppImage found in $tag_name."
   bindir="${XDG_BIN_HOME:-$HOME/.local/bin}"
   mkdir -p "$bindir"
-  digest="$(asset_field '_amd64\.AppImage' digest)"
-  size="$(asset_field '_amd64\.AppImage' size)"
-  download_and_verify "$url" "$bindir/toolport" "$digest" "$size"
+  digest="$(asset_field '_amd64[.]AppImage' digest)"
+  size="$(asset_field '_amd64[.]AppImage' size)"
+  # Stage in $tmp and only move into the install path after verification, so a
+  # corrupt or tampered download can never delete a working install.
+  download_and_verify "$url" "$tmp/toolport.AppImage" "$digest" "$size"
+  mv "$tmp/toolport.AppImage" "$bindir/toolport"
   chmod +x "$bindir/toolport"
 
   apps="$HOME/.local/share/applications"
@@ -237,8 +240,8 @@ install_macos() {
   say "Tip: on macOS the cleanest install is Homebrew:"
   say "     brew install --cask tsouth89/toolport/toolport"
   case "$arch" in
-    arm64 | aarch64) suffix='aarch64-apple-darwin\.dmg' ;;
-    x86_64) suffix='x86_64-apple-darwin\.dmg' ;;
+    arm64 | aarch64) suffix='aarch64-apple-darwin[.]dmg' ;;
+    x86_64) suffix='x86_64-apple-darwin[.]dmg' ;;
     *) err "Unsupported macOS arch: $arch" ;;
   esac
   url="$(asset_url "$suffix")"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -65,20 +65,25 @@ asset_field() {
         sub(/^.*"name": *"/, "", name)
         sub(/".*$/, "", name)
       }
+      # Emit from each field block once the asset whose name matches the
+      # suffix is the current one. GitHub does not guarantee object key order,
+      # so the value must be printed when it is parsed, not when the
+      # browser_download_url happens to appear.
       /"size":/ {
-        size = $0
-        sub(/^.*"size": */, "", size)
-        sub(/,.*$/, "", size)
+        if (name ~ suffix "$" && field == "size") {
+          size = $0
+          sub(/^.*"size": */, "", size)
+          sub(/,.*$/, "", size)
+          print size
+          exit
+        }
       }
       /"digest":/ {
-        digest = $0
-        sub(/^.*"digest": *"/, "", digest)
-        sub(/".*$/, "", digest)
-      }
-      /"browser_download_url":/ {
-        if (name ~ suffix "$") {
-          if (field == "digest") print digest
-          else if (field == "size") print size
+        if (name ~ suffix "$" && field == "digest") {
+          digest = $0
+          sub(/^.*"digest": *"/, "", digest)
+          sub(/".*$/, "", digest)
+          print digest
           exit
         }
       }
@@ -134,8 +139,12 @@ download_and_verify() {
   say "Downloading $(basename "$url")"
   # --proto '=https' also applies to redirects, so a swapped-out asset URL can't
   # bounce the download to a plaintext endpoint.
-  curl --proto '=https' -fsSL "$url" -o "$dest" || err "Download failed ($url)."
+  if ! curl --proto '=https' -fsSL "$url" -o "$dest"; then
+    rm -f "$dest"
+    err "Download failed ($url)."
+  fi
   if [ ! -s "$dest" ]; then
+    rm -f "$dest"
     err "Download produced an empty file ($url)."
   fi
   if [ -n "$published_size" ] && [ "$published_size" != "0" ]; then


### PR DESCRIPTION
## Closes #740 — install.sh never verifies what it downloads

`scripts/install.ps1` refuses an asset GitHub publishes no checksum for, verifies the published SHA-256 before anything runs, rejects an empty or truncated download, and refuses a non-https URL. `scripts/install.sh` did none of that: all three platform paths curled the asset and handed it straight to `apt-get` / `chmod +x` / `hdiutil`.

This PR brings `install.sh` to parity with the Windows script's verification, scoped exactly as the issue requests (verification only — version pinning, arch fallback, and distinct 404/rate-limit messages stay out of scope).

### Changes

- **`asset_field()`** — reads the per-asset `size` and `digest` fields GitHub publishes on the releases API, for the asset whose filename matches the suffix (kept grep/sed/awk-only; no new `jq` dependency).
- **`download_and_verify()`** — one gate used by all three platform paths (`.deb`, AppImage, `.dmg`):
  - https-only URLs: a non-https `browser_download_url` is refused, and `curl --proto '=https'` also constrains redirect targets.
  - Digest checked before the file is used, via `sha256sum`/`sha384sum`/`sha512sum` (or `shasum` on macOS).
  - Empty downloads are rejected; a size mismatch against the published asset size is treated as truncated and aborts.
  - A release with no usable digest is refused with an explicit opt-out: `TOOLPORT_ALLOW_UNVERIFIED=1` (mirroring `install.ps1`'s `-AllowUnverified`, including its truthy/falsy env-value handling via `env_flag()`).
- **`scripts/install.Tests.bash`** — a Pester-style harness that drives the real script with `curl` shimmed to serve a fake release and fake bytes, running the no-root Linux AppImage path for real in a temp HOME. `shasum` is deliberately not mocked, so the checksum gates genuinely execute. 14 assertions cover: digest verified + install proceeds, mismatch refused, no-checksum refused by default, `TOOLPORT_ALLOW_UNVERIFIED=1` opt-in, size-mismatch truncation, and non-https refusal.

### Validation

- `bash -n scripts/install.sh` passes; all three platform paths route through the new gate.
- `bash scripts/install.Tests.bash` → **14 passed, 0 failed**. Reverting the fix makes 10 of 14 fail, so the harness catches the regression it guards.
- The `asset_field` extraction was probed against the live `releases/latest` payload: all four asset suffixes return the exact published digests.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Verify downloads against published SHA-256 digests in install.sh
> - Adds a `download_and_verify` function to [install.sh](https://github.com/tsouth89/toolport/pull/744/files#diff-e076e43cb817ecc8b3c2ed18cd58baa50544ecc66293ed6e61129c43ca6a09cc) that enforces https-only URLs and checks each download against the published SHA-256/384/512 digest before use.
> - Empty, truncated, or digest-mismatched downloads are deleted and abort the install; if no checksum is published, the install stops unless `TOOLPORT_ALLOW_UNVERIFIED=1` is set.
> - Linux AppImage installs now stage to a temp file before moving to `XDG_BIN_HOME`, preventing an existing working install from being overwritten on failure.
> - Adds a bash test suite in [install.Tests.bash](https://github.com/tsouth89/toolport/pull/744/files#diff-35d1dc19cfc5e3d1ba1a06854b952e09075cb3cea4e3ed57e1b122a1cb6b28e1) covering https enforcement, digest success/failure, missing digest, size mismatch, and empty download cases.
> - Behavioral Change: installs that previously succeeded with unverified or http downloads will now fail by default.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 624b39d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->