### PR TITLE
docs(changelog): reframe the 1.14.0 reliability paragraph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,10 +20,10 @@ more findings in the same family are closed here, along with a set of local-file
 permissions that were wider than intended and an installer that never checked who
 signed the build it was about to install.
 
-Underneath that is the same defect this project keeps finding in new places: code
-that reads a failed probe as good news. A failed reload signal, a failed vault read,
-a failed restart check, a failed backup stat could each come back looking like
-success. Each one now fails closed and says so.
+A run of hardening across the app, on one theme: a check that could not finish used
+to look exactly like a check that passed. A reload signal, a vault read, a restart
+check, a backup stat each had a failure path that came back looking like good news.
+They now report the failure, so what the app shows you is what it actually knows.
 
 ### Added
 


### PR DESCRIPTION
The 1.14.0 intro's third paragraph read as an apology for the codebase rather than a release note:

> Underneath that is the same defect this project keeps finding in new places: code that reads a failed probe as good news.

Replaced with the same facts framed as what the user gets:

> A run of hardening across the app, on one theme: a check that could not finish used to look exactly like a check that passed. A reload signal, a vault read, a restart check, a backup stat each had a failure path that came back looking like good news. They now report the failure, so what the app shows you is what it actually knows.

The security paragraph above it is deliberately left as-is. That one is a disclosure, and someone deciding whether to upgrade needs it stated plainly.

The v1.14.0 draft release body is a snapshot taken at tag time, so it does not pick this up automatically. I am updating the draft body to match once this merges.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reframe 1.14.0 reliability paragraph in CHANGELOG to clarify previous behavior
> Updates the introductory hardening paragraph in [CHANGELOG.md](https://github.com/tsouth89/toolport/pull/787/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed) to make clear that checks for reload signal, vault read, restart, and backup stat previously appeared as passes when incomplete, and now explicitly report failures.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e064017.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->