### PR TITLE
fix(integrity): do not treat a rename-window NotFound as an empty quarantine set (SBS-871)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,14 @@ Entries before the rename below shipped under the project's former name, Conduit
 
 ### Fixed
 
+- **A transient missing quarantine store no longer installs an empty block set.**
+  Rewriting `quarantine.json` uses a temp file plus rename, so a reader can see
+  `NotFound` for a tick. That used to look like "nothing is blocked" and the
+  gateway would un-hide every quarantined tool. The read now retries the same
+  way the pin store already does, and a miss after those retries is an error
+  unless this profile has never written pins (a real first run). A rebuild
+  keeps the live set, or hides the catalog on a cold start until the store
+  reads. (SBS-871)
 - **Linux `.deb` installs a `toolport` command.** The package still ships the
   crate binary as `conduit` (compat alias) and now also puts `toolport` on
   `PATH`, matching the AppImage installer and the brand. `install.sh` tells apt

--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -8536,9 +8536,63 @@ fn merge_tool_scopes_for_http(reg: &Registry) -> HashMap<String, HashSet<String>
     by_server
 }
 
+/// Live quarantine enforcement a rebuild can keep when the store read fails
+/// (SBS-871). `None` is a genuine cold start (no prior decision).
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct PriorQuarantine {
+    set: BTreeSet<String>,
+    fail_closed: bool,
+}
+
+/// How [`build_router`] should start the quarantine set after a store read.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum QuarantineBootstrap {
+    UseSet(BTreeSet<String>),
+    KeepSet(BTreeSet<String>),
+    KeepFailClosed,
+    FailClosedCatalog,
+}
+
+/// Decide the quarantine set a rebuilt router starts with (SBS-871).
+///
+/// A store `Err` must never become an empty set: keep the pre-rebuild live set
+/// when we have one, and hide the whole catalog on a genuine cold start.
+fn quarantine_bootstrap(
+    stored: Result<BTreeSet<String>, String>,
+    previous: Option<&PriorQuarantine>,
+) -> QuarantineBootstrap {
+    match stored {
+        Ok(set) => QuarantineBootstrap::UseSet(set),
+        Err(_) => match previous {
+            Some(prior) if prior.fail_closed => QuarantineBootstrap::KeepFailClosed,
+            Some(prior) => QuarantineBootstrap::KeepSet(prior.set.clone()),
+            None => QuarantineBootstrap::FailClosedCatalog,
+        },
+    }
+}
+
+/// Snapshot the live router's quarantine decision BEFORE a rebuild (SBS-871).
+/// A never-built placeholder (`Router::new()`) is not a prior live set.
+fn prior_quarantine_from_router(router: &Router) -> Option<PriorQuarantine> {
+    if router.catalog_fail_closed() {
+        return Some(PriorQuarantine {
+            set: router.quarantined().clone(),
+            fail_closed: true,
+        });
+    }
+    if router.server_count() == 0 && router.quarantined().is_empty() {
+        return None;
+    }
+    Some(PriorQuarantine {
+        set: router.quarantined().clone(),
+        fail_closed: false,
+    })
+}
+
 /// Spawn and connect every enabled server into a router. With `profile` set, only
 /// that profile's servers are connected (per-client scoping); otherwise the
 /// active profile is used.
