### PR TITLE
feat(ui): make safety posture calmer and promote clients

### DIFF
--- a/src/App.posture.test.ts
+++ b/src/App.posture.test.ts
@@ -36,6 +36,42 @@ describe("serverPostureCopy", () => {
     expect(posture.detail).toBe("1 of 3 checked so far.");
   });
 
+  it("distinguishes an idle incomplete check from an active probe", () => {
+    expect(
+      serverPostureCopy({
+        backendReachable: true,
+        probing: false,
+        enabled: 2,
+        checked: 0,
+        connected: 0,
+        attention: 0,
+        disabled: 0,
+      }),
+    ).toEqual({
+      healthy: false,
+      title: "Reachability check incomplete",
+      detail: "0 of 2 checked. Refresh to try again.",
+    });
+  });
+
+  it("reports when no servers are enabled", () => {
+    expect(
+      serverPostureCopy({
+        backendReachable: true,
+        probing: false,
+        enabled: 0,
+        checked: 0,
+        connected: 0,
+        attention: 0,
+        disabled: 2,
+      }),
+    ).toEqual({
+      healthy: false,
+      title: "No servers enabled",
+      detail: "2 servers disabled in this profile.",
+    });
+  });
+
   it("names attention without turning it into a global protection claim", () => {
     const posture = serverPostureCopy({
       backendReachable: true,
@@ -66,5 +102,23 @@ describe("serverPostureCopy", () => {
     expect(posture.healthy).toBe(false);
     expect(posture.title).toBe("Reachability status unavailable");
     expect(posture.detail).toContain("Status may be out of date");
+  });
+
+  it("does not invent last-known health when the backend read failed", () => {
+    expect(
+      serverPostureCopy({
+        backendReachable: false,
+        probing: false,
+        enabled: 2,
+        checked: 0,
+        connected: 0,
+        attention: 0,
+        disabled: 0,
+      }),
+    ).toEqual({
+      healthy: false,
+      title: "Reachability status unavailable",
+      detail: "The last health check did not complete.",
+    });
   });
 });

--- a/src/App.posture.test.ts
+++ b/src/App.posture.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import { serverPostureCopy } from "./App";
+
+describe("serverPostureCopy", () => {
+  it("reports a confirmed healthy check", () => {
+    expect(
+      serverPostureCopy({
+        backendReachable: true,
+        probing: false,
+        enabled: 3,
+        checked: 3,
+        connected: 3,
+        attention: 0,
+        disabled: 1,
+      }),
+    ).toEqual({
+      healthy: true,
+      title: "3 enabled servers reachable",
+      detail: "1 disabled in this profile.",
+    });
+  });
+
+  it("does not claim health while a check is incomplete", () => {
+    const posture = serverPostureCopy({
+      backendReachable: true,
+      probing: true,
+      enabled: 3,
+      checked: 1,
+      connected: 1,
+      attention: 0,
+      disabled: 0,
+    });
+
+    expect(posture.healthy).toBe(false);
+    expect(posture.title).toBe("Checking server reachability");
+    expect(posture.detail).toBe("1 of 3 checked so far.");
+  });
+
+  it("names attention without turning it into a global protection claim", () => {
+    const posture = serverPostureCopy({
+      backendReachable: true,
+      probing: false,
+      enabled: 3,
+      checked: 3,
+      connected: 2,
+      attention: 1,
+      disabled: 0,
+    });
+
+    expect(posture.healthy).toBe(false);
+    expect(posture.title).toBe("2 of 3 enabled servers reachable");
+    expect(posture.detail).toBe("1 needs a quick check.");
+  });
+
+  it("treats a failed health read as unknown, never all-clear", () => {
+    const posture = serverPostureCopy({
+      backendReachable: false,
+      probing: false,
+      enabled: 3,
+      checked: 3,
+      connected: 3,
+      attention: 0,
+      disabled: 0,
+    });
+
+    expect(posture.healthy).toBe(false);
+    expect(posture.title).toBe("Reachability status unavailable");
+    expect(posture.detail).toContain("Status may be out of date");
+  });
+});

--- a/src/App.posture.test.ts
+++ b/src/App.posture.test.ts
@@ -121,4 +121,22 @@ describe("serverPostureCopy", () => {
       detail: "The last health check did not complete.",
     });
   });
+
+  it("preserves an all-failed last-known check when the backend becomes unavailable", () => {
+    expect(
+      serverPostureCopy({
+        backendReachable: false,
+        probing: false,
+        enabled: 2,
+        checked: 2,
+        connected: 0,
+        attention: 2,
+        disabled: 0,
+      }),
+    ).toEqual({
+      healthy: false,
+      title: "Reachability status unavailable",
+      detail: "Last known: 0 reachable; 2 need a quick check. Status may be out of date.",
+    });
+  });
 });

--- a/src/App.probe.test.tsx
+++ b/src/App.probe.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { act, render, waitFor } from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import App from "./App";
 import type { ProbeResult } from "@/lib/types";
 
@@ -43,7 +44,13 @@ vi.mock("@/lib/theme", () => ({
   useTheme: () => ({ resolved: "light" }),
 }));
 
-vi.mock("@/components/AppSidebar", () => ({ AppSidebar: () => null }));
+vi.mock("@/components/AppSidebar", () => ({
+  AppSidebar: ({ onSelectView }: { onSelectView: (view: "clients") => void }) => (
+    <button type="button" onClick={() => onSelectView("clients")}>
+      Clients
+    </button>
+  ),
+}));
 vi.mock("@/components/PendingApprovals", () => ({ PendingApprovals: () => null }));
 vi.mock("@/components/QuarantineAlert", () => ({ QuarantineAlert: () => null }));
 
