### PR TITLE
fix(desktop): do not mint a replacement bearer when the vault read fails

### DIFF
--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -1086,7 +1086,10 @@ fn ensure_client_http_token_with(
     // request it makes 401s until the user reconnects that client by hand. Only a
     // confirmed "nothing vaulted" may mint (SBS-840 class).
     if let Some(existing) = read_vaulted_token(VAULT_SERVER, client_id)
-        .map_err(|e| format!("could not read the vaulted bearer for {client_id}: {e}"))?
+        // Complete sentence, capitalized: `install_gateway`'s caller renders this
+        // verbatim in a toast (`ClientDetail.tsx` `toastError(`${e}`)`), so a bare
+        // lowercase fragment would reach the user untethered.
+        .map_err(|e| format!("Could not read the saved token for {client_id}: {e}"))?
     {
         let hash = registry::sha256_hex(&existing);
         let mut matched = false;
@@ -7173,18 +7176,34 @@ mod tests {
         .expect_err("a failed vault read must not mint a replacement bearer");
 
         assert!(
-            err.contains("could not read the vaulted bearer"),
-            "the vault read failure must reach the caller, got: {err}"
+            err.starts_with("Could not read the saved token"),
+            "the vault read failure must reach the caller as a complete sentence \
+             (the frontend renders it verbatim), got: {err}"
         );
         assert!(
             err.contains("the keychain is locked"),
             "the underlying cause must survive, got: {err}"
         );
-        // The row is what `http_client_for_token` authenticates against, so it
-        // surviving is the whole point: the client's existing bearer still works.
-        assert!(
-            fixture.http_row_present(),
-            "a failed vault read must not drop the client's http_clients row"
+        // The `expect_err` above is what pins the reported bug; today's mint path
+        // returns `Ok`, so execution never reaches here under it.
+        //
+        // This guards the ORDERING invariant instead: nothing may error out after
+        // already replacing the row. Assert the HASH rather than the id, because the
+        // mint path `retain`s the old row away and pushes a new one under the SAME
+        // id, so an id-only check cannot tell a surviving bearer from a replaced one.
+        // `http_client_for_token` matches on `token_sha256`, so that is what decides
+        // whether the client's configured token still authenticates.
+        let on_disk = registry::load().expect("scratch registry loads");
+        let row = on_disk
+            .http_clients
+            .iter()
+            .find(|c| c.id == fixture.http_id)
+            .expect("a failed vault read must not drop the client's http_clients row");
+        assert_eq!(
+            row.token_sha256,
+            registry::sha256_hex("leftover-bearer"),
+            "the row must still carry the ORIGINAL bearer's hash; a new hash means a \
+             replacement was minted and the client's configured token is now dead"
         );
     }
 

--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -1059,11 +1059,35 @@ fn ensure_client_http_token(
     client_id: &str,
     profile: Option<&str>,
 ) -> Result<String, String> {
+    ensure_client_http_token_with(state, client_id, profile, crate::secrets::get_secret_result)
+}
+
+/// [`ensure_client_http_token`] with the vault read injected.
+///
+/// The vault server id is fixed here, so the reserved-namespace trick the other
+/// fail-closed tests use cannot reach it. Injecting the read is how
+/// [`revoke_client_http_token_with`] solves the same problem in this file.
+fn ensure_client_http_token_with(
+    state: &RegistryState,
+    client_id: &str,
+    profile: Option<&str>,
+    read_vaulted_token: impl FnOnce(&str, &str) -> Result<Option<String>, String>,
+) -> Result<String, String> {
     const VAULT_SERVER: &str = "__toolport_http_clients__";
     let http_id = format!("client:{client_id}");
     let desired_profile = profile.unwrap_or("").trim().to_string();
     // Reuse vaulted token when we still have a matching http_clients row.
-    if let Some(existing) = crate::secrets::get_secret(VAULT_SERVER, client_id) {
+    //
+    // A failed vault READ must not fall through to minting a replacement. `get_secret`
+    // collapses a read error into `None`, so a locked or flaky keychain looked exactly
+    // like "this client has no bearer yet": the mint path below then overwrites the
+    // vaulted copy AND `retain`s the client's `http_clients` row away for a new one.
+    // The bearer the client is already configured with now hashes to no row, so every
+    // request it makes 401s until the user reconnects that client by hand. Only a
+    // confirmed "nothing vaulted" may mint (SBS-840 class).
+    if let Some(existing) = read_vaulted_token(VAULT_SERVER, client_id)
+        .map_err(|e| format!("could not read the vaulted bearer for {client_id}: {e}"))?
+    {
         let hash = registry::sha256_hex(&existing);
         let mut matched = false;
         let mut profile_stale = false;
@@ -7127,6 +7151,61 @@ mod tests {
             let on_disk = registry::load().expect("scratch registry loads");
             on_disk.http_clients.iter().any(|c| c.id == self.http_id)
         }
+    }
+
+    /// SBS-840 class, the instance left behind by that sweep. A failed vault READ
+    /// must not fall through to minting a replacement bearer. `get_secret` collapsed
+    /// a read error into `None`, which looks exactly like "this client has no bearer
+    /// yet", so the mint path overwrote the vaulted copy and `retain`ed the client's
+    /// `http_clients` row away for a new one. The bearer the client was already
+    /// configured with then hashed to no row, so every request it made 401'd until
+    /// the user reconnected that client by hand.
+    #[test]
+    fn ensure_client_http_token_propagates_a_failed_vault_read_instead_of_minting() {
+        let fixture = RevokeFixture::new("sbs-840-ensure-read");
+
+        let err = ensure_client_http_token_with(
+            &fixture.state,
+            &fixture.client_id,
+            None,
+            |_server, _client| Err("the keychain is locked".into()),
+        )
+        .expect_err("a failed vault read must not mint a replacement bearer");
+
+        assert!(
+            err.contains("could not read the vaulted bearer"),
+            "the vault read failure must reach the caller, got: {err}"
+        );
+        assert!(
+            err.contains("the keychain is locked"),
+            "the underlying cause must survive, got: {err}"
+        );
+        // The row is what `http_client_for_token` authenticates against, so it
+        // surviving is the whole point: the client's existing bearer still works.
+        assert!(
+            fixture.http_row_present(),
+            "a failed vault read must not drop the client's http_clients row"
+        );
+    }
+
+    /// The reuse path is unchanged by the fix: a confirmed vaulted token that still
+    /// matches a registered row is handed back as-is, with nothing minted. Guards
+    /// against over-correcting the above into "never reuse".
+    #[test]
+    fn ensure_client_http_token_reuses_a_vaulted_token_that_matches_its_row() {
+        let fixture = RevokeFixture::new("sbs-840-ensure-reuse");
+
+        let token = ensure_client_http_token_with(
+            &fixture.state,
+            &fixture.client_id,
+            None,
+            // The fixture's row is registered against this exact token.
+            |_server, _client| Ok(Some("leftover-bearer".to_string())),
+        )
+        .expect("a matching vaulted token must be reused");
+
+        assert_eq!(token, "leftover-bearer");
+        assert!(fixture.http_row_present());
     }
 
     #[test]

--- a/src-tauri/src/remote.rs
+++ b/src-tauri/src/remote.rs
@@ -360,11 +360,14 @@ pub fn reset_client_credentials(server_id: &str) -> Result<(), String> {
 /// whether to discard state, and discarding on a parse failure would loop a broken
 /// vault into re-acquiring on every connect.
 ///
-/// Deliberately still `get_secret`, not `get_secret_result`. The sole caller,
-/// [`client_credentials_state_is_stale`], already reads the same key through
-/// `get_secret_result` and returns the error before it can reach here, so a read
-/// failure never lands on this line. Converting it would add an error path that
-/// cannot be taken (SBS-840 sweep).
+/// Deliberately still `get_secret`, not `get_secret_result` (SBS-840 sweep). The sole
+/// caller, [`client_credentials_state_is_stale`], reads the same key through
+/// `get_secret_result` first, so the common failure is caught one frame up. Note this
+/// narrows the window rather than closing it: that is a SECOND round trip to the vault,
+/// so a backend that dies between the two calls still collapses to `None` here and skips
+/// the reset. Left as-is because the window is one round trip wide and also needs the
+/// user to have changed this server's URL; converting it means threading a `Result`
+/// through a `bool` helper for that. Re-evaluate if the vault gets flakier.
 fn client_credentials_resource_changed(server_id: &str, url: &str) -> bool {
     let Some(state) = secrets::get_secret(server_id, CC_STATE_KEY)
         .and_then(|s| serde_json::from_str::<ClientCredentialsState>(&s).ok())

--- a/src-tauri/src/remote.rs
+++ b/src-tauri/src/remote.rs
@@ -359,6 +359,12 @@ pub fn reset_client_credentials(server_id: &str) -> Result<(), String> {
 /// An unreadable state counts as unchanged: the caller only uses this to decide
 /// whether to discard state, and discarding on a parse failure would loop a broken
 /// vault into re-acquiring on every connect.
+///
+/// Deliberately still `get_secret`, not `get_secret_result`. The sole caller,
+/// [`client_credentials_state_is_stale`], already reads the same key through
+/// `get_secret_result` and returns the error before it can reach here, so a read
+/// failure never lands on this line. Converting it would add an error path that
+/// cannot be taken (SBS-840 sweep).
 fn client_credentials_resource_changed(server_id: &str, url: &str) -> bool {
     let Some(state) = secrets::get_secret(server_id, CC_STATE_KEY)
         .and_then(|s| serde_json::from_str::<ClientCredentialsState>(&s).ok())
@@ -862,6 +868,12 @@ fn authed_transport(
     // the extension requires. Keyed off vaulted state rather than registry config
     // so it is true of the credential actually being sent: a server configured for
     // the flow but not yet provisioned has nothing to declare.
+    //
+    // Deliberately still `get_secret`, not `get_secret_result`. A read failure here
+    // only omits an informational extension declaration: no credential is minted,
+    // sent, or overwritten, and the request itself is unaffected. Failing the whole
+    // transport build over a missing declaration would be worse than the omission
+    // (SBS-840 sweep).
     if secrets::get_secret(server_id, CC_STATE_KEY).is_some() {
         transport.declare_extension(
             crate::downstream::OAUTH_CLIENT_CREDENTIALS_EXTENSION,


### PR DESCRIPTION
Completes the SBS-840 sweep. `#750` converted the OAuth vault reads; this is the
one real instance that sweep left behind, plus comments on the two sites that
deliberately stay as they are.

## The bug

`ensure_client_http_token` read the vaulted bearer with `secrets::get_secret`,
which collapses a read **error** into `None`. A locked or flaky keychain
therefore looked identical to "this client has no bearer yet".

The mint path below then does two destructive things: `set_secret` overwrites
the vaulted copy, and `write_registry` does
`retain(|c| c.id != http_id)` before pushing a row with the *new* hash.

## What a user hits

A managed shared-HTTP client is installed with bearer `T`. The user re-runs the
install, or changes that client's profile, at a moment when the vault read fails
transiently and the subsequent write succeeds. On Linux `with_service` retries
for roughly 1.5s before erroring, so this window is real rather than theoretical.

`T` is destroyed and its `http_clients` row is replaced. The gateway
authenticates through `http_client_for_token`, which matches the row's
`token_sha256`, so the already-configured downstream client keeps sending `T`,
which now hashes to no row. **Every request 401s until the user reconnects that
client by hand**, and nothing on screen explains why.

Only a confirmed "nothing vaulted" may mint now. A read failure propagates.

## Why the read is injected

The vault server id is hardcoded (`__toolport_http_clients__`), so the
reserved-namespace trick the other fail-closed tests use cannot reach this call.
`ensure_client_http_token_with` takes the read as a parameter, which is how
`revoke_client_http_token_with` already solves the same problem in this file.
Behaviour of the public function is unchanged.

## The rest of the sweep

I grepped every non-test `get_secret(` call site. Three remained; one was this
bug and two are deliberate. Both now carry a comment saying why, so the next
sweep does not "fix" them wrongly:

| Site | Verdict |
| --- | --- |
| `desktop.rs` `ensure_client_http_token` | Fixed here. |
| `remote.rs` `client_credentials_resource_changed` | Left. Its only caller, `client_credentials_state_is_stale`, already reads the same key through `get_secret_result` and returns first, so a read error cannot land there. Converting it adds an unreachable error path. |
| `remote.rs` `authed_transport` extension check | Left. A read error only omits an informational extension declaration. No credential is minted, sent or overwritten. Failing the whole transport build over that is worse than the omission. |

## Verification

Ran what the required `Build + test` job runs, with default features
(`default = ["desktop"]`), not `--no-default-features`:

- `cargo test --lib --bins --tests` -> 1082 passed
- `npx prettier --check .` -> clean
- `desktop::tests` 65 passed, `remote::` 41 passed

The new test fails without the production change. Reverting only the
`get_secret_result` conversion gives:

```
panicked at src/desktop.rs:7174:
the vault read failure must reach the caller, got:
Couldn't access platform secure storage: Secret Service: no result found
```

That message is itself the proof: the old code swallowed the injected error and
ran on into the mint path, which then hit the real keychain.

A second test pins the reuse path, so this cannot over-correct into "never
reuse".

## What I did not do

- **No ticket number in the title.** This needs an `SBS-` issue; I did not want
  to invent one. Happy to rename once it exists.
- Two tests failed on the first full-suite run:
  `routines::tests::concurrent_updates_do_not_lose_records` and
  `secrets::tests::file_backend_concurrent_sets_preserve_all_keys`. Both are
  pre-existing load flakes that race a 5s registry lock timeout, both are in
  files this PR does not touch, and both passed 3/3 when re-run alone. They are
  worth their own issue but are not from this change.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `ensure_client_http_token` to return an error when the vault read fails instead of minting a replacement bearer
> Previously, a failed vault read was silently treated as an absent token, causing a new bearer to be minted and the existing `http_clients` row to be overwritten. The fix introduces `ensure_client_http_token_with` in [desktop.rs](https://github.com/tsouth89/toolport/pull/758/files#diff-fe6823673f9c91b7a17eb4b96e5bc54bc3c58e75d02ae0a2d2fae6f7ce03ecd5), which accepts an injected vault-read function and maps read errors to an explicit `Err("Could not read the saved token for {client_id}: ...")`. Only a confirmed `Ok(None)` from the vault can trigger minting a replacement token.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a8a2a67.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->