### PR TITLE
docs(rules): document agent rules and every supported client path (SBS-821)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,19 @@ Entries before the rename below shipped under the project's former name, Conduit
 
 ### Added
 
+- **Agent rules: write your instructions once, apply them everywhere.** A new Agent
+  rules tab holds one or more named rule sets and writes the active one into every
+  AI client's own global rules file (`CLAUDE.md`, `AGENTS.md`, `GEMINI.md`,
+  `.goosehints`, Windsurf's `global_rules.md`), so keeping 13 clients in agreement
+  is no longer 13 files to hand-edit. Your own content is never overwritten:
+  Toolport either owns its own file in the client's rules directory or owns a
+  marked block inside a shared file and leaves every other byte exactly as it is.
+  Each client is off until you turn it on, a per-client preview shows the exact
+  bytes before the first write, and turning a client off or deleting the set
+  removes what Toolport wrote and nothing else. Cursor and Warp keep their globals
+  in their own UI, so they are listed as "Copy manually" rather than silently
+  skipped. Needs no MCP server or gateway. Team instructions are unaffected and
+  coexist in the same files. See [docs/agent-rules.md](docs/agent-rules.md).
 - **Official brand marks for 14 more clients.** Grok Build, OpenCode, Qwen Code, Kimi
   Code, JetBrains Junie, Kilo Code, GitHub Copilot CLI, Amp, Pi, Oh My Pi, Factory Droid,
   BoltAI, AnythingLLM and Continue now show their own logo in the Clients view instead of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,8 @@ Entries before the rename below shipped under the project's former name, Conduit
   rules tab holds one or more named rule sets and writes the active one into every
   AI client's own global rules location (`AGENTS.md`, `GEMINI.md`, `.goosehints`,
   Windsurf's `global_rules.md`, and a `toolport-rules.md` in the rules directory of
-  clients that read one), so keeping 13 clients in agreement is no longer 13 files
-  to hand-edit. Your own content is never overwritten:
+  clients that read one), so keeping every supported client in agreement no longer
+  means hand-editing each file. Your own content is never overwritten:
   Toolport either owns its own file in the client's rules directory or owns a
   marked block inside a shared file and leaves every other byte exactly as it is.
   Each client is off until you turn it on, a per-client preview shows the exact

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,16 +18,17 @@ Entries before the rename below shipped under the project's former name, Conduit
 
 - **Agent rules: write your instructions once, apply them everywhere.** A new Agent
   rules tab holds one or more named rule sets and writes the active one into every
-  AI client's own global rules file (`CLAUDE.md`, `AGENTS.md`, `GEMINI.md`,
-  `.goosehints`, Windsurf's `global_rules.md`), so keeping 13 clients in agreement
-  is no longer 13 files to hand-edit. Your own content is never overwritten:
+  AI client's own global rules location (`AGENTS.md`, `GEMINI.md`, `.goosehints`,
+  Windsurf's `global_rules.md`, and a `toolport-rules.md` in the rules directory of
+  clients that read one), so keeping 13 clients in agreement is no longer 13 files
+  to hand-edit. Your own content is never overwritten:
   Toolport either owns its own file in the client's rules directory or owns a
   marked block inside a shared file and leaves every other byte exactly as it is.
   Each client is off until you turn it on, a per-client preview shows the exact
   bytes before the first write, and turning a client off or deleting the set
   removes what Toolport wrote and nothing else. Cursor and Warp keep their globals
-  in their own UI, so they are listed as "Copy manually" rather than silently
-  skipped. Needs no MCP server or gateway. Team instructions are unaffected and
+  in their own UI, so the tab names them as clients it cannot write rather than
+  silently skipping them. Needs no MCP server or gateway. Team instructions are unaffected and
   coexist in the same files. See [docs/agent-rules.md](docs/agent-rules.md).
 - **Official brand marks for 14 more clients.** Grok Build, OpenCode, Qwen Code, Kimi
   Code, JetBrains Junie, Kilo Code, GitHub Copilot CLI, Amp, Pi, Oh My Pi, Factory Droid,

--- a/README.md
+++ b/README.md
@@ -87,8 +87,9 @@ fixes both.
 - **Per-agent scoping.** Give each client only the servers it should see. A coding
   agent literally cannot call a billing tool that isn't in its profile.
 - **One set of agent rules.** Write your instructions once and Toolport applies them
