### PR TITLE
fix(ci): make Windows keyring and install.ps1 able to block merge (SBS-874)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
         run: cargo clippy --manifest-path src-tauri/Cargo.toml --no-default-features --lib --bins
 
   build-test:
-    name: Build + test
+    name: Linux build + test
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -200,3 +200,32 @@ jobs:
           Import-Module Pester -MinimumVersion 5.5.0 -MaximumVersion 5.99.99
           $result = Invoke-Pester -Path scripts/install.Tests.ps1 -Output Detailed -PassThru
           if ($result.FailedCount -gt 0) { exit 1 }
+
+  # SBS-874: branch protection required contexts are only the check named
+  # "Build + test". That name used to belong to the Linux-only job, so a red
+  # Windows keyring run (Headless Rust tests (windows-latest)) or a red
+  # install.ps1 Pester job could not block merge. This job keeps the required
+  # name and fails unless every job that must gate merge succeeded. A skipped
+  # or cancelled dependency must not count as success (`if: always()` plus
+  # explicit result checks). Clippy stays out of this gate (non-blocking
+  # until existing warnings are cleared). Adding the individual job names as
+  # separate required contexts still needs a GitHub settings click; this file
+  # cannot do that.
+  merge-gate:
+    name: Build + test
+    if: always()
+    needs:
+      - build-test
+      - cross-platform-rust
+      - installer-script
+    runs-on: ubuntu-22.04
+    timeout-minutes: 5
+    steps:
+      - name: Require Linux, Windows/macOS headless, and install.ps1
+        run: |
+          echo "build-test=${{ needs.build-test.result }}"
+          echo "cross-platform-rust=${{ needs.cross-platform-rust.result }}"
+          echo "installer-script=${{ needs.installer-script.result }}"
+          test "${{ needs.build-test.result }}" = "success"
+          test "${{ needs.cross-platform-rust.result }}" = "success"
+          test "${{ needs.installer-script.result }}" = "success"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,14 @@ Entries before the rename below shipped under the project's former name, Conduit
 
 ### Fixed
 
