### PR TITLE
test(install): fix the AppImage assertion broken by merging #744 and #756

### DIFF
--- a/src/test/linux-deb-command.test.ts
+++ b/src/test/linux-deb-command.test.ts
@@ -52,9 +52,21 @@ describe("install.sh apt path (SBS-846)", () => {
   });
 
   it("still installs the AppImage as bindir/toolport", () => {
-    expect(script).toContain('curl -fsSL "$url" -o "$bindir/toolport"');
     expect(script).toContain('chmod +x "$bindir/toolport"');
     expect(script).toContain("Installed the AppImage to $bindir/toolport");
+  });
+
+  // SBS-843/#744 moved the AppImage download out of the install path: it stages in
+  // $tmp and is only moved into place after verification, so a corrupt or tampered
+  // download can no longer delete a working install. Assert the STAGING, not just the
+  // final path — the previous assertion pinned the literal `curl -o "$bindir/toolport"`
+  // and so silently described the unsafe shape as the intended one.
+  it("stages the AppImage in tmp and only moves it in after verification", () => {
+    expect(script).toContain('download_and_verify "$url" "$tmp/toolport.AppImage"');
+    expect(script).toContain('mv "$tmp/toolport.AppImage" "$bindir/toolport"');
+    // The direct-to-destination download is what made a failed verification
+    // destructive. It must not come back.
+    expect(script).not.toContain('-o "$bindir/toolport"');
   });
 });
 


### PR DESCRIPTION
**main is currently red.** This fixes it.

## What happened

#756 added a test pinning the literal string `curl -fsSL "$url" -o "$bindir/toolport"`.

#744 then removed that line. The AppImage now stages in `$tmp` and is moved into place only after verification, so a corrupt or tampered download can no longer delete a working install.

Both PRs were green against their own bases. Git merged them without conflict. The combination fails, because neither branch's CI ever ran against the other. Main has been red since #742 landed on top.

Entirely my fault for merging both without re-checking the combination.

## The fix

I did not just repoint the assertion at the new string. The old test pinned the *unsafe* shape as though it were the intended one, which is why it broke the moment the code got safer.

It now asserts the property that matters:

- the download stages in `$tmp`
- it is moved into `$bindir/toolport` afterwards
- the direct-to-destination form does **not** come back

That last one is a regression guard for the actual bug #744 fixed.

## Verified

`npx vitest run src/test/linux-deb-command.test.ts` -> 6 passed, 1 skipped (the skip is the Windows-only exec case from #756).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix AppImage assertion in install script tests broken by PR merges
> - Updates the `it("still installs the AppImage as bindir/toolport")` test in [linux-deb-command.test.ts](https://github.com/tsouth89/toolport/pull/760/files#diff-97b0e0cf27f927af06dbb4204f6a1d8e42c87e65ad871940b546853d904cb00d) to drop the expectation that curl downloads directly to `$bindir/toolport`.
> - Adds a new `it("stages the AppImage in tmp and only moves it in after verification")` test that asserts the script downloads to `$tmp/toolport.AppImage`, verifies it, then moves it to `$bindir/toolport` — and rejects any direct-to-destination download.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 90c79e2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->