### PR TITLE
fix(gateway): do not treat a failed registry load as no HTTP clients (SBS-900)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,13 +18,19 @@ Entries before the rename below shipped under the project's former name, Conduit
 
 ### Fixed
 
-- **A failed registry load no longer counts as "no HTTP clients".** `--insecure-loopback`
-  treats an empty `http_clients` list as permission to bind and serve without a bearer.
-  Boot used to fall back to `Registry::default()` on `load_resolved` Err, which is also
-  empty, so a corrupt or unreadable registry silently satisfied that precondition. The
-  open branch now requires a successful load _and_ no registered clients. A missing
-  registry file was already `Ok(default)` and is unchanged. A failed load with
-  `TOOLPORT_HTTP_TOKEN` still binds. (SBS-900)
+- **A registry that was not really read no longer counts as "no HTTP clients".**
+  `--insecure-loopback` treats an empty `http_clients` list as permission to bind and
+  serve without a bearer, and that list came back empty for three unrelated reasons: a
+  load error falling back to `Registry::default()`, a load that could not read the file
+  at all (locked, permissions) and reported it as absent, and a load recovered from a
+  backup, which is the state before the last save and so is missing exactly the save
+  that registered the first client. Loading now reports where the registry came from,
+  and the open branch requires a load that actually saw the configured state. The check
+  is also live rather than decided at boot: the file watcher republishes that verdict
+  with every reload, so a registry corrupted while the gateway runs closes the listener
+  instead of quietly re-opening it. A missing registry file is a real first run and still
+  opens with `--insecure-loopback`, and a failed load with `TOOLPORT_HTTP_TOKEN` still
+  binds. (SBS-900)
 - **Connect keeps stow/chezmoi config symlinks.** Writing a client config
   (Connect, Disconnect, migrate, launch-time re-point) used to replace a
   symlink at the config path with a regular file, leaving the file in the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,13 @@ Entries before the rename below shipped under the project's former name, Conduit
 
 ### Fixed
 
+- **A failed registry load no longer counts as "no HTTP clients".** `--insecure-loopback`
+  treats an empty `http_clients` list as permission to bind and serve without a bearer.
+  Boot used to fall back to `Registry::default()` on `load_resolved` Err, which is also
+  empty, so a corrupt or unreadable registry silently satisfied that precondition. The
+  open branch now requires a successful load _and_ no registered clients. A missing
+  registry file was already `Ok(default)` and is unchanged. A failed load with
+  `TOOLPORT_HTTP_TOKEN` still binds. (SBS-900)
 - **Linux `.deb` installs a `toolport` command.** The package still ships the
   crate binary as `conduit` (compat alias) and now also puts `toolport` on
   `PATH`, matching the AppImage installer and the brand. `install.sh` tells apt

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -51,8 +51,11 @@ manager around it. What network surface exists depends on the mode you run:
   when no token is set **and** `http_clients` is empty. Registered clients left
   over from earlier use keep the bind authenticated, so the listener still
   answers `401` to every request without a matching bearer; revoke those entries
-  first if you want the open listener. The flag never permits an open
-  non-loopback bind.
+  first if you want the open listener. An empty `http_clients` list only counts
+  when the registry was actually read: a registry recovered from a backup, or one
+  the gateway could not read at all, is empty for a reason that says nothing about
+  what is configured, so the flag does not open a listener over it. The flag never
+  permits an open non-loopback bind.
 - **Headless / Docker.** The published image runs the HTTP bridge and sets
   `TOOLPORT_HTTP_HOST=0.0.0.0` so it is reachable off-host. Every bind, including
   loopback, **requires** `TOOLPORT_HTTP_TOKEN` (legacy `CONDUIT_HTTP_TOKEN`) or a

