### PR TITLE
fix(ci): keep Azure signer secrets off the frontend install (SBS-925)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,23 +41,15 @@ jobs:
           - os: ubuntu-22.04
             bundles: deb,appimage
     runs-on: ${{ matrix.os }}
-    env:
-      # Azure Trusted Signing credentials for Windows Authenticode. These stay empty
-      # until you add the repo secrets, which keeps signing inert: the setup step
-      # below is gated on AZURE_CLIENT_ID being non-empty, so a release tagged before
-      # the secrets exist builds an unsigned Windows installer exactly as before.
-      # trusted-signing-cli reads these via DefaultAzureCredential during the build.
-      AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
-      AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
-      AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
     steps:
       # Third-party actions are pinned to full commit SHAs (not mutable tags): this
       # workflow holds the Apple/Azure/Tauri signing secrets, so a compromised upstream
       # tag must not be able to inject code into a signed release. Version in the comment.
       # persist-credentials: false so the GITHUB_TOKEN isn't left in .git/config where a
-      # malicious npm/cargo dependency install script (run with the signing secrets in
-      # env) could read and exfiltrate it. Nothing here uses the persisted credential:
-      # the only token use is an explicit GH_TOKEN env var on the manifest step.
+      # malicious npm/cargo dependency install script could read and exfiltrate it.
+      # Azure/Tauri/Apple signing secrets are step-scoped (SBS-925), so those scripts
+      # never see them either. Nothing here uses the persisted credential: the only
+      # token use is an explicit GH_TOKEN env var on the manifest step.
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           persist-credentials: false
@@ -134,9 +126,12 @@ jobs:
           echo "disk:"; df -h /
           echo "mem:"; free -h
 
-      # Windows Authenticode signing via Azure Trusted Signing. Gated on the
-      # AZURE_CLIENT_ID secret being present, so until the signing secrets exist
-      # this step is skipped and the Windows build is unsigned, exactly as before.
+      # Windows Authenticode signing via Azure Trusted Signing. Gated on a boolean
+      # derived from whether AZURE_CLIENT_ID is set (GitHub forbids `secrets` in
+      # `steps.if`), so until the signing secrets exist this step is skipped and the
+      # Windows build is unsigned, exactly as before. The actual AZURE_* values are
+      # injected only on the Build installer step so install scripts
+      # never see them (SBS-925).
       # trusted-signing-cli is a small Rust tool (the runner already has cargo).
       # Tauri runs it as a per-binary signCommand, signing the app exe, the bundled
       # gateway sidecar, and the NSIS installer BEFORE it computes the updater
@@ -147,7 +142,10 @@ jobs:
       # the compiled binary so a release only rebuilds it when the key is bumped. Bump the
       # `-v1` suffix to force a fresh install (e.g. to pick up a new version of the tool).
       - name: Cache trusted-signing-cli
-        if: matrix.os == 'windows-latest' && env.AZURE_CLIENT_ID != ''
+        if: matrix.os == 'windows-latest' && env.AZURE_SIGNING_CONFIGURED == 'true'
+        env:
+          # Presence flag only. steps.if cannot read secrets.
+          AZURE_SIGNING_CONFIGURED: ${{ secrets.AZURE_CLIENT_ID != '' }}
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/.cargo/bin/trusted-signing-cli.exe
@@ -155,7 +153,10 @@ jobs:
 
       - name: Set up Windows code signing (Azure Trusted Signing)
         id: winsign
