### PR TITLE
feat(rules): Agent rules tab (SBS-821)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -84,6 +84,9 @@ const CatalogView = lazy(() =>
 const PlaygroundView = lazy(() =>
   import("@/components/PlaygroundView").then((m) => ({ default: m.PlaygroundView })),
 );
+const RulesView = lazy(() =>
+  import("@/components/RulesView").then((m) => ({ default: m.RulesView })),
+);
 const TeamsView = lazy(() =>
   import("@/components/TeamsView").then((m) => ({ default: m.TeamsView })),
 );
@@ -805,13 +808,15 @@ function App() {
                       ? "Browse catalog"
                       : view === "playground"
                         ? "Playground"
-                        : view === "teams"
-                          ? "Teams"
-                          : view === "settings"
-                            ? "Settings"
-                            : selectedClient
-                              ? selectedClient.name
-                              : "Servers"}
+                        : view === "rules"
+                          ? "Agent rules"
+                          : view === "teams"
+                            ? "Teams"
+                            : view === "settings"
+                              ? "Settings"
+                              : selectedClient
+                                ? selectedClient.name
+                                : "Servers"}
                 </h1>
                 <p className="truncate text-sm text-muted-foreground">
                   {view === "activity"
@@ -820,15 +825,17 @@ function App() {
                       ? "Add MCP servers from the registry"
                       : view === "playground"
                         ? "Invoke a server's tools and see the raw result"
-                        : view === "teams"
-                          ? "Share one MCP server set across your team"
-                          : view === "settings"
-                            ? "Global discovery and security policy"
-                            : selectedClient
-                              ? "MCP client"
-                              : loading || !registry
-                                ? "Loading…"
-                                : "One gateway in front of every MCP server you run"}
+                        : view === "rules"
+                          ? "Write your rules once, apply them to every AI client"
+                          : view === "teams"
+                            ? "Share one MCP server set across your team"
+                            : view === "settings"
+                              ? "Global discovery and security policy"
+                              : selectedClient
+                                ? "MCP client"
+                                : loading || !registry
+                                  ? "Loading…"
+                                  : "One gateway in front of every MCP server you run"}
                 </p>
               </div>
             </div>
@@ -968,6 +975,8 @@ function App() {
                     <CatalogView registry={registry} onAdded={setRegistry} />
                   ) : view === "playground" ? (
                     <PlaygroundView registry={registry} onRegistryChange={setRegistry} />
+                  ) : view === "rules" ? (
+                    <RulesView />
                   ) : view === "teams" ? (
                     <TeamsView registry={registry} onRegistryChange={setRegistry} />
                   ) : view === "settings" ? (

--- a/src/components/AppSidebar.test.tsx
+++ b/src/components/AppSidebar.test.tsx
@@ -119,6 +119,46 @@ describe("AppSidebar accessibility", () => {
     );
   });
 