--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -9966,6 +9966,9 @@ struct TickOutcome {
 fn watch_registry(
     path: PathBuf,
     registry: Arc<Mutex<Registry>>,
+    // Republished with every registry swap so the HTTP auth path never reads a
+    // recovered or defaulted registry as "no clients configured" (SBS-900).
+    registry_trusted: Arc<AtomicBool>,
     router: Arc<Mutex<Arc<Router>>>,
     stdout: Arc<Mutex<std::io::Stdout>>,
     cached_tools: SharedCatalog,
@@ -10006,6 +10009,7 @@ fn watch_registry(
         let _ = watch_tick(
             &path,
             &registry,
+            &registry_trusted,
             &router,
             &stdout,
             &cached_tools,
@@ -10035,6 +10039,8 @@ fn watch_registry(
 fn watch_tick(
     path: &Path,
     registry: &Arc<Mutex<Registry>>,
+    // Published together with every swap of `registry` (SBS-900).
+    registry_trusted: &Arc<AtomicBool>,
     router: &Arc<Mutex<Arc<Router>>>,
     stdout: &Arc<Mutex<std::io::Stdout>>,
     cached_tools: &SharedCatalog,
@@ -10103,8 +10109,16 @@ fn watch_tick(
         eprintln!("toolport: registry file changed on disk");
         // Don't advance `last_mtime` until a successful load, so a half-written file
         // (caught mid-save) is retried on the next tick instead of skipped.
-        let new_reg = match registry::load_from(path) {
-            Ok(r) => r,
+        //
+        // SBS-900: `Ok` is not "we read the registry". It also covers a recovery
+        // from a backup (state N-1, so the save that registered the first HTTP
+        // client is exactly the one whose backup has none) and a default standing
+        // in for a file that could not be read. Both are indistinguishable from
+        // "no clients configured" once in memory, which is what re-opens an
+        // `--insecure-loopback` listener that auth had already closed. The verdict
+        // rides along and is published with the registry below.
+        let (new_reg, new_source) = match registry::load_from_with_source(path) {
+            Ok(loaded) => loaded,
             Err(e) => {
                 eprintln!("toolport: reload failed (will retry): {e}");
                 return TickOutcome {
@@ -10114,6 +10128,16 @@ fn watch_tick(
             }
         };
         state.last_mtime = current;
+        // Publish the new registry and how far it can be trusted as one step, under
+        // the registry lock. The HTTP auth path reads the flag while holding that
+        // lock, so it can never pair one reload's registry with another's verdict.
+        let publish_registry = |new_reg: Registry| {
+            let mut live = registry
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            registry_trusted.store(new_source.is_authoritative(), Ordering::SeqCst);
+            *live = new_reg;
+        };
         // Refresh the live discovery mode from the freshly-loaded registry: a per-client
         // override edit (`client_discovery`) may be the only change, and it isn't
         // router-relevant, so resolve it here before the rebuild fast-path can return.
@@ -10137,9 +10161,7 @@ fn watch_tick(
         // also signaled a change, so that path is never dropped.
         let new_relevant = router_relevant(&new_reg);
         if downstream_changed == 0 && new_relevant == state.last_relevant {
-            *registry
-                .lock()
-                .unwrap_or_else(std::sync::PoisonError::into_inner) = new_reg;
+            publish_registry(new_reg);
             if routine_surface_changed || routine_catalog_changed {
                 notify_tools_changed(stdout, mcp_sessions);
                 eprintln!(
@@ -10215,9 +10237,7 @@ fn watch_tick(
                 .unwrap_or_else(std::sync::PoisonError::into_inner);
             (**guard).clone()
         };
-        *registry
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner) = new_reg;
+        publish_registry(new_reg);
         *router
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner) = Arc::new(new_router);
@@ -10356,6 +10376,14 @@ fn watch_tick(
 #[derive(Clone)]
 struct GatewayState {
     registry: Arc<Mutex<Registry>>,
+    /// Whether `registry` above is a faithful copy of what is on disk, i.e.
+    /// whether an EMPTY field in it means the user configured nothing (SBS-900).
+    /// False after a load that was recovered from a backup or defaulted over
+    /// contents that could not be read; see [`conduit_lib::registry::LoadSource`].
+    /// Live, not a boot constant: the watcher republishes it with every registry
+    /// swap, under the `registry` lock, so a reader holding that lock can never
+    /// pair one reload's registry with another's verdict.
+    registry_trusted: Arc<AtomicBool>,
     // The live router behind a swappable Arc: dispatch clones the Arc and releases the
     // lock before the (possibly long) downstream call / approval hold, so nothing blocks
     // behind an in-flight request. Rebuilds swap in a new Arc; refresh/requarantine fork
@@ -13897,7 +13925,7 @@ fn http_allows_insecure_open(
     loopback && insecure_loopback && !auth_configured && registry_loaded
 }
 
-fn serve_http(state: GatewayState, port: u16, registry_loaded: bool) {
+fn serve_http(state: GatewayState, port: u16) {
     let host = conduit_lib::brand::env_var("TOOLPORT_HTTP_HOST", "CONDUIT_HTTP_HOST")
         .filter(|s| !s.trim().is_empty())
         .unwrap_or_else(|| "127.0.0.1".to_string());
@@ -13909,11 +13937,21 @@ fn serve_http(state: GatewayState, port: u16, registry_loaded: bool) {
         .filter(|t| !t.is_empty());
 
     let loopback = matches!(host.as_str(), "127.0.0.1" | "::1" | "localhost");
-    let registered_clients = state
-        .registry
-        .lock()
-        .map(|reg| !reg.http_clients.is_empty())
-        .unwrap_or(false);
+    // A poisoned lock must not read as "no clients registered": that is the input
+    // that turns auth off and lets the escape hatch serve an open listener. Every
+    // other registry lock in this file recovers the guard instead, and so does
+    // this one. The trust verdict is read under the same lock the watcher
+    // publishes it with (SBS-900).
+    let (registered_clients, registry_loaded) = {
+        let reg = state
+            .registry
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        (
+            !reg.http_clients.is_empty(),
+            state.registry_trusted.load(Ordering::SeqCst),
+        )
+    };
     let auth_configured = token.is_some() || registered_clients;
     let args: Vec<String> = std::env::args().collect();
     let insecure_loopback = insecure_loopback_requested(&args);
@@ -13924,8 +13962,12 @@ fn serve_http(state: GatewayState, port: u16, registry_loaded: bool) {
         registry_loaded,
     );
 
-    if !http_bind_is_authorized(loopback, auth_configured, insecure_loopback, registry_loaded)
-    {
+    if !http_bind_is_authorized(
+        loopback,
+        auth_configured,
+        insecure_loopback,
+        registry_loaded,
+    ) {
         if loopback {
             eprintln!(
                 "toolport-gateway: refusing to bind {host}:{port} without HTTP authentication. \
@@ -13978,7 +14020,6 @@ fn serve_http(state: GatewayState, port: u16, registry_loaded: bool) {
                     search6,
                     confirm6,
                     allow_insecure_open,
-                    registry_loaded,
                 )
             });
             glog(&format!(
@@ -14004,15 +14045,7 @@ fn serve_http(state: GatewayState, port: u16, registry_loaded: bool) {
     eprintln!(
         "toolport-gateway: HTTP on http://localhost:{port}  (OpenAPI /openapi.json, MCP POST /mcp)"
     );
-    serve_http_loop(
-        server,
-        state,
-        token,
-        search,
-        confirm,
-        allow_insecure_open,
-        registry_loaded,
-    );
+    serve_http_loop(server, state, token, search, confirm, allow_insecure_open);
 }
 
 /// The accept loop for one listener. Each accepted request is handed to its own
@@ -14168,7 +14201,6 @@ fn serve_http_loop(
     search: Arc<SearchGuard>,
     confirm: Arc<ConfirmGuard>,
     allow_insecure_open: bool,
-    registry_loaded: bool,
 ) {
     serve_http_loop_with_inflight(
         server,
@@ -14177,7 +14209,6 @@ fn serve_http_loop(
         search,
         confirm,
         allow_insecure_open,
-        registry_loaded,
         Arc::new(AtomicUsize::new(0)),
     );
 }
@@ -14189,7 +14220,6 @@ fn serve_http_loop_with_inflight(
     search: Arc<SearchGuard>,
     confirm: Arc<ConfirmGuard>,
     allow_insecure_open: bool,
-    registry_loaded: bool,
     inflight: Arc<AtomicUsize>,
 ) {
     for request in server.incoming_requests() {
@@ -14212,7 +14242,6 @@ fn serve_http_loop_with_inflight(
                 &search,
                 &confirm,
                 allow_insecure_open,
-                registry_loaded,
             );
         });
     }
@@ -14243,7 +14272,6 @@ fn handle_connection(
     search: &SearchGuard,
     confirm: &ConfirmGuard,
     allow_insecure_open: bool,
-    registry_loaded: bool,
 ) {
     let method = request.method().to_string().to_uppercase();
     let url = request.url().to_string();
@@ -14353,6 +14381,12 @@ fn handle_connection(
             .registry
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
+        // Read the trust verdict for THIS registry, under the lock the watcher
+        // publishes both with, rather than the one boot started with. `reg` is the
+        // live registry the watcher swaps: a reload that recovered from a backup
+        // can drop the http_clients that closed this listener, and without a live
+        // verdict the open branch below would quietly re-open it (SBS-900).
+        let registry_loaded = state.registry_trusted.load(Ordering::SeqCst);
         // Resolve authorization, routing scope, audit attribution, and MCP
         // session ownership from one token lookup and one effective allow-set.
         match resolve_http_caller(
@@ -14672,14 +14706,16 @@ fn main() {
         );
         glog("WARNING: MSIX container detected but devirtualization failed (UNC view unreachable)");
     }
-    // SBS-900: keep the load *outcome* next to the in-memory registry. Err falls
-    // back to `Registry::default()`, whose empty `http_clients` must not satisfy
-    // the `--insecure-loopback` open branch. A missing file is `Ok(default)` and
-    // is not this case. Watcher reload-fail already keeps the previous registry.
-    let (loaded, registry_loaded) = match registry::load_resolved() {
-        Ok(r) => {
+    // SBS-900: keep the load *outcome* next to the in-memory registry. An empty
+    // `http_clients` list satisfies the `--insecure-loopback` open branch, and it
+    // is empty for three unrelated reasons: nothing configured (fine), an Err
+    // fallback to `Registry::default()`, and an Ok whose contents came from a
+    // backup or stood in for a file that could not be read. Only a load that
+    // actually saw the configured state may be read as "no clients".
+    let (loaded, registry_loaded) = match registry::load_resolved_with_source() {
+        Ok((r, source)) => {
             glog(&format!(
-                "load_resolved OK: {} servers total, {} enabled (active={})",
+                "load_resolved OK ({source:?}): {} servers total, {} enabled (active={})",
                 r.servers.len(),
                 r.enabled_servers().len(),
                 r.active_profile_id()
@@ -14689,7 +14725,14 @@ fn main() {
             // re-enable code mode after a corrupt registry (WS2-5). The watcher
             // already fails safe by not updating the flag on reload failure.
             seed_code_mode_after_registry_load(Ok(&r));
-            (r, true)
+            if !source.is_authoritative() {
+                eprintln!(
+                    "toolport-gateway: registry was recovered or could not be read ({source:?}); \
+                     its HTTP client list may be incomplete, so {INSECURE_LOOPBACK_FLAG} will not \
+                     open an unauthenticated listener. Set TOOLPORT_HTTP_TOKEN or repair the registry."
+                );
+            }
+            (r, source.is_authoritative())
         }
         Err(e) => {
             // Always surface this (not only under CONDUIT_DEBUG). A corrupt or
@@ -14718,6 +14761,10 @@ fn main() {
         resolve_live_profile(&loaded, client_id.as_deref(), &env_profile)
     };
     let registry = Arc::new(Mutex::new(loaded));
+    // Travels with the registry above for the rest of the process: the watcher
+    // republishes it on every reload, and the HTTP request path reads it while
+    // holding the registry lock (SBS-900).
+    let registry_trusted = Arc::new(AtomicBool::new(registry_loaded));
     // Empty router + cached catalog: the handshake and tools/list answer instantly
     // (from cache), while downstream servers connect in the background for the
     // actual tool calls.
@@ -14875,6 +14922,7 @@ fn main() {
 
     if let Some(path) = registry::resolved_path() {
         let registry = Arc::clone(&registry);
+        let registry_trusted = Arc::clone(&registry_trusted);
         let router = Arc::clone(&router);
         let stdout = Arc::clone(&stdout);
         let cached_tools = Arc::clone(&cached_tools);
@@ -14892,6 +14940,7 @@ fn main() {
             watch_registry(
                 path,
                 registry,
+                registry_trusted,
                 router,
                 stdout,
                 cached_tools,
@@ -14912,6 +14961,7 @@ fn main() {
 
     let state = GatewayState {
         registry: Arc::clone(&registry),
+        registry_trusted: Arc::clone(&registry_trusted),
         router: Arc::clone(&router),
         cached_tools: Arc::clone(&cached_tools),
         routine_candidates: CandidateRegistry::default(),
@@ -14947,7 +14997,7 @@ fn main() {
     // so it replaces the stdio loop; the background build + registry watcher
     // started above still keep the router and cache live underneath it.
     if let Some(port) = http_port_opt {
-        serve_http(state, port, registry_loaded);
+        serve_http(state, port);
         return;
     }
 
@@ -19704,6 +19754,8 @@ mod tests {
         ));
         GatewayState {
             registry: Arc::new(Mutex::new(Registry::default())),
+            // Tests stand in for a clean boot load; the ones that care flip it.
+            registry_trusted: Arc::new(AtomicBool::new(true)),
             router: Arc::new(Mutex::new(Arc::new(Router::new()))),
             cached_tools: Arc::new(Mutex::new(Arc::new(CatalogSnapshot::default()))),
             routine_candidates: CandidateRegistry::default(),
@@ -19985,9 +20037,7 @@ mod tests {
         let port = server.server_addr().to_ip().unwrap().port();
         let search = Arc::new(SearchGuard::default());
         let confirm = Arc::new(ConfirmGuard::new());
-        std::thread::spawn(move || {
-            serve_http_loop(server, state, None, search, confirm, true, true)
-        });
+        std::thread::spawn(move || serve_http_loop(server, state, None, search, confirm, true));
         std::thread::sleep(Duration::from_millis(50)); // let the listener come up
 
         // Kick off the slow (blocking) call on its own thread, then let it get parked
@@ -20106,7 +20156,6 @@ mod tests {
                 None,
                 search,
                 confirm,
-                true,
                 true,
                 listener_inflight,
             )
@@ -20348,6 +20397,54 @@ mod tests {
         assert!(resolve_http_caller(&reg, None, None, true, true).is_some());
         assert!(http_allows_insecure_open(true, false, true, true));
         assert!(http_bind_is_authorized(true, false, true, true));
+    }
+
+    /// SBS-900 (runtime): the boot verdict alone is not enough. `state.registry`
+    /// is the same Arc the watcher swaps, so a reload that recovered from a
+    /// backup can empty `http_clients` long after boot. The request path reads
+    /// the CURRENT verdict, so a listener that started open closes on that
+    /// reload instead of silently reverting to unauthenticated.
+    #[test]
+    fn a_reload_that_loses_trust_closes_the_open_listener() {
+        let state = http_state(true);
+        // Same flag the watcher publishes with every registry swap.
+        let trusted = Arc::clone(&state.registry_trusted);
+        let server = tiny_http::Server::http("127.0.0.1:0").unwrap();
+        let port = server.server_addr().to_ip().unwrap().port();
+        let search = Arc::new(SearchGuard::default());
+        let confirm = Arc::new(ConfirmGuard::new());
+        // Started open: loopback, `--insecure-loopback`, and a clean empty registry.
+        std::thread::spawn(move || serve_http_loop(server, state, None, search, confirm, true));
+        std::thread::sleep(Duration::from_millis(50)); // let the listener come up
+
+        let body = modern_http_body(1, "tools/list", json!({}));
+        let headers = [
+            ("MCP-Protocol-Version", MODERN_PROTOCOL_VERSION),
+            ("Mcp-Method", "tools/list"),
+            ("Accept", "application/json"),
+        ];
+        let open = http_post_with_headers(port, "/mcp", &body, &headers);
+        assert!(
+            open.starts_with("HTTP/1.1 200"),
+            "a clean empty registry still opens: {open}"
+        );
+
+        // The watcher swaps in a registry it could not vouch for (recovered from a
+        // backup, or defaulted over a file it could not read).
+        trusted.store(false, Ordering::SeqCst);
+        let closed = http_post_with_headers(port, "/mcp", &body, &headers);
+        assert!(
+            closed.starts_with("HTTP/1.1 401"),
+            "an untrusted live registry must not keep the listener open: {closed}"
+        );
+
+        // Trust comes back with the next clean reload; this is not a latch.
+        trusted.store(true, Ordering::SeqCst);
+        let reopened = http_post_with_headers(port, "/mcp", &body, &headers);
+        assert!(
+            reopened.starts_with("HTTP/1.1 200"),
+            "a clean reload restores the startup policy: {reopened}"
+        );
     }
 
     #[test]
@@ -21348,9 +21445,7 @@ mod tests {
         let port = server.server_addr().to_ip().unwrap().port();
         let search = Arc::new(SearchGuard::default());
         let confirm = Arc::new(ConfirmGuard::new());
-        std::thread::spawn(move || {
-            serve_http_loop(server, state, None, search, confirm, true, true)
-        });
+        std::thread::spawn(move || serve_http_loop(server, state, None, search, confirm, true));
 
         let body = modern_http_body(1, "tools/list", json!({}));
         let response = http_post_with_headers(
@@ -25185,6 +25280,7 @@ mod tests {
         let _data_dir = conduit_lib::registry::DataDirOverride::set(&dir);
 
         let registry = Arc::new(Mutex::new(Registry::default()));
+        let registry_trusted = Arc::new(AtomicBool::new(true));
         let router = Arc::new(Mutex::new(Arc::new(Router::new())));
         let stdout = Arc::new(Mutex::new(std::io::stdout()));
         let cached_tools = Arc::new(Mutex::new(Arc::new(CatalogSnapshot::default())));
@@ -25204,6 +25300,7 @@ mod tests {
         let _ = watch_tick(
             &reg_path,
             &registry,
+            &registry_trusted,
             &router,
             &stdout,
             &cached_tools,
@@ -25224,6 +25321,95 @@ mod tests {
             profile_slot.lock().unwrap().is_none(),
             "HTTP mode must not adopt the active profile after a registry reload"
         );
+        assert!(
+            registry_trusted.load(Ordering::SeqCst),
+            "a clean reload keeps the registry trustworthy"
+        );
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    /// SBS-900: the watcher swaps the live registry on ANY `Ok`, and `Ok` covers a
+    /// recovery from a backup. `save_to` snapshots the PRE-write content, so the
+    /// save that registered the FIRST http client is exactly the one whose backup
+    /// still has none: that reload hands the request path an empty client list and
+    /// used to re-open a listener that auth had already closed. The reload has to
+    /// publish how much it can be trusted along with the registry it swaps in.
+    #[test]
+    fn watch_tick_marks_a_recovered_registry_untrusted() {
+        let _env = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let dir = std::env::temp_dir().join(format!("toolport-sbs900-tick-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let _data_dir = conduit_lib::registry::DataDirOverride::set(&dir);
+
+        let reg_path = dir.join("registry.json");
+        // State N-1: nothing registered, so `--insecure-loopback` served an open
+        // listener. State N: the first HTTP client, which closed it.
+        conduit_lib::registry::save_to(&reg_path, &Registry::default()).unwrap();
+        let mut with_client = Registry::default();
+        with_client.http_clients.push(registry::HttpClient {
+            id: "c1".into(),
+            label: "Open WebUI".into(),
+            token_sha256: registry::sha256_hex("tok"),
+            profile: String::new(),
+        });
+        conduit_lib::registry::save_to(&reg_path, &with_client).unwrap();
+
+        let registry = Arc::new(Mutex::new(with_client));
+        let registry_trusted = Arc::new(AtomicBool::new(true));
+        let router = Arc::new(Mutex::new(Arc::new(Router::new())));
+        let stdout = Arc::new(Mutex::new(std::io::stdout()));
+        let cached_tools = Arc::new(Mutex::new(Arc::new(CatalogSnapshot::default())));
+        let profile_slot = Arc::new(Mutex::new(None));
+        let downstream_dirty = Arc::new(AtomicU8::new(0));
+        let client_root = Arc::new(Mutex::new(None));
+        let server_handler: ServerRequestHandler = Arc::new(|_| None);
+        let rebuild_lock = Arc::new(Mutex::new(()));
+
+        // Corrupt the primary, exactly as the incident did.
+        std::fs::write(&reg_path, "{ not json").unwrap();
+        let mut state = WatchLoopState {
+            last_mtime: None,
+            last_relevant: json!({}),
+            last_routines_mtime: None,
+        };
+        let _ = watch_tick(
+            &reg_path,
+            &registry,
+            &registry_trusted,
+            &router,
+            &stdout,
+            &cached_tools,
+            &profile_slot,
+            None,
+            None,
+            true,
+            &downstream_dirty,
+            &server_handler,
+            &client_root,
+            None,
+            None,
+            None,
+            &rebuild_lock,
+            &mut state,
+        );
+
+        let live = registry.lock().unwrap_or_else(|e| e.into_inner());
+        assert!(
+            live.http_clients.is_empty(),
+            "the recovery really did lose the registered client"
+        );
+        let trusted = registry_trusted.load(Ordering::SeqCst);
+        assert!(
+            !trusted,
+            "a recovered registry must not be read as 'no clients configured'"
+        );
+        // Which is what the request path asks before serving an open caller.
+        assert!(
+            resolve_http_scope(&live, None, None, true, trusted).is_none(),
+            "the open branch must stay shut on a recovered registry"
+        );
+        drop(live);
+
         let _ = std::fs::remove_dir_all(dir);
     }
 
@@ -25251,6 +25437,7 @@ mod tests {
         let mut reg = Registry::default();
         reg.quarantine_on_drift = true;
         let registry = Arc::new(Mutex::new(reg));
+        let registry_trusted = Arc::new(AtomicBool::new(true));
         let router = Arc::new(Mutex::new(Arc::new(Router::new())));
         let stdout = Arc::new(Mutex::new(std::io::stdout()));
         let cached_tools = Arc::new(Mutex::new(Arc::new(CatalogSnapshot::default())));
@@ -25273,6 +25460,7 @@ mod tests {
         let load = watch_tick(
             &reg_path,
             &registry,
+            &registry_trusted,
             &router,
             &stdout,
             &cached_tools,
@@ -25303,6 +25491,7 @@ mod tests {
         let steady = watch_tick(
             &reg_path,
             &registry,
+            &registry_trusted,
             &router,
             &stdout,
             &cached_tools,
@@ -25327,6 +25516,7 @@ mod tests {
         let after = watch_tick(
             &reg_path,
             &registry,
+            &registry_trusted,
             &router,
             &stdout,
             &cached_tools,
@@ -25372,6 +25562,7 @@ mod tests {
         let _data_dir = conduit_lib::registry::DataDirOverride::set(&dir);
 
         let registry = Arc::new(Mutex::new(Registry::default()));
+        let registry_trusted = Arc::new(AtomicBool::new(true));
         let original_router = Arc::new(Router::new());
         let router = Arc::new(Mutex::new(Arc::clone(&original_router)));
         let stdout = Arc::new(Mutex::new(std::io::stdout()));
@@ -25401,6 +25592,7 @@ mod tests {
         let outcome = watch_tick(
             &path,
             &registry,
+            &registry_trusted,
             &router,
             &stdout,
             &cached_tools,
@@ -25445,6 +25637,7 @@ mod tests {
         let catalog_change = watch_tick(
             &path,
             &registry,
+            &registry_trusted,
             &router,
             &stdout,
             &cached_tools,

--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -22595,7 +22595,7 @@ mod tests {
             profile: personal,
         });
         let (allowed, caller) =
-            resolve_http_caller(&reg, None, Some("tok-personal"), false).unwrap();
+            resolve_http_caller(&reg, None, Some("tok-personal"), false, true).unwrap();
         let set = allowed.expect("Personal client is scoped");
         assert!(set.contains("team-slack"));
         assert!(

--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -3683,6 +3683,7 @@ fn resolve_http_caller(
     env_token: Option<&str>,
     provided: Option<&str>,
     allow_insecure_open: bool,
+    registry_loaded: bool,
 ) -> Option<(Option<std::collections::HashSet<String>>, HttpCaller)> {
     let owner_scope = |allowed: &Option<std::collections::HashSet<String>>| {
         allowed.as_ref().map(|set| {
@@ -3747,7 +3748,11 @@ fn resolve_http_caller(
     // resolves for the server that minted it), so this is a weaker isolation
     // boundary rather than an open channel. The mode is already labelled insecure;
     // this is one more thing it gives up.
-    if allow_insecure_open && env_token.is_none() && reg.http_clients.is_empty() {
+    //
+    // SBS-900: `reg.http_clients.is_empty()` is also true when boot `load_resolved`
+    // returned Err and fell back to `Registry::default()`. That is not "no clients
+    // configured". A missing registry file is `Ok(default)` and is not this case.
+    if allow_insecure_open && env_token.is_none() && registry_loaded && reg.http_clients.is_empty() {
         return Some((
             None,
             HttpCaller {
@@ -3770,8 +3775,16 @@ fn resolve_http_scope(
     env_token: Option<&str>,
     provided: Option<&str>,
     allow_insecure_open: bool,
+    registry_loaded: bool,
 ) -> Option<Option<std::collections::HashSet<String>>> {
-    resolve_http_caller(reg, env_token, provided, allow_insecure_open).map(|(allowed, _)| allowed)
+    resolve_http_caller(
+        reg,
+        env_token,
+        provided,
+        allow_insecure_open,
+        registry_loaded,
+    )
+    .map(|(allowed, _)| allowed)
 }
 
 /// The audit label for a registered HTTP client's bearer: its `label`, or its `id`
@@ -13853,20 +13866,38 @@ fn insecure_loopback_requested(args: &[String]) -> bool {
 }
 
 /// Startup admission policy. The escape hatch is never valid for a non-loopback bind.
-fn http_bind_is_authorized(loopback: bool, auth_configured: bool, insecure_loopback: bool) -> bool {
-    auth_configured || http_allows_insecure_open(loopback, auth_configured, insecure_loopback)
+///
+/// `registry_loaded` is the boot `load_resolved` outcome (Ok=true, Err=false). A
+/// failed load must not authorize the `--insecure-loopback` open bind (SBS-900).
+fn http_bind_is_authorized(
+    loopback: bool,
+    auth_configured: bool,
+    insecure_loopback: bool,
+    registry_loaded: bool,
+) -> bool {
+    auth_configured
+        || http_allows_insecure_open(
+            loopback,
+            auth_configured,
+            insecure_loopback,
+            registry_loaded,
+        )
 }
 
-/// Activate the open-listener fallback only when the escape hatch was required at startup.
+/// Activate the open-listener fallback only when the escape hatch was required at startup
+/// and the registry actually loaded. `Registry::default()` after `load_resolved` Err
+/// also has empty `http_clients`; that must not count as "no clients configured"
+/// (SBS-900).
 fn http_allows_insecure_open(
     loopback: bool,
     auth_configured: bool,
     insecure_loopback: bool,
+    registry_loaded: bool,
 ) -> bool {
-    loopback && insecure_loopback && !auth_configured
+    loopback && insecure_loopback && !auth_configured && registry_loaded
 }
 
-fn serve_http(state: GatewayState, port: u16) {
+fn serve_http(state: GatewayState, port: u16, registry_loaded: bool) {
     let host = conduit_lib::brand::env_var("TOOLPORT_HTTP_HOST", "CONDUIT_HTTP_HOST")
         .filter(|s| !s.trim().is_empty())
         .unwrap_or_else(|| "127.0.0.1".to_string());
@@ -13886,10 +13917,15 @@ fn serve_http(state: GatewayState, port: u16) {
     let auth_configured = token.is_some() || registered_clients;
     let args: Vec<String> = std::env::args().collect();
     let insecure_loopback = insecure_loopback_requested(&args);
-    let allow_insecure_open =
-        http_allows_insecure_open(loopback, auth_configured, insecure_loopback);
+    let allow_insecure_open = http_allows_insecure_open(
+        loopback,
+        auth_configured,
+        insecure_loopback,
+        registry_loaded,
+    );
 
-    if !http_bind_is_authorized(loopback, auth_configured, insecure_loopback) {
+    if !http_bind_is_authorized(loopback, auth_configured, insecure_loopback, registry_loaded)
+    {
         if loopback {
             eprintln!(
                 "toolport-gateway: refusing to bind {host}:{port} without HTTP authentication. \
@@ -13942,6 +13978,7 @@ fn serve_http(state: GatewayState, port: u16) {
                     search6,
                     confirm6,
                     allow_insecure_open,
+                    registry_loaded,
                 )
             });
             glog(&format!(
@@ -13967,7 +14004,15 @@ fn serve_http(state: GatewayState, port: u16) {
     eprintln!(
         "toolport-gateway: HTTP on http://localhost:{port}  (OpenAPI /openapi.json, MCP POST /mcp)"
     );
-    serve_http_loop(server, state, token, search, confirm, allow_insecure_open);
+    serve_http_loop(
+        server,
+        state,
+        token,
+        search,
+        confirm,
+        allow_insecure_open,
+        registry_loaded,
+    );
 }
 
 /// The accept loop for one listener. Each accepted request is handed to its own
@@ -14123,6 +14168,7 @@ fn serve_http_loop(
     search: Arc<SearchGuard>,
     confirm: Arc<ConfirmGuard>,
     allow_insecure_open: bool,
+    registry_loaded: bool,
 ) {
     serve_http_loop_with_inflight(
         server,
@@ -14131,6 +14177,7 @@ fn serve_http_loop(
         search,
         confirm,
         allow_insecure_open,
+        registry_loaded,
         Arc::new(AtomicUsize::new(0)),
     );
 }
@@ -14142,6 +14189,7 @@ fn serve_http_loop_with_inflight(
     search: Arc<SearchGuard>,
     confirm: Arc<ConfirmGuard>,
     allow_insecure_open: bool,
+    registry_loaded: bool,
     inflight: Arc<AtomicUsize>,
 ) {
     for request in server.incoming_requests() {
@@ -14164,6 +14212,7 @@ fn serve_http_loop_with_inflight(
                 &search,
                 &confirm,
                 allow_insecure_open,
+                registry_loaded,
             );
         });
     }
@@ -14194,6 +14243,7 @@ fn handle_connection(
     search: &SearchGuard,
     confirm: &ConfirmGuard,
     allow_insecure_open: bool,
+    registry_loaded: bool,
 ) {
     let method = request.method().to_string().to_uppercase();
     let url = request.url().to_string();
@@ -14305,7 +14355,13 @@ fn handle_connection(
             .unwrap_or_else(std::sync::PoisonError::into_inner);
         // Resolve authorization, routing scope, audit attribution, and MCP
         // session ownership from one token lookup and one effective allow-set.
-        match resolve_http_caller(&reg, token.as_deref(), provided_tok, allow_insecure_open) {
+        match resolve_http_caller(
+            &reg,
+            token.as_deref(),
+            provided_tok,
+            allow_insecure_open,
+            registry_loaded,
+        ) {
             Some((allowed, resolved_caller)) => {
                 caller = Some(resolved_caller);
                 Some(allowed)
@@ -14616,7 +14672,11 @@ fn main() {
         );
         glog("WARNING: MSIX container detected but devirtualization failed (UNC view unreachable)");
     }
-    let loaded = match registry::load_resolved() {
+    // SBS-900: keep the load *outcome* next to the in-memory registry. Err falls
+    // back to `Registry::default()`, whose empty `http_clients` must not satisfy
+    // the `--insecure-loopback` open branch. A missing file is `Ok(default)` and
+    // is not this case. Watcher reload-fail already keeps the previous registry.
+    let (loaded, registry_loaded) = match registry::load_resolved() {
         Ok(r) => {
             glog(&format!(
                 "load_resolved OK: {} servers total, {} enabled (active={})",
@@ -14629,7 +14689,7 @@ fn main() {
             // re-enable code mode after a corrupt registry (WS2-5). The watcher
             // already fails safe by not updating the flag on reload failure.
             seed_code_mode_after_registry_load(Ok(&r));
-            r
+            (r, true)
         }
         Err(e) => {
             // Always surface this (not only under CONDUIT_DEBUG). A corrupt or
@@ -14643,7 +14703,7 @@ fn main() {
             );
             glog(&format!("load_resolved ERR: {e}"));
             seed_code_mode_after_registry_load(Err(()));
-            registry::Registry::default()
+            (registry::Registry::default(), false)
         }
     };
     inspect::clear();
@@ -14887,7 +14947,7 @@ fn main() {
     // so it replaces the stdio loop; the background build + registry watcher
     // started above still keep the router and cache live underneath it.
     if let Some(port) = http_port_opt {
-        serve_http(state, port);
+        serve_http(state, port, registry_loaded);
         return;
     }
 
@@ -19925,7 +19985,9 @@ mod tests {
         let port = server.server_addr().to_ip().unwrap().port();
         let search = Arc::new(SearchGuard::default());
         let confirm = Arc::new(ConfirmGuard::new());
-        std::thread::spawn(move || serve_http_loop(server, state, None, search, confirm, true));
+        std::thread::spawn(move || {
+            serve_http_loop(server, state, None, search, confirm, true, true)
+        });
         std::thread::sleep(Duration::from_millis(50)); // let the listener come up
 
         // Kick off the slow (blocking) call on its own thread, then let it get parked
@@ -20044,6 +20106,7 @@ mod tests {
                 None,
                 search,
                 confirm,
+                true,
                 true,
                 listener_inflight,
             )
@@ -20224,15 +20287,67 @@ mod tests {
 
     #[test]
     fn http_bind_requires_auth_except_for_explicit_loopback_escape_hatch() {
-        assert!(http_bind_is_authorized(true, true, false));
-        assert!(http_bind_is_authorized(false, true, false));
-        assert!(http_bind_is_authorized(true, false, true));
-        assert!(!http_bind_is_authorized(true, false, false));
-        assert!(!http_bind_is_authorized(false, false, false));
-        assert!(!http_bind_is_authorized(false, false, true));
-        assert!(http_allows_insecure_open(true, false, true));
-        assert!(!http_allows_insecure_open(true, true, true));
-        assert!(!http_allows_insecure_open(false, false, true));
+        assert!(http_bind_is_authorized(true, true, false, true));
+        assert!(http_bind_is_authorized(false, true, false, true));
+        assert!(http_bind_is_authorized(true, false, true, true));
+        assert!(!http_bind_is_authorized(true, false, false, true));
+        assert!(!http_bind_is_authorized(false, false, false, true));
+        assert!(!http_bind_is_authorized(false, false, true, true));
+        assert!(http_allows_insecure_open(true, false, true, true));
+        assert!(!http_allows_insecure_open(true, true, true, true));
+        assert!(!http_allows_insecure_open(false, false, true, true));
+    }
+
+    /// SBS-900: boot `load_resolved` Err falls back to `Registry::default()`, whose
+    /// empty `http_clients` used to satisfy the `--insecure-loopback` open branch.
+    /// A failed load is not "no clients configured". A missing file is `Ok(default)`
+    /// and is not this case.
+    #[test]
+    fn failed_registry_load_does_not_open_insecure_loopback() {
+        let reg = Registry::default();
+        // Request resolver: flag + empty default after a failed load must not open.
+        assert!(
+            resolve_http_scope(&reg, None, None, true, false).is_none(),
+            "failed load must not authorize the open caller"
+        );
+        assert!(
+            resolve_http_caller(&reg, None, None, true, false).is_none(),
+            "failed load must not mint the open HttpCaller"
+        );
+        // Startup: failed load + no env token must not authorize the open bind.
+        assert!(
+            !http_allows_insecure_open(true, false, true, false),
+            "failed load must not activate the open-listener fallback"
+        );
+        assert!(
+            !http_bind_is_authorized(true, false, true, false),
+            "failed load + no env token must not authorize the open bind"
+        );
+        // Failed load + env token still binds; the token is the auth, not the hatch.
+        assert!(
+            http_bind_is_authorized(true, true, true, false),
+            "failed load + env token must still bind"
+        );
+        assert!(
+            !http_allows_insecure_open(true, true, true, false),
+            "an env token must not also open the unauthenticated branch"
+        );
+        assert_eq!(
+            resolve_http_scope(&reg, Some("envtok"), Some("envtok"), true, false),
+            Some(None),
+            "failed load + matching env token must still authorize"
+        );
+    }
+
+    /// SBS-900: a successful empty load (`Ok(Registry::default())`, including a
+    /// missing file) plus `--insecure-loopback` still opens.
+    #[test]
+    fn successful_empty_registry_load_still_opens_insecure_loopback() {
+        let reg = Registry::default();
+        assert_eq!(resolve_http_scope(&reg, None, None, true, true), Some(None));
+        assert!(resolve_http_caller(&reg, None, None, true, true).is_some());
+        assert!(http_allows_insecure_open(true, false, true, true));
+        assert!(http_bind_is_authorized(true, false, true, true));
     }
 
     #[test]
@@ -20457,14 +20572,14 @@ mod tests {
     fn resolve_http_scope_auth_and_scope_policy() {
         let mut reg = Registry::default();
         // No auth configured at all -> open only under the explicit escape hatch.
-        assert_eq!(resolve_http_scope(&reg, None, None, true), Some(None));
-        assert_eq!(resolve_http_scope(&reg, None, None, false), None);
+        assert_eq!(resolve_http_scope(&reg, None, None, true, true), Some(None));
+        assert_eq!(resolve_http_scope(&reg, None, None, false, true), None);
         // Legacy env token: exact match -> unscoped; mismatch -> rejected.
         assert_eq!(
-            resolve_http_scope(&reg, Some("envtok"), Some("envtok"), false),
+            resolve_http_scope(&reg, Some("envtok"), Some("envtok"), false, true),
             Some(None)
         );
-        assert!(resolve_http_scope(&reg, Some("envtok"), Some("nope"), false).is_none());
+        assert!(resolve_http_scope(&reg, Some("envtok"), Some("nope"), false, true).is_none());
         // A registered client with an empty profile is authorized but unscoped.
         reg.http_clients.push(registry::HttpClient {
             id: "c1".into(),
@@ -20473,13 +20588,13 @@ mod tests {
             profile: String::new(),
         });
         assert_eq!(
-            resolve_http_scope(&reg, None, Some("fulltok"), false),
+            resolve_http_scope(&reg, None, Some("fulltok"), false, true),
             Some(None)
         );
         // Once any client is registered, an unknown/absent bearer is rejected
         // (the open default no longer applies).
-        assert!(resolve_http_scope(&reg, None, Some("unknown"), false).is_none());
-        assert!(resolve_http_scope(&reg, None, None, false).is_none());
+        assert!(resolve_http_scope(&reg, None, Some("unknown"), false, true).is_none());
+        assert!(resolve_http_scope(&reg, None, None, false, true).is_none());
         // A client scoped to a non-empty profile resolves to a (possibly empty)
         // allow-set; exact membership is covered by enabled_servers_for tests.
         reg.http_clients.push(registry::HttpClient {
@@ -20489,19 +20604,22 @@ mod tests {
             profile: "Default".into(),
         });
         assert!(matches!(
-            resolve_http_scope(&reg, None, Some("scopedtok"), false),
+            resolve_http_scope(&reg, None, Some("scopedtok"), false, true),
             Some(Some(_))
         ));
 
         // Removing the last registered client while the gateway is live must not
         // turn an authenticated listener into an open one. Only immutable startup
         // policy from `--insecure-loopback` enables the fallback.
-        let authenticated_startup_allows_open = http_allows_insecure_open(true, true, true);
+        let authenticated_startup_allows_open = http_allows_insecure_open(true, true, true, true);
         reg.http_clients.clear();
-        assert!(resolve_http_scope(&reg, None, None, authenticated_startup_allows_open).is_none());
-        let explicit_open_startup = http_allows_insecure_open(true, false, true);
+        assert!(
+            resolve_http_scope(&reg, None, None, authenticated_startup_allows_open, true)
+                .is_none()
+        );
+        let explicit_open_startup = http_allows_insecure_open(true, false, true, true);
         assert_eq!(
-            resolve_http_scope(&reg, None, None, explicit_open_startup),
+            resolve_http_scope(&reg, None, None, explicit_open_startup, true),
             Some(None)
         );
     }
@@ -20525,7 +20643,7 @@ mod tests {
         });
 
         let (_, caller) =
-            resolve_http_caller(&reg, None, Some("client-token"), false).unwrap();
+            resolve_http_caller(&reg, None, Some("client-token"), false, true).unwrap();
 
         // Use a real in-memory downstream route so the tools/call request reaches
         // execute_call(), which is where the audit entry is recorded.
@@ -20650,8 +20768,8 @@ mod tests {
             profile: String::new(),
         });
 
-        let (_, first) = resolve_http_caller(&reg, None, Some("tok1"), false).unwrap();
-        let (_, second) = resolve_http_caller(&reg, None, Some("tok2"), false).unwrap();
+        let (_, first) = resolve_http_caller(&reg, None, Some("tok1"), false, true).unwrap();
+        let (_, second) = resolve_http_caller(&reg, None, Some("tok2"), false, true).unwrap();
         assert_eq!(first.audit_label.as_deref(), Some("Open WebUI"));
         assert_eq!(second.audit_label.as_deref(), Some("Open WebUI"));
         assert_ne!(
@@ -20703,8 +20821,8 @@ mod tests {
             token_sha256: registry::sha256_hex("t-b"),
             profile: String::new(),
         });
-        let (_, a) = resolve_http_caller(&reg, None, Some("t-a"), false).unwrap();
-        let (_, b) = resolve_http_caller(&reg, None, Some("t-b"), false).unwrap();
+        let (_, a) = resolve_http_caller(&reg, None, Some("t-a"), false, true).unwrap();
+        let (_, b) = resolve_http_caller(&reg, None, Some("t-b"), false, true).unwrap();
         // What handle_http must pass into process_request (stable id, not label).
         assert_eq!(a.session_owner.identity, "client:alpha");
         assert_eq!(b.session_owner.identity, "client:beta");
@@ -21230,7 +21348,9 @@ mod tests {
         let port = server.server_addr().to_ip().unwrap().port();
         let search = Arc::new(SearchGuard::default());
         let confirm = Arc::new(ConfirmGuard::new());
-        std::thread::spawn(move || serve_http_loop(server, state, None, search, confirm, true));
+        std::thread::spawn(move || {
+            serve_http_loop(server, state, None, search, confirm, true, true)
+        });
 
         let body = modern_http_body(1, "tools/list", json!({}));
         let response = http_post_with_headers(

--- a/src-tauri/src/registry.rs
+++ b/src-tauri/src/registry.rs
@@ -2341,6 +2341,11 @@ enum ReadOutcome {
     Content(String),
     /// Still missing or empty after retries: genuinely absent, not a race.
     Absent,
+    /// The file is there but every read failed with something other than
+    /// not-found (sharing violation, permissions, I/O error). Recovery treats
+    /// this exactly like `Absent`, but a caller reading a security decision out
+    /// of the result has to know the real contents were never seen (SBS-900).
+    Unreadable,
 }
 
 /// Read the registry tolerating the transient states a concurrent `atomic_write`
@@ -2355,18 +2360,29 @@ enum ReadOutcome {
 fn read_registry_file(path: &Path) -> ReadOutcome {
     const ATTEMPTS: u32 = 4;
     const BACKOFF_MS: u64 = 75;
+    // Why the last attempt failed, so a file we were never allowed to read is not
+    // reported as a file that is not there (SBS-900). Recovery behaves the same
+    // for both; only the reported outcome differs.
+    let mut last_error: Option<std::io::ErrorKind> = None;
     for attempt in 0..ATTEMPTS {
         match std::fs::read_to_string(path) {
             Ok(content) if !content.trim().is_empty() => return ReadOutcome::Content(content),
+            // An empty read is the rename window itself, not an error.
+            Ok(_) => last_error = None,
             // Empty, missing, locked (sharing violation), or any other error:
             // all indistinguishable from a rename in flight. Wait and re-look.
-            _ => {}
+            Err(e) => last_error = Some(e.kind()),
         }
         if attempt + 1 < ATTEMPTS {
             std::thread::sleep(std::time::Duration::from_millis(BACKOFF_MS));
         }
     }
-    ReadOutcome::Absent
+    match last_error {
+        // Nothing there (or an empty file): a first run, or a deletion.
+        None | Some(std::io::ErrorKind::NotFound) => ReadOutcome::Absent,
+        // Present, but its contents were never seen by this process.
+        Some(_) => ReadOutcome::Unreadable,
+    }
 }
 
 /// Preserve an unreadable registry file next to the original before anything
@@ -2411,21 +2427,69 @@ fn quarantine_unreadable(path: &Path, content: &str) -> Option<PathBuf> {
     Some(dest)
 }
 
-fn load_from_inner(path: &Path) -> Result<Registry, String> {
-    let mut registry = match read_registry_file(path) {
+/// Where a loaded [`Registry`] actually came from.
+///
+/// `load_from` returns `Ok` for several quite different situations, and only some
+/// of them mean "this is everything the user configured". A caller that reads a
+/// security decision out of an EMPTY field has to tell them apart: the gateway
+/// treats an empty `http_clients` as "no HTTP auth is configured, so
+/// `--insecure-loopback` may serve an open listener", and a registry that was
+/// defaulted over contents nobody could read, or rebuilt from a backup taken
+/// before the first client was registered, is empty for a completely different
+/// reason (SBS-900).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LoadSource {
+    /// The primary registry file was read and parsed. Memory matches disk.
+    File,
+    /// No registry file and no backup worth recovering: a genuine first run.
+    /// Empty here is the truth.
+    FirstRun,
+    /// The primary was absent, unreadable, or unparseable, and the registry came
+    /// from a backup. `save_to` snapshots the PRE-write content, so the newest
+    /// backup is state N-1: the save that registered the first HTTP client is
+    /// exactly the one whose backup still has none.
+    Backup,
+    /// The primary exists but could not be read (locked, permissions, I/O) and
+    /// no backup was usable, so this is a `Registry::default()` standing in for
+    /// contents nobody has seen.
+    Unreadable,
+}
+
+impl LoadSource {
+    /// True only when an absent value in the loaded registry means the user never
+    /// configured it, rather than "this build could not tell". Everything
+    /// reconstructed or defaulted over unread contents is `false`, so a caller
+    /// that must fail closed can just ask.
+    pub fn is_authoritative(self) -> bool {
+        matches!(self, LoadSource::File | LoadSource::FirstRun)
+    }
+}
+
+fn load_from_inner(path: &Path) -> Result<(Registry, LoadSource), String> {
+    let (mut registry, source) = match read_registry_file(path) {
         // Genuinely missing or empty (not a rename race - read_registry_file
         // already waited that out): recover the last-known-good from the .bak
         // sibling if one survived, else this is a first run.
         ReadOutcome::Absent => {
             if let Some(reg) = restore_from_backup(path) {
                 record_registry_recovery("missing", None);
-                Ok(reg)
+                Ok((reg, LoadSource::Backup))
             } else {
-                Ok(Registry::default())
+                Ok((Registry::default(), LoadSource::FirstRun))
+            }
+        }
+        // Same recovery, different truth: the file is there and we never saw it,
+        // so a default here is a placeholder, not a first run (SBS-900).
+        ReadOutcome::Unreadable => {
+            if let Some(reg) = restore_from_backup(path) {
+                record_registry_recovery("missing", None);
+                Ok((reg, LoadSource::Backup))
+            } else {
+                Ok((Registry::default(), LoadSource::Unreadable))
             }
         }
         ReadOutcome::Content(content) => match serde_json::from_str(&content) {
-            Ok(reg) => Ok(reg),
+            Ok(reg) => Ok((reg, LoadSource::File)),
             // Present but unparseable by THIS build: corrupt, or a newer schema.
             // Quarantine the evidence BEFORE restore_from_backup self-heals the
             // primary from .bak, so nothing is ever silently destroyed.
@@ -2434,7 +2498,7 @@ fn load_from_inner(path: &Path) -> Result<Registry, String> {
                 match restore_from_backup(path) {
                     Some(reg) => {
                         record_registry_recovery("corrupt", quarantine);
-                        Ok(reg)
+                        Ok((reg, LoadSource::Backup))
                     }
                     None => Err(format!("Corrupt registry: {e}")),
                 }
@@ -2442,21 +2506,35 @@ fn load_from_inner(path: &Path) -> Result<Registry, String> {
         },
     }?;
     registry.normalize_profile_references();
-    Ok(registry)
+    Ok((registry, source))
 }
 
 /// Load an explicit registry while holding its cross-process lock across the full
 /// read/recovery path. Recovery can rewrite the primary from a backup, so even a caller
 /// that only intends to read must serialize with writers (SOU-330).
 pub fn load_from(path: &Path) -> Result<Registry, String> {
+    load_from_with_source(path).map(|(registry, _)| registry)
+}
+
+/// [`load_from`] plus where the result actually came from, for the callers that
+/// must not read "empty" as "nothing configured" (SBS-900).
+pub fn load_from_with_source(path: &Path) -> Result<(Registry, LoadSource), String> {
     let lock = lock_for(path, registry_lock_timeout())?;
-    load_from_locked(path, &lock)
+    load_from_locked_with_source(path, &lock)
 }
 
 /// Load while the caller already holds a registry lock. Requiring the guard by reference
 /// prevents nested acquisition in read-modify-write paths while making the lock requirement
 /// explicit at call sites that need to keep it through a later save.
-pub fn load_from_locked(path: &Path, _lock: &FileLock) -> Result<Registry, String> {
+pub fn load_from_locked(path: &Path, lock: &FileLock) -> Result<Registry, String> {
+    load_from_locked_with_source(path, lock).map(|(registry, _)| registry)
+}
+
+/// [`load_from_locked`] plus the [`LoadSource`] of the result.
+pub fn load_from_locked_with_source(
+    path: &Path,
+    _lock: &FileLock,
+) -> Result<(Registry, LoadSource), String> {
     load_from_inner(path)
 }
 
@@ -2690,12 +2768,22 @@ pub fn resolved_path() -> Option<PathBuf> {
 /// Load honoring the `TOOLPORT_REGISTRY` / `CONDUIT_REGISTRY` env override (used
 /// by the gateway and tests), falling back to the default path.
 pub fn load_resolved() -> Result<Registry, String> {
-    let registry = match resolved_path() {
-        Some(path) => load_from(&path),
-        None => Ok(Registry::default()),
+    load_resolved_with_source().map(|(registry, _)| registry)
+}
+
+/// [`load_resolved`] plus where the result came from. `Ok` alone does not mean the
+/// registry on disk was read: it also covers a recovery from a backup and a
+/// default standing in for a file that could not be read, both of which are empty
+/// for reasons that are not "the user configured nothing" (SBS-900).
+pub fn load_resolved_with_source() -> Result<(Registry, LoadSource), String> {
+    let (registry, source) = match resolved_path() {
+        Some(path) => load_from_with_source(&path),
+        // No resolvable path means there is no registry to configure anything in,
+        // so an empty one is the whole truth rather than a stand-in.
+        None => Ok((Registry::default(), LoadSource::FirstRun)),
     }?;
     migrate_profile_stores(&registry)?;
-    Ok(registry)
+    Ok((registry, source))
 }
 
 /// True when a command argument looks like it carries a secret: an inline
@@ -4173,6 +4261,113 @@ mod tests {
         cleanup_quarantine(&path);
         std::fs::remove_file(&path).ok();
         std::fs::remove_file(&bak).ok();
+    }
+
+    fn sample_http_client() -> HttpClient {
+        HttpClient {
+            id: "c1".into(),
+            label: "Open WebUI".into(),
+            token_sha256: sha256_hex("tok"),
+            profile: String::new(),
+        }
+    }
+
+    fn clear_registry_files(path: &Path) {
+        cleanup_quarantine(path);
+        std::fs::remove_file(path).ok();
+        std::fs::remove_file(backup_path(path)).ok();
+        std::fs::remove_file(backup_sequence_path(path)).ok();
+        for generation in backup_generations(path) {
+            std::fs::remove_file(generation).ok();
+        }
+    }
+
+    /// SBS-900: `load_from` answers `Ok` to three different questions, and the
+    /// gateway reads a security decision out of an EMPTY field (an empty
+    /// `http_clients` is what lets `--insecure-loopback` serve an open listener).
+    /// The source has to say which `Ok` this was.
+    #[test]
+    fn load_source_separates_a_real_read_from_a_recovery() {
+        let path =
+            std::env::temp_dir().join(format!("conduit-reg-source-{}.json", std::process::id()));
+        clear_registry_files(&path);
+
+        // A genuine first run: no file, no backup. Empty here IS the truth, so
+        // this must stay authoritative or `--insecure-loopback` breaks on day one.
+        let (fresh, source) = load_from_with_source(&path).unwrap();
+        assert_eq!(source, LoadSource::FirstRun);
+        assert!(source.is_authoritative());
+        assert!(fresh.http_clients.is_empty());
+
+        // State N-1: a server configured, no HTTP client registered yet.
+        let mut reg = Registry::default();
+        reg.add_server(sample_server("alpha"));
+        save_to(&path, &reg).unwrap();
+        // State N: the save that registers the FIRST http client. `save_to`
+        // snapshots the PRE-write content, so every backup on disk is now a
+        // registry with no clients at all.
+        reg.http_clients.push(sample_http_client());
+        save_to(&path, &reg).unwrap();
+
+        let (read, source) = load_from_with_source(&path).unwrap();
+        assert_eq!(source, LoadSource::File);
+        assert!(source.is_authoritative());
+        assert_eq!(read.http_clients.len(), 1);
+
+        // Corrupt the primary. Recovery succeeds from that N-1 backup and hands
+        // back every server with ZERO http_clients: byte for byte the same thing
+        // as "no client is registered" unless the source says otherwise.
+        std::fs::write(&path, "{ not json").unwrap();
+        let (recovered, source) = load_from_with_source(&path).unwrap();
+        assert_eq!(source, LoadSource::Backup);
+        assert!(
+            !source.is_authoritative(),
+            "a backup is state N-1; its empty client list is not a fact about now"
+        );
+        assert_eq!(recovered.servers.len(), 1, "self-healed from .bak");
+        assert!(
+            recovered.http_clients.is_empty(),
+            "the recovery really did lose the registered client"
+        );
+
+        clear_registry_files(&path);
+    }
+
+    /// SBS-900: `read_registry_file` used to fold every read failure into
+    /// "absent", so a registry this process was not allowed to read came back as
+    /// a first run. Unix-only: it needs a mode the current user is denied.
+    #[cfg(unix)]
+    #[test]
+    fn unreadable_registry_is_not_reported_as_a_first_run() {
+        use std::os::unix::fs::PermissionsExt;
+        let path = std::env::temp_dir().join(format!(
+            "conduit-reg-unreadable-{}.json",
+            std::process::id()
+        ));
+        clear_registry_files(&path);
+
+        let mut reg = Registry::default();
+        reg.http_clients.push(sample_http_client());
+        // A first save leaves no backup, so recovery cannot mask the read failure.
+        save_to(&path, &reg).unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o000)).unwrap();
+        // root ignores the mode; there is nothing to assert on such a machine.
+        if std::fs::read_to_string(&path).is_ok() {
+            std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600)).ok();
+            clear_registry_files(&path);
+            return;
+        }
+
+        let (loaded, source) = load_from_with_source(&path).unwrap();
+        assert_eq!(source, LoadSource::Unreadable);
+        assert!(
+            !source.is_authoritative(),
+            "a default standing in for contents nobody read is not a first run"
+        );
+        assert!(loaded.http_clients.is_empty(), "it really is a default");
+
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600)).ok();
+        clear_registry_files(&path);
     }
 
     #[test]


### PR DESCRIPTION
Fixes [SBS-900](https://linear.app/southboundsoftware/issue/SBS-900/insecure-loopbacks-open-branch-shares-a-condition-between-no-clients).

## User-visible result

A user who starts the HTTP gateway with `--insecure-loopback` after a **failed** registry load (`load_resolved` Err), and without `TOOLPORT_HTTP_TOKEN` / `CONDUIT_HTTP_TOKEN`, now sees the gateway **refuse to bind** instead of opening an unauthenticated loopback listener.

A failed load plus an env token still binds (the token is the auth). A successful empty load — including a missing registry file, which is already `Ok(default)` — plus the flag still opens.

## The bug

`resolve_http_caller`'s open branch used `reg.http_clients.is_empty()`. That is also true when boot `load_resolved` returns Err and falls back to `Registry::default()`. So a corrupt or unreadable registry silently satisfied the "no clients configured" precondition for `--insecure-loopback`.

Nothing reaches a tool today (the fallback has zero servers). The auth posture of an explicitly-insecure mode still should not flip on a read failure.

## Fix

Thread `registry_loaded` (`Ok=true`, `Err=false`) into `resolve_http_caller`, `resolve_http_scope`, and startup `allow_insecure_open` / `http_bind_is_authorized`. The open branch now requires `registry_loaded && http_clients.is_empty()`.

Watcher reload-fail already keeps the previous registry. That path was not changed.

Existing tests that use `Registry::default()` as a successful empty registry pass `registry_loaded=true`.

## Sweep

`rg -n 'http_clients\.is_empty|allow_insecure_open'` (excluding `docs/audit/`):

| Site | Action |
| --- | --- |
| `resolve_http_caller` open branch | Fixed: also requires `registry_loaded` |
| `http_allows_insecure_open` / `http_bind_is_authorized` | Fixed: open bind requires `registry_loaded` |
| `serve_http` `!reg.http_clients.is_empty()` | Left as-is. This is the inverse check: "do registered clients count as auth?" After a failed load the in-memory default is empty, so it does **not** invent auth. Treating a failed load as "clients exist" would allow a bind with neither a token nor the flag. Combined with the open hatch it used to authorize `--insecure-loopback`; the hatch is what this PR closes. |
| `serve_http_loop` / `handle_connection` | Plumbing only: pass `registry_loaded` through |
| Watcher `load_from` Err | Unchanged: keeps the previous registry |

## Fail-without-fix

Reverted only the two production gates (`&& registry_loaded` in `resolve_http_caller` and in `http_allows_insecure_open`). Signatures stayed so the tests compiled. Then:

```
cargo test --manifest-path src-tauri/Cargo.toml --no-default-features --bin toolport-gateway -- failed_registry_load_does_not_open_insecure_loopback
```

```
running 1 test
test tests::failed_registry_load_does_not_open_insecure_loopback ... FAILED

failures:

---- tests::failed_registry_load_does_not_open_insecure_loopback stdout ----

thread 'tests::failed_registry_load_does_not_open_insecure_loopback' (556449) panicked at src/bin/toolport-gateway.rs:20309:9:
failed load must not authorize the open caller

failures:
    tests::failed_registry_load_does_not_open_insecure_loopback

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 307 filtered out; finished in 0.00s
```

Restored the gates. The same test, plus `successful_empty_registry_load_still_opens_insecure_loopback`, then passed.

## Tests

In `src-tauri/src/bin/toolport-gateway.rs`, both citing SBS-900:

- `failed_registry_load_does_not_open_insecure_loopback` — failed load must not open; failed load + no env token must not authorize the open bind; failed load + env token still binds
- `successful_empty_registry_load_still_opens_insecure_loopback` — successful empty load + flag still opens

## CI (this worktree)

| Gate | Command | Result |
| --- | --- | --- |
| format | `npm run format:check` | pass |
| lint | `npm run lint` | pass (0 errors; 49 pre-existing warnings) |
| frontend build | `npm run build` | pass |
| frontend tests | `npm run test` | 37 files, 382 tests passed |
| clippy | `cargo clippy --manifest-path src-tauri/Cargo.toml --no-default-features --lib --bins` | pass (exit 0; pre-existing warnings only) |
| rust (headless) | `cargo test --manifest-path src-tauri/Cargo.toml --no-default-features --lib --bins --tests` | pass (lib 1006 passed / 1 ignored; gateway bin 308 passed; integration crates all passed) |
| rust (CI `test:rust`, default features) | `npm run test:rust` | pass (lib 1085 passed / 1 ignored; gateway bin 308 passed; integration crates all passed) |

## What this makes more likely

An operator who used `--insecure-loopback` as a recovery hatch after a **corrupt** registry, with no env token, now gets a refuse-to-bind error instead of an open listener. They must set `TOOLPORT_HTTP_TOKEN` or repair the registry. That is the intended fail-closed direction.

A later successful watcher reload after a failed boot does not flip `registry_loaded` to true. Startup policy stays immutable. Env-token and registered-client auth still work on that path if the process bound.

## Gaps / not done

- Did not change the watcher reload-fail path (already keeps the previous registry).
- Did not run Windows/macOS rust jobs, installer-script, or `smoke:headless`.
- Did not run clippy with default desktop features (CI clippy is `--no-default-features`).
- Did not touch `/home/box/projects/toolport` or other worktrees.
- Did not commit `docs/audit/`.
- **NOT MERGED.** Linear SBS-900 left open.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix gateway to reject insecure loopback binding when registry load fails
> - Introduces a `LoadSource` enum in [registry.rs](https://github.com/tsouth89/toolport/pull/775/files#diff-8187fea44e15daa4059544c5fcff94f80f39fa1ec39c67eccccc153a98b39349) to track whether a registry load was authoritative (`File`) or a fallback (`FirstRun`, `Backup`, `Unreadable`).
> - Adds `registry_trusted: Arc<AtomicBool>` to `GatewayState` and propagates it through `watch_registry`/`watch_tick` so auth decisions reflect live reload outcomes.
> - `resolve_http_caller`, `http_bind_is_authorized`, and `http_allows_insecure_open` now require `registry_loaded == true` before treating an empty `http_clients` list as "no clients configured" for the `--insecure-loopback` escape hatch.
> - The live watcher can now close an insecure listener on reload if the newly loaded registry is non-authoritative.
> - Behavioral Change: a failed, unreadable, or backup-recovered registry no longer satisfies the "empty http_clients" condition; previously this could leave an open unauthenticated listener.
>
> #### 🖇️ Linked Issues
> Fixes [SBS-900](https://linear.app/southboundsoftware/issue/SBS-900) — the gateway incorrectly treated a failed registry load as having no HTTP clients, potentially opening an insecure loopback listener.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 320c0a7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->