### PR TITLE
fix(desktop): treat a locked keyring as a secret_status error (SBS-841)

### DIFF
--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -3113,6 +3113,9 @@ async fn search_catalog(query: String) -> Result<Vec<catalog::CatalogEntry>, Str
 }
 
 /// Which of a server's env keys currently have a value stored in the keychain.
+///
+/// Errs on a failed vault read instead of reporting `(key, false)` (SBS-841): a
+/// locked keychain must not make a vaulted env secret look like "not stored".
 #[tauri::command]
 async fn secret_status(server_id: String, keys: Vec<String>) -> Result<Vec<(String, bool)>, String> {
     // Async, like every keychain command here: a Secret Service read is a
@@ -3120,21 +3123,25 @@ async fn secret_status(server_id: String, keys: Vec<String>) -> Result<Vec<(Stri
     // slow keyring, and as sync commands they ran on the GTK main loop,
     // freezing window controls while a dialog probed the vault (SBS-813).
     //
-    // Errs rather than returning an empty list on a worker failure, for the same
-    // reason `has_auth_token` errs (SBS-789): the dialog treats a resolved list
-    // as authoritative and would mark every key unvaulted, while its `catch`
-    // leaves the badges alone. The polled readers below can absorb a panic as an
-    // empty result because they run again in seconds; this is a one-shot probe.
+    // Errs rather than returning an empty list on a worker failure, and rather
+    // than mapping a failed per-key read to `false`, for the same reason
+    // `has_auth_token` / `has_client_secret` err (SBS-789 / SBS-722 / SBS-841):
+    // the dialog treats a resolved list as authoritative and would mark every
+    // key unvaulted, while its `catch` leaves the badges alone. `get_secret`
+    // swallows a locked or failed keyring into `None`; the presence probe must
+    // use `get_secret_result` so that becomes `Err`. The polled readers below
+    // can absorb a panic as an empty result because they run again in seconds;
+    // this is a one-shot probe.
     tauri::async_runtime::spawn_blocking(move || {
         keys.into_iter()
             .map(|k| {
-                let present = secrets::get_secret(&server_id, &k).is_some();
-                (k, present)
+                let present = secrets::get_secret_result(&server_id, &k)?.is_some();
+                Ok((k, present))
             })
-            .collect()
+            .collect::<Result<Vec<_>, String>>()
     })
     .await
-    .map_err(|e| format!("keychain task join failed: {e}"))
+    .map_err(|e| format!("keychain task join failed: {e}"))?
 }
 
 /// Open Toolport's data directory (registry, logs, audit) in the OS file manager,
@@ -5212,6 +5219,23 @@ mod tests {
         assert!(
             result.is_err(),
             "a failed secret read must propagate, not resolve to a boolean: {result:?}"
+        );
+    }
+
+    /// Same fail-closed contract as `has_client_secret` (SBS-841): a locked or
+    /// otherwise failed vault read must not resolve to `(key, false)`, which the
+    /// Secrets dialog treats as "not vaulted" and would overwrite. The reserved
+    /// internal namespace is the deterministic way to make `get_secret_result`
+    /// fail on every platform; `get_secret` swallows that into `None`.
+    #[test]
+    fn secret_status_reports_a_failed_read_as_an_error_not_missing() {
+        let result = tauri::async_runtime::block_on(secret_status(
+            "__toolport_internal__".to_string(),
+            vec!["SOME_KEY".to_string()],
+        ));
+        assert!(
+            result.is_err(),
+            "a failed secret read must propagate, not resolve to unvaulted: {result:?}"
         );
     }
 

--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -3132,6 +3132,14 @@ async fn secret_status(server_id: String, keys: Vec<String>) -> Result<Vec<(Stri
     // use `get_secret_result` so that becomes `Err`. The polled readers below
     // can absorb a panic as an empty result because they run again in seconds;
     // this is a one-shot probe.
+    //
+    // All-or-nothing on purpose, rather than a per-key `Option<bool>`. The
+    // realistic failures are process-wide (locked keyring, no Secret Service,
+    // denied keychain access), so a per-key answer would report "unknown" for
+    // every key anyway, while pushing a third state through the dialog's
+    // `vaulted` map at every use site - badge, placeholder, Remove button. One
+    // `Err` maps to the one "couldn't check the keychain" warning the dialog
+    // now shows, and keeps the shape of `has_auth_token` / `has_client_secret`.
     tauri::async_runtime::spawn_blocking(move || {
         keys.into_iter()
             .map(|k| {

--- a/src/components/SecretsDialog.secretStatus.test.tsx
+++ b/src/components/SecretsDialog.secretStatus.test.tsx
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { SecretsDialog } from "./SecretsDialog";
+import type { ServerEntry } from "@/lib/types";
+
+const secretStatus = vi.fn();
+const setSecret = vi.fn();
+
+vi.mock("@/lib/api", () => ({
+  secretStatus: (...a: unknown[]) => secretStatus(...a),
+  setSecret: (...a: unknown[]) => setSecret(...a),
+  hasAuthToken: vi.fn().mockResolvedValue(false),
+  hasClientSecret: vi.fn().mockResolvedValue(false),
+  probeAuth: vi.fn().mockResolvedValue({ kind: "oauth", guidance: null }),
+  setClientCredentials: vi.fn(),
+  clearClientCredentials: vi.fn(),
+  deleteSecret: vi.fn(),
+  setAuthToken: vi.fn(),
+  clearAuthToken: vi.fn(),
+  authenticateOauth: vi.fn(),
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+    warning: vi.fn(),
+    info: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/toast", () => ({ toastError: vi.fn() }));
+
+vi.mock("@/lib/openUrl", () => ({ openExternal: vi.fn() }));
+
+/** A stdio server (it has a command) with one declared secret env key. */
+function server(over: Partial<ServerEntry> = {}): ServerEntry {
+  return {
+    id: "srv-1",
+    name: "Resend",
+    transport: "stdio",
+    command: "npx",
+    args: [],
+    env: [{ key: "RESEND_API_KEY", value: null, secret: true }],
+    url: null,
+    source: "manual",
+    ...over,
+  };
+}
+
+async function openDialog(entry: ServerEntry) {
+  const user = userEvent.setup();
+  render(<SecretsDialog server={entry} onSaved={vi.fn()} />);
+  await user.click(screen.getByRole("button", { name: /Manage secrets/i }));
+  return user;
+}
+
+/// SBS-841. The backend errs when a vault read fails instead of reporting the
+/// key as unvaulted. That only helps if the dialog says so: `vaulted` starts
+/// empty, so a swallowed rejection leaves the screen identical to "no key is
+/// saved" - no badge, an inviting first-time paste prompt, and no Remove button
+/// for a key that does exist.
+describe("SecretsDialog vault probe (SBS-841)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    secretStatus.mockResolvedValue([["RESEND_API_KEY", true]]);
+  });
+
+  it("says the check failed instead of showing the key as unsaved", async () => {
+    secretStatus.mockRejectedValue(new Error("keyring is locked"));
+    await openDialog(server());
+
+    await waitFor(() =>
+      expect(secretStatus).toHaveBeenCalledWith("srv-1", ["RESEND_API_KEY"]),
+    );
+    await waitFor(() =>
+      expect(screen.getByText(/Couldn't check the keychain/i)).toBeInTheDocument(),
+    );
+    // And it must not claim the opposite either way.
+    expect(screen.queryByText("saved")).not.toBeInTheDocument();
+  });
+
+  it("stays quiet when the probe succeeds", async () => {
+    await openDialog(server());
+
+    await waitFor(() => expect(screen.getByText("saved")).toBeInTheDocument());
+    expect(screen.queryByText(/Couldn't check the keychain/i)).not.toBeInTheDocument();
+  });
+
+  /// The keychain is usually unlockable on the spot, so the fix has to offer a
+  /// way forward, not just an explanation.
+  it("recovers the badges on retry, without reopening the dialog", async () => {
+    secretStatus
+      .mockRejectedValueOnce(new Error("keyring is locked"))
+      .mockResolvedValueOnce([["RESEND_API_KEY", true]]);
+    const user = await openDialog(server());
+
+    await waitFor(() =>
+      expect(screen.getByText(/Couldn't check the keychain/i)).toBeInTheDocument(),
+    );
+    await user.click(screen.getByRole("button", { name: "Retry the keychain check" }));
+
+    await waitFor(() => expect(secretStatus).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(screen.getByText("saved")).toBeInTheDocument());
+    expect(screen.queryByText(/Couldn't check the keychain/i)).not.toBeInTheDocument();
+    // The key exists, so removing it must be offered again.
+    expect(
+      screen.getByRole("button", { name: "Remove RESEND_API_KEY" }),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/components/SecretsDialog.tsx
+++ b/src/components/SecretsDialog.tsx
@@ -87,6 +87,11 @@ function vendorFromKey(key: string): string {
 export function SecretsDialog({ server, onSaved, trigger, onChanged }: Props) {
   const [open, setOpen] = useState(false);
   const [vaulted, setVaulted] = useState<Record<string, boolean>>({});
+  // Whether the `secretStatus` probe succeeded. Failure must stay unknown
+  // (SBS-841): an empty `vaulted` renders exactly like "nothing is saved" - no
+  // badge, a first-time paste prompt, no Remove button - which is the lie the
+  // backend now refuses to tell. Same rule as `ccSecretProbeError` (SBS-722).
+  const [secretProbeError, setSecretProbeError] = useState(false);
   const [inputs, setInputs] = useState<Record<string, string>>({});
   const [newKey, setNewKey] = useState("");
   const [newValue, setNewValue] = useState("");
@@ -148,14 +153,10 @@ export function SecretsDialog({ server, onSaved, trigger, onChanged }: Props) {
     const fresh = () => runId === runIdRef.current;
     const vaultFresh = () => vaultRunId === vaultRunIdRef.current;
     if (secretKeys.length > 0) {
-      try {
-        const pairs = await secretStatus(server.id, secretKeys);
-        if (vaultFresh()) setVaulted(Object.fromEntries(pairs));
-      } catch {
-        /* non-fatal */
-      }
+      await probeVaultedKeys(vaultRunId);
     } else {
       setVaulted({});
+      setSecretProbeError(false);
     }
     if (isRemote && server.url) {
       hasAuthToken(server.id)
@@ -202,6 +203,37 @@ export function SecretsDialog({ server, onSaved, trigger, onChanged }: Props) {
         .catch(() => {})
         .finally(() => fresh() && setProbing(false));
     }
+  }
+
+  /** Ask which env keys are vaulted, under an already-claimed vault generation.
+   * `secret_status` is all-or-nothing: it errs if any key read fails, so there
+   * is one answer for the whole list and one warning to show. */
+  async function probeVaultedKeys(vaultRunId: number) {
+    try {
+      const pairs = await secretStatus(server.id, secretKeys);
+      if (vaultRunId !== vaultRunIdRef.current) return;
+      setVaulted(Object.fromEntries(pairs));
+      setSecretProbeError(false);
+    } catch {
+      // Unknown ≠ absent (SBS-841). The backend errs on a failed vault read
+      // rather than reporting the key unvaulted; swallowing that here would put
+      // the same lie back on screen - no badge, a first-time paste prompt, no
+      // Remove button - so drop any stale badge and say the check failed.
+      if (vaultRunId !== vaultRunIdRef.current) return;
+      setVaulted({});
+      setSecretProbeError(true);
+    }
+  }
+
+  /** Re-run the env-key probe once the keychain is unlocked. Deliberately not
+   * cleared by a successful `save`: writing one key says nothing about the
+   * others, and only a clean read makes the list authoritative again. */
+  async function retryVaultedKeysProbe() {
+    // A vault probe, so it rides the vault generation: a mutation started while
+    // this retry is in flight must win.
+    const vaultRunId = ++vaultRunIdRef.current;
+    setSecretProbeError(false);
+    await probeVaultedKeys(vaultRunId);
   }
 
   async function retrySecretProbe() {
@@ -706,6 +738,25 @@ export function SecretsDialog({ server, onSaved, trigger, onChanged }: Props) {
                       <ExternalLink className="size-3" />
                     </button>
                   )}
+                </div>
+              )}
+
+              {/* Without this the failed probe is invisible: every badge and
+                  Remove button is simply missing, which reads as "nothing is
+                  saved here" (SBS-841). */}
+              {secretProbeError && (
+                <div className="rounded-md border border-warning/40 bg-warning/5 p-2.5 text-xs text-warning">
+                  <p>
+                    Couldn't check the keychain, so saved keys aren't shown below. Unlock
+                    it and retry; saving now overwrites anything already stored.
+                  </p>
+                  <button
+                    type="button"
+                    className="mt-1 font-medium underline underline-offset-2"
+                    onClick={() => void retryVaultedKeysProbe()}
+                  >
+                    Retry the keychain check
+                  </button>
                 </div>
               )}
 


### PR DESCRIPTION
secret_status probed vault presence with get_secret().is_some(). get_secret
swallows a locked or failed keyring into None, so the Secrets dialog treated
every env key as unvaulted and invited overwrite.

Use get_secret_result and return Err when any key read fails, matching
has_auth_token / has_client_secret. The command stays async/off the GTK
main loop (SBS-813). get_secret itself is unchanged.

Tests: secret_status_reports_a_failed_read_as_an_error_not_missing pins the
reserved __toolport_internal__ namespace as Err, not Ok(vec![(key, false)]).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `secret_status` to treat a locked keyring as an error in SecretsDialog
> - The `secret_status` Tauri command now propagates keychain read failures as errors instead of returning `(key, false)` for failed reads, giving it fail-closed, all-or-nothing semantics.
> - `SecretsDialog` introduces a `secretProbeError` state: when the vault probe fails, stale vaulted state is cleared and a warning banner with a Retry button is shown instead of marking keys as unsaved.
> - A `retryVaultedKeysProbe` helper re-runs the env-key probe without reopening the dialog, so badges refresh once the keychain is unlocked.
> - Behavioral Change: previously a locked or unavailable keychain caused keys to appear as unsaved; they now show no saved/unsaved status and display an explicit warning.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3e0cdb4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->