### PR TITLE
fix(clients): honor CODEX_HOME so Connect writes the live Codex config (SBS-885)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,17 @@ Entries before the rename below shipped under the project's former name, Conduit
 
 ### Fixed
 
+- **Codex Connect honors `CODEX_HOME`.** Connect, migrate, and launch-time
+  re-point wrote `~/.codex/config.toml` even when Codex was reading
+  `$CODEX_HOME/config.toml`, so a relocated live config never got a gateway
+  entry and Toolport still reported success. Team-instructions `AGENTS.md`
+  follows the same home. Empty or relative `CODEX_HOME` still falls back to
+  `~/.codex` (Toolport's cwd is not Codex's home). The same class is now
+  honored for Gemini CLI (`GEMINI_CLI_HOME` →
+  `$GEMINI_CLI_HOME/.gemini/settings.json` and `GEMINI.md`), Grok Build
+  (`GROK_HOME`), and Qwen Code (`QWEN_HOME`). A GUI-only Toolport process
+  still cannot see a shell-only export; that limitation already applied to
+  `CLAUDE_CONFIG_DIR`. (SBS-885)
 - **Linux `.deb` installs a `toolport` command.** The package still ships the
   crate binary as `conduit` (compat alias) and now also puts `toolport` on
   `PATH`, matching the AppImage installer and the brand. `install.sh` tells apt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,9 +26,11 @@ Entries before the rename below shipped under the project's former name, Conduit
   `~/.codex` (Toolport's cwd is not Codex's home). The same class is now
   honored for Gemini CLI (`GEMINI_CLI_HOME` →
   `$GEMINI_CLI_HOME/.gemini/settings.json` and `GEMINI.md`), Grok Build
-  (`GROK_HOME`), and Qwen Code (`QWEN_HOME`). A GUI-only Toolport process
-  still cannot see a shell-only export; that limitation already applied to
-  `CLAUDE_CONFIG_DIR`. (SBS-885)
+  (`GROK_HOME`), and Qwen Code (`QWEN_HOME`). A leading `~` in `QWEN_HOME` is
+  expanded, because Qwen expands it too; the other three use their env value
+  verbatim, so a literal `~` there stays a fallback. A GUI-only Toolport
+  process still cannot see a shell-only export; that limitation already
+  applied to `CLAUDE_CONFIG_DIR`. (SBS-885)
 - **Linux `.deb` installs a `toolport` command.** The package still ships the
   crate binary as `conduit` (compat alias) and now also puts `toolport` on
   `PATH`, matching the AppImage installer and the brand. `install.sh` tells apt

--- a/README.md
+++ b/README.md
@@ -170,14 +170,14 @@ below for you, so you never have to edit these by hand.
 | Windsurf        | `~/.codeium/windsurf/mcp_config.json`                                                                  | JSON (`mcpServers`)      |
 | OpenCode        | `~/.config/opencode/opencode.json`                                                                     | JSON (`mcp`)             |
 | Kilo Code       | `~/.config/kilo/kilo.jsonc`                                                                            | JSONC (`mcp`)            |
-| Codex           | `~/.codex/config.toml`                                                                                 | TOML (`mcp_servers`)     |
+| Codex           | `$CODEX_HOME/config.toml` (default `~/.codex/config.toml`)                                             | TOML (`mcp_servers`)     |
 | Copilot CLI     | `~/.copilot/mcp-config.json`                                                                           | JSON (`mcpServers`)      |
-| Grok Build      | `~/.grok/config.toml`                                                                                  | TOML (`mcp_servers`)     |
+| Grok Build      | `$GROK_HOME/config.toml` (default `~/.grok/config.toml`)                                               | TOML (`mcp_servers`)     |
 | Toolport Studio | `~/.toolport-studio/mcp.json`                                                                          | JSON (`mcpServers`)      |
 | Continue        | `~/.continue/config.yaml`                                                                              | YAML (`mcpServers`)      |
 | Antigravity     | `~/.gemini/config/mcp_config.json`                                                                     | JSON (`mcpServers`)      |
-| Gemini CLI      | `~/.gemini/settings.json`                                                                              | JSON (`mcpServers`)      |
-| Qwen Code       | `~/.qwen/settings.json`                                                                                | JSON (`mcpServers`)      |
+| Gemini CLI      | `$GEMINI_CLI_HOME/.gemini/settings.json` (default `~/.gemini/settings.json`)                           | JSON (`mcpServers`)      |
+| Qwen Code       | `$QWEN_HOME/settings.json` (default `~/.qwen/settings.json`)                                           | JSON (`mcpServers`)      |
 | JetBrains Junie | `~/.junie/mcp/mcp.json`                                                                                | JSON (`mcpServers`)      |
 | Cline           | `<config>/Code/User/globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json`             | JSON (`mcpServers`)      |
 | Roo Code        | `<config>/Code/User/globalStorage/rooveterinaryinc.roo-cline/settings/mcp_settings.json`               | JSON (`mcpServers`)      |
