### PR TITLE
fix(clients): write through config symlinks so Connect does not break dotfiles (SBS-886)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,13 @@ Entries before the rename below shipped under the project's former name, Conduit
 
 ### Fixed
 
+- **Connect keeps stow/chezmoi config symlinks.** Writing a client config
+  (Connect, Disconnect, migrate, launch-time re-point) used to replace a
+  symlink at the config path with a regular file, leaving the file in the
+  dotfiles repo unchanged. The next `chezmoi apply` / `stow` restored the
+  old content and the gateway entry disappeared. Writes now follow the
+  link and update the target, so the path under home stays a symlink.
+  (SBS-886)
 - **Linux `.deb` installs a `toolport` command.** The package still ships the
   crate binary as `conduit` (compat alias) and now also puts `toolport` on
   `PATH`, matching the AppImage installer and the brand. `install.sh` tells apt

--- a/src-tauri/src/clients.rs
+++ b/src-tauri/src/clients.rs
@@ -6482,6 +6482,60 @@ bad = "not-a-table"
         std::fs::remove_file(&path).ok();
     }
 
+    /// SBS-886: Connect (`edit_json_gateway` / `install_or_remove`) must write
+    /// through a stow/chezmoi symlink. Failure mode: POSIX rename replaced
+    /// `~/.claude.json -> ~/dotfiles/claude.json` with a regular file, the repo
+    /// copy never got the gateway entry, and the next chezmoi apply restored
+    /// the old link and the entry disappeared.
+    #[cfg(unix)]
+    #[test]
+    fn connect_write_through_symlinked_config_keeps_link_and_updates_target() {
+        let stamp = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let dir = std::env::temp_dir().join(format!(
+            "toolport-sbs886-connect-{}-{stamp}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let target = dir.join("dotfiles").join("claude.json");
+        let link = dir.join("home").join(".claude.json");
+        std::fs::create_dir_all(target.parent().unwrap()).unwrap();
+        std::fs::create_dir_all(link.parent().unwrap()).unwrap();
+        std::fs::write(
+            &target,
+            r#"{"theme":"dark","mcpServers":{"existing":{"command":"node","env":{"SECRET":"keepme"}}}}"#,
+        )
+        .unwrap();
+        std::os::unix::fs::symlink(&target, &link).unwrap();
+
+        {
+            let entry = sample_gateway(Some("Billing"), "claude-code");
+            edit_json_gateway(&link, "mcpServers", Some(&entry), true)
+        }
+        .unwrap();
+
+        let meta = std::fs::symlink_metadata(&link).unwrap();
+        assert!(
+            meta.file_type().is_symlink(),
+            "Connect must leave the config path a symlink, became {:?}",
+            meta.file_type()
+        );
+        assert_eq!(std::fs::read_link(&link).unwrap(), target);
+        let root: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&target).unwrap()).unwrap();
+        let servers = root["mcpServers"].as_object().unwrap();
+        assert!(
+            servers.contains_key(GATEWAY_ENTRY_NAME),
+            "gateway entry must land in the symlink target"
+        );
+        assert!(servers.contains_key("existing"));
+        assert_eq!(root["theme"], "dark");
+        assert_eq!(servers["existing"]["env"]["SECRET"], "keepme");
+        std::fs::remove_dir_all(dir).ok();
+    }
+
     #[test]
     fn droid_install_preserves_existing_factory_server() {
         let path = temp_path("droid-install-json");

--- a/src-tauri/src/registry.rs
+++ b/src-tauri/src/registry.rs
@@ -8,7 +8,7 @@
 //! Secrets are never stored here. Env vars marked `secret` keep their value in
 //! the OS keychain; this file only records that a secret exists.
 
-use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 
@@ -81,12 +81,86 @@ impl Drop for TempFileCleanup {
     }
 }
 