+- **Windows keyring and install.ps1 tests can now block merge.** Branch
+  protection still requires only the check named `Build + test`. That name now
+  belongs to a merge-gate job that fails unless the Linux suite, the
+  cross-platform headless Rust matrix (including the Windows keyring tests),
+  and the `install.ps1` Pester job all succeeded. Adding those names as
+  separate required contexts still needs a GitHub settings click; this change
+  does not edit branch protection.
+
 - **Linux `.deb` installs a `toolport` command.** The package still ships the
   crate binary as `conduit` (compat alias) and now also puts `toolport` on
   `PATH`, matching the AppImage installer and the brand. `install.sh` tells apt

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,6 +76,13 @@ matches CI. Frontend tests use [Vitest](https://vitest.dev) and live alongside
 the code as `*.test.ts` or `*.test.tsx` files inside `src/`, depending on whether
 the test contains JSX.
 
+The GitHub required check is still named **Build + test**. That name is a
+merge gate over the Linux suite, the headless Rust matrix (the Windows
+keyring tests live on `windows-latest`), and the `install.ps1` Pester job
+(SBS-874). Clippy stays non-blocking until existing warnings are cleared.
+Adding the individual job names as separate required contexts is a GitHub
+settings click; it is not something a workflow file can do.
+
 `scripts/install.ps1` is the `irm ... | iex` one-liner, so a regression in asset
 selection, checksum enforcement, or the silent-install flag reaches users with no
 build step in between. `scripts/install.Tests.ps1` drives the real script end to

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,8 @@
         "typescript": "~5.8.3",
         "typescript-eslint": "^8.62.1",
         "vite": "^7.0.4",
-        "vitest": "^4.1.9"
+        "vitest": "^4.1.9",
+        "yaml": "^2.9.0"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -11524,8 +11525,8 @@
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
       "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "devOptional": true,
       "license": "ISC",
-      "optional": true,
       "bin": {
         "yaml": "bin.mjs"
       },

--- a/package.json
+++ b/package.json
@@ -74,7 +74,8 @@
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.62.1",
     "vite": "^7.0.4",
-    "vitest": "^4.1.9"
+    "vitest": "^4.1.9",
+    "yaml": "^2.9.0"
   },
   "overrides": {
     "esbuild": "^0.28.1",

--- a/src/test/ci-required-checks.test.ts
+++ b/src/test/ci-required-checks.test.ts
@@ -30,27 +30,35 @@ interface WorkflowStep {
   "continue-on-error"?: boolean;
 }
 
+interface RunDefaults {
+  run?: { shell?: string };
+}
+
 interface WorkflowJob {
   name?: string;
   if?: string;
   needs?: string | string[];
-  "runs-on"?: string;
+  "runs-on"?: string | string[];
   "continue-on-error"?: boolean;
+  defaults?: RunDefaults;
   strategy?: { "fail-fast"?: boolean; matrix?: Record<string, unknown> };
   steps?: WorkflowStep[];
 }
 
 interface Workflow {
+  defaults?: RunDefaults;
   jobs?: Record<string, WorkflowJob>;
 }
 
-function parseJobs(source: string): Record<string, WorkflowJob> {
+type ParsedWorkflow = Workflow & { jobs: Record<string, WorkflowJob> };
+
+function parseWorkflow(source: string): ParsedWorkflow {
   const workflow = parse(source) as Workflow | null;
   const jobs = workflow?.jobs;
-  if (!jobs || typeof jobs !== "object") {
+  if (!workflow || !jobs || typeof jobs !== "object") {
     throw new Error("workflow has no jobs: block");
   }
-  return jobs;
+  return { ...workflow, jobs };
 }
 
 /** GitHub falls back to the job id when a job has no display `name:`. */
@@ -79,32 +87,78 @@ function runScripts(job: WorkflowJob): string[] {
   return (job.steps ?? []).flatMap((step) => (step.run ? [step.run] : []));
 }
 
+/** `test` / `[` only mean the POSIX builtins under one of these. */
+const POSIX_SHELLS = new Set(["bash", "sh"]);
+
+function runsOnLabels(job: WorkflowJob): string[] {
+  const runsOn = job["runs-on"];
+  if (typeof runsOn === "string") return [runsOn];
+  if (Array.isArray(runsOn)) return runsOn.map(String);
+  return [];
+}
+
+/**
+ * Whether the step's script is run by a POSIX shell, so that a failing `test`
+ * aborts it (GitHub runs `bash -e {0}` / `sh -e {0}`).
+ *
+ * With no `shell:` the default follows the runner, and on Windows runners that
+ * default is `pwsh`, where `test` is not the comparison builtin and the exit
+ * code stops tracking the comparison. So an unset `shell:` only counts when
+ * the runner is plainly not Windows; anything unrecognised is rejected.
+ */
+function stepUsesPosixShell(
+  workflow: Workflow,
+  job: WorkflowJob,
+  step: WorkflowStep,
+): boolean {
+  const shell = step.shell ?? job.defaults?.run?.shell ?? workflow.defaults?.run?.shell;
+  if (shell !== undefined) return POSIX_SHELLS.has(shell.trim());
+  const labels = runsOnLabels(job);
+  return labels.length > 0 && labels.every((label) => /^(ubuntu|macos)-/.test(label));
+}
+
+// Matches `test "${{ needs.x.result }}" = "success"` and the `[ ... ]` /
+// `[[ ... ]]` spellings, with or without quotes, `=` or `==`. Anchoring the
+// left side keeps `if test ...` and commented-out lines out.
+const RESULT_COMPARISON =
+  /(?:^|\n|;|&&|\|\|)[ \t]*(?:test|\[\[?)[ \t]+"?\$\{\{[ \t]*needs\.([A-Za-z0-9_-]+)\.result[ \t]*\}\}"?[ \t]*={1,2}[ \t]*"?success"?/g;
+
+// `test ... || <anything>` is a compound command whose status is the right
+// side, so under `set -e` the comparison no longer aborts the step. Only a
+// right side that itself fails keeps the line fail-closed.
+const FAILING_FALLBACK =
+  /^[ \t]*\|\|[ \t]*(?:exit[ \t]+[1-9][0-9]*|false)[ \t]*;?[ \t]*$/;
+
 /**
  * Dependency ids that the job actually gates on: ids whose
  * `needs.<id>.result` is compared against `success` by a shell test that
  * aborts the step on mismatch.
  *
- * Only steps that always run and always count are considered, so neither
- * `continue-on-error: true` nor an `if:` guard that skips the step on failure
- * can be used to smuggle a check past this. A bare
- * `echo "${{ needs.x.result }}"` line does not count either: it never changes
- * the exit code.
+ * Only steps that always run, always count, and can actually fail are
+ * considered. `continue-on-error: true`, an `if:` guard that skips the step on
+ * failure, a non-POSIX shell, and a `|| true` style fallback all disqualify a
+ * comparison, because each one lets the comparison be false while the step
+ * still exits 0. A bare `echo "${{ needs.x.result }}"` does not count either:
+ * it never changes the exit code.
  */
-function failClosedResultChecks(job: WorkflowJob): string[] {
+function failClosedResultChecks(workflow: Workflow, job: WorkflowJob): string[] {
   if (job["continue-on-error"] === true) return [];
   const gatingSteps = (job.steps ?? []).filter((step) => {
     if (step["continue-on-error"] === true) return false;
+    if (!stepUsesPosixShell(workflow, job, step)) return false;
     const guard = step.if?.trim();
     return guard === undefined || guard === "always()" || guard === "${{ always() }}";
   });
-  // Matches `test "${{ needs.x.result }}" = "success"` and the `[ ... ]` /
-  // `[[ ... ]]` spellings, with or without quotes, `=` or `==`.
-  const comparison =
-    /(?:^|\n|;|&&|\|\|)[ \t]*(?:test|\[\[?)[ \t]+"?\$\{\{[ \t]*needs\.([A-Za-z0-9_-]+)\.result[ \t]*\}\}"?[ \t]*={1,2}[ \t]*"?success"?/g;
   const gated = new Set<string>();
   for (const script of gatingSteps.flatMap((step) => (step.run ? [step.run] : []))) {
-    for (const match of script.matchAll(comparison)) {
-      gated.add(match[1]);
+    for (const match of script.matchAll(RESULT_COMPARISON)) {
+      const lineEnd = script.indexOf("\n", match.index + match[0].length);
+      const rest = script.slice(
+        match.index + match[0].length,
+        lineEnd === -1 ? undefined : lineEnd,
+      );
+      const swallowed = rest.includes("||") && !FAILING_FALLBACK.test(rest);
+      if (!swallowed) gated.add(match[1]);
     }
   }
   return [...gated].sort();
@@ -114,7 +168,8 @@ const ciYaml = readFileSync(
   join(process.cwd(), ".github", "workflows", "ci.yml"),
   "utf8",
 );
-const jobs = parseJobs(ciYaml);
+const ci = parseWorkflow(ciYaml);
+const jobs = ci.jobs;
 
 describe("CI required merge gate (SBS-874)", () => {
   it("puts the required check name on a gate that needs Windows rust and install.ps1", () => {
@@ -134,8 +189,9 @@ describe("CI required merge gate (SBS-874)", () => {
     const [, gate] = jobsWithCheckName(jobs, REQUIRED_CHECK_NAME)[0];
     // The point of the gate: `if: always()` means the step runs on failed,
     // skipped, and cancelled dependencies, so it must compare each result
-    // against `success` itself.
-    expect(failClosedResultChecks(gate)).toEqual([...GATED_JOB_IDS].sort());
+    // against `success` itself, in a step where a false comparison is what
+    // makes the step exit non-zero.
+    expect(failClosedResultChecks(ci, gate)).toEqual([...GATED_JOB_IDS].sort());
   });
 
   it("keeps the Linux suite under a different check name", () => {
@@ -164,7 +220,7 @@ describe("CI required merge gate (SBS-874)", () => {
 // stop failing and this block goes red.
 describe("the gate assertions reject a workflow that reopens the hole", () => {
   it("rejects a gate step that only echoes the dependency results", () => {
-    const fixture = parseJobs(`
+    const fixture = parseWorkflow(`
 jobs:
   merge-gate:
     name: Build + test
@@ -178,14 +234,14 @@ jobs:
           echo "cross-platform-rust=\${{ needs.cross-platform-rust.result }}"
           echo "installer-script=\${{ needs.installer-script.result }}"
 `);
-    const gate = jobsWithCheckName(fixture, REQUIRED_CHECK_NAME)[0][1];
+    const gate = jobsWithCheckName(fixture.jobs, REQUIRED_CHECK_NAME)[0][1];
     // Passes the name / always() / needs assertions, but gates nothing.
     expect(needsOf(gate)).toEqual(expect.arrayContaining(GATED_JOB_IDS));
-    expect(failClosedResultChecks(gate)).toEqual([]);
+    expect(failClosedResultChecks(fixture, gate)).toEqual([]);
   });
 
   it("rejects result checks parked behind continue-on-error or a skip guard", () => {
-    const fixture = parseJobs(`
+    const fixture = parseWorkflow(`
 jobs:
   merge-gate:
     name: Build + test
@@ -202,12 +258,64 @@ jobs:
       - name: Real check
         run: test "\${{ needs.installer-script.result }}" = "success"
 `);
-    const gate = jobsWithCheckName(fixture, REQUIRED_CHECK_NAME)[0][1];
-    expect(failClosedResultChecks(gate)).toEqual(["installer-script"]);
+    const gate = jobsWithCheckName(fixture.jobs, REQUIRED_CHECK_NAME)[0][1];
+    expect(failClosedResultChecks(fixture, gate)).toEqual(["installer-script"]);
+  });
+
+  it("rejects a comparison whose failure is swallowed by a fallback", () => {
+    const fixture = parseWorkflow(`
+jobs:
+  merge-gate:
+    name: Build + test
+    if: always()
+    needs: [build-test, cross-platform-rust, installer-script]
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Require everything
+        run: |
+          test "\${{ needs.build-test.result }}" = "success" || true
+          test "\${{ needs.cross-platform-rust.result }}" = "success" || exit 0
+          test "\${{ needs.installer-script.result }}" = "success" || exit 1
+`);
+    const gate = jobsWithCheckName(fixture.jobs, REQUIRED_CHECK_NAME)[0][1];
+    // All three compare against success, but only the last one can fail.
+    expect(failClosedResultChecks(fixture, gate)).toEqual(["installer-script"]);
+  });
+
+  it("rejects comparisons run by a shell where test is not the POSIX builtin", () => {
+    const script = `
+        run: |
+          test "\${{ needs.build-test.result }}" = "success"
+          test "\${{ needs.cross-platform-rust.result }}" = "success"
+          test "\${{ needs.installer-script.result }}" = "success"`;
+    const gateWith = (extra: string, runsOn = "ubuntu-22.04") =>
+      parseWorkflow(`
+jobs:
+  merge-gate:
+    name: Build + test
+    if: always()
+    needs: [build-test, cross-platform-rust, installer-script]
+    runs-on: ${runsOn}
+    steps:
+      - name: Require everything${extra}${script}
+`);
+
+    const posix = gateWith("");
+    expect(failClosedResultChecks(posix, posix.jobs["merge-gate"])).toEqual(
+      [...GATED_JOB_IDS].sort(),
+    );
+
+    // pwsh has no POSIX `test`, so the exit code stops tracking the comparison.
+    const pwsh = gateWith("\n        shell: pwsh");
+    expect(failClosedResultChecks(pwsh, pwsh.jobs["merge-gate"])).toEqual([]);
+
+    // Same hole with no `shell:` at all: GitHub defaults Windows runners to pwsh.
+    const windows = gateWith("", "windows-latest");
+    expect(failClosedResultChecks(windows, windows.jobs["merge-gate"])).toEqual([]);
   });
 
   it("rejects a matrix that mentions windows-latest only in step guards", () => {
-    const fixture = parseJobs(`
+    const fixture = parseWorkflow(`
 jobs:
   cross-platform-rust:
     name: Headless Rust tests (\${{ matrix.os }})
@@ -220,7 +328,7 @@ jobs:
         if: matrix.os == 'windows-latest'
         run: powershell -ExecutionPolicy Bypass -File scripts/test-rust-windows.ps1
 `);
-    const job = fixture["cross-platform-rust"];
+    const job = fixture.jobs["cross-platform-rust"];
     // The old substring pins both still pass on this workflow.
     expect(JSON.stringify(job)).toContain("windows-latest");
     expect(runScripts(job).join("\n")).toContain("scripts/test-rust-windows.ps1");

--- a/src/test/ci-required-checks.test.ts
+++ b/src/test/ci-required-checks.test.ts
@@ -1,0 +1,104 @@
+// Pins SBS-874: branch protection required contexts are only the check named
+// "Build + test". If that name sits on the Linux-only job again, a red
+// Windows keyring run or a red install.ps1 Pester job cannot block merge.
+// These are file-content assertions against .github/workflows/ci.yml so a
+// rename or a dropped `needs` fails CI instead of silently reopening the hole.
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const repoRoot = process.cwd();
+const ciYaml = readFileSync(join(repoRoot, ".github", "workflows", "ci.yml"), "utf8");
+
+/** Job blocks under `jobs:` keyed by id. Keys are the 2-space identifiers. */
+function parseJobs(yaml: string): Record<string, string> {
+  const marker = "\njobs:\n";
+  const jobsIdx = yaml.indexOf(marker);
+  if (jobsIdx < 0) {
+    throw new Error("ci.yml has no jobs: block");
+  }
+  const body = yaml.slice(jobsIdx + marker.length);
+  const re = /^[ ]{2}([a-z][a-z0-9-]*):$/gm;
+  const matches = [...body.matchAll(re)];
+  const jobs: Record<string, string> = {};
+  for (let i = 0; i < matches.length; i++) {
+    const id = matches[i][1];
+    const start = matches[i].index ?? 0;
+    const end =
+      i + 1 < matches.length ? (matches[i + 1].index ?? body.length) : body.length;
+    jobs[id] = body.slice(start, end);
+  }
+  return jobs;
+}
+
+function jobDisplayName(block: string): string | undefined {
+  const match = block.match(/^[ ]{4}name:\s*(.+)$/m);
+  return match?.[1]?.trim();
+}
+
+function jobNeeds(block: string): string[] {
+  const inline = block.match(/^[ ]{4}needs:\s*\[([^\]]+)\]/m);
+  if (inline) {
+    return inline[1]
+      .split(",")
+      .map((s) => s.trim())
+      .filter(Boolean);
+  }
+  const list: string[] = [];
+  const lines = block.split("\n");
+  let inNeeds = false;
+  for (const line of lines) {
+    if (/^[ ]{4}needs:\s*$/.test(line)) {
+      inNeeds = true;
+      continue;
+    }
+    if (inNeeds) {
+      const item = line.match(/^[ ]{6}-\s+(\S+)\s*$/);
+      if (item) {
+        list.push(item[1]);
+        continue;
+      }
+      if (/^[ ]{4}\S/.test(line) || /^[ ]{2}[a-z]/.test(line)) {
+        break;
+      }
+    }
+  }
+  return list;
+}
+
+describe("CI required merge gate (SBS-874)", () => {
+  const jobs = parseJobs(ciYaml);
+
+  it("puts the required check name on a gate that needs Windows rust and install.ps1", () => {
+    const namedBuildPlusTest = Object.entries(jobs).filter(
+      ([, block]) => jobDisplayName(block) === "Build + test",
+    );
+    expect(namedBuildPlusTest).toHaveLength(1);
+    const [id, block] = namedBuildPlusTest[0];
+    expect(id).not.toBe("build-test");
+    expect(block).toMatch(/^[ ]{4}if:\s*always\(\)\s*$/m);
+    const needs = jobNeeds(block);
+    expect(needs).toEqual(
+      expect.arrayContaining(["build-test", "cross-platform-rust", "installer-script"]),
+    );
+    expect(needs).not.toContain("clippy");
+  });
+
+  it("keeps the Linux suite under a different check name", () => {
+    expect(jobDisplayName(jobs["build-test"])).toBe("Linux build + test");
+  });
+
+  it("still runs install.ps1 Pester as Installer script tests", () => {
+    const block = jobs["installer-script"];
+    expect(block).toBeDefined();
+    expect(jobDisplayName(block)).toBe("Installer script tests");
+    expect(block).toContain("scripts/install.Tests.ps1");
+  });
+
+  it("still runs Windows keyring tests on windows-latest", () => {
+    const block = jobs["cross-platform-rust"];
+    expect(block).toBeDefined();
+    expect(block).toMatch(/windows-latest/);
+    expect(block).toContain("scripts/test-rust-windows.ps1");
+  });
+});

--- a/src/test/ci-required-checks.test.ts
+++ b/src/test/ci-required-checks.test.ts
@@ -1,104 +1,230 @@
 // Pins SBS-874: branch protection required contexts are only the check named
-// "Build + test". If that name sits on the Linux-only job again, a red
-// Windows keyring run or a red install.ps1 Pester job cannot block merge.
-// These are file-content assertions against .github/workflows/ci.yml so a
-// rename or a dropped `needs` fails CI instead of silently reopening the hole.
+// "Build + test". If that name sits on the Linux-only job again, a red Windows
+// keyring run or a red install.ps1 Pester job cannot block merge.
+//
+// These assertions run against the PARSED .github/workflows/ci.yml, not raw
+// text. Substring checks were not enough: `windows-latest` also appears in
+// step `if:` guards, so dropping it from `strategy.matrix.os` used to keep a
+// text-matching test green while the Windows cell never ran. Likewise the gate
+// job carries `if: always()`, so a step that only echoes the dependency
+// results would keep the required check green while Linux, the Rust matrix, or
+// install.ps1 was red. Each helper below is exercised against a fixture that
+// reopens the hole, so a helper that stops biting fails its own test.
 import { describe, expect, it } from "vitest";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
+import { parse } from "yaml";
 
-const repoRoot = process.cwd();
-const ciYaml = readFileSync(join(repoRoot, ".github", "workflows", "ci.yml"), "utf8");
+/** The single required context configured in branch protection. */
+const REQUIRED_CHECK_NAME = "Build + test";
 
-/** Job blocks under `jobs:` keyed by id. Keys are the 2-space identifiers. */
-function parseJobs(yaml: string): Record<string, string> {
-  const marker = "\njobs:\n";
-  const jobsIdx = yaml.indexOf(marker);
-  if (jobsIdx < 0) {
-    throw new Error("ci.yml has no jobs: block");
-  }
-  const body = yaml.slice(jobsIdx + marker.length);
-  const re = /^[ ]{2}([a-z][a-z0-9-]*):$/gm;
-  const matches = [...body.matchAll(re)];
-  const jobs: Record<string, string> = {};
-  for (let i = 0; i < matches.length; i++) {
-    const id = matches[i][1];
-    const start = matches[i].index ?? 0;
-    const end =
-      i + 1 < matches.length ? (matches[i + 1].index ?? body.length) : body.length;
-    jobs[id] = body.slice(start, end);
+/** Jobs that must be green before the required check can be green. */
+const GATED_JOB_IDS = ["build-test", "cross-platform-rust", "installer-script"];
+
+interface WorkflowStep {
+  name?: string;
+  if?: string;
+  run?: string;
+  uses?: string;
+  shell?: string;
+  "continue-on-error"?: boolean;
+}
+
+interface WorkflowJob {
+  name?: string;
+  if?: string;
+  needs?: string | string[];
+  "runs-on"?: string;
+  "continue-on-error"?: boolean;
+  strategy?: { "fail-fast"?: boolean; matrix?: Record<string, unknown> };
+  steps?: WorkflowStep[];
+}
+
+interface Workflow {
+  jobs?: Record<string, WorkflowJob>;
+}
+
+function parseJobs(source: string): Record<string, WorkflowJob> {
+  const workflow = parse(source) as Workflow | null;
+  const jobs = workflow?.jobs;
+  if (!jobs || typeof jobs !== "object") {
+    throw new Error("workflow has no jobs: block");
   }
   return jobs;
 }
 
-function jobDisplayName(block: string): string | undefined {
-  const match = block.match(/^[ ]{4}name:\s*(.+)$/m);
-  return match?.[1]?.trim();
+/** GitHub falls back to the job id when a job has no display `name:`. */
+function jobsWithCheckName(
+  jobs: Record<string, WorkflowJob>,
+  checkName: string,
+): [string, WorkflowJob][] {
+  return Object.entries(jobs).filter(([id, job]) => (job.name ?? id) === checkName);
 }
 
-function jobNeeds(block: string): string[] {
-  const inline = block.match(/^[ ]{4}needs:\s*\[([^\]]+)\]/m);
-  if (inline) {
-    return inline[1]
-      .split(",")
-      .map((s) => s.trim())
-      .filter(Boolean);
-  }
-  const list: string[] = [];
-  const lines = block.split("\n");
-  let inNeeds = false;
-  for (const line of lines) {
-    if (/^[ ]{4}needs:\s*$/.test(line)) {
-      inNeeds = true;
-      continue;
-    }
-    if (inNeeds) {
-      const item = line.match(/^[ ]{6}-\s+(\S+)\s*$/);
-      if (item) {
-        list.push(item[1]);
-        continue;
-      }
-      if (/^[ ]{4}\S/.test(line) || /^[ ]{2}[a-z]/.test(line)) {
-        break;
-      }
-    }
-  }
-  return list;
+function needsOf(job: WorkflowJob): string[] {
+  const needs = job.needs;
+  if (needs === undefined) return [];
+  return Array.isArray(needs) ? needs : [needs];
 }
+
+/** The `strategy.matrix.os` list, or undefined when it is absent or dynamic. */
+function matrixOs(job: WorkflowJob): string[] | undefined {
+  const os = job.strategy?.matrix?.os;
+  if (!Array.isArray(os)) return undefined;
+  return os.map(String);
+}
+
+/** Every `run:` script in the job, flattened, regardless of step guards. */
+function runScripts(job: WorkflowJob): string[] {
+  return (job.steps ?? []).flatMap((step) => (step.run ? [step.run] : []));
+}
+
+/**
+ * Dependency ids that the job actually gates on: ids whose
+ * `needs.<id>.result` is compared against `success` by a shell test that
+ * aborts the step on mismatch.
+ *
+ * Only steps that always run and always count are considered, so neither
+ * `continue-on-error: true` nor an `if:` guard that skips the step on failure
+ * can be used to smuggle a check past this. A bare
+ * `echo "${{ needs.x.result }}"` line does not count either: it never changes
+ * the exit code.
+ */
+function failClosedResultChecks(job: WorkflowJob): string[] {
+  if (job["continue-on-error"] === true) return [];
+  const gatingSteps = (job.steps ?? []).filter((step) => {
+    if (step["continue-on-error"] === true) return false;
+    const guard = step.if?.trim();
+    return guard === undefined || guard === "always()" || guard === "${{ always() }}";
+  });
+  // Matches `test "${{ needs.x.result }}" = "success"` and the `[ ... ]` /
+  // `[[ ... ]]` spellings, with or without quotes, `=` or `==`.
+  const comparison =
+    /(?:^|\n|;|&&|\|\|)[ \t]*(?:test|\[\[?)[ \t]+"?\$\{\{[ \t]*needs\.([A-Za-z0-9_-]+)\.result[ \t]*\}\}"?[ \t]*={1,2}[ \t]*"?success"?/g;
+  const gated = new Set<string>();
+  for (const script of gatingSteps.flatMap((step) => (step.run ? [step.run] : []))) {
+    for (const match of script.matchAll(comparison)) {
+      gated.add(match[1]);
+    }
+  }
+  return [...gated].sort();
+}
+
+const ciYaml = readFileSync(
+  join(process.cwd(), ".github", "workflows", "ci.yml"),
+  "utf8",
+);
+const jobs = parseJobs(ciYaml);
 
 describe("CI required merge gate (SBS-874)", () => {
-  const jobs = parseJobs(ciYaml);
-
   it("puts the required check name on a gate that needs Windows rust and install.ps1", () => {
-    const namedBuildPlusTest = Object.entries(jobs).filter(
-      ([, block]) => jobDisplayName(block) === "Build + test",
-    );
-    expect(namedBuildPlusTest).toHaveLength(1);
-    const [id, block] = namedBuildPlusTest[0];
+    const named = jobsWithCheckName(jobs, REQUIRED_CHECK_NAME);
+    expect(named).toHaveLength(1);
+    const [id, gate] = named[0];
     expect(id).not.toBe("build-test");
-    expect(block).toMatch(/^[ ]{4}if:\s*always\(\)\s*$/m);
-    const needs = jobNeeds(block);
-    expect(needs).toEqual(
-      expect.arrayContaining(["build-test", "cross-platform-rust", "installer-script"]),
-    );
-    expect(needs).not.toContain("clippy");
+    // Without always() the gate is skipped when a dependency fails, and a
+    // skipped required check does not block merge.
+    expect(gate.if?.trim()).toBe("always()");
+    expect(needsOf(gate)).toEqual(expect.arrayContaining(GATED_JOB_IDS));
+    // Clippy is non-blocking until the existing warnings are cleared.
+    expect(needsOf(gate)).not.toContain("clippy");
+  });
+
+  it("fails the required check unless every gated job reported success", () => {
+    const [, gate] = jobsWithCheckName(jobs, REQUIRED_CHECK_NAME)[0];
+    // The point of the gate: `if: always()` means the step runs on failed,
+    // skipped, and cancelled dependencies, so it must compare each result
+    // against `success` itself.
+    expect(failClosedResultChecks(gate)).toEqual([...GATED_JOB_IDS].sort());
   });
 
   it("keeps the Linux suite under a different check name", () => {
-    expect(jobDisplayName(jobs["build-test"])).toBe("Linux build + test");
+    expect(jobs["build-test"]?.name).toBe("Linux build + test");
   });
 
   it("still runs install.ps1 Pester as Installer script tests", () => {
-    const block = jobs["installer-script"];
-    expect(block).toBeDefined();
-    expect(jobDisplayName(block)).toBe("Installer script tests");
-    expect(block).toContain("scripts/install.Tests.ps1");
+    const job = jobs["installer-script"];
+    expect(job).toBeDefined();
+    expect(job.name).toBe("Installer script tests");
+    expect(job["runs-on"]).toBe("windows-latest");
+    expect(runScripts(job).join("\n")).toContain("scripts/install.Tests.ps1");
   });
 
-  it("still runs Windows keyring tests on windows-latest", () => {
-    const block = jobs["cross-platform-rust"];
-    expect(block).toBeDefined();
-    expect(block).toMatch(/windows-latest/);
-    expect(block).toContain("scripts/test-rust-windows.ps1");
+  it("still runs Windows keyring tests on a windows-latest matrix cell", () => {
+    const job = jobs["cross-platform-rust"];
+    expect(job).toBeDefined();
+    // The list itself, not a substring of the block: `windows-latest` also
+    // appears in step `if:` guards, so those must not stand in for a cell.
+    expect(matrixOs(job)).toContain("windows-latest");
+    expect(runScripts(job).join("\n")).toContain("scripts/test-rust-windows.ps1");
+  });
+});
+
+// Fixtures that reopen the exact holes above. If a helper stops biting, these
+// stop failing and this block goes red.
+describe("the gate assertions reject a workflow that reopens the hole", () => {
+  it("rejects a gate step that only echoes the dependency results", () => {
+    const fixture = parseJobs(`
+jobs:
+  merge-gate:
+    name: Build + test
+    if: always()
+    needs: [build-test, cross-platform-rust, installer-script]
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Require everything
+        run: |
+          echo "build-test=\${{ needs.build-test.result }}"
+          echo "cross-platform-rust=\${{ needs.cross-platform-rust.result }}"
+          echo "installer-script=\${{ needs.installer-script.result }}"
+`);
+    const gate = jobsWithCheckName(fixture, REQUIRED_CHECK_NAME)[0][1];
+    // Passes the name / always() / needs assertions, but gates nothing.
+    expect(needsOf(gate)).toEqual(expect.arrayContaining(GATED_JOB_IDS));
+    expect(failClosedResultChecks(gate)).toEqual([]);
+  });
+
+  it("rejects result checks parked behind continue-on-error or a skip guard", () => {
+    const fixture = parseJobs(`
+jobs:
+  merge-gate:
+    name: Build + test
+    if: always()
+    needs: [build-test, cross-platform-rust, installer-script]
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Soft check
+        continue-on-error: true
+        run: test "\${{ needs.build-test.result }}" = "success"
+      - name: Guarded check
+        if: needs.cross-platform-rust.result == 'success'
+        run: test "\${{ needs.cross-platform-rust.result }}" = "success"
+      - name: Real check
+        run: test "\${{ needs.installer-script.result }}" = "success"
+`);
+    const gate = jobsWithCheckName(fixture, REQUIRED_CHECK_NAME)[0][1];
+    expect(failClosedResultChecks(gate)).toEqual(["installer-script"]);
+  });
+
+  it("rejects a matrix that mentions windows-latest only in step guards", () => {
+    const fixture = parseJobs(`
+jobs:
+  cross-platform-rust:
+    name: Headless Rust tests (\${{ matrix.os }})
+    strategy:
+      matrix:
+        os: [ubuntu-22.04, macos-latest]
+    runs-on: \${{ matrix.os }}
+    steps:
+      - name: Rust tests (Windows, no desktop)
+        if: matrix.os == 'windows-latest'
+        run: powershell -ExecutionPolicy Bypass -File scripts/test-rust-windows.ps1
+`);
+    const job = fixture["cross-platform-rust"];
+    // The old substring pins both still pass on this workflow.
+    expect(JSON.stringify(job)).toContain("windows-latest");
+    expect(runScripts(job).join("\n")).toContain("scripts/test-rust-windows.ps1");
+    // The parsed matrix does not.
+    expect(matrixOs(job)).not.toContain("windows-latest");
   });
 });


### PR DESCRIPTION
## Summary

- Branch protection required contexts are only **Build + test**. That name sat on the Linux-only job, so a red Windows keyring run or a red install.ps1 Pester job could not block merge.
- The Linux suite is now named **Linux build + test**. The required name **Build + test** is a merge-gate job (`if: always()`) that fails unless `build-test`, `cross-platform-rust` (all matrix legs, including Windows keyring), and `installer-script` each report `success`.
- A reviewer who hits a red Windows keyring or Pester job now sees the required **Build + test** check fail. Merge is blocked for non-admins.

Linear: https://linear.app/southboundsoftware/issue/SBS-874/toolport-only-build-test-is-required-so-windows-keyring-and-installps1

## Files

- ci.yml: Linux job renamed; merge-gate owns Build + test
- src/test/ci-required-checks.test.ts pins the gate
- CHANGELOG and CONTRIBUTING updated; no GitHub settings claim

## Test plan

- prettier check pass; eslint 0 errors 49 warnings; build pass; vitest 386 passed

### Fail without fix

Reverted only ci.yml to origin/main. Two SBS-874 tests failed (gate name still on Linux job). Installer and windows-latest existence tests passed either way. Restored; 4/4 pass.

## Sweep

No other stale claim that Build + test is the Linux-only required job. docs/audit LEDGER still describes the pre-fix hole (not committed).

## What this makes more likely

macOS headless failure now also blocks merge (same matrix job as Windows). A skipped Windows runner fails the required check instead of looking green. Merge waits for Windows + installer tests, so PRs are slower. Clippy stays out of the gate.

## Gaps

Did not change GitHub branch protection via API. Tyler still needs to click if he wants Installer script tests and Headless Rust tests (windows-latest) listed as separate required contexts. enforce_admins is still false so an admin can merge red. Ruleset 18179593 is still deletion / non_fast_forward only. Clippy stays non-blocking. Did not run rust/smoke/Pester locally. Did not merge.

Not merged. Issue left open.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add merge-gate job to enforce Windows keyring and install.ps1 CI checks
> - Introduces a new `Build + test` merge-gate job in [ci.yml](https://github.com/tsouth89/toolport/pull/773/files#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03f) that requires success from the Linux build, cross-platform Rust matrix (including Windows keyring), and installer.ps1 Pester jobs before allowing merge.
> - The previous `Build + test` job is renamed to `Linux build + test`; clippy remains non-blocking.
> - Adds a [test file](https://github.com/tsouth89/toolport/pull/773/files#diff-83bd03a54be30e6a22b43f32133e5dfed33e97b9c109d419f0f5ba10711dc598) that parses the workflow YAML and asserts invariants — gate structure, fail-closed result checks, Windows presence in the Rust matrix, and Pester invocation in the installer job.
>
> #### 🖇️ Linked Issues
> Resolves [SBS-874](https://linear.app/southboundsoftware/issue/SBS-874).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 30c58da.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->