### PR TITLE
refactor(rules): scope the managed-rules markers (SBS-821)

### DIFF
--- a/src-tauri/src/clients.rs
+++ b/src-tauri/src/clients.rs
@@ -445,10 +445,14 @@ fn goose_hints_under_root(root: &Path) -> PathBuf {
     root.join("config").join(".goosehints")
 }
 
-fn rules_sentinel_block(path: PathBuf) -> crate::instructions::Target {
+fn rules_sentinel_block(
+    path: PathBuf,
+    scope: crate::instructions::Scope,
+) -> crate::instructions::Target {
     crate::instructions::Target {
         path,
         strategy: crate::instructions::Strategy::SentinelBlock,
+        scope,
         char_cap: None,
         blocked_if_present: None,
     }
@@ -634,7 +638,11 @@ fn resolve_client_config_path_linux(client_id: &str, home: &std::path::Path) -> 
     Some(path)
 }
 
-/// Resolve where a client reads its GLOBAL agent-rules file (Team Instructions, spec "W2").
+/// Resolve where a client reads its GLOBAL agent-rules file, for one [`crate::instructions::Scope`]
+/// (Team Instructions spec "W2"; personal rules in the `agent-rules` spec). The scope only changes
+/// the file NAME under [`crate::instructions::Strategy::OwnedFile`] — sentinel clients share one
+/// file and are separated by their markers instead, so both scopes resolve to the same path there
+/// by design.
 /// This is DISTINCT from the client's MCP-config path — e.g. Claude Code's config is
 /// `~/.claude.json` but its rules live under `~/.claude/rules/`. `None` means the client has
 /// no global-rules location we write: either its globals are UI/cloud-stored (Cursor, Warp),
@@ -649,18 +657,23 @@ fn resolve_rules_target(
     client_id: &str,
     home: &std::path::Path,
     platform: Platform,
+    scope: crate::instructions::Scope,
 ) -> Option<crate::instructions::Target> {
     use crate::instructions::{Strategy, Target};
     let config = roaming_config_dir(home, platform);
-    let owned = |path: PathBuf| Target {
-        path,
+    // `dir` is the client's rules DIRECTORY; the file name inside it is the scope's, so a team
+    // file and a personal file sit side by side and the client loads both.
+    let owned = |dir: PathBuf| Target {
+        path: dir.join(scope.owned_file_name()),
         strategy: Strategy::OwnedFile,
+        scope,
         char_cap: None,
         blocked_if_present: None,
     };
     let block = |path: PathBuf| Target {
         path,
         strategy: Strategy::SentinelBlock,
+        scope,
         char_cap: None,
         blocked_if_present: None,
     };
@@ -669,31 +682,14 @@ fn resolve_rules_target(
         // Claude Code's `~/.claude/rules/` is also read by VS Code Copilot (Claude-compat
         // paths), so both map here; path-dedup writes it once when both are installed and a
         // standalone VS Code install is still covered.
-        "claude-code" | "vscode" => owned(
-            home.join(".claude")
-                .join("rules")
-                .join("toolport-team-rules.md"),
-        ),
-        "kiro" => owned(
-            home.join(".kiro")
-                .join("steering")
-                .join("toolport-team-rules.md"),
-        ),
-        "roo-code" => owned(
-            home.join(".roo")
-                .join("rules")
-                .join("toolport-team-rules.md"),
-        ),
-        "cline" => owned(
-            home.join("Documents")
-                .join("Cline")
-                .join("Rules")
-                .join("toolport-team-rules.md"),
-        ),
+        "claude-code" | "vscode" => owned(home.join(".claude").join("rules")),
+        "kiro" => owned(home.join(".kiro").join("steering")),
+        "roo-code" => owned(home.join(".roo").join("rules")),
+        "cline" => owned(home.join("Documents").join("Cline").join("Rules")),
         // Strategy B — Toolport owns only the sentinel span in a shared global file.
         // Default home only. `client_rules_target` relocates Codex / Gemini CLI
         // when `CODEX_HOME` / `GEMINI_CLI_HOME` is an absolute path (SBS-885).
-        "codex" => codex_rules_target(&home.join(".codex")),
+        "codex" => codex_rules_target(&home.join(".codex"), scope),
         // Gemini CLI and Antigravity share `~/.gemini/GEMINI.md` at the default
         // home so a standalone install of EITHER is covered, and
         // `apply_instructions`' path-dedup writes it once when both are present.
@@ -707,6 +703,7 @@ fn resolve_rules_target(
                 .join("memories")
                 .join("global_rules.md"),
             strategy: Strategy::SentinelBlock,
+            scope,
             char_cap: Some(6000), // Windsurf hard-caps the global rules file.
             blocked_if_present: None,
         },
@@ -739,48 +736,60 @@ fn resolve_rules_target(
     Some(target)
 }
 
-/// Codex team-instructions live next to `config.toml` under `CODEX_HOME`
-/// (default `~/.codex`). `AGENTS.override.md` in that same directory, if
-/// present, makes Codex ignore `AGENTS.md` entirely.
-fn codex_rules_target(codex_home: &Path) -> crate::instructions::Target {
+/// Codex rules live next to `config.toml` under `CODEX_HOME` (default `~/.codex`).
+/// `AGENTS.override.md` in that same directory, if present, makes Codex ignore
+/// `AGENTS.md` entirely — for either scope, since both share the one file.
+fn codex_rules_target(
+    codex_home: &Path,
+    scope: crate::instructions::Scope,
+) -> crate::instructions::Target {
     crate::instructions::Target {
         path: codex_home.join("AGENTS.md"),
         strategy: crate::instructions::Strategy::SentinelBlock,
+        scope,
         char_cap: None,
         blocked_if_present: Some(codex_home.join("AGENTS.override.md")),
     }
 }
 
-/// Gemini CLI team-instructions follow `GEMINI_CLI_HOME` the same way settings
+/// Gemini CLI rules follow `GEMINI_CLI_HOME` the same way settings
 /// do: the env replaces the process home, then `.gemini/` is still appended.
-fn gemini_cli_rules_target(cli_home: &Path) -> crate::instructions::Target {
+fn gemini_cli_rules_target(
+    cli_home: &Path,
+    scope: crate::instructions::Scope,
+) -> crate::instructions::Target {
     crate::instructions::Target {
         path: cli_home.join(".gemini").join("GEMINI.md"),
         strategy: crate::instructions::Strategy::SentinelBlock,
+        scope,
         char_cap: None,
         blocked_if_present: None,
     }
 }
 
-/// The rules-file target for a client on the current machine, or `None` if unsupported /
-/// transitively covered. Mirrors [`client_config_path`]: Goose/Zed on Linux honor
-/// `XDG_CONFIG_HOME`, and Goose honors absolute `GOOSE_PATH_ROOT` (SBS-899).
-pub fn client_rules_target(client_id: &str) -> Option<crate::instructions::Target> {
+/// The rules-file target for a client on the current machine for one
+/// [`crate::instructions::Scope`], or `None` if unsupported / transitively covered. Mirrors
+/// [`client_config_path`]: Goose/Zed on Linux honor `XDG_CONFIG_HOME`, and Goose honors absolute
+/// `GOOSE_PATH_ROOT` (SBS-899).
+pub fn client_rules_target(
+    client_id: &str,
+    scope: crate::instructions::Scope,
+) -> Option<crate::instructions::Target> {
     // Honor relocate envs even when `$HOME` is unset: the live file is under
     // the override, not the default home table (SBS-885, SBS-899).
     if client_id == "goose" {
         if let Some(root) = goose_path_root_from(std::env::var_os("GOOSE_PATH_ROOT")) {
-            return Some(rules_sentinel_block(goose_hints_under_root(&root)));
+            return Some(rules_sentinel_block(goose_hints_under_root(&root), scope));
         }
     }
     if client_id == "codex" {
         if let Some(dir) = codex_home_from(std::env::var_os("CODEX_HOME")) {
-            return Some(codex_rules_target(&dir));
+            return Some(codex_rules_target(&dir, scope));
         }
     }
     if client_id == "gemini-cli" {
         if let Some(dir) = gemini_cli_home_from(std::env::var_os("GEMINI_CLI_HOME")) {
-            return Some(gemini_cli_rules_target(&dir));
+            return Some(gemini_cli_rules_target(&dir, scope));
         }
     }
     let home = home()?;
@@ -792,9 +801,9 @@ pub fn client_rules_target(client_id: &str) -> Option<crate::instructions::Targe
             "zed" => config.join("zed").join("AGENTS.md"),
             _ => unreachable!("guarded by matches! above"),
         };
-        return Some(rules_sentinel_block(path));
+        return Some(rules_sentinel_block(path, scope));
     }
-    resolve_rules_target(client_id, &home, Platform::current())
+    resolve_rules_target(client_id, &home, Platform::current(), scope)
 }
 
 fn claude_desktop_path() -> Option<PathBuf> {
@@ -6381,7 +6390,7 @@ mod tests {
             Some(relocated.clone())
         );
         assert_eq!(codex_config_path(&relocated), relocated.join("config.toml"));
-        let rules = codex_rules_target(&relocated);
+        let rules = codex_rules_target(&relocated, crate::instructions::Scope::Team);
         assert_eq!(rules.path, relocated.join("AGENTS.md"));
         assert_eq!(
             rules.blocked_if_present,
@@ -6410,7 +6419,7 @@ mod tests {
             relocated.join(".gemini").join("settings.json")
         );
         assert_eq!(
-            gemini_cli_rules_target(&relocated).path,
+            gemini_cli_rules_target(&relocated, crate::instructions::Scope::Team).path,
             relocated.join(".gemini").join("GEMINI.md")
         );
     }
@@ -9667,7 +9676,8 @@ command = "npx"
         let root = std::env::temp_dir().join(format!("toolport-codex-home-{}", std::process::id()));
         let _restore = EnvRestore::set("CODEX_HOME", &root);
         assert_eq!(codex_path(), Some(root.join("config.toml")));
-        let rules = client_rules_target("codex").expect("codex rules");
+        let rules = client_rules_target("codex", crate::instructions::Scope::Team)
+            .expect("codex rules");
         assert_eq!(rules.path, root.join("AGENTS.md"));
         assert_eq!(
             rules.blocked_if_present,
@@ -9685,12 +9695,18 @@ command = "npx"
             gemini_cli_path(),
             Some(root.join(".gemini").join("settings.json"))
         );
-        let rules = client_rules_target("gemini-cli").expect("gemini rules");
+        let rules = client_rules_target("gemini-cli", crate::instructions::Scope::Team)
+            .expect("gemini rules");
         assert_eq!(rules.path, root.join(".gemini").join("GEMINI.md"));
         // Antigravity is a different product; GEMINI_CLI_HOME must not move it.
         let home = home().expect("home");
-        let antigravity = resolve_rules_target("antigravity", &home, Platform::current())
-            .expect("antigravity rules");
+        let antigravity = resolve_rules_target(
+            "antigravity",
+            &home,
+            Platform::current(),
+            crate::instructions::Scope::Team,
+        )
+        .expect("antigravity rules");
         assert_eq!(antigravity.path, home.join(".gemini").join("GEMINI.md"));
     }
 
@@ -10429,11 +10445,22 @@ rules:
         }
     }
 
+    /// Team-scope resolution, the default for these path tests. Scope changes only the owned-file
+    /// NAME; `rules_target_owned_file_name_follows_the_scope` covers the personal variant, and
+    /// sentinel clients share one file across scopes by design.
+    fn team_rules_target(
+        client_id: &str,
+        home: &Path,
+        platform: Platform,
+    ) -> Option<crate::instructions::Target> {
+        resolve_rules_target(client_id, home, platform, crate::instructions::Scope::Team)
+    }
+
     #[test]
     fn rules_target_claude_code_is_owned_file_all_platforms() {
         use crate::instructions::Strategy;
         for p in [Platform::Windows, Platform::MacOs, Platform::Linux] {
-            let t = resolve_rules_target("claude-code", &mock_home(p), p).expect("supported");
+            let t = team_rules_target("claude-code", &mock_home(p), p).expect("supported");
             assert_eq!(t.strategy, Strategy::OwnedFile);
             assert!(
                 t.path
@@ -10445,11 +10472,54 @@ rules:
         }
     }
 
+    /// Team and personal owned files are siblings in the client's rules DIRECTORY, never the same
+    /// file: the client reads the whole directory, so both apply and neither clobbers the other.
+    #[test]
+    fn rules_target_owned_file_name_follows_the_scope() {
+        use crate::instructions::Scope;
+        let home = mock_home(Platform::MacOs);
+        let p = Platform::MacOs;
+        for client in ["claude-code", "vscode", "kiro", "roo-code", "cline"] {
+            let team = resolve_rules_target(client, &home, p, Scope::Team).expect("supported");
+            let personal =
+                resolve_rules_target(client, &home, p, Scope::Personal).expect("supported");
+            assert_eq!(
+                team.path.parent(),
+                personal.path.parent(),
+                "{client}: both scopes live in the same rules directory"
+            );
+            assert_ne!(team.path, personal.path, "{client}: scopes must not share a file");
+            assert!(team.path.ends_with(Scope::Team.owned_file_name()));
+            assert!(personal.path.ends_with(Scope::Personal.owned_file_name()));
+            assert_eq!(personal.scope, Scope::Personal);
+        }
+    }
+
+    /// Sentinel clients deliberately resolve to ONE file for both scopes. The two managed spans
+    /// coexist there, separated by their disjoint markers.
+    #[test]
+    fn rules_target_sentinel_clients_share_one_file_across_scopes() {
+        use crate::instructions::Scope;
+        let home = mock_home(Platform::MacOs);
+        let p = Platform::MacOs;
+        for client in ["codex", "gemini-cli", "windsurf", "goose", "zed", "pi", "omp"] {
+            let team = resolve_rules_target(client, &home, p, Scope::Team).expect("supported");
+            let personal =
+                resolve_rules_target(client, &home, p, Scope::Personal).expect("supported");
+            assert_eq!(team.path, personal.path, "{client}: one shared rules file");
+            assert_eq!(team.char_cap, personal.char_cap, "{client}: same cap");
+            assert_eq!(
+                team.blocked_if_present, personal.blocked_if_present,
+                "{client}: a shadow file blocks both scopes"
+            );
+        }
+    }
+
     #[test]
     fn rules_target_codex_is_sentinel_and_flags_override() {
         use crate::instructions::Strategy;
         let home = mock_home(Platform::MacOs);
-        let t = resolve_rules_target("codex", &home, Platform::MacOs).expect("supported");
+        let t = team_rules_target("codex", &home, Platform::MacOs).expect("supported");
         assert_eq!(t.strategy, Strategy::SentinelBlock);
         assert!(t.path.ends_with(PathBuf::from(".codex").join("AGENTS.md")));
         assert_eq!(
@@ -10461,17 +10531,17 @@ rules:
 
     #[test]
     fn rules_target_windsurf_carries_hard_cap() {
-        let t = resolve_rules_target("windsurf", &mock_home(Platform::Linux), Platform::Linux)
+        let t = team_rules_target("windsurf", &mock_home(Platform::Linux), Platform::Linux)
             .expect("supported");
         assert_eq!(t.char_cap, Some(6000));
     }
 
     #[test]
     fn rules_target_zed_is_platform_specific() {
-        let win = resolve_rules_target("zed", &mock_home(Platform::Windows), Platform::Windows)
+        let win = team_rules_target("zed", &mock_home(Platform::Windows), Platform::Windows)
             .expect("supported");
         assert!(win.path.to_string_lossy().contains("Zed"));
-        let mac = resolve_rules_target("zed", &mock_home(Platform::MacOs), Platform::MacOs)
+        let mac = team_rules_target("zed", &mock_home(Platform::MacOs), Platform::MacOs)
             .expect("supported");
         assert!(mac
             .path
@@ -10486,7 +10556,7 @@ rules:
         // Application Support — a pre-existing split, listed in the PR).
         for platform in Platform::ALL {
             let home = mock_home(platform);
-            let rules = resolve_rules_target("goose", &home, platform).expect("supported");
+            let rules = team_rules_target("goose", &home, platform).expect("supported");
             let config =
                 resolve_client_config_path("goose", &home, platform).expect("goose config");
             match platform {
@@ -10526,7 +10596,7 @@ rules:
             "hermes",
         ] {
             assert!(
-                resolve_rules_target(id, &mock_home(Platform::MacOs), Platform::MacOs).is_none(),
+                team_rules_target(id, &mock_home(Platform::MacOs), Platform::MacOs).is_none(),
                 "{id} should have no managed rules target"
             );
         }
@@ -10540,13 +10610,13 @@ rules:
         let home = mock_home(Platform::MacOs);
         let p = Platform::MacOs;
         assert_eq!(
-            resolve_rules_target("antigravity", &home, p),
-            resolve_rules_target("gemini-cli", &home, p),
+            team_rules_target("antigravity", &home, p),
+            team_rules_target("gemini-cli", &home, p),
             "Antigravity shares Gemini's GEMINI.md"
         );
         assert_eq!(
-            resolve_rules_target("vscode", &home, p),
-            resolve_rules_target("claude-code", &home, p),
+            team_rules_target("vscode", &home, p),
+            team_rules_target("claude-code", &home, p),
             "VS Code Copilot shares Claude Code's rules file"
         );
     }
@@ -10888,7 +10958,7 @@ rules:
             Some(root.join("config").join("config.yaml"))
         );
         assert_eq!(
-            client_rules_target("goose")
+            client_rules_target("goose", crate::instructions::Scope::Team)
                 .expect("goose has a rules target")
                 .path,
             root.join("config").join(".goosehints")

--- a/src-tauri/src/clients.rs
+++ b/src-tauri/src/clients.rs
@@ -10916,8 +10916,10 @@ rules:
         let _xdg = EnvRestore::set("XDG_CONFIG_HOME", &xdg_config);
         let _goose_root = EnvRestore::set("GOOSE_PATH_ROOT", Path::new(""));
 
-        let goose = client_rules_target("goose").expect("goose has a rules target");
-        let zed = client_rules_target("zed").expect("zed has a rules target");
+        let goose = client_rules_target("goose", crate::instructions::Scope::Team)
+            .expect("goose has a rules target");
+        let zed = client_rules_target("zed", crate::instructions::Scope::Team)
+            .expect("zed has a rules target");
         let goose_config = client_config_path("goose").expect("goose config");
         let zed_config = client_config_path("zed").expect("zed config");
 

--- a/src-tauri/src/instructions.rs
+++ b/src-tauri/src/instructions.rs
@@ -450,26 +450,41 @@ pub fn current_state(t: &Target, id: &str, version: i64, content: &str) -> Apply
 /// cleanup survives a client that was uninstalled or whose detection changed. An owned file (our
 /// header) is deleted whole; a shared file has only that scope's sentinel block stripped, and is
 /// deleted if nothing but whitespace remains. A file that is neither (already cleaned, or
-/// user-replaced) is left untouched. Best-effort: unreadable/missing paths are a no-op.
+/// user-replaced) is left untouched.
 ///
 /// `scope` is required, not sniffed: a shared file can hold BOTH a team and a personal block, and
 /// leaving a team must strip only the team one. The "nothing but whitespace remains" delete is
 /// therefore also correct — a surviving other-scope block is not whitespace, so the file stays.
-pub fn remove_recorded(path: &std::path::Path, scope: Scope) {
+///
+/// Returns whether this scope's artifact is now GONE from `path`. `false` means the file still
+/// holds our block (unreadable, locked, read-only, or a hand-mangled marker pair) and the caller
+/// must KEEP the path on record: cleanup is driven by that recorded list, so forgetting a path we
+/// failed to clean strands the block forever with nothing left that would ever look for it.
+pub fn remove_recorded(path: &std::path::Path, scope: Scope) -> bool {
     let existing = match std::fs::read_to_string(path) {
+        // Already gone: nothing of ours can be there, so the caller may stop tracking it.
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return true,
+        // Unreadable (locked, permissions): we cannot tell, so report NOT cleaned. A caller that
+        // dropped the path here would strand our block forever, since cleanup is by recorded path
+        // and nothing else would ever look at this file again.
+        Err(_) => return false,
         Ok(s) => s,
-        Err(_) => return,
     };
     if existing.contains(scope.sentinel_start_prefix()) {
-        if let Some(stripped) = remove_block(&existing, scope) {
-            if stripped.trim().is_empty() {
-                let _ = std::fs::remove_file(path);
-            } else {
-                let _ = write_atomic(path, &stripped);
-            }
+        let Some(stripped) = remove_block(&existing, scope) else {
+            // A START marker with no END: a hand-mangled file we must not guess at, and our
+            // marker is still in it.
+            return false;
+        };
+        if stripped.trim().is_empty() {
+            std::fs::remove_file(path).is_ok()
+        } else {
+            write_atomic(path, &stripped).is_ok()
         }
     } else if existing.starts_with(scope.owned_header_prefix()) {
-        let _ = std::fs::remove_file(path);
+        std::fs::remove_file(path).is_ok()
+    } else {
+        true // neither ours nor recognizable: already cleaned, or the user replaced it
     }
 }
 
@@ -1121,8 +1136,41 @@ mod tests {
         let path = s.path("someones.md");
         let foreign = "# not ours\njust user content\n";
         std::fs::write(&path, foreign).unwrap();
-        remove_recorded(&path, Scope::Team);
-        remove_recorded(&path, Scope::Personal);
+        assert!(remove_recorded(&path, Scope::Team), "nothing of ours to clean");
+        assert!(remove_recorded(&path, Scope::Personal));
         assert_eq!(std::fs::read_to_string(&path).unwrap(), foreign);
+    }
+
+    /// The return value is what lets a caller keep a path on record when cleanup did not actually
+    /// happen. Callers drive cleanup off that record, so a `true` here on a file that still holds
+    /// our block would strand it permanently.
+    #[test]
+    fn remove_recorded_reports_whether_our_artifact_is_really_gone() {
+        let s = Scratch::new();
+
+        // Absent file: nothing of ours can be there.
+        assert!(remove_recorded(&s.path("never-existed.md"), Scope::Personal));
+
+        // A real removal.
+        let t = block_target(s.path("AGENTS.md"), Scope::Personal);
+        write_target(&t, SET, 1, "My rule");
+        assert!(remove_recorded(&t.path, Scope::Personal));
+        assert!(!t.path.exists());
+
+        // A START marker with no END: hand-mangled, our marker is still in the file, and we must
+        // not guess where the block ends. Reported as NOT cleaned so the caller keeps looking.
+        let mangled = s.path("mangled.md");
+        std::fs::write(
+            &mangled,
+            format!("{PERSONAL_SENTINEL_START_PREFIX} set=x v=1 -->\nrules, no end marker\n"),
+        )
+        .unwrap();
+        assert!(
+            !remove_recorded(&mangled, Scope::Personal),
+            "a marker we could not remove must not be reported as gone"
+        );
+        assert!(std::fs::read_to_string(&mangled)
+            .unwrap()
+            .contains(PERSONAL_SENTINEL_START_PREFIX));
     }
 }

--- a/src-tauri/src/instructions.rs
+++ b/src-tauri/src/instructions.rs
@@ -194,10 +194,28 @@ impl Scope {
 /// content carrying a *team* START marker, placed before the real team block, would make the
 /// team's [`find_block`] span the personal block and swallow it on the next org sync. Refusing
 /// every family is the only safe rule.
-fn content_carries_a_marker(content: &str) -> bool {
+pub fn content_carries_a_marker(content: &str) -> bool {
     ALL_SCOPES
         .iter()
         .any(|s| content.contains(s.sentinel_start_prefix()) || content.contains(s.sentinel_end()))
+}
+
+/// Read-only: is this scope's managed artifact present at `path` right now?
+///
+/// Distinct from [`current_state`], which asks "does the file match THIS content". This asks only
+/// "is anything of ours there", which is the question when there is no longer any content to
+/// match: after a rule set is cleared, "nothing of ours on disk" is success and a leftover block
+/// is not. An unreadable file counts as present, for the same reason [`remove_recorded`] reports
+/// it as not-cleaned: we cannot see inside, so we must not claim it is clean.
+pub fn is_present(path: &std::path::Path, scope: Scope) -> bool {
+    match std::fs::read_to_string(path) {
+        Ok(existing) => {
+            existing.contains(scope.sentinel_start_prefix())
+                || existing.starts_with(scope.owned_header_prefix())
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => false,
+        Err(_) => true,
+    }
 }
 
 /// Stable content hash reported to the server as the "effective rules receipt": it identifies
@@ -1139,6 +1157,40 @@ mod tests {
         assert!(remove_recorded(&path, Scope::Team), "nothing of ours to clean");
         assert!(remove_recorded(&path, Scope::Personal));
         assert_eq!(std::fs::read_to_string(&path).unwrap(), foreign);
+    }
+
+    #[test]
+    fn is_present_answers_only_whether_something_of_ours_is_there() {
+        let s = Scratch::new();
+        let absent = s.path("nope.md");
+        assert!(!is_present(&absent, Scope::Personal));
+
+        // A file that is entirely someone else's.
+        let foreign = s.path("theirs.md");
+        std::fs::write(&foreign, "# mine\n").unwrap();
+        assert!(!is_present(&foreign, Scope::Personal));
+
+        // Our block, and the other scope's block, are told apart.
+        let shared = block_target(s.path("AGENTS.md"), Scope::Personal);
+        write_target(&shared, SET, 1, "My rule");
+        assert!(is_present(&shared.path, Scope::Personal));
+        assert!(
+            !is_present(&shared.path, Scope::Team),
+            "a personal block is not a team block"
+        );
+
+        // Presence does not care whether the content is current, unlike `current_state`.
+        assert_eq!(
+            current_state(&shared, SET, 2, "My rule"),
+            ApplyState::Stale,
+            "fixture: a newer revision is not applied"
+        );
+        assert!(is_present(&shared.path, Scope::Personal));
+
+        // Owned files are recognised by their header.
+        let owned = owned_target(s.path("rules").join("toolport-rules.md"), Scope::Personal);
+        write_target(&owned, SET, 1, "My rule");
+        assert!(is_present(&owned.path, Scope::Personal));
     }
 
     /// The return value is what lets a caller keep a path on record when cleanup did not actually

--- a/src-tauri/src/instructions.rs
+++ b/src-tauri/src/instructions.rs
@@ -1,10 +1,15 @@
-//! Team Instructions — write org-managed agent rules to each AI client's rules file.
+//! Agent rules — write Toolport-managed agent rules to each AI client's rules file.
 //!
-//! An admin authors the team's agent instructions once in the Teams dashboard; the server
-//! carries them in the team config under the top-level `instructions` key (see the
-//! `team-instructions` spec). This module is the client half (spec "W2"): it turns that
-//! content into files on disk next to — never over — the member's own instructions, and
-//! removes them cleanly when the member leaves the team.
+//! Two [`Scope`]s share this engine and can coexist in one file:
+//!
+//!   * [`Scope::Team`] — an admin authors the team's agent instructions once in the Teams
+//!     dashboard; the server carries them in the team config under the top-level `instructions`
+//!     key (see the `team-instructions` spec). This module is the client half (spec "W2").
+//!   * [`Scope::Personal`] — the user's own rule set, authored in the desktop app (see the
+//!     `agent-rules` spec). No server; the version pair is `(rule_set_id, revision)`.
+//!
+//! Either way it turns that content into files on disk next to — never over — the user's own
+//! instructions, and removes them cleanly when the member leaves the team or switches rule set.
 //!
 //! Two write strategies, both non-destructive:
 //!
@@ -15,9 +20,12 @@
 //!     the user may also edit, so we own only the span between two HTML-comment markers and
 //!     leave every byte outside them untouched.
 //!
-//! The invariant the tests pin: an upsert changes only the managed span (or appends one), and
-//! a remove takes the managed span back out, so a full join→edit→leave cycle returns the
-//! user's own content unchanged.
+//! The invariants the tests pin:
+//!
+//!   * An upsert changes only the managed span (or appends one), and a remove takes the managed
+//!     span back out, so a full join→edit→leave cycle returns the user's own content unchanged.
+//!   * Every operation is scoped. A team block and a personal block can sit in the same file;
+//!     writing or removing one leaves the other byte-identical.
 
 /// How a client's rules file is written.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -28,12 +36,34 @@ pub enum Strategy {
     SentinelBlock,
 }
 
-/// A resolved place to write one client's copy of the org instructions.
+/// Which set of rules a managed artifact belongs to.
+///
+/// The two scopes coexist: a member of a Toolport Teams org still has their own personal rules,
+/// and both land in the same client files. Each scope therefore owns a DISTINCT sentinel marker
+/// pair and a DISTINCT owned-file name, chosen so neither family is a substring of the other. A
+/// scoped [`find_block`] can then never match the other scope's span, and removing one scope's
+/// artifact leaves the other byte-identical.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Scope {
+    /// Org-pushed Team Instructions, keyed by `(team_id, version)` from the server.
+    Team,
+    /// The user's own rule set, keyed by `(rule_set_id, revision)` held locally.
+    Personal,
+}
+
+/// Every scope, for the checks that must consider all of them (see [`content_carries_a_marker`]).
+const ALL_SCOPES: [Scope; 2] = [Scope::Team, Scope::Personal];
+
+/// A resolved place to write one client's copy of the rules for one [`Scope`].
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Target {
     /// Absolute path of the file to write.
     pub path: std::path::PathBuf,
     pub strategy: Strategy,
+    /// Which rule set this target carries. Determines the markers and the owned-file name, so a
+    /// team target and a personal target for the same client are different files (owned) or
+    /// different spans in one file (sentinel).
+    pub scope: Scope,
     /// Hard character cap for clients that truncate/ignore an over-long global file
     /// (e.g. Windsurf's 6,000-char global rules). `None` = no client-imposed cap.
     pub char_cap: Option<usize>,
@@ -82,26 +112,92 @@ pub struct Receipt {
     pub clients: Vec<ClientReceipt>,
 }
 
-/// Sentinel markers. FROZEN compatibility contract — an older build must still recognize and
+/// Team sentinel markers. FROZEN compatibility contract — an older build must still recognize and
 /// replace/remove a block a newer build wrote, so these strings never change. The team id and
 /// version live in the START marker for provenance and cheap change display; only the START
 /// *prefix* is matched, so the id/version can vary without breaking recognition.
 pub const SENTINEL_START_PREFIX: &str = "<!-- toolport:team-instructions:start";
 pub const SENTINEL_END: &str = "<!-- toolport:team-instructions:end -->";
 
-/// FROZEN prefix of the header stamped on an [`Strategy::OwnedFile`] file. Cleanup on
+/// FROZEN prefix of the header stamped on a team [`Strategy::OwnedFile`] file. Cleanup on
 /// team-leave identifies our owned files by this prefix (so it only ever deletes files we
 /// wrote), which must stay recognizable across versions.
 pub const OWNED_HEADER_PREFIX: &str = "<!-- Managed by Toolport";
 
-/// The one-line header stamped at the top of an [`Strategy::OwnedFile`] file so a member who
-/// opens it understands it is managed and will be overwritten.
-fn owned_header(team_id: &str, version: i64) -> String {
-    format!("{OWNED_HEADER_PREFIX} — team {team_id}, v{version}. Edits are overwritten on sync; leave the team to remove. -->")
+/// Personal-scope markers, frozen on the same terms from first release. Deliberately NOT a
+/// substring of (nor containing) their team counterparts: [`find_block`] matches on the START
+/// prefix alone, so an overlapping family would let one scope find and overwrite the other's
+/// span. `personal_and_team_marker_families_are_disjoint` pins this.
+pub const PERSONAL_SENTINEL_START_PREFIX: &str = "<!-- toolport:rules:start";
+pub const PERSONAL_SENTINEL_END: &str = "<!-- toolport:rules:end -->";
+pub const PERSONAL_OWNED_HEADER_PREFIX: &str = "<!-- Toolport personal rules";
+
+impl Scope {
+    /// The frozen START-marker prefix this scope matches on.
+    pub fn sentinel_start_prefix(self) -> &'static str {
+        match self {
+            Scope::Team => SENTINEL_START_PREFIX,
+            Scope::Personal => PERSONAL_SENTINEL_START_PREFIX,
+        }
+    }
+
+    /// The frozen END marker that closes this scope's block.
+    pub fn sentinel_end(self) -> &'static str {
+        match self {
+            Scope::Team => SENTINEL_END,
+            Scope::Personal => PERSONAL_SENTINEL_END,
+        }
+    }
+
+    /// The frozen header prefix that identifies this scope's [`Strategy::OwnedFile`] files.
+    pub fn owned_header_prefix(self) -> &'static str {
+        match self {
+            Scope::Team => OWNED_HEADER_PREFIX,
+            Scope::Personal => PERSONAL_OWNED_HEADER_PREFIX,
+        }
+    }
+
+    /// The file name Toolport owns inside a client's rules DIRECTORY. Distinct per scope so a
+    /// team file and a personal file sit side by side rather than clobbering each other; both are
+    /// loaded by the client, which reads the whole directory.
+    pub fn owned_file_name(self) -> &'static str {
+        match self {
+            Scope::Team => "toolport-team-rules.md",
+            Scope::Personal => "toolport-rules.md",
+        }
+    }
+
+    /// The one-line header stamped at the top of an [`Strategy::OwnedFile`] file so whoever opens
+    /// it understands it is managed and will be overwritten.
+    fn owned_header(self, id: &str, version: i64) -> String {
+        match self {
+            Scope::Team => format!(
+                "{OWNED_HEADER_PREFIX} — team {id}, v{version}. Edits are overwritten on sync; leave the team to remove. -->"
+            ),
+            Scope::Personal => format!(
+                "{PERSONAL_OWNED_HEADER_PREFIX}: set {id}, v{version}. Edits are overwritten on the next apply; change them in Toolport. -->"
+            ),
+        }
+    }
+
+    fn start_marker(self, id: &str, version: i64) -> String {
+        match self {
+            Scope::Team => format!("{SENTINEL_START_PREFIX} team={id} v={version} -->"),
+            Scope::Personal => format!("{PERSONAL_SENTINEL_START_PREFIX} set={id} v={version} -->"),
+        }
+    }
 }
 
-fn start_marker(team_id: &str, version: i64) -> String {
-    format!("{SENTINEL_START_PREFIX} team={team_id} v={version} -->")
+/// True when `content` carries ANY scope's sentinel marker.
+///
+/// Checked across ALL scopes, not just the writing one, because the scopes share files: personal
+/// content carrying a *team* START marker, placed before the real team block, would make the
+/// team's [`find_block`] span the personal block and swallow it on the next org sync. Refusing
+/// every family is the only safe rule.
+fn content_carries_a_marker(content: &str) -> bool {
+    ALL_SCOPES
+        .iter()
+        .any(|s| content.contains(s.sentinel_start_prefix()) || content.contains(s.sentinel_end()))
 }
 
 /// Stable content hash reported to the server as the "effective rules receipt": it identifies
@@ -125,25 +221,33 @@ pub fn content_hash(content: &str) -> String {
 
 /// Render the full body of an [`Strategy::OwnedFile`] file (header + a blank line + content).
 /// Always newline-terminated.
-pub fn render_owned_file(team_id: &str, version: i64, content: &str) -> String {
+pub fn render_owned_file(scope: Scope, id: &str, version: i64, content: &str) -> String {
     let body = content.trim_end_matches('\n');
-    format!("{}\n\n{}\n", owned_header(team_id, version), body)
+    format!("{}\n\n{}\n", scope.owned_header(id, version), body)
 }
 
 /// The managed block text for the sentinel strategy: START marker, content, END marker.
-fn render_block(team_id: &str, version: i64, content: &str) -> String {
+fn render_block(scope: Scope, id: &str, version: i64, content: &str) -> String {
     let body = content.trim_end_matches('\n');
-    format!("{}\n{}\n{}", start_marker(team_id, version), body, SENTINEL_END)
+    format!(
+        "{}\n{}\n{}",
+        scope.start_marker(id, version),
+        body,
+        scope.sentinel_end()
+    )
 }
 
-/// Byte range `[start, end)` of an existing managed block in `existing`, or `None`. `start` is
+/// Byte range `[start, end)` of `scope`'s managed block in `existing`, or `None`. `start` is
 /// the offset of the START marker; `end` is just past the END marker (not its trailing
 /// newline). Matches on the frozen START prefix + END, so a block from any version is found.
-fn find_block(existing: &str) -> Option<(usize, usize)> {
-    let start = existing.find(SENTINEL_START_PREFIX)?;
+///
+/// Scope-exact: another scope's block in the same file is invisible here, because the two marker
+/// families are disjoint by construction (see [`Scope`]).
+fn find_block(existing: &str, scope: Scope) -> Option<(usize, usize)> {
+    let start = existing.find(scope.sentinel_start_prefix())?;
     // The END marker that closes THIS block is the first one at or after START.
-    let end_rel = existing[start..].find(SENTINEL_END)?;
-    let end = start + end_rel + SENTINEL_END.len();
+    let end_rel = existing[start..].find(scope.sentinel_end())?;
+    let end = start + end_rel + scope.sentinel_end().len();
     Some((start, end))
 }
 
@@ -155,10 +259,11 @@ fn find_block(existing: &str) -> Option<(usize, usize)> {
 ///   * Otherwise the block is appended after the user's content with a single blank-line
 ///     separator, so a later [`remove_block`] can take exactly those bytes back out.
 ///
-/// Idempotent: re-running with the same team/version/content yields byte-identical output.
-pub fn upsert_block(existing: &str, team_id: &str, version: i64, content: &str) -> String {
-    let block = render_block(team_id, version, content);
-    if let Some((start, end)) = find_block(existing) {
+/// Idempotent: re-running with the same scope/id/version/content yields byte-identical output.
+/// Another scope's block in the same file is left byte-identical.
+pub fn upsert_block(existing: &str, scope: Scope, id: &str, version: i64, content: &str) -> String {
+    let block = render_block(scope, id, version, content);
+    if let Some((start, end)) = find_block(existing, scope) {
         let mut out = String::with_capacity(existing.len() + block.len());
         out.push_str(&existing[..start]);
         out.push_str(&block);
@@ -181,8 +286,12 @@ pub fn upsert_block(existing: &str, team_id: &str, version: i64, content: &str) 
 /// own line is indistinguishable on the way out from a newline the user typed — an unavoidable
 /// ambiguity, and a cosmetically irrelevant one for a rules file. A block the user relocated
 /// mid-file is removed in place, leaving at most one blank line where it sat.
-pub fn remove_block(existing: &str) -> Option<String> {
-    let (start, end) = find_block(existing)?;
+///
+/// Scope-exact, including when the other scope's block is the immediate neighbour: the separator
+/// consumed here is exactly the one this scope's append added, so the survivor is byte-identical
+/// to what its own append produced (`removing_one_scope_leaves_an_adjacent_block_intact`).
+pub fn remove_block(existing: &str, scope: Scope) -> Option<String> {
+    let (start, end) = find_block(existing, scope)?;
     // Consume the block's own trailing newline if present.
     let mut cut_end = end;
     if existing[cut_end..].starts_with('\n') {
@@ -204,11 +313,17 @@ pub fn remove_block(existing: &str) -> Option<String> {
     Some(out)
 }
 
-/// True when `existing` already carries a managed block for the exact `team_id`+`version`+
+/// True when `existing` already carries `scope`'s managed block for the exact `id`+`version`+
 /// `content` (so a re-sync with no change can skip the write entirely).
-pub fn block_is_current(existing: &str, team_id: &str, version: i64, content: &str) -> bool {
-    match find_block(existing) {
-        Some((start, end)) => existing[start..end] == render_block(team_id, version, content),
+pub fn block_is_current(
+    existing: &str,
+    scope: Scope,
+    id: &str,
+    version: i64,
+    content: &str,
+) -> bool {
+    match find_block(existing, scope) {
+        Some((start, end)) => existing[start..end] == render_block(scope, id, version, content),
         None => false,
     }
 }
@@ -232,10 +347,10 @@ fn write_atomic(path: &std::path::Path, contents: &str) -> Result<(), String> {
     crate::registry::atomic_write(path, contents)
 }
 
-/// Apply the org instructions to ONE client target. Atomic and non-destructive: it never
-/// partially writes, never overwrites a shared file it couldn't read, and skips (reporting why)
-/// when a client shadow-file or hard cap makes the write pointless.
-pub fn write_target(t: &Target, team_id: &str, version: i64, content: &str) -> ApplyState {
+/// Apply the rules to ONE client target. Atomic and non-destructive: it never partially writes,
+/// never overwrites a shared file it couldn't read, and skips (reporting why) when a client
+/// shadow-file or hard cap makes the write pointless.
+pub fn write_target(t: &Target, id: &str, version: i64, content: &str) -> ApplyState {
     // Codex-style shadow file: the client ignores our target entirely, so writing it would be
     // invisible and confusing. Report it instead.
     if let Some(shadow) = &t.blocked_if_present {
@@ -243,29 +358,31 @@ pub fn write_target(t: &Target, team_id: &str, version: i64, content: &str) -> A
             return ApplyState::BlockedOverride;
         }
     }
-    // Org content that contains our own frozen markers would corrupt everything downstream: an
+    // Content that contains any scope's frozen markers would corrupt everything downstream: an
     // embedded END would fool `find_block` into terminating the managed span early, and an
-    // embedded START would make `remove_recorded` misclassify an owned file as a sentinel one.
-    // Refuse rather than write something we can't later find and cleanly remove.
-    if content.contains(SENTINEL_START_PREFIX) || content.contains(SENTINEL_END) {
+    // embedded START would make `remove_recorded` misclassify an owned file as a sentinel one, or
+    // make the OTHER scope's span swallow this block. Refuse rather than write something we can't
+    // later find and cleanly remove.
+    if content_carries_a_marker(content) {
         return ApplyState::Error;
     }
     let desired = match t.strategy {
-        Strategy::OwnedFile => render_owned_file(team_id, version, content),
+        Strategy::OwnedFile => render_owned_file(t.scope, id, version, content),
         Strategy::SentinelBlock => {
             let existing = match read_existing(&t.path) {
                 Ok(s) => s,
                 Err(_) => return ApplyState::Error,
             };
-            if block_is_current(&existing, team_id, version, content) {
+            if block_is_current(&existing, t.scope, id, version, content) {
                 return ApplyState::Applied; // already up to date; skip the write
             }
-            upsert_block(&existing, team_id, version, content)
+            upsert_block(&existing, t.scope, id, version, content)
         }
     };
     // Hard client cap (Windsurf) applies to the WHOLE global-rules file we're about to write —
-    // the member's existing rules plus our block and markers — not just the org content. Check
-    // the fully rendered result so we never write a file the client will silently truncate.
+    // the user's existing rules, the OTHER scope's block if present, and our block and markers —
+    // not just this scope's content. Check the fully rendered result so we never write a file the
+    // client will silently truncate.
     if let Some(cap) = t.char_cap {
         if desired.chars().count() > cap {
             return ApplyState::TooLong;
@@ -277,18 +394,18 @@ pub fn write_target(t: &Target, team_id: &str, version: i64, content: &str) -> A
     }
 }
 
-/// Read-only: what state IS this client's rules file in right now, relative to the current org
-/// `content`+`version`? Used to build the coverage receipt (spec W5) every report cycle, so the
-/// dashboard reflects reality — a client installed after the last write reports `Stale`, a
-/// deleted/hand-edited block reports `Stale`, a shadowed Codex reports `BlockedOverride`, etc.
-/// Never writes.
-pub fn current_state(t: &Target, team_id: &str, version: i64, content: &str) -> ApplyState {
+/// Read-only: what state IS this client's rules file in right now, relative to the current
+/// `content`+`version` for this target's scope? Used to build the coverage receipt (spec W5)
+/// every report cycle, so the dashboard reflects reality — a client installed after the last
+/// write reports `Stale`, a deleted/hand-edited block reports `Stale`, a shadowed Codex reports
+/// `BlockedOverride`, etc. Never writes.
+pub fn current_state(t: &Target, id: &str, version: i64, content: &str) -> ApplyState {
     if let Some(shadow) = &t.blocked_if_present {
         if shadow.exists() {
             return ApplyState::BlockedOverride;
         }
     }
-    if content.contains(SENTINEL_START_PREFIX) || content.contains(SENTINEL_END) {
+    if content_carries_a_marker(content) {
         return ApplyState::Error;
     }
     let existing = match read_existing(&t.path) {
@@ -297,12 +414,14 @@ pub fn current_state(t: &Target, team_id: &str, version: i64, content: &str) -> 
     };
     let (is_current, rendered_len) = match t.strategy {
         Strategy::OwnedFile => {
-            let desired = render_owned_file(team_id, version, content);
+            let desired = render_owned_file(t.scope, id, version, content);
             (existing == desired, desired.chars().count())
         }
         Strategy::SentinelBlock => (
-            block_is_current(&existing, team_id, version, content),
-            upsert_block(&existing, team_id, version, content).chars().count(),
+            block_is_current(&existing, t.scope, id, version, content),
+            upsert_block(&existing, t.scope, id, version, content)
+                .chars()
+                .count(),
         ),
     };
     if let Some(cap) = t.char_cap {
@@ -317,25 +436,29 @@ pub fn current_state(t: &Target, team_id: &str, version: i64, content: &str) -> 
     }
 }
 
-/// Remove a previously-written managed artifact, identifying its kind by content so cleanup
-/// survives a client that was uninstalled or whose detection changed. An owned file (our header)
-/// is deleted whole; a shared file has only our sentinel block stripped, and is deleted if
-/// nothing but whitespace remains. A file that is neither (already cleaned, or user-replaced) is
-/// left untouched. Best-effort: unreadable/missing paths are a no-op.
-pub fn remove_recorded(path: &std::path::Path) {
+/// Remove a previously-written managed artifact for ONE scope, identifying its kind by content so
+/// cleanup survives a client that was uninstalled or whose detection changed. An owned file (our
+/// header) is deleted whole; a shared file has only that scope's sentinel block stripped, and is
+/// deleted if nothing but whitespace remains. A file that is neither (already cleaned, or
+/// user-replaced) is left untouched. Best-effort: unreadable/missing paths are a no-op.
+///
+/// `scope` is required, not sniffed: a shared file can hold BOTH a team and a personal block, and
+/// leaving a team must strip only the team one. The "nothing but whitespace remains" delete is
+/// therefore also correct — a surviving other-scope block is not whitespace, so the file stays.
+pub fn remove_recorded(path: &std::path::Path, scope: Scope) {
     let existing = match std::fs::read_to_string(path) {
         Ok(s) => s,
         Err(_) => return,
     };
-    if existing.contains(SENTINEL_START_PREFIX) {
-        if let Some(stripped) = remove_block(&existing) {
+    if existing.contains(scope.sentinel_start_prefix()) {
+        if let Some(stripped) = remove_block(&existing, scope) {
             if stripped.trim().is_empty() {
                 let _ = std::fs::remove_file(path);
             } else {
                 let _ = write_atomic(path, &stripped);
             }
         }
-    } else if existing.starts_with(OWNED_HEADER_PREFIX) {
+    } else if existing.starts_with(scope.owned_header_prefix()) {
         let _ = std::fs::remove_file(path);
     }
 }
@@ -345,21 +468,34 @@ mod tests {
     use super::*;
 
     const TEAM: &str = "team_abc";
+    const SET: &str = "set_xyz";
 
     #[test]
     fn owned_file_has_header_and_content_and_trailing_newline() {
-        let f = render_owned_file(TEAM, 3, "Never commit secrets.");
+        let f = render_owned_file(Scope::Team, TEAM, 3, "Never commit secrets.");
         assert!(f.starts_with("<!-- Managed by Toolport"));
         assert!(f.contains("team team_abc, v3"));
         assert!(f.contains("Never commit secrets."));
         assert!(f.ends_with('\n'));
         // Idempotent render.
-        assert_eq!(f, render_owned_file(TEAM, 3, "Never commit secrets.\n"));
+        assert_eq!(
+            f,
+            render_owned_file(Scope::Team, TEAM, 3, "Never commit secrets.\n")
+        );
+    }
+
+    #[test]
+    fn personal_owned_file_has_its_own_header() {
+        let f = render_owned_file(Scope::Personal, SET, 3, "Never commit secrets.");
+        assert!(f.starts_with(PERSONAL_OWNED_HEADER_PREFIX));
+        assert!(f.contains("set set_xyz, v3"));
+        // Must NOT be mistakable for a team-owned file, or cleanup would cross scopes.
+        assert!(!f.starts_with(OWNED_HEADER_PREFIX));
     }
 
     #[test]
     fn upsert_into_empty_file() {
-        let out = upsert_block("", TEAM, 1, "Rule one");
+        let out = upsert_block("", Scope::Team, TEAM, 1, "Rule one");
         assert!(out.contains(SENTINEL_START_PREFIX));
         assert!(out.contains("Rule one"));
         assert!(out.trim_end().ends_with(SENTINEL_END));
@@ -368,7 +504,7 @@ mod tests {
     #[test]
     fn upsert_appends_and_preserves_user_bytes() {
         let user = "# My personal rules\nAlways run tests.\n";
-        let out = upsert_block(user, TEAM, 1, "Org rule");
+        let out = upsert_block(user, Scope::Team, TEAM, 1, "Org rule");
         // Every user byte is preserved as a prefix.
         assert!(out.starts_with(user), "user content must be byte-preserved");
         assert!(out.contains("Org rule"));
@@ -377,7 +513,7 @@ mod tests {
     #[test]
     fn upsert_appends_when_user_file_lacks_trailing_newline() {
         let user = "no trailing newline";
-        let out = upsert_block(user, TEAM, 1, "Org rule");
+        let out = upsert_block(user, Scope::Team, TEAM, 1, "Org rule");
         assert!(out.starts_with(user));
         // Block sits on its own line after a blank separator.
         assert!(out.contains("\n\n<!-- toolport:team-instructions:start"));
@@ -387,8 +523,11 @@ mod tests {
     fn upsert_replaces_in_place_leaving_outside_bytes_identical() {
         let user_pre = "# Top\n\n";
         let user_post = "\n# Bottom\n";
-        let v1 = format!("{user_pre}{}{user_post}", render_block(TEAM, 1, "old"));
-        let v2 = upsert_block(&v1, TEAM, 2, "new");
+        let v1 = format!(
+            "{user_pre}{}{user_post}",
+            render_block(Scope::Team, TEAM, 1, "old")
+        );
+        let v2 = upsert_block(&v1, Scope::Team, TEAM, 2, "new");
         // Text outside the managed block is byte-for-byte unchanged.
         assert!(v2.starts_with(user_pre), "prefix must be untouched");
         assert!(v2.ends_with(user_post), "suffix must be untouched");
@@ -399,8 +538,8 @@ mod tests {
     #[test]
     fn upsert_is_idempotent() {
         let user = "# Rules\nkeep me\n";
-        let once = upsert_block(user, TEAM, 5, "org content");
-        let twice = upsert_block(&once, TEAM, 5, "org content");
+        let once = upsert_block(user, Scope::Team, TEAM, 5, "org content");
+        let twice = upsert_block(&once, Scope::Team, TEAM, 5, "org content");
         assert_eq!(once, twice, "re-applying the same version is a no-op");
     }
 
@@ -415,8 +554,8 @@ mod tests {
             "trailing spaces   \nand more\n",
             "",
         ] {
-            let with = upsert_block(user, TEAM, 1, "Org rule");
-            let back = remove_block(&with).expect("a block was inserted");
+            let with = upsert_block(user, Scope::Team, TEAM, 1, "Org rule");
+            let back = remove_block(&with, Scope::Team).expect("a block was inserted");
             let normalized = if user.is_empty() || user.ends_with('\n') {
                 user.to_string()
             } else {
@@ -428,15 +567,18 @@ mod tests {
 
     #[test]
     fn remove_returns_none_without_a_block() {
-        assert_eq!(remove_block("# just user rules\n"), None);
+        assert_eq!(remove_block("# just user rules\n", Scope::Team), None);
     }
 
     #[test]
     fn remove_in_place_block_leaves_surrounding_text() {
         let user_pre = "# Top\ntext\n\n";
         let user_post = "\n# Bottom\nmore\n";
-        let full = format!("{user_pre}{}{user_post}", render_block(TEAM, 1, "org"));
-        let back = remove_block(&full).expect("block present");
+        let full = format!(
+            "{user_pre}{}{user_post}",
+            render_block(Scope::Team, TEAM, 1, "org")
+        );
+        let back = remove_block(&full, Scope::Team).expect("block present");
         assert!(!back.contains(SENTINEL_START_PREFIX));
         assert!(!back.contains(SENTINEL_END));
         assert!(back.contains("# Top"));
@@ -445,11 +587,20 @@ mod tests {
 
     #[test]
     fn block_is_current_detects_matching_and_stale() {
-        let f = upsert_block("user\n", TEAM, 7, "content");
-        assert!(block_is_current(&f, TEAM, 7, "content"));
-        assert!(!block_is_current(&f, TEAM, 8, "content"), "version change");
-        assert!(!block_is_current(&f, TEAM, 7, "different"), "content change");
-        assert!(!block_is_current("user\n", TEAM, 7, "content"), "no block");
+        let f = upsert_block("user\n", Scope::Team, TEAM, 7, "content");
+        assert!(block_is_current(&f, Scope::Team, TEAM, 7, "content"));
+        assert!(
+            !block_is_current(&f, Scope::Team, TEAM, 8, "content"),
+            "version change"
+        );
+        assert!(
+            !block_is_current(&f, Scope::Team, TEAM, 7, "different"),
+            "content change"
+        );
+        assert!(
+            !block_is_current("user\n", Scope::Team, TEAM, 7, "content"),
+            "no block"
+        );
     }
 
     #[test]
@@ -462,10 +613,112 @@ mod tests {
     fn upsert_survives_content_with_marker_lookalikes() {
         // User text that mentions the marker words must not confuse find/replace.
         let user = "I documented the toolport:team-instructions format once.\n";
-        let out = upsert_block(user, TEAM, 1, "real org rule");
+        let out = upsert_block(user, Scope::Team, TEAM, 1, "real org rule");
         assert!(out.starts_with(user));
-        let back = remove_block(&out).expect("block present");
+        let back = remove_block(&out, Scope::Team).expect("block present");
         assert_eq!(back, user);
+    }
+
+    // ---- scope isolation ----
+
+    /// The whole coexistence design rests on the two marker families being disjoint: `find_block`
+    /// matches on the START prefix alone, so if either family contained the other, one scope would
+    /// find and overwrite the other's span. Pin it here rather than trusting the eye.
+    #[test]
+    fn personal_and_team_marker_families_are_disjoint() {
+        let team = [SENTINEL_START_PREFIX, SENTINEL_END, OWNED_HEADER_PREFIX];
+        let personal = [
+            PERSONAL_SENTINEL_START_PREFIX,
+            PERSONAL_SENTINEL_END,
+            PERSONAL_OWNED_HEADER_PREFIX,
+        ];
+        for t in team {
+            for p in personal {
+                assert!(!t.contains(p), "team marker {t:?} contains personal {p:?}");
+                assert!(!p.contains(t), "personal marker {p:?} contains team {t:?}");
+            }
+        }
+    }
+
+    #[test]
+    fn owned_file_names_differ_per_scope() {
+        assert_ne!(
+            Scope::Team.owned_file_name(),
+            Scope::Personal.owned_file_name(),
+            "a shared name would make one scope's owned file clobber the other's"
+        );
+    }
+
+    /// Both scopes write into one shared file, in either order, and each upsert leaves the other's
+    /// block byte-identical.
+    #[test]
+    fn team_and_personal_blocks_coexist_in_one_file() {
+        let user = "# Mine\nAlways run tests.\n";
+        let team_block = render_block(Scope::Team, TEAM, 1, "Org rule");
+        let personal_block = render_block(Scope::Personal, SET, 1, "My rule");
+        let apply = |acc: &str, s: Scope| match s {
+            Scope::Team => upsert_block(acc, Scope::Team, TEAM, 1, "Org rule"),
+            Scope::Personal => upsert_block(acc, Scope::Personal, SET, 1, "My rule"),
+        };
+
+        for (first, second) in [
+            (Scope::Team, Scope::Personal),
+            (Scope::Personal, Scope::Team),
+        ] {
+            let out = apply(&apply(user, first), second);
+            assert!(
+                out.starts_with(user),
+                "user bytes preserved ({first:?} then {second:?})"
+            );
+            assert!(out.contains(&team_block), "team block intact");
+            assert!(out.contains(&personal_block), "personal block intact");
+
+            // Updating one scope must not disturb the other's bytes.
+            let bumped = upsert_block(&out, Scope::Team, TEAM, 2, "Org rule v2");
+            assert!(
+                bumped.contains(&personal_block),
+                "personal survives a team bump"
+            );
+            assert!(!bumped.contains(&team_block), "team block was replaced");
+        }
+    }
+
+    /// The separator `remove_block` eats is exactly the one this scope's append added, so an
+    /// adjacent block from the other scope comes out as its own append left it.
+    #[test]
+    fn removing_one_scope_leaves_an_adjacent_block_intact() {
+        let user = "# Mine\nAlways run tests.\n";
+        let team_only = upsert_block(user, Scope::Team, TEAM, 1, "Org rule");
+        let personal_only = upsert_block(user, Scope::Personal, SET, 1, "My rule");
+        let both = upsert_block(&team_only, Scope::Personal, SET, 1, "My rule");
+
+        assert_eq!(
+            remove_block(&both, Scope::Personal).expect("personal block present"),
+            team_only,
+            "removing personal must restore the team-only file byte-for-byte"
+        );
+        assert_eq!(
+            remove_block(&both, Scope::Team).expect("team block present"),
+            personal_only,
+            "removing team must leave the personal file as its own append would write it"
+        );
+        // Removing both, in either order, gets the user's own file back.
+        let neither = remove_block(&remove_block(&both, Scope::Team).unwrap(), Scope::Personal)
+            .expect("personal block still present");
+        assert_eq!(neither, user);
+    }
+
+    #[test]
+    fn a_scope_does_not_see_the_other_scopes_block() {
+        let personal_only = upsert_block("user\n", Scope::Personal, SET, 1, "My rule");
+        assert_eq!(remove_block(&personal_only, Scope::Team), None);
+        assert!(!block_is_current(
+            &personal_only,
+            Scope::Team,
+            TEAM,
+            1,
+            "My rule"
+        ));
     }
 
     // ---- filesystem-level apply/remove ----
@@ -496,23 +749,38 @@ mod tests {
         }
     }
 
-    fn owned_target(path: PathBuf) -> Target {
-        Target { path, strategy: Strategy::OwnedFile, char_cap: None, blocked_if_present: None }
+    fn owned_target(path: PathBuf, scope: Scope) -> Target {
+        Target {
+            path,
+            strategy: Strategy::OwnedFile,
+            scope,
+            char_cap: None,
+            blocked_if_present: None,
+        }
     }
-    fn block_target(path: PathBuf) -> Target {
-        Target { path, strategy: Strategy::SentinelBlock, char_cap: None, blocked_if_present: None }
+    fn block_target(path: PathBuf, scope: Scope) -> Target {
+        Target {
+            path,
+            strategy: Strategy::SentinelBlock,
+            scope,
+            char_cap: None,
+            blocked_if_present: None,
+        }
     }
 
     #[test]
     fn owned_file_apply_creates_then_remove_deletes() {
         let s = Scratch::new();
         // Parent dirs are created on demand.
-        let t = owned_target(s.path("rules").join("toolport-team-rules.md"));
+        let t = owned_target(
+            s.path("rules").join(Scope::Team.owned_file_name()),
+            Scope::Team,
+        );
         assert_eq!(write_target(&t, TEAM, 2, "Org rule"), ApplyState::Applied);
         let on_disk = std::fs::read_to_string(&t.path).unwrap();
         assert!(on_disk.starts_with(OWNED_HEADER_PREFIX));
         assert!(on_disk.contains("Org rule"));
-        remove_recorded(&t.path);
+        remove_recorded(&t.path, Scope::Team);
         assert!(!t.path.exists(), "owned file should be deleted on leave");
     }
 
@@ -522,7 +790,7 @@ mod tests {
         let path = s.path("AGENTS.md");
         let user = "# My rules\nAlways run tests.\n";
         std::fs::write(&path, user).unwrap();
-        let t = block_target(path.clone());
+        let t = block_target(path.clone(), Scope::Team);
         assert_eq!(write_target(&t, TEAM, 1, "Org rule"), ApplyState::Applied);
         let after = std::fs::read_to_string(&path).unwrap();
         assert!(after.starts_with(user), "user bytes preserved");
@@ -531,7 +799,7 @@ mod tests {
         assert_eq!(write_target(&t, TEAM, 1, "Org rule"), ApplyState::Applied);
         assert_eq!(std::fs::read_to_string(&path).unwrap(), after);
         // Leaving strips only our block; the user's file survives with their content.
-        remove_recorded(&path);
+        remove_recorded(&path, Scope::Team);
         assert_eq!(std::fs::read_to_string(&path).unwrap(), user);
     }
 
@@ -539,11 +807,11 @@ mod tests {
     fn sentinel_into_absent_file_then_remove_deletes_empty_file() {
         let s = Scratch::new();
         let path = s.path("GEMINI.md"); // does not exist yet
-        let t = block_target(path.clone());
+        let t = block_target(path.clone(), Scope::Team);
         assert_eq!(write_target(&t, TEAM, 1, "Only org content"), ApplyState::Applied);
         assert!(path.exists());
         // The whole file was ours -> stripping the block leaves nothing -> delete.
-        remove_recorded(&path);
+        remove_recorded(&path, Scope::Team);
         assert!(!path.exists(), "a file that held only our block should be removed");
     }
 
@@ -556,6 +824,7 @@ mod tests {
         let t = Target {
             path: target_path.clone(),
             strategy: Strategy::SentinelBlock,
+            scope: Scope::Team,
             char_cap: None,
             blocked_if_present: Some(shadow),
         };
@@ -570,6 +839,7 @@ mod tests {
         let t = Target {
             path: path.clone(),
             strategy: Strategy::SentinelBlock,
+            scope: Scope::Team,
             char_cap: Some(10),
             blocked_if_present: None,
         };
@@ -582,18 +852,111 @@ mod tests {
         let s = Scratch::new();
         // A START marker in owned content would make cleanup misclassify the file; an END marker
         // in sentinel content would truncate the block. Both must be refused, nothing written.
-        let owned = owned_target(s.path("owned.md"));
+        let owned = owned_target(s.path("owned.md"), Scope::Team);
         assert_eq!(
             write_target(&owned, TEAM, 1, &format!("evil {SENTINEL_START_PREFIX} x -->")),
             ApplyState::Error
         );
         assert!(!owned.path.exists());
-        let block = block_target(s.path("block.md"));
+        let block = block_target(s.path("block.md"), Scope::Team);
         assert_eq!(
             write_target(&block, TEAM, 1, &format!("evil {SENTINEL_END} tail")),
             ApplyState::Error
         );
         assert!(!block.path.exists());
+    }
+
+    /// The guard spans every scope, not just the writing one. Personal content carrying a TEAM
+    /// START marker, appended before the real team block, would make the team's `find_block` span
+    /// the personal block and swallow it on the next org sync.
+    #[test]
+    fn content_carrying_the_other_scopes_markers_is_refused() {
+        let s = Scratch::new();
+        let personal = block_target(s.path("AGENTS.md"), Scope::Personal);
+        assert_eq!(
+            write_target(&personal, SET, 1, &format!("evil {SENTINEL_START_PREFIX} x -->")),
+            ApplyState::Error
+        );
+        assert_eq!(
+            write_target(&personal, SET, 1, &format!("evil {SENTINEL_END} tail")),
+            ApplyState::Error
+        );
+        assert!(!personal.path.exists());
+
+        let team = block_target(s.path("team-AGENTS.md"), Scope::Team);
+        assert_eq!(
+            write_target(
+                &team,
+                TEAM,
+                1,
+                &format!("evil {PERSONAL_SENTINEL_START_PREFIX} x -->")
+            ),
+            ApplyState::Error
+        );
+        assert_eq!(
+            write_target(&team, TEAM, 1, &format!("evil {PERSONAL_SENTINEL_END} tail")),
+            ApplyState::Error
+        );
+        assert!(!team.path.exists());
+    }
+
+    /// A shared file holding BOTH scopes: cleaning up one leaves the other and the user's own
+    /// bytes untouched, and the "delete when only whitespace remains" rule does not fire while the
+    /// other scope's block is still there.
+    #[test]
+    fn remove_recorded_is_scope_exact_in_a_shared_file() {
+        let s = Scratch::new();
+        let path = s.path("AGENTS.md");
+        let user = "# Mine\nAlways run tests.\n";
+        std::fs::write(&path, user).unwrap();
+        let team = block_target(path.clone(), Scope::Team);
+        let personal = block_target(path.clone(), Scope::Personal);
+        assert_eq!(write_target(&team, TEAM, 1, "Org rule"), ApplyState::Applied);
+        assert_eq!(
+            write_target(&personal, SET, 1, "My rule"),
+            ApplyState::Applied
+        );
+
+        // Leaving the team strips only the org block; the personal one still applies.
+        remove_recorded(&path, Scope::Team);
+        let after = std::fs::read_to_string(&path).unwrap();
+        assert!(after.starts_with(user), "user bytes preserved");
+        assert!(!after.contains(SENTINEL_START_PREFIX), "team block gone");
+        assert!(after.contains("My rule"), "personal block survives");
+        assert_eq!(
+            current_state(&personal, SET, 1, "My rule"),
+            ApplyState::Applied
+        );
+
+        // Dropping the personal set too takes the file back to the user's own content.
+        remove_recorded(&path, Scope::Personal);
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), user);
+    }
+
+    /// Owned files are per-scope paths, so a personal cleanup must never delete the team file.
+    #[test]
+    fn remove_recorded_does_not_cross_scopes_on_owned_files() {
+        let s = Scratch::new();
+        let dir = s.path("rules");
+        let team = owned_target(dir.join(Scope::Team.owned_file_name()), Scope::Team);
+        let personal = owned_target(
+            dir.join(Scope::Personal.owned_file_name()),
+            Scope::Personal,
+        );
+        assert_eq!(write_target(&team, TEAM, 1, "Org rule"), ApplyState::Applied);
+        assert_eq!(
+            write_target(&personal, SET, 1, "My rule"),
+            ApplyState::Applied
+        );
+        assert_ne!(team.path, personal.path, "scopes must own different files");
+
+        // Pointing a personal cleanup at the TEAM file is a no-op: the header prefix is not ours.
+        remove_recorded(&team.path, Scope::Personal);
+        assert!(team.path.exists(), "team file must survive a personal cleanup");
+
+        remove_recorded(&personal.path, Scope::Personal);
+        assert!(!personal.path.exists());
+        assert!(team.path.exists(), "team file untouched throughout");
     }
 
     #[test]
@@ -606,6 +969,7 @@ mod tests {
         let t = Target {
             path: path.clone(),
             strategy: Strategy::SentinelBlock,
+            scope: Scope::Team,
             char_cap: Some(50),
             blocked_if_present: None,
         };
@@ -614,11 +978,58 @@ mod tests {
         assert_eq!(std::fs::read_to_string(&path).unwrap(), "x".repeat(40));
     }
 
+    /// The cap counts the OTHER scope's block too. A personal set that fits on its own can still
+    /// tip a Windsurf file over once the org block is in there, and must report `TooLong` rather
+    /// than write a file the client silently truncates.
+    #[test]
+    fn the_cap_counts_the_other_scopes_block_too() {
+        let s = Scratch::new();
+        let path = s.path("global_rules.md");
+        let cap = 400;
+        let team = Target {
+            path: path.clone(),
+            strategy: Strategy::SentinelBlock,
+            scope: Scope::Team,
+            char_cap: Some(cap),
+            blocked_if_present: None,
+        };
+        let personal = Target {
+            path: path.clone(),
+            strategy: Strategy::SentinelBlock,
+            scope: Scope::Personal,
+            char_cap: Some(cap),
+            blocked_if_present: None,
+        };
+        // Alone, the personal set fits.
+        assert_eq!(
+            current_state(&personal, SET, 1, "My rule"),
+            ApplyState::Stale
+        );
+        // With the org block present, the same personal set no longer does.
+        assert_eq!(
+            write_target(&team, TEAM, 1, &"o".repeat(cap - 120)),
+            ApplyState::Applied
+        );
+        assert_eq!(
+            write_target(&personal, SET, 1, "My rule"),
+            ApplyState::TooLong
+        );
+        assert_eq!(
+            current_state(&personal, SET, 1, "My rule"),
+            ApplyState::TooLong
+        );
+        // Nothing was written: the org block is still exactly as it was.
+        assert_eq!(
+            current_state(&team, TEAM, 1, &"o".repeat(cap - 120)),
+            ApplyState::Applied
+        );
+    }
+
     #[test]
     fn current_state_reports_applied_stale_and_blocked() {
         let s = Scratch::new();
         // Owned file: absent -> Stale; after write -> Applied; hand-edited -> Stale.
-        let owned = owned_target(s.path("rules.md"));
+        let owned = owned_target(s.path("rules.md"), Scope::Team);
         assert_eq!(current_state(&owned, TEAM, 1, "c"), ApplyState::Stale);
         write_target(&owned, TEAM, 1, "c");
         assert_eq!(current_state(&owned, TEAM, 1, "c"), ApplyState::Applied);
@@ -630,7 +1041,7 @@ mod tests {
         // Sentinel block in a shared file.
         let path = s.path("AGENTS.md");
         std::fs::write(&path, "# user\n").unwrap();
-        let block = block_target(path.clone());
+        let block = block_target(path.clone(), Scope::Team);
         assert_eq!(current_state(&block, TEAM, 1, "c"), ApplyState::Stale);
         write_target(&block, TEAM, 1, "c");
         assert_eq!(current_state(&block, TEAM, 1, "c"), ApplyState::Applied);
@@ -641,6 +1052,7 @@ mod tests {
         let shadowed = Target {
             path: s.path("codex-AGENTS.md"),
             strategy: Strategy::SentinelBlock,
+            scope: Scope::Team,
             char_cap: None,
             blocked_if_present: Some(shadow),
         };
@@ -655,6 +1067,7 @@ mod tests {
         let t = Target {
             path,
             strategy: Strategy::SentinelBlock,
+            scope: Scope::Team,
             char_cap: Some(50),
             blocked_if_present: None,
         };
@@ -667,7 +1080,8 @@ mod tests {
         let path = s.path("someones.md");
         let foreign = "# not ours\njust user content\n";
         std::fs::write(&path, foreign).unwrap();
-        remove_recorded(&path);
+        remove_recorded(&path, Scope::Team);
+        remove_recorded(&path, Scope::Personal);
         assert_eq!(std::fs::read_to_string(&path).unwrap(), foreign);
     }
 }

--- a/src-tauri/src/instructions.rs
+++ b/src-tauri/src/instructions.rs
@@ -307,9 +307,19 @@ pub fn remove_block(existing: &str, scope: Scope) -> Option<String> {
             cut_start -= 1;
         }
     }
+    // A block at offset 0 has no preceding separator to eat, so the loop above cannot run — but
+    // the blank line BETWEEN it and whatever follows is still ours, added when that next thing was
+    // appended. Without this, removing the first of two blocks from a file we created (team writes
+    // AGENTS.md, personal appends, member leaves the team) leaves "\n{survivor}" where a lone
+    // append would have written "{survivor}". Symmetric with the trailing-separator rule above:
+    // exactly one newline, and only the one we are responsible for.
+    let mut tail_start = cut_end;
+    if cut_start == 0 && existing[tail_start..].starts_with('\n') {
+        tail_start += 1;
+    }
     let mut out = String::with_capacity(existing.len());
     out.push_str(&existing[..cut_start]);
-    out.push_str(&existing[cut_end..]);
+    out.push_str(&existing[tail_start..]);
     Some(out)
 }
 
@@ -706,6 +716,37 @@ mod tests {
         let neither = remove_block(&remove_block(&both, Scope::Team).unwrap(), Scope::Personal)
             .expect("personal block still present");
         assert_eq!(neither, user);
+    }
+
+    /// The same invariant when the FILE ITSELF is ours: Toolport created it (the client had no
+    /// rules file), one scope appended after the other, and now the first scope leaves. The
+    /// survivor must look exactly as a lone append into an absent file would have written it,
+    /// with no leftover leading blank line. A block at offset 0 has no preceding separator, so
+    /// this is the case the generic separator rule cannot reach.
+    #[test]
+    fn removing_the_leading_scope_from_a_file_we_created_leaves_no_stray_newline() {
+        let personal_alone = upsert_block("", Scope::Personal, SET, 1, "My rule");
+        let team_alone = upsert_block("", Scope::Team, TEAM, 1, "Org rule");
+
+        // Team created the file, personal appended. Team leaves.
+        let team_then_personal = upsert_block(&team_alone, Scope::Personal, SET, 1, "My rule");
+        assert_eq!(
+            remove_block(&team_then_personal, Scope::Team).expect("team block present"),
+            personal_alone
+        );
+
+        // And the mirror image.
+        let personal_then_team = upsert_block(&personal_alone, Scope::Team, TEAM, 1, "Org rule");
+        assert_eq!(
+            remove_block(&personal_then_team, Scope::Personal).expect("personal block present"),
+            team_alone
+        );
+
+        // Removing the LAST one still empties the file, so `remove_recorded` deletes it.
+        assert!(remove_block(&personal_alone, Scope::Personal)
+            .expect("block present")
+            .trim()
+            .is_empty());
     }
 
     #[test]

--- a/src-tauri/src/instructions.rs
+++ b/src-tauri/src/instructions.rs
@@ -366,6 +366,28 @@ fn read_existing(path: &std::path::Path) -> Result<String, String> {
     }
 }
 
+/// Serializes read-modify-write on rules files.
+///
+/// Team and personal blocks share ONE file for every sentinel client (Codex, Gemini CLI, Windsurf,
+/// Goose, Zed, ...), and both writers read the file, insert their own span, and write it back.
+/// Without this, a team sync and a personal apply that read the same bytes concurrently each write
+/// back only their own block and whichever lands second silently drops the other's. That is not
+/// hypothetical: the ~25s team-sync loop and `rules::apply_on_startup` both run at launch.
+///
+/// A process mutex is the whole exposure. Both writers live in the desktop app, and the gateway
+/// binary never touches rules files. Deliberately NOT a `<path>.lock` file next to the target:
+/// that would leave Toolport's litter inside the user's client directories, which is the one thing
+/// this module is otherwise scrupulous about never doing.
+static WRITE_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+/// Hold the rules-write lock. Poisoning is irrelevant here: the guard protects a file, not an
+/// invariant in memory, so a panicking writer leaves nothing for the next one to misread.
+fn write_lock() -> std::sync::MutexGuard<'static, ()> {
+    WRITE_LOCK
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+}
+
 /// Create parent dirs then write atomically (temp + rename, 0600), reusing the registry's
 /// hardened primitive so a crash mid-write can't leave a torn rules file.
 fn write_atomic(path: &std::path::Path, contents: &str) -> Result<(), String> {
@@ -379,6 +401,8 @@ fn write_atomic(path: &std::path::Path, contents: &str) -> Result<(), String> {
 /// never overwrites a shared file it couldn't read, and skips (reporting why) when a client
 /// shadow-file or hard cap makes the write pointless.
 pub fn write_target(t: &Target, id: &str, version: i64, content: &str) -> ApplyState {
+    // Held across the read AND the write: the other scope shares this file (see `WRITE_LOCK`).
+    let _guard = write_lock();
     // Codex-style shadow file: the client ignores our target entirely, so writing it would be
     // invisible and confusing. Report it instead.
     if let Some(shadow) = &t.blocked_if_present {
@@ -479,6 +503,8 @@ pub fn current_state(t: &Target, id: &str, version: i64, content: &str) -> Apply
 /// must KEEP the path on record: cleanup is driven by that recorded list, so forgetting a path we
 /// failed to clean strands the block forever with nothing left that would ever look for it.
 pub fn remove_recorded(path: &std::path::Path, scope: Scope) -> bool {
+    // Stripping our span is also read-modify-write on a file the other scope may be writing.
+    let _guard = write_lock();
     let existing = match std::fs::read_to_string(path) {
         // Already gone: nothing of ours can be there, so the caller may stop tracking it.
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => return true,
@@ -1157,6 +1183,77 @@ mod tests {
         assert!(remove_recorded(&path, Scope::Team), "nothing of ours to clean");
         assert!(remove_recorded(&path, Scope::Personal));
         assert_eq!(std::fs::read_to_string(&path).unwrap(), foreign);
+    }
+
+    /// Team and personal share one file for every sentinel client, and both writers read it then
+    /// write it back. Unserialized, each would write back only its own block and the later write
+    /// would drop the other's. Run over many rounds because a single interleaving may not race.
+    #[test]
+    fn concurrent_team_and_personal_writes_both_survive() {
+        let s = Scratch::new();
+        for round in 0..200 {
+            let path = s.path(&format!("AGENTS-{round}.md"));
+            let user = "# Mine\nkeep me\n";
+            std::fs::write(&path, user).unwrap();
+
+            let team = block_target(path.clone(), Scope::Team);
+            let personal = block_target(path.clone(), Scope::Personal);
+            std::thread::scope(|scope| {
+                scope.spawn(|| {
+                    write_target(&team, TEAM, 1, "Org rule");
+                });
+                scope.spawn(|| {
+                    write_target(&personal, SET, 1, "My rule");
+                });
+            });
+
+            let after = std::fs::read_to_string(&path).unwrap();
+            assert!(after.starts_with(user), "round {round}: user bytes preserved");
+            assert!(after.contains("Org rule"), "round {round}: team block lost");
+            assert!(after.contains("My rule"), "round {round}: personal block lost");
+        }
+    }
+
+    /// Same shared file, but one writer is removing while the other writes. Stripping a span is
+    /// read-modify-write too, so it needs the same serialization.
+    #[test]
+    fn a_concurrent_remove_does_not_swallow_the_other_scopes_write() {
+        let s = Scratch::new();
+        for round in 0..200 {
+            let path = s.path(&format!("AGENTS-rm-{round}.md"));
+            let user = "# Mine\nkeep me\n";
+            std::fs::write(&path, user).unwrap();
+
+            let team = block_target(path.clone(), Scope::Team);
+            let personal = block_target(path.clone(), Scope::Personal);
+            // Fixture: both blocks present, then the team leaves while personal re-applies.
+            write_target(&team, TEAM, 1, "Org rule");
+            write_target(&personal, SET, 1, "My rule");
+
+            std::thread::scope(|scope| {
+                scope.spawn(|| {
+                    remove_recorded(&path, Scope::Team);
+                });
+                scope.spawn(|| {
+                    write_target(&personal, SET, 2, "My rule v2");
+                });
+            });
+
+            // Serialized, BOTH orders converge on the same end state, so this is deterministic:
+            // remove-then-write leaves user + personal v2; write-then-remove writes personal v2
+            // and then strips the team span from it. Either way the team block is gone and the
+            // new personal block is there. Unserialized, one of the two is lost.
+            let after = std::fs::read_to_string(&path).unwrap();
+            assert!(after.starts_with(user), "round {round}: user bytes preserved");
+            assert!(
+                after.contains("My rule v2"),
+                "round {round}: the personal write was swallowed by the team removal"
+            );
+            assert!(
+                !after.contains(SENTINEL_START_PREFIX),
+                "round {round}: the removed team block came back"
+            );
+        }
     }
 
     #[test]

--- a/src-tauri/src/teams.rs
+++ b/src-tauri/src/teams.rs
@@ -903,7 +903,9 @@ fn installed_rules_targets() -> Vec<crate::instructions::Target> {
         // into an absent client's home.
         .filter(|client| client.app_present)
         // `None` = unsupported or covered transitively (Antigravity/Copilot).
-        .filter_map(|client| crate::clients::client_rules_target(&client.id))
+        .filter_map(|client| {
+            crate::clients::client_rules_target(&client.id, crate::instructions::Scope::Team)
+        })
         .filter(|target| seen_paths.insert(target.path.clone()))
         .collect()
 }
@@ -1007,7 +1009,7 @@ fn apply_instructions_to(
     // (not a fresh client scan) means cleanup survives a client that has since disappeared.
     for old in &prev_targets {
         if !written.iter().any(|w| w == old) {
-            instructions::remove_recorded(std::path::Path::new(old));
+            instructions::remove_recorded(std::path::Path::new(old), instructions::Scope::Team);
         }
     }
 
@@ -1030,7 +1032,7 @@ fn apply_instructions_to(
     });
     if !matches!(recorded, Ok((_, true))) {
         for path in &written {
-            instructions::remove_recorded(std::path::Path::new(path));
+            instructions::remove_recorded(std::path::Path::new(path), instructions::Scope::Team);
         }
     }
 }
@@ -1049,7 +1051,8 @@ fn build_instructions_receipt(
         .into_iter()
         .filter(|c| c.app_present)
         .map(|c| {
-            let state = match crate::clients::client_rules_target(&c.id) {
+            let state = match crate::clients::client_rules_target(&c.id, instructions::Scope::Team)
+            {
                 Some(target) => instructions::current_state(&target, team_id, version, content),
                 None => ApplyState::Unsupported,
             };
@@ -1096,7 +1099,8 @@ pub fn instructions_status() -> Option<InstructionsStatusView> {
         .into_iter()
         .filter(|c| c.app_present)
         .map(|c| {
-            let state = match crate::clients::client_rules_target(&c.id) {
+            let state = match crate::clients::client_rules_target(&c.id, instructions::Scope::Team)
+            {
                 Some(target) => instructions::current_state(&target, &team_id, version, &content),
                 None => ApplyState::Unsupported,
             };
@@ -1394,7 +1398,10 @@ pub fn disconnect() -> Result<(), String> {
         Ok(())
     })?;
     for path in &instr_targets {
-        crate::instructions::remove_recorded(std::path::Path::new(path));
+        crate::instructions::remove_recorded(
+            std::path::Path::new(path),
+            crate::instructions::Scope::Team,
+        );
     }
     let _ = clear_token();
     Ok(())
@@ -1966,6 +1973,7 @@ mod tests {
         let old_target = Target {
             path: old_path.clone(),
             strategy: Strategy::SentinelBlock,
+            scope: crate::instructions::Scope::Team,
             char_cap: None,
             blocked_if_present: None,
         };
@@ -1989,7 +1997,8 @@ mod tests {
         })
         .expect("seed the registry");
 
-        let target = crate::clients::client_rules_target("goose").expect("goose rules target");
+        let target = crate::clients::client_rules_target("goose", crate::instructions::Scope::Team)
+            .expect("goose rules target");
         assert_eq!(
             target.path,
             root.join("config").join(".goosehints"),

--- a/src-tauri/src/teams.rs
+++ b/src-tauri/src/teams.rs
@@ -1009,7 +1009,12 @@ fn apply_instructions_to(
     // (not a fresh client scan) means cleanup survives a client that has since disappeared.
     for old in &prev_targets {
         if !written.iter().any(|w| w == old) {
-            instructions::remove_recorded(std::path::Path::new(old), instructions::Scope::Team);
+            // Result ignored deliberately: this writer replaces `team_instructions_targets`
+            // wholesale below, so it has nowhere to carry "we could not clean that one" forward.
+            // Pre-existing behaviour, unchanged here; the personal writer in `rules.rs` does use
+            // the flag, and aligning Teams with it is its own change.
+            let _ =
+                instructions::remove_recorded(std::path::Path::new(old), instructions::Scope::Team);
         }
     }
 
@@ -1032,7 +1037,10 @@ fn apply_instructions_to(
     });
     if !matches!(recorded, Ok((_, true))) {
         for path in &written {
-            instructions::remove_recorded(std::path::Path::new(path), instructions::Scope::Team);
+            let _ = instructions::remove_recorded(
+                std::path::Path::new(path),
+                instructions::Scope::Team,
+            );
         }
     }
 }
@@ -1398,7 +1406,9 @@ pub fn disconnect() -> Result<(), String> {
         Ok(())
     })?;
     for path in &instr_targets {
-        crate::instructions::remove_recorded(
+        // Leaving the team clears the record either way, so there is nothing to carry a failure
+        // forward into. Same pre-existing behaviour as `apply_instructions_to`.
+        let _ = crate::instructions::remove_recorded(
             std::path::Path::new(path),
             crate::instructions::Scope::Team,
         );


### PR DESCRIPTION
Groundwork for personal agent rules ([SBS-821](https://linear.app/southboundsoftware/issue/SBS-821), item 1 of 5 in epic SBS-820). **No behaviour change for Teams.**

## Problem

Team Instructions and the upcoming personal agent rules share one write engine and, for sentinel clients, one file on disk. They could not coexist:

- `find_block` located a managed block by searching for the frozen `SENTINEL_START_PREFIX` alone, ignoring the team id carried in the marker.
- The owned-file name `toolport-team-rules.md` was hardcoded in `resolve_rules_target`.

So a personal block and a team block in the same file would have found and overwritten each other, and personal owned files would have clobbered team ones. A member of a Teams org still has their own rules, so this had to be fixed before any of the personal-rules work.

## Change

Introduce `instructions::Scope { Team, Personal }`, carried on `Target`.

- Each scope owns a **disjoint** sentinel marker pair and owned-header prefix. Disjointness is asserted in a test, not just by eye, because `find_block` matches on the START prefix alone.
- Each scope owns a **distinct owned-file name**, so team and personal files are siblings in the client's rules directory and the client loads both.
- `resolve_rules_target` now takes the rules DIRECTORY for the 5 owned-file clients and appends the scope's file name. Sentinel clients keep resolving to one shared path across scopes, by design; the two managed spans coexist there.
- The `write_target` / `current_state` content guard now refuses **every** scope's markers, not just the writing scope's. Personal content carrying a team START marker, appended before the real team block, would otherwise make the team's span swallow the personal block on the next org sync.
- `remove_recorded` takes the scope explicitly rather than sniffing it, so leaving a team strips only the team block, and the "delete when only whitespace remains" rule cannot eat a surviving personal one.

The team strings, paths, and header text are byte-identical (frozen compatibility contract). Every existing call site passes `Scope::Team`.

## Tests

10 new cases:

- marker families are disjoint, and owned-file names differ per scope
- both scopes coexist in one file in either write order, and updating one leaves the other byte-identical
- removing one scope leaves an adjacent block **byte-exactly** as its own append wrote it
- cross-scope marker content is refused, both directions
- scope-exact cleanup for both strategies (shared sentinel file, and owned files)
- Windsurf's 6000-char cap counts the other scope's block too
- owned clients get sibling files per scope; sentinel clients share one file, cap, and shadow-file across scopes

**Mutation check:** reverting `find_block` to scope-blind makes 4 of the new tests fail, so they pin the actual defect rather than restating the implementation.

## Verification

- `cargo test --manifest-path src-tauri/Cargo.toml` -> 1181 + 333 passed, 0 failed
- `cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets` -> no new warnings in the three touched files; the rest are pre-existing and outside the diff

Refs SBS-821


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Scope managed-rules markers to support independent Team and Personal rule sets
> - Introduces a `Scope` enum (`Team`/`Personal`) in [instructions.rs](https://github.com/tsouth89/toolport/pull/793/files#diff-7b46ac75ec8a86091aa2f6e2e1c9c7877c663f4ac5cc9ea6b89f75565ac02285) with distinct marker families, owned file names, and block delimiters per scope, allowing both rule sets to coexist in the same file without interference.
> - Updates `write_target`, `current_state`, `remove_recorded`, `upsert_block`, and `remove_block` to operate on a single scope at a time, leaving the other scope's content untouched.
> - Changes the `client_rules_target` public API in [clients.rs](https://github.com/tsouth89/toolport/pull/793/files#diff-6f95d037b6a920242364b6cfc2417b10affa37691d35ce5da93633c9da12c167) to require an explicit `Scope` argument; owned-file clients resolve different file paths per scope, while sentinel-block clients share the same path across scopes.
> - Propagates `Scope::Team` through all call sites in [teams.rs](https://github.com/tsouth89/toolport/pull/793/files#diff-cd8712bc1a5c6c56e55e867d15f3fb7aaf0c25b20186b10e164686e8f9926526) covering install, status, receipt building, and disconnect cleanup.
> - Risk: `client_rules_target` is a breaking API change — all callers must now supply a scope argument.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 020d1d4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->