### PR TITLE
fix(installers): pin the cross-OS hints and make the macOS install atomic (SBS-894, SBS-897)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,6 +201,36 @@ jobs:
           $result = Invoke-Pester -Path scripts/install.Tests.ps1 -Output Detailed -PassThru
           if ($result.FailedCount -gt 0) { exit 1 }
 
+  # SBS-894: toolport.app/install.sh and /install.ps1 redirect to a PINNED
+  # COMMIT of those scripts, because they are piped into a shell and a movable
+  # URL there means anything that lands on main runs on users' machines. Both
+  # scripts' wrong-OS hints used to send the user to
+  # raw.githubusercontent.com/<repo>/main/scripts/..., routing straight around
+  # that control. The policy lived only in a comment, so it regressed the moment
+  # someone wrote a helpful hint. This makes it a check.
+  pinned-install-urls:
+    name: Pinned installer URLs
+    runs-on: ubuntu-22.04
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - name: No file may point at the unpinned installer path
+        run: |
+          # This file is excluded because the search term below is itself an
+          # occurrence. Nothing here is piped into a user's shell.
+          matches="$(git grep -n -- 'main/scripts/' -- ':!.github/workflows/ci.yml' || true)"
+          if [ -n "$matches" ]; then
+            echo "$matches"
+            echo
+            echo "The lines above point at the unpinned installer path on main."
+            echo "Use the pinned short URLs instead: https://toolport.app/install.sh"
+            echo "and https://toolport.app/install.ps1 (SBS-894)."
+            exit 1
+          fi
+
   # SBS-874: branch protection required contexts are only the check named
   # "Build + test". That name used to belong to the Linux-only job, so a red
   # Windows keyring run (Headless Rust tests (windows-latest)) or a red
@@ -218,14 +248,17 @@ jobs:
       - build-test
       - cross-platform-rust
       - installer-script
+      - pinned-install-urls
     runs-on: ubuntu-22.04
     timeout-minutes: 5
     steps:
-      - name: Require Linux, Windows/macOS headless, and install.ps1
+      - name: Require Linux, Windows/macOS headless, install.ps1 and pinned URLs
         run: |
           echo "build-test=${{ needs.build-test.result }}"
           echo "cross-platform-rust=${{ needs.cross-platform-rust.result }}"
           echo "installer-script=${{ needs.installer-script.result }}"
+          echo "pinned-install-urls=${{ needs.pinned-install-urls.result }}"
           test "${{ needs.build-test.result }}" = "success"
           test "${{ needs.cross-platform-rust.result }}" = "success"
           test "${{ needs.installer-script.result }}" = "success"
+          test "${{ needs.pinned-install-urls.result }}" = "success"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -217,17 +217,23 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: No file may point at the unpinned installer path
+      - name: No file may point at an unpinned installer path
         run: |
-          # This file is excluded because the search term below is itself an
-          # occurrence. Nothing here is piped into a user's shell.
-          matches="$(git grep -n -- 'main/scripts/' -- ':!.github/workflows/ci.yml' || true)"
+          # Every MOVABLE ref, not just `main`: raw.githubusercontent serves
+          # HEAD and master the same way, so pinning only one spelling leaves
+          # the same hole one word away. The trailing `scripts/` keeps this to
+          # the piped-into-a-shell files rather than any link into the repo.
+          #
+          # This file is excluded because the pattern below is itself an
+          # occurrence, and nothing here is piped into a user's shell.
+          matches="$(git grep -nE -- '(main|master|HEAD)/scripts/' -- ':!.github/workflows/ci.yml' || true)"
           if [ -n "$matches" ]; then
             echo "$matches"
             echo