@@ -109,5 +116,47 @@ describe("App onboarding probe wiring", () => {
     // ...and no trailing probeServers pass was queued behind it.
     await act(async () => {});
     expect(probeServers).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("App health visibility", () => {
+  it("keeps the backend warning visible after navigating away from Servers", async () => {
+    localStorage.setItem("toolport.onboarded", "1");
+    probeServers.mockRejectedValue(new Error("backend unavailable"));
+
+    render(<App />);
+
+    expect(await screen.findByText(/backend didn't respond/i)).toBeInTheDocument();
+    await userEvent.click(screen.getByRole("button", { name: "Clients" }));
+    expect(screen.getByText(/backend didn't respond/i)).toBeInTheDocument();
+  });
+
+  it("keeps an enabled server with no health result out of Ready", async () => {
+    localStorage.setItem("toolport.onboarded", "1");
+    getRegistry.mockResolvedValue({
+      version: 1,
+      servers: [
+        {
+          id: "server-1",
+          name: "Unchecked server",
+          transport: "stdio",
+          command: "example",
+          args: [],
+          env: [],
+          url: null,
+          source: "manual",
+        },
+      ],
+      profiles: [{ id: "default", name: "Default", enabledServerIds: ["server-1"] }],
+      activeProfileId: "default",
+    });
+    probeServers.mockResolvedValue([]);
+
+    render(<App />);
+
+    expect(
+      await screen.findByRole("button", { name: /checking 1/i }),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /ready/i })).not.toBeInTheDocument();
   });
 });

--- a/src/App.probe.test.tsx
+++ b/src/App.probe.test.tsx
@@ -2,13 +2,14 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import App from "./App";
-import type { ProbeResult } from "@/lib/types";
+import type { ProbeResult, Registry } from "@/lib/types";
 
 const probeServers = vi.fn();
 const getRegistry = vi.fn();
 const detectClients = vi.fn();
 const takeRegistryRecoveryNotice = vi.fn();
 const setServerEnabled = vi.fn();
+const setAllEnabled = vi.fn();
 
 // Captures the props App hands to the (mocked) Onboarding wizard so the test can
 // invoke onProbe exactly the way the Done step does.
@@ -24,7 +25,7 @@ vi.mock("@/lib/api", () => ({
   previewImportServers: vi.fn(),
   probeServers: (...a: unknown[]) => probeServers(...a),
   removeServer: vi.fn(),
-  setAllEnabled: vi.fn(),
+  setAllEnabled: (...a: unknown[]) => setAllEnabled(...a),
   setSecret: vi.fn(),
   setServerEnabled: (...a: unknown[]) => setServerEnabled(...a),
   takeRegistryRecoveryNotice: (...a: unknown[]) => takeRegistryRecoveryNotice(...a),
@@ -46,10 +47,28 @@ vi.mock("@/lib/theme", () => ({
 }));
 
 vi.mock("@/components/AppSidebar", () => ({
-  AppSidebar: ({ onSelectView }: { onSelectView: (view: "clients") => void }) => (
-    <button type="button" onClick={() => onSelectView("clients")}>
-      Clients
-    </button>
+  AppSidebar: ({
+    registry,
+    onRegistryChange,
+    onSelectView,
+  }: {
+    registry: Registry | null;
+    onRegistryChange: (registry: Registry) => void;
+    onSelectView: (view: "clients") => void;
+  }) => (
+    <>
+      <button type="button" onClick={() => onSelectView("clients")}>
+        Clients
+      </button>
+      {registry?.profiles.some((profile) => profile.id === "work") && (
+        <button
+          type="button"
+          onClick={() => onRegistryChange({ ...registry, activeProfileId: "work" })}
+        >
+          Switch profile
+        </button>
+      )}
+    </>
   ),
 }));
 vi.mock("@/components/PendingApprovals", () => ({ PendingApprovals: () => null }));
@@ -218,5 +237,106 @@ describe("App health visibility", () => {
     expect(
       screen.queryByText(/1 of 1 enabled servers reachable/i),
     ).not.toBeInTheDocument();
+  });
+
+  it("drops stale health when all servers are re-enabled", async () => {
+    localStorage.setItem("toolport.onboarded", "1");
+    const server = {
+      id: "server-1",
+      name: "Example",
+      transport: "stdio",
+      command: "example",
+      args: [],
+      env: [],
+      url: null,
+      source: "manual",
+    };
+    const enabledRegistry = {
+      version: 1,
+      servers: [server],
+      profiles: [{ id: "default", name: "Default", enabledServerIds: ["server-1"] }],
+      activeProfileId: "default",
+    };
+    const disabledRegistry = {
+      ...enabledRegistry,
+      profiles: [{ id: "default", name: "Default", enabledServerIds: [] }],
+    };
+    const nextProbe = deferred<ProbeResult[]>();
+    probeServers
+      .mockResolvedValueOnce([
+        {
+          serverId: "server-1",
+          ok: true,
+          toolCount: 1,
+          error: null,
+          authRequired: false,
+        },
+      ])
+      .mockReturnValueOnce(nextProbe.promise);
+    getRegistry.mockResolvedValue(enabledRegistry);
+    setAllEnabled
+      .mockResolvedValueOnce(disabledRegistry)
+      .mockResolvedValueOnce(enabledRegistry);
+
+    render(<App />);
+
+    expect(await screen.findByRole("button", { name: /ready 1/i })).toBeInTheDocument();
+    await userEvent.click(screen.getByRole("button", { name: "More actions" }));
+    await userEvent.click(screen.getByText("Disable all"));
+    await waitFor(() => expect(setAllEnabled).toHaveBeenCalledWith("default", false));
+
+    await userEvent.click(screen.getByRole("button", { name: "More actions" }));
+    await userEvent.click(screen.getByText("Enable all"));
+
+    expect(
+      await screen.findByRole("button", { name: /checking 1/i }),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /ready/i })).not.toBeInTheDocument();
+  });
+
+  it("invalidates health and probes after switching profiles", async () => {
+    localStorage.setItem("toolport.onboarded", "1");
+    const server = (id: string, name: string) => ({
+      id,
+      name,
+      transport: "stdio",
+      command: "example",
+      args: [],
+      env: [],
+      url: null,
+      source: "manual",
+    });
+    getRegistry.mockResolvedValue({
+      version: 1,
+      servers: [server("server-1", "Default server"), server("server-2", "Work server")],
+      profiles: [
+        { id: "default", name: "Default", enabledServerIds: ["server-1"] },
+        { id: "work", name: "Work", enabledServerIds: ["server-2"] },
+      ],
+      activeProfileId: "default",
+    });
+    const nextProbe = deferred<ProbeResult[]>();
+    probeServers
+      .mockResolvedValueOnce([
+        {
+          serverId: "server-1",
+          ok: true,
+          toolCount: 1,
+          error: null,
+          authRequired: false,
+        },
+      ])
+      .mockReturnValueOnce(nextProbe.promise);
+
+    render(<App />);
+
+    expect(await screen.findByRole("button", { name: /ready 1/i })).toBeInTheDocument();
+    await userEvent.click(screen.getByRole("button", { name: "Switch profile" }));
+
+    await waitFor(() => expect(probeServers).toHaveBeenCalledTimes(2));
+    expect(
+      await screen.findByRole("button", { name: /checking 1/i }),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /ready/i })).not.toBeInTheDocument();
   });
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -575,11 +575,12 @@ function App() {
 
   // Bucket each server so the list can lead with what needs action. A server
   // needs attention when it's enabled but its probe failed (auth or error).
-  type Group = "attention" | "active" | "disabled";
+  type Group = "attention" | "checking" | "active" | "disabled";
   const groupOf = (s: ServerEntry): Group => {
     if (!registry || !isEnabled(registry, s.id)) return "disabled";
     const h = health[s.id];
-    return h && !h.ok ? "attention" : "active";
+    if (!h) return "checking";
+    return h.ok ? "active" : "attention";
   };
   const attentionServers = servers.filter((s) => groupOf(s) === "attention");
   const attentionCount = attentionServers.length;
@@ -599,6 +600,7 @@ function App() {
   const visible = servers.filter(matches);
   const grouped: Record<Group, ServerEntry[]> = {
     attention: visible.filter((s) => groupOf(s) === "attention").sort(byName),
+    checking: visible.filter((s) => groupOf(s) === "checking").sort(byName),
     active: visible.filter((s) => groupOf(s) === "active").sort(byName),
     disabled: visible.filter((s) => groupOf(s) === "disabled").sort(byName),
   };
@@ -951,7 +953,7 @@ function App() {
             </div>
           </header>
 
-          {view === "servers" && !backendReachable && (
+          {!backendReachable && (
             <Callout
               variant="warning"
               role="status"
@@ -959,8 +961,8 @@ function App() {
             >
               <WifiOff className="size-4 shrink-0" aria-hidden="true" />
               <span className="min-w-0 flex-1">
-                Toolport's backend didn't respond to the last health check, so server
-                status below may be stale.
+                Toolport's backend didn't respond to the last health check. Some features
+                may be unavailable, and server status may be stale.
               </span>
               <Button
                 variant="outline"
@@ -1001,6 +1003,7 @@ function App() {
                       <ClientsView
                         clients={clients}
                         registry={registry}
+                        loading={loading}
                         onSelectClient={selectClient}
                       />
                     )
@@ -1061,6 +1064,9 @@ function App() {
                       )}
                       <ServerGroup title="To finish" count={grouped.attention.length}>
                         {grouped.attention.map(serverRow)}
+                      </ServerGroup>
+                      <ServerGroup title="Checking" count={grouped.checking.length}>
+                        {grouped.checking.map(serverRow)}
                       </ServerGroup>
                       <ServerGroup title="Ready" count={grouped.active.length}>
                         {grouped.active.map(serverRow)}
@@ -1234,24 +1240,28 @@ export function serverPostureCopy({
     ? "Reachability status unavailable"
     : enabled === 0
       ? "No servers enabled"
-      : probing || checked < enabled
+      : probing
         ? "Checking server reachability"
-        : attention === 0
-          ? `${connected} enabled server${connected === 1 ? "" : "s"} reachable`
-          : `${connected} of ${enabled} enabled servers reachable`;
+        : checked < enabled
+          ? "Reachability check incomplete"
+          : attention === 0
+            ? `${connected} enabled server${connected === 1 ? "" : "s"} reachable`
+            : `${connected} of ${enabled} enabled servers reachable`;
   const detail = !backendReachable
     ? connected > 0
       ? `Last known: ${connected} reachable. Status may be out of date.`
       : "The last health check did not complete."
     : enabled === 0
       ? `${disabled} server${disabled === 1 ? "" : "s"} disabled in this profile.`
-      : probing || checked < enabled
+      : probing
         ? `${checked} of ${enabled} checked so far.`
-        : attention > 0
-          ? `${attention} need${attention === 1 ? "s" : ""} a quick check.`
-          : disabled > 0
-            ? `${disabled} disabled in this profile.`
-            : "Everything enabled in this profile is ready.";
+        : checked < enabled
+          ? `${checked} of ${enabled} checked. Refresh to try again.`
+          : attention > 0
+            ? `${attention} need${attention === 1 ? "s" : ""} a quick check.`
+            : disabled > 0
+              ? `${disabled} disabled in this profile.`
+              : "Everything enabled in this profile is ready.";
   return { healthy, title, detail };
 }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -121,6 +121,7 @@ const BULK_DISABLE_CONFIRM_MIN = 3;
 function App() {
   const { resolved: resolvedTheme } = useTheme();
   const [registry, setRegistry] = useState<Registry | null>(null);
+  const registryRef = useRef<Registry | null>(null);
   const [clients, setClients] = useState<DetectedClient[]>([]);
   const [importPreview, setImportPreview] = useState<ImportItem[] | null>(null);
   const [importing, setImporting] = useState(false);
@@ -214,6 +215,42 @@ function App() {
     [],
   );
 
+  const applyRegistryChange = useCallback(
+    (next: Registry) => {
+      const activeId = (value: Registry | null) =>
+        value?.activeProfileId ?? value?.profiles[0]?.id;
+      const enabledIds = (value: Registry | null) =>
+        new Set(
+          value?.profiles.find((profile) => profile.id === activeId(value))
+            ?.enabledServerIds ?? [],
+        );
+      const previous = registryRef.current;
+      const previousProfileId = activeId(previous);
+      const nextProfileId = activeId(next);
+      const previousEnabled = enabledIds(previous);
+      const nextEnabled = enabledIds(next);
+      const invalidate =
+        previousProfileId !== nextProfileId
+          ? nextEnabled
+          : new Set([...nextEnabled].filter((id) => !previousEnabled.has(id)));
+
+      if (invalidate.size > 0) {
+        // A profile switch or enablement must not inherit the previous profile/set's
+        // health. Clear those rows before the new registry lands, then probe the
+        // authoritative backend state.
+        setHealth((current) => {
+          const fresh = { ...current };
+          invalidate.forEach((id) => delete fresh[id]);
+          return fresh;
+        });
+      }
+      registryRef.current = next;
+      setRegistry(next);
+      if (invalidate.size > 0) void reprobeAfterMutation().catch(() => {});
+    },
+    [reprobeAfterMutation],
+  );
+
   // Refresh statuses when the user returns to the window, so a server that came
   // up (or went down) while they were away reflects reality without a manual
   // refresh. Guarded so rapid alt-tabbing doesn't re-spawn every server.
@@ -238,6 +275,7 @@ function App() {
           detectClients(),
           takeRegistryRecoveryNotice(),
         ]);
+        registryRef.current = reg;
         setRegistry(reg);
         setClients(dc);
         if (recovery) {
@@ -294,13 +332,13 @@ function App() {
   // without a manual reload.
   useEffect(() => {
     const unlisten = listen<Registry>("registry-changed", (e) => {
-      setRegistry(e.payload);
+      applyRegistryChange(e.payload);
       setActivityKey((k) => k + 1);
     });
     return () => {
       void unlisten.then((f) => f());
     };
-  }, []);
+  }, [applyRegistryChange]);
 
   // The tray remains available while the window is hidden. Its approvals entry
   // should reveal the app at the exact place where the waiting calls can be
@@ -460,7 +498,7 @@ function App() {
         try {
           const fresh = await teamSyncWait(WAIT_SECS);
           if (cancelled) break;
-          setRegistry(fresh);
+          applyRegistryChange(fresh);
         } catch {
           // Network blip or server down: back off before re-parking so we don't spin.
           // Removal is a clean 401/403 the backend turns into a cleared team + the
@@ -486,7 +524,7 @@ function App() {
         wake = null;
       }
     };
-  }, [teamId]);
+  }, [applyRegistryChange, teamId]);
 
   function selectClient(id: string) {
     setSelectedClientId(id);
@@ -670,18 +708,7 @@ function App() {
     setBusyId(serverId);
     try {
       const next = await setServerEnabled(profileId, serverId, enabled, reviewed);
-      if (enabled) {
-        // A previous probe can outlive a disable/re-enable cycle. Drop it before the
-        // enabled registry lands so the row and posture stay Checking until this
-        // enablement's probe produces a fresh result.
-        setHealth((current) => {
-          const fresh = { ...current };
-          delete fresh[serverId];
-          return fresh;
-        });
-      }
-      setRegistry(next);
-      if (enabled) void reprobeAfterMutation().catch(() => {});
+      applyRegistryChange(next);
     } catch (e) {
       toastError(`Couldn't toggle: ${e}`);
     } finally {
@@ -703,7 +730,7 @@ function App() {
   async function handleRemove(serverId: string, name: string) {
     setBusyId(serverId);
     try {
-      setRegistry(await removeServer(serverId));
+      applyRegistryChange(await removeServer(serverId));
       toast.success(`Removed "${name}"`);
     } catch (e) {
       toastError(`Couldn't remove: ${e}`);
@@ -730,8 +757,7 @@ function App() {
     }
     setTogglingAll(true);
     try {
-      setRegistry(await setAllEnabled(profileId, enable));
-      if (enable) void reprobeAfterMutation().catch(() => {});
+      applyRegistryChange(await setAllEnabled(profileId, enable));
       let message = enable ? "Enabled all servers" : "Disabled all servers";
       if (enable && pendingReview > 0) {
         message =
@@ -768,7 +794,7 @@ function App() {
     try {
       const before = registry?.servers.length ?? 0;
       const next = await importServers(selected);
-      setRegistry(next);
+      applyRegistryChange(next);
       const added = next.servers.length - before;
       toast.success(
         added > 0
@@ -793,7 +819,7 @@ function App() {
       health={health[server.id]}
       onToggle={(en) => handleToggle(server.id, en)}
       onRemove={() => handleRemove(server.id, server.name)}
-      onRegistryChange={setRegistry}
+      onRegistryChange={applyRegistryChange}
       onReprobe={() => void reprobeAfterMutation().catch(() => {})}
     />
   );
@@ -803,7 +829,7 @@ function App() {
       <div className="flex h-screen overflow-hidden bg-background text-foreground">
         <AppSidebar
           registry={registry}
-          onRegistryChange={setRegistry}
+          onRegistryChange={applyRegistryChange}
           view={view}
           onSelectView={selectView}
           onReplayOnboarding={() => {
@@ -1012,7 +1038,7 @@ function App() {
                         client={selectedClient}
                         registry={registry}
                         onChanged={load}
-                        onRegistryChange={setRegistry}
+                        onRegistryChange={applyRegistryChange}
                       />
                     ) : (
                       <ClientsView
@@ -1025,15 +1051,24 @@ function App() {
                   ) : view === "activity" ? (
                     <ActivityView refreshKey={activityKey} registry={registry} />
                   ) : view === "catalog" ? (
-                    <CatalogView registry={registry} onAdded={setRegistry} />
+                    <CatalogView registry={registry} onAdded={applyRegistryChange} />
                   ) : view === "playground" ? (
-                    <PlaygroundView registry={registry} onRegistryChange={setRegistry} />
+                    <PlaygroundView
+                      registry={registry}
+                      onRegistryChange={applyRegistryChange}
+                    />
                   ) : view === "rules" ? (
                     <RulesView />
                   ) : view === "teams" ? (
-                    <TeamsView registry={registry} onRegistryChange={setRegistry} />
+                    <TeamsView
+                      registry={registry}
+                      onRegistryChange={applyRegistryChange}
+                    />
                   ) : view === "settings" ? (
-                    <SettingsView registry={registry} onRegistryChange={setRegistry} />
+                    <SettingsView
+                      registry={registry}
+                      onRegistryChange={applyRegistryChange}
+                    />
                   ) : loading && registry === null ? (
                     <div className="flex flex-col gap-2">
                       {Array.from({ length: 6 }).map((_, i) => (
@@ -1119,7 +1154,7 @@ function App() {
             initialStep={onboardingStep}
             clients={clients}
             registry={registry}
-            onRegistryChange={setRegistry}
+            onRegistryChange={applyRegistryChange}
             onClientsRefresh={load}
             onBrowseCatalog={() => {
               setShowOnboarding(false);
@@ -1197,7 +1232,7 @@ function App() {
           autoOpen
           onClose={() => setAddServerOpen(false)}
           onSaved={(reg) => {
-            setRegistry(reg);
+            applyRegistryChange(reg);
             // A successful save closes the dialog internally without going through
             // onOpenChange, so `onClose` never fires and this stays mounted-but-open.
             // Without clearing it here the next Ctrl+N is a silent no-op. Same pattern
@@ -1265,8 +1300,10 @@ export function serverPostureCopy({
             ? `${connected} enabled server${connected === 1 ? "" : "s"} reachable`
             : `${connected} of ${enabled} enabled servers reachable`;
   const detail = !backendReachable
-    ? connected > 0
-      ? `Last known: ${connected} reachable. Status may be out of date.`
+    ? checked > 0
+      ? attention > 0
+        ? `Last known: ${connected} reachable; ${attention} need${attention === 1 ? "s" : ""} a quick check. Status may be out of date.`
+        : `Last known: ${connected} reachable. Status may be out of date.`
       : "The last health check did not complete."
     : enabled === 0
       ? `${disabled} server${disabled === 1 ? "" : "s"} disabled in this profile.`

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,7 +9,10 @@ import {
 } from "react";
 import { listen } from "@tauri-apps/api/event";
 import {
+  ArrowLeft,
   ChevronDown,
+  CircleCheck,
+  KeyRound,
   MoreHorizontal,
   Download,
   Plus,
@@ -74,6 +77,9 @@ const Onboarding = lazy(() =>
 );
 const ClientDetail = lazy(() =>
   import("@/components/ClientDetail").then((m) => ({ default: m.ClientDetail })),
+);
+const ClientsView = lazy(() =>
+  import("@/components/ClientsView").then((m) => ({ default: m.ClientsView })),
 );
 const ActivityView = lazy(() =>
   import("@/components/ActivityView").then((m) => ({ default: m.ActivityView })),
@@ -479,12 +485,12 @@ function App() {
     };
   }, [teamId]);
 
-  function selectClient(id: string | null) {
+  function selectClient(id: string) {
     setSelectedClientId(id);
-    setView("servers");
+    setView("clients");
   }
 
-  // Catalog and Activity are top-level destinations, so leave any selected client.
+  // Top-level destinations leave any selected client detail behind.
   function selectView(v: View) {
     setSelectedClientId(null);
     setView(v);
@@ -560,7 +566,12 @@ function App() {
   const enabledCount = registry
     ? servers.filter((s) => isEnabled(registry, s.id)).length
     : 0;
-  const connectedCount = servers.filter((s) => health[s.id]?.ok).length;
+  // Probe results can outlive a profile toggle, so only count servers that are
+  // still enabled. Otherwise a newly disabled server makes the posture claim
+  // more reachable "enabled servers" than the profile actually contains.
+  const connectedCount = registry
+    ? servers.filter((s) => isEnabled(registry, s.id) && health[s.id]?.ok).length
+    : 0;
 
   // Bucket each server so the list can lead with what needs action. A server
   // needs attention when it's enabled but its probe failed (auth or error).
@@ -570,7 +581,11 @@ function App() {
     const h = health[s.id];
     return h && !h.ok ? "attention" : "active";
   };
-  const attentionCount = servers.filter((s) => groupOf(s) === "attention").length;
+  const attentionServers = servers.filter((s) => groupOf(s) === "attention");
+  const attentionCount = attentionServers.length;
+  const checkedCount = registry
+    ? servers.filter((s) => isEnabled(registry, s.id) && health[s.id]).length
+    : 0;
 
   const q = query.trim().toLowerCase();
   const matches = (s: ServerEntry) =>
@@ -587,6 +602,11 @@ function App() {
     active: visible.filter((s) => groupOf(s) === "active").sort(byName),
     disabled: visible.filter((s) => groupOf(s) === "disabled").sort(byName),
   };
+  // The posture and next action summarize the profile, not the current search.
+  // Keep these counts independent of `visible` so a filter cannot produce a
+  // misleading "0 servers" action while hiding an affected row.
+  const authAttention = attentionServers.filter((s) => health[s.id]?.authRequired);
+  const errorAttention = attentionServers.filter((s) => !health[s.id]?.authRequired);
 
   // Count what would actually be imported: drop the gateway entry and anything
   // already in the registry, then dedupe by name across clients (the backend
@@ -769,11 +789,8 @@ function App() {
     <TooltipProvider delayDuration={200}>
       <div className="flex h-screen overflow-hidden bg-background text-foreground">
         <AppSidebar
-          clients={clients}
           registry={registry}
           onRegistryChange={setRegistry}
-          selectedClientId={selectedClientId}
-          onSelectClient={selectClient}
           view={view}
           onSelectView={selectView}
           onReplayOnboarding={() => {
@@ -785,18 +802,26 @@ function App() {
         <main className="flex min-w-0 flex-1 flex-col">
           <header className="flex items-center justify-between gap-4 border-b px-6 py-4">
             <div className="flex min-w-0 flex-1 items-center gap-3">
-              {view !== "activity" &&
-                view !== "catalog" &&
-                view !== "playground" &&
-                view !== "teams" &&
-                view !== "settings" &&
-                selectedClient && (
+              {view === "clients" && selectedClient && (
+                <>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="-ml-2 text-muted-foreground"
+                    onClick={() => selectView("clients")}
+                    aria-label="Back to clients"
+                  >
+                    <ArrowLeft className="size-4" />
+                    Clients
+                  </Button>
+                  <div className="h-7 w-px bg-border" aria-hidden="true" />
                   <ClientLogo
                     id={selectedClient.id}
                     name={selectedClient.name}
                     size={32}
                   />
-                )}
+                </>
+              )}
               <div className="min-w-0">
                 <h1 className="truncate text-lg font-semibold tracking-tight">
                   {view === "activity"
@@ -809,8 +834,8 @@ function App() {
                           ? "Teams"
                           : view === "settings"
                             ? "Settings"
-                            : selectedClient
-                              ? selectedClient.name
+                            : view === "clients"
+                              ? (selectedClient?.name ?? "Clients")
                               : "Servers"}
                 </h1>
                 <p className="truncate text-sm text-muted-foreground">
@@ -824,8 +849,10 @@ function App() {
                           ? "Share one MCP server set across your team"
                           : view === "settings"
                             ? "Global discovery and security policy"
-                            : selectedClient
-                              ? "MCP client"
+                            : view === "clients"
+                              ? selectedClient
+                                ? "MCP client"
+                                : "Manage Toolport in your installed AI tools"
                               : loading || !registry
                                 ? "Loading…"
                                 : "One gateway in front of every MCP server you run"}
@@ -833,7 +860,7 @@ function App() {
               </div>
             </div>
             <div className="flex shrink-0 items-center gap-2">
-              {view === "servers" && !selectedClient && (
+              {view === "servers" && (
                 <>
                   <div className="relative">
                     <Search className="pointer-events-none absolute top-1/2 left-2.5 size-3.5 -translate-y-1/2 text-muted-foreground" />
@@ -924,7 +951,7 @@ function App() {
             </div>
           </header>
 
-          {!backendReachable && (
+          {view === "servers" && !backendReachable && (
             <Callout
               variant="warning"
               role="status"
@@ -962,7 +989,22 @@ function App() {
                     </div>
                   }
                 >
-                  {view === "activity" ? (
+                  {view === "clients" ? (
+                    selectedClient ? (
+                      <ClientDetail
+                        client={selectedClient}
+                        registry={registry}
+                        onChanged={load}
+                        onRegistryChange={setRegistry}
+                      />
+                    ) : (
+                      <ClientsView
+                        clients={clients}
+                        registry={registry}
+                        onSelectClient={selectClient}
+                      />
+                    )
+                  ) : view === "activity" ? (
                     <ActivityView refreshKey={activityKey} registry={registry} />
                   ) : view === "catalog" ? (
                     <CatalogView registry={registry} onAdded={setRegistry} />
@@ -972,13 +1014,6 @@ function App() {
                     <TeamsView registry={registry} onRegistryChange={setRegistry} />
                   ) : view === "settings" ? (
                     <SettingsView registry={registry} onRegistryChange={setRegistry} />
-                  ) : selectedClient ? (
-                    <ClientDetail
-                      client={selectedClient}
-                      registry={registry}
-                      onChanged={load}
-                      onRegistryChange={setRegistry}
-                    />
                   ) : loading && registry === null ? (
                     <div className="flex flex-col gap-2">
                       {Array.from({ length: 6 }).map((_, i) => (
@@ -1009,29 +1044,29 @@ function App() {
                     </div>
                   ) : (
                     <div className="flex flex-col gap-5">
-                      <StatusBar
-                        total={servers.length}
+                      <ServerPosture
+                        backendReachable={backendReachable}
+                        probing={probing}
+                        enabled={enabledCount}
+                        checked={checkedCount}
                         connected={connectedCount}
                         attention={attentionCount}
                         disabled={servers.length - enabledCount}
                       />
-                      <ServerGroup
-                        title="Needs attention"
-                        dot="bg-warning"
-                        count={grouped.attention.length}
-                      >
+                      {backendReachable && attentionCount > 0 && (
+                        <ServerNextAction
+                          authServers={authAttention}
+                          errorServers={errorAttention}
+                        />
+                      )}
+                      <ServerGroup title="To finish" count={grouped.attention.length}>
                         {grouped.attention.map(serverRow)}
                       </ServerGroup>
-                      <ServerGroup
-                        title="Active"
-                        dot="bg-success"
-                        count={grouped.active.length}
-                      >
+                      <ServerGroup title="Ready" count={grouped.active.length}>
                         {grouped.active.map(serverRow)}
                       </ServerGroup>
                       <ServerGroup
                         title="Disabled"
-                        dot="bg-muted-foreground/40"
                         count={grouped.disabled.length}
                         defaultCollapsed
                       >
@@ -1174,48 +1209,150 @@ function App() {
   );
 }
 
-/** At-a-glance server health as a row of chips: the primary status summary, promoted out
- * of the grey header caption into a scannable status bar with the same semantic dots the
- * groups use. */
-function StatusBar({
-  total,
+/** A factual reachability baseline. Security posture remains in Settings; this only
+ * summarizes the health probe and never presents a stale or partial check as healthy. */
+export function serverPostureCopy({
+  backendReachable,
+  probing,
+  enabled,
+  checked,
   connected,
   attention,
   disabled,
 }: {
-  total: number;
+  backendReachable: boolean;
+  probing: boolean;
+  enabled: number;
+  checked: number;
   connected: number;
   attention: number;
   disabled: number;
 }) {
-  const chip =
-    "inline-flex items-center gap-2 rounded-full border border-border/60 bg-card/50 px-3 py-1.5 text-xs font-semibold";
-  const dot = "size-1.5 rounded-full";
+  const complete = enabled > 0 && checked === enabled && !probing;
+  const healthy = backendReachable && complete && attention === 0;
+  const title = !backendReachable
+    ? "Reachability status unavailable"
+    : enabled === 0
+      ? "No servers enabled"
+      : probing || checked < enabled
+        ? "Checking server reachability"
+        : attention === 0
+          ? `${connected} enabled server${connected === 1 ? "" : "s"} reachable`
+          : `${connected} of ${enabled} enabled servers reachable`;
+  const detail = !backendReachable
+    ? connected > 0
+      ? `Last known: ${connected} reachable. Status may be out of date.`
+      : "The last health check did not complete."
+    : enabled === 0
+      ? `${disabled} server${disabled === 1 ? "" : "s"} disabled in this profile.`
+      : probing || checked < enabled
+        ? `${checked} of ${enabled} checked so far.`
+        : attention > 0
+          ? `${attention} need${attention === 1 ? "s" : ""} a quick check.`
+          : disabled > 0
+            ? `${disabled} disabled in this profile.`
+            : "Everything enabled in this profile is ready.";
+  return { healthy, title, detail };
+}
+
+function ServerPosture({
+  backendReachable,
+  probing,
+  enabled,
+  checked,
+  connected,
+  attention,
+  disabled,
+}: {
+  backendReachable: boolean;
+  probing: boolean;
+  enabled: number;
+  checked: number;
+  connected: number;
+  attention: number;
+  disabled: number;
+}) {
+  const { healthy, title, detail } = serverPostureCopy({
+    backendReachable,
+    probing,
+    enabled,
+    checked,
+    connected,
+    attention,
+    disabled,
+  });
+
   return (
-    <div className="flex flex-wrap gap-2">
-      <span className={chip}>
-        <span className="tabular-nums">{total}</span>
-        <span className="font-normal text-muted-foreground">servers</span>
-      </span>
-      <span className={chip}>
-        <span className={`${dot} bg-success`} />
-        <span className="tabular-nums">{connected}</span>
-        <span className="font-normal text-muted-foreground">connected</span>
-      </span>
-      {attention > 0 && (
-        <span className={`${chip} border-warning/40`}>
-          <span className={`${dot} bg-warning`} />
-          <span className="tabular-nums">{attention}</span>
-          <span className="font-normal text-muted-foreground">
-            need{attention === 1 ? "s" : ""} attention
-          </span>
-        </span>
-      )}
-      <span className={chip}>
-        <span className={`${dot} bg-muted-foreground/40`} />
-        <span className="tabular-nums">{disabled}</span>
-        <span className="font-normal text-muted-foreground">disabled</span>
-      </span>
+    <div
+      role="status"
+      className={`flex items-center gap-3 rounded-xl border px-4 py-3 ${
+        healthy ? "border-success/20 bg-success/5" : "border-border/70 bg-card/40"
+      }`}
+    >
+      <div
+        className={`grid size-8 shrink-0 place-items-center rounded-lg ${
+          healthy
+            ? "bg-success/10 text-success"
+            : probing
+              ? "bg-info/10 text-info"
+              : "bg-muted text-muted-foreground"
+        }`}
+      >
+        {healthy ? (
+          <CircleCheck className="size-4" />
+        ) : (
+          <RefreshCw className={`size-4 ${probing ? "animate-spin" : ""}`} />
+        )}
+      </div>
+      <div>
+        <p className="text-sm font-semibold">{title}</p>
+        <p className="text-xs text-muted-foreground">{detail}</p>
+      </div>
+    </div>
+  );
+}
+
+/** One page-level owner for the next useful action. The rows below retain the
+ * controls and evidence, but no longer compete with multiple warning summaries. */
+function ServerNextAction({
+  authServers,
+  errorServers,
+}: {
+  authServers: ServerEntry[];
+  errorServers: ServerEntry[];
+}) {
+  const authCount = authServers.length;
+  const errorCount = errorServers.length;
+  const title =
+    authCount === 1 && errorCount === 0
+      ? `Sign in to ${authServers[0].name}`
+      : authCount > 0 && errorCount === 0
+        ? `Sign in to ${authCount} servers`
+        : errorCount === 1 && authCount === 0
+          ? `${errorServers[0].name} couldn't start`
+          : errorCount > 0 && authCount === 0
+            ? `${errorCount} servers couldn't start`
+            : `${authCount + errorCount} servers need a quick check`;
+  const detail =
+    authCount > 0 && errorCount === 0
+      ? "Use Authenticate below to finish setup. Everything else stays available."
+      : errorCount > 0 && authCount === 0
+        ? "Open the affected rows below for the error and recovery details."
+        : `${authCount} need sign-in; ${errorCount} couldn't start. The other servers stay available.`;
+
+  return (
+    <div className="flex items-start gap-3 rounded-xl border border-warning/25 bg-card/45 px-4 py-3">
+      <div className="grid size-8 shrink-0 place-items-center rounded-lg bg-warning/10 text-warning">
+        {authCount > 0 && errorCount === 0 ? (
+          <KeyRound className="size-4" />
+        ) : (
+          <TriangleAlert className="size-4" />
+        )}
+      </div>
+      <div>
+        <p className="text-sm font-semibold">{title}</p>
+        <p className="text-xs text-muted-foreground">{detail}</p>
+      </div>
     </div>
   );
 }
@@ -1225,13 +1362,11 @@ function StatusBar({
  * group; the Disabled bucket starts collapsed. */
 function ServerGroup({
   title,
-  dot,
   count,
   defaultCollapsed = false,
   children,
 }: {
   title: string;
-  dot: string;
   count: number;
   defaultCollapsed?: boolean;
   children: ReactNode;
@@ -1265,7 +1400,6 @@ function ServerGroup({
           }`}
           aria-hidden="true"
         />
-        <span className={`size-2 rounded-full ${dot}`} aria-hidden="true" />
         <h2 className="text-xs font-medium tracking-wide text-muted-foreground uppercase">
           {title}
         </h2>

--- a/src/components/ActivityView.tsx
+++ b/src/components/ActivityView.tsx
@@ -254,8 +254,7 @@ function SecurityResting() {
       <ShieldCheck className="size-4 shrink-0 text-owned" />
       <span>
         <span className="font-medium text-foreground">Protection active.</span> Toolport
-        watches every tool for tampering (rug pulls), poisoned definitions, and injected
-        output (agentjacking). No issues right now.
+        is watching tool definitions and results. Nothing needs your attention right now.
       </span>
     </div>
   );

--- a/src/components/AppSidebar.test.tsx
+++ b/src/components/AppSidebar.test.tsx
@@ -4,7 +4,6 @@ import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
 
 import { TooltipProvider } from "@/components/ui/tooltip";
-import type { DetectedClient } from "@/lib/types";
 import { AppSidebar } from "./AppSidebar";
 
 const getSavingsSummary = vi.fn();
@@ -54,23 +53,6 @@ vi.mock("@/components/ShareDialog", () => ({
   ShareDialog: ({ trigger }: { trigger: ReactNode }) => trigger,
 }));
 
-function client(overrides: Partial<DetectedClient> = {}): DetectedClient {
-  return {
-    id: "cursor",
-    name: "Cursor",
-    usesConnectors: false,
-    configPath: "/tmp/cursor.json",
-    configExists: true,
-    appPresent: true,
-    servers: [],
-    pluginServers: [],
-    gatewayInstalled: false,
-    entryState: "absent",
-    error: null,
-    ...overrides,
-  };
-}
-
 beforeEach(() => {
   getSavingsSummary.mockReset();
   listQuarantined.mockReset();
@@ -95,16 +77,13 @@ afterEach(() => {
 });
 
 describe("AppSidebar accessibility", () => {
-  it("names both navigation landmarks and exposes client selection state", () => {
+  it("promotes Clients into the primary navigation", () => {
     render(
       <TooltipProvider>
         <AppSidebar
-          clients={[client()]}
           registry={null}
           onRegistryChange={vi.fn()}
-          selectedClientId="cursor"
-          onSelectClient={vi.fn()}
-          view="servers"
+          view="clients"
           onSelectView={vi.fn()}
           onReplayOnboarding={vi.fn()}
         />
@@ -112,35 +91,11 @@ describe("AppSidebar accessibility", () => {
     );
 
     expect(screen.getByRole("navigation", { name: "Views" })).toBeInTheDocument();
-    expect(screen.getByRole("navigation", { name: "Clients" })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /cursor/i })).toHaveAttribute(
+    expect(screen.queryByRole("navigation", { name: "Clients" })).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Clients" })).toHaveAttribute(
       "aria-current",
       "page",
     );
-  });
-
-  it("exposes whether the not-detected client list is expanded", async () => {
-    render(
-      <TooltipProvider>
-        <AppSidebar
-          clients={[client(), client({ id: "zed", name: "Zed", appPresent: false })]}
-          registry={null}
-          onRegistryChange={vi.fn()}
-          selectedClientId={null}
-          onSelectClient={vi.fn()}
-          view="servers"
-          onSelectView={vi.fn()}
-          onReplayOnboarding={vi.fn()}
-        />
-      </TooltipProvider>,
-    );
-
-    const toggle = screen.getByRole("button", { name: /not detected/i });
-    expect(toggle).toHaveAttribute("aria-expanded", "false");
-
-    await userEvent.click(toggle);
-    expect(toggle).toHaveAttribute("aria-expanded", "true");
-    expect(screen.getByRole("button", { name: /zed/i })).toBeInTheDocument();
   });
 
   it("rechecks updates when a stale tray-hidden window is shown", async () => {
@@ -150,11 +105,8 @@ describe("AppSidebar accessibility", () => {
     render(
       <TooltipProvider>
         <AppSidebar
-          clients={[client()]}
           registry={null}
           onRegistryChange={vi.fn()}
-          selectedClientId={null}
-          onSelectClient={vi.fn()}
           view="servers"
           onSelectView={vi.fn()}
           onReplayOnboarding={vi.fn()}
@@ -178,11 +130,8 @@ describe("AppSidebar accessibility", () => {
     render(
       <TooltipProvider>
         <AppSidebar
-          clients={[client()]}
           registry={null}
           onRegistryChange={vi.fn()}
-          selectedClientId={null}
-          onSelectClient={vi.fn()}
           view="servers"
           onSelectView={vi.fn()}
           onReplayOnboarding={vi.fn()}
@@ -214,11 +163,8 @@ describe("AppSidebar accessibility", () => {
     render(
       <TooltipProvider>
         <AppSidebar
-          clients={[client()]}
           registry={null}
           onRegistryChange={vi.fn()}
-          selectedClientId={null}
-          onSelectClient={vi.fn()}
           view="servers"
           onSelectView={vi.fn()}
           onReplayOnboarding={vi.fn()}
@@ -246,11 +192,8 @@ describe("AppSidebar accessibility", () => {
     render(
       <TooltipProvider>
         <AppSidebar
-          clients={[client()]}
           registry={null}
           onRegistryChange={vi.fn()}
-          selectedClientId={null}
-          onSelectClient={vi.fn()}
           view="servers"
           onSelectView={vi.fn()}
           onReplayOnboarding={vi.fn()}
@@ -287,11 +230,8 @@ describe("AppSidebar accessibility", () => {
     render(
       <TooltipProvider>
         <AppSidebar
-          clients={[client()]}
           registry={null}
           onRegistryChange={vi.fn()}
-          selectedClientId={null}
-          onSelectClient={vi.fn()}
           view="servers"
           onSelectView={vi.fn()}
           onReplayOnboarding={vi.fn()}
@@ -321,11 +261,8 @@ describe("AppSidebar accessibility", () => {
     render(
       <TooltipProvider>
         <AppSidebar
-          clients={[client()]}
           registry={null}
           onRegistryChange={vi.fn()}
-          selectedClientId={null}
-          onSelectClient={vi.fn()}
           view="servers"
           onSelectView={vi.fn()}
           onReplayOnboarding={vi.fn()}
@@ -351,11 +288,8 @@ describe("AppSidebar quarantine badge", () => {
     return render(
       <TooltipProvider>
         <AppSidebar
-          clients={[client()]}
           registry={null}
           onRegistryChange={vi.fn()}
-          selectedClientId={null}
-          onSelectClient={vi.fn()}
           view="servers"
           onSelectView={vi.fn()}
           onReplayOnboarding={vi.fn()}
@@ -499,11 +433,8 @@ describe("AppSidebar open data folder", () => {
     render(
       <TooltipProvider>
         <AppSidebar
-          clients={[client()]}
           registry={null}
           onRegistryChange={vi.fn()}
-          selectedClientId={null}
-          onSelectClient={vi.fn()}
           view="servers"
           onSelectView={vi.fn()}
           onReplayOnboarding={vi.fn()}

--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -2,16 +2,13 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { listen } from "@tauri-apps/api/event";
 import {
   ArrowUpCircle,
-  ChevronRight,
   ClipboardList,
   Compass,
-  Download,
   FlaskConical,
   FolderOpen,
   Layers,
-  Link2,
   Loader2,
-  Puzzle,
+  MonitorCog,
   ScrollText,
   Settings,
   Share2,
@@ -24,13 +21,7 @@ import { openExternal } from "@/lib/openUrl";
 import { toast } from "sonner";
 import { toastError } from "@/lib/toast";
 import type { Update } from "@tauri-apps/plugin-updater";
-import {
-  importableServers,
-  type DetectedClient,
-  type Registry,
-  type SavingsSummary,
-  type View,
-} from "@/lib/types";
+import { type Registry, type SavingsSummary, type View } from "@/lib/types";
 import {
   gatherDiagnostics,
   getSavingsSummary,
@@ -41,7 +32,6 @@ import { fmtTokens } from "@/lib/utils";
 import { checkForUpdate, installUpdate, type UpdateProgress } from "@/lib/updater";
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
-import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { ProfileBar } from "@/components/ProfileBar";
 import { ShareDialog } from "@/components/ShareDialog";
 
@@ -356,148 +346,21 @@ function UpdateNotes({
   );
 }
 
-/** Present clients (have a config or use connectors) first, then by how many
- * servers they manage, then alphabetical. Keeps not-installed clients at the
- * bottom. */
-function sortClients(clients: DetectedClient[]): DetectedClient[] {
-  const present = (c: DetectedClient) => (c.appPresent ? 1 : 0);
-  const count = (c: DetectedClient) => c.servers.length + c.pluginServers.length;
-  return [...clients].sort((a, b) => {
-    if (present(a) !== present(b)) return present(b) - present(a);
-    if (count(a) !== count(b)) return count(b) - count(a);
-    return a.name.localeCompare(b.name);
-  });
-}
-
-type ClientStatus = "active" | "empty" | "error" | "missing";
-
-function statusOf(client: DetectedClient): ClientStatus {
-  if (client.error) return "error";
-  // "missing" means the app itself isn't here, not merely that MCP is
-  // unconfigured. A present-but-unconfigured client (installed, no servers yet)
-  // is "empty", so it reads as "ready" rather than "not found".
-  if (!client.appPresent) return "missing";
-  return client.servers.length > 0 ? "active" : "empty";
-}
-
-const dotClass: Record<ClientStatus, string> = {
-  // These dots only render for NOT-connected clients (connected ones use the
-  // green chain icon), so none of them should be green - green means connected.
-  active: "bg-muted-foreground/50",
-  empty: "bg-muted-foreground/40",
-  error: "bg-warning",
-  missing: "bg-muted-foreground/20",
-};
-
-interface RowProps {
-  client: DetectedClient;
-  importCount: number;
-  selected: boolean;
-  onSelect: () => void;
-}
-
-/** A client row is about two things only: is Toolport connected here, and is
- * there anything left to import. Raw server counts are deliberately gone -
- * client inventory isn't something you manage from the sidebar. */
-function ClientRow({ client, importCount, selected, onSelect }: RowProps) {
-  const status = statusOf(client);
-  const missing = status === "missing";
-  const connected = client.gatewayInstalled;
-
-  // Label the exception, not the rule. The green chain icon already says
-  // "connected", so we don't repeat the word on every row - that just buries the
-  // one row that isn't connected under a wall of green. Only non-connected /
-  // error / missing states get a status word, so "not connected" actually stands
-  // out. The import backlog is a separate, secondary badge either way.
-  const statusWord =
-    status === "error"
-      ? "error"
-      : status === "missing"
-        ? "not found"
-        : connected
-          ? null
-          : "not connected";
-  const showBadge = importCount > 0 && status !== "error" && status !== "missing";
-
-  return (
-    <Tooltip>
-      <TooltipTrigger asChild>
-        <button
-          onClick={onSelect}
-          aria-current={selected ? "page" : undefined}
-          className={`${NAV_ITEM} ${selected ? "bg-accent" : ""} ${
-            missing ? "opacity-50" : ""
-          }`}
-        >
-          {connected ? (
-            <Link2 className="size-3.5 shrink-0 text-success" />
-          ) : client.usesConnectors ? (
-            <Puzzle className="size-3.5 shrink-0 text-info" />
-          ) : (
-            <span className={`size-2 shrink-0 rounded-full ${dotClass[status]}`} />
-          )}
-          <span className="truncate">{client.name}</span>
-          <span className="ml-auto flex shrink-0 items-center gap-1.5">
-            {showBadge && (
-              <span className="inline-flex items-center gap-0.5 rounded-full bg-owned/15 px-1.5 text-[10px] font-medium text-owned">
-                <Download className="size-2.5" />
-                {importCount}
-              </span>
-            )}
-            {statusWord && (
-              <span
-                className={`text-xs ${
-                  status === "error" ? "text-warning" : "text-muted-foreground"
-                }`}
-              >
-                {statusWord}
-              </span>
-            )}
-          </span>
-        </button>
-      </TooltipTrigger>
-      <TooltipContent side="right" className="max-w-xs">
-        <p className="font-mono text-xs break-all">
-          {client.configPath || "path unavailable on this OS"}
-        </p>
-        <p className="mt-1 text-xs text-muted-foreground">
-          {connected
-            ? "Toolport is the gateway here. Other entries are just import sources."
-            : "Connect Toolport here, and import any servers you want it to manage."}
-        </p>
-        {client.usesConnectors && (
-          <p className="mt-1 text-xs text-info">
-            Manages servers as account connectors, outside the config file.
-          </p>
-        )}
-        {client.error && <p className="mt-1 text-xs text-warning">{client.error}</p>}
-      </TooltipContent>
-    </Tooltip>
-  );
-}
-
 interface Props {
-  clients: DetectedClient[];
   registry: Registry | null;
   onRegistryChange: (registry: Registry) => void;
-  selectedClientId: string | null;
-  onSelectClient: (id: string | null) => void;
   view: View;
   onSelectView: (view: View) => void;
   onReplayOnboarding: () => void;
 }
 
 export function AppSidebar({
-  clients,
   registry,
   onRegistryChange,
-  selectedClientId,
-  onSelectClient,
   view,
   onSelectView,
   onReplayOnboarding,
 }: Props) {
-  const [showMissing, setShowMissing] = useState(false);
   const [savings, setSavings] = useState<SavingsSummary | null>(null);
   // `null` means "no confirmed count": the first poll hasn't answered yet. It
   // must render distinctly from a confirmed zero so a gateway that never
@@ -509,10 +372,6 @@ export function AppSidebar({
   // the "?" glyph and its "Could not reach the gateway" tooltip must only appear
   // once a poll has actually failed, not on every app start (#742).
   const [quarantineStale, setQuarantineStale] = useState(false);
-  const sorted = sortClients(clients);
-  const detectedClients = sorted.filter((c) => statusOf(c) !== "missing");
-  const missingClients = sorted.filter((c) => statusOf(c) === "missing");
-
   // Surface the running token savings in the sidebar so the headline number isn't
   // hidden one click away in Activity. Refresh on a light interval as calls flow.
   useEffect(() => {
@@ -651,11 +510,11 @@ export function AppSidebar({
         )}
 
         <nav aria-label="Views" className="flex flex-col gap-0.5 px-3 pt-2">
-          {navItem(
-            Layers,
-            "All servers",
-            view === "servers" && selectedClientId === null,
-            () => onSelectClient(null),
+          {navItem(Layers, "All servers", view === "servers", () =>
+            onSelectView("servers"),
+          )}
+          {navItem(MonitorCog, "Clients", view === "clients", () =>
+            onSelectView("clients"),
           )}
           {navItem(Store, "Browse catalog", view === "catalog", () =>
             onSelectView("catalog"),
@@ -692,57 +551,6 @@ export function AppSidebar({
             </span>
           </button>
         )}
-
-        <div className="px-3 pt-3">
-          <div className="px-2.5 pb-1.5 text-xs font-medium tracking-wide text-muted-foreground uppercase">
-            Clients
-          </div>
-          <nav aria-label="Clients" className="flex flex-col gap-0.5">
-            {clients.length === 0 ? (
-              <p className="px-2.5 py-1.5 text-xs text-muted-foreground">
-                No MCP clients found. Install Claude Desktop, Cursor, or another supported
-                tool, then refresh.
-              </p>
-            ) : (
-              <>
-                {detectedClients.map((client) => (
-                  <ClientRow
-                    key={client.id}
-                    client={client}
-                    importCount={importableServers(client, registry).length}
-                    selected={view === "servers" && selectedClientId === client.id}
-                    onSelect={() => onSelectClient(client.id)}
-                  />
-                ))}
-                {missingClients.length > 0 && (
-                  <>
-                    <button
-                      onClick={() => setShowMissing((v) => !v)}
-                      aria-expanded={showMissing}
-                      className={`mt-1 flex w-full items-center gap-2 rounded-md px-2.5 py-1.5 text-left text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-foreground ${FOCUS_RING}`}
-                    >
-                      <ChevronRight
-                        className={`size-3.5 shrink-0 transition-transform ${showMissing ? "rotate-90" : ""}`}
-                      />
-                      <span>Not detected</span>
-                      <span className="ml-auto">{missingClients.length}</span>
-                    </button>
-                    {showMissing &&
-                      missingClients.map((client) => (
-                        <ClientRow
-                          key={client.id}
-                          client={client}
-                          importCount={importableServers(client, registry).length}
-                          selected={view === "servers" && selectedClientId === client.id}
-                          onSelect={() => onSelectClient(client.id)}
-                        />
-                      ))}
-                  </>
-                )}
-              </>
-            )}
-          </nav>
-        </div>
       </div>
 
       <VersionFooter onImport={onRegistryChange} onReplay={onReplayOnboarding} />

--- a/src/components/ClientDetail.tsx
+++ b/src/components/ClientDetail.tsx
@@ -33,6 +33,7 @@ import {
   type ServerEntry,
 } from "@/lib/types";
 import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
 import { Card, CardContent } from "@/components/ui/card";
 import {
   Dialog,
@@ -422,19 +423,24 @@ export function ClientDetail({ client, registry, onChanged, onRegistryChange }: 
       <div className="flex items-start justify-between gap-4">
         <div className="min-w-0">
           {customized ? (
-            <span className="mb-1 inline-flex items-center gap-1 rounded-full border border-warning/30 bg-warning/10 px-2 py-0.5 text-xs font-medium text-warning">
+            <Badge variant="warning" className="mb-1">
               <TriangleAlert className="size-3" />
               custom configuration
-            </span>
+            </Badge>
           ) : installed ? (
-            <span className="mb-1 inline-flex items-center gap-1 rounded-full border border-success/30 bg-success/10 px-2 py-0.5 text-xs font-medium text-success">
+            <Badge variant="success" className="mb-1">
               <Link2 className="size-3" />
-              connected to Toolport
-            </span>
+              connected
+            </Badge>
+          ) : present ? (
+            <Badge variant="info" className="mb-1">
+              <Monitor className="size-3" />
+              ready to connect
+            </Badge>
           ) : (
-            <span className="mb-1 inline-flex items-center gap-1 rounded-full border border-border bg-muted/40 px-2 py-0.5 text-xs font-medium text-muted-foreground">
-              not connected
-            </span>
+            <Badge variant="outline" className="mb-1 text-muted-foreground">
+              not installed
+            </Badge>
           )}
           <p className="truncate font-mono text-xs text-muted-foreground">
             {client.configExists
@@ -445,8 +451,8 @@ export function ClientDetail({ client, registry, onChanged, onRegistryChange }: 
           </p>
           {customized && (
             <p className="mt-1 text-xs text-muted-foreground">
-              Custom configuration - not managed by Toolport. Hand-edited gateway entry is
-              left as-is until you reset it.
+              Toolport is leaving your hand-edited gateway entry as-is. Reset it only if
+              you want Toolport to manage the entry.
             </p>
           )}
           {installed && !customized && (
@@ -461,9 +467,8 @@ export function ClientDetail({ client, registry, onChanged, onRegistryChange }: 
             </p>
           )}
           {!present && !installed && (
-            <p className="mt-1 text-xs text-warning">
-              {client.name} doesn't appear to be installed here. Install it first, then
-              connect.
+            <p className="mt-1 text-xs text-muted-foreground">
+              Install {client.name} on this machine before connecting it to Toolport.
             </p>
           )}
         </div>
@@ -893,14 +898,14 @@ function GatewayFlow({ clientName, servers }: { clientName: string; servers: str
   return (
     <div className="flex flex-wrap items-center justify-center gap-1 rounded-xl border border-border/60 bg-card/40 px-4 py-5">
       <div className="flex flex-col items-center gap-2 text-center">
-        <div className="grid size-14 place-items-center rounded-2xl border border-border bg-secondary text-xl">
+        <div className="grid size-14 place-items-center rounded-xl border border-border bg-secondary text-xl">
           <Monitor className="size-6 text-muted-foreground" />
         </div>
         <div className="text-2xs font-semibold">{clientName}</div>
       </div>
-      <div className={`${link} bg-gradient-to-r from-border to-primary`} />
+      <div className={`${link} bg-border`} />
       <div className="flex flex-col items-center gap-2 text-center">
-        <div className="grid size-16 place-items-center rounded-2xl border border-primary/45 bg-primary/10 shadow-[0_0_0_5px_color-mix(in_oklch,var(--primary)_12%,transparent),0_16px_34px_-16px_color-mix(in_oklch,var(--primary)_50%,transparent)]">
+        <div className="grid size-16 place-items-center rounded-xl border border-primary/35 bg-primary/10">
           <svg width="30" height="30" viewBox="0 0 32 32" aria-hidden="true">
             <circle
               cx="16"
@@ -918,7 +923,7 @@ function GatewayFlow({ clientName, servers }: { clientName: string; servers: str
           <span className="block font-normal text-muted-foreground">gateway</span>
         </div>
       </div>
-      <div className={`${link} bg-gradient-to-r from-primary to-border`} />
+      <div className={`${link} bg-border`} />
       <div className="flex flex-col gap-1">
         {shown.map((s) => (
           <span

--- a/src/components/ClientsView.test.tsx
+++ b/src/components/ClientsView.test.tsx
@@ -46,6 +46,55 @@ describe("ClientsView", () => {
     expect(rows[1]).toHaveTextContent("Ready to connect");
   });
 
+  it("does not describe a customized gateway entry as connected", () => {
+    render(
+      <ClientsView
+        clients={[
+          client({
+            gatewayInstalled: true,
+            entryState: "customized",
+          }),
+        ]}
+        registry={null}
+        onSelectClient={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Custom configuration")).toBeInTheDocument();
+    expect(screen.getByText("1 using custom configuration.")).toBeInTheDocument();
+    expect(
+      screen.queryByText("Your installed clients are connected to Toolport."),
+    ).not.toBeInTheDocument();
+  });
+
+  it("mentions config-read errors alongside connected clients", () => {
+    render(
+      <ClientsView
+        clients={[
+          client({
+            id: "claude-desktop",
+            name: "Claude Desktop",
+            gatewayInstalled: true,
+            entryState: "managed",
+          }),
+          client({
+            id: "cursor",
+            name: "Cursor",
+            error: "invalid JSON",
+          }),
+        ]}
+        registry={null}
+        onSelectClient={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("1 client connected")).toBeInTheDocument();
+    expect(screen.getByText("1 config read needs attention.")).toBeInTheDocument();
+    expect(
+      screen.queryByText("Your installed clients are connected to Toolport."),
+    ).not.toBeInTheDocument();
+  });
+
   it("opens the selected client", async () => {
     const onSelectClient = vi.fn();
     render(
@@ -94,6 +143,13 @@ describe("ClientsView", () => {
 
     expect(screen.getByText("No AI clients detected")).toBeInTheDocument();
     expect(screen.getByText(/install claude desktop/i)).toBeInTheDocument();
+  });
+
+  it("shows loading placeholders before client detection completes", () => {
+    render(<ClientsView clients={[]} registry={null} loading onSelectClient={vi.fn()} />);
+
+    expect(screen.getByLabelText("Loading AI clients")).toBeInTheDocument();
+    expect(screen.queryByText("No AI clients detected")).not.toBeInTheDocument();
   });
 
   it("explains an inventory containing only clients that are not installed", () => {

--- a/src/components/ClientsView.test.tsx
+++ b/src/components/ClientsView.test.tsx
@@ -1,0 +1,122 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import type { DetectedClient } from "@/lib/types";
+import { ClientsView } from "./ClientsView";
+
+function client(overrides: Partial<DetectedClient> = {}): DetectedClient {
+  return {
+    id: "cursor",
+    name: "Cursor",
+    usesConnectors: false,
+    configPath: "/tmp/cursor.json",
+    configExists: true,
+    appPresent: true,
+    servers: [],
+    pluginServers: [],
+    gatewayInstalled: false,
+    entryState: "absent",
+    error: null,
+    ...overrides,
+  };
+}
+
+describe("ClientsView", () => {
+  it("orders connected clients first and uses calm factual states", () => {
+    render(
+      <ClientsView
+        clients={[
+          client({ id: "cursor", name: "Cursor" }),
+          client({
+            id: "claude-desktop",
+            name: "Claude Desktop",
+            gatewayInstalled: true,
+            entryState: "managed",
+          }),
+        ]}
+        registry={null}
+        onSelectClient={vi.fn()}
+      />,
+    );
+
+    const rows = screen.getAllByRole("button");
+    expect(rows[0]).toHaveTextContent("Claude Desktop");
+    expect(rows[0]).toHaveTextContent("Connected");
+    expect(rows[1]).toHaveTextContent("Cursor");
+    expect(rows[1]).toHaveTextContent("Ready to connect");
+  });
+
+  it("opens the selected client", async () => {
+    const onSelectClient = vi.fn();
+    render(
+      <ClientsView
+        clients={[client()]}
+        registry={null}
+        onSelectClient={onSelectClient}
+      />,
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: /cursor/i }));
+    expect(onSelectClient).toHaveBeenCalledWith("cursor");
+  });
+
+  it("keeps clients that are not installed behind a disclosure", async () => {
+    render(
+      <ClientsView
+        clients={[
+          client(),
+          client({
+            id: "zed",
+            name: "Zed",
+            appPresent: false,
+            configExists: false,
+            configPath: "",
+          }),
+        ]}
+        registry={null}
+        onSelectClient={vi.fn()}
+      />,
+    );
+
+    const toggle = screen.getByRole("button", { name: /not installed/i });
+    expect(toggle).toHaveAttribute("aria-expanded", "false");
+    expect(screen.queryByRole("button", { name: /zed/i })).not.toBeInTheDocument();
+
+    await userEvent.click(toggle);
+    expect(toggle).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByRole("button", { name: /zed/i })).toHaveTextContent(
+      "Not installed",
+    );
+  });
+
+  it("shows an honest empty state when detection returns nothing", () => {
+    render(<ClientsView clients={[]} registry={null} onSelectClient={vi.fn()} />);
+
+    expect(screen.getByText("No AI clients detected")).toBeInTheDocument();
+    expect(screen.getByText(/install claude desktop/i)).toBeInTheDocument();
+  });
+
+  it("explains an inventory containing only clients that are not installed", () => {
+    render(
+      <ClientsView
+        clients={[
+          client({
+            id: "zed",
+            name: "Zed",
+            appPresent: false,
+            configExists: false,
+            configPath: "",
+          }),
+        ]}
+        registry={null}
+        onSelectClient={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("No supported clients installed")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /not installed/i })).toHaveAttribute(
+      "aria-expanded",
+      "false",
+    );
+  });
+});

--- a/src/components/ClientsView.tsx
+++ b/src/components/ClientsView.tsx
@@ -4,12 +4,14 @@ import { ClientLogo } from "@/components/ClientLogo";
 import { Badge } from "@/components/ui/badge";
 import { EmptyState } from "@/components/ui/empty-state";
 import { SectionHeader } from "@/components/ui/section-header";
+import { Skeleton } from "@/components/ui/skeleton";
 import { importableServers, type DetectedClient, type Registry } from "@/lib/types";
 
-type ClientStatus = "connected" | "ready" | "error" | "missing";
+type ClientStatus = "connected" | "ready" | "customized" | "error" | "missing";
 
 function statusOf(client: DetectedClient): ClientStatus {
   if (client.error) return "error";
+  if (client.entryState === "customized") return "customized";
   if (client.gatewayInstalled) return "connected";
   if (client.appPresent) return "ready";
   return "missing";
@@ -22,10 +24,12 @@ function sortClients(clients: DetectedClient[]): DetectedClient[] {
         return 0;
       case "ready":
         return 1;
-      case "error":
+      case "customized":
         return 2;
-      case "missing":
+      case "error":
         return 3;
+      case "missing":
+        return 4;
     }
   };
   return [...clients].sort((a, b) => rank(a) - rank(b) || a.name.localeCompare(b.name));
@@ -37,6 +41,8 @@ function StatusBadge({ status }: { status: ClientStatus }) {
       return <Badge variant="success">Connected</Badge>;
     case "ready":
       return <Badge variant="info">Ready to connect</Badge>;
+    case "customized":
+      return <Badge variant="warning">Custom configuration</Badge>;
     case "error":
       return <Badge variant="warning">Couldn&apos;t read config</Badge>;
     case "missing":
@@ -100,10 +106,12 @@ function ClientRow({
 export function ClientsView({
   clients,
   registry,
+  loading = false,
   onSelectClient,
 }: {
   clients: DetectedClient[];
   registry: Registry | null;
+  loading?: boolean;
   onSelectClient: (id: string) => void;
 }) {
   const [showMissing, setShowMissing] = useState(false);
@@ -112,6 +120,25 @@ export function ClientsView({
   const missing = sorted.filter((client) => statusOf(client) === "missing");
   const connected = present.filter((client) => statusOf(client) === "connected").length;
   const ready = present.filter((client) => statusOf(client) === "ready").length;
+  const customized = present.filter((client) => statusOf(client) === "customized").length;
+  const errors = present.filter((client) => statusOf(client) === "error").length;
+  const allConnected = present.length > 0 && connected === present.length;
+  const summaryIssues = [
+    customized > 0 ? `${customized} using custom configuration` : null,
+    errors > 0
+      ? `${errors} config read${errors === 1 ? "" : "s"} need${errors === 1 ? "s" : ""} attention`
+      : null,
+  ].filter((part): part is string => part !== null);
+
+  if (loading && clients.length === 0) {
+    return (
+      <div className="flex flex-col gap-2" aria-label="Loading AI clients">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <Skeleton key={i} className="h-14 w-full rounded-lg" />
+        ))}
+      </div>
+    );
+  }
 
   if (clients.length === 0) {
     return (
@@ -134,23 +161,39 @@ export function ClientsView({
         />
       )}
 
-      {connected + ready > 0 && (
-        <div className="flex items-center gap-3 rounded-xl border border-success/20 bg-success/5 px-4 py-3">
-          <div className="grid size-8 shrink-0 place-items-center rounded-lg bg-success/10 text-success">
+      {present.length > 0 && (
+        <div
+          className={`flex items-center gap-3 rounded-xl border px-4 py-3 ${
+            allConnected
+              ? "border-success/20 bg-success/5"
+              : "border-border/70 bg-card/40"
+          }`}
+        >
+          <div
+            className={`grid size-8 shrink-0 place-items-center rounded-lg ${
+              allConnected
+                ? "bg-success/10 text-success"
+                : "bg-muted text-muted-foreground"
+            }`}
+          >
             <MonitorCog className="size-4" />
           </div>
           <div>
             <p className="text-sm font-semibold">
-              {connected === 0
-                ? `${ready} client${ready === 1 ? "" : "s"} ready to connect`
-                : `${connected} client${connected === 1 ? "" : "s"} connected`}
+              {allConnected || connected > 0
+                ? `${connected} client${connected === 1 ? "" : "s"} connected`
+                : ready > 0
+                  ? `${ready} client${ready === 1 ? "" : "s"} ready to connect`
+                  : `${present.length} installed client${present.length === 1 ? "" : "s"}`}
             </p>
             <p className="text-xs text-muted-foreground">
-              {connected > 0 && ready > 0
-                ? `${ready} more installed and ready when you are.`
-                : connected > 0
-                  ? "Your installed clients are connected to Toolport."
-                  : "Choose a client below to connect it to Toolport."}
+              {allConnected
+                ? "Your installed clients are connected to Toolport."
+                : summaryIssues.length > 0
+                  ? `${summaryIssues.join(". ")}.`
+                  : connected > 0 && ready > 0
+                    ? `${ready} more installed and ready when you are.`
+                    : "Choose a client below to connect it to Toolport."}
             </p>
           </div>
         </div>

--- a/src/components/ClientsView.tsx
+++ b/src/components/ClientsView.tsx
@@ -1,0 +1,206 @@
+import { useState } from "react";
+import { ChevronRight, Download, MonitorCog, Puzzle } from "lucide-react";
+import { ClientLogo } from "@/components/ClientLogo";
+import { Badge } from "@/components/ui/badge";
+import { EmptyState } from "@/components/ui/empty-state";
+import { SectionHeader } from "@/components/ui/section-header";
+import { importableServers, type DetectedClient, type Registry } from "@/lib/types";
+
+type ClientStatus = "connected" | "ready" | "error" | "missing";
+
+function statusOf(client: DetectedClient): ClientStatus {
+  if (client.error) return "error";
+  if (client.gatewayInstalled) return "connected";
+  if (client.appPresent) return "ready";
+  return "missing";
+}
+
+function sortClients(clients: DetectedClient[]): DetectedClient[] {
+  const rank = (client: DetectedClient) => {
+    switch (statusOf(client)) {
+      case "connected":
+        return 0;
+      case "ready":
+        return 1;
+      case "error":
+        return 2;
+      case "missing":
+        return 3;
+    }
+  };
+  return [...clients].sort((a, b) => rank(a) - rank(b) || a.name.localeCompare(b.name));
+}
+
+function StatusBadge({ status }: { status: ClientStatus }) {
+  switch (status) {
+    case "connected":
+      return <Badge variant="success">Connected</Badge>;
+    case "ready":
+      return <Badge variant="info">Ready to connect</Badge>;
+    case "error":
+      return <Badge variant="warning">Couldn&apos;t read config</Badge>;
+    case "missing":
+      return <Badge variant="outline">Not installed</Badge>;
+  }
+}
+
+function ClientRow({
+  client,
+  importCount,
+  onSelect,
+}: {
+  client: DetectedClient;
+  importCount: number;
+  onSelect: () => void;
+}) {
+  const status = statusOf(client);
+  const detail =
+    status === "missing"
+      ? "Install this client to configure it with Toolport"
+      : client.configPath ||
+        (client.usesConnectors ? "Uses account connectors" : "Config path unavailable");
+
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      className={`grid min-h-14 w-full grid-cols-[32px_minmax(0,1fr)_auto_16px] items-center gap-3 border-b border-border/60 px-3.5 py-2.5 text-left transition-colors last:border-b-0 hover:bg-accent/40 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-ring ${
+        status === "missing" ? "opacity-60" : ""
+      }`}
+    >
+      <ClientLogo id={client.id} name={client.name} size={32} />
+      <span className="min-w-0">
+        <span className="flex items-center gap-1.5">
+          <span className="truncate text-sm font-medium">{client.name}</span>
+          {client.usesConnectors && (
+            <Puzzle
+              className="size-3.5 shrink-0 text-info"
+              aria-label="Uses connectors"
+            />
+          )}
+        </span>
+        <span className="block truncate font-mono text-2xs text-muted-foreground">
+          {detail}
+        </span>
+      </span>
+      <span className="flex items-center gap-2">
+        {importCount > 0 && status !== "error" && status !== "missing" && (
+          <Badge variant="owned">
+            <Download />
+            {importCount} to import
+          </Badge>
+        )}
+        <StatusBadge status={status} />
+      </span>
+      <ChevronRight className="size-4 text-muted-foreground/50" aria-hidden="true" />
+    </button>
+  );
+}
+
+export function ClientsView({
+  clients,
+  registry,
+  onSelectClient,
+}: {
+  clients: DetectedClient[];
+  registry: Registry | null;
+  onSelectClient: (id: string) => void;
+}) {
+  const [showMissing, setShowMissing] = useState(false);
+  const sorted = sortClients(clients);
+  const present = sorted.filter((client) => statusOf(client) !== "missing");
+  const missing = sorted.filter((client) => statusOf(client) === "missing");
+  const connected = present.filter((client) => statusOf(client) === "connected").length;
+  const ready = present.filter((client) => statusOf(client) === "ready").length;
+
+  if (clients.length === 0) {
+    return (
+      <EmptyState
+        icon={<MonitorCog />}
+        title="No AI clients detected"
+        description="Install Claude Desktop, Cursor, VS Code, or another supported client, then refresh."
+      />
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-5">
+      {present.length === 0 && (
+        <EmptyState
+          icon={<MonitorCog />}
+          title="No supported clients installed"
+          description="Install Claude Desktop, Cursor, VS Code, or another supported client, then refresh."
+          className="py-12"
+        />
+      )}
+
+      {connected + ready > 0 && (
+        <div className="flex items-center gap-3 rounded-xl border border-success/20 bg-success/5 px-4 py-3">
+          <div className="grid size-8 shrink-0 place-items-center rounded-lg bg-success/10 text-success">
+            <MonitorCog className="size-4" />
+          </div>
+          <div>
+            <p className="text-sm font-semibold">
+              {connected === 0
+                ? `${ready} client${ready === 1 ? "" : "s"} ready to connect`
+                : `${connected} client${connected === 1 ? "" : "s"} connected`}
+            </p>
+            <p className="text-xs text-muted-foreground">
+              {connected > 0 && ready > 0
+                ? `${ready} more installed and ready when you are.`
+                : connected > 0
+                  ? "Your installed clients are connected to Toolport."
+                  : "Choose a client below to connect it to Toolport."}
+            </p>
+          </div>
+        </div>
+      )}
+
+      {present.length > 0 && (
+        <section>
+          <SectionHeader count={present.length}>On this machine</SectionHeader>
+          <div className="overflow-hidden rounded-xl border border-border/60 bg-card/40">
+            {present.map((client) => (
+              <ClientRow
+                key={client.id}
+                client={client}
+                importCount={importableServers(client, registry).length}
+                onSelect={() => onSelectClient(client.id)}
+              />
+            ))}
+          </div>
+        </section>
+      )}
+
+      {missing.length > 0 && (
+        <section>
+          <button
+            type="button"
+            onClick={() => setShowMissing((value) => !value)}
+            aria-expanded={showMissing}
+            className="flex w-full items-center gap-2 rounded-md px-1 py-1.5 text-left text-xs text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+          >
+            <ChevronRight
+              className={`size-3.5 transition-transform ${showMissing ? "rotate-90" : ""}`}
+              aria-hidden="true"
+            />
+            <span className="font-medium">Not installed</span>
+            <span>{missing.length}</span>
+          </button>
+          {showMissing && (
+            <div className="mt-2 overflow-hidden rounded-xl border border-border/60 bg-card/30">
+              {missing.map((client) => (
+                <ClientRow
+                  key={client.id}
+                  client={client}
+                  importCount={0}
+                  onSelect={() => onSelectClient(client.id)}
+                />
+              ))}
+            </div>
+          )}
+        </section>
+      )}
+    </div>
+  );
+}

--- a/src/components/Onboarding.tsx
+++ b/src/components/Onboarding.tsx
@@ -742,7 +742,7 @@ function ConnectClients({
       {present.length === 0 ? (
         <p className="rounded-md bg-muted/50 px-3 py-2 text-sm text-muted-foreground">
           No clients detected yet. Install Claude Desktop, Cursor, VS Code, or another
-          supported tool, then connect it from the sidebar.
+          supported tool, then connect it from Clients.
         </p>
       ) : (
         <div className="flex flex-col gap-2">

--- a/src/components/PlaygroundView.tsx
+++ b/src/components/PlaygroundView.tsx
@@ -928,11 +928,11 @@ export function PlaygroundView({ registry, onRegistryChange }: PlaygroundProps) 
             (looksLikeAuthError(toolsError) ? (
               <Callout variant="warning">
                 <span className="font-medium">
-                  {serverEntry?.name ?? "This server"} needs authentication.
+                  Sign in to {serverEntry?.name ?? "this server"} first.
                 </span>{" "}
-                Listing its tools failed with what looks like an auth error. Open{" "}
-                <span className="font-medium">Servers</span>, pick this server, and add
-                its credentials (the key icon / Secrets) before testing here.
+                Toolport couldn&apos;t list its tools without credentials. Open{" "}
+                <span className="font-medium">Servers</span>, choose this server, and use{" "}
+                <span className="font-medium">Authenticate</span>.
                 <p className="mt-1.5 font-mono text-xs break-words opacity-70">
                   {toolsError}
                 </p>

--- a/src/components/QuarantineAlert.test.tsx
+++ b/src/components/QuarantineAlert.test.tsx
@@ -250,7 +250,7 @@ describe("QuarantineAlert", () => {
     listQuarantined.mockResolvedValue([tool()]);
     render(<QuarantineAlert />);
 
-    await userEvent.click(await screen.findByRole("button", { name: /keep blocked/i }));
+    await userEvent.click(await screen.findByRole("button", { name: /review later/i }));
     expect(screen.queryByRole("region")).not.toBeInTheDocument();
 
     listQuarantined.mockResolvedValue([tool(), tool({ tool: "linear__delete_issue" })]);
@@ -269,7 +269,7 @@ describe("QuarantineAlert", () => {
     listQuarantined.mockResolvedValue([first]);
     render(<QuarantineAlert />);
 
-    await userEvent.click(await screen.findByRole("button", { name: /keep blocked/i }));
+    await userEvent.click(await screen.findByRole("button", { name: /review later/i }));
     expect(screen.queryByRole("region")).not.toBeInTheDocument();
 
     // Released elsewhere, then quarantined again: same tool, same profile, new event.

--- a/src/components/QuarantineAlert.test.tsx
+++ b/src/components/QuarantineAlert.test.tsx
@@ -250,7 +250,7 @@ describe("QuarantineAlert", () => {
     listQuarantined.mockResolvedValue([tool()]);
     render(<QuarantineAlert />);
 
-    await userEvent.click(await screen.findByRole("button", { name: /review later/i }));
+    await userEvent.click(await screen.findByRole("button", { name: /dismiss/i }));
     expect(screen.queryByRole("region")).not.toBeInTheDocument();
 
     listQuarantined.mockResolvedValue([tool(), tool({ tool: "linear__delete_issue" })]);
@@ -269,7 +269,7 @@ describe("QuarantineAlert", () => {
     listQuarantined.mockResolvedValue([first]);
     render(<QuarantineAlert />);
 
-    await userEvent.click(await screen.findByRole("button", { name: /review later/i }));
+    await userEvent.click(await screen.findByRole("button", { name: /dismiss/i }));
     expect(screen.queryByRole("region")).not.toBeInTheDocument();
 
     // Released elsewhere, then quarantined again: same tool, same profile, new event.

--- a/src/components/QuarantineAlert.tsx
+++ b/src/components/QuarantineAlert.tsx
@@ -171,14 +171,14 @@ export function QuarantineAlert({ onReview }: { onReview?: () => void }) {
     <div className="pointer-events-none fixed inset-x-0 bottom-0 z-40 flex justify-center px-4 pb-4">
       <div
         role="region"
-        aria-label={`${items.length} tool${many ? "s" : ""} blocked after a high-risk change`}
+        aria-label={`Toolport paused ${items.length} changed tool${many ? "s" : ""}`}
         className="animate-in fade-in slide-in-from-bottom-2 pointer-events-auto relative w-full max-w-lg overflow-hidden rounded-xl border border-warning/40 bg-popover/95 shadow-2xl ring-1 ring-warning/10 backdrop-blur"
       >
         {/* Announced politely rather than moving focus. This card appears while you are
             working, so stealing focus would be hostile; it is a status surface, not a
             dialog, which is why it is a labelled region rather than an alertdialog. */}
         <div aria-live="polite" className="sr-only">
-          {items.length} tool{many ? "s" : ""} blocked after a high-risk change.
+          Toolport paused {items.length} changed tool{many ? "s" : ""} for review.
         </div>
         <div className="flex items-start gap-2.5 border-b border-border/60 px-4 py-3">
           <ShieldAlert
@@ -187,11 +187,11 @@ export function QuarantineAlert({ onReview }: { onReview?: () => void }) {
           />
           <div className="min-w-0">
             <p className="text-sm font-medium">
-              {items.length} tool{many ? "s" : ""} blocked after a high-risk change
+              Toolport paused {items.length} changed tool{many ? "s" : ""}
             </p>
             <p className="mt-0.5 text-xs text-muted-foreground">
-              Toolport hid {many ? "these" : "this"} from every client. Re-approve only if
-              you expected the change.
+              {many ? "They can’t" : "It can’t"} run from any client until you review the
+              change. Everything else stays available.
             </p>
           </div>
         </div>
@@ -270,7 +270,7 @@ export function QuarantineAlert({ onReview }: { onReview?: () => void }) {
           {/* Scoped to the current set, so a NEW quarantine re-opens the card rather
               than inheriting an earlier dismissal. */}
           <Button size="sm" variant="ghost" onClick={() => setDismissedFor(signature)}>
-            Keep blocked
+            Review later
           </Button>
         </div>
       </div>

--- a/src/components/QuarantineAlert.tsx
+++ b/src/components/QuarantineAlert.tsx
@@ -270,7 +270,7 @@ export function QuarantineAlert({ onReview }: { onReview?: () => void }) {
           {/* Scoped to the current set, so a NEW quarantine re-opens the card rather
               than inheriting an earlier dismissal. */}
           <Button size="sm" variant="ghost" onClick={() => setDismissedFor(signature)}>
-            Review later
+            Dismiss
           </Button>
         </div>
       </div>

--- a/src/components/RegistryServerRow.test.tsx
+++ b/src/components/RegistryServerRow.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { act, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import type { ProbeResult, ServerEntry } from "@/lib/types";
 import { TooltipProvider } from "@/components/ui/tooltip";
@@ -26,11 +26,11 @@ function health(overrides: Partial<ProbeResult>): ProbeResult {
   };
 }
 
-function renderRow(enabled: boolean, result?: ProbeResult) {
+function renderRow(enabled: boolean, result?: ProbeResult, rowServer = server) {
   return render(
     <TooltipProvider>
       <RegistryServerRow
-        server={server}
+        server={rowServer}
         registry={null}
         enabled={enabled}
         health={result}
@@ -54,5 +54,22 @@ describe("RegistryServerRow status accessibility", () => {
 
     expect(screen.getByRole("status", { name: label })).toBeInTheDocument();
     view.unmount();
+  });
+
+  it("announces when a launcher package is being installed", () => {
+    vi.useFakeTimers();
+    const view = renderRow(true, undefined, {
+      ...server,
+      command: "npx",
+      args: ["example-package"],
+    });
+
+    act(() => vi.advanceTimersByTime(4000));
+
+    expect(
+      screen.getByRole("status", { name: "Installing the server package" }),
+    ).toBeInTheDocument();
+    view.unmount();
+    vi.useRealTimers();
   });
 });

--- a/src/components/RegistryServerRow.test.tsx
+++ b/src/components/RegistryServerRow.test.tsx
@@ -1,0 +1,58 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { ProbeResult, ServerEntry } from "@/lib/types";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import { RegistryServerRow } from "./RegistryServerRow";
+
+const server: ServerEntry = {
+  id: "server-1",
+  name: "Example",
+  transport: "stdio",
+  command: "example",
+  args: [],
+  env: [],
+  url: null,
+  source: "manual",
+};
+
+function health(overrides: Partial<ProbeResult>): ProbeResult {
+  return {
+    serverId: server.id,
+    ok: false,
+    toolCount: 0,
+    error: null,
+    authRequired: false,
+    ...overrides,
+  };
+}
+
+function renderRow(enabled: boolean, result?: ProbeResult) {
+  return render(
+    <TooltipProvider>
+      <RegistryServerRow
+        server={server}
+        registry={null}
+        enabled={enabled}
+        health={result}
+        onToggle={vi.fn()}
+        onRemove={vi.fn()}
+        onRegistryChange={vi.fn()}
+      />
+    </TooltipProvider>,
+  );
+}
+
+describe("RegistryServerRow status accessibility", () => {
+  it.each([
+    ["Server disabled", false, undefined],
+    ["Checking connection", true, undefined],
+    ["Connected", true, health({ ok: true, toolCount: 2 })],
+    ["Authentication required", true, health({ authRequired: true })],
+    ["Connection error", true, health({ error: "connection refused" })],
+  ] as const)("announces %s", (label, enabled, result) => {
+    const view = renderRow(enabled, result);
+
+    expect(screen.getByRole("status", { name: label })).toBeInTheDocument();
+    view.unmount();
+  });
+});

--- a/src/components/RegistryServerRow.test.tsx
+++ b/src/components/RegistryServerRow.test.tsx
@@ -46,7 +46,7 @@ describe("RegistryServerRow status accessibility", () => {
   it.each([
     ["Server disabled", false, undefined],
     ["Checking connection", true, undefined],
-    ["Connected", true, health({ ok: true, toolCount: 2 })],
+    ["Ready, 2 tools", true, health({ ok: true, toolCount: 2 })],
     ["Authentication required", true, health({ authRequired: true })],
     ["Connection error", true, health({ error: "connection refused" })],
   ] as const)("announces %s", (label, enabled, result) => {

--- a/src/components/RegistryServerRow.tsx
+++ b/src/components/RegistryServerRow.tsx
@@ -152,7 +152,11 @@ export function RegistryServerRow({
           <span
             role="status"
             aria-label={
-              installing ? "Installing the server package" : STATUS_ARIA_LABEL[status]
+              installing
+                ? "Installing the server package"
+                : status === "connected"
+                  ? label.replace(" · ", ", ")
+                  : STATUS_ARIA_LABEL[status]
             }
             className="sr-only"
           />
@@ -314,7 +318,10 @@ function StatusLabel({
   error: string | null;
 }) {
   const text = (
-    <span className={`text-xs font-medium whitespace-nowrap ${STATUS_TEXT[status]}`}>
+    <span
+      aria-hidden="true"
+      className={`text-xs font-medium whitespace-nowrap ${STATUS_TEXT[status]}`}
+    >
       {label}
     </span>
   );

--- a/src/components/RegistryServerRow.tsx
+++ b/src/components/RegistryServerRow.tsx
@@ -43,6 +43,14 @@ const STATUS_TEXT: Record<Status, string> = {
   error: "text-destructive",
 };
 
+const STATUS_ARIA_LABEL: Record<Status, string> = {
+  disabled: "Server disabled",
+  checking: "Checking connection",
+  connected: "Connected",
+  "needs-auth": "Authentication required",
+  error: "Connection error",
+};
+
 const ACTION =
   "inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring";
 
@@ -141,6 +149,11 @@ export function RegistryServerRow({
         ) : null}
 
         <span className="ml-auto flex shrink-0 items-center gap-2.5">
+          <span
+            role="status"
+            aria-label={STATUS_ARIA_LABEL[status]}
+            className="sr-only"
+          />
           {status === "needs-auth" ? (
             <SecretsDialog
               server={server}

--- a/src/components/RegistryServerRow.tsx
+++ b/src/components/RegistryServerRow.tsx
@@ -35,17 +35,6 @@ function statusOf(enabled: boolean, health?: ProbeResult): Status {
   return "error";
 }
 
-const DOT: Record<Status, string> = {
-  disabled: "bg-muted-foreground/40",
-  // Distinct hue so "checking" survives without its pulse under prefers-reduced-motion.
-  checking: "bg-info/70 animate-pulse",
-  connected: "bg-success",
-  "needs-auth": "bg-warning",
-  error: "bg-destructive",
-};
-
-// The status word carries the color too, not just the 8px dot, so a broken or
-// needs-attention server reads at a glance instead of hinging on a tiny dot.
 const STATUS_TEXT: Record<Status, string> = {
   disabled: "text-muted-foreground",
   checking: "text-muted-foreground",
@@ -53,21 +42,6 @@ const STATUS_TEXT: Record<Status, string> = {
   "needs-auth": "text-warning",
   error: "text-destructive",
 };
-
-function statusAriaLabel(status: Status, label: string): string {
-  switch (status) {
-    case "disabled":
-      return "Server disabled";
-    case "checking":
-      return "Checking connection";
-    case "connected":
-      return `Connected, ${label}`;
-    case "needs-auth":
-      return "Authentication required";
-    case "error":
-      return "Connection error";
-  }
-}
 
 const ACTION =
   "inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring";
@@ -112,7 +86,7 @@ export function RegistryServerRow({
 
   const label =
     status === "connected"
-      ? `${health?.toolCount ?? 0} tool${health?.toolCount === 1 ? "" : "s"}`
+      ? `Ready · ${health?.toolCount ?? 0} tool${health?.toolCount === 1 ? "" : "s"}`
       : status === "error"
         ? "Error"
         : status === "checking"
@@ -152,14 +126,6 @@ export function RegistryServerRow({
             aria-label={`Toggle ${server.name}`}
           />
         </span>
-
-        <span
-          className={`size-2 shrink-0 rounded-full ${DOT[status]}`}
-          aria-label={
-            installing ? "Installing the server package" : statusAriaLabel(status, label)
-          }
-          role="status"
-        />
 
         <span className="min-w-0 truncate text-sm font-medium">{server.name}</span>
 
@@ -333,10 +299,7 @@ function StatusLabel({
   error: string | null;
 }) {
   const text = (
-    <span
-      aria-hidden="true"
-      className={`text-xs font-medium whitespace-nowrap ${STATUS_TEXT[status]}`}
-    >
+    <span className={`text-xs font-medium whitespace-nowrap ${STATUS_TEXT[status]}`}>
       {label}
     </span>
   );

--- a/src/components/RegistryServerRow.tsx
+++ b/src/components/RegistryServerRow.tsx
@@ -151,7 +151,9 @@ export function RegistryServerRow({
         <span className="ml-auto flex shrink-0 items-center gap-2.5">
           <span
             role="status"
-            aria-label={STATUS_ARIA_LABEL[status]}
+            aria-label={
+              installing ? "Installing the server package" : STATUS_ARIA_LABEL[status]
+            }
             className="sr-only"
           />
           {status === "needs-auth" ? (

--- a/src/components/SettingsView.tsx
+++ b/src/components/SettingsView.tsx
@@ -581,11 +581,11 @@ function PostureSummary({
   blockOnInjection: boolean;
 }) {
   const active = [
-    humanApproval && "human approval required",
-    denyDestructive && "destructive tools blocked",
-    confirmDestructive && "destructive calls confirmed",
-    quarantineOnDrift && "drifted tools quarantined",
-    blockOnInjection && "injection hits blocked",
+    humanApproval && "human approval on",
+    denyDestructive && "destructive tools denied",
+    confirmDestructive && "destructive calls ask first",
+    quarantineOnDrift && "changed tools paused",
+    blockOnInjection && "injection-like output blocked",
   ].filter(Boolean) as string[];
   // A hard gate (block or human-approval) = guarded; softer measures alone = partial.
   const gated = humanApproval || denyDestructive || blockOnInjection;
@@ -595,19 +595,19 @@ function PostureSummary({
       Icon: ShieldCheck,
       ring: "border-success/30 bg-success/5",
       tint: "text-success",
-      label: "Protected",
+      label: "Guardrails active",
     },
     partial: {
       Icon: ShieldAlert,
       ring: "border-warning/35 bg-warning/5",
       tint: "text-warning",
-      label: "Partly protected",
+      label: "Some guardrails active",
     },
     open: {
-      Icon: ShieldX,
-      ring: "border-destructive/35 bg-destructive/5",
-      tint: "text-destructive",
-      label: "Unprotected",
+      Icon: ShieldAlert,
+      ring: "border-warning/35 bg-warning/5",
+      tint: "text-warning",
+      label: "Approval gates are off",
     },
   }[state];
   const { Icon } = meta;
@@ -618,7 +618,7 @@ function PostureSummary({
         <span className={`font-medium ${meta.tint}`}>{meta.label}.</span>{" "}
         <span className="text-muted-foreground">
           {state === "open"
-            ? "No blocking or approval is active, so every tool call runs unattended."
+            ? "Tool calls run without a Toolport approval or blocking gate."
             : `Active: ${active.join(", ")}.`}
         </span>
       </p>

--- a/src/components/TeamsView.tsx
+++ b/src/components/TeamsView.tsx
@@ -45,7 +45,7 @@ const INSTR_STATE_META: Record<
   { label: string; className: string; Icon: typeof Check }
 > = {
   applied: { label: "Applied", className: "text-success", Icon: Check },
-  stale: { label: "Not applied yet", className: "text-warning", Icon: Clock },
+  stale: { label: "Pending sync", className: "text-info", Icon: Clock },
   blocked_override: {
     label: "Blocked by a local override",
     className: "text-warning",

--- a/src/lib/shortcuts.test.ts
+++ b/src/lib/shortcuts.test.ts
@@ -19,7 +19,7 @@ function key(k: string, mods: Partial<ShortcutEvent> = {}): ShortcutEvent {
 }
 
 describe("resolveShortcut (SBS-143)", () => {
-  it("maps Ctrl+1..6 to the six views in order", () => {
+  it("maps Ctrl+1..7 to the seven views in order", () => {
     SHORTCUT_VIEWS.forEach((view, i) => {
       expect(resolveShortcut(key(String(i + 1), { ctrlKey: true }))).toEqual({
         kind: "view",
@@ -35,8 +35,16 @@ describe("resolveShortcut (SBS-143)", () => {
     });
   });
 
-  it("does not claim a seventh number", () => {
-    expect(resolveShortcut(key("7", { ctrlKey: true }))).toBeNull();
+  it("keeps the shipped mappings and appends Clients as the seventh view", () => {
+    expect(resolveShortcut(key("2", { ctrlKey: true }))).toEqual({
+      kind: "view",
+      view: "activity",
+    });
+    expect(resolveShortcut(key("7", { ctrlKey: true }))).toEqual({
+      kind: "view",
+      view: "clients",
+    });
+    expect(resolveShortcut(key("8", { ctrlKey: true }))).toBeNull();
   });
 
   it("focuses search on bare / only outside a text field", () => {
@@ -104,6 +112,7 @@ describe("shortcutHelp", () => {
   it("names the platform modifier so a Mac user is not told to press Ctrl", () => {
     expect(shortcutHelp(true)[0].keys).toContain("⌘");
     expect(shortcutHelp(false)[0].keys).toContain("Ctrl");
+    expect(shortcutHelp(false)[0].keys).toContain("7");
   });
 
   it("documents every action the resolver can produce", () => {

--- a/src/lib/shortcuts.ts
+++ b/src/lib/shortcuts.ts
@@ -8,6 +8,8 @@ export const SHORTCUT_VIEWS: View[] = [
   "playground",
   "teams",
   "settings",
+  // Keep the shipped 1–6 mappings stable; Clients was promoted later.
+  "clients",
 ];
 
 /** What a keystroke resolved to, or `null` when it is not a shortcut. */
@@ -52,7 +54,7 @@ export function isTextEntry(target: ShortcutTarget | null | undefined): boolean 
  * rather than through a rendered tree.
  *
  * Rules:
- *   * `Ctrl/Cmd+1..6` switch views, and work even while typing — an explicit modifier
+ *   * `Ctrl/Cmd+1..7` switch views, and work even while typing — an explicit modifier
  *     chord is never something the user meant as text.
  *   * `/` focuses search, but only outside a text field, or it eats the character.
  *   * `Ctrl/Cmd+F` also focuses search, everywhere. `Ctrl/Cmd+N` adds a server,
@@ -102,7 +104,7 @@ export interface ShortcutHelpRow {
 export function shortcutHelp(isMac: boolean): ShortcutHelpRow[] {
   const mod = isMac ? "⌘" : "Ctrl";
   return [
-    { keys: `${mod}1 – ${mod}6`, what: "Switch view" },
+    { keys: `${mod}1 – ${mod}7`, what: "Switch view" },
     { keys: `/ or ${mod}F`, what: "Focus the server search" },
     { keys: `${mod}N`, what: "Add a server" },
     { keys: `${mod}R`, what: "Refresh servers and clients" },

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -2,7 +2,7 @@ export type Transport = "stdio" | "http" | "sse" | "unknown";
 
 /** The main content views, selected from the sidebar. */
 export type View =
-  "servers" | "activity" | "catalog" | "playground" | "teams" | "settings";
+  "servers" | "clients" | "activity" | "catalog" | "playground" | "teams" | "settings";
 
 export interface McpServer {
   name: string;


### PR DESCRIPTION
## Summary
- promote Clients into a first-class inventory and detail destination with calm, factual connection states
- replace the Servers chip row with verified reachability posture and one prioritized next-action surface
- align safety language and severity across Activity, Settings, Teams, Playground, onboarding, and quarantine

## Test plan
- [x] `npm test` — 413 passed, 1 skipped
- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm run format:check`
- [x] `git diff --check`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add dedicated Clients view and promote it to top-level navigation
> - Moves client management out of the sidebar into a new `ClientsView` component, accessible via a 'Clients' nav item (Ctrl/Cmd+7) with sorting, status badges, and a not-installed disclosure section.
> - `ClientDetail` now renders inside the Clients view branch; the Servers view no longer conditionally shows client details.
> - Re-enabling a server now clears stale health data so the row returns to 'Checking' until a fresh probe completes.
> - Adds `serverPostureCopy` to derive a consistent posture summary that avoids reporting healthy while checks are incomplete or the backend is unreachable; replaces the old `StatusBar` with `ServerPosture` and `ServerNextAction` components.
> - Calms safety posture copy throughout: open-state uses a warning icon instead of destructive styling, `QuarantineAlert` secondary button relabeled from 'Keep blocked' to 'Dismiss', and status dot removed from `RegistryServerRow` in favor of screen-reader-only announcements.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #792 opened
>
> - Invalidate and re-probe health when servers are enabled or active profile changes [4d9c83c]
> - Preserve last-known failure context in posture detail when backend is unreachable [4d9c83c]
> - Changed server row status accessibility label from 'Connected' to 'Ready, N tools' [4d9c83c]
> - Updated tests for health invalidation, profile switching, and accessibility changes [4d9c83c]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized def7bd2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->