+/// Linux `MAXSYMLINKS`. A hop cap is the backstop when a cycle is spelled
+/// differently on each visit (`link` vs `dir/../link`) and the seen-set misses it.
+const ATOMIC_WRITE_MAX_SYMLINK_HOPS: usize = 40;
+
+/// Where `atomic_write` should create its sibling temp file and `rename`.
+///
+/// POSIX `rename` does not follow a destination symlink: it replaces the link
+/// inode with a regular file and leaves the target unchanged. Stow/chezmoi
+/// users then lose the gateway entry on the next apply (SBS-886).
+///
+/// Walk with `read_link` + parent-join. Do **not** `canonicalize`: that fails
+/// on a dangling link (the usual first-Connect case) and would refuse to create
+/// the target. A `symlink_metadata` error other than `NotFound` is not "not a
+/// symlink" — failing open would clobber a link we could not inspect.
+///
+/// This is the shared primitive, so following also applies to a Toolport-owned
+/// file (`registry.json`, pins, audit, secrets.enc) that is already a symlink.
+fn resolve_atomic_write_dest(path: &Path) -> Result<PathBuf, String> {
+    let mut current = path.to_path_buf();
+    let mut seen = HashSet::new();
+
+    for _ in 0..ATOMIC_WRITE_MAX_SYMLINK_HOPS {
+        match std::fs::symlink_metadata(&current) {
+            Ok(meta) => {
+                if !meta.file_type().is_symlink() {
+                    // Followed a config symlink onto a directory (or a further
+                    // link that resolved to one). Cannot write file bytes there.
+                    if meta.is_dir() && current != path {
+                        return Err(format!(
+                            "{} is a symlink to the directory {}, which cannot be overwritten as a file",
+                            path.display(),
+                            current.display()
+                        ));
+                    }
+                    return Ok(current);
+                }
+                if !seen.insert(current.clone()) {
+                    return Err(format!(
+                        "symlink loop at {} while resolving atomic write destination",
+                        current.display()
+                    ));
+                }
+                let target = std::fs::read_link(&current).map_err(|e| {
+                    format!("could not read symlink {}: {e}", current.display())
+                })?;
+                // Relative targets are relative to the link's parent, not cwd.
+                current = match current.parent() {
+                    Some(parent) => parent.join(target),
+                    None => target,
+                };
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                // Missing original path, or a dangling link's target: write a
+                // regular file there. create_dir_all of the dest parent happens
+                // at the call site so a first write can create the target.
+                return Ok(current);
+            }
+            Err(e) => {
+                return Err(format!(
+                    "could not inspect {} before writing: {e}",
+                    current.display()
+                ));
+            }
+        }
+    }
+    Err(format!(
+        "too many symlink hops ({ATOMIC_WRITE_MAX_SYMLINK_HOPS}) resolving {}",
+        path.display()
+    ))
+}
+
 /// Write `contents` to `path` atomically: a uniquely-named sibling temp file,
 /// then rename over the target. The unique name (pid + per-process sequence)
 /// means two writers to the same path can't overwrite each other's half-written
 /// temp. The temp sits in the same directory so the rename stays on one
 /// filesystem (and is therefore atomic). Once created, the temp is guarded so
 /// any permissions, write, sync, or rename failure removes it.
+///
+/// If `path` is a symlink, the temp and rename target the resolved file so the
+/// link inode is left in place (SBS-886).
 pub fn atomic_write(path: &Path, contents: &str) -> Result<(), String> {
     atomic_write_with_ops(path, contents, &FsAtomicWriteOps)
 }
