### PR TITLE
Show an error when checking for apps using an old gateway fails

### DIFF
--- a/src/components/SettingsView.test.tsx
+++ b/src/components/SettingsView.test.tsx
@@ -14,6 +14,7 @@ import {
   listServerTools,
   setAllowRoutineWrites,
   setCodeMode,
+  stopStaleGateways,
 } from "@/lib/api";
 import type { Registry, RoutineSuggestion } from "@/lib/types";
 
@@ -36,6 +37,7 @@ vi.mock("@/lib/api", async (importOriginal) => {
     approveRoutineSuggestion: vi.fn(),
     dismissRoutineSuggestion: vi.fn(),
     clientsNeedingRestart: vi.fn().mockResolvedValue([]),
+    stopStaleGateways: vi.fn(),
   };
 });
 vi.mock("@tauri-apps/api/event", () => ({
@@ -52,6 +54,7 @@ const mockedListRoutineSuggestions = vi.mocked(listRoutineSuggestions);
 const mockedApproveRoutineSuggestion = vi.mocked(approveRoutineSuggestion);
 const mockedDismissRoutineSuggestion = vi.mocked(dismissRoutineSuggestion);
 const mockedClientsNeedingRestart = vi.mocked(clientsNeedingRestart);
+const mockedStopStaleGateways = vi.mocked(stopStaleGateways);
 const mockedToastError = vi.mocked(toastError);
 const mockedListen = vi.mocked(listen);
 
@@ -619,5 +622,31 @@ describe("SettingsView restart check", () => {
     expect(
       screen.queryByRole("button", { name: "Retry checking for old gateway" }),
     ).not.toBeInTheDocument();
+  });
+
+  it("clears the error panel when Stop old gateways answers the same question", async () => {
+    // A successful run IS a fresh answer to "which apps need a restart", so
+    // leaving the failure panel up would say the check failed directly above
+    // the check's own result.
+    mockedClientsNeedingRestart.mockRejectedValue(new Error("backend down"));
+    mockedStopStaleGateways.mockResolvedValue({
+      killed: [],
+      failed: [],
+      needsRestart: [{ client: "Codex", gateway: "old", clientPid: 1234 }],
+    });
+    const user = userEvent.setup();
+    renderSettings();
+
+    await screen.findByRole("button", { name: "Retry checking for old gateway" });
+    await user.click(screen.getByRole("button", { name: "Run" }));
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("button", { name: "Retry checking for old gateway" }),
+      ).not.toBeInTheDocument();
+    });
+    expect(
+      screen.getByText(/1 app is still launching an old gateway/i),
+    ).toBeInTheDocument();
   });
 });

--- a/src/components/SettingsView.test.tsx
+++ b/src/components/SettingsView.test.tsx
@@ -3,9 +3,11 @@ import { act, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import { ThemeProvider } from "@/lib/theme";
+import { toastError } from "@/lib/toast";
 import { SettingsView } from "./SettingsView";
 import {
   approveRoutineSuggestion,
+  clientsNeedingRestart,
   dismissRoutineSuggestion,
   listRoutineSuggestions,
   isAutostartEnabled,
@@ -14,6 +16,10 @@ import {
   setCodeMode,
 } from "@/lib/api";
 import type { Registry, RoutineSuggestion } from "@/lib/types";
+
+vi.mock("@/lib/toast", () => ({
+  toastError: vi.fn(),
+}));
 
 vi.mock("@/lib/api", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/lib/api")>();
@@ -29,6 +35,7 @@ vi.mock("@/lib/api", async (importOriginal) => {
     listRoutineSuggestions: vi.fn().mockResolvedValue([]),
     approveRoutineSuggestion: vi.fn(),
     dismissRoutineSuggestion: vi.fn(),
+    clientsNeedingRestart: vi.fn().mockResolvedValue([]),
   };
 });
 vi.mock("@tauri-apps/api/event", () => ({
@@ -44,6 +51,8 @@ const mockedSetCodeMode = vi.mocked(setCodeMode);
 const mockedListRoutineSuggestions = vi.mocked(listRoutineSuggestions);
 const mockedApproveRoutineSuggestion = vi.mocked(approveRoutineSuggestion);
 const mockedDismissRoutineSuggestion = vi.mocked(dismissRoutineSuggestion);
+const mockedClientsNeedingRestart = vi.mocked(clientsNeedingRestart);
+const mockedToastError = vi.mocked(toastError);
 const mockedListen = vi.mocked(listen);
 
 const registry: Registry = {
@@ -277,6 +286,9 @@ describe("SettingsView routine suggestions", () => {
     mockedListen.mockResolvedValue(() => {});
     mockedListRoutineSuggestions.mockReset();
     mockedListRoutineSuggestions.mockResolvedValue([]);
+    mockedClientsNeedingRestart.mockReset();
+    mockedClientsNeedingRestart.mockResolvedValue([]);
+    mockedToastError.mockReset();
   });
 
   const suggestion: RoutineSuggestion = {
@@ -572,5 +584,18 @@ describe("SettingsView launch at login", () => {
     await waitFor(() => expect(control).toBeEnabled());
     expect(control).toHaveAttribute("aria-checked", "true");
     expect(screen.queryByText(/couldn't read the os setting/i)).not.toBeInTheDocument();
+  });
+});
+
+describe("SettingsView restart check", () => {
+  it("shows an error toast when the old-gateway check fails", async () => {
+    mockedClientsNeedingRestart.mockRejectedValue(new Error("backend down"));
+    renderSettings();
+
+    await waitFor(() => {
+      expect(mockedToastError).toHaveBeenCalledWith(
+        "Couldn't check for apps using an old gateway",
+      );
+    });
   });
 });

--- a/src/components/SettingsView.test.tsx
+++ b/src/components/SettingsView.test.tsx
@@ -598,4 +598,26 @@ describe("SettingsView restart check", () => {
       );
     });
   });
+
+  it("retries the check from the error panel", async () => {
+    mockedClientsNeedingRestart
+      .mockRejectedValueOnce(new Error("backend down"))
+      .mockResolvedValueOnce([{ client: "Codex", gateway: "old", clientPid: 1234 }]);
+    const user = userEvent.setup();
+    renderSettings();
+
+    const retry = await screen.findByRole("button", {
+      name: "Retry checking for old gateway",
+    });
+    await user.click(retry);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/1 app is still launching an old gateway/i),
+      ).toBeInTheDocument();
+    });
+    expect(
+      screen.queryByRole("button", { name: "Retry checking for old gateway" }),
+    ).not.toBeInTheDocument();
+  });
 });