+  it("routes to the agent-rules view and marks it current", async () => {
+    const onSelectView = vi.fn();
+    const { rerender } = render(
+      <TooltipProvider>
+        <AppSidebar
+          clients={[client()]}
+          registry={null}
+          onRegistryChange={vi.fn()}
+          selectedClientId={null}
+          onSelectClient={vi.fn()}
+          view="servers"
+          onSelectView={onSelectView}
+          onReplayOnboarding={vi.fn()}
+        />
+      </TooltipProvider>,
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: "Agent rules" }));
+    expect(onSelectView).toHaveBeenCalledWith("rules");
+
+    rerender(
+      <TooltipProvider>
+        <AppSidebar
+          clients={[client()]}
+          registry={null}
+          onRegistryChange={vi.fn()}
+          selectedClientId={null}
+          onSelectClient={vi.fn()}
+          view="rules"
+          onSelectView={onSelectView}
+          onReplayOnboarding={vi.fn()}
+        />
+      </TooltipProvider>,
+    );
+    expect(screen.getByRole("button", { name: "Agent rules" })).toHaveAttribute(
+      "aria-current",
+      "page",
+    );
+  });
+
   it("exposes whether the not-detected client list is expanded", async () => {
     render(
       <TooltipProvider>

--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -6,6 +6,7 @@ import {
   ClipboardList,
   Compass,
   Download,
+  FileText,
   FlaskConical,
   FolderOpen,
   Layers,
@@ -665,6 +666,9 @@ export function AppSidebar({
           )}
           {navItem(ScrollText, "Activity", view === "activity", () =>
             onSelectView("activity"),
+          )}
+          {navItem(FileText, "Agent rules", view === "rules", () =>
+            onSelectView("rules"),
           )}
           {navItem(Users, "Teams", view === "teams", () => onSelectView("teams"))}
           {navItem(

--- a/src/components/RuleStateBadge.tsx
+++ b/src/components/RuleStateBadge.tsx
@@ -1,0 +1,60 @@
+import { AlertTriangle, Ban, Check, Clock, Minus } from "lucide-react";
+import type { InstructionsApplyState } from "@/lib/types";
+
+/**
+ * How each per-client rules state renders. Shared by the Teams tab (org instructions, spec W4)
+ * and the Rules tab (the user's own sets): both run through the same writer and report the same
+ * `ApplyState`, so they must read identically. A user seeing "Not applied yet" in one place and
+ * different wording for the same on-disk situation in the other would reasonably think they were
+ * different problems.
+ */
+const RULE_STATE_META: Record<
+  InstructionsApplyState,
+  { label: string; className: string; Icon: typeof Check }
+> = {
+  applied: { label: "Applied", className: "text-success", Icon: Check },
+  stale: { label: "Not applied yet", className: "text-warning", Icon: Clock },
+  blocked_override: {
+    label: "Blocked by a local override",
+    className: "text-warning",
+    Icon: Ban,
+  },
+  too_long: {
+    label: "Too long for this client",
+    className: "text-warning",
+    Icon: AlertTriangle,
+  },
+  unsupported: {
+    label: "Copy manually",
+    className: "text-muted-foreground",
+    Icon: Minus,
+  },
+  error: { label: "Write error", className: "text-destructive", Icon: AlertTriangle },
+};
+
+/** Why a client is in this state, in one sentence. Surfaced as the badge's tooltip. */
+const EXPLANATION: Record<InstructionsApplyState, string> = {
+  applied: "This client's rules file is up to date.",
+  stale: "The current rules are not on disk for this client yet.",
+  blocked_override:
+    "This client has a local override file that makes it ignore the file Toolport writes.",
+  too_long: "This client caps its global rules file, and these rules would exceed it.",
+  unsupported:
+    "This client has no global rules file Toolport can write. Paste the rules in by hand.",
+  error: "The rules file could not be read or written. It was left untouched.",
+};
+
+/** The state badge for one client, icon + label. */
+export function RuleStateBadge({ state }: { state: InstructionsApplyState }) {
+  const meta = RULE_STATE_META[state];
+  const Icon = meta.Icon;
+  return (
+    <span
+      title={EXPLANATION[state]}
+      className={`flex shrink-0 items-center gap-1 text-xs ${meta.className}`}
+    >
+      <Icon className="size-3.5" />
+      {meta.label}
+    </span>
+  );
+}

--- a/src/components/RulesView.test.tsx
+++ b/src/components/RulesView.test.tsx
@@ -15,7 +15,7 @@ const api = vi.hoisted(() => ({
 
 vi.mock("@/lib/api", () => api);
 
-import { clearRulesDraftCache } from "@/lib/rulesDraftCache";
+import { clearRulesDraftCache, setRulesDraft } from "@/lib/rulesDraftCache";
 import { RulesView } from "./RulesView";
 
 function view(over: Partial<RulesViewData> = {}): RulesViewData {
@@ -92,6 +92,23 @@ describe("RulesView", () => {
     await waitFor(() =>
       expect(api.rulesSaveSet).toHaveBeenCalledWith("Work", "Be brief.", "work"),
     );
+  });
+
+  it("refuses to save generated Toolport markers pasted from a preview", async () => {
+    render(<RulesView />);
+    const editor = await screen.findByLabelText("Rules");
+
+    await userEvent.clear(editor);
+    await userEvent.type(
+      editor,
+      "<!-- toolport:rules:start set=work v=2 -->\nAlways run tests.",
+    );
+    await userEvent.click(screen.getByRole("button", { name: "Save and apply" }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      /Remove Toolport's generated markers/,
+    );
+    expect(api.rulesSaveSet).not.toHaveBeenCalled();
   });
 
   it("toggling a client off calls through with false", async () => {
@@ -315,6 +332,10 @@ describe("RulesView", () => {
     expect(await screen.findByText(/Pick one above/)).toBeInTheDocument();
     expect(screen.queryByText(/No rule set yet/)).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Personal" })).toBeInTheDocument();
+    expect(screen.getAllByRole("button", { name: /Preview/ })[0]).toHaveAttribute(
+      "title",
+      "Pick a rule set first",
+    );
   });
 
   it("a failed preview does not leave another client's card on screen", async () => {
@@ -370,6 +391,25 @@ describe("RulesView", () => {
     expect(screen.queryByText(/No AI clients/)).not.toBeInTheDocument();
     expect(screen.queryByText(/No rule set yet/)).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: /Try again/ })).toBeInTheDocument();
+  });
+
+  it("restores a held draft when retrying a failed load", async () => {
+    setRulesDraft("work", {
+      name: "Work",
+      content: "Always run tests. And lint.",
+    });
+    api.rulesView
+      .mockRejectedValueOnce(new Error("registry unreadable"))
+      .mockResolvedValueOnce(view());
+    render(<RulesView />);
+
+    await screen.findByRole("alert");
+    await userEvent.click(screen.getByRole("button", { name: /Try again/ }));
+
+    expect(await screen.findByLabelText("Rules")).toHaveValue(
+      "Always run tests. And lint.",
+    );
+    expect(screen.getByRole("button", { name: "Save and apply" })).toBeEnabled();
   });
 
   /**
@@ -463,24 +503,54 @@ describe("RulesView", () => {
    * Deleting a set that is not active must not activate it on the way. Activation applies, so
    * every opted-in client's file would be rewritten to the set being discarded and then emptied.
    */
-  it("deletes a non-active set without activating it first", async () => {
-    api.rulesView.mockResolvedValue(
+  it("saves the active draft before deleting a non-active set", async () => {
+    const sets = [
+      { id: "work", name: "Work", content: "Always run tests.", revision: 2 },
+      { id: "personal", name: "Personal", content: "Be brief.", revision: 1 },
+    ];
+    const saved = view({
+      sets: [
+        { id: "work", name: "Work", content: "Always run tests. And lint.", revision: 3 },
+        sets[1],
+      ],
+    });
+    api.rulesView.mockResolvedValue(view({ sets }));
+    api.rulesSaveSet.mockResolvedValue(saved);
+    api.rulesDeleteSet.mockResolvedValue(
       view({
         sets: [
-          { id: "work", name: "Work", content: "Always run tests.", revision: 2 },
-          { id: "personal", name: "Personal", content: "Be brief.", revision: 1 },
+          {
+            id: "work",
+            name: "Work",
+            content: "Always run tests. And lint.",
+            revision: 3,
+          },
         ],
       }),
     );
-    api.rulesDeleteSet.mockResolvedValue(view());
     render(<RulesView />);
-    await screen.findByLabelText("Rules");
+    const editor = await screen.findByLabelText("Rules");
 
+    await userEvent.type(editor, " And lint.");
     await userEvent.click(screen.getByRole("button", { name: "Delete Personal" }));
+    expect(
+      screen.getByText(/active set and client files stay unchanged/i),
+    ).toBeInTheDocument();
     await userEvent.click(screen.getByRole("button", { name: "Delete" }));
 
+    await waitFor(() =>
+      expect(api.rulesSaveSet).toHaveBeenCalledWith(
+        "Work",
+        "Always run tests. And lint.",
+        "work",
+      ),
+    );
     await waitFor(() => expect(api.rulesDeleteSet).toHaveBeenCalledWith("personal"));
     expect(api.rulesSetActive).not.toHaveBeenCalled();
+    expect(api.rulesSaveSet.mock.invocationCallOrder[0]).toBeLessThan(
+      api.rulesDeleteSet.mock.invocationCallOrder[0],
+    );
+    expect(screen.getByLabelText("Rules")).toHaveValue("Always run tests. And lint.");
   });
 
   it("shows no state badge while no set is applied", async () => {
@@ -506,6 +576,26 @@ describe("RulesView", () => {
     expect(screen.queryByText("Applied")).not.toBeInTheDocument();
   });
 
+  it("shows a stale cleanup state when no set is active", async () => {
+    api.rulesView.mockResolvedValue(
+      view({
+        activeSetId: undefined,
+        clients: [
+          {
+            id: "codex",
+            name: "Codex",
+            enabled: true,
+            path: "/home/a/.codex/AGENTS.md",
+            state: "stale",
+          },
+        ],
+      }),
+    );
+    render(<RulesView />);
+
+    expect(await screen.findByText("Not applied yet")).toBeInTheDocument();
+  });
+
   it("with no set, the editor is replaced by a prompt and preview is unavailable", async () => {
     api.rulesView.mockResolvedValue(view({ sets: [], activeSetId: undefined }));
     render(<RulesView />);
@@ -514,6 +604,7 @@ describe("RulesView", () => {
     expect(screen.queryByLabelText("Rules")).not.toBeInTheDocument();
     for (const b of screen.getAllByRole("button", { name: /Preview/ })) {
       expect(b).toBeDisabled();
+      expect(b).toHaveAttribute("title", "Create a rule set first");
     }
   });
 

--- a/src/components/RulesView.test.tsx
+++ b/src/components/RulesView.test.tsx
@@ -121,6 +121,47 @@ describe("RulesView", () => {
     expect(api.rulesSaveSet).not.toHaveBeenCalled();
   });
 
+  it("preview says so when the write would be refused, instead of just showing bytes", async () => {
+    // Windsurf's cap is a refusal, not a truncation. A preview that looks like any other write,
+    // followed by nothing landing, reads as a bug rather than a documented limit.
+    api.rulesPreview.mockResolvedValue({
+      clientId: "codex",
+      path: "/home/a/.codex/AGENTS.md",
+      strategy: "sentinelBlock",
+      before: "# Mine\n",
+      after: "# Mine\n\nAlways run tests.\n",
+      state: "too_long",
+    });
+    render(<RulesView />);
+    await screen.findByLabelText("Rules");
+
+    await userEvent.click(screen.getAllByRole("button", { name: /Preview/ })[0]);
+
+    expect(
+      await screen.findByText(/will not be written to this client/),
+    ).toHaveTextContent(/hard limit/);
+  });
+
+  it("preview shows no warning when the write would land", async () => {
+    api.rulesPreview.mockResolvedValue({
+      clientId: "codex",
+      path: "/home/a/.codex/AGENTS.md",
+      strategy: "sentinelBlock",
+      before: "# Mine\n",
+      after: "# Mine\n\nAlways run tests.\n",
+      state: "stale",
+    });
+    render(<RulesView />);
+    await screen.findByLabelText("Rules");
+
+    await userEvent.click(screen.getAllByRole("button", { name: /Preview/ })[0]);
+
+    expect(await screen.findByText(/owns only the marked block/)).toBeInTheDocument();
+    expect(
+      screen.queryByText(/will not be written to this client/),
+    ).not.toBeInTheDocument();
+  });
+
   it("switching sets saves an unsaved draft first, so edits are never dropped", async () => {
     api.rulesView.mockResolvedValue(
       view({

--- a/src/components/RulesView.test.tsx
+++ b/src/components/RulesView.test.tsx
@@ -312,6 +312,61 @@ describe("RulesView", () => {
     expect(screen.getByRole("button", { name: "Personal" })).toBeInTheDocument();
   });
 
+  it("a failed preview does not leave another client's card on screen", async () => {
+    api.rulesPreview.mockResolvedValueOnce({
+      clientId: "codex",
+      path: "/home/a/.codex/AGENTS.md",
+      strategy: "sentinelBlock",
+      before: "",
+      after: "Always run tests.\n",
+      state: "stale",
+    });
+    render(<RulesView />);
+    await screen.findByLabelText("Rules");
+
+    const previews = screen.getAllByRole("button", { name: /Preview/ });
+    await userEvent.click(previews[0]);
+    expect(await screen.findByText("/home/a/.codex/AGENTS.md")).toBeInTheDocument();
+
+    // Second client's preview fails. Codex's bytes must not sit under the error looking like
+    // they belong to Claude Code.
+    api.rulesPreview.mockRejectedValueOnce(new Error("permission denied"));
+    await userEvent.click(screen.getAllByRole("button", { name: /Preview/ })[1]);
+
+    expect(await screen.findByRole("alert")).toHaveTextContent("permission denied");
+    expect(screen.queryByText("/home/a/.codex/AGENTS.md")).not.toBeInTheDocument();
+  });
+
+  it("editing clears an open preview instead of letting it go stale", async () => {
+    api.rulesPreview.mockResolvedValue({
+      clientId: "codex",
+      path: "/home/a/.codex/AGENTS.md",
+      strategy: "sentinelBlock",
+      before: "",
+      after: "Always run tests.\n",
+      state: "stale",
+    });
+    render(<RulesView />);
+    const editor = await screen.findByLabelText("Rules");
+
+    await userEvent.click(screen.getAllByRole("button", { name: /Preview/ })[0]);
+    expect(await screen.findByText("/home/a/.codex/AGENTS.md")).toBeInTheDocument();
+
+    await userEvent.type(editor, " And lint.");
+    expect(screen.queryByText("/home/a/.codex/AGENTS.md")).not.toBeInTheDocument();
+  });
+
+  it("a failed load says so instead of claiming the machine is empty", async () => {
+    api.rulesView.mockRejectedValue(new Error("registry unreadable"));
+    render(<RulesView />);
+
+    expect(await screen.findByRole("alert")).toHaveTextContent("registry unreadable");
+    // We never found out what is on this machine, so we must not report an answer.
+    expect(screen.queryByText(/No AI clients/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/No rule set yet/)).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Try again/ })).toBeInTheDocument();
+  });
+
   it("with no set, the editor is replaced by a prompt and preview is unavailable", async () => {
     api.rulesView.mockResolvedValue(view({ sets: [], activeSetId: undefined }));
     render(<RulesView />);

--- a/src/components/RulesView.test.tsx
+++ b/src/components/RulesView.test.tsx
@@ -148,6 +148,52 @@ describe("RulesView", () => {
     expect(api.rulesSetActive).toHaveBeenCalledWith("personal");
   });
 
+  it("creating a set switches to it, so the editor is not still on the old one", async () => {
+    // The backend only auto-activates a new set when nothing else is active, so without an
+    // explicit select this button would look like it did nothing.
+    const created = view({
+      sets: [
+        { id: "work", name: "Work", content: "Always run tests.", revision: 2 },
+        { id: "new-rules", name: "New rules", content: "", revision: 1 },
+      ],
+    });
+    api.rulesSaveSet.mockResolvedValue(created);
+    api.rulesSetActive.mockResolvedValue({ ...created, activeSetId: "new-rules" });
+    render(<RulesView />);
+    await screen.findByLabelText("Rules");
+
+    await userEvent.click(screen.getByRole("button", { name: "New set" }));
+
+    await waitFor(() => expect(api.rulesSetActive).toHaveBeenCalledWith("new-rules"));
+    expect(screen.getByLabelText("Rules")).toHaveValue("");
+    expect(screen.getByLabelText("Rule set name")).toHaveValue("New rules");
+  });
+
+  it("creating a set saves an unsaved draft first, so edits are never dropped", async () => {
+    const created = view({
+      sets: [
+        { id: "work", name: "Work", content: "Always run tests. And lint.", revision: 3 },
+        { id: "new-rules", name: "New rules", content: "", revision: 1 },
+      ],
+    });
+    api.rulesSaveSet.mockResolvedValue(created);
+    api.rulesSetActive.mockResolvedValue({ ...created, activeSetId: "new-rules" });
+    render(<RulesView />);
+    const editor = await screen.findByLabelText("Rules");
+
+    await userEvent.type(editor, " And lint.");
+    await userEvent.click(screen.getByRole("button", { name: "New set" }));
+
+    await waitFor(() =>
+      expect(api.rulesSaveSet).toHaveBeenCalledWith(
+        "Work",
+        "Always run tests. And lint.",
+        "work",
+      ),
+    );
+    expect(api.rulesSaveSet).toHaveBeenCalledWith("New rules", "");
+  });
+
   it("with no set, the editor is replaced by a prompt and preview is unavailable", async () => {
     api.rulesView.mockResolvedValue(view({ sets: [], activeSetId: undefined }));
     render(<RulesView />);

--- a/src/components/RulesView.test.tsx
+++ b/src/components/RulesView.test.tsx
@@ -1,0 +1,170 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { RulesView as RulesViewData } from "@/lib/types";
+
+const api = vi.hoisted(() => ({
+  rulesView: vi.fn(),
+  rulesSaveSet: vi.fn(),
+  rulesDeleteSet: vi.fn(),
+  rulesSetActive: vi.fn(),
+  rulesSetClientEnabled: vi.fn(),
+  rulesPreview: vi.fn(),
+  rulesApply: vi.fn(),
+}));
+
+vi.mock("@/lib/api", () => api);
+
+import { RulesView } from "./RulesView";
+
+function view(over: Partial<RulesViewData> = {}): RulesViewData {
+  return {
+    sets: [{ id: "work", name: "Work", content: "Always run tests.", revision: 2 }],
+    activeSetId: "work",
+    clients: [
+      {
+        id: "codex",
+        name: "Codex",
+        enabled: true,
+        path: "/home/a/.codex/AGENTS.md",
+        state: "applied",
+      },
+      {
+        id: "claude-code",
+        name: "Claude Code",
+        enabled: false,
+        path: "/home/a/.claude/rules/toolport-rules.md",
+        state: "stale",
+      },
+      { id: "cursor", name: "Cursor", enabled: false, state: "unsupported" },
+    ],
+    ...over,
+  };
+}
+
+describe("RulesView", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    api.rulesView.mockResolvedValue(view());
+  });
+
+  it("loads the active set into the editor and shows per-client state", async () => {
+    render(<RulesView />);
+    expect(await screen.findByLabelText("Rules")).toHaveValue("Always run tests.");
+    expect(screen.getByLabelText("Rule set name")).toHaveValue("Work");
+
+    // An opted-in client shows its state; an opted-out one does not claim to be applied.
+    expect(screen.getByLabelText("Codex")).toBeChecked();
+    expect(screen.getByText("Applied")).toBeInTheDocument();
+    expect(screen.getByLabelText("Claude Code")).not.toBeChecked();
+    expect(screen.queryByText("Not applied yet")).not.toBeInTheDocument();
+  });
+
+  it("names the clients it cannot write instead of hiding them", async () => {
+    render(<RulesView />);
+    await screen.findByLabelText("Rules");
+    // Cursor has no rules file we manage: it must be called out, not silently dropped, or the
+    // user thinks their rules reached it.
+    expect(screen.getByText(/No rules file Toolport can write for/)).toHaveTextContent(
+      "Cursor",
+    );
+    expect(screen.queryByLabelText("Cursor")).not.toBeInTheDocument();
+  });
+
+  it("saves only once the draft differs, and sends the edited text", async () => {
+    api.rulesSaveSet.mockResolvedValue(
+      view({ sets: [{ id: "work", name: "Work", content: "Be brief.", revision: 3 }] }),
+    );
+    render(<RulesView />);
+    const editor = await screen.findByLabelText("Rules");
+
+    // Nothing to save yet.
+    expect(screen.getByRole("button", { name: "Saved" })).toBeDisabled();
+
+    await userEvent.clear(editor);
+    await userEvent.type(editor, "Be brief.");
+    await userEvent.click(screen.getByRole("button", { name: "Save and apply" }));
+
+    await waitFor(() =>
+      expect(api.rulesSaveSet).toHaveBeenCalledWith("Work", "Be brief.", "work"),
+    );
+  });
+
+  it("toggling a client off calls through with false", async () => {
+    api.rulesSetClientEnabled.mockResolvedValue(view());
+    render(<RulesView />);
+    await screen.findByLabelText("Rules");
+
+    await userEvent.click(screen.getByLabelText("Codex"));
+    await waitFor(() =>
+      expect(api.rulesSetClientEnabled).toHaveBeenCalledWith("codex", false),
+    );
+  });
+
+  it("preview shows the exact bytes and writes nothing", async () => {
+    api.rulesPreview.mockResolvedValue({
+      clientId: "codex",
+      path: "/home/a/.codex/AGENTS.md",
+      strategy: "sentinelBlock",
+      before: "# Mine\n",
+      after: "# Mine\n\n<!-- toolport:rules:start -->\nAlways run tests.\n",
+      state: "stale",
+    });
+    render(<RulesView />);
+    await screen.findByLabelText("Rules");
+
+    await userEvent.click(screen.getAllByRole("button", { name: /Preview/ })[0]);
+
+    expect(await screen.findByText(/toolport:rules:start/)).toBeInTheDocument();
+    expect(screen.getByText(/owns only the marked block/)).toBeInTheDocument();
+    expect(api.rulesApply).not.toHaveBeenCalled();
+    expect(api.rulesSaveSet).not.toHaveBeenCalled();
+  });
+
+  it("switching sets saves an unsaved draft first, so edits are never dropped", async () => {
+    api.rulesView.mockResolvedValue(
+      view({
+        sets: [
+          { id: "work", name: "Work", content: "Always run tests.", revision: 2 },
+          { id: "personal", name: "Personal", content: "Be brief.", revision: 1 },
+        ],
+      }),
+    );
+    api.rulesSaveSet.mockResolvedValue(view());
+    api.rulesSetActive.mockResolvedValue(view());
+    render(<RulesView />);
+    const editor = await screen.findByLabelText("Rules");
+
+    await userEvent.type(editor, " And lint.");
+    await userEvent.click(screen.getByRole("button", { name: "Personal" }));
+
+    await waitFor(() =>
+      expect(api.rulesSaveSet).toHaveBeenCalledWith(
+        "Work",
+        "Always run tests. And lint.",
+        "work",
+      ),
+    );
+    expect(api.rulesSetActive).toHaveBeenCalledWith("personal");
+  });
+
+  it("with no set, the editor is replaced by a prompt and preview is unavailable", async () => {
+    api.rulesView.mockResolvedValue(view({ sets: [], activeSetId: undefined }));
+    render(<RulesView />);
+
+    expect(await screen.findByText(/No rule set yet/)).toBeInTheDocument();
+    expect(screen.queryByLabelText("Rules")).not.toBeInTheDocument();
+    for (const b of screen.getAllByRole("button", { name: /Preview/ })) {
+      expect(b).toBeDisabled();
+    }
+  });
+
+  it("surfaces a failed write instead of leaving the UI looking clean", async () => {
+    api.rulesSetClientEnabled.mockRejectedValue(new Error("permission denied"));
+    render(<RulesView />);
+    await screen.findByLabelText("Rules");
+
+    await userEvent.click(screen.getByLabelText("Claude Code"));
+    expect(await screen.findByRole("alert")).toHaveTextContent("permission denied");
+  });
+});

--- a/src/components/RulesView.test.tsx
+++ b/src/components/RulesView.test.tsx
@@ -15,6 +15,7 @@ const api = vi.hoisted(() => ({
 
 vi.mock("@/lib/api", () => api);
 
+import { clearRulesDraftCache } from "@/lib/rulesDraftCache";
 import { RulesView } from "./RulesView";
 
 function view(over: Partial<RulesViewData> = {}): RulesViewData {
@@ -45,6 +46,9 @@ function view(over: Partial<RulesViewData> = {}): RulesViewData {
 describe("RulesView", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // Held drafts are module state, so they outlive a component and would otherwise leak from one
+    // case into the next as phantom unsaved text.
+    clearRulesDraftCache();
     api.rulesView.mockResolvedValue(view());
   });
 
@@ -240,10 +244,11 @@ describe("RulesView", () => {
    * refreshes the view reseats the editor from the SAVED set, so any of them that forgets to
    * flush first silently replaces what the user typed with the old text.
    */
+  // Preview is deliberately NOT in this list: it must not save, because saving applies to every
+  // opted-in client. It sends the draft to the backend instead, covered separately below.
   it.each([
     ["toggling a client", () => screen.getByLabelText("Claude Code")],
     ["Re-apply", () => screen.getByRole("button", { name: "Re-apply" })],
-    ["Preview", () => screen.getAllByRole("button", { name: /Preview/ })[0]],
   ])("%s saves an unsaved draft instead of discarding it", async (_label, target) => {
     const saved = view({
       sets: [
@@ -365,6 +370,140 @@ describe("RulesView", () => {
     expect(screen.queryByText(/No AI clients/)).not.toBeInTheDocument();
     expect(screen.queryByText(/No rule set yet/)).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: /Try again/ })).toBeInTheDocument();
+  });
+
+  /**
+   * The control says it writes nothing, so it must write nothing. Routing it through a save (to
+   * make the bytes accurate) applied the draft to every opted-in client's file first, which is the
+   * opposite of a dry run.
+   */
+  it("preview of an unsaved draft writes nothing and still shows the typed text", async () => {
+    api.rulesPreview.mockResolvedValue({
+      clientId: "codex",
+      path: "/home/a/.codex/AGENTS.md",
+      strategy: "sentinelBlock",
+      before: "# Mine\n",
+      after: "# Mine\n\nAlways run tests. And lint.\n",
+      state: "stale",
+    });
+    render(<RulesView />);
+    const editor = await screen.findByLabelText("Rules");
+
+    await userEvent.type(editor, " And lint.");
+    await userEvent.click(screen.getAllByRole("button", { name: /Preview/ })[0]);
+
+    // The draft goes to the backend as an argument, not through a save.
+    await waitFor(() =>
+      expect(api.rulesPreview).toHaveBeenCalledWith(
+        "codex",
+        "Always run tests. And lint.",
+      ),
+    );
+    expect(api.rulesSaveSet).not.toHaveBeenCalled();
+    expect(api.rulesApply).not.toHaveBeenCalled();
+    // Scoped to the preview block: the same text is also in the textarea the user just typed it in.
+    expect(
+      await screen.findByText(/And lint\./, { selector: "pre" }),
+    ).toBeInTheDocument();
+  });
+
+  it("previewing a clean editor sends no draft override", async () => {
+    api.rulesPreview.mockResolvedValue(null);
+    render(<RulesView />);
+    await screen.findByLabelText("Rules");
+
+    await userEvent.click(screen.getAllByRole("button", { name: /Preview/ })[0]);
+    await waitFor(() =>
+      expect(api.rulesPreview).toHaveBeenCalledWith("codex", undefined),
+    );
+  });
+
+  it("keeps an unsaved draft across leaving and returning to the tab", async () => {
+    const { unmount } = render(<RulesView />);
+    const editor = await screen.findByLabelText("Rules");
+    await userEvent.type(editor, " And lint.");
+
+    // Switching sidebar views unmounts this tree with no chance to flush. Losing the text there
+    // would break the same promise every in-tab action keeps.
+    unmount();
+    expect(api.rulesSaveSet).not.toHaveBeenCalled();
+
+    render(<RulesView />);
+    expect(await screen.findByLabelText("Rules")).toHaveValue(
+      "Always run tests. And lint.",
+    );
+    expect(screen.getByRole("button", { name: "Save and apply" })).toBeEnabled();
+  });
+
+  it("does not resurrect a draft that was already saved", async () => {
+    const saved = view({
+      sets: [
+        { id: "work", name: "Work", content: "Always run tests. And lint.", revision: 3 },
+      ],
+    });
+    api.rulesSaveSet.mockResolvedValue(saved);
+    const { unmount } = render(<RulesView />);
+    const editor = await screen.findByLabelText("Rules");
+
+    await userEvent.type(editor, " And lint.");
+    await userEvent.click(screen.getByRole("button", { name: "Save and apply" }));
+    await waitFor(() => expect(api.rulesSaveSet).toHaveBeenCalled());
+    unmount();
+
+    api.rulesView.mockResolvedValue(saved);
+    render(<RulesView />);
+    // Same text, but from the saved set, so it must not read as unsaved work.
+    expect(await screen.findByLabelText("Rules")).toHaveValue(
+      "Always run tests. And lint.",
+    );
+    expect(screen.getByRole("button", { name: "Saved" })).toBeDisabled();
+  });
+
+  /**
+   * Deleting a set that is not active must not activate it on the way. Activation applies, so
+   * every opted-in client's file would be rewritten to the set being discarded and then emptied.
+   */
+  it("deletes a non-active set without activating it first", async () => {
+    api.rulesView.mockResolvedValue(
+      view({
+        sets: [
+          { id: "work", name: "Work", content: "Always run tests.", revision: 2 },
+          { id: "personal", name: "Personal", content: "Be brief.", revision: 1 },
+        ],
+      }),
+    );
+    api.rulesDeleteSet.mockResolvedValue(view());
+    render(<RulesView />);
+    await screen.findByLabelText("Rules");
+
+    await userEvent.click(screen.getByRole("button", { name: "Delete Personal" }));
+    await userEvent.click(screen.getByRole("button", { name: "Delete" }));
+
+    await waitFor(() => expect(api.rulesDeleteSet).toHaveBeenCalledWith("personal"));
+    expect(api.rulesSetActive).not.toHaveBeenCalled();
+  });
+
+  it("shows no state badge while no set is applied", async () => {
+    // The backend reports Applied for "correctly nothing on disk". Rendering that as
+    // "Applied / up to date" right after the user deleted their rules reads as still in place.
+    api.rulesView.mockResolvedValue(
+      view({
+        activeSetId: undefined,
+        clients: [
+          {
+            id: "codex",
+            name: "Codex",
+            enabled: true,
+            path: "/home/a/.codex/AGENTS.md",
+            state: "applied",
+          },
+        ],
+      }),
+    );
+    render(<RulesView />);
+
+    expect(await screen.findByText(/No set is applied right now/)).toBeInTheDocument();
+    expect(screen.queryByText("Applied")).not.toBeInTheDocument();
   });
 
   it("with no set, the editor is replaced by a prompt and preview is unavailable", async () => {

--- a/src/components/RulesView.test.tsx
+++ b/src/components/RulesView.test.tsx
@@ -235,6 +235,83 @@ describe("RulesView", () => {
     expect(api.rulesSaveSet).toHaveBeenCalledWith("New rules", "");
   });
 
+  /**
+   * "Type your rules, then switch a client on" is the first thing anyone does. Every action that
+   * refreshes the view reseats the editor from the SAVED set, so any of them that forgets to
+   * flush first silently replaces what the user typed with the old text.
+   */
+  it.each([
+    ["toggling a client", () => screen.getByLabelText("Claude Code")],
+    ["Re-apply", () => screen.getByRole("button", { name: "Re-apply" })],
+    ["Preview", () => screen.getAllByRole("button", { name: /Preview/ })[0]],
+  ])("%s saves an unsaved draft instead of discarding it", async (_label, target) => {
+    const saved = view({
+      sets: [
+        { id: "work", name: "Work", content: "Always run tests. And lint.", revision: 3 },
+      ],
+    });
+    api.rulesSaveSet.mockResolvedValue(saved);
+    api.rulesSetClientEnabled.mockResolvedValue(saved);
+    api.rulesApply.mockResolvedValue(saved);
+    api.rulesPreview.mockResolvedValue(null);
+    render(<RulesView />);
+    const editor = await screen.findByLabelText("Rules");
+
+    await userEvent.type(editor, " And lint.");
+    await userEvent.click(target());
+
+    await waitFor(() =>
+      expect(api.rulesSaveSet).toHaveBeenCalledWith(
+        "Work",
+        "Always run tests. And lint.",
+        "work",
+      ),
+    );
+    expect(screen.getByLabelText("Rules")).toHaveValue("Always run tests. And lint.");
+  });
+
+  it("clears a stale preview when the view is reseated", async () => {
+    api.rulesPreview.mockResolvedValue({
+      clientId: "codex",
+      path: "/home/a/.codex/AGENTS.md",
+      strategy: "sentinelBlock",
+      before: "",
+      after: "Always run tests.\n",
+      state: "stale",
+    });
+    api.rulesApply.mockResolvedValue(view());
+    render(<RulesView />);
+    await screen.findByLabelText("Rules");
+
+    await userEvent.click(screen.getAllByRole("button", { name: /Preview/ })[0]);
+    expect(await screen.findByText("/home/a/.codex/AGENTS.md")).toBeInTheDocument();
+
+    // A preview naming a path and bytes that no longer match the editor is worse than none.
+    await userEvent.click(screen.getByRole("button", { name: "Re-apply" }));
+    await waitFor(() =>
+      expect(screen.queryByText("/home/a/.codex/AGENTS.md")).not.toBeInTheDocument(),
+    );
+  });
+
+  it("does not claim there are no sets when a deleted set left siblings behind", async () => {
+    // `remove_rule_set` clears the selection rather than promoting a sibling, so the other sets
+    // are still on screen. Saying none exist would contradict the chips right above.
+    api.rulesView.mockResolvedValue(
+      view({
+        sets: [
+          { id: "work", name: "Work", content: "Always run tests.", revision: 2 },
+          { id: "personal", name: "Personal", content: "Be brief.", revision: 1 },
+        ],
+        activeSetId: undefined,
+      }),
+    );
+    render(<RulesView />);
+
+    expect(await screen.findByText(/Pick one above/)).toBeInTheDocument();
+    expect(screen.queryByText(/No rule set yet/)).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Personal" })).toBeInTheDocument();
+  });
+
   it("with no set, the editor is replaced by a prompt and preview is unavailable", async () => {
     api.rulesView.mockResolvedValue(view({ sets: [], activeSetId: undefined }));
     render(<RulesView />);

--- a/src/components/RulesView.tsx
+++ b/src/components/RulesView.tsx
@@ -14,7 +14,25 @@ import {
   rulesSetClientEnabled,
   rulesView,
 } from "@/lib/api";
-import type { RulesPreview, RulesView as RulesViewData } from "@/lib/types";
+import type {
+  InstructionsApplyState,
+  RulesPreview,
+  RulesView as RulesViewData,
+} from "@/lib/types";
+
+/**
+ * States where `write_target` refuses the write outright, so the previewed bytes describe what
+ * WOULD land rather than what will. `too_long` is a refusal, not a truncation: Toolport never
+ * writes a file it knows the client will silently cut short.
+ */
+const PREVIEW_BLOCKED_REASON: Partial<Record<InstructionsApplyState, string>> = {
+  blocked_override:
+    "a local override file makes this client ignore it, so writing would be invisible.",
+  too_long:
+    "the finished file would exceed this client's hard limit, and a truncated rules file is worse than none.",
+  error: "the file could not be read or written, so it was left untouched.",
+};
+const BLOCKING_STATES = new Set(Object.keys(PREVIEW_BLOCKED_REASON));
 
 /**
  * Agent rules: write your own instructions once and have Toolport put them in every AI client's
@@ -299,6 +317,15 @@ export function RulesView() {
               ? "Toolport owns this whole file. Nothing of yours lives in it."
               : "Toolport owns only the marked block. Every other byte in this file is left exactly as it is."}
           </p>
+          {/* The bytes below are what an unblocked write would produce. When this client refuses
+              the write, saying so here matters more than the bytes do: a preview that looks like
+              a normal write, followed by nothing landing, reads as a bug rather than a rule. */}
+          {BLOCKING_STATES.has(preview.state) && (
+            <Callout variant="warning" className="mb-2 text-xs">
+              This is what Toolport would write, but it will not be written to this
+              client: {PREVIEW_BLOCKED_REASON[preview.state]}
+            </Callout>
+          )}
           <pre className="max-h-64 overflow-auto rounded-lg border bg-muted/20 p-3 font-mono text-xs whitespace-pre-wrap text-foreground">
             {preview.after}
           </pre>

--- a/src/components/RulesView.tsx
+++ b/src/components/RulesView.tsx
@@ -34,6 +34,14 @@ const PREVIEW_BLOCKED_REASON: Partial<Record<InstructionsApplyState, string>> = 
   error: "the file could not be read or written, so it was left untouched.",
 };
 const BLOCKING_STATES = new Set(Object.keys(PREVIEW_BLOCKED_REASON));
+const RESERVED_MARKERS = [
+  "<!-- toolport:rules:start",
+  "<!-- toolport:rules:end -->",
+  "<!-- toolport:team-instructions:start",
+  "<!-- toolport:team-instructions:end -->",
+  "<!-- Managed by Toolport",
+  "<!-- Toolport personal rules",
+];
 
 /**
  * Agent rules: write your own instructions once and have Toolport put them in every AI client's
@@ -82,6 +90,18 @@ export function RulesView() {
     setPreview(null);
   }
 
+  /** Reseat a reloaded view without discarding an unsaved draft held across an unmount. */
+  function adoptPreservingDraft(next: RulesViewData) {
+    const set = next.sets.find((s) => s.id === next.activeSetId);
+    const held = set ? getRulesDraft(set.id) : undefined;
+    adopt(next);
+    if (held) {
+      setDraft(held.content);
+      setDraftName(held.name);
+      setRulesDraft(set!.id, held);
+    }
+  }
+
   useEffect(() => {
     let cancelled = false;
     rulesView()
@@ -110,11 +130,13 @@ export function RulesView() {
   }, []);
 
   /** Run a mutating call, adopt the refreshed view, and surface any failure in place. */
-  async function run(fn: () => Promise<RulesViewData>) {
+  async function run(fn: () => Promise<RulesViewData>, preserveDraft = false) {
     setBusy(true);
     setError(null);
     try {
-      adopt(await fn());
+      const next = await fn();
+      if (preserveDraft) adoptPreservingDraft(next);
+      else adopt(next);
     } catch (e) {
       setError(String(e));
     } finally {
@@ -142,9 +164,22 @@ export function RulesView() {
     }
   }
 
+  function assertDraftHasNoMarkers() {
+    if (RESERVED_MARKERS.some((marker) => draft.includes(marker))) {
+      throw new Error(
+        "Remove Toolport's generated markers before saving. Paste only your rules, not the preview wrapper.",
+      );
+    }
+  }
+
+  async function saveDraft() {
+    assertDraftHasNoMarkers();
+    return rulesSaveSet(draftName, draft, active!.id);
+  }
+
   /** Persist an unsaved draft, adopting the refreshed view. No-op when nothing changed. */
   async function flushDraft() {
-    if (dirty && active) adopt(await rulesSaveSet(draftName, draft, active.id));
+    if (dirty && active) adopt(await saveDraft());
   }
 
   /**
@@ -225,7 +260,7 @@ export function RulesView() {
           variant="outline"
           className="self-start"
           disabled={busy}
-          onClick={() => run(rulesView)}
+          onClick={() => run(rulesView, true)}
         >
           <RefreshCw className="size-3.5" />
           Try again
@@ -317,11 +352,7 @@ export function RulesView() {
               className="mb-3 w-full resize-y rounded-lg border bg-background p-3 font-mono text-xs text-foreground"
             />
             <div className="flex flex-wrap items-center gap-2">
-              <Button
-                size="sm"
-                disabled={busy || !dirty}
-                onClick={() => run(() => rulesSaveSet(draftName, draft, active.id))}
-              >
+              <Button size="sm" disabled={busy || !dirty} onClick={() => run(saveDraft)}>
                 {dirty ? "Save and apply" : "Saved"}
               </Button>
               <Button
@@ -380,17 +411,20 @@ export function RulesView() {
                 </span>
               </label>
               <span className="flex shrink-0 items-center gap-2">
-                {/* Only meaningful while a set is active. With none, the backend reports Applied
-                    for "correctly nothing on disk", and an "Applied / up to date" badge moments
-                    after the user deleted their rules reads as though they were still in place. */}
-                {c.enabled && active && <RuleStateBadge state={c.state} />}
+                {/* With no active set, Applied means correctly empty and is hidden. Refusal/error
+                    states still matter because they mean cleanup left rules on disk. */}
+                {c.enabled && (active || c.state !== "applied") && (
+                  <RuleStateBadge state={c.state} />
+                )}
                 <button
                   type="button"
                   disabled={busy || !active}
                   title={
                     active
                       ? "See exactly what would be written"
-                      : "Create a rule set first"
+                      : data.sets.length > 0
+                        ? "Pick a rule set first"
+                        : "Create a rule set first"
                   }
                   onClick={() => openPreview(c.id)}
                   className="inline-flex items-center gap-1 rounded-md border px-2 py-0.5 text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-foreground disabled:opacity-50"
@@ -450,13 +484,21 @@ export function RulesView() {
         open={confirmDelete !== null}
         onOpenChange={(o) => !o && setConfirmDelete(null)}
         title="Delete this rule set?"
-        description="Toolport removes what it wrote from every client. Your own content in those files is left alone."
+        description={
+          confirmDelete === data.activeSetId
+            ? "Toolport removes what it wrote from every client. Your own content in those files is left alone."
+            : "This unused rule set is deleted. The active set and client files stay unchanged."
+        }
         confirmLabel="Delete"
         destructive
         onConfirm={() => {
           const id = confirmDelete;
           setConfirmDelete(null);
-          if (id) void run(() => rulesDeleteSet(id));
+          if (id) {
+            void (id === data.activeSetId
+              ? run(() => rulesDeleteSet(id))
+              : act(() => rulesDeleteSet(id)));
+          }
         }}
       />
     </div>

--- a/src/components/RulesView.tsx
+++ b/src/components/RulesView.tsx
@@ -1,0 +1,310 @@
+import { useEffect, useState } from "react";
+import { Eye, FileText, Plus, RefreshCw, Trash2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Callout } from "@/components/Callout";
+import { ConfirmDialog } from "@/components/ConfirmDialog";
+import { RuleStateBadge } from "@/components/RuleStateBadge";
+import {
+  rulesApply,
+  rulesDeleteSet,
+  rulesPreview,
+  rulesSaveSet,
+  rulesSetActive,
+  rulesSetClientEnabled,
+  rulesView,
+} from "@/lib/api";
+import type { RulesPreview, RulesView as RulesViewData } from "@/lib/types";
+
+/**
+ * Agent rules: write your own instructions once and have Toolport put them in every AI client's
+ * rules file (CLAUDE.md, AGENTS.md, GEMINI.md, and the rest) instead of editing each by hand.
+ *
+ * Two things this screen is careful about, because they involve writing into files the user owns:
+ *
+ *   * A client receives nothing until it is switched on here.
+ *   * "Preview" shows the exact bytes that would land, before anything is written.
+ *
+ * Needs no MCP server and no gateway, so it works on a fresh install.
+ */
+export function RulesView() {
+  const [data, setData] = useState<RulesViewData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // The editor is a local draft so typing never round-trips to disk. Every view refresh goes
+  // through `adopt`, which reseats the draft on the active set, so one set's text can never be
+  // carried into another and saved over it.
+  const [draft, setDraft] = useState("");
+  const [draftName, setDraftName] = useState("");
+
+  const [preview, setPreview] = useState<RulesPreview | null>(null);
+  const [confirmDelete, setConfirmDelete] = useState<string | null>(null);
+
+  const active = data?.sets.find((s) => s.id === data.activeSetId) ?? null;
+  const dirty =
+    active !== null && (draft !== active.content || draftName !== active.name);
+
+  function adopt(next: RulesViewData) {
+    setData(next);
+    const set = next.sets.find((s) => s.id === next.activeSetId) ?? null;
+    setDraft(set?.content ?? "");
+    setDraftName(set?.name ?? "");
+  }
+
+  useEffect(() => {
+    let cancelled = false;
+    rulesView()
+      .then((v) => {
+        if (!cancelled) adopt(v);
+      })
+      .catch((e) => {
+        if (!cancelled) setError(String(e));
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  /** Run a mutating call, adopt the refreshed view, and surface any failure in place. */
+  async function run(fn: () => Promise<RulesViewData>) {
+    setBusy(true);
+    setError(null);
+    try {
+      adopt(await fn());
+    } catch (e) {
+      setError(String(e));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  /** Switch the edited set. An unsaved draft is kept by saving it first, never silently dropped. */
+  async function selectSet(id: string) {
+    if (dirty && active) {
+      const name = draftName;
+      const content = draft;
+      await run(async () => {
+        await rulesSaveSet(name, content, active.id);
+        return rulesSetActive(id);
+      });
+      return;
+    }
+    await run(() => rulesSetActive(id));
+  }
+
+  if (loading) {
+    return <p className="text-sm text-muted-foreground">Loading…</p>;
+  }
+
+  const clients = data?.clients ?? [];
+  const supported = clients.filter((c) => c.path);
+  const unsupported = clients.filter((c) => !c.path);
+  const onCount = supported.filter((c) => c.enabled).length;
+
+  return (
+    <div className="flex flex-col gap-5">
+      {error && (
+        <Callout variant="danger" role="alert">
+          {error}
+        </Callout>
+      )}
+
+      <div className="rounded-xl border bg-card p-5">
+        <div className="mb-1 flex items-center gap-2">
+          <FileText className="size-4 text-muted-foreground" />
+          <h2 className="text-sm font-medium">Your agent rules</h2>
+        </div>
+        <p className="mb-4 text-xs text-muted-foreground">
+          Written into each client's own rules file next to, never over, anything you
+          already have there. Turning a client off removes what Toolport put in it.
+        </p>
+
+        <div className="mb-3 flex flex-wrap items-center gap-1.5">
+          {(data?.sets ?? []).map((s) => (
+            <button
+              key={s.id}
+              type="button"
+              disabled={busy}
+              onClick={() => selectSet(s.id)}
+              aria-current={s.id === data?.activeSetId}
+              className={`rounded-md border px-2.5 py-1 text-xs transition-colors ${
+                s.id === data?.activeSetId
+                  ? "border-primary bg-primary/10 text-foreground"
+                  : "text-muted-foreground hover:bg-accent hover:text-foreground"
+              }`}
+            >
+              {s.name}
+            </button>
+          ))}
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={busy}
+            onClick={() => run(() => rulesSaveSet("New rules", ""))}
+          >
+            <Plus className="size-3.5" />
+            New set
+          </Button>
+        </div>
+
+        {active ? (
+          <>
+            <Input
+              value={draftName}
+              disabled={busy}
+              aria-label="Rule set name"
+              onChange={(e) => setDraftName(e.target.value)}
+              className="mb-2 h-9"
+            />
+            <textarea
+              value={draft}
+              disabled={busy}
+              aria-label="Rules"
+              onChange={(e) => setDraft(e.target.value)}
+              rows={12}
+              spellCheck={false}
+              placeholder="Always run the tests before you say you're done."
+              className="mb-3 w-full resize-y rounded-lg border bg-background p-3 font-mono text-xs text-foreground"
+            />
+            <div className="flex flex-wrap items-center gap-2">
+              <Button
+                size="sm"
+                disabled={busy || !dirty}
+                onClick={() => run(() => rulesSaveSet(draftName, draft, active.id))}
+              >
+                {dirty ? "Save and apply" : "Saved"}
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={busy}
+                onClick={() => run(rulesApply)}
+              >
+                <RefreshCw className="size-3.5" />
+                Re-apply
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={busy}
+                onClick={() => setConfirmDelete(active.id)}
+              >
+                <Trash2 className="size-3.5" />
+                Delete set
+              </Button>
+            </div>
+          </>
+        ) : (
+          <p className="text-sm text-muted-foreground">
+            No rule set yet. Create one and it applies to the clients you switch on below.
+          </p>
+        )}
+      </div>
+
+      <div className="rounded-xl border bg-card p-5">
+        <h2 className="mb-1 text-sm font-medium">Clients</h2>
+        <p className="mb-3 text-xs text-muted-foreground">
+          {supported.length === 0
+            ? "No AI clients with a rules file Toolport can manage were found on this machine."
+            : `${onCount} of ${supported.length} switched on. Nothing is written to a client until you turn it on.`}
+        </p>
+
+        <ul className="grid gap-1.5">
+          {supported.map((c) => (
+            <li key={c.id} className="flex items-center justify-between gap-3 text-sm">
+              <label className="flex min-w-0 items-center gap-2">
+                <input
+                  type="checkbox"
+                  checked={c.enabled}
+                  disabled={busy}
+                  aria-label={c.name}
+                  onChange={(e) =>
+                    run(() => rulesSetClientEnabled(c.id, e.target.checked))
+                  }
+                />
+                <span className="truncate" title={c.path}>
+                  {c.name}
+                </span>
+              </label>
+              <span className="flex shrink-0 items-center gap-2">
+                {c.enabled && <RuleStateBadge state={c.state} />}
+                <button
+                  type="button"
+                  disabled={busy || !active}
+                  title={
+                    active
+                      ? "See exactly what would be written"
+                      : "Create a rule set first"
+                  }
+                  onClick={async () => {
+                    try {
+                      setPreview(await rulesPreview(c.id));
+                    } catch (e) {
+                      setError(String(e));
+                    }
+                  }}
+                  className="inline-flex items-center gap-1 rounded-md border px-2 py-0.5 text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-foreground disabled:opacity-50"
+                >
+                  <Eye className="size-3" />
+                  Preview
+                </button>
+              </span>
+            </li>
+          ))}
+        </ul>
+
+        {unsupported.length > 0 && (
+          <p className="mt-3 text-xs text-muted-foreground">
+            No rules file Toolport can write for{" "}
+            {unsupported.map((c) => c.name).join(", ")}. Paste your rules in by hand.
+          </p>
+        )}
+      </div>
+
+      {preview && (
+        <div className="rounded-xl border bg-card p-5">
+          <div className="mb-1 flex items-center justify-between gap-3">
+            <h2 className="text-sm font-medium">Preview</h2>
+            <button
+              type="button"
+              onClick={() => setPreview(null)}
+              className="text-xs text-muted-foreground hover:text-foreground"
+            >
+              Close
+            </button>
+          </div>
+          <p className="mb-3 font-mono text-xs break-all text-muted-foreground">
+            {preview.path}
+          </p>
+          <p className="mb-2 text-xs text-muted-foreground">
+            {preview.strategy === "ownedFile"
+              ? "Toolport owns this whole file. Nothing of yours lives in it."
+              : "Toolport owns only the marked block. Every other byte in this file is left exactly as it is."}
+          </p>
+          <pre className="max-h-64 overflow-auto rounded-lg border bg-muted/20 p-3 font-mono text-xs whitespace-pre-wrap text-foreground">
+            {preview.after}
+          </pre>
+        </div>
+      )}
+
+      <ConfirmDialog
+        open={confirmDelete !== null}
+        onOpenChange={(o) => !o && setConfirmDelete(null)}
+        title="Delete this rule set?"
+        description="Toolport removes what it wrote from every client. Your own content in those files is left alone."
+        confirmLabel="Delete"
+        destructive
+        onConfirm={() => {
+          const id = confirmDelete;
+          setConfirmDelete(null);
+          if (id) void run(() => rulesDeleteSet(id));
+        }}
+      />
+    </div>
+  );
+}

--- a/src/components/RulesView.tsx
+++ b/src/components/RulesView.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { Eye, FileText, Plus, RefreshCw, Trash2 } from "lucide-react";
+import { Eye, FileText, Plus, RefreshCw, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Callout } from "@/components/Callout";
@@ -14,6 +14,7 @@ import {
   rulesSetClientEnabled,
   rulesView,
 } from "@/lib/api";
+import { forgetRulesDraft, getRulesDraft, setRulesDraft } from "@/lib/rulesDraftCache";
 import type {
   InstructionsApplyState,
   RulesPreview,
@@ -64,9 +65,15 @@ export function RulesView() {
   const dirty =
     active !== null && (draft !== active.content || draftName !== active.name);
 
+  /**
+   * Reseat the editor on the refreshed view. A save just landed, so the cached draft for that set
+   * is spent: drop it, or the next mount would resurrect text the user already committed and show
+   * it as unsaved.
+   */
   function adopt(next: RulesViewData) {
     setData(next);
     const set = next.sets.find((s) => s.id === next.activeSetId) ?? null;
+    if (set) forgetRulesDraft(set.id);
     setDraft(set?.content ?? "");
     setDraftName(set?.name ?? "");
     // The preview card describes one client's file under whichever set was active when it was
@@ -79,7 +86,17 @@ export function RulesView() {
     let cancelled = false;
     rulesView()
       .then((v) => {
-        if (!cancelled) adopt(v);
+        if (cancelled) return;
+        // Read the held draft BEFORE `adopt`, which clears the cache entry for the set it seats.
+        const set = v.sets.find((s) => s.id === v.activeSetId);
+        const held = set ? getRulesDraft(set.id) : undefined;
+        adopt(v);
+        // Restore text typed before the tab was switched away, onto the set it was typed for.
+        if (held) {
+          setDraft(held.content);
+          setDraftName(held.name);
+          setRulesDraft(set!.id, held);
+        }
       })
       .catch((e) => {
         if (!cancelled) setError(String(e));
@@ -102,6 +119,26 @@ export function RulesView() {
       setError(String(e));
     } finally {
       setBusy(false);
+    }
+  }
+
+  /**
+   * Apply an edit to the editor, and hold the result against an unmount.
+   *
+   * Editing also invalidates any open preview: that card is rendered from the set as it stood when
+   * it was opened, so leaving it up would show bytes that quietly stop matching as you type.
+   */
+  function editDraft(next: { name?: string; content?: string }) {
+    const name = next.name ?? draftName;
+    const content = next.content ?? draft;
+    setDraftName(name);
+    setDraft(content);
+    setPreview(null);
+    if (!active) return;
+    if (content === active.content && name === active.name) {
+      forgetRulesDraft(active.id); // typed back to the saved text: nothing to hold
+    } else {
+      setRulesDraft(active.id, { name, content });
     }
   }
 
@@ -147,9 +184,11 @@ export function RulesView() {
   }
 
   /**
-   * Open the dry run for one client. Saves first: the backend renders the preview from the SAVED
-   * set, so previewing a dirty editor would show the previous bytes under a button that promises
-   * to show exactly what would be written.
+   * Open the dry run for one client.
+   *
+   * Sends the DRAFT to the backend rather than saving it first. Saving applies to every opted-in
+   * client, so a save-then-preview would have this button write the files it claims to be a dry
+   * run of. It does not go through `act` for the same reason.
    */
   async function openPreview(clientId: string) {
     setBusy(true);
@@ -158,8 +197,7 @@ export function RulesView() {
     // would sit there under the error looking like it belongs to the client just clicked.
     setPreview(null);
     try {
-      await flushDraft();
-      setPreview(await rulesPreview(clientId));
+      setPreview(await rulesPreview(clientId, dirty ? draft : undefined));
     } catch (e) {
       setError(String(e));
     } finally {
@@ -219,20 +257,37 @@ export function RulesView() {
 
         <div className="mb-3 flex flex-wrap items-center gap-1.5">
           {(data?.sets ?? []).map((s) => (
-            <button
+            // Each set carries its own delete. Offering it only for the ACTIVE set meant deleting
+            // any other one required selecting it first, which applies it: every opted-in client's
+            // file would be rewritten to the set being thrown away, then emptied again.
+            <span
               key={s.id}
-              type="button"
-              disabled={busy}
-              onClick={() => selectSet(s.id)}
-              aria-current={s.id === data?.activeSetId}
-              className={`rounded-md border px-2.5 py-1 text-xs transition-colors ${
+              className={`inline-flex items-center gap-1 rounded-md border pr-1 pl-2.5 text-xs transition-colors ${
                 s.id === data?.activeSetId
                   ? "border-primary bg-primary/10 text-foreground"
-                  : "text-muted-foreground hover:bg-accent hover:text-foreground"
+                  : "text-muted-foreground"
               }`}
             >
-              {s.name}
-            </button>
+              <button
+                type="button"
+                disabled={busy}
+                onClick={() => selectSet(s.id)}
+                aria-current={s.id === data?.activeSetId}
+                className="py-1 hover:text-foreground"
+              >
+                {s.name}
+              </button>
+              <button
+                type="button"
+                disabled={busy}
+                aria-label={`Delete ${s.name}`}
+                title={`Delete ${s.name}`}
+                onClick={() => setConfirmDelete(s.id)}
+                className="rounded p-0.5 text-muted-foreground hover:bg-accent hover:text-destructive"
+              >
+                <X className="size-3" />
+              </button>
+            </span>
           ))}
           <Button variant="outline" size="sm" disabled={busy} onClick={newSet}>
             <Plus className="size-3.5" />
@@ -246,23 +301,14 @@ export function RulesView() {
               value={draftName}
               disabled={busy}
               aria-label="Rule set name"
-              onChange={(e) => {
-                setDraftName(e.target.value);
-                setPreview(null);
-              }}
+              onChange={(e) => editDraft({ name: e.target.value })}
               className="mb-2 h-9"
             />
             <textarea
               value={draft}
               disabled={busy}
               aria-label="Rules"
-              // Editing invalidates an open preview: the card is rendered from the SAVED set, so
-              // it would keep showing the old bytes under a button that promises the exact ones.
-              // Clearing beats leaving a card that quietly stops being true as you type.
-              onChange={(e) => {
-                setDraft(e.target.value);
-                setPreview(null);
-              }}
+              onChange={(e) => editDraft({ content: e.target.value })}
               rows={12}
               spellCheck={false}
               placeholder="Always run the tests before you say you're done."
@@ -284,15 +330,6 @@ export function RulesView() {
               >
                 <RefreshCw className="size-3.5" />
                 Re-apply
-              </Button>
-              <Button
-                variant="outline"
-                size="sm"
-                disabled={busy}
-                onClick={() => setConfirmDelete(active.id)}
-              >
-                <Trash2 className="size-3.5" />
-                Delete set
               </Button>
             </div>
           </>
@@ -341,7 +378,10 @@ export function RulesView() {
                 </span>
               </label>
               <span className="flex shrink-0 items-center gap-2">
-                {c.enabled && <RuleStateBadge state={c.state} />}
+                {/* Only meaningful while a set is active. With none, the backend reports Applied
+                    for "correctly nothing on disk", and an "Applied / up to date" badge moments
+                    after the user deleted their rules reads as though they were still in place. */}
+                {c.enabled && active && <RuleStateBadge state={c.state} />}
                 <button
                   type="button"
                   disabled={busy || !active}

--- a/src/components/RulesView.tsx
+++ b/src/components/RulesView.tsx
@@ -153,9 +153,11 @@ export function RulesView() {
    * `adopt` reseats the editor from the SAVED set, so any action that refreshes the view would
    * otherwise discard whatever the user had typed and put the old text back. That is not an edge
    * case: "type your rules, then switch a client on" is the first thing anyone does. Flushing
-   * first turns that discard into a save. Save skips it because flushing before it would do the
-   * same write twice; Delete skips it because the only deletable set is the active one, so
-   * saving into it first is pure waste.
+   * first turns that discard into a save.
+   *
+   * Three deliberate exceptions. Save IS the flush. Delete would save into a set that is about to
+   * be thrown away. Preview promises to write nothing, so it sends the draft as an argument
+   * instead (see `openPreview`).
    */
   async function act(fn: () => Promise<RulesViewData>) {
     await run(async () => {

--- a/src/components/RulesView.tsx
+++ b/src/components/RulesView.tsx
@@ -69,6 +69,10 @@ export function RulesView() {
     const set = next.sets.find((s) => s.id === next.activeSetId) ?? null;
     setDraft(set?.content ?? "");
     setDraftName(set?.name ?? "");
+    // The preview card describes one client's file under whichever set was active when it was
+    // opened. Anything that reseats the editor can invalidate it, and a preview showing a path
+    // and bytes that no longer match what is on screen is worse than showing no preview at all.
+    setPreview(null);
   }
 
   useEffect(() => {
@@ -101,21 +105,31 @@ export function RulesView() {
     }
   }
 
-  /**
-   * Persist an unsaved draft before an action that reseats the editor. Every such action calls
-   * this first: losing typed rules to a stray click on another set is not an acceptable outcome,
-   * and `adopt` reseats the draft unconditionally on the refreshed view.
-   */
+  /** Persist an unsaved draft, adopting the refreshed view. No-op when nothing changed. */
   async function flushDraft() {
-    if (dirty && active) await rulesSaveSet(draftName, draft, active.id);
+    if (dirty && active) adopt(await rulesSaveSet(draftName, draft, active.id));
+  }
+
+  /**
+   * Every action EXCEPT Save and Delete goes through here.
+   *
+   * `adopt` reseats the editor from the SAVED set, so any action that refreshes the view would
+   * otherwise discard whatever the user had typed and put the old text back. That is not an edge
+   * case: "type your rules, then switch a client on" is the first thing anyone does. Flushing
+   * first turns that discard into a save. Save skips it because flushing before it would do the
+   * same write twice; Delete skips it because the only deletable set is the active one, so
+   * saving into it first is pure waste.
+   */
+  async function act(fn: () => Promise<RulesViewData>) {
+    await run(async () => {
+      await flushDraft();
+      return fn();
+    });
   }
 
   /** Switch the edited set. */
   async function selectSet(id: string) {
-    await run(async () => {
-      await flushDraft();
-      return rulesSetActive(id);
-    });
+    await act(() => rulesSetActive(id));
   }
 
   /**
@@ -125,12 +139,29 @@ export function RulesView() {
    */
   async function newSet() {
     const known = new Set((data?.sets ?? []).map((s) => s.id));
-    await run(async () => {
-      await flushDraft();
+    await act(async () => {
       const created = await rulesSaveSet("New rules", "");
       const fresh = created.sets.find((s) => !known.has(s.id));
       return fresh ? rulesSetActive(fresh.id) : created;
     });
+  }
+
+  /**
+   * Open the dry run for one client. Saves first: the backend renders the preview from the SAVED
+   * set, so previewing a dirty editor would show the previous bytes under a button that promises
+   * to show exactly what would be written.
+   */
+  async function openPreview(clientId: string) {
+    setBusy(true);
+    setError(null);
+    try {
+      await flushDraft();
+      setPreview(await rulesPreview(clientId));
+    } catch (e) {
+      setError(String(e));
+    } finally {
+      setBusy(false);
+    }
   }
 
   if (loading) {
@@ -214,7 +245,7 @@ export function RulesView() {
                 variant="outline"
                 size="sm"
                 disabled={busy}
-                onClick={() => run(rulesApply)}
+                onClick={() => act(rulesApply)}
               >
                 <RefreshCw className="size-3.5" />
                 Re-apply
@@ -230,6 +261,13 @@ export function RulesView() {
               </Button>
             </div>
           </>
+        ) : (data?.sets.length ?? 0) > 0 ? (
+          // Deleting the active set clears the selection rather than promoting a sibling, so the
+          // other sets are still right there. Saying "no rule set yet" would be a plain lie about
+          // what is on screen.
+          <p className="text-sm text-muted-foreground">
+            No set is applied right now. Pick one above to edit and apply it.
+          </p>
         ) : (
           <p className="text-sm text-muted-foreground">
             No rule set yet. Create one and it applies to the clients you switch on below.
@@ -254,9 +292,14 @@ export function RulesView() {
                   checked={c.enabled}
                   disabled={busy}
                   aria-label={c.name}
-                  onChange={(e) =>
-                    run(() => rulesSetClientEnabled(c.id, e.target.checked))
-                  }
+                  onChange={(e) => {
+                    // Read the new value NOW. `act` awaits a possible draft save first, and by
+                    // the time the inner callback runs React has re-rendered this controlled
+                    // input back to `c.enabled`, so a lazy `e.target.checked` reads the OLD
+                    // value and the toggle silently does nothing.
+                    const next = e.target.checked;
+                    act(() => rulesSetClientEnabled(c.id, next));
+                  }}
                 />
                 <span className="truncate" title={c.path}>
                   {c.name}
@@ -272,13 +315,7 @@ export function RulesView() {
                       ? "See exactly what would be written"
                       : "Create a rule set first"
                   }
-                  onClick={async () => {
-                    try {
-                      setPreview(await rulesPreview(c.id));
-                    } catch (e) {
-                      setError(String(e));
-                    }
-                  }}
+                  onClick={() => openPreview(c.id)}
                   className="inline-flex items-center gap-1 rounded-md border px-2 py-0.5 text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-foreground disabled:opacity-50"
                 >
                   <Eye className="size-3" />

--- a/src/components/RulesView.tsx
+++ b/src/components/RulesView.tsx
@@ -154,6 +154,9 @@ export function RulesView() {
   async function openPreview(clientId: string) {
     setBusy(true);
     setError(null);
+    // Drop any previous preview up front. If this one fails, a card left over from ANOTHER client
+    // would sit there under the error looking like it belongs to the client just clicked.
+    setPreview(null);
     try {
       await flushDraft();
       setPreview(await rulesPreview(clientId));
@@ -166,6 +169,29 @@ export function RulesView() {
 
   if (loading) {
     return <p className="text-sm text-muted-foreground">Loading…</p>;
+  }
+
+  // A failed load has no data, and every empty-state line below reads off `data`. Rendering them
+  // would tell the user their machine has no clients and no rule sets, which is a claim we have no
+  // basis for: we never found out. Show the failure and a way to retry instead.
+  if (!data) {
+    return (
+      <div className="flex flex-col gap-3">
+        <Callout variant="danger" role="alert">
+          {error ?? "Could not load your agent rules."}
+        </Callout>
+        <Button
+          size="sm"
+          variant="outline"
+          className="self-start"
+          disabled={busy}
+          onClick={() => run(rulesView)}
+        >
+          <RefreshCw className="size-3.5" />
+          Try again
+        </Button>
+      </div>
+    );
   }
 
   const clients = data?.clients ?? [];
@@ -220,14 +246,23 @@ export function RulesView() {
               value={draftName}
               disabled={busy}
               aria-label="Rule set name"
-              onChange={(e) => setDraftName(e.target.value)}
+              onChange={(e) => {
+                setDraftName(e.target.value);
+                setPreview(null);
+              }}
               className="mb-2 h-9"
             />
             <textarea
               value={draft}
               disabled={busy}
               aria-label="Rules"
-              onChange={(e) => setDraft(e.target.value)}
+              // Editing invalidates an open preview: the card is rendered from the SAVED set, so
+              // it would keep showing the old bytes under a button that promises the exact ones.
+              // Clearing beats leaving a card that quietly stops being true as you type.
+              onChange={(e) => {
+                setDraft(e.target.value);
+                setPreview(null);
+              }}
               rows={12}
               spellCheck={false}
               placeholder="Always run the tests before you say you're done."

--- a/src/components/RulesView.tsx
+++ b/src/components/RulesView.tsx
@@ -83,18 +83,36 @@ export function RulesView() {
     }
   }
 
-  /** Switch the edited set. An unsaved draft is kept by saving it first, never silently dropped. */
+  /**
+   * Persist an unsaved draft before an action that reseats the editor. Every such action calls
+   * this first: losing typed rules to a stray click on another set is not an acceptable outcome,
+   * and `adopt` reseats the draft unconditionally on the refreshed view.
+   */
+  async function flushDraft() {
+    if (dirty && active) await rulesSaveSet(draftName, draft, active.id);
+  }
+
+  /** Switch the edited set. */
   async function selectSet(id: string) {
-    if (dirty && active) {
-      const name = draftName;
-      const content = draft;
-      await run(async () => {
-        await rulesSaveSet(name, content, active.id);
-        return rulesSetActive(id);
-      });
-      return;
-    }
-    await run(() => rulesSetActive(id));
+    await run(async () => {
+      await flushDraft();
+      return rulesSetActive(id);
+    });
+  }
+
+  /**
+   * Create a set and switch to it. The backend only auto-activates a new set when nothing else
+   * is active (so a background create can never hijack the user's current rules), which means
+   * this button has to select it explicitly: someone who asks for a new set means to edit it.
+   */
+  async function newSet() {
+    const known = new Set((data?.sets ?? []).map((s) => s.id));
+    await run(async () => {
+      await flushDraft();
+      const created = await rulesSaveSet("New rules", "");
+      const fresh = created.sets.find((s) => !known.has(s.id));
+      return fresh ? rulesSetActive(fresh.id) : created;
+    });
   }
 
   if (loading) {
@@ -141,12 +159,7 @@ export function RulesView() {
               {s.name}
             </button>
           ))}
-          <Button
-            variant="outline"
-            size="sm"
-            disabled={busy}
-            onClick={() => run(() => rulesSaveSet("New rules", ""))}
-          >
+          <Button variant="outline" size="sm" disabled={busy} onClick={newSet}>
             <Plus className="size-3.5" />
             New set
           </Button>

--- a/src/components/TeamsView.tsx
+++ b/src/components/TeamsView.tsx
@@ -7,10 +7,6 @@ import {
   Users,
   Server,
   AlertTriangle,
-  Check,
-  Clock,
-  Ban,
-  Minus,
   FileText,
 } from "lucide-react";
 import { listen } from "@tauri-apps/api/event";
@@ -18,6 +14,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { ConfirmDialog } from "@/components/ConfirmDialog";
 import { Callout } from "@/components/Callout";
+import { RuleStateBadge } from "@/components/RuleStateBadge";
 import { TransportPill } from "@/components/TransportPill";
 import { Input } from "@/components/ui/input";
 import {
@@ -33,36 +30,7 @@ import {
 import { HOSTED_TEAMS_URL, teamUrlError } from "@/lib/teamUrl";
 import { isEnabled, activeProfile } from "@/lib/types";
 import type { TeamPushPreview } from "@/lib/api";
-import type {
-  Registry,
-  InstructionsStatusView,
-  InstructionsApplyState,
-} from "@/lib/types";
-
-/** How each per-client instructions state renders in the member's Teams tab (spec W4). */
-const INSTR_STATE_META: Record<
-  InstructionsApplyState,
-  { label: string; className: string; Icon: typeof Check }
-> = {
-  applied: { label: "Applied", className: "text-success", Icon: Check },
-  stale: { label: "Not applied yet", className: "text-warning", Icon: Clock },
-  blocked_override: {
-    label: "Blocked by a local override",
-    className: "text-warning",
-    Icon: Ban,
-  },
-  too_long: {
-    label: "Too long for this client",
-    className: "text-warning",
-    Icon: AlertTriangle,
-  },
-  unsupported: {
-    label: "Copy manually",
-    className: "text-muted-foreground",
-    Icon: Minus,
-  },
-  error: { label: "Write error", className: "text-destructive", Icon: AlertTriangle },
-};
+import type { Registry, InstructionsStatusView } from "@/lib/types";
 
 /**
  * Toolport Teams: join a team and have its shared MCP server set appear locally. The
@@ -632,24 +600,15 @@ export function TeamsView({
                 </p>
               ) : (
                 <ul className="grid gap-1.5">
-                  {instr.clients.map((c) => {
-                    const meta = INSTR_STATE_META[c.state];
-                    const Icon = meta.Icon;
-                    return (
-                      <li
-                        key={c.id}
-                        className="flex items-center justify-between gap-3 text-sm"
-                      >
-                        <span className="truncate">{c.name}</span>
-                        <span
-                          className={`flex shrink-0 items-center gap-1 text-xs ${meta.className}`}
-                        >
-                          <Icon className="size-3.5" />
-                          {meta.label}
-                        </span>
-                      </li>
-                    );
-                  })}
+                  {instr.clients.map((c) => (
+                    <li
+                      key={c.id}
+                      className="flex items-center justify-between gap-3 text-sm"
+                    >
+                      <span className="truncate">{c.name}</span>
+                      <RuleStateBadge state={c.state} />
+                    </li>
+                  ))}
                 </ul>
               )}
             </div>

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -19,6 +19,8 @@ import type {
   ProbeResult,
   Registry,
   RoutineSuggestion,
+  RulesPreview,
+  RulesView,
   SavingsSummary,
   SearchTrace,
   ToolIdentity,
@@ -544,6 +546,56 @@ export function teamInstructionsStatus(): Promise<InstructionsStatusView | null>
 /** Leave the team: remove its merged servers and clear the saved token. */
 export function teamDisconnect(): Promise<Registry> {
   return invoke<Registry>("team_disconnect");
+}
+
+// ---- Personal agent rules (SBS-821) ----
+//
+// Every mutating call returns the refreshed view, so the tab never has to re-fetch to stay
+// honest about what is on disk. All of these work with no MCP server configured.
+
+/** The user's rule sets, which one is active, and each installed client's on-disk state. */
+export function rulesView(): Promise<RulesView> {
+  return invoke<RulesView>("rules_view");
+}
+
+/** Create (`id` omitted) or update a rule set, then apply it to every opted-in client. */
+export function rulesSaveSet(
+  name: string,
+  content: string,
+  id?: string,
+): Promise<RulesView> {
+  return invoke<RulesView>("rules_save_set", { id: id ?? null, name, content });
+}
+
+/** Delete a rule set. Deleting the active one also removes the files Toolport wrote. */
+export function rulesDeleteSet(id: string): Promise<RulesView> {
+  return invoke<RulesView>("rules_delete_set", { id });
+}
+
+/** Switch the active set, or pass nothing to clear it and remove our files everywhere. */
+export function rulesSetActive(id?: string): Promise<RulesView> {
+  return invoke<RulesView>("rules_set_active", { id: id ?? null });
+}
+
+/** Opt one client in or out. Opting out removes that client's rules file. */
+export function rulesSetClientEnabled(
+  clientId: string,
+  enabled: boolean,
+): Promise<RulesView> {
+  return invoke<RulesView>("rules_set_client_enabled", { clientId, enabled });
+}
+
+/**
+ * Dry-run one client's write: the exact before/after bytes, without touching disk. `null` when
+ * the client is not installed, has no rules file we manage, or no set is active.
+ */
+export function rulesPreview(clientId: string): Promise<RulesPreview | null> {
+  return invoke<RulesPreview | null>("rules_preview", { clientId });
+}
+
+/** Re-apply the active set to every opted-in client. */
+export function rulesApply(): Promise<RulesView> {
+  return invoke<RulesView>("rules_apply");
 }
 
 export interface TeamPushPreview {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -587,10 +587,19 @@ export function rulesSetClientEnabled(
 
 /**
  * Dry-run one client's write: the exact before/after bytes, without touching disk. `null` when
- * the client is not installed, has no rules file we manage, or no set is active.
+ * the client has no rules file we manage, or no set is active.
+ *
+ * Pass `content` to preview unsaved editor text. Do NOT save first to get an accurate preview: a
+ * save applies to every opted-in client, which would turn the dry run into a write.
  */
-export function rulesPreview(clientId: string): Promise<RulesPreview | null> {
-  return invoke<RulesPreview | null>("rules_preview", { clientId });
+export function rulesPreview(
+  clientId: string,
+  content?: string,
+): Promise<RulesPreview | null> {
+  return invoke<RulesPreview | null>("rules_preview", {
+    clientId,
+    content: content ?? null,
+  });
 }
 
 /** Re-apply the active set to every opted-in client. */

--- a/src/lib/rulesDraftCache.ts
+++ b/src/lib/rulesDraftCache.ts
@@ -1,0 +1,40 @@
+/**
+ * Unsaved Agent-rules editor text, surviving the view's unmount.
+ *
+ * `App.tsx` mounts the Rules view only while its tab is selected, and the keyboard shortcuts stay
+ * live inside a textarea, so Ctrl+2 or a click on Teams tears the component down mid-sentence.
+ * In-tab actions flush the draft precisely so typed rules are never lost; leaving the tab has to
+ * honour the same promise.
+ *
+ * Held in memory, NOT auto-saved on the way out: a save applies to every opted-in client, so
+ * rewriting someone's `AGENTS.md` because they changed tabs would be far worse than keeping the
+ * text here until they come back. Keyed by rule-set id, so a draft can only ever be restored onto
+ * the set it was typed for. Lives as long as the window it belongs to.
+ *
+ * A module rather than component state for the obvious reason (it must outlive the component), and
+ * its own file so the view keeps exporting only a component (react-refresh).
+ */
+const drafts = new Map<string, { name: string; content: string }>();
+
+/** The draft held for a set, if any. */
+export function getRulesDraft(setId: string) {
+  return drafts.get(setId);
+}
+
+/** Hold a draft for a set, replacing any previous one. */
+export function setRulesDraft(setId: string, draft: { name: string; content: string }) {
+  drafts.set(setId, draft);
+}
+
+/** Forget the draft for one set: it was saved, or edited back to the saved text. */
+export function forgetRulesDraft(setId: string) {
+  drafts.delete(setId);
+}
+
+/**
+ * Forget every held draft. Module state outlives a component, so tests reset it between cases or
+ * one case's typing shows up as another's "unsaved" text.
+ */
+export function clearRulesDraftCache() {
+  drafts.clear();
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -2,7 +2,7 @@ export type Transport = "stdio" | "http" | "sse" | "unknown";
 
 /** The main content views, selected from the sidebar. */
 export type View =
-  "servers" | "activity" | "catalog" | "playground" | "teams" | "settings";
+  "servers" | "activity" | "catalog" | "playground" | "rules" | "teams" | "settings";
 
 export interface McpServer {
   name: string;
@@ -553,6 +553,49 @@ export interface InstructionsStatusView {
   content: string;
   version: number;
   clients: InstructionsClientStatus[];
+}
+
+/**
+ * One of the user's own named rule sets (SBS-821). `revision` moves only when `content` changes,
+ * because it rides in the marker written into each client's file.
+ */
+export interface RuleSet {
+  id: string;
+  name: string;
+  content: string;
+  revision: number;
+}
+
+/**
+ * One client's row in the Rules tab. Reuses {@link InstructionsApplyState}: personal rules and
+ * team instructions run through the same writer, so the states (and their badges) are identical.
+ */
+export interface RulesClientStatus {
+  id: string;
+  name: string;
+  /** User opt-in. A client is off until turned on; nothing is written to it until then. */
+  enabled: boolean;
+  /** Absent when this client has no global-rules file Toolport can manage (Cursor, Warp). */
+  path?: string;
+  state: InstructionsApplyState;
+}
+
+/** Everything the Rules tab renders, from one `rules_view` call. */
+export interface RulesView {
+  sets: RuleSet[];
+  activeSetId?: string;
+  clients: RulesClientStatus[];
+}
+
+/** A dry run of one client's write, shown before the first apply. Nothing is written to get it. */
+export interface RulesPreview {
+  clientId: string;
+  path: string;
+  /** `ownedFile` = Toolport owns the file; `sentinelBlock` = it owns only the marked span. */
+  strategy: "ownedFile" | "sentinelBlock";
+  before: string;
+  after: string;
+  state: InstructionsApplyState;
 }
 
 export function activeProfile(registry: Registry): Profile | undefined {


### PR DESCRIPTION
PR 3 of 4 for [SBS-821](https://linear.app/southboundsoftware/issue/SBS-821). **Stacked on #794** (base is `feat/personal-agent-rules-backend`).

The UI. New "Agent rules" sidebar entry between Activity and Teams, backed by the `rules_*` commands from #794.

## `RulesView`

- Named rule sets as a row of chips, plus a plain textarea. No rich editor, per the ticket's "keep it thin".
- Per-client checkboxes with the shared state badge. A client is off until switched on, and the copy says so: *"Nothing is written to a client until you turn it on."*
- **Preview** shows the exact bytes that would land, per client, writing nothing. It also states which of the two strategies applies, so the user knows whether Toolport owns the whole file or only a marked block inside a file they also edit.
- Clients with no rules file we can manage (Cursor, Warp) are **named**, not hidden, with "paste your rules in by hand". Dropping them silently is how someone concludes their rules reached a client they never did.
- Switching sets with an unsaved draft **saves the draft first**. Losing typed rules to a stray click is not an acceptable failure mode.
- Deleting a set confirms, and the confirm says what happens to the files.

## `RuleStateBadge`

Extracts the per-client state badge that lived inside `TeamsView`. Personal rules and team instructions run through one writer and report the same `ApplyState`, so they have to read identically; the same on-disk situation described two different ways would look like two different problems.

The badge also gained a tooltip explaining each state, which the Teams tab did not have. So Teams gets slightly better too.

## Fresh install

Nothing in this tab needs the gateway or a configured MCP server, which the epic requires: this is the first feature a non-MCP user touches.

## Tests

9 new cases.

`RulesView` (8): loading the active set into the editor, per-client state rendering, unsupported clients being named rather than hidden, save gated on a real change and sending the edited text, opt-out calling through with `false`, preview rendering the bytes while calling neither apply nor save, set switching saving the unsaved draft first, and a failed write surfacing as an `alert` rather than a silent no-op.

`AppSidebar` (1): the entry routes to `rules` and marks itself `aria-current` when active.

## Verification

- `npx vitest run` -> 40 files, 414 passed, 1 skipped, 0 failed
- `npx tsc --noEmit` -> clean
- `npx eslint src/` -> 0 errors (50 warnings, all pre-existing)
- `npx vite build` -> builds

Refs SBS-821


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Agent rules tab for creating and applying rule sets to AI clients
> - Adds a new `RulesView` component behind a sidebar 'Agent rules' nav item, allowing users to create, edit, select, and delete rule sets, then apply them to opted-in AI clients.
> - Adds seven new API functions in [`api.ts`](https://github.com/tsouth89/toolport/pull/795/files#diff-400f714a60b9cf9cb8d716a1010cd6de05f9841d153876783ad7442be601af0d) (`rulesView`, `rulesSaveSet`, `rulesDeleteSet`, `rulesSetActive`, `rulesSetClientEnabled`, `rulesPreview`, `rulesApply`) to back the view.
> - Draft edits persist across tab navigation via an in-memory [`rulesDraftCache`](https://github.com/tsouth89/toolport/pull/795/files#diff-827b39e562a53cf6be82376c7adacd6fd4928c510e175d432ec5c8f19354bac5), and are flushed before any mutating action to prevent data loss.
> - Adds a reusable `RuleStateBadge` component that renders an icon and label for each `InstructionsApplyState`; replaces inline badge logic in `TeamsView`.
> - Saves are blocked if the content contains reserved Toolport markers; a preview mode shows exact byte counts without writing to disk.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fa7318f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->