-  to every client's own rules file (`CLAUDE.md`, `AGENTS.md`, `GEMINI.md`, and the
-  rest) instead of you editing each by hand. Keep several named sets and switch
+  to every client's own global rules location (`AGENTS.md`, `GEMINI.md`,
+  `.goosehints`, and a `toolport-rules.md` in the rules directory of clients that
+  read one) instead of you editing each by hand. Keep several named sets and switch
   between them. Your own content is never overwritten: Toolport either owns its own
   file or owns a marked block and leaves every other byte alone, and turning a client
   off removes what it wrote. Each client is off until you turn it on, and a preview

--- a/README.md
+++ b/README.md
@@ -86,6 +86,13 @@ fixes both.
   including environment variable values.
 - **Per-agent scoping.** Give each client only the servers it should see. A coding
   agent literally cannot call a billing tool that isn't in its profile.
+- **One set of agent rules.** Write your instructions once and Toolport applies them
+  to every client's own rules file (`CLAUDE.md`, `AGENTS.md`, `GEMINI.md`, and the
+  rest) instead of you editing each by hand. Keep several named sets and switch
+  between them. Your own content is never overwritten: Toolport either owns its own
+  file or owns a marked block and leaves every other byte alone, and turning a client
+  off removes what it wrote. Each client is off until you turn it on, and a preview
+  shows the exact bytes first. See [docs/agent-rules.md](docs/agent-rules.md).
 - **Obvious auth.** OAuth or API key, stored once in the OS keychain, a single click per
   server. Newly-authed servers propagate to connected clients without a restart.
 - **No secrets in client configs.** Clients only ever say "talk to Toolport." Keys live

--- a/docs/agent-rules.md
+++ b/docs/agent-rules.md
@@ -26,6 +26,16 @@ Either way, your own instructions are never overwritten. Turning a client off, o
 deleting the active set, removes what Toolport wrote and leaves the rest of the
 file alone.
 
+Deleting the set that is currently applied clears the selection rather than
+promoting another one, so nothing is pushed to your clients that you did not pick.
+Deleting any other set changes nothing on disk.
+
+One thing Toolport will not store: rules containing its own marker comments
+(`toolport:rules:start` and friends). It uses those to find the block it owns, so
+it refuses the save and tells you. This only comes up if you copy out of the
+preview pane, which shows the finished file including the markers. Copy just your
+own text.
+
 ## Before anything is written
 
 - **Every client starts switched off.** Nothing is written until you tick a client
@@ -33,7 +43,9 @@ file alone.
   the sidebar: that one connects a client to the MCP gateway and has nothing to do
   with rules.)
 - **Preview shows the exact bytes.** Each client has a Preview button that renders
-  the file Toolport would write, without writing it.
+  the file Toolport would write, without writing it. It reflects whatever is in the
+  editor, saved or not, and previewing never saves: a save applies to every client
+  you have switched on, so it would defeat the point.
 
 ## Supported clients
 

--- a/docs/agent-rules.md
+++ b/docs/agent-rules.md
@@ -28,28 +28,30 @@ file alone.
 
 ## Before anything is written
 
-- **Every client starts switched off.** Nothing is written until you turn a client
-  on in the Clients list.
+- **Every client starts switched off.** Nothing is written until you tick a client
+  in the **Clients** section of the **Agent rules** tab. (Not the Clients entry in
+  the sidebar: that one connects a client to the MCP gateway and has nothing to do
+  with rules.)
 - **Preview shows the exact bytes.** Each client has a Preview button that renders
   the file Toolport would write, without writing it.
 
 ## Supported clients
 
