### PR TITLE
fix(metrics): skip HITL and routine rows in call aggregators (SBS-932)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ Entries before the rename below shipped under the project's former name, Conduit
 
 ## [Unreleased]
 
+### Fixed
+
+- **HITL and routine audit rows no longer count as successful tool calls.**
+  Prometheus `toolport_tool_calls_total`, Activity "calls logged", and team
+  showback `calls` treated every `audit.jsonl` line as a routed call and a
+  missing `ok` as success. An approved human-approval gate writes a
+  `kind:approval` decision (`ok:true` on purpose, so a deny stays out of the
+  error rate) plus the timed exec, so one approval showed as two successful
+  calls. Advisor / suggestion / candidate lines omit `ok` and were counted as
+  successes while the Activity list painted them as failures. Aggregators now
+  require `ok` to be present and skip `kind` in {approval, routine, advisor,
+  suggestion, candidate}. (SBS-932)
+
 ### Removed
 
 - **Toolport Studio is no longer a supported client.** The project is discontinued, so

--- a/src-tauri/src/audit.rs
+++ b/src-tauri/src/audit.rs
@@ -712,6 +712,23 @@ pub fn read_all() -> std::io::Result<Vec<Value>> {
         .collect())
 }
 
+/// Outcome of a routed tool-call audit row.
+///
+/// `None` means this line is not a tool call and must not increment call or
+/// success counters (SBS-932):
+/// - a missing `ok` is unknown, not success (advisor / suggestion / candidate
+///   writers omit the field)
+/// - `kind` in {approval, routine, advisor, suggestion, candidate} is a
+///   governance or routine row, even when `ok` is present (`ok:true` on
+///   approval is intentional so a deny stays out of the error-rate numerator)
+pub fn tool_call_ok(entry: &Value) -> Option<bool> {
+    let ok = entry.get("ok").and_then(Value::as_bool)?;
+    match entry.get("kind").and_then(Value::as_str) {
+        Some("approval" | "routine" | "advisor" | "suggestion" | "candidate") => None,
+        _ => Some(ok),
+    }
+}
+
 /// Aggregate the FULL retained log into per-server stats plus global totals: call volume,
 /// error rate, and latency per server, computed locally. Totals are the real count of what's
 /// retained (the byte cap bounds it), not a fixed window, so the error rate stays consistent
