### PR TITLE
fix(clients): abort writes when the pre-write backup stat fails

### DIFF
--- a/src-tauri/src/clients.rs
+++ b/src-tauri/src/clients.rs
@@ -2820,8 +2820,21 @@ fn backup_file_named(
 ) -> Result<Option<PathBuf>, String> {
     match std::fs::metadata(path) {
         Ok(meta) if meta.is_file() && meta.len() <= MAX_CONFIG_BYTES => {}
-        // Missing, special file, or oversized: nothing safe to back up.
-        _ => return Ok(None),
+        // Genuinely missing: nothing to back up yet, and the caller may create
+        // the file from scratch. Special file or oversized: deliberately nothing
+        // safe to back up (kept from the original behaviour).
+        Ok(_) => return Ok(None),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        // A stat that failed for any other reason (permission, network share,
+        // transient I/O) must NOT read as "no file here": the caller would then
+        // treat the config as absent, start from an empty document, and overwrite
+        // the user's real file with no backup to recover it.
+        Err(e) => {
+            return Err(format!(
+                "could not stat {} before backing it up: {e}",
+                path.display()
+            ))
+        }
     }
     let dir = backup_dir(client_id).ok_or("Could not resolve backup dir")?;
     std::fs::create_dir_all(&dir).map_err(|e| e.to_string())?;
@@ -5629,6 +5642,57 @@ mod tests {
             left.contains("10000000000000-config.yaml"),
             "a lexical sort would have deleted this newer backup instead: {left:?}"
         );
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// SBS-735: a stat that fails for a reason other than "missing" must abort
+    /// the write, not read as "no file to back up". A metadata error on a config
+    /// whose path sits on an unreadable network share was folded into the same
+    /// `Ok(None)` as a genuinely absent file, so the caller started from an
+    /// empty document and overwrote the user's config with no recovery copy.
+    #[test]
+    fn backup_propagates_stat_failures_instead_of_noop() {
+        // A directory path makes metadata() succeed but is_file() fail -> still
+        // the deliberate Ok(None) "nothing safe to back up" case. Use a path
+        // whose parent cannot be traversed so metadata() itself errors.
+        let dir = std::env::temp_dir().join(format!("toolport-bk-stat-{}", std::process::id()));
+        std::fs::remove_dir_all(&dir).ok();
+        std::fs::create_dir_all(&dir).unwrap();
+        let file = dir.join("config.json");
+        std::fs::write(&file, "{}").unwrap();
+        // metadata(file/child) fails: file is a regular file, so traversing into
+        // it is ENOTDIR on unix (NotADirectory) / ERROR_DIRECTORY on Windows.
+        let broken = file.join("child.json");
+
+        let err = backup_file_named("claude-desktop", &broken, "child.json").unwrap_err();
+        assert!(
+            err.contains("could not stat"),
+            "a stat failure must be reported, not treated as no backup: {err}"
+        );
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// SBS-735 acceptance: a write must not proceed when the app could not tell
+    /// whether an existing file was there. Drive the full caller (`write_servers`)
+    /// with CLAUDE_CONFIG_DIR pointed at a path whose parent is a regular file, so
+    /// the pre-write backup stat fails and the write must abort.
+    #[test]
+    fn write_servers_aborts_when_backup_stat_fails() {
+        let dir = std::env::temp_dir().join(format!("toolport-bk-write-{}", std::process::id()));
+        std::fs::remove_dir_all(&dir).ok();
+        std::fs::create_dir_all(&dir).unwrap();
+        // Parent-of-config is a regular file: metadata(config) fails ENOTDIR.
+        let not_a_dir = dir.join("claude-home");
+        std::fs::write(&not_a_dir, "not a directory").unwrap();
+        let _restore = EnvRestore::set("CLAUDE_CONFIG_DIR", &not_a_dir);
+
+        let err = write_servers("claude-code", &[stdio("filesystem")]).unwrap_err();
+        assert!(
+            err.contains("could not stat"),
+            "the caller must surface the stat failure instead of writing: {err}"
+        );
+        // No destructive write happened: the "config" file was never created.
+        assert!(!not_a_dir.join(".claude.json").exists());
         std::fs::remove_dir_all(&dir).ok();
     }
 

--- a/src-tauri/src/clients.rs
+++ b/src-tauri/src/clients.rs
@@ -5682,6 +5682,12 @@ mod tests {
     /// ENOTDIR on unix but ERROR_PATH_NOT_FOUND (NotFound) on Windows.
     #[test]
     fn write_servers_aborts_when_backup_stat_fails() {
+        // Serialize against other tests that mutate the process-global
+        // CLAUDE_CONFIG_DIR (e.g. client_config_paths_match_current_platform):
+        // without the lock, that test could resolve the default home config
+        // path mid-flight and make this one flaky.
+        let _env = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+
         let dir = std::env::temp_dir().join(format!("toolport-bk-write-{}", std::process::id()));
         std::fs::remove_dir_all(&dir).ok();
         std::fs::create_dir_all(&dir).unwrap();

--- a/src-tauri/src/clients.rs
+++ b/src-tauri/src/clients.rs
@@ -5654,15 +5654,16 @@ mod tests {
     fn backup_propagates_stat_failures_instead_of_noop() {
         // A directory path makes metadata() succeed but is_file() fail -> still
         // the deliberate Ok(None) "nothing safe to back up" case. Use a path
-        // whose parent cannot be traversed so metadata() itself errors.
+        // that fails to stat for a reason other than "missing".
         let dir = std::env::temp_dir().join(format!("toolport-bk-stat-{}", std::process::id()));
         std::fs::remove_dir_all(&dir).ok();
         std::fs::create_dir_all(&dir).unwrap();
-        let file = dir.join("config.json");
-        std::fs::write(&file, "{}").unwrap();
-        // metadata(file/child) fails: file is a regular file, so traversing into
-        // it is ENOTDIR on unix (NotADirectory) / ERROR_DIRECTORY on Windows.
-        let broken = file.join("child.json");
+        // A NUL byte makes the path invalid on BOTH platforms: the stat fails
+        // with InvalidInput (unix) / InvalidFilename (Windows), never NotFound.
+        // (The file/child ENOTDIR trick only errors non-NotFound on unix — on
+        // Windows a path under a regular file reports ERROR_PATH_NOT_FOUND,
+        // which maps to NotFound and would be swallowed by the missing-file arm.)
+        let broken = dir.join("child\u{0}.json");
 
         let err = backup_file_named("claude-desktop", &broken, "child.json").unwrap_err();
         assert!(
@@ -5674,25 +5675,49 @@ mod tests {
 
     /// SBS-735 acceptance: a write must not proceed when the app could not tell
     /// whether an existing file was there. Drive the full caller (`write_servers`)
-    /// with CLAUDE_CONFIG_DIR pointed at a path whose parent is a regular file, so
-    /// the pre-write backup stat fails and the write must abort.
+    /// with CLAUDE_CONFIG_DIR pointed at a path that fails to stat for a reason
+    /// other than "missing", so the pre-write backup stat fails and the write
+    /// must abort. Each platform gets its own non-NotFound stat failure: a NUL
+    /// byte cannot go into an env var, and a path under a regular file is
+    /// ENOTDIR on unix but ERROR_PATH_NOT_FOUND (NotFound) on Windows.
     #[test]
     fn write_servers_aborts_when_backup_stat_fails() {
         let dir = std::env::temp_dir().join(format!("toolport-bk-write-{}", std::process::id()));
         std::fs::remove_dir_all(&dir).ok();
         std::fs::create_dir_all(&dir).unwrap();
-        // Parent-of-config is a regular file: metadata(config) fails ENOTDIR.
-        let not_a_dir = dir.join("claude-home");
-        std::fs::write(&not_a_dir, "not a directory").unwrap();
-        let _restore = EnvRestore::set("CLAUDE_CONFIG_DIR", &not_a_dir);
 
-        let err = write_servers("claude-code", &[stdio("filesystem")]).unwrap_err();
-        assert!(
-            err.contains("could not stat"),
-            "the caller must surface the stat failure instead of writing: {err}"
-        );
-        // No destructive write happened: the "config" file was never created.
-        assert!(!not_a_dir.join(".claude.json").exists());
+        #[cfg(unix)]
+        {
+            // Parent-of-config is a regular file: metadata(config) fails ENOTDIR.
+            let not_a_dir = dir.join("claude-home");
+            std::fs::write(&not_a_dir, "not a directory").unwrap();
+            let _restore = EnvRestore::set("CLAUDE_CONFIG_DIR", &not_a_dir);
+
+            let err = write_servers("claude-code", &[stdio("filesystem")]).unwrap_err();
+            assert!(
+                err.contains("could not stat"),
+                "the caller must surface the stat failure instead of writing: {err}"
+            );
+            // No destructive write happened: the "config" file was never created.
+            assert!(!not_a_dir.join(".claude.json").exists());
+        }
+
+        #[cfg(windows)]
+        {
+            // A '<' is an invalid filename character on Windows: metadata fails
+            // with ERROR_INVALID_NAME (InvalidFilename), not ERROR_PATH_NOT_FOUND.
+            let not_a_dir = dir.join("claude-home<>");
+            let _restore = EnvRestore::set("CLAUDE_CONFIG_DIR", &not_a_dir);
+
+            let err = write_servers("claude-code", &[stdio("filesystem")]).unwrap_err();
+            assert!(
+                err.contains("could not stat"),
+                "the caller must surface the stat failure instead of writing: {err}"
+            );
+            // No destructive write happened: the "config" file was never created.
+            assert!(!not_a_dir.join(".claude.json").exists());
+        }
+
         std::fs::remove_dir_all(&dir).ok();
     }
 


### PR DESCRIPTION
## Closes #735 — a failed metadata call must not skip the config backup

`backup_file_named` funnelled the `Err` arm of `std::fs::metadata` into the same `return Ok(None)` used for a genuinely missing file. Callers (`install_or_remove`, `write_servers`) treat `Ok(None)` as "there was no file here" and proceed with the write — starting from an empty `{}` and replacing the user's entire config with no recovery copy, exactly the case the module header says must never happen.

### The fix

`backup_file_named` now distinguishes the outcomes of the pre-write stat:

- **Genuinely missing** (`NotFound`) → `Ok(None)`, caller may create the file from scratch — unchanged.
- **Special file / oversized** (metadata succeeds but not a regular file, or over the 64 MB cap) → `Ok(None)`, the deliberate "nothing safe to back up" behaviour — unchanged.
- **Any other stat error** (permission, network share, transient I/O) → `Err` propagated. Because both callers use `?` on the backup, the write **aborts before touching the config**, and the failure is reported instead of masquerading as a successful write with `backup: null`.

### Tests

Two regression tests (both **proven to fail against the pre-fix code**, pass now):

- `backup_propagates_stat_failures_instead_of_noop` — unit-level: `metadata()` errors (path under a regular file → `ENOTDIR`/`ERROR_DIRECTORY`) and the error is surfaced, not folded into a no-op.
- `write_servers_aborts_when_backup_stat_fails` — caller-level: `CLAUDE_CONFIG_DIR` pointed at a stat-failing path, `write_servers("claude-code", ...)` must return the error and **must not create the config file**.

Validation: `npm run test:rust` equivalent — lib **1020 passed**, bins **305 passed**, 0 failures. Changed hunks are rustfmt-clean (remaining `cargo fmt --check` diffs are pre-existing version drift in untouched lines).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `backup_file_named` to abort writes when pre-write `metadata()` fails
> Previously, any `metadata()` error in `backup_file_named` fell through to `Ok(None)`, silently skipping the backup and allowing writes to proceed. This fix distinguishes between a missing file (`NotFound` → `Ok(None)`), a non-regular or oversized file (`Ok(None)`), and any other stat failure (now returns `Err("could not stat …")`).
> - Two tests are added: one unit test using a NUL-byte path to trigger a non-`NotFound` error, and one acceptance test that wires up `write_servers` end-to-end to assert no config file is written when stat fails.
> - Behavioral Change: callers that previously received `Ok(None)` on unexpected `metadata()` failures will now receive an `Err`, causing `write_servers` to abort instead of silently proceeding.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 315849b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->