-| Client            | Rules file                                                           | Strategy     |
-| ----------------- | -------------------------------------------------------------------- | ------------ |
-| Claude Code       | `~/.claude/rules/toolport-rules.md`                                  | Owned file   |
-| VS Code (Copilot) | `~/.claude/rules/toolport-rules.md` (shared with Claude Code)        | Owned file   |
-| Kiro              | `~/.kiro/steering/toolport-rules.md`                                 | Owned file   |
-| Roo Code          | `~/.roo/rules/toolport-rules.md`                                     | Owned file   |
-| Cline             | `~/Documents/Cline/Rules/toolport-rules.md`                          | Owned file   |
-| Codex             | `$CODEX_HOME/AGENTS.md` (default `~/.codex/AGENTS.md`)               | Marked block |
-| Gemini CLI        | `$GEMINI_CLI_HOME/.gemini/GEMINI.md` (default `~/.gemini/GEMINI.md`) | Marked block |
-| Antigravity       | `~/.gemini/GEMINI.md` (shared with Gemini CLI)                       | Marked block |
-| Windsurf          | `~/.codeium/windsurf/memories/global_rules.md`                       | Marked block |
-| Goose             | `.goosehints` beside `config.yaml` (honours `GOOSE_PATH_ROOT`)       | Marked block |
-| Zed               | `AGENTS.md` in Zed's config directory                                | Marked block |
-| Pi                | `~/.pi/agent/AGENTS.md`                                              | Marked block |
-| Oh My Pi          | `~/.omp/agent/AGENTS.md`                                             | Marked block |
+| Client      | Rules file                                                           | Strategy     |
+| ----------- | -------------------------------------------------------------------- | ------------ |
+| Claude Code | `~/.claude/rules/toolport-rules.md`                                  | Owned file   |
+| VS Code     | `~/.claude/rules/toolport-rules.md` (shared with Claude Code)        | Owned file   |
+| Kiro        | `~/.kiro/steering/toolport-rules.md`                                 | Owned file   |
+| Roo Code    | `~/.roo/rules/toolport-rules.md`                                     | Owned file   |
+| Cline       | `~/Documents/Cline/Rules/toolport-rules.md`                          | Owned file   |
+| Codex       | `$CODEX_HOME/AGENTS.md` (default `~/.codex/AGENTS.md`)               | Marked block |
+| Gemini CLI  | `$GEMINI_CLI_HOME/.gemini/GEMINI.md` (default `~/.gemini/GEMINI.md`) | Marked block |
+| Antigravity | `~/.gemini/GEMINI.md` (shared with Gemini CLI)                       | Marked block |
+| Windsurf    | `~/.codeium/windsurf/memories/global_rules.md`                       | Marked block |
+| Goose       | `.goosehints` beside `config.yaml` (honours `GOOSE_PATH_ROOT`)       | Marked block |
+| Zed         | `AGENTS.md` in Zed's config directory                                | Marked block |
+| Pi          | `~/.pi/agent/AGENTS.md`                                              | Marked block |
+| Oh My Pi    | `~/.omp/agent/AGENTS.md`                                             | Marked block |
 
 On Linux, Goose and Zed follow `XDG_CONFIG_HOME`. On Windows, Goose and Zed use the
 roaming config directory.
@@ -57,11 +59,19 @@ roaming config directory.
 Where two clients share a file, Toolport writes it once. Both are covered even if
 only one is installed.
 
+The VS Code row resolves to Claude Code's rules directory, which is what Toolport
+has always done for team instructions. That covers a VS Code install running a
+Claude-compatible extension. It is **not** a claim that GitHub Copilot Chat reads
+that directory: Copilot's own instruction files are `.github/copilot-instructions.md`
+and repo-level `AGENTS.md`, which Toolport does not write. If Copilot is your only
+assistant in VS Code, paste the rules into its own file.
+
 ### Clients with no rules file Toolport can write
 
 **Cursor** and **Warp** keep their global rules in their own UI or account rather
-than in a file on disk. They appear in the Clients list marked "Copy manually", so
-you can paste your rules in yourself. Toolport does not silently skip them.
+than in a file on disk. They have no checkbox; the Clients section names them
+underneath ("No rules file Toolport can write for Cursor, Warp"), so you know to
+paste your rules in yourself. Toolport does not silently skip them.
 
 ## Per-client states
 
@@ -71,7 +81,7 @@ you can paste your rules in yourself. Toolport does not silently skip them.
 | Not applied yet             | The current rules are not on disk for this client yet. Use Re-apply.                                                                                                                                                       |
 | Blocked by a local override | The client has an override file making it ignore the file Toolport writes. Codex's `AGENTS.override.md` is the case this covers: while it exists, Codex ignores `AGENTS.md` entirely, so writing there would be invisible. |
 | Too long for this client    | The client caps its global rules file and these rules would exceed it. Windsurf caps its file at 6,000 characters, counted across the whole file, including anything you have in it.                                       |
