### PR TITLE
test: stop three multi-process tests flaking on a loaded runner (SBS-895)

### DIFF
--- a/src-tauri/src/registry.rs
+++ b/src-tauri/src/registry.rs
@@ -2371,7 +2371,7 @@ fn load_from_inner(path: &Path) -> Result<Registry, String> {
 /// read/recovery path. Recovery can rewrite the primary from a backup, so even a caller
 /// that only intends to read must serialize with writers (SOU-330).
 pub fn load_from(path: &Path) -> Result<Registry, String> {
-    let lock = lock_for(path, REGISTRY_LOCK_TIMEOUT)?;
+    let lock = lock_for(path, registry_lock_timeout())?;
     load_from_locked(path, &lock)
 }
 
@@ -2472,7 +2472,58 @@ fn lock_path(path: &Path) -> PathBuf {
 /// Acquire the exclusive registry lock, retrying briefly under contention. Registry writes
 /// are sub-millisecond, so a real conflict clears at once; a holder stuck past the deadline
 /// surfaces as an error rather than hanging the caller indefinitely.
-const REGISTRY_LOCK_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+const DEFAULT_REGISTRY_LOCK_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+
+/// The contention deadline, overridable via `TOOLPORT_LOCK_TIMEOUT_MS`.
+///
+/// The default is a PRODUCTION budget: giving up is the right answer when a holder is
+/// stuck, because hanging the app is worse. But the multi-process concurrency tests
+/// deliberately run eight or more writers at once and assert an INVARIANT ("no update is
+/// lost"), not a latency budget. On a loaded CI runner the 5s default expires, one writer
+/// correctly gives up, and the test fails for the machine's timing rather than for the
+/// thing it exists to catch. That flake hit three separate tests and made a clean PR look
+/// broken (SBS-895).
+///
+/// An env override rather than `cfg!(test)` because the rate-limit repro spawns real child
+/// processes, which are not test builds and inherit only the environment.
+fn registry_lock_timeout() -> std::time::Duration {
+    crate::brand::env_var("TOOLPORT_LOCK_TIMEOUT_MS", "CONDUIT_LOCK_TIMEOUT_MS")
+        .and_then(|raw| raw.trim().parse::<u64>().ok())
+        .filter(|ms| *ms > 0)
+        .map(std::time::Duration::from_millis)
+        .unwrap_or(DEFAULT_REGISTRY_LOCK_TIMEOUT)
+}
+
+/// Raise the store-lock deadline for a test that deliberately runs many concurrent
+/// writers, restoring the previous value on drop.
+///
+/// Those tests assert that no update is LOST, not that every writer wins the lock inside
+/// the production budget. Raising the deadline is monotonically safe: it can only make a
+/// concurrently-running test more tolerant, never less. Child processes inherit it, which
+/// is why this is an env var and not a `cfg!(test)` branch (SBS-895).
+#[cfg(any(debug_assertions, test, feature = "test-support"))]
+#[doc(hidden)]
+#[must_use = "the override is reverted when the guard drops, so it must be bound"]
+pub struct LockTimeoutOverride(Option<std::ffi::OsString>);
+
+#[cfg(any(debug_assertions, test, feature = "test-support"))]
+impl LockTimeoutOverride {
+    pub fn generous() -> Self {
+        let previous = std::env::var_os("TOOLPORT_LOCK_TIMEOUT_MS");
+        std::env::set_var("TOOLPORT_LOCK_TIMEOUT_MS", "60000");
+        Self(previous)
+    }
+}
+
+#[cfg(any(debug_assertions, test, feature = "test-support"))]
+impl Drop for LockTimeoutOverride {
+    fn drop(&mut self) {
+        match &self.0 {
+            Some(value) => std::env::set_var("TOOLPORT_LOCK_TIMEOUT_MS", value),
+            None => std::env::remove_var("TOOLPORT_LOCK_TIMEOUT_MS"),
+        }
+    }
+}
 
 fn lock_for(path: &Path, timeout: std::time::Duration) -> Result<FileLock, String> {
     if let Some(parent) = path.parent() {
@@ -2512,7 +2563,7 @@ pub fn update<T>(
     f: impl FnOnce(&mut Registry) -> Result<T, String>,
 ) -> Result<(Registry, T), String> {
     let path = resolved_path().ok_or("Could not resolve registry path")?;
-    let lock = lock_for(&path, REGISTRY_LOCK_TIMEOUT)?;
+    let lock = lock_for(&path, registry_lock_timeout())?;
     let mut reg = load_from_locked(&path, &lock)?;
     let out = f(&mut reg)?;
     // Save to the exact path we locked and loaded. Re-resolving after `f` would let a
@@ -2526,7 +2577,7 @@ pub fn update<T>(
 /// agent toggle (which interleaves audit + early returns), and the integrity pins/quarantine
 /// stores (SOU-165). Hold the returned guard across the entire read-decide-write.
 pub fn lock_at(path: &Path) -> Result<FileLock, String> {
-    lock_for(path, REGISTRY_LOCK_TIMEOUT)
+    lock_for(path, registry_lock_timeout())
 }
 
 /// Acquire an explicit-path lock with a caller-appropriate contention deadline.
@@ -2542,7 +2593,7 @@ pub fn update_at<T>(
     path: &Path,
     f: impl FnOnce(&mut Registry) -> Result<T, String>,
 ) -> Result<(Registry, T), String> {
-    let lock = lock_for(path, REGISTRY_LOCK_TIMEOUT)?;
+    let lock = lock_for(path, registry_lock_timeout())?;
     let mut reg = load_from_locked(path, &lock)?;
     let out = f(&mut reg)?;
     save_to(path, &reg)?;
@@ -2638,6 +2689,47 @@ mod tests {
     use crate::approval::fingerprint_allow_key;
 
     static REGISTRY_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    /// Pins the plumbing the concurrency tests rely on (SBS-895). Without this, a typo in
+    /// the env-var name would silently leave those tests on the 5s production budget and
+    /// they would go on flaking under load with nothing to point at.
+    #[test]
+    fn lock_timeout_honors_the_env_override_and_ignores_junk() {
+        let _env = REGISTRY_ENV_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let previous = std::env::var_os("TOOLPORT_LOCK_TIMEOUT_MS");
+        std::env::remove_var("TOOLPORT_LOCK_TIMEOUT_MS");
+
+        assert_eq!(registry_lock_timeout(), DEFAULT_REGISTRY_LOCK_TIMEOUT);
+
+        {
+            let _guard = LockTimeoutOverride::generous();
+            assert_eq!(
+                registry_lock_timeout(),
+                std::time::Duration::from_millis(60_000),
+                "the override must actually reach the lock, or the concurrency tests \
+                 silently keep the production budget"
+            );
+        }
+        // Dropping the guard restores, so one test cannot leak a long budget into another.
+        assert_eq!(registry_lock_timeout(), DEFAULT_REGISTRY_LOCK_TIMEOUT);
+
+        // Junk and zero fall back rather than producing a 0ms (instantly-expiring) budget.
+        for bad in ["", "   ", "abc", "0", "-5", "9999999999999999999999"] {
+            std::env::set_var("TOOLPORT_LOCK_TIMEOUT_MS", bad);
+            assert_eq!(
+                registry_lock_timeout(),
+                DEFAULT_REGISTRY_LOCK_TIMEOUT,
+                "{bad:?} must fall back to the default, not disable locking"
+            );
+        }
+
+        match previous {
+            Some(value) => std::env::set_var("TOOLPORT_LOCK_TIMEOUT_MS", value),
+            None => std::env::remove_var("TOOLPORT_LOCK_TIMEOUT_MS"),
+        }
+    }
 
     fn sample_server(name: &str) -> ServerEntry {
         ServerEntry {

--- a/src-tauri/src/routines.rs
+++ b/src-tauri/src/routines.rs
@@ -919,6 +919,10 @@ mod tests {
 
     #[test]
     fn concurrent_updates_do_not_lose_records() {
+        // Asserts no record is LOST, not that all eight writers win the lock inside the
+        // production budget. On a loaded runner the 5s default expires, one writer
+        // correctly gives up, and this fails for the machine's timing (SBS-895).
+        let _lock_budget = crate::registry::LockTimeoutOverride::generous();
         let path = temp_path("concurrent");
         let workers: Vec<_> = (0..8)
             .map(|index| {

--- a/src-tauri/src/secrets.rs
+++ b/src-tauri/src/secrets.rs
@@ -1925,6 +1925,10 @@ mod tests {
     fn file_backend_concurrent_sets_preserve_all_keys() {
         let _env = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let _data_dir = crate::registry::data_dir_test_lock();
+        // This asserts no key is LOST, not that every writer wins the lock inside the
+        // production budget. On a loaded runner the 5s default expires, a writer
+        // correctly gives up, and this fails for the machine's timing (SBS-895).
+        let _lock_budget = crate::registry::LockTimeoutOverride::generous();
         let dir = std::env::temp_dir().join(format!(
             "toolport-sou332-secrets-{}-{}",
             std::process::id(),

--- a/src-tauri/tests/rate_limit_multiproc_repro.rs
+++ b/src-tauri/tests/rate_limit_multiproc_repro.rs
@@ -67,6 +67,13 @@ fn concurrent_gateway_processes_must_not_lose_rate_limit_increments() {
                 .env("TOOLPORT_RL_CHILD", "1")
                 .env("TOOLPORT_RL_CHILD_ID", id)
                 .env("TOOLPORT_RL_DIR", &dir)
+                // Four processes racing one counter file is the point of this test, and
+                // what it asserts is that no increment is LOST — not that every child
+                // wins the lock inside the production budget. On a loaded runner the 5s
+                // default expires, a child correctly gives up, `check_and_count` returns
+                // Err, and the child panics on its `expect`. That is the machine's
+                // timing, not the invariant (SBS-895).
+                .env("TOOLPORT_LOCK_TIMEOUT_MS", "60000")
                 .args([
                     "--exact",
                     "concurrent_gateway_processes_must_not_lose_rate_limit_increments",


### PR DESCRIPTION
Closes the flake tracked in SBS-895.

## One root cause, three symptoms

These three tests were failing intermittently and had already made a clean PR (#744) look broken:

- `secrets::tests::file_backend_concurrent_sets_preserve_all_keys`
- `routines::tests::concurrent_updates_do_not_lose_records`
- `concurrent_gateway_processes_must_not_lose_rate_limit_increments`

They all reach the same place. `rate_limits` locks through `registry::lock_at`, routines through `lock_at`, the secrets file backend through the same helper — and every one of those used a hardcoded 5s `REGISTRY_LOCK_TIMEOUT`.

## The tests were asserting the wrong thing

5s is the correct **production** budget. When a lock holder is stuck, giving up beats hanging the app.

It is the wrong budget for these tests. They deliberately run eight or more writers at once and assert an **invariant** — no update is lost. On a loaded runner the deadline expires, one writer *correctly* gives up, `check_and_count` returns `Err`, and the test panics on its `expect`. That is the machine's timing, not the invariant.

The proof it was never a real regression: in a single CI job the same test appeared three times, `ok` (5.88s), `FAILED` (5.89s), `ok` (12.26s).

## The change

`TOOLPORT_LOCK_TIMEOUT_MS` overrides the deadline; the three tests raise it. Production behaviour is untouched — the default is unchanged and nothing outside tests sets the variable.

Two things worth flagging for review:

**An env var rather than `cfg!(test)`.** The rate-limit repro spawns real child processes via `Command::new(current_exe())`. Those are not test builds, so a compile-time flag would never reach them. They inherit the environment.

**Raising it is monotonically safe.** A longer deadline can only make a concurrently-running test more tolerant, never less, so this cannot destabilise anything else even though the env is process-global. `LockTimeoutOverride` restores the previous value on drop, so no test leaks a long budget into another.

## Verification

- All three pass with **all 28 cores saturated**, which is the condition that broke them.
- Full CI-equivalent run (`--lib --bins --tests`): 1083 + 306 + every integration binary, zero failures.
- New unit test `lock_timeout_honors_the_env_override_and_ignores_junk` pins the plumbing, including that `""`, `"abc"`, `"0"`, `"-5"` and an overflowing value all fall back to the default rather than producing a 0ms budget that would disable locking.

That last test matters more than it looks: without it, a typo in the env-var name would silently leave all three tests on the 5s budget, and they would keep flaking with nothing to point at.

## Not done here

The deeper question is whether these tests belong in the normal suite at all, given they need an unloaded machine to be meaningful. Moving them to a serialised job is the alternative fix. This change is the smaller one and does not preclude that.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make registry lock timeout configurable via environment variable to fix flaky multi-process tests
> - Replaces the hardcoded 5s `REGISTRY_LOCK_TIMEOUT` constant with a `registry_lock_timeout()` function that reads `TOOLPORT_LOCK_TIMEOUT_MS` (or `CONDUIT_LOCK_TIMEOUT_MS`) at runtime, falling back to the 5s default for missing, zero, or invalid values.
> - Adds a test-only `LockTimeoutOverride::generous()` guard that sets the timeout to 60s for the duration of a test and restores the previous value on drop.
> - Applies the generous timeout guard to three flaky multi-process tests in [routines.rs](https://github.com/tsouth89/toolport/pull/761/files#diff-cdd9be6b9ad3e640eb0b1055af217ea02e7d7082ae39914719d72104156255aa), [secrets.rs](https://github.com/tsouth89/toolport/pull/761/files#diff-146b42413a5a996a396d692f778a3b9c6bd57c21fcfc2f71abf39d753a2201b3), and [rate_limit_multiproc_repro.rs](https://github.com/tsouth89/toolport/pull/761/files#diff-01400ed1853bb6c84108f58932e83814d638b2f248886c2293975ae3999fce8c) to prevent false failures under load.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a48c894.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->