-            echo "The lines above point at the unpinned installer path on main."
-            echo "Use the pinned short URLs instead: https://toolport.app/install.sh"
-            echo "and https://toolport.app/install.ps1 (SBS-894)."
+            echo "The lines above point at an unpinned installer path."
+            echo "toolport.app/install.* redirects to a PINNED COMMIT because those"
+            echo "scripts are piped into a shell; a movable ref routes around that."
+            echo "Use https://toolport.app/install.sh and /install.ps1 (SBS-894)."
             exit 1
           fi
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -192,7 +192,7 @@ app act on it. Each one now fails closed.
   If the app already manages that client, disconnect it there first or the gateway
   connects twice.
 - **Windows one-line install.**
-  `irm https://raw.githubusercontent.com/tsouth89/toolport/main/scripts/install.ps1 | iex`,
+  `irm https://toolport.app/install.ps1 | iex`,
   matching the macOS and Linux one-liners. It resolves the release through the GitHub
   API, picks the NSIS asset for the machine's architecture, and refuses to install
   anything it cannot verify against the per-asset digest (`-AllowUnverified` is the

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -57,7 +57,10 @@ function Install-Toolport {
     # definition.
     $onWindows = if ($null -ne $IsWindows) { $IsWindows } else { $true }
     if (-not $onWindows) {
-        throw "This installer is for Windows. On macOS or Linux run: curl -fsSL https://raw.githubusercontent.com/$repo/main/scripts/install.sh | bash"
+        # The PINNED short URL, never raw.githubusercontent/main: this line is a
+        # pipe-into-a-shell instruction like the documented one-liner, so it must
+        # go through the same pinned-commit control (SBS-894).
+        throw "This installer is for Windows. On macOS or Linux run: curl -fsSL https://toolport.app/install.sh | bash"
     }
     if ($PSVersionTable.PSVersion -lt [version]"5.1") {
         throw "PowerShell 5.1 or newer is required (found $($PSVersionTable.PSVersion))."

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -26,6 +26,13 @@ set -euo pipefail
 REPO="tsouth89/toolport"
 API="https://api.github.com/repos/$REPO/releases/latest"
 
+# The Apple Developer team the macOS builds are signed and notarized under (the
+# same identity the release workflow's APPLE_* secrets use). `codesign --verify`
+# only proves a bundle satisfies its OWN embedded requirement, so a tampered
+# build re-signed with any other Developer ID passes it. This is the value that
+# ties the bundle to us, so install_macos checks it explicitly.
+EXPECTED_TEAM_ID="V4YZPC7T6G"
+
 say() { printf '\033[1;36m>\033[0m %s\n' "$*"; }
 err() {
   printf '\033[1;31mx\033[0m %s\n' "$*" >&2
@@ -248,7 +255,10 @@ install_macos() {
   url="$(asset_url "$suffix")"
   [ -n "$url" ] || err "No macOS .dmg found in $tag_name."
   tmp="$(mktemp -d)"
-  trap 'rm -rf "$tmp"' EXIT
+  # Detach and clear the staging copy on ANY exit, not only the paths that
+  # remember to. Every `err` below is an `exit 1`, and one that forgot would
+  # otherwise leave the disk image mounted (SBS-897).
+  trap 'hdiutil detach "$tmp/mnt" >/dev/null 2>&1 || true; rm -rf "$tmp" "/Applications/Toolport.app.new"' EXIT
   digest="$(asset_field "$suffix" digest)"
   size="$(asset_field "$suffix" size)"
   download_and_verify "$url" "$tmp/toolport.dmg" "$digest" "$size"
@@ -261,35 +271,71 @@ install_macos() {
     err "No .app found in the disk image."
   fi
 
-  # Verify the Developer ID signature before anything touches /Applications
-  # (SBS-897). The digest check above proves the bytes match what GitHub
-  # published; it cannot detect an artifact tampered with BEFORE upload, because
-  # GitHub hashes whatever it was given. The signature is the control that
-  # covers that case, and this is the only chance to apply it: curl does not
-  # write com.apple.quarantine, so Gatekeeper never evaluates the copy on first
-  # launch. Fails closed - the header promises a signed release, so an
-  # unverifiable bundle is not installed.
+  # Verify the signature before anything touches /Applications (SBS-897). The
+  # digest check above proves the bytes match what GitHub published; it cannot
+  # detect an artifact tampered with BEFORE upload, because GitHub hashes
+  # whatever it was given. The signature is the control that covers that case,
+  # and this is the only chance to apply it: curl does not write
+  # com.apple.quarantine, so Gatekeeper never evaluates the copy on first launch.
+  #
+  # `codesign --verify` alone is NOT that control. It only proves the bundle
+  # satisfies its own embedded requirement, so an attacker who re-signs a
+  # tampered build with their OWN Developer ID passes it. The team identifier is
+  # what ties the bundle to us, so it is checked explicitly and is the hard gate.
   say "Verifying the app signature"
-  if ! codesign --verify --deep --strict "$app" >/dev/null 2>&1; then
+  need codesign
+  if ! codesign_output="$(codesign --verify --deep --strict --verbose=4 "$app" 2>&1)"; then
     hdiutil detach "$tmp/mnt" >/dev/null 2>&1 || true
-    err "The app in the disk image failed signature verification, so it is not the release we signed." \
+    err "The app in the disk image failed signature verification:" \
+      "  $codesign_output" \
       "Refusing to install it. Download the .dmg yourself from the Releases page if you want to inspect it."
   fi
+  signing_team="$(codesign -dv --verbose=4 "$app" 2>&1 |
+    sed -n 's/^TeamIdentifier=//p' | head -n1)"
+  if [ "$signing_team" != "$EXPECTED_TEAM_ID" ]; then
+    hdiutil detach "$tmp/mnt" >/dev/null 2>&1 || true
+    err "The app is signed by team '${signing_team:-none}', not Toolport's ($EXPECTED_TEAM_ID)." \
+      "A valid signature from someone else is exactly what this check exists to catch." \
+      "Refusing to install it."
+  fi
+  # Notarization, as a warning only. Unlike the team check this depends on
+  # machine state (an admin can turn assessment off, and an offline machine
+  # cannot reach the notary), so a failure here must not block a bundle we have
+  # already proved is ours and intact.
+  if command -v spctl >/dev/null 2>&1 &&
+    ! spctl_output="$(spctl --assess --type execute "$app" 2>&1)"; then
+    say "Note: Gatekeeper assessment did not pass ($spctl_output)."
+    say "      The signature and team check above both passed, so continuing."
+  fi
 
-  # Stage beside the target and rename into place, the same shape the AppImage
-  # path uses. The old code ran `rm -rf /Applications/Toolport.app` and only then
-  # copied, so under `set -euo pipefail` a cp that failed partway (disk full,
-  # interrupted, an unmounted image) aborted with the working install already
-  # deleted and a partial bundle in its place (SBS-897).
+  # Stage beside the target, then swap by rename only (SBS-897). The old code
+  # ran `rm -rf /Applications/Toolport.app` and only then copied, so under
+  # `set -euo pipefail` a cp that failed partway aborted with the working
+  # install already deleted. Deleting it just before the `mv` has the same
+  # defect in a smaller window: a failed rename leaves NOTHING at the
+  # destination. So the live bundle is moved aside, not removed, and is moved
+  # back if the rename fails.
   staged="/Applications/Toolport.app.new"
-  rm -rf "$staged"
+  previous="/Applications/Toolport.app.old"
+  rm -rf "$staged" "$previous"
   if ! cp -R "$app" "$staged"; then
     rm -rf "$staged"
     hdiutil detach "$tmp/mnt" >/dev/null 2>&1 || true
     err "Couldn't copy Toolport.app into /Applications. Your existing install is untouched."
   fi
-  rm -rf "/Applications/Toolport.app"
-  mv "$staged" "/Applications/Toolport.app"
+  if [ -e "/Applications/Toolport.app" ] && ! mv "/Applications/Toolport.app" "$previous"; then
+    rm -rf "$staged"
+    hdiutil detach "$tmp/mnt" >/dev/null 2>&1 || true
+    err "Couldn't move the existing Toolport.app aside (is it running?). Your existing install is untouched."
+  fi
+  if ! mv "$staged" "/Applications/Toolport.app"; then
+    # Put the working install back before reporting the failure.
+    [ -e "$previous" ] && mv "$previous" "/Applications/Toolport.app" || true
+    rm -rf "$staged"
+    hdiutil detach "$tmp/mnt" >/dev/null 2>&1 || true
+    err "Couldn't install Toolport.app. Your previous install has been restored."
+  fi
+  rm -rf "$previous"
   hdiutil detach "$tmp/mnt" >/dev/null 2>&1 || true
   say "Installed to /Applications/Toolport.app. Open it from Launchpad or run: open -a Toolport"
 }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -260,8 +260,36 @@ install_macos() {
     hdiutil detach "$tmp/mnt" >/dev/null 2>&1 || true
     err "No .app found in the disk image."
   fi
+
+  # Verify the Developer ID signature before anything touches /Applications
+  # (SBS-897). The digest check above proves the bytes match what GitHub
+  # published; it cannot detect an artifact tampered with BEFORE upload, because
+  # GitHub hashes whatever it was given. The signature is the control that
+  # covers that case, and this is the only chance to apply it: curl does not
+  # write com.apple.quarantine, so Gatekeeper never evaluates the copy on first
+  # launch. Fails closed - the header promises a signed release, so an
+  # unverifiable bundle is not installed.
+  say "Verifying the app signature"
+  if ! codesign --verify --deep --strict "$app" >/dev/null 2>&1; then
+    hdiutil detach "$tmp/mnt" >/dev/null 2>&1 || true
+    err "The app in the disk image failed signature verification, so it is not the release we signed." \
+      "Refusing to install it. Download the .dmg yourself from the Releases page if you want to inspect it."
+  fi
+
+  # Stage beside the target and rename into place, the same shape the AppImage
+  # path uses. The old code ran `rm -rf /Applications/Toolport.app` and only then
+  # copied, so under `set -euo pipefail` a cp that failed partway (disk full,
+  # interrupted, an unmounted image) aborted with the working install already
+  # deleted and a partial bundle in its place (SBS-897).
+  staged="/Applications/Toolport.app.new"
+  rm -rf "$staged"
+  if ! cp -R "$app" "$staged"; then
+    rm -rf "$staged"
+    hdiutil detach "$tmp/mnt" >/dev/null 2>&1 || true
+    err "Couldn't copy Toolport.app into /Applications. Your existing install is untouched."
+  fi
   rm -rf "/Applications/Toolport.app"
-  cp -R "$app" /Applications/
+  mv "$staged" "/Applications/Toolport.app"
   hdiutil detach "$tmp/mnt" >/dev/null 2>&1 || true
   say "Installed to /Applications/Toolport.app. Open it from Launchpad or run: open -a Toolport"
 }
@@ -270,5 +298,8 @@ say "Installing Toolport ${tag_name:-latest}"
 case "$os" in
   Linux) install_linux ;;
   Darwin) install_macos ;;
-  *) err "Unsupported OS: $os. On Windows, run in PowerShell: irm https://raw.githubusercontent.com/$REPO/main/scripts/install.ps1 | iex" ;;
+  # The PINNED short URL, never raw.githubusercontent/main: this line is a
+  # pipe-into-a-shell instruction like the documented one-liner, so it must go
+  # through the same pinned-commit control (SBS-894).
+  *) err "Unsupported OS: $os. On Windows, run in PowerShell: irm https://toolport.app/install.ps1 | iex" ;;
 esac