-| Copy manually               | No rules file Toolport can write. See above.                                                                                                                                                                               |
+| Copy manually               | No rules file Toolport can write. Shown in the Teams tab; the Agent rules tab lists these clients separately instead. See above.                                                                                           |
 | Write error                 | The file could not be read or written. It was left untouched.                                                                                                                                                              |
 
 ## Team instructions

--- a/docs/agent-rules.md
+++ b/docs/agent-rules.md
@@ -1,0 +1,89 @@
+# Agent rules
+
+Write your agent instructions once in Toolport and have them applied to every AI
+client on your machine, instead of hand-editing `CLAUDE.md`, `AGENTS.md`,
+`GEMINI.md` and the rest and keeping them in sync yourself.
+
+Open the **Agent rules** tab in the sidebar. No MCP server or gateway needed.
+
+## How it works
+
+You write one or more named **rule sets**. Exactly one is active at a time, so you
+can keep, say, a "Work" set and a "Personal" set and switch between them.
+
+Toolport writes the active set into each client's own **global** rules file, using
+one of two strategies depending on how the client stores them:
+
+- **Toolport owns a whole file.** For clients that read a rules _directory_,
+  Toolport creates its own file in it (`toolport-rules.md`). Nothing of yours is
+  in that file, so it can be replaced and deleted freely.
+- **Toolport owns a marked block.** For clients that read a single shared file you
+  also edit, Toolport appends a block between two HTML-comment markers and only
+  ever rewrites what is between them. Every other byte in the file is left exactly
+  as it is.
+
+Either way, your own instructions are never overwritten. Turning a client off, or
+deleting the active set, removes what Toolport wrote and leaves the rest of the
+file alone.
+
+## Before anything is written
+
+- **Every client starts switched off.** Nothing is written until you turn a client
+  on in the Clients list.
+- **Preview shows the exact bytes.** Each client has a Preview button that renders
+  the file Toolport would write, without writing it.
+
+## Supported clients
+
+| Client            | Rules file                                                           | Strategy     |
+| ----------------- | -------------------------------------------------------------------- | ------------ |
+| Claude Code       | `~/.claude/rules/toolport-rules.md`                                  | Owned file   |
+| VS Code (Copilot) | `~/.claude/rules/toolport-rules.md` (shared with Claude Code)        | Owned file   |
+| Kiro              | `~/.kiro/steering/toolport-rules.md`                                 | Owned file   |
+| Roo Code          | `~/.roo/rules/toolport-rules.md`                                     | Owned file   |
+| Cline             | `~/Documents/Cline/Rules/toolport-rules.md`                          | Owned file   |
+| Codex             | `$CODEX_HOME/AGENTS.md` (default `~/.codex/AGENTS.md`)               | Marked block |
+| Gemini CLI        | `$GEMINI_CLI_HOME/.gemini/GEMINI.md` (default `~/.gemini/GEMINI.md`) | Marked block |
+| Antigravity       | `~/.gemini/GEMINI.md` (shared with Gemini CLI)                       | Marked block |
+| Windsurf          | `~/.codeium/windsurf/memories/global_rules.md`                       | Marked block |
+| Goose             | `.goosehints` beside `config.yaml` (honours `GOOSE_PATH_ROOT`)       | Marked block |
+| Zed               | `AGENTS.md` in Zed's config directory                                | Marked block |
+| Pi                | `~/.pi/agent/AGENTS.md`                                              | Marked block |
+| Oh My Pi          | `~/.omp/agent/AGENTS.md`                                             | Marked block |
+
+On Linux, Goose and Zed follow `XDG_CONFIG_HOME`. On Windows, Goose and Zed use the
+roaming config directory.
+
+Where two clients share a file, Toolport writes it once. Both are covered even if
+only one is installed.
+
+### Clients with no rules file Toolport can write
+
+**Cursor** and **Warp** keep their global rules in their own UI or account rather
+than in a file on disk. They appear in the Clients list marked "Copy manually", so
+you can paste your rules in yourself. Toolport does not silently skip them.
+
+## Per-client states
+
+| State                       | Meaning                                                                                                                                                                                                                    |
+| --------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Applied                     | This client's rules file is up to date.                                                                                                                                                                                    |
+| Not applied yet             | The current rules are not on disk for this client yet. Use Re-apply.                                                                                                                                                       |
+| Blocked by a local override | The client has an override file making it ignore the file Toolport writes. Codex's `AGENTS.override.md` is the case this covers: while it exists, Codex ignores `AGENTS.md` entirely, so writing there would be invisible. |
+| Too long for this client    | The client caps its global rules file and these rules would exceed it. Windsurf caps its file at 6,000 characters, counted across the whole file, including anything you have in it.                                       |
+| Copy manually               | No rules file Toolport can write. See above.                                                                                                                                                                               |
+| Write error                 | The file could not be read or written. It was left untouched.                                                                                                                                                              |
+
+## Team instructions
+
+If you are in a Toolport Teams org, your admin can push team-wide instructions as
+well (see the Teams tab). Team and personal rules are independent and coexist in
+the same files: they use different markers and different file names, so applying or
+removing one never disturbs the other.
+
+Where a client caps its rules file, both blocks count toward that cap.
+
+## Project-level rules
+
+Not supported yet. Agent rules currently covers **global** (user-level) rules only.
+Per-project `CLAUDE.md` / `AGENTS.md` files are yours to manage.


