### PR TITLE
fix(integrity): make a lost pin baseline recoverable, and add a bulk Re-approve all

### DIFF
--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -2523,6 +2523,38 @@ fn release_quarantine(
     Ok(())
 }
 
+/// Re-approve every quarantined tool for a profile in one action.
+///
+/// A lost integrity baseline blocks the whole catalog at once, which on a real
+/// install is thousands of tools. Recovering through `release_quarantine` means one
+/// IPC round trip, one cross-process lock and two store writes per tool, so the
+/// only recovery the UI offered did not finish in practice. `integrity::release_all`
+/// does the same repair with a single pass. Tools whose captured definition could
+/// not be read stay blocked and come back in `skipped`, so this can never expose a
+/// tool without re-establishing its baseline.
+#[tauri::command]
+async fn release_all_quarantine(
+    app: AppHandle,
+    profile: String,
+) -> Result<integrity::ReleaseAllOutcome, String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        let state = app.state::<RegistryState>();
+        let prof = if profile.is_empty() {
+            None
+        } else {
+            Some(profile.as_str())
+        };
+        let outcome = integrity::release_all(prof)
+            .map_err(|e| format!("Could not re-approve the blocked tools: {e}"))?;
+        // Same reasoning as `release_quarantine`: refresh the cache rather than
+        // blind-writing a possibly stale snapshot over a concurrent gateway write.
+        reload_into_state(state.inner())?;
+        Ok(outcome)
+    })
+    .await
+    .map_err(|e| format!("re-approval task join failed: {e}"))?
+}
+
 /// Set lazy discovery globally. The gateway reads this from the registry, so it
 /// takes effect for every client (including ones that don't forward env vars).
 /// Clients pick it up the next time they (re)spawn the gateway.