-        if: matrix.os == 'windows-latest' && env.AZURE_CLIENT_ID != ''
+        if: matrix.os == 'windows-latest' && env.AZURE_SIGNING_CONFIGURED == 'true'
+        env:
+          # Presence flag only. steps.if cannot read secrets.
+          AZURE_SIGNING_CONFIGURED: ${{ secrets.AZURE_CLIENT_ID != '' }}
         shell: pwsh
         run: |
           if (-not (Test-Path "$env:USERPROFILE\.cargo\bin\trusted-signing-cli.exe")) {
@@ -185,6 +186,11 @@ jobs:
           # as-is.
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+          # Azure Trusted Signing. Step-scoped and Windows-only so install
+          # scripts and macOS/Linux builds never see the signer (SBS-925).
+          AZURE_TENANT_ID: ${{ matrix.os == 'windows-latest' && secrets.AZURE_TENANT_ID || '' }}
+          AZURE_CLIENT_ID: ${{ matrix.os == 'windows-latest' && secrets.AZURE_CLIENT_ID || '' }}
+          AZURE_CLIENT_SECRET: ${{ matrix.os == 'windows-latest' && secrets.AZURE_CLIENT_SECRET || '' }}
           # macOS is intentionally built UNSIGNED here. The keychain-access-group
           # fix needs the gateway nested in its own .app + embedded provisioning
           # profiles + inside-out signing, none of which Tauri's built-in macOS

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,9 @@ jobs:
           - os: ubuntu-22.04
             bundles: deb,appimage
     runs-on: ${{ matrix.os }}
+    env:
+      # Presence flag only; job-level env is available when steps.if is evaluated.
+      AZURE_SIGNING_CONFIGURED: ${{ secrets.AZURE_CLIENT_ID != '' }}
     steps:
       # Third-party actions are pinned to full commit SHAs (not mutable tags): this
       # workflow holds the Apple/Azure/Tauri signing secrets, so a compromised upstream
@@ -143,9 +146,6 @@ jobs:
       # `-v1` suffix to force a fresh install (e.g. to pick up a new version of the tool).
       - name: Cache trusted-signing-cli
         if: matrix.os == 'windows-latest' && env.AZURE_SIGNING_CONFIGURED == 'true'
-        env:
-          # Presence flag only. steps.if cannot read secrets.
-          AZURE_SIGNING_CONFIGURED: ${{ secrets.AZURE_CLIENT_ID != '' }}
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/.cargo/bin/trusted-signing-cli.exe
@@ -154,9 +154,6 @@ jobs:
       - name: Set up Windows code signing (Azure Trusted Signing)
         id: winsign
         if: matrix.os == 'windows-latest' && env.AZURE_SIGNING_CONFIGURED == 'true'
-        env:
-          # Presence flag only. steps.if cannot read secrets.
-          AZURE_SIGNING_CONFIGURED: ${{ secrets.AZURE_CLIENT_ID != '' }}
         shell: pwsh
         run: |
           if (-not (Test-Path "$env:USERPROFILE\.cargo\bin\trusted-signing-cli.exe")) {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ Entries before the rename below shipped under the project's former name, Conduit
 
 ## [Unreleased]
 
+### Security
+
+- **Release job no longer inherits Azure Trusted Signing credentials during
+  frontend install.** They are now step-scoped to the Windows tauri build,
+  matching TAURI and APPLE. (SBS-925)
+
 ### Removed
 
 - **Toolport Studio is no longer a supported client.** The project is discontinued, so

--- a/docs/SIGNING.md
+++ b/docs/SIGNING.md
@@ -54,8 +54,9 @@ Get-ChildItem Cert:\CurrentUser\My | Format-List Subject, Thumbprint
 ## Azure Trusted Signing in this repo's CI (the live setup)
 
 The release workflow (`.github/workflows/release.yml`) already wires this up, and
-stays **inert until the secrets exist** (the signing step is gated on
-`AZURE_CLIENT_ID`, so an earlier-tagged release just builds unsigned). It installs
+stays **inert until the secrets exist** (signing is gated on whether
+`AZURE_CLIENT_ID` is set, via a boolean flag — the secret is not in the
+job env — so an earlier-tagged release just builds unsigned). It installs
 `trusted-signing-cli`, writes a `signCommand` config, and Tauri signs the app exe,
 the bundled gateway sidecar, and the NSIS installer during the build (before the
 updater `.sig` is computed, so auto-update keeps working).

--- a/src/test/release-azure-signer-env.test.ts
+++ b/src/test/release-azure-signer-env.test.ts
@@ -78,27 +78,22 @@ describe("release Azure signer env scope (SBS-925)", () => {
     expect(envHasAny(build.env, APPLE_SIGNER_KEYS)).toBe(false);
   });
 
-  it("keeps frontend and signer setup steps free of Azure signer secrets", () => {
-    const names = [
-      "Install dependencies",
-      "Set up Windows code signing (Azure Trusted Signing)",
-      "Cache trusted-signing-cli",
-    ];
-    for (const name of names) {
-      const step = stepByName(build, name);
-      expect(step, name).toBeDefined();
-      expect(envHasAny(step!.env, AZURE_SIGNER_KEYS), name).toBe(false);
-    }
-  });
-
   it("injects Azure signer secrets only on the Windows-gated Build installer step", () => {
     const step = stepByName(build, "Build installer");
     expect(step).toBeDefined();
+    for (const other of build.steps ?? []) {
+      if (other !== step) {
+        expect(envHasAny(other.env, AZURE_SIGNER_KEYS), other.name).toBe(false);
+      }
+    }
     for (const key of AZURE_SIGNER_KEYS) {
       const value = step!.env?.[key];
       expect(value, key).toBeDefined();
-      expect(value, key).toContain("windows-latest");
-      expect(value, key).toContain("secrets." + key);
+      expect(value, key).toMatch(
+        new RegExp(
+          String.raw`^\s*\$\{\{\s*matrix\.os\s*==\s*'windows-latest'\s*&&\s*secrets\.${key}\s*\|\|\s*''\s*\}\}\s*$`,
+        ),
+      );
     }
     for (const key of TAURI_SIGNER_KEYS) {
       expect(step!.env?.[key]).toContain("secrets." + key);

--- a/src/test/release-azure-signer-env.test.ts
+++ b/src/test/release-azure-signer-env.test.ts
@@ -66,14 +66,27 @@ function jobLevelSignerSecrets(job: WorkflowJob): string[] {
   return AZURE_SIGNER_KEYS.filter((k) => envKeys(job.env).includes(k));
 }
 
+function azureValueIsWindowsGated(value: string | undefined, key: string): boolean {
+  return (
+    value !== undefined &&
+    new RegExp(
+      String.raw`^\s*\$\{\{\s*matrix\.os\s*==\s*'windows-latest'\s*&&\s*secrets\.${key}\s*\|\|\s*''\s*\}\}\s*$`,
+    ).test(value)
+  );
+}
+
 const release = parseWorkflow(
   readFileSync(join(process.cwd(), ".github", "workflows", "release.yml"), "utf8"),
 );
-const build = release.jobs!.build;
+const jobs = release.jobs!;
+const build = jobs.build;
+if (!build) throw new Error("release.yml has no build job");
 
 describe("release Azure signer env scope (SBS-925)", () => {
-  it("does not put Azure signer secrets on the build job env", () => {
-    expect(jobLevelSignerSecrets(build)).toEqual([]);
+  it("does not put Azure signer secrets on any job env", () => {
+    for (const [jobName, job] of Object.entries(jobs)) {
+      expect(jobLevelSignerSecrets(job), jobName).toEqual([]);
+    }
     expect(envHasAny(build.env, TAURI_SIGNER_KEYS)).toBe(false);
     expect(envHasAny(build.env, APPLE_SIGNER_KEYS)).toBe(false);
   });
@@ -81,19 +94,19 @@ describe("release Azure signer env scope (SBS-925)", () => {
   it("injects Azure signer secrets only on the Windows-gated Build installer step", () => {
     const step = stepByName(build, "Build installer");
     expect(step).toBeDefined();
-    for (const other of build.steps ?? []) {
-      if (other !== step) {
-        expect(envHasAny(other.env, AZURE_SIGNER_KEYS), other.name).toBe(false);
+    for (const [jobName, job] of Object.entries(jobs)) {
+      for (const other of job.steps ?? []) {
+        if (other !== step) {
+          expect(
+            envHasAny(other.env, AZURE_SIGNER_KEYS),
+            `${jobName} / ${other.name ?? "unnamed step"}`,
+          ).toBe(false);
+        }
       }
     }
     for (const key of AZURE_SIGNER_KEYS) {
       const value = step!.env?.[key];
-      expect(value, key).toBeDefined();
-      expect(value, key).toMatch(
-        new RegExp(
-          String.raw`^\s*\$\{\{\s*matrix\.os\s*==\s*'windows-latest'\s*&&\s*secrets\.${key}\s*\|\|\s*''\s*\}\}\s*$`,
-        ),
-      );
+      expect(azureValueIsWindowsGated(value, key), key).toBe(true);
     }
     for (const key of TAURI_SIGNER_KEYS) {
       expect(step!.env?.[key]).toContain("secrets." + key);
@@ -103,7 +116,7 @@ describe("release Azure signer env scope (SBS-925)", () => {
   it("keeps APPLE secrets on the macOS signing step only", () => {
     const step = stepByName(build, "Sign + notarize + package (macOS)");
     expect(step).toBeDefined();
-    expect(step!.if).toMatch(/macos/);
+    expect(step!.if).toBe("startsWith(matrix.os, 'macos')");
     for (const key of APPLE_SIGNER_KEYS) {
       expect(step!.env?.[key]).toContain("secrets." + key);
     }
@@ -118,9 +131,13 @@ describe("release Azure signer env scope (SBS-925)", () => {
       "Set up Windows code signing (Azure Trusted Signing)",
     );
     const cache = stepByName(build, "Cache trusted-signing-cli");
-    expect(build.env?.AZURE_SIGNING_CONFIGURED).toContain("secrets.AZURE_CLIENT_ID");
-    expect(setup?.if).toContain("AZURE_SIGNING_CONFIGURED");
-    expect(cache?.if).toContain("AZURE_SIGNING_CONFIGURED");
+    const windowsGate =
+      "matrix.os == 'windows-latest' && env.AZURE_SIGNING_CONFIGURED == 'true'";
+    expect(build.env?.AZURE_SIGNING_CONFIGURED).toBe(
+      "${{ secrets.AZURE_CLIENT_ID != '' }}",
+    );
+    expect(setup?.if).toBe(windowsGate);
+    expect(cache?.if).toBe(windowsGate);
     expect(setup?.env?.AZURE_SIGNING_CONFIGURED).toBeUndefined();
     expect(cache?.env?.AZURE_SIGNING_CONFIGURED).toBeUndefined();
     expect(envHasAny(setup?.env, AZURE_SIGNER_KEYS)).toBe(false);
@@ -149,6 +166,8 @@ describe("the Azure env assertions reject a workflow that reopens the hole", () 
       "jobs:\n  build:\n    steps:\n      - name: Build installer\n        run: echo build\n        env:\n          TAURI_SIGNING_PRIVATE_KEY: x\n",
     );
     const step = stepByName(fixture.jobs!.build, "Build installer");
-    expect(step?.env?.AZURE_CLIENT_SECRET).toBeUndefined();
+    for (const key of AZURE_SIGNER_KEYS) {
+      expect(azureValueIsWindowsGated(step?.env?.[key], key), key).toBe(false);
+    }
   });
 });

--- a/src/test/release-azure-signer-env.test.ts
+++ b/src/test/release-azure-signer-env.test.ts
@@ -1,0 +1,156 @@
+// Pins SBS-925: Azure signer secrets must not sit on the release job env.
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { parse } from "yaml";
+
+const AZURE_SIGNER_KEYS = [
+  "AZURE_TENANT_ID",
+  "AZURE_CLIENT_ID",
+  "AZURE_CLIENT_SECRET",
+] as const;
+const TAURI_SIGNER_KEYS = [
+  "TAURI_SIGNING_PRIVATE_KEY",
+  "TAURI_SIGNING_PRIVATE_KEY_PASSWORD",
+] as const;
+const APPLE_SIGNER_KEYS = [
+  "APPLE_CERTIFICATE",
+  "APPLE_CERTIFICATE_PASSWORD",
+  "APPLE_SIGNING_IDENTITY",
+  "APPLE_PROVISIONING_PROFILE_APP",
+  "APPLE_PROVISIONING_PROFILE_GATEWAY",
+  "APPLE_ID",
+  "APPLE_PASSWORD",
+  "APPLE_TEAM_ID",
+] as const;
+
+interface WorkflowStep {
+  name?: string;
+  if?: string;
+  run?: string;
+  uses?: string;
+  env?: Record<string, string>;
+}
+interface WorkflowJob {
+  env?: Record<string, string>;
+  steps?: WorkflowStep[];
+}
+interface Workflow {
+  jobs?: Record<string, WorkflowJob>;
+}
+
+function parseWorkflow(source: string): Workflow {
+  const workflow = parse(source) as Workflow | null;
+  if (!workflow?.jobs || typeof workflow.jobs !== "object") {
+    throw new Error("workflow has no jobs: block");
+  }
+  return workflow;
+}
+
+function envKeys(env: Record<string, string> | undefined): string[] {
+  return env ? Object.keys(env) : [];
+}
+
+function envHasAny(
+  env: Record<string, string> | undefined,
+  keys: readonly string[],
+): boolean {
+  return keys.some((k) => envKeys(env).includes(k));
+}
+
+function stepByName(job: WorkflowJob, name: string): WorkflowStep | undefined {
+  return (job.steps ?? []).find((s) => s.name === name);
+}
+
+function jobLevelSignerSecrets(job: WorkflowJob): string[] {
+  return AZURE_SIGNER_KEYS.filter((k) => envKeys(job.env).includes(k));
+}
+
+const release = parseWorkflow(
+  readFileSync(join(process.cwd(), ".github", "workflows", "release.yml"), "utf8"),
+);
+const build = release.jobs!.build;
+
+describe("release Azure signer env scope (SBS-925)", () => {
+  it("does not put Azure signer secrets on the build job env", () => {
+    expect(jobLevelSignerSecrets(build)).toEqual([]);
+    expect(envHasAny(build.env, TAURI_SIGNER_KEYS)).toBe(false);
+    expect(envHasAny(build.env, APPLE_SIGNER_KEYS)).toBe(false);
+  });
+
+  it("keeps frontend and signer setup steps free of Azure signer secrets", () => {
+    const names = [
+      "Install dependencies",
+      "Set up Windows code signing (Azure Trusted Signing)",
+      "Cache trusted-signing-cli",
+    ];
+    for (const name of names) {
+      const step = stepByName(build, name);
+      expect(step, name).toBeDefined();
+      expect(envHasAny(step!.env, AZURE_SIGNER_KEYS), name).toBe(false);
+    }
+  });
+
+  it("injects Azure signer secrets only on the Windows-gated Build installer step", () => {
+    const step = stepByName(build, "Build installer");
+    expect(step).toBeDefined();
+    for (const key of AZURE_SIGNER_KEYS) {
+      const value = step!.env?.[key];
+      expect(value, key).toBeDefined();
+      expect(value, key).toContain("windows-latest");
+      expect(value, key).toContain("secrets." + key);
+    }
+    for (const key of TAURI_SIGNER_KEYS) {
+      expect(step!.env?.[key]).toContain("secrets." + key);
+    }
+  });
+
+  it("keeps APPLE secrets on the macOS signing step only", () => {
+    const step = stepByName(build, "Sign + notarize + package (macOS)");
+    expect(step).toBeDefined();
+    expect(step!.if).toMatch(/macos/);
+    for (const key of APPLE_SIGNER_KEYS) {
+      expect(step!.env?.[key]).toContain("secrets." + key);
+    }
+    for (const s of build.steps ?? []) {
+      if (s !== step) expect(envHasAny(s.env, APPLE_SIGNER_KEYS), s.name).toBe(false);
+    }
+  });
+
+  it("gates Windows signing setup on a boolean, not the secret value", () => {
+    const setup = stepByName(
+      build,
+      "Set up Windows code signing (Azure Trusted Signing)",
+    );
+    const cache = stepByName(build, "Cache trusted-signing-cli");
+    expect(setup?.if).toContain("AZURE_SIGNING_CONFIGURED");
+    expect(cache?.if).toContain("AZURE_SIGNING_CONFIGURED");
+    expect(envHasAny(setup?.env, AZURE_SIGNER_KEYS)).toBe(false);
+    expect(envHasAny(cache?.env, AZURE_SIGNER_KEYS)).toBe(false);
+  });
+});
+
+describe("the Azure env assertions reject a workflow that reopens the hole", () => {
+  it("rejects Azure signer secrets on the job env", () => {
+    const fixture = parseWorkflow(
+      "jobs:\n  build:\n    env:\n      AZURE_CLIENT_SECRET: x\n    steps:\n      - run: true\n",
+    );
+    expect(jobLevelSignerSecrets(fixture.jobs!.build)).toEqual(["AZURE_CLIENT_SECRET"]);
+  });
+
+  it("rejects Azure signer secrets on the frontend install step", () => {
+    const fixture = parseWorkflow(
+      "jobs:\n  build:\n    steps:\n      - name: Install dependencies\n        run: echo ci\n        env:\n          AZURE_CLIENT_ID: x\n",
+    );
+    const step = stepByName(fixture.jobs!.build, "Install dependencies");
+    expect(envHasAny(step?.env, AZURE_SIGNER_KEYS)).toBe(true);
+  });
+
+  it("rejects a Build installer step that dropped the Azure signer env", () => {
+    const fixture = parseWorkflow(
+      "jobs:\n  build:\n    steps:\n      - name: Build installer\n        run: echo build\n        env:\n          TAURI_SIGNING_PRIVATE_KEY: x\n",
+    );
+    const step = stepByName(fixture.jobs!.build, "Build installer");
+    expect(step?.env?.AZURE_CLIENT_SECRET).toBeUndefined();
+  });
+});

--- a/src/test/release-azure-signer-env.test.ts
+++ b/src/test/release-azure-signer-env.test.ts
@@ -123,8 +123,11 @@ describe("release Azure signer env scope (SBS-925)", () => {
       "Set up Windows code signing (Azure Trusted Signing)",
     );
     const cache = stepByName(build, "Cache trusted-signing-cli");
+    expect(build.env?.AZURE_SIGNING_CONFIGURED).toContain("secrets.AZURE_CLIENT_ID");
     expect(setup?.if).toContain("AZURE_SIGNING_CONFIGURED");
     expect(cache?.if).toContain("AZURE_SIGNING_CONFIGURED");
+    expect(setup?.env?.AZURE_SIGNING_CONFIGURED).toBeUndefined();
+    expect(cache?.env?.AZURE_SIGNING_CONFIGURED).toBeUndefined();
     expect(envHasAny(setup?.env, AZURE_SIGNER_KEYS)).toBe(false);
     expect(envHasAny(cache?.env, AZURE_SIGNER_KEYS)).toBe(false);
   });


### PR DESCRIPTION
## Summary

- Release build job no longer puts AZURE_TENANT_ID / AZURE_CLIENT_ID / AZURE_CLIENT_SECRET on the job env, so the frontend install (and cargo install of the signer) cannot read them.
- GitHub forbids secrets in steps.if, so the Windows cache/setup steps gate on a boolean presence flag (AZURE_SIGNING_CONFIGURED). The real values are injected only on Build installer, and only when matrix.os is windows-latest.
- Ticket suggested also putting the secrets on Set up Windows code signing. That step runs cargo install; this PR keeps secrets off it. Setup only writes the signCommand config.

A compromised frontend install script on a release runner now sees no Azure signer env. Windows tauri build still gets the vars for trusted-signing-cli / DefaultAzureCredential.

## Test plan

- Parsed-workflow test in src/test/release-azure-signer-env.test.ts
- Test fails against origin/main workflow (job-level signer env present)
- format:check clean; lint 0 errors / 50 pre-existing warnings; 414 tests passed; tsc clean
- Cannot fire a real release or confirm live Azure signing

## Pattern sweep

Searched .github/workflows for secrets.

- release.yml: this ticket. TAURI already on Build installer. APPLE already on the macOS sign step.
- ci.yml: no secrets; persist-credentials false. No change.
- docker-publish.yml: GITHUB_TOKEN is a login-action input, not job env. No frontend install. No change.
- winget.yml: job-level WINGET_TOKEN, but no install-script step. Token is the empty-secret gate. Listed, not fixed (one ticket).
- audit.yml: no secrets. No change.
- pr-review.yml: FIND2 key is a step input. No change.

## Gaps

- No actionlint job in this repo.
- Cannot tag a release or watch Windows signing succeed.
- Did not run Rust tests or vite build; this is a YAML + vitest change.
- WINGET_TOKEN remains job-scoped (no install-script step).
- Azure env on Build installer is an empty string on macOS/Linux rather than omitted.

Not merged. Issue left In Progress.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Scope Azure Trusted Signing secrets to the Windows build installer step in CI
> - Removes Azure signer secrets (`AZURE_TENANT_ID`, `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET`) from the job-level `env` in [release.yml](.github/workflows/release.yml) so they are never present during the frontend install phase.
> - Introduces a boolean flag `AZURE_SIGNING_CONFIGURED` (derived from secret presence) to gate Windows signing setup steps instead of checking the secret value directly.
> - Injects Azure secrets only on the `Build installer` step, conditionally scoped to Windows runners via matrix expressions.
> - Adds a Vitest suite in [release-azure-signer-env.test.ts](src/test/release-azure-signer-env.test.ts) that parses the workflow YAML and fails if Azure secrets appear at the job level or outside the intended step.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3288f3f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->