--- a/src/components/SettingsView.tsx
+++ b/src/components/SettingsView.tsx
@@ -1693,6 +1693,12 @@ export function SettingsView({ registry, onRegistryChange }: Props) {
                   // clicking Run before a client has respawned cannot blank the
                   // panel below (SOU-435).
                   setNeedsRestart(outcome.needsRestart);
+                  // This outcome IS a fresh answer to "which apps need a
+                  // restart", so a stale "couldn't check" panel must go with it.
+                  // Leaving it up would state the check failed directly above
+                  // the check's own result, which is the same contradiction the
+                  // panel exists to prevent (#730).
+                  setRestartCheckFailed(false);
                   const parts: string[] = [];
                   if (outcome.killed.length > 0) {
                     parts.push(

--- a/src/components/SettingsView.tsx
+++ b/src/components/SettingsView.tsx
@@ -852,7 +852,7 @@ export function SettingsView({ registry, onRegistryChange }: Props) {
   useEffect(() => {
     clientsNeedingRestart()
       .then(setNeedsRestart)
-      .catch(() => {});
+      .catch(() => toastError("Couldn't check for apps using an old gateway"));
   }, []);
   // Launch-at-login is OS-level state owned by the autostart plugin. Model
   // loading/ready/error explicitly so the switch is never presented as a

--- a/src/components/SettingsView.tsx
+++ b/src/components/SettingsView.tsx
@@ -849,11 +849,19 @@ export function SettingsView({ registry, onRegistryChange }: Props) {
   // launch reaper already found them before this view existed; refreshed from the
   // button's own outcome, which merges rather than replaces (SOU-435).
   const [needsRestart, setNeedsRestart] = useState<ClientNeedingRestart[]>([]);
-  useEffect(() => {
-    clientsNeedingRestart()
-      .then(setNeedsRestart)
-      .catch(() => toastError("Couldn't check for apps using an old gateway"));
+  const [restartCheckFailed, setRestartCheckFailed] = useState(false);
+  const loadNeedsRestart = useCallback(async () => {
+    try {
+      setNeedsRestart(await clientsNeedingRestart());
+      setRestartCheckFailed(false);
+    } catch {
+      setRestartCheckFailed(true);
+      toastError("Couldn't check for apps using an old gateway");
+    }
   }, []);
+  useEffect(() => {
+    void loadNeedsRestart();
+  }, [loadNeedsRestart]);
   // Launch-at-login is OS-level state owned by the autostart plugin. Model
   // loading/ready/error explicitly so the switch is never presented as a
   // verified Off while the real OS value is unknown or unreadable (#694).
@@ -1727,6 +1735,19 @@ export function SettingsView({ registry, onRegistryChange }: Props) {
             </button>
           </div>
           {reapResult && <p className="text-xs text-muted-foreground">{reapResult}</p>}
+          {restartCheckFailed && (
+            <p className="flex items-center gap-2 rounded-md border border-destructive/30 bg-destructive/5 px-3 py-2 text-xs text-muted-foreground">
+              Couldn&apos;t check for apps using an old gateway.
+              <button
+                type="button"
+                aria-label="Retry checking for old gateway"
+                onClick={() => void loadNeedsRestart()}
+                className="shrink-0 font-medium text-foreground underline underline-offset-2 hover:text-primary"
+              >
+                Retry
+              </button>
+            </p>
+          )}
           {needsRestart.length > 0 && (
             <div className="rounded-md border border-warning/40 bg-warning/5 p-3">
               <p className="text-xs font-medium text-warning">


### PR DESCRIPTION
## Summary

Show the existing error toast when checking for apps using an old gateway fails instead of silently ignoring the error.

## Testing

- added regression coverage for a rejected `clientsNeedingRestart` call
- relevant frontend checks pass

Closes #730


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show an error toast and inline retry panel when the restart check fails in `SettingsView`
> - Wraps the `clientsNeedingRestart` call in a `useCallback` (`loadNeedsRestart`) that sets a `restartCheckFailed` flag on failure and calls `toastError` with a fixed message.
> - Renders an inline error panel in [SettingsView.tsx](https://github.com/tsouth89/toolport/pull/778/files#diff-7df3701f815f17f65cca4085a374bd5c5b1c545381f096cd2b64498355a39209) when `restartCheckFailed` is true, with a Retry button that re-runs the check.
> - A successful `stopStaleGateways` run clears the error state in addition to updating the `needsRestart` list.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized baf385e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->