### PR TITLE
fix(security): create append-mode logs owner-only (SBS-868)

### DIFF
--- a/src-tauri/src/audit.rs
+++ b/src-tauri/src/audit.rs
@@ -590,12 +590,8 @@ fn write_line_at_with_rotation_hook(
             return;
         }
     };
-    let open = || {
-        std::fs::OpenOptions::new()
-            .create(true)
-            .append(true)
-            .open(&path)
-    };
+    // Owner-only from creation, not from the first rotation onward (SBS-868).
+    let open = || crate::registry::open_append_private(&path);
     // The registry normally created this directory before any call. Avoid a
     // redundant create-directory syscall on every append, but retain the
     // standalone/first-writer behavior by creating it and retrying on NotFound.

--- a/src-tauri/src/gatewaylog.rs
+++ b/src-tauri/src/gatewaylog.rs
@@ -65,11 +65,9 @@ pub(crate) fn append_to(path: &Path, msg: &str) {
 /// One `O_APPEND` write of the whole record, so even the unlocked fallback
 /// cannot interleave half a line with another writer's.
 fn append_line(path: &Path, msg: &str) {
-    if let Ok(mut f) = std::fs::OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(path)
-    {
+    // Owner-only from creation: this log carries the broker's bound HITL port
+    // (SBS-868).
+    if let Ok(mut f) = crate::registry::open_append_private(path) {
         let _ = f.write_all(format!("{msg}\n").as_bytes());
     }
 }

--- a/src-tauri/src/inspect.rs
+++ b/src-tauri/src/inspect.rs
@@ -95,11 +95,9 @@ fn write_line(entry: &Value) {
     if let Some(parent) = path.parent() {
         let _ = std::fs::create_dir_all(parent);
     }
-    if let Ok(mut file) = std::fs::OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(&path)
-    {
+    // Owner-only from creation: these are raw request and response bodies, so
+    // arguments that may carry secrets and PII (SBS-868).
+    if let Ok(mut file) = crate::registry::open_append_private(&path) {
         let _ = file.write_all(format!("{entry}\n").as_bytes());
     }
     ring_trim(&path);

--- a/src-tauri/src/integrity.rs
+++ b/src-tauri/src/integrity.rs
@@ -2886,7 +2886,9 @@ fn record_event(event: &Value) {
         if recently_recorded(event, &path) {
             return;
         }
-        if let Ok(mut file) = std::fs::OpenOptions::new().create(true).append(true).open(&path) {
+        // Owner-only from creation (SBS-868): drift events carry injection
+        // signatures and evidence snippets.
+        if let Ok(mut file) = crate::registry::open_append_private(&path) {
             // Single write_all (not writeln!, which issues several syscalls) so the many
             // client-spawned gateways sharing this file can't interleave into corrupt JSON.
             let _ = file.write_all(format!("{event}\n").as_bytes());

--- a/src-tauri/src/oauth.rs
+++ b/src-tauri/src/oauth.rs
@@ -191,11 +191,8 @@ fn debug_log(msg: &str) {
         if let Some(parent) = path.parent() {
             let _ = std::fs::create_dir_all(parent);
         }
-        if let Ok(mut f) = std::fs::OpenOptions::new()
-            .create(true)
-            .append(true)
-            .open(&path)
-        {
+        // Owner-only from creation (SBS-868).
+        if let Ok(mut f) = crate::registry::open_append_private(&path) {
             let _ = writeln!(f, "{msg}");
         }
     }

--- a/src-tauri/src/registry.rs
+++ b/src-tauri/src/registry.rs
@@ -22,6 +22,30 @@ const REGISTRY_VERSION: u32 = 1;
 /// Per-process counter for unique atomic-write temp names.
 static ATOMIC_WRITE_SEQ: AtomicU64 = AtomicU64::new(0);
 
+/// Open an append-mode log, creating it owner-only.
+///
+/// The plain `OpenOptions::new().create(true).append(true)` pattern takes the
+/// process umask, which under the usual 022 lands 0644: world-readable. These
+/// files only became 0600 on their FIRST size-triggered rotation, because
+/// rotation goes through [`atomic_write`], which sets the mode before writing.
+/// So every append-mode log was readable by a second OS user from creation until
+/// its first rotation, including `gateway.log`, which publishes the HITL broker's
+/// bound port, and `inspect`'s raw request and response bodies (SBS-868).
+///
+/// The mode is applied at creation, not after: setting it afterwards leaves a
+/// window in which the file exists world-readable. On Windows this is a no-op,
+/// the same way [`AtomicWriteOps::set_owner_only`] is.
+pub fn open_append_private(path: &Path) -> std::io::Result<std::fs::File> {
+    let mut options = std::fs::OpenOptions::new();
+    options.create(true).append(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    options.open(path)
+}
+
 trait AtomicWriteOps {
     fn set_owner_only(&self, file: &std::fs::File) -> std::io::Result<()>;
     fn write_all(&self, file: &mut std::fs::File, contents: &[u8]) -> std::io::Result<()>;

--- a/src-tauri/src/registry.rs
+++ b/src-tauri/src/registry.rs
@@ -32,9 +32,25 @@ static ATOMIC_WRITE_SEQ: AtomicU64 = AtomicU64::new(0);
 /// its first rotation, including `gateway.log`, which publishes the HITL broker's
 /// bound port, and `inspect`'s raw request and response bodies (SBS-868).
 ///
-/// The mode is applied at creation, not after: setting it afterwards leaves a
-/// window in which the file exists world-readable. On Windows this is a no-op,
-/// the same way [`AtomicWriteOps::set_owner_only`] is.
+/// Two halves, because one is not enough:
+///
+/// 1. `mode(0o600)` at open, so a file this creates is never BORN 0644. Setting
+///    the mode after creating it would leave a window in which the file exists
+///    world-readable.
+/// 2. A tighten pass on the opened handle, because `mode()` is an `open(2)`
+///    create mask and POSIX applies it only when the inode is born. Every file
+///    that already exists from a build before this one is 0644 and would stay
+///    0644 forever: `oauth-debug.log` never rotates, and `inspect.jsonl` is not
+///    opened at all while capture is off, so neither ever reaches
+///    [`atomic_write`]'s 0600 rewrite. Without this an upgrade fixes nothing for
+///    an existing install, which is every install.
+///
+/// The tighten is scoped to the file being written, at the moment of writing,
+/// and only when the mode is actually wider - the same rule `atomic_write`
+/// already applies on rotation. It is not a startup sweep over the data dir.
+///
+/// On Windows both halves are a no-op, the same way
+/// [`AtomicWriteOps::set_owner_only`] is.
 pub fn open_append_private(path: &Path) -> std::io::Result<std::fs::File> {
     let mut options = std::fs::OpenOptions::new();
     options.create(true).append(true);
@@ -43,7 +59,16 @@ pub fn open_append_private(path: &Path) -> std::io::Result<std::fs::File> {
         use std::os::unix::fs::OpenOptionsExt;
         options.mode(0o600);
     }
-    options.open(path)
+    let file = options.open(path)?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mode = file.metadata()?.permissions().mode();
+        if mode & 0o177 != 0 {
+            file.set_permissions(std::fs::Permissions::from_mode(0o600))?;
+        }
+    }
+    Ok(file)
 }
 
 trait AtomicWriteOps {

--- a/src-tauri/src/savings.rs
+++ b/src-tauri/src/savings.rs
@@ -124,11 +124,8 @@ fn append_line(entry: &Value) {
         if let Some(parent) = path.parent() {
             let _ = std::fs::create_dir_all(parent);
         }
-        if let Ok(mut file) = std::fs::OpenOptions::new()
-            .create(true)
-            .append(true)
-            .open(&path)
-        {
+        // Owner-only from creation (SBS-868).
+        if let Ok(mut file) = crate::registry::open_append_private(&path) {
             let _ = file.write_all(format!("{entry}\n").as_bytes());
         }
         rotate_if_large(&path);

--- a/src-tauri/src/searchtrace.rs
+++ b/src-tauri/src/searchtrace.rs
@@ -114,11 +114,9 @@ fn write_line(entry: &Value) {
     if let Some(parent) = path.parent() {
         let _ = std::fs::create_dir_all(parent);
     }
-    if let Ok(mut file) = std::fs::OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(&path)
-    {
+    // Owner-only from creation (SBS-868): these are the model's queries and the
+    // tool names they matched.
+    if let Ok(mut file) = crate::registry::open_append_private(&path) {
         let _ = file.write_all(format!("{entry}\n").as_bytes());
     }
     rotate_if_large(&path);

--- a/src-tauri/tests/private_logs.rs
+++ b/src-tauri/tests/private_logs.rs
@@ -13,15 +13,18 @@
 //! the control meant to keep another OS user out, and this log routed around it.
 //!
 //! Every production writer now goes through `registry::open_append_private`,
-//! which applies the mode AT creation - setting it afterwards would leave a
-//! window in which the file exists world-readable.
+//! which applies the mode at creation AND tightens a file that already exists -
+//! `mode()` is an `open(2)` create mask, so without the second half an upgrade
+//! would leave every existing 0644 log exactly as it was.
 
 use std::path::{Path, PathBuf};
 
-/// The only files allowed to spell the raw append-open themselves: the helper
-/// that defines the safe pattern, and a test-only binary that writes a
-/// transcript into a temp dir.
-const EXEMPT: [&str; 2] = ["registry.rs", "mock-mcp-server.rs"];
+/// The only files allowed to spell the raw append-open themselves, by path
+/// relative to `src-tauri/`: the helper that defines the safe pattern, and a
+/// test-only binary that writes a transcript into a temp dir. Matched on the
+/// full relative path, not the basename, so a future `foo/registry.rs` is not
+/// silently exempt too.
+const EXEMPT: [&str; 2] = ["src/registry.rs", "src/bin/mock-mcp-server.rs"];
 
 fn rust_sources(dir: &Path, out: &mut Vec<PathBuf>) {
     let entries = std::fs::read_dir(dir).unwrap_or_else(|e| panic!("read {}: {e}", dir.display()));
@@ -35,22 +38,38 @@ fn rust_sources(dir: &Path, out: &mut Vec<PathBuf>) {
     }
 }
 
+/// True when `source` opens a file in append mode anywhere.
+///
+/// Whitespace is stripped first, so `.append ( true )` and a call broken across
+/// lines by a formatter are the same match as `.append(true)`. A literal
+/// substring search would miss both, which would let the pattern back in through
+/// nothing more than a reformat.
+fn opens_in_append_mode(source: &str) -> bool {
+    let dense: String = source.chars().filter(|c| !c.is_whitespace()).collect();
+    dense.contains(".append(true)")
+}
+
 #[test]
 fn no_production_log_opens_append_mode_directly() {
-    let src = PathBuf::from(concat!(env!("CARGO_MANIFEST_DIR"), "/src"));
+    let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let src = manifest.join("src");
     let mut files = Vec::new();
     rust_sources(&src, &mut files);
     assert!(!files.is_empty(), "no sources found under {}", src.display());
 
     let mut offenders = Vec::new();
     for file in files {
-        let name = file.file_name().unwrap().to_string_lossy().to_string();
-        if EXEMPT.contains(&name.as_str()) {
+        let relative = file
+            .strip_prefix(&manifest)
+            .unwrap_or(&file)
+            .to_string_lossy()
+            .replace('\\', "/");
+        if EXEMPT.contains(&relative.as_str()) {
             continue;
         }
         let text = std::fs::read_to_string(&file).unwrap_or_else(|e| panic!("read {file:?}: {e}"));
-        if text.contains(".append(true)") {
-            offenders.push(name);
+        if opens_in_append_mode(&text) {
+            offenders.push(relative);
         }
     }
     assert!(
@@ -61,32 +80,100 @@ fn no_production_log_opens_append_mode_directly() {
     );
 }
 
-/// The helper's actual effect, which the source scan above cannot check.
+/// The scan above is only worth having if it still bites when the call is
+/// spelled differently, which is how a guard like this usually dies.
+#[test]
+fn the_append_scan_survives_reformatting() {
+    assert!(opens_in_append_mode(".append(true)"));
+    assert!(opens_in_append_mode(". append ( true )"));
+    assert!(opens_in_append_mode(
+        "std::fs::OpenOptions::new()\n    .create(true)\n    .append(true)\n"
+    ));
+    assert!(!opens_in_append_mode(".append(false)"));
+    assert!(!opens_in_append_mode("appended(true)"));
+}
+
+/// The helper's effect on a file it CREATES.
 #[cfg(unix)]
 #[test]
 fn open_append_private_creates_an_owner_only_file() {
     use std::io::Write;
     use std::os::unix::fs::PermissionsExt;
 
-    let dir = std::env::temp_dir().join(format!("toolport-sbs868-{}", std::process::id()));
-    std::fs::create_dir_all(&dir).expect("temp dir");
+    let dir = temp_dir("create");
     let path = dir.join("gateway.log");
-    let _ = std::fs::remove_file(&path);
 
     let mut file = conduit_lib::registry::open_append_private(&path).expect("create log");
-    file.write_all(b"[broker] bound 127.0.0.1:54321\n").expect("write");
+    file.write_all(b"[broker] bound 127.0.0.1:54321\n")
+        .expect("write");
 
-    let mode = std::fs::metadata(&path).expect("stat").permissions().mode() & 0o777;
     assert_eq!(
-        mode, 0o600,
-        "the log was created {mode:o}, so a second OS user can read the broker port"
+        mode_of(&path),
+        0o600,
+        "the log was created {:o}, so a second OS user can read the broker port",
+        mode_of(&path)
     );
 
-    // Appending again must not widen it either.
-    let mut again = conduit_lib::registry::open_append_private(&path).expect("reopen log");
-    again.write_all(b"second line\n").expect("write");
-    let mode = std::fs::metadata(&path).expect("stat").permissions().mode() & 0o777;
-    assert_eq!(mode, 0o600, "reopening widened the mode to {mode:o}");
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// The half a create-time mode cannot cover, and the one that decides whether
+/// SBS-868 is fixed for anyone who already has these files.
+///
+/// `OpenOptionsExt::mode` is an `open(2)` create mask: POSIX applies it only
+/// when the inode is born. Every install upgrading into this change already has
+/// `gateway.log`, `inspect.jsonl`, `oauth-debug.log` and the rest sitting at
+/// 0644, and `oauth-debug.log` never rotates while `inspect.jsonl` is not opened
+/// at all when capture is off, so neither would ever reach `atomic_write`'s 0600
+/// rewrite.
+///
+/// This is also the assertion that cannot pass by accident: it sets 0644
+/// explicitly rather than relying on the umask, so removing the tighten fails it
+/// on any host, including one hardened to umask 077.
+#[cfg(unix)]
+#[test]
+fn open_append_private_tightens_a_file_that_is_already_world_readable() {
+    use std::io::Write;
+    use std::os::unix::fs::PermissionsExt;
+
+    let dir = temp_dir("tighten");
+    let path = dir.join("gateway.log");
+
+    // A log left behind by a build before this change.
+    std::fs::write(&path, "[broker] bound 127.0.0.1:54321\n").expect("seed log");
+    std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644)).expect("chmod 0644");
+    assert_eq!(mode_of(&path), 0o644, "fixture did not take");
+
+    let mut file = conduit_lib::registry::open_append_private(&path).expect("reopen log");
+    file.write_all(b"second line\n").expect("write");
+
+    assert_eq!(
+        mode_of(&path),
+        0o600,
+        "an existing log stayed {:o}: mode() only applies at creation, so the \
+         upgrade path fixes nothing without an explicit tighten",
+        mode_of(&path)
+    );
+    // The tighten must not cost the contents.
+    let body = std::fs::read_to_string(&path).expect("read back");
+    assert!(body.contains("bound 127.0.0.1:54321") && body.contains("second line"));
 
     let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[cfg(unix)]
+fn temp_dir(label: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!(
+        "toolport-sbs868-{label}-{}",
+        std::process::id()
+    ));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).expect("temp dir");
+    dir
+}
+
+#[cfg(unix)]
+fn mode_of(path: &Path) -> u32 {
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::metadata(path).expect("stat").permissions().mode() & 0o777
 }

--- a/src-tauri/tests/private_logs.rs
+++ b/src-tauri/tests/private_logs.rs
@@ -1,0 +1,92 @@
+//! Regression guard for append-mode log permissions (SBS-868).
+//!
+//! Ten log writers opened their file with a bare
+//! `OpenOptions::new().create(true).append(true)`, which takes the process umask
+//! and lands 0644 under the usual 022. They only became owner-only on their
+//! FIRST size-triggered rotation, because rotation goes through
+//! `registry::atomic_write`, which sets the mode before writing. So each one was
+//! readable by a second OS user from creation until its first rotation.
+//!
+//! That mattered most for `gateway.log`: it carries the line
+//! `[broker] bound 127.0.0.1:<port>; endpoint published at <path>`, which
+//! publishes the HITL broker's port. The 0600 on `approval-endpoint.json` was
+//! the control meant to keep another OS user out, and this log routed around it.
+//!
+//! Every production writer now goes through `registry::open_append_private`,
+//! which applies the mode AT creation - setting it afterwards would leave a
+//! window in which the file exists world-readable.
+
+use std::path::{Path, PathBuf};
+
+/// The only files allowed to spell the raw append-open themselves: the helper
+/// that defines the safe pattern, and a test-only binary that writes a
+/// transcript into a temp dir.
+const EXEMPT: [&str; 2] = ["registry.rs", "mock-mcp-server.rs"];
+
+fn rust_sources(dir: &Path, out: &mut Vec<PathBuf>) {
+    let entries = std::fs::read_dir(dir).unwrap_or_else(|e| panic!("read {}: {e}", dir.display()));
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            rust_sources(&path, out);
+        } else if path.extension().is_some_and(|e| e == "rs") {
+            out.push(path);
+        }
+    }
+}
+
+#[test]
+fn no_production_log_opens_append_mode_directly() {
+    let src = PathBuf::from(concat!(env!("CARGO_MANIFEST_DIR"), "/src"));
+    let mut files = Vec::new();
+    rust_sources(&src, &mut files);
+    assert!(!files.is_empty(), "no sources found under {}", src.display());
+
+    let mut offenders = Vec::new();
+    for file in files {
+        let name = file.file_name().unwrap().to_string_lossy().to_string();
+        if EXEMPT.contains(&name.as_str()) {
+            continue;
+        }
+        let text = std::fs::read_to_string(&file).unwrap_or_else(|e| panic!("read {file:?}: {e}"));
+        if text.contains(".append(true)") {
+            offenders.push(name);
+        }
+    }
+    assert!(
+        offenders.is_empty(),
+        "these files open an append-mode log directly, so it is created \
+         world-readable under the usual umask (SBS-868): {offenders:?}. Use \
+         registry::open_append_private instead."
+    );
+}
+
+/// The helper's actual effect, which the source scan above cannot check.
+#[cfg(unix)]
+#[test]
+fn open_append_private_creates_an_owner_only_file() {
+    use std::io::Write;
+    use std::os::unix::fs::PermissionsExt;
+
+    let dir = std::env::temp_dir().join(format!("toolport-sbs868-{}", std::process::id()));
+    std::fs::create_dir_all(&dir).expect("temp dir");
+    let path = dir.join("gateway.log");
+    let _ = std::fs::remove_file(&path);
+
+    let mut file = conduit_lib::registry::open_append_private(&path).expect("create log");
+    file.write_all(b"[broker] bound 127.0.0.1:54321\n").expect("write");
+
+    let mode = std::fs::metadata(&path).expect("stat").permissions().mode() & 0o777;
+    assert_eq!(
+        mode, 0o600,
+        "the log was created {mode:o}, so a second OS user can read the broker port"
+    );
+
+    // Appending again must not widen it either.
+    let mut again = conduit_lib::registry::open_append_private(&path).expect("reopen log");
+    again.write_all(b"second line\n").expect("write");
+    let mode = std::fs::metadata(&path).expect("stat").permissions().mode() & 0o777;
+    assert_eq!(mode, 0o600, "reopening widened the mode to {mode:o}");
+
+    let _ = std::fs::remove_dir_all(&dir);
+}


### PR DESCRIPTION
## What

Ten log writers opened their file with a bare `OpenOptions::new().create(true).append(true)`. That takes the process umask, which under the usual 022 lands **0644, world-readable**. They only became 0600 on their FIRST size-triggered rotation, because rotation goes through `registry::atomic_write`, which sets the mode before writing. So every one was readable by a second OS user from creation until its first rotation.

## The one that matters

`log_broker_event` writes this into `gateway.log`:

```
[broker] bound 127.0.0.1:<port>; endpoint published at <path>
```

That publishes the HITL broker's port world-readably. Combined with SBS-867 (the approval **decision** channel has no authentication), a second OS user on a shared machine can read the port, wait for the app to quit (the descriptor is only removed on `RunEvent::Exit`), bind the freed port, receive full `ApprovalRequest` payloads including **rehydrated PII values** on the release gate, and reply `"approved"`.

The 0600 on `approval-endpoint.json` was the control meant to keep that user out. This log routed around it. Defence in depth only: SBS-867 is the real fix.

`inspect.log` is the worst for content, since it holds raw request and response bodies, world-readable until the 50th entry triggers `ring_trim`.

## Changes

- `registry::open_append_private` sets 0600 **at creation**. Setting it afterwards would leave a window in which the file exists world-readable. No-op on Windows, the same way `atomic_write`'s `set_owner_only` is
- all seven production writers move onto it: `audit`, `gatewaylog`, `inspect`, `integrity`, `oauth`, `savings`, `searchtrace`. `approval_broker` and `downstream` log through `gatewaylog`, so those two sites are covered by the same change
- `bin/mock-mcp-server.rs` is left alone (test-only, temp dir)

## Test

`tests/private_logs.rs` does two things: asserts the created mode is 0600 on Unix, and scans the source so a future writer cannot reintroduce the bare pattern, which is how ten of these accumulated in the first place.

Verified on both platforms: Windows `cargo test --no-default-features --lib --bins --tests` (the 4 `launcher::tests` failures are pre-existing and are SBS-839), and the Unix mode test under WSL Ubuntu-24.04, where both tests pass.

Fixes SBS-868

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix log files to be created with owner-only (0600) permissions on Unix
> - Adds `open_append_private` in [registry.rs](https://github.com/tsouth89/toolport/pull/782/files#diff-8187fea44e15daa4059544c5fcff94f80f39fa1ec39c67eccccc153a98b39349), a helper that opens files with create+append semantics and enforces 0600 permissions on Unix — setting the mode before creation and tightening any existing broader permissions after open.
> - Replaces direct `OpenOptions` append-open calls across audit, gateway, inspect, integrity, oauth, savings, and search trace log writers with `open_append_private`.
> - Adds tests in [private_logs.rs](https://github.com/tsouth89/toolport/pull/782/files#diff-5bbf06df17308446f8cc09acd440919904b00f07fd40709a10da81b7d7fd53df) that verify new files are created 0600, existing world-readable files are tightened to 0600, and no production source file opens append-mode logs directly.
> - Behavioral Change: existing log files with group or world read/write bits will have those bits removed on the next append; Windows behavior is unchanged.
>
> #### 🖇️ Linked Issues
> Addresses SBS-868 (referenced in PR title; no ticket system link provided).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2d9ffaf.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->