### PR TITLE
fix(packaging): pin Homebrew cask snapshot to 1.14.0 (SBS-936)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ Entries before the rename below shipped under the project's former name, Conduit
 
 ## [Unreleased]
 
+### Fixed
+
+- **Homebrew cask snapshot was three releases behind.** `packaging/homebrew/toolport.rb`
+  still said 1.11.0 after 1.14.0 shipped, and `docs/RELEASING.md` had no tap-bump
+  step, so the next release would leave `brew install --cask tsouth89/toolport/toolport`
+  stale again. The snapshot now matches 1.14.0 (sha256s from the published dmgs)
+  and the release doc names `tsouth89/homebrew-toolport`. The live tap is a
+  separate repo; bumping it is that step, not this file. (SBS-936)
+
 ### Removed
 
 - **Toolport Studio is no longer a supported client.** The project is discontinued, so

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -13,6 +13,10 @@ Releases are built by CI on a version tag (`.github/workflows/release.yml`).
      `packaging/agent-plugin/toolport/.claude-plugin/plugin.json` (`version`) —
      a vitest check (`src/test/agent-plugin.test.ts`) fails CI if these drift
      from `package.json`
+   - `packaging/homebrew/toolport.rb` (`version` + both dmg `sha256`s) — a
+     vitest check (`src/test/homebrew-cask.test.ts`) fails CI if the version
+     drifts from `package.json`. This file is a snapshot; `brew install` reads
+     the live tap, not this copy (see Homebrew tap below)
    - `CHANGELOG.md` — move `[Unreleased]` entries into a dated section
    - `server.json` only when publishing a matching standalone gateway package
    - `scripts/install.ps1` / `scripts/install.sh` only if you changed them, in which
@@ -52,6 +56,45 @@ in all three files, plus `InstallerUrl`, `InstallerSha256`, `ReleaseDate` and
 shipped, so submitting it unchanged re-submits that version's metadata and the new
 release never reaches winget. Check it with `winget validate --manifest <dir>`
 before opening the PR.
