### PR TITLE
fix(security): bound downstream stderr drain (SBS-930)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ Entries before the rename below shipped under the project's former name, Conduit
 
 ## [Unreleased]
 
+### Security
+
+- **Downstream stderr drain no longer grows without bound on a newline-less write.**
+  Stdout was already capped at 16 MiB per line; stderr still used unbounded
+  `read_line` and only trimmed the kept tail afterwards. A hostile or buggy
+  stdio server that wrote a multi-GB chunk with no newline could OOM the
+  gateway and take every HTTP-bridge client with it. The drain now uses the
+  same `take(MAX_RESPONSE_BYTES)` bound as stdout and stops on an unterminated
+  full-cap line. (SBS-930)
+
 ### Removed
 
 - **Toolport Studio is no longer a supported client.** The project is discontinued, so

--- a/src-tauri/src/downstream.rs
+++ b/src-tauri/src/downstream.rs
@@ -837,14 +837,24 @@ const STDERR_TAIL_CAP: usize = 4096;
 /// MCP responses are tiny.
 const MAX_RESPONSE_BYTES: u64 = 16 * 1024 * 1024;
 
-/// Bound a `read_line` so a newline-less write cannot grow `line` without
+/// Bound a line read so a newline-less write cannot grow `line` without
 /// limit. Same cap and stop rule as the stdout drain (SBS-930).
 fn read_capped_line<R: BufRead>(
     reader: &mut R,
     line: &mut String,
     max_bytes: u64,
 ) -> std::io::Result<usize> {
-    reader.take(max_bytes).read_line(line)
+    let mut bytes = Vec::new();
+    let n = reader.take(max_bytes).read_until(b'\n', &mut bytes)?;
+    let decoded = String::from_utf8_lossy(&bytes);
+    let mut keep = decoded
+        .len()
+        .min(usize::try_from(max_bytes).unwrap_or(usize::MAX));
+    while !decoded.is_char_boundary(keep) {
+        keep -= 1;
+    }
+    line.push_str(&decoded[..keep]);
+    Ok(n)
 }
 
 fn is_unterminated_capped_line(n: usize, line: &str, max_bytes: u64) -> bool {
@@ -858,7 +868,10 @@ fn append_stderr_tail(buf: &Mutex<String>, line: &str, tail_cap: usize) {
     if let Ok(mut guard) = buf.lock() {
         guard.push_str(line);
         if guard.len() > tail_cap {
-            let cut = guard.len() - tail_cap;
+            let mut cut = guard.len() - tail_cap;
+            while !guard.is_char_boundary(cut) {
+                cut += 1;
+            }
             guard.drain(..cut);
         }
     }
@@ -887,6 +900,9 @@ fn drain_stderr_bounded<R: BufRead>(
                 max_line = max_line.max(line.len());
                 append_stderr_tail(buf, &line, tail_cap);
                 if is_unterminated_capped_line(n, &line, read_cap) {
+                    eprintln!(
+                        "toolport: downstream emitted an unterminated stderr line >= {read_cap} bytes; stopping stderr drain"
+                    );
                     break;
                 }
             }
@@ -11789,6 +11805,33 @@ mod tests {
         let kept = buf.lock().unwrap();
         assert!(kept.len() <= 16, "kept tail grew to {}", kept.len());
         assert!(kept.chars().all(|c| c == 'x'));
+    }
+
+    #[test]
+    fn capped_stderr_keeps_a_utf8_prefix_when_the_cap_splits_a_character() {
+        let payload = "中".repeat(64);
+        let mut reader = std::io::Cursor::new(payload.as_bytes());
+        let buf = Mutex::new(String::new());
+        let max_line = super::drain_stderr_bounded(&mut reader, &buf, 64, 16);
+
+        assert!(max_line <= 64);
+        assert_eq!(reader.position(), 64);
+        let kept = buf.lock().unwrap();
+        assert!(!kept.is_empty());
+        assert!(kept.len() <= 16);
+        assert!(kept.chars().all(|c| c == '中'));
+    }
+
+    #[test]
+    fn stderr_tail_trimming_stays_on_a_utf8_boundary() {
+        let buf = Mutex::new(String::new());
+        let line = format!("é{}", "x".repeat(4095));
+
+        super::append_stderr_tail(&buf, &line, 4096);
+
+        let kept = buf.lock().unwrap();
+        assert!(kept.len() <= 4096);
+        assert_eq!(kept.as_str(), "x".repeat(4095));
     }
 
     /// Ordinary newline-terminated stderr still lands in the tail, and a chatty

--- a/src-tauri/src/downstream.rs
+++ b/src-tauri/src/downstream.rs
@@ -836,6 +836,66 @@ const STDERR_TAIL_CAP: usize = 4096;
 /// or broken server can't stream gigabytes to exhaust gateway memory. Generous: real
 /// MCP responses are tiny.
 const MAX_RESPONSE_BYTES: u64 = 16 * 1024 * 1024;
+
+/// Bound a `read_line` so a newline-less write cannot grow `line` without
+/// limit. Same cap and stop rule as the stdout drain (SBS-930).
+fn read_capped_line<R: BufRead>(
+    reader: &mut R,
+    line: &mut String,
+    max_bytes: u64,
+) -> std::io::Result<usize> {
+    reader.take(max_bytes).read_line(line)
+}
+
+fn is_unterminated_capped_line(n: usize, line: &str, max_bytes: u64) -> bool {
+    n as u64 >= max_bytes && !line.ends_with('\n')
+}
+
+/// Keep the most recent `tail_cap` bytes of a child's stderr for error
+/// reporting. The *read* that feeds this must itself be bounded; this only
+/// trims what we retain after a line is already in memory.
+fn append_stderr_tail(buf: &Mutex<String>, line: &str, tail_cap: usize) {
+    if let Ok(mut guard) = buf.lock() {
+        guard.push_str(line);
+        if guard.len() > tail_cap {
+            let cut = guard.len() - tail_cap;
+            guard.drain(..cut);
+        }
+    }
+}
+
+/// Drain stderr line-by-line into `buf`. Each read is capped at `read_cap`
+/// (the same `take` stdout uses). An unterminated full-cap line is treated
+/// as abuse / a broken server: we keep the truncated prefix in the tail and
+/// stop, so a multi-GB newline-less write cannot OOM the gateway.
+///
+/// Returns the largest `line` length observed, so tests can prove the
+/// read itself is bounded — `STDERR_TAIL_CAP` alone would hide the leak.
+fn drain_stderr_bounded<R: BufRead>(
+    mut reader: R,
+    buf: &Mutex<String>,
+    read_cap: u64,
+    tail_cap: usize,
+) -> usize {
+    let mut line = String::new();
+    let mut max_line = 0;
+    loop {
+        line.clear();
+        match read_capped_line(&mut reader, &mut line, read_cap) {
+            Ok(0) => break,
+            Ok(n) => {
+                max_line = max_line.max(line.len());
+                append_stderr_tail(buf, &line, tail_cap);
+                if is_unterminated_capped_line(n, &line, read_cap) {
+                    break;
+                }
+            }
+            Err(_) => break,
+        }
+    }
+    max_line
+}
+
 /// Bound paginated MCP catalog traversal so a malicious server cannot keep the
 /// gateway in an infinite cursor chain or grow its in-memory catalog without limit.
 const MAX_LIST_PAGES: usize = 1_000;
@@ -3241,10 +3301,10 @@ impl StdioTransport {
                 // grow this String without limit (a plain `read_line` would). `take`
                 // stops at the cap; a full-cap line with no terminator is a protocol
                 // violation, so we close the connection.
-                match (&mut reader).take(MAX_RESPONSE_BYTES).read_line(&mut line) {
+                match read_capped_line(&mut reader, &mut line, MAX_RESPONSE_BYTES) {
                     Ok(0) => break,
                     Ok(n) => {
-                        if n as u64 >= MAX_RESPONSE_BYTES && !line.ends_with('\n') {
+                        if is_unterminated_capped_line(n, &line, MAX_RESPONSE_BYTES) {
                             eprintln!(
                                 "toolport: downstream emitted an unterminated line >= {MAX_RESPONSE_BYTES} bytes; closing connection"
                             );
@@ -3268,25 +3328,18 @@ impl StdioTransport {
 
         // Drain stderr into a shared buffer, capped so a chatty server can't grow
         // it without bound. We keep the most recent output (where the fatal error
-        // usually is).
+        // usually is). The *read* is bounded the same way as stdout: STDERR_TAIL_CAP
+        // only trims after a line is in memory, so a newline-less write used to
+        // grow `line` without limit (SBS-930).
         let stderr_buf = Arc::new(Mutex::new(String::new()));
         let stderr_writer = Arc::clone(&stderr_buf);
         std::thread::spawn(move || {
-            let mut reader = BufReader::new(stderr);
-            let mut line = String::new();
-            while let Ok(n) = reader.read_line(&mut line) {
-                if n == 0 {
-                    break;
-                }
-                if let Ok(mut buf) = stderr_writer.lock() {
-                    buf.push_str(&line);
-                    if buf.len() > STDERR_TAIL_CAP {
-                        let cut = buf.len() - STDERR_TAIL_CAP;
-                        buf.drain(..cut);
-                    }
-                }
-                line.clear();
-            }
+            drain_stderr_bounded(
+                BufReader::new(stderr),
+                &stderr_writer,
+                MAX_RESPONSE_BYTES,
+                STDERR_TAIL_CAP,
+            );
         });
 
         Ok(StdioTransport {
@@ -11712,5 +11765,40 @@ mod tests {
             &protocol_meta_for("2026-07-28"),
             "declaring nothing must not alter the standard per-request meta"
         );
+    }
+
+    /// SBS-930. `STDERR_TAIL_CAP` only trims the *kept* buffer after `read_line`
+    /// returns. A newline-less write larger than the read cap must stop at the
+    /// cap instead of growing the line String to the full payload. The returned
+    /// max line length is the leak: the kept tail would look fine either way.
+    #[test]
+    fn newline_less_stderr_write_stops_at_the_read_cap() {
+        let payload = vec![b'x'; 1024];
+        let mut reader = std::io::Cursor::new(payload);
+        let buf = Mutex::new(String::new());
+        let max_line = super::drain_stderr_bounded(&mut reader, &buf, 64, 16);
+        assert!(
+            max_line <= 64,
+            "line grew to {max_line} bytes; unbounded read_line would take the full 1024"
+        );
+        assert_eq!(
+            reader.position(),
+            64,
+            "drain must stop at the cap, not slurp the rest of the blob"
+        );
+        let kept = buf.lock().unwrap();
+        assert!(kept.len() <= 16, "kept tail grew to {}", kept.len());
+        assert!(kept.chars().all(|c| c == 'x'));
+    }
+
+    /// Ordinary newline-terminated stderr still lands in the tail, and a chatty
+    /// server is still trimmed to the most recent bytes.
+    #[test]
+    fn stderr_tail_keeps_the_most_recent_bytes() {
+        let reader = std::io::Cursor::new(b"aaaa\nbbbb\ncccc\n");
+        let buf = Mutex::new(String::new());
+        let max_line = super::drain_stderr_bounded(reader, &buf, 1024, 8);
+        assert!(max_line <= 5, "each line is 5 bytes including newline");
+        assert_eq!(buf.lock().unwrap().as_str(), "bb\ncccc\n");
     }
 }

--- a/src-tauri/src/downstream.rs
+++ b/src-tauri/src/downstream.rs
@@ -846,14 +846,19 @@ fn read_capped_line<R: BufRead>(
 ) -> std::io::Result<usize> {
     let mut bytes = Vec::new();
     let n = reader.take(max_bytes).read_until(b'\n', &mut bytes)?;
-    let decoded = String::from_utf8_lossy(&bytes);
-    let mut keep = decoded
-        .len()
-        .min(usize::try_from(max_bytes).unwrap_or(usize::MAX));
-    while !decoded.is_char_boundary(keep) {
-        keep -= 1;
-    }
-    line.push_str(&decoded[..keep]);
+    let decoded = match std::str::from_utf8(&bytes) {
+        Ok(text) => std::borrow::Cow::Borrowed(text),
+        // `take` may split a valid multi-byte character exactly at the raw-byte cap. Drop only
+        // that incomplete suffix; genuinely invalid bytes are retained lossily below.
+        Err(error) if error.error_len().is_none() => std::borrow::Cow::Borrowed(
+            std::str::from_utf8(&bytes[..error.valid_up_to()])
+                .expect("valid_up_to is always valid UTF-8"),
+        ),
+        Err(_) => String::from_utf8_lossy(&bytes),
+    };
+    // The raw read is capped. Lossy decoding may expand invalid bytes to U+FFFD, so capping this
+    // decoded length again would be both unnecessary and capable of dropping a real newline.
+    line.push_str(&decoded);
     Ok(n)
 }
 
@@ -11820,6 +11825,21 @@ mod tests {
         assert!(!kept.is_empty());
         assert!(kept.len() <= 16);
         assert!(kept.chars().all(|c| c == '中'));
+    }
+
+    #[test]
+    fn capped_line_keeps_newline_after_lossy_utf8_expansion() {
+        let mut reader = std::io::Cursor::new([0xff, 0xff, 0xff, 0xff, b'\n']);
+        let mut line = String::new();
+
+        let n = super::read_capped_line(&mut reader, &mut line, 5).unwrap();
+
+        assert_eq!(n, 5);
+        assert!(line.ends_with('\n'), "lossy decoding must preserve the raw terminator");
+        assert!(
+            !super::is_unterminated_capped_line(n, &line, 5),
+            "a newline-terminated raw line must not be rejected as unterminated"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Why

Downstream stdio stderr drain used unbounded `read_line`. Stdout was already capped at `MAX_RESPONSE_BYTES` (16 MiB) so a newline-less multi-GB line cannot grow the String. The stderr thread still called `BufReader::read_line` with no `take()`. `STDERR_TAIL_CAP` (4 KiB) only trims the *kept* buffer *after* the full line is in memory, so one unterminated stderr write can OOM the gateway. HTTP-bridge mode then kills every client.

SBS-930. Audited at `34b1aee`.

A user whose stdio MCP server (buggy package or hostile) writes a huge stderr blob with no newline no longer OOMs the gateway. The drain stops at 16 MiB, keeps the last 4 KiB of what it did read, and the process stays up.

## Change

Reuse the same `take(MAX_RESPONSE_BYTES)` bound stdout already uses. Extracted `read_capped_line` / `is_unterminated_capped_line` so stdout and stderr share one cap and one stop rule. The stderr thread now calls `drain_stderr_bounded`, which:

- reads through `take(read_cap)` so `line` cannot grow past the cap
- still trims the kept tail to `STDERR_TAIL_CAP`
- stops on an unterminated full-cap line (same as stdout closing the connection)

Did not invent a second cap. Did not move `read_bounded_line` out of the gateway binary: that helper drains the rest of an oversized frame so the caller can continue; stderr stops, matching stdout.

## Pattern sweep

Searched with `rg -n read_line --type rust`.

Hits after this change:

- `downstream.rs` stdout drain: already bounded; now shares `read_capped_line`
- `downstream.rs` stderr drain: this fix
- `downstream.rs` SSE `read_sse_stream`: reader is already `take(MAX_RESPONSE_BYTES + 1)`
- `downstream.rs` `subscriptions/listen`: already `take(MAX_RESPONSE_BYTES).read_line`
- `toolport-gateway.rs:3903` HITL approval broker reply: loopback to our own desktop approval endpoint. Pass 12 noted this. Left as-is: the peer is our process, not an untrusted downstream. Not GH-736.
- `toolport-gateway.rs:6031` suggestion reply: same loopback broker. Left as-is.
- `toolport-gateway.rs:15600` / `19640`: test helpers
- `spec_conformance.rs:105`: test
- `downstream.rs:2776`: comment only
- `toolport-gateway.rs` `read_bounded_line`: upstream client stdio; already bounded

Did not expand into GH-736 (HTTP stop).

## Test

Required CI rust jobs:
- Clippy: cargo clippy --no-default-features --lib --bins — exit 0 (pre-existing warnings only; none in this diff)
- Headless rust: cargo test --no-default-features --lib --bins --tests — lib 1108 passed (incl. both new tests), gateway 333 passed, integration tests passed

Could not run the desktop-feature rust suite here (needs WebKitGTK). rustfmt clean on downstream.rs.

New tests actually ran: newline_less_stderr_write_stops_at_the_read_cap ok, and stderr_tail_keeps_the_most_recent_bytes ok.

### Fail without the fix

Reverted only read_capped_line to unbounded read_line. The new test failed:

line grew to 1024 bytes; unbounded read_line would take the full 1024
test result: FAILED. 0 passed; 1 failed

The kept-tail assertion would have passed either way. The max-line-length assertion is the leak. Restored take() after.

## What this makes more likely

- Stopping the stderr drain on a 16 MiB unterminated write means we stop collecting further stderr. A later real error line after a huge blob is missed. Same tradeoff as stdout closing the connection.
- The child may block if the OS pipe fills after we stop reading. The gateway now survives instead of OOM.
- Peak memory is now 16 MiB for the line plus 4 KiB tail, not unbounded. A hostile server can still force one 16 MiB allocation per drain. Same as stdout.

## Gaps

- Did not run desktop-feature rust suite (WebKitGTK not on this box).
- Did not spawn a 16 MiB child process; the helper is the production drain, tested with a 64-byte cap.
- Left HITL / suggestion loopback read_line (see sweep).
- Did not expand into GH-736.
- Did not change subscriptions/listen or SSE (already bounded).
- src-tauri/target deleted after tests. No audit ledgers.

Not merged.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bound downstream stderr drain to prevent unbounded growth from newline-less writes
> - Introduces `drain_stderr_bounded` in [`downstream.rs`](https://github.com/tsouth89/toolport/pull/801/files#diff-920fdf1b1d5b155e925a542634d5b599e0e7b1b32319d2349f19f1886a245489), which caps each stderr read at `MAX_RESPONSE_BYTES` and stops draining when an unterminated line hits the cap.
> - Adds `read_capped_line` and `is_unterminated_capped_line` helpers, replacing the inline unbounded `read_line` loop in both the stdout and stderr drain threads.
> - Adds `append_stderr_tail` to trim the retained tail buffer at UTF-8 character boundaries, preventing cuts in the middle of multibyte characters.
> - Behavioral Change: the stderr drain now halts and logs an error when a newline-less write reaches the read cap, rather than reading indefinitely.
>
> #### 🖇️ Linked Issues
> Fixes [SBS-930](https://linear.app/southboundsoftware/issue/SBS-930).
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #801 opened
>
> - Rewrote UTF-8 decoding and capping logic in `read_capped_line` function [74fb35f]
> - Added unit test `capped_line_keeps_newline_after_lossy_utf8_expansion` [74fb35f]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0d7a74f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->