### PR TITLE
fix(settings): do not treat a failed routine-suggestion load as an empty queue (SBS-879)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ Entries before the rename below shipped under the project's former name, Conduit
 
 ### Fixed
 
+- **Failed routine-suggestion load no longer hides the save queue.** Settings treated
+  an unreachable `list_routine_suggestions` as "nothing pending" and hid the section,
+  including wiping cards already on screen when a later refresh failed. A failed load
+  is now its own state: empty after a successful read still hides; error shows retry
+  and keeps the last loaded queue. (SBS-879)
 - **Linux `.deb` installs a `toolport` command.** The package still ships the
   crate binary as `conduit` (compat alias) and now also puts `toolport` on
   `PATH`, matching the AppImage installer and the brand. `install.sh` tells apt

--- a/src/components/SettingsView.test.tsx
+++ b/src/components/SettingsView.test.tsx
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { render, screen, waitFor, within } from "@testing-library/react";
+import { act, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import { ThemeProvider } from "@/lib/theme";
@@ -395,6 +395,116 @@ describe("SettingsView routine suggestions", () => {
     expect(screen.getByText("Suggested routines")).toBeInTheDocument();
     expect(screen.getByText("Calls: 3")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /save routine/i })).toBeInTheDocument();
+  });
+
+  it("ignores a stale failure that settles after a newer success (SBS-879)", async () => {
+    const handlers: Array<() => void> = [];
+    mockedListen.mockImplementation(async (event, handler) => {
+      if (event === "routine-suggestion") {
+        handlers.push(() => {
+          (handler as (event: unknown) => void)({});
+        });
+      }
+      return () => {};
+    });
+    // The mount list hangs; an event starts a later list that succeeds first.
+    const mountRequest = deferred<RoutineSuggestion[]>();
+    mockedListRoutineSuggestions
+      .mockReturnValueOnce(mountRequest.promise)
+      .mockResolvedValueOnce([suggestion]);
+
+    renderSettings();
+    await waitFor(() => expect(handlers.length).toBeGreaterThan(0));
+
+    handlers[0]();
+    expect(await screen.findByText("Suggested routines")).toBeInTheDocument();
+
+    mountRequest.reject(new Error("backend down"));
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(screen.getByText("Suggested routines")).toBeInTheDocument();
+    expect(screen.getByText("Calls: 3")).toBeInTheDocument();
+    expect(
+      screen.queryByText(/couldn't load suggested routines/i),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(/couldn't refresh suggested routines/i),
+    ).not.toBeInTheDocument();
+  });
+
+  it("drops a saved card even when the follow-up refresh fails (SBS-879)", async () => {
+    const user = userEvent.setup();
+    mockedListRoutineSuggestions
+      .mockResolvedValueOnce([suggestion])
+      .mockRejectedValueOnce(new Error("backend down"));
+    mockedApproveRoutineSuggestion.mockResolvedValueOnce({});
+
+    renderSettings();
+
+    expect(await screen.findByText("Suggested routines")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: /save routine/i }));
+
+    expect(mockedApproveRoutineSuggestion).toHaveBeenCalledWith(
+      "sha256:fp1",
+      "batch-deepwiki-ask-question",
+    );
+    // The broker already consumed the fingerprint, so the card must not survive the
+    // failed refresh with Save still armed.
+    await waitFor(() =>
+      expect(
+        screen.queryByRole("button", { name: /save routine/i }),
+      ).not.toBeInTheDocument(),
+    );
+    expect(screen.queryByText("Suggested routines")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(/couldn't load suggested routines/i),
+    ).not.toBeInTheDocument();
+  });
+
+  it("drops a dismissed card even when the follow-up refresh fails (SBS-879)", async () => {
+    const user = userEvent.setup();
+    mockedListRoutineSuggestions
+      .mockResolvedValueOnce([suggestion])
+      .mockRejectedValueOnce(new Error("backend down"));
+    mockedDismissRoutineSuggestion.mockResolvedValueOnce(undefined);
+
+    renderSettings();
+
+    await screen.findByText("Suggested routines");
+    await user.click(screen.getByRole("button", { name: /dismiss/i }));
+
+    expect(mockedDismissRoutineSuggestion).toHaveBeenCalledWith("sha256:fp1");
+    await waitFor(() =>
+      expect(screen.queryByText("Suggested routines")).not.toBeInTheDocument(),
+    );
+    expect(
+      screen.queryByText(/couldn't load suggested routines/i),
+    ).not.toBeInTheDocument();
+  });
+
+  it("disables Retry while a load is in flight (SBS-879)", async () => {
+    const user = userEvent.setup();
+    const retryRequest = deferred<RoutineSuggestion[]>();
+    mockedListRoutineSuggestions
+      .mockRejectedValueOnce(new Error("backend down"))
+      .mockReturnValueOnce(retryRequest.promise);
+
+    renderSettings();
+
+    const error = await screen.findByText(/couldn't load suggested routines/i);
+    const row = error.closest("div")!;
+    await user.click(within(row).getByRole("button", { name: /retry/i }));
+    expect(mockedListRoutineSuggestions).toHaveBeenCalledTimes(2);
+
+    const retry = within(row).getByRole("button", { name: /retry/i });
+    expect(retry).toBeDisabled();
+    await user.click(retry);
+    expect(mockedListRoutineSuggestions).toHaveBeenCalledTimes(2);
+
+    retryRequest.resolve([suggestion]);
+    expect(await screen.findByText("Suggested routines")).toBeInTheDocument();
   });
 
   it("still hides the section after a successful empty read", async () => {

--- a/src/components/SettingsView.test.tsx
+++ b/src/components/SettingsView.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
@@ -35,6 +35,8 @@ vi.mock("@tauri-apps/api/event", () => ({
   listen: vi.fn().mockResolvedValue(() => {}),
 }));
 
+import { listen } from "@tauri-apps/api/event";
+
 const mockedListServerTools = vi.mocked(listServerTools);
 const mockedIsAutostartEnabled = vi.mocked(isAutostartEnabled);
 const mockedSetAllowRoutineWrites = vi.mocked(setAllowRoutineWrites);
@@ -42,6 +44,7 @@ const mockedSetCodeMode = vi.mocked(setCodeMode);
 const mockedListRoutineSuggestions = vi.mocked(listRoutineSuggestions);
 const mockedApproveRoutineSuggestion = vi.mocked(approveRoutineSuggestion);
 const mockedDismissRoutineSuggestion = vi.mocked(dismissRoutineSuggestion);
+const mockedListen = vi.mocked(listen);
 
 const registry: Registry = {
   version: 1,
@@ -269,6 +272,13 @@ describe("SettingsView routine writes", () => {
 });
 
 describe("SettingsView routine suggestions", () => {
+  beforeEach(() => {
+    mockedListen.mockReset();
+    mockedListen.mockResolvedValue(() => {});
+    mockedListRoutineSuggestions.mockReset();
+    mockedListRoutineSuggestions.mockResolvedValue([]);
+  });
+
   const suggestion: RoutineSuggestion = {
     suggestedName: "batch-deepwiki-ask-question",
     source:
@@ -333,6 +343,70 @@ describe("SettingsView routine suggestions", () => {
     await waitFor(() =>
       expect(screen.queryByText("Suggested routines")).not.toBeInTheDocument(),
     );
+  });
+
+  it("shows retry instead of hiding when the first load fails (SBS-879)", async () => {
+    const user = userEvent.setup();
+    mockedListRoutineSuggestions.mockRejectedValueOnce(new Error("backend down"));
+
+    renderSettings();
+
+    const error = await screen.findByText(/couldn't load suggested routines/i);
+    const row = error.closest("div");
+    expect(row).not.toBeNull();
+    expect(within(row!).getByRole("button", { name: /retry/i })).toBeInTheDocument();
+    expect(screen.queryByText("Suggested routines")).not.toBeInTheDocument();
+
+    mockedListRoutineSuggestions.mockResolvedValueOnce([suggestion]);
+    await user.click(within(row!).getByRole("button", { name: /retry/i }));
+
+    expect(await screen.findByText("Suggested routines")).toBeInTheDocument();
+    expect(screen.getByText("Calls: 3")).toBeInTheDocument();
+    expect(
+      screen.queryByText(/couldn't load suggested routines/i),
+    ).not.toBeInTheDocument();
+  });
+
+  it("keeps on-screen cards when a later refresh fails (SBS-879)", async () => {
+    const handlers: Array<() => void> = [];
+    mockedListen.mockImplementation(async (event, handler) => {
+      if (event === "routine-suggestion") {
+        handlers.push(() => {
+          (handler as (event: unknown) => void)({});
+        });
+      }
+      return () => {};
+    });
+    mockedListRoutineSuggestions
+      .mockResolvedValueOnce([suggestion])
+      .mockRejectedValueOnce(new Error("backend down"));
+
+    renderSettings();
+
+    expect(await screen.findByText("Suggested routines")).toBeInTheDocument();
+    expect(screen.getByText("Calls: 3")).toBeInTheDocument();
+    await waitFor(() => expect(handlers.length).toBeGreaterThan(0));
+
+    handlers[0]();
+
+    expect(
+      await screen.findByText(/couldn't refresh suggested routines/i),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Suggested routines")).toBeInTheDocument();
+    expect(screen.getByText("Calls: 3")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /save routine/i })).toBeInTheDocument();
+  });
+
+  it("still hides the section after a successful empty read", async () => {
+    mockedListRoutineSuggestions.mockResolvedValueOnce([]);
+
+    renderSettings();
+
+    await waitFor(() => expect(mockedListRoutineSuggestions).toHaveBeenCalled());
+    expect(screen.queryByText("Suggested routines")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(/couldn't load suggested routines/i),
+    ).not.toBeInTheDocument();
   });
 });
 

--- a/src/components/SettingsView.tsx
+++ b/src/components/SettingsView.tsx
@@ -95,16 +95,50 @@ function RoutineSuggestions() {
   const [names, setNames] = useState<Record<string, string>>({});
   const [busy, setBusy] = useState<string | null>(null);
   // SBS-879: a failed invoke is not an empty queue. Keep last-known cards and
-  // surface retry; only a successful read of [] hides the section.
-  const [status, setStatus] = useState<"loading" | "ready" | "error">("loading");
+  // surface retry; only a successful read of [] hides the section. "error" is a load
+  // that never succeeded (nothing to show); "stale" is a failed refresh on top of a
+  // queue we already have (keep the cards, say the list may be out of date).
+  const [status, setStatus] = useState<"loading" | "ready" | "error" | "stale">(
+    "loading",
+  );
+  const [refreshing, setRefreshing] = useState(false);
+  // Mount, Retry and the "routine-suggestion" listener all call refresh(), so their
+  // invokes can overlap. Same latest-wins guard loadTools uses below: a slow failure
+  // must never overwrite a newer success (or vice versa).
+  const requestId = useRef(0);
 
   const refresh = useCallback(async () => {
+    const id = requestId.current + 1;
+    requestId.current = id;
+    setRefreshing(true);
     try {
-      setSuggestions(await listRoutineSuggestions());
+      const next = await listRoutineSuggestions();
+      if (requestId.current !== id) return;
+      setSuggestions(next);
       setStatus("ready");
     } catch {
-      setStatus("error");
+      if (requestId.current !== id) return;
+      // Only a read that never succeeded is a hard error; anything after one is stale.
+      setStatus((prev) => (prev === "ready" || prev === "stale" ? "stale" : "error"));
+    } finally {
+      if (requestId.current === id) setRefreshing(false);
     }
+  }, []);
+
+  /** Drop a suggestion the broker already consumed. Refreshing alone is not enough:
+   * if the follow-up list fails we keep the previous queue, which would leave a ghost
+   * card whose Save now fails with "no queued suggestion with that fingerprint". */
+  const forget = useCallback((fingerprint: string) => {
+    // Discard any list started before the broker dropped this fingerprint; it would
+    // resurrect the card. The refresh that follows this call carries the newer id.
+    requestId.current += 1;
+    setSuggestions((prev) => prev.filter((s) => s.definitionFingerprint !== fingerprint));
+    setNames((prev) => {
+      if (!(fingerprint in prev)) return prev;
+      const next = { ...prev };
+      delete next[fingerprint];
+      return next;
+    });
   }, []);
 
   useEffect(() => {
@@ -127,6 +161,7 @@ function RoutineSuggestions() {
         fingerprint,
         names[fingerprint]?.trim() || suggestion.suggestedName,
       );
+      forget(fingerprint);
       await refresh();
     } catch (e) {
       toastError(`Couldn't save the routine: ${e}`);
@@ -139,6 +174,7 @@ function RoutineSuggestions() {
     setBusy(fingerprint);
     try {
       await dismissRoutineSuggestion(fingerprint);
+      forget(fingerprint);
       await refresh();
     } catch (e) {
       toastError(`Couldn't dismiss the suggestion: ${e}`);
@@ -148,8 +184,10 @@ function RoutineSuggestions() {
   }
 
   if (status === "loading") return null;
-  if (status === "ready" && suggestions.length === 0) return null;
-  if (status === "error" && suggestions.length === 0) {
+  if (suggestions.length === 0) {
+    // A successful empty read, or a queue we just drained ourselves, hides the section.
+    // Only a load that never succeeded has something to report.
+    if (status !== "error") return null;
     return (
       <div className="flex items-center gap-2 rounded-lg border border-border/60 bg-muted/20 p-3 text-xs text-muted-foreground">
         <Braces className="size-3.5 shrink-0 text-warning" />
@@ -158,6 +196,7 @@ function RoutineSuggestions() {
           size="sm"
           variant="ghost"
           className="ml-auto gap-1.5"
+          disabled={refreshing}
           onClick={() => void refresh()}
         >
           <RefreshCw className="size-3.5" />
@@ -178,7 +217,7 @@ function RoutineSuggestions() {
           repeated patterns Toolport verified; saving advertises them to every client
         </span>
       </div>
-      {status === "error" && (
+      {status === "stale" && (
         <div className="mt-2 flex items-center gap-2 text-xs text-muted-foreground">
           <span>
             Couldn&apos;t refresh suggested routines; showing the last loaded queue.
@@ -187,6 +226,7 @@ function RoutineSuggestions() {
             size="sm"
             variant="ghost"
             className="ml-auto gap-1.5"
+            disabled={refreshing}
             onClick={() => void refresh()}
           >
             <RefreshCw className="size-3.5" />

--- a/src/components/SettingsView.tsx
+++ b/src/components/SettingsView.tsx
@@ -94,13 +94,16 @@ function RoutineSuggestions() {
   const [suggestions, setSuggestions] = useState<RoutineSuggestion[]>([]);
   const [names, setNames] = useState<Record<string, string>>({});
   const [busy, setBusy] = useState<string | null>(null);
+  // SBS-879: a failed invoke is not an empty queue. Keep last-known cards and
+  // surface retry; only a successful read of [] hides the section.
+  const [status, setStatus] = useState<"loading" | "ready" | "error">("loading");
 
   const refresh = useCallback(async () => {
     try {
       setSuggestions(await listRoutineSuggestions());
+      setStatus("ready");
     } catch {
-      // An unreachable backend renders as an empty queue; the section hides itself.
-      setSuggestions([]);
+      setStatus("error");
     }
   }, []);
 
@@ -144,7 +147,25 @@ function RoutineSuggestions() {
     }
   }
 
-  if (suggestions.length === 0) return null;
+  if (status === "loading") return null;
+  if (status === "ready" && suggestions.length === 0) return null;
+  if (status === "error" && suggestions.length === 0) {
+    return (
+      <div className="flex items-center gap-2 rounded-lg border border-border/60 bg-muted/20 p-3 text-xs text-muted-foreground">
+        <Braces className="size-3.5 shrink-0 text-warning" />
+        <span>Couldn&apos;t load suggested routines.</span>
+        <Button
+          size="sm"
+          variant="ghost"
+          className="ml-auto gap-1.5"
+          onClick={() => void refresh()}
+        >
+          <RefreshCw className="size-3.5" />
+          Retry
+        </Button>
+      </div>
+    );
+  }
   return (
     <div className="rounded-lg border border-border/60 bg-muted/20 p-3">
       <div className="flex items-center gap-2 text-xs">
@@ -157,6 +178,22 @@ function RoutineSuggestions() {
           repeated patterns Toolport verified; saving advertises them to every client
         </span>
       </div>
+      {status === "error" && (
+        <div className="mt-2 flex items-center gap-2 text-xs text-muted-foreground">
+          <span>
+            Couldn&apos;t refresh suggested routines; showing the last loaded queue.
+          </span>
+          <Button
+            size="sm"
+            variant="ghost"
+            className="ml-auto gap-1.5"
+            onClick={() => void refresh()}
+          >
+            <RefreshCw className="size-3.5" />
+            Retry
+          </Button>
+        </div>
+      )}
       <ul className="mt-2 space-y-2">
         {suggestions.map((suggestion) => {
           const fingerprint = suggestion.definitionFingerprint;
@@ -1209,8 +1246,9 @@ export function SettingsView({ registry, onRegistryChange }: Props) {
             )
           : null}
         {/* Rendered independently of the writes toggle: a suggestion queued while
-            writes were on stays actionable (the user is the authority here), and the
-            section hides itself entirely when the queue is empty. */}
+            writes were on stays actionable (the user is the authority here). A
+            successful empty read hides the section; a failed load is a visible
+            error, not an empty queue (SBS-879). */}
         <RoutineSuggestions />
       </section>
       <section className="flex flex-col gap-2">


### PR DESCRIPTION
## Summary

- Settings `RoutineSuggestions` treated a failed `listRoutineSuggestions` invoke as an empty queue (`catch` set `[]`, then `length === 0` hid the section). A user with queued suggestions who hit an unreachable backend saw nothing — no cards, no error, no retry. A later failed refresh also wiped cards already on screen.
- Failed load is now its own state (`loading` / `ready` / `error`). A successful read of `[]` still hides. A failed first load shows an error + Retry. A failed refresh keeps the last loaded cards and says the list may be stale.
- A user who hits this now sees either the last known save queue plus retry, or a visible "Could not load suggested routines" row with Retry — not a blank Settings section that looks like nothing is pending.

Linear: https://linear.app/southboundsoftware/issue/SBS-879/toolport-a-failed-routine-suggestion-load-hides-the-save-queue-as-if

## Test plan

- format:check pass
- lint 0 errors
- build pass
- vitest 385 passed
- audit:prod 0 vulns
- cargo test lib+bins+tests 1441 passed 1 ignored
- smoke:headless not re-run (frontend-only)

### Fail without fix

Reverted only SettingsView.tsx to HEAD. Two SBS-879 tests failed (hidden section / wiped queue). Empty-success test passed either way. Restored fix; 13 SettingsView tests pass.

## Sweep

rg setSuggestions and hide-on-empty in src/*.tsx:
- RoutineSuggestions: this PR
- SettingsView servers.length: registry props, not a failed list
- PendingApprovals: keeps list on refresh fail; first-load fail still hides. Same class, not this ticket.
- ActivityView: SBS-873 / PR 766
- Quarantine and allowed-tools already keep prior list + error flag

## What this makes more likely

- Retry re-calls listRoutineSuggestions. Persistent failure keeps the stale banner. Intended.
- Save/dismiss then failed refresh leaves the old card. A second Save can re-hit approve. Backend already treats equivalent fingerprint as success; dismiss of missing fingerprint is a no-op.
- Initial failure now shows a section that used to be absent. Third state; does not claim suggestions exist.

## Gaps

- No poll added (ticket is mount + event). Retry is recovery.
- No loading skeleton on first mount.
- Did not change list_routine_suggestions (returns Vec). Catch is invoke rejection.
- Did not fix PendingApprovals first-load hide.
- Did not run smoke:headless or cross-platform / install.ps1 jobs.
- Did not click through the desktop app (tests only).
- Did not merge.

Not merged. Issue left open.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `RoutineSuggestions` to show a retry error instead of hiding on failed load
> - A failed `listRoutineSuggestions` call previously produced the same empty-queue result as a successful empty response, silently hiding the section.
> - Introduces a `'loading' | 'ready' | 'error' | 'stale'` status state machine in [SettingsView.tsx](https://github.com/tsouth89/toolport/pull/769/files#diff-7df3701f815f17f65cca4085a374bd5c5b1c545381f096cd2b64498355a39209): initial load failures render an inline error row with a Retry button; failed refreshes after a successful load mark the list as `'stale'` while preserving visible cards.
> - A `requestId` ref guards concurrent requests so older in-flight responses cannot overwrite newer results.
> - Save and dismiss now immediately drop the card from local state before triggering a refresh, so the card stays gone even if the follow-up refresh fails.
> - Behavioral Change: a failed first load now renders an error UI instead of hiding the routine suggestions section entirely.
>
> #### 🖇️ Linked Issues
> Resolves [SBS-879](https://linear.app/southboundsoftware/issue/SBS-879).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 299bc59.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->