@@ -4718,6 +4750,7 @@ pub fn run() {
             set_pii_redaction,
             list_quarantined,
             release_quarantine,
+            release_all_quarantine,
             set_lazy_discovery,
             set_code_mode,
             set_allow_routine_writes,

--- a/src-tauri/src/integrity.rs
+++ b/src-tauri/src/integrity.rs
@@ -275,6 +275,62 @@ enum PinsLoad {
     Corrupt,
 }
 
+/// Reads and retries before giving up on a pin store.
+///
+/// Every connected client spawns its own gateway and they all share this file, so a
+/// read can land between another gateway's temp-write and its atomic rename. That
+/// transient bad read clears on a retry and must NOT raise the "baseline lost"
+/// alarm, because that alarm quarantines the entire catalog.
+///
+/// The original budget was 3 attempts 15ms apart, about 45ms total. That is not
+/// enough on a restart, when several gateways rebuild at once and contend for the
+/// same file; a real install lost its baseline that way. `None` means the file was
+/// present and still unusable after the full budget.
+const PINS_READ_ATTEMPTS: u32 = 5;
+const PINS_READ_BACKOFF_MS: u64 = 40;
+
+fn read_pins_at(path: &Path) -> Option<Pins> {
+    for attempt in 0..PINS_READ_ATTEMPTS {
+        let last = attempt + 1 == PINS_READ_ATTEMPTS;
+        let retry = || std::thread::sleep(std::time::Duration::from_millis(PINS_READ_BACKOFF_MS));
+        let raw = match std::fs::read_to_string(path) {
+            Ok(s) => s,
+            // The file existed a moment ago, so a read error here is most likely another
+            // process replacing it (on Windows that surfaces as a sharing violation).
+            Err(_) if !last => {
+                retry();
+                continue;
+            }
+            Err(_) => return None,
+        };
+        // An empty baseline is a LOST baseline, not a fresh start: atomic_write
+        // (temp + fsync + rename) never leaves an empty file, so emptiness means it was
+        // truncated by a crash mid write, or wiped to silently reset drift detection.
+        // Treating it as Fresh would re-baseline whatever is present now, re-trusting a
+        // poisoned definition with no signal at all.
+        if raw.trim().is_empty() {
+            if !last {
+                retry();
+                continue;
+            }
+            return None;
+        }
+        match serde_json::from_str::<BTreeMap<String, PinRepr>>(&raw) {
+            Ok(pins) => return Some(pins.into_iter().map(|(k, v)| (k, v.into())).collect()),
+            Err(_) if !last => retry(),
+            Err(_) => return None,
+        }
+    }
+    None
+}
+
+/// Sidecar holding the last baseline that parsed, written by [`save_pins_with`].
+fn pins_backup_path(path: &Path) -> PathBuf {
+    let mut name = path.as_os_str().to_os_string();
+    name.push(".bak");
+    PathBuf::from(name)
+}
+
 fn load_pins(profile: Option<&str>) -> PinsLoad {
     let Some(path) = pins_path(profile) else {
         return PinsLoad::Fresh;
@@ -285,45 +341,18 @@ fn load_pins(profile: Option<&str>) -> PinsLoad {
         }
         return PinsLoad::Fresh;
     }
-    // Every connected client spawns its own gateway, and they all share this one pins file.
-    // A read that lands in the moment between another gateway's temp-write and its atomic
-    // rename can occasionally see the file mid-swap on some filesystems. That transient bad
-    // read clears on a quick retry, so it should NOT raise the loud "integrity baseline lost"
-    // alarm. But a file that is genuinely present and still won't parse after the retries -
-    // including an EMPTY one - is a lost baseline and stays Corrupt (loud), because that is
-    // what baseline tampering actually looks like.
-    for attempt in 0..3 {
-        let raw = match std::fs::read_to_string(&path) {
-            Ok(s) => s,
-            // The file existed a moment ago; a read error here is transient (another process
-            // replacing it). Retry, then fall through to Corrupt only if it persists.
-            Err(_) if attempt < 2 => {
-                std::thread::sleep(std::time::Duration::from_millis(15));
-                continue;
-            }
-            Err(_) => return PinsLoad::Corrupt,
-        };
-        if raw.trim().is_empty() {
-            // An empty baseline file is a LOST baseline, not a fresh start: atomic_write
-            // (temp + fsync + rename) never leaves an empty file, so emptiness means it was
-            // truncated - a crash mid foreign write, or an attacker wiping it to silently
-            // reset drift detection. Returning Fresh here would silently re-baseline whatever
-            // tools are present now (re-trusting a poisoned definition with zero signal), so
-            // retry a transient empty read, then treat a persistently-empty file as Corrupt.
-            if attempt < 2 {
-                std::thread::sleep(std::time::Duration::from_millis(15));
-                continue;
-            }
-            return PinsLoad::Corrupt;
-        }
-        match serde_json::from_str::<BTreeMap<String, PinRepr>>(&raw) {
-            Ok(pins) => {
-                return PinsLoad::Loaded(pins.into_iter().map(|(k, v)| (k, v.into())).collect());
-            }
-            Err(_) if attempt < 2 => {
-                std::thread::sleep(std::time::Duration::from_millis(15));
-            }
-            Err(_) => return PinsLoad::Corrupt,
+    if let Some(pins) = read_pins_at(&path) {
+        return PinsLoad::Loaded(pins);
+    }
+    // The live baseline is unusable. Before declaring the trust root lost - which blocks
+    // every tool in the catalog and, at real catalog sizes, is indistinguishable from the
+    // app breaking - fall back to the last copy that parsed. The backup is only ever
+    // written from a file that already parsed, so it cannot itself be the corrupt one.
+    // Deliberately read-only: the next successful save rewrites the primary.
+    let backup = pins_backup_path(&path);
+    if backup.exists() {
+        if let Some(pins) = read_pins_at(&backup) {
+            return PinsLoad::Loaded(pins);
         }
     }
     PinsLoad::Corrupt
@@ -339,6 +368,17 @@ fn save_pins_with(
     })?;
     let serialized = serde_json::to_string(pins)
         .map_err(|e| format!("Could not serialize the integrity pin store at {path:?}: {e}"))?;
+    // Keep the outgoing baseline as `<store>.bak` so a later unreadable primary can be
+    // recovered instead of reported as a lost trust root, which quarantines the whole
+    // catalog. Only a file that still parses is copied, so the backup can never become
+    // the corrupt one; a save whose backup fails still proceeds, since refusing to
+    // persist a fresh baseline would be the worse outcome. Callers hold the pin-store
+    // lock, so this cannot race a peer gateway.
+    if let Some(previous) = read_pins_at(&path) {
+        if let Ok(encoded) = serde_json::to_string(&previous) {
+            let _ = crate::registry::atomic_write(&pins_backup_path(&path), &encoded);
+        }
+    }
     write(&path, &serialized)
         .map_err(|e| format!("Could not persist the integrity pin store at {path:?}: {e}"))
 }
@@ -1139,6 +1179,118 @@ fn release_inner(
         return Ok(true);
     }
     Ok(false)
+}
+
+/// How a bulk re-approval went: how many blocks were lifted, and the tools that
+/// could not be repaired and stay blocked.
+#[derive(Debug, Default, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ReleaseAllOutcome {
+    pub released: usize,
+    pub skipped: Vec<String>,
+}
+
+/// Re-approve every quarantined tool for a profile in one pass.
+///
+/// A lost baseline quarantines the WHOLE catalog (see `apply_quarantine_inner_with`),
+/// which on a real install is thousands of tools. [`release`] is per-tool, so
+/// recovering that way means one lock acquisition, one store load and two store
+/// writes per tool - unusable at that size, and the UI offered nothing else. This
+/// does the same work with one lock, one load and one write of each store.
+///
+/// A record whose captured pin is missing or unreadable cannot be repaired, so it
+/// is left blocked and named in `skipped` rather than failing the whole batch or,
+/// worse, being unblocked without re-establishing its baseline.
+pub fn release_all(profile: Option<&str>) -> Result<ReleaseAllOutcome, String> {
+    let path = quarantine_path(profile).ok_or_else(|| {
+        "Could not resolve the quarantine-store path; nothing was released".to_string()
+    })?;
+    with_store_lock(&path, || {
+        release_all_inner(profile, save_pins, save_quarantine)
+    })
+}
+
+fn release_all_inner(
+    profile: Option<&str>,
+    save_pin: impl FnOnce(Option<&str>, &Pins) -> Result<(), String>,
+    save_quarantine: impl FnOnce(Option<&str>, &Quarantine) -> Result<(), String>,
+) -> Result<ReleaseAllOutcome, String> {
+    // Fail closed on a corrupt store, exactly as `release_inner` does: never treat it
+    // as empty and save `{}`, which would drop every block without repairing anything.
+    let q = load_quarantine(profile)
+        .map_err(|e| format!("{e}; refusing to release until the store is fixed"))?;
+    if q.is_empty() {
+        return Ok(ReleaseAllOutcome::default());
+    }
+
+    let mut accepted: Vec<(String, Pin)> = Vec::new();
+    let mut skipped: Vec<String> = Vec::new();
+    let mut tamper_seen = false;
+    for (tool, record) in q.iter() {
+        let tamper = record.get("change").and_then(Value::as_str) == Some("tamper");
+        match record.get("pending_pin").cloned() {
+            Some(value) => match serde_json::from_value::<Pin>(value) {
+                Ok(pin) => {
+                    tamper_seen |= tamper;
+                    accepted.push((tool.clone(), pin));
+                }
+                // No usable captured definition: releasing would expose the tool with
+                // no baseline to compare against later.
+                Err(_) => skipped.push(tool.clone()),
+            },
+            // A tamper record without a captured pin has no trust root to repair.
+            None if tamper => skipped.push(tool.clone()),
+            // Ordinary drift with nothing staged: the block can simply be lifted.
+            None => {}
+        }
+    }
+
+    if !accepted.is_empty() {
+        let pin_path = pins_path(profile)
+            .ok_or_else(|| "the integrity pin-store path is unavailable".to_string())?;
+        with_store_lock(&pin_path, || {
+            let pins = match load_pins(profile) {
+                PinsLoad::Loaded(p) => p,
+                PinsLoad::Fresh => Pins::new(),
+                // Re-approving after baseline tamper is precisely how the lost trust
+                // root is rebuilt, so a corrupt store is expected on this path.
+                PinsLoad::Corrupt if tamper_seen => Pins::new(),
+                PinsLoad::Corrupt => {
+                    return Err(
+                        "the integrity pin store is corrupt; refusing to overwrite the lost trust root"
+                            .to_string(),
+                    );
+                }
+            };
+            let mut updated = pins.clone();
+            let stamp = epoch_millis();
+            for (tool, pin) in &accepted {
+                updated.insert(
+                    tool.clone(),
+                    merge_pending_pin(pins.get(tool), pin.clone(), stamp),
+                );
+            }
+            if updated != pins {
+                save_pin(profile, &updated)?;
+            }
+            Ok(())
+        })
+        .map_err(|e| format!("Refusing to release; the accepted pins could not be saved: {e}"))?;
+    }
+
+    // Everything repaired (or needing no repair) is unblocked in one write. Anything
+    // skipped stays in the store so it is still blocked and still visible in the UI.
+    let mut remaining = Quarantine::new();
+    for tool in &skipped {
+        if let Some(record) = q.get(tool) {
+            remaining.insert(tool.clone(), record.clone());
+        }
+    }
+    let released = q.len() - remaining.len();
+    if released > 0 {
+        save_quarantine(profile, &remaining)?;
+    }
+    Ok(ReleaseAllOutcome { released, skipped })
 }
 
 /// From `check`'s drift `events` and the `current` tool list, quarantine the HIGH-RISK