@@ -201,11 +201,11 @@ below for you, so you never have to edit these by hand.
 
 ### Codex setup walkthrough
 
-Use this when Codex has already created its `~/.codex/` directory.
+Use this when Codex has already created its home directory (`$CODEX_HOME`, or `~/.codex/` when that env is unset).
 
 1. In Toolport, add or enable the MCP servers you want Codex to use.
 2. Open **Clients**, select **Codex**, optionally choose a profile, and click **Connect to Toolport**.
-3. Toolport updates `~/.codex/config.toml` with a single `[mcp_servers.toolport]` entry. That entry runs the resolved `toolport-gateway` binary; existing Codex TOML keys and other MCP servers are preserved, and an existing config is backed up before the write. (Older installs that still have `[mcp_servers.conduit]` are renamed to `toolport` on the next Toolport launch.)
+3. Toolport updates `$CODEX_HOME/config.toml` (default `~/.codex/config.toml`) with a single `[mcp_servers.toolport]` entry. That entry runs the resolved `toolport-gateway` binary; existing Codex TOML keys and other MCP servers are preserved, and an existing config is backed up before the write. (Older installs that still have `[mcp_servers.conduit]` are renamed to `toolport` on the next Toolport launch.)
 4. Start a new Codex session so it re-reads the config. In Toolport, the Codex row changes to **connected to Toolport**; in Codex, Toolport-managed tools are served through the one `toolport` MCP server. With lazy discovery enabled, Codex gets Toolport's compact search tools instead of every downstream tool up front.
 
 Gotcha: when running Toolport from source, build the gateway first with `npm run build:gateway`. The desktop dev server does not build the separate binary that Codex spawns, so Codex will report the gateway as missing until that binary exists.

