### PR TITLE
fix(linux): put a toolport command on PATH from the .deb (SBS-846)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ Entries before the rename below shipped under the project's former name, Conduit
 
 ### Fixed
 
+- **Linux `.deb` installs a `toolport` command.** The package still ships the
+  crate binary as `conduit` (compat alias) and now also puts `toolport` on
+  `PATH`, matching the AppImage installer and the brand. `install.sh` tells apt
+  users to run `toolport`.
 - **A second Claude Code profile no longer gets stuck on an old gateway.**
   `CLAUDE_CONFIG_DIR` is usually set per shell or per launcher rather than exported, so a
   machine often has several Claude configs (a personal `~/.claude` beside a work

--- a/packaging/linux/deb/toolport
+++ b/packaging/linux/deb/toolport
@@ -1,0 +1,14 @@
+#!/bin/sh
+# The .deb still ships the Cargo bin as `conduit`. This wrapper puts `toolport`
+# on PATH so apt users get the same command as the AppImage installer.
+#
+# Prefer the crate binary next to this file (`/usr/bin/conduit` in the package).
+# Fall back to PATH so a test prefix and a bare `toolport` argv0 still work.
+case "$0" in
+  */*) here=${0%/*} ;;
+  *) here=. ;;
+esac
+if [ -x "$here/conduit" ]; then
+  exec "$here/conduit" "$@"
+fi
+exec conduit "$@"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -67,9 +67,10 @@ install_linux() {
     fi
     say "Installing with apt${sudo:+ (you may be prompted for your password)}"
     $sudo apt-get install -y "$tmp/toolport.deb"
-    # The .deb installs the app binary as `conduit` (the crate name) plus a Toolport
-    # desktop entry; the AppImage path below installs a `toolport` command instead.
-    say "Installed. Launch Toolport from your app menu, or run: conduit"
+    # The .deb still ships the crate binary as `conduit` and adds a `toolport`
+    # wrapper on PATH (see packaging/linux/deb/toolport). AppImage below is
+    # installed as `$bindir/toolport` as well.
+    say "Installed. Launch Toolport from your app menu, or run: toolport"
     return
   fi
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -38,6 +38,13 @@
       "nsis": {
         "installerHooks": "nsis-hooks.nsh"
       }
+    },
+    "linux": {
+      "deb": {
+        "files": {
+          "/usr/bin/toolport": "../packaging/linux/deb/toolport"
+        }
+      }
     }
   },
   "plugins": {

--- a/src/test/linux-deb-command.test.ts
+++ b/src/test/linux-deb-command.test.ts
@@ -89,29 +89,37 @@ describe("Linux .deb toolport packaging hook (SBS-846)", () => {
     expect(firstBin).toMatch(/^path = "src\/main\.rs"$/m);
   });
 
-  it("installs a toolport command that execs the conduit binary", () => {
-    const prefix = mkdtempSync(join(tmpdir(), "sbs-846-deb-"));
-    try {
-      writeFileSync(
-        join(prefix, "conduit"),
-        '#!/bin/sh\nprintf "conduit-ran"\n[ $# -gt 0 ] && printf " %s" "$@"\nprintf "\\n"\n',
-      );
-      chmodSync(join(prefix, "conduit"), 0o755);
-      copyFileSync(wrapperPath, join(prefix, "toolport"));
-      chmodSync(join(prefix, "toolport"), 0o755);
+  // Actually runs the wrapper, so it needs a POSIX shell and a real exec bit.
+  // On Windows `chmodSync` is a no-op and execFileSync on an extensionless
+  // `#!/bin/sh` file is ENOENT, so this one case is Linux/macOS only. CI runs
+  // the suite on ubuntu, so the coverage that matters is unaffected; this only
+  // stops `npm test` failing on a Windows dev box.
+  it.skipIf(process.platform === "win32")(
+    "installs a toolport command that execs the conduit binary",
+    () => {
+      const prefix = mkdtempSync(join(tmpdir(), "sbs-846-deb-"));
+      try {
+        writeFileSync(
+          join(prefix, "conduit"),
+          '#!/bin/sh\nprintf "conduit-ran"\n[ $# -gt 0 ] && printf " %s" "$@"\nprintf "\\n"\n',
+        );
+        chmodSync(join(prefix, "conduit"), 0o755);
+        copyFileSync(wrapperPath, join(prefix, "toolport"));
+        chmodSync(join(prefix, "toolport"), 0o755);
 
-      const viaAbs = execFileSync(join(prefix, "toolport"), ["--version"], {
-        encoding: "utf8",
-      });
-      expect(viaAbs).toBe("conduit-ran --version\n");
+        const viaAbs = execFileSync(join(prefix, "toolport"), ["--version"], {
+          encoding: "utf8",
+        });
+        expect(viaAbs).toBe("conduit-ran --version\n");
 
-      const viaPath = execFileSync("toolport", ["launch"], {
-        encoding: "utf8",
-        env: { ...process.env, PATH: prefix },
-      });
-      expect(viaPath).toBe("conduit-ran launch\n");
-    } finally {
-      rmSync(prefix, { recursive: true, force: true });
-    }
-  });
+        const viaPath = execFileSync("toolport", ["launch"], {
+          encoding: "utf8",
+          env: { ...process.env, PATH: prefix },
+        });
+        expect(viaPath).toBe("conduit-ran launch\n");
+      } finally {
+        rmSync(prefix, { recursive: true, force: true });
+      }
+    },
+  );
 });

--- a/src/test/linux-deb-command.test.ts
+++ b/src/test/linux-deb-command.test.ts
@@ -1,0 +1,117 @@
+// SBS-846: the Linux .deb must put a `toolport` command on PATH. The crate
+// binary stays `conduit` (compat alias); AppImage install is already `toolport`.
+// These are file-content + prefix-install assertions so CI can check the
+// packaging hook without running `tauri build`.
+import { describe, expect, it } from "vitest";
+import { execFileSync } from "node:child_process";
+import {
+  chmodSync,
+  copyFileSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const repoRoot = process.cwd();
+const wrapperPath = join(repoRoot, "packaging", "linux", "deb", "toolport");
+const installShPath = join(repoRoot, "scripts", "install.sh");
+const tauriConfPath = join(repoRoot, "src-tauri", "tauri.conf.json");
+const cargoTomlPath = join(repoRoot, "src-tauri", "Cargo.toml");
+
+function linuxAptBranch(script: string): string {
+  const marker =
+    "if command -v dpkg >/dev/null 2>&1 && command -v apt-get >/dev/null 2>&1; then";
+  const start = script.indexOf(marker);
+  expect(start, "install.sh is missing the apt/dpkg .deb branch").toBeGreaterThan(-1);
+  const after = script.slice(start + marker.length);
+  const end = after.search(/\n {4}return\n/);
+  expect(end, "could not find the apt/dpkg branch return").toBeGreaterThan(-1);
+  return after.slice(0, end);
+}
+
+function sayLines(branch: string): string[] {
+  return [...branch.matchAll(/^\s*say\s+"([^"]*)"/gm)].map((m) => m[1]);
+}
+
+describe("install.sh apt path (SBS-846)", () => {
+  const script = readFileSync(installShPath, "utf8");
+  const aptBranch = linuxAptBranch(script);
+
+  it("tells apt users to run toolport", () => {
+    const says = sayLines(aptBranch);
+    expect(says.some((line) => /\brun: toolport\b/.test(line))).toBe(true);
+  });
+
+  it("does not tell apt users to run conduit after the deb path", () => {
+    const says = sayLines(aptBranch);
+    expect(says.some((line) => /\bconduit\b/.test(line))).toBe(false);
+    expect(aptBranch).not.toMatch(/run:\s*conduit\b/);
+  });
+
+  it("still installs the AppImage as bindir/toolport", () => {
+    expect(script).toContain('curl -fsSL "$url" -o "$bindir/toolport"');
+    expect(script).toContain('chmod +x "$bindir/toolport"');
+    expect(script).toContain("Installed the AppImage to $bindir/toolport");
+  });
+});
+
+describe("Linux .deb toolport packaging hook (SBS-846)", () => {
+  it("ships a /usr/bin/toolport wrapper in the .deb only", () => {
+    const conf = JSON.parse(readFileSync(tauriConfPath, "utf8")) as {
+      identifier?: string;
+      mainBinaryName?: string;
+      bundle?: {
+        linux?: {
+          deb?: { files?: Record<string, string> };
+          appimage?: { files?: Record<string, string> };
+        };
+      };
+    };
+    expect(conf.identifier).toBe("com.tsout.conduit");
+    expect(conf.mainBinaryName).toBeUndefined();
+    expect(conf.bundle?.linux?.deb?.files?.["/usr/bin/toolport"]).toBe(
+      "../packaging/linux/deb/toolport",
+    );
+    expect(conf.bundle?.linux?.appimage).toBeUndefined();
+  });
+
+  it("keeps the Cargo package and app bin named conduit", () => {
+    const cargo = readFileSync(cargoTomlPath, "utf8");
+    expect(cargo).toMatch(/^name = "conduit"$/m);
+    expect(cargo).toMatch(/^default-run = "conduit"$/m);
+    const binBlock = cargo.slice(cargo.indexOf("[[bin]]"));
+    const nextTable = binBlock.indexOf("\n[");
+    const firstBin = nextTable === -1 ? binBlock : binBlock.slice(0, nextTable);
+    expect(firstBin).toMatch(/^name = "conduit"$/m);
+    expect(firstBin).toMatch(/^path = "src\/main\.rs"$/m);
+  });
+
+  it("installs a toolport command that execs the conduit binary", () => {
+    const prefix = mkdtempSync(join(tmpdir(), "sbs-846-deb-"));
+    try {
+      writeFileSync(
+        join(prefix, "conduit"),
+        '#!/bin/sh\nprintf "conduit-ran"\n[ $# -gt 0 ] && printf " %s" "$@"\nprintf "\\n"\n',
+      );
+      chmodSync(join(prefix, "conduit"), 0o755);
+      copyFileSync(wrapperPath, join(prefix, "toolport"));
+      chmodSync(join(prefix, "toolport"), 0o755);
+
+      const viaAbs = execFileSync(join(prefix, "toolport"), ["--version"], {
+        encoding: "utf8",
+      });
+      expect(viaAbs).toBe("conduit-ran --version\n");
+
+      const viaPath = execFileSync("toolport", ["launch"], {
+        encoding: "utf8",
+        env: { ...process.env, PATH: prefix },
+      });
+      expect(viaPath).toBe("conduit-ran launch\n");
+    } finally {
+      rmSync(prefix, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
The crate binary stays conduit so Windows/macOS packaging and the bundle
id are unchanged. The .deb now ships a /usr/bin/toolport wrapper, and
install.sh tells apt users to run toolport.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `toolport` command to PATH in Linux .deb package
> - Adds a POSIX shell wrapper script at [packaging/linux/deb/toolport](https://github.com/tsouth89/toolport/pull/756/files#diff-29832e0c88624017fd8e5fe6c9c2b5cd97e710d5f59f9359ce6ddc70c8aa8e3b) that executes the sibling `conduit` binary if present, otherwise falls back to `conduit` on PATH.
> - Includes the wrapper as `/usr/bin/toolport` in the generated .deb via [tauri.conf.json](https://github.com/tsouth89/toolport/pull/756/files#diff-fa09f1dac39604a735cd6a53957d3c35e0c3298cca9cf4829180f167abbd69b7), while the crate binary name remains `conduit`.
> - Updates [install.sh](https://github.com/tsouth89/toolport/pull/756/files#diff-e076e43cb817ecc8b3c2ed18cd58baa50544ecc66293ed6e61129c43ca6a09cc) to tell apt users to run `toolport` instead of `conduit` after installation.
> - Adds a Vitest test suite in [linux-deb-command.test.ts](https://github.com/tsouth89/toolport/pull/756/files#diff-97b0e0cf27f927af06dbb4204f6a1d8e42c87e65ad871940b546853d904cb00d) verifying the wrapper, install script messaging, and package config.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e16ccee.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->