### PR TITLE
Show an error when opening the data folder fails

### DIFF
--- a/src/components/AppSidebar.test.tsx
+++ b/src/components/AppSidebar.test.tsx
@@ -13,6 +13,7 @@ const checkForUpdate = vi.fn();
 const installUpdate = vi.fn();
 const toastInfo = vi.fn();
 const toastError = vi.fn();
+const openDataDir = vi.fn();
 const eventListeners = new Map<string, (event: { payload: unknown }) => void>();
 
 vi.mock("sonner", () => ({
@@ -30,7 +31,7 @@ vi.mock("@/lib/api", () => ({
   gatherDiagnostics: vi.fn(),
   getSavingsSummary: (...args: unknown[]) => getSavingsSummary(...args),
   listQuarantined: (...args: unknown[]) => listQuarantined(...args),
-  openDataDir: vi.fn(),
+  openDataDir: (...args: unknown[]) => openDataDir(...args),
 }));
 
 vi.mock("@tauri-apps/api/app", () => ({
@@ -77,6 +78,7 @@ beforeEach(() => {
   installUpdate.mockReset();
   toastInfo.mockReset();
   toastError.mockReset();
+  openDataDir.mockReset();
   eventListeners.clear();
   checkForUpdate.mockResolvedValue({ kind: "current" });
   getSavingsSummary.mockResolvedValue({
@@ -486,5 +488,33 @@ describe("AppSidebar quarantine badge", () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+});
+
+describe("AppSidebar open data folder", () => {
+  it("shows an error toast when opening the data folder fails", async () => {
+    openDataDir.mockRejectedValue(new Error("no such directory"));
+    const user = userEvent.setup();
+
+    render(
+      <TooltipProvider>
+        <AppSidebar
+          clients={[client()]}
+          registry={null}
+          onRegistryChange={vi.fn()}
+          selectedClientId={null}
+          onSelectClient={vi.fn()}
+          view="servers"
+          onSelectView={vi.fn()}
+          onReplayOnboarding={vi.fn()}
+        />
+      </TooltipProvider>,
+    );
+
+    await user.click(await screen.findByLabelText("Open data folder"));
+
+    await waitFor(() => {
+      expect(toastError).toHaveBeenCalledWith("Couldn't open data folder");
+    });
   });
 });

--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -271,7 +271,9 @@ function VersionFooter({
           <Compass className="size-3.5" />
         </button>
         <button
-          onClick={() => openDataDir().catch(() => {})}
+          onClick={() =>
+            openDataDir().catch(() => toastError("Couldn't open data folder"))
+          }
           title="Open data folder (config, logs)"
           aria-label="Open data folder"
           className={ICON_BTN}


### PR DESCRIPTION
## Summary

Show the existing error toast when opening the data folder fails instead of silently ignoring the error.

## Testing

- added regression coverage for a rejected `openDataDir` call
- relevant tests pass

Closes #729


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show an error toast when opening the data folder fails
> The `openDataDir` call in [AppSidebar.tsx](https://github.com/tsouth89/toolport/pull/768/files#diff-c20ed4ea1b04ac9d0cf52f7091af6d6acb852144b5e36ed7c496ac1afe8e03f0) previously swallowed rejections silently. Now, if `openDataDir` rejects, a `toastError("Couldn't open data folder")` is shown to the user. A test covering this error path is added in [AppSidebar.test.tsx](https://github.com/tsouth89/toolport/pull/768/files#diff-97d9f664f02c2fa61337de6ccfb3f0ad1371cd8ce76592284eafdbdbb0a221ec).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9c15b22.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->