@@ -96,13 +170,16 @@ fn atomic_write_with_ops(
     contents: &str,
     ops: &impl AtomicWriteOps,
 ) -> Result<(), String> {
-    if let Some(parent) = path.parent() {
+    // SBS-886: rename(2) replaces a destination symlink. Resolve first so the
+    // temp file and rename land next to the real target.
+    let dest = resolve_atomic_write_dest(path)?;
+    if let Some(parent) = dest.parent() {
         std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
     }
     let seq = ATOMIC_WRITE_SEQ.fetch_add(1, Ordering::Relaxed);
     let tmp = PathBuf::from(format!(
         "{}.{}.{}.conduit-tmp",
-        path.display(),
+        dest.display(),
         std::process::id(),
         seq
     ));
@@ -123,12 +200,13 @@ fn atomic_write_with_ops(
     // leave a truncated registry.json. `fs::write` + `rename` alone did not.
     ops.sync_all(&f).map_err(|e| e.to_string())?;
     drop(f);
-    std::fs::rename(&tmp, path).map_err(|e| e.to_string())?;
+    std::fs::rename(&tmp, &dest).map_err(|e| e.to_string())?;
     cleanup.disarm();
     // Best-effort: fsync the containing directory so the rename entry itself is durable
     // (Unix). Opening a directory as a File fails on Windows, where NTFS journals the
-    // rename anyway, so the error is ignored.
-    if let Some(dir) = path.parent() {
+    // rename anyway, so the error is ignored. Fsync the *resolved* parent so a
+    // write-through-symlink still durables the directory that holds the new file.
+    if let Some(dir) = dest.parent() {
         if let Ok(d) = std::fs::File::open(dir) {
             let _ = d.sync_all();
         }
@@ -3774,6 +3852,271 @@ mod tests {
         let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
         assert_eq!(mode, 0o600, "overwrite must stay owner-only");
         std::fs::remove_file(&path).ok();
+    }
+
+    #[cfg(unix)]
+    fn atomic_write_symlink_scratch(label: &str) -> PathBuf {
+        let stamp = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let dir = std::env::temp_dir().join(format!(
+            "toolport-aw-symlink-{}-{}-{stamp}",
+            std::process::id(),
+            label
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    #[cfg(unix)]
+    fn assert_is_symlink_to(link: &Path, target: &Path) {
+        let meta = std::fs::symlink_metadata(link).expect("link must still exist");
+        assert!(
+            meta.file_type().is_symlink(),
+            "expected {} to remain a symlink, became {:?}",
+            link.display(),
+            meta.file_type()
+        );
+        assert_eq!(
+            std::fs::read_link(link).unwrap(),
+            target,
+            "symlink target must be left unchanged"
+        );
+    }
+
+    /// SBS-886: rename(2) over a symlink dest replaces the link inode and leaves
+    /// the target bytes unchanged. Connect then "succeeds" while the file in the
+    /// dotfiles repo still has the old content.
+    #[cfg(unix)]
+    #[test]
+    fn atomic_write_follows_existing_symlink() {
+        let dir = atomic_write_symlink_scratch("existing");
+        let target = dir.join("dotfiles").join("config.toml");
+        let link = dir.join("home").join("config.toml");
+        std::fs::create_dir_all(target.parent().unwrap()).unwrap();
+        std::fs::create_dir_all(link.parent().unwrap()).unwrap();
+        std::fs::write(&target, "old").unwrap();
+        std::os::unix::fs::symlink(&target, &link).unwrap();
+
+        atomic_write(&link, "new").unwrap();
+
+        assert_is_symlink_to(&link, &target);
+        assert_eq!(std::fs::read_to_string(&target).unwrap(), "new");
+        assert!(
+            atomic_temp_files(&target).is_empty(),
+            "temp must land next to the resolved dest and be cleaned up"
+        );
+        assert!(
+            atomic_temp_files(&link).is_empty(),
+            "must not leave a temp next to the symlink"
+        );
+        std::fs::remove_dir_all(dir).ok();
+    }
+
+    /// SBS-886: a dangling stow/chezmoi link (repo file not created yet) must
+    /// still stay a link; the write creates the target instead of replacing the
+    /// inode under home.
+    #[cfg(unix)]
+    #[test]
+    fn atomic_write_dangling_symlink_creates_target_and_keeps_link() {
+        let dir = atomic_write_symlink_scratch("dangling");
+        let target = dir
+            .join("dotfiles")
+            .join("codex")
+            .join("config.toml");
+        let link = dir.join("home").join(".codex").join("config.toml");
+        std::fs::create_dir_all(link.parent().unwrap()).unwrap();
+        // Target parent is missing on purpose: first Connect should create it.
+        std::os::unix::fs::symlink(&target, &link).unwrap();
+        assert!(std::fs::symlink_metadata(&link)
+            .unwrap()
+            .file_type()
+            .is_symlink());
+        assert_eq!(
+            std::fs::symlink_metadata(&target).unwrap_err().kind(),
+            std::io::ErrorKind::NotFound
+        );
+
+        atomic_write(&link, "created").unwrap();
+
+        assert_is_symlink_to(&link, &target);
+        assert_eq!(std::fs::read_to_string(&target).unwrap(), "created");
+        std::fs::remove_dir_all(dir).ok();
+    }
+
+    /// SBS-886: relative link targets are relative to the link's parent, not cwd.
+    #[cfg(unix)]
+    #[test]
+    fn atomic_write_relative_symlink_target() {
+        let dir = atomic_write_symlink_scratch("relative");
+        let target = dir.join("dotfiles").join("config.toml");
+        let link = dir.join("home").join("config.toml");
+        std::fs::create_dir_all(target.parent().unwrap()).unwrap();
+        std::fs::create_dir_all(link.parent().unwrap()).unwrap();
+        std::fs::write(&target, "old").unwrap();
+        std::os::unix::fs::symlink("../dotfiles/config.toml", &link).unwrap();
+
+        atomic_write(&link, "via-relative").unwrap();
+
+        assert!(std::fs::symlink_metadata(&link)
+            .unwrap()
+            .file_type()
+            .is_symlink());
+        assert_eq!(
+            std::fs::read_link(&link).unwrap(),
+            Path::new("../dotfiles/config.toml")
+        );
+        assert_eq!(std::fs::read_to_string(&target).unwrap(), "via-relative");
+        std::fs::remove_dir_all(dir).ok();
+    }
+
+    /// SBS-886: a chain A -> B -> file must walk to the file, leaving every
+    /// link inode in place.
+    #[cfg(unix)]
+    #[test]
+    fn atomic_write_walks_nested_symlinks() {
+        let dir = atomic_write_symlink_scratch("nested");
+        let file = dir.join("real.toml");
+        let mid = dir.join("mid.toml");
+        let link = dir.join("home.toml");
+        std::fs::write(&file, "old").unwrap();
+        std::os::unix::fs::symlink(&file, &mid).unwrap();
+        std::os::unix::fs::symlink(&mid, &link).unwrap();
+
+        atomic_write(&link, "nested").unwrap();
+
+        assert_is_symlink_to(&link, &mid);
+        assert_is_symlink_to(&mid, &file);
+        assert_eq!(std::fs::read_to_string(&file).unwrap(), "nested");
+        std::fs::remove_dir_all(dir).ok();
+    }
+
+    /// SBS-886: a loop is its own state. Do not treat it as "not a symlink"
+    /// and replace one of the link inodes.
+    #[cfg(unix)]
+    #[test]
+    fn atomic_write_symlink_loop_errors() {
+        let dir = atomic_write_symlink_scratch("loop");
+        let a = dir.join("a.toml");
+        let b = dir.join("b.toml");
+        std::os::unix::fs::symlink(&b, &a).unwrap();
+        std::os::unix::fs::symlink(&a, &b).unwrap();
+
+        let err = atomic_write(&a, "loop").expect_err("a symlink loop must fail");
+        assert!(
+            err.contains("symlink loop") || err.contains("too many symlink hops"),
+            "unexpected loop error: {err}"
+        );
+        assert_is_symlink_to(&a, &b);
+        assert_is_symlink_to(&b, &a);
+        std::fs::remove_dir_all(dir).ok();
+    }
+
+    /// SBS-886: writing file bytes over a symlink-to-directory must error
+    /// rather than rename a regular file onto a directory inode.
+    #[cfg(unix)]
+    #[test]
+    fn atomic_write_symlink_to_dir_errors() {
+        let dir = atomic_write_symlink_scratch("to-dir");
+        let target_dir = dir.join("dotfiles");
+        let link = dir.join("config.toml");
+        std::fs::create_dir_all(&target_dir).unwrap();
+        std::fs::write(target_dir.join("keep"), "safe").unwrap();
+        std::os::unix::fs::symlink(&target_dir, &link).unwrap();
+
+        let err = atomic_write(&link, "nope").expect_err("symlink-to-dir must fail");
+        assert!(
+            err.contains("directory"),
+            "unexpected symlink-to-dir error: {err}"
+        );
+        assert_is_symlink_to(&link, &target_dir);
+        assert_eq!(
+            std::fs::read_to_string(target_dir.join("keep")).unwrap(),
+            "safe"
+        );
+        std::fs::remove_dir_all(dir).ok();
+    }
+
+    /// A missing path is not a symlink: create a regular file, same as before.
+    #[cfg(unix)]
+    #[test]
+    fn atomic_write_missing_path_creates_regular_file() {
+        let dir = atomic_write_symlink_scratch("missing");
+        let path = dir.join("new").join("config.toml");
+        atomic_write(&path, "fresh").unwrap();
+        let meta = std::fs::symlink_metadata(&path).unwrap();
+        assert!(
+            meta.file_type().is_file() && !meta.file_type().is_symlink(),
+            "a first write to a missing path must create a regular file"
+        );
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), "fresh");
+        std::fs::remove_dir_all(dir).ok();
+    }
+
+    /// Regular-file dest is unchanged: still overwrite in place, never invent
+    /// a symlink, never write beside a different path.
+    #[cfg(unix)]
+    #[test]
+    fn atomic_write_regular_file_destination_unchanged() {
+        let dir = atomic_write_symlink_scratch("regular");
+        let path = dir.join("config.toml");
+        std::fs::write(&path, "old").unwrap();
+        atomic_write(&path, "new").unwrap();
+        let meta = std::fs::symlink_metadata(&path).unwrap();
+        assert!(
+            meta.file_type().is_file() && !meta.file_type().is_symlink(),
+            "a regular file dest must stay a regular file"
+        );
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), "new");
+        std::fs::remove_dir_all(dir).ok();
+    }
+
+    /// SBS-886: `symlink_metadata` failing for a reason other than NotFound is
+    /// unknown, not "not a symlink". Collapsing those would let the write
+    /// proceed against a path we could not inspect.
+    #[cfg(unix)]
+    #[test]
+    fn atomic_write_inspect_error_is_not_treated_as_missing() {
+        let dir = atomic_write_symlink_scratch("inspect");
+        let not_a_dir = dir.join("file");
+        std::fs::write(&not_a_dir, "regular").unwrap();
+        // Parent is a regular file: lstat of child is ENOTDIR, never NotFound.
+        let child = not_a_dir.join("config.toml");
+
+        let err = resolve_atomic_write_dest(&child)
+            .expect_err("an inspect failure must not collapse to missing");
+        assert!(
+            err.contains("could not inspect"),
+            "inspect failure must be reported as inspect, not as a write: {err}"
+        );
+        assert_eq!(std::fs::read_to_string(&not_a_dir).unwrap(), "regular");
+        std::fs::remove_dir_all(dir).ok();
+    }
+
+    /// A failed write through a symlink must not replace the link and must
+    /// leave the target bytes and no sibling temp.
+    #[cfg(unix)]
+    #[test]
+    fn atomic_write_failed_write_through_symlink_keeps_link_and_target() {
+        let dir = atomic_write_symlink_scratch("fail-keep");
+        let target = dir.join("target.toml");
+        let link = dir.join("link.toml");
+        std::fs::write(&target, "original").unwrap();
+        std::os::unix::fs::symlink(&target, &link).unwrap();
+
+        let err = atomic_write_with_ops(
+            &link,
+            "replacement",
+            &FailingAtomicWriteOps(FailingAtomicWriteStep::Write),
+        )
+        .expect_err("injected write must fail");
+        assert!(err.contains("write"), "unexpected error: {err}");
+        assert_is_symlink_to(&link, &target);
+        assert_eq!(std::fs::read_to_string(&target).unwrap(), "original");
+        assert!(atomic_temp_files(&target).is_empty());
+        assert!(atomic_temp_files(&link).is_empty());
+        std::fs::remove_dir_all(dir).ok();
     }
 
     fn quarantine_files(path: &Path) -> Vec<PathBuf> {


### PR DESCRIPTION
Fixes [SBS-886](https://linear.app/southboundsoftware/issue/SBS-886/toolport-client-config-atomic-write-replaces-a-symlink-with-a-regular).

Do not merge.


**Linear:** [SBS-886](https://linear.app/southboundsoftware/issue/SBS-886/toolport-client-config-atomic-write-replaces-a-symlink-with-a-regular) — `[Toolport] Client-config atomic_write replaces a symlink with a regular file, so Connect breaks dotfiles`

**Branch:** `fix/sbs-886-atomic-write-symlink` (from `origin/main` @ `02a9c79`)

**Commit:** `47873d9ca07f42e37a3034368da3648dc4a76dbf`

```
fix(clients): write through config symlinks so Connect does not break dotfiles (SBS-886)
```

Not pushed. Not merged. No PR opened.

A user who Connects (or is re-pointed on launch) against a stow/chezmoi config now keeps the symlink under home and sees the gateway entry in the **target** file.

---

## What changed

`registry::atomic_write` / `atomic_write_with_ops` now resolve the destination before creating the sibling temp file and `rename`.

- If `path` is a symlink (or a chain), walk with `read_link` + parent-join to the first non-symlink path.
- Temp name stays `{dest}.{pid}.{seq}.conduit-tmp` next to that **resolved** dest.
- `create_dir_all` is of the resolved dest parent (so a dangling link can create the target).
- Directory fsync is of the resolved dest parent.
- 0600, temp cleanup, unique temp names unchanged.

All ticket entry points already call this primitive (Connect `install_or_remove`, Disconnect, migrate `write_servers`, `repoint_stale_gateways`, unused-from-UI `write_to_client`, team-instructions `write_atomic`). No second primitive.

Documented on `resolve_atomic_write_dest`: following in the shared primitive also follows a Toolport-owned file (`registry.json`, pins, audit, secrets.enc) that is already a symlink.

Files: `src-tauri/src/registry.rs`, `src-tauri/src/clients.rs` (Connect-level test), `CHANGELOG.md` Unreleased Fixed (SBS-886).

---

## Test names

**Primitive (unix):**

- `registry::tests::atomic_write_follows_existing_symlink`
- `registry::tests::atomic_write_dangling_symlink_creates_target_and_keeps_link`
- `registry::tests::atomic_write_relative_symlink_target`
- `registry::tests::atomic_write_walks_nested_symlinks`
- `registry::tests::atomic_write_symlink_loop_errors`
- `registry::tests::atomic_write_symlink_to_dir_errors`
- `registry::tests::atomic_write_missing_path_creates_regular_file`
- `registry::tests::atomic_write_regular_file_destination_unchanged`
- `registry::tests::atomic_write_inspect_error_is_not_treated_as_missing`
- `registry::tests::atomic_write_failed_write_through_symlink_keeps_link_and_target`

**Connect write path (unix):**

- `clients::tests::connect_write_through_symlinked_config_keeps_link_and_updates_target`

  Drives `edit_json_gateway` (the Connect/`install_or_remove` write) against `home/.claude.json -> dotfiles/claude.json`. Asserts the path stays a symlink, the target bytes get the gateway entry, and unrelated keys survive.

---

## Fail-without-fix

Reverted only `atomic_write_with_ops` to rename over `path` (left `resolve_atomic_write_dest` in place so the inspect test still compiled). Ran:

```
cargo test --manifest-path src-tauri/Cargo.toml --lib --no-default-features -- --test-threads=1 \
  atomic_write_follows_existing_symlink atomic_write_dangling_symlink \
  atomic_write_relative_symlink atomic_write_walks_nested \
  connect_write_through_symlinked atomic_write_symlink_loop \
  atomic_write_symlink_to_dir
```

**FAILED. 0 passed; 7 failed:**

```
---- clients::tests::connect_write_through_symlinked_config_keeps_link_and_updates_target stdout ----
thread '...' panicked at src/clients.rs:6548:9:
Connect must leave the config path a symlink, became FileType { is_file: true, is_dir: false, is_symlink: false, .. }

---- registry::tests::atomic_write_dangling_symlink_creates_target_and_keeps_link stdout ----
expected .../home/.codex/config.toml to remain a symlink, became FileType { is_file: true, ... }

---- registry::tests::atomic_write_follows_existing_symlink stdout ----
expected .../home/config.toml to remain a symlink, became FileType { is_file: true, ... }

---- registry::tests::atomic_write_relative_symlink_target stdout ----
assertion failed: std::fs::symlink_metadata(&link).unwrap().file_type().is_symlink()

---- registry::tests::atomic_write_symlink_loop_errors stdout ----
a symlink loop must fail: ()

---- registry::tests::atomic_write_symlink_to_dir_errors stdout ----
symlink-to-dir must fail: ()

---- registry::tests::atomic_write_walks_nested_symlinks stdout ----
expected .../home.toml to remain a symlink, became FileType { is_file: true, ... }
```

Production change restored; those seven then passed.

**Would pass either way (not used as proof):** `atomic_write_failed_write_through_symlink_keeps_link_and_target` — injected write failure happens before `rename`, so the link is kept even on the old path. Kept as a cleanup/regression check.

---

## CI outcomes (Build + test commands)

Read `.github/workflows/ci.yml` `Build + test` and `package.json` scripts. Ran those commands locally with rustc 1.97.1 (system `/usr/bin/rustc` is 1.85 and cannot compile `boa_*`).

| Step | Command | Result |
| --- | --- | --- |
| format:check | `npm run format:check` | pass — “All matched files use Prettier code style!” |
| lint | `npm run lint` | exit 0 — pre-existing react-hooks warnings only; no new errors |
| build | `npm run build` (`tsc && vite build`) | pass |
| test | `npm run test` | **37 files, 382 passed** |
| test:rust | `npm run test:rust` (`cargo test --lib --bins --tests`, **default/desktop features**) | **lib: 1096 passed, 0 failed, 1 ignored** (1097 run; includes the new tests). **bins: 306 passed** (`toolport-gateway`). Integration targets all passed (3+1+1+3+1+1+2+3+1+1+26+3). |

Also ran (not the required job, but useful):

- `cargo test --no-default-features --lib --bins --tests`: **lib 1017 passed, 0 failed, 1 ignored**; **bins 306 passed**; same integration set green. Confirms the new tests run in the headless crate, not only desktop.
- `cargo clippy --no-default-features --lib --bins` (CI Clippy job, no `-D warnings`): **exit 0**. No new warnings in `registry.rs` / `clients.rs` from this change. Pre-existing warnings elsewhere (e.g. `suspicious_open_options` on the registry lock open).

Did **not** run `npm run audit:prod` or `npm run smoke:headless` (also in the Build + test job, not in the listed command set).

---

## Grep sweep — rename / write paths that can clobber a symlink

```
rg -n "std::fs::rename|fs::rename" --type rust src-tauri/src
```

Production `rename` sites:

| Site | Verdict |
| --- | --- |
| `registry.rs` `atomic_write_with_ops` | **Fixed.** |
| `clients.rs` `replace_gateway_copy` | Gateway binary under `~/.toolport/bin`. `rename` over dest is the ETXTBSY-survival swap (replace the directory entry, not truncate a running inode). Not a user dotfile. **Listed, not changed.** Not SBS-843 (content-vs-size recopy). |
| `brand.rs` `migrate_legacy_data_dir_under` | One-shot **directory** rename of the data-dir leaf. Not a config-file write. **Listed, not changed.** |

Callers of `registry::atomic_write` (inherit the fix): Connect/Disconnect/migrate/repoint/`write_to_client`, `instructions.rs` `write_atomic`, registry/pins/quarantine/audit/secrets/routines/etc.

`fs::write` that is **not** this ticket: `gatewaylog.rs` trim (SBS-869 — do not expand). Did not touch SBS-884, SBS-885, SBS-878, SBS-869.

---

## Unknown is its own state

| Input | Handling |
| --- | --- |
| `symlink_metadata` `NotFound` | dest = current path (missing original, or dangling target). Create regular file there. |
| `symlink_metadata` any other IO error | **Error** `"could not inspect … before writing"`. Not treated as not-a-symlink. |
| `read_link` error after lstat says symlink | **Error** `"could not read symlink"`. |
| Dangling symlink | `read_link` + parent-join. **Not** `canonicalize`. |
| Relative target | Joined to the **link's parent**, not cwd. |
| Nested chain | Walk until a non-symlink. Hop cap 40 (`MAXSYMLINKS`); seen-set catches exact-path loops. |
| Symlink to a directory | **Error**; link and dir contents left alone. |
| Symlink loop | **Error**; both links left in place. |
| Missing path | Regular file created (unchanged). |
| Regular file | Overwrite in place (unchanged). |
| Original path is a directory (not via symlink) | Unchanged: still attempt rename (pre-existing). |

---

## What this makes more likely

1. **Toolport-owned files that are already symlinks are followed.** Ticket asked to fix the shared primitive, not add a second one. Documented on the resolver.
2. **Target mode becomes 0600.** The primitive already sets 0600 on a regular dest. After this, the **dotfiles-repo file** gets 0600. Git may show a mode change from 0644.
3. **Unwritable target, writable link dir:** write now **fails** instead of replacing the home-path symlink with a regular file. Correct, but a user who relied on the old accidental local copy will see an error.
4. **Dangling link whose dest parent is missing:** `create_dir_all` can create directories in the user's dotfiles tree.
5. **Dest on another filesystem that is full/read-only:** fail instead of silently converting the home path to a regular file.
6. **TOCTOU** between resolve and rename is the same class as before (another process swapping the dest).

---

## Gaps

- Unix-only symlink tests, as specified. No Windows junction coverage.
- Connect-level test uses `edit_json_gateway` (the Connect write), not `install_gateway` itself — that needs a `toolport-gateway` binary next to the test exe.
- No live `chezmoi apply` / `stow` run against a real `~/.codex/config.toml`.
- `atomic_write_failed_write_through_symlink_keeps_link_and_target` does not fail without the dest resolve (see above).
- No injected `read_link` failure after a successful lstat.
- Seen-set is exact `PathBuf`; `link` vs `dir/../link` loops rely on the hop cap.
- `replace_gateway_copy` still `rename`s over its dest (listed above).
- Did not run `audit:prod` or `smoke:headless`.
- Did not open, push, or merge a PR.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `atomic_write` to write through config symlinks instead of replacing them
> - Tools like `stow` and `chezmoi` manage dotfiles via symlinks; the previous `atomic_write` replaced the symlink inode with a regular file, breaking the dotfile setup.
> - Adds `resolve_atomic_write_dest` in [registry.rs](https://github.com/tsouth89/toolport/pull/765/files#diff-8187fea44e15daa4059544c5fcff94f80f39fa1ec39c67eccccc153a98b39349) to follow symlink chains (up to 40 hops) and return the real destination file before writing.
> - `atomic_write_with_ops` now creates the temp file beside the resolved destination and renames into it, preserving the symlink at the original path.
> - Dangling symlinks are supported by creating the target file; symlink loops and symlink-to-directory destinations are surfaced as errors.
> - Risk: any path previously written atomically that happened to be a symlink will now write through to the target — callers that relied on the old behavior of replacing the symlink will observe a change.
>
> #### 🖇️ Linked Issues
> Addresses [SBS-886](https://linear.app/southboundsoftware/issue/SBS-886).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 47873d9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->