### PR TITLE
fix(linux): honor XDG_CONFIG_HOME for Zed, Goose, AnythingLLM (SBS-847)

### DIFF
--- a/src-tauri/src/clients.rs
+++ b/src-tauri/src/clients.rs
@@ -535,10 +535,9 @@ fn resolve_client_config_path_linux(client_id: &str, home: &std::path::Path) -> 
         "kimi-code" => home.join(".kimi-code").join("mcp.json"),
         "lm-studio" => home.join(".lmstudio").join("mcp.json"),
         "jan" => data.join("Jan").join("data").join("mcp_config.json"),
-        "zed" => home.join(".config").join("zed").join("settings.json"),
-        "goose" => home.join(".config").join("goose").join("config.yaml"),
-        "anythingllm" => home
-            .join(".config")
+        "zed" => config.join("zed").join("settings.json"),
+        "goose" => config.join("goose").join("config.yaml"),
+        "anythingllm" => config
             .join("anythingllm-desktop")
             .join("storage")
             .join("plugins")
@@ -8935,6 +8934,9 @@ command = "npx"
         let vscode = client_config_path("vscode").unwrap();
         let jan = client_config_path("jan").unwrap();
         let crush = client_config_path("crush").unwrap();
+        let zed = client_config_path("zed").unwrap();
+        let goose = client_config_path("goose").unwrap();
+        let anythingllm = client_config_path("anythingllm").unwrap();
         let opencode = client_config_path("opencode").unwrap();
         let kilo_code = client_config_path("kilo-code").unwrap();
 
@@ -8953,6 +8955,22 @@ command = "npx"
         assert_eq!(
             crush,
             xdg_config.join("crush").join("crush.json")
+        );
+        assert_eq!(
+            zed,
+            xdg_config.join("zed").join("settings.json")
+        );
+        assert_eq!(
+            goose,
+            xdg_config.join("goose").join("config.yaml")
+        );
+        assert_eq!(
+            anythingllm,
+            xdg_config
+                .join("anythingllm-desktop")
+                .join("storage")
+                .join("plugins")
+                .join("anythingllm_mcp_servers.json")
         );
         assert_eq!(
             opencode,


### PR DESCRIPTION
Linux Connect now writes those clients under dirs::config_dir() so a
relocated XDG_CONFIG_HOME is the file they actually read.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `client_config_path` for Zed, Goose, and AnythingLLM to honor `XDG_CONFIG_HOME` on Linux
> On Linux, config paths for `zed`, `goose`, and `anythingllm` were hardcoded to `~/.config/...` via `home.join(".config")` in [clients.rs](https://github.com/tsouth89/toolport/pull/757/files#diff-6f95d037b6a920242364b6cfc2417b10affa37691d35ce5da93633c9da12c167), ignoring `XDG_CONFIG_HOME`. They now resolve via `dirs::config_dir()`, which respects `XDG_CONFIG_HOME` and falls back to `~/.config` when unset. Tests are extended to assert correct resolution under a custom `XDG_CONFIG_HOME`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e8ee3d9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->