@@ -2655,6 +2807,142 @@ mod tests {
         assert!(
             check_staged(profile, &changed).unwrap().is_empty(),
             "one release must leave the recovered definition exposed without re-quarantining"
+        );
+    }
+
+    #[test]
+    /// A lost baseline quarantines the entire catalog. On a real install that was
+    /// 2,156 tools, and `release` is per-tool, so recovery meant 2,156 lock
+    /// acquisitions and 4,312 store writes. One pass must lift them all.
+    #[test]
+    fn release_all_lifts_the_whole_catalog_and_repairs_every_baseline() {
+        let _data_dir_lock = crate::registry::data_dir_test_lock();
+        let _data_dir = TestDataDir::new("release-all-bulk");
+        let profile = Some("release-all-bulk");
+
+        let catalog: Vec<Value> = (0..25)
+            .map(|i| destructive_tool(&format!("srv__wipe{i}"), "Wipe records."))
+            .collect();
+        check(profile, &catalog).unwrap();
+        // Lose the trust root, which is what triggers the mandatory whole-catalog block.
+        let path = pins_path(profile).expect("profile path");
+        std::fs::write(&path, "{ not json").unwrap();
+        let events = check(profile, &catalog).unwrap();
+        assert!(baseline_tamper_detected(&events), "the baseline must read as lost");
+        assert!(apply_quarantine(profile, &catalog, &events).unwrap());
+        assert_eq!(quarantined(profile).unwrap().len(), 25, "whole catalog blocked");
+
+        let outcome = release_all(profile).unwrap();
+
+        assert_eq!(outcome.released, 25);
+        assert!(outcome.skipped.is_empty(), "every record carried a pin: {outcome:?}");
+        assert!(quarantined(profile).unwrap().is_empty(), "nothing stays blocked");
+        // The trust root is rebuilt, so the very next check is quiet rather than
+        // re-detecting drift against a baseline that is still missing.
+        let pins = baselines(profile);
+        assert_eq!(pins.len(), 25, "every tool was re-pinned");
+        assert_eq!(pins["srv__wipe0"].fingerprint, pin_of(&catalog[0]).fp);
+        assert!(
+            check_staged(profile, &catalog).unwrap().is_empty(),
+            "a repaired baseline must not immediately re-flag the same catalog"
+        );
+    }
+
+    /// One unrepairable record must not fail the whole batch, and must not be
+    /// unblocked without a baseline either.
+    #[test]
+    fn release_all_keeps_records_it_cannot_repair_blocked() {
+        let _data_dir_lock = crate::registry::data_dir_test_lock();
+        let _data_dir = TestDataDir::new("release-all-skips");
+        let profile = Some("release-all-skips");
+        let catalog = vec![
+            destructive_tool("srv__keeps", "Wipe records."),
+            destructive_tool("srv__broken", "Wipe records."),
+        ];
+        check(profile, &catalog).unwrap();
+        let path = pins_path(profile).expect("profile path");
+        std::fs::write(&path, "{ not json").unwrap();
+        let events = check(profile, &catalog).unwrap();
+        assert!(apply_quarantine(profile, &catalog, &events).unwrap());
+
+        // Corrupt one record's captured pin, the way a partial write would.
+        let qpath = quarantine_path(profile).expect("quarantine path");
+        let mut store: Quarantine =
+            serde_json::from_str(&std::fs::read_to_string(&qpath).unwrap()).unwrap();
+        store.get_mut("srv__broken").unwrap()["pending_pin"] = json!("not-a-pin");
+        std::fs::write(&qpath, serde_json::to_string(&store).unwrap()).unwrap();
+
+        let outcome = release_all(profile).unwrap();
+
+        assert_eq!(outcome.released, 1, "the healthy record is still released");
+        assert_eq!(outcome.skipped, vec!["srv__broken".to_string()]);
+        assert_eq!(
+            quarantined(profile).unwrap().into_iter().collect::<Vec<_>>(),
+            vec!["srv__broken".to_string()],
+            "an unrepairable tool stays blocked instead of being exposed unpinned"
+        );
+    }
+
+    /// The baseline had no backup at all, so a single unreadable read blocked every
+    /// tool with nothing to recover from. The last file that parsed is now kept
+    /// beside it and used before declaring the trust root lost.
+    #[test]
+    fn a_corrupt_baseline_recovers_from_its_backup_instead_of_blocking_everything() {
+        let _data_dir_lock = crate::registry::data_dir_test_lock();
+        let _data_dir = TestDataDir::new("pins-backup");
+        let profile = Some("pins-backup");
+        let catalog = vec![destructive_tool("srv__wipe", "Wipe records.")];
+
+        // First save establishes the baseline; a second one leaves the first as the backup.
+        check(profile, &catalog).unwrap();
+        let changed = vec![destructive_tool("srv__wipe", "Wipe every record.")];
+        check(profile, &changed).unwrap();
+
+        let path = pins_path(profile).expect("profile path");
+        let backup = pins_backup_path(&path);
+        assert!(backup.exists(), "a parseable baseline must be kept as a backup");
+
+        // Truncate the live baseline, the exact shape that blocked a real catalog.
+        std::fs::write(&path, "").unwrap();
+        match load_pins(profile) {
+            PinsLoad::Loaded(pins) => {
+                assert!(pins.contains_key("srv__wipe"), "recovered the real baseline");
+            }
+            PinsLoad::Fresh => panic!("expected recovery from the backup, got Fresh"),
+            PinsLoad::Corrupt => panic!("expected recovery from the backup, got Corrupt"),
+        }
+        // And therefore no tamper event and no whole-catalog block.
+        let events = check(profile, &changed).unwrap();
+        assert!(
+            !baseline_tamper_detected(&events),
+            "a recoverable baseline must not report the trust root as lost"
+        );
+    }
+
+    /// The backup is only ever written from a file that parsed, so a corrupt primary
+    /// can never overwrite the last good copy.
+    #[test]
+    fn a_corrupt_baseline_never_overwrites_the_good_backup() {
+        let _data_dir_lock = crate::registry::data_dir_test_lock();
+        let _data_dir = TestDataDir::new("pins-backup-guard");
+        let profile = Some("pins-backup-guard");
+        let catalog = vec![destructive_tool("srv__wipe", "Wipe records.")];
+        check(profile, &catalog).unwrap();
+        let changed = vec![destructive_tool("srv__wipe", "Wipe every record.")];
+        check(profile, &changed).unwrap();
+
+        let path = pins_path(profile).expect("profile path");
+        let backup = pins_backup_path(&path);
+        let good = std::fs::read_to_string(&backup).unwrap();
+
+        // Corrupt the primary, then force a save. The backup must not absorb the garbage.
+        std::fs::write(&path, "{ not json").unwrap();
+        save_pins(profile, &Pins::new()).unwrap();
+
+        assert_eq!(
+            std::fs::read_to_string(&backup).unwrap(),
+            good,
+            "a corrupt primary must never become the recovery copy"
         );
     }
 

