### PR TITLE
docs(security): stop claiming unauthenticated loopback HTTP binds are allowed (SBS-878)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ Entries before the rename below shipped under the project's former name, Conduit
 
 ### Fixed
 
+- **SECURITY.md now matches the HTTP bind admission policy.** A hand-launched
+  loopback gateway without a token does not bind; it exits 1 unless
+  `--insecure-loopback` is passed. Non-loopback still requires a token or
+  registered HTTP client. (SBS-878)
 - **Linux `.deb` installs a `toolport` command.** The package still ships the
   crate binary as `conduit` (compat alias) and now also puts `toolport` on
   `PATH`, matching the AppImage installer and the brand. `install.sh` tells apt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,10 +18,13 @@ Entries before the rename below shipped under the project's former name, Conduit
 
 ### Fixed
 
-- **SECURITY.md now matches the HTTP bind admission policy.** A hand-launched
-  loopback gateway without a token does not bind; it exits 1 unless
-  `--insecure-loopback` is passed. Non-loopback still requires a token or
-  registered HTTP client. (SBS-878)
+- **SECURITY.md now matches the HTTP bind admission policy.** Every bind, loopback
+  or not, needs HTTP authentication: a bearer token, or at least one registered
+  HTTP client in `registry.json`. A hand-launched loopback gateway with neither
+  does not bind; it exits 1 unless `--insecure-loopback` is passed, and that flag
+  opens an unauthenticated listener only while no token is set and no HTTP clients
+  are registered. SECURITY.md also now explains what a registered HTTP client is
+  and how the desktop app creates one. (SBS-878)
 - **Linux `.deb` installs a `toolport` command.** The package still ships the
   crate binary as `conduit` (compat alias) and now also puts `toolport` on
   `PATH`, matching the AppImage installer and the brand. `install.sh` tells apt

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -34,14 +34,25 @@ manager around it. What network surface exists depends on the mode you run:
 - **Local HTTP / OpenAPI bridge (`TOOLPORT_HTTP`, legacy `CONDUIT_HTTP`).** For clients that speak HTTP
   or OpenAPI instead of stdio, the gateway can bind a listener. It defaults to
   `127.0.0.1:8765` (loopback only), configurable with `TOOLPORT_HTTP_HOST` and the
-  port. Every bind requires a bearer token (`TOOLPORT_HTTP_TOKEN`; legacy
-  `CONDUIT_HTTP_TOKEN` still accepted) or a registered HTTP client. Without one the
-  process prints a line to stderr and exits 1, including a hand-launched
-  loopback listener. When the desktop app starts this bridge it auto-generates a
-  token. A request without a valid token gets `401`, and any cross-site browser
-  request is rejected with `403` regardless of token. For isolated local
-  development only, `--insecure-loopback` explicitly permits an unauthenticated
-  loopback listener; it never permits an open non-loopback bind.
+  port. Every bind requires HTTP authentication: either a bearer token
+  (`TOOLPORT_HTTP_TOKEN`; legacy `CONDUIT_HTTP_TOKEN` still accepted) or at least
+  one registered HTTP client. With neither, the process prints a line to stderr
+  and exits 1, including a hand-launched loopback listener. A **registered HTTP
+  client** is a scoped bearer you create in the desktop app under Settings,
+  "Open WebUI / HTTP endpoint", "Scoped clients": each entry gets its own token
+  and its own set of servers, and the app stores only the token's SHA-256 in the
+  `http_clients` list in `registry.json` in Toolport's local data directory (the
+  plaintext token is shown once, at creation, and is not stored). One or more of
+  those entries counts as authentication configured, exactly like an env token.
+  When the desktop app starts this bridge it auto-generates a token. A request
+  without a valid token gets `401`, and any cross-site browser request is
+  rejected with `403` regardless of token. For isolated local development only,
+  `--insecure-loopback` permits an unauthenticated loopback listener, but only
+  when no token is set **and** `http_clients` is empty. Registered clients left
+  over from earlier use keep the bind authenticated, so the listener still
+  answers `401` to every request without a matching bearer; revoke those entries
+  first if you want the open listener. The flag never permits an open
+  non-loopback bind.
 - **Headless / Docker.** The published image runs the HTTP bridge and sets
   `TOOLPORT_HTTP_HOST=0.0.0.0` so it is reachable off-host. Every bind, including
   loopback, **requires** `TOOLPORT_HTTP_TOKEN` (legacy `CONDUIT_HTTP_TOKEN`) or a
