### PR TITLE
ci: add Rust Clippy gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,26 @@ permissions:
   contents: read
 
 jobs:
+  clippy:
+    name: Rust Clippy
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
+        with:
+          components: clippy
+
+      - name: Install Linux build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential libssl-dev pkg-config libdbus-1-dev
+
+      - name: Clippy
+        run: cargo clippy --manifest-path src-tauri/Cargo.toml --lib --bins
+
   build-test:
     name: Build + test
     runs-on: ubuntu-22.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,13 +27,17 @@ jobs:
         with:
           components: clippy
 
+      # Same headless dependency set as build-test: no GTK/WebKit, because the
+      # lint below skips the Tauri desktop feature for the same reason.
       - name: Install Linux build dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y build-essential libssl-dev pkg-config libdbus-1-dev
 
+      # --no-default-features matches every other Rust job here. With the desktop
+      # feature on, this needs the GTK and WebKit headers and dies building gdk-sys.
       - name: Clippy
-        run: cargo clippy --manifest-path src-tauri/Cargo.toml --lib --bins
+        run: cargo clippy --manifest-path src-tauri/Cargo.toml --no-default-features --lib --bins
 
   build-test:
     name: Build + test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -114,6 +114,17 @@ warning, it's usually the standard Tauri pattern of loading data from the Rust
 backend in a `useEffect` — review it for unnecessary re-renders, but it won't
 block the build.
 
+### Rust linting
+
+Clippy checks the Rust backend and gateway binary. CI runs it on every PR.
+
+```bash
+cargo clippy --manifest-path src-tauri/Cargo.toml --lib --bins
+```
+
+Clippy warnings are currently non-blocking. The CI gate will be made blocking
+after the existing warnings have been cleared.
+
 ### Git hooks (pre-commit)
 
 When you run `npm install`, Husky installs a pre-commit hook that automatically


### PR DESCRIPTION
 ## Summary

- Add a dedicated Rust Clippy job to CI for the backend library and gateway binary
- Install the Linux build dependencies required for the Clippy check
- Document the local Clippy command and current warning policy in `CONTRIBUTING.md`

## Validation

- `cargo clippy --manifest-path src-tauri/Cargo.toml --lib --bins` — passes with existing warnings
- `git diff --check` — passes
- Pre-commit hooks — passed

Clippy warnings remain non-blocking for now; the gate can be made blocking after the existing warnings are cleared.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Rust Clippy lint job to CI pipeline
> - Adds a `clippy` job to [ci.yml](.github/workflows/ci.yml) that runs `cargo clippy` against `src-tauri/Cargo.toml` with `--no-default-features --lib --bins` on Ubuntu 22.04.
> - Documents the local equivalent command and lint policy in [CONTRIBUTING.md](https://github.com/tsouth89/toolport/pull/749/files#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055).
> - Behavioral Change: Clippy warnings are currently non-blocking but the contributing docs note they may become blocking once existing warnings are cleared.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cb6eafb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->