@@ -747,9 +764,11 @@ fn aggregate(entries: &[Value]) -> Value {
     let mut errors = 0u64;
 
     for e in entries {
+        let Some(ok) = tool_call_ok(e) else {
+            continue;
+        };
         let server = e.get("server").and_then(|v| v.as_str()).unwrap_or("?");
         let tool = e.get("tool").and_then(|v| v.as_str()).unwrap_or("?");
-        let ok = e.get("ok").and_then(|v| v.as_bool()).unwrap_or(true);
         let ts = e.get("ts").and_then(|v| v.as_u64()).unwrap_or(0);
         let dur = e.get("durationMs").and_then(|v| v.as_u64());
 
@@ -1135,6 +1154,54 @@ mod tests {
         assert_eq!(s["total"], 0);
         assert_eq!(s["errorRate"], 0.0);
         assert_eq!(s["servers"].as_array().unwrap().len(), 0);
+    }
+
+    /// HITL / routine rows must not inflate Activity "calls logged" or the
+    /// error-rate denominator. Missing `ok` is unknown, not success (SBS-932).
+    #[test]
+    fn aggregate_skips_hitl_and_omitted_ok_rows() {
+        let entries = vec![
+            json!({"server":"github","tool":"list","ok":true,"ts":10,"durationMs":8}),
+            json!({"server":"github","tool":"wipe","ok":true,"kind":"approval","decision":"denied","held":true,"ts":20}),
+            json!({"server":"github","tool":"wipe","ok":true,"kind":"approval","decision":"approved","held":false,"ts":30}),
+            json!({"server":"github","tool":"wipe","ok":true,"ts":31,"durationMs":12}),
+            json!({"server":"toolport","tool":"routine.advisor.hint_shown","kind":"routine","action":"hint_shown","ts":40}),
+            json!({"server":"github","tool":"get","ok":false,"ts":50,"durationMs":4}),
+        ];
+        let s = aggregate(&entries);
+        // Two successful timed calls + one failed timed call. Approval pair and
+        // the omitted-ok hint are not tool calls.
+        assert_eq!(s["total"], 3);
+        assert_eq!(s["errors"], 1);
+        assert_eq!(s["servers"][0]["calls"], 3);
+        assert_eq!(s["servers"][0]["errors"], 1);
+        assert!(s["servers"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .all(|row| row["server"] != "toolport"));
+    }
+
+    #[test]
+    fn tool_call_ok_treats_missing_ok_and_hitl_kinds_as_not_a_call() {
+        assert_eq!(tool_call_ok(&json!({"ok":true})), Some(true));
+        assert_eq!(tool_call_ok(&json!({"ok":false})), Some(false));
+        assert_eq!(tool_call_ok(&json!({"tool":"hint"})), None);
+        assert_eq!(
+            tool_call_ok(&json!({"ok":true,"kind":"approval","decision":"denied"})),
+            None
+        );
+        assert_eq!(
+            tool_call_ok(&json!({"ok":true,"kind":"routine","action":"save"})),
+            None
+        );
+        for kind in ["advisor", "suggestion", "candidate"] {
+            assert_eq!(
+                tool_call_ok(&json!({"ok":true,"kind":kind})),
+                None,
+                "kind {kind} is not a tool call"
+            );
+        }
     }
 
     #[test]

--- a/src-tauri/src/metrics.rs
+++ b/src-tauri/src/metrics.rs
@@ -40,6 +40,9 @@ pub fn render_from_parts(entries: &[Value], tokens_saved: u64, quarantined_tools
     let mut dur_count: BTreeMap<(String, String), u64> = BTreeMap::new();
 
     for e in entries {
+        let Some(ok) = crate::audit::tool_call_ok(e) else {
+            continue;
+        };
         let server = e
             .get("server")
             .and_then(Value::as_str)
@@ -56,7 +59,6 @@ pub fn render_from_parts(entries: &[Value], tokens_saved: u64, quarantined_tools
             .filter(|c| !c.is_empty())
             .unwrap_or("")
             .to_string();
-        let ok = e.get("ok").and_then(Value::as_bool).unwrap_or(true);
         *calls
             .entry((server.clone(), tool.clone(), client.clone(), ok))
             .or_insert(0) += 1;
@@ -179,6 +181,37 @@ mod tests {
         assert!(text.contains("toolport_tokens_saved_total 42"));
         assert!(text.contains("toolport_quarantined_tools 1"));
         assert!(text.contains("# TYPE toolport_tool_calls_total counter"));
+    }
+
+    /// An approved HITL writes decision + timed (2x). The decision is `ok:true`
+    /// on purpose; it still must not increment successful tool calls. An
+    /// advisor row that omits `ok` is unknown, not success (SBS-932).
+    #[test]
+    fn render_skips_hitl_and_omitted_ok_rows() {
+        let entries = vec![
+            json!({"server":"s1","tool":"echo","ok":true,"durationMs":10,"client":"web"}),
+            json!({"server":"s1","tool":"wipe","ok":true,"kind":"approval","decision":"denied","held":true,"client":"web"}),
+            json!({"server":"s1","tool":"wipe","ok":true,"kind":"approval","decision":"approved","held":false,"client":"web"}),
+            json!({"server":"s1","tool":"wipe","ok":true,"durationMs":15,"client":"web"}),
+            json!({"server":"toolport","tool":"routine.advisor.hint_shown","kind":"routine","action":"hint_shown"}),
+        ];
+        let text = render_from_parts(&entries, 0, 0);
+        assert!(text.contains(
+            r#"toolport_tool_calls_total{server="s1",tool="echo",client="web",ok="true"} 1"#
+        ));
+        assert!(text.contains(
+            r#"toolport_tool_calls_total{server="s1",tool="wipe",client="web",ok="true"} 1"#
+        ));
+        assert!(!text.contains(r#"tool="routine.advisor.hint_shown""#));
+        assert!(!text.contains(r#"ok="true"} 2"#));
+        // HITL deny is not a confirm-destructive hold.
+        assert!(!text.contains("toolport_held_calls_total{"));
+        assert!(text.contains(
+            r#"toolport_tool_call_duration_milliseconds_count{server="s1",tool="echo"} 1"#
+        ));
+        assert!(text.contains(
+            r#"toolport_tool_call_duration_milliseconds_count{server="s1",tool="wipe"} 1"#
+        ));
     }
 
     #[test]

--- a/src-tauri/src/usage_report.rs
+++ b/src-tauri/src/usage_report.rs
@@ -66,11 +66,13 @@ pub(crate) fn civil_from_days(z: i64) -> (i64, u32, u32) {
 /// only `team_servers`. Pure so the math is testable without touching disk; the
 /// caller feeds it the on-disk lines (see `teams::report_usage`).
 ///
-/// Calls count every routed attempt, failed ones included: the dashboard figure
-/// is "tool calls routed through the gateway", and a failed downstream call was
-/// still routed. Savings lines carry a `byServer` token map (new format); lines
-/// without one (pre-attribution builds, rotation carry lines) still count in the
-/// in-app total but can't be placed per server, so they are skipped here.
+/// Calls count every routed tool-call attempt, failed ones included: the
+/// dashboard figure is "tool calls routed through the gateway", and a failed
+/// downstream call was still routed. HITL / routine rows and lines that omit
+/// `ok` are not tool calls (SBS-932). Savings lines carry a `byServer` token
+/// map (new format); lines without one (pre-attribution builds, rotation carry
+/// lines) still count in the in-app total but can't be placed per server, so
+/// they are skipped here.
 pub fn rollup(
     day: &str,
     audit_lines: &[Value],
@@ -84,6 +86,9 @@ pub fn rollup(
             .is_some_and(|ts| utc_day(ts) == day)
     };
     for e in audit_lines.iter().filter(|e| ts_day(e)) {
+        if crate::audit::tool_call_ok(e).is_none() {
+            continue;
+        }
         let Some(server) = e.get("server").and_then(Value::as_str) else {
             continue;
         };
@@ -143,6 +148,30 @@ mod tests {
         let rows = rollup("2026-07-08", &audit, &[], &team(&["github", "stripe"]));
         assert_eq!(rows.len(), 1);
         assert_eq!(rows["github"], Row { calls: 2, tokens_saved: 0 });
+    }
+
+    /// Approval rows are `ok:true` by design; an omitted-ok advisor is not
+    /// success. Neither may increment team showback `calls` (SBS-932).
+    #[test]
+    fn rollup_skips_hitl_and_omitted_ok_rows() {
+        let audit = vec![
+            json!({ "ts": TS_A, "server": "github", "tool": "list", "ok": true }),
+            json!({ "ts": TS_A, "server": "github", "tool": "wipe", "ok": true, "kind": "approval", "decision": "denied" }),
+            json!({ "ts": TS_A, "server": "github", "tool": "wipe", "ok": true, "kind": "approval", "decision": "approved" }),
+            json!({ "ts": TS_B, "server": "github", "tool": "wipe", "ok": true }),
+            json!({ "ts": TS_B, "server": "github", "tool": "routine.advisor.hint_shown", "kind": "routine" }),
+            json!({ "ts": TS_B, "server": "github", "tool": "get", "ok": false }),
+        ];
+        let rows = rollup("2026-07-08", &audit, &[], &team(&["github"]));
+        // timed success + approved-pair timed + failed timed. Not the two
+        // approval rows or the omitted-ok hint.
+        assert_eq!(
+            rows["github"],
+            Row {
+                calls: 3,
+                tokens_saved: 0
+            }
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Prometheus `toolport_tool_calls_total`, Activity calls-logged, and team showback `calls` treated every `audit.jsonl` line as a routed tool call and a missing `ok` as success.
- An approved HITL gate writes `kind:approval` (`ok:true` on purpose, so a deny stays out of the error-rate numerator) plus the timed exec, so one approval showed as two successful calls. A deny showed as one successful routed call.
- Advisor / suggestion / candidate rows omit `ok`. Metrics counted them as success; the Activity list painted them as a red X.
- `audit::tool_call_ok` now requires `ok` to be a bool and returns `None` for `kind` in {approval, routine, advisor, suggestion, candidate}. `metrics::render_from_parts`, `audit::aggregate`, and `usage_report::rollup` skip those rows.

A user who looks at metrics after one HITL approval now sees one successful tool call (the timed exec), not two. The approval decision still appears in the Activity list.

Fixes SBS-932


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Skip HITL and routine rows in audit call aggregators
> - Introduces `audit.tool_call_ok` in [audit.rs](https://github.com/tsouth89/toolport/pull/802/files#diff-853a8e9a7f76700c4050b1c24c17426ec0f3ae9ba14b4dec35d0f7a5ecc91dd1) as a shared helper that returns `None` for entries with no `ok` field or with `kind` in `{approval, routine, advisor, suggestion, candidate}`, and `Some(bool)` otherwise.
> - Updates the aggregation loop in `audit.aggregate`, the Prometheus renderer in `metrics.render_from_parts`, and the team showback rollup in `usage_report.rollup` to skip any entry where `tool_call_ok` returns `None`.
> - Behavioral Change: entries previously counted as successful tool calls when `ok` was absent are now excluded from all totals, error rates, and duration metrics.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0aefd4b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->