--- a/src-tauri/src/integrity.rs
+++ b/src-tauri/src/integrity.rs
@@ -2810,7 +2810,6 @@ mod tests {
         );
     }
 
-    #[test]
     /// A lost baseline quarantines the entire catalog. On a real install that was
     /// 2,156 tools, and `release` is per-tool, so recovery meant 2,156 lock
     /// acquisitions and 4,312 store writes. One pass must lift them all.

--- a/src/components/QuarantineAlert.test.tsx
+++ b/src/components/QuarantineAlert.test.tsx
@@ -148,6 +148,34 @@ describe("QuarantineAlert bulk re-approval", () => {
     expect(toastSuccess).not.toHaveBeenCalled();
     expect(screen.getByRole("region")).toBeInTheDocument();
   });
+
+  it("still counts and refreshes the profiles that succeeded when one fails", async () => {
+    // One locked store must not discard the other profile's result. With Promise.all
+    // the whole batch was thrown away: the tools that really were released stayed on
+    // the card, and the count never came down.
+    listQuarantined.mockResolvedValueOnce([
+      ...catalog(2, "default"),
+      ...catalog(2, "work"),
+    ]);
+    releaseAllQuarantine
+      .mockResolvedValueOnce({ released: 2, skipped: [] })
+      .mockRejectedValueOnce(new Error("store locked"));
+    listQuarantined.mockResolvedValue(catalog(2, "work"));
+
+    render(<QuarantineAlert />);
+    await screen.findByRole("region");
+    const pollsBefore = listQuarantined.mock.calls.length;
+    await confirmReapproveAll();
+
+    await waitFor(() => expect(toastError).toHaveBeenCalled());
+    // The successful profile is reported, not silently dropped.
+    expect(toastError.mock.calls[0][0]).toMatch(/Re-approved 2\./);
+    expect(toastError.mock.calls[0][0]).toMatch(/1 profile could not be re-approved/);
+    expect(toastSuccess).not.toHaveBeenCalled();
+    // The refresh still ran, so the card drops the tools that did come free.
+    expect(listQuarantined.mock.calls.length).toBeGreaterThan(pollsBefore);
+    expect(screen.getByRole("region")).toBeInTheDocument();
+  });
 });
 
 describe("QuarantineAlert", () => {

--- a/src/components/QuarantineAlert.test.tsx
+++ b/src/components/QuarantineAlert.test.tsx
@@ -1,18 +1,33 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { QuarantineAlert } from "./QuarantineAlert";
 import type { QuarantinedTool } from "@/lib/api";
 
 const listQuarantined = vi.fn();
 const releaseQuarantine = vi.fn();
+const releaseAllQuarantine = vi.fn();
 const toastError = vi.fn();
+const toastSuccess = vi.fn();
 
 vi.mock("@/lib/api", () => ({
   listQuarantined: (...a: unknown[]) => listQuarantined(...a),
   releaseQuarantine: (...a: unknown[]) => releaseQuarantine(...a),
+  releaseAllQuarantine: (...a: unknown[]) => releaseAllQuarantine(...a),
 }));
 vi.mock("@/lib/toast", () => ({ toastError: (...a: unknown[]) => toastError(...a) }));
+vi.mock("sonner", () => ({
+  toast: { success: (...a: unknown[]) => toastSuccess(...a) },
+}));
+
+/** Open the bulk confirm and press its confirm button. */
+async function confirmReapproveAll() {
+  await userEvent.click(screen.getByRole("button", { name: /re-approve all \(/i }));
+  const dialog = await screen.findByRole("dialog");
+  await userEvent.click(
+    within(dialog).getByRole("button", { name: /^re-approve all$/i }),
+  );
+}
 
 function tool(over: Partial<QuarantinedTool> = {}): QuarantinedTool {
   return {
@@ -28,7 +43,111 @@ function tool(over: Partial<QuarantinedTool> = {}): QuarantinedTool {
 beforeEach(() => {
   listQuarantined.mockReset();
   releaseQuarantine.mockReset();
+  releaseAllQuarantine.mockReset();
   toastError.mockReset();
+  toastSuccess.mockReset();
+});
+
+describe("QuarantineAlert bulk re-approval", () => {
+  /** A lost integrity baseline blocks the whole catalog at once. A real install saw
+   * 2,156 tools blocked in one shot, and the only recovery on offer was a per-tool
+   * button, so the card was an unusable wall. */
+  function catalog(n: number, profile = "default"): QuarantinedTool[] {
+    return Array.from({ length: n }, (_, i) =>
+      tool({
+        tool: `clerk__call_api_key_${i}`,
+        reason: "the integrity baseline was corrupt or tampered with",
+        profile,
+      }),
+    );
+  }
+
+  it("clears a whole blocked catalog in one call per profile", async () => {
+    listQuarantined.mockResolvedValueOnce(catalog(40));
+    releaseAllQuarantine.mockResolvedValue({ released: 40, skipped: [] });
+    listQuarantined.mockResolvedValue([]);
+
+    render(<QuarantineAlert />);
+    expect(
+      await screen.findByRole("button", { name: /re-approve all \(40\)/i }),
+    ).toBeInTheDocument();
+    await confirmReapproveAll();
+
+    // One call for the one profile, not one per tool.
+    await waitFor(() => expect(releaseAllQuarantine).toHaveBeenCalledTimes(1));
+    expect(releaseAllQuarantine).toHaveBeenCalledWith("default");
+    expect(releaseQuarantine).not.toHaveBeenCalled();
+    await waitFor(() => expect(screen.queryByRole("region")).not.toBeInTheDocument());
+    expect(toastSuccess).toHaveBeenCalledWith("Re-approved 40 tools");
+  });
+
+  it("clears every profile the card covers", async () => {
+    // The same tool can be blocked in one profile and fine in another, and the store is
+    // per-profile, so a single call would silently leave the other profile blocked.
+    listQuarantined.mockResolvedValueOnce([
+      ...catalog(2, "default"),
+      ...catalog(2, "work"),
+    ]);
+    releaseAllQuarantine.mockResolvedValue({ released: 2, skipped: [] });
+    listQuarantined.mockResolvedValue([]);
+
+    render(<QuarantineAlert />);
+    await screen.findByRole("region");
+    await confirmReapproveAll();
+
+    await waitFor(() => expect(releaseAllQuarantine).toHaveBeenCalledTimes(2));
+    expect(releaseAllQuarantine).toHaveBeenCalledWith("default");
+    expect(releaseAllQuarantine).toHaveBeenCalledWith("work");
+  });
+
+  it("does not release anything until the confirm is accepted", async () => {
+    // Bulk-trusting definitions is a security decision, so it gets the same gate as
+    // every other action that changes what clients may call.
+    listQuarantined.mockResolvedValue(catalog(3));
+
+    render(<QuarantineAlert />);
+    await userEvent.click(
+      await screen.findByRole("button", { name: /re-approve all \(3\)/i }),
+    );
+
+    expect(await screen.findByRole("dialog")).toBeInTheDocument();
+    expect(releaseAllQuarantine).not.toHaveBeenCalled();
+  });
+
+  it("reports tools it could not repair as still blocked, not as success", async () => {
+    // Saying "re-approved" when some tools are still hidden would send the user away
+    // believing the catalog is whole.
+    listQuarantined.mockResolvedValue(catalog(3));
+    releaseAllQuarantine.mockResolvedValue({
+      released: 1,
+      skipped: ["clerk__call_api_key_1", "clerk__call_api_key_2"],
+    });
+
+    render(<QuarantineAlert />);
+    await screen.findByRole("region");
+    await confirmReapproveAll();
+
+    await waitFor(() => expect(toastError).toHaveBeenCalled());
+    expect(toastError.mock.calls[0][0]).toMatch(
+      /Re-approved 1\. 2 could not be repaired/,
+    );
+    expect(toastSuccess).not.toHaveBeenCalled();
+    // Still blocked, so the card must stay up.
+    expect(screen.getByRole("region")).toBeInTheDocument();
+  });
+
+  it("keeps the card up and reports a failed bulk re-approval", async () => {
+    listQuarantined.mockResolvedValue(catalog(3));
+    releaseAllQuarantine.mockRejectedValue(new Error("store locked"));
+
+    render(<QuarantineAlert />);
+    await screen.findByRole("region");
+    await confirmReapproveAll();
+
+    await waitFor(() => expect(toastError).toHaveBeenCalled());
+    expect(toastSuccess).not.toHaveBeenCalled();
+    expect(screen.getByRole("region")).toBeInTheDocument();
+  });
 });
 
 describe("QuarantineAlert", () => {
@@ -75,7 +194,8 @@ describe("QuarantineAlert", () => {
     listQuarantined.mockResolvedValue([]);
 
     render(<QuarantineAlert />);
-    await userEvent.click(await screen.findByRole("button", { name: /re-approve/i }));
+    // Exact match: the footer also offers a bulk "Re-approve all" button.
+    await userEvent.click(await screen.findByRole("button", { name: /^re-approve$/i }));
 
     expect(releaseQuarantine).toHaveBeenCalledWith("work", "linear__save_issue");
     await waitFor(() => expect(screen.queryByRole("region")).not.toBeInTheDocument());
@@ -88,7 +208,8 @@ describe("QuarantineAlert", () => {
     releaseQuarantine.mockRejectedValue(new Error("locked"));
 
     render(<QuarantineAlert />);
-    await userEvent.click(await screen.findByRole("button", { name: /re-approve/i }));
+    // Exact match: the footer also offers a bulk "Re-approve all" button.
+    await userEvent.click(await screen.findByRole("button", { name: /^re-approve$/i }));
 
     await waitFor(() => expect(toastError).toHaveBeenCalled());
     expect(screen.getByRole("region")).toBeInTheDocument();

--- a/src/components/QuarantineAlert.tsx
+++ b/src/components/QuarantineAlert.tsx
@@ -124,11 +124,28 @@ export function QuarantineAlert({ onReview }: { onReview?: () => void }) {
       // The card can span profiles (the same tool may be blocked in one and fine in
       // another), and the store is per-profile, so clear each one it covers.
       const profiles = [...new Set(items.map((q) => q.profile))];
-      const outcomes = await Promise.all(profiles.map((p) => releaseAllQuarantine(p)));
+      // allSettled, not all: one profile's store being locked must not throw away the
+      // outcome of the profiles that did succeed, nor skip the refresh that takes
+      // their tools off the card. With Promise.all the card kept listing tools that
+      // were already released, and the count never came down.
+      const settled = await Promise.allSettled(
+        profiles.map((p) => releaseAllQuarantine(p)),
+      );
+      const outcomes = settled.flatMap((r) =>
+        r.status === "fulfilled" ? [r.value] : [],
+      );
+      const failed = settled.flatMap((r) => (r.status === "rejected" ? [r.reason] : []));
       const released = outcomes.reduce((n, o) => n + o.released, 0);
       const skipped = outcomes.flatMap((o) => o.skipped);
       await refresh();
-      if (skipped.length > 0) {
+      if (failed.length > 0) {
+        // Say what did get through, so the number still on the card adds up.
+        toastError(
+          `Re-approved ${released}. ${failed.length} profile${
+            failed.length === 1 ? "" : "s"
+          } could not be re-approved: ${failed[0]}`,
+        );
+      } else if (skipped.length > 0) {
         // Not a success: these are still blocked, and saying otherwise would send the
         // user away believing the catalog is whole.
         toastError(

--- a/src/components/QuarantineAlert.tsx
+++ b/src/components/QuarantineAlert.tsx
@@ -1,8 +1,15 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { ShieldAlert } from "lucide-react";
-import { listQuarantined, releaseQuarantine, type QuarantinedTool } from "@/lib/api";
+import { toast } from "sonner";
+import {
+  listQuarantined,
+  releaseAllQuarantine,
+  releaseQuarantine,
+  type QuarantinedTool,
+} from "@/lib/api";
 import { toastError } from "@/lib/toast";
 import { Button } from "@/components/ui/button";
+import { ConfirmDialog } from "@/components/ConfirmDialog";
 import { fmtTs } from "@/lib/utils";
 
 /** Matches the PendingApprovals cadence so the two attention surfaces feel equally live. */
@@ -56,6 +63,7 @@ function whenLabel(ts: number): string {
 export function QuarantineAlert({ onReview }: { onReview?: () => void }) {
   const [items, setItems] = useState<QuarantinedTool[]>([]);
   const [releasing, setReleasing] = useState<Set<string>>(new Set());
+  const [bulkBusy, setBulkBusy] = useState(false);
   const [dismissedFor, setDismissedFor] = useState<string | null>(null);
   // Monotonic request id: `release` refreshes while the interval may already have a poll
   // in flight, so an older response can land last and momentarily resurrect a tool the
@@ -98,6 +106,43 @@ export function QuarantineAlert({ onReview }: { onReview?: () => void }) {
         next.delete(k);
         return next;
       });
+    }
+  }
+
+  /**
+   * Re-approve everything on the card in one action.
+   *
+   * A lost integrity baseline blocks the entire catalog, which is thousands of tools
+   * on a real install. Clearing that one row at a time is not something anyone will
+   * do, so without this the card is an unusable wall and the app is effectively
+   * stuck. The backend repairs each baseline in a single pass and refuses to expose
+   * any tool whose captured definition it could not read, so those stay listed.
+   */
+  async function releaseEverything() {
+    setBulkBusy(true);
+    try {
+      // The card can span profiles (the same tool may be blocked in one and fine in
+      // another), and the store is per-profile, so clear each one it covers.
+      const profiles = [...new Set(items.map((q) => q.profile))];
+      const outcomes = await Promise.all(profiles.map((p) => releaseAllQuarantine(p)));
+      const released = outcomes.reduce((n, o) => n + o.released, 0);
+      const skipped = outcomes.flatMap((o) => o.skipped);
+      await refresh();
+      if (skipped.length > 0) {
+        // Not a success: these are still blocked, and saying otherwise would send the
+        // user away believing the catalog is whole.
+        toastError(
+          `Re-approved ${released}. ${skipped.length} could not be repaired and ${
+            skipped.length === 1 ? "is" : "are"
+          } still blocked.`,
+        );
+      } else {
+        toast.success(`Re-approved ${released} tool${released === 1 ? "" : "s"}`);
+      }
+    } catch (e) {
+      toastError(`Couldn't re-approve the blocked tools: ${e}`);
+    } finally {
+      setBulkBusy(false);
     }
   }
 
@@ -171,6 +216,35 @@ export function QuarantineAlert({ onReview }: { onReview?: () => void }) {
         </ul>
 
         <div className="flex items-center justify-end gap-2 border-t border-border/60 px-4 py-2.5">
+          {/* Bulk re-approval is confirmed, like every other decision that changes what
+              clients can call. It is the recovery path for a lost baseline, which blocks
+              the whole catalog at once, so it is the difference between the app being
+              usable and not. */}
+          <ConfirmDialog
+            title={`Re-approve ${items.length} blocked tool${many ? "s" : ""}?`}
+            description={
+              <div className="space-y-2">
+                <p>
+                  This trusts{" "}
+                  {many
+                    ? "these tools' current definitions"
+                    : "this tool's current definition"}{" "}
+                  and makes {many ? "them" : "it"} callable by every client again.
+                </p>
+                <p>
+                  Only do this if you expected the change. If a definition was altered by
+                  something you did not do, re-approving accepts it.
+                </p>
+              </div>
+            }
+            confirmLabel="Re-approve all"
+            onConfirm={releaseEverything}
+            trigger={
+              <Button size="sm" variant="outline" disabled={bulkBusy} className="mr-auto">
+                {bulkBusy ? "Re-approving…" : `Re-approve all (${items.length})`}
+              </Button>
+            }
+          />
           {onReview && (
             <Button size="sm" variant="ghost" onClick={onReview}>
               Review in Settings

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -350,6 +350,22 @@ export function releaseQuarantine(profile: string, tool: string): Promise<void> 
   return invoke<void>("release_quarantine", { profile, tool });
 }
 
+/** Outcome of a bulk re-approval. `skipped` names tools that stay blocked. */
+export type ReleaseAllOutcome = {
+  released: number;
+  skipped: string[];
+};
+
+/**
+ * Re-approve every blocked tool for a profile in one pass. A lost integrity
+ * baseline blocks the whole catalog at once, which is far too many to clear one
+ * at a time. Tools whose captured definition could not be read stay blocked and
+ * are returned in `skipped`.
+ */
+export function releaseAllQuarantine(profile: string): Promise<ReleaseAllOutcome> {
+  return invoke<ReleaseAllOutcome>("release_all_quarantine", { profile });
+}
+
 /** Toggle global lazy discovery (meta-tools vs full catalog) for all clients. */
 export function setLazyDiscovery(lazy: boolean): Promise<Registry> {
   return invoke<Registry>("set_lazy_discovery", { lazy });


### PR DESCRIPTION
A single unreadable read of the pin store quarantines the **entire catalog**. On my install that was 2,156 tools in one shot, and the only recovery the UI offered was a per-tool Re-approve button. The app was effectively bricked.

From the logs:

```
08:37:09  app restarts
08:37:11  registry.json written
08:37:18  security.jsonl: {"type":"pins_load_failed","change":"tamper","severity":"high"}
08:37:30  quarantine store written, 691 KB, 2,156 tamper records
```

`apply_quarantine_inner_with` treats one `pins_load_failed` event as grounds to block every tool in the catalog, and that path is deliberately mandatory: it runs even with drift quarantine turned off. Failing closed on a lost baseline is right. Doing it to 100% of tools with per-tool recovery only is not.

Also worth knowing: four gateway processes were running concurrently, sharing these stores and outliving the app close. That contention is the likely trigger and is its own bug, not addressed here.

## Changes

**1. The baseline now has a backup.** `save_pins` keeps the outgoing store as `<store>.bak`, and `load_pins` falls back to it before declaring the trust root lost. Only a file that already parses is copied, so the backup can never become the corrupt one. The fallback is read-only, so it cannot race a peer gateway. The registry has had backups for ages; the pin store, which is far more dangerous to lose, had none.

**2. `release_all` re-approves a whole profile in one pass** — one lock, one load and one write of each store, instead of that per tool. A record whose captured pin is missing or unreadable is left blocked and named in `skipped`, so one damaged record cannot fail the batch and cannot be quietly exposed without a baseline either.

**3. The read budget goes from 3 attempts 15ms apart (~45ms) to 5 attempts 40ms apart (~200ms).** Several gateways rebuild simultaneously on restart and contend for this one shared file; on Windows that surfaces as a sharing violation. 45ms was not enough, and the penalty for losing that race is blocking every tool the user has.

**4. A confirmed "Re-approve all (N)" action** in the QuarantineAlert footer, over a new `release_all_quarantine` command. The card can span profiles, since the same tool may be blocked in one and fine in another, so it clears each profile it covers rather than assuming one.

Confirmed rather than one-click: bulk-accepting definitions is a security decision and gets the same gate as every other action that changes what clients can call. Tools the backend could not repair are reported through `toastError`, not a success toast, so a partial recovery never reads as a whole one. The command runs on the blocking pool, since it takes cross-process locks and rewrites both stores (SBS-818).

## What is deliberately unchanged

An empty, garbage, or genuinely absent baseline **with no backup** is still `Corrupt` and still freezes the catalog. This does not weaken the fail-closed posture; it gives it something to recover from first.

## Verification

Mutation-tested, each applied and reverted:

| mutation | test that went red |
| --- | --- |
| remove the backup fallback in `load_pins` | `a_corrupt_baseline_recovers_from_its_backup_instead_of_blocking_everything` |
| stop writing the backup on save | that one plus `a_corrupt_baseline_never_overwrites_the_good_backup` |
| let `release_all` release records it cannot repair | `release_all_keeps_records_it_cannot_repair_blocked` |

- `cargo test --lib integrity::` : 60 passed, including all 55 that existed before
- `npm test` : 365 passed
- `npx tsc --noEmit` clean
- The 4 `launcher::tests` failures on my machine are pre-existing and reproduce on a clean checkout of `main`.

Two existing `QuarantineAlert` tests had to switch to an exact `/^re-approve$/i` query, since the footer now also offers "Re-approve all".

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add bulk re-approve for quarantined tools and make lost pin baselines recoverable
> - Adds a "Re-approve all (N)" button to `QuarantineAlert` that bulk re-approves quarantined tools across all profiles in one confirmed action, reporting partial failures and skipped tools via toast.
> - Implements `release_all` / `release_all_inner` in [integrity.rs](https://github.com/tsouth89/toolport/pull/747/files#diff-e926b9c6ea4577b150d98237f9e0fb477ca203e123a57258760db4535cf32511) to batch-lift quarantine blocks in a single store lock pass, leaving unrecoverable records (missing or invalid pins) in place and returning counts via `ReleaseAllOutcome`.
> - Adds a `.bak` sidecar backup: `save_pins_with` writes the last parseable baseline to `<store>.bak` before each save, and `load_pins` now falls back to this backup when the primary pin store is unreadable or corrupt instead of returning a hard failure.
> - Exposes the new `release_all_quarantine` Tauri command and `releaseAllQuarantine` frontend API wrapper in [api.ts](https://github.com/tsouth89/toolport/pull/747/files#diff-400f714a60b9cf9cb8d716a1010cd6de05f9841d153876783ad7442be601af0d).
> - Risk: the backup fallback in `load_pins` silently promotes a stale baseline on primary corruption, which could cause previously-approved tools to re-enter quarantine if the backup is also outdated.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4fa4507.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->