### PR TITLE
fix(clients): honor XDG and GOOSE_PATH_ROOT for Goose/Zed Team Instructions (SBS-899)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ Entries before the rename below shipped under the project's former name, Conduit
 
 ### Fixed
 
+- **Team Instructions now follow `XDG_CONFIG_HOME` for Goose and Zed.** Connect
+  already wrote those clients' MCP configs under XDG (#757 / SBS-847); the rules
+  writer still hardcoded `~/.config`, so an org push could succeed and never
+  apply. Absolute `GOOSE_PATH_ROOT` is honoured on both the config and rules
+  paths (`<root>/config/config.yaml` and `<root>/config/.goosehints`). (SBS-899)
 - **Linux `.deb` installs a `toolport` command.** The package still ships the
   crate binary as `conduit` (compat alias) and now also puts `toolport` on
   `PATH`, matching the AppImage installer and the brand. `install.sh` tells apt

--- a/src-tauri/src/clients.rs
+++ b/src-tauri/src/clients.rs
@@ -5966,6 +5966,47 @@ fn log_repoint_outcome(current: &str, outcome: &RepointOutcome) {
     ));
 }
 
+/// Serializes tests that read or mutate the process-global env vars these resolvers depend on
+/// (`XDG_*`, `GOOSE_PATH_ROOT`, `CLAUDE_CONFIG_DIR`). The env is process-global and Rust runs
+/// tests in parallel, so a test in ANY module that sets one of those keys must hold this lock,
+/// not a lock of its own. Poison is recovered: a panic elsewhere shouldn't wedge these.
+#[cfg(test)]
+pub(crate) fn env_test_lock() -> std::sync::MutexGuard<'static, ()> {
+    ENV_TEST_LOCK
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+}
+
+#[cfg(test)]
+static ENV_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+/// Sets a process env var and puts the old value back when the guard drops. Only valid while
+/// [`env_test_lock`] is held. Lives beside the lock so other modules' tests use both.
+#[cfg(test)]
+pub(crate) struct EnvRestore {
+    key: &'static str,
+    previous: Option<std::ffi::OsString>,
+}
+
+#[cfg(test)]
+impl EnvRestore {
+    pub(crate) fn set(key: &'static str, value: &Path) -> Self {
+        let previous = std::env::var_os(key);
+        std::env::set_var(key, value);
+        Self { key, previous }
+    }
+}
+
+#[cfg(test)]
+impl Drop for EnvRestore {
+    fn drop(&mut self) {
+        match &self.previous {
+            Some(value) => std::env::set_var(self.key, value),
+            None => std::env::remove_var(self.key),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -10297,30 +10338,9 @@ rules:
     /// runs tests in parallel, so without this the test that sets `XDG_CONFIG_HOME`
     /// could change `dirs::config_dir()` mid-flight under a test that reads it,
     /// which is exactly what made `client_config_paths_match_current_platform`
-    /// flake on CI. Poison is recovered: a panic elsewhere shouldn't wedge these.
-    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-
-    struct EnvRestore {
-        key: &'static str,
-        previous: Option<std::ffi::OsString>,
-    }
-
-    impl EnvRestore {
-        fn set(key: &'static str, value: &Path) -> Self {
-            let previous = std::env::var_os(key);
-            std::env::set_var(key, value);
-            Self { key, previous }
-        }
-    }
-
-    impl Drop for EnvRestore {
-        fn drop(&mut self) {
-            match &self.previous {
-                Some(value) => std::env::set_var(self.key, value),
-                None => std::env::remove_var(self.key),
-            }
-        }
-    }
+    /// flake on CI. Lives on the module (see [`super::env_test_lock`]) so tests in
+    /// other modules that set the same keys take the SAME lock.
+    use super::ENV_TEST_LOCK as ENV_LOCK;
 
     #[test]
     fn amp_is_registered() {

--- a/src-tauri/src/clients.rs
+++ b/src-tauri/src/clients.rs
@@ -387,6 +387,33 @@ fn claude_code_config_path(config_dir: &std::path::Path) -> PathBuf {
     config_dir.join(".claude.json")
 }
 
+/// Goose relocates its whole tree — `config/config.yaml` and
+/// `config/.goosehints` included — when `GOOSE_PATH_ROOT` is an absolute path
+/// (SBS-899). Relative or empty values are a misconfiguration, not an
+/// instruction to write relative to Toolport's cwd. Matches Goose's own
+/// `Paths::validated_path_root`.
+fn goose_path_root_from(raw: Option<std::ffi::OsString>) -> Option<PathBuf> {
+    let dir = PathBuf::from(raw.filter(|p| !p.is_empty())?);
+    dir.is_absolute().then_some(dir)
+}
+
+fn goose_config_under_root(root: &Path) -> PathBuf {
+    root.join("config").join("config.yaml")
+}
+
+fn goose_hints_under_root(root: &Path) -> PathBuf {
+    root.join("config").join(".goosehints")
+}
+
+fn rules_sentinel_block(path: PathBuf) -> crate::instructions::Target {
+    crate::instructions::Target {
+        path,
+        strategy: crate::instructions::Strategy::SentinelBlock,
+        char_cap: None,
+        blocked_if_present: None,
+    }
+}
+
 /// Every `.claude.json` on this machine that some Claude Code process may read.
 ///
 /// [`claude_config_dir_override`] resolves the ONE config Toolport reads and writes,
@@ -476,6 +503,11 @@ fn client_config_path(client_id: &str) -> Option<PathBuf> {
             return Some(claude_code_config_path(&dir));
         }
     }
+    if client_id == "goose" {
+        if let Some(root) = goose_path_root_from(std::env::var_os("GOOSE_PATH_ROOT")) {
+            return Some(goose_config_under_root(&root));
+        }
+    }
     #[cfg(all(unix, not(target_os = "macos")))]
     {
         return resolve_client_config_path_linux(client_id, &home);
@@ -556,10 +588,12 @@ fn resolve_client_config_path_linux(client_id: &str, home: &std::path::Path) -> 
 /// `~/.claude.json` but its rules live under `~/.claude/rules/`. `None` means the client has
 /// no global-rules location we write: either its globals are UI/cloud-stored (Cursor, Warp),
 /// or it's covered transitively by another client's file (Antigravity reads Gemini's
-/// `GEMINI.md`; VS Code Copilot reads Claude Code's `~/.claude` rules). Unlike the config
-/// resolver these paths are all home-anchored (or literal `~/.config`), so one cross-platform
-/// resolver covers Linux too — no XDG/data-dir or MSIX handling needed. See the spec's adapter
-/// table for citations.
+/// `GEMINI.md`; VS Code Copilot reads Claude Code's `~/.claude` rules). Most of these
+/// paths are home-anchored. Goose and Zed on Linux follow `XDG_CONFIG_HOME` via
+/// [`client_rules_target`] / `dirs::config_dir()`, matching [`client_config_path`]
+/// (SBS-899 / #757). Goose also honours absolute `GOOSE_PATH_ROOT`, which relocates
+/// both `config/config.yaml` and `config/.goosehints`. See the spec's adapter table
+/// for citations.
 fn resolve_rules_target(
     client_id: &str,
     home: &std::path::Path,
@@ -627,7 +661,22 @@ fn resolve_rules_target(
             char_cap: Some(6000), // Windsurf hard-caps the global rules file.
             blocked_if_present: None,
         },
-        "goose" => block(home.join(".config").join("goose").join(".goosehints")),
+        // Sibling of config.yaml. Windows uses the etcetera config dir
+        // (%APPDATA%\\Block\\goose\\config); macOS/Linux default to ~/.config/goose
+        // (Goose's documented XDG location). Production Linux overlays XDG via
+        // client_rules_target; GOOSE_PATH_ROOT is handled there too.
+        "goose" => match platform {
+            Platform::Windows => block(
+                config
+                    .join("Block")
+                    .join("goose")
+                    .join("config")
+                    .join(".goosehints"),
+            ),
+            Platform::MacOs | Platform::Linux => {
+                block(home.join(".config").join("goose").join(".goosehints"))
+            }
+        },
         "pi" => block(home.join(".pi").join("agent").join("AGENTS.md")),
         "omp" => block(home.join(".omp").join("agent").join("AGENTS.md")),
         "zed" => match platform {
@@ -642,9 +691,25 @@ fn resolve_rules_target(
 }
 
 /// The rules-file target for a client on the current machine, or `None` if unsupported /
-/// transitively covered. Mirrors [`client_config_path`].
+/// transitively covered. Mirrors [`client_config_path`]: Goose/Zed on Linux honor
+/// `XDG_CONFIG_HOME`, and Goose honors absolute `GOOSE_PATH_ROOT` (SBS-899).
 pub fn client_rules_target(client_id: &str) -> Option<crate::instructions::Target> {
+    if client_id == "goose" {
+        if let Some(root) = goose_path_root_from(std::env::var_os("GOOSE_PATH_ROOT")) {
+            return Some(rules_sentinel_block(goose_hints_under_root(&root)));
+        }
+    }
     let home = home()?;
+    #[cfg(all(unix, not(target_os = "macos")))]
+    if matches!(client_id, "goose" | "zed") {
+        let config = dirs::config_dir().unwrap_or_else(|| home.join(".config"));
+        let path = match client_id {
+            "goose" => config.join("goose").join(".goosehints"),
+            "zed" => config.join("zed").join("AGENTS.md"),
+            _ => unreachable!("guarded by matches! above"),
+        };
+        return Some(rules_sentinel_block(path));
+    }
     resolve_rules_target(client_id, &home, Platform::current())
 }
 
@@ -8935,6 +9000,40 @@ command = "npx"
     }
 
     #[test]
+    fn rules_target_goose_matches_config_directory() {
+        // Rules sit beside config.yaml so the two path families cannot drift
+        // (SBS-899). Windows uses the etcetera config dir; macOS/Linux stay on
+        // Goose's documented ~/.config/goose (macOS config in Toolport is
+        // Application Support — a pre-existing split, listed in the PR).
+        for platform in Platform::ALL {
+            let home = mock_home(platform);
+            let rules = resolve_rules_target("goose", &home, platform).expect("supported");
+            let config =
+                resolve_client_config_path("goose", &home, platform).expect("goose config");
+            match platform {
+                Platform::Windows => {
+                    assert_eq!(
+                        rules.path,
+                        home.join("AppData")
+                            .join("Roaming")
+                            .join("Block")
+                            .join("goose")
+                            .join("config")
+                            .join(".goosehints")
+                    );
+                    assert_eq!(rules.path.parent(), config.parent());
+                }
+                Platform::MacOs | Platform::Linux => {
+                    assert_eq!(
+                        rules.path,
+                        home.join(".config").join("goose").join(".goosehints")
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
     fn rules_target_unsupported_clients_return_none() {
         // Cursor/Warp store globals in UI/cloud; Continue is deferred; chat/identity apps have
         // no global rules file we manage.
@@ -9061,6 +9160,9 @@ command = "npx"
         // `.claude.json`). The override itself is covered by
         // `claude_code_config_follows_a_relocated_config_dir`.
         let _claude_config_dir = EnvRestore::set("CLAUDE_CONFIG_DIR", Path::new(""));
+        // goose_path / client_config_path honor GOOSE_PATH_ROOT; clear it so this
+        // table assertion stays on the documented default (SBS-899).
+        let _goose_root = EnvRestore::set("GOOSE_PATH_ROOT", Path::new(""));
         let home = home().expect("home dir should be available in tests");
         let platform = Platform::current();
         for client in defs() {
@@ -9218,6 +9320,9 @@ command = "npx"
 
         std::env::set_var("XDG_CONFIG_HOME", &xdg_config);
         std::env::set_var("XDG_DATA_HOME", &xdg_data);
+        // Absolute GOOSE_PATH_ROOT wins over XDG; neutralize it so this test
+        // pins the XDG branch (SBS-899).
+        let _goose_root = EnvRestore::set("GOOSE_PATH_ROOT", Path::new(""));
 
         let home = home().expect("home dir");
         let vscode = client_config_path("vscode").unwrap();
@@ -9268,6 +9373,95 @@ command = "npx"
         assert_eq!(
             kilo_code,
             home.join(".config").join("kilo").join("kilo.jsonc")
+        );
+    }
+
+    /// SBS-899: Team Instructions for Goose/Zed must land in the same XDG
+    /// config dir as Connect already writes (`client_config_path`). Without
+    /// this, a user with `XDG_CONFIG_HOME=/data/cfg` gets a successful write
+    /// to `~/.config/...` that Goose/Zed never read.
+    #[test]
+    #[cfg(all(unix, not(target_os = "macos")))]
+    fn client_rules_paths_honor_xdg_dirs_on_linux() {
+        let _env = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let base = std::env::temp_dir().join(format!("conduit-xdg-rules-{}", std::process::id()));
+        std::fs::create_dir_all(&base).unwrap();
+        let xdg_config = base.join("xdg-config");
+        std::fs::create_dir_all(&xdg_config).unwrap();
+
+        let _xdg = EnvRestore::set("XDG_CONFIG_HOME", &xdg_config);
+        let _goose_root = EnvRestore::set("GOOSE_PATH_ROOT", Path::new(""));
+
+        let goose = client_rules_target("goose").expect("goose has a rules target");
+        let zed = client_rules_target("zed").expect("zed has a rules target");
+        let goose_config = client_config_path("goose").expect("goose config");
+        let zed_config = client_config_path("zed").expect("zed config");
+
+        let _ = std::fs::remove_dir_all(&base);
+
+        assert_eq!(
+            goose.path,
+            xdg_config.join("goose").join(".goosehints"),
+            "Goose Team Instructions must follow XDG_CONFIG_HOME"
+        );
+        assert_eq!(
+            zed.path,
+            xdg_config.join("zed").join("AGENTS.md"),
+            "Zed Team Instructions must follow XDG_CONFIG_HOME"
+        );
+        assert_eq!(
+            goose.path.parent(),
+            goose_config.parent(),
+            "Goose rules and config must share a directory so the two families cannot drift"
+        );
+        assert_eq!(
+            zed.path.parent(),
+            zed_config.parent(),
+            "Zed rules and config must share a directory so the two families cannot drift"
+        );
+    }
+
+    /// SBS-899: absolute GOOSE_PATH_ROOT relocates both config.yaml and
+    /// .goosehints to `<root>/config/`, matching Goose `Paths::get_dir`.
+    #[test]
+    fn goose_path_root_relocates_config_and_rules() {
+        let _env = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let root = std::env::temp_dir().join(format!("goose-root-{}", std::process::id()));
+        let _restore = EnvRestore::set("GOOSE_PATH_ROOT", &root);
+
+        assert_eq!(
+            client_config_path("goose"),
+            Some(root.join("config").join("config.yaml"))
+        );
+        assert_eq!(
+            client_rules_target("goose")
+                .expect("goose has a rules target")
+                .path,
+            root.join("config").join(".goosehints")
+        );
+    }
+
+    /// Relative / empty GOOSE_PATH_ROOT is ignored — same rule as
+    /// `CLAUDE_CONFIG_DIR` and Goose's own `validated_path_root`.
+    #[test]
+    fn goose_path_root_relative_or_empty_is_ignored() {
+        assert_eq!(goose_path_root_from(None), None);
+        assert_eq!(
+            goose_path_root_from(Some(std::ffi::OsString::from(""))),
+            None
+        );
+        assert_eq!(
+            goose_path_root_from(Some(std::ffi::OsString::from("relative/goose"))),
+            None
+        );
+        let absolute = if cfg!(windows) {
+            PathBuf::from(r"C:\\abs\\goose")
+        } else {
+            PathBuf::from("/abs/goose")
+        };
+        assert_eq!(
+            goose_path_root_from(Some(absolute.clone().into_os_string())),
+            Some(absolute)
         );
     }
 

--- a/src-tauri/src/clients.rs
+++ b/src-tauri/src/clients.rs
@@ -542,15 +542,27 @@ fn claude_code_config_paths_from(
 }
 
 fn client_config_path(client_id: &str) -> Option<PathBuf> {
-    let home = home()?;
-    if client_id == "claude-code" {
-        if let Some(dir) = claude_config_dir_override() {
-            return Some(claude_code_config_path(&dir));
-        }
-    }
+    client_config_path_with_home(client_id, home())
+}
+
+/// [`client_config_path`] with the home directory passed in, so a test can drive the
+/// `$HOME`-unavailable case on any platform (`dirs::home_dir` reads a known folder on
+/// Windows, so it cannot be unset from a test).
+fn client_config_path_with_home(client_id: &str, home: Option<PathBuf>) -> Option<PathBuf> {
+    // An absolute `GOOSE_PATH_ROOT` names the live config outright, so it resolves even
+    // when there is no home directory to fall back to. This mirrors `codex_path`, which
+    // checks `CODEX_HOME` before it ever calls this (SBS-885), and it keeps the config
+    // path in step with `client_rules_target`: without it Connect could write Goose Team
+    // Instructions under the root but fail to find the config beside them (SBS-899).
     if client_id == "goose" {
         if let Some(root) = goose_path_root_from(std::env::var_os("GOOSE_PATH_ROOT")) {
             return Some(goose_config_under_root(&root));
+        }
+    }
+    let home = home?;
+    if client_id == "claude-code" {
+        if let Some(dir) = claude_config_dir_override() {
+            return Some(claude_code_config_path(&dir));
         }
     }
     #[cfg(all(unix, not(target_os = "macos")))]
@@ -11038,6 +11050,26 @@ rules:
                 .path,
             root.join("config").join(".goosehints")
         );
+    }
+
+    /// SBS-899: an absolute GOOSE_PATH_ROOT names the live config outright, so it must
+    /// resolve with no home directory at all. `client_rules_target` already did, so
+    /// without this the rules file relocates but the config beside it comes back `None`
+    /// and Connect cannot write the gateway entry. Same rule `codex_path` applies to
+    /// `CODEX_HOME` (SBS-885).
+    #[test]
+    fn goose_path_root_resolves_without_a_home_dir() {
+        let _env = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let root = std::env::temp_dir().join(format!("goose-nohome-{}", std::process::id()));
+        let _restore = EnvRestore::set("GOOSE_PATH_ROOT", &root);
+
+        assert_eq!(
+            client_config_path_with_home("goose", None),
+            Some(root.join("config").join("config.yaml")),
+            "an absolute GOOSE_PATH_ROOT must not depend on a resolvable home dir"
+        );
+        // The override is Goose-only: every other client still needs a home.
+        assert_eq!(client_config_path_with_home("zed", None), None);
     }
 
     /// Relative / empty GOOSE_PATH_ROOT is ignored — same rule as

--- a/src-tauri/src/teams.rs
+++ b/src-tauri/src/teams.rs
@@ -732,9 +732,15 @@ fn sync_inner(wait_secs: u64) -> Result<SyncResult, String> {
         Some(applied) => applied,
     };
     // Write/refresh the org instructions to each installed client's rules file (skips unless the
-    // content actually changed). Outside the lock, best-effort, never fails the sync.
-    if let Some((version, desired)) = desired_instr {
-        apply_instructions(&conn.team_id, version, desired.as_deref());
+    // content actually changed, or a target moved). Outside the lock, best-effort, never fails
+    // the sync.
+    match desired_instr {
+        Some((version, desired)) => apply_instructions(&conn.team_id, version, desired.as_deref()),
+        // A 304 means the org text is unchanged, but a release can still move where a client
+        // reads its rules from (Goose/Zed under XDG, SBS-899). Re-run against the content we
+        // already applied so the block relocates on the next quiet cycle rather than waiting for
+        // an admin edit; `apply_instructions` returns immediately unless a target really moved.
+        None => relocate_stored_instructions(&conn.team_id),
     }
     // Best-effort showback after the config work: report today's/yesterday's per-server
     // usage rollup to the team server. Any failure here must never affect the sync
@@ -880,12 +886,81 @@ fn desired_instructions(cfg: &serde_json::Value) -> Option<String> {
     (enabled && !content.trim().is_empty()).then(|| content.to_string())
 }
 
+/// Every installed client's rules target, de-duped by path so a file two clients share (e.g.
+/// Gemini/Antigravity) is only written once. Split out of [`apply_instructions`] so a test can
+/// drive an apply over a known target set instead of over the developer's real machine.
+fn installed_rules_targets() -> Vec<crate::instructions::Target> {
+    let mut seen_paths = std::collections::HashSet::new();
+    crate::clients::detect_clients()
+        .into_iter()
+        // Only write into clients that are actually installed, so we never scatter rules files
+        // into an absent client's home.
+        .filter(|client| client.app_present)
+        // `None` = unsupported or covered transitively (Antigravity/Copilot).
+        .filter_map(|client| crate::clients::client_rules_target(&client.id))
+        .filter(|target| seen_paths.insert(target.path.clone()))
+        .collect()
+}
+
+/// True when a current target is a path we have never written AND does not already hold the
+/// current block. That is the signature of a RELOCATED rules file: the org text is unchanged, so
+/// the hash skip in [`apply_instructions_to`] would fire, but a release moved where the client
+/// reads its rules from (Goose/Zed following `XDG_CONFIG_HOME` or `GOOSE_PATH_ROOT`, SBS-899).
+/// Without this a member who upgrades in place keeps the block at the OLD path forever and
+/// coverage reports Stale until an admin happens to edit the text.
+///
+/// Reusing `current_state` keeps the check from spinning the sync loop: a target that can never
+/// be written (a Codex shadow file, an over-cap Windsurf file) never lands in the recorded set,
+/// but it reports `BlockedOverride` / `TooLong` rather than `Stale`, so it is not read as a
+/// relocation and does not make every cycle rewrite every rules file.
+fn targets_relocated(
+    team_id: &str,
+    version: i64,
+    content: &str,
+    targets: &[crate::instructions::Target],
+    recorded: &[String],
+) -> bool {
+    use crate::instructions::{self, ApplyState};
+    targets.iter().any(|target| {
+        let key = target.path.to_string_lossy().to_string();
+        !recorded.iter().any(|old| *old == key)
+            && instructions::current_state(target, team_id, version, content) == ApplyState::Stale
+    })
+}
+
 /// Write (or remove) the org Team Instructions across every installed client's rules file after
 /// a config change (spec "W2"). Best-effort and run OUTSIDE the registry lock — a failure here
 /// must never affect the already-applied, already-saved server config. Skips entirely when the
-/// org content is unchanged since the last write (hash match), so the ~25s sync loop only ever
-/// touches rules files when an admin actually edits the instructions.
+/// org content is unchanged since the last write (hash match) and every client's rules file is
+/// still at the path we wrote it to, so the ~25s sync loop only ever touches rules files when an
+/// admin actually edits the instructions or a target moves ([`targets_relocated`]).
 fn apply_instructions(team_id: &str, version: i64, desired: Option<&str>) {
+    apply_instructions_to(team_id, version, desired, &installed_rules_targets());
+}
+
+/// Re-run [`apply_instructions`] with the content already on record, so a moved rules path is
+/// still picked up on a cycle that pulled nothing (HTTP 304). A no-op when the team has no
+/// instructions, and [`apply_instructions`] itself is a no-op unless a target moved.
+fn relocate_stored_instructions(team_id: &str) {
+    let Ok(reg) = crate::registry::load() else {
+        return;
+    };
+    let Some(team) = reg.team.as_ref().filter(|t| t.team_id == team_id) else {
+        return;
+    };
+    let Some(content) = team.team_instructions_content.clone() else {
+        return;
+    };
+    apply_instructions(team_id, team.team_instructions_version, Some(&content));
+}
+
+/// [`apply_instructions`] over an explicit target set.
+fn apply_instructions_to(
+    team_id: &str,
+    version: i64,
+    desired: Option<&str>,
+    targets: &[crate::instructions::Target],
+) {
     use crate::instructions::{self, ApplyState};
     // Prior state: only act if still connected to THIS team.
     let (prev_content, prev_targets) = match crate::registry::load() {
@@ -898,28 +973,24 @@ fn apply_instructions(team_id: &str, version: i64, desired: Option<&str>) {
         },
         Err(_) => return,
     };
-    if desired == prev_content.as_deref() {
-        return; // content unchanged — nothing to write or clean up (coverage is re-checked and
-                // reported every cycle by `report_instructions_status`, independent of this)
+    // Skip only when the content AND the target paths are both unchanged. A release that moves
+    // where a client reads its rules from (Goose/Zed under XDG, SBS-899) leaves the org text
+    // identical, so the content check on its own would return here and strand an existing
+    // member's block at the old path until an admin happened to edit the instructions.
+    let relocated = desired.is_some_and(|content| {
+        targets_relocated(team_id, version, content, targets, &prev_targets)
+    });
+    if desired == prev_content.as_deref() && !relocated {
+        return; // content unchanged and every target is still where we left it, so there is
+                // nothing to write or clean up (coverage is re-checked and reported every cycle
+                // by `report_instructions_status`, independent of this)
     }
 
     let mut written: Vec<String> = Vec::new();
     if let Some(content) = desired {
-        let mut seen_paths = std::collections::HashSet::new();
-        for client in crate::clients::detect_clients() {
-            // Only write into clients that are actually installed, so we never scatter rules
-            // files into an absent client's home.
-            if !client.app_present {
-                continue;
-            }
-            let Some(target) = crate::clients::client_rules_target(&client.id) else {
-                continue; // unsupported or covered transitively (Antigravity/Copilot)
-            };
+        for target in targets {
             let key = target.path.to_string_lossy().to_string();
-            if !seen_paths.insert(key.clone()) {
-                continue; // a shared file (e.g. Gemini/Antigravity) already handled this round
-            }
-            if instructions::write_target(&target, team_id, version, content) == ApplyState::Applied
+            if instructions::write_target(target, team_id, version, content) == ApplyState::Applied
             {
                 written.push(key);
             }
@@ -1854,6 +1925,96 @@ mod tests {
         ] {
             assert_eq!(desired_instructions(&cfg), None, "should mean removal: {cfg}");
         }
+    }
+
+    /// SBS-899: a release that MOVES where a client reads its rules from must relocate an
+    /// already-applied block. The org text is unchanged, so the content-hash skip used to return
+    /// before writing anything: the new path stayed empty and coverage reported Stale until an
+    /// admin happened to edit the instructions.
+    #[test]
+    fn apply_instructions_relocates_a_block_whose_target_path_moved() {
+        const TEAM: &str = "team_relocate";
+        const CONTENT: &str = "Use the approved issue workflow.";
+        const VERSION: i64 = 4;
+        use crate::instructions::{ApplyState, Strategy, Target};
+
+        // Both guards: the test sets GOOSE_PATH_ROOT and redirects the data dir, and both are
+        // process-global.
+        let _env = crate::clients::env_test_lock();
+        let _dirs = crate::registry::data_dir_test_lock();
+        let base = std::env::temp_dir().join(format!("toolport-relocate-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&base);
+        let _data_dir = crate::registry::DataDirOverride::set(base.join("data"));
+        // Stands in for the pre-fix `~/.config/goose/.goosehints` (a test must not write into the
+        // developer's real home). An absolute GOOSE_PATH_ROOT then puts the live target at
+        // `<root>/config/.goosehints`, exactly the move this PR introduces.
+        let old_path = base
+            .join("old-home")
+            .join(".config")
+            .join("goose")
+            .join(".goosehints");
+        let root = base.join("goose-root");
+        let _root = crate::clients::EnvRestore::set("GOOSE_PATH_ROOT", &root);
+
+        let old_target = Target {
+            path: old_path.clone(),
+            strategy: Strategy::SentinelBlock,
+            char_cap: None,
+            blocked_if_present: None,
+        };
+        assert_eq!(
+            crate::instructions::write_target(&old_target, TEAM, VERSION, CONTENT),
+            ApplyState::Applied,
+            "fixture: the previous release's block at the old path"
+        );
+        let conn: TeamConnection = serde_json::from_value(json!({
+            "serverUrl": "https://teams.example.com",
+            "teamId": TEAM,
+            "role": "member",
+            "teamInstructionsContent": CONTENT,
+            "teamInstructionsVersion": VERSION,
+            "teamInstructionsTargets": [old_path.to_string_lossy()],
+        }))
+        .expect("team connection fixture");
+        crate::registry::update(|reg| {
+            reg.team = Some(conn.clone());
+            Ok(())
+        })
+        .expect("seed the registry");
+
+        let target = crate::clients::client_rules_target("goose").expect("goose rules target");
+        assert_eq!(
+            target.path,
+            root.join("config").join(".goosehints"),
+            "fixture: GOOSE_PATH_ROOT must move the live target"
+        );
+
+        // Same content, same version. Only the PATH moved.
+        apply_instructions_to(TEAM, VERSION, Some(CONTENT), std::slice::from_ref(&target));
+
+        let moved = std::fs::read_to_string(&target.path).unwrap_or_default();
+        let recorded = crate::registry::load()
+            .ok()
+            .and_then(|reg| reg.team)
+            .map(|t| t.team_instructions_targets)
+            .unwrap_or_default();
+        let old_left_behind = old_path.exists();
+        let _ = std::fs::remove_dir_all(&base);
+
+        assert!(
+            moved.contains(crate::instructions::SENTINEL_START_PREFIX) && moved.contains(CONTENT),
+            "the block must be rewritten at the new path, not skipped as unchanged content"
+        );
+        assert!(
+            !old_left_behind,
+            "the old file held only our block, so cleanup must remove it rather than leave a \
+             stale duplicate"
+        );
+        assert_eq!(
+            recorded,
+            vec![target.path.to_string_lossy().to_string()],
+            "the recorded target must follow the move, so leave/disconnect cleans up the right file"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Team Instructions wrote Goose and Zed rules under ~/.config even after #757 / SBS-847 taught Connect to follow XDG_CONFIG_HOME for those clients MCP configs. An org push could succeed and never apply.

This routes production rules through the same XDG-aware resolution as client_config_path (dirs::config_dir() on Linux). Absolute GOOSE_PATH_ROOT now relocates both config/config.yaml and .goosehints to <root>/config/, matching Goose Paths::validated_path_root (relative/empty ignored). Windows Goose rules move to %APPDATA%/Block/goose/config/.goosehints (sibling of config.yaml).

A user who hits this now sees: Team Instructions land in the file Goose/Zed actually read. With XDG_CONFIG_HOME=/data/cfg that is /data/cfg/goose/.goosehints and /data/cfg/zed/AGENTS.md.

## Fail without the fix

New tests kept; production path code reverted. All three failed. Restored after that run.
- XDG rules still wrote ~/.config/goose/.goosehints
- GOOSE_PATH_ROOT was ignored for config.yaml
- Windows rules stayed at ~/.config instead of AppData/Roaming/Block/goose/config

## CI

cargo clippy --no-default-features --lib --bins: finished 0 (pre-existing warnings only).
cargo test --no-default-features --lib --bins --tests: lib 1010 passed (1 ignored), gateway 306 passed, integration ok.
Did not run rustfmt as a gate (repo CI does not). Did not run JS/desktop/smoke/Windows/macOS jobs. No JS or installer changes.

## Sweep

rg home.join(.config) .goosehints GOOSE_PATH_ROOT resolve_rules_target in src-tauri.
Fixed: Linux production Goose/Zed rules via dirs::config_dir(); GOOSE_PATH_ROOT on config and rules; Windows Goose rules sibling of config.yaml.
Left: parameterized Linux table still home/.config (mock-home tests); Amp/OpenCode/Kilo Code intentionally ignore XDG; Crush has its own resolver; other rules targets are home-anchored.

## What this makes more likely

GOOSE_PATH_ROOT set in Toolport but not in Goose writes where Goose never looks (same class as CLAUDE_CONFIG_DIR). Relative values are ignored.
Stale ~/.config/goose/.goosehints is not deleted when we start writing to XDG or GOOSE_PATH_ROOT.
Windows leftovers at ~/.config/goose/.goosehints are not migrated.

## Gaps

macOS Goose config in Toolport is Application Support; Goose docs list ~/.config/goose on macOS. Rules stay on ~/.config/goose/.goosehints. Unifying macOS Goose config is a pre-existing leftover, not this ticket.
CONTEXT_FILE_NAMES can rename Goose hints; we still write .goosehints.
Did not run JS/frontend/smoke/Windows/macOS CI or default-feature desktop rust tests.
Did not merge.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Goose and Zed Team Instructions to honor XDG_CONFIG_HOME and GOOSE_PATH_ROOT
> - Config and rules paths for Goose now resolve under `GOOSE_PATH_ROOT` when that env var is set to an absolute path, even if the home directory is unavailable.
> - On Linux, Goose and Zed rules files are placed under `XDG_CONFIG_HOME` (via `dirs::config_dir()`), falling back to `~/.config` if unset.
> - On Windows, Goose rules resolve under `%APPDATA%/Block/goose/config/.goosehints`.
> - When a sync cycle returns HTTP 304 (no content change), instruction blocks are now relocated to updated target paths and old files are cleaned up, rather than being skipped entirely.
> - Behavioral Change: previously written instruction blocks will be moved to new paths on upgrade when `GOOSE_PATH_ROOT` or `XDG_CONFIG_HOME` causes the resolved path to change.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d51ec53.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->