### PR TITLE
fix(security): redact credentials on every egress path (SBS-889, SBS-890)

### DIFF
--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -5184,13 +5184,16 @@ fn approve_pii_release(
 ///
 /// Falls back to `raw` only when the defended body has no text at all, so a failure is
 /// never audited with an empty reason.
+///
+/// Defended is not the same as secret-free. The injection scan looks for instruction
+/// overrides and the PII pass matches PII shapes; an API key is neither, so a server that
+/// echoes the argument it rejected ("invalid api key sk-live-... ") writes a live
+/// credential into `audit.jsonl` and into every CSV exported from it. The credential pass
+/// runs last, over whichever text is about to be stored (SBS-890).
 fn audited_error_text(raw: &str, defended: &Value) -> String {
     let text = content_text(defended);
-    if text.trim().is_empty() {
-        raw.to_string()
-    } else {
-        text
-    }
+    let stored = if text.trim().is_empty() { raw } else { &text };
+    registry::redact_secret_text(stored)
 }
 
 /// True when none of `tokens` still appears literally in `value`.

--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -1789,7 +1789,16 @@ fn registry_summary(reg: &Registry) -> String {
 fn safe_command_target(cmd: &str, args: &[String]) -> String {
     let mut parts = Vec::with_capacity(args.len() + 1);
     parts.push(redact_arg_for_sharing(cmd));
-    parts.extend(args.iter().map(|arg| redact_arg_for_sharing(arg)));
+    // The mask, not a per-argument test: `--token sk-...` hides the credential in
+    // an entry that looks like any other word on its own (SBS-889).
+    let mask = registry::secret_arg_mask(args);
+    for (arg, secret) in args.iter().zip(mask) {
+        parts.push(if secret {
+            "<redacted>".to_string()
+        } else {
+            redact_url_userinfo(arg)
+        });
+    }
     parts.join(" ").trim().to_string()
 }
 
@@ -3656,8 +3665,11 @@ fn build_export(
             // Some servers take credentials inline in args (e.g. a Postgres
             // connection string with a password). Redact those too, so a shared
             // setup never leaks a secret the env-stripping above wouldn't catch.
-            for a in &mut s.args {
-                if arg_looks_secret(a) {
+            // The mask sees the whole slice, so the split form (`--api-key`
+            // `sk-...`) is caught as well as the joined one (SBS-889).
+            let mask = registry::secret_arg_mask(&s.args);
+            for (a, secret) in s.args.iter_mut().zip(mask) {
+                if secret {
                     *a = "<redacted>".to_string();
                 }
             }
@@ -5329,7 +5341,7 @@ fn registry_startup_failure_message(path: Option<&std::path::Path>, error: &str)
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{arg_looks_secret, redact_url_userinfo};
+    use crate::registry::{arg_looks_secret, redact_url_userinfo};
     use registry::EnvVar;
 
     fn unique_update_test_dir(label: &str) -> std::path::PathBuf {
@@ -6243,11 +6255,24 @@ mod tests {
         assert!(arg_looks_secret("Basic dXNlcjpwYXNz"));
         assert!(arg_looks_secret("Digest username=admin,response=secret"));
         assert!(arg_looks_secret("Proxy-Authorization: Basic dXNlcjpwYXNz"));
+        // SBS-889: spellings the needle list and the prefix-only header test
+        // walked past. Every one of these shipped a live credential.
+        assert!(arg_looks_secret("--api-key=sk-live-secret"));
+        assert!(arg_looks_secret("--auth-token=sk-live-secret"));
+        assert!(arg_looks_secret("--header=Authorization: Bearer sk-live-secret"));
+        assert!(arg_looks_secret("--header=X-API-Key: sk-live-secret"));
+        assert!(arg_looks_secret("X-API-Key: sk-live-secret"));
+        assert!(arg_looks_secret("Cookie: session=abc123"));
+        assert!(arg_looks_secret("--token=sk-live-secret"));
         // Legitimate args must NOT be redacted.
         assert!(!arg_looks_secret("-y"));
         assert!(!arg_looks_secret("@modelcontextprotocol/server-postgres"));
         assert!(!arg_looks_secret("--stdio"));
         assert!(!arg_looks_secret("https://api.githubcopilot.com/mcp/")); // no userinfo
+        // A bare flag carries nothing on its own; only the value after it does,
+        // and that is secret_arg_mask's job.
+        assert!(!arg_looks_secret("--token"));
+        assert!(!arg_looks_secret("--header"));
 
         let mut reg = Registry::default();
         reg.add_server(ServerEntry {
@@ -6280,6 +6305,58 @@ mod tests {
         assert_eq!(args[1], "@modelcontextprotocol/server-postgres");
         assert_eq!(args[2], "<redacted>");
         assert_eq!(args[3], "<redacted>");
+    }
+
+    /// SBS-889: the split form. `--token` `sk-...` puts the credential in an argv
+    /// entry that looks like any other word on its own, so a per-argument test
+    /// cannot see it. Every egress sink must use the slice-aware mask.
+    #[test]
+    fn export_redacts_space_separated_secret_args() {
+        let secret_args = vec![
+            "-y".to_string(),
+            "mcp-remote".to_string(),
+            "--header".to_string(),
+            "Authorization: Bearer sk-live-secret".to_string(),
+            "--api-key".to_string(),
+            "sk-live-other".to_string(),
+            "-H".to_string(),
+            "X-API-Key: sk-live-third".to_string(),
+        ];
+        let mask = registry::secret_arg_mask(&secret_args);
+        // Benign args survive, and so does the flag NAME - only its value goes.
+        assert_eq!(
+            mask,
+            vec![false, false, false, true, false, true, false, true]
+        );
+
+        let mut reg = Registry::default();
+        reg.add_server(ServerEntry {
+            id: "remote".into(),
+            name: "Remote".into(),
+            transport: "stdio".into(),
+            command: Some("npx".into()),
+            args: secret_args.clone(),
+            env: vec![],
+            url: None,
+            source: None,
+            disabled_tools: vec![],
+            cwd: None,
+            client_credentials: None,
+            unknown_fields: serde_json::Map::new(),
+        });
+        let serialized = serde_json::to_string(&build_export(&reg, None, None, None)).unwrap();
+        for leaked in ["sk-live-secret", "sk-live-other", "sk-live-third"] {
+            assert!(!serialized.contains(leaked), "{leaked} leaked: {serialized}");
+        }
+        // The diagnostics bundle is the second sink, over the same argv.
+        let diagnostics = safe_command_target("npx", &secret_args);
+        for leaked in ["sk-live-secret", "sk-live-other", "sk-live-third"] {
+            assert!(
+                !diagnostics.contains(leaked),
+                "{leaked} leaked into diagnostics: {diagnostics}"
+            );
+        }
+        assert!(diagnostics.contains("--header"), "flag name kept readable");
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -38,7 +38,7 @@ pub mod topology;
 pub mod usage_report;
 pub mod vendors;
 
-pub(crate) use registry::{arg_looks_secret, redact_url_userinfo};
+pub(crate) use registry::redact_url_userinfo;
 
 #[cfg(feature = "desktop")]
 pub fn run() {

--- a/src-tauri/src/registry.rs
+++ b/src-tauri/src/registry.rs
@@ -2832,9 +2832,28 @@ const SECRET_FLAGS: [&str; 14] = [
 /// its own argv entry with no marker of its own, so it is invisible here and
 /// needs [`secret_arg_mask`], which sees the whole slice.
 pub fn arg_looks_secret(arg: &str) -> bool {
+    looks_secret(arg, BareNeedles::Match)
+}
+
+/// Whether the two no-`=` needles count.
+///
+/// `access_key` / `access-key` as a bare substring is the right bias for an argv
+/// entry, where a false positive costs a `<redacted>` in a setup nobody reads
+/// closely. It is the wrong bias for free text, where it turns "missing
+/// access-key in config" into "missing <redacted> in config" and leaves an audit
+/// row nobody can act on.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum BareNeedles {
+    Match,
+    Ignore,
+}
+
+fn looks_secret(arg: &str, bare: BareNeedles) -> bool {
     let lower = arg.to_ascii_lowercase();
     let trimmed = lower.trim();
-    const NEEDLES: [&str; 12] = [
+    /// Needles in assignment form: the `=` is what makes the value a credential
+    /// rather than a mention of one.
+    const ASSIGNED_NEEDLES: [&str; 10] = [
         "password=",
         "pwd=",
         "token=",
@@ -2843,12 +2862,15 @@ pub fn arg_looks_secret(arg: &str) -> bool {
         "api-key=",
         "secret=",
         "accountkey=",
-        "access_key",
-        "access-key",
         "session=",
         "credential=",
     ];
-    if NEEDLES.iter().any(|n| lower.contains(n)) {
+    /// Needles with no assignment marker, so the name alone is the whole signal.
+    const BARE_NEEDLES: [&str; 2] = ["access_key", "access-key"];
+    if ASSIGNED_NEEDLES.iter().any(|n| lower.contains(n)) {
+        return true;
+    }
+    if bare == BareNeedles::Match && BARE_NEEDLES.iter().any(|n| lower.contains(n)) {
         return true;
     }
     // `--api-key=sk-...`, `--header=Authorization: ...`: the needle list keys off
@@ -2919,9 +2941,15 @@ pub fn secret_arg_mask<S: AsRef<str>>(args: &[S]) -> Vec<bool> {
         if arg_looks_secret(arg) {
             mask[i] = true;
         }
-        // A bare flag: the credential is the next entry. `--token=x` is already
-        // self-describing and handled above, so only the value-less form counts.
-        if !arg.contains('=') && arg_is_secret_flag(arg) {
+        // A flag with no value of its own: the credential is the next entry.
+        // `--token=x` is self-describing and already handled above, but
+        // `--token=` with an EMPTY value is the split form wearing an `=`, and
+        // launchers do emit it - so it must mark the next entry too.
+        let (name, joined_value) = match arg.split_once('=') {
+            Some((name, value)) => (name, Some(value)),
+            None => (arg, None),
+        };
+        if joined_value.is_none_or(|value| value.trim().is_empty()) && arg_is_secret_flag(name) {
             if let Some(next) = mask.get_mut(i + 1) {
                 *next = true;
             }
@@ -2931,35 +2959,74 @@ pub fn secret_arg_mask<S: AsRef<str>>(args: &[S]) -> Vec<bool> {
 }
 
 /// Vendor prefixes that make a bare token recognisable as a credential with no
-/// key beside it. Matched case-insensitively against a word with surrounding
-/// punctuation stripped.
-const SECRET_TOKEN_PREFIXES: [&str; 18] = [
-    "sk-", "sk_", "pk_live_", "rk_", "ghp_", "gho_", "ghu_", "ghs_", "ghr_", "github_pat_",
-    "glpat-", "xoxb-", "xoxa-", "xoxp-", "xoxs-", "akia", "asia", "aiza",
+/// key beside it. Matched case-insensitively against a single token run.
+const SECRET_TOKEN_PREFIXES: [&str; 15] = [
+    "sk-",
+    "sk_",
+    "pk_live_",
+    "rk_",
+    "ghp_",
+    "gho_",
+    "ghu_",
+    "ghs_",
+    "ghr_",
+    "github_pat_",
+    "glpat-",
+    "xoxb-",
+    "xoxa-",
+    "xoxp-",
+    "xoxs-",
 ];
 
-/// Minimum length for a token-shaped word, so ordinary prose that happens to
-/// start with a prefix is left alone.
+/// Cloud key prefixes that are four bare letters with no separator, so they sit
+/// one `starts_with` away from ordinary words: `asia` also begins
+/// `asia-southeast1` and `asia-northeast1`, Google Cloud region ids that appear
+/// in perfectly normal upstream errors. These therefore require the whole run to
+/// be alphanumeric (no `-`, `_` or `.`) and full key length - an AWS key is the
+/// prefix plus 16 characters, and a Google key is longer still.
+const SECRET_CLOUD_KEY_PREFIXES: [&str; 3] = ["akia", "asia", "aiza"];
+
+/// Minimum length for a prefixed token, so ordinary prose that happens to start
+/// with a prefix is left alone.
 const SECRET_TOKEN_MIN_LEN: usize = 12;
 
-/// Auth schemes and bare key names whose credential is the NEXT word.
-/// Auth schemes whose next word is the credential, always. "Bearer" is not a
-/// word that appears in an error message for any other reason.
+/// Minimum length for a bare cloud key: `AKIA` + 16 characters.
+const CLOUD_KEY_MIN_LEN: usize = 20;
+
+/// Auth schemes that introduce a credential. Deliberately NOT unconditional:
+/// "basic authentication failed" and "digest authentication required" are
+/// ordinary sentences, so what follows must still look like a credential.
 const SECRET_SCHEME_WORDS: [&str; 3] = ["bearer", "basic", "digest"];
 
-/// Words that USUALLY precede a credential but are also ordinary English
-/// ("missing key in request", "invalid token for user"). The word after one of
-/// these is redacted only when it is itself credential-shaped, so a real key
-/// with no vendor prefix is still caught without shredding the sentence around
-/// it.
-const SECRET_HINT_WORDS: [&str; 6] = ["token", "key", "apikey", "password", "secret", "credential"];
+/// Names that introduce a credential, as a whole run or as the tail of a field
+/// name (`access_token`, `apiKey`, `client_secret`). What follows is redacted
+/// only when it also looks like a credential, because every one of these is also
+/// ordinary English: "missing key in request" must not become "missing key
+/// <redacted> request".
+const SECRET_HINT_NAMES: [&str; 10] = [
+    "token",
+    "key",
+    "apikey",
+    "password",
+    "passwd",
+    "pwd",
+    "secret",
+    "credential",
+    "authorization",
+    "cookie",
+];
 
-/// How long an opaque word must be, after a hint word, before it is treated as
-/// a credential rather than prose. Real keys are long; "for", "in" and "request"
-/// are not.
+/// Minimum length before an opaque run is treated as a credential rather than as
+/// a word in a sentence. Real keys are long; "for", "in" and "request" are not.
 const OPAQUE_SECRET_MIN_LEN: usize = 16;
 
-/// Redact credential-shaped words from free text.
+/// Minimum length for the mixed-case form, which is a stronger signal than
+/// length alone (a base64 credential is rarely shorter than this).
+const MIXED_CASE_SECRET_MIN_LEN: usize = 10;
+
+const REDACTED: &str = "<redacted>";
+
+/// Redact credential-shaped text from a free-text message.
 ///
 /// Sized for text that came back from a downstream server. An error body is the
 /// server's own words and routinely echoes the argument it just rejected
@@ -2969,115 +3036,125 @@ const OPAQUE_SECRET_MIN_LEN: usize = 16;
 /// and rides every CSV exported from it (SBS-890). No attacker is needed - a
 /// merely buggy server that echoes its input on failure produces this.
 ///
-/// Word-granular and deliberately blunt: a word that looks like a credential, or
-/// that follows a credential key or auth scheme, is replaced whole; inside any
-/// other word, a vendor-prefixed token is replaced on its own, so a key quoted
-/// in a JSON body (`{"apiKey":"sk-live-..."}`) goes too. Whitespace is preserved
-/// so the surrounding message stays readable.
+/// Works on TOKEN RUNS, not whitespace-separated words, because an error body is
+/// as often JSON as prose: in `{"access_token":"A1b2..."}` the field name and its
+/// value are one word, and that name is the only thing saying the value is a
+/// credential. Punctuation and whitespace are preserved so the surrounding
+/// message survives - an audit reason nobody can interpret is its own failure.
 pub fn redact_secret_text(text: &str) -> String {
+    fn is_run_char(c: char) -> bool {
+        c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.' | '+' | '/' | '=')
+    }
     let mut out = String::with_capacity(text.len());
-    let mut prev = String::new();
+    // Set by a run that NAMES a credential ("access_token", "Authorization",
+    // "Bearer"); consumed by the run after it.
+    let mut named = false;
     let mut rest = text;
     while !rest.is_empty() {
-        let word_start = rest
+        let ws_end = rest
             .find(|c: char| !c.is_whitespace())
             .unwrap_or(rest.len());
-        out.push_str(&rest[..word_start]);
-        rest = &rest[word_start..];
+        out.push_str(&rest[..ws_end]);
+        rest = &rest[ws_end..];
         if rest.is_empty() {
             break;
         }
         let word_end = rest.find(char::is_whitespace).unwrap_or(rest.len());
         let word = &rest[..word_end];
         rest = &rest[word_end..];
-        if arg_looks_secret(word) || follows_a_credential_marker(&prev, word) {
+        // Whole-word forms first: a URI with userinfo, or an inline `key=value`,
+        // spans several runs, so only the word sees them.
+        if looks_secret(word, BareNeedles::Ignore) {
             out.push_str(REDACTED);
-        } else {
-            out.push_str(&redact_token_runs(word));
+            named = false;
+            continue;
         }
-        prev = word.to_ascii_lowercase();
-    }
-    out
-}
-
-const REDACTED: &str = "<redacted>";
-
-/// Replace vendor-prefixed tokens inside one word, leaving its punctuation in
-/// place. An error body is often JSON, so the credential arrives glued to quotes,
-/// braces and a field name rather than standing alone.
-fn redact_token_runs(word: &str) -> String {
-    fn is_token_char(c: char) -> bool {
-        c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.')
-    }
-    let mut out = String::with_capacity(word.len());
-    let mut rest = word;
-    while !rest.is_empty() {
-        let run_start = rest.find(is_token_char).unwrap_or(rest.len());
-        out.push_str(&rest[..run_start]);
-        rest = &rest[run_start..];
-        if rest.is_empty() {
-            break;
-        }
-        let run_end = rest.find(|c: char| !is_token_char(c)).unwrap_or(rest.len());
-        let run = &rest[..run_end];
-        rest = &rest[run_end..];
-        if token_looks_secret(run) {
-            out.push_str(REDACTED);
-        } else {
-            out.push_str(run);
+        // Otherwise walk the word's runs, carrying the marker across words so
+        // `api key <opaque>` and `"apiKey":"<opaque>"` are the same case.
+        let mut inner = word;
+        while !inner.is_empty() {
+            let run_start = inner.find(is_run_char).unwrap_or(inner.len());
+            out.push_str(&inner[..run_start]);
+            inner = &inner[run_start..];
+            if inner.is_empty() {
+                break;
+            }
+            let run_end = inner.find(|c: char| !is_run_char(c)).unwrap_or(inner.len());
+            let run = &inner[..run_end];
+            inner = &inner[run_end..];
+            if token_looks_secret(run) || (named && looks_like_a_credential(run)) {
+                out.push_str(REDACTED);
+                named = false;
+            } else {
+                out.push_str(run);
+                named = names_a_credential(run);
+            }
         }
     }
     out
 }
 
-/// True when a bare token is credential-shaped by its vendor prefix alone, with
-/// no key beside it to say so.
-fn token_looks_secret(token: &str) -> bool {
-    if token.len() < SECRET_TOKEN_MIN_LEN {
-        return false;
-    }
-    let lower = token.to_ascii_lowercase();
-    SECRET_TOKEN_PREFIXES.iter().any(|p| lower.starts_with(p))
-}
-
-/// True when the PREVIOUS word says `word` is a credential.
-///
-/// Two strengths, because the audit `err` field has to stay readable: an error
-/// nobody can interpret is its own failure. An auth scheme or a header name
-/// ("Bearer", "Authorization:") is never followed by anything but the
-/// credential, so it redacts unconditionally. A hint word ("key", "token") is
-/// ordinary English - "missing key in request" must not become "missing key
-/// <redacted> request" - so it redacts only an opaque, long, mixed-case-and-digit
-/// word, which prose does not produce and an unprefixed API key does.
-fn follows_a_credential_marker(prev: &str, word: &str) -> bool {
-    let bare_prev = trim_word_punctuation(prev);
-    if SECRET_SCHEME_WORDS.contains(&bare_prev) || SECRET_HEADERS.iter().any(|h| prev == *h) {
+/// True when a run is recognisable as a credential from its own shape, with no
+/// name beside it to say so.
+fn token_looks_secret(run: &str) -> bool {
+    let lower = run.to_ascii_lowercase();
+    if run.len() >= SECRET_TOKEN_MIN_LEN
+        && SECRET_TOKEN_PREFIXES.iter().any(|p| lower.starts_with(p))
+    {
         return true;
     }
-    SECRET_HINT_WORDS.contains(&bare_prev) && looks_opaque(word)
+    run.len() >= CLOUD_KEY_MIN_LEN
+        && run.chars().all(|c| c.is_ascii_alphanumeric())
+        && SECRET_CLOUD_KEY_PREFIXES
+            .iter()
+            .any(|p| lower.starts_with(p))
 }
 
-/// A long word that mixes letters and digits: the shape of a credential with no
-/// vendor prefix to recognise it by, and not the shape of a word in a sentence.
-fn looks_opaque(word: &str) -> bool {
-    let bare = trim_word_punctuation(word);
-    bare.len() >= OPAQUE_SECRET_MIN_LEN
-        && bare.chars().any(|c| c.is_ascii_digit())
-        && bare.chars().any(|c| c.is_ascii_alphabetic())
-        && bare
-            .chars()
-            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.' | '+' | '/' | '='))
-}
-
-/// Strip the quotes, brackets and sentence punctuation that wrap a word in prose
-/// or in a JSON error body, so the shape test sees the token itself.
-fn trim_word_punctuation(word: &str) -> &str {
-    word.trim_matches(|c: char| {
-        matches!(
-            c,
-            '"' | '\'' | '`' | '(' | ')' | '[' | ']' | '{' | '}' | '<' | '>' | ',' | ';' | ':' | '.'
-        )
+/// True when a run NAMES a credential, so the run after it is its value: a
+/// scheme word, or a name that is (or ends with) one of [`SECRET_HINT_NAMES`].
+///
+/// The tail match needs a separator or a camelCase hump before the hint, so
+/// `access_token`, `client-secret` and `apiKey` count while `monkey` does not.
+fn names_a_credential(run: &str) -> bool {
+    let lower = run.to_ascii_lowercase();
+    if SECRET_SCHEME_WORDS.contains(&lower.as_str()) {
+        return true;
+    }
+    SECRET_HINT_NAMES.iter().any(|hint| {
+        if lower == *hint {
+            return true;
+        }
+        let Some(head) = lower.strip_suffix(hint) else {
+            return false;
+        };
+        if head.is_empty() {
+            return false;
+        }
+        head.ends_with(['-', '_', '.'])
+            || run[head.len()..]
+                .chars()
+                .next()
+                .is_some_and(|c| c.is_ascii_uppercase())
     })
+}
+
+/// True when a run could be the credential a preceding name introduced: long and
+/// opaque, or shorter but mixed-case like a base64 secret.
+///
+/// Never a scheme word: "Bearer" after "Authorization:" is the scheme, and
+/// dropping it leaves an audit reason reading "Authorization: <redacted>
+/// <redacted>".
+fn looks_like_a_credential(run: &str) -> bool {
+    if SECRET_SCHEME_WORDS.contains(&run.to_ascii_lowercase().as_str()) {
+        return false;
+    }
+    let long_and_opaque = run.len() >= OPAQUE_SECRET_MIN_LEN
+        && run.chars().any(|c| c.is_ascii_digit())
+        && run.chars().any(|c| c.is_ascii_alphabetic());
+    let mixed_case = run.len() >= MIXED_CASE_SECRET_MIN_LEN
+        && run.chars().any(|c| c.is_ascii_uppercase())
+        && run.chars().any(|c| c.is_ascii_lowercase());
+    long_and_opaque || mixed_case
 }
 
 /// Redact credentials embedded in a URL's authority: `scheme://user:pass@host/x`
@@ -3128,18 +3205,52 @@ mod tests {
             assert!(redacted.contains("<redacted>"), "nothing redacted: {case}");
         }
 
-        // An unprefixed credential is caught by shape when a key word precedes it.
+        // An unprefixed credential is caught by shape when a name precedes it.
         let opaque = redact_secret_text("rejected api key A1b2C3d4E5f6G7h8J9k0 at edge");
         assert!(!opaque.contains("A1b2C3d4E5f6G7h8J9k0"), "{opaque}");
         assert!(opaque.ends_with("at edge"), "lost the rest: {opaque}");
 
+        // The JSON shape, which no whitespace-word pass can see: the field name
+        // and its value are ONE word, and the name is the only thing that says
+        // the value is a credential.
+        for json in [
+            r#"{"access_token":"A1b2C3d4E5f6G7h8J9k0L1m2N3p4Q5r6"}"#,
+            r#"{"apiKey":"A1b2C3d4E5f6G7h8J9k0L1m2N3p4Q5r6"}"#,
+            r#"{"client_secret": "A1b2C3d4E5f6G7h8J9k0L1m2N3p4Q5r6"}"#,
+        ] {
+            let redacted = redact_secret_text(json);
+            assert!(
+                !redacted.contains("A1b2C3d4E5f6G7h8J9k0L1m2N3p4Q5r6"),
+                "JSON credential survived: {redacted}"
+            );
+        }
+
+        // A bare cloud key still goes, but only at full length with no separator.
+        let aws = redact_secret_text("denied for AKIAIOSFODNN7EXAMPLE at edge");
+        assert!(!aws.contains("AKIAIOSFODNN7EXAMPLE"), "{aws}");
+
+        // The scheme word is not the credential. Dropping it leaves an audit
+        // reason reading "Authorization: <redacted> <redacted>".
+        let header = redact_secret_text("Authorization: Bearer sk-live-abcdefghijklmnop");
+        assert!(header.contains("Bearer"), "lost the scheme: {header}");
+        assert!(!header.contains("sk-live-abcdefghijklmnop"), "{header}");
+
         // An ordinary failure must stay readable, or the audit row loses its
-        // reason. "key" and "token" are English as often as they are markers.
+        // reason. Every marker below is also plain English.
         for plain in [
             "HTTP 503: upstream unavailable, retry after 30s",
             "missing key in request body",
             "invalid token for user 42",
             "the api key was rejected",
+            // basic/digest introduce a credential AND start ordinary sentences.
+            "basic authentication failed",
+            "digest authentication required",
+            // asia-* are Google Cloud region ids, not AWS keys.
+            "asia-southeast1 endpoint unavailable",
+            "asia-northeast1 is degraded",
+            // The two no-equals argv needles are prose here, not credentials.
+            "missing access-key in config",
+            "rotate access_key failed",
         ] {
             assert_eq!(redact_secret_text(plain), plain, "over-redacted: {plain}");
         }
@@ -3164,6 +3275,16 @@ mod tests {
         assert_eq!(
             secret_arg_mask(&args),
             vec![false, false, false, false, true, true, false, true]
+        );
+
+        // `--token=` with an EMPTY value is the split form wearing an `=`: the
+        // credential is still the next entry, and must be masked. The flag
+        // entry goes too, the same way every other joined form does - the
+        // `token=` needle cannot tell an empty value from a real one, and
+        // over-redacting a flag name is the harmless direction.
+        assert_eq!(
+            secret_arg_mask(&["--token=", "sk-live-split"]),
+            vec![true, true]
         );
 
         // A value-less trailing flag must not panic or over-run the slice.

--- a/src-tauri/src/registry.rs
+++ b/src-tauri/src/registry.rs
@@ -2786,29 +2786,85 @@ pub fn load_resolved_with_source() -> Result<(Registry, LoadSource), String> {
     Ok((registry, source))
 }
 
+/// Credential-bearing HTTP header names. Matched ANYWHERE in an argument, not
+/// only as a prefix: launchers routinely wrap the header in a flag
+/// (`--header=Authorization: Bearer sk-...`), and a prefix test walks straight
+/// past that (SBS-889).
+const SECRET_HEADERS: [&str; 8] = [
+    "authorization:",
+    "proxy-authorization:",
+    "x-api-key:",
+    "x-auth-token:",
+    "x-goog-api-key:",
+    "api-key:",
+    "cookie:",
+    "private-token:",
+];
+
+/// Flags whose VALUE is a credential, in the joined form (`--api-key=sk-...`).
+/// The leading dashes are stripped before comparison, so both `-` and `--`
+/// spellings match.
+const SECRET_FLAGS: [&str; 14] = [
+    "header",
+    "headers",
+    "api-key",
+    "apikey",
+    "api_key",
+    "token",
+    "auth",
+    "auth-token",
+    "auth_token",
+    "access-token",
+    "access_token",
+    "password",
+    "secret",
+    "bearer",
+];
+
 /// True when a command argument looks like it carries a secret: an inline
-/// credential param (password=, token=, ...) or a connection URI with embedded
+/// credential param (password=, token=, ...), a credential-bearing flag
+/// (`--api-key=...`), an HTTP auth header, or a connection URI with embedded
 /// userinfo (scheme://user:pass@host). Used to redact args before sharing, since
 /// some servers (e.g. Postgres) take a connection string with a password in args.
 /// Biased toward over-redacting: for a share, a false positive is harmless.
-pub(crate) fn arg_looks_secret(arg: &str) -> bool {
+///
+/// Per-argument only. The SPLIT form (`--api-key` `sk-...`) puts the secret in
+/// its own argv entry with no marker of its own, so it is invisible here and
+/// needs [`secret_arg_mask`], which sees the whole slice.
+pub fn arg_looks_secret(arg: &str) -> bool {
     let lower = arg.to_ascii_lowercase();
     let trimmed = lower.trim();
-    const NEEDLES: [&str; 8] = [
-        "password=", "pwd=", "token=", "apikey=", "api_key=", "secret=", "accountkey=",
+    const NEEDLES: [&str; 12] = [
+        "password=",
+        "pwd=",
+        "token=",
+        "apikey=",
+        "api_key=",
+        "api-key=",
+        "secret=",
+        "accountkey=",
         "access_key",
+        "access-key",
+        "session=",
+        "credential=",
     ];
     if NEEDLES.iter().any(|n| lower.contains(n)) {
         return true;
     }
+    // `--api-key=sk-...`, `--header=Authorization: ...`: the needle list keys off
+    // the parameter name, which here sits behind a flag spelling it does not know.
+    if let Some((flag, value)) = trimmed.split_once('=') {
+        if arg_is_secret_flag(flag) && !value.trim().is_empty() {
+            return true;
+        }
+    }
     // Common remote-MCP launchers pass an HTTP auth header as one argument.
     // It has no key=value marker, but sharing it would disclose the credential.
-    for header in ["authorization:", "proxy-authorization:"] {
-        if trimmed
-            .strip_prefix(header)
-            .is_some_and(|value| !value.trim().is_empty())
-        {
-            return true;
+    for header in SECRET_HEADERS {
+        if let Some(at) = trimmed.find(header) {
+            if !trimmed[at + header.len()..].trim().is_empty() {
+                return true;
+            }
         }
     }
     // Some launchers split the header name and value into separate arguments.
@@ -2828,6 +2884,168 @@ pub(crate) fn arg_looks_secret(arg: &str) -> bool {
         }
     }
     false
+}
+
+/// True when `arg` is a flag whose value is a credential (`--header`, `-H`,
+/// `--api-key`, ...), so the argument AFTER it must be redacted.
+///
+/// `-H` is matched case-sensitively: lowercased it collides with `-h`/`--help`,
+/// and redacting the argument after a help flag would corrupt a shared setup for
+/// no gain. Every other spelling is case-insensitive.
+fn arg_is_secret_flag(arg: &str) -> bool {
+    let raw = arg.trim();
+    if raw == "-H" {
+        return true;
+    }
+    let name = raw.trim_start_matches('-').to_ascii_lowercase();
+    !name.is_empty() && SECRET_FLAGS.contains(&name.as_str())
+}
+
+/// Per-argument redaction mask for a whole argv slice: `mask[i]` is true when
+/// argument `i` must not leave the machine.
+///
+/// [`arg_looks_secret`] alone cannot be correct here. Launchers split the flag
+/// and its value into separate entries (`--token` `sk-live-...`), and the value
+/// entry carries no `=`, no header name and no URI userinfo - nothing a
+/// per-argument test can see. Only the flag before it says what it is, which
+/// needs the slice (SBS-889).
+///
+/// The flag itself is left visible: the NAME is not a credential, and keeping it
+/// makes a shared setup readable ("--token <redacted>" rather than two blanks).
+pub fn secret_arg_mask<S: AsRef<str>>(args: &[S]) -> Vec<bool> {
+    let mut mask = vec![false; args.len()];
+    for (i, arg) in args.iter().enumerate() {
+        let arg = arg.as_ref();
+        if arg_looks_secret(arg) {
+            mask[i] = true;
+        }
+        // A bare flag: the credential is the next entry. `--token=x` is already
+        // self-describing and handled above, so only the value-less form counts.
+        if !arg.contains('=') && arg_is_secret_flag(arg) {
+            if let Some(next) = mask.get_mut(i + 1) {
+                *next = true;
+            }
+        }
+    }
+    mask
+}
+
+/// Vendor prefixes that make a bare token recognisable as a credential with no
+/// key beside it. Matched case-insensitively against a word with surrounding
+/// punctuation stripped.
+const SECRET_TOKEN_PREFIXES: [&str; 18] = [
+    "sk-", "sk_", "pk_live_", "rk_", "ghp_", "gho_", "ghu_", "ghs_", "ghr_", "github_pat_",
+    "glpat-", "xoxb-", "xoxa-", "xoxp-", "xoxs-", "akia", "asia", "aiza",
+];
+
+/// Minimum length for a token-shaped word, so ordinary prose that happens to
+/// start with a prefix is left alone.
+const SECRET_TOKEN_MIN_LEN: usize = 12;
+
+/// Auth schemes and bare key names whose credential is the NEXT word.
+const SECRET_LEAD_WORDS: [&str; 6] = ["bearer", "basic", "digest", "token", "key", "password"];
+
+/// Redact credential-shaped words from free text.
+///
+/// Sized for text that came back from a downstream server. An error body is the
+/// server's own words and routinely echoes the argument it just rejected
+/// ("invalid api key sk-live-... for request 42"). The injection scan looks for
+/// instruction overrides and the PII pass matches PII shapes; neither is a
+/// credential test, so without this the key lands verbatim in the audit store
+/// and rides every CSV exported from it (SBS-890). No attacker is needed - a
+/// merely buggy server that echoes its input on failure produces this.
+///
+/// Word-granular and deliberately blunt: a word that looks like a credential, or
+/// that follows a credential key or auth scheme, is replaced whole; inside any
+/// other word, a vendor-prefixed token is replaced on its own, so a key quoted
+/// in a JSON body (`{"apiKey":"sk-live-..."}`) goes too. Whitespace is preserved
+/// so the surrounding message stays readable.
+pub fn redact_secret_text(text: &str) -> String {
+    let mut out = String::with_capacity(text.len());
+    let mut prev = String::new();
+    let mut rest = text;
+    while !rest.is_empty() {
+        let word_start = rest
+            .find(|c: char| !c.is_whitespace())
+            .unwrap_or(rest.len());
+        out.push_str(&rest[..word_start]);
+        rest = &rest[word_start..];
+        if rest.is_empty() {
+            break;
+        }
+        let word_end = rest.find(char::is_whitespace).unwrap_or(rest.len());
+        let word = &rest[..word_end];
+        rest = &rest[word_end..];
+        if arg_looks_secret(word) || leads_a_secret(&prev) {
+            out.push_str(REDACTED);
+        } else {
+            out.push_str(&redact_token_runs(word));
+        }
+        prev = word.to_ascii_lowercase();
+    }
+    out
+}
+
+const REDACTED: &str = "<redacted>";
+
+/// Replace vendor-prefixed tokens inside one word, leaving its punctuation in
+/// place. An error body is often JSON, so the credential arrives glued to quotes,
+/// braces and a field name rather than standing alone.
+fn redact_token_runs(word: &str) -> String {
+    fn is_token_char(c: char) -> bool {
+        c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.')
+    }
+    let mut out = String::with_capacity(word.len());
+    let mut rest = word;
+    while !rest.is_empty() {
+        let run_start = rest.find(is_token_char).unwrap_or(rest.len());
+        out.push_str(&rest[..run_start]);
+        rest = &rest[run_start..];
+        if rest.is_empty() {
+            break;
+        }
+        let run_end = rest.find(|c: char| !is_token_char(c)).unwrap_or(rest.len());
+        let run = &rest[..run_end];
+        rest = &rest[run_end..];
+        if token_looks_secret(run) {
+            out.push_str(REDACTED);
+        } else {
+            out.push_str(run);
+        }
+    }
+    out
+}
+
+/// True when a bare token is credential-shaped by its vendor prefix alone, with
+/// no key beside it to say so.
+fn token_looks_secret(token: &str) -> bool {
+    if token.len() < SECRET_TOKEN_MIN_LEN {
+        return false;
+    }
+    let lower = token.to_ascii_lowercase();
+    SECRET_TOKEN_PREFIXES.iter().any(|p| lower.starts_with(p))
+}
+
+/// True when the PREVIOUS word says the next one is a credential: an auth scheme
+/// ("Bearer"), a header name ("Authorization:") or a bare key word ("key").
+fn leads_a_secret(prev: &str) -> bool {
+    let bare = trim_word_punctuation(prev);
+    if SECRET_LEAD_WORDS.contains(&bare) {
+        return true;
+    }
+    // "Authorization:" as its own word: the value is whatever follows.
+    SECRET_HEADERS.iter().any(|h| prev == *h)
+}
+
+/// Strip the quotes, brackets and sentence punctuation that wrap a word in prose
+/// or in a JSON error body, so the shape test sees the token itself.
+fn trim_word_punctuation(word: &str) -> &str {
+    word.trim_matches(|c: char| {
+        matches!(
+            c,
+            '"' | '\'' | '`' | '(' | ')' | '[' | ']' | '{' | '}' | '<' | '>' | ',' | ';' | ':' | '.'
+        )
+    })
 }
 
 /// Redact credentials embedded in a URL's authority: `scheme://user:pass@host/x`
@@ -2855,6 +3073,67 @@ mod tests {
     use crate::approval::fingerprint_allow_key;
 
     static REGISTRY_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    /// SBS-890: an error body is the downstream server's own words. It has been
+    /// through the injection scan and the PII pass, and neither is a credential
+    /// test, so the redactor is what keeps a key out of `audit.jsonl`.
+    #[test]
+    fn redact_secret_text_removes_credential_shapes_and_keeps_the_message() {
+        let cases = [
+            "invalid api key sk-live-abcdefghijklmnop for request 42",
+            "auth failed: Authorization: Bearer sk-live-abcdefghijklmnop",
+            "rejected token ghp_abcdefghijklmnopqrstuvwxyz0123456789",
+            "bad request {\"apiKey\":\"sk-live-abcdefghijklmnop\"}",
+            "upstream said: X-API-Key: sk-live-abcdefghijklmnop is expired",
+        ];
+        for case in cases {
+            let redacted = redact_secret_text(case);
+            assert!(
+                !redacted.contains("sk-live-abcdefghijklmnop")
+                    && !redacted.contains("ghp_abcdefghijklmnopqrstuvwxyz0123456789"),
+                "credential survived: {redacted}"
+            );
+            assert!(redacted.contains("<redacted>"), "nothing redacted: {case}");
+        }
+
+        // An ordinary failure must stay readable, or the audit row loses its reason.
+        let plain = "HTTP 503: upstream unavailable, retry after 30s";
+        assert_eq!(redact_secret_text(plain), plain);
+        assert_eq!(redact_secret_text(""), "");
+    }
+
+    /// The mask is what the three egress sinks share; a regression here leaks to
+    /// a public share link, a pasted diagnostics bundle and the org control plane
+    /// at once (SBS-889).
+    #[test]
+    fn secret_arg_mask_covers_joined_and_split_credential_flags() {
+        let args = [
+            "-y",
+            "mcp-remote",
+            "https://mcp.example.com/sse",
+            "--header",
+            "Authorization: Bearer sk-live-secret",
+            "--api-key=sk-live-joined",
+            "--token",
+            "sk-live-split",
+        ];
+        assert_eq!(
+            secret_arg_mask(&args),
+            vec![false, false, false, false, true, true, false, true]
+        );
+
+        // A value-less trailing flag must not panic or over-run the slice.
+        assert_eq!(secret_arg_mask(&["--token"]), vec![false]);
+        assert!(secret_arg_mask::<&str>(&[]).is_empty());
+
+        // `-h` is help, not a header: redacting what follows would corrupt the
+        // shared setup for nothing. `-H` (curl's spelling) is the credential one.
+        assert_eq!(secret_arg_mask(&["-h", "topic"]), vec![false, false]);
+        assert_eq!(
+            secret_arg_mask(&["-H", "X-API-Key: sk-live"]),
+            vec![false, true]
+        );
+    }
 
     /// Pins the plumbing the concurrency tests rely on (SBS-895). Without this, a typo in
     /// the env-var name would silently leave those tests on the 5s production budget and

--- a/src-tauri/src/registry.rs
+++ b/src-tauri/src/registry.rs
@@ -2943,7 +2943,21 @@ const SECRET_TOKEN_PREFIXES: [&str; 18] = [
 const SECRET_TOKEN_MIN_LEN: usize = 12;
 
 /// Auth schemes and bare key names whose credential is the NEXT word.
-const SECRET_LEAD_WORDS: [&str; 6] = ["bearer", "basic", "digest", "token", "key", "password"];
+/// Auth schemes whose next word is the credential, always. "Bearer" is not a
+/// word that appears in an error message for any other reason.
+const SECRET_SCHEME_WORDS: [&str; 3] = ["bearer", "basic", "digest"];
+
+/// Words that USUALLY precede a credential but are also ordinary English
+/// ("missing key in request", "invalid token for user"). The word after one of
+/// these is redacted only when it is itself credential-shaped, so a real key
+/// with no vendor prefix is still caught without shredding the sentence around
+/// it.
+const SECRET_HINT_WORDS: [&str; 6] = ["token", "key", "apikey", "password", "secret", "credential"];
+
+/// How long an opaque word must be, after a hint word, before it is treated as
+/// a credential rather than prose. Real keys are long; "for", "in" and "request"
+/// are not.
+const OPAQUE_SECRET_MIN_LEN: usize = 16;
 
 /// Redact credential-shaped words from free text.
 ///
@@ -2976,7 +2990,7 @@ pub fn redact_secret_text(text: &str) -> String {
         let word_end = rest.find(char::is_whitespace).unwrap_or(rest.len());
         let word = &rest[..word_end];
         rest = &rest[word_end..];
-        if arg_looks_secret(word) || leads_a_secret(&prev) {
+        if arg_looks_secret(word) || follows_a_credential_marker(&prev, word) {
             out.push_str(REDACTED);
         } else {
             out.push_str(&redact_token_runs(word));
@@ -3026,15 +3040,33 @@ fn token_looks_secret(token: &str) -> bool {
     SECRET_TOKEN_PREFIXES.iter().any(|p| lower.starts_with(p))
 }
 
-/// True when the PREVIOUS word says the next one is a credential: an auth scheme
-/// ("Bearer"), a header name ("Authorization:") or a bare key word ("key").
-fn leads_a_secret(prev: &str) -> bool {
-    let bare = trim_word_punctuation(prev);
-    if SECRET_LEAD_WORDS.contains(&bare) {
+/// True when the PREVIOUS word says `word` is a credential.
+///
+/// Two strengths, because the audit `err` field has to stay readable: an error
+/// nobody can interpret is its own failure. An auth scheme or a header name
+/// ("Bearer", "Authorization:") is never followed by anything but the
+/// credential, so it redacts unconditionally. A hint word ("key", "token") is
+/// ordinary English - "missing key in request" must not become "missing key
+/// <redacted> request" - so it redacts only an opaque, long, mixed-case-and-digit
+/// word, which prose does not produce and an unprefixed API key does.
+fn follows_a_credential_marker(prev: &str, word: &str) -> bool {
+    let bare_prev = trim_word_punctuation(prev);
+    if SECRET_SCHEME_WORDS.contains(&bare_prev) || SECRET_HEADERS.iter().any(|h| prev == *h) {
         return true;
     }
-    // "Authorization:" as its own word: the value is whatever follows.
-    SECRET_HEADERS.iter().any(|h| prev == *h)
+    SECRET_HINT_WORDS.contains(&bare_prev) && looks_opaque(word)
+}
+
+/// A long word that mixes letters and digits: the shape of a credential with no
+/// vendor prefix to recognise it by, and not the shape of a word in a sentence.
+fn looks_opaque(word: &str) -> bool {
+    let bare = trim_word_punctuation(word);
+    bare.len() >= OPAQUE_SECRET_MIN_LEN
+        && bare.chars().any(|c| c.is_ascii_digit())
+        && bare.chars().any(|c| c.is_ascii_alphabetic())
+        && bare
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.' | '+' | '/' | '='))
 }
 
 /// Strip the quotes, brackets and sentence punctuation that wrap a word in prose
@@ -3096,9 +3128,21 @@ mod tests {
             assert!(redacted.contains("<redacted>"), "nothing redacted: {case}");
         }
 
-        // An ordinary failure must stay readable, or the audit row loses its reason.
-        let plain = "HTTP 503: upstream unavailable, retry after 30s";
-        assert_eq!(redact_secret_text(plain), plain);
+        // An unprefixed credential is caught by shape when a key word precedes it.
+        let opaque = redact_secret_text("rejected api key A1b2C3d4E5f6G7h8J9k0 at edge");
+        assert!(!opaque.contains("A1b2C3d4E5f6G7h8J9k0"), "{opaque}");
+        assert!(opaque.ends_with("at edge"), "lost the rest: {opaque}");
+
+        // An ordinary failure must stay readable, or the audit row loses its
+        // reason. "key" and "token" are English as often as they are markers.
+        for plain in [
+            "HTTP 503: upstream unavailable, retry after 30s",
+            "missing key in request body",
+            "invalid token for user 42",
+            "the api key was rejected",
+        ] {
+            assert_eq!(redact_secret_text(plain), plain, "over-redacted: {plain}");
+        }
         assert_eq!(redact_secret_text(""), "");
     }
 

--- a/src-tauri/src/teams.rs
+++ b/src-tauri/src/teams.rs
@@ -1467,8 +1467,9 @@ fn team_server_export(reg: &Registry) -> Value {
             let args: Vec<String> = s
                 .args
                 .iter()
-                .map(|a| {
-                    if crate::arg_looks_secret(a) {
+                .zip(crate::registry::secret_arg_mask(&s.args))
+                .map(|(a, secret)| {
+                    if secret {
                         "<redacted>".to_string()
                     } else {
                         a.clone()


### PR DESCRIPTION
## What

`arg_looks_secret` is the single gate in front of three egress paths, and its own doc comment claims a bias toward over-redacting. It did not deliver that.

| Argument | Why it passed before |
| -- | -- |
| `--api-key=sk-live-...` | needles had `apikey=` and `api_key=`, not `api-key=` |
| `--header=Authorization: Bearer sk-...` | the header test was a `strip_prefix`, and the string starts with `--header=` |
| `X-API-Key: sk-...` | only `authorization:` / `proxy-authorization:` were checked |
| `Cookie: session=...` | no needle matched |
| `--token` `sk-...` (split form) | neither entry contains `token=`; the flag has no `=` |

Three sinks share that gate: the public share link (`toolport.app/api/share`, 90-day TTL), the diagnostics bundle users paste into public issues, and the **team config push**, which reaches the org control plane and every teammate.

The existing eight-case test table read as thorough but every case was a form that already passed, so it could not fail for the bug that existed.

## Changes

- widen the needles; match credential headers **anywhere** in an argument, not only as a prefix
- recognise credential-bearing flags in the joined form (`--api-key=...`)
- add `registry::secret_arg_mask`, which sees the whole argv slice and so catches the split form. The flag NAME stays visible (`--token <redacted>`), only its value goes
- move all three sinks onto the mask
- every miss from the report is now in the test table, plus a slice-level test for the split form

`-H` is matched case-sensitively on purpose: lowercased it collides with `-h`/`--help`, and redacting what follows a help flag would corrupt a shared setup for nothing.

## SBS-890, same class

The audited error text is the *defended* body, but defended is not secret-free: the injection scan looks for instruction overrides and the PII pass matches PII shapes, and an API key is neither. A server that echoes the argument it rejected (`invalid api key sk-live-...`) wrote a live credential into `audit.jsonl` and into every CSV exported from it. No attacker needed, just a buggy server. `audited_error_text` now runs a credential pass over whichever text is about to be stored, including the vendor token shapes (`sk-`, `ghp_`, `xox`, `AKIA`, ...) that have no key beside them to key off.

## Test

`cargo test --no-default-features --lib --bins --tests` passes (the 4 `launcher::tests` failures are pre-existing on this machine and are SBS-839, unrelated). Desktop-feature tests `desktop::tests::export_*` pass locally.

Fixes SBS-889
Fixes SBS-890

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Redact credentials on all egress paths including split flag/value args and free-text error messages
> - Introduces `secret_arg_mask` in [registry.rs](https://github.com/tsouth89/toolport/pull/781/files#diff-8187fea44e15daa4059544c5fcff94f80f39fa1ec39c67eccccc153a98b39349) for slice-aware argv masking that correctly handles split flag/value pairs (e.g., `--token sk-...`) and joined forms (e.g., `--api-key=...`), leaving flag names visible while redacting values.
> - Introduces `redact_secret_text` for sanitizing arbitrary free-text (e.g., error reasons) by detecting and replacing credential-shaped substrings while preserving surrounding context.
> - Updates `safe_command_target` and `build_export` in [desktop.rs](https://github.com/tsouth89/toolport/pull/781/files#diff-fe6823673f9c91b7a17eb4b96e5bc54bc3c58e75d02ae0a2d2fae6f7ce03ecd5) and `team_server_export` in [teams.rs](https://github.com/tsouth89/toolport/pull/781/files#diff-cd8712bc1a5c6c56e55e867d15f3fb7aaf0c25b20186b10e164686e8f9926526) to use `secret_arg_mask` instead of per-argument `arg_looks_secret`.
> - Updates `audited_error_text` in [toolport-gateway.rs](https://github.com/tsouth89/toolport/pull/781/files#diff-fe5f13c01103f5adf39c870989b67ecdb11c19b3ba86b88c4acb028a7374cc01) to pass stored audit reasons through `redact_secret_text`.
> - Behavioral Change: split-flag credential values (e.g., `--token`, `sk-...` as separate argv entries) are now redacted in exports and diagnostics where they previously were not.
>
> #### 🖇️ Linked Issues
> Addresses [SBS-889](ticket:jira/SBS-889) and [SBS-890](ticket:jira/SBS-890).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 68c8537.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->