### PR TITLE
fix(tests): stop two suites depending on the developer's machine (SBS-839, SBS-827)

### DIFF
--- a/src-tauri/src/launcher.rs
+++ b/src-tauri/src/launcher.rs
@@ -90,11 +90,29 @@ pub fn resolve_direct(command: &str, args: &[String]) -> Option<DirectSpawn> {
 
 fn resolve_direct_uncached(command: &str, args: &[String]) -> Option<DirectSpawn> {
     let node = node_executable()?;
-    resolve_in(command, args, &npx_package_roots(), &node)
+    resolve_in(
+        command,
+        args,
+        &npx_package_roots(),
+        &node,
+        &crate::downstream::resolve_command,
+    )
 }
 
-/// The body of [`resolve_direct`], with the two pieces of machine state - where npm
-/// unpacks `_npx` packages, and where `node` lives - passed in.
+/// How the launcher finds a bare command name on this machine. Production passes
+/// [`crate::downstream::resolve_command`]; tests pass a fixture-scoped lookup.
+///
+/// This is the THIRD piece of machine state, and the one that was missed: an
+/// `npx_roots` fixture bounds the cache walk, but the shim fallback still asked
+/// the host PATH where `npx` lives. On a developer machine that answers, so four
+/// tests asserting "this spec must fall back to npx" resolved against whatever
+/// npm the developer had installed and failed on a clean checkout of main while
+/// CI stayed green (SBS-839).
+type CommandLookup<'a> = &'a dyn Fn(&str) -> String;
+
+/// The body of [`resolve_direct`], with the three pieces of machine state - where
+/// npm unpacks `_npx` packages, where `node` lives, and how a bare command name is
+/// found on PATH - passed in.
 ///
 /// Split out so tests drive the real resolution against a fixture tree instead of the
 /// developer's actual npm cache, and without mutating process-wide environment.
@@ -103,13 +121,14 @@ fn resolve_in(
     args: &[String],
     npx_roots: &[PathBuf],
     node: &Path,
+    lookup: CommandLookup,
 ) -> Option<DirectSpawn> {
     if let Some(plan) = parse_launcher(command, args) {
         if let Some(direct) = resolve_npx_plan(&plan, npx_roots, node) {
             return Some(direct);
         }
     }
-    resolve_shim(command, args, node)
+    resolve_shim(command, args, node, lookup)
 }
 
 // ---------------------------------------------------------------------------
@@ -520,8 +539,13 @@ impl Version {
 /// npm's shims end with a line that invokes node on a `"%dp0%\..\<pkg>\bin\cli.js"`
 /// path. That is a generated format rather than a documented one, so this only
 /// rewrites when it finds exactly one such path and that path is a real `.js` file.
-fn resolve_shim(command: &str, args: &[String], node: &Path) -> Option<DirectSpawn> {
-    let resolved = crate::downstream::resolve_command(command);
+fn resolve_shim(
+    command: &str,
+    args: &[String],
+    node: &Path,
+    lookup: CommandLookup,
+) -> Option<DirectSpawn> {
+    let resolved = lookup(command);
     let path = Path::new(&resolved);
     let ext = path.extension()?.to_str()?.to_ascii_lowercase();
     if ext != "cmd" && ext != "bat" {
@@ -669,6 +693,36 @@ mod tests {
         }
     }
 
+    /// A PATH on which nothing is installed. `resolve_command` echoes its input
+    /// back on a miss, so this is exactly what the production lookup returns for a
+    /// command that is not on the machine.
+    ///
+    /// Every fixture-driven resolution passes this. Without it the shim fallback
+    /// asks the DEVELOPER's PATH where `npx` is, which on a machine with npm
+    /// installed answers with a real shim - so four tests that assert a spec must
+    /// fall back to npx instead resolved against that install and failed on a
+    /// clean checkout, while CI (no npm shim in scope) stayed green (SBS-839).
+    fn nothing_on_path(command: &str) -> String {
+        command.to_string()
+    }
+
+    /// The production lookup, for the shim tests: they pass an ABSOLUTE path, which
+    /// `resolve_command` returns untouched on both platforms, so those tests drive
+    /// `resolve_shim` for real without a PATH search.
+    fn host_lookup(command: &str) -> String {
+        crate::downstream::resolve_command(command)
+    }
+
+    /// [`resolve_in`] against a fixture, with the host PATH out of scope.
+    fn resolve_fixture(
+        command: &str,
+        args: &[String],
+        roots: &[PathBuf],
+        node: &Path,
+    ) -> Option<DirectSpawn> {
+        resolve_in(command, args, roots, node, &nothing_on_path)
+    }
+
     impl Drop for Fixture {
         fn drop(&mut self) {
             let _ = std::fs::remove_dir_all(&self.root);
@@ -789,7 +843,7 @@ mod tests {
         );
         let node = fx.node();
 
-        let direct = resolve_in(
+        let direct = resolve_fixture(
             "npx",
             &s(&["-y", "toolport-mcp-servers", "vercel"]),
             &fx.roots(),
@@ -811,7 +865,7 @@ mod tests {
         let node = fx.node();
 
         let direct =
-            resolve_in("npx", &s(&["srv"]), &fx.roots(), &node).expect("string bin resolves");
+            resolve_fixture("npx", &s(&["srv"]), &fx.roots(), &node).expect("string bin resolves");
         // 1.10.0 > 1.9.0 numerically, which a string comparison would get wrong.
         assert!(
             direct.args[0].replace('\\', "/").contains("/new/"),
@@ -847,7 +901,7 @@ mod tests {
         let node = fx.node();
 
         let direct =
-            resolve_in("npx", &s(&["srv"]), &fx.roots(), &node).expect("cached package resolves");
+            resolve_fixture("npx", &s(&["srv"]), &fx.roots(), &node).expect("cached package resolves");
         assert!(
             direct.args[0].replace('\\', "/").contains("/rel/"),
             "expected the 1.4.0 release copy, got {}",
@@ -862,13 +916,13 @@ mod tests {
         let node = fx.node();
 
         assert!(
-            resolve_in("npx", &s(&["srv@2.0.0"]), &fx.roots(), &node).is_some(),
+            resolve_fixture("npx", &s(&["srv@2.0.0"]), &fx.roots(), &node).is_some(),
             "an exact match is safe to shortcut"
         );
         // A different version, a range, or a dist-tag all need the registry.
         for spec in ["srv@2.0.1", "srv@^2.0.0", "srv@latest"] {
             assert!(
-                resolve_in("npx", &s(&[spec]), &fx.roots(), &node).is_none(),
+                resolve_fixture("npx", &s(&[spec]), &fx.roots(), &node).is_none(),
                 "{spec} must fall back to npx"
             );
         }
@@ -881,9 +935,9 @@ mod tests {
         let node = fx.node();
 
         // Never installed.
-        assert!(resolve_in("npx", &s(&["other-srv"]), &fx.roots(), &node).is_none());
+        assert!(resolve_fixture("npx", &s(&["other-srv"]), &fx.roots(), &node).is_none());
         // Installed, but the bin the caller asked for is not one of its bins.
-        assert!(resolve_in("npx", &s(&["-p", "srv", "nope"]), &fx.roots(), &node).is_none());
+        assert!(resolve_fixture("npx", &s(&["-p", "srv", "nope"]), &fx.roots(), &node).is_none());
 
         // Manifest promises an entry that is not on disk.
         let fx2 = Fixture::new("dangling");
@@ -894,7 +948,7 @@ mod tests {
             r#"{"name":"srv","version":"1.0.0","bin":{"srv":"bin/gone.js"}}"#,
         )
         .unwrap();
-        assert!(resolve_in("npx", &s(&["srv"]), &fx2.roots(), &fx2.node()).is_none());
+        assert!(resolve_fixture("npx", &s(&["srv"]), &fx2.roots(), &fx2.node()).is_none());
     }
 
     /// A downloaded package's `bin` is untrusted input; it must not be able to point
@@ -926,7 +980,7 @@ mod tests {
         .unwrap();
 
         assert!(
-            resolve_in("npx", &s(&["srv"]), &fx.roots(), &fx.node()).is_none(),
+            resolve_fixture("npx", &s(&["srv"]), &fx.roots(), &fx.node()).is_none(),
             "a bin field pointing outside the package must not be spawned"
         );
     }
@@ -936,7 +990,7 @@ mod tests {
         let fx = Fixture::new("nonjs");
         // A package whose bin is a shell script, not something node can run.
         fx.package("h", "srv", "1.0.0", serde_json::json!({ "srv": "bin/cli.sh" }));
-        assert!(resolve_in("npx", &s(&["srv"]), &fx.roots(), &fx.node()).is_none());
+        assert!(resolve_fixture("npx", &s(&["srv"]), &fx.roots(), &fx.node()).is_none());
     }
 
     // ----- .cmd shim parsing -----------------------------------------------
@@ -996,7 +1050,8 @@ endLocal & goto #_undefined_# 2>NUL || title %COMSPEC% & "%_prog%"  "%dp0%\..\to
             &["..\\pkg\\bin\\cli.js"],
         );
 
-        let direct = resolve_shim(&shim, &s(&["--flag"]), &node).expect("shim must resolve");
+        let direct = resolve_shim(&shim, &s(&["--flag"]), &node, &host_lookup)
+            .expect("shim must resolve");
         assert_eq!(direct.command, node.to_string_lossy());
         assert!(direct.args[0].replace('\\', "/").ends_with("pkg/bin/cli.js"));
         assert_eq!(direct.args[1], "--flag", "shim args pass through");
@@ -1014,7 +1069,7 @@ endLocal & goto #_undefined_# 2>NUL || title %COMSPEC% & "%_prog%"  "%dp0%\..\to
             &["..\\pkg\\bin\\one.js", "..\\pkg\\bin\\two.js"],
         );
 
-        assert!(resolve_shim(&shim, &[], &node).is_none());
+        assert!(resolve_shim(&shim, &[], &node, &host_lookup).is_none());
     }
 
     /// A shim that climbs out of its own `node_modules` is refused, matching what
@@ -1032,7 +1087,7 @@ endLocal & goto #_undefined_# 2>NUL || title %COMSPEC% & "%_prog%"  "%dp0%\..\to
             &[],
         );
         assert!(outside.is_file(), "the decoy must exist for this to prove anything");
-        assert!(resolve_shim(&shim, &[], &node).is_none());
+        assert!(resolve_shim(&shim, &[], &node, &host_lookup).is_none());
     }
 
     #[test]
@@ -1044,7 +1099,7 @@ endLocal & goto #_undefined_# 2>NUL || title %COMSPEC% & "%_prog%"  "%dp0%\..\to
             "@ECHO off\r\n\"%dp0%\\..\\pkg\\bin\\cli.sh\" %*\r\n",
             &["..\\pkg\\bin\\cli.sh"],
         );
-        assert!(resolve_shim(&shim, &[], &node).is_none());
+        assert!(resolve_shim(&shim, &[], &node, &host_lookup).is_none());
     }
 
     #[test]

--- a/src-tauri/src/oauth.rs
+++ b/src-tauri/src/oauth.rs
@@ -756,20 +756,42 @@ pub(crate) fn ip_is_private(ip: &std::net::IpAddr) -> bool {
     }
 }
 
+/// How a host name becomes addresses. `Err` is NXDOMAIN, the case each caller
+/// below treats differently and the whole point of the #422 split.
+///
+/// Injectable because these three checks are the only DNS in the SSRF guard, and
+/// a test that wants to pin the unresolvable branch cannot get one from the
+/// network. RFC 2606 guarantees `.invalid` is never DELEGATED; it does not
+/// guarantee the local resolver returns NXDOMAIN, and ISP resolvers, captive
+/// portals, split-horizon corporate DNS and consumer routers routinely answer
+/// every query with a sinkhole address. When that address is private, the guard
+/// correctly says "private" and the test that assumed otherwise correctly fails.
+/// The test was wrong about its environment, not the code (SBS-827).
+pub(crate) type HostResolver<'a> = &'a dyn Fn(&str) -> Result<Vec<std::net::IpAddr>, ()>;
+
+/// The system resolver. A literal IP resolves to itself without touching DNS.
+pub(crate) fn resolve_host(host: &str) -> Result<Vec<std::net::IpAddr>, ()> {
+    use std::net::ToSocketAddrs;
+    match (host, 0u16).to_socket_addrs() {
+        Ok(addrs) => Ok(addrs.map(|sa| sa.ip()).collect()),
+        Err(_) => Err(()),
+    }
+}
+
 /// True if `host` is loopback, private, or link-local. Resolves DNS (literal IPs
 /// resolve to themselves); fails closed (treats an unresolvable host as private).
 pub fn host_is_private(host: &str) -> bool {
-    use std::net::ToSocketAddrs;
+    host_is_private_with(host, &resolve_host)
+}
+
+fn host_is_private_with(host: &str, resolve: HostResolver) -> bool {
     let h = host.trim().to_ascii_lowercase();
     if h.is_empty() || h == "localhost" || h.ends_with(".localhost") {
         return true;
     }
-    match (h.as_str(), 0u16).to_socket_addrs() {
-        Ok(addrs) => {
-            let ips: Vec<_> = addrs.map(|sa| sa.ip()).collect();
-            ips.is_empty() || ips.iter().any(ip_is_private)
-        }
-        Err(_) => true,
+    match resolve(&h) {
+        Ok(ips) => ips.is_empty() || ips.iter().any(ip_is_private),
+        Err(()) => true,
     }
 }
 
@@ -781,7 +803,10 @@ pub fn host_is_private(host: &str) -> bool {
 /// trust: an attacker who serves NXDOMAIN for their own domain cannot get it classified as
 /// local and thereby switch off the SSRF endpoint guard. See issue #422.
 pub fn host_is_definitely_private(host: &str) -> bool {
-    use std::net::ToSocketAddrs;
+    host_is_definitely_private_with(host, &resolve_host)
+}
+
+pub(crate) fn host_is_definitely_private_with(host: &str, resolve: HostResolver) -> bool {
     let h = host.trim().to_ascii_lowercase();
     if h.is_empty() {
         return false;
@@ -789,14 +814,11 @@ pub fn host_is_definitely_private(host: &str) -> bool {
     if h == "localhost" || h.ends_with(".localhost") {
         return true;
     }
-    match (h.as_str(), 0u16).to_socket_addrs() {
+    match resolve(&h) {
         // Confirmed local ONLY if it resolved to at least one address and every one is
         // private. A mix of private + public is not confirmed-local (fail safe: guard on).
-        Ok(addrs) => {
-            let ips: Vec<_> = addrs.map(|sa| sa.ip()).collect();
-            !ips.is_empty() && ips.iter().all(ip_is_private)
-        }
-        Err(_) => false,
+        Ok(ips) => !ips.is_empty() && ips.iter().all(ip_is_private),
+        Err(()) => false,
     }
 }
 
@@ -805,14 +827,17 @@ pub fn host_is_definitely_private(host: &str) -> bool {
 /// NOT link-local. Fails OPEN (false on an empty/unresolvable host) so the stricter
 /// `host_is_private` check downstream still catches those.
 pub fn host_is_link_local(host: &str) -> bool {
-    use std::net::ToSocketAddrs;
+    host_is_link_local_with(host, &resolve_host)
+}
+
+fn host_is_link_local_with(host: &str, resolve: HostResolver) -> bool {
     let h = host.trim().to_ascii_lowercase();
     if h.is_empty() || h == "localhost" || h.ends_with(".localhost") {
         return false;
     }
-    match (h.as_str(), 0u16).to_socket_addrs() {
-        Ok(addrs) => addrs.map(|sa| sa.ip()).any(|ip| ip_is_link_local(&ip)),
-        Err(_) => false,
+    match resolve(&h) {
+        Ok(ips) => ips.iter().any(ip_is_link_local),
+        Err(()) => false,
     }
 }
 
@@ -1751,25 +1776,38 @@ mod tests {
         assert!(!host_is_private("8.8.8.8"));
     }
 
+    /// A resolver that answers for literal IPs (which need no DNS) and NXDOMAINs
+    /// every NAME.
+    ///
+    /// This is what these tests always assumed the network would do for
+    /// `.invalid`, and what a resolver that hijacks NXDOMAIN does not do. Passing
+    /// it makes the unresolvable-host assertions mean what they claim instead of
+    /// asking whichever DNS the developer is behind for permission (SBS-827).
+    fn no_dns(host: &str) -> Result<Vec<std::net::IpAddr>, ()> {
+        host.parse::<std::net::IpAddr>()
+            .map(|ip| vec![ip])
+            .map_err(|_| ())
+    }
+
     #[test]
     fn host_is_definitely_private_requires_positive_confirmation() {
+        let confirmed = |h: &str| host_is_definitely_private_with(h, &no_dns);
         // Positively local: localhost and literal private IPs (no DNS needed).
-        assert!(host_is_definitely_private("localhost"));
-        assert!(host_is_definitely_private("foo.localhost"));
-        assert!(host_is_definitely_private("127.0.0.1"));
-        assert!(host_is_definitely_private("10.1.2.3"));
-        assert!(host_is_definitely_private("192.168.1.10"));
+        assert!(confirmed("localhost"));
+        assert!(confirmed("foo.localhost"));
+        assert!(confirmed("127.0.0.1"));
+        assert!(confirmed("10.1.2.3"));
+        assert!(confirmed("192.168.1.10"));
 
         // NOT confirmable, so NOT local: empty, public, and (the #422 fix) unresolvable.
-        // `.invalid` is guaranteed non-resolvable (RFC 2606), so this needs no network.
-        assert!(!host_is_definitely_private(""));
-        assert!(!host_is_definitely_private("8.8.8.8"));
-        assert!(!host_is_definitely_private("no-such-host-422.invalid"));
+        assert!(!confirmed(""));
+        assert!(!confirmed("8.8.8.8"));
+        assert!(!confirmed("no-such-host-422.invalid"));
 
         // The contrast that is the whole bug: host_is_private treats an unresolvable
         // host as private (fail closed, for refusing), but that must NOT grant local trust.
-        assert!(host_is_private("no-such-host-422.invalid"));
-        assert!(!host_is_definitely_private("no-such-host-422.invalid"));
+        assert!(host_is_private_with("no-such-host-422.invalid", &no_dns));
+        assert!(!confirmed("no-such-host-422.invalid"));
     }
 
     #[test]
@@ -1779,7 +1817,7 @@ mod tests {
         // true and made guard_endpoint a no-op, so a metadata doc pointing at 127.0.0.1
         // was accepted. With host_is_definitely_private it's false, so the guard still
         // refuses the internal endpoint.
-        let server_local = host_is_definitely_private("no-such-host-422.invalid");
+        let server_local = host_is_definitely_private_with("no-such-host-422.invalid", &no_dns);
         assert!(!server_local, "an unresolvable server host is not local");
         assert!(
             guard_endpoint("http://127.0.0.1:9999/token", server_local, "token").is_err(),
@@ -1787,7 +1825,7 @@ mod tests {
         );
 
         // A genuinely local server (literal private IP) still gets its local endpoints.
-        let local = host_is_definitely_private("192.168.1.10");
+        let local = host_is_definitely_private_with("192.168.1.10", &no_dns);
         assert!(local);
         assert!(guard_endpoint("http://127.0.0.1:9999/token", local, "token").is_ok());
     }

--- a/src-tauri/src/teams.rs
+++ b/src-tauri/src/teams.rs
@@ -79,8 +79,14 @@ fn require_secure_team_url(server_url: &str) -> Result<(), String> {
 /// public name whose first lookup merely fails - turned the guard off and let the
 /// connection land on RFC1918.
 fn block_private_for_team_url(server_url: &str) -> bool {
+    block_private_for_team_url_with(server_url, &crate::oauth::resolve_host)
+}
+
+/// [`block_private_for_team_url`] with the resolver passed in, so the NXDOMAIN case
+/// can be tested without asking whichever DNS the developer is behind (SBS-827).
+fn block_private_for_team_url_with(server_url: &str, resolve: crate::oauth::HostResolver) -> bool {
     let host = crate::oauth::host_of_url(server_url).unwrap_or_default();
-    !crate::oauth::host_is_definitely_private(&host)
+    !crate::oauth::host_is_definitely_private_with(&host, resolve)
 }
 
 /// A ureq agent with a connect + read timeout. The team commands run on the Tauri
@@ -2933,12 +2939,22 @@ mod tests {
     /// exactly the host an attacker controls the DNS for.
     #[test]
     fn an_unresolvable_team_host_still_blocks_private_targets() {
-        // `.invalid` is reserved never to resolve (RFC 2606), so this is the NXDOMAIN
-        // case with no network dependency.
-        assert!(block_private_for_team_url("https://no-such-host-422.invalid"));
+        // A resolver that answers for literal IPs and NXDOMAINs every name. RFC 2606
+        // reserves `.invalid` from DELEGATION, which is not a promise that the local
+        // resolver says NXDOMAIN - plenty of them sinkhole every query, and when the
+        // sinkhole is a private address this assertion inverts. Injecting the answer
+        // is what makes it the NXDOMAIN case rather than a question for the network
+        // (SBS-827).
+        fn no_dns(host: &str) -> Result<Vec<std::net::IpAddr>, ()> {
+            host.parse::<std::net::IpAddr>()
+                .map(|ip| vec![ip])
+                .map_err(|_| ())
+        }
+        let blocks = |url: &str| block_private_for_team_url_with(url, &no_dns);
+        assert!(blocks("https://no-such-host-422.invalid"));
         // An empty or unparseable host must not grant LAN trust either.
-        assert!(block_private_for_team_url("https://"));
-        assert!(block_private_for_team_url("not a url"));
+        assert!(blocks("https://"));
+        assert!(blocks("not a url"));
     }
 
     #[test]


### PR DESCRIPTION
## Why these are one PR

Same shape, same victim. A test claims to need no network or no host state, is wrong about that, and so passes in CI and fails on a contributor's machine. Someone runs `npm run test:rust` on a fresh clone, sees red, and cannot tell whether they broke something.

## SBS-839: four `launcher::tests` read the developer's npx cache

`resolve_in` already took the npx cache roots and the `node` path as fixtures. Its **shim fallback** did not: it asked the host PATH where `npx` lives. On any machine with npm installed that answers with a real shim, so these resolved against the developer's npm install:

```
launcher::tests::an_escaping_bin_path_is_refused_by_the_real_resolution
launcher::tests::an_exact_version_request_must_match_the_cached_copy
launcher::tests::falls_back_when_the_package_is_not_cached_or_the_entry_is_missing
launcher::tests::only_javascript_entries_are_rewritten
```

Failure message: `srv@2.0.1 must fall back to npx` — the fixture said fall back, the host's npm said resolve.

The PATH lookup is now the third injected piece of machine state. Fixture-driven tests pass a lookup on which nothing is installed, which is exactly what `resolve_command` returns for a miss. The shim tests keep the production lookup on purpose: they pass an absolute path, which it returns untouched on both platforms, so they still drive `resolve_shim` for real.

## SBS-827: `.invalid` is not a promise about your resolver

Reported by @forever-ivy on PR #724 while running the full suite before submitting. The test comment said:

> `.invalid` is guaranteed non-resolvable (RFC 2606), so this needs no network.

RFC 2606 guarantees the name is never **delegated**. It does not guarantee the local resolver returns NXDOMAIN. ISP resolvers, captive portals, split-horizon corporate DNS and consumer routers routinely answer every query with a sinkhole address, and when that address is private, `host_is_definitely_private` correctly returns true and the assertion correctly fails. The test was wrong about its environment, not the code.

Fixed the way the issue calls for (option 1, inject the resolver, not skip or document away): `host_is_private`, `host_is_definitely_private` and `host_is_link_local` take the resolver, and `teams::block_private_for_team_url` threads it through too. The tests pass one that answers for literal IPs (which need no DNS) and NXDOMAINs every name — what they always assumed the network would do. The #422 SSRF behaviour these pin is worth a deterministic test rather than one that asks the network for permission.

Covered: `oauth.rs` `host_is_definitely_private_requires_positive_confirmation` and `unresolvable_server_host_does_not_disable_the_ssrf_guard`, and `teams.rs` `an_unresolvable_team_host_still_blocks_private_targets`.

## Production behaviour

Unchanged in both. The public entry points are thin wrappers that pass the real PATH lookup and the system resolver.

## Test

`cargo test --no-default-features --lib --bins --tests` on a Windows dev machine: **1083 passed, 0 failed**, where four failed before this branch. `cargo check` with the desktop feature is clean, and the new code adds no clippy warnings.

Fixes SBS-839
Fixes SBS-827

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix test suites in launcher, oauth, and teams to not depend on developer machine state
> - Introduces injectable function pointer types (`CommandLookup` in [launcher.rs](https://github.com/tsouth89/toolport/pull/784/files#diff-c444b6dfa15cf2e4c1f64d1079e2ee1ad449d82cb50c2641333f1481f1a96edb), `HostResolver` in [oauth.rs](https://github.com/tsouth89/toolport/pull/784/files#diff-50cff2ae3eeec2d6db908a761f2902387ac0fc4a860aeffc8d19ac12051afc9b)) so tests can supply deterministic resolvers instead of relying on the host's PATH or DNS.
> - Adds `*_with` variants of `resolve_in`, `host_is_private`, `host_is_definitely_private`, `host_is_link_local`, and `block_private_for_team_url` that accept the injected resolver; production code delegates to these with the real system resolver.
> - Test helpers (`nothing_on_path`, `no_dns`) replace real lookups with no-ops or literal-IP passthrough, eliminating failures caused by captive DNS resolvers or unexpected PATH entries on a developer's machine.
>
> #### 🖇️ Linked Issues
> Addresses [SBS-839](ticket:jira/SBS-839) and [SBS-827](ticket:jira/SBS-827).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8c3925c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->