### PR TITLE
build: cut debug info, and document the smallest test loop per change

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,8 +97,13 @@ which is also exactly what CI runs:
 
 ```bash
 cargo test --manifest-path src-tauri/Cargo.toml --no-default-features --lib
-cargo test --manifest-path src-tauri/Cargo.toml --no-default-features --lib registry
+cargo test --manifest-path src-tauri/Cargo.toml --no-default-features --lib clients
 ```
+
+A filter runs a different subset than the full suite does, which can expose test
+interference the whole run happens to avoid. If a filtered run fails, re-run the
+named test on its own before assuming your change caused it, and check whether
+it also fails on `main` (SBS-904 is one such case).
 
 **Only `desktop.rs` itself needs the full build.** That module is
 `#[cfg(feature = "desktop")]`, so a test you add there does not run under

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,6 +76,51 @@ matches CI. Frontend tests use [Vitest](https://vitest.dev) and live alongside
 the code as `*.test.ts` or `*.test.tsx` files inside `src/`, depending on whether
 the test contains JSX.
 
+### Run the smallest loop your change needs
+
+`npm run test:rust` builds with the `desktop` feature, which pulls Tauri and
+(on Linux) WebKitGTK: **528 crates against 288 without it**. On a laptop or a
+default 32G Codespace that is the difference between a build that finishes and
+one that fills the disk. Most changes do not need it.
+
+**Frontend only** (anything under `src/`, including every panel in
+`ActivityView.tsx` and `SettingsView.tsx`) needs no Rust build at all:
+
+```bash
+npm run test          # vitest
+npm run lint
+npx tsc --noEmit
+```
+
+**Rust outside `src-tauri/src/desktop.rs`** runs with the desktop feature off,
+which is also exactly what CI runs:
+
+```bash
+cargo test --manifest-path src-tauri/Cargo.toml --no-default-features --lib
+cargo test --manifest-path src-tauri/Cargo.toml --no-default-features --lib registry
+```
+
+**Only `desktop.rs` itself needs the full build.** That module is
+`#[cfg(feature = "desktop")]`, so a test you add there does not run under
+`--no-default-features` and therefore **does not run in CI either**, since every
+Rust job there passes that flag. If the logic you are fixing has no Tauri
+dependency (file reads, string formatting, path resolution), prefer moving the
+core into the module that owns it (`gatewaylog`, `registry`, `clients`, ...) and
+leaving a thin caller in `desktop.rs`. That makes it testable in the light loop
+and gets it CI coverage it would otherwise never have.
+
+If `target/` is still too large, `--lib` alone beats `--lib --bins --tests`,
+`cargo clean -p conduit` drops just this crate's artifacts, and
+`CARGO_TARGET_DIR=/some/other/volume` moves the whole thing off a full disk.
+
+### Let CI do the verifying
+
+CI runs the full matrix on **every pull request**, including the platforms most
+contributors do not have. You do not need a clean local run before opening one:
+push a draft PR and iterate on what CI reports. That is the intended path when
+your machine cannot build the whole project, and it is never treated as a lower
+grade of contribution.
+
 The GitHub required check is still named **Build + test**. That name is a
 merge gate over the Linux suite, the headless Rust matrix (the Windows
 keyring tests live on `windows-latest`), and the `install.ps1` Pester job

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -112,3 +112,17 @@ core-foundation = "0.10"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 keyring = { version = "3", features = ["sync-secret-service", "crypto-rust"] }
+
+# Debug builds carried full debug info, which is most of what makes `target/`
+# enormous: it reached 21G on a maintainer machine, and a contributor reported
+# Codespaces' 32G disk filling before a clean build finished (#728). Line tables
+# keep backtraces with file and line numbers, which is what a failing test
+# actually needs, and drop the variable-level DWARF that nothing in this
+# project's workflow reads. `RUSTFLAGS=-Cdebuginfo=2` restores the rest for a
+# real debugger session.
+[profile.dev]
+debug = "line-tables-only"
+
+# Same for the profile `cargo test` builds under.
+[profile.test]
+debug = "line-tables-only"


### PR DESCRIPTION
Prompted by @Vermitrude on #728, who reported a clean build running 24+ hours locally and filling a 32G Codespace disk, with `target/` at 17-19G.

Reproduced. A maintainer `target/` here is **21G**, and `src-tauri/Cargo.toml` carried **no `[profile]` section at all**, so every debug build wrote full variable-level DWARF. That is not a contributor environment problem.

## The profile

`debug = "line-tables-only"` keeps file and line numbers in backtraces, which is what a failing test actually needs, and drops the rest.

Measured on the headless build (`--no-default-features --lib`, clean target dir each time):

| | `target/` |
|---|---|
| before | 1.7G |
| after | **1.2G** (29% smaller) |

The desktop build is far larger, so the absolute saving there is bigger. I did not measure it and am not going to claim a number for it.

`RUSTFLAGS=-Cdebuginfo=2` restores full info for a real debugger session.

## The docs, which matter more

`npm run test:rust` builds with the `desktop` feature: **528 crates against 288 without it**, plus WebKitGTK on Linux. Contributors reach for it because it is the command CONTRIBUTING shows, and most changes never need it:

- **Frontend work needs no Rust build at all.** Every panel in `ActivityView.tsx` / `SettingsView.tsx` is `npm run test`.
- **Rust outside `desktop.rs`** runs under `--no-default-features`, which is also exactly what CI runs.
- **Only `desktop.rs` needs the full build** — and a test added there **does not run in CI either**, because every Rust job passes `--no-default-features`.

That last point is a real coverage gap and the new section says so. The way out is usually to move Tauri-independent logic (file reads, string formatting, path resolution) into the module that owns it and leave a thin caller in `desktop.rs`, which makes it testable in the light loop and gets it CI coverage it would otherwise never have. #733 is precisely that shape.

It also states plainly that a draft PR is a fine way to get verification when a machine cannot build the project, because that is the real answer for anyone in this position and it should not feel like an admission.

## Test

`cargo test --no-default-features --lib --bins --tests` passes under the new profile. Format check clean. Nothing in the profile change affects release builds.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Cut debug info to line-tables-only in dev and test Cargo profiles
> - Sets `debug = "line-tables-only"` in `[profile.dev]` and `[profile.test]` in [Cargo.toml](https://github.com/tsouth89/toolport/pull/790/files#diff-fe4c6a80a21e81339e2e0faeb9134d0f9636c168987df13c8abf1927a1caee39), reducing artifact size while retaining line info for backtraces.
> - Adds a section to [CONTRIBUTING.md](https://github.com/tsouth89/toolport/pull/790/files#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055) documenting the smallest test/build loop for frontend-only changes, Rust changes, and changes touching `desktop.rs`, including tips for managing `target/` size and using draft PRs to rely on CI.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5325e93.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->