--- a/src-tauri/src/clients.rs
+++ b/src-tauri/src/clients.rs
@@ -403,7 +403,10 @@ fn expand_leading_tilde(raw: Option<std::ffi::OsString>) -> Option<std::ffi::OsS
     let rest = if text == "~" {
         ""
     } else if let Some(rest) = text.strip_prefix("~/").or_else(|| text.strip_prefix(r"~\")) {
-        rest
+        // Every further separator has to go too. `~//work/qwen` leaves `/work/qwen`,
+        // which `PathBuf::join` reads as rooted and substitutes for the home dir
+        // instead of appending to it, so the value escapes home entirely.
+        rest.trim_start_matches(['/', '\\'])
     } else {
         return Some(raw);
     };
@@ -6446,6 +6449,36 @@ mod tests {
         // No separator, so it is a literal directory name and not a home
         // reference, the same call Qwen's `resolvePath` makes.
         assert_eq!(qwen_home_from(Some("~work".into())), None);
+    }
+
+    /// A doubled separator after the `~` used to leave a rooted remainder, and
+    /// `PathBuf::join` substitutes a rooted path for the base rather than
+    /// appending to it. `~//work/qwen` resolved to `/work/qwen`, outside the home
+    /// dir the tilde asked for. Every leading separator is stripped now, so an
+    /// expanded value always stays under home.
+    #[test]
+    fn extra_separators_after_the_tilde_cannot_escape_the_home_dir() {
+        let home = home().expect("home dir should be available in tests");
+
+        for raw in ["~", "~/", r"~\", "~//work/qwen", r"~\\work\qwen", "~///"] {
+            let expanded = qwen_home_from(Some(raw.into()))
+                .unwrap_or_else(|| panic!("{raw} should expand to an absolute path"));
+            assert!(
+                expanded.starts_with(&home),
+                "{raw} expanded to {expanded:?}, which escapes {home:?}"
+            );
+        }
+
+        assert_eq!(
+            qwen_home_from(Some("~//work/qwen".into())),
+            Some(home.join("work/qwen"))
+        );
+        assert_eq!(
+            qwen_home_from(Some(r"~\\work\qwen".into())),
+            Some(home.join(r"work\qwen"))
+        );
+        assert_eq!(qwen_home_from(Some("~".into())), Some(home.clone()));
+        assert_eq!(qwen_home_from(Some("~///".into())), Some(home));
     }
 
     /// The tilde rule is Qwen-only on purpose. Codex (`find_codex_home_from_env`),

--- a/src-tauri/src/clients.rs
+++ b/src-tauri/src/clients.rs
@@ -372,14 +372,19 @@ fn claude_config_dir_override() -> Option<PathBuf> {
     claude_config_dir_from(std::env::var_os("CLAUDE_CONFIG_DIR"))
 }
 
+/// An env-supplied directory is only used when it is an absolute path.
+/// Empty or relative values are a misconfiguration, not an instruction to
+/// write relative to Toolport's cwd. Shared by `CLAUDE_CONFIG_DIR`,
+/// `CODEX_HOME`, `GEMINI_CLI_HOME`, `GROK_HOME`, and `QWEN_HOME` (SBS-885).
+fn absolute_env_dir(raw: Option<std::ffi::OsString>) -> Option<PathBuf> {
+    let dir = PathBuf::from(raw?);
+    dir.is_absolute().then_some(dir)
+}
+
 /// The env-free half of [`claude_config_dir_override`], so the validation rules
 /// are testable without mutating process environment from a parallel test.
 fn claude_config_dir_from(raw: Option<std::ffi::OsString>) -> Option<PathBuf> {
-    let dir = PathBuf::from(raw?);
-    // An empty or relative value is a misconfiguration, not an instruction to
-    // write somewhere surprising: fall back to the documented default rather
-    // than resolving against whatever cwd Toolport happens to have.
-    dir.is_absolute().then_some(dir)
+    absolute_env_dir(raw)
 }
 
 /// The `.claude.json` a Claude Code process reads, given its config dir.
@@ -606,16 +611,14 @@ fn resolve_rules_target(
                 .join("toolport-team-rules.md"),
         ),
         // Strategy B — Toolport owns only the sentinel span in a shared global file.
-        "codex" => Target {
-            path: home.join(".codex").join("AGENTS.md"),
-            strategy: Strategy::SentinelBlock,
-            char_cap: None,
-            // AGENTS.override.md, if present, makes Codex ignore AGENTS.md entirely.
-            blocked_if_present: Some(home.join(".codex").join("AGENTS.override.md")),
-        },
-        // Gemini CLI and Antigravity share `~/.gemini/GEMINI.md`; both resolve to it so a
-        // standalone install of EITHER is covered, and `apply_instructions`' path-dedup writes
-        // it once when both are present.
+        // Default home only. `client_rules_target` relocates Codex / Gemini CLI
+        // when `CODEX_HOME` / `GEMINI_CLI_HOME` is an absolute path (SBS-885).
+        "codex" => codex_rules_target(&home.join(".codex")),
+        // Gemini CLI and Antigravity share `~/.gemini/GEMINI.md` at the default
+        // home so a standalone install of EITHER is covered, and
+        // `apply_instructions`' path-dedup writes it once when both are present.
+        // A relocated Gemini CLI home is handled in `client_rules_target` and
+        // does not move Antigravity (`GEMINI_CLI_HOME` is CLI-only).
         "gemini-cli" | "antigravity" => block(home.join(".gemini").join("GEMINI.md")),
         "windsurf" => Target {
             path: home
@@ -641,9 +644,44 @@ fn resolve_rules_target(
     Some(target)
 }
 
+/// Codex team-instructions live next to `config.toml` under `CODEX_HOME`
+/// (default `~/.codex`). `AGENTS.override.md` in that same directory, if
+/// present, makes Codex ignore `AGENTS.md` entirely.
+fn codex_rules_target(codex_home: &Path) -> crate::instructions::Target {
+    crate::instructions::Target {
+        path: codex_home.join("AGENTS.md"),
+        strategy: crate::instructions::Strategy::SentinelBlock,
+        char_cap: None,
+        blocked_if_present: Some(codex_home.join("AGENTS.override.md")),
+    }
+}
+
+/// Gemini CLI team-instructions follow `GEMINI_CLI_HOME` the same way settings
+/// do: the env replaces the process home, then `.gemini/` is still appended.
+fn gemini_cli_rules_target(cli_home: &Path) -> crate::instructions::Target {
+    crate::instructions::Target {
+        path: cli_home.join(".gemini").join("GEMINI.md"),
+        strategy: crate::instructions::Strategy::SentinelBlock,
+        char_cap: None,
+        blocked_if_present: None,
+    }
+}
+
 /// The rules-file target for a client on the current machine, or `None` if unsupported /
 /// transitively covered. Mirrors [`client_config_path`].
 pub fn client_rules_target(client_id: &str) -> Option<crate::instructions::Target> {
+    // Honor relocate envs even when `$HOME` is unset: the live file is under
+    // the override, not the default home table (SBS-885).
+    if client_id == "codex" {
+        if let Some(dir) = codex_home_from(std::env::var_os("CODEX_HOME")) {
+            return Some(codex_rules_target(&dir));
+        }
+    }
+    if client_id == "gemini-cli" {
+        if let Some(dir) = gemini_cli_home_from(std::env::var_os("GEMINI_CLI_HOME")) {
+            return Some(gemini_cli_rules_target(&dir));
+        }
+    }
     let home = home()?;
     resolve_rules_target(client_id, &home, Platform::current())
 }
@@ -770,7 +808,22 @@ fn windsurf_path() -> Option<PathBuf> {
     client_config_path("windsurf")
 }
 
+/// Codex reads `$CODEX_HOME/config.toml` when `CODEX_HOME` is set, otherwise
+/// `~/.codex/config.toml`. The env *is* the Codex home directory, not its
+/// parent. Empty or relative values fall back: resolving them would depend
+/// on Toolport's cwd, which is not where Codex looks (SBS-885).
+fn codex_home_from(raw: Option<std::ffi::OsString>) -> Option<PathBuf> {
+    absolute_env_dir(raw)
+}
+
+fn codex_config_path(codex_home: &Path) -> PathBuf {
+    codex_home.join("config.toml")
+}
+
 fn codex_path() -> Option<PathBuf> {
+    if let Some(dir) = codex_home_from(std::env::var_os("CODEX_HOME")) {
+        return Some(codex_config_path(&dir));
+    }
     client_config_path("codex")
 }
 
@@ -784,13 +837,24 @@ fn github_copilot_cli_path() -> Option<PathBuf> {
         .or_else(|| client_config_path("github-copilot-cli"))
 }
 
-/// Grok Build (xAI's terminal coding agent) stores MCP servers in
-/// `~/.grok/config.toml` under `[mcp_servers.<name>]` - the same TOML shape as
-/// Codex, so it shares the `TomlMcpServers` format. It also reads Claude Code's
-/// config as a fallback, but writing our own explicit entry is what makes the
-/// gateway reliably visible (`grok mcp list` doesn't surface the Claude-config
-/// pickup).
+/// Grok Build stores MCP servers in `$GROK_HOME/config.toml` (default
+/// `~/.grok/config.toml`) under `[mcp_servers.<name>]` - the same TOML
+/// shape as Codex. `GROK_HOME` is the same relocate class as `CODEX_HOME`
+/// (SBS-885). It also reads Claude Code's config as a fallback, but writing
+/// our own explicit entry is what makes the gateway reliably visible
+/// (`grok mcp list` doesn't surface the Claude-config pickup).
+fn grok_home_from(raw: Option<std::ffi::OsString>) -> Option<PathBuf> {
+    absolute_env_dir(raw)
+}
+
+fn grok_config_path(grok_home: &Path) -> PathBuf {
+    grok_home.join("config.toml")
+}
+
 fn grok_path() -> Option<PathBuf> {
+    if let Some(dir) = grok_home_from(std::env::var_os("GROK_HOME")) {
+        return Some(grok_config_path(&dir));
+    }
     client_config_path("grok")
 }
 
@@ -860,13 +924,42 @@ fn claude_code_path() -> Option<PathBuf> {
     client_config_path("claude-code")
 }
 
+/// Gemini CLI treats `GEMINI_CLI_HOME` as a replacement *home directory*,
+/// then still appends `.gemini/`. Settings live at
+/// `$GEMINI_CLI_HOME/.gemini/settings.json`. Empty or relative values fall
+/// back the same way `CLAUDE_CONFIG_DIR` does (SBS-885).
+fn gemini_cli_home_from(raw: Option<std::ffi::OsString>) -> Option<PathBuf> {
+    absolute_env_dir(raw)
+}
+
+fn gemini_cli_settings_path(cli_home: &Path) -> PathBuf {
+    cli_home.join(".gemini").join("settings.json")
+}
+
 fn gemini_cli_path() -> Option<PathBuf> {
+    if let Some(dir) = gemini_cli_home_from(std::env::var_os("GEMINI_CLI_HOME")) {
+        return Some(gemini_cli_settings_path(&dir));
+    }
     client_config_path("gemini-cli")
 }
 
-/// Qwen Code stores user-scoped settings at `~/.qwen/settings.json` on every
-/// supported platform.
+/// Qwen Code stores user-scoped settings at `~/.qwen/settings.json`.
+/// `QWEN_HOME` relocates that directory (`$QWEN_HOME/settings.json`), the
+/// same class as `CODEX_HOME` (SBS-885). Qwen itself also accepts a
+/// relative `QWEN_HOME` resolved against cwd; we do not, because Toolport's
+/// cwd is not Qwen's.
+fn qwen_home_from(raw: Option<std::ffi::OsString>) -> Option<PathBuf> {
+    absolute_env_dir(raw)
+}
+
+fn qwen_settings_path(qwen_home: &Path) -> PathBuf {
+    qwen_home.join("settings.json")
+}
+
 fn qwen_code_path() -> Option<PathBuf> {
+    if let Some(dir) = qwen_home_from(std::env::var_os("QWEN_HOME")) {
+        return Some(qwen_settings_path(&dir));
+    }
     client_config_path("qwen-code")
 }
 
@@ -1230,7 +1323,8 @@ fn defs() -> Vec<ClientDef> {
             plugin_scan: None,
         },
         ClientDef {
-            // The Codex CLI and the Codex desktop app share ~/.codex/config.toml.
+            // The Codex CLI and the Codex desktop app share config.toml under
+            // `CODEX_HOME` (default ~/.codex).
             id: "codex",
             name: "Codex",
             format: Format::TomlMcpServers,
@@ -5535,6 +5629,103 @@ mod tests {
         assert_eq!(claude_config_dir_from(Some("relative/dir".into())), None);
     }
 
+    fn relocated_abs(unix: &str, windows: &str) -> PathBuf {
+        if cfg!(windows) {
+            PathBuf::from(windows)
+        } else {
+            PathBuf::from(unix)
+        }
+    }
+
+    /// Pins the failure mode in SBS-885: an absolute `CODEX_HOME` is the
+    /// directory Codex reads, so Connect must write `$CODEX_HOME/config.toml`
+    /// rather than a leftover `~/.codex/config.toml`.
+    #[test]
+    fn an_absolute_codex_home_is_the_config_and_rules_root() {
+        let relocated = relocated_abs("/work/codex", r"D:\work\codex");
+        assert_eq!(
+            codex_home_from(Some(relocated.clone().into_os_string())),
+            Some(relocated.clone())
+        );
+        assert_eq!(codex_config_path(&relocated), relocated.join("config.toml"));
+        let rules = codex_rules_target(&relocated);
+        assert_eq!(rules.path, relocated.join("AGENTS.md"));
+        assert_eq!(
+            rules.blocked_if_present,
+            Some(relocated.join("AGENTS.override.md"))
+        );
+    }
+
+    #[test]
+    fn an_unset_or_unusable_codex_home_falls_back_to_the_default() {
+        assert_eq!(codex_home_from(None), None);
+        assert_eq!(codex_home_from(Some("".into())), None);
+        assert_eq!(codex_home_from(Some("relative/dir".into())), None);
+    }
+
+    /// Gemini CLI replaces the process home, then still appends `.gemini/`.
+    /// Writing `$GEMINI_CLI_HOME/settings.json` would miss the live file.
+    #[test]
+    fn an_absolute_gemini_cli_home_nests_settings_and_rules_under_dot_gemini() {
+        let relocated = relocated_abs("/work/gemini", r"D:\work\gemini");
+        assert_eq!(
+            gemini_cli_home_from(Some(relocated.clone().into_os_string())),
+            Some(relocated.clone())
+        );
+        assert_eq!(
+            gemini_cli_settings_path(&relocated),
+            relocated.join(".gemini").join("settings.json")
+        );
+        assert_eq!(
+            gemini_cli_rules_target(&relocated).path,
+            relocated.join(".gemini").join("GEMINI.md")
+        );
+    }
+
+    #[test]
+    fn an_unset_or_unusable_gemini_cli_home_falls_back_to_the_default() {
+        assert_eq!(gemini_cli_home_from(None), None);
+        assert_eq!(gemini_cli_home_from(Some("".into())), None);
+        assert_eq!(gemini_cli_home_from(Some("relative/dir".into())), None);
+    }
+
+    #[test]
+    fn an_absolute_grok_home_is_the_config_root() {
+        let relocated = relocated_abs("/work/grok", r"D:\work\grok");
+        assert_eq!(
+            grok_home_from(Some(relocated.clone().into_os_string())),
+            Some(relocated.clone())
+        );
+        assert_eq!(grok_config_path(&relocated), relocated.join("config.toml"));
+    }
+
+    #[test]
+    fn an_unset_or_unusable_grok_home_falls_back_to_the_default() {
+        assert_eq!(grok_home_from(None), None);
+        assert_eq!(grok_home_from(Some("".into())), None);
+        assert_eq!(grok_home_from(Some("relative/dir".into())), None);
+    }
+
+    #[test]
+    fn an_absolute_qwen_home_is_the_settings_root() {
+        let relocated = relocated_abs("/work/qwen", r"D:\work\qwen");
+        assert_eq!(
+            qwen_home_from(Some(relocated.clone().into_os_string())),
+            Some(relocated.clone())
+        );
+        assert_eq!(
+            qwen_settings_path(&relocated),
+            relocated.join("settings.json")
+        );
+    }
+
+    #[test]
+    fn an_unset_or_unusable_qwen_home_falls_back_to_the_default() {
+        assert_eq!(qwen_home_from(None), None);
+        assert_eq!(qwen_home_from(Some("".into())), None);
+        assert_eq!(qwen_home_from(Some("relative/dir".into())), None);
+    }
+
     fn sample_gateway(profile: Option<&str>, client_id: &str) -> ServerEntry {
         let mut env = vec![EnvVar {
             key: crate::brand::CLIENT_ID.to_string(),
@@ -8377,6 +8568,55 @@ command = "npx"
     }
 
     #[test]
+    fn codex_path_and_rules_honor_an_absolute_codex_home() {
+        let _env = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let root = std::env::temp_dir().join(format!("toolport-codex-home-{}", std::process::id()));
+        let _restore = EnvRestore::set("CODEX_HOME", &root);
+        assert_eq!(codex_path(), Some(root.join("config.toml")));
+        let rules = client_rules_target("codex").expect("codex rules");
+        assert_eq!(rules.path, root.join("AGENTS.md"));
+        assert_eq!(
+            rules.blocked_if_present,
+            Some(root.join("AGENTS.override.md"))
+        );
+    }
+
+    #[test]
+    fn gemini_cli_path_and_rules_honor_an_absolute_gemini_cli_home() {
+        let _env = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let root =
+            std::env::temp_dir().join(format!("toolport-gemini-cli-home-{}", std::process::id()));
+        let _restore = EnvRestore::set("GEMINI_CLI_HOME", &root);
+        assert_eq!(
+            gemini_cli_path(),
+            Some(root.join(".gemini").join("settings.json"))
+        );
+        let rules = client_rules_target("gemini-cli").expect("gemini rules");
+        assert_eq!(rules.path, root.join(".gemini").join("GEMINI.md"));
+        // Antigravity is a different product; GEMINI_CLI_HOME must not move it.
+        let home = home().expect("home");
+        let antigravity = resolve_rules_target("antigravity", &home, Platform::current())
+            .expect("antigravity rules");
+        assert_eq!(antigravity.path, home.join(".gemini").join("GEMINI.md"));
+    }
+
+    #[test]
+    fn grok_path_honors_an_absolute_grok_home() {
+        let _env = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let root = std::env::temp_dir().join(format!("toolport-grok-home-{}", std::process::id()));
+        let _restore = EnvRestore::set("GROK_HOME", &root);
+        assert_eq!(grok_path(), Some(root.join("config.toml")));
+    }
+
+    #[test]
+    fn qwen_code_path_honors_an_absolute_qwen_home() {
+        let _env = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let root = std::env::temp_dir().join(format!("toolport-qwen-home-{}", std::process::id()));
+        let _restore = EnvRestore::set("QWEN_HOME", &root);
+        assert_eq!(qwen_code_path(), Some(root.join("settings.json")));
+    }
+
+    #[test]
     fn kimi_json_parses_sse_transport_hint_and_bearer_env_var() {
         let content = r#"{
             "mcpServers": {
@@ -9061,6 +9301,12 @@ command = "npx"
         // `.claude.json`). The override itself is covered by
         // `claude_code_config_follows_a_relocated_config_dir`.
         let _claude_config_dir = EnvRestore::set("CLAUDE_CONFIG_DIR", Path::new(""));
+        // Same class as CLAUDE_CONFIG_DIR: neutralize relocate envs the host
+        // (or a parallel test) may have exported so this asserts the default table.
+        let _codex_home = EnvRestore::set("CODEX_HOME", Path::new(""));
+        let _gemini_cli_home = EnvRestore::set("GEMINI_CLI_HOME", Path::new(""));
+        let _grok_home = EnvRestore::set("GROK_HOME", Path::new(""));
+        let _qwen_home = EnvRestore::set("QWEN_HOME", Path::new(""));
         let home = home().expect("home dir should be available in tests");
         let platform = Platform::current();
         for client in defs() {

--- a/src-tauri/src/clients.rs
+++ b/src-tauri/src/clients.rs
@@ -376,9 +376,46 @@ fn claude_config_dir_override() -> Option<PathBuf> {
 /// Empty or relative values are a misconfiguration, not an instruction to
 /// write relative to Toolport's cwd. Shared by `CLAUDE_CONFIG_DIR`,
 /// `CODEX_HOME`, `GEMINI_CLI_HOME`, `GROK_HOME`, and `QWEN_HOME` (SBS-885).
+///
+/// A literal `~` is NOT a home reference here. Every one of those clients except
+/// Qwen Code uses its env value verbatim (Codex `find_codex_home_from_env`, Grok
+/// `resolve_grok_home_from`, Gemini CLI `homedir()`), so a value the shell left
+/// unexpanded is already broken for the client itself and the default path is the
+/// closer guess. Qwen Code expands it, so `qwen_home_from` runs the value through
+/// [`expand_leading_tilde`] first.
 fn absolute_env_dir(raw: Option<std::ffi::OsString>) -> Option<PathBuf> {
     let dir = PathBuf::from(raw?);
     dir.is_absolute().then_some(dir)
+}
+
+/// Expand a leading `~`, `~/`, or `~\` against the home directory.
+///
+/// Only for env vars whose owning client performs the same expansion; see
+/// [`absolute_env_dir`] for why the rest keep the value verbatim. A bare `~work`
+/// has no separator and is not a home reference, which matches the client. A
+/// non-UTF-8 value, or one read with no home directory available, passes through
+/// untouched so the caller's absolute check still sees the original.
+fn expand_leading_tilde(raw: Option<std::ffi::OsString>) -> Option<std::ffi::OsString> {
+    let raw = raw?;
+    let Some(text) = raw.to_str() else {
+        return Some(raw);
+    };
+    let rest = if text == "~" {
+        ""
+    } else if let Some(rest) = text.strip_prefix("~/").or_else(|| text.strip_prefix(r"~\")) {
+        rest
+    } else {
+        return Some(raw);
+    };
+    let Some(home) = home() else {
+        return Some(raw);
+    };
+    let expanded = if rest.is_empty() {
+        home
+    } else {
+        home.join(rest)
+    };
+    Some(expanded.into_os_string())
 }
 
 /// The env-free half of [`claude_config_dir_override`], so the validation rules
@@ -948,8 +985,17 @@ fn gemini_cli_path() -> Option<PathBuf> {
 /// same class as `CODEX_HOME` (SBS-885). Qwen itself also accepts a
 /// relative `QWEN_HOME` resolved against cwd; we do not, because Toolport's
 /// cwd is not Qwen's.
+///
+/// A leading `~` IS honored, unlike the sibling relocate envs: Qwen's
+/// `Storage.resolvePath` expands `~`, `~/`, and `~\` against `os.homedir()`
+/// before any cwd resolve, so `$expanded/settings.json` is the live file. An
+/// unquoted `export QWEN_HOME=~/work` is expanded by the shell before Toolport
+/// sees it, but a quoted export, a PowerShell `$env:QWEN_HOME`, and a Windows
+/// user-env value all stay literal. Dropping those left Connect, migrate, and
+/// the launch re-point writing `~/.qwen/settings.json` while Qwen read the
+/// expanded home.
 fn qwen_home_from(raw: Option<std::ffi::OsString>) -> Option<PathBuf> {
-    absolute_env_dir(raw)
+    absolute_env_dir(expand_leading_tilde(raw))
 }
 
 fn qwen_settings_path(qwen_home: &Path) -> PathBuf {
@@ -5724,6 +5770,46 @@ mod tests {
         assert_eq!(qwen_home_from(None), None);
         assert_eq!(qwen_home_from(Some("".into())), None);
         assert_eq!(qwen_home_from(Some("relative/dir".into())), None);
+    }
+
+    /// Qwen's own `Storage.resolvePath` expands a leading `~` before it reads
+    /// `$QWEN_HOME/settings.json`, and a quoted export or a PowerShell
+    /// `$env:QWEN_HOME` never gets shell expansion. Dropping the value as "not
+    /// absolute" left Connect writing `~/.qwen/settings.json` while Qwen read
+    /// the expanded home.
+    #[test]
+    fn a_tilde_qwen_home_expands_against_the_home_dir() {
+        let home = home().expect("home dir should be available in tests");
+
+        assert_eq!(qwen_home_from(Some("~".into())), Some(home.clone()));
+        assert_eq!(
+            qwen_home_from(Some("~/work/qwen".into())),
+            Some(home.join("work/qwen"))
+        );
+        assert_eq!(
+            qwen_home_from(Some(r"~\work\qwen".into())),
+            Some(home.join(r"work\qwen"))
+        );
+        assert_eq!(
+            qwen_settings_path(&qwen_home_from(Some("~/work/qwen".into())).expect("expanded")),
+            home.join("work/qwen").join("settings.json")
+        );
+        // No separator, so it is a literal directory name and not a home
+        // reference, the same call Qwen's `resolvePath` makes.
+        assert_eq!(qwen_home_from(Some("~work".into())), None);
+    }
+
+    /// The tilde rule is Qwen-only on purpose. Codex (`find_codex_home_from_env`),
+    /// Grok (`resolve_grok_home_from`), Gemini CLI (`homedir()`), and Claude Code
+    /// all use the env value verbatim, so a literal `~` is already broken for the
+    /// client and the default path is the closer guess. Expanding it here would
+    /// have Toolport write a config the client never reads.
+    #[test]
+    fn a_tilde_is_not_expanded_for_the_verbatim_relocate_envs() {
+        assert_eq!(codex_home_from(Some("~/work/codex".into())), None);
+        assert_eq!(gemini_cli_home_from(Some("~/work/gemini".into())), None);
+        assert_eq!(grok_home_from(Some("~/work/grok".into())), None);
+        assert_eq!(claude_config_dir_from(Some("~/work/claude".into())), None);
     }
 
     fn sample_gateway(profile: Option<&str>, client_id: &str) -> ServerEntry {

--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -7105,10 +7105,18 @@ mod tests {
     /// Scratch data dir + seeded `http_clients` row. Holds the process-global
     /// hook lock and `data_dir_test_lock` so persist and injected failures cannot
     /// interleave with another test.
+    ///
+    /// Field order IS drop order (unlike locals, struct fields drop in declaration
+    /// order), so the override is declared before the guards that protect it. The
+    /// other way round, teardown released `data_dir_test_lock` while this fixture's
+    /// `DataDirOverride` was still installed; the next test could take the lock and
+    /// install its own override, only for this drop to land and clear it. That
+    /// test's `registry::load()` then read the REAL data dir, where its seeded
+    /// `http_clients` row does not exist.
     struct RevokeFixture {
-        _hooks: std::sync::MutexGuard<'static, ()>,
-        _data_dir: std::sync::MutexGuard<'static, ()>,
         _override: crate::registry::DataDirOverride,
+        _data_dir: std::sync::MutexGuard<'static, ()>,
+        _hooks: std::sync::MutexGuard<'static, ()>,
         state: RegistryState,
         client_id: String,
         http_id: String,
@@ -7141,9 +7149,9 @@ mod tests {
             });
             registry::save(&reg).unwrap();
             Self {
-                _hooks: hooks,
-                _data_dir: data_dir,
                 _override: over,
+                _data_dir: data_dir,
+                _hooks: hooks,
                 state: Mutex::new(reg),
                 client_id,
                 http_id,

--- a/src-tauri/src/remote.rs
+++ b/src-tauri/src/remote.rs
@@ -1635,9 +1635,15 @@ mod tests {
     ///
     /// Holds `data_dir_test_lock` for the whole test: the data-dir override and the
     /// backend-selecting env var are both process-global.
+    ///
+    /// Field order IS drop order (unlike locals, struct fields drop in declaration
+    /// order), so the override is declared before the guard that protects it. The
+    /// other way round, teardown released the lock with the override still
+    /// installed, and this drop could then clear the override the NEXT test had
+    /// just installed, sending that test at the REAL data dir.
     struct VaultFixture {
-        _data_dir_lock: std::sync::MutexGuard<'static, ()>,
         _override: crate::registry::DataDirOverride,
+        _data_dir_lock: std::sync::MutexGuard<'static, ()>,
         dir: std::path::PathBuf,
         previous_key: Option<String>,
     }
@@ -1655,8 +1661,8 @@ mod tests {
             let previous_key = std::env::var("TOOLPORT_SECRET_KEY").ok();
             std::env::set_var("TOOLPORT_SECRET_KEY", "sbs-615-unit-test-passphrase");
             Self {
-                _data_dir_lock: lock,
                 _override: over,
+                _data_dir_lock: lock,
                 dir,
                 previous_key,
             }


### PR DESCRIPTION
Fixes SBS-885. Do not merge.

Connect/migrate/repoint and Codex AGENTS.md honor an absolute CODEX_HOME. Empty/relative falls back to ~/.codex. Same class: GEMINI_CLI_HOME, GROK_HOME, QWEN_HOME.

Wiring tests failed without the production wrappers (wrote ~/.codex instead of the override) and passed after restore. Required CI gate run locally: prettier pass, lint 0 errors, tsc+vite pass, vitest 382, cargo test lib 1097 + bins 306, audit 0, smoke 10 PASS.

Did not merge.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Honor `CODEX_HOME` and analogous env vars when resolving client config paths
> - Config path resolvers for Codex, Grok Build, Gemini CLI, and Qwen Code now check their respective home env vars (`CODEX_HOME`, `GROK_HOME`, `GEMINI_CLI_HOME`, `QWEN_HOME`) and use them when set to an absolute path.
> - Adds `absolute_env_dir` helper in [clients.rs](https://github.com/tsouth89/toolport/pull/770/files#diff-6f95d037b6a920242364b6cfc2417b10affa37691d35ce5da93633c9da12c167) to reject relative or empty env values, and `expand_leading_tilde` to support tilde expansion for `QWEN_HOME`.
> - Team-instructions files (`AGENTS.md`) for Codex and Gemini CLI are also resolved under the relocated home directories.
> - Behavioral Change: previously, relative env values were silently resolved against the process working directory; they are now ignored and fall back to defaults.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c8b13e2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->