+#[allow(clippy::too_many_arguments)] // SBS-871 adds the pre-rebuild quarantine set.
 fn build_router(
     reg: &Registry,
     profile: Option<&str>,
@@ -8554,6 +8608,8 @@ fn build_router(
     resource_updated: Option<ResourceUpdatedDispatch>,
     // Live subscription table so reconnect factories re-issue resources/subscribe.
     resource_subs: Option<Arc<Mutex<ResourceSubscriptionTable>>>,
+    // Pre-rebuild live quarantine set. `None` is a genuine cold start (SBS-871).
+    previous_quarantine: Option<PriorQuarantine>,
 ) -> Router {
     // In HTTP mode one process serves every registered client, so connect the
     // union of all their profiles (per-request filtering scopes each one down).
@@ -8601,35 +8657,57 @@ fn build_router(
         }
         allow
     };
+    // Historical installs have pins without quarantine.json. Materialize `{}`
+    // under the store lock so a later missing-while-pins-exist read is a real
+    // rename-window error, not every boot (SBS-871).
+    integrity::ensure_quarantine_store_for_existing_pins(profile);
+    let stored = if reg.quarantine_on_drift_effective() {
+        integrity::quarantined(profile)
+    } else {
+        // Baseline tamper invalidates the catalog's trust root, so those entries
+        // remain blocked even when optional high-risk drift quarantine is off.
+        integrity::mandatory_quarantined(profile)
+    };
+    let stored_error = stored.as_ref().err().cloned();
+    let bootstrap = quarantine_bootstrap(stored, previous_quarantine.as_ref());
+    if let Some(e) = stored_error {
+        match &bootstrap {
+            QuarantineBootstrap::KeepSet(_) => {
+                glog(&format!(
+                    "SECURITY: {e}; keeping the pre-rebuild quarantine set rather than \
+                     installing an empty one. Fix or replace the quarantine store."
+                ));
+                eprintln!("toolport: {e}; keeping the pre-rebuild quarantine set");
+            }
+            QuarantineBootstrap::KeepFailClosed | QuarantineBootstrap::FailClosedCatalog => {
+                glog(&format!(
+                    "SECURITY: {e}; blocking the catalog until the quarantine store reads. \
+                     Fix or replace the quarantine store."
+                ));
+                eprintln!(
+                    "toolport: {e}; blocking the catalog until the quarantine store reads"
+                );
+            }
+            QuarantineBootstrap::UseSet(_) => {}
+        }
+    }
+    let (quarantined, fail_closed_catalog) = match bootstrap {
+        QuarantineBootstrap::UseSet(set) | QuarantineBootstrap::KeepSet(set) => (set, false),
+        QuarantineBootstrap::KeepFailClosed | QuarantineBootstrap::FailClosedCatalog => {
+            (BTreeSet::new(), true)
+        }
+    };
     let policy = ToolPolicy {
         disabled,
         allow,
         deny_destructive: reg.deny_destructive_effective(),
         // Hide already-quarantined tools from the first build (the set persists across
         // restarts); newly detected drift is added during the integrity check below.
-        // On store failure, start with empty blocked and log loudly (SOU-320): there is
-        // no prior live set yet. We deliberately do NOT rename/clear a corrupt file —
-        // that would make the next reconcile install a permanent empty set.
-        quarantined: {
-            let stored = if reg.quarantine_on_drift_effective() {
-                integrity::quarantined(profile)
-            } else {
-                // Baseline tamper invalidates the catalog's trust root, so those entries
-                // remain blocked even when optional high-risk drift quarantine is off.
-                integrity::mandatory_quarantined(profile)
-            };
-            match stored {
-                Ok(set) => set,
-                Err(e) => {
-                    glog(&format!(
-                        "SECURITY: {e}; starting with no quarantine set (cold start has \
-                         no prior set to keep). Fix or replace the quarantine store."
-                    ));
-                    eprintln!("toolport: {e}; starting with no quarantine set");
-                    Default::default()
-                }
-            }
-        },
+        // On store Err, keep the pre-rebuild live set or hide the catalog (SBS-871).
+        // We deliberately do NOT rename/clear a corrupt file — that would make the
+        // next reconcile install a permanent empty set (SOU-320).
+        quarantined,
+        fail_closed_catalog,
     };
 
     // Connect concurrently so total time is the slowest server, not the sum. Each
@@ -10176,6 +10254,16 @@ fn watch_tick(
         let _rebuild = rebuild_lock
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
+        // Snapshot the pre-rebuild router BEFORE build_router so a store Err
+        // can keep the live quarantine set (SBS-871). The routes map is also
+        // the authoritative (server, original) source for tools a guarded
+        // rebuild keeps from the previous catalog (issue #700).
+        let previous_router = {
+            let guard = router
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            (**guard).clone()
+        };
         // Build the new router (spawns processes) before taking the router lock.
         let new_router = build_router(
             &new_reg,
@@ -10186,6 +10274,7 @@ fn watch_tick(
             root.as_deref(),
             resource_updated.cloned(),
             resource_subs.cloned(),
+            prior_quarantine_from_router(&previous_router),
         );
         // Re-issue tracked resource subscriptions against the fresh connections.
         if let Some(subs) = resource_subs {
@@ -10193,15 +10282,6 @@ fn watch_tick(
         }
         let server_count = new_router.server_count();
         let tools = new_router.aggregated_tools();
-        // Snapshot the pre-rebuild router BEFORE publishing the new one: its
-        // routes map is the authoritative (server, original) source for tools a
-        // guarded rebuild keeps from the previous catalog (issue #700).
-        let previous_router = {
-            let guard = router
-                .lock()
-                .unwrap_or_else(std::sync::PoisonError::into_inner);
-            (**guard).clone()
-        };
         *registry
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner) = new_reg;
@@ -11778,6 +11858,14 @@ fn rebuild_router_for_root(state: &GatewayState) {
         .unwrap_or_else(std::sync::PoisonError::into_inner)
         .clone();
     let root = current_client_root(state);
+    // Snapshot before build_router so a store Err keeps the live set (SBS-871).
+    let previous_router = {
+        let guard = state
+            .router
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        (**guard).clone()
+    };
     let new_router = build_router(
         &reg,
         profile.as_deref(),
@@ -11787,18 +11875,10 @@ fn rebuild_router_for_root(state: &GatewayState) {
         root.as_deref(),
         state.resource_updated_sink.clone(),
         Some(Arc::clone(&state.resource_subs)),
+        prior_quarantine_from_router(&previous_router),
     );
     reestablish_all_resource_subscriptions(&new_router, &state.resource_subs);
     let tools = new_router.aggregated_tools();
-    // Snapshot the pre-rebuild router before publishing: authoritative routes
-    // for tools a guarded rebuild keeps from the previous catalog (issue #700).
-    let previous_router = {
-        let guard = state
-            .router
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
-        (**guard).clone()
-    };
     *state
         .router
         .lock()
@@ -12054,6 +12134,14 @@ fn process_request(
                 .unwrap_or_else(std::sync::PoisonError::into_inner)
                 .clone();
             let root = current_client_root(state);
+            // Snapshot before build_router so a store Err keeps the live set (SBS-871).
+            let previous_router = {
+                let guard = state
+                    .router
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner);
+                (**guard).clone()
+            };
             let built = build_router(
                 &reg,
                 profile_snapshot.as_deref(),
@@ -12063,19 +12151,11 @@ fn process_request(
                 root.as_deref(),
                 state.resource_updated_sink.clone(),
                 Some(Arc::clone(&state.resource_subs)),
+                prior_quarantine_from_router(&previous_router),
             );
             if built.server_count() > 0 {
                 reestablish_all_resource_subscriptions(&built, &state.resource_subs);
                 let tools = built.aggregated_tools();
-                // Snapshot the pre-rebuild router before publishing: authoritative
-                // routes for tools the guard keeps from the previous catalog.
-                let previous_router = {
-                    let guard = state
-                        .router
-                        .lock()
-                        .unwrap_or_else(std::sync::PoisonError::into_inner);
-                    (**guard).clone()
-                };
                 *state
                     .router
                     .lock()
@@ -14760,6 +14840,8 @@ fn main() {
                 // Cold start: no upstream clients yet; reconnect factories still
                 // capture the shared table for later re-subscribes.
                 Some(resource_subs_for_build),
+                // Genuine cold start: no prior live set to keep (SBS-871).
+                None,
             );
             let tools = built.aggregated_tools();
             glog(&format!(
@@ -24826,6 +24908,53 @@ mod tests {
         assert!(reconcile_to(&router, &stdout, None, set_of(&["a__x"])));
         assert_eq!(router.lock().unwrap().quarantined(), &set_of(&["a__x"]));
         assert!(!reconcile_to(&router, &stdout, None, set_of(&["a__x"])));
+    }
+
+    /// SBS-871: build_router must not Default::default() an empty set on store Err.
+    /// Extracted so the decision can be tested without spawning downstream servers.
+    #[test]
+    fn sbs871_quarantine_bootstrap_keeps_prior_set_on_store_err() {
+        let prior = PriorQuarantine {
+            set: set_of(&["srv__wipe"]),
+            fail_closed: false,
+        };
+        assert_eq!(
+            quarantine_bootstrap(Err("store unreadable".into()), Some(&prior)),
+            QuarantineBootstrap::KeepSet(set_of(&["srv__wipe"]))
+        );
+    }
+
+    #[test]
+    fn sbs871_quarantine_bootstrap_fail_closes_catalog_on_cold_start_err() {
+        assert_eq!(
+            quarantine_bootstrap(Err("store unreadable".into()), None),
+            QuarantineBootstrap::FailClosedCatalog
+        );
+    }
+
+    #[test]
+    fn sbs871_quarantine_bootstrap_keeps_fail_closed_across_rebuild() {
+        let prior = PriorQuarantine {
+            set: BTreeSet::new(),
+            fail_closed: true,
+        };
+        assert_eq!(
+            quarantine_bootstrap(Err("still unreadable".into()), Some(&prior)),
+            QuarantineBootstrap::KeepFailClosed
+        );
+    }
+
+    #[test]
+    fn sbs871_quarantine_bootstrap_uses_the_store_on_ok() {
+        assert_eq!(
+            quarantine_bootstrap(Ok(set_of(&["srv__wipe"])), None),
+            QuarantineBootstrap::UseSet(set_of(&["srv__wipe"]))
+        );
+    }
+
+    #[test]
+    fn sbs871_prior_quarantine_from_placeholder_router_is_none() {
+        assert_eq!(prior_quarantine_from_router(&Router::new()), None);
     }
 
     #[test]

--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -8549,7 +8549,9 @@ struct PriorQuarantine {
 enum QuarantineBootstrap {
     UseSet(BTreeSet<String>),
     KeepSet(BTreeSet<String>),
-    KeepFailClosed,
+    /// Carry the previous set forward AND keep the catalog hidden: the store is
+    /// still unreadable, so the set alone is not the full enforcement state.
+    KeepFailClosed(BTreeSet<String>),
     FailClosedCatalog,
 }
 
@@ -8564,7 +8566,9 @@ fn quarantine_bootstrap(
     match stored {
         Ok(set) => QuarantineBootstrap::UseSet(set),
         Err(_) => match previous {
-            Some(prior) if prior.fail_closed => QuarantineBootstrap::KeepFailClosed,
+            Some(prior) if prior.fail_closed => {
+                QuarantineBootstrap::KeepFailClosed(prior.set.clone())
+            }
             Some(prior) => QuarantineBootstrap::KeepSet(prior.set.clone()),
             None => QuarantineBootstrap::FailClosedCatalog,
         },
@@ -8572,20 +8576,18 @@ fn quarantine_bootstrap(
 }
 
 /// Snapshot the live router's quarantine decision BEFORE a rebuild (SBS-871).
-/// A never-built placeholder (`Router::new()`) is not a prior live set.
+///
+/// `None` only for the never-built startup placeholder. A router that WAS built but
+/// connected zero servers (every connect failed, or the profile is empty) is still a
+/// real prior decision, so a store `Err` on the next rebuild keeps that decision
+/// instead of pretending this is a cold start.
 fn prior_quarantine_from_router(router: &Router) -> Option<PriorQuarantine> {
-    if router.catalog_fail_closed() {
-        return Some(PriorQuarantine {
-            set: router.quarantined().clone(),
-            fail_closed: true,
-        });
-    }
-    if router.server_count() == 0 && router.quarantined().is_empty() {
+    if !router.is_built() {
         return None;
     }
     Some(PriorQuarantine {
         set: router.quarantined().clone(),
-        fail_closed: false,
+        fail_closed: router.catalog_fail_closed(),
     })
 }
 
@@ -8679,23 +8681,23 @@ fn build_router(
                 ));
                 eprintln!("toolport: {e}; keeping the pre-rebuild quarantine set");
             }
-            QuarantineBootstrap::KeepFailClosed | QuarantineBootstrap::FailClosedCatalog => {
+            QuarantineBootstrap::KeepFailClosed(_) | QuarantineBootstrap::FailClosedCatalog => {
                 glog(&format!(
                     "SECURITY: {e}; blocking the catalog until the quarantine store reads. \
                      Fix or replace the quarantine store."
                 ));
-                eprintln!(
-                    "toolport: {e}; blocking the catalog until the quarantine store reads"
-                );
+                eprintln!("toolport: {e}; blocking the catalog until the quarantine store reads");
             }
             QuarantineBootstrap::UseSet(_) => {}
         }
     }
     let (quarantined, fail_closed_catalog) = match bootstrap {
         QuarantineBootstrap::UseSet(set) | QuarantineBootstrap::KeepSet(set) => (set, false),
-        QuarantineBootstrap::KeepFailClosed | QuarantineBootstrap::FailClosedCatalog => {
-            (BTreeSet::new(), true)
-        }
+        // Carry the set forward too: a fail-closed router can hold real blocks (an
+        // integrity write failure unions them in), and dropping them would weaken
+        // enforcement the moment the hide lifts.
+        QuarantineBootstrap::KeepFailClosed(set) => (set, true),
+        QuarantineBootstrap::FailClosedCatalog => (BTreeSet::new(), true),
     };
     let policy = ToolPolicy {
         disabled,
@@ -8704,7 +8706,7 @@ fn build_router(
         // Hide already-quarantined tools from the first build (the set persists across
         // restarts); newly detected drift is added during the integrity check below.
         // On store Err, keep the pre-rebuild live set or hide the catalog (SBS-871).
-        // We deliberately do NOT rename/clear a corrupt file — that would make the
+        // We deliberately do NOT rename/clear a corrupt file: that would make the
         // next reconcile install a permanent empty set (SOU-320).
         quarantined,
         fail_closed_catalog,
@@ -9668,6 +9670,8 @@ fn requarantine_after_integrity_change(
     let mut guard = router
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner);
+    // Only a successful read is allowed to lift a fail-closed catalog (SBS-871).
+    let store_read_ok = persisted.is_ok();
     let mut enforce = match persisted {
         Ok(set) => set,
         Err(e) => {
@@ -9686,7 +9690,12 @@ fn requarantine_after_integrity_change(
     // make_mut clones the Router (sharing its Arc<ServerSlot> connections) only if an in-flight
     // request still holds the old Arc; the old snapshot keeps serving until that request ends.
     let r = Arc::make_mut(&mut guard);
-    r.requarantine(enforce);
+    if store_read_ok {
+        r.requarantine_from_store(enforce);
+    } else {
+        // Store still unreadable: install the union, but leave any fail-closed hide up.
+        r.requarantine(enforce);
+    }
     r.aggregated_tools()
 }
 
@@ -9707,6 +9716,9 @@ fn fail_closed_integrity_catalog(
         fail_closed.extend(persisted);
     }
     let r = Arc::make_mut(&mut guard);
+    // Never `requarantine_from_store` here: this is the integrity-store FAILURE path,
+    // so a fail-closed catalog stays hidden. `reconcile_quarantine` lifts it on the
+    // next watcher tick that actually reads the store (SBS-871).
     r.requarantine(fail_closed);
     r.aggregated_tools()
 }
@@ -9793,6 +9805,10 @@ fn reconcile_quarantine(
 /// only if it actually differs. Split out from the disk read so the decision logic is
 /// testable without touching `conduit_dir()`, which memoizes per process and so can't be
 /// redirected from a test once anything else has resolved it.
+///
+/// This is THE lift point for a fail-closed catalog (SBS-871): its only caller,
+/// `reconcile_quarantine`, gets here solely on a successful store read. Every other
+/// `requarantine` call sits on an error path and leaves the hide up.
 fn reconcile_to(
     router: &Arc<Mutex<Arc<Router>>>,
     stdout: &Arc<Mutex<std::io::Stdout>>,
@@ -9803,13 +9819,17 @@ fn reconcile_to(
         let mut guard = router
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
-        if guard.quarantined() == &want {
+        // The set alone is not the enforcement state: a fail-closed router hides
+        // everything while reporting an empty set, so comparing sets only would make a
+        // successful read of an empty store a no-op and leave the gateway dark until
+        // the process restarted (SBS-871).
+        if guard.quarantined() == &want && !guard.catalog_fail_closed() {
             false
         } else {
             // make_mut clones only if an in-flight request still holds the old Arc, so a
             // request mid-flight keeps serving its snapshot until it finishes.
             let r = Arc::make_mut(&mut guard);
-            r.requarantine(want);
+            r.requarantine_from_store(want);
             true
         }
     };
@@ -9828,6 +9848,33 @@ fn reconcile_to(
     changed
 }
 
+/// A fail-closed catalog serves nothing, so the last-good cache must go too
+/// (SBS-871). Every other empty build is treated as transient and deliberately keeps
+/// the cache; without this the hide would only reach `route_call` while `tools/list`
+/// kept advertising the catalog it was supposed to hide.
+///
+/// The on-disk cache is cleared as well, so a restart before the store recovers does
+/// not seed `tools/list` from it. The cost of a false alarm is one rebuild.
+fn clear_catalog_for_fail_closed(cached_tools: &SharedCatalog, profile: Option<&str>) {
+    *cached_tools
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner) = Arc::new(CatalogSnapshot::default());
+    save_tool_cache(&[], profile);
+    glog(
+        "SECURITY: quarantine store unreadable; cleared the tool cache so tools/list \
+         cannot serve the hidden catalog",
+    );
+}
+
+/// Whether the live router is hiding everything because the quarantine store could
+/// not be read (SBS-871).
+fn router_is_fail_closed(router: &Arc<Mutex<Arc<Router>>>) -> bool {
+    router
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .catalog_fail_closed()
+}
+
 fn persist_and_emit_with_sessions(
     tools: &[Value],
     cached_tools: &SharedCatalog,
@@ -9837,6 +9884,11 @@ fn persist_and_emit_with_sessions(
     mcp_sessions: Option<&Arc<Mutex<HashMap<String, Arc<McpSession>>>>>,
     profile: Option<&str>,
 ) {
+    if router_is_fail_closed(router) {
+        clear_catalog_for_fail_closed(cached_tools, profile);
+        notify_tools_changed(stdout, mcp_sessions);
+        return;
+    }
     if !tools.is_empty() {
         let started = Instant::now();
         let tools = {
@@ -12179,7 +12231,11 @@ fn process_request(
                         .unwrap_or_else(std::sync::PoisonError::into_inner);
                     Arc::make_mut(&mut guard).adopt_restored_routes(&previous_router, &tools);
                 }
-                if !tools.is_empty() {
+                // A fail-closed rebuild hides everything, so the cache must not keep
+                // serving the last-good catalog past it (SBS-871).
+                if router_is_fail_closed(&state.router) {
+                    clear_catalog_for_fail_closed(&state.cached_tools, profile_snapshot.as_deref());
+                } else if !tools.is_empty() {
                     *state
                         .cached_tools
                         .lock()
@@ -14844,6 +14900,9 @@ fn main() {
                 None,
             );
             let tools = built.aggregated_tools();
+            // Read before the router is moved below: a fail-closed build must clear
+            // the cache instead of being treated as a transient empty one (SBS-871).
+            let fail_closed = built.catalog_fail_closed();
             glog(&format!(
                 "background build: {} tools from {} servers",
                 tools.len(),
@@ -14862,8 +14921,11 @@ fn main() {
                 .unwrap_or_else(std::sync::PoisonError::into_inner) = Arc::new(built);
             // Don't let a transient empty build (registry caught mid-write, or
             // every downstream momentarily unreachable) clobber a good catalog -
-            // that's what leaves a client showing only toolport_status.
-            if !tools.is_empty() {
+            // that's what leaves a client showing only toolport_status. A
+            // fail-closed build is the deliberate exception: it MUST clobber it.
+            if fail_closed {
+                clear_catalog_for_fail_closed(&cached_tools, p.as_deref());
+            } else if !tools.is_empty() {
                 // The disk cache loaded at startup is the baseline here, so a cold
                 // start that reaches a degraded downstream cannot overwrite a
                 // known-good catalog with its subset.
@@ -24940,7 +25002,22 @@ mod tests {
         };
         assert_eq!(
             quarantine_bootstrap(Err("still unreadable".into()), Some(&prior)),
-            QuarantineBootstrap::KeepFailClosed
+            QuarantineBootstrap::KeepFailClosed(BTreeSet::new())
+        );
+    }
+
+    /// SBS-871: a fail-closed router can still hold real blocks (an integrity write
+    /// failure unions the pending names in). Carrying only the flag forward would
+    /// drop them the moment the hide lifted.
+    #[test]
+    fn sbs871_quarantine_bootstrap_keeps_the_set_under_fail_closed() {
+        let prior = PriorQuarantine {
+            set: set_of(&["srv__wipe"]),
+            fail_closed: true,
+        };
+        assert_eq!(
+            quarantine_bootstrap(Err("still unreadable".into()), Some(&prior)),
+            QuarantineBootstrap::KeepFailClosed(set_of(&["srv__wipe"]))
         );
     }
 
@@ -24955,6 +25032,138 @@ mod tests {
     #[test]
     fn sbs871_prior_quarantine_from_placeholder_router_is_none() {
         assert_eq!(prior_quarantine_from_router(&Router::new()), None);
+    }
+
+    /// SBS-871: a router that was really built but connected zero servers (every
+    /// connect failed, or an empty profile) still carries a quarantine decision.
+    /// Reading that as "no prior state" turned a transient store Err on a running
+    /// gateway into a full catalog hide.
+    #[test]
+    fn sbs871_prior_quarantine_from_a_live_zero_server_router_is_a_decision() {
+        let live = Router::with_policy(ToolPolicy::default());
+        assert_eq!(live.server_count(), 0);
+        let prior = prior_quarantine_from_router(&live);
+        assert_eq!(
+            prior,
+            Some(PriorQuarantine {
+                set: BTreeSet::new(),
+                fail_closed: false,
+            })
+        );
+        assert_eq!(
+            quarantine_bootstrap(Err("store unreadable".into()), prior.as_ref()),
+            QuarantineBootstrap::KeepSet(BTreeSet::new()),
+            "a live decision is kept, not replaced with a cold-start hide"
+        );
+    }
+
+    /// The gateway's router wrapper holding a router that fail-closed because the
+    /// quarantine store could not be read (SBS-871).
+    fn fail_closed_harness() -> (Arc<Mutex<Arc<Router>>>, Arc<Mutex<std::io::Stdout>>) {
+        let policy = ToolPolicy {
+            fail_closed_catalog: true,
+            ..ToolPolicy::default()
+        };
+        (
+            Arc::new(Mutex::new(Arc::new(Router::with_policy(policy)))),
+            Arc::new(Mutex::new(std::io::stdout())),
+        )
+    }
+
+    /// SBS-871: the hide must LIFT on a successful store read, including a successful
+    /// read of an EMPTY store. Comparing sets alone made that case a no-op (empty vs
+    /// empty), so a running gateway stayed dark until it restarted.
+    #[test]
+    fn sbs871_reconcile_to_lifts_fail_closed_on_a_successful_empty_read() {
+        let (router, stdout) = fail_closed_harness();
+        assert!(router.lock().unwrap().catalog_fail_closed());
+
+        assert!(
+            reconcile_to(&router, &stdout, None, BTreeSet::new()),
+            "a successful read of an empty store must reconcile, not no-op"
+        );
+        assert!(
+            !router.lock().unwrap().catalog_fail_closed(),
+            "a successful store read is exactly what lifts the hide"
+        );
+        // And it settles: the next watcher tick does nothing.
+        assert!(!reconcile_to(&router, &stdout, None, BTreeSet::new()));
+    }
+
+    /// SBS-871: everything that is NOT a successful store read must leave the hide up.
+    /// watch_tick, the ${ROOT} rebuild, and downstream tools/list_changed all run
+    /// requarantine_if_needed, so lifting here re-exposed every connected tool while
+    /// the store was still unreadable.
+    #[test]
+    fn sbs871_integrity_change_with_an_unreadable_store_keeps_fail_closed() {
+        let (router, _stdout) = fail_closed_harness();
+
+        requarantine_after_integrity_change(
+            &router,
+            set_of(&["srv__new_drift"]),
+            Err("quarantine store unreadable".into()),
+        );
+
+        assert!(
+            router.lock().unwrap().catalog_fail_closed(),
+            "an unreadable store must not re-expose the catalog"
+        );
+        assert!(
+            router
+                .lock()
+                .unwrap()
+                .quarantined()
+                .contains("srv__new_drift"),
+            "the new candidate is still recorded for when the hide lifts"
+        );
+    }
+
+    /// SBS-871: the counterpart. When the same path DOES read the store, the set is
+    /// known and the catalog comes back.
+    #[test]
+    fn sbs871_integrity_change_with_a_readable_store_lifts_fail_closed() {
+        let (router, _stdout) = fail_closed_harness();
+
+        requarantine_after_integrity_change(&router, BTreeSet::new(), Ok(set_of(&["srv__wipe"])));
+
+        assert!(!router.lock().unwrap().catalog_fail_closed());
+        assert_eq!(
+            router.lock().unwrap().quarantined(),
+            &set_of(&["srv__wipe"])
+        );
+    }
+
+    /// SBS-871: fail-closed makes aggregated_tools() empty, but every publish path
+    /// treats an empty build as transient and keeps the last-good cache. tools/list
+    /// prefers that cache, so the hide reached route_call and nothing else.
+    #[test]
+    fn sbs871_fail_closed_publish_clears_the_tool_cache() {
+        let _env = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let dir = std::env::temp_dir().join(format!(
+            "toolport-sbs871-fail-closed-cache-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let _data_dir = conduit_lib::registry::DataDirOverride::set(&dir);
+
+        let (router, stdout) = fail_closed_harness();
+        let cached_tools: SharedCatalog =
+            Arc::new(Mutex::new(Arc::new(CatalogSnapshot::new(vec![
+                json!({ "name": "srv__wipe", "description": "", "inputSchema": {} }),
+            ]))));
+
+        persist_and_emit_with_sessions(&[], &cached_tools, &router, None, &stdout, None, None);
+
+        assert!(
+            cached_tools.lock().unwrap().tools.is_empty(),
+            "the last-good cache must not outlive the hide"
+        );
+        assert!(
+            load_tool_cache(None).is_empty(),
+            "and a restart must not seed tools/list from the on-disk copy"
+        );
+        let _ = std::fs::remove_dir_all(dir);
     }
 
     #[test]

--- a/src-tauri/src/integrity.rs
+++ b/src-tauri/src/integrity.rs
@@ -43,6 +43,18 @@ static QUARANTINE_READ_CACHE: Mutex<Option<QuarantineReadCache>> = Mutex::new(No
 static QUARANTINE_READ_COUNT: std::sync::atomic::AtomicUsize =
     std::sync::atomic::AtomicUsize::new(0);
 
+/// Remaining injected `NotFound` answers for [`read_quarantine_to_string`]. Tests use
+/// this to pin the metadata-then-vanished arm of SBS-871 without a multi-process race.
+#[cfg(test)]
+static QUARANTINE_INJECT_READ_NOTFOUND: std::sync::atomic::AtomicU32 =
+    std::sync::atomic::AtomicU32::new(0);
+
+/// How many quarantine-file read attempts the current test has observed, including
+/// injected `NotFound`s. Reset by each SBS-871 test.
+#[cfg(test)]
+static QUARANTINE_READ_IO_ATTEMPTS: std::sync::atomic::AtomicUsize =
+    std::sync::atomic::AtomicUsize::new(0);
+
 /// Pins map: namespaced tool name (`server__tool`) -> pinned baseline.
 type Pins = BTreeMap<String, Pin>;
 
@@ -842,7 +854,9 @@ type Quarantine = BTreeMap<String, Value>;
 
 /// Load the quarantine map for `profile`.
 ///
-/// - Missing file → empty set (nothing quarantined yet).
+/// - Missing file after retries, pin store `Fresh` → empty set (honest first run).
+/// - Missing file after retries while pins are `Loaded`/`Corrupt` → `Err` (SBS-871).
+///   A rename-window `NotFound` is not "nothing blocked".
 /// - Unreadable or corrupt → `Err` (fail closed). Never renames the file aside: moving a
 ///   corrupt store to `.corrupt` made the next read look like a legitimate empty set and
 ///   silently unblocked every tool (SOU-320). Leave the broken file for inspection.
@@ -850,23 +864,114 @@ fn load_quarantine(profile: Option<&str>) -> Result<Quarantine, String> {
     let Some(path) = quarantine_path(profile) else {
         return Ok(Quarantine::new());
     };
-    let raw = match std::fs::read_to_string(&path) {
-        Ok(s) => s,
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-            if profile
-                .is_some_and(|id| crate::registry::unmigrated_legacy_profile_store(id, false))
-            {
-                return Err(format!(
-                    "quarantine store at {path:?} was not migrated from a legacy file; refusing to treat that as empty"
-                ));
+    match read_quarantine_file(&path) {
+        QuarantineFileRead::Raw(raw) => parse_quarantine_raw(&raw, &path),
+        QuarantineFileRead::Missing => missing_quarantine_store(profile, &path),
+        QuarantineFileRead::Unreadable(e) => {
+            Err(format!("quarantine store at {path:?} is unreadable: {e}"))
+        }
+    }
+}
+
+/// Outcome of a retried quarantine-file read. Parse failures are not an IO outcome:
+/// empty/corrupt content is fail-closed by [`parse_quarantine_raw`] (SBS-654 / SBS-320).
+enum QuarantineFileRead {
+    Raw(String),
+    Missing,
+    Unreadable(std::io::Error),
+}
+
+/// Read the quarantine file, retrying the same transient rename window [`read_pins_at`]
+/// already covers (SBS-871): a brief `NotFound`, empty-handle, or sharing-violation
+/// moment during another gateway's `atomic_write`.
+fn read_quarantine_file(path: &Path) -> QuarantineFileRead {
+    for attempt in 0..PINS_READ_ATTEMPTS {
+        #[cfg(test)]
+        QUARANTINE_READ_IO_ATTEMPTS.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        let last = attempt + 1 == PINS_READ_ATTEMPTS;
+        match read_quarantine_to_string(path) {
+            Ok(raw) => return QuarantineFileRead::Raw(raw),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                if last {
+                    return QuarantineFileRead::Missing;
+                }
             }
-            return Ok(Quarantine::new());
+            Err(e) => {
+                if last {
+                    return QuarantineFileRead::Unreadable(e);
+                }
+            }
         }
-        Err(e) => {
-            return Err(format!("quarantine store at {path:?} is unreadable: {e}"))
+        std::thread::sleep(std::time::Duration::from_millis(PINS_READ_BACKOFF_MS));
+    }
+    QuarantineFileRead::Missing
+}
+
+fn read_quarantine_to_string(path: &Path) -> std::io::Result<String> {
+    #[cfg(test)]
+    {
+        let left = QUARANTINE_INJECT_READ_NOTFOUND.load(std::sync::atomic::Ordering::SeqCst);
+        if left > 0 {
+            QUARANTINE_INJECT_READ_NOTFOUND.fetch_sub(1, std::sync::atomic::Ordering::SeqCst);
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                "injected NotFound after metadata (SBS-871)",
+            ));
         }
+    }
+    std::fs::read_to_string(path)
+}
+
+/// Phrase that marks "file lastingly gone, but this is not a first run" (SBS-871).
+/// The write path matches this so a first persist can still create the store; enforcement
+/// reads must not treat it as empty.
+fn quarantine_absent_not_fresh_message(path: &Path) -> String {
+    format!(
+        "quarantine store at {path:?} is missing while the pin store is not a first-run Fresh baseline; \
+         refusing to treat a rename-window NotFound as an empty quarantine set"
+    )
+}
+
+fn is_absent_quarantine_not_fresh(err: &str) -> bool {
+    err.contains("missing while the pin store is not a first-run Fresh baseline")
+}
+
+/// A missing quarantine file is an honest empty set only on a real first run
+/// (pin store `Fresh`). Same shape as the SBS-715 unmigrated-legacy guard: the pin
+/// store is the first-run marker. SBS-871.
+fn missing_quarantine_store(profile: Option<&str>, path: &Path) -> Result<Quarantine, String> {
+    if profile.is_some_and(|id| crate::registry::unmigrated_legacy_profile_store(id, false)) {
+        return Err(format!(
+            "quarantine store at {path:?} was not migrated from a legacy file; refusing to treat that as empty"
+        ));
+    }
+    match load_pins(profile) {
+        PinsLoad::Fresh => Ok(Quarantine::new()),
+        PinsLoad::Loaded(_) | PinsLoad::Corrupt => Err(quarantine_absent_not_fresh_message(path)),
+    }
+}
+
+/// Historical installs write pins on the first catalog check but never create
+/// `quarantine.json` until the first high-risk drift. That shape is honest-empty,
+/// not a lost store. Materialize `{}` under the quarantine lock so later
+/// enforcement reads can treat "missing while pins exist" as a rename-window
+/// error (SBS-871) without hiding the catalog on every boot.
+pub fn ensure_quarantine_store_for_existing_pins(profile: Option<&str>) {
+    let Some(path) = quarantine_path(profile) else {
+        return;
     };
-    parse_quarantine_raw(&raw, &path)
+    if path.exists() {
+        return;
+    }
+    if matches!(load_pins(profile), PinsLoad::Fresh) {
+        return;
+    }
+    let _ = with_store_lock(&path, || {
+        if path.exists() {
+            return Ok(());
+        }
+        crate::registry::atomic_write(&path, "{}")
+    });
 }
 
 /// Parse quarantine JSON. Shared by disk load and the mtime-cached read path.
@@ -937,7 +1042,7 @@ pub fn quarantined_checked(profile: Option<&str>) -> Result<BTreeSet<String>, St
             "quarantine store at {path:?} was not migrated from a legacy file; refusing to treat that as empty"
         ));
     }
-    quarantined_checked_at(&path)
+    quarantined_checked_at(&path, profile)
 }
 
 /// Tools quarantined because the integrity baseline itself was lost. Unlike ordinary
@@ -968,7 +1073,7 @@ pub fn mandatory_quarantined_checked(profile: Option<&str>) -> Result<BTreeSet<S
             "quarantine store at {path:?} was not migrated from a legacy file; refusing to treat that as empty"
         ));
     }
-    Ok(quarantined_sets_checked_at(&path)?.1)
+    Ok(quarantined_sets_checked_at(&path, profile)?.1)
 }
 
 fn mandatory_quarantine_set(q: &Quarantine) -> BTreeSet<String> {
@@ -980,71 +1085,116 @@ fn mandatory_quarantine_set(q: &Quarantine) -> BTreeSet<String> {
 
 /// Path-level read used by [`quarantined_checked`]. Separated so the mtime/len
 /// pre-filter (SOU-303) and fail-closed parse sit in one place.
-fn quarantined_checked_at(path: &Path) -> Result<BTreeSet<String>, String> {
-    Ok(quarantined_sets_checked_at(path)?.0)
+fn quarantined_checked_at(
+    path: &Path,
+    profile: Option<&str>,
+) -> Result<BTreeSet<String>, String> {
+    Ok(quarantined_sets_checked_at(path, profile)?.0)
 }
 
 fn quarantined_sets_checked_at(
     path: &Path,
+    profile: Option<&str>,
 ) -> Result<(BTreeSet<String>, BTreeSet<String>), String> {
-    let meta = match std::fs::metadata(path) {
-        Ok(m) => m,
-        // Missing is the normal first-run state: nothing quarantined yet.
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-            // Drop a stale hit for this path so a later recreate is re-parsed.
-            clear_quarantine_read_cache_for(path);
-            return Ok((BTreeSet::new(), BTreeSet::new()));
-        }
-        Err(e) => return Err(format!("quarantine store at {path:?} is unreadable: {e}")),
-    };
-    let mtime = match meta.modified() {
-        Ok(t) => t,
-        Err(e) => {
-            return Err(format!(
-                "quarantine store at {path:?} has unreadable mtime: {e}"
-            ))
-        }
-    };
-    let len = meta.len();
+    // SBS-871: retry the same transient rename window `read_pins_at` already covers
+    // instead of treating a vanished file as a legitimate empty set.
+    for attempt in 0..PINS_READ_ATTEMPTS {
+        #[cfg(test)]
+        QUARANTINE_READ_IO_ATTEMPTS.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        let last = attempt + 1 == PINS_READ_ATTEMPTS;
+        let meta = match std::fs::metadata(path) {
+            Ok(m) => m,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                if last {
+                    return missing_quarantine_as_sets(profile, path);
+                }
+                std::thread::sleep(std::time::Duration::from_millis(PINS_READ_BACKOFF_MS));
+                continue;
+            }
+            Err(_) if !last => {
+                std::thread::sleep(std::time::Duration::from_millis(PINS_READ_BACKOFF_MS));
+                continue;
+            }
+            Err(e) => return Err(format!("quarantine store at {path:?} is unreadable: {e}")),
+        };
+        let mtime = match meta.modified() {
+            Ok(t) => t,
+            Err(_) if !last => {
+                std::thread::sleep(std::time::Duration::from_millis(PINS_READ_BACKOFF_MS));
+                continue;
+            }
+            Err(e) => {
+                return Err(format!(
+                    "quarantine store at {path:?} has unreadable mtime: {e}"
+                ))
+            }
+        };
+        let len = meta.len();
 
-    {
-        let cache = QUARANTINE_READ_CACHE
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
-        if let Some(c) = cache.as_ref() {
-            if c.path == path && c.mtime == mtime && c.len == len {
-                return Ok((c.set.clone(), c.mandatory.clone()));
+        {
+            let cache = QUARANTINE_READ_CACHE
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            if let Some(c) = cache.as_ref() {
+                if c.path == path && c.mtime == mtime && c.len == len {
+                    return Ok((c.set.clone(), c.mandatory.clone()));
+                }
             }
         }
+
+        #[cfg(test)]
+        QUARANTINE_READ_COUNT.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+
+        let raw = match read_quarantine_to_string(path) {
+            Ok(s) => s,
+            // Race: file vanished between metadata and open. Retry; after the budget,
+            // a miss while pins are not Fresh is Err, not empty (SBS-871).
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                if last {
+                    return missing_quarantine_as_sets(profile, path);
+                }
+                std::thread::sleep(std::time::Duration::from_millis(PINS_READ_BACKOFF_MS));
+                continue;
+            }
+            Err(_) if !last => {
+                std::thread::sleep(std::time::Duration::from_millis(PINS_READ_BACKOFF_MS));
+                continue;
+            }
+            Err(e) => return Err(format!("quarantine store at {path:?} is unreadable: {e}")),
+        };
+        // Fail closed: do not cache a corrupt parse, do not return empty, do not rename.
+        let records = parse_quarantine_raw(&raw, path)?;
+        let mandatory = mandatory_quarantine_set(&records);
+        let set: BTreeSet<String> = records.into_keys().collect();
+
+        *QUARANTINE_READ_CACHE
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(QuarantineReadCache {
+            path: path.to_path_buf(),
+            mtime,
+            len,
+            set: set.clone(),
+            mandatory: mandatory.clone(),
+        });
+        return Ok((set, mandatory));
     }
+    missing_quarantine_as_sets(profile, path)
+}
 
-    #[cfg(test)]
-    QUARANTINE_READ_COUNT.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-
-    let raw = match std::fs::read_to_string(path) {
-        Ok(s) => s,
-        // Race: file vanished between metadata and open — treat as empty.
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+fn missing_quarantine_as_sets(
+    profile: Option<&str>,
+    path: &Path,
+) -> Result<(BTreeSet<String>, BTreeSet<String>), String> {
+    match missing_quarantine_store(profile, path) {
+        Ok(_) => {
             clear_quarantine_read_cache_for(path);
-            return Ok((BTreeSet::new(), BTreeSet::new()));
+            Ok((BTreeSet::new(), BTreeSet::new()))
         }
-        Err(e) => return Err(format!("quarantine store at {path:?} is unreadable: {e}")),
-    };
-    // Fail closed: do not cache a corrupt parse, do not return empty, do not rename.
-    let records = parse_quarantine_raw(&raw, path)?;
-    let mandatory = mandatory_quarantine_set(&records);
-    let set: BTreeSet<String> = records.into_keys().collect();
-
-    *QUARANTINE_READ_CACHE
-        .lock()
-        .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(QuarantineReadCache {
-        path: path.to_path_buf(),
-        mtime,
-        len,
-        set: set.clone(),
-        mandatory: mandatory.clone(),
-    });
-    Ok((set, mandatory))
+        Err(e) => {
+            clear_quarantine_read_cache_for(path);
+            Err(e)
+        }
+    }
 }
 
 fn clear_quarantine_read_cache_for(path: &Path) {
@@ -1354,8 +1504,19 @@ fn apply_quarantine_inner_with(
 ) -> Result<bool, String> {
     // Fail closed: do not load a corrupt store as empty and rewrite it with only the
     // new entries (that would drop every previously quarantined tool).
-    let mut q = load_quarantine(profile)
-        .map_err(|e| format!("{e}; refusing to apply quarantine until the store is fixed"))?;
+    // SBS-871: enforcement treats "missing while pins exist" as Err. This write path
+    // holds the store lock and has already retried, so a still-missing file is
+    // lastingly gone (first persist after pins exist, or a deleted store). Start
+    // empty so the new blocks can be written. Do not use this arm for reads.
+    let mut q = match load_quarantine(profile) {
+        Ok(q) => q,
+        Err(e) if is_absent_quarantine_not_fresh(&e) => Quarantine::new(),
+        Err(e) => {
+            return Err(format!(
+                "{e}; refusing to apply quarantine until the store is fixed"
+            ))
+        }
+    };
     let mut added = false;
 
     // A corrupt baseline invalidates every trust decision in the current catalog. This
@@ -3320,6 +3481,157 @@ mod tests {
         std::fs::write(&v2, record).unwrap();
         assert_eq!(quarantined_checked(Some("billing")).unwrap().len(), 1);
         assert_eq!(mandatory_quarantined_checked(Some("billing")).unwrap().len(), 1);
+    }
+
+    fn write_loaded_pin_store(profile: Option<&str>) {
+        let path = pins_path(profile).expect("pin path");
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        // Legacy bare-fingerprint form is enough for load_pins to return Loaded.
+        std::fs::write(&path, r#"{"srv__a":"deadbeef"}"#).unwrap();
+        assert!(
+            matches!(load_pins(profile), PinsLoad::Loaded(_)),
+            "fixture must be a real Loaded pin store"
+        );
+    }
+
+    fn reset_sbs871_read_hooks() {
+        QUARANTINE_INJECT_READ_NOTFOUND.store(0, std::sync::atomic::Ordering::SeqCst);
+        QUARANTINE_READ_IO_ATTEMPTS.store(0, std::sync::atomic::Ordering::SeqCst);
+        *QUARANTINE_READ_CACHE
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = None;
+    }
+
+    /// SBS-871: a missing quarantine file is an honest first-run empty set only
+    /// when the pin store is Fresh. Without this, every clean profile would refuse
+    /// to serve tools.
+    #[test]
+    fn sbs871_missing_quarantine_with_fresh_pins_is_empty_first_run() {
+        let _data_dir_lock = crate::registry::data_dir_test_lock();
+        let _data_dir = TestDataDir::new("sbs871-missing-fresh");
+        let profile = Some("sbs871-fresh");
+        reset_sbs871_read_hooks();
+        assert!(
+            matches!(load_pins(profile), PinsLoad::Fresh),
+            "fixture is a real first run"
+        );
+        assert!(
+            !quarantine_path(profile).expect("path").exists(),
+            "quarantine file must be absent"
+        );
+
+        let set = quarantined(profile).expect("first run is Ok empty, not Err");
+        assert!(set.is_empty(), "honest first run has nothing blocked");
+        assert!(
+            quarantined_checked(profile)
+                .expect("cached first-run path is also Ok empty")
+                .is_empty()
+        );
+        assert!(load_quarantine(profile).expect("load first run").is_empty());
+    }
+
+    /// SBS-871: a missing quarantine file while pins are Loaded is not "nothing
+    /// blocked". The previous assertion (missing = Ok empty whenever the file is
+    /// gone) pinned the rename-window fail-open.
+    #[test]
+    fn sbs871_missing_quarantine_with_loaded_pins_is_err_not_empty() {
+        let _data_dir_lock = crate::registry::data_dir_test_lock();
+        let _data_dir = TestDataDir::new("sbs871-missing-loaded");
+        let profile = Some("sbs871-loaded");
+        reset_sbs871_read_hooks();
+        write_loaded_pin_store(profile);
+        assert!(
+            !quarantine_path(profile).expect("path").exists(),
+            "quarantine file must be absent"
+        );
+
+        let err = quarantined(profile).expect_err("missing + Loaded must not be Ok empty");
+        assert!(
+            is_absent_quarantine_not_fresh(&err),
+            "error must name the SBS-871 missing-not-fresh case, got {err}"
+        );
+        assert!(
+            quarantined_checked(profile).is_err(),
+            "the watcher's cached read must also refuse"
+        );
+        assert!(load_quarantine(profile).is_err());
+    }
+
+    /// SBS-871: NotFound after metadata (file vanished between stat and open) is
+    /// retried like `read_pins_at`. After the budget, pins Loaded means Err, not
+    /// Ok empty. The old comment on that arm was "Race: file vanished between
+    /// metadata and open — treat as empty."
+    #[test]
+    fn sbs871_quarantine_notfound_after_metadata_is_retried_then_err_when_pins_loaded() {
+        let _data_dir_lock = crate::registry::data_dir_test_lock();
+        let _data_dir = TestDataDir::new("sbs871-meta-then-notfound");
+        let profile = Some("sbs871-meta-race");
+        reset_sbs871_read_hooks();
+        write_loaded_pin_store(profile);
+
+        let mut q = Quarantine::new();
+        q.insert(
+            "srv__wipe".to_string(),
+            json!({"tool":"srv__wipe","change":"changed"}),
+        );
+        save_quarantine(profile, &q).unwrap();
+        assert!(
+            quarantine_path(profile).expect("path").exists(),
+            "metadata must succeed so the injected NotFound is the post-stat arm"
+        );
+
+        QUARANTINE_INJECT_READ_NOTFOUND.store(
+            PINS_READ_ATTEMPTS,
+            std::sync::atomic::Ordering::SeqCst,
+        );
+        let err = quarantined_checked(profile)
+            .expect_err("exhausted post-metadata NotFound with Loaded pins must be Err");
+        assert!(
+            is_absent_quarantine_not_fresh(&err),
+            "must not collapse the race to Ok empty, got {err}"
+        );
+        assert!(
+            QUARANTINE_READ_IO_ATTEMPTS.load(std::sync::atomic::Ordering::SeqCst)
+                >= PINS_READ_ATTEMPTS as usize,
+            "NotFound after metadata must be retried, attempts={}",
+            QUARANTINE_READ_IO_ATTEMPTS.load(std::sync::atomic::Ordering::SeqCst)
+        );
+        assert_eq!(
+            QUARANTINE_INJECT_READ_NOTFOUND.load(std::sync::atomic::Ordering::SeqCst),
+            0,
+            "the retry budget must consume every injected NotFound"
+        );
+        reset_sbs871_read_hooks();
+    }
+
+    /// SBS-871: a transient post-metadata NotFound that clears before the budget
+    /// is exhausted must return the real set, not empty and not Err.
+    #[test]
+    fn sbs871_quarantine_notfound_after_metadata_recovers_on_retry() {
+        let _data_dir_lock = crate::registry::data_dir_test_lock();
+        let _data_dir = TestDataDir::new("sbs871-meta-recover");
+        let profile = Some("sbs871-meta-recover");
+        reset_sbs871_read_hooks();
+        write_loaded_pin_store(profile);
+
+        let mut q = Quarantine::new();
+        q.insert(
+            "srv__wipe".to_string(),
+            json!({"tool":"srv__wipe","change":"changed"}),
+        );
+        save_quarantine(profile, &q).unwrap();
+
+        QUARANTINE_INJECT_READ_NOTFOUND.store(2, std::sync::atomic::Ordering::SeqCst);
+        let set = quarantined_checked(profile).expect("retry must see the file");
+        assert!(
+            set.contains("srv__wipe"),
+            "a transient post-metadata miss must not drop the live block"
+        );
+        assert!(
+            QUARANTINE_READ_IO_ATTEMPTS.load(std::sync::atomic::Ordering::SeqCst) >= 3,
+            "two injected misses plus the successful read"
+        );
+        reset_sbs871_read_hooks();
     }
 
     #[test]

--- a/src-tauri/src/integrity.rs
+++ b/src-tauri/src/integrity.rs
@@ -956,6 +956,12 @@ fn missing_quarantine_store(profile: Option<&str>, path: &Path) -> Result<Quaran
 /// not a lost store. Materialize `{}` under the quarantine lock so later
 /// enforcement reads can treat "missing while pins exist" as a rename-window
 /// error (SBS-871) without hiding the catalog on every boot.
+///
+/// Only a `Loaded` pin store earns that `{}`. A `Corrupt` pin store is a destroyed
+/// trust root, which is exactly the input an attacker controls, and writing an empty
+/// quarantine store beside it would hand back "nothing is blocked" on demand. Leave
+/// the file missing there so `missing_quarantine_store` stays `Err` and the caller
+/// fails closed.
 pub fn ensure_quarantine_store_for_existing_pins(profile: Option<&str>) {
     let Some(path) = quarantine_path(profile) else {
         return;
@@ -963,7 +969,7 @@ pub fn ensure_quarantine_store_for_existing_pins(profile: Option<&str>) {
     if path.exists() {
         return;
     }
-    if matches!(load_pins(profile), PinsLoad::Fresh) {
+    if !matches!(load_pins(profile), PinsLoad::Loaded(_)) {
         return;
     }
     let _ = with_store_lock(&path, || {
@@ -3494,12 +3500,100 @@ mod tests {
         );
     }
 
+    fn write_corrupt_pin_store(profile: Option<&str>) {
+        let path = pins_path(profile).expect("pin path");
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(&path, "{ this is not json").unwrap();
+        assert!(
+            matches!(load_pins(profile), PinsLoad::Corrupt),
+            "fixture must be a real Corrupt pin store"
+        );
+    }
+
     fn reset_sbs871_read_hooks() {
         QUARANTINE_INJECT_READ_NOTFOUND.store(0, std::sync::atomic::Ordering::SeqCst);
         QUARANTINE_READ_IO_ATTEMPTS.store(0, std::sync::atomic::Ordering::SeqCst);
         *QUARANTINE_READ_CACHE
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner) = None;
+    }
+
+    /// SBS-871: a Corrupt pin store is a destroyed trust root, which is exactly the
+    /// input an attacker controls. Materializing `{}` beside it would create an empty
+    /// quarantine store on demand, and the very next read would answer "nothing is
+    /// blocked" while the real block set stayed gone.
+    #[test]
+    fn sbs871_corrupt_pins_must_not_materialize_an_empty_quarantine_store() {
+        let _data_dir_lock = crate::registry::data_dir_test_lock();
+        let _data_dir = TestDataDir::new("sbs871-corrupt-pins");
+        let profile = Some("sbs871-corrupt");
+        reset_sbs871_read_hooks();
+        write_corrupt_pin_store(profile);
+        let path = quarantine_path(profile).expect("path");
+        assert!(!path.exists(), "fixture starts with no quarantine file");
+
+        ensure_quarantine_store_for_existing_pins(profile);
+
+        assert!(
+            !path.exists(),
+            "a corrupt trust root must not get an empty quarantine store written for it"
+        );
+        let err = quarantined(profile).expect_err("corrupt pins + no store must fail closed");
+        assert!(
+            is_absent_quarantine_not_fresh(&err),
+            "must stay the SBS-871 missing-not-fresh error, got {err}"
+        );
+        assert!(
+            quarantined_checked(profile).is_err(),
+            "the watcher's cached read must refuse too"
+        );
+        assert!(
+            mandatory_quarantined(profile).is_err(),
+            "the quarantine-off path reads the same store and must also refuse"
+        );
+    }
+
+    /// SBS-871 companion: the heal must still fire for the shape it exists for, an
+    /// upgraded install with real pins and no quarantine file yet. Without this the
+    /// tightening above would hide the catalog on every boot of such an install.
+    #[test]
+    fn sbs871_loaded_pins_still_materialize_the_quarantine_store() {
+        let _data_dir_lock = crate::registry::data_dir_test_lock();
+        let _data_dir = TestDataDir::new("sbs871-loaded-heal");
+        let profile = Some("sbs871-heal");
+        reset_sbs871_read_hooks();
+        write_loaded_pin_store(profile);
+        let path = quarantine_path(profile).expect("path");
+        assert!(!path.exists(), "fixture starts with no quarantine file");
+
+        ensure_quarantine_store_for_existing_pins(profile);
+
+        assert!(path.exists(), "an upgraded install gets its empty store");
+        assert!(
+            quarantined(profile)
+                .expect("materialized store reads")
+                .is_empty(),
+            "and it reads as a real, empty block set"
+        );
+    }
+
+    /// SBS-871: a genuine first run has no pins either, so there is nothing to heal.
+    /// Writing the store here would be harmless but pointless; assert the shape so a
+    /// later refactor cannot start creating files for profiles that never ran.
+    #[test]
+    fn sbs871_fresh_pins_do_not_materialize_the_quarantine_store() {
+        let _data_dir_lock = crate::registry::data_dir_test_lock();
+        let _data_dir = TestDataDir::new("sbs871-fresh-heal");
+        let profile = Some("sbs871-fresh-heal");
+        reset_sbs871_read_hooks();
+        assert!(matches!(load_pins(profile), PinsLoad::Fresh));
+
+        ensure_quarantine_store_for_existing_pins(profile);
+
+        assert!(
+            !quarantine_path(profile).expect("path").exists(),
+            "a first run stays a first run"
+        );
     }
 
     /// SBS-871: a missing quarantine file is an honest first-run empty set only

--- a/src-tauri/src/router.rs
+++ b/src-tauri/src/router.rs
@@ -435,6 +435,10 @@ pub struct ToolPolicy {
     /// Exposed (namespaced) tool names quarantined after a high-risk drift; hidden
     /// until the user re-approves them. Empty unless quarantine-on-drift is enabled.
     pub quarantined: BTreeSet<String>,
+    /// Hide every tool. Used when a cold-start quarantine-store read fails
+    /// (SBS-871): there is no prior live set to keep, so the catalog stays
+    /// blocked until a later successful read `requarantine`s a real set.
+    pub fail_closed_catalog: bool,
 }
 
 impl ToolPolicy {
@@ -465,6 +469,11 @@ impl ToolPolicy {
         }
         if self.deny_destructive && is_destructive(tool) {
             return Some("blocked by the destructive-tool policy");
+        }
+        if self.fail_closed_catalog {
+            return Some(
+                "quarantine store unreadable; catalog blocked until the store reads",
+            );
         }
         if self.quarantined.contains(exposed) {
             return Some("quarantined after a high-risk change; re-approve to restore");
@@ -1069,7 +1078,16 @@ impl Router {
     /// downstream. Cheap: it only re-applies the policy to the cached tool lists.
     pub fn requarantine(&mut self, quarantined: BTreeSet<String>) {
         self.policy.quarantined = quarantined;
+        // A successful reconcile/rebuild installs a known set, so lift the
+        // cold-start fail-closed hide (SBS-871).
+        self.policy.fail_closed_catalog = false;
         self.rebuild_aggregation();
+    }
+
+    /// True when this router is hiding the whole catalog because the quarantine
+    /// store could not be read on a cold start (SBS-871).
+    pub fn catalog_fail_closed(&self) -> bool {
+        self.policy.fail_closed_catalog
     }
 
     /// The quarantine set this router is currently enforcing. Lets a caller diff the
@@ -3198,6 +3216,33 @@ mod tests {
 
         router.requarantine(BTreeSet::new());
         assert!(router.quarantined().is_empty());
+    }
+
+    #[test]
+    fn sbs871_fail_closed_catalog_hides_every_tool_until_requarantine() {
+        // SBS-871: a cold-start store Err has no prior live set, so the whole
+        // catalog stays hidden until a later successful read installs a set.
+        let mut policy = ToolPolicy::default();
+        policy.fail_closed_catalog = true;
+        let mut router = Router::with_policy(policy);
+        router.add(mock_server("github"));
+        assert!(
+            router.aggregated_tools().is_empty(),
+            "fail-closed catalog must hide every tool"
+        );
+        assert!(router.catalog_fail_closed());
+        let err = router.route_call("github__echo", json!({})).unwrap_err();
+        assert!(
+            err.contains("quarantine store unreadable"),
+            "unexpected: {err}"
+        );
+
+        router.requarantine(BTreeSet::new());
+        assert!(!router.catalog_fail_closed());
+        assert!(
+            !router.aggregated_tools().is_empty(),
+            "a later known set must re-expose the catalog"
+        );
     }
 
     #[test]

--- a/src-tauri/src/router.rs
+++ b/src-tauri/src/router.rs
@@ -437,7 +437,9 @@ pub struct ToolPolicy {
     pub quarantined: BTreeSet<String>,
     /// Hide every tool. Used when a cold-start quarantine-store read fails
     /// (SBS-871): there is no prior live set to keep, so the catalog stays
-    /// blocked until a later successful read `requarantine`s a real set.
+    /// blocked until a SUCCESSFUL store read installs a real set through
+    /// [`Router::requarantine_from_store`]. Error paths must use
+    /// [`Router::requarantine`], which leaves this set.
     pub fail_closed_catalog: bool,
 }
 
@@ -591,6 +593,11 @@ pub struct Router {
     prompts: Vec<Value>,
     /// Exposed prompt name -> (server id, original prompt name).
     prompt_routes: HashMap<String, (String, String)>,
+    /// False only for the never-built placeholder the gateway installs before its
+    /// first build. `with_policy` (the constructor every real build uses) sets it,
+    /// so a live router whose connects all failed is still a real prior decision
+    /// and not a cold start (SBS-871).
+    built: bool,
 }
 
 impl Router {
@@ -602,8 +609,16 @@ impl Router {
     pub fn with_policy(policy: ToolPolicy) -> Self {
         Router {
             policy,
+            built: true,
             ..Router::default()
         }
+    }
+
+    /// Whether this router came from a real build rather than the startup
+    /// placeholder. A built router carries a quarantine decision even when it
+    /// connected zero servers (SBS-871).
+    pub fn is_built(&self) -> bool {
+        self.built
     }
 
     /// Set the per-tool exposure overrides. Must be called BEFORE `add`/`refresh`, since
@@ -1076,16 +1091,26 @@ impl Router {
     /// Replace the quarantine set and re-derive the exposed aggregation so newly
     /// quarantined tools are hidden (or re-approved ones restored) without re-querying
     /// downstream. Cheap: it only re-applies the policy to the cached tool lists.
+    ///
+    /// Deliberately does NOT lift a fail-closed catalog (SBS-871): every caller that
+    /// reaches here on a store error would otherwise re-expose the whole catalog while
+    /// the store is still unreadable. Use [`Self::requarantine_from_store`] when the
+    /// set came from a successful read.
     pub fn requarantine(&mut self, quarantined: BTreeSet<String>) {
         self.policy.quarantined = quarantined;
-        // A successful reconcile/rebuild installs a known set, so lift the
-        // cold-start fail-closed hide (SBS-871).
-        self.policy.fail_closed_catalog = false;
         self.rebuild_aggregation();
     }
 
+    /// Install a quarantine set that came from a SUCCESSFUL store read, lifting the
+    /// fail-closed hide (SBS-871). This is the only way the catalog comes back: the
+    /// store answered, so the set is known and enforcement can resume normally.
+    pub fn requarantine_from_store(&mut self, quarantined: BTreeSet<String>) {
+        self.policy.fail_closed_catalog = false;
+        self.requarantine(quarantined);
+    }
+
     /// True when this router is hiding the whole catalog because the quarantine
-    /// store could not be read on a cold start (SBS-871).
+    /// store could not be read and there was no prior live set to keep (SBS-871).
     pub fn catalog_fail_closed(&self) -> bool {
         self.policy.fail_closed_catalog
     }
@@ -1093,6 +1118,11 @@ impl Router {
     /// The quarantine set this router is currently enforcing. Lets a caller diff the
     /// live set against the persisted one and skip `requarantine` (and the client
     /// `list_changed` that follows it) when nothing actually changed.
+    ///
+    /// NOT the whole enforcement picture: while [`Self::catalog_fail_closed`] is true
+    /// every tool is hidden even though this set can be empty, so a caller diffing
+    /// live against persisted MUST check `catalog_fail_closed()` too or it will read
+    /// "blocked everything" as "nothing blocked" (SBS-871).
     pub fn quarantined(&self) -> &BTreeSet<String> {
         &self.policy.quarantined
     }
@@ -3237,12 +3267,52 @@ mod tests {
             "unexpected: {err}"
         );
 
-        router.requarantine(BTreeSet::new());
+        router.requarantine_from_store(BTreeSet::new());
         assert!(!router.catalog_fail_closed());
         assert!(
             !router.aggregated_tools().is_empty(),
             "a later known set must re-expose the catalog"
         );
+    }
+
+    /// SBS-871: the whole point of the hide is that it survives every path that is
+    /// NOT a successful store read. `requarantine` runs on store-error paths
+    /// (integrity write failure, unreadable persisted set), so it must leave the
+    /// catalog hidden; only `requarantine_from_store` lifts it.
+    #[test]
+    fn sbs871_requarantine_on_an_error_path_does_not_lift_fail_closed() {
+        let mut policy = ToolPolicy::default();
+        policy.fail_closed_catalog = true;
+        let mut router = Router::with_policy(policy);
+        router.add(mock_server("github"));
+
+        // The error paths union the live set with the names that triggered the write.
+        router.requarantine(["github__echo".to_string()].into_iter().collect());
+        assert!(
+            router.catalog_fail_closed(),
+            "a store-error requarantine must not re-expose the catalog"
+        );
+        assert!(
+            router.aggregated_tools().is_empty(),
+            "the catalog must stay hidden while the store is still unreadable"
+        );
+        // The reported set is not the whole picture, so callers have to consult
+        // catalog_fail_closed() as well.
+        assert_eq!(router.quarantined().len(), 1);
+
+        router.requarantine_from_store(BTreeSet::new());
+        assert!(!router.catalog_fail_closed());
+        assert!(!router.aggregated_tools().is_empty());
+    }
+
+    /// SBS-871: `Router::new()` is the startup placeholder, but a router that was
+    /// really built and connected nothing is still a prior quarantine decision.
+    #[test]
+    fn sbs871_built_flag_separates_a_placeholder_from_a_live_empty_router() {
+        assert!(!Router::new().is_built(), "placeholder is not a build");
+        let built = Router::with_policy(ToolPolicy::default());
+        assert!(built.is_built(), "a policy build is a real build");
+        assert_eq!(built.server_count(), 0, "even with zero connected servers");
     }
 
     #[test]

--- a/src-tauri/tests/quarantine_empty_truncation.rs
+++ b/src-tauri/tests/quarantine_empty_truncation.rs
@@ -94,8 +94,9 @@ fn empty_quarantine_file_must_not_silently_unblock() {
 
 #[test]
 fn a_missing_quarantine_file_is_still_an_empty_set() {
-    // First run has no file at all. That must stay a legitimate empty set, or every
-    // clean install would refuse to serve tools.
+    // First run has no file at all and the pin store is Fresh. That must stay a
+    // legitimate empty set, or every clean install would refuse to serve tools.
+    // SBS-871: missing + Loaded pins is a different case (Err, not Ok empty).
     let dir = scratch_dir("absent");
     let _lock = data_dir_guard();
     let _data_dir = conduit_lib::registry::DataDirOverride::set(&dir);


### PR DESCRIPTION
Linear: https://linear.app/southboundsoftware/issue/SBS-871/quarantine-store-a-transient-notfound-during-atomic-writes-rename

## What a user who hits this now sees

Blocked tools stay blocked across a rewrite tick. A cold-start unreadable store does not expose the catalog. The gateway no longer logs "starting with no quarantine set" when it kept a live set or fail-closed.

## The bug

Third arm of a class already closed: SBS-320 (corrupt/unreadable) and SBS-654 (present-but-empty) are Done. A missing `quarantine.json` during `atomic_write`'s rename still returned success-empty. The pin and registry stores already retry this transient; quarantine did not.

`effective_quarantine` already returns `None` on `Err` (keeps the live set). That path is untouched. The hole was the cold-start / rebuild path in `build_router`, plus the two NotFound arms that collapsed a vanished file to `Ok(empty)`.

## What changed

1. Quarantine reads retry on `NotFound` and other transient IO errors with the same budget as `read_pins_at` (5 attempts, 40ms). Cite SBS-871.
2. Missing is legitimately empty only when the pin store is `Fresh` for that profile (real first run). Otherwise `Err`. Same first-run marker shape as the SBS-715 guard.
3. `build_router` no longer `Default::default()` on `Err`.
   - The pre-rebuild live set is snapshotted **before** `build_router` (it used to be captured after the build, too late) and passed in.
   - On `Err` with a prior live set: keep that set.
   - On genuine cold start with `Err`: hide the whole catalog (`fail_closed_catalog`) until a later successful read `requarantine`s a known set.
4. Historical installs have pins without `quarantine.json` (baseline written, nothing ever blocked). `ensure_quarantine_store_for_existing_pins` materializes `{}` under the store lock before a rebuild read so that shape does not hide the catalog on every boot, and so a later missing-while-pins-exist read is a real rename-window error. First persist after pins exist still works: `apply_quarantine` starts empty on the specific "absent, not Fresh" error after retries while holding the lock.

## Files changed

- `src-tauri/src/integrity.rs` — retry, Fresh vs Loaded/Corrupt, tests
- `src-tauri/src/bin/toolport-gateway.rs` — `quarantine_bootstrap`, prior-set parameter on every `build_router` call site
- `src-tauri/src/router.rs` — `fail_closed_catalog` policy flag
- `src-tauri/tests/quarantine_empty_truncation.rs` — comment only: missing is empty when pins are Fresh
- `CHANGELOG.md` — Unreleased Fixed

## Sweep (exclude `target` and `docs/audit`)

| Hit | Action |
| -- | -- |
| `integrity.rs` `load_quarantine` NotFound → `Ok(empty)` | Fixed: retry, then Fresh vs not-Fresh |
| `integrity.rs` `quarantined_sets_checked_at` metadata NotFound → `Ok(empty)` | Fixed |
| `integrity.rs` `quarantined_sets_checked_at` read NotFound "treat as empty" | Fixed |
| `toolport-gateway.rs` `build_router` `Err` → `Default::default()` + "starting with no quarantine set" | Fixed |
| `effective_quarantine` `Err` → `None` (keep live set) | Left: already fail-closed; do not regress |
| `reconcile_quarantine` `None` → no `reconcile_to` | Left: already fail-closed |
| `quarantine_list` `Err` → empty `Vec` | Left: UI display only; enforcement is `quarantined` / the router. Logged as unavailable |
| `all_quarantined` / `all_quarantined_names` skip unreadable/missing files | Left: UI aggregation; a racing miss briefly omits that profile's rows from the card, not from the router |
| Desktop `list_quarantined` | Left: calls `all_quarantined`; same UI-only gap |
| SBS-715 unmigrated-legacy guards | Untouched |
| `parse_quarantine_raw` empty/corrupt (SBS-654 / SBS-320) | Untouched |
| Pins Fresh/Corrupt/Loaded + `read_pins_at` retry | Untouched |

`rg` for `treat as empty`, `starting with no quarantine`, `ErrorKind::NotFound`, `Default::default` near quarantin, `load_quarantine`, `quarantined_sets_checked_at`: remaining NotFound hits are unrelated stores (audit, secrets, autostart, rate limits, etc.). Remaining `load_quarantine` callers either propagate `Err` (`release`, `accept_quarantined_pins`) or are the apply write path documented above.

## Fail-without-fix (rule 6)

Reverted only `missing_quarantine_store`'s Fresh vs Loaded/Corrupt arm to the old "missing = Ok empty" (kept tests and the SBS-715 guard). New tests that must fail without the production change:

```
---- integrity::tests::sbs871_missing_quarantine_with_loaded_pins_is_err_not_empty stdout ----

thread 'integrity::tests::sbs871_missing_quarantine_with_loaded_pins_is_err_not_empty' panicked at src/integrity.rs:3548:40:
missing + Loaded must not be Ok empty: {}

---- integrity::tests::sbs871_quarantine_notfound_after_metadata_is_retried_then_err_when_pins_loaded stdout ----

thread 'integrity::tests::sbs871_quarantine_notfound_after_metadata_is_retried_then_err_when_pins_loaded' panicked at src/integrity.rs:3588:14:
exhausted post-metadata NotFound with Loaded pins must be Err: {}

test result: FAILED. 3 passed; 2 failed; 0 ignored; 0 measured; 1086 filtered out
```

Restored the production arm; the same tests then passed.

## CI results (this worktree, rustc 1.97.1)

Required job **Build + test**:

- `npm run format:check` — All matched files use Prettier code style
- `npm run lint` — 0 errors (49 pre-existing warnings in `src/`)
- `npm run build` — passed
- `npm run test` — 37 files, 382 passed
- `npm run test:rust` (`cargo test --lib --bins --tests`, default features) — lib **1090 passed**, gateway bin **311 passed**, integration tests passed including `quarantine_empty_truncation`

New tests that actually ran (default features):

- `integrity::tests::sbs871_missing_quarantine_with_fresh_pins_is_empty_first_run`
- `integrity::tests::sbs871_missing_quarantine_with_loaded_pins_is_err_not_empty`
- `integrity::tests::sbs871_quarantine_notfound_after_metadata_is_retried_then_err_when_pins_loaded`
- `integrity::tests::sbs871_quarantine_notfound_after_metadata_recovers_on_retry`
- `router::tests::sbs871_fail_closed_catalog_hides_every_tool_until_requarantine`
- `tests::sbs871_quarantine_bootstrap_keeps_prior_set_on_store_err`
- `tests::sbs871_quarantine_bootstrap_fail_closes_catalog_on_cold_start_err`
- `tests::sbs871_quarantine_bootstrap_keeps_fail_closed_across_rebuild`
- `tests::sbs871_quarantine_bootstrap_uses_the_store_on_ok`
- `tests::sbs871_prior_quarantine_from_placeholder_router_is_none`

Existing SBS-320 / SBS-654 / SBS-715 tests still passed (not weakened):

- `corrupt_quarantine_store_fails_closed_and_is_not_renamed_aside`
- `empty_quarantine_file_must_not_silently_unblock`
- `a_missing_quarantine_file_is_still_an_empty_set` (pins Fresh; comment updated)
- `quarantine_reads_fail_closed_when_a_legacy_file_was_not_migrated`

Also run (not the required job, requested locally):

- `cargo clippy --no-default-features --lib --bins` — finished; new code warning-clean. Pre-existing main warnings remain (e.g. `clippy::int_plus_one` in `integrity.rs:2325`, unused items in the gateway). `build_router` already had `too_many_arguments` at 8 params; allowed on the fn after adding the prior-set argument.
- `cargo test --no-default-features --lib --bins --tests` — lib **1011 passed** (desktop tests not compiled), gateway **311 passed**, same integration tests. All `sbs871_*` names ran.

Desktop WebKit **did** compile on this runner (default-features lib tests include `desktop.rs`). No tauri bundle.

## Rule 9 — what this makes more likely

- Retries make a persistently-missing file ~200ms slower before `Err` (and slower on honest first-run missing, same budget as pins).
- First-run is still `Ok` empty only when pins are `Fresh`.
- `build_router` now fail-closes, so a corrupt store on first boot hides tools until readable.
- `ensure_quarantine_store_for_existing_pins` writes `{}` under the lock when pins already exist and the file is lastingly gone. After retries that is "no file", not a rename window. An attacker who deleted the store still gets an empty durable set on the next rebuild; the live process keeps its set via `effective_quarantine` until then. Without this write, an existing install with pins and no quarantine file would hide the catalog forever (check sees an empty aggregated list, apply never creates the file).
- `apply_quarantine` starting empty on the specific absent-not-Fresh error can persist only the new blocks if the file is lastingly gone. It holds the lock and has already retried.

## Adjacent arms left alone

SBS-320 (corrupt), SBS-654 (present-but-empty), and SBS-715 (unmigrated legacy) are distinct and untouched. Pins Fresh/Corrupt/Loaded plus `read_pins_at` retry are unchanged.

## Gaps

- No flaky multi-process rename-race test (injected NotFound after metadata instead).
- `all_quarantined` / desktop UI still skip a missing file rather than surface "unreadable"; enforcement is the router.
- Dual-file race (pins and quarantine both mid-rename) can still look Fresh+missing for one tick; pins already retry.
- Did not run `npm run smoke:headless` (required job step after gateway build). Did not run the Windows/macOS matrix.
- Did not merge.

**NOT MERGED.**


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix quarantine store read to avoid treating a transient rename-window NotFound as an empty set
> - A missing quarantine file is no longer silently treated as an empty block set; it now fails closed (hiding the catalog) unless the pin store is fresh (first run).
> - Quarantine reads retry on transient `NotFound` and IO races, mirroring pin store read behavior.
> - `Router` gains a `fail_closed_catalog` flag; all tools are blocked with an explicit reason until a successful store read lifts it via `requarantine_from_store`.
> - Prior quarantine state is snapshotted before router rebuilds and restored on store read errors, preventing regressions to an empty set during transient failures.
> - Risk: existing installs with pins but no quarantine file will have an empty store materialized on first enforcement; corrupt pin stores will not get this materialization.
>
> #### 🖇️ Linked Issues
> Fixes [SBS-871](https://linear.app/southboundsoftware/issue/SBS-871) — transient missing quarantine store no longer installs an empty block set.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 550ca3c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->