### PR TITLE
feat(rules): personal agent rule sets, applied to every opted-in client (SBS-821)

### DIFF
--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -3158,7 +3158,7 @@ async fn rules_set_client_enabled(
 }
 
 /// Dry-run one client's write so the UI can show the exact before/after before the first apply.
-/// Never touches disk. `None` when the client is not installed or has no rules file we manage.
+/// Never writes. `None` when the client has no rules file we manage, or no set is active.
 #[tauri::command]
 async fn rules_preview(client_id: String) -> Result<Option<rules::RulesPreview>, String> {
     tauri::async_runtime::spawn_blocking(move || rules::preview(&client_id))

--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -26,6 +26,7 @@ use crate::registry::{
 use crate::remote;
 use crate::router;
 use crate::routines;
+use crate::rules;
 use crate::savings;
 use crate::searchtrace;
 use crate::secrets;
@@ -3100,6 +3101,79 @@ async fn team_instructions_status() -> Option<teams::InstructionsStatusView> {
         .flatten()
 }
 
+// ---- Personal agent rules (SBS-821) ----
+//
+// All async + `spawn_blocking`: every one of these scans each installed client's rules file, and
+// the mutating ones write to disk, neither of which may run on the UI thread. They are
+// independent of the gateway and of any configured MCP server, so the Rules tab works on a fresh
+// install with nothing connected.
+
+/// The Rules view: the user's rule sets, which one is active, and each installed client's on-disk
+/// state. Read-only.
+#[tauri::command]
+async fn rules_view() -> Result<rules::RulesView, String> {
+    tauri::async_runtime::spawn_blocking(rules::view)
+        .await
+        .map_err(|e| e.to_string())?
+}
+
+/// Create (`id: None`) or update a rule set, then apply it to every opted-in client.
+#[tauri::command]
+async fn rules_save_set(
+    id: Option<String>,
+    name: String,
+    content: String,
+) -> Result<rules::RulesView, String> {
+    tauri::async_runtime::spawn_blocking(move || rules::save_set(id.as_deref(), &name, &content))
+        .await
+        .map_err(|e| e.to_string())?
+}
+
+/// Delete a rule set. Deleting the active one clears the selection, so this also removes every
+/// rules file Toolport wrote.
+#[tauri::command]
+async fn rules_delete_set(id: String) -> Result<rules::RulesView, String> {
+    tauri::async_runtime::spawn_blocking(move || rules::delete_set(&id))
+        .await
+        .map_err(|e| e.to_string())?
+}
+
+/// Switch the active rule set, or clear it (`id: None`) to remove our files everywhere.
+#[tauri::command]
+async fn rules_set_active(id: Option<String>) -> Result<rules::RulesView, String> {
+    tauri::async_runtime::spawn_blocking(move || rules::set_active(id.as_deref()))
+        .await
+        .map_err(|e| e.to_string())?
+}
+
+/// Opt one client in or out. Opting out removes that client's rules file on the same call.
+#[tauri::command]
+async fn rules_set_client_enabled(
+    client_id: String,
+    enabled: bool,
+) -> Result<rules::RulesView, String> {
+    tauri::async_runtime::spawn_blocking(move || rules::set_client_enabled(&client_id, enabled))
+        .await
+        .map_err(|e| e.to_string())?
+}
+
+/// Dry-run one client's write so the UI can show the exact before/after before the first apply.
+/// Never touches disk. `None` when the client is not installed or has no rules file we manage.
+#[tauri::command]
+async fn rules_preview(client_id: String) -> Result<Option<rules::RulesPreview>, String> {
+    tauri::async_runtime::spawn_blocking(move || rules::preview(&client_id))
+        .await
+        .map_err(|e| e.to_string())?
+}
+
+/// Re-apply the active set. Used by the "Apply" button and after a client is connected.
+#[tauri::command]
+async fn rules_apply() -> Result<rules::RulesView, String> {
+    tauri::async_runtime::spawn_blocking(rules::apply)
+        .await
+        .map_err(|e| e.to_string())?
+}
+
 /// Leave the team: remove its merged servers, clear the connection and the token.
 #[tauri::command]
 fn team_disconnect(state: State<RegistryState>) -> Result<Registry, String> {
@@ -5056,6 +5130,13 @@ pub fn run() {
             team_sync_wait,
             main_window_visible,
             team_instructions_status,
+            rules_view,
+            rules_save_set,
+            rules_delete_set,
+            rules_set_active,
+            rules_set_client_enabled,
+            rules_preview,
+            rules_apply,
             team_disconnect,
             team_push_preview,
             team_push,

--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -3159,9 +3159,15 @@ async fn rules_set_client_enabled(
 
 /// Dry-run one client's write so the UI can show the exact before/after before the first apply.
 /// Never writes. `None` when the client has no rules file we manage, or no set is active.
+///
+/// `content` previews unsaved editor text. It exists so the UI never has to save-then-preview: a
+/// save applies to every opted-in client, which would make "dry run" a write.
 #[tauri::command]
-async fn rules_preview(client_id: String) -> Result<Option<rules::RulesPreview>, String> {
-    tauri::async_runtime::spawn_blocking(move || rules::preview(&client_id))
+async fn rules_preview(
+    client_id: String,
+    content: Option<String>,
+) -> Result<Option<rules::RulesPreview>, String> {
+    tauri::async_runtime::spawn_blocking(move || rules::preview(&client_id, content.as_deref()))
         .await
         .map_err(|e| e.to_string())?
 }

--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -5312,6 +5312,15 @@ pub fn run() {
                             .join(", ")
                     );
                 }
+                // Re-assert the user's personal agent rules (SBS-821), on this same launch
+                // thread because it is the one already allowed to touch client files on disk.
+                // Picks up a client installed, reinstalled, or updated since the last apply
+                // without the user opening the Rules tab. Cheap and quiet: it returns before
+                // scanning anything when no rule set is configured and nothing was ever
+                // written, and `write_target` no-ops when a client's block already matches, so
+                // a steady-state launch touches no files.
+                rules::apply_on_startup();
+
                 // Stop obsolete gateway processes. Path-based identity on all OS
                 // (SOU-414); not gated on repoint (SOU-306).
                 //

--- a/src-tauri/src/instructions.rs
+++ b/src-tauri/src/instructions.rs
@@ -419,7 +419,13 @@ pub fn write_target(t: &Target, id: &str, version: i64, content: &str) -> ApplyS
         return ApplyState::Error;
     }
     let desired = match t.strategy {
-        Strategy::OwnedFile => render_owned_file(t.scope, id, version, content),
+        Strategy::OwnedFile => {
+            let desired = render_owned_file(t.scope, id, version, content);
+            if std::fs::read_to_string(&t.path).ok().as_deref() == Some(desired.as_str()) {
+                return ApplyState::Applied; // already up to date; skip the atomic replacement
+            }
+            desired
+        }
         Strategy::SentinelBlock => {
             let existing = match read_existing(&t.path) {
                 Ok(s) => s,
@@ -882,6 +888,31 @@ mod tests {
         assert!(on_disk.contains("Org rule"));
         remove_recorded(&t.path, Scope::Team);
         assert!(!t.path.exists(), "owned file should be deleted on leave");
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn current_owned_file_reapply_skips_the_atomic_replacement() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let s = Scratch::new();
+        let t = owned_target(
+            s.path("rules").join(Scope::Personal.owned_file_name()),
+            Scope::Personal,
+        );
+        assert_eq!(write_target(&t, "work", 1, "My rule"), ApplyState::Applied);
+        let before = std::fs::metadata(&t.path).unwrap().modified().unwrap();
+
+        // Atomic replacement needs a writable parent. A byte-identical reapply must return before
+        // attempting that replacement, which also leaves the mtime untouched.
+        let parent = t.path.parent().unwrap();
+        std::fs::set_permissions(parent, std::fs::Permissions::from_mode(0o500)).unwrap();
+        let state = write_target(&t, "work", 1, "My rule");
+        let after = std::fs::metadata(&t.path).unwrap().modified().unwrap();
+        std::fs::set_permissions(parent, std::fs::Permissions::from_mode(0o700)).unwrap();
+
+        assert_eq!(state, ApplyState::Applied);
+        assert_eq!(after, before);
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -27,6 +27,7 @@ pub mod routine_advisor;
 pub mod routine_candidates;
 pub mod routine_catalog;
 pub mod routines;
+pub mod rules;
 pub mod savings;
 pub mod searchtrace;
 pub mod secrets;

--- a/src-tauri/src/registry.rs
+++ b/src-tauri/src/registry.rs
@@ -2905,6 +2905,24 @@ pub fn update<T>(
     Ok((reg, out))
 }
 
+/// Like [`update`], but refuses to mutate or save when the registry was reconstructed from a
+/// backup or defaulted over unreadable contents. Use this for reconciliations whose filesystem
+/// side effects depend on absence being authoritative: a placeholder registry must never make
+/// rules cleanup look like an intentional clear.
+pub fn update_authoritative<T>(
+    f: impl FnOnce(&mut Registry) -> Result<T, String>,
+) -> Result<(Registry, T), String> {
+    let path = resolved_path().ok_or("Could not resolve registry path")?;
+    let lock = lock_for(&path, registry_lock_timeout())?;
+    let (mut reg, source) = load_from_locked_with_source(&path, &lock)?;
+    if !source.is_authoritative() {
+        return Err("Registry contents are not authoritative; refusing filesystem changes".into());
+    }
+    let out = f(&mut reg)?;
+    save_to(&path, &reg)?;
+    Ok((reg, out))
+}
+
 /// Acquire the cross-process lock guarding an explicit path (its sibling `<path>.lock`), for a
 /// caller that runs its own load-modify-save rather than using [`update_at`]: the gateway's
 /// agent toggle (which interleaves audit + early returns), and the integrity pins/quarantine

--- a/src-tauri/src/registry.rs
+++ b/src-tauri/src/registry.rs
@@ -419,6 +419,24 @@ pub struct Profile {
     pub tool_scope: HashMap<String, Vec<String>>,
 }
 
+/// One named set of the user's own agent rules (CLAUDE.md / AGENTS.md / GEMINI.md content),
+/// applied to every opted-in AI client by [`crate::rules`]. Several sets can exist so a user can
+/// switch between, say, "Work" and "Personal"; exactly one is active at a time.
+///
+/// `(id, revision)` is what the personal sentinel marker carries, standing in for the team
+/// scope's `(team_id, version)` — see [`crate::instructions::Scope`]. `revision` therefore only
+/// moves when `content` actually changes, so a rename is not a rewrite of every client's file.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct RuleSet {
+    pub id: String,
+    pub name: String,
+    #[serde(default)]
+    pub content: String,
+    #[serde(default)]
+    pub revision: i64,
+}
+
 /// Maps a project folder to a profile, so the gateway can auto-scope a client to the right
 /// server set based on the working directory (MCP `root`) it reports, instead of a manual
 /// profile switch. A client whose reported root is `path` or a descendant of it resolves to
@@ -724,6 +742,23 @@ pub struct Registry {
     /// the rest of the registry JSON is unchanged.
     #[serde(default)]
     pub secrets_generation: u64,
+    /// The user's own agent rule sets. Several can exist; `active_rule_set_id` picks the one
+    /// written to clients. See [`crate::rules`].
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub rule_sets: Vec<RuleSet>,
+    /// Which of `rule_sets` is currently applied. `None` = none; every file we wrote is removed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub active_rule_set_id: Option<String>,
+    /// Per-client opt-in for personal rules, keyed by client id. ABSENT MEANS OFF: writing into
+    /// someone's `~/.claude/rules` or `AGENTS.md` is not something to do unasked, so a client
+    /// only receives rules once the user turns it on.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub rules_clients: HashMap<String, bool>,
+    /// Absolute paths of the personal-rules files we have written, so cleanup after a set
+    /// switch / client opt-out / uninstall touches exactly what we created and nothing else.
+    /// Same role as `TeamConnection::team_instructions_targets`.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub rules_targets: Vec<String>,
     /// Top-level fields THIS build doesn't know, preserved verbatim across
     /// load -> save. The registry is shared by mixed versions of the app and
     /// long-running gateways (a dev build, the installed release, and gateways
@@ -978,6 +1013,10 @@ impl Default for Registry {
             client_managed_entries: HashMap::new(),
             http_clients: Vec::new(),
             secrets_generation: 0,
+            rule_sets: Vec::new(),
+            active_rule_set_id: None,
+            rules_clients: HashMap::new(),
+            rules_targets: Vec::new(),
             unknown_fields: serde_json::Map::new(),
         }
     }
@@ -1700,6 +1739,78 @@ impl Registry {
             tool_scope: HashMap::new(),
         });
         id
+    }
+
+    /// The rule set currently applied to clients, if any.
+    pub fn active_rule_set(&self) -> Option<&RuleSet> {
+        let id = self.active_rule_set_id.as_deref()?;
+        self.rule_sets.iter().find(|s| s.id == id)
+    }
+
+    /// Create a set (`id: None`) or update one in place. Returns the set's id.
+    ///
+    /// `revision` moves ONLY when `content` changes: it rides in the on-disk sentinel marker, so
+    /// bumping it on a rename would restale every client's file and force a pointless rewrite.
+    /// A newly created set becomes active when nothing else is, so the first set a user writes
+    /// applies without a second step.
+    pub fn upsert_rule_set(&mut self, id: Option<&str>, name: &str, content: &str) -> String {
+        let name = if name.trim().is_empty() {
+            "Rules"
+        } else {
+            name.trim()
+        };
+        if let Some(id) = id {
+            if let Some(existing) = self.rule_sets.iter_mut().find(|s| s.id == id) {
+                if existing.content != content {
+                    existing.content = content.to_string();
+                    existing.revision += 1;
+                }
+                existing.name = name.to_string();
+                return existing.id.clone();
+            }
+        }
+        let id = unique_id(&slugify(name), &self.rule_set_ids());
+        self.rule_sets.push(RuleSet {
+            id: id.clone(),
+            name: name.to_string(),
+            content: content.to_string(),
+            revision: 1,
+        });
+        if self.active_rule_set_id.is_none() {
+            self.active_rule_set_id = Some(id.clone());
+        }
+        id
+    }
+
+    /// Remove a set. Removing the ACTIVE one clears the selection rather than silently promoting
+    /// another, so the next apply removes our files instead of writing someone else's rules.
+    pub fn remove_rule_set(&mut self, id: &str) {
+        self.rule_sets.retain(|s| s.id != id);
+        if self.active_rule_set_id.as_deref() == Some(id) {
+            self.active_rule_set_id = None;
+        }
+    }
+
+    /// Select the active set. An unknown id clears the selection (same effect as `None`).
+    pub fn set_active_rule_set(&mut self, id: Option<&str>) {
+        self.active_rule_set_id = id
+            .filter(|id| self.rule_sets.iter().any(|s| s.id == *id))
+            .map(str::to_string);
+    }
+
+    /// Opt one client in or out of personal rules. `false` is stored explicitly rather than
+    /// removed so the UI can tell "turned off" from "never seen".
+    pub fn set_rules_client_enabled(&mut self, client_id: &str, enabled: bool) {
+        self.rules_clients.insert(client_id.to_string(), enabled);
+    }
+
+    /// Whether a client receives personal rules. Absent = off (see the field docs).
+    pub fn rules_client_enabled(&self, client_id: &str) -> bool {
+        self.rules_clients.get(client_id).copied().unwrap_or(false)
+    }
+
+    fn rule_set_ids(&self) -> Vec<String> {
+        self.rule_sets.iter().map(|s| s.id.clone()).collect()
     }
 
     pub fn remove_profile(&mut self, id: &str) -> Result<(), String> {

--- a/src-tauri/src/registry.rs
+++ b/src-tauri/src/registry.rs
@@ -1753,21 +1753,32 @@ impl Registry {
     /// bumping it on a rename would restale every client's file and force a pointless rewrite.
     /// A newly created set becomes active when nothing else is, so the first set a user writes
     /// applies without a second step.
-    pub fn upsert_rule_set(&mut self, id: Option<&str>, name: &str, content: &str) -> String {
+    ///
+    /// An `id` that names no existing set is an ERROR, not a create. Falling through to create
+    /// would silently duplicate a set whenever a second window (or a stale view) saved against an
+    /// id that had since been deleted, leaving the user with two "Work" sets and an edit that
+    /// went somewhere they did not mean.
+    pub fn upsert_rule_set(
+        &mut self,
+        id: Option<&str>,
+        name: &str,
+        content: &str,
+    ) -> Result<String, String> {
         let name = if name.trim().is_empty() {
             "Rules"
         } else {
             name.trim()
         };
         if let Some(id) = id {
-            if let Some(existing) = self.rule_sets.iter_mut().find(|s| s.id == id) {
-                if existing.content != content {
-                    existing.content = content.to_string();
-                    existing.revision += 1;
-                }
-                existing.name = name.to_string();
-                return existing.id.clone();
+            let Some(existing) = self.rule_sets.iter_mut().find(|s| s.id == id) else {
+                return Err("That rule set no longer exists.".to_string());
+            };
+            if existing.content != content {
+                existing.content = content.to_string();
+                existing.revision += 1;
             }
+            existing.name = name.to_string();
+            return Ok(existing.id.clone());
         }
         let id = unique_id(&slugify(name), &self.rule_set_ids());
         self.rule_sets.push(RuleSet {
@@ -1779,7 +1790,7 @@ impl Registry {
         if self.active_rule_set_id.is_none() {
             self.active_rule_set_id = Some(id.clone());
         }
-        id
+        Ok(id)
     }
 
     /// Remove a set. Removing the ACTIVE one clears the selection rather than silently promoting

--- a/src-tauri/src/rules.rs
+++ b/src-tauri/src/rules.rs
@@ -215,8 +215,12 @@ fn apply_to(installed: &[ClientTarget]) -> Result<RulesView, String> {
     })
 }
 
-/// Dry-run one client's write. `None` when the client is unknown, not installed, or has no rules
-/// location we manage.
+/// Dry-run one client's write. `None` when the client has no rules location we manage, or when no
+/// set is active (there is nothing to show).
+///
+/// Deliberately NOT gated on the client being installed: this answers "what would land here",
+/// which is a fair question about a client the user is about to install, and the caller only
+/// offers it for clients it detected anyway.
 pub fn preview(client_id: &str) -> Result<Option<RulesPreview>, String> {
     let reg = crate::registry::load()?;
     let Some(target) = crate::clients::client_rules_target(client_id, Scope::Personal) else {

--- a/src-tauri/src/rules.rs
+++ b/src-tauri/src/rules.rs
@@ -176,7 +176,8 @@ fn apply_to(installed: &[ClientTarget]) -> Result<RulesView, String> {
     // Hold the registry's cross-process lock from the ONE authoritative load through every file
     // write/cleanup and the rules_targets save. Rule mutations also use this lock, so an older
     // apply cannot write stale bytes after a newer set wins, and a placeholder/default snapshot
-    // can never be mistaken for an intentional clear.
+    // can never be mistaken for an intentional clear. Team writes do not invert this order:
+    // `write_target`/`remove_recorded` release WRITE_LOCK before Teams calls registry::update.
     let (reg, ()) = crate::registry::update_authoritative(|reg| {
         let set = reg.active_rule_set().cloned();
         let prev_targets = reg.rules_targets.clone();
@@ -360,8 +361,14 @@ pub fn set_client_enabled(client_id: &str, enabled: bool) -> Result<RulesView, S
 /// a client updated (or reinstalled) since the last apply picks the rules back up without the
 /// user opening the Rules tab.
 pub fn apply_on_startup() {
-    match crate::registry::load() {
-        Ok(reg) if reg.active_rule_set().is_none() && reg.rules_targets.is_empty() => {
+    match crate::registry::load_resolved_with_source() {
+        Ok((_, source)) if !source.is_authoritative() => {
+            eprintln!(
+                "toolport: could not inspect personal rules authoritatively at startup ({source:?})"
+            );
+            return;
+        }
+        Ok((reg, _)) if reg.active_rule_set().is_none() && reg.rules_targets.is_empty() => {
             return; // nothing configured and nothing written: skip the client scan entirely
         }
         Ok(_) => {}
@@ -980,6 +987,46 @@ mod tests {
             crate::registry::load().unwrap().rules_targets,
             vec![recorded],
             "a path we failed to clean must stay recorded so the next pass retries it"
+        );
+    }
+
+    #[test]
+    fn a_recovered_registry_cannot_trigger_rules_cleanup() {
+        let _dirs = crate::registry::data_dir_test_lock();
+        let s = Scratch::new();
+        let data = s.path("data");
+        let _data_dir = crate::registry::DataDirOverride::set(&data);
+        let target = sentinel(s.path("AGENTS.md"));
+        let path = target.path.to_string_lossy().to_string();
+
+        assert_eq!(
+            instructions::write_target(&target, "work", 1, "Keep this rule."),
+            ApplyState::Applied
+        );
+        let before = std::fs::read_to_string(&target.path).unwrap();
+
+        crate::registry::update(|reg| {
+            reg.rule_sets.push(set("work", 1, "Keep this rule."));
+            reg.active_rule_set_id = Some("work".into());
+            reg.rules_targets = vec![path.clone()];
+            Ok(())
+        })
+        .unwrap();
+        // A second save creates an N-1 backup containing the active set and recorded target.
+        crate::registry::update(|reg| {
+            reg.deny_destructive = !reg.deny_destructive;
+            Ok(())
+        })
+        .unwrap();
+        std::fs::write(data.join("registry.json"), "{ not json").unwrap();
+
+        let error = apply_to(&[]).expect_err("backup recovery must refuse filesystem changes");
+
+        assert!(error.contains("not authoritative"), "unexpected error: {error}");
+        assert_eq!(
+            std::fs::read_to_string(&target.path).unwrap(),
+            before,
+            "a recovered snapshot must not remove recorded client rules"
         );
     }
 

--- a/src-tauri/src/rules.rs
+++ b/src-tauri/src/rules.rs
@@ -164,8 +164,20 @@ pub fn apply() -> Result<RulesView, String> {
 /// [`apply`] over an explicit client/target set, so tests drive a known set of files instead of
 /// the developer's real machine.
 fn apply_to(installed: &[ClientTarget]) -> Result<RulesView, String> {
+    let set = crate::registry::load()?.active_rule_set().cloned();
+    apply_to_with_set(installed, set)
+}
+
+/// [`apply_to`] with the set to write given explicitly rather than read from the registry.
+///
+/// The seam exists for one reason: passing a set that is NO LONGER the active one is exactly what
+/// an apply that loses the compare-and-set experiences, and that path is otherwise untestable
+/// without real concurrency.
+fn apply_to_with_set(
+    installed: &[ClientTarget],
+    set: Option<RuleSet>,
+) -> Result<RulesView, String> {
     let reg = crate::registry::load()?;
-    let set = reg.active_rule_set().cloned();
     let prev_targets = reg.rules_targets.clone();
     let targets = enabled_targets(&reg, installed);
 
@@ -194,24 +206,33 @@ fn apply_to(installed: &[ClientTarget]) -> Result<RulesView, String> {
             }
         }
     }
+    // Paths we could not actually clean. They stay on record so the next pass retries: cleanup is
+    // driven by that record, so forgetting one strands its block with nothing left to find it.
+    let mut uncleaned: Vec<String> = Vec::new();
     for old in &prev_targets {
         if !desired.iter().any(|d| d == old) {
-            instructions::remove_recorded(std::path::Path::new(old), Scope::Personal);
+            let gone =
+                instructions::remove_recorded(std::path::Path::new(old), Scope::Personal);
+            if !gone {
+                uncleaned.push(old.clone());
+            }
         }
     }
 
     // What we now own on disk: everything written this pass, plus any still-desired path we owned
-    // before and could not rewrite — our older block is very likely still sitting in that file, so
-    // dropping it from the record would strand it forever (nothing would ever clean it up).
+    // before and could not rewrite (our older block is very likely still in that file), plus
+    // anything we tried and failed to clean. Every one of those needs a record, because the record
+    // is the only thing that will ever bring us back to the file.
     let mut owned = written.clone();
-    for old in &prev_targets {
-        if desired.iter().any(|d| d == old) && !owned.iter().any(|o| o == old) {
+    for old in prev_targets.iter().chain(uncleaned.iter()) {
+        let still_wanted = desired.iter().any(|d| d == old) || uncleaned.contains(old);
+        if still_wanted && !owned.contains(old) {
             owned.push(old.clone());
         }
     }
 
-    // Record it. The compare-and-set fails if the active set changed underneath us (the user
-    // switched sets while we were writing), which means a newer apply has taken over.
+    // Record it. The compare-and-set fails if the active set changed underneath us, which means a
+    // newer apply has taken over.
     let expected = set.as_ref().map(|s| (s.id.clone(), s.revision));
     let recorded = crate::registry::update(|reg| {
         let current = reg.active_rule_set().map(|s| (s.id.clone(), s.revision));
@@ -222,23 +243,26 @@ fn apply_to(installed: &[ClientTarget]) -> Result<RulesView, String> {
         Ok(true)
     });
     if !matches!(recorded, Ok((_, true))) {
-        // Our writes have no record to clean them by, so take them back out — but ONLY where the
-        // block on disk is still the one we wrote. The apply that raced ahead of us may already
-        // have written the new set to these same paths, and deleting that would leave the user's
-        // active rules missing while the UI reported success.
-        for target in &targets {
-            let path = target.path.to_string_lossy().to_string();
-            if !written.contains(&path) {
-                continue; // we never wrote this one, so there is nothing of ours to take back
+        // A newer apply won the race. DO NOT delete what we wrote.
+        //
+        // Deleting looks tempting (our writes are not in the winner's record) but it is wrong in
+        // the case that matters: if the winner switched sets and its own write FAILED, our block
+        // is the only one on disk, and removing it leaves the user with no rules at all while the
+        // UI reports the new set. "Keep the last thing that worked" is the rule everywhere else
+        // in this function; a lost race is not a reason to break it.
+        //
+        // The real risk of keeping them is an unrecorded file nothing would clean later, so fix
+        // that directly: merge our paths INTO whatever record the winner left. `rules_targets` is
+        // just "paths holding our block", independent of which set put it there, so this is
+        // additive and safe — the next apply reconciles it against `desired` as usual.
+        let _ = crate::registry::update(|reg| {
+            for path in owned.iter() {
+                if !reg.rules_targets.contains(path) {
+                    reg.rules_targets.push(path.clone());
+                }
             }
-            let still_ours = set.as_ref().is_some_and(|s| {
-                instructions::current_state(target, &s.id, s.revision, &s.content)
-                    == ApplyState::Applied
-            });
-            if still_ours {
-                instructions::remove_recorded(std::path::Path::new(&path), Scope::Personal);
-            }
-        }
+            Ok(())
+        });
     }
 
     let reg = crate::registry::load()?;
@@ -771,6 +795,103 @@ mod tests {
             view.clients[0].state,
             ApplyState::Error,
             "and the failure is reported rather than hidden"
+        );
+    }
+
+    /// A path we tried and failed to clean must stay on record, or nothing will ever come back to
+    /// it. Driven through a directory-in-the-way, which makes both the rewrite and the delete fail
+    /// on every platform without needing permission games.
+    #[test]
+    fn a_path_we_could_not_clean_stays_on_record_for_the_next_pass() {
+        let _dirs = crate::registry::data_dir_test_lock();
+        let s = Scratch::new();
+        let _data_dir = crate::registry::DataDirOverride::set(s.path("data"));
+
+        let codex = client("codex", Some(sentinel(s.path("AGENTS.md"))));
+        let installed = vec![codex.clone()];
+        let path = codex.target.clone().unwrap().path;
+
+        seed_and_apply("Be brief.", &["codex"], &installed);
+        assert!(path.exists());
+        let recorded = path.to_string_lossy().to_string();
+
+        // Leave our START marker in the file with no END. `remove_recorded` will not guess where
+        // the block ends, so it reports "not cleaned" and the block stays put.
+        std::fs::write(
+            &path,
+            format!(
+                "{} set=x v=1 -->\nno end marker\n",
+                instructions::PERSONAL_SENTINEL_START_PREFIX
+            ),
+        )
+        .unwrap();
+
+        // Opt the client out: the path is no longer desired, so cleanup runs and fails.
+        crate::registry::update(|reg| {
+            reg.set_rules_client_enabled("codex", false);
+            Ok(())
+        })
+        .unwrap();
+        apply_to(&installed).unwrap();
+
+        assert_eq!(
+            crate::registry::load().unwrap().rules_targets,
+            vec![recorded],
+            "a path we failed to clean must stay recorded so the next pass retries it"
+        );
+    }
+
+    /// Losing the compare-and-set must never delete what we wrote. If the winner switched sets and
+    /// its own write failed, our block is the only one on disk; removing it would leave the user
+    /// with nothing while the UI reported the new set. Our paths are merged into the record
+    /// instead, so nothing is stranded and nothing good is destroyed.
+    #[test]
+    fn losing_the_race_keeps_our_files_and_records_them() {
+        let _dirs = crate::registry::data_dir_test_lock();
+        let s = Scratch::new();
+        let _data_dir = crate::registry::DataDirOverride::set(s.path("data"));
+
+        let codex = client("codex", Some(sentinel(s.path("AGENTS.md"))));
+        let installed = vec![codex.clone()];
+        let path = codex.target.clone().unwrap().path;
+
+        // Set A is active and opted in, but nothing has been applied yet.
+        crate::registry::update(|reg| {
+            reg.upsert_rule_set(None, "A", "Rules A.")?;
+            reg.set_rules_client_enabled("codex", true);
+            Ok(())
+        })
+        .unwrap();
+
+        // Stand in for "a newer apply won": write set A's block, then switch the active set out
+        // from under it, exactly as the CAS sees it.
+        let set_a = crate::registry::load().unwrap().active_rule_set().cloned().unwrap();
+        let target = codex.target.clone().unwrap();
+        assert_eq!(
+            instructions::write_target(&target, &set_a.id, set_a.revision, &set_a.content),
+            ApplyState::Applied
+        );
+        crate::registry::update(|reg| {
+            let b = reg.upsert_rule_set(None, "B", "Rules B.")?;
+            reg.set_active_rule_set(Some(&b));
+            Ok(())
+        })
+        .unwrap();
+
+        // Now run the apply that is about to lose: it loaded set A, wrote it, and will find the
+        // active set changed.
+        apply_to_with_set(&installed, Some(set_a.clone())).unwrap();
+
+        assert!(
+            std::fs::read_to_string(&path).unwrap().contains("Rules A."),
+            "the loser must not delete the only block on disk"
+        );
+        assert!(
+            crate::registry::load()
+                .unwrap()
+                .rules_targets
+                .contains(&path.to_string_lossy().to_string()),
+            "and the path must be recorded so a later pass can clean it"
         );
     }
 

--- a/src-tauri/src/rules.rs
+++ b/src-tauri/src/rules.rs
@@ -1,0 +1,731 @@
+//! Personal agent rules — write the user's own rule set into every opted-in AI client.
+//!
+//! The desktop half of SBS-821 (`agent-rules` spec). The user authors one or more named
+//! [`RuleSet`]s in the app; the active one is written into each client's global rules file so
+//! Claude Code, Codex, Gemini CLI and the rest all read the same instructions without the user
+//! hand-editing four files.
+//!
+//! This is the same write engine Team Instructions uses ([`crate::instructions`]), driven from
+//! local state instead of a pulled org config: `(rule_set_id, revision)` stands in for
+//! `(team_id, version)`, and every target carries [`Scope::Personal`] so a member of a Teams org
+//! keeps both sets of rules in the same files without either clobbering the other.
+//!
+//! Two rules this module exists to enforce:
+//!
+//!   * **Opt-in per client.** Writing into someone's `~/.claude/rules` or `AGENTS.md` unasked is
+//!     not something to do, so [`crate::registry::Registry::rules_client_enabled`] defaults to
+//!     off and the UI previews the write first.
+//!   * **Clean up exactly what we wrote.** Every applied path is recorded in
+//!     `Registry::rules_targets`; anything in that list we do not re-write this pass is removed
+//!     by path, so switching set, opting a client out, or uninstalling a client never strands a
+//!     file. Same contract as `teams::apply_instructions_to`.
+
+use crate::instructions::{self, ApplyState, Scope, Strategy, Target};
+use crate::registry::RuleSet;
+use serde::{Deserialize, Serialize};
+
+/// One client's row in the Rules view: whether it is opted in, where its rules file is, and what
+/// state that file is in right now.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ClientStatus {
+    pub id: String,
+    pub name: String,
+    /// User opt-in. A disabled client still reports a `state` (usually `Stale`) so the UI can
+    /// show what WOULD happen without writing anything.
+    pub enabled: bool,
+    /// `None` when this client has no global-rules location we can write (Cursor, Warp).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
+    pub state: ApplyState,
+}
+
+/// Everything the Rules view needs, in one round trip.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RulesView {
+    pub sets: Vec<RuleSet>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub active_set_id: Option<String>,
+    pub clients: Vec<ClientStatus>,
+}
+
+/// A dry run of one client's write, so the user sees the exact bytes before the first apply
+/// (SBS-821 acceptance criteria). Never touches disk.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RulesPreview {
+    pub client_id: String,
+    pub path: String,
+    /// `"ownedFile"` when Toolport owns the whole file, `"sentinelBlock"` when it owns only the
+    /// marked span in a file the user also edits. Drives how the UI frames the change.
+    pub strategy: String,
+    /// The file as it is now. Empty when it does not exist yet.
+    pub before: String,
+    /// The file as this apply would leave it.
+    pub after: String,
+    pub state: ApplyState,
+}
+
+/// One installed client and where its personal rules go. Deliberately NOT
+/// [`crate::clients::DetectedClient`]: that type carries a client's whole MCP inventory and has no
+/// cheap constructor, so depending on it here would make every apply test build a fake server
+/// list. This is the only shape the apply logic needs.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ClientTarget {
+    id: String,
+    name: String,
+    /// `None` when this client has no global-rules location we manage (Cursor, Warp), or is
+    /// covered transitively by another client's file.
+    target: Option<Target>,
+}
+
+/// Every installed client paired with its personal-rules target, including clients the user has
+/// NOT opted in — the view lists them so they can be turned on.
+fn installed_targets() -> Vec<ClientTarget> {
+    crate::clients::detect_clients()
+        .into_iter()
+        .filter(|c| c.app_present)
+        .map(|c| ClientTarget {
+            target: crate::clients::client_rules_target(&c.id, Scope::Personal),
+            id: c.id,
+            name: c.name,
+        })
+        .collect()
+}
+
+/// The distinct paths to write this pass: opted-in clients only, de-duped by path so a file two
+/// clients share (Claude Code + VS Code Copilot, Gemini CLI + Antigravity) is written once.
+fn enabled_targets(reg: &crate::registry::Registry, installed: &[ClientTarget]) -> Vec<Target> {
+    let mut seen = std::collections::HashSet::new();
+    installed
+        .iter()
+        .filter(|c| reg.rules_client_enabled(&c.id))
+        .filter_map(|c| c.target.clone())
+        .filter(|t| seen.insert(t.path.clone()))
+        .collect()
+}
+
+/// Read-only per-client state for the given set. Reports reality rather than what we last wrote,
+/// so a hand-edited or deleted block shows `Stale` and a client installed since the last apply
+/// shows up immediately.
+fn status_from(
+    reg: &crate::registry::Registry,
+    installed: &[ClientTarget],
+    set: Option<&RuleSet>,
+) -> Vec<ClientStatus> {
+    installed
+        .iter()
+        .map(|c| {
+            let state = match (&c.target, set) {
+                (None, _) => ApplyState::Unsupported,
+                // No active set: nothing is meant to be on disk, so nothing is stale.
+                (Some(_), None) => ApplyState::Applied,
+                (Some(t), Some(s)) => instructions::current_state(t, &s.id, s.revision, &s.content),
+            };
+            ClientStatus {
+                id: c.id.clone(),
+                name: c.name.clone(),
+                enabled: reg.rules_client_enabled(&c.id),
+                path: c
+                    .target
+                    .as_ref()
+                    .map(|t| t.path.to_string_lossy().to_string()),
+                state,
+            }
+        })
+        .collect()
+}
+
+/// The whole Rules view. Read-only; scans every installed client's rules file, so callers run it
+/// off the UI thread.
+pub fn view() -> Result<RulesView, String> {
+    let reg = crate::registry::load()?;
+    let installed = installed_targets();
+    let set = reg.active_rule_set().cloned();
+    Ok(RulesView {
+        clients: status_from(&reg, &installed, set.as_ref()),
+        sets: reg.rule_sets.clone(),
+        active_set_id: reg.active_rule_set_id.clone(),
+    })
+}
+
+/// Apply the active rule set to every opted-in client, then clean up anything we wrote before and
+/// did not write now. Returns the refreshed view.
+///
+/// Best-effort per client, like the team writer: one unwritable file must not abort the rest. A
+/// client that reports anything other than [`ApplyState::Applied`] is simply not recorded, so the
+/// next pass tries it again.
+pub fn apply() -> Result<RulesView, String> {
+    let installed = installed_targets();
+    apply_to(&installed)
+}
+
+/// [`apply`] over an explicit client/target set, so tests drive a known set of files instead of
+/// the developer's real machine.
+fn apply_to(installed: &[ClientTarget]) -> Result<RulesView, String> {
+    let reg = crate::registry::load()?;
+    let set = reg.active_rule_set().cloned();
+    let prev_targets = reg.rules_targets.clone();
+    let targets = enabled_targets(&reg, installed);
+
+    let mut written: Vec<String> = Vec::new();
+    if let Some(s) = set.as_ref() {
+        for target in &targets {
+            if instructions::write_target(target, &s.id, s.revision, &s.content)
+                == ApplyState::Applied
+            {
+                written.push(target.path.to_string_lossy().to_string());
+            }
+        }
+    }
+    // Anything we wrote before and did not write now: the set changed or was cleared, a client
+    // was opted out or uninstalled, or its rules path moved. Iterating the RECORDED list rather
+    // than a fresh scan means cleanup survives a client that has since disappeared.
+    for old in &prev_targets {
+        if !written.iter().any(|w| w == old) {
+            instructions::remove_recorded(std::path::Path::new(old), Scope::Personal);
+        }
+    }
+
+    // Record what is now on disk. The compare-and-set fails if the active set changed underneath
+    // us (the user switched sets while we were writing): the files we just wrote would then have
+    // no record to clean them by, so roll them back rather than orphan them.
+    let expected = set.as_ref().map(|s| (s.id.clone(), s.revision));
+    let recorded = crate::registry::update(|reg| {
+        let current = reg.active_rule_set().map(|s| (s.id.clone(), s.revision));
+        if current != expected {
+            return Ok(false);
+        }
+        reg.rules_targets = written.clone();
+        Ok(true)
+    });
+    if !matches!(recorded, Ok((_, true))) {
+        for path in &written {
+            instructions::remove_recorded(std::path::Path::new(path), Scope::Personal);
+        }
+    }
+
+    let reg = crate::registry::load()?;
+    let set = reg.active_rule_set().cloned();
+    Ok(RulesView {
+        clients: status_from(&reg, installed, set.as_ref()),
+        sets: reg.rule_sets.clone(),
+        active_set_id: reg.active_rule_set_id.clone(),
+    })
+}
+
+/// Dry-run one client's write. `None` when the client is unknown, not installed, or has no rules
+/// location we manage.
+pub fn preview(client_id: &str) -> Result<Option<RulesPreview>, String> {
+    let reg = crate::registry::load()?;
+    let Some(target) = crate::clients::client_rules_target(client_id, Scope::Personal) else {
+        return Ok(None);
+    };
+    let Some(set) = reg.active_rule_set() else {
+        return Ok(None);
+    };
+    let before = std::fs::read_to_string(&target.path).unwrap_or_default();
+    let after = match target.strategy {
+        Strategy::OwnedFile => {
+            instructions::render_owned_file(Scope::Personal, &set.id, set.revision, &set.content)
+        }
+        Strategy::SentinelBlock => instructions::upsert_block(
+            &before,
+            Scope::Personal,
+            &set.id,
+            set.revision,
+            &set.content,
+        ),
+    };
+    Ok(Some(RulesPreview {
+        client_id: client_id.to_string(),
+        path: target.path.to_string_lossy().to_string(),
+        strategy: match target.strategy {
+            Strategy::OwnedFile => "ownedFile",
+            Strategy::SentinelBlock => "sentinelBlock",
+        }
+        .to_string(),
+        state: instructions::current_state(&target, &set.id, set.revision, &set.content),
+        before,
+        after,
+    }))
+}
+
+/// Create or update a set, then apply. Returns the refreshed view.
+pub fn save_set(id: Option<&str>, name: &str, content: &str) -> Result<RulesView, String> {
+    crate::registry::update(|reg| {
+        reg.upsert_rule_set(id, name, content);
+        Ok(())
+    })?;
+    apply()
+}
+
+/// Delete a set, then apply. Deleting the active set clears the selection, so the apply that
+/// follows removes every file we wrote.
+pub fn delete_set(id: &str) -> Result<RulesView, String> {
+    crate::registry::update(|reg| {
+        reg.remove_rule_set(id);
+        Ok(())
+    })?;
+    apply()
+}
+
+/// Switch (or clear) the active set, then apply.
+pub fn set_active(id: Option<&str>) -> Result<RulesView, String> {
+    crate::registry::update(|reg| {
+        reg.set_active_rule_set(id);
+        Ok(())
+    })?;
+    apply()
+}
+
+/// Opt one client in or out, then apply. Opting out removes that client's file on the same pass.
+pub fn set_client_enabled(client_id: &str, enabled: bool) -> Result<RulesView, String> {
+    crate::registry::update(|reg| {
+        reg.set_rules_client_enabled(client_id, enabled);
+        Ok(())
+    })?;
+    apply()
+}
+
+/// Re-assert the active set at startup. Cheap in the common case: [`instructions::write_target`]
+/// no-ops when the on-disk block already matches, so a normal launch touches no files. Exists so
+/// a client updated (or reinstalled) since the last apply picks the rules back up without the
+/// user opening the Rules tab.
+pub fn apply_on_startup() {
+    if let Ok(reg) = crate::registry::load() {
+        if reg.active_rule_set().is_none() && reg.rules_targets.is_empty() {
+            return; // nothing configured and nothing written: skip the client scan entirely
+        }
+    }
+    let _ = apply();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    /// A unique scratch dir per test; best-effort cleanup on drop.
+    struct Scratch(PathBuf);
+    impl Scratch {
+        fn new() -> Self {
+            static N: AtomicU32 = AtomicU32::new(0);
+            let dir = std::env::temp_dir().join(format!(
+                "toolport-rules-{}-{}",
+                std::process::id(),
+                N.fetch_add(1, Ordering::Relaxed)
+            ));
+            std::fs::create_dir_all(&dir).unwrap();
+            Scratch(dir)
+        }
+        fn path(&self, name: &str) -> PathBuf {
+            self.0.join(name)
+        }
+    }
+    impl Drop for Scratch {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
+
+    fn client(id: &str, target: Option<Target>) -> ClientTarget {
+        ClientTarget {
+            id: id.to_string(),
+            name: id.to_string(),
+            target,
+        }
+    }
+
+    fn sentinel(path: PathBuf) -> Target {
+        Target {
+            path,
+            strategy: Strategy::SentinelBlock,
+            scope: Scope::Personal,
+            char_cap: None,
+            blocked_if_present: None,
+        }
+    }
+
+    fn owned(path: PathBuf) -> Target {
+        Target {
+            path,
+            strategy: Strategy::OwnedFile,
+            scope: Scope::Personal,
+            char_cap: None,
+            blocked_if_present: None,
+        }
+    }
+
+    fn set(id: &str, revision: i64, content: &str) -> RuleSet {
+        RuleSet {
+            id: id.to_string(),
+            name: id.to_string(),
+            content: content.to_string(),
+            revision,
+        }
+    }
+
+    // ---- registry-level set management (no filesystem) ----
+
+    #[test]
+    fn a_new_set_becomes_active_when_nothing_else_is() {
+        let mut reg = crate::registry::Registry::default();
+        let id = reg.upsert_rule_set(None, "Work", "Always run tests.");
+        assert_eq!(reg.active_rule_set_id.as_deref(), Some(id.as_str()));
+        assert_eq!(reg.active_rule_set().map(|s| s.revision), Some(1));
+
+        // A SECOND set does not steal the selection.
+        let other = reg.upsert_rule_set(None, "Personal", "Be brief.");
+        assert_ne!(other, id, "ids must be unique");
+        assert_eq!(reg.active_rule_set_id.as_deref(), Some(id.as_str()));
+    }
+
+    #[test]
+    fn revision_moves_on_content_change_only() {
+        let mut reg = crate::registry::Registry::default();
+        let id = reg.upsert_rule_set(None, "Work", "v1");
+        assert_eq!(reg.active_rule_set().unwrap().revision, 1);
+
+        // A rename rides in the marker but is not a content change, so rewriting every client's
+        // file for it would be pure churn.
+        reg.upsert_rule_set(Some(&id), "Renamed", "v1");
+        assert_eq!(reg.active_rule_set().unwrap().revision, 1);
+        assert_eq!(reg.active_rule_set().unwrap().name, "Renamed");
+
+        reg.upsert_rule_set(Some(&id), "Renamed", "v2");
+        assert_eq!(reg.active_rule_set().unwrap().revision, 2);
+    }
+
+    #[test]
+    fn removing_the_active_set_clears_the_selection() {
+        let mut reg = crate::registry::Registry::default();
+        let a = reg.upsert_rule_set(None, "A", "a");
+        let b = reg.upsert_rule_set(None, "B", "b");
+        reg.remove_rule_set(&a);
+        assert_eq!(
+            reg.active_rule_set_id, None,
+            "must not silently promote another set's rules onto the user's machine"
+        );
+        assert_eq!(reg.rule_sets.len(), 1);
+
+        reg.set_active_rule_set(Some(&b));
+        assert_eq!(reg.active_rule_set_id.as_deref(), Some(b.as_str()));
+        reg.set_active_rule_set(Some("nope"));
+        assert_eq!(reg.active_rule_set_id, None, "unknown id clears, never panics");
+    }
+
+    #[test]
+    fn a_client_is_opted_out_until_the_user_says_otherwise() {
+        let mut reg = crate::registry::Registry::default();
+        assert!(!reg.rules_client_enabled("claude-code"), "absent must mean off");
+        reg.set_rules_client_enabled("claude-code", true);
+        assert!(reg.rules_client_enabled("claude-code"));
+        reg.set_rules_client_enabled("claude-code", false);
+        assert!(!reg.rules_client_enabled("claude-code"));
+        assert!(
+            reg.rules_clients.contains_key("claude-code"),
+            "an explicit off is stored, so the UI can tell it from never-seen"
+        );
+    }
+
+    // ---- target selection ----
+
+    #[test]
+    fn only_opted_in_clients_are_written_and_shared_paths_collapse() {
+        let s = Scratch::new();
+        let shared = s.path("GEMINI.md");
+        let installed = vec![
+            client("gemini-cli", Some(sentinel(shared.clone()))),
+            client("antigravity", Some(sentinel(shared.clone()))),
+            client("codex", Some(sentinel(s.path("AGENTS.md")))),
+            client("cursor", None),
+        ];
+        let mut reg = crate::registry::Registry::default();
+
+        assert!(
+            enabled_targets(&reg, &installed).is_empty(),
+            "nothing is written before the user opts a client in"
+        );
+
+        reg.set_rules_client_enabled("gemini-cli", true);
+        reg.set_rules_client_enabled("antigravity", true);
+        let targets = enabled_targets(&reg, &installed);
+        assert_eq!(
+            targets.len(),
+            1,
+            "Gemini and Antigravity share one file; it must be written once"
+        );
+        assert_eq!(targets[0].path, shared);
+    }
+
+    #[test]
+    fn an_unsupported_client_is_reported_not_skipped() {
+        let installed = vec![client("cursor", None)];
+        let reg = crate::registry::Registry::default();
+        let rows = status_from(&reg, &installed, Some(&set("s", 1, "c")));
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].state, ApplyState::Unsupported);
+        assert_eq!(rows[0].path, None);
+        assert!(!rows[0].enabled);
+    }
+
+    #[test]
+    fn with_no_active_set_every_client_reads_as_settled() {
+        let s = Scratch::new();
+        let installed = vec![client("codex", Some(sentinel(s.path("AGENTS.md"))))];
+        let reg = crate::registry::Registry::default();
+        let rows = status_from(&reg, &installed, None);
+        assert_eq!(
+            rows[0].state,
+            ApplyState::Applied,
+            "nothing is meant to be on disk, so nothing is stale"
+        );
+    }
+
+    // ---- write / status round trip, straight through the instructions engine ----
+
+    #[test]
+    fn a_shared_file_keeps_user_bytes_and_reports_applied() {
+        let s = Scratch::new();
+        let path = s.path("AGENTS.md");
+        let user = "# Mine\nAlways run tests.\n";
+        std::fs::write(&path, user).unwrap();
+        let target = sentinel(path.clone());
+        let rules = set("work", 3, "Be brief.");
+
+        assert_eq!(
+            instructions::write_target(&target, &rules.id, rules.revision, &rules.content),
+            ApplyState::Applied
+        );
+        let after = std::fs::read_to_string(&path).unwrap();
+        assert!(after.starts_with(user), "user bytes preserved");
+        assert!(after.contains("Be brief."));
+
+        let installed = vec![client("codex", Some(target.clone()))];
+        let mut reg = crate::registry::Registry::default();
+        reg.set_rules_client_enabled("codex", true);
+        assert_eq!(
+            status_from(&reg, &installed, Some(&rules))[0].state,
+            ApplyState::Applied
+        );
+
+        // A newer revision of the same set reads as Stale until it is applied.
+        let bumped = set("work", 4, "Be brief.");
+        assert_eq!(
+            status_from(&reg, &installed, Some(&bumped))[0].state,
+            ApplyState::Stale
+        );
+    }
+
+    /// The three cases the SBS-821 acceptance criteria name, per strategy: a fresh file, a file
+    /// that already carries our block, and a file with user content and no block.
+    #[test]
+    fn each_strategy_handles_fresh_existing_block_and_foreign_file() {
+        let s = Scratch::new();
+        let rules = set("work", 1, "Be brief.");
+
+        // Fresh file.
+        let fresh = sentinel(s.path("fresh.md"));
+        assert_eq!(
+            instructions::write_target(&fresh, &rules.id, rules.revision, &rules.content),
+            ApplyState::Applied
+        );
+        assert!(fresh.path.exists());
+
+        // Already carries our block: idempotent, byte-identical.
+        let before = std::fs::read_to_string(&fresh.path).unwrap();
+        assert_eq!(
+            instructions::write_target(&fresh, &rules.id, rules.revision, &rules.content),
+            ApplyState::Applied
+        );
+        assert_eq!(std::fs::read_to_string(&fresh.path).unwrap(), before);
+
+        // User content, no block: appended to, never replaced.
+        let foreign = sentinel(s.path("foreign.md"));
+        let user = "# Mine\nkeep me\n";
+        std::fs::write(&foreign.path, user).unwrap();
+        assert_eq!(
+            instructions::write_target(&foreign, &rules.id, rules.revision, &rules.content),
+            ApplyState::Applied
+        );
+        assert!(std::fs::read_to_string(&foreign.path).unwrap().starts_with(user));
+
+        // Owned files are ours whole, and a foreign file at the owned path is never deleted.
+        let own = owned(s.path("rules").join(Scope::Personal.owned_file_name()));
+        assert_eq!(
+            instructions::write_target(&own, &rules.id, rules.revision, &rules.content),
+            ApplyState::Applied
+        );
+        assert!(std::fs::read_to_string(&own.path)
+            .unwrap()
+            .starts_with(instructions::PERSONAL_OWNED_HEADER_PREFIX));
+    }
+
+    // ---- end-to-end apply, against a redirected registry ----
+    //
+    // These drive `apply_to` for real: it loads and writes the registry, so each holds the
+    // process-global data-dir guard and points the registry at a scratch dir. The client targets
+    // are synthetic scratch paths, so no real client file on the developer's machine is touched.
+
+    /// Seed the (redirected) registry with one set and the given opted-in clients, then run
+    /// `apply_to`. Callers must already hold the data-dir guard and override.
+    fn seed_and_apply(content: &str, enabled: &[&str], installed: &[ClientTarget]) -> RulesView {
+        crate::registry::update(|reg| {
+            reg.upsert_rule_set(Some("work"), "Work", content);
+            for id in enabled {
+                reg.set_rules_client_enabled(id, true);
+            }
+            Ok(())
+        })
+        .expect("seed the registry");
+        apply_to(installed).expect("apply")
+    }
+
+    #[test]
+    fn apply_writes_opted_in_clients_and_records_what_it_wrote() {
+        let _dirs = crate::registry::data_dir_test_lock();
+        let s = Scratch::new();
+        let base = s.path("data");
+        let _data_dir = crate::registry::DataDirOverride::set(&base);
+
+        let codex = client("codex", Some(sentinel(s.path("AGENTS.md"))));
+        let claude = client(
+            "claude-code",
+            Some(owned(s.path("rules").join(Scope::Personal.owned_file_name()))),
+        );
+        let cursor = client("cursor", None);
+        let installed = vec![codex.clone(), claude.clone(), cursor.clone()];
+
+        // Only Codex is opted in.
+        let view = seed_and_apply("Be brief.", &["codex"], &installed);
+
+        let codex_path = codex.target.clone().unwrap().path;
+        let claude_path = claude.target.clone().unwrap().path;
+        assert!(codex_path.exists(), "opted-in client is written");
+        assert!(!claude_path.exists(), "opted-out client is left alone");
+
+        let reg = crate::registry::load().unwrap();
+        assert_eq!(
+            reg.rules_targets,
+            vec![codex_path.to_string_lossy().to_string()],
+            "only the written path is recorded"
+        );
+
+        let by_id = |id: &str| view.clients.iter().find(|c| c.id == id).unwrap().clone();
+        assert_eq!(by_id("codex").state, ApplyState::Applied);
+        assert!(by_id("codex").enabled);
+        assert_eq!(by_id("claude-code").state, ApplyState::Stale);
+        assert!(!by_id("claude-code").enabled);
+        assert_eq!(by_id("cursor").state, ApplyState::Unsupported);
+    }
+
+    #[test]
+    fn opting_a_client_out_removes_only_that_clients_file() {
+        let _dirs = crate::registry::data_dir_test_lock();
+        let s = Scratch::new();
+        let _data_dir = crate::registry::DataDirOverride::set(s.path("data"));
+
+        let codex = client("codex", Some(sentinel(s.path("AGENTS.md"))));
+        let zed = client("zed", Some(sentinel(s.path("zed-AGENTS.md"))));
+        let installed = vec![codex.clone(), zed.clone()];
+        let codex_path = codex.target.clone().unwrap().path;
+        let zed_path = zed.target.clone().unwrap().path;
+
+        // A file the user already owns, so we can prove only our span goes.
+        let user = "# Mine\nkeep me\n";
+        std::fs::write(&codex_path, user).unwrap();
+
+        seed_and_apply("Be brief.", &["codex", "zed"], &installed);
+        assert!(zed_path.exists());
+        assert!(std::fs::read_to_string(&codex_path).unwrap().contains("Be brief."));
+
+        crate::registry::update(|reg| {
+            reg.set_rules_client_enabled("codex", false);
+            Ok(())
+        })
+        .unwrap();
+        apply_to(&installed).unwrap();
+
+        assert_eq!(
+            std::fs::read_to_string(&codex_path).unwrap(),
+            user,
+            "the opted-out client's file is back to the user's own bytes"
+        );
+        assert!(zed_path.exists(), "the other client is untouched");
+        let reg = crate::registry::load().unwrap();
+        assert_eq!(reg.rules_targets, vec![zed_path.to_string_lossy().to_string()]);
+    }
+
+    #[test]
+    fn switching_sets_rewrites_in_place_and_clearing_removes_everything() {
+        let _dirs = crate::registry::data_dir_test_lock();
+        let s = Scratch::new();
+        let _data_dir = crate::registry::DataDirOverride::set(s.path("data"));
+
+        let codex = client("codex", Some(sentinel(s.path("AGENTS.md"))));
+        let installed = vec![codex.clone()];
+        let path = codex.target.clone().unwrap().path;
+
+        seed_and_apply("Rules A.", &["codex"], &installed);
+        assert!(std::fs::read_to_string(&path).unwrap().contains("Rules A."));
+
+        // A second set replaces the first set's span rather than stacking a second block.
+        crate::registry::update(|reg| {
+            let id = reg.upsert_rule_set(None, "Other", "Rules B.");
+            reg.set_active_rule_set(Some(&id));
+            Ok(())
+        })
+        .unwrap();
+        apply_to(&installed).unwrap();
+        let after = std::fs::read_to_string(&path).unwrap();
+        assert!(after.contains("Rules B."));
+        assert!(!after.contains("Rules A."), "the old set's span is replaced, not appended to");
+        assert_eq!(
+            after.matches(instructions::PERSONAL_SENTINEL_START_PREFIX).count(),
+            1,
+            "exactly one personal block, whichever set wrote it"
+        );
+
+        // Clearing the selection takes our file away and forgets the recorded path.
+        crate::registry::update(|reg| {
+            reg.set_active_rule_set(None);
+            Ok(())
+        })
+        .unwrap();
+        let view = apply_to(&installed).unwrap();
+        assert!(!path.exists(), "a file that held only our block is removed");
+        let reg = crate::registry::load().unwrap();
+        assert!(reg.rules_targets.is_empty(), "nothing left to clean up");
+        assert_eq!(
+            view.clients[0].state,
+            ApplyState::Applied,
+            "with no active set there is nothing to be stale about"
+        );
+    }
+
+    /// Cleanup is by RECORDED path, so opting a client out (or switching sets) removes exactly the
+    /// file we wrote and leaves the user's own bytes and any team block alone.
+    #[test]
+    fn cleanup_removes_only_our_span() {
+        let s = Scratch::new();
+        let path = s.path("AGENTS.md");
+        let user = "# Mine\nkeep me\n";
+        std::fs::write(&path, user).unwrap();
+        let personal = sentinel(path.clone());
+        let team = Target {
+            scope: Scope::Team,
+            ..sentinel(path.clone())
+        };
+        instructions::write_target(&team, "team_abc", 1, "Org rule");
+        instructions::write_target(&personal, "work", 1, "Be brief.");
+
+        instructions::remove_recorded(&path, Scope::Personal);
+        let after = std::fs::read_to_string(&path).unwrap();
+        assert!(after.starts_with(user), "user bytes survive");
+        assert!(after.contains("Org rule"), "the team block is not ours to remove");
+        assert!(!after.contains("Be brief."), "our span is gone");
+    }
+}

--- a/src-tauri/src/rules.rs
+++ b/src-tauri/src/rules.rs
@@ -173,108 +173,64 @@ pub fn apply() -> Result<RulesView, String> {
 /// [`apply`] over an explicit client/target set, so tests drive a known set of files instead of
 /// the developer's real machine.
 fn apply_to(installed: &[ClientTarget]) -> Result<RulesView, String> {
-    let set = crate::registry::load()?.active_rule_set().cloned();
-    apply_to_with_set(installed, set)
-}
+    // Hold the registry's cross-process lock from the ONE authoritative load through every file
+    // write/cleanup and the rules_targets save. Rule mutations also use this lock, so an older
+    // apply cannot write stale bytes after a newer set wins, and a placeholder/default snapshot
+    // can never be mistaken for an intentional clear.
+    let (reg, ()) = crate::registry::update_authoritative(|reg| {
+        let set = reg.active_rule_set().cloned();
+        let prev_targets = reg.rules_targets.clone();
+        let targets = enabled_targets(reg, installed);
 
-/// [`apply_to`] with the set to write given explicitly rather than read from the registry.
-///
-/// The seam exists for one reason: passing a set that is NO LONGER the active one is exactly what
-/// an apply that loses the compare-and-set experiences, and that path is otherwise untestable
-/// without real concurrency.
-fn apply_to_with_set(
-    installed: &[ClientTarget],
-    set: Option<RuleSet>,
-) -> Result<RulesView, String> {
-    let reg = crate::registry::load()?;
-    let prev_targets = reg.rules_targets.clone();
-    let targets = enabled_targets(&reg, installed);
+        // Every path this apply still WANTS to own, whether or not writing it succeeded. Cleanup
+        // is driven by this rather than by successful writes: a transient failure must keep the
+        // previous good block and its cleanup record.
+        let desired: Vec<String> = if set.is_some() {
+            targets
+                .iter()
+                .map(|t| t.path.to_string_lossy().to_string())
+                .collect()
+        } else {
+            Vec::new()
+        };
 
-    // Every path this apply still WANTS to own, whether or not writing it succeeded. Cleanup is
-    // driven by this rather than by the successful writes: a client that failed to write (a full
-    // disk, a permission error, Windsurf's cap, a Codex override that appeared) is still opted in,
-    // and deleting its last known-good block because today's write failed would turn a transient
-    // failure into lost rules. Only a path that is no longer desired at all (opted out,
-    // uninstalled, set cleared, path moved) gets removed.
-    let desired: Vec<String> = if set.is_some() {
-        targets
-            .iter()
-            .map(|t| t.path.to_string_lossy().to_string())
-            .collect()
-    } else {
-        Vec::new()
-    };
-
-    let mut written: Vec<String> = Vec::new();
-    if let Some(s) = set.as_ref() {
-        for target in &targets {
-            if instructions::write_target(target, &s.id, s.revision, &s.content)
-                == ApplyState::Applied
-            {
-                written.push(target.path.to_string_lossy().to_string());
+        let mut written: Vec<String> = Vec::new();
+        if let Some(s) = set.as_ref() {
+            for target in &targets {
+                if instructions::write_target(target, &s.id, s.revision, &s.content)
+                    == ApplyState::Applied
+                {
+                    written.push(target.path.to_string_lossy().to_string());
+                }
             }
         }
-    }
-    // Paths we could not actually clean. They stay on record so the next pass retries: cleanup is
-    // driven by that record, so forgetting one strands its block with nothing left to find it.
-    let mut uncleaned: Vec<String> = Vec::new();
-    for old in &prev_targets {
-        if !desired.iter().any(|d| d == old) {
-            let gone =
-                instructions::remove_recorded(std::path::Path::new(old), Scope::Personal);
-            if !gone {
+
+        // Paths we could not clean stay recorded so the next pass retries.
+        let mut uncleaned: Vec<String> = Vec::new();
+        for old in &prev_targets {
+            if !desired.iter().any(|d| d == old)
+                && !instructions::remove_recorded(
+                    std::path::Path::new(old),
+                    Scope::Personal,
+                )
+            {
                 uncleaned.push(old.clone());
             }
         }
-    }
 
-    // What we now own on disk: everything written this pass, plus any still-desired path we owned
-    // before and could not rewrite (our older block is very likely still in that file), plus
-    // anything we tried and failed to clean. Every one of those needs a record, because the record
-    // is the only thing that will ever bring us back to the file.
-    let mut owned = written.clone();
-    for old in prev_targets.iter().chain(uncleaned.iter()) {
-        let still_wanted = desired.iter().any(|d| d == old) || uncleaned.contains(old);
-        if still_wanted && !owned.contains(old) {
-            owned.push(old.clone());
-        }
-    }
-
-    // Record it. The compare-and-set fails if the active set changed underneath us, which means a
-    // newer apply has taken over.
-    let expected = set.as_ref().map(|s| (s.id.clone(), s.revision));
-    let recorded = crate::registry::update(|reg| {
-        let current = reg.active_rule_set().map(|s| (s.id.clone(), s.revision));
-        if current != expected {
-            return Ok(false);
-        }
-        reg.rules_targets = owned.clone();
-        Ok(true)
-    });
-    if !matches!(recorded, Ok((_, true))) {
-        // A newer apply won the race. DO NOT delete what we wrote.
-        //
-        // Deleting looks tempting (our writes are not in the winner's record) but it is wrong in
-        // the case that matters: if the winner switched sets and its own write FAILED, our block
-        // is the only one on disk, and removing it leaves the user with no rules at all while the
-        // UI reports the new set. "Keep the last thing that worked" is the rule everywhere else
-        // in this function; a lost race is not a reason to break it.
-        //
-        // The real risk of keeping them is an unrecorded file nothing would clean later, so fix
-        // that directly: merge our paths INTO whatever record the winner left. `rules_targets` is
-        // just "paths holding our block", independent of which set put it there, so this is
-        // additive and safe — the next apply reconciles it against `desired` as usual.
-        let _ = crate::registry::update(|reg| {
-            for path in owned.iter() {
-                if !reg.rules_targets.contains(path) {
-                    reg.rules_targets.push(path.clone());
-                }
+        // What we now own on disk: successful writes, still-desired previous good files, and
+        // failed cleanups. Every path remains discoverable for a later reconciliation.
+        let mut owned = written;
+        for old in prev_targets.iter().chain(uncleaned.iter()) {
+            let still_wanted = desired.iter().any(|d| d == old) || uncleaned.contains(old);
+            if still_wanted && !owned.contains(old) {
+                owned.push(old.clone());
             }
-            Ok(())
-        });
-    }
+        }
+        reg.rules_targets = owned;
+        Ok(())
+    })?;
 
-    let reg = crate::registry::load()?;
     let set = reg.active_rule_set().cloned();
     Ok(RulesView {
         clients: status_from(&reg, installed, set.as_ref()),
@@ -301,6 +257,15 @@ pub fn preview(client_id: &str, content: Option<&str>) -> Result<Option<RulesPre
         return Ok(None);
     };
     let content = content.unwrap_or(set.content.as_str());
+    preview_target(client_id, &target, set, content).map(Some)
+}
+
+fn preview_target(
+    client_id: &str,
+    target: &Target,
+    set: &RuleSet,
+    content: &str,
+) -> Result<RulesPreview, String> {
     // An unreadable file must NOT read as empty. Preview is the safeguard the user leans on
     // before letting Toolport touch a file they own, and "" would render the dry-run as a
     // first-time write of a file that actually has content we could not see. Only a genuinely
@@ -310,7 +275,7 @@ pub fn preview(client_id: &str, content: Option<&str>) -> Result<Option<RulesPre
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => String::new(),
         Err(e) => return Err(format!("Could not read {}: {e}", target.path.display())),
     };
-    let after = match target.strategy {
+    let candidate = match target.strategy {
         Strategy::OwnedFile => {
             instructions::render_owned_file(Scope::Personal, &set.id, set.revision, content)
         }
@@ -318,7 +283,14 @@ pub fn preview(client_id: &str, content: Option<&str>) -> Result<Option<RulesPre
             instructions::upsert_block(&before, Scope::Personal, &set.id, set.revision, content)
         }
     };
-    Ok(Some(RulesPreview {
+    let state = instructions::current_state(target, &set.id, set.revision, content);
+    // Blocked, over-cap, and invalid writes leave the file untouched. Showing the candidate bytes
+    // in those states would promise a result that write_target deliberately refuses to create.
+    let after = match state {
+        ApplyState::Applied | ApplyState::Stale => candidate,
+        _ => before.clone(),
+    };
+    Ok(RulesPreview {
         client_id: client_id.to_string(),
         path: target.path.to_string_lossy().to_string(),
         strategy: match target.strategy {
@@ -326,10 +298,10 @@ pub fn preview(client_id: &str, content: Option<&str>) -> Result<Option<RulesPre
             Strategy::SentinelBlock => "sentinelBlock",
         }
         .to_string(),
-        state: instructions::current_state(&target, &set.id, set.revision, content),
+        state,
         before,
         after,
-    }))
+    })
 }
 
 /// Create or update a set, then apply. Returns the refreshed view.
@@ -388,12 +360,19 @@ pub fn set_client_enabled(client_id: &str, enabled: bool) -> Result<RulesView, S
 /// a client updated (or reinstalled) since the last apply picks the rules back up without the
 /// user opening the Rules tab.
 pub fn apply_on_startup() {
-    if let Ok(reg) = crate::registry::load() {
-        if reg.active_rule_set().is_none() && reg.rules_targets.is_empty() {
+    match crate::registry::load() {
+        Ok(reg) if reg.active_rule_set().is_none() && reg.rules_targets.is_empty() => {
             return; // nothing configured and nothing written: skip the client scan entirely
         }
+        Ok(_) => {}
+        Err(error) => {
+            eprintln!("toolport: could not inspect personal rules at startup: {error}");
+            return;
+        }
     }
-    let _ = apply();
+    if let Err(error) = apply() {
+        eprintln!("toolport: could not apply personal rules at startup: {error}");
+    }
 }
 
 #[cfg(test)]
@@ -861,16 +840,10 @@ mod tests {
             .cloned()
             .unwrap();
 
-        // Rendering the draft is the same call the command makes, minus the client lookup.
-        let rendered = instructions::upsert_block(
-            &before,
-            Scope::Personal,
-            &set.id,
-            set.revision,
-            "Draft rules.",
-        );
-        assert!(rendered.contains("Draft rules."));
-        assert!(!rendered.contains("Saved rules."));
+        let preview = preview_target("codex", &target, &set, "Draft rules.").unwrap();
+        assert!(preview.after.contains("Draft rules."));
+        assert!(!preview.after.contains("Saved rules."));
+        assert_eq!(preview.state, ApplyState::Stale);
 
         // And nothing was written: the file is byte-identical and the set still holds saved text.
         assert_eq!(std::fs::read_to_string(&target.path).unwrap(), before);
@@ -882,6 +855,49 @@ mod tests {
                 .content,
             "Saved rules."
         );
+    }
+
+    #[test]
+    fn preview_matches_refused_writes_and_rejects_unreadable_files() {
+        let s = Scratch::new();
+        let path = s.path("AGENTS.md");
+        let before = "# Mine\n";
+        std::fs::write(&path, before).unwrap();
+        let rules = set("work", 1, "A rule that does not fit.");
+
+        let capped = Target {
+            char_cap: Some(before.chars().count()),
+            ..sentinel(path.clone())
+        };
+        let capped_preview = preview_target("windsurf", &capped, &rules, &rules.content).unwrap();
+        assert_eq!(capped_preview.state, ApplyState::TooLong);
+        assert_eq!(capped_preview.after, before);
+        assert_eq!(
+            instructions::write_target(&capped, &rules.id, rules.revision, &rules.content),
+            ApplyState::TooLong
+        );
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), before);
+
+        let shadow = s.path("shadow.md");
+        std::fs::write(&shadow, "local override").unwrap();
+        let blocked = Target {
+            blocked_if_present: Some(shadow),
+            ..sentinel(path.clone())
+        };
+        let blocked_preview = preview_target("codex", &blocked, &rules, &rules.content).unwrap();
+        assert_eq!(blocked_preview.state, ApplyState::BlockedOverride);
+        assert_eq!(blocked_preview.after, before);
+        assert_eq!(
+            instructions::write_target(&blocked, &rules.id, rules.revision, &rules.content),
+            ApplyState::BlockedOverride
+        );
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), before);
+
+        let directory = s.path("unreadable");
+        std::fs::create_dir_all(&directory).unwrap();
+        let err = preview_target("codex", &sentinel(directory), &rules, &rules.content)
+            .expect_err("an unreadable target must not preview as empty");
+        assert!(err.contains("Could not read"), "unexpected error: {err}");
     }
 
     /// Marker text must be refused when the user submits it, not when the write fails. Realistic
@@ -967,12 +983,11 @@ mod tests {
         );
     }
 
-    /// Losing the compare-and-set must never delete what we wrote. If the winner switched sets and
-    /// its own write failed, our block is the only one on disk; removing it would leave the user
-    /// with nothing while the UI reported the new set. Our paths are merged into the record
-    /// instead, so nothing is stranded and nothing good is destroyed.
+    /// A rules mutation and its reconciliation are separate calls, so two UI workers can interleave
+    /// them. Each apply must reconcile the fresh registry state while holding the same cross-process
+    /// lock as mutations; whichever set is active at the end must also be the bytes on disk.
     #[test]
-    fn losing_the_race_keeps_our_files_and_records_them() {
+    fn concurrent_applies_leave_the_active_sets_bytes_on_disk() {
         let _dirs = crate::registry::data_dir_test_lock();
         let s = Scratch::new();
         let _data_dir = crate::registry::DataDirOverride::set(s.path("data"));
@@ -981,44 +996,49 @@ mod tests {
         let installed = vec![codex.clone()];
         let path = codex.target.clone().unwrap().path;
 
-        // Set A is active and opted in, but nothing has been applied yet.
-        crate::registry::update(|reg| {
-            reg.upsert_rule_set(None, "A", "Rules A.")?;
-            reg.set_rules_client_enabled("codex", true);
-            Ok(())
-        })
-        .unwrap();
-
-        // Stand in for "a newer apply won": write set A's block, then switch the active set out
-        // from under it, exactly as the CAS sees it.
-        let set_a = crate::registry::load().unwrap().active_rule_set().cloned().unwrap();
-        let target = codex.target.clone().unwrap();
-        assert_eq!(
-            instructions::write_target(&target, &set_a.id, set_a.revision, &set_a.content),
-            ApplyState::Applied
-        );
-        crate::registry::update(|reg| {
+        let (_, (a, b)) = crate::registry::update(|reg| {
+            let a = reg.upsert_rule_set(None, "A", "Rules A.")?;
             let b = reg.upsert_rule_set(None, "B", "Rules B.")?;
-            reg.set_active_rule_set(Some(&b));
-            Ok(())
+            reg.set_rules_client_enabled("codex", true);
+            Ok((a, b))
         })
         .unwrap();
 
-        // Now run the apply that is about to lose: it loaded set A, wrote it, and will find the
-        // active set changed.
-        apply_to_with_set(&installed, Some(set_a.clone())).unwrap();
+        for _ in 0..20 {
+            std::thread::scope(|scope| {
+                scope.spawn(|| {
+                    crate::registry::update(|reg| {
+                        reg.set_active_rule_set(Some(&a));
+                        Ok(())
+                    })
+                    .unwrap();
+                    apply_to(&installed).unwrap();
+                });
+                scope.spawn(|| {
+                    crate::registry::update(|reg| {
+                        reg.set_active_rule_set(Some(&b));
+                        Ok(())
+                    })
+                    .unwrap();
+                    apply_to(&installed).unwrap();
+                });
+            });
 
-        assert!(
-            std::fs::read_to_string(&path).unwrap().contains("Rules A."),
-            "the loser must not delete the only block on disk"
-        );
-        assert!(
-            crate::registry::load()
-                .unwrap()
-                .rules_targets
-                .contains(&path.to_string_lossy().to_string()),
-            "and the path must be recorded so a later pass can clean it"
-        );
+            let reg = crate::registry::load().unwrap();
+            let active = reg.active_rule_set().unwrap();
+            assert_eq!(
+                instructions::current_state(
+                    codex.target.as_ref().unwrap(),
+                    &active.id,
+                    active.revision,
+                    &active.content,
+                ),
+                ApplyState::Applied,
+                "disk and registry diverged for active set {}",
+                active.id
+            );
+            assert_eq!(reg.rules_targets, vec![path.to_string_lossy().to_string()]);
+        }
     }
 
     #[test]

--- a/src-tauri/src/rules.rs
+++ b/src-tauri/src/rules.rs
@@ -169,6 +169,21 @@ fn apply_to(installed: &[ClientTarget]) -> Result<RulesView, String> {
     let prev_targets = reg.rules_targets.clone();
     let targets = enabled_targets(&reg, installed);
 
+    // Every path this apply still WANTS to own, whether or not writing it succeeded. Cleanup is
+    // driven by this rather than by the successful writes: a client that failed to write (a full
+    // disk, a permission error, Windsurf's cap, a Codex override that appeared) is still opted in,
+    // and deleting its last known-good block because today's write failed would turn a transient
+    // failure into lost rules. Only a path that is no longer desired at all (opted out,
+    // uninstalled, set cleared, path moved) gets removed.
+    let desired: Vec<String> = if set.is_some() {
+        targets
+            .iter()
+            .map(|t| t.path.to_string_lossy().to_string())
+            .collect()
+    } else {
+        Vec::new()
+    };
+
     let mut written: Vec<String> = Vec::new();
     if let Some(s) = set.as_ref() {
         for target in &targets {
@@ -179,30 +194,50 @@ fn apply_to(installed: &[ClientTarget]) -> Result<RulesView, String> {
             }
         }
     }
-    // Anything we wrote before and did not write now: the set changed or was cleared, a client
-    // was opted out or uninstalled, or its rules path moved. Iterating the RECORDED list rather
-    // than a fresh scan means cleanup survives a client that has since disappeared.
     for old in &prev_targets {
-        if !written.iter().any(|w| w == old) {
+        if !desired.iter().any(|d| d == old) {
             instructions::remove_recorded(std::path::Path::new(old), Scope::Personal);
         }
     }
 
-    // Record what is now on disk. The compare-and-set fails if the active set changed underneath
-    // us (the user switched sets while we were writing): the files we just wrote would then have
-    // no record to clean them by, so roll them back rather than orphan them.
+    // What we now own on disk: everything written this pass, plus any still-desired path we owned
+    // before and could not rewrite — our older block is very likely still sitting in that file, so
+    // dropping it from the record would strand it forever (nothing would ever clean it up).
+    let mut owned = written.clone();
+    for old in &prev_targets {
+        if desired.iter().any(|d| d == old) && !owned.iter().any(|o| o == old) {
+            owned.push(old.clone());
+        }
+    }
+
+    // Record it. The compare-and-set fails if the active set changed underneath us (the user
+    // switched sets while we were writing), which means a newer apply has taken over.
     let expected = set.as_ref().map(|s| (s.id.clone(), s.revision));
     let recorded = crate::registry::update(|reg| {
         let current = reg.active_rule_set().map(|s| (s.id.clone(), s.revision));
         if current != expected {
             return Ok(false);
         }
-        reg.rules_targets = written.clone();
+        reg.rules_targets = owned.clone();
         Ok(true)
     });
     if !matches!(recorded, Ok((_, true))) {
-        for path in &written {
-            instructions::remove_recorded(std::path::Path::new(path), Scope::Personal);
+        // Our writes have no record to clean them by, so take them back out — but ONLY where the
+        // block on disk is still the one we wrote. The apply that raced ahead of us may already
+        // have written the new set to these same paths, and deleting that would leave the user's
+        // active rules missing while the UI reported success.
+        for target in &targets {
+            let path = target.path.to_string_lossy().to_string();
+            if !written.contains(&path) {
+                continue; // we never wrote this one, so there is nothing of ours to take back
+            }
+            let still_ours = set.as_ref().is_some_and(|s| {
+                instructions::current_state(target, &s.id, s.revision, &s.content)
+                    == ApplyState::Applied
+            });
+            if still_ours {
+                instructions::remove_recorded(std::path::Path::new(&path), Scope::Personal);
+            }
         }
     }
 
@@ -229,7 +264,15 @@ pub fn preview(client_id: &str) -> Result<Option<RulesPreview>, String> {
     let Some(set) = reg.active_rule_set() else {
         return Ok(None);
     };
-    let before = std::fs::read_to_string(&target.path).unwrap_or_default();
+    // An unreadable file must NOT read as empty. Preview is the safeguard the user leans on
+    // before letting Toolport touch a file they own, and "" would render the dry-run as a
+    // first-time write of a file that actually has content we could not see. Only a genuinely
+    // absent file is empty; anything else is reported.
+    let before = match std::fs::read_to_string(&target.path) {
+        Ok(s) => s,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => String::new(),
+        Err(e) => return Err(format!("Could not read {}: {e}", target.path.display())),
+    };
     let after = match target.strategy {
         Strategy::OwnedFile => {
             instructions::render_owned_file(Scope::Personal, &set.id, set.revision, &set.content)
@@ -258,10 +301,7 @@ pub fn preview(client_id: &str) -> Result<Option<RulesPreview>, String> {
 
 /// Create or update a set, then apply. Returns the refreshed view.
 pub fn save_set(id: Option<&str>, name: &str, content: &str) -> Result<RulesView, String> {
-    crate::registry::update(|reg| {
-        reg.upsert_rule_set(id, name, content);
-        Ok(())
-    })?;
+    crate::registry::update(|reg| reg.upsert_rule_set(id, name, content).map(|_| ()))?;
     apply()
 }
 
@@ -377,12 +417,12 @@ mod tests {
     #[test]
     fn a_new_set_becomes_active_when_nothing_else_is() {
         let mut reg = crate::registry::Registry::default();
-        let id = reg.upsert_rule_set(None, "Work", "Always run tests.");
+        let id = reg.upsert_rule_set(None, "Work", "Always run tests.").expect("create");
         assert_eq!(reg.active_rule_set_id.as_deref(), Some(id.as_str()));
         assert_eq!(reg.active_rule_set().map(|s| s.revision), Some(1));
 
         // A SECOND set does not steal the selection.
-        let other = reg.upsert_rule_set(None, "Personal", "Be brief.");
+        let other = reg.upsert_rule_set(None, "Personal", "Be brief.").expect("create");
         assert_ne!(other, id, "ids must be unique");
         assert_eq!(reg.active_rule_set_id.as_deref(), Some(id.as_str()));
     }
@@ -390,24 +430,41 @@ mod tests {
     #[test]
     fn revision_moves_on_content_change_only() {
         let mut reg = crate::registry::Registry::default();
-        let id = reg.upsert_rule_set(None, "Work", "v1");
+        let id = reg.upsert_rule_set(None, "Work", "v1").expect("create");
         assert_eq!(reg.active_rule_set().unwrap().revision, 1);
 
         // A rename rides in the marker but is not a content change, so rewriting every client's
         // file for it would be pure churn.
-        reg.upsert_rule_set(Some(&id), "Renamed", "v1");
+        reg.upsert_rule_set(Some(&id), "Renamed", "v1").expect("update");
         assert_eq!(reg.active_rule_set().unwrap().revision, 1);
         assert_eq!(reg.active_rule_set().unwrap().name, "Renamed");
 
-        reg.upsert_rule_set(Some(&id), "Renamed", "v2");
+        reg.upsert_rule_set(Some(&id), "Renamed", "v2").expect("update");
         assert_eq!(reg.active_rule_set().unwrap().revision, 2);
+    }
+
+    #[test]
+    fn saving_against_an_unknown_id_errors_rather_than_duplicating() {
+        let mut reg = crate::registry::Registry::default();
+        let id = reg.upsert_rule_set(None, "Work", "v1").expect("create");
+        let err = reg
+            .upsert_rule_set(Some("deleted-in-another-window"), "Work", "v2")
+            .expect_err("an unknown id must not create");
+        assert!(err.contains("no longer exists"), "unexpected message: {err}");
+        assert_eq!(reg.rule_sets.len(), 1, "must not grow a duplicate set");
+        assert_eq!(reg.active_rule_set().unwrap().id, id);
+        assert_eq!(
+            reg.active_rule_set().unwrap().content,
+            "v1",
+            "the real set must be untouched"
+        );
     }
 
     #[test]
     fn removing_the_active_set_clears_the_selection() {
         let mut reg = crate::registry::Registry::default();
-        let a = reg.upsert_rule_set(None, "A", "a");
-        let b = reg.upsert_rule_set(None, "B", "b");
+        let a = reg.upsert_rule_set(None, "A", "a").expect("create");
+        let b = reg.upsert_rule_set(None, "B", "b").expect("create");
         reg.remove_rule_set(&a);
         assert_eq!(
             reg.active_rule_set_id, None,
@@ -578,7 +635,12 @@ mod tests {
     /// `apply_to`. Callers must already hold the data-dir guard and override.
     fn seed_and_apply(content: &str, enabled: &[&str], installed: &[ClientTarget]) -> RulesView {
         crate::registry::update(|reg| {
-            reg.upsert_rule_set(Some("work"), "Work", content);
+            // First call creates (the id is not there yet), later calls update in place.
+            if reg.rule_sets.iter().any(|s| s.id == "work") {
+                reg.upsert_rule_set(Some("work"), "Work", content)?;
+            } else {
+                reg.upsert_rule_set(None, "Work", content)?;
+            }
             for id in enabled {
                 reg.set_rules_client_enabled(id, true);
             }
@@ -663,6 +725,55 @@ mod tests {
         assert_eq!(reg.rules_targets, vec![zed_path.to_string_lossy().to_string()]);
     }
 
+    /// A write that fails must NOT be treated as an opt-out. The client is still enabled, so its
+    /// last known-good block stays on disk and its path stays recorded; a transient failure must
+    /// not cost the user the rules they already had.
+    #[test]
+    fn a_failed_write_keeps_the_previous_good_block_and_its_record() {
+        let _dirs = crate::registry::data_dir_test_lock();
+        let s = Scratch::new();
+        let _data_dir = crate::registry::DataDirOverride::set(s.path("data"));
+
+        let codex = client("codex", Some(sentinel(s.path("AGENTS.md"))));
+        let installed = vec![codex.clone()];
+        let path = codex.target.clone().unwrap().path;
+
+        seed_and_apply("Good rules.", &["codex"], &installed);
+        let good = std::fs::read_to_string(&path).unwrap();
+        assert!(good.contains("Good rules."));
+
+        // Content carrying our own frozen marker is refused by `write_target` (it would corrupt
+        // the block), which is the cheapest way to drive a real per-client failure: exactly what a
+        // user pasting an existing AGENTS.md into the editor would hit.
+        crate::registry::update(|reg| {
+            let id = reg.active_rule_set().unwrap().id.clone();
+            reg.upsert_rule_set(
+                Some(&id),
+                "Work",
+                &format!("Bad {} rules.", instructions::PERSONAL_SENTINEL_END),
+            )?;
+            Ok(())
+        })
+        .unwrap();
+        let view = apply_to(&installed).unwrap();
+
+        assert_eq!(
+            std::fs::read_to_string(&path).unwrap(),
+            good,
+            "the previous good block must survive a failed rewrite"
+        );
+        assert_eq!(
+            crate::registry::load().unwrap().rules_targets,
+            vec![path.to_string_lossy().to_string()],
+            "a still-desired path stays recorded, or nothing would ever clean it up"
+        );
+        assert_eq!(
+            view.clients[0].state,
+            ApplyState::Error,
+            "and the failure is reported rather than hidden"
+        );
+    }
+
     #[test]
     fn switching_sets_rewrites_in_place_and_clearing_removes_everything() {
         let _dirs = crate::registry::data_dir_test_lock();
@@ -678,7 +789,7 @@ mod tests {
 
         // A second set replaces the first set's span rather than stacking a second block.
         crate::registry::update(|reg| {
-            let id = reg.upsert_rule_set(None, "Other", "Rules B.");
+            let id = reg.upsert_rule_set(None, "Other", "Rules B.").expect("create");
             reg.set_active_rule_set(Some(&id));
             Ok(())
         })

--- a/src-tauri/src/rules.rs
+++ b/src-tauri/src/rules.rs
@@ -119,8 +119,17 @@ fn status_from(
         .map(|c| {
             let state = match (&c.target, set) {
                 (None, _) => ApplyState::Unsupported,
-                // No active set: nothing is meant to be on disk, so nothing is stale.
-                (Some(_), None) => ApplyState::Applied,
+                // No active set: the desired end state is "nothing of ours on disk", so the
+                // question is presence, not content. Reporting Applied unconditionally here hid a
+                // cleanup that failed — the block was still sitting in the file while the row
+                // said "up to date".
+                (Some(t), None) => {
+                    if instructions::is_present(&t.path, Scope::Personal) {
+                        ApplyState::Stale
+                    } else {
+                        ApplyState::Applied
+                    }
+                }
                 (Some(t), Some(s)) => instructions::current_state(t, &s.id, s.revision, &s.content),
             };
             ClientStatus {
@@ -280,7 +289,10 @@ fn apply_to_with_set(
 /// Deliberately NOT gated on the client being installed: this answers "what would land here",
 /// which is a fair question about a client the user is about to install, and the caller only
 /// offers it for clients it detected anyway.
-pub fn preview(client_id: &str) -> Result<Option<RulesPreview>, String> {
+/// `content`, when given, is previewed INSTEAD of the saved set's content. That is what makes this
+/// honest for an editor with unsaved text: the alternative (save first, then preview) would apply
+/// the draft to every opted-in client's file, which is the exact opposite of what a dry run is for.
+pub fn preview(client_id: &str, content: Option<&str>) -> Result<Option<RulesPreview>, String> {
     let reg = crate::registry::load()?;
     let Some(target) = crate::clients::client_rules_target(client_id, Scope::Personal) else {
         return Ok(None);
@@ -288,6 +300,7 @@ pub fn preview(client_id: &str) -> Result<Option<RulesPreview>, String> {
     let Some(set) = reg.active_rule_set() else {
         return Ok(None);
     };
+    let content = content.unwrap_or(set.content.as_str());
     // An unreadable file must NOT read as empty. Preview is the safeguard the user leans on
     // before letting Toolport touch a file they own, and "" would render the dry-run as a
     // first-time write of a file that actually has content we could not see. Only a genuinely
@@ -299,15 +312,11 @@ pub fn preview(client_id: &str) -> Result<Option<RulesPreview>, String> {
     };
     let after = match target.strategy {
         Strategy::OwnedFile => {
-            instructions::render_owned_file(Scope::Personal, &set.id, set.revision, &set.content)
+            instructions::render_owned_file(Scope::Personal, &set.id, set.revision, content)
         }
-        Strategy::SentinelBlock => instructions::upsert_block(
-            &before,
-            Scope::Personal,
-            &set.id,
-            set.revision,
-            &set.content,
-        ),
+        Strategy::SentinelBlock => {
+            instructions::upsert_block(&before, Scope::Personal, &set.id, set.revision, content)
+        }
     };
     Ok(Some(RulesPreview {
         client_id: client_id.to_string(),
@@ -317,7 +326,7 @@ pub fn preview(client_id: &str) -> Result<Option<RulesPreview>, String> {
             Strategy::SentinelBlock => "sentinelBlock",
         }
         .to_string(),
-        state: instructions::current_state(&target, &set.id, set.revision, &set.content),
+        state: instructions::current_state(&target, &set.id, set.revision, content),
         before,
         after,
     }))
@@ -325,6 +334,23 @@ pub fn preview(client_id: &str) -> Result<Option<RulesPreview>, String> {
 
 /// Create or update a set, then apply. Returns the refreshed view.
 pub fn save_set(id: Option<&str>, name: &str, content: &str) -> Result<RulesView, String> {
+    // Refuse content carrying Toolport's own markers, at the point the user submits it.
+    //
+    // `write_target` already refuses such content, but only at write time: without this the text
+    // is persisted first, and then EVERY opted-in client reports a write error until the user
+    // works out which invisible HTML comment is to blame. The realistic way in is copying out of
+    // the preview panel, which shows the rendered file including its markers.
+    //
+    // Rejected, not auto-stripped: silently editing someone's rules is worse than telling them.
+    if instructions::content_carries_a_marker(content) {
+        return Err(
+            "These rules contain Toolport's own marker comments (toolport:rules:start / :end, or \
+             the team-instructions equivalents). Toolport uses those to find the block it owns, so \
+             it cannot store them as rules. Remove them and save again — if you copied this out of \
+             the preview, copy just your own text."
+                .to_string(),
+        );
+    }
     crate::registry::update(|reg| reg.upsert_rule_set(id, name, content).map(|_| ()))?;
     apply()
 }
@@ -557,16 +583,28 @@ mod tests {
         assert!(!rows[0].enabled);
     }
 
+    /// With no active set, the desired end state is "nothing of ours on disk", so the row must
+    /// report PRESENCE. Reporting Applied unconditionally told the user their rules were up to
+    /// date while a block we failed to clean was still sitting in the file.
     #[test]
-    fn with_no_active_set_every_client_reads_as_settled() {
+    fn with_no_active_set_the_row_reports_whether_our_block_is_gone() {
         let s = Scratch::new();
-        let installed = vec![client("codex", Some(sentinel(s.path("AGENTS.md"))))];
+        let target = sentinel(s.path("AGENTS.md"));
+        let installed = vec![client("codex", Some(target.clone()))];
         let reg = crate::registry::Registry::default();
-        let rows = status_from(&reg, &installed, None);
+
+        // Nothing on disk: the end state is reached.
         assert_eq!(
-            rows[0].state,
-            ApplyState::Applied,
-            "nothing is meant to be on disk, so nothing is stale"
+            status_from(&reg, &installed, None)[0].state,
+            ApplyState::Applied
+        );
+
+        // Our block still there after a failed cleanup: NOT settled.
+        instructions::write_target(&target, "work", 1, "Be brief.");
+        assert_eq!(
+            status_from(&reg, &installed, None)[0].state,
+            ApplyState::Stale,
+            "a leftover block must not read as up to date"
         );
     }
 
@@ -795,6 +833,94 @@ mod tests {
             view.clients[0].state,
             ApplyState::Error,
             "and the failure is reported rather than hidden"
+        );
+    }
+
+    /// Preview must render the DRAFT without saving it. Saving applies to every opted-in client,
+    /// so a save-then-preview would make the dry run a write, which is the one thing this control
+    /// promises not to do.
+    #[test]
+    fn preview_renders_unsaved_content_without_touching_disk() {
+        let _dirs = crate::registry::data_dir_test_lock();
+        let s = Scratch::new();
+        let _data_dir = crate::registry::DataDirOverride::set(s.path("data"));
+
+        crate::registry::update(|reg| {
+            reg.upsert_rule_set(None, "Work", "Saved rules.")?;
+            Ok(())
+        })
+        .unwrap();
+
+        let target = sentinel(s.path("AGENTS.md"));
+        std::fs::write(&target.path, "# Mine\n").unwrap();
+        let before = std::fs::read_to_string(&target.path).unwrap();
+
+        let set = crate::registry::load()
+            .unwrap()
+            .active_rule_set()
+            .cloned()
+            .unwrap();
+
+        // Rendering the draft is the same call the command makes, minus the client lookup.
+        let rendered = instructions::upsert_block(
+            &before,
+            Scope::Personal,
+            &set.id,
+            set.revision,
+            "Draft rules.",
+        );
+        assert!(rendered.contains("Draft rules."));
+        assert!(!rendered.contains("Saved rules."));
+
+        // And nothing was written: the file is byte-identical and the set still holds saved text.
+        assert_eq!(std::fs::read_to_string(&target.path).unwrap(), before);
+        assert_eq!(
+            crate::registry::load()
+                .unwrap()
+                .active_rule_set()
+                .unwrap()
+                .content,
+            "Saved rules."
+        );
+    }
+
+    /// Marker text must be refused when the user submits it, not when the write fails. Realistic
+    /// way in: copying out of the preview panel, which shows the rendered file with its markers.
+    #[test]
+    fn saving_rules_that_contain_our_markers_is_refused_up_front() {
+        let _dirs = crate::registry::data_dir_test_lock();
+        let s = Scratch::new();
+        let _data_dir = crate::registry::DataDirOverride::set(s.path("data"));
+
+        crate::registry::update(|reg| {
+            reg.upsert_rule_set(None, "Work", "Good rules.")?;
+            Ok(())
+        })
+        .unwrap();
+        let id = crate::registry::load()
+            .unwrap()
+            .active_rule_set()
+            .unwrap()
+            .id
+            .clone();
+
+        for bad in [
+            format!("{} set=x v=1 -->", instructions::PERSONAL_SENTINEL_START_PREFIX),
+            instructions::PERSONAL_SENTINEL_END.to_string(),
+            instructions::SENTINEL_END.to_string(),
+        ] {
+            let err = save_set(Some(&id), "Work", &bad).expect_err("must be refused");
+            assert!(err.contains("marker"), "unhelpful message: {err}");
+        }
+
+        // Refused, so the good rules are still what is stored: no half-written state.
+        assert_eq!(
+            crate::registry::load()
+                .unwrap()
+                .active_rule_set()
+                .unwrap()
+                .content,
+            "Good rules."
         );
     }
 


### PR DESCRIPTION
PR 2 of 4 for [SBS-821](https://linear.app/southboundsoftware/issue/SBS-821). **Stacked on #793** (base is `feat/scope-agent-rules-markers`, not `main`).

The backend half. The user authors named rule sets; the active one is written into each opted-in client's global rules file through the same engine Team Instructions uses, at `Scope::Personal`.

## New `rules` module

- `view` / `apply` / `preview`, plus `save_set` / `delete_set` / `set_active` / `set_client_enabled`, each returning the refreshed view.
- `apply_to` mirrors `teams::apply_instructions_to`: write the opted-in targets, remove every recorded path we did not re-write, then record what landed. The record is a compare-and-set on `(active set id, revision)`, so a set switch racing an apply rolls the just-written files back instead of orphaning them.
- Targets de-dupe by path, so a file two clients share (Claude Code + VS Code Copilot, Gemini CLI + Antigravity) is written once.
- `apply_on_startup` re-asserts the active set, and returns before scanning clients at all when nothing is configured and nothing was ever written.

## Registry

Adds `rule_sets`, `active_rule_set_id`, `rules_clients`, `rules_targets`, all `#[serde(default)]`, plus the matching methods beside the existing profile ones.

`revision` moves only when a set's **content** changes. It rides in the on-disk marker, so bumping it on a rename would restale every client's file for nothing.

## Two product decisions worth flagging

**A client is opted out until the user turns it on.** `rules_client_enabled` returns false for an absent entry. Writing into someone's `~/.claude/rules` or `AGENTS.md` unasked is not a thing to do, and the UI (PR 3) previews the write first. The alternative (default on for every detected client) would be a nicer first run but a worse surprise.

**Deleting or clearing the active set does not promote another.** The selection goes to `None`, so the next apply removes our files rather than silently pushing a different set's rules onto the machine.

## Commands

7 Tauri commands, all async + `spawn_blocking` since they scan and write files. None of this needs the gateway or any configured MCP server, so the Rules tab works on a fresh install with nothing connected (an epic requirement).

## Tests

13 cases:

- registry-level set management: activation, revision-on-content-only, removal clearing the selection, opt-in default
- target selection: opt-in gating, shared paths collapsing to one write, unsupported clients reported rather than skipped
- the three per-strategy file cases from the acceptance criteria: fresh file, file already carrying our block, foreign user file
- three end-to-end `apply_to` runs against a redirected registry (`DataDirOverride`): writing and recording, opting a client out removing only its file, and a set switch replacing the span in place before a clear removes everything

## Verification

- `cargo test --manifest-path src-tauri/Cargo.toml` -> 1194 + 333 passed, 0 failed
- `cargo clippy --all-targets` -> no warnings in `rules.rs`; the `registry.rs` / `desktop.rs` ones are pre-existing and outside this diff (which is additions only)

Refs SBS-821


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add personal agent rule sets with per-client opt-in applied at startup and via Tauri commands
> - Introduces a new `rules` module ([rules.rs](https://github.com/tsouth89/toolport/pull/794/files#diff-95ba6d6d222bbceda1b2370fcec193a459a1a3fb8065e0fa9521ec07a1cbad51)) that manages named personal rule sets: creating, updating, deleting, switching the active set, opting clients in/out, previewing changes without writes, and applying rules across all opted-in clients.
> - Extends the registry schema ([registry.rs](https://github.com/tsouth89/toolport/pull/794/files#diff-8187fea44e15daa4059544c5fcff94f80f39fa1ec39c67eccccc153a98b39349)) with `rule_sets`, `active_rule_set_id`, `rules_clients`, and `rules_targets` fields, plus new APIs for deterministic revisioning and a guarded `update_authoritative` that aborts when the registry isn't authoritative.
> - Exposes seven new Tauri commands in [desktop.rs](https://github.com/tsouth89/toolport/pull/794/files#diff-fe6823673f9c91b7a17eb4b96e5bc54bc3c58e75d02ae0a2d2fae6f7ce03ecd5): `rules_view`, `rules_save_set`, `rules_delete_set`, `rules_set_active`, `rules_set_client_enabled`, `rules_preview`, and `rules_apply`.
> - Calls `rules::apply_on_startup()` at launch to reconcile rules across clients without rewriting identical file content.
> - Behavioral Change: `instructions::write_target` now skips the atomic file replacement when reapplying byte-identical content, preserving mtime.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 38f8031.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->