+
+Publishing is also when the **Homebrew tap** must be bumped. There is no
+workflow for this next to `winget.yml` (SBS-260 is the backlog for automating
+it). `brew install --cask tsouth89/toolport/toolport` and
+`brew upgrade --cask toolport` install the version + sha256 pinned in
+[`tsouth89/homebrew-toolport`](https://github.com/tsouth89/homebrew-toolport)
+`Casks/toolport.rb`. The `livecheck` / `github_latest` block in that cask only
+feeds `brew livecheck`; it does not move the pin. The copy at
+`packaging/homebrew/toolport.rb` in this repo is a snapshot `brew install` does
+not read.
+
+After the GitHub release is **published** (the `.dmg` URLs 404 while the
+release is still a draft, same reason `winget.yml` waits for `released`):
+
+```bash
+# Hashes must come from the published assets. Do not reuse the previous
+# release's sha256, and do not invent one. Verified for v1.14.0: GitHub's
+# asset digest matched sha256sum of the downloaded dmgs.
+gh release download vX.Y.Z --repo tsouth89/toolport --pattern 'Toolport_*apple-darwin.dmg'
+sha256sum Toolport_aarch64-apple-darwin.dmg Toolport_x86_64-apple-darwin.dmg
+```
+
+Then in `tsouth89/homebrew-toolport` `Casks/toolport.rb` (and the snapshot
+here):
+
+1. Set `version` to the tag without the `v`.
+2. Set the `on_arm` sha256 to the `Toolport_aarch64-apple-darwin.dmg` digest.
+3. Set the `on_intel` sha256 to the `Toolport_x86_64-apple-darwin.dmg` digest.
+4. Keep both zap roots: `~/Library/Application Support/Conduit` (legacy
+   installs that have not migrated) and `~/Library/Application Support/Toolport`
+   (current `data_dir_leaf_name` in `src-tauri/src/brand.rs`). Cache/pref zap
+   paths stay `com.tsout.conduit` because the bundle id is intentionally
+   unchanged.
+5. Open a PR on the tap. `brew install` keeps serving the old pin until that
+   change is on the tap's default branch.
+
+`src/test/homebrew-cask.test.ts` fails CI if the in-repo snapshot version
+drifts from `package.json`, so a release bump that skips this file is loud.
+It cannot see the live tap; that is this checklist.
 
 The **gateway container image** (`ghcr.io/tsouth89/toolport-gateway`) publishes
 separately on every push to `main` via `docker-publish.yml` — no tag required.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -13,10 +13,11 @@ Releases are built by CI on a version tag (`.github/workflows/release.yml`).
      `packaging/agent-plugin/toolport/.claude-plugin/plugin.json` (`version`) —
      a vitest check (`src/test/agent-plugin.test.ts`) fails CI if these drift
      from `package.json`
-   - `packaging/homebrew/toolport.rb` (`version` + both dmg `sha256`s) — a
-     vitest check (`src/test/homebrew-cask.test.ts`) fails CI if the version
-     drifts from `package.json`. This file is a snapshot; `brew install` reads
-     the live tap, not this copy (see Homebrew tap below)
+   - `packaging/homebrew/toolport.rb` (`version`; update both dmg `sha256`s
+     after publishing, in the Homebrew tap step below) — a vitest check
+     (`src/test/homebrew-cask.test.ts`) fails CI if the version drifts from
+     `package.json`. This file is a snapshot; `brew install` reads the live
+     tap, not this copy (see Homebrew tap below)
    - `CHANGELOG.md` — move `[Unreleased]` entries into a dated section
    - `server.json` only when publishing a matching standalone gateway package
    - `scripts/install.ps1` / `scripts/install.sh` only if you changed them, in which
@@ -73,9 +74,10 @@ release is still a draft, same reason `winget.yml` waits for `released`):
 ```bash
 # Hashes must come from the published assets. Do not reuse the previous
 # release's sha256, and do not invent one. Verified for v1.14.0: GitHub's
-# asset digest matched sha256sum of the downloaded dmgs.
-gh release download vX.Y.Z --repo tsouth89/toolport --pattern 'Toolport_*apple-darwin.dmg'
-sha256sum Toolport_aarch64-apple-darwin.dmg Toolport_x86_64-apple-darwin.dmg
+# asset digest matched shasum of the downloaded dmgs. --clobber prevents
+# versionless files left by an earlier run from being reused.
+gh release download vX.Y.Z --repo tsouth89/toolport --pattern 'Toolport_*apple-darwin.dmg' --clobber
+shasum -a 256 Toolport_aarch64-apple-darwin.dmg Toolport_x86_64-apple-darwin.dmg
 ```
 
 Then in `tsouth89/homebrew-toolport` `Casks/toolport.rb` (and the snapshot

--- a/packaging/homebrew/toolport.rb
+++ b/packaging/homebrew/toolport.rb
@@ -1,13 +1,13 @@
 cask "toolport" do
-  version "1.11.0"
+  version "1.14.0"
 
   on_arm do
-    sha256 "59688fe3e302a88a61b0c093f734b987390dd7c1d16b02083db92fdeaa95c116"
+    sha256 "ab87135036bade39e8aebcb93988a7319cd85c9b83ae1ffe807d9c108446646f"
     url "https://github.com/tsouth89/toolport/releases/download/v#{version}/Toolport_aarch64-apple-darwin.dmg",
         verified: "github.com/tsouth89/toolport/"
   end
   on_intel do
-    sha256 "5ce884fdc62860d235bc4eee4acd9bf45bfc0573d73706f1c45b92956f096f61"
+    sha256 "593f18d73318f0c6d6d672b9feb83fa59e520741141f07d69ab54e18582eff84"
     url "https://github.com/tsouth89/toolport/releases/download/v#{version}/Toolport_x86_64-apple-darwin.dmg",
         verified: "github.com/tsouth89/toolport/"
   end
@@ -16,8 +16,9 @@ cask "toolport" do
   desc "One local gateway for every MCP server, shared by every AI client"
   homepage "https://toolport.app/"
 
-  # The updater ships new versions in-app; livecheck tracks the GitHub releases so
-  # `brew upgrade` also works for anyone who prefers it.
+  # livecheck reports the latest GitHub tag for `brew livecheck`. brew install
+  # and brew upgrade still use the pinned version + sha256 below. Bump those
+  # on each published release (see docs/RELEASING.md).
   livecheck do
     url :url
     strategy :github_latest
@@ -26,8 +27,12 @@ cask "toolport" do
   app "Toolport.app"
 
   # The gateway is a nested helper the app manages; no separate binaries to link.
+  # Application Support: current leaf is Toolport (brand.rs data_dir_leaf_name);
+  # Conduit remains for installs that have not migrated. Cache/pref paths keep
+  # com.tsout.conduit because the bundle id is intentionally unchanged.
   zap trash: [
     "~/Library/Application Support/Conduit",
+    "~/Library/Application Support/Toolport",
     "~/Library/Caches/com.tsout.conduit",
     "~/Library/HTTPStorages/com.tsout.conduit",
     "~/Library/Preferences/com.tsout.conduit.plist",

--- a/packaging/homebrew/toolport.rb
+++ b/packaging/homebrew/toolport.rb
@@ -17,7 +17,7 @@ cask "toolport" do
   homepage "https://toolport.app/"
 
   # livecheck reports the latest GitHub tag for `brew livecheck`. brew install
-  # and brew upgrade still use the pinned version + sha256 below. Bump those
+  # and brew upgrade still use the pinned version + sha256 above. Bump those
   # on each published release (see docs/RELEASING.md).
   livecheck do
     url :url

--- a/src/test/homebrew-cask.test.ts
+++ b/src/test/homebrew-cask.test.ts
@@ -1,0 +1,62 @@
+// Pins the in-repo Homebrew cask snapshot to package.json so a release
+// bump that forgets packaging/homebrew/toolport.rb fails CI. brew install
+// reads tsouth89/homebrew-toolport, not this file; RELEASING.md is the
+// step that updates the live tap. SBS-936.
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+// Not import.meta.url: under the jsdom environment vitest serves modules from
+// an http:// URL, so file-relative resolution breaks. Vitest's cwd is the repo
+// root (where vite.config.ts lives).
+const repoRoot = process.cwd();
+const cask = readFileSync(join(repoRoot, "packaging", "homebrew", "toolport.rb"), "utf8");
+const releasing = readFileSync(join(repoRoot, "docs", "RELEASING.md"), "utf8");
+const pkg = JSON.parse(readFileSync(join(repoRoot, "package.json"), "utf8")) as {
+  version: string;
+};
+
+const versionMatch = cask.match(/^\s*version\s+"([^"]+)"/m);
+const armSha = cask.match(/on_arm do\s+sha256 "([0-9a-f]{64})"/);
+const intelSha = cask.match(/on_intel do\s+sha256 "([0-9a-f]{64})"/);
+
+describe("homebrew cask snapshot (packaging/homebrew/toolport.rb)", () => {
+  it("stays in version lockstep with package.json", () => {
+    // RELEASING.md bumps this file with the rest; this is the backstop.
+    // The live tap is a different repo and is not visible to CI.
+    expect(versionMatch?.[1]).toBe(pkg.version);
+  });
+
+  it("declares two distinct 64-hex sha256s for on_arm and on_intel", () => {
+    expect(armSha?.[1], "on_arm sha256").toMatch(/^[0-9a-f]{64}$/);
+    expect(intelSha?.[1], "on_intel sha256").toMatch(/^[0-9a-f]{64}$/);
+    expect(armSha?.[1]).not.toBe(intelSha?.[1]);
+  });
+
+  it("zaps both the current Toolport data dir and the legacy Conduit leaf", () => {
+    // brand.rs data_dir_leaf_name is Toolport; legacy_data_dir_leaf_name is
+    // Conduit. Bundle id stays com.tsout.conduit, so cache/pref zap paths
+    // keep that id.
+    expect(cask).toContain("~/Library/Application Support/Toolport");
+    expect(cask).toContain("~/Library/Application Support/Conduit");
+    expect(cask).toContain("~/Library/Caches/com.tsout.conduit");
+  });
+
+  it("points at the published darwin dmgs for this version", () => {
+    expect(cask).toContain(
+      "releases/download/v#{version}/Toolport_aarch64-apple-darwin.dmg",
+    );
+    expect(cask).toContain(
+      "releases/download/v#{version}/Toolport_x86_64-apple-darwin.dmg",
+    );
+  });
+});
+
+describe("RELEASING.md Homebrew tap step", () => {
+  it("names the live tap and the hash-from-assets checklist", () => {
+    expect(releasing).toContain("tsouth89/homebrew-toolport");
+    expect(releasing).toContain("Casks/toolport.rb");
+    expect(releasing).toContain("sha256sum");
+    expect(releasing).toContain("Toolport_*apple-darwin.dmg");
+  });
+});

--- a/src/test/homebrew-cask.test.ts
+++ b/src/test/homebrew-cask.test.ts
@@ -56,7 +56,7 @@ describe("RELEASING.md Homebrew tap step", () => {
   it("names the live tap and the hash-from-assets checklist", () => {
     expect(releasing).toContain("tsouth89/homebrew-toolport");
     expect(releasing).toContain("Casks/toolport.rb");
-    expect(releasing).toContain("sha256sum");
+    expect(releasing).toContain("shasum -a 256");
     expect(releasing).toContain("Toolport_*apple-darwin.dmg");
   });
 });


### PR DESCRIPTION
## Why

The documented `brew install --cask tsouth89/toolport/toolport` ships whatever `tsouth89/homebrew-toolport` `Casks/toolport.rb` pins. That pin was 1.10.0 (2026-07-30). Latest GitHub release is 1.14.0. The in-repo snapshot `packaging/homebrew/toolport.rb` was 1.11.0. `docs/RELEASING.md` had a winget step and no tap step, so the next release would leave brew stale again. SBS-936. Audited at 34b1aee.

A macOS user who follows README Quickest now gets 1.14.0 once the companion tap PR is on the tap default branch. This PR does not change what `brew install` does by itself.

## Change

- `packaging/homebrew/toolport.rb` to 1.14.0. sha256s from the published v1.14.0 dmgs:
  - `Toolport_aarch64-apple-darwin.dmg` `ab87135036bade39e8aebcb93988a7319cd85c9b83ae1ffe807d9c108446646f` (GitHub asset digest == local sha256sum, size 18183962)
  - `Toolport_x86_64-apple-darwin.dmg` `593f18d73318f0c6d6d672b9feb83fa59e520741141f07d69ab54e18582eff84` (same check, size 21023881)
- Zap now includes `~/Library/Application Support/Toolport` (current data_dir_leaf_name) and keeps `Conduit` for unmigrated installs. Cache/pref paths stay `com.tsout.conduit` (bundle id unchanged; read `src-tauri/src/brand.rs`).
- livecheck comment no longer claims `brew upgrade` follows GitHub. It only feeds `brew livecheck`.
- `docs/RELEASING.md` names `tsouth89/homebrew-toolport`, `Casks/toolport.rb`, and the `gh release download` + `sha256sum` checklist I just ran. Snapshot added to the version-bump list.
- `src/test/homebrew-cask.test.ts` fails CI if the snapshot version drifts from `package.json`, or if the tap-step strings leave RELEASING.md.

Companion tap PR: the live pin. This file is not what brew reads.

## Fail without the fix

vitest on unmodified main (cask 1.11.0, RELEASING.md with no tap name):

```
AssertionError: expected '1.11.0' to be '1.14.0'
AssertionError: expected ... to contain '~/Library/Application Support/Toolport'
AssertionError: expected ... to contain 'tsouth89/homebrew-toolport'
Tests  3 failed | 2 passed (5)
```

After the production change: 5 passed.

## Quality gate

Ran the required Linux CI frontend layer from this worktree, Node 24:

- prettier --check . — All matched files use Prettier code style
- eslint src/ — 0 errors, 50 warnings (all pre-existing; none in the new test)
- vitest run — 40 files, 411 tests passed (includes the new 5)
- tsc --noEmit — clean

Did not run cargo clippy, Rust tests, the Vite production build, or the headless smoke. Nothing in those layers changed. This box has no Homebrew, so I did not run brew audit / brew bump-cask-pr.

## Pattern sweep

rg for homebrew / tsouth89/toolport/toolport / packaging/homebrew / bump-cask, excluding target and node_modules.

Documented install paths and why this PR does or does not touch them:

- Live tap tsouth89/homebrew-toolport — this is what brew install reads. Bumped in the companion PR. Not this repo.
- packaging/homebrew/toolport.rb — snapshot only. This PR.
- docs/RELEASING.md — missing tap step. This PR.
- README.md brew command — command is correct; the tap was stale. No README edit.
- scripts/install.sh brew tip — same tip, then downloads GitHub releases/latest and verifies digest. That path already gets 1.14.0. Not this. Live toolport.app/install.sh is pinned via site INSTALL_SCRIPTS_REF (GH-740); not this.
- packaging/winget still 1.13.0 — SBS-903 (1.14.0 first-publish in microsoft/winget-pkgs moderation). winget.yml already exists and documents the retry. Did not expand into SBS-903.
- scripts/install.Tests.* use 1.13.0 fixture URLs — test fixtures, not the live install path. Left alone.
- SBS-260 — auto-bump the cask from the release workflow. Still the right backlog; this PR is the manual step + current pin, not that automation.

## What I did not do

- Did not merge.
- Did not mark SBS-936 Done.
- Did not add a brew workflow (SBS-260).
- Did not bump the winget snapshot (SBS-903).
- Did not change install.sh / the site pin.
- The live tap bump is a separate PR on tsouth89/homebrew-toolport. Until that lands on the tap default branch, brew install still ships 1.10.0.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Pin Homebrew cask `packaging/homebrew/toolport.rb` to version 1.14.0
> - Updates the cask version from 1.11.0 to 1.14.0 with correct arm64 and x86_64 sha256 values for the published dmg assets.
> - Expands the `zap` trash list to include `~/Library/Application Support/Toolport` alongside the existing Conduit path.
> - Adds a Vitest test in [`src/test/homebrew-cask.test.ts`](https://github.com/tsouth89/toolport/pull/803/files#diff-9a01f10b510b8d6f2e5deb7db9a2364a5b79e9951533f4d466d3814218ef0202) that enforces the cask version matches `package.json`, validates distinct sha256s, checks zap paths, and verifies dmg URLs.
> - Expands [`docs/RELEASING.md`](https://github.com/tsouth89/toolport/pull/803/files#diff-8936340d2e7844f9c8b77f67065f4e0c66c738ea4dd3844727002289f6d381cb) with a Homebrew tap publishing section covering sha256 computation and version/sha update steps.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a987d6d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->