@@ -158,11 +169,14 @@ agent, and the governance controls above can gate a call, but a tool you approve
 still executes upstream.
 
 When you run Toolport outside the desktop app, some safety defaults become your
-responsibility: set `TOOLPORT_HTTP_TOKEN` (legacy `CONDUIT_HTTP_TOKEN`; required for
-every bind, including loopback, unless you pass `--insecure-loopback` for isolated
-local development), choose a high-entropy `TOOLPORT_SECRET_KEY` (legacy
-`CONDUIT_SECRET_KEY`) for the encrypted file backend, and put the HTTP bridge
-behind your own TLS.
+responsibility: configure HTTP authentication for every bind, including loopback,
+by setting `TOOLPORT_HTTP_TOKEN` (legacy `CONDUIT_HTTP_TOKEN`) or by registering an
+HTTP client in the desktop app (both are described under
+[How Toolport runs](#how-toolport-runs-and-where-the-boundaries-are) above), then
+choose a high-entropy `TOOLPORT_SECRET_KEY` (legacy `CONDUIT_SECRET_KEY`) for the
+encrypted file backend, and put the HTTP bridge behind your own TLS.
+`--insecure-loopback` waives the requirement for isolated local development only,
+and only while neither a token nor a registered client exists.
 
 ## Known issues
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -34,17 +34,21 @@ manager around it. What network surface exists depends on the mode you run:
 - **Local HTTP / OpenAPI bridge (`TOOLPORT_HTTP`, legacy `CONDUIT_HTTP`).** For clients that speak HTTP
   or OpenAPI instead of stdio, the gateway can bind a listener. It defaults to
   `127.0.0.1:8765` (loopback only), configurable with `TOOLPORT_HTTP_HOST` and the
-  port. When the desktop app starts this bridge it auto-generates a bearer token
-  (`TOOLPORT_HTTP_TOKEN`; legacy `CONDUIT_HTTP_TOKEN` still accepted); a request without a valid token gets `401`, and any
-  cross-site browser request is rejected with `403` regardless of token. A gateway
-  you launch by hand on loopback **without** a token binds anyway and is reachable
-  by any local process, so set a token if other local users or processes are not
-  trusted.
+  port. Every bind requires a bearer token (`TOOLPORT_HTTP_TOKEN`; legacy
+  `CONDUIT_HTTP_TOKEN` still accepted) or a registered HTTP client. Without one the
+  process prints a line to stderr and exits 1, including a hand-launched
+  loopback listener. When the desktop app starts this bridge it auto-generates a
+  token. A request without a valid token gets `401`, and any cross-site browser
+  request is rejected with `403` regardless of token. For isolated local
+  development only, `--insecure-loopback` explicitly permits an unauthenticated
+  loopback listener; it never permits an open non-loopback bind.
 - **Headless / Docker.** The published image runs the HTTP bridge and sets
-  `TOOLPORT_HTTP_HOST=0.0.0.0` so it is reachable off-host. Binding to a
-  non-loopback address **requires** `TOOLPORT_HTTP_TOKEN` (legacy `CONDUIT_HTTP_TOKEN`): without one the gateway
-  refuses to start. Put it behind your own TLS/ingress; the gateway serves plain
-  HTTP and expects the operator to terminate TLS.
+  `TOOLPORT_HTTP_HOST=0.0.0.0` so it is reachable off-host. Every bind, including
+  loopback, **requires** `TOOLPORT_HTTP_TOKEN` (legacy `CONDUIT_HTTP_TOKEN`) or a
+  registered HTTP client: without one the gateway refuses to start.
+  `--insecure-loopback` cannot open a non-loopback address. Put it behind your
+  own TLS/ingress; the gateway serves plain HTTP and expects the operator to
+  terminate TLS.
 - **Sharing and Teams (opt-in, hosted).** These make explicit, user-initiated
   requests to hosted services and are covered under
   [Telemetry and hosted services](#telemetry-and-hosted-services) below.
@@ -154,9 +158,11 @@ agent, and the governance controls above can gate a call, but a tool you approve
 still executes upstream.
 
 When you run Toolport outside the desktop app, some safety defaults become your
-responsibility: set `TOOLPORT_HTTP_TOKEN` (legacy `CONDUIT_HTTP_TOKEN`; required for any non-loopback bind),
-choose a high-entropy `TOOLPORT_SECRET_KEY` (legacy `CONDUIT_SECRET_KEY`) for the encrypted file backend, and put
-the HTTP bridge behind your own TLS.
+responsibility: set `TOOLPORT_HTTP_TOKEN` (legacy `CONDUIT_HTTP_TOKEN`; required for
+every bind, including loopback, unless you pass `--insecure-loopback` for isolated
+local development), choose a high-entropy `TOOLPORT_SECRET_KEY` (legacy
+`CONDUIT_SECRET_KEY`) for the encrypted file backend, and put the HTTP bridge
+behind your own TLS.
 
 ## Known issues
 


### PR DESCRIPTION
## Summary

- Linear SBS-878: SECURITY.md still told operators that a hand-launched loopback gateway without a token binds anyway. The gateway refuses that bind in serve_http. A reader following the security policy page would expect a listener and get exit 1.
- Docs now match the live admission policy: every bind needs TOOLPORT_HTTP_TOKEN (legacy CONDUIT_HTTP_TOKEN) or a registered HTTP client; loopback without those exits 1 unless the insecure-loopback flag is passed; that flag never opens a non-loopback address.
- A user who hits this now reads the same rule README and docs/headless.md already had, so a hand launch without a token is an expected refuse rather than a surprise.

## Files

- SECURITY.md: HTTP bridge, Headless/Docker, and operator-responsibility paragraphs.
- CHANGELOG.md: Unreleased Fixed.

## Sweep

Searched SECURITY.md, README.md, CHANGELOG.md, CONTRIBUTING.md, docs/headless.md, docs/openwebui.md for binds anyway, insecure-loopback, insecure-open, unauthenticated loopback, required for any non-loopback.

Hits after the edit:
- SECURITY.md: current policy only.
- README.md lines 276-278: already correct; left alone.
- docs/headless.md lines 206, 273, 301: already correct; left alone.
- docs/openwebui.md line 55: already correct; left alone.
- CHANGELOG.md historical notes for insecure-open and an older non-loopback refuse: past-version notes, not current policy. Left alone.

Also searched other docs (RELEASING, ROADMAP, SIGNING, grouped-discovery, macos-keychain-test-runbook, windows-msix-virtualization, cloudflare-comparison-claim-matrix) plus docker-compose.example.yml, Dockerfile, Dockerfile.source, CONTRIBUTING.md, BENCHMARK.md: no stale binds-anyway or required-for-any-non-loopback claims.

## Verified (not assumed)

Installed gateway 1.13.0, empty data dir, tokens unset, no registered HTTP clients:
- loopback HTTP without a token: refused 127.0.0.1, mentioned the insecure-loopback flag, exit 1
- non-loopback without a token: refused, said the flag is valid only for loopback, exit 1
- non-loopback with the insecure-loopback flag: same refuse, exit 1

Unit tests already pin http_bind_requires_auth_except_for_explicit_loopback_escape_hatch. This PR does not change Rust. The old insecure-open flag is not accepted.

## What this makes more likely

Operators who used to follow SECURITY.md and launch an open loopback listener will now set a token or pass the documented escape-hatch flag. That is the intended fail-closed default. The escape hatch is still documented. No runtime path changed.
## Tests

Docs-only. Prettier passed on SECURITY.md and CHANGELOG.md. Cargo was not run.

## Gaps

Docs-only change. Refuse path was checked against current serve_http on origin/main. Not merged.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix SECURITY.md to reflect that all HTTP binds require authentication
> - Updates [SECURITY.md](https://github.com/tsouth89/toolport/pull/767/files#diff-f6ed156e4bf5c791680662464b94ea5d753f219ee816b385f67870e2c0d7d4c7) to remove the claim that unauthenticated loopback HTTP binds are permitted; every bind now requires a bearer token or at least one registered HTTP client in `registry.json`.
> - Documents `--insecure-loopback` behavior: it only permits an unauthenticated loopback listener when no token is set and `http_clients` is empty, and cannot open non-loopback addresses.
> - Adds explanation of registered HTTP clients, how the desktop app creates scoped clients and tokens, and that only token hashes are stored.
> - Updates [CHANGELOG.md](https://github.com/tsouth89/toolport/pull/767/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed) with a Fixed entry covering the corrected policy.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b8b7838.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->