### PR TITLE
fix(gateway): atomically replace gateway.log on trim (SBS-869)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Entries before the rename below shipped under the project's former name, Conduit
 
 ### Fixed
 
+- **A diagnostics bundle or second gateway can no longer see an empty `gateway.log` or lose a connect-failure line.** Trim used to rewrite the shared log in place, so a concurrent diagnostics read could land in the empty window and a concurrent append could be overwritten by the pre-truncate snapshot. Trim now replaces the file atomically under the same lock as append.
 - **Linux `.deb` installs a `toolport` command.** The package still ships the
   crate binary as `conduit` (compat alias) and now also puts `toolport` on
   `PATH`, matching the AppImage installer and the brand. `install.sh` tells apt

--- a/src-tauri/src/approval_broker.rs
+++ b/src-tauri/src/approval_broker.rs
@@ -415,12 +415,7 @@ pub fn start(app: AppHandle) -> ApprovalBroker {
 /// location sits right next to the gateway's `dir_resolution=` line. Best-effort: a logging
 /// failure never touches an approval decision.
 fn log_broker_event(msg: &str) {
-    if let Some(path) = crate::registry::gateway_log_path() {
-        use std::io::Write;
-        if let Ok(mut f) = std::fs::OpenOptions::new().create(true).append(true).open(path) {
-            let _ = writeln!(f, "[broker] {msg}");
-        }
-    }
+    crate::gatewaylog::append(&format!("[broker] {msg}"));
 }
 
 /// Best-effort removal of the endpoint descriptor on app shutdown, so a gateway that dials

--- a/src-tauri/src/downstream.rs
+++ b/src-tauri/src/downstream.rs
@@ -1912,20 +1912,11 @@ fn downstream_trace(msg: &str) {
     if crate::brand::env_var_os("TOOLPORT_DEBUG", "CONDUIT_DEBUG").is_none() {
         return;
     }
-    let Some(path) = crate::registry::gateway_log_path() else {
+    if crate::registry::gateway_log_path().is_none() {
         eprintln!("toolport: {msg}");
         return;
-    };
-    if let Some(parent) = path.parent() {
-        let _ = std::fs::create_dir_all(parent);
     }
-    if let Ok(mut file) = std::fs::OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(path)
-    {
-        let _ = writeln!(file, "{msg}");
-    }
+    crate::gatewaylog::append(msg);
 }
 
 /// Bitmask of which downstream list a `notifications/.../list_changed` announces.

--- a/src-tauri/src/gatewaylog.rs
+++ b/src-tauri/src/gatewaylog.rs
@@ -31,7 +31,8 @@ pub fn append(msg: &str) {
 
 /// Append `msg` to `path` and trim if needed, holding the sibling lock across
 /// both so a concurrent writer cannot land a line that this process's stale
-/// trim snapshot then overwrites (SBS-869).
+/// trim snapshot then overwrites (SBS-869). A lock we cannot take degrades to
+/// an unlocked append rather than to a lost line.
 pub(crate) fn append_to(path: &Path, msg: &str) {
     if let Some(parent) = path.parent() {
         let _ = std::fs::create_dir_all(parent);
@@ -39,16 +40,31 @@ pub(crate) fn append_to(path: &Path, msg: &str) {
     // Atomic replacement protects readers from an empty window, but only this
     // shared cross-process critical section prevents a stale trim snapshot
     // from replacing a line another gateway just appended (SBS-869).
-    let _lock = match crate::registry::lock_at(path) {
-        Ok(lock) => lock,
+    match crate::registry::lock_at(path) {
+        Ok(_lock) => {
+            append_line(path, msg);
+            trim_log_if_large(path);
+        }
+        // Never trade a line for the lock. This log exists so a diagnostics
+        // bundle still shows the connect failure, and before SBS-869 the append
+        // ran with no lock at all - so a stale lock file or a contended
+        // deadline must not make us quieter than the code we replaced. Write
+        // the line and skip only the trim, which is the half that is unsafe
+        // unserialized; the next append that does win the lock re-bounds the
+        // file.
         Err(error) => {
             eprintln!(
-                "toolport: gateway log line dropped because the lock for '{}' could not be acquired: {error}",
+                "toolport: appending to '{}' without the gateway log lock ({error}); trim deferred",
                 path.display()
             );
-            return;
+            append_line(path, msg);
         }
-    };
+    }
+}
+
+/// One `O_APPEND` write of the whole record, so even the unlocked fallback
+/// cannot interleave half a line with another writer's.
+fn append_line(path: &Path, msg: &str) {
     if let Ok(mut f) = std::fs::OpenOptions::new()
         .create(true)
         .append(true)
@@ -56,7 +72,6 @@ pub(crate) fn append_to(path: &Path, msg: &str) {
     {
         let _ = f.write_all(format!("{msg}\n").as_bytes());
     }
-    trim_log_if_large(path);
 }
 
 /// Trim the log to roughly its back half once it exceeds [`GATEWAY_LOG_CAP`],
@@ -215,17 +230,17 @@ mod tests {
         cleanup(&path);
     }
 
-    /// Failure mode: sequential appends plus a trim-triggering append drop a
-    /// unique marker line that another writer just added (SBS-869 race 2).
+    /// Failure mode: the append that crosses [`GATEWAY_LOG_CAP`] trims away a
+    /// line an earlier append just wrote (SBS-869 race 2, one process).
     #[test]
-    fn append_under_lock_retains_unique_marker_lines_across_trim() {
+    fn appends_that_cross_the_cap_keep_every_line_written_after_the_cut() {
         let path = unique_log_path();
-        // Just under the cap so two small appends stay put and the third
-        // unique line is what crosses GATEWAY_LOG_CAP and forces a trim.
-        let prefix_len = GATEWAY_LOG_CAP as usize - 80;
+        // One giant already-over-cap line, so the first append is what runs the
+        // trim and the line-boundary cut lands right after that prefix: the
+        // kept tail is then exactly the appends, with nothing to hide a loss.
         std::fs::write(
             &path,
-            format!("{}\n", "o".repeat(prefix_len.saturating_sub(1))),
+            format!("{}\n", "o".repeat(GATEWAY_LOG_CAP as usize + 4096)),
         )
         .unwrap();
 
@@ -236,11 +251,113 @@ mod tests {
         let after = std::fs::read_to_string(&path).unwrap();
         assert!(
             (after.len() as u64) <= GATEWAY_LOG_CAP,
-            "trim-triggering append left the file over cap"
+            "the trim-triggering append left the file over cap"
         );
-        assert!(after.contains("UNIQUE_A"), "lost UNIQUE_A across trim");
-        assert!(after.contains("UNIQUE_B"), "lost UNIQUE_B across trim");
-        assert!(after.contains("UNIQUE_C"), "lost UNIQUE_C across trim");
+        assert_eq!(after, "UNIQUE_A\nUNIQUE_B\nUNIQUE_C\n");
         cleanup(&path);
+    }
+
+    fn wait_for_path(path: &Path, label: &str) {
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(15);
+        while !path.exists() && std::time::Instant::now() < deadline {
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        }
+        assert!(path.exists(), "timed out waiting for {label}");
+    }
+
+    fn wait_for_child(child: &mut std::process::Child, label: &str) -> std::process::ExitStatus {
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
+        loop {
+            match child.try_wait().expect("poll gateway log child") {
+                Some(status) => return status,
+                None if std::time::Instant::now() < deadline => {
+                    std::thread::sleep(std::time::Duration::from_millis(10));
+                }
+                None => {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    panic!("timed out waiting for {label}");
+                }
+            }
+        }
+    }
+
+    /// The separate process for
+    /// [`append_to_waits_for_a_log_lock_another_process_holds`]. Inert without
+    /// its env vars, so a normal run of this module skips it.
+    #[test]
+    fn gatewaylog_lock_sentinel_child() {
+        let Some(path) = std::env::var_os("TOOLPORT_GATEWAYLOG_SENTINEL_PATH") else {
+            return;
+        };
+        let attempting = PathBuf::from(
+            std::env::var_os("TOOLPORT_GATEWAYLOG_SENTINEL_ATTEMPTING")
+                .expect("sentinel attempting path"),
+        );
+        let done = PathBuf::from(
+            std::env::var_os("TOOLPORT_GATEWAYLOG_SENTINEL_DONE").expect("sentinel done path"),
+        );
+
+        std::fs::write(&attempting, "attempting").expect("signal sentinel append attempt");
+        append_to(Path::new(&path), "UNIQUE_CHILD");
+        std::fs::write(done, "done").expect("signal sentinel append complete");
+    }
+
+    /// Failure mode: `append_to` writes without the shared cross-process lock,
+    /// so a second gateway's line can land inside another process's read-then-
+    /// replace trim window and be lost (SBS-869 race 2, two processes). Drop
+    /// the lock from `append_to` and the child's line lands immediately.
+    #[test]
+    fn append_to_waits_for_a_log_lock_another_process_holds() {
+        let root = std::env::temp_dir().join(format!(
+            "toolport-sbs869-gatewaylog-lock-{}-{}",
+            std::process::id(),
+            TEST_SEQ.fetch_add(1, Ordering::Relaxed)
+        ));
+        std::fs::create_dir_all(&root).unwrap();
+        let path = root.join("gateway.log");
+        let attempting = root.join("attempting");
+        let done = root.join("done");
+        std::fs::write(&path, "SEED\n").unwrap();
+        // The child has to wait out the hold below, not time out into the
+        // unlocked fallback append. Children inherit the raised deadline.
+        let _lock_budget = crate::registry::LockTimeoutOverride::generous();
+        let held = crate::registry::lock_at(&path).expect("hold the gateway log lock");
+
+        let mut child = std::process::Command::new(std::env::current_exe().unwrap())
+            .args([
+                "--exact",
+                "gatewaylog::tests::gatewaylog_lock_sentinel_child",
+                "--nocapture",
+            ])
+            .env("TOOLPORT_GATEWAYLOG_SENTINEL_PATH", &path)
+            .env("TOOLPORT_GATEWAYLOG_SENTINEL_ATTEMPTING", &attempting)
+            .env("TOOLPORT_GATEWAYLOG_SENTINEL_DONE", &done)
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+            .expect("spawn independent gateway log appender");
+        wait_for_path(&attempting, "sentinel append attempt");
+        std::thread::sleep(std::time::Duration::from_millis(200));
+        // Read the verdict before releasing, but assert after, so a failure
+        // still unblocks and reaps the child.
+        let blocked = !done.exists();
+        drop(held);
+
+        let status = wait_for_child(&mut child, "gateway log sentinel child");
+        assert!(
+            blocked,
+            "a separate process must not append while another holds the log lock"
+        );
+        assert!(status.success(), "sentinel child failed: {status}");
+        assert!(
+            done.exists(),
+            "the child's append must finish once the lock frees"
+        );
+        assert_eq!(
+            std::fs::read_to_string(&path).unwrap(),
+            "SEED\nUNIQUE_CHILD\n"
+        );
+        std::fs::remove_dir_all(&root).ok();
     }
 }

--- a/src-tauri/src/gatewaylog.rs
+++ b/src-tauri/src/gatewaylog.rs
@@ -26,21 +26,48 @@ pub fn append(msg: &str) {
     let Some(path) = crate::registry::gateway_log_path() else {
         return;
     };
+    append_to(&path, msg);
+}
+
+/// Append `msg` to `path` and trim if needed, holding the sibling lock across
+/// both so a concurrent writer cannot land a line that this process's stale
+/// trim snapshot then overwrites (SBS-869).
+pub(crate) fn append_to(path: &Path, msg: &str) {
     if let Some(parent) = path.parent() {
         let _ = std::fs::create_dir_all(parent);
     }
+    // Atomic replacement protects readers from an empty window, but only this
+    // shared cross-process critical section prevents a stale trim snapshot
+    // from replacing a line another gateway just appended (SBS-869).
+    let _lock = match crate::registry::lock_at(path) {
+        Ok(lock) => lock,
+        Err(error) => {
+            eprintln!(
+                "toolport: gateway log line dropped because the lock for '{}' could not be acquired: {error}",
+                path.display()
+            );
+            return;
+        }
+    };
     if let Ok(mut f) = std::fs::OpenOptions::new()
         .create(true)
         .append(true)
-        .open(&path)
+        .open(path)
     {
         let _ = f.write_all(format!("{msg}\n").as_bytes());
     }
-    trim_log_if_large(&path);
+    trim_log_if_large(path);
 }
 
 /// Trim the log to roughly its back half once it exceeds [`GATEWAY_LOG_CAP`],
 /// cutting at a line boundary so the survivor never starts mid-record.
+///
+/// The kept tail is written with `atomic_write` (temp + fsync + rename), never
+/// a truncating `fs::write`, so a concurrent diagnostics read never sees an
+/// empty file and a concurrent append cannot land in a truncated hole
+/// (SBS-869). Callers that already hold `registry::lock_at` (production
+/// `append`) keep it across this replace; the function still works without
+/// that lock so the gateway binary's existing trim test can call it directly.
 pub fn trim_log_if_large(path: &Path) {
     let over = std::fs::metadata(path)
         .map(|m| m.len() > GATEWAY_LOG_CAP)
@@ -57,5 +84,163 @@ pub fn trim_log_if_large(path: &Path) {
         .position(|&b| b == b'\n')
         .map(|i| keep_from + i + 1)
         .unwrap_or(keep_from);
-    let _ = std::fs::write(path, &data[start..]);
+    // Lossy so a non-UTF-8 byte cannot skip the trim: atomic_write takes &str.
+    let kept = String::from_utf8_lossy(&data[start..]);
+    let _ = crate::registry::atomic_write(path, &kept);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static TEST_SEQ: AtomicU64 = AtomicU64::new(0);
+
+    fn unique_log_path() -> PathBuf {
+        let n = TEST_SEQ.fetch_add(1, Ordering::Relaxed);
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0);
+        std::env::temp_dir().join(format!(
+            "toolport-sbs869-gatewaylog-{}-{nanos}-{n}.log",
+            std::process::id()
+        ))
+    }
+
+    fn lock_sibling(path: &Path) -> PathBuf {
+        let mut s = path.as_os_str().to_os_string();
+        s.push(".lock");
+        PathBuf::from(s)
+    }
+
+    fn cleanup(path: &Path) {
+        let _ = std::fs::remove_file(path);
+        let _ = std::fs::remove_file(lock_sibling(path));
+    }
+
+    fn over_cap_body() -> String {
+        let filler = "x".repeat(GATEWAY_LOG_CAP as usize + 8192);
+        format!("OLDEST\n{filler}\nNEWEST\n")
+    }
+
+    fn assert_trimmed_tail(after: &str) {
+        assert!((after.len() as u64) <= GATEWAY_LOG_CAP, "still over cap");
+        assert!(after.ends_with("NEWEST\n"), "lost the newest line");
+        assert!(
+            !after.contains("OLDEST"),
+            "kept the oldest line past the cap"
+        );
+        assert!(!after.starts_with('x'), "did not cut on a line boundary");
+    }
+
+    /// Failure mode: an over-cap gateway.log is not bounded, or the kept tail
+    /// starts mid-record / drops the newest line.
+    #[test]
+    fn trim_over_cap_keeps_back_half_on_a_line_boundary() {
+        let path = unique_log_path();
+        std::fs::write(&path, over_cap_body()).unwrap();
+
+        trim_log_if_large(&path);
+
+        let after = std::fs::read_to_string(&path).unwrap();
+        assert_trimmed_tail(&after);
+        cleanup(&path);
+    }
+
+    /// Failure mode: trim rewrites gateway.log with a truncating write, so a
+    /// concurrent diagnostics read can observe an empty file (SBS-869 race 1)
+    /// and a concurrent append can land in the hole then be overwritten (race 2).
+    ///
+    /// `atomic_write` creates a sibling temp, sets owner-only 0o600, then
+    /// renames; `fs::write` truncates in place and keeps the old inode/mode.
+    /// Creating the over-cap file with `fs::write` (then 0o644) makes both
+    /// signals fail if someone reverts the production write.
+    #[test]
+    fn trim_replaces_via_new_inode_and_owner_only_mode() {
+        let path = unique_log_path();
+        std::fs::write(&path, over_cap_body()).unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut perms = std::fs::metadata(&path).unwrap().permissions();
+            perms.set_mode(0o644);
+            std::fs::set_permissions(&path, perms).unwrap();
+        }
+        let before = std::fs::metadata(&path).unwrap();
+        #[cfg(unix)]
+        let before_ino = {
+            use std::os::unix::fs::MetadataExt;
+            before.ino()
+        };
+
+        trim_log_if_large(&path);
+
+        let after = std::fs::read_to_string(&path).unwrap();
+        assert_trimmed_tail(&after);
+        let after_meta = std::fs::metadata(&path).unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::MetadataExt;
+            assert_ne!(
+                after_meta.ino(),
+                before_ino,
+                "trim must replace via rename, not truncate in place"
+            );
+            assert_eq!(
+                after_meta.mode() & 0o777,
+                0o600,
+                "atomic_write sets owner-only before writing"
+            );
+        }
+        #[cfg(not(unix))]
+        {
+            let _ = (before, after_meta);
+        }
+        cleanup(&path);
+    }
+
+    /// Failure mode: a small gateway.log is rewritten even though it is under
+    /// the cap.
+    #[test]
+    fn trim_under_cap_is_a_noop() {
+        let path = unique_log_path();
+        let content = "small\nunder-cap\n";
+        std::fs::write(&path, content).unwrap();
+
+        trim_log_if_large(&path);
+
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), content);
+        cleanup(&path);
+    }
+
+    /// Failure mode: sequential appends plus a trim-triggering append drop a
+    /// unique marker line that another writer just added (SBS-869 race 2).
+    #[test]
+    fn append_under_lock_retains_unique_marker_lines_across_trim() {
+        let path = unique_log_path();
+        // Just under the cap so two small appends stay put and the third
+        // unique line is what crosses GATEWAY_LOG_CAP and forces a trim.
+        let prefix_len = GATEWAY_LOG_CAP as usize - 80;
+        std::fs::write(
+            &path,
+            format!("{}\n", "o".repeat(prefix_len.saturating_sub(1))),
+        )
+        .unwrap();
+
+        append_to(&path, "UNIQUE_A");
+        append_to(&path, "UNIQUE_B");
+        append_to(&path, "UNIQUE_C");
+
+        let after = std::fs::read_to_string(&path).unwrap();
+        assert!(
+            (after.len() as u64) <= GATEWAY_LOG_CAP,
+            "trim-triggering append left the file over cap"
+        );
+        assert!(after.contains("UNIQUE_A"), "lost UNIQUE_A across trim");
+        assert!(after.contains("UNIQUE_B"), "lost UNIQUE_B across trim");
+        assert!(after.contains("UNIQUE_C"), "lost UNIQUE_C across trim");
+        cleanup(&path);
+    }
 }


### PR DESCRIPTION
## Linear

[SBS-869](https://linear.app/southboundsoftware/issue/SBS-869/toolport-gatewaylog-trim-uses-truncating-fswrite-concurrent-gateway) — `gateway.log` trim used `std::fs::write`, which truncates the shared file to zero before writing the kept tail.

**Race 1 — empty diagnostics (Gateway A vs Desktop):** Gateway A reads an over-cap log, then `fs::write` opens with `O_TRUNC`. Desktop `gather_diagnostics` → `gateway_log_tail` `read_to_string`s the empty file and reports "(no gateway log yet, connect a client to populate it)". Gateway A then writes the trimmed half. A bug report that this log exists to populate is empty.

**Race 2 — lost connect-failure (Gateway A vs Gateway B):** Gateway A truncates. Gateway B `O_APPEND`s a connect-failure into the now-empty file. Gateway A `write_all`s its pre-truncate snapshot from offset 0 and overwrites B's line. The connect-failure this module exists to capture is gone.

`approval_broker::log_broker_event` also appended to the same path without going through `gatewaylog::append`, so it could land in the same truncate window. `downstream_trace` was the same class of writer (`TOOLPORT_DEBUG`-only).

## What a user who hits this now sees

A diagnostics bundle keeps the recent gateway log instead of an empty-window lie. A second gateway's connect-failure line is not overwritten by another process's trim snapshot.

## What changed

- `gatewaylog::append` holds `registry::lock_at` across append + trim. If the lock cannot be acquired, the line is dropped (`eprintln`, same shape as audit) so best-effort logging cannot take down a connection.
- `trim_log_if_large` writes the kept tail with `registry::atomic_write` (temp + fsync + rename). Kept bytes go through `String::from_utf8_lossy` so a non-UTF-8 byte cannot skip the trim. Size-cap + line-boundary algorithm is unchanged. The function still works without the caller holding the lock (gateway binary test).
- `approval_broker::log_broker_event` and `downstream::downstream_trace` now go through `gatewaylog::append` (broker still prefixes `[broker] `). `glog` in `toolport-gateway.rs` already called `append`; left alone.

### Files

- `src-tauri/src/gatewaylog.rs`
- `src-tauri/src/approval_broker.rs`
- `src-tauri/src/downstream.rs`
- `CHANGELOG.md`

## Sweep (rule 4)

Grep for truncating writes of live shared logs (`fs::write` / OpenOptions append to `gateway.log`):

- `gatewaylog.rs` — this fix (`atomic_write` + lock).
- `audit.rs` / `inspect.rs` / `searchtrace.rs` / `savings.rs` — already `atomic_write`. Audit already takes `lock_at` across append + rotation. Left alone.
- `approval_broker::log_broker_event` and `downstream_trace` — routed through `append` in this PR.
- `glog` in `toolport-gateway.rs` — already `gatewaylog::append`. Not rewritten.
- `desktop.rs` `export_config_to_path` / `export_audit_to_path` — user save-dialog destinations, not a live shared log. Left as a gap.
- `desktop.rs` `gateway_log_tail` empty/error collapse (GitHub #733) — not this ticket. Atomic write is what stops the empty-window lie. Listed as a gap.
- Other `fs::write` hits in this crate are test fixtures, markers, or autostart desktop entries — not shared log rotation.

## Fail-without-fix (rule 6)

Reverted **only** the production write in `trim_log_if_large` back to `std::fs::write`, left the tests in place, and ran `trim_replaces_via_new_inode_and_owner_only_mode`:

```
thread 'gatewaylog::tests::trim_replaces_via_new_inode_and_owner_only_mode' (280420) panicked at src/gatewaylog.rs:184:13:
assertion `left != right` failed: trim must replace via rename, not truncate in place
  left: 532893
 right: 532893
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
test gatewaylog::tests::trim_replaces_via_new_inode_and_owner_only_mode ... FAILED

failures:

failures:
    gatewaylog::tests::trim_replaces_via_new_inode_and_owner_only_mode

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 1010 filtered out; finished in 0.00s
```

Restored `atomic_write`. Same test: **ok**.

## CI commands run (this worktree)

Required job is **Build + test** (`.github/workflows/ci.yml`). Clippy job is `--no-default-features --lib --bins`. Cross-platform rust job is `--no-default-features --lib --bins --tests`.

| Command | Result |
| --- | --- |
| `npm run format:check` | pass |
| `npm run lint` | pass (0 errors, 49 pre-existing warnings, none in this change) |
| `npm run test` | pass — 37 files, 382 tests |
| `npm run build` (`tsc && vite build`) | pass |
| `cargo clippy --manifest-path src-tauri/Cargo.toml --no-default-features --lib --bins` | pass (pre-existing warnings only; none in the files this PR touches) |
| `cargo test --manifest-path src-tauri/Cargo.toml --no-default-features --lib --bins --tests` | pass. lib: **1010 passed**, 1 ignored. New tests that ran by name: `gatewaylog::tests::trim_over_cap_keeps_back_half_on_a_line_boundary`, `gatewaylog::tests::trim_replaces_via_new_inode_and_owner_only_mode`, `gatewaylog::tests::trim_under_cap_is_a_noop`, `gatewaylog::tests::append_under_lock_retains_unique_marker_lines_across_trim`. Gateway binary: `tests::trim_log_bounds_size_and_keeps_a_line_boundary` **ok**. Integration tests also passed. |
| `npm run test:rust` (default features, desktop) | **did not finish green**. lib: 1088 passed, 1 failed, 1 ignored. The four `gatewaylog::tests::*` names above all **ok**. Failure: `remote::tests::a_url_edit_that_only_changes_path_case_rebinds_the_credential` (`src/remote.rs:1720`). This PR does not touch `remote.rs`. Re-ran that test in isolation: **ok**. A second default-features lib run then passed that test and failed a different desktop test (`desktop::tests::ensure_client_http_token_reuses_a_vaulted_token_that_matches_its_row` at `src/desktop.rs:7227`); this PR does not touch `desktop.rs`. I am not claiming the default-features suite is green on this runner. |
| `npm run smoke:headless` | pass (existing debug `toolport-gateway` + `mock-mcp-server`) |

`npm run audit:prod` was not run. Full tauri bundle was not run (not asked). rustfmt is not a CI gate; I rustfmt'd `gatewaylog.rs` only and did not reformat unrelated lines in `approval_broker.rs`.

## Gaps (rule 8)

- GitHub #733: `gateway_log_tail` still collapses unreadable and empty into "(no gateway log yet…)". Not this ticket. Atomic replace is what stops the empty-window lie.
- Desktop export paths (`export_config_to_path`, `export_audit_to_path`) still use `fs::write` to a user-chosen save-dialog path. Not a live shared log.
- `inspect.rs` / `searchtrace.rs` / `savings.rs` already use `atomic_write` but, unlike audit, do not take `lock_at` across append + rotate. Out of scope.
- Default-features `npm run test:rust` did not stay green here because of two unrelated tests that fail under the full desktop lib suite and pass in isolation (or on the next run). Headless `--no-default-features` is the crate that actually contains these new tests without the desktop feature set, and that suite passed.
- Did not run `npm run audit:prod`. Did not run a tauri bundle.

## What this makes more likely (rule 9)

- A lock timeout now **drops** a gateway-log line instead of writing unlocked. That is intentional (best-effort logging must not take down a connection), but a stuck lock holder can now lose connect-failure lines that previously would have been appended (and then possibly clobbered).
- After trim, `gateway.log` is **0o600** (atomic_write sets owner-only before writing). Readers that assumed the previous umask mode still see the content; only the mode changes.
- A reader that opens the path during trim still sees the **pre-trim** file until rename completes. That is intended. They must not treat a missing/unreadable file as "the operation failed" — and `gateway_log_tail` still collapses that case (#733).
- Routing broker + `downstream_trace` through `append` means those writers now wait on the same 5s lock budget. A stuck lock drops those lines too.

Not merged. Linear issue left open / Backlog.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix gateway.log trim to atomically replace the file under a cross-process lock
> - `gatewaylog.trim_log_if_large` now replaces the log file via temp+fsync+rename instead of truncating in place, eliminating the empty-file window seen by concurrent readers.
> - A new `append_to` function in [gatewaylog.rs](https://github.com/tsouth89/toolport/pull/762/files#diff-b2a62656d18aa520b130cf13b1445ec1c97d5ea6a27efcd09653db21f054e30d) acquires a cross-process lock before appending and trimming, so concurrent appends from a second gateway or diagnostics bundle are serialized.
> - `approval_broker` and `downstream` log writes are consolidated to use `gatewaylog::append`, picking up the new locking and atomic-replace behavior.
> - If the cross-process lock cannot be acquired, the append still proceeds and trim is deferred with a stderr notice.
> - Risk: trim now requires a successful rename, which may behave differently on some filesystems or across volumes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 49ca027.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->