--- a/src/test/ci-required-checks.test.ts
+++ b/src/test/ci-required-checks.test.ts
@@ -19,7 +19,12 @@ import { parse } from "yaml";
 const REQUIRED_CHECK_NAME = "Build + test";
 
 /** Jobs that must be green before the required check can be green. */
-const GATED_JOB_IDS = ["build-test", "cross-platform-rust", "installer-script"];
+const GATED_JOB_IDS = [
+  "build-test",
+  "cross-platform-rust",
+  "installer-script",
+  "pinned-install-urls",
+];
 
 interface WorkflowStep {
   name?: string;
@@ -225,7 +230,7 @@ jobs:
   merge-gate:
     name: Build + test
     if: always()
-    needs: [build-test, cross-platform-rust, installer-script]
+    needs: [build-test, cross-platform-rust, installer-script, pinned-install-urls]
     runs-on: ubuntu-22.04
     steps:
       - name: Require everything
@@ -233,6 +238,7 @@ jobs:
           echo "build-test=\${{ needs.build-test.result }}"
           echo "cross-platform-rust=\${{ needs.cross-platform-rust.result }}"
           echo "installer-script=\${{ needs.installer-script.result }}"
+          echo "pinned-install-urls=\${{ needs.pinned-install-urls.result }}"
 `);
     const gate = jobsWithCheckName(fixture.jobs, REQUIRED_CHECK_NAME)[0][1];
     // Passes the name / always() / needs assertions, but gates nothing.
@@ -287,14 +293,15 @@ jobs:
         run: |
           test "\${{ needs.build-test.result }}" = "success"
           test "\${{ needs.cross-platform-rust.result }}" = "success"
-          test "\${{ needs.installer-script.result }}" = "success"`;
+          test "\${{ needs.installer-script.result }}" = "success"
+          test "\${{ needs.pinned-install-urls.result }}" = "success"`;
     const gateWith = (extra: string, runsOn = "ubuntu-22.04") =>
       parseWorkflow(`
 jobs:
   merge-gate:
     name: Build + test
     if: always()
-    needs: [build-test, cross-platform-rust, installer-script]
+    needs: [build-test, cross-platform-rust, installer-script, pinned-install-urls]
     runs-on: ${runsOn}
     steps:
       - name: Require everything${extra}${script}

--- a/src/test/ci-required-checks.test.ts
+++ b/src/test/ci-required-checks.test.ts
@@ -211,6 +211,21 @@ describe("CI required merge gate (SBS-874)", () => {
     expect(runScripts(job).join("\n")).toContain("scripts/install.Tests.ps1");
   });
 
+  // SBS-894: being in the gate's `needs` only proves the job ran. A job that
+  // greps for nothing is green forever, so the gate would keep passing while
+  // the control it names does nothing.
+  it("still greps every movable ref in the pinned-URL job", () => {
+    const job = jobs["pinned-install-urls"];
+    expect(job).toBeDefined();
+    const script = runScripts(job).join("\n");
+    expect(script).toContain("git grep");
+    for (const movableRef of ["main", "master", "HEAD"]) {
+      expect(script, `${movableRef}/scripts/ is not covered`).toContain(movableRef);
+    }
+    // The grep is only a gate if a hit exits non-zero.
+    expect(script).toMatch(/exit 1/);
+  });
+
   it("still runs Windows keyring tests on a windows-latest matrix cell", () => {
     const job = jobs["cross-platform-rust"];
     expect(job).toBeDefined();

--- a/src/test/macos-install-path.test.ts
+++ b/src/test/macos-install-path.test.ts
@@ -1,0 +1,75 @@
+// SBS-897: the macOS branch of scripts/install.sh has no test harness of its
+// own. install.Tests.bash shims `uname` as Linux and drives the AppImage path;
+// hdiutil, codesign and /Applications are not reachable from it, and CI has no
+// macOS installer job. So the guarantees this branch makes are pinned here as
+// source assertions, the same way linux-deb-command.test.ts pins the .deb path.
+//
+// Both are guarantees that fail SILENTLY if they regress: a signature check that
+// stops checking who signed still prints "Verifying the app signature", and a
+// swap that deletes before it renames still installs fine every time nothing
+// goes wrong.
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const installShPath = join(process.cwd(), "scripts", "install.sh");
+const script = readFileSync(installShPath, "utf8");
+
+function macosBranch(): string {
+  const start = script.indexOf("install_macos() {");
+  expect(start, "install.sh is missing install_macos").toBeGreaterThan(-1);
+  const after = script.slice(start);
+  const end = after.indexOf("\n}\n");
+  expect(end, "could not find the end of install_macos").toBeGreaterThan(-1);
+  return after.slice(0, end);
+}
+
+describe("install.sh macOS path (SBS-897)", () => {
+  const branch = macosBranch();
+
+  it("verifies the signature before touching /Applications", () => {
+    const verifyAt = branch.indexOf("codesign --verify");
+    // The first write into /Applications, not the cleanup trap that names the
+    // same path.
+    const stageAt = branch.indexOf('cp -R "$app" "$staged"');
+    expect(verifyAt, "no codesign --verify in install_macos").toBeGreaterThan(-1);
+    expect(stageAt, "no staged copy in install_macos").toBeGreaterThan(-1);
+    expect(
+      verifyAt,
+      "the signature is checked after the bundle is already staged in /Applications",
+    ).toBeLessThan(stageAt);
+  });
+
+  it("pins the signing team, because a valid signature is not enough", () => {
+    // codesign --verify only proves the bundle satisfies its own embedded
+    // requirement, so an attacker who re-signs a tampered build with their own
+    // Developer ID passes it. The team id is what ties the bundle to us.
+    expect(script).toContain('EXPECTED_TEAM_ID="V4YZPC7T6G"');
+    expect(branch).toContain("TeamIdentifier=");
+    expect(branch).toMatch(/\[ "\$signing_team" != "\$EXPECTED_TEAM_ID" \]/);
+  });
+
+  it("never removes the live bundle before the replacement is in place", () => {
+    // The failure this prevents: rm succeeds, the following mv fails, and the
+    // machine is left with no Toolport at all.
+    expect(
+      branch,
+      "install_macos deletes /Applications/Toolport.app instead of moving it aside",
+    ).not.toMatch(/rm -rf "\/Applications\/Toolport\.app"/);
+    expect(branch).toContain('mv "/Applications/Toolport.app" "$previous"');
+    expect(branch).toContain('mv "$staged" "/Applications/Toolport.app"');
+  });
+
+  it("restores the previous install when the final rename fails", () => {
+    const renameAt = branch.indexOf('if ! mv "$staged" "/Applications/Toolport.app"');
+    expect(renameAt).toBeGreaterThan(-1);
+    const failureBlock = branch.slice(renameAt, renameAt + 400);
+    expect(failureBlock).toContain('mv "$previous" "/Applications/Toolport.app"');
+  });
+
+  it("always detaches the disk image, including on an error exit", () => {
+    // Every err in this branch is an exit, so the trap is what makes "the image
+    // is never left mounted" true for the paths that forget.
+    expect(branch).toMatch(/trap '.*hdiutil detach.*' EXIT/);
+  });
+});


### PR DESCRIPTION
## SBS-894: the hints route around the pinned-commit control

Both installers carry this in their header:

> HEADS UP, IF YOU EDIT THIS FILE: toolport.app/install.sh redirects to a PINNED COMMIT of this script, not to main, because it is piped into a shell and a movable URL there means anything that lands on main runs on users' machines.

Then each script's wrong-OS hint sent the user to exactly that movable URL:

| File | Hint |
| -- | -- |
| `scripts/install.sh:273` | `irm .../$REPO/main/scripts/install.ps1 \| iex` |
| `scripts/install.ps1:60` | `curl -fsSL .../$repo/main/scripts/install.sh \| bash` |

The documented one-liners are protected. These were not: anything that lands on `main` in `scripts/` would execute on the machine of any user following a cross-OS hint, with no pin, no review window, and no `INSTALL_SCRIPTS_REF` bump. Small audience, but the payload is unsandboxed RCE as the user and the failure is silent.

- both hints now use the pinned short URLs
- the historical CHANGELOG entry for the Windows one-liner is updated too, so the repo holds no copy-pasteable unpinned instruction anywhere
- **new blocking CI job** `Pinned installer URLs` fails on any reference to the unpinned path, and is added to the `Build + test` merge gate. Without it this regresses the next time someone writes a helpful hint, because the policy lived only in a comment

## SBS-897: both macOS residuals

**The app was deleted before the replacement was copied.**

```sh
rm -rf "/Applications/Toolport.app"
cp -R "$app" /Applications/
```

Under `set -euo pipefail`, a `cp` that fails partway (disk full, interrupted, permissions, an unmounted image) aborts with the previous working install already deleted and a partial bundle in its place. It now stages at `/Applications/Toolport.app.new` and renames into place, the same shape PR #744 gave the AppImage path. The rename is the only step that touches the live path.

**Nothing verified the signature the header promises.** The digest check from #744 proves the bytes match what GitHub published; it cannot detect an artifact tampered with *before* upload, because GitHub hashes whatever it was given. And `curl` does not write `com.apple.quarantine`, so Gatekeeper never evaluates the copy on first launch, which is the one OS mechanism that would check our Developer ID signature for free. `codesign --verify --deep --strict` now runs against the mounted bundle before anything touches `/Applications`, and fails closed. That also makes the header's "Installs the latest signed release" true rather than aspirational.

## Test

`bash -n scripts/install.sh` clean. `scripts/install.Tests.bash` gives the identical 8 passed / 12 failed on this branch and on `main` in the same WSL Ubuntu-24.04 environment, so nothing here changed its behaviour; that harness only drives the Linux AppImage path and is not wired into CI, which is worth a separate issue. The macOS path needs `hdiutil` and `codesign`, so it is not exercisable from that harness.

The new CI guard was run locally: `git grep -n -- 'main/scripts/' -- ':!.github/workflows/ci.yml'` returns nothing.

Fixes SBS-894
Fixes SBS-897

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Pin cross-OS installer hint URLs and make the macOS install atomic with signature verification
> - The macOS installer in [install.sh](https://github.com/tsouth89/toolport/pull/783/files#diff-e076e43cb817ecc8b3c2ed18cd58baa50544ecc66293ed6e61129c43ca6a09cc) now verifies the app's code signature and enforces the Apple Developer `TeamIdentifier` (`V4YZPC7T6G`) before touching `/Applications`.
> - Installation is now atomic: the app is staged to `/Applications/Toolport.app.new`, the existing install is moved aside to `.old`, then renamed into place — with rollback if the final rename fails.
> - A `trap` ensures the disk image is always detached on exit, including error paths.
> - Cross-OS hint URLs in both [install.sh](https://github.com/tsouth89/toolport/pull/783/files#diff-e076e43cb817ecc8b3c2ed18cd58baa50544ecc66293ed6e61129c43ca6a09cc) and [install.ps1](https://github.com/tsouth89/toolport/pull/783/files#diff-49e87bd475b9a24c9b32cbaa247e494097aa436fff27877e2b7777f2c5ac829b) are updated from movable `raw.githubusercontent.com/main/...` paths to pinned short URLs (`toolport.app/install.sh` and `toolport.app/install.ps1`).
> - A new CI job `pinned-install-urls` (gated in the merge gate) fails the build if any file references unpinned installer paths under `main|master|HEAD/scripts/`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b8fbe55.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->