### PR TITLE
fix(clients): write Kimi Shared HTTP as url, not Qwen httpUrl (SBS-921)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,14 @@ Entries before the rename below shipped under the project's former name, Conduit
   a letter badge, so 31 of the 34 supported clients now carry their own mark. Crush, Jan
   and Witsy keep the badge, since none of them publish a usable vector mark.
 
+### Fixed
+
+- **Kimi Shared HTTP Connect writes `url`, not Qwen's `httpUrl`.** Connect, rescope
+  and reset for Kimi went through the generic JSON editor, which remapped remotes
+  via Qwen's `url` → `httpUrl` whenever the map key was not VS Code `"servers"`.
+  Kimi requires `url` and rejects `httpUrl`. The Kimi writer already emitted the
+  right shape; Shared HTTP now uses that same formatter. (SBS-921)
+
 ## [1.14.0] - 2026-08-16
 
 Agents can now keep what worked. A proven multi-tool orchestration can become a

--- a/src-tauri/src/clients.rs
+++ b/src-tauri/src/clients.rs
@@ -9876,9 +9876,15 @@ command = "npx"
     /// strips the hint `entry_to_json` would emit.
     #[test]
     fn kimi_shared_http_connect_writes_url_not_qwen_http_url() {
+        let _data_lock = crate::registry::data_dir_test_lock();
         let _env = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
-        let root = std::env::temp_dir().join(format!("toolport-kimi-sbs921-{}", std::process::id()));
+        let root =
+            std::env::temp_dir().join(format!("toolport-kimi-sbs921-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
         std::fs::create_dir_all(&root).unwrap();
+        let data_dir = root.join("toolport-data");
+        std::fs::create_dir_all(&data_dir).unwrap();
+        let _data_dir = crate::registry::DataDirOverride::set(&data_dir);
         let path = root.join("mcp.json");
         std::fs::write(
             &path,
@@ -9918,7 +9924,14 @@ command = "npx"
             written["mcpServers"].get("keep").is_some(),
             "Connect must preserve existing servers: {written}"
         );
+        let backups = data_dir.join("backups").join("kimi-code");
+        assert_eq!(
+            std::fs::read_dir(&backups).unwrap().count(),
+            1,
+            "the fixture backup must stay under the overridden test data dir"
+        );
 
+        drop(_data_dir);
         drop(_restore);
         std::fs::remove_dir_all(&root).ok();
     }

--- a/src-tauri/src/clients.rs
+++ b/src-tauri/src/clients.rs
@@ -5291,6 +5291,33 @@ fn edit_droid_json_gateway(path: &Path, entry: Option<&ServerEntry>) -> Result<(
     )
 }
 
+fn edit_qwen_json_gateway(path: &Path, entry: Option<&ServerEntry>) -> Result<(), String> {
+    edit_json_gateway_with(
+        path,
+        "mcpServers",
+        entry,
+        true,
+        Some(entry_to_qwen_json),
+        false,
+        false,
+    )
+}
+
+/// Kimi requires `url` (and `transport: "sse"` on legacy SSE). The generic
+/// editor used to remap remotes through `entry_to_qwen_json` (`url` → `httpUrl`)
+/// whenever the map key was not VS Code `"servers"`, which Kimi rejects (SBS-921).
+fn edit_kimi_json_gateway(path: &Path, entry: Option<&ServerEntry>) -> Result<(), String> {
+    edit_json_gateway_with(
+        path,
+        "mcpServers",
+        entry,
+        true,
+        Some(entry_to_kimi_json),
+        false,
+        false,
+    )
+}
+
 fn edit_json_gateway_with(
     path: &Path,
     key: &str,
@@ -5357,18 +5384,12 @@ fn edit_json_gateway_body(
         !gateway_identity_matches(name, name, command)
     });
     if let Some(entry) = entry {
+        // Default is the standard `url`/`command` shape. Qwen's `httpUrl` remap
+        // used to fire for every remote whose map key was not VS Code `"servers"`,
+        // so Kimi Shared HTTP Connect wrote a field Kimi rejects (SBS-921).
+        // Clients with a distinct remote schema pass their own formatter.
         let mut value = if let Some(formatter) = entry_formatter {
             formatter(entry)
-        } else if include_tools {
-            entry_to_json(entry)
-        } else if entry.command.is_none() && entry.url.is_some() {
-            // Remote-only entries: Qwen wants httpUrl+headers; VS Code "servers" keeps url.
-            // entry_to_qwen_json leaves url as-is for SSE and renames for streamable HTTP.
-            if key == "servers" {
-                entry_to_json(entry)
-            } else {
-                entry_to_qwen_json(entry)
-            }
         } else {
             entry_to_json(entry)
         };
@@ -5474,8 +5495,8 @@ fn install_or_remove(client_id: &str, entry: Option<&ServerEntry>) -> Result<Wri
         Format::JsonCopilotMcpServers => edit_copilot_json_gateway(&path, entry)?,
         Format::JsonDroidMcpServers => edit_droid_json_gateway(&path, entry)?,
         Format::JsonAmpMcpServers => edit_json_gateway(&path, "amp.mcpServers", entry, true)?,
-        Format::JsonQwenMcpServers => edit_json_gateway(&path, "mcpServers", entry, true)?,
-        Format::JsonKimiMcpServers => edit_json_gateway(&path, "mcpServers", entry, true)?,
+        Format::JsonQwenMcpServers => edit_qwen_json_gateway(&path, entry)?,
+        Format::JsonKimiMcpServers => edit_kimi_json_gateway(&path, entry)?,
         Format::JsonServers => edit_json_gateway(&path, "servers", entry, lenient)?,
         Format::JsonMcp => edit_crush_gateway(&path, entry)?,
         Format::JsonOpenCodeMcp => edit_opencode_gateway(&path, entry)?,
@@ -7789,7 +7810,7 @@ bad = "not-a-table"
             let path = temp_path("ws3-qwen.json");
             std::fs::write(&path, r#"{"mcpServers":{}}"#).unwrap();
             let entry = gateway_entry_shared_http("qwen-code", None, &spec);
-            edit_json_gateway(&path, "mcpServers", Some(&entry), true).unwrap();
+            edit_qwen_json_gateway(&path, Some(&entry)).unwrap();
             let root: serde_json::Value =
                 serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
             let slot = &root["mcpServers"][GATEWAY_ENTRY_NAME];
@@ -9845,6 +9866,61 @@ command = "npx"
         assert!(installed.iter().any(|s| s.name == GATEWAY_ENTRY_NAME));
 
         std::fs::remove_file(&path).ok();
+    }
+
+    /// SBS-921: Shared HTTP Connect/rescope/reset for Kimi goes through
+    /// `install_gateway_shared_http` → `install_or_remove`. That used to remap
+    /// remotes via `entry_to_qwen_json` (`url` → `httpUrl`) whenever the key was
+    /// not VS Code `"servers"`. Kimi requires `url` and rejects `httpUrl`.
+    /// `type` must also stay off: Kimi ignores it, and `entry_to_kimi_json`
+    /// strips the hint `entry_to_json` would emit.
+    #[test]
+    fn kimi_shared_http_connect_writes_url_not_qwen_http_url() {
+        let _env = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let root = std::env::temp_dir().join(format!("toolport-kimi-sbs921-{}", std::process::id()));
+        std::fs::create_dir_all(&root).unwrap();
+        let path = root.join("mcp.json");
+        std::fs::write(
+            &path,
+            r#"{"mcpServers":{"keep":{"command":"node","args":["server.js"]}}}"#,
+        )
+        .unwrap();
+        let _restore = EnvRestore::set("KIMI_CODE_HOME", &root);
+
+        let spec = SharedHttpSpec {
+            url: "http://127.0.0.1:8765/mcp".into(),
+            token: "kimi-tok".into(),
+        };
+        install_gateway_shared_http("kimi-code", Some("Work"), &spec).unwrap();
+
+        let written: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        let slot = &written["mcpServers"][GATEWAY_ENTRY_NAME];
+        assert_eq!(
+            slot["url"],
+            spec.url,
+            "Kimi Shared HTTP must write url: {slot}"
+        );
+        assert!(
+            slot.get("httpUrl").is_none(),
+            "Kimi rejects Qwen's httpUrl: {slot}"
+        );
+        assert!(
+            slot.get("type").is_none(),
+            "Kimi ignores type; entry_to_kimi_json must strip it: {slot}"
+        );
+        assert!(
+            slot.get("transport").is_none(),
+            "streamable HTTP is Kimi's default; do not emit transport: {slot}"
+        );
+        assert_eq!(slot["headers"]["Authorization"], "Bearer kimi-tok");
+        assert!(
+            written["mcpServers"].get("keep").is_some(),
+            "Connect must preserve existing servers: {written}"
+        );
+
+        drop(_restore);
+        std::fs::remove_dir_all(&root).ok();
     }
 
     #[test]

--- a/src-tauri/src/clients.rs
+++ b/src-tauri/src/clients.rs
@@ -9876,8 +9876,8 @@ command = "npx"
     /// strips the hint `entry_to_json` would emit.
     #[test]
     fn kimi_shared_http_connect_writes_url_not_qwen_http_url() {
-        let _data_lock = crate::registry::data_dir_test_lock();
         let _env = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _data_lock = crate::registry::data_dir_test_lock();
         let root =
             std::env::temp_dir().join(format!("toolport-kimi-sbs921-{}", std::process::id()));
         let _ = std::fs::remove_dir_all(&root);


### PR DESCRIPTION
## Summary

- Shared HTTP Connect, rescope, and reset for Kimi went through edit_json_gateway_body, which remapped remotes via entry_to_qwen_json (url to httpUrl) whenever the map key was not VS Code servers.
- Kimi requires url and rejects httpUrl. write_kimi_json / migrate already emitted the right shape; stdio Connect was already fine.
- A user who Shared-HTTP-Connects Kimi now gets a working url + headers entry (no httpUrl, no type). Rescope and reset use the same install_gateway_shared_http path.

## Test plan

- [x] kimi_shared_http_connect_writes_url_not_qwen_http_url fails without the production change (output below)
- [x] Same test passes with the fix
- [x] Existing Kimi write/parse tests still pass
- [x] Qwen Shared HTTP still writes httpUrl via the explicit Qwen editor
- [ ] Click Shared HTTP Connect on Kimi in the Clients UI and confirm ~/.kimi-code/mcp.json has url, not httpUrl


## Fail-without-fix

Reverted only the production dispatch and default remote formatter, kept the new test. It failed because the written slot had httpUrl and no url. Restored the fix; the test then passed.

```
assertion left == right failed: Kimi Shared HTTP must write url
written slot had httpUrl and url was Null
test clients::tests::kimi_shared_http_connect_writes_url_not_qwen_http_url ... FAILED
```

## Quality gate

Required merge-gate job is Build + test. Ran locally: format:check, lint, audit:prod, frontend build, vitest (406), cargo test --no-default-features --lib --bins --tests (1494), clippy --no-default-features --lib --bins, build:gateway, smoke:headless, pinned installer URL grep. All passed.

Could not run: cargo test with default desktop features (no GTK/WebKit on this box); Windows Pester; macOS/Windows headless matrix; a live Kimi Code process.

## Pattern sweep

rg entry_to_qwen_json / edit_json_gateway / httpUrl in src-tauri/src/clients.rs (only file that writes this shape):

- JsonQwenMcpServers wants httpUrl — now edit_qwen_json_gateway
- JsonKimiMcpServers wants url — now edit_kimi_json_gateway (this ticket)
- JsonServers (VS Code) wants url — already entry_to_json; default is now entry_to_json anyway
- Copilot / Droid / Crush / OpenCode — already have dedicated editors
- JsonMcpServers / Amp / Zed context_servers — Shared HTTP uses the npx mcp-remote stdio bridge, so they never hit the remote remap
- YAML Hermes / Continue — own editors
- write_kimi_json / migrate — already correct; unchanged

The generic remote default is no longer Qwen httpUrl. Only Qwen passes that formatter.

rg httpUrl under docs/ and src/ (frontend): no hits. The UI only calls installGateway with a transport.

## What this makes more likely

A future native-remote client that goes through the generic editor now gets url instead of httpUrl. That is the common MCP shape. The only client that wants httpUrl is Qwen, and it now has an explicit editor. If that dispatch is later pointed back at the generic helper, Qwen Shared HTTP would write url — the existing Qwen test calls edit_qwen_json_gateway directly, not install_gateway_shared_http, so it would not catch a dispatch-only regression.

## Gaps

- No live Kimi Code run against the written file.
- Did not add an install_gateway_shared_http(qwen-code) production-path test.
- Did not run the desktop-featured rust suite or the Windows/macOS CI jobs.
- Did not change the Clients UI: Shared HTTP remains offered for every client, including Kimi. That is intended.

Linear: SBS-921. Left In Progress / open. Do not merge from this PR alone.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Kimi Shared HTTP to write `url` instead of Qwen's `httpUrl`
> - Adds dedicated `edit_kimi_json_gateway` and `edit_qwen_json_gateway` wrappers in [clients.rs](https://github.com/tsouth89/toolport/pull/798/files#diff-6f95d037b6a920242364b6cfc2417b10affa37691d35ce5da93633c9da12c167) so each client uses its own schema formatter instead of sharing the generic JSON writer.
> - `Format::JsonKimiMcpServers` now routes to `edit_kimi_json_gateway`, which uses `entry_to_kimi_json` and writes `url` (omitting `httpUrl` and `transport`).
> - `Format::JsonQwenMcpServers` routes to `edit_qwen_json_gateway`, which writes `httpUrl` + headers as before.
> - Removes the implicit `url`→`httpUrl` remap in `edit_json_gateway_body` that previously applied to all non-`"servers"` map keys; client-specific remapping now requires an explicit formatter.
>
> #### 🖇️ Linked Issues
> Fixes [SBS-921](https://linear.app/southboundsoftware/issue/SBS-921), which reported that Kimi Shared HTTP Connect was incorrectly writing `httpUrl` (Qwen's field) instead of `url`.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #798 opened
>
> - Reordered lock acquisition in `clients.kimi_shared_http_connect_writes_url_not_qwen_http_url` test [65a865e]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c7bb556.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->