### PR DESCRIPTION
PR 4 of 4 for [SBS-821](https://linear.app/southboundsoftware/issue/SBS-821). **Stacked on #795** (base is `feat/personal-agent-rules-ui`).

Closes the last acceptance criterion: *"Docs page listing exactly which agents and file paths are supported."*

## `docs/agent-rules.md`

- The two write strategies, and why your own content survives either one.
- The two safeguards before anything is written: every client starts off, and preview renders the exact bytes.
- A table of all **13 supported clients** with exact paths, including the relocate env vars (`CODEX_HOME`, `GEMINI_CLI_HOME`, `GOOSE_PATH_ROOT`, `XDG_CONFIG_HOME`) and which clients share a file.
- The clients with no writable rules file (Cursor, Warp) and why they are listed rather than skipped.
- What each per-client state means, including the two non-obvious ones: Codex's `AGENTS.override.md` shadowing, and Windsurf's 6,000-character cap counting the whole file rather than just the rules.
- How team and personal rules coexist, and that both count toward a client's cap.
- Project-level rules are explicitly out of scope for now, so nobody goes looking.

Every path in the table was checked against `resolve_rules_target` in `clients.rs` rather than written from memory.

## README and CHANGELOG

README gains a bullet under "One setup, every client". CHANGELOG gains an Unreleased entry.

---

### Stack

| PR | What |
| --- | --- |
| #793 | Scope the managed-rules markers so team and personal can coexist |
| #794 | The `rules` module, registry state, and Tauri commands |
| #795 | The Agent rules tab |
| this | Docs |

Refs SBS-821


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Document Agent rules feature and all supported client file paths
> Adds documentation for the Agent rules feature across [docs/agent-rules.md](https://github.com/tsouth89/toolport/pull/796/files#diff-e26a0f163aa98c9b6b162b32cb45bf71c0f876d52e2b4a49e756cb30d6b1bdc4), [README.md](https://github.com/tsouth89/toolport/pull/796/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5), and [CHANGELOG.md](https://github.com/tsouth89/toolport/pull/796/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed).
>
> - [docs/agent-rules.md](https://github.com/tsouth89/toolport/pull/796/files#diff-e26a0f163aa98c9b6b162b32cb45bf71c0f876d52e2b4a49e756cb30d6b1bdc4) covers rule sets, per-client write strategies (owned file vs. marked block), opt-in defaults, exact-byte previews, per-client states, and interaction with team instructions
> - Supported clients include `AGENTS.md`, `GEMINI.md`, `.goosehints`, Windsurf's `global_rules.md`, and a `toolport-rules.md`; Cursor and Warp are explicitly called out as unmanaged due to UI-managed globals
> - README adds a summary bullet under "One setup, every client" linking to the new doc
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 963bfba.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->