### PR TITLE
ci(winget): allow a manual catch-up submission (SBS-903)

### DIFF
--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -9,14 +9,27 @@ name: winget
 on:
   release:
     types: [released]
+  # Manual catch-up, because `release` fires exactly once per release and the
+  # submission can fail for a reason that resolves later. A NEW package waits in
+  # a moderation queue at winget-pkgs (community volunteers approve it), and
+  # `wingetcreate update` cannot run until that manifest is actually in the repo.
+  # So the approval can land days after the release whose job already failed,
+  # with no way to retry it. That is exactly what happened to 1.14.0 (SBS-903).
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to submit, e.g. v1.14.0"
+        required: true
+        type: string
 
 permissions:
   contents: read
 
 jobs:
   submit:
-    # Prereleases are not what `winget install` should hand people.
-    if: ${{ !github.event.release.prerelease }}
+    # Prereleases are not what `winget install` should hand people. On a manual
+    # run `github.event.release` is null, so the tag is checked below instead.
+    if: ${{ github.event_name == 'workflow_dispatch' || !github.event.release.prerelease }}
     runs-on: windows-latest
     env:
       # A PAT with `public_repo`, because GITHUB_TOKEN cannot push to the
@@ -24,8 +37,26 @@ jobs:
       # below no-ops, so adding this workflow cannot fail a release. Same
       # gating style as the Azure signing steps in release.yml.
       WINGET_TOKEN: ${{ secrets.WINGET_TOKEN }}
-      TAG: ${{ github.event.release.tag_name }}
+      TAG: ${{ github.event.release.tag_name || inputs.tag }}
     steps:
+      # The release trigger cannot fire for a draft or a prerelease, but a manual
+      # run can name any tag, so it gets the check the trigger gave us for free.
+      - name: Check the tag is a published, non-prerelease release
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          $ErrorActionPreference = "Stop"
+          $release = gh release view $env:TAG --repo ${{ github.repository }} --json isDraft,isPrerelease | ConvertFrom-Json
+          if ($release.isDraft) {
+            throw "$env:TAG is still a draft. winget validation downloads the installer URL, which 404s until the release is published."
+          }
+          if ($release.isPrerelease) {
+            throw "$env:TAG is a prerelease, which is not what ``winget install`` should hand people."
+          }
+          Write-Output "$env:TAG is published and is not a prerelease."
+
       - name: Submit the manifest update
         if: ${{ env.WINGET_TOKEN != '' }}
         shell: pwsh


### PR DESCRIPTION
## Why

`release: [released]` fires exactly once per release, and this submission can fail for a reason that resolves *later*.

A new package waits in a moderation queue at winget-pkgs, and `wingetcreate update` cannot run until that manifest is actually in the repo. So a moderator approving days after the fact leaves a version with no way to be submitted at all.

That is what happened here. [microsoft/winget-pkgs#417106](https://github.com/microsoft/winget-pkgs/pull/417106) (the 1.13.0 new-package submission) passed automated validation on Aug 13 and is still queued for a community volunteer. The v1.14.0 job therefore failed with `manifests/t/Toolport/Toolport was not found`, and there was no way to retry it once the manifest lands.

## Change

`workflow_dispatch` with the tag as an input, so a version can be submitted on demand once the manifest exists.

A manual run can name any tag, unlike the trigger, so it first checks the release is:

- **published** — winget validation downloads the installer URL, which 404s while the release is a draft (the same reason this workflow runs on `released` rather than on the tag)
- **not a prerelease** — the guard `if: !github.event.release.prerelease` gave us for free on the trigger path, which is null on a manual run

`TAG` resolves from `github.event.release.tag_name || inputs.tag`, so both paths feed the existing steps unchanged. The `WINGET_TOKEN` no-op gating is untouched.

## Test

`yaml.safe_load` parses it; triggers are `release` + `workflow_dispatch`, `TAG` and the job guard resolve as intended on both paths, and the step order is check → submit → explain-if-no-token. The submit step itself is unchanged, and it cannot be exercised without pushing a real submission to Microsoft.

## After this merges

Once #417106 is approved, run this workflow manually with `v1.14.0` to catch winget up.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add manual `workflow_dispatch` trigger to winget submission workflow
> - Adds a `workflow_dispatch` trigger with a required `tag` input to [winget.yml](https://github.com/tsouth89/toolport/pull/789/files#diff-3dff7c7e5f08f6f3163d130bec2c030f16b50bddf8d11a6b1d930592d7bd2434), allowing catch-up submissions without a release event.
> - On manual runs, a PowerShell step validates that the provided tag refers to a published, non-prerelease release via `gh release view`, failing early if it is a draft or prerelease.
> - The `TAG` env var falls back to `inputs.tag` when `github.event.release.tag_name` is absent (i.e. on manual runs).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 331e927.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->