### PR TITLE
fix(desktop): do not treat an unreadable activity log as Protection active (SBS-873)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,11 @@ Entries before the rename below shipped under the project's former name, Conduit
   read of `audit.jsonl`, `security.jsonl`, `inspect.jsonl`, or `search-trace.jsonl`
   used to come back as an empty list, so Activity showed **No tool calls yet** /
   **Protection active**. A missing file is still empty (honest). Any other IO error
-  now rejects the invoke, and the existing error/retry UI surfaces it. (SBS-873)
+  now rejects the invoke (including the dashboard's `audit_stats`), and the existing
+  error/retry UI surfaces it. `GET /metrics` answers 500 on the same unreadable log
+  instead of 200 with every series missing, so a Prometheus scrape fails rather than
+  reading as an idle instance. Security events also no longer lose an older row when
+  a corrupt or mid-write line lands in the newest page. (SBS-873)
 - **Linux `.deb` installs a `toolport` command.** The package still ships the
   crate binary as `conduit` (compat alias) and now also puts `toolport` on
   `PATH`, matching the AppImage installer and the brand. `install.sh` tells apt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ Entries before the rename below shipped under the project's former name, Conduit
 
 ### Fixed
 
+- **Unreadable activity/security log no longer renders as empty healthy.** A failed
+  read of `audit.jsonl`, `security.jsonl`, `inspect.jsonl`, or `search-trace.jsonl`
+  used to come back as an empty list, so Activity showed **No tool calls yet** /
+  **Protection active**. A missing file is still empty (honest). Any other IO error
+  now rejects the invoke, and the existing error/retry UI surfaces it. (SBS-873)
 - **Linux `.deb` installs a `toolport` command.** The package still ships the
   crate binary as `conduit` (compat alias) and now also puts `toolport` on
   `PATH`, matching the AppImage installer and the brand. `install.sh` tells apt

--- a/docs/headless.md
+++ b/docs/headless.md
@@ -64,6 +64,11 @@ Emits counters for tool calls (`server`, `tool`, `client`, `ok`), held
 destructive calls, duration sum/count, lazy-discovery tokens saved, and a
 quarantine gauge. Labels are ids only (never arguments). Same auth as OpenAPI.
 
+An instance that has not run a tool yet scrapes 200 with the gauges at zero. If a
+local stat file exists but cannot be read (permissions, a sharing lock), the
+endpoint answers `500` instead of a 200 with no series, so the scrape fails and
+Prometheus `up` goes to 0 rather than the instance looking idle.
+
 ### Modern MCP request (curl)
 
 ```bash

--- a/src-tauri/src/audit.rs
+++ b/src-tauri/src/audit.rs
@@ -654,27 +654,30 @@ fn trimmed_tail(content: &str, keep: usize) -> String {
 }
 
 /// The most recent `limit` entries, newest first.
-pub fn read_recent(limit: usize) -> Vec<Value> {
-    let path = match audit_path() {
-        Some(p) => p,
-        None => return Vec::new(),
+///
+/// A missing file is an empty log: nothing has been written yet. Any other IO
+/// error is returned so a caller cannot treat an unreadable existing file as
+/// "no tool calls" / Protection active (SBS-873). Unparseable lines are skipped
+/// — a mid-write or corrupt line is not an IO failure.
+pub fn read_recent(limit: usize) -> std::io::Result<Vec<Value>> {
+    let Some(path) = audit_path() else {
+        return Ok(Vec::new());
     };
     let content = match std::fs::read_to_string(&path) {
         Ok(c) => c,
-        Err(_) => return Vec::new(),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(e) => return Err(e),
     };
     // Filter BEFORE take, matching `inspect::read_recent` and `searchtrace`. Taking
     // first let an unparseable line consume a slot, so one corrupt row among the
     // newest entries returned a short page and dropped older valid history that
     // should have filled it.
-    let entries: Vec<Value> = content
+    Ok(content
         .lines()
         .rev()
         .filter_map(|line| serde_json::from_str(line).ok())
         .take(limit)
-        .collect();
-    // `rev()` gives newest-first already.
-    entries
+        .collect())
 }
 
 /// Average and 95th-percentile of a duration sample, in ms. `None` when the
@@ -695,28 +698,30 @@ fn latency(durs: &mut [u64]) -> (Option<u64>, Option<u64>) {
 
 /// Every retained entry, newest first. The log is size-capped (see `MAX_AUDIT_BYTES`), so
 /// this stays bounded no matter how long Toolport has been running.
-pub fn read_all() -> Vec<Value> {
-    let path = match audit_path() {
-        Some(p) => p,
-        None => return Vec::new(),
+///
+/// Same empty-vs-unreadable contract as [`read_recent`] (SBS-873).
+pub fn read_all() -> std::io::Result<Vec<Value>> {
+    let Some(path) = audit_path() else {
+        return Ok(Vec::new());
     };
     let content = match std::fs::read_to_string(&path) {
         Ok(c) => c,
-        Err(_) => return Vec::new(),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(e) => return Err(e),
     };
-    content
+    Ok(content
         .lines()
         .rev()
         .filter_map(|line| serde_json::from_str(line).ok())
-        .collect()
+        .collect())
 }
 
 /// Aggregate the FULL retained log into per-server stats plus global totals: call volume,
 /// error rate, and latency per server, computed locally. Totals are the real count of what's
 /// retained (the byte cap bounds it), not a fixed window, so the error rate stays consistent
 /// with the call count instead of being taken over an arbitrary slice.
-pub fn stats() -> Value {
-    aggregate(&read_all())
+pub fn stats() -> std::io::Result<Value> {
+    Ok(aggregate(&read_all()?))
 }
 
 /// Pure aggregation of audit entries into per-server + global stats. Split from
@@ -863,7 +868,10 @@ pub fn to_csv(entries: &[Value]) -> String {
     out.push_str(&CSV_COLUMNS.join(","));
     out.push_str("\r\n");
     for e in entries {
-        let row: Vec<String> = CSV_COLUMNS.iter().map(|col| csv_cell(e.get(*col))).collect();
+        let row: Vec<String> = CSV_COLUMNS
+            .iter()
+            .map(|col| csv_cell(e.get(*col)))
+            .collect();
         out.push_str(&row.join(","));
         out.push_str("\r\n");
     }
@@ -880,9 +888,7 @@ fn csv_cell(value: Option<&Value>) -> String {
     };
     // Formula-injection guard (OWASP): a cell starting with one of these could be
     // executed as a formula by a spreadsheet, so shift it behind a quote.
-    let guarded = if raw
-        .starts_with(['=', '+', '-', '@', '\t', '\r'])
-    {
+    let guarded = if raw.starts_with(['=', '+', '-', '@', '\t', '\r']) {
         format!("'{raw}")
     } else {
         raw
@@ -1048,7 +1054,10 @@ mod tests {
             true,
         );
         assert_eq!(e["event"], "agent_control.server_toggle");
-        assert!(e["resolvedServerId"].is_null(), "a scoped miss must not resolve a server");
+        assert!(
+            e["resolvedServerId"].is_null(),
+            "a scoped miss must not resolve a server"
+        );
         assert_eq!(e["decision"], "unresolved");
         assert_eq!(e["knownListScope"], "client_allowed_only");
         assert_eq!(e["ok"], false);
@@ -1560,5 +1569,59 @@ mod tests {
             args_hash(&value),
             "943d56ce0b02b80a8afcd12d849426226b68f2d8cd2840af8f6f93067f14c360"
         );
+    }
+
+    fn isolated_data_dir(label: &str) -> (crate::registry::DataDirOverride, PathBuf) {
+        let path = std::env::temp_dir().join(format!(
+            "toolport-audit-read-{label}-{}-{}",
+            std::process::id(),
+            epoch_millis()
+        ));
+        let _ = std::fs::remove_dir_all(&path);
+        std::fs::create_dir_all(&path).expect("scratch data dir");
+        (crate::registry::DataDirOverride::set(&path), path)
+    }
+
+    /// A missing audit.jsonl is an empty log, not a load failure.
+    #[test]
+    fn read_recent_missing_file_is_ok_empty() {
+        let _lock = crate::registry::data_dir_test_lock();
+        let (_override, root) = isolated_data_dir("missing");
+        let path = audit_path().expect("audit path under override");
+        assert!(!path.exists(), "fixture must not create the log");
+        let entries = read_recent(10).expect("missing file is Ok empty");
+        assert!(entries.is_empty());
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    /// A readable JSONL returns newest-first parsed rows.
+    #[test]
+    fn read_recent_readable_jsonl_is_newest_first() {
+        let _lock = crate::registry::data_dir_test_lock();
+        let (_override, root) = isolated_data_dir("readable");
+        let path = audit_path().expect("audit path under override");
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        std::fs::write(&path, "{\"i\":1}\n{\"i\":2}\n").unwrap();
+        let entries = read_recent(10).expect("readable fixture");
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0]["i"], 2);
+        assert_eq!(entries[1]["i"], 1);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    /// An existing but unreadable audit.jsonl must not look like "no tool calls"
+    /// / Protection active (SBS-873).
+    #[test]
+    fn read_recent_unreadable_existing_path_is_err() {
+        let _lock = crate::registry::data_dir_test_lock();
+        let (_override, root) = isolated_data_dir("unreadable");
+        let path = audit_path().expect("audit path under override");
+        // IsADirectory: the log path exists but cannot be read as a file.
+        std::fs::create_dir_all(&path).unwrap();
+        let err = read_recent(10).expect_err("unreadable existing path must be Err");
+        assert_ne!(err.kind(), std::io::ErrorKind::NotFound);
+        let _ = std::fs::remove_dir_all(root);
     }
 }

--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -13227,11 +13227,13 @@ fn handle_http_with_headers(
                     "metrics disabled; set TOOLPORT_METRICS=1 on the gateway to enable",
                 );
             }
-            HttpOut::new(
-                200,
-                "text/plain; version=0.0.4; charset=utf-8",
-                conduit_lib::metrics::render(),
-            )
+            match conduit_lib::metrics::render() {
+                Ok(body) => HttpOut::new(200, "text/plain; version=0.0.4; charset=utf-8", body),
+                // A failed read is a failed scrape, not an idle instance: 200 with
+                // no series drops every metric while Prometheus `up` stays 1, so a
+                // persistent permission error looks like silence (SBS-873).
+                Err(error) => HttpOut::json_err(500, &format!("metrics unavailable: {error}")),
+            }
         }
         ("POST", p) => {
             let name = p.trim_start_matches('/');

--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -1638,22 +1638,24 @@ async fn has_client_secret(server_id: String) -> Result<bool, String> {
 
 /// The most recent tool-call audit entries (newest first).
 #[tauri::command]
-async fn get_audit_log(limit: usize) -> Vec<serde_json::Value> {
+async fn get_audit_log(limit: usize) -> Result<Vec<serde_json::Value>, String> {
     // Async, like every polled reader here: Activity invokes these every few
     // seconds, and as sync commands the file reads ran on the GTK main loop,
     // where a large log made window controls intermittently dead on Linux
-    // (SBS-813). A join failure only means the worker panicked; return the
-    // benign empty shape rather than poisoning the poll loop.
-    tauri::async_runtime::spawn_blocking(move || audit::read_recent(limit))
-        .await
-        .unwrap_or_default()
+    // (SBS-813). An unreadable log or a join failure must reject so Activity
+    // can show error/retry instead of "No tool calls yet" (SBS-873).
+    tauri::async_runtime::spawn_blocking(move || {
+        audit::read_recent(limit).map_err(|e| format!("Couldn't read the activity log: {e}"))
+    })
+    .await
+    .map_err(|e| format!("activity log task join failed: {e}"))?
 }
 
 /// Aggregate the full retained audit log into per-server call/error/latency stats for
 /// the observability dashboard. Bounded by the log's byte cap, so totals are real.
 #[tauri::command]
 async fn audit_stats() -> serde_json::Value {
-    tauri::async_runtime::spawn_blocking(audit::stats)
+    tauri::async_runtime::spawn_blocking(|| audit::stats().unwrap_or(serde_json::Value::Null))
         .await
         .unwrap_or(serde_json::Value::Null)
 }
@@ -1662,10 +1664,12 @@ async fn audit_stats() -> serde_json::Value {
 /// tool whose definition changed (rug-pull signal) or a known server that added a
 /// tool. Powers the in-app security notices.
 #[tauri::command]
-async fn get_security_events(limit: usize) -> Vec<serde_json::Value> {
-    tauri::async_runtime::spawn_blocking(move || integrity::read_recent(limit))
-        .await
-        .unwrap_or_default()
+async fn get_security_events(limit: usize) -> Result<Vec<serde_json::Value>, String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        integrity::read_recent(limit).map_err(|e| format!("Couldn't read security events: {e}"))
+    })
+    .await
+    .map_err(|e| format!("security events task join failed: {e}"))?
 }
 
 /// Cumulative tool-definition tokens that lazy discovery has kept out of clients'
@@ -2327,10 +2331,12 @@ fn set_live_inspect(state: State<RegistryState>, enabled: bool) -> Result<Regist
 /// The most recent live-inspection captures (newest first): each tool call's args and
 /// result, only present while live inspection has been on. Empty when off/unused.
 #[tauri::command]
-async fn get_inspect_log(limit: usize) -> Vec<serde_json::Value> {
-    tauri::async_runtime::spawn_blocking(move || inspect::read_recent(limit))
-        .await
-        .unwrap_or_default()
+async fn get_inspect_log(limit: usize) -> Result<Vec<serde_json::Value>, String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        inspect::read_recent(limit).map_err(|e| format!("Couldn't read the inspector log: {e}"))
+    })
+    .await
+    .map_err(|e| format!("inspector log task join failed: {e}"))?
 }
 
 /// Clear the live-inspection ring (delete `inspect.jsonl`), so no captured args/results
@@ -2346,10 +2352,12 @@ fn clear_inspect_log() -> Result<(), String> {
 /// the whole catalog. The in-path proof that lazy discovery is working. Empty when
 /// nothing has searched yet.
 #[tauri::command]
-async fn get_search_traces(limit: usize) -> Vec<serde_json::Value> {
-    tauri::async_runtime::spawn_blocking(move || searchtrace::read_recent(limit))
-        .await
-        .unwrap_or_default()
+async fn get_search_traces(limit: usize) -> Result<Vec<serde_json::Value>, String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        searchtrace::read_recent(limit).map_err(|e| format!("Couldn't read search traces: {e}"))
+    })
+    .await
+    .map_err(|e| format!("search traces task join failed: {e}"))?
 }
 
 /// Clear the search-trace log (delete `search-trace.jsonl`).
@@ -3361,7 +3369,8 @@ fn export_config_to_path(
 /// log, which the audit module already caps.
 #[tauri::command]
 fn export_audit_to_path(path: String, format: String) -> Result<(), String> {
-    let entries = audit::read_recent(usize::MAX);
+    let entries = audit::read_recent(usize::MAX)
+        .map_err(|e| format!("Couldn't read the activity log: {e}"))?;
     let body = if format == "csv" {
         audit::to_csv(&entries)
     } else {

--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -1654,10 +1654,15 @@ async fn get_audit_log(limit: usize) -> Result<Vec<serde_json::Value>, String> {
 /// Aggregate the full retained audit log into per-server call/error/latency stats for
 /// the observability dashboard. Bounded by the log's byte cap, so totals are real.
 #[tauri::command]
-async fn audit_stats() -> serde_json::Value {
-    tauri::async_runtime::spawn_blocking(|| audit::stats().unwrap_or(serde_json::Value::Null))
-        .await
-        .unwrap_or(serde_json::Value::Null)
+async fn audit_stats() -> Result<serde_json::Value, String> {
+    // Rejects on the same unreadable log that makes `get_audit_log` reject. A
+    // `null` here only hides the dashboard, which reads as "no data" rather
+    // than "the read failed" (SBS-873).
+    tauri::async_runtime::spawn_blocking(|| {
+        audit::stats().map_err(|e| format!("Couldn't read the activity log: {e}"))
+    })
+    .await
+    .map_err(|e| format!("activity stats task join failed: {e}"))?
 }
 
 /// Recent tool-definition integrity events (newest first): a previously-approved
@@ -5447,6 +5452,47 @@ mod tests {
             result.is_err(),
             "a failed secret read must propagate, not resolve to unvaulted: {result:?}"
         );
+    }
+
+    /// An unreadable activity log must reject `audit_stats`, not resolve to
+    /// `null` (SBS-873). Activity hides the dashboard on `null`, so a failed
+    /// read looked like "no data" while `get_audit_log` on the same file
+    /// rejected.
+    #[test]
+    fn audit_stats_rejects_an_unreadable_activity_log() {
+        let _lock = crate::registry::data_dir_test_lock();
+        let dir = unique_update_test_dir("audit-stats-unreadable");
+        std::fs::create_dir_all(&dir).unwrap();
+        let _override = crate::registry::DataDirOverride::set(&dir);
+        let path = audit::audit_path().expect("audit path under override");
+        // IsADirectory: the log path exists but cannot be read as a file.
+        std::fs::create_dir_all(&path).unwrap();
+
+        let result = tauri::async_runtime::block_on(audit_stats());
+        assert!(
+            result.is_err(),
+            "a failed activity-log read must reject, not resolve to null: {result:?}"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// The other half of the contract: a missing log is an honest empty
+    /// dashboard, so a first run still resolves.
+    #[test]
+    fn audit_stats_resolves_when_the_activity_log_is_missing() {
+        let _lock = crate::registry::data_dir_test_lock();
+        let dir = unique_update_test_dir("audit-stats-missing");
+        std::fs::create_dir_all(&dir).unwrap();
+        let _override = crate::registry::DataDirOverride::set(&dir);
+        let path = audit::audit_path().expect("audit path under override");
+        assert!(!path.exists(), "fixture must not create the log");
+
+        let stats = tauri::async_runtime::block_on(audit_stats())
+            .expect("a missing log is an empty dashboard, not a failure");
+        assert!(stats.is_object(), "expected aggregated stats: {stats}");
+
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     fn github_with_secret() -> ServerEntry {

--- a/src-tauri/src/inspect.rs
+++ b/src-tauri/src/inspect.rs
@@ -123,22 +123,26 @@ fn ring_trim(path: &std::path::Path) {
 }
 
 /// The most recent `limit` captured calls, newest first.
-pub fn read_recent(limit: usize) -> Vec<Value> {
-    let path = match inspect_path() {
-        Some(p) => p,
-        None => return Vec::new(),
+///
+/// A missing file is an empty inspector: capture has never written. Any other
+/// IO error is returned so a caller cannot treat an unreadable existing file as
+/// "no captures" (SBS-873). Unparseable lines are skipped — a mid-write or
+/// corrupt line is not an IO failure.
+pub fn read_recent(limit: usize) -> std::io::Result<Vec<Value>> {
+    let Some(path) = inspect_path() else {
+        return Ok(Vec::new());
     };
     let content = match std::fs::read_to_string(&path) {
         Ok(c) => c,
-        Err(_) => return Vec::new(),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(e) => return Err(e),
     };
-    let entries: Vec<Value> = content
+    Ok(content
         .lines()
         .rev()
         .filter_map(|line| serde_json::from_str(line).ok())
         .take(limit)
-        .collect();
-    entries
+        .collect())
 }
 
 /// Delete the inspect ring. Returns `Err` only on a real removal failure; a missing
@@ -182,7 +186,7 @@ mod tests {
             true,
             42,
         );
-        let recent = read_recent(10);
+        let recent = read_recent(10).unwrap();
         assert_eq!(recent.len(), 1);
         let e = &recent[0];
         assert_eq!(e["server"], "github");
@@ -210,7 +214,7 @@ mod tests {
                 1,
             );
         }
-        let recent = read_recent(1000);
+        let recent = read_recent(1000).unwrap();
         // Ring-trimmed to the last 50, so only 50 remain...
         assert_eq!(recent.len(), 50);
         // ...and they are the most recent (i = 59 newest, i = 10 oldest kept).
@@ -234,11 +238,14 @@ mod tests {
             true,
             1,
         );
-        let recent = read_recent(10);
+        let recent = read_recent(10).unwrap();
         assert_eq!(recent.len(), 1);
         let req = &recent[0]["request"];
         // The full body is NOT stored: request collapses to the marker string.
-        assert!(req.is_string(), "oversized request should be a marker string");
+        assert!(
+            req.is_string(),
+            "oversized request should be a marker string"
+        );
         let marker = req.as_str().unwrap();
         assert!(marker.starts_with("<truncated "), "got: {marker}");
         assert!(marker.contains("bytes>"));
@@ -277,11 +284,64 @@ mod tests {
         {"i":4}"#,
         )
         .unwrap();
-        let recent = read_recent(3);
+        let recent = read_recent(3).unwrap();
         assert_eq!(recent.len(), 3);
         assert_eq!(recent[0]["i"], 4);
         assert_eq!(recent[1]["i"], 3);
         assert_eq!(recent[2]["i"], 2);
         reset();
+    }
+
+    fn isolated_data_dir(label: &str) -> (crate::registry::DataDirOverride, PathBuf) {
+        let path = std::env::temp_dir().join(format!(
+            "toolport-inspect-read-{label}-{}-{}",
+            std::process::id(),
+            epoch_millis()
+        ));
+        let _ = std::fs::remove_dir_all(&path);
+        std::fs::create_dir_all(&path).expect("scratch data dir");
+        (crate::registry::DataDirOverride::set(&path), path)
+    }
+
+    /// A missing inspect.jsonl is an empty inspector, not a load failure.
+    #[test]
+    fn read_recent_missing_file_is_ok_empty() {
+        let _lock = crate::registry::data_dir_test_lock();
+        let (_override, root) = isolated_data_dir("missing");
+        let path = inspect_path().expect("inspect path under override");
+        assert!(!path.exists(), "fixture must not create the log");
+        let entries = read_recent(10).expect("missing file is Ok empty");
+        assert!(entries.is_empty());
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    /// A readable JSONL returns newest-first parsed rows.
+    #[test]
+    fn read_recent_readable_jsonl_is_newest_first() {
+        let _lock = crate::registry::data_dir_test_lock();
+        let (_override, root) = isolated_data_dir("readable");
+        let path = inspect_path().expect("inspect path under override");
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        std::fs::write(&path, "{\"i\":1}\n{\"i\":2}\n").unwrap();
+        let entries = read_recent(10).expect("readable fixture");
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0]["i"], 2);
+        assert_eq!(entries[1]["i"], 1);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    /// An existing but unreadable inspect.jsonl must not look like "no captures"
+    /// (SBS-873).
+    #[test]
+    fn read_recent_unreadable_existing_path_is_err() {
+        let _lock = crate::registry::data_dir_test_lock();
+        let (_override, root) = isolated_data_dir("unreadable");
+        let path = inspect_path().expect("inspect path under override");
+        std::fs::create_dir_all(&path).unwrap();
+        let err = read_recent(10).expect_err("unreadable existing path must be Err");
+        assert_ne!(err.kind(), std::io::ErrorKind::NotFound);
+        let _ = std::fs::remove_dir_all(root);
     }
 }

--- a/src-tauri/src/integrity.rs
+++ b/src-tauri/src/integrity.rs
@@ -2431,11 +2431,15 @@ pub fn read_recent(limit: usize) -> std::io::Result<Vec<Value>> {
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
         Err(e) => return Err(e),
     };
+    // Filter BEFORE take, matching `audit::read_recent` and the other readers.
+    // Taking first let an unparseable line consume a slot, so one corrupt or
+    // mid-write row among the newest events returned a short page and dropped
+    // an older valid security event that should have filled it.
     Ok(content
         .lines()
         .rev()
-        .take(limit)
         .filter_map(|line| serde_json::from_str(line).ok())
+        .take(limit)
         .collect())
 }
 
@@ -4198,5 +4202,33 @@ mod tests {
         std::fs::create_dir_all(&path).unwrap();
         let err = read_recent(10).expect_err("unreadable existing path must be Err");
         assert_ne!(err.kind(), std::io::ErrorKind::NotFound);
+    }
+
+    /// A corrupt or mid-write line among the NEWEST events must not consume a
+    /// slot of `limit`. Taking before filtering returned a short page and lost
+    /// an older valid security event that should have filled it.
+    #[test]
+    fn read_recent_corrupt_newest_line_does_not_shorten_the_page() {
+        let _lock = crate::registry::data_dir_test_lock();
+        let _dir = TestDataDir::new("read-recent-corrupt");
+        let path = security_path().expect("security path under override");
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        // Oldest to newest; the half-written row is the second-newest line.
+        std::fs::write(
+            &path,
+            "{\"i\":1}\n{\"i\":2}\n{\"i\":3}\n{\"i\":4,\"partial\":\n{\"i\":5}\n",
+        )
+        .unwrap();
+        let entries = read_recent(3).expect("readable fixture");
+        assert_eq!(
+            entries.len(),
+            3,
+            "a corrupt newest-window line must not shorten the page"
+        );
+        assert_eq!(entries[0]["i"], 5);
+        assert_eq!(entries[1]["i"], 3);
+        assert_eq!(entries[2]["i"], 2);
     }
 }

--- a/src-tauri/src/integrity.rs
+++ b/src-tauri/src/integrity.rs
@@ -2417,21 +2417,26 @@ fn rotate_if_large(path: &Path) {
 
 /// The most recent `limit` security events, newest first. Powers the app's
 /// security panel.
-pub fn read_recent(limit: usize) -> Vec<Value> {
-    let path = match security_path() {
-        Some(p) => p,
-        None => return Vec::new(),
+///
+/// A missing file is an empty event log: nothing has been recorded yet. Any
+/// other IO error is returned so a caller cannot treat an unreadable existing
+/// file as "Protection active" (SBS-873). Unparseable lines are skipped — a
+/// mid-write or corrupt line is not an IO failure.
+pub fn read_recent(limit: usize) -> std::io::Result<Vec<Value>> {
+    let Some(path) = security_path() else {
+        return Ok(Vec::new());
     };
     let content = match std::fs::read_to_string(&path) {
         Ok(c) => c,
-        Err(_) => return Vec::new(),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(e) => return Err(e),
     };
-    content
+    Ok(content
         .lines()
         .rev()
         .take(limit)
         .filter_map(|line| serde_json::from_str(line).ok())
-        .collect()
+        .collect())
 }
 
 #[cfg(test)]
@@ -4154,5 +4159,44 @@ mod tests {
             }
         }
         drifts
+    }
+
+    /// A missing security.jsonl is an empty event log, not a load failure.
+    #[test]
+    fn read_recent_missing_file_is_ok_empty() {
+        let _lock = crate::registry::data_dir_test_lock();
+        let _dir = TestDataDir::new("read-recent-missing");
+        let path = security_path().expect("security path under override");
+        assert!(!path.exists(), "fixture must not create the log");
+        let entries = read_recent(10).expect("missing file is Ok empty");
+        assert!(entries.is_empty());
+    }
+
+    /// A readable JSONL returns newest-first parsed rows.
+    #[test]
+    fn read_recent_readable_jsonl_is_newest_first() {
+        let _lock = crate::registry::data_dir_test_lock();
+        let _dir = TestDataDir::new("read-recent-readable");
+        let path = security_path().expect("security path under override");
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        std::fs::write(&path, "{\"i\":1}\n{\"i\":2}\n").unwrap();
+        let entries = read_recent(10).expect("readable fixture");
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0]["i"], 2);
+        assert_eq!(entries[1]["i"], 1);
+    }
+
+    /// An existing but unreadable security.jsonl must not look like "Protection
+    /// active" (SBS-873).
+    #[test]
+    fn read_recent_unreadable_existing_path_is_err() {
+        let _lock = crate::registry::data_dir_test_lock();
+        let _dir = TestDataDir::new("read-recent-unreadable");
+        let path = security_path().expect("security path under override");
+        std::fs::create_dir_all(&path).unwrap();
+        let err = read_recent(10).expect_err("unreadable existing path must be Err");
+        assert_ne!(err.kind(), std::io::ErrorKind::NotFound);
     }
 }

--- a/src-tauri/src/metrics.rs
+++ b/src-tauri/src/metrics.rs
@@ -14,20 +14,21 @@ pub fn metrics_enabled() -> bool {
 }
 
 /// Prometheus text exposition of current local stats.
-pub fn render() -> String {
-    let entries = match crate::audit::read_all() {
-        Ok(entries) => entries,
-        Err(error) => return format!("# Toolport metrics unavailable: {error}\n"),
-    };
+///
+/// `Err` when a local stat file exists but cannot be read. The caller answers
+/// non-200 so the scrape fails loudly (`up` goes 0) instead of serving a body
+/// that is indistinguishable from an idle instance with every series missing
+/// (SBS-873). Same contract as the desktop readers: a missing file is empty,
+/// an unreadable one is an error.
+pub fn render() -> Result<String, String> {
+    let entries =
+        crate::audit::read_all().map_err(|e| format!("couldn't read the activity log: {e}"))?;
     let tokens_saved = crate::savings::summary()
         .get("tokensSaved")
         .and_then(Value::as_u64)
         .unwrap_or(0);
-    let quarantined = match crate::integrity::all_quarantined() {
-        Ok(entries) => entries.len() as u64,
-        Err(error) => return format!("# Toolport metrics unavailable: {error}\n"),
-    };
-    render_from_parts(&entries, tokens_saved, quarantined)
+    let quarantined = crate::integrity::all_quarantined()?.len() as u64;
+    Ok(render_from_parts(&entries, tokens_saved, quarantined))
 }
 
 /// Pure renderer for tests (no disk).
@@ -186,5 +187,50 @@ mod tests {
         assert!(text.contains("toolport_tokens_saved_total 0"));
         assert!(text.contains("toolport_quarantined_tools 0"));
         assert!(!text.contains("toolport_tool_calls_total{"));
+    }
+
+    /// Scratch data dir for the disk-backed `render()` cases.
+    fn scratch_data_dir(label: &str) -> std::path::PathBuf {
+        let path = std::env::temp_dir().join(format!(
+            "toolport-metrics-{label}-{}-{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        let _ = std::fs::remove_dir_all(&path);
+        std::fs::create_dir_all(&path).expect("scratch data dir");
+        path
+    }
+
+    /// A missing audit.jsonl is a real idle instance: render the gauges and
+    /// answer 200, exactly like an empty log.
+    #[test]
+    fn missing_audit_log_renders_an_idle_instance() {
+        let _lock = crate::registry::data_dir_test_lock();
+        let dir = scratch_data_dir("missing");
+        let _override = crate::registry::DataDirOverride::set(&dir);
+        let text = render().expect("a missing log is an idle instance, not a scrape failure");
+        assert!(text.contains("toolport_tokens_saved_total"));
+        assert!(text.contains("toolport_quarantined_tools"));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// An existing but unreadable audit.jsonl must be a FAILED scrape, not a
+    /// 200 whose body is indistinguishable from `render_from_parts(&[], 0, 0)`
+    /// (SBS-873). Otherwise a persistent permission error reads as an idle
+    /// instance while Prometheus `up` stays 1.
+    #[test]
+    fn unreadable_audit_log_fails_the_scrape() {
+        let _lock = crate::registry::data_dir_test_lock();
+        let dir = scratch_data_dir("unreadable");
+        let _override = crate::registry::DataDirOverride::set(&dir);
+        let path = crate::audit::audit_path().expect("audit path under override");
+        // IsADirectory: the log path exists but cannot be read as a file.
+        std::fs::create_dir_all(&path).expect("unreadable log fixture");
+        let error = render().expect_err("an unreadable log must fail the scrape");
+        assert!(
+            error.contains("activity log"),
+            "the scrape error must name what failed: {error}"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/src-tauri/src/metrics.rs
+++ b/src-tauri/src/metrics.rs
@@ -15,7 +15,10 @@ pub fn metrics_enabled() -> bool {
 
 /// Prometheus text exposition of current local stats.
 pub fn render() -> String {
-    let entries = crate::audit::read_all();
+    let entries = match crate::audit::read_all() {
+        Ok(entries) => entries,
+        Err(error) => return format!("# Toolport metrics unavailable: {error}\n"),
+    };
     let tokens_saved = crate::savings::summary()
         .get("tokensSaved")
         .and_then(Value::as_u64)

--- a/src-tauri/src/searchtrace.rs
+++ b/src-tauri/src/searchtrace.rs
@@ -145,19 +145,26 @@ fn rotate_if_large(path: &Path) {
 }
 
 /// The most recent `limit` traces, newest first.
-pub fn read_recent(limit: usize) -> Vec<Value> {
+///
+/// A missing file is an empty trace log: nothing has searched yet. Any other
+/// IO error is returned so a caller cannot treat an unreadable existing file as
+/// "no traces" (SBS-873). Unparseable lines are skipped — a mid-write or
+/// corrupt line is not an IO failure.
+pub fn read_recent(limit: usize) -> std::io::Result<Vec<Value>> {
     let Some(path) = trace_path() else {
-        return Vec::new();
+        return Ok(Vec::new());
     };
-    let Ok(content) = std::fs::read_to_string(&path) else {
-        return Vec::new();
+    let content = match std::fs::read_to_string(&path) {
+        Ok(c) => c,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(e) => return Err(e),
     };
-    content
+    Ok(content
         .lines()
         .rev()
         .filter_map(|line| serde_json::from_str(line).ok())
         .take(limit)
-        .collect()
+        .collect())
 }
 
 /// Delete the trace log. Returns `Err` only on a real removal failure; a missing file
@@ -217,7 +224,7 @@ mod tests {
             &[],
             "lexical",
         );
-        let recent = read_recent(10);
+        let recent = read_recent(10).unwrap();
         assert_eq!(recent.len(), 2);
         // Newest first.
         assert_eq!(recent[0]["query"], "send email");
@@ -254,7 +261,8 @@ mod tests {
             &ranking,
             "semantic",
         );
-        let e = &read_recent(1)[0];
+        let recent = read_recent(1).unwrap();
+        let e = &recent[0];
         assert_eq!(e["mode"], "semantic");
         assert_eq!(e["fallbacks"], 30);
         let r = e["ranking"].as_array().unwrap();
@@ -279,7 +287,8 @@ mod tests {
             &[],
             "lexical",
         );
-        let e = &read_recent(1)[0];
+        let recent = read_recent(1).unwrap();
+        let e = &recent[0];
         assert_eq!(e["mode"], "lexical");
         assert!(e.get("ranking").is_none());
         clear();
@@ -306,10 +315,15 @@ mod tests {
             &[],
             "lexical",
         );
-        let e = &read_recent(1)[0];
+        let recent = read_recent(1).unwrap();
+        let e = &recent[0];
         let stored_q = e["query"].as_str().unwrap();
         // Capped to MAX_QUERY_CHARS (+ the ellipsis), never the full 500.
-        assert!(stored_q.chars().count() <= MAX_QUERY_CHARS + 1, "query not capped: {}", stored_q.chars().count());
+        assert!(
+            stored_q.chars().count() <= MAX_QUERY_CHARS + 1,
+            "query not capped: {}",
+            stored_q.chars().count()
+        );
         assert_eq!(e["names"].as_array().unwrap().len(), MAX_NAMES);
         clear();
     }
@@ -333,11 +347,65 @@ mod tests {
             &[],
             "lexical",
         );
-        let e = &read_recent(1)[0];
+        let recent = read_recent(1).unwrap();
+        let e = &recent[0];
         assert_eq!(e["returned"], 0);
         assert_eq!(e["top"], "");
         // A miss still shows what a full catalog would have cost.
         assert_eq!(e["flatTokens"], 5000);
         clear();
+    }
+
+    fn isolated_data_dir(label: &str) -> (crate::registry::DataDirOverride, PathBuf) {
+        let path = std::env::temp_dir().join(format!(
+            "toolport-searchtrace-read-{label}-{}-{}",
+            std::process::id(),
+            epoch_millis()
+        ));
+        let _ = std::fs::remove_dir_all(&path);
+        std::fs::create_dir_all(&path).expect("scratch data dir");
+        (crate::registry::DataDirOverride::set(&path), path)
+    }
+
+    /// A missing search-trace.jsonl is an empty trace log, not a load failure.
+    #[test]
+    fn read_recent_missing_file_is_ok_empty() {
+        let _lock = crate::registry::data_dir_test_lock();
+        let (_override, root) = isolated_data_dir("missing");
+        let path = trace_path().expect("trace path under override");
+        assert!(!path.exists(), "fixture must not create the log");
+        let entries = read_recent(10).expect("missing file is Ok empty");
+        assert!(entries.is_empty());
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    /// A readable JSONL returns newest-first parsed rows.
+    #[test]
+    fn read_recent_readable_jsonl_is_newest_first() {
+        let _lock = crate::registry::data_dir_test_lock();
+        let (_override, root) = isolated_data_dir("readable");
+        let path = trace_path().expect("trace path under override");
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        std::fs::write(&path, "{\"i\":1}\n{\"i\":2}\n").unwrap();
+        let entries = read_recent(10).expect("readable fixture");
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0]["i"], 2);
+        assert_eq!(entries[1]["i"], 1);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    /// An existing but unreadable search-trace.jsonl must not look like "no
+    /// traces" (SBS-873).
+    #[test]
+    fn read_recent_unreadable_existing_path_is_err() {
+        let _lock = crate::registry::data_dir_test_lock();
+        let (_override, root) = isolated_data_dir("unreadable");
+        let path = trace_path().expect("trace path under override");
+        std::fs::create_dir_all(&path).unwrap();
+        let err = read_recent(10).expect_err("unreadable existing path must be Err");
+        assert_ne!(err.kind(), std::io::ErrorKind::NotFound);
+        let _ = std::fs::remove_dir_all(root);
     }
 }

--- a/src-tauri/src/teams.rs
+++ b/src-tauri/src/teams.rs
@@ -804,7 +804,11 @@ fn report_usage(conn: &TeamConnection, token: &str) {
     if team_servers.is_empty() {
         return;
     }
-    let audit_lines = crate::audit::read_recent(usize::MAX);
+    // An unreadable audit log is not "zero usage". Skip this cycle rather than
+    // POST a false empty report (SBS-873).
+    let Ok(audit_lines) = crate::audit::read_recent(usize::MAX) else {
+        return;
+    };
     let savings_lines = crate::savings::entries();
     let mut new_state: HashMap<String, HashMap<String, [u64; 2]>> = HashMap::new();
     let mut changed = false;
@@ -1158,7 +1162,11 @@ fn report_call_events(conn: &TeamConnection, token: &str) {
     if !enabled {
         return;
     }
-    let lines = crate::audit::read_recent(usize::MAX);
+    // An unreadable audit log is not "no new calls". Skip this cycle rather
+    // than POST an empty batch that would advance nothing honestly (SBS-873).
+    let Ok(lines) = crate::audit::read_recent(usize::MAX) else {
+        return;
+    };
     let mut batch: Vec<Value> = Vec::new();
     let mut max_ts = cursor;
     for line in &lines {

--- a/src-tauri/tests/repro_audit_read_recent_corrupt.rs
+++ b/src-tauri/tests/repro_audit_read_recent_corrupt.rs
@@ -40,7 +40,7 @@ not json
     )
     .expect("write fixture audit log");
 
-    let recent = read_recent(3);
+    let recent = read_recent(3).unwrap();
     assert_eq!(
         recent.len(),
         3,
@@ -73,13 +73,13 @@ fn a_fully_valid_log_is_unchanged() {
     )
     .expect("write fixture audit log");
 
-    let recent = read_recent(2);
+    let recent = read_recent(2).unwrap();
     assert_eq!(recent.len(), 2);
     assert_eq!(recent[0].get("i").and_then(|v| v.as_u64()), Some(3));
     assert_eq!(recent[1].get("i").and_then(|v| v.as_u64()), Some(2));
 
     // A limit past the end returns everything, newest first.
-    let all = read_recent(99);
+    let all = read_recent(99).unwrap();
     assert_eq!(all.len(), 3);
     assert_eq!(all[0].get("i").and_then(|v| v.as_u64()), Some(3));
 


### PR DESCRIPTION
## Linear

https://linear.app/southboundsoftware/issue/SBS-873/toolport-activity-log-reads-swallow-io-errors-as-empty-so-a-failed

## What a user who hits this now sees

Activity already modeled `LoadStatus` error/stale and retry (GH-728 / SBS-719). Production commands never rejected on file IO, so that catch could not fire.

A user whose `audit.jsonl` or `security.jsonl` exists but is unreadable now sees the existing **Couldn't load activity** / **Couldn't verify protection status** error with Retry — not **No tool calls yet** / **Protection active**.

A missing file is still empty. That is honest: nothing has been written yet.

This PR does not rewrite Activity `LoadStatus` and does not change GH-728 panels.

## What changed

- `audit::read_recent`, `audit::read_all`, `inspect::read_recent`, `searchtrace::read_recent`, and `integrity::read_recent` return `io::Result<Vec<Value>>`.
- No path or `NotFound` → `Ok(vec![])`.
- Any other IO error → `Err`.
- Unparseable JSONL lines are still skipped. A mid-write is not an IO failure. Comments cite SBS-873.
- Tauri `get_audit_log`, `get_security_events`, `get_inspect_log`, and `get_search_traces` return `Result` so invoke rejects. Join failure is `Err`, not empty.
- `export_audit_to_path` propagates a read error instead of writing an empty export.
- `teams.rs` `report_usage` and `report_call_events` skip the cycle on IO error. They never `unwrap_or_default` and POST zero.
- `metrics::render` reports unavailable on an unreadable audit log, matching the existing quarantine-read pattern.
- Existing `read_recent` fixture tests unwrap the `Result`.

## Files changed

- `src-tauri/src/audit.rs`
- `src-tauri/src/inspect.rs`
- `src-tauri/src/searchtrace.rs`
- `src-tauri/src/integrity.rs`
- `src-tauri/src/desktop.rs`
- `src-tauri/src/teams.rs`
- `src-tauri/src/metrics.rs`
- `src-tauri/tests/repro_audit_read_recent_corrupt.rs`
- `CHANGELOG.md` (Unreleased Fixed)

## Sweep: swallow-IO-as-empty log reads

Grep was `read_to_string` / `Err(_) => return Vec::new()` / `unwrap_or_default` on log readers.

**Fixed in this PR**

- Four `read_recent` + `audit::read_all`
- Four Tauri getters + join `unwrap_or_default`
- `export_audit_to_path`
- `teams.rs` usage and call-event reporters
- `metrics::render` (compile-driven; same fail-closed shape as quarantine)

**Listed, not fixed**

- `savings::entries` still maps `read_to_string` `Err` to empty. Team usage still rolls savings as zero if only the savings file is unreadable. Distinct log (`savings.jsonl`), not the Activity Protection-active lie.
- `audit_stats` / `savings_summary` still `unwrap_or(Null)` on join (and `audit_stats` now also Nulls a stats IO error). Frontend already `.catch`s these to `null` and hides the panel. Not LoadStatus. Not GH-728 panels.
- **GH-728 / SBS-719**: frontend rejected-promise catch. Already Done. Commands now reject so that catch can fire. Did not rewrite the panels.
- **GH-733**: `gateway_log_tail` still treats any non-success read of `gateway.log` as `(no gateway log yet…)`. Different file, different command. Not this hole.
- **SBS-869**: `gateway.log` trim uses truncating `fs::write`. Concurrent empty/lost lines. Not this hole.
- Rotation / ring-trim best-effort reads (`audit::rotate_if_large`, `inspect::ring_trim`, `searchtrace::rotate_if_large`, `integrity::rotate_if_large`): write-path, failure must not drop the call being logged. Not a dashboard empty-healthy lie.

## Rule 6: fail without the fix

Reverted only the four production `read_recent` Err-to-empty arms (`Err(_) => return Ok(Vec::new())`), kept the new tests, ran:

```
cargo test --manifest-path src-tauri/Cargo.toml --lib --no-default-features \
  read_recent_unreadable_existing_path_is_err -- --test-threads=1 --nocapture
```

```
running 4 tests
test audit::tests::read_recent_unreadable_existing_path_is_err ...
thread 'audit::tests::read_recent_unreadable_existing_path_is_err' panicked at src/audit.rs:
unreadable existing path must be Err: []
FAILED
test inspect::tests::read_recent_unreadable_existing_path_is_err ...
thread 'inspect::tests::read_recent_unreadable_existing_path_is_err' panicked at src/inspect.rs:
unreadable existing path must be Err: []
FAILED
test integrity::tests::read_recent_unreadable_existing_path_is_err ...
thread 'integrity::tests::read_recent_unreadable_existing_path_is_err' panicked at src/integrity.rs:
unreadable existing path must be Err: []
FAILED
test searchtrace::tests::read_recent_unreadable_existing_path_is_err ...
thread 'searchtrace::tests::read_recent_unreadable_existing_path_is_err' panicked at src/searchtrace.rs:
unreadable existing path must be Err: []
FAILED

failures:
    audit::tests::read_recent_unreadable_existing_path_is_err
    inspect::tests::read_recent_unreadable_existing_path_is_err
    integrity::tests::read_recent_unreadable_existing_path_is_err
    searchtrace::tests::read_recent_unreadable_existing_path_is_err

test result: FAILED. 0 passed; 4 failed; 0 ignored; 0 measured; 1015 filtered out
```

Restored the Err arms. Same four tests: ok.

The unreadable fixture is `create_dir_all` on the log filename (`IsADirectory`). Missing-file tests still `Ok` empty. Readable JSONL tests still newest-first.

## CI (this worktree, `.github/workflows/ci.yml`)

| Check | Result |
| --- | --- |
| `cargo clippy --no-default-features --lib --bins` | pass (pre-existing warnings only) |
| `npm run format:check` (prettier) | pass |
| `npm run lint` | pass (0 errors, 49 pre-existing warnings) |
| `npm run build` | pass |
| `npm run test` | pass (37 files, 382 tests) |
| `npm run test:rust` (default features, lib+bins+tests) | **could not finish**: linking `toolport-gateway` with WebKitGTK died with `ld terminated with signal 7 [Bus error]` on this box. Headers are present (`webkit2gtk-4.1`). Not a source compile error. |
| `cargo test --no-default-features --lib --bins --tests` | pass. New names ran: `audit/inspect/integrity/searchtrace::tests::read_recent_{missing_file_is_ok_empty,readable_jsonl_is_newest_first,unreadable_existing_path_is_err}` |

No tauri bundle. No docs/audit commit. No merge.

## Rule 9: what this makes more likely

- Activity polls now reject more often. The existing stale path must keep last-known rows (it already does: `setAuditLoadStatus` / `setSecurityLoadStatus` go to `stale` after a successful read). A first-read failure stays `error`, not empty healthy.
- Export fails instead of writing an empty file that looks like a successful empty log.
- Teams skips a usage / call-events cycle on audit IO error instead of POSTing zero. A later successful cycle reports the real counts. The cursor is not advanced on a failed read.

## Distinct issues (cite, do not refile)

- GH-728 / SBS-719: frontend catch. Done. Necessary but not sufficient; this PR makes the commands reject.
- GH-733: `gateway_log_tail` empty lie on `gateway.log`. Different file and command.

## Gaps

- `savings::entries` still swallows IO as empty.
- `audit_stats` / `savings_summary` still Null on join / stats IO.
- Rotation best-effort reads left as write-path.
- GH-733 not implemented.
- Desktop default-features rust suite did not complete here because the WebKit-linked `toolport-gateway` link died with a bus error.
- Did not close or merge Linear SBS-873.

**Not merged.**

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Tauri commands to surface errors when activity/security/inspect/search-trace logs are unreadable
> - `read_recent` and `read_all` in audit, inspect, integrity, and searchtrace modules now return `Result`, distinguishing between a missing file (returns empty) and an unreadable file (returns `Err`).
> - Tauri commands (`get_audit_log`, `audit_stats`, `get_security_events`, `get_inspect_log`, `get_search_traces`, `export_audit_to_path`) now reject with a descriptive error string instead of silently returning empty data when log files are unreadable.
> - `metrics.render` returns `Err` on unreadable stat files; the `/metrics` HTTP route now returns 500 in that case instead of 200 with empty series.
> - Teams usage reporting skips a cycle when the audit log is unreadable instead of posting an empty report.
> - Behavioral Change: previously unreadable logs appeared as empty data to callers; they now receive explicit errors, which may surface in the UI where empty results were shown before.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 11cc27c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->