### PR TITLE
feat(hooks): agent hook sensor, so Toolport can see native tool calls (SBS-822)

### DIFF
--- a/src-tauri/src/audit.rs
+++ b/src-tauri/src/audit.rs
@@ -4,7 +4,6 @@
 //! This is the artifact the governance/MSP story is built on: a record of which
 //! AI tool invoked which server's tool, and when. Local and append-only.
 
-use std::io::Write;
 use std::path::{Path, PathBuf};
 
 use serde_json::{json, Value};
@@ -572,81 +571,30 @@ fn write_line_at(path: &Path, entry: &Value) {
     write_line_at_with_rotation_hook(path, entry, None);
 }
 
+/// Append one audit line, trimming to [`KEEP_LINES`] once the log passes
+/// [`MAX_AUDIT_BYTES`].
+///
+/// The locked append and the rotation live in [`crate::registry::append_line_locked`],
+/// shared with the agent-hook sensor log so both files keep the same cross-process
+/// guarantees by construction rather than by two copies staying in step (#708,
+/// SBS-868, SBS-869).
 fn write_line_at_with_rotation_hook(
     path: &Path,
     entry: &Value,
     after_snapshot: Option<&mut dyn FnMut()>,
 ) {
-    // Atomic replacement protects readers from partial files, but only this
-    // shared cross-process critical section prevents a stale rotation snapshot
-    // from replacing an append that completed in another gateway.
-    let _lock = match crate::registry::lock_at(path) {
-        Ok(lock) => lock,
-        Err(error) => {
-            eprintln!(
-                "toolport: audit record dropped because the lock for '{}' could not be acquired: {error}",
-                path.display()
-            );
-            return;
-        }
-    };
-    // Owner-only from creation, not from the first rotation onward (SBS-868).
-    let open = || crate::registry::open_append_private(&path);
-    // The registry normally created this directory before any call. Avoid a
-    // redundant create-directory syscall on every append, but retain the
-    // standalone/first-writer behavior by creating it and retrying on NotFound.
-    let mut file = match open() {
-        Ok(file) => file,
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
-            if let Some(parent) = path.parent() {
-                let _ = std::fs::create_dir_all(parent);
-            }
-            match open() {
-                Ok(file) => file,
-                Err(_) => return,
-            }
-        }
-        Err(_) => return,
-    };
-    let line = format!("{entry}\n");
-    if file.write_all(line.as_bytes()).is_err() {
-        return;
+    if let Err(error) = crate::registry::append_line_locked(
+        path,
+        &entry.to_string(),
+        MAX_AUDIT_BYTES,
+        KEEP_LINES,
+        after_snapshot,
+    ) {
+        eprintln!(
+            "toolport: audit record dropped for '{}': {error}",
+            path.display()
+        );
     }
-    // Query size through the handle we already opened instead of reopening the
-    // path for metadata. Drop it before rotation so Windows can atomically
-    // replace the log when the cap is crossed.
-    let size = file.metadata().map(|metadata| metadata.len()).unwrap_or(0);
-    drop(file);
-    rotate_if_large(path, size, after_snapshot);
-}
-
-/// Trim the audit log to its most recent `KEEP_LINES` lines once it exceeds the
-/// size cap, so it stays bounded over months of use. Best-effort: a failure here
-/// never affects the call being logged.
-fn rotate_if_large(path: &Path, size: u64, after_snapshot: Option<&mut dyn FnMut()>) {
-    if size <= MAX_AUDIT_BYTES {
-        return;
-    }
-    if let Ok(content) = std::fs::read_to_string(path) {
-        if let Some(hook) = after_snapshot {
-            hook();
-        }
-        let trimmed = trimmed_tail(&content, KEEP_LINES);
-        // Atomic + unique temp: every client's gateway shares this file, so a
-        // bespoke fixed temp name could let two rotations collide.
-        let _ = crate::registry::atomic_write(path, &trimmed);
-    }
-}
-
-/// Keep the last `keep` non-empty lines of `content`, newline-terminated.
-fn trimmed_tail(content: &str, keep: usize) -> String {
-    let lines: Vec<&str> = content.lines().filter(|l| !l.trim().is_empty()).collect();
-    let start = lines.len().saturating_sub(keep);
-    let mut out = lines[start..].join("\n");
-    if !out.is_empty() {
-        out.push('\n');
-    }
-    out
 }
 
 /// The most recent `limit` entries, newest first.
@@ -1202,16 +1150,6 @@ mod tests {
                 "kind {kind} is not a tool call"
             );
         }
-    }
-
-    #[test]
-    fn trimmed_tail_keeps_last_n_lines() {
-        assert_eq!(trimmed_tail("a\nb\nc\nd\ne\n", 2), "d\ne\n");
-        // Fewer lines than the cap -> unchanged (re-normalized with trailing \n).
-        assert_eq!(trimmed_tail("x\ny\n", 5), "x\ny\n");
-        // Blank lines are dropped.
-        assert_eq!(trimmed_tail("a\n\n\nb\n", 5), "a\nb\n");
-        assert_eq!(trimmed_tail("", 5), "");
     }
 
     #[test]

--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -14945,12 +14945,15 @@ fn main() {
             // no socket, no gateway startup. This path runs once per observed tool
             // call, so it has to stay a parse-and-append.
             //
-            // Exit 0 on EVERY path, including a stdin that never arrives or does not
-            // parse. A hook's exit status is a signal to the harness, and on some
-            // events a non-zero one stops the user's work; a sensor that can do that
-            // is not a sensor. Nothing is written to stdout for the same reason.
-            let mut payload = String::new();
-            let _ = std::io::Read::read_to_string(&mut std::io::stdin(), &mut payload);
+            // Exit 0 on EVERY path, including a payload that does not parse or is too
+            // large to keep. A hook's exit status is a signal to the harness, and on
+            // some events a non-zero one stops the user's work; a sensor that can do
+            // that is not a sensor. Nothing is written to stdout for the same reason.
+            //
+            // The read is capped: a PostToolUse payload embeds the tool's whole
+            // response, which `handle_event` discards but would otherwise have to
+            // allocate and parse first.
+            let (payload, _truncated) = conduit_lib::hooks::read_payload(std::io::stdin());
             conduit_lib::hooks::handle_event(&event, &payload);
             std::process::exit(0);
         }

--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -14851,6 +14851,11 @@ enum ArgAction {
     /// An argument looked like a flag (`-`-prefixed) but isn't one of the
     /// flags this binary knows. Carries the offending argument for the error.
     Unknown(String),
+    /// Invoked as an agent lifecycle hook (`--toolport-hook <event>`). Record the
+    /// event and exit 0. Carries the event argument, which may be empty when the
+    /// flag was written without one - [`conduit_lib::hooks::handle_event`] treats
+    /// that as an unknown event rather than a reason to fail.
+    Hook(String),
     /// Nothing that changes startup mode; fall through to normal gateway
     /// startup.
     Run,
@@ -14870,6 +14875,14 @@ fn parse_args(args: &[String]) -> ArgAction {
     }
     if args.iter().any(|a| a == "--version" || a == "-V") {
         return ArgAction::Version;
+    }
+    // Checked before the unknown-flag scan, and never added to KNOWN_FLAGS: falling
+    // through to `Run` would start a whole gateway for what must be a record-and-exit.
+    if let Some(index) = args
+        .iter()
+        .position(|a| a == conduit_lib::hooks::HOOK_MARKER)
+    {
+        return ArgAction::Hook(args.get(index + 1).cloned().unwrap_or_default());
     }
     for arg in args {
         if arg.starts_with('-') && !KNOWN_FLAGS.contains(&arg.as_str()) {
@@ -14892,6 +14905,8 @@ fn usage() -> String {
          \x20   --http [port]         Serve over HTTP instead of stdio (default port 8765)\n\
          \x20   {insecure}   Allow unauthenticated HTTP access on a loopback bind\n\
          \x20   --selftest-secrets    Diagnostic: read every vaulted secret and report\n\
+         \x20   --toolport-hook EVENT Record one agent lifecycle event and exit (installed\n\
+         \x20                         into an agent's settings by Toolport; always exits 0)\n\
          \x20   -h, --help            Print this message and exit\n\
          \x20   -V, --version         Print the version and exit\n\
          \n\
@@ -14924,6 +14939,20 @@ fn main() {
                 usage()
             );
             std::process::exit(1);
+        }
+        ArgAction::Hook(event) => {
+            // Deliberately the first thing main can do: no registry load, no keychain,
+            // no socket, no gateway startup. This path runs once per observed tool
+            // call, so it has to stay a parse-and-append.
+            //
+            // Exit 0 on EVERY path, including a stdin that never arrives or does not
+            // parse. A hook's exit status is a signal to the harness, and on some
+            // events a non-zero one stops the user's work; a sensor that can do that
+            // is not a sensor. Nothing is written to stdout for the same reason.
+            let mut payload = String::new();
+            let _ = std::io::Read::read_to_string(&mut std::io::stdin(), &mut payload);
+            conduit_lib::hooks::handle_event(&event, &payload);
+            std::process::exit(0);
         }
         ArgAction::Run => {}
     }
@@ -27742,6 +27771,24 @@ mod tests {
         assert_eq!(
             parse_args(&["--insecure".to_string()]),
             ArgAction::Unknown("--insecure".to_string())
+        );
+    }
+
+    #[test]
+    fn parse_args_routes_the_hook_flag_away_from_gateway_startup() {
+        assert_eq!(
+            parse_args(&[
+                conduit_lib::hooks::HOOK_MARKER.to_string(),
+                "tool".to_string()
+            ]),
+            ArgAction::Hook("tool".to_string())
+        );
+        // A flag written without its event argument must still take the hook path,
+        // which exits 0, rather than being rejected as an unknown flag (exit 1) or
+        // falling through and starting a gateway.
+        assert_eq!(
+            parse_args(&[conduit_lib::hooks::HOOK_MARKER.to_string()]),
+            ArgAction::Hook(String::new())
         );
     }
 

--- a/src-tauri/src/clients.rs
+++ b/src-tauri/src/clients.rs
@@ -649,29 +649,40 @@ pub(crate) fn write_settings_json(
     if original.is_some() {
         backup_file_named("claude-code", path, &claude_settings_backup_name(path))?;
     }
+    atomic_write(path, &render_settings_json(original, root)?)
+}
+
+/// The exact bytes [`write_settings_json`] would put on disk.
+///
+/// Split out so a dry run can show the real result. Pretty-printing the value instead
+/// would report that every comment in the file is about to vanish, which is the
+/// opposite of what the CST write does (SBS-822 review).
+pub(crate) fn render_settings_json(
+    original: Option<&str>,
+    root: &serde_json::Value,
+) -> Result<String, String> {
     match (original, root.get("hooks")) {
-        // The key is gone, which is what uninstall produces. `atomic_write_json_config`
+        // The key is gone, which is what uninstall produces. `render_json_config`
         // only rewrites a key it can still find, so this case would fall through to a
         // pretty-print of the whole file and strip every comment in it. Delete the key
         // through the CST instead.
-        (Some(src), None) if !src.trim().is_empty() => {
-            let text = remove_json_key_preserving(src, "hooks")?;
-            atomic_write(path, &text)
-        }
-        _ => atomic_write_json_config(path, original, root, "hooks"),
+        (Some(src), None) if !src.trim().is_empty() => remove_json_key_preserving(src, "hooks"),
+        _ => render_json_config(original, root, "hooks"),
     }
 }
 
-/// Give each profile's `settings.json` its own backup identity, so a work profile's
-/// backups can never overwrite or prune a personal profile's. Same rule, and the same
-/// reason, as [`secondary_claude_backup_name`].
+/// Give each profile's `settings.json` its own backup identity, so one profile's
+/// backups can never overwrite or prune another's.
+///
+/// Hashes the FULL path, exactly like [`secondary_claude_backup_name`] and for the same
+/// reason: the parent directory's leaf name is not unique. `~/.claude` and a
+/// `CLAUDE_CONFIG_DIR` of `D:\work\.claude` share the leaf `.claude`, so a leaf-based
+/// identity makes both profiles share one backup series and `prune_backups` then deletes
+/// one profile's only recovery copies to stay inside `CONFIG_BACKUP_GENERATIONS`
+/// (SBS-822 review).
 fn claude_settings_backup_name(path: &Path) -> String {
-    let profile = path
-        .parent()
-        .and_then(|dir| dir.file_name())
-        .map(|name| name.to_string_lossy().replace(['/', '\\'], "-"))
-        .unwrap_or_else(|| "claude".into());
-    format!("{profile}-settings.json")
+    let digest = crate::registry::sha256_hex(&path.to_string_lossy());
+    format!("claude-settings-{}.json", &digest[..16])
 }
 
 fn client_config_path(client_id: &str) -> Option<PathBuf> {
@@ -3553,6 +3564,16 @@ fn atomic_write_json_config(
     root: &serde_json::Value,
     changed_key: &str,
 ) -> Result<(), String> {
+    atomic_write(path, &render_json_config(original, root, changed_key)?)
+}
+
+/// The rendering half of [`atomic_write_json_config`], so a dry run can show the exact
+/// bytes without writing them.
+fn render_json_config(
+    original: Option<&str>,
+    root: &serde_json::Value,
+    changed_key: &str,
+) -> Result<String, String> {
     let pretty = || serde_json::to_string_pretty(root).map_err(|e| e.to_string());
 
     let out = match (original, root.get(changed_key)) {
@@ -3570,7 +3591,7 @@ fn atomic_write_json_config(
         }
         _ => pretty()?,
     };
-    atomic_write(path, &out)
+    Ok(out)
 }
 
 /// Convert a `toml::Value` into a `toml_edit::Item` so we can splice a rewritten
@@ -5070,7 +5091,36 @@ pub(crate) fn resolve_gateway_path() -> Option<PathBuf> {
     if let Some(p) = crate::gateway_publish::client_gateway_path() {
         return Some(p);
     }
+    resolve_gateway_sidecar()
+}
 
+/// [`resolve_gateway_path`] with every side effect removed: no publish of the bundled
+/// gateway, no AppImage stable copy, and no optimistic "here is where it would be"
+/// fallback. Returns a path only when that exact file exists right now.
+///
+/// For callers that must not write, which is narrower than it sounds: publishing copies
+/// a versioned binary into the data dir and writes a manifest, and the AppImage path
+/// copies a binary, so a read-only view or a dry run that used the normal resolver
+/// would create files as a side effect of rendering (SBS-822 review).
+pub(crate) fn resolve_gateway_path_readonly() -> Option<PathBuf> {
+    if let Some(p) = crate::gateway_publish::published_gateway_path() {
+        return Some(p);
+    }
+    // An AppImage's in-mount binary is the wrong answer: it dies with the mount. Only
+    // an existing stable copy counts, and making one is a write.
+    if std::env::var_os("APPIMAGE").is_some() {
+        let dest_dir = crate::registry::conduit_dir()?.join("bin");
+        let ext = std::env::consts::EXE_SUFFIX;
+        return ["toolport-gateway", "conduit-gateway"]
+            .into_iter()
+            .map(|name| dest_dir.join(format!("{name}{ext}")))
+            .find(|p| p.is_file());
+    }
+    resolve_gateway_sidecar().filter(|p| p.is_file())
+}
+
+/// The gateway that ships beside the app binary, for when nothing has been published.
+fn resolve_gateway_sidecar() -> Option<PathBuf> {
     let exe = std::env::current_exe().ok()?;
     let dir = exe.parent()?;
     let ext = std::env::consts::EXE_SUFFIX;
@@ -6391,13 +6441,22 @@ mod tests {
     #[test]
     fn each_claude_profile_backs_its_settings_up_under_its_own_name() {
         // A work profile's backups must never overwrite or prune a personal profile's,
-        // which is why the profile directory is part of the backup identity.
+        // which is why the FULL path is the backup identity.
         let home = PathBuf::from("/home/someone");
         let personal = claude_settings_backup_name(&home.join(".claude").join("settings.json"));
         let work = claude_settings_backup_name(&home.join(".claude-work").join("settings.json"));
         assert_ne!(personal, work);
-        assert!(personal.ends_with("settings.json"));
-        assert!(work.starts_with(".claude-work"));
+
+        // The case a leaf-name identity got wrong: two profiles whose directories share
+        // a leaf. `prune_backups` keys on this name, so a collision here deletes one
+        // profile's recovery copies (SBS-822 review).
+        let other_volume =
+            claude_settings_backup_name(Path::new("/mnt/work/.claude/settings.json"));
+        assert_ne!(
+            personal, other_volume,
+            "two profiles both ending in `.claude` must not share a backup series"
+        );
+        assert!(personal.ends_with(".json"));
     }
 
     #[test]

--- a/src-tauri/src/clients.rs
+++ b/src-tauri/src/clients.rs
@@ -540,6 +540,140 @@ fn claude_code_config_paths_from(
     out
 }
 
+/// The `settings.json` a Claude Code process reads, given its config dir. This is the
+/// file that carries `hooks`, which `.claude.json` does not.
+fn claude_settings_path(config_dir: &Path) -> PathBuf {
+    config_dir.join("settings.json")
+}
+
+/// Every Claude Code profile's `settings.json` on this machine.
+///
+/// Same discovery, and the same reason, as [`claude_code_config_paths`]: a machine
+/// routinely has `~/.claude` beside `~/.claude-work`, chosen per shell by
+/// `CLAUDE_CONFIG_DIR`. A hook sensor installed into only the profile Toolport
+/// resolved today is blind to every session run under any other one, and would
+/// under-report silently rather than visibly (SBS-822).
+///
+/// Two deliberate differences from the config list:
+///
+///   * The default lives at `~/.claude/settings.json`, a file inside the profile
+///     directory, not `~/.claude.json` at the home root.
+///   * Paths are kept when the file does not exist yet, because a profile that has
+///     never had settings written still needs the sensor; the caller creates it.
+///     What IS required is that the profile directory exists, so a stale
+///     `CLAUDE_CONFIG_DIR` cannot make Toolport conjure a profile that Claude Code
+///     has never used.
+pub(crate) fn claude_settings_paths() -> Vec<PathBuf> {
+    let Some(home) = home() else {
+        return Vec::new();
+    };
+    let dirs = match claude_profile_dirs(&home) {
+        Ok(dirs) => dirs,
+        Err(error) => {
+            let msg = format!(
+                "toolport: could not scan {} for Claude Code profiles: {error}",
+                home.display()
+            );
+            eprintln!("{msg}");
+            crate::gatewaylog::append(&msg);
+            Vec::new()
+        }
+    };
+    claude_settings_paths_from(&home, claude_config_dir_override().as_deref(), &dirs)
+        .into_iter()
+        .filter(|p| p.parent().map(Path::is_dir).unwrap_or(false))
+        .collect()
+}
+
+/// The env- and filesystem-free half of [`claude_settings_paths`], so ordering and
+/// de-duplication are testable without a home directory full of fixtures.
+fn claude_settings_paths_from(
+    home: &Path,
+    override_dir: Option<&Path>,
+    home_dirs: &[String],
+) -> Vec<PathBuf> {
+    let mut out: Vec<PathBuf> = Vec::new();
+    let push = |path: PathBuf, out: &mut Vec<PathBuf>| {
+        if !out.contains(&path) {
+            out.push(path);
+        }
+    };
+    if let Some(dir) = override_dir {
+        push(claude_settings_path(dir), &mut out);
+    }
+    push(claude_settings_path(&home.join(".claude")), &mut out);
+    let mut siblings: Vec<&String> = home_dirs
+        .iter()
+        .filter(|name| *name == ".claude" || name.starts_with(".claude-"))
+        .collect();
+    // read_dir order is unspecified; sort so the log and any diagnostics are stable.
+    siblings.sort();
+    for name in siblings {
+        push(claude_settings_path(&home.join(name)), &mut out);
+    }
+    out
+}
+
+/// Read one agent settings file as a value, plus its original text.
+///
+/// A missing file is an empty object: the caller is about to create it. Any other
+/// read failure, and any syntax error, is an `Err` so a caller cannot silently
+/// replace a file it could not understand (the failure mode behind SBS-873 and
+/// friends). The original text is returned so the write can go back through the
+/// JSONC CST and keep the user's comments.
+pub(crate) fn read_settings_json(
+    path: &Path,
+) -> Result<(serde_json::Value, Option<String>), String> {
+    match std::fs::read_to_string(path) {
+        Ok(text) => {
+            let value = parse_json_value(&text)?;
+            Ok((value, Some(text)))
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            Ok((serde_json::Value::Object(serde_json::Map::new()), None))
+        }
+        Err(e) => Err(e.to_string()),
+    }
+}
+
+/// Write an agent settings file after backing up whatever was there.
+///
+/// Rewrites only the `hooks` key through the JSONC CST ([`atomic_write_json_config`]),
+/// so comments, trailing commas, and the formatting of every other setting survive.
+/// A duplicate top-level `hooks` key is a hard refusal that leaves the file untouched.
+pub(crate) fn write_settings_json(
+    path: &Path,
+    original: Option<&str>,
+    root: &serde_json::Value,
+) -> Result<(), String> {
+    if original.is_some() {
+        backup_file_named("claude-code", path, &claude_settings_backup_name(path))?;
+    }
+    match (original, root.get("hooks")) {
+        // The key is gone, which is what uninstall produces. `atomic_write_json_config`
+        // only rewrites a key it can still find, so this case would fall through to a
+        // pretty-print of the whole file and strip every comment in it. Delete the key
+        // through the CST instead.
+        (Some(src), None) if !src.trim().is_empty() => {
+            let text = remove_json_key_preserving(src, "hooks")?;
+            atomic_write(path, &text)
+        }
+        _ => atomic_write_json_config(path, original, root, "hooks"),
+    }
+}
+
+/// Give each profile's `settings.json` its own backup identity, so a work profile's
+/// backups can never overwrite or prune a personal profile's. Same rule, and the same
+/// reason, as [`secondary_claude_backup_name`].
+fn claude_settings_backup_name(path: &Path) -> String {
+    let profile = path
+        .parent()
+        .and_then(|dir| dir.file_name())
+        .map(|name| name.to_string_lossy().replace(['/', '\\'], "-"))
+        .unwrap_or_else(|| "claude".into());
+    format!("{profile}-settings.json")
+}
+
 fn client_config_path(client_id: &str) -> Option<PathBuf> {
     client_config_path_with_home(client_id, home())
 }
@@ -3376,6 +3510,36 @@ fn rewrite_json_key_preserving(
     Ok(root.to_string())
 }
 
+/// Delete a single top-level property from `original` JSON/JSONC text, preserving
+/// comments, trailing commas, and the formatting of everything else.
+///
+/// The counterpart to [`rewrite_json_key_preserving`], and needed for the same reason:
+/// that function can only set or append, so a caller removing a managed key would
+/// otherwise fall through to a pretty-print that silently strips the user's comments
+/// from the whole file. Uninstalling a feature must not cost someone their annotations.
+///
+/// Removing a key that is not there is success, not an error: the outcome is what the
+/// caller asked for.
+fn remove_json_key_preserving(original: &str, key: &str) -> Result<String, String> {
+    use jsonc_parser::cst::CstRootNode;
+    use jsonc_parser::ParseOptions;
+
+    let root = CstRootNode::parse(original, &ParseOptions::default()).map_err(|e| e.to_string())?;
+    let Some(obj) = root.object_value() else {
+        return Err("JSONC root is not an object".into());
+    };
+    let n = count_top_level_key(&obj, key);
+    if n > 1 {
+        return Err(format!(
+            "malformed config: top-level key '{key}' appears {n} times; refusing to write"
+        ));
+    }
+    if let Some(prop) = obj.get(key) {
+        prop.remove();
+    }
+    Ok(root.to_string())
+}
+
 /// Serialize `root` for disk. When `original` is present, surgically rewrite
 /// only `changed_key` via a JSONC CST so comments outside that key survive.
 /// Falls back to `serde_json::to_string_pretty` for new/empty files or when the
@@ -6173,6 +6337,67 @@ mod tests {
                 "{impostor} is not a Claude Code profile and must not be written"
             );
         }
+    }
+
+    #[test]
+    fn every_claude_profile_gets_a_settings_path_for_the_hook_sensor() {
+        // Same discovery as the config list, and the same reason: a sensor installed
+        // into only the resolved profile is blind to every session run under another
+        // one, and under-reports silently (SBS-822).
+        let home = PathBuf::from(if cfg!(windows) {
+            r"C:\Users\someone"
+        } else {
+            "/home/someone"
+        });
+        let dirs = [
+            ".claude-work".to_string(),
+            ".claude".to_string(),
+            ".claude.bak".to_string(),
+            ".claudesync".to_string(),
+        ];
+        let paths = claude_settings_paths_from(&home, Some(&home.join(".claude-work")), &dirs);
+        assert_eq!(
+            paths,
+            vec![
+                home.join(".claude-work").join("settings.json"),
+                // Unlike `.claude.json`, the default settings file lives INSIDE the
+                // profile directory, not at the home root.
+                home.join(".claude").join("settings.json"),
+            ],
+            "expected the override first, then the default, de-duplicated"
+        );
+        for impostor in [".claude.bak", ".claudesync"] {
+            assert!(
+                !paths.iter().any(|p| p.starts_with(home.join(impostor))),
+                "{impostor} is not a Claude Code profile and must not be written"
+            );
+        }
+    }
+
+    #[test]
+    fn a_settings_path_is_never_listed_twice() {
+        let home = PathBuf::from(if cfg!(windows) {
+            r"C:\Users\someone"
+        } else {
+            "/home/someone"
+        });
+        // The override commonly IS the default profile; writing it twice would take
+        // two backups of one file and rewrite it needlessly.
+        let paths =
+            claude_settings_paths_from(&home, Some(&home.join(".claude")), &[".claude".to_string()]);
+        assert_eq!(paths, vec![home.join(".claude").join("settings.json")]);
+    }
+
+    #[test]
+    fn each_claude_profile_backs_its_settings_up_under_its_own_name() {
+        // A work profile's backups must never overwrite or prune a personal profile's,
+        // which is why the profile directory is part of the backup identity.
+        let home = PathBuf::from("/home/someone");
+        let personal = claude_settings_backup_name(&home.join(".claude").join("settings.json"));
+        let work = claude_settings_backup_name(&home.join(".claude-work").join("settings.json"));
+        assert_ne!(personal, work);
+        assert!(personal.ends_with("settings.json"));
+        assert!(work.starts_with(".claude-work"));
     }
 
     #[test]

--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -17,6 +17,7 @@ use crate::audit;
 use crate::catalog;
 use crate::clients;
 use crate::downstream::{resolve_root_token, DownstreamServer, StdioTransport};
+use crate::hooks;
 use crate::inspect;
 use crate::integrity;
 use crate::oauth;
@@ -3180,6 +3181,47 @@ async fn rules_apply() -> Result<rules::RulesView, String> {
         .map_err(|e| e.to_string())?
 }
 
+// --- Agent hook sensor (SBS-822) -------------------------------------------
+//
+// Same shape and the same reasons as the rules commands above: every one of these
+// reads or writes an agent settings file, so none of them may run on the UI thread,
+// and none of them needs the gateway or any configured MCP server.
+
+/// The hook sensor's state: the opt-in, the events it registers, and every Claude Code
+/// profile found with whether the sensor is currently in it. Read-only.
+#[tauri::command]
+async fn hooks_view() -> Result<hooks::HooksView, String> {
+    tauri::async_runtime::spawn_blocking(hooks::view)
+        .await
+        .map_err(|e| e.to_string())
+}
+
+/// Turn the sensor on or off. Turning it off removes it from every profile we wrote.
+#[tauri::command]
+async fn hooks_set_enabled(enabled: bool) -> Result<hooks::HooksView, String> {
+    tauri::async_runtime::spawn_blocking(move || hooks::set_enabled(enabled))
+        .await
+        .map_err(|e| e.to_string())?
+}
+
+/// Dry-run the write for every profile, so the UI can show the exact before/after
+/// before the sensor touches a settings file. Never writes.
+#[tauri::command]
+async fn hooks_preview() -> Result<Vec<hooks::HooksPreview>, String> {
+    tauri::async_runtime::spawn_blocking(hooks::preview)
+        .await
+        .map_err(|e| e.to_string())?
+}
+
+/// The most recent sensor rows, newest first. The read half SBS-823 builds on.
+#[tauri::command]
+async fn hooks_recent(limit: usize) -> Result<Vec<serde_json::Value>, String> {
+    tauri::async_runtime::spawn_blocking(move || hooks::read_recent(limit))
+        .await
+        .map_err(|e| e.to_string())?
+        .map_err(|e| e.to_string())
+}
+
 /// Leave the team: remove its merged servers, clear the connection and the token.
 #[tauri::command]
 fn team_disconnect(state: State<RegistryState>) -> Result<Registry, String> {
@@ -5165,6 +5207,10 @@ pub fn run() {
             rules_set_client_enabled,
             rules_preview,
             rules_apply,
+            hooks_view,
+            hooks_set_enabled,
+            hooks_preview,
+            hooks_recent,
             team_disconnect,
             team_push_preview,
             team_push,
@@ -5348,6 +5394,13 @@ pub fn run() {
                 // written, and `write_target` no-ops when a client's block already matches, so
                 // a steady-state launch touches no files.
                 rules::apply_on_startup();
+                // Same launch thread, same reason, for the agent hook sensor (SBS-822).
+                // This one additionally repairs the binary path after an update: the
+                // published gateway is versioned and the reaper prunes superseded
+                // builds, so hooks written before an update would name a binary that
+                // no longer exists. Returns immediately when the sensor was never
+                // turned on.
+                hooks::apply_on_startup();
 
                 // Stop obsolete gateway processes. Path-based identity on all OS
                 // (SOU-414); not gated on repoint (SOU-306).

--- a/src-tauri/src/hooks.rs
+++ b/src-tauri/src/hooks.rs
@@ -408,12 +408,20 @@ pub fn handle_event(event_arg: &str, stdin: &str) {
 ///
 /// A missing file is an empty log. Any other IO error is returned, so a caller cannot
 /// show "no agent activity" for a log it simply failed to read (SBS-873).
+///
+/// Read as bytes, not `read_to_string`. This is the same log
+/// [`crate::registry::append_line_locked`] just conceded can hold invalid UTF-8 - one
+/// hook process killed mid-write leaves a half-codepoint line - and `read_to_string`
+/// answers `Err(InvalidData)` for the whole file over that one byte. The activity view
+/// would then report "couldn't read your agent activity" for every row until a rotation
+/// happened to trim the bad line out. Lossy decoding costs the torn line, which
+/// `from_str` was going to reject anyway, and keeps every intact row (SBS-822 review).
 pub fn read_recent(limit: usize) -> std::io::Result<Vec<Value>> {
     let Some(path) = log_path() else {
         return Ok(Vec::new());
     };
-    let content = match std::fs::read_to_string(&path) {
-        Ok(c) => c,
+    let content = match std::fs::read(&path) {
+        Ok(bytes) => String::from_utf8_lossy(&bytes).into_owned(),
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
         Err(e) => return Err(e),
     };
@@ -545,16 +553,23 @@ fn apply_with(set_enabled: Option<bool>) -> Result<Vec<ProfileStatus>, String> {
     apply_to(
         set_enabled,
         &crate::clients::claude_settings_paths(),
-        hook_binary().as_deref(),
+        &hook_binary,
     )
 }
 
 /// [`apply_with`] over an explicit profile set and binary, so tests drive known files
 /// instead of the developer's real `~/.claude`. Same rationale as `rules::apply_to`.
+///
+/// The binary arrives as a resolver, not a path, because resolving it is not free:
+/// `hook_binary` goes through `clients::resolve_gateway_path`, which publishes the
+/// bundled gateway on packaged Windows and copies one into the data directory on
+/// AppImage. Passing an already-resolved `Option<&Path>` meant turning the sensor OFF -
+/// or a startup pass that only had stale targets to clean up - created files for a
+/// feature nobody was installing. Only the enable branch calls it (SBS-822 review).
 fn apply_to(
     set_enabled: Option<bool>,
     profiles: &[PathBuf],
-    binary: Option<&Path>,
+    resolve_binary: &dyn Fn() -> Option<PathBuf>,
 ) -> Result<Vec<ProfileStatus>, String> {
     let (_, statuses) = crate::registry::update_authoritative(|reg| {
         if let Some(enabled) = set_enabled {
@@ -575,11 +590,11 @@ fn apply_to(
         if reg.hooks_enabled {
             // Resolved before any write. Failing here aborts the whole transaction, so
             // an un-installable build leaves the opt-in exactly as it was.
-            let binary = binary.ok_or_else(|| {
+            let binary = resolve_binary().ok_or_else(|| {
                 "no gateway binary is available to run as a hook".to_string()
             })?;
             for path in candidates.iter().map(Path::new) {
-                statuses.push(match install_at(path, binary) {
+                statuses.push(match install_at(path, &binary) {
                     Ok(()) => {
                         written.push(path.display().to_string());
                         ProfileStatus {
@@ -1306,7 +1321,7 @@ mod tests {
         let profile = dir.join("settings.json");
         std::fs::write(&profile, "{ not json").unwrap();
 
-        let statuses = apply_to(Some(true), &[profile.clone()], Some(&binary())).unwrap();
+        let statuses = apply_to(Some(true), &[profile.clone()], &|| Some(binary())).unwrap();
         assert_eq!(statuses.len(), 1);
         assert!(!statuses[0].installed);
         assert!(statuses[0].error.is_some(), "the failure must be reported");
@@ -1326,7 +1341,7 @@ mod tests {
         let dir = env.dir.clone();
         let profile = dir.join("settings.json");
 
-        apply_to(Some(true), &[profile.clone()], Some(&binary())).unwrap();
+        apply_to(Some(true), &[profile.clone()], &|| Some(binary())).unwrap();
         assert_eq!(
             crate::registry::load().unwrap().hook_targets,
             vec![profile.display().to_string()]
@@ -1334,7 +1349,7 @@ mod tests {
 
         // The user (or another tool) breaks the file after we installed into it.
         std::fs::write(&profile, "{ broken").unwrap();
-        apply_to(None, &[profile.clone()], Some(&binary())).unwrap();
+        apply_to(None, &[profile.clone()], &|| Some(binary())).unwrap();
         assert_eq!(
             crate::registry::load().unwrap().hook_targets,
             vec![profile.display().to_string()],
@@ -1395,7 +1410,7 @@ mod tests {
 
         // No resolvable binary is the real-world case this models: every non-Windows
         // build before a gateway is published.
-        let err = apply_to(Some(true), &[profile.clone()], None).unwrap_err();
+        let err = apply_to(Some(true), &[profile.clone()], &|| None).unwrap_err();
         assert!(err.contains("gateway binary"), "unexpected error: {err}");
 
         assert!(
@@ -1416,7 +1431,7 @@ mod tests {
         let profile = dir.join(".claude").join("settings.json");
         std::fs::create_dir_all(profile.parent().unwrap()).unwrap();
 
-        apply_to(Some(true), &[profile.clone()], Some(&binary())).unwrap();
+        apply_to(Some(true), &[profile.clone()], &|| Some(binary())).unwrap();
 
         let reg = crate::registry::load().unwrap();
         assert!(reg.hooks_enabled);
@@ -1429,13 +1444,61 @@ mod tests {
         // Deliberately with NO binary: turning the sensor off must never depend on
         // resolving one, or a user whose gateway went missing could not uninstall the
         // hooks it left in their settings.
-        apply_to(Some(false), &[profile.clone()], None).unwrap();
+        apply_to(Some(false), &[profile.clone()], &|| None).unwrap();
         let reg = crate::registry::load().unwrap();
         assert!(!reg.hooks_enabled);
         assert!(reg.hook_targets.is_empty());
         assert!(!is_installed(
             &crate::clients::read_settings_json(&profile).unwrap().0
         ));
+
+    }
+
+    #[test]
+    fn read_recent_keeps_every_intact_row_around_a_torn_one() {
+        let env = scratch_env("torn");
+        let dir = env.dir.clone();
+        let path = dir.join("hooks.jsonl");
+
+        // A hook killed mid-write leaves a half-codepoint line. `append_line_locked`
+        // already had to concede this file can hold invalid UTF-8; a reader that answers
+        // `Err` for the whole log over that one byte would blank the activity view until
+        // some later rotation happened to trim it out.
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(br#"{"event":"tool","tool":"Read"}"#);
+        bytes.push(b'\n');
+        bytes.extend_from_slice(&[0xE2, 0x82]); // a truncated euro sign
+        bytes.push(b'\n');
+        bytes.extend_from_slice(br#"{"event":"tool","tool":"Bash"}"#);
+        bytes.push(b'\n');
+        std::fs::write(&path, bytes).unwrap();
+
+        let rows = read_recent(10).expect("one torn line must not fail the whole log");
+        let tools: Vec<&str> = rows
+            .iter()
+            .filter_map(|r| r.get("tool").and_then(Value::as_str))
+            .collect();
+        assert_eq!(tools, vec!["Bash", "Read"], "newest first, torn line dropped");
+
+    }
+
+    #[test]
+    fn disabling_never_resolves_a_gateway_binary() {
+        let env = scratch_env("disable-lazy");
+        let dir = env.dir.clone();
+        let profile = dir.join("settings.json");
+        apply_to(Some(true), &[profile.clone()], &|| Some(binary())).unwrap();
+
+        // Resolving is not free: `hook_binary` publishes the bundled gateway on packaged
+        // Windows and copies one into the data directory on AppImage. Turning the sensor
+        // OFF must not create files for a feature the user is removing.
+        let calls = std::cell::Cell::new(0u32);
+        apply_to(Some(false), &[profile.clone()], &|| {
+            calls.set(calls.get() + 1);
+            Some(binary())
+        })
+        .unwrap();
+        assert_eq!(calls.get(), 0, "the disable path asked for a binary");
 
     }
 

--- a/src-tauri/src/hooks.rs
+++ b/src-tauri/src/hooks.rs
@@ -1,0 +1,1080 @@
+//! Native-agent hook sensor - record what an agent does outside the gateway.
+//!
+//! The sensor half of SBS-822 (`agent-permissions` spec). Toolport governs calls that
+//! go through the gateway; it is blind to what Claude Code does natively (`Bash`,
+//! `Edit`, `Read`), because none of that is MCP. Agent harnesses expose hooks - a
+//! command the harness runs at a lifecycle point, fed a JSON payload on stdin - so
+//! this module installs three of them and records one line per event.
+//!
+//! Three properties this module exists to hold:
+//!
+//!   * **It cannot block a tool call.** `PreToolUse` is the blocking event and is
+//!     deliberately not registered ([`SENSOR_EVENTS`]). "The sensor cannot stop your
+//!     agent" is therefore structural, not a promise that the code is correct.
+//!   * **It stores no content.** Hook payloads carry `tool_input` and `tool_response`:
+//!     the `Bash` command line, the bytes of an `Edit`, whatever a `Read` returned.
+//!     [`row`] keeps a tool name and an [`crate::audit::args_hash`] and drops the rest,
+//!     the same contract the gateway audit log already holds.
+//!   * **It cleans up exactly what it wrote.** JSON has no comments, so a settings
+//!     block cannot carry a sentinel the way [`crate::instructions`] markers do.
+//!     Instead every entry Toolport installs carries [`HOOK_MARKER`] in its command,
+//!     and removal drops entries by that marker and nothing else - the same
+//!     "identify what we wrote by content" rule as `instructions::remove_recorded`.
+
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Map, Value};
+use std::path::{Path, PathBuf};
+
+/// The literal that marks a hook entry as Toolport's, in the command it runs.
+///
+/// Doubles as the gateway subcommand flag, so one string is both "how the binary
+/// knows it is being invoked as a hook" and "how we recognise our own entry later".
+pub const HOOK_MARKER: &str = "--toolport-hook";
+
+/// The harness lifecycle events the sensor registers, paired with the argument the
+/// hook command passes back to us.
+///
+/// `PreToolUse` is absent on purpose: it is the event whose exit status can refuse a
+/// user's tool call, and this ship has no enforcement story yet (see the spec's
+/// "Why the sensor ships alone"). `UserPromptSubmit` and `Notification` are absent
+/// because their payload is the user's prompt text and there is no redaction path
+/// for it here.
+const SENSOR_EVENTS: [(&str, &str); 3] = [
+    ("SessionStart", "session-start"),
+    ("PostToolUse", "tool"),
+    ("SessionEnd", "session-end"),
+];
+
+/// Seconds the harness should allow a hook before giving up on it. A wedged sensor
+/// must cost the user a bounded pause, never a hung agent.
+const HOOK_TIMEOUT_SECS: u64 = 5;
+
+/// Trim the sensor log once it passes this size.
+const MAX_HOOK_LOG_BYTES: u64 = 4 * 1024 * 1024;
+/// Lines kept when trimming. Rows are small (no content), so this stays well inside
+/// the byte cap; if it did not, every append past the cap would re-trim.
+const KEEP_HOOK_LINES: usize = 10_000;
+
+/// One agent settings file and what the sensor's state in it is.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ProfileStatus {
+    /// Absolute path to the profile's `settings.json`.
+    pub path: String,
+    /// True when this file currently carries Toolport's hook entries.
+    pub installed: bool,
+    /// Why this profile could not be read or written, when that is the case. A
+    /// profile that is merely not installed reports `None` here; an unreadable or
+    /// malformed one reports the reason instead of silently looking "not installed".
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+/// Everything the (future) hooks view needs, in one round trip.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HooksView {
+    /// The user's opt-in. Off by default.
+    pub enabled: bool,
+    /// The harness events the sensor registers, for the UI to name them honestly.
+    pub events: Vec<String>,
+    /// Every Claude Code profile found, installed or not.
+    pub profiles: Vec<ProfileStatus>,
+    /// Absent when no gateway binary is resolvable, which is the one condition that
+    /// makes installing impossible.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub binary: Option<String>,
+}
+
+/// A dry run: the exact hook block that would be written, and where.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HooksPreview {
+    pub path: String,
+    /// The file as it is now (empty string when it does not exist yet).
+    pub before: String,
+    /// The file as it would be after the write.
+    pub after: String,
+}
+
+// ---------------------------------------------------------------------------
+// The hook block: pure functions over a settings value
+// ---------------------------------------------------------------------------
+
+/// The command the harness runs for one event.
+///
+/// Quoted because the harness hands this to a shell and installed paths contain
+/// spaces on every platform Toolport ships to (`C:\Program Files\...`,
+/// `/Applications/...`).
+fn hook_command(binary: &Path, event_arg: &str) -> String {
+    format!("\"{}\" {HOOK_MARKER} {event_arg}", binary.display())
+}
+
+/// One matcher group holding one Toolport hook.
+///
+/// No `matcher` key: an absent matcher observes every tool, which is what a sensor
+/// wants, and it avoids guessing a matcher dialect that differs between harness
+/// versions.
+fn matcher_group(command: String) -> Value {
+    json!({
+        "hooks": [{
+            "type": "command",
+            "command": command,
+            "timeout": HOOK_TIMEOUT_SECS,
+        }]
+    })
+}
+
+/// True when this hook entry is one Toolport installed.
+fn is_ours(entry: &Value) -> bool {
+    entry
+        .get("command")
+        .and_then(Value::as_str)
+        .map(|command| command.contains(HOOK_MARKER))
+        .unwrap_or(false)
+}
+
+/// True when `root` currently carries any Toolport hook entry.
+pub fn is_installed(root: &Value) -> bool {
+    let Some(hooks) = root.get("hooks").and_then(Value::as_object) else {
+        return false;
+    };
+    hooks.values().any(|groups| {
+        groups
+            .as_array()
+            .map(|groups| {
+                groups.iter().any(|group| {
+                    group
+                        .get("hooks")
+                        .and_then(Value::as_array)
+                        .map(|entries| entries.iter().any(is_ours))
+                        .unwrap_or(false)
+                })
+            })
+            .unwrap_or(false)
+    })
+}
+
+/// Return `root` with every Toolport hook entry removed, pruning each container the
+/// removal empties.
+///
+/// Removal is per ENTRY, not per group: a user who added their own hook to the same
+/// event, in the same group, keeps it. Pruning matters because a leftover
+/// `"hooks": {}` or `"PostToolUse": []` is residue from a feature the user turned
+/// off, and "clean up exactly what we wrote" includes the shape.
+pub fn strip_hooks(root: &Value) -> Value {
+    let mut out = root.clone();
+    let Some(obj) = out.as_object_mut() else {
+        return out;
+    };
+    let Some(hooks) = obj.get_mut("hooks").and_then(Value::as_object_mut) else {
+        return out;
+    };
+
+    let events: Vec<String> = hooks.keys().cloned().collect();
+    for event in events {
+        let Some(groups) = hooks.get_mut(&event).and_then(Value::as_array_mut) else {
+            continue;
+        };
+        for group in groups.iter_mut() {
+            if let Some(entries) = group.get_mut("hooks").and_then(Value::as_array_mut) {
+                entries.retain(|entry| !is_ours(entry));
+            }
+        }
+        // A group whose hook list we emptied was ours alone; drop it. A group that
+        // never had a `hooks` array is left exactly as found.
+        groups.retain(|group| match group.get("hooks").and_then(Value::as_array) {
+            Some(entries) => !entries.is_empty(),
+            None => true,
+        });
+        if groups.is_empty() {
+            hooks.remove(&event);
+        }
+    }
+    if hooks.is_empty() {
+        obj.remove("hooks");
+    }
+    out
+}
+
+/// Return `root` with Toolport's sensor entries present exactly once per event.
+///
+/// Built as strip-then-add so it is idempotent: applying it to a file we already
+/// wrote, or to one carrying an entry from an older build that pointed at a
+/// superseded gateway binary, converges on one current entry per event rather than
+/// accumulating them.
+pub fn upsert_hooks(root: &Value, binary: &Path) -> Result<Value, String> {
+    let mut out = strip_hooks(root);
+    let obj = out
+        .as_object_mut()
+        .ok_or_else(|| "settings root is not a JSON object".to_string())?;
+
+    let hooks = obj
+        .entry("hooks".to_string())
+        .or_insert_with(|| Value::Object(Map::new()));
+    let hooks = hooks
+        .as_object_mut()
+        .ok_or_else(|| "`hooks` is present but is not an object".to_string())?;
+
+    for (event, arg) in SENSOR_EVENTS {
+        let groups = hooks
+            .entry(event.to_string())
+            .or_insert_with(|| Value::Array(Vec::new()));
+        let groups = groups
+            .as_array_mut()
+            .ok_or_else(|| format!("`hooks.{event}` is present but is not an array"))?;
+        groups.push(matcher_group(hook_command(binary, arg)));
+    }
+    Ok(out)
+}
+
+// ---------------------------------------------------------------------------
+// The sensor log
+// ---------------------------------------------------------------------------
+
+/// Where hook rows are recorded.
+///
+/// Deliberately NOT `audit.jsonl`. One active Claude Code session fires
+/// `PostToolUse` on every `Read`, `Edit` and `Bash`, which is one to two orders of
+/// magnitude more rows than gateway traffic; sharing the file would push the
+/// governance rows out through the audit log's own trim, so the compliance artifact
+/// would be evicted by telemetry. Separate files, separate caps; SBS-823 merges them
+/// at read time.
+pub fn log_path() -> Option<PathBuf> {
+    Some(crate::registry::conduit_dir()?.join("hooks.jsonl"))
+}
+
+/// Outcome of one observed native tool call.
+///
+/// `None` means unknown and must never be counted as success. The harness does not
+/// promise a machine-readable outcome on every tool, so an absent `ok` is the normal
+/// case rather than an error - which is exactly why defaulting it to `true` would
+/// quietly inflate a success rate (the SBS-932 rule, applied before the bug).
+pub fn hook_call_ok(entry: &Value) -> Option<bool> {
+    entry.get("ok").and_then(Value::as_bool)
+}
+
+/// Read a tool call's outcome out of a `PostToolUse` payload, when it says.
+fn tool_outcome(payload: &Value) -> Option<bool> {
+    let response = payload.get("tool_response")?;
+    if let Some(success) = response.get("success").and_then(Value::as_bool) {
+        return Some(success);
+    }
+    // An `error` that is present and not null is a failure. Its VALUE is not read:
+    // an error string can carry the same content the rest of this module drops.
+    match response.get("error") {
+        Some(Value::Null) | None => None,
+        Some(_) => Some(false),
+    }
+}
+
+/// Build the row for one hook event.
+///
+/// Pure, so the "no content is ever stored" contract is unit-testable against a
+/// payload carrying a secret. Everything recorded is either a name, an identifier,
+/// a path, or a hash.
+pub fn row(event_arg: &str, payload: &Value) -> Value {
+    let mut entry = json!({
+        "ts": epoch_millis(),
+        "event": event_arg,
+        "agent": "claude-code",
+    });
+
+    if let Some(session) = payload.get("session_id").and_then(Value::as_str) {
+        entry["sessionId"] = json!(session);
+    }
+    if let Some(cwd) = payload.get("cwd").and_then(Value::as_str) {
+        entry["cwd"] = json!(cwd);
+    }
+    if let Some(tool) = payload.get("tool_name").and_then(Value::as_str) {
+        entry["tool"] = json!(tool);
+    }
+    // Identity without content, from the same canonical hash the gateway audit uses,
+    // so a repeated call is recognisable across both logs.
+    if let Some(input) = payload.get("tool_input") {
+        entry["argsHash"] = json!(crate::audit::args_hash(input));
+    }
+    if let Some(ok) = tool_outcome(payload) {
+        entry["ok"] = json!(ok);
+    }
+    entry
+}
+
+fn epoch_millis() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+/// Handle one hook invocation, from the gateway binary's `--toolport-hook` path.
+///
+/// **Never fails the caller.** The binary exits 0 whatever happens here, because a
+/// non-zero exit from a hook is a signal to the harness, and on some events that
+/// signal stops the user's work. Nothing is printed to stdout either: the harness
+/// reads hook stdout, so noise there lands in the user's session. Diagnostics go to
+/// the gateway log.
+pub fn handle_event(event_arg: &str, stdin: &str) {
+    if !SENSOR_EVENTS.iter().any(|(_, arg)| *arg == event_arg) {
+        // A settings.json written by another build naming an event this one does not
+        // record. Dropping it is correct; saying so is what makes it debuggable.
+        crate::gatewaylog::append(&format!(
+            "toolport: ignoring unknown hook event '{event_arg}'"
+        ));
+        return;
+    }
+
+    let entry = match serde_json::from_str::<Value>(stdin) {
+        Ok(payload) => row(event_arg, &payload),
+        Err(error) => {
+            crate::gatewaylog::append(&format!(
+                "toolport: hook '{event_arg}' payload did not parse: {error}"
+            ));
+            // Recorded anyway, flagged, and with no `tool` key so no reader can
+            // mistake it for an observed call. Silence here would be indistinguishable
+            // from the agent doing nothing.
+            json!({
+                "ts": epoch_millis(),
+                "event": event_arg,
+                "agent": "claude-code",
+                "malformed": true,
+            })
+        }
+    };
+
+    let Some(path) = log_path() else {
+        crate::gatewaylog::append("toolport: hook row dropped, no data directory");
+        return;
+    };
+    if let Err(error) = crate::registry::append_line_locked(
+        &path,
+        &entry.to_string(),
+        MAX_HOOK_LOG_BYTES,
+        KEEP_HOOK_LINES,
+        None,
+    ) {
+        crate::gatewaylog::append(&format!("toolport: hook row dropped: {error}"));
+    }
+}
+
+/// The most recent `limit` rows, newest first.
+///
+/// A missing file is an empty log. Any other IO error is returned, so a caller cannot
+/// show "no agent activity" for a log it simply failed to read (SBS-873).
+pub fn read_recent(limit: usize) -> std::io::Result<Vec<Value>> {
+    let Some(path) = log_path() else {
+        return Ok(Vec::new());
+    };
+    let content = match std::fs::read_to_string(&path) {
+        Ok(c) => c,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(e) => return Err(e),
+    };
+    Ok(content
+        .lines()
+        .rev()
+        .filter_map(|line| serde_json::from_str(line).ok())
+        .take(limit)
+        .collect())
+}
+
+// ---------------------------------------------------------------------------
+// Install / remove
+// ---------------------------------------------------------------------------
+
+/// The gateway binary the hook command should invoke.
+///
+/// The same binary clients already spawn, so it inherits the install location,
+/// version pinning, pruning and signing that path already has.
+///
+/// Publishes the bundled gateway if it has not been published yet, so this is the
+/// write-capable variant. Read-only callers use [`hook_binary_readonly`].
+fn hook_binary() -> Option<PathBuf> {
+    crate::gateway_publish::client_gateway_path()
+}
+
+/// The published gateway path, without publishing one as a side effect.
+///
+/// `view` must not write: a UI that merely renders the hooks panel should not be able
+/// to publish a binary.
+fn hook_binary_readonly() -> Option<PathBuf> {
+    crate::gateway_publish::published_gateway_path()
+}
+
+/// Re-apply at app start, so the sensor keeps pointing at a gateway that exists.
+///
+/// The published gateway path is VERSIONED, and the reaper prunes superseded builds.
+/// An update therefore leaves every installed hook naming a binary that is about to
+/// disappear, and the harness would run a missing command once per tool call. Because
+/// [`upsert_hooks`] is idempotent and rewrites a stale binary path, one apply on the
+/// launch after an update repairs every profile; a launch with nothing to change
+/// writes no bytes ([`install_at`] compares first).
+pub fn apply_on_startup() {
+    let enabled = crate::registry::load()
+        .map(|reg| reg.hooks_enabled || !reg.hook_targets.is_empty())
+        .unwrap_or(false);
+    if !enabled {
+        return;
+    }
+    if let Err(error) = apply() {
+        crate::gatewaylog::append(&format!("toolport: hook sensor startup apply failed: {error}"));
+    }
+}
+
+/// Current state, without writing anything.
+pub fn view() -> HooksView {
+    let reg = crate::registry::load().unwrap_or_default();
+    let binary = hook_binary_readonly();
+    let profiles = crate::clients::claude_settings_paths()
+        .into_iter()
+        .map(|path| match crate::clients::read_settings_json(&path) {
+            Ok((root, _)) => ProfileStatus {
+                path: path.display().to_string(),
+                installed: is_installed(&root),
+                error: None,
+            },
+            Err(error) => ProfileStatus {
+                path: path.display().to_string(),
+                installed: false,
+                error: Some(error),
+            },
+        })
+        .collect();
+
+    HooksView {
+        enabled: reg.hooks_enabled,
+        events: SENSOR_EVENTS
+            .iter()
+            .map(|(event, _)| (*event).to_string())
+            .collect(),
+        profiles,
+        binary: binary.map(|p| p.display().to_string()),
+    }
+}
+
+/// Turn the sensor on or off, then make every profile match.
+pub fn set_enabled(enabled: bool) -> Result<HooksView, String> {
+    crate::registry::update(|reg| {
+        reg.hooks_enabled = enabled;
+        Ok(())
+    })?;
+    apply()?;
+    Ok(view())
+}
+
+/// Write the sensor into every profile when enabled, and remove it from every
+/// recorded target when not.
+///
+/// A profile that fails is reported, not fatal: one unreadable `settings.json` must
+/// not stop the other profiles from being installed or, more importantly, cleaned.
+pub fn apply() -> Result<Vec<ProfileStatus>, String> {
+    let reg = crate::registry::load()?;
+    let mut statuses: Vec<ProfileStatus> = Vec::new();
+
+    // Every profile that SHOULD carry the sensor right now. Empty when the user has
+    // opted out, which is what turns this pass into a full removal.
+    let candidates: Vec<String> = if reg.hooks_enabled {
+        crate::clients::claude_settings_paths()
+            .iter()
+            .map(|p| p.display().to_string())
+            .collect()
+    } else {
+        Vec::new()
+    };
+
+    if reg.hooks_enabled {
+        let binary = hook_binary()
+            .ok_or_else(|| "no gateway binary is available to run as a hook".to_string())?;
+        for path in candidates.iter().map(Path::new) {
+            let status = match install_at(path, &binary) {
+                Ok(()) => ProfileStatus {
+                    path: path.display().to_string(),
+                    installed: true,
+                    error: None,
+                },
+                Err(error) => ProfileStatus {
+                    path: path.display().to_string(),
+                    installed: false,
+                    error: Some(error),
+                },
+            };
+            statuses.push(status);
+        }
+    }
+
+    // Clean what we recorded and no longer want: a profile that disappeared, or every
+    // profile once the user opts out. Same contract as `rules_targets`.
+    //
+    // Cleanup is keyed on "no longer a candidate", NOT on "failed to write this pass".
+    // A transient read failure must not be read as "this profile is gone" and trigger
+    // an uninstall of a sensor that is working.
+    let mut unremovable: Vec<String> = Vec::new();
+    for stale in reg.hook_targets.iter().filter(|p| !candidates.contains(p)) {
+        if let Err(error) = remove_at(Path::new(stale)) {
+            // Keep it on the list. Dropping a path whose removal failed would strand
+            // the file forever, because nothing would ever try again (SBS-914 is the
+            // same bug on the rules path).
+            unremovable.push(stale.clone());
+            statuses.push(ProfileStatus {
+                path: stale.clone(),
+                installed: false,
+                error: Some(error),
+            });
+        }
+    }
+
+    let mut targets = candidates;
+    targets.extend(unremovable);
+    crate::registry::update(|reg| {
+        reg.hook_targets = targets.clone();
+        Ok(())
+    })?;
+    Ok(statuses)
+}
+
+/// Install the sensor into one settings file. No-op (and no backup) when the file
+/// already says exactly what we would write.
+fn install_at(path: &Path, binary: &Path) -> Result<(), String> {
+    let (root, original) = crate::clients::read_settings_json(path)?;
+    let updated = upsert_hooks(&root, binary)?;
+    if updated == root {
+        return Ok(());
+    }
+    crate::clients::write_settings_json(path, original.as_deref(), &updated)
+}
+
+/// Remove the sensor from one settings file.
+///
+/// A file that is gone is success: the profile it belonged to was deleted, which is a
+/// stronger form of removed. A file we cannot parse is NOT success - refusing loudly
+/// beats rewriting a file we do not understand.
+fn remove_at(path: &Path) -> Result<(), String> {
+    let (root, original) = match crate::clients::read_settings_json(path) {
+        Ok(pair) => pair,
+        Err(error) => {
+            if !path.exists() {
+                return Ok(());
+            }
+            return Err(error);
+        }
+    };
+    if original.is_none() {
+        return Ok(());
+    }
+    let stripped = strip_hooks(&root);
+    if stripped == root {
+        return Ok(());
+    }
+    crate::clients::write_settings_json(path, original.as_deref(), &stripped)
+}
+
+/// The exact bytes the write would produce, for every profile. Touches nothing.
+pub fn preview() -> Result<Vec<HooksPreview>, String> {
+    let binary =
+        hook_binary().ok_or_else(|| "no gateway binary is available to run as a hook".to_string())?;
+    let mut out = Vec::new();
+    for path in crate::clients::claude_settings_paths() {
+        let (root, original) = crate::clients::read_settings_json(&path)?;
+        let updated = upsert_hooks(&root, &binary)?;
+        out.push(HooksPreview {
+            path: path.display().to_string(),
+            before: original.unwrap_or_default(),
+            after: serde_json::to_string_pretty(&updated).map_err(|e| e.to_string())?,
+        });
+    }
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn binary() -> PathBuf {
+        PathBuf::from("/opt/Toolport/toolport-gateway")
+    }
+
+    fn our_command() -> String {
+        hook_command(&binary(), "tool")
+    }
+
+    fn foreign_group() -> Value {
+        json!({
+            "matcher": "Bash",
+            "hooks": [{ "type": "command", "command": "/usr/local/bin/my-linter" }]
+        })
+    }
+
+    #[test]
+    fn upsert_into_a_fresh_file_registers_every_sensor_event_once() {
+        let out = upsert_hooks(&json!({}), &binary()).unwrap();
+        let hooks = out["hooks"].as_object().unwrap();
+
+        assert_eq!(hooks.len(), SENSOR_EVENTS.len());
+        for (event, arg) in SENSOR_EVENTS {
+            let groups = hooks[event].as_array().unwrap();
+            assert_eq!(groups.len(), 1, "{event} should have exactly one group");
+            let entries = groups[0]["hooks"].as_array().unwrap();
+            assert_eq!(entries.len(), 1);
+            assert_eq!(entries[0]["command"], json!(hook_command(&binary(), arg)));
+            assert_eq!(entries[0]["type"], json!("command"));
+        }
+    }
+
+    #[test]
+    fn pre_tool_use_is_never_registered() {
+        let out = upsert_hooks(&json!({}), &binary()).unwrap();
+        assert!(
+            out["hooks"].get("PreToolUse").is_none(),
+            "the sensor must not register on the blocking event"
+        );
+        assert!(!SENSOR_EVENTS.iter().any(|(event, _)| *event == "PreToolUse"));
+    }
+
+    #[test]
+    fn upsert_is_idempotent_and_refreshes_a_stale_binary_path() {
+        let once = upsert_hooks(&json!({}), &binary()).unwrap();
+        let twice = upsert_hooks(&once, &binary()).unwrap();
+        assert_eq!(once, twice, "re-applying must not accumulate entries");
+
+        // An entry an older build wrote, pointing at a gateway that has since been
+        // pruned, is replaced rather than joined.
+        let stale = upsert_hooks(&json!({}), Path::new("/old/toolport-gateway")).unwrap();
+        let fresh = upsert_hooks(&stale, &binary()).unwrap();
+        let entries = fresh["hooks"]["PostToolUse"].as_array().unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0]["hooks"].as_array().unwrap().len(), 1);
+        assert_eq!(
+            entries[0]["hooks"][0]["command"],
+            json!(hook_command(&binary(), "tool"))
+        );
+    }
+
+    #[test]
+    fn foreign_hooks_and_unrelated_settings_survive_a_round_trip() {
+        let before = json!({
+            "model": "opus",
+            "permissions": { "allow": ["Bash(git status)"] },
+            "hooks": {
+                "PostToolUse": [foreign_group()],
+                "PreToolUse": [foreign_group()],
+            }
+        });
+
+        let installed = upsert_hooks(&before, &binary()).unwrap();
+        assert_eq!(installed["model"], json!("opus"));
+        assert_eq!(installed["permissions"]["allow"][0], json!("Bash(git status)"));
+        // Ours is added alongside theirs, and their PreToolUse hook is untouched.
+        assert_eq!(installed["hooks"]["PostToolUse"].as_array().unwrap().len(), 2);
+        assert_eq!(installed["hooks"]["PreToolUse"], json!([foreign_group()]));
+
+        let removed = strip_hooks(&installed);
+        assert_eq!(removed, before, "uninstall must restore the file exactly");
+    }
+
+    #[test]
+    fn strip_removes_only_our_entry_from_a_shared_group() {
+        // A user who hand-edited our group to add their own hook keeps it.
+        let shared = json!({
+            "hooks": {
+                "PostToolUse": [{
+                    "hooks": [
+                        { "type": "command", "command": our_command() },
+                        { "type": "command", "command": "/usr/local/bin/my-linter" },
+                    ]
+                }]
+            }
+        });
+        let out = strip_hooks(&shared);
+        let entries = out["hooks"]["PostToolUse"][0]["hooks"].as_array().unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0]["command"], json!("/usr/local/bin/my-linter"));
+    }
+
+    #[test]
+    fn strip_prunes_the_containers_it_empties() {
+        let installed = upsert_hooks(&json!({ "model": "opus" }), &binary()).unwrap();
+        let out = strip_hooks(&installed);
+        assert_eq!(
+            out,
+            json!({ "model": "opus" }),
+            "no empty `hooks` object or event array may be left behind"
+        );
+    }
+
+    #[test]
+    fn strip_leaves_a_file_that_was_never_ours_untouched() {
+        let theirs = json!({ "hooks": { "PostToolUse": [foreign_group()] } });
+        assert_eq!(strip_hooks(&theirs), theirs);
+        assert!(!is_installed(&theirs));
+    }
+
+    #[test]
+    fn is_installed_tracks_upsert_and_strip() {
+        let empty = json!({});
+        assert!(!is_installed(&empty));
+        let installed = upsert_hooks(&empty, &binary()).unwrap();
+        assert!(is_installed(&installed));
+        assert!(!is_installed(&strip_hooks(&installed)));
+    }
+
+    #[test]
+    fn a_hooks_key_of_the_wrong_type_is_refused_not_overwritten() {
+        let broken = json!({ "hooks": "off" });
+        assert!(upsert_hooks(&broken, &binary()).is_err());
+
+        let broken_event = json!({ "hooks": { "PostToolUse": {} } });
+        let err = upsert_hooks(&broken_event, &binary()).unwrap_err();
+        assert!(err.contains("PostToolUse"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn a_non_object_root_is_refused() {
+        assert!(upsert_hooks(&json!([1, 2, 3]), &binary()).is_err());
+    }
+
+    #[test]
+    fn the_command_is_quoted_so_an_installed_path_with_spaces_survives_a_shell() {
+        let command = hook_command(Path::new("/Applications/My Toolport/toolport-gateway"), "tool");
+        assert!(command.starts_with('"'));
+        assert!(command.contains("My Toolport"));
+        assert!(command.ends_with(&format!("{HOOK_MARKER} tool")));
+    }
+
+    #[test]
+    fn a_row_stores_identity_and_never_content() {
+        let secret = "AKIAIOSFODNN7EXAMPLE";
+        let payload = json!({
+            "session_id": "sess-1",
+            "cwd": "/home/dev/app",
+            "tool_name": "Bash",
+            "tool_input": { "command": format!("aws configure set key {secret}") },
+            "tool_response": { "success": true, "stdout": secret },
+        });
+
+        let row = row("tool", &payload);
+        let text = row.to_string();
+
+        assert!(
+            !text.contains(secret),
+            "a hook row must never carry payload content: {text}"
+        );
+        assert!(!text.contains("aws configure"));
+        assert_eq!(row["tool"], json!("Bash"));
+        assert_eq!(row["sessionId"], json!("sess-1"));
+        assert_eq!(row["cwd"], json!("/home/dev/app"));
+        assert_eq!(row["ok"], json!(true));
+        assert_eq!(
+            row["argsHash"],
+            json!(crate::audit::args_hash(&payload["tool_input"]))
+        );
+        assert!(row["ts"].as_u64().is_some());
+    }
+
+    #[test]
+    fn an_undecidable_outcome_is_absent_rather_than_success() {
+        // No tool_response at all.
+        let row = row("tool", &json!({ "tool_name": "Read" }));
+        assert!(row.get("ok").is_none());
+        assert_eq!(hook_call_ok(&row), None);
+
+        // A response that simply does not say.
+        let quiet = row_for(json!({ "tool_response": { "stdout": "hi" } }));
+        assert!(quiet.get("ok").is_none());
+
+        // An explicit null error is not a failure, and not a success either.
+        let null_error = row_for(json!({ "tool_response": { "error": Value::Null } }));
+        assert!(null_error.get("ok").is_none());
+    }
+
+    #[test]
+    fn an_error_in_the_response_is_a_failed_call() {
+        let failed = row_for(json!({ "tool_response": { "error": "no such file" } }));
+        assert_eq!(hook_call_ok(&failed), Some(false));
+        assert!(
+            !failed.to_string().contains("no such file"),
+            "the error VALUE must not be stored, only the outcome"
+        );
+
+        let explicit = row_for(json!({ "tool_response": { "success": false } }));
+        assert_eq!(hook_call_ok(&explicit), Some(false));
+    }
+
+    fn row_for(payload: Value) -> Value {
+        row("tool", &payload)
+    }
+
+    #[test]
+    fn a_session_row_carries_no_tool_and_no_outcome() {
+        let row = row("session-start", &json!({ "session_id": "s", "cwd": "/w" }));
+        assert!(row.get("tool").is_none());
+        assert!(row.get("ok").is_none());
+        assert!(row.get("argsHash").is_none());
+        assert_eq!(row["event"], json!("session-start"));
+    }
+
+    #[test]
+    fn hook_call_ok_never_infers_success_from_a_missing_field() {
+        assert_eq!(hook_call_ok(&json!({ "tool": "Bash" })), None);
+        assert_eq!(hook_call_ok(&json!({ "ok": true })), Some(true));
+        assert_eq!(hook_call_ok(&json!({ "ok": "yes" })), None);
+    }
+
+    // --- on-disk behavior ---------------------------------------------------
+
+    fn scratch(name: &str) -> PathBuf {
+        static SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+        let dir = std::env::temp_dir().join(format!(
+            "toolport-hooks-{name}-{}-{}",
+            std::process::id(),
+            SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    fn read(path: &Path) -> String {
+        std::fs::read_to_string(path).unwrap()
+    }
+
+    #[test]
+    fn install_creates_a_settings_file_that_did_not_exist() {
+        let dir = scratch("fresh");
+        let path = dir.join("settings.json");
+
+        install_at(&path, &binary()).unwrap();
+
+        let root: Value = serde_json::from_str(&read(&path)).unwrap();
+        assert!(is_installed(&root));
+        // A file we created holds nothing but our block.
+        assert_eq!(root.as_object().unwrap().len(), 1);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn install_preserves_comments_and_every_unrelated_setting() {
+        let dir = scratch("comments");
+        let path = dir.join("settings.json");
+        let original = "{\n  // the model I actually want\n  \"model\": \"opus\",\n  \"permissions\": { \"allow\": [\"Bash(git status)\"] }\n}\n";
+        std::fs::write(&path, original).unwrap();
+
+        install_at(&path, &binary()).unwrap();
+
+        let after = read(&path);
+        assert!(
+            after.contains("// the model I actually want"),
+            "the comment must survive the write: {after}"
+        );
+        assert!(after.contains("\"model\": \"opus\""));
+        assert!(after.contains(HOOK_MARKER));
+
+        // Removing puts every byte outside the `hooks` key back as it was.
+        remove_at(&path).unwrap();
+        let restored = read(&path);
+        assert!(restored.contains("// the model I actually want"));
+        assert!(!restored.contains(HOOK_MARKER));
+        let root: Value = crate::clients::read_settings_json(&path).unwrap().0;
+        assert!(
+            root.get("hooks").is_none(),
+            "uninstall must not leave an empty hooks object: {restored}"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn install_is_a_no_op_when_the_file_already_says_what_we_would_write() {
+        let dir = scratch("noop");
+        let path = dir.join("settings.json");
+
+        install_at(&path, &binary()).unwrap();
+        let first = read(&path);
+        install_at(&path, &binary()).unwrap();
+
+        assert_eq!(first, read(&path), "a second apply must not rewrite bytes");
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn a_duplicate_hooks_key_is_refused_and_the_file_is_left_alone() {
+        let dir = scratch("dupe");
+        let path = dir.join("settings.json");
+        // Ambiguous: a rewrite would silently drop one of the two.
+        let original = "{ \"hooks\": {}, \"hooks\": {} }";
+        std::fs::write(&path, original).unwrap();
+
+        assert!(install_at(&path, &binary()).is_err());
+        assert_eq!(read(&path), original, "the file must be untouched");
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn a_malformed_settings_file_is_refused_rather_than_replaced() {
+        let dir = scratch("malformed");
+        let path = dir.join("settings.json");
+        let original = "{ this is not json";
+        std::fs::write(&path, original).unwrap();
+
+        assert!(install_at(&path, &binary()).is_err());
+        assert!(remove_at(&path).is_err(), "removal must not rewrite it either");
+        assert_eq!(read(&path), original);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn removing_from_a_profile_that_no_longer_exists_is_success() {
+        let dir = scratch("gone");
+        let path = dir.join("settings.json");
+        // A profile the user deleted between apply and remove is a stronger form of
+        // "removed", not an error to report.
+        assert!(remove_at(&path).is_ok());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn removing_leaves_a_foreign_hook_on_the_same_event_intact() {
+        let dir = scratch("foreign");
+        let path = dir.join("settings.json");
+        std::fs::write(
+            &path,
+            serde_json::to_string_pretty(&json!({
+                "hooks": { "PostToolUse": [foreign_group()] }
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+
+        install_at(&path, &binary()).unwrap();
+        remove_at(&path).unwrap();
+
+        let root: Value = crate::clients::read_settings_json(&path).unwrap().0;
+        assert_eq!(root["hooks"]["PostToolUse"], json!([foreign_group()]));
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn handle_event_records_a_row_without_a_registry() {
+        // The hook path runs before any gateway startup, so it must work against a
+        // data directory that holds nothing at all - no registry.json, no keychain.
+        // This is the "does not touch the registry" property from the spec.
+        let _guard = crate::registry::data_dir_test_lock();
+        let dir = scratch("no-registry");
+        let _override = crate::registry::DataDirOverride::set(&dir);
+
+        handle_event(
+            "tool",
+            &json!({ "session_id": "s1", "tool_name": "Bash", "tool_input": { "command": "ls" } })
+                .to_string(),
+        );
+
+        let rows = read_recent(10).unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0]["tool"], json!("Bash"));
+        assert_eq!(rows[0]["sessionId"], json!("s1"));
+        assert!(!dir.join("registry.json").exists(), "no registry was created");
+
+        drop(_override);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn handle_event_survives_junk_stdin_and_an_unknown_event() {
+        let _guard = crate::registry::data_dir_test_lock();
+        let dir = scratch("junk");
+        let _override = crate::registry::DataDirOverride::set(&dir);
+
+        // Unparseable payload: recorded, flagged, and with no `tool` key so no reader
+        // can mistake it for an observed call.
+        handle_event("tool", "not json at all");
+        // An event this build does not record is dropped, not recorded as junk.
+        handle_event("no-such-event", "{}");
+
+        let rows = read_recent(10).unwrap();
+        assert_eq!(rows.len(), 1, "only the malformed-payload row is kept");
+        assert_eq!(rows[0]["malformed"], json!(true));
+        assert!(rows[0].get("tool").is_none());
+        assert!(rows[0].get("ok").is_none());
+
+        drop(_override);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn recorded_rows_are_one_json_line_each_and_newest_first() {
+        let _guard = crate::registry::data_dir_test_lock();
+        let dir = scratch("order");
+        let _override = crate::registry::DataDirOverride::set(&dir);
+
+        handle_event("session-start", &json!({ "session_id": "s1" }).to_string());
+        handle_event("tool", &json!({ "session_id": "s1", "tool_name": "Read" }).to_string());
+        handle_event("session-end", &json!({ "session_id": "s1" }).to_string());
+
+        let raw = std::fs::read_to_string(log_path().unwrap()).unwrap();
+        assert_eq!(raw.lines().count(), 3, "one line per event: {raw}");
+
+        let rows = read_recent(10).unwrap();
+        assert_eq!(rows[0]["event"], json!("session-end"));
+        assert_eq!(rows[2]["event"], json!("session-start"));
+
+        drop(_override);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn startup_apply_does_nothing_when_the_sensor_was_never_turned_on() {
+        // The overwhelmingly common launch. It must not scan profiles, resolve a
+        // gateway binary, or write to the registry, because it runs on the same
+        // thread as every other launch task.
+        let _guard = crate::registry::data_dir_test_lock();
+        let dir = scratch("startup-off");
+        let _override = crate::registry::DataDirOverride::set(&dir);
+
+        apply_on_startup();
+
+        assert!(
+            !dir.join("registry.json").exists(),
+            "a launch with the sensor off must not write anything"
+        );
+
+        drop(_override);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn a_target_whose_removal_failed_stays_recorded_for_the_next_pass() {
+        // The SBS-914 shape: dropping a path we could not clean strands the file,
+        // because nothing would ever try again.
+        let dir = scratch("retry");
+        let path = dir.join("settings.json");
+        std::fs::write(&path, "{ not json }").unwrap();
+
+        assert!(
+            remove_at(&path).is_err(),
+            "an unparseable file must not report a successful removal"
+        );
+        assert!(path.exists(), "and must not be deleted or rewritten");
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn read_recent_reports_an_unreadable_log_instead_of_saying_nothing_happened() {
+        let _guard = crate::registry::data_dir_test_lock();
+        let dir = scratch("unreadable");
+        let _override = crate::registry::DataDirOverride::set(&dir);
+
+        // A directory where the log file should be: readable as a path, not as a file.
+        std::fs::create_dir_all(dir.join("hooks.jsonl")).unwrap();
+        assert!(
+            read_recent(10).is_err(),
+            "an unreadable log must not read as an empty one (SBS-873)"
+        );
+
+        drop(_override);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}

--- a/src-tauri/src/hooks.rs
+++ b/src-tauri/src/hooks.rs
@@ -49,6 +49,16 @@ const SENSOR_EVENTS: [(&str, &str); 3] = [
 /// must cost the user a bounded pause, never a hung agent.
 const HOOK_TIMEOUT_SECS: u64 = 5;
 
+/// Cap on the payload read from stdin.
+///
+/// A `PostToolUse` payload embeds `tool_response`: the body of a `Read`, a `Bash`
+/// process's stdout. [`row`] drops all of it, but an unbounded `read_to_string` would
+/// allocate and parse the whole thing first, so a large native result could stall the
+/// agent until the harness's hook timeout, or OOM this process and lose the row
+/// entirely (SBS-822 review; SBS-930 is the same shape on the gateway's stderr drain).
+/// Generous next to any real payload's identifying fields, which are all this keeps.
+const MAX_HOOK_STDIN_BYTES: u64 = 1024 * 1024;
+
 /// Trim the sensor log once it passes this size.
 const MAX_HOOK_LOG_BYTES: u64 = 4 * 1024 * 1024;
 /// Lines kept when trimming. Rows are small (no content), so this stays well inside
@@ -307,6 +317,31 @@ fn epoch_millis() -> u64 {
         .unwrap_or(0)
 }
 
+/// Read a hook payload from `reader`, bounded by [`MAX_HOOK_STDIN_BYTES`].
+///
+/// Returns the bytes read and whether the cap was reached. A payload at the cap is
+/// truncated, so it will not parse, and [`handle_event`] records the flagged
+/// `malformed` row rather than guessing at half a document.
+///
+/// This bounds SIZE, not TIME: the read still ends at EOF. The harness closes the pipe
+/// after writing and kills a hook that overruns its own timeout, so waiting on EOF is
+/// bounded by the caller rather than by us.
+pub fn read_payload(reader: impl std::io::Read) -> (String, bool) {
+    use std::io::Read as _;
+
+    let mut buf = String::new();
+    // cap + 1 so filling the cap is distinguishable from a payload that ends exactly
+    // on it.
+    let _ = reader
+        .take(MAX_HOOK_STDIN_BYTES + 1)
+        .read_to_string(&mut buf);
+    let truncated = buf.len() as u64 > MAX_HOOK_STDIN_BYTES;
+    if truncated {
+        buf.truncate(MAX_HOOK_STDIN_BYTES as usize);
+    }
+    (buf, truncated)
+}
+
 /// Handle one hook invocation, from the gateway binary's `--toolport-hook` path.
 ///
 /// **Never fails the caller.** The binary exits 0 whatever happens here, because a
@@ -384,21 +419,25 @@ pub fn read_recent(limit: usize) -> std::io::Result<Vec<Value>> {
 
 /// The gateway binary the hook command should invoke.
 ///
-/// The same binary clients already spawn, so it inherits the install location,
-/// version pinning, pruning and signing that path already has.
+/// The same resolution client MCP install uses, so the sensor inherits the install
+/// location, version pinning, pruning and signing that path already has.
 ///
-/// Publishes the bundled gateway if it has not been published yet, so this is the
-/// write-capable variant. Read-only callers use [`hook_binary_readonly`].
+/// NOT `gateway_publish::client_gateway_path` on its own: that returns `None` unless
+/// `should_publish_client_gateway()`, which is hard-false on macOS and Linux and on any
+/// Windows `cargo run`. Using it alone made the sensor un-installable everywhere except
+/// a packaged Windows build, while `hook_command` quoted `/Applications/...` paths it
+/// could never actually produce (SBS-822 review).
 fn hook_binary() -> Option<PathBuf> {
-    crate::gateway_publish::client_gateway_path()
+    crate::clients::resolve_gateway_path().filter(|p| p.is_file())
 }
 
-/// The published gateway path, without publishing one as a side effect.
+/// [`hook_binary`] for callers that must not write.
 ///
-/// `view` must not write: a UI that merely renders the hooks panel should not be able
-/// to publish a binary.
+/// `resolve_gateway_path` publishes the bundled gateway, and copies one on AppImage,
+/// when nothing is published yet. Rendering a read-only view or a dry run must not
+/// create files, so this resolves only what already exists.
 fn hook_binary_readonly() -> Option<PathBuf> {
-    crate::gateway_publish::published_gateway_path()
+    crate::clients::resolve_gateway_path_readonly()
 }
 
 /// Re-apply at app start, so the sensor keeps pointing at a gateway that exists.
@@ -453,12 +492,13 @@ pub fn view() -> HooksView {
 }
 
 /// Turn the sensor on or off, then make every profile match.
+///
+/// The opt-in and the install commit together. Persisting `hooks_enabled = true` first
+/// and applying second meant a failed install left the registry saying the user opted
+/// in with nothing installed, `view()` reporting `enabled` with no profile, and every
+/// later startup retrying the same failing apply, with no path back (SBS-822 review).
 pub fn set_enabled(enabled: bool) -> Result<HooksView, String> {
-    crate::registry::update(|reg| {
-        reg.hooks_enabled = enabled;
-        Ok(())
-    })?;
-    apply()?;
+    apply_with(Some(enabled))?;
     Ok(view())
 }
 
@@ -468,66 +508,103 @@ pub fn set_enabled(enabled: bool) -> Result<HooksView, String> {
 /// A profile that fails is reported, not fatal: one unreadable `settings.json` must
 /// not stop the other profiles from being installed or, more importantly, cleaned.
 pub fn apply() -> Result<Vec<ProfileStatus>, String> {
-    let reg = crate::registry::load()?;
-    let mut statuses: Vec<ProfileStatus> = Vec::new();
+    apply_with(None)
+}
 
-    // Every profile that SHOULD carry the sensor right now. Empty when the user has
-    // opted out, which is what turns this pass into a full removal.
-    let candidates: Vec<String> = if reg.hooks_enabled {
-        crate::clients::claude_settings_paths()
-            .iter()
-            .map(|p| p.display().to_string())
-            .collect()
-    } else {
-        Vec::new()
-    };
+/// [`apply`], optionally committing an opt-in change in the same transaction.
+///
+/// Everything runs inside `registry::update_authoritative`, holding the registry's
+/// cross-process lock from the one authoritative load through every settings write and
+/// the `hook_targets` save. Three things that buys, all of which the earlier
+/// load-then-write-then-update shape got wrong (SBS-822 review):
+///
+///   * `registry::load` discards its [`crate::registry::LoadSource`], so a backup
+///     snapshot read because the primary was missing or unreadable looked like live
+///     opt-in state. `update_authoritative` refuses a non-authoritative registry
+///     BEFORE the closure runs, so no settings file is touched on that path. Previously
+///     the refusal came after the writes.
+///   * A concurrent `set_enabled(false)` could commit while a slow apply was mid-flight,
+///     and the apply would then reinstall the sensor the user just turned off.
+///   * An `Err` out of the closure means nothing is saved, so a failed install cannot
+///     leave `hooks_enabled = true` behind.
+///
+/// Matches `rules::apply_to`, which holds the same lock across the same shape of work.
+fn apply_with(set_enabled: Option<bool>) -> Result<Vec<ProfileStatus>, String> {
+    apply_to(
+        set_enabled,
+        &crate::clients::claude_settings_paths(),
+        hook_binary().as_deref(),
+    )
+}
 
-    if reg.hooks_enabled {
-        let binary = hook_binary()
-            .ok_or_else(|| "no gateway binary is available to run as a hook".to_string())?;
-        for path in candidates.iter().map(Path::new) {
-            let status = match install_at(path, &binary) {
-                Ok(()) => ProfileStatus {
-                    path: path.display().to_string(),
-                    installed: true,
-                    error: None,
-                },
-                Err(error) => ProfileStatus {
-                    path: path.display().to_string(),
+/// [`apply_with`] over an explicit profile set and binary, so tests drive known files
+/// instead of the developer's real `~/.claude`. Same rationale as `rules::apply_to`.
+fn apply_to(
+    set_enabled: Option<bool>,
+    profiles: &[PathBuf],
+    binary: Option<&Path>,
+) -> Result<Vec<ProfileStatus>, String> {
+    let (_, statuses) = crate::registry::update_authoritative(|reg| {
+        if let Some(enabled) = set_enabled {
+            reg.hooks_enabled = enabled;
+        }
+        let mut statuses: Vec<ProfileStatus> = Vec::new();
+
+        // Every profile that SHOULD carry the sensor right now. Empty when the user has
+        // opted out, which is what turns this pass into a full removal.
+        let candidates: Vec<String> = if reg.hooks_enabled {
+            profiles.iter().map(|p| p.display().to_string()).collect()
+        } else {
+            Vec::new()
+        };
+
+        if reg.hooks_enabled {
+            // Resolved before any write. Failing here aborts the whole transaction, so
+            // an un-installable build leaves the opt-in exactly as it was.
+            let binary = binary.ok_or_else(|| {
+                "no gateway binary is available to run as a hook".to_string()
+            })?;
+            for path in candidates.iter().map(Path::new) {
+                statuses.push(match install_at(path, binary) {
+                    Ok(()) => ProfileStatus {
+                        path: path.display().to_string(),
+                        installed: true,
+                        error: None,
+                    },
+                    Err(error) => ProfileStatus {
+                        path: path.display().to_string(),
+                        installed: false,
+                        error: Some(error),
+                    },
+                });
+            }
+        }
+
+        // Clean what we recorded and no longer want: a profile that disappeared, or
+        // every profile once the user opts out. Same contract as `rules_targets`.
+        //
+        // Cleanup is keyed on "no longer a candidate", NOT on "failed to write this
+        // pass". A transient read failure must not be read as "this profile is gone"
+        // and trigger an uninstall of a sensor that is working.
+        let mut unremovable: Vec<String> = Vec::new();
+        for stale in reg.hook_targets.iter().filter(|p| !candidates.contains(p)) {
+            if let Err(error) = remove_at(Path::new(stale)) {
+                // Keep it on the list. Dropping a path whose removal failed would
+                // strand the file forever, because nothing would ever try again
+                // (SBS-914 is the same bug on the rules path).
+                unremovable.push(stale.clone());
+                statuses.push(ProfileStatus {
+                    path: stale.clone(),
                     installed: false,
                     error: Some(error),
-                },
-            };
-            statuses.push(status);
+                });
+            }
         }
-    }
 
-    // Clean what we recorded and no longer want: a profile that disappeared, or every
-    // profile once the user opts out. Same contract as `rules_targets`.
-    //
-    // Cleanup is keyed on "no longer a candidate", NOT on "failed to write this pass".
-    // A transient read failure must not be read as "this profile is gone" and trigger
-    // an uninstall of a sensor that is working.
-    let mut unremovable: Vec<String> = Vec::new();
-    for stale in reg.hook_targets.iter().filter(|p| !candidates.contains(p)) {
-        if let Err(error) = remove_at(Path::new(stale)) {
-            // Keep it on the list. Dropping a path whose removal failed would strand
-            // the file forever, because nothing would ever try again (SBS-914 is the
-            // same bug on the rules path).
-            unremovable.push(stale.clone());
-            statuses.push(ProfileStatus {
-                path: stale.clone(),
-                installed: false,
-                error: Some(error),
-            });
-        }
-    }
-
-    let mut targets = candidates;
-    targets.extend(unremovable);
-    crate::registry::update(|reg| {
-        reg.hook_targets = targets.clone();
-        Ok(())
+        let mut targets = candidates;
+        targets.extend(unremovable);
+        reg.hook_targets = targets;
+        Ok(statuses)
     })?;
     Ok(statuses)
 }
@@ -568,18 +645,36 @@ fn remove_at(path: &Path) -> Result<(), String> {
     crate::clients::write_settings_json(path, original.as_deref(), &stripped)
 }
 
-/// The exact bytes the write would produce, for every profile. Touches nothing.
+/// The exact bytes the write would produce, for every profile. Writes nothing, anywhere.
+///
+/// `after` goes through the same renderer as the real write
+/// ([`crate::clients::render_settings_json`]), not `to_string_pretty`. Pretty-printing
+/// the value reformats the document and drops every comment, so the dry run would tell
+/// the user that enabling the sensor is about to destroy their annotations when the
+/// actual write preserves them (SBS-822 review).
+///
+/// The binary is resolved read-only for the same reason the doc says "writes nothing":
+/// the normal resolver publishes a versioned gateway and a manifest into the data dir
+/// when none exists, which a dry run must not do. When nothing is published yet this
+/// reports that instead of publishing one.
 pub fn preview() -> Result<Vec<HooksPreview>, String> {
-    let binary =
-        hook_binary().ok_or_else(|| "no gateway binary is available to run as a hook".to_string())?;
+    let binary = hook_binary_readonly().ok_or_else(|| {
+        "no gateway binary has been published yet, so there is nothing to preview".to_string()
+    })?;
+    preview_to(&crate::clients::claude_settings_paths(), &binary)
+}
+
+/// [`preview`] over an explicit profile set and binary, so tests drive known files
+/// instead of the developer's real `~/.claude`. Same rationale as [`apply_to`].
+fn preview_to(profiles: &[PathBuf], binary: &Path) -> Result<Vec<HooksPreview>, String> {
     let mut out = Vec::new();
-    for path in crate::clients::claude_settings_paths() {
-        let (root, original) = crate::clients::read_settings_json(&path)?;
-        let updated = upsert_hooks(&root, &binary)?;
+    for path in profiles {
+        let (root, original) = crate::clients::read_settings_json(path)?;
+        let updated = upsert_hooks(&root, binary)?;
         out.push(HooksPreview {
             path: path.display().to_string(),
-            before: original.unwrap_or_default(),
-            after: serde_json::to_string_pretty(&updated).map_err(|e| e.to_string())?,
+            before: original.clone().unwrap_or_default(),
+            after: crate::clients::render_settings_json(original.as_deref(), &updated)?,
         });
     }
     Ok(out)
@@ -1058,6 +1153,164 @@ mod tests {
         );
         assert!(path.exists(), "and must not be deleted or rewritten");
 
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn the_hook_binary_resolves_on_every_platform_not_just_packaged_windows() {
+        // `gateway_publish::client_gateway_path` is gated on
+        // `should_publish_client_gateway()`, which is false on macOS, Linux, and any
+        // Windows `cargo run`. Resolving through it alone made the sensor
+        // un-installable everywhere but a packaged Windows build (SBS-822 review).
+        // This test runs on all three CI platforms, and in dev, where that gate is off.
+        assert!(
+            !crate::gateway_publish::should_publish_client_gateway(),
+            "test premise: this build is not publish-capable, so a publish-only \
+             resolver returns None here"
+        );
+        assert!(
+            crate::gateway_publish::client_gateway_path().is_none(),
+            "test premise: the publish-gated resolver is the one that returns None"
+        );
+        // `hook_binary` is this resolver, filtered to a file that exists. It is the
+        // difference between the two that the bug was: one of them can answer on this
+        // platform and the other cannot.
+        assert!(
+            crate::clients::resolve_gateway_path().is_some(),
+            "the resolver the sensor uses must still answer where the publish-gated \
+             one cannot"
+        );
+    }
+
+    #[test]
+    fn a_capped_payload_is_recorded_as_malformed_and_never_carries_its_content() {
+        let secret = "AKIAIOSFODNN7EXAMPLE";
+        // A single tool_response far past the cap, the shape a big Read or Bash
+        // produces.
+        let huge = json!({
+            "session_id": "s1",
+            "tool_name": "Read",
+            "tool_response": { "stdout": format!("{}{secret}", "x".repeat(2 * 1024 * 1024)) },
+        })
+        .to_string();
+
+        let (payload, truncated) = read_payload(huge.as_bytes());
+        assert!(truncated, "a payload past the cap must report as truncated");
+        assert_eq!(payload.len() as u64, MAX_HOOK_STDIN_BYTES);
+        assert!(
+            !payload.contains(secret),
+            "the cap must land before the tail of the response"
+        );
+
+        // Truncated JSON does not parse, so this lands on the flagged row rather than
+        // a guess at half a document.
+        assert!(serde_json::from_str::<Value>(&payload).is_err());
+    }
+
+    #[test]
+    fn a_payload_inside_the_cap_is_read_whole() {
+        let payload = json!({ "session_id": "s1", "tool_name": "Bash" }).to_string();
+        let (read, truncated) = read_payload(payload.as_bytes());
+        assert!(!truncated);
+        assert_eq!(read, payload);
+    }
+
+    #[test]
+    fn preview_text_is_the_bytes_install_actually_writes() {
+        // The dry run must not claim a comment is about to disappear when the real
+        // write keeps it (SBS-822 review).
+        let dir = scratch("preview-bytes");
+        let path = dir.join("settings.json");
+        let original =
+            "{\n  // the model I actually want\n  \"model\": \"opus\"\n}\n";
+        std::fs::write(&path, original).unwrap();
+
+        // Drive preview() itself, not just the renderer underneath it, so swapping the
+        // dry run back to `to_string_pretty` is caught.
+        let previews = preview_to(&[path.clone()], &binary()).unwrap();
+        assert_eq!(previews.len(), 1);
+        assert_eq!(previews[0].before, original);
+
+        install_at(&path, &binary()).unwrap();
+        assert_eq!(
+            previews[0].after,
+            read(&path),
+            "preview text and the written file must be byte-identical"
+        );
+        assert!(previews[0].after.contains("// the model I actually want"));
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn preview_writes_nothing_at_all() {
+        let dir = scratch("preview-readonly");
+        let path = dir.join("settings.json");
+
+        // A profile with no settings file yet: the dry run must not create one.
+        let previews = preview_to(&[path.clone()], &binary()).unwrap();
+        assert!(previews[0].before.is_empty());
+        assert!(previews[0].after.contains(HOOK_MARKER));
+        assert!(!path.exists(), "a dry run must not create the settings file");
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn enabling_does_not_persist_the_opt_in_when_the_install_cannot_run() {
+        // A failed apply must leave the registry exactly as it was. Otherwise `view()`
+        // reports enabled with nothing installed and every startup retries the same
+        // failing apply forever, with no path back (SBS-822 review).
+        let _guard = crate::registry::data_dir_test_lock();
+        let dir = scratch("enable-fails");
+        let _override = crate::registry::DataDirOverride::set(&dir);
+        let profile = dir.join(".claude").join("settings.json");
+
+        // No resolvable binary is the real-world case this models: every non-Windows
+        // build before a gateway is published.
+        let err = apply_to(Some(true), &[profile.clone()], None).unwrap_err();
+        assert!(err.contains("gateway binary"), "unexpected error: {err}");
+
+        assert!(
+            !crate::registry::load().unwrap().hooks_enabled,
+            "a failed enable must not leave hooks_enabled = true behind"
+        );
+        assert!(
+            !profile.exists(),
+            "and must not have written a settings file first"
+        );
+
+        drop(_override);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn enabling_commits_the_opt_in_and_the_targets_together() {
+        let _guard = crate::registry::data_dir_test_lock();
+        let dir = scratch("enable-commits");
+        let _override = crate::registry::DataDirOverride::set(&dir);
+        let profile = dir.join(".claude").join("settings.json");
+        std::fs::create_dir_all(profile.parent().unwrap()).unwrap();
+
+        apply_to(Some(true), &[profile.clone()], Some(&binary())).unwrap();
+
+        let reg = crate::registry::load().unwrap();
+        assert!(reg.hooks_enabled);
+        assert_eq!(reg.hook_targets, vec![profile.display().to_string()]);
+        assert!(is_installed(
+            &crate::clients::read_settings_json(&profile).unwrap().0
+        ));
+
+        // Opting out removes the sensor and forgets the target in one transaction.
+        apply_to(Some(false), &[profile.clone()], Some(&binary())).unwrap();
+        let reg = crate::registry::load().unwrap();
+        assert!(!reg.hooks_enabled);
+        assert!(reg.hook_targets.is_empty());
+        assert!(!is_installed(
+            &crate::clients::read_settings_json(&profile).unwrap().0
+        ));
+
+        drop(_override);
         let _ = std::fs::remove_dir_all(&dir);
     }
 

--- a/src-tauri/src/hooks.rs
+++ b/src-tauri/src/hooks.rs
@@ -1302,7 +1302,10 @@ mod tests {
         ));
 
         // Opting out removes the sensor and forgets the target in one transaction.
-        apply_to(Some(false), &[profile.clone()], Some(&binary())).unwrap();
+        // Deliberately with NO binary: turning the sensor off must never depend on
+        // resolving one, or a user whose gateway went missing could not uninstall the
+        // hooks it left in their settings.
+        apply_to(Some(false), &[profile.clone()], None).unwrap();
         let reg = crate::registry::load().unwrap();
         assert!(!reg.hooks_enabled);
         assert!(reg.hook_targets.is_empty());

--- a/src-tauri/src/hooks.rs
+++ b/src-tauri/src/hooks.rs
@@ -329,17 +329,29 @@ fn epoch_millis() -> u64 {
 pub fn read_payload(reader: impl std::io::Read) -> (String, bool) {
     use std::io::Read as _;
 
-    let mut buf = String::new();
+    // BYTES, not a String, and this is load-bearing for the exit-0 guarantee:
+    //
+    //   * `String::truncate` panics when the index is not a char boundary. A capped
+    //     payload whose 1 MiB mark lands inside a multi-byte codepoint - any non-ASCII
+    //     in a `tool_input` or a `Bash` stdout - would panic the hook process, which
+    //     exits non-zero, which is the one thing this path must never do.
+    //   * `read_to_string` fails with `InvalidData` on invalid UTF-8 and leaves the
+    //     buffer as it found it. Cutting a stream at a fixed byte count produces
+    //     exactly that whenever the cut lands mid-codepoint, so the payload, and the
+    //     fact that it was truncated at all, would both be silently lost.
+    //
+    // Truncating bytes and converting lossily cannot do either. A cut codepoint
+    // becomes U+FFFD, the JSON then fails to parse, and the event is recorded as the
+    // flagged `malformed` row, which is the honest outcome.
+    let mut bytes: Vec<u8> = Vec::new();
     // cap + 1 so filling the cap is distinguishable from a payload that ends exactly
     // on it.
-    let _ = reader
-        .take(MAX_HOOK_STDIN_BYTES + 1)
-        .read_to_string(&mut buf);
-    let truncated = buf.len() as u64 > MAX_HOOK_STDIN_BYTES;
+    let _ = reader.take(MAX_HOOK_STDIN_BYTES + 1).read_to_end(&mut bytes);
+    let truncated = bytes.len() as u64 > MAX_HOOK_STDIN_BYTES;
     if truncated {
-        buf.truncate(MAX_HOOK_STDIN_BYTES as usize);
+        bytes.truncate(MAX_HOOK_STDIN_BYTES as usize);
     }
-    (buf, truncated)
+    (String::from_utf8_lossy(&bytes).into_owned(), truncated)
 }
 
 /// Handle one hook invocation, from the gateway binary's `--toolport-hook` path.
@@ -549,6 +561,7 @@ fn apply_to(
             reg.hooks_enabled = enabled;
         }
         let mut statuses: Vec<ProfileStatus> = Vec::new();
+        let previous: Vec<String> = reg.hook_targets.clone();
 
         // Every profile that SHOULD carry the sensor right now. Empty when the user has
         // opted out, which is what turns this pass into a full removal.
@@ -558,6 +571,7 @@ fn apply_to(
             Vec::new()
         };
 
+        let mut written: Vec<String> = Vec::new();
         if reg.hooks_enabled {
             // Resolved before any write. Failing here aborts the whole transaction, so
             // an un-installable build leaves the opt-in exactly as it was.
@@ -566,11 +580,14 @@ fn apply_to(
             })?;
             for path in candidates.iter().map(Path::new) {
                 statuses.push(match install_at(path, binary) {
-                    Ok(()) => ProfileStatus {
-                        path: path.display().to_string(),
-                        installed: true,
-                        error: None,
-                    },
+                    Ok(()) => {
+                        written.push(path.display().to_string());
+                        ProfileStatus {
+                            path: path.display().to_string(),
+                            installed: true,
+                            error: None,
+                        }
+                    }
                     Err(error) => ProfileStatus {
                         path: path.display().to_string(),
                         installed: false,
@@ -601,7 +618,21 @@ fn apply_to(
             }
         }
 
-        let mut targets = candidates;
+        // What we now believe may carry our block on disk. A candidate earns a place by
+        // being written this pass, OR by already being recorded.
+        //
+        // The second half matters and is not the same as "record every candidate". A
+        // profile whose `settings.json` we could not parse may still hold a block from
+        // an earlier successful pass, and we cannot tell, precisely because we could not
+        // read it; forgetting it would strand a sensor that is still firing (SBS-914).
+        // But a profile we have never written and cannot read has no such history, so it
+        // is not recorded, and a broken file the user never enabled does not become a
+        // permanent retry.
+        let mut targets: Vec<String> = candidates
+            .iter()
+            .filter(|p| written.contains(p) || previous.contains(p))
+            .cloned()
+            .collect();
         targets.extend(unremovable);
         reg.hook_targets = targets;
         Ok(statuses)
@@ -1213,6 +1244,100 @@ mod tests {
         let (read, truncated) = read_payload(payload.as_bytes());
         assert!(!truncated);
         assert_eq!(read, payload);
+    }
+
+    #[test]
+    fn a_cap_landing_inside_a_codepoint_does_not_panic() {
+        // The exit-0 guarantee's sharpest edge. `String::truncate` panics off a char
+        // boundary, and a hook process that panics exits non-zero, which on some events
+        // stops the user's work. Three-byte characters mean the 1 MiB mark lands inside
+        // one, not on it.
+        let mut payload = String::from("{\"tool_input\":\"");
+        while payload.len() < (MAX_HOOK_STDIN_BYTES as usize + 64) {
+            payload.push('あ');
+        }
+
+        let (read, truncated) = read_payload(payload.as_bytes());
+        assert!(truncated);
+        // Bounded, but not by the byte cap exactly: a cut codepoint becomes U+FFFD,
+        // which is 3 bytes and can be wider than the 1-2 bytes it replaced. At most one
+        // sits at the end, so the slack is a constant, not a multiplier.
+        assert!(
+            read.len() <= MAX_HOOK_STDIN_BYTES as usize + 3,
+            "payload grew past the cap by more than one replacement char: {}",
+            read.len()
+        );
+        // Lossy conversion, so a cut codepoint is a replacement char, never a panic and
+        // never invalid UTF-8.
+        assert!(std::str::from_utf8(read.as_bytes()).is_ok());
+    }
+
+    #[test]
+    fn invalid_utf8_input_still_produces_a_payload() {
+        // `read_to_string` would fail with InvalidData and leave the buffer empty, so
+        // both the payload AND the fact it was oversized would be lost. Reading bytes
+        // cannot do that.
+        let mut raw: Vec<u8> = b"{\"tool_name\":\"Bash\",\"x\":\"".to_vec();
+        raw.push(0xff); // never valid UTF-8
+        raw.extend_from_slice(b"\"}");
+
+        let (read, truncated) = read_payload(raw.as_slice());
+        assert!(!truncated);
+        assert!(read.contains("Bash"), "the readable part must survive: {read}");
+        assert!(read.contains('\u{fffd}'), "the bad byte becomes a replacement char");
+    }
+
+    #[test]
+    fn a_profile_we_never_wrote_and_cannot_read_is_not_recorded_as_a_target() {
+        // Recording a candidate we never wrote makes a file the user broke into a
+        // permanent retry: every later pass tries to remove a block that was never
+        // there and fails on the same parse error.
+        let _guard = crate::registry::data_dir_test_lock();
+        let dir = scratch("never-written");
+        let _override = crate::registry::DataDirOverride::set(&dir);
+        let profile = dir.join("settings.json");
+        std::fs::write(&profile, "{ not json").unwrap();
+
+        let statuses = apply_to(Some(true), &[profile.clone()], Some(&binary())).unwrap();
+        assert_eq!(statuses.len(), 1);
+        assert!(!statuses[0].installed);
+        assert!(statuses[0].error.is_some(), "the failure must be reported");
+        assert!(
+            crate::registry::load().unwrap().hook_targets.is_empty(),
+            "a profile we never wrote must not be recorded as ours"
+        );
+
+        drop(_override);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn a_profile_we_did_write_stays_recorded_when_a_later_pass_cannot_read_it() {
+        // The other half, and the one the naive "record only successful writes" rule
+        // gets wrong: a block we really did write must stay tracked through a failure,
+        // or a later disable will not clean it and the sensor keeps firing (SBS-914).
+        let _guard = crate::registry::data_dir_test_lock();
+        let dir = scratch("written-then-broken");
+        let _override = crate::registry::DataDirOverride::set(&dir);
+        let profile = dir.join("settings.json");
+
+        apply_to(Some(true), &[profile.clone()], Some(&binary())).unwrap();
+        assert_eq!(
+            crate::registry::load().unwrap().hook_targets,
+            vec![profile.display().to_string()]
+        );
+
+        // The user (or another tool) breaks the file after we installed into it.
+        std::fs::write(&profile, "{ broken").unwrap();
+        apply_to(None, &[profile.clone()], Some(&binary())).unwrap();
+        assert_eq!(
+            crate::registry::load().unwrap().hook_targets,
+            vec![profile.display().to_string()],
+            "a profile we wrote must stay recorded through a read failure"
+        );
+
+        drop(_override);
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]

--- a/src-tauri/src/hooks.rs
+++ b/src-tauri/src/hooks.rs
@@ -947,15 +947,39 @@ mod tests {
 
     // --- on-disk behavior ---------------------------------------------------
 
-    fn scratch(name: &str) -> PathBuf {
+    /// A scratch directory that is ALSO the process-global data dir for the test.
+    ///
+    /// Both halves are required. `install_at` on an existing file takes a backup, and
+    /// backups land under `registry::conduit_dir()`, so a test without the override
+    /// writes into the real Toolport data directory and races every other test doing
+    /// the same. That is what failed on CI Windows with "the system cannot find the
+    /// path specified" while passing locally.
+    ///
+    /// Field order IS drop order: the override is cleared before the lock is released,
+    /// so no other test can observe this scratch dir.
+    struct ScratchEnv {
+        dir: PathBuf,
+        _override: crate::registry::DataDirOverride,
+        _lock: std::sync::MutexGuard<'static, ()>,
+    }
+
+    impl Drop for ScratchEnv {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.dir);
+        }
+    }
+
+    fn scratch_env(name: &str) -> ScratchEnv {
         static SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+        let lock = crate::registry::data_dir_test_lock();
         let dir = std::env::temp_dir().join(format!(
             "toolport-hooks-{name}-{}-{}",
             std::process::id(),
             SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
         ));
         std::fs::create_dir_all(&dir).unwrap();
-        dir
+        let over = crate::registry::DataDirOverride::set(&dir);
+        ScratchEnv { dir, _override: over, _lock: lock }
     }
 
     fn read(path: &Path) -> String {
@@ -964,7 +988,8 @@ mod tests {
 
     #[test]
     fn install_creates_a_settings_file_that_did_not_exist() {
-        let dir = scratch("fresh");
+        let env = scratch_env("fresh");
+        let dir = env.dir.clone();
         let path = dir.join("settings.json");
 
         install_at(&path, &binary()).unwrap();
@@ -974,12 +999,12 @@ mod tests {
         // A file we created holds nothing but our block.
         assert_eq!(root.as_object().unwrap().len(), 1);
 
-        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]
     fn install_preserves_comments_and_every_unrelated_setting() {
-        let dir = scratch("comments");
+        let env = scratch_env("comments");
+        let dir = env.dir.clone();
         let path = dir.join("settings.json");
         let original = "{\n  // the model I actually want\n  \"model\": \"opus\",\n  \"permissions\": { \"allow\": [\"Bash(git status)\"] }\n}\n";
         std::fs::write(&path, original).unwrap();
@@ -1005,12 +1030,12 @@ mod tests {
             "uninstall must not leave an empty hooks object: {restored}"
         );
 
-        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]
     fn install_is_a_no_op_when_the_file_already_says_what_we_would_write() {
-        let dir = scratch("noop");
+        let env = scratch_env("noop");
+        let dir = env.dir.clone();
         let path = dir.join("settings.json");
 
         install_at(&path, &binary()).unwrap();
@@ -1019,12 +1044,12 @@ mod tests {
 
         assert_eq!(first, read(&path), "a second apply must not rewrite bytes");
 
-        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]
     fn a_duplicate_hooks_key_is_refused_and_the_file_is_left_alone() {
-        let dir = scratch("dupe");
+        let env = scratch_env("dupe");
+        let dir = env.dir.clone();
         let path = dir.join("settings.json");
         // Ambiguous: a rewrite would silently drop one of the two.
         let original = "{ \"hooks\": {}, \"hooks\": {} }";
@@ -1033,12 +1058,12 @@ mod tests {
         assert!(install_at(&path, &binary()).is_err());
         assert_eq!(read(&path), original, "the file must be untouched");
 
-        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]
     fn a_malformed_settings_file_is_refused_rather_than_replaced() {
-        let dir = scratch("malformed");
+        let env = scratch_env("malformed");
+        let dir = env.dir.clone();
         let path = dir.join("settings.json");
         let original = "{ this is not json";
         std::fs::write(&path, original).unwrap();
@@ -1047,22 +1072,22 @@ mod tests {
         assert!(remove_at(&path).is_err(), "removal must not rewrite it either");
         assert_eq!(read(&path), original);
 
-        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]
     fn removing_from_a_profile_that_no_longer_exists_is_success() {
-        let dir = scratch("gone");
+        let env = scratch_env("gone");
+        let dir = env.dir.clone();
         let path = dir.join("settings.json");
         // A profile the user deleted between apply and remove is a stronger form of
         // "removed", not an error to report.
         assert!(remove_at(&path).is_ok());
-        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]
     fn removing_leaves_a_foreign_hook_on_the_same_event_intact() {
-        let dir = scratch("foreign");
+        let env = scratch_env("foreign");
+        let dir = env.dir.clone();
         let path = dir.join("settings.json");
         std::fs::write(
             &path,
@@ -1079,7 +1104,6 @@ mod tests {
         let root: Value = crate::clients::read_settings_json(&path).unwrap().0;
         assert_eq!(root["hooks"]["PostToolUse"], json!([foreign_group()]));
 
-        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]
@@ -1087,9 +1111,8 @@ mod tests {
         // The hook path runs before any gateway startup, so it must work against a
         // data directory that holds nothing at all - no registry.json, no keychain.
         // This is the "does not touch the registry" property from the spec.
-        let _guard = crate::registry::data_dir_test_lock();
-        let dir = scratch("no-registry");
-        let _override = crate::registry::DataDirOverride::set(&dir);
+        let env = scratch_env("no-registry");
+        let dir = env.dir.clone();
 
         handle_event(
             "tool",
@@ -1103,15 +1126,11 @@ mod tests {
         assert_eq!(rows[0]["sessionId"], json!("s1"));
         assert!(!dir.join("registry.json").exists(), "no registry was created");
 
-        drop(_override);
-        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]
     fn handle_event_survives_junk_stdin_and_an_unknown_event() {
-        let _guard = crate::registry::data_dir_test_lock();
-        let dir = scratch("junk");
-        let _override = crate::registry::DataDirOverride::set(&dir);
+        let _env = scratch_env("junk");
 
         // Unparseable payload: recorded, flagged, and with no `tool` key so no reader
         // can mistake it for an observed call.
@@ -1124,16 +1143,11 @@ mod tests {
         assert_eq!(rows[0]["malformed"], json!(true));
         assert!(rows[0].get("tool").is_none());
         assert!(rows[0].get("ok").is_none());
-
-        drop(_override);
-        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]
     fn recorded_rows_are_one_json_line_each_and_newest_first() {
-        let _guard = crate::registry::data_dir_test_lock();
-        let dir = scratch("order");
-        let _override = crate::registry::DataDirOverride::set(&dir);
+        let _env = scratch_env("order");
 
         handle_event("session-start", &json!({ "session_id": "s1" }).to_string());
         handle_event("tool", &json!({ "session_id": "s1", "tool_name": "Read" }).to_string());
@@ -1146,8 +1160,6 @@ mod tests {
         assert_eq!(rows[0]["event"], json!("session-end"));
         assert_eq!(rows[2]["event"], json!("session-start"));
 
-        drop(_override);
-        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]
@@ -1155,9 +1167,8 @@ mod tests {
         // The overwhelmingly common launch. It must not scan profiles, resolve a
         // gateway binary, or write to the registry, because it runs on the same
         // thread as every other launch task.
-        let _guard = crate::registry::data_dir_test_lock();
-        let dir = scratch("startup-off");
-        let _override = crate::registry::DataDirOverride::set(&dir);
+        let env = scratch_env("startup-off");
+        let dir = env.dir.clone();
 
         apply_on_startup();
 
@@ -1166,15 +1177,14 @@ mod tests {
             "a launch with the sensor off must not write anything"
         );
 
-        drop(_override);
-        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]
     fn a_target_whose_removal_failed_stays_recorded_for_the_next_pass() {
         // The SBS-914 shape: dropping a path we could not clean strands the file,
         // because nothing would ever try again.
-        let dir = scratch("retry");
+        let env = scratch_env("retry");
+        let dir = env.dir.clone();
         let path = dir.join("settings.json");
         std::fs::write(&path, "{ not json }").unwrap();
 
@@ -1184,7 +1194,6 @@ mod tests {
         );
         assert!(path.exists(), "and must not be deleted or rewritten");
 
-        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]
@@ -1292,9 +1301,8 @@ mod tests {
         // Recording a candidate we never wrote makes a file the user broke into a
         // permanent retry: every later pass tries to remove a block that was never
         // there and fails on the same parse error.
-        let _guard = crate::registry::data_dir_test_lock();
-        let dir = scratch("never-written");
-        let _override = crate::registry::DataDirOverride::set(&dir);
+        let env = scratch_env("never-written");
+        let dir = env.dir.clone();
         let profile = dir.join("settings.json");
         std::fs::write(&profile, "{ not json").unwrap();
 
@@ -1307,8 +1315,6 @@ mod tests {
             "a profile we never wrote must not be recorded as ours"
         );
 
-        drop(_override);
-        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]
@@ -1316,9 +1322,8 @@ mod tests {
         // The other half, and the one the naive "record only successful writes" rule
         // gets wrong: a block we really did write must stay tracked through a failure,
         // or a later disable will not clean it and the sensor keeps firing (SBS-914).
-        let _guard = crate::registry::data_dir_test_lock();
-        let dir = scratch("written-then-broken");
-        let _override = crate::registry::DataDirOverride::set(&dir);
+        let env = scratch_env("written-then-broken");
+        let dir = env.dir.clone();
         let profile = dir.join("settings.json");
 
         apply_to(Some(true), &[profile.clone()], Some(&binary())).unwrap();
@@ -1336,15 +1341,14 @@ mod tests {
             "a profile we wrote must stay recorded through a read failure"
         );
 
-        drop(_override);
-        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]
     fn preview_text_is_the_bytes_install_actually_writes() {
         // The dry run must not claim a comment is about to disappear when the real
         // write keeps it (SBS-822 review).
-        let dir = scratch("preview-bytes");
+        let env = scratch_env("preview-bytes");
+        let dir = env.dir.clone();
         let path = dir.join("settings.json");
         let original =
             "{\n  // the model I actually want\n  \"model\": \"opus\"\n}\n";
@@ -1364,12 +1368,12 @@ mod tests {
         );
         assert!(previews[0].after.contains("// the model I actually want"));
 
-        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]
     fn preview_writes_nothing_at_all() {
-        let dir = scratch("preview-readonly");
+        let env = scratch_env("preview-readonly");
+        let dir = env.dir.clone();
         let path = dir.join("settings.json");
 
         // A profile with no settings file yet: the dry run must not create one.
@@ -1378,7 +1382,6 @@ mod tests {
         assert!(previews[0].after.contains(HOOK_MARKER));
         assert!(!path.exists(), "a dry run must not create the settings file");
 
-        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]
@@ -1386,9 +1389,8 @@ mod tests {
         // A failed apply must leave the registry exactly as it was. Otherwise `view()`
         // reports enabled with nothing installed and every startup retries the same
         // failing apply forever, with no path back (SBS-822 review).
-        let _guard = crate::registry::data_dir_test_lock();
-        let dir = scratch("enable-fails");
-        let _override = crate::registry::DataDirOverride::set(&dir);
+        let env = scratch_env("enable-fails");
+        let dir = env.dir.clone();
         let profile = dir.join(".claude").join("settings.json");
 
         // No resolvable binary is the real-world case this models: every non-Windows
@@ -1405,15 +1407,12 @@ mod tests {
             "and must not have written a settings file first"
         );
 
-        drop(_override);
-        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]
     fn enabling_commits_the_opt_in_and_the_targets_together() {
-        let _guard = crate::registry::data_dir_test_lock();
-        let dir = scratch("enable-commits");
-        let _override = crate::registry::DataDirOverride::set(&dir);
+        let env = scratch_env("enable-commits");
+        let dir = env.dir.clone();
         let profile = dir.join(".claude").join("settings.json");
         std::fs::create_dir_all(profile.parent().unwrap()).unwrap();
 
@@ -1438,15 +1437,12 @@ mod tests {
             &crate::clients::read_settings_json(&profile).unwrap().0
         ));
 
-        drop(_override);
-        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]
     fn read_recent_reports_an_unreadable_log_instead_of_saying_nothing_happened() {
-        let _guard = crate::registry::data_dir_test_lock();
-        let dir = scratch("unreadable");
-        let _override = crate::registry::DataDirOverride::set(&dir);
+        let env = scratch_env("unreadable");
+        let dir = env.dir.clone();
 
         // A directory where the log file should be: readable as a path, not as a file.
         std::fs::create_dir_all(dir.join("hooks.jsonl")).unwrap();
@@ -1455,7 +1451,5 @@ mod tests {
             "an unreadable log must not read as an empty one (SBS-873)"
         );
 
-        drop(_override);
-        let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/src-tauri/src/hooks.rs
+++ b/src-tauri/src/hooks.rs
@@ -105,6 +105,11 @@ pub struct HooksPreview {
     pub before: String,
     /// The file as it would be after the write.
     pub after: String,
+    /// Why this profile has no dry run, when that is the case. Mirrors
+    /// [`ProfileStatus::error`], and for the same reason: one profile we cannot read
+    /// must not answer for the ones we can.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
 }
 
 // ---------------------------------------------------------------------------
@@ -712,15 +717,33 @@ pub fn preview() -> Result<Vec<HooksPreview>, String> {
 
 /// [`preview`] over an explicit profile set and binary, so tests drive known files
 /// instead of the developer's real `~/.claude`. Same rationale as [`apply_to`].
+///
+/// Per profile, not all-or-nothing. `?`-ing the first bad `settings.json` out meant one
+/// hand-broken file - a stray comma in a `.claude-backup` nobody uses - hid the dry run
+/// for every healthy profile, and the error named none of them. [`apply_to`] already
+/// takes the opposite position, so the preview also disagreed with what the install it
+/// is previewing would actually do (SBS-822 review).
 fn preview_to(profiles: &[PathBuf], binary: &Path) -> Result<Vec<HooksPreview>, String> {
     let mut out = Vec::new();
     for path in profiles {
-        let (root, original) = crate::clients::read_settings_json(path)?;
-        let updated = upsert_hooks(&root, binary)?;
-        out.push(HooksPreview {
-            path: path.display().to_string(),
-            before: original.clone().unwrap_or_default(),
-            after: crate::clients::render_settings_json(original.as_deref(), &updated)?,
+        let rendered = crate::clients::read_settings_json(path).and_then(|(root, original)| {
+            let updated = upsert_hooks(&root, binary)?;
+            let after = crate::clients::render_settings_json(original.as_deref(), &updated)?;
+            Ok((original.unwrap_or_default(), after))
+        });
+        out.push(match rendered {
+            Ok((before, after)) => HooksPreview {
+                path: path.display().to_string(),
+                before,
+                after,
+                error: None,
+            },
+            Err(error) => HooksPreview {
+                path: path.display().to_string(),
+                before: String::new(),
+                after: String::new(),
+                error: Some(error),
+            },
         });
     }
     Ok(out)
@@ -1396,6 +1419,32 @@ mod tests {
         assert!(previews[0].before.is_empty());
         assert!(previews[0].after.contains(HOOK_MARKER));
         assert!(!path.exists(), "a dry run must not create the settings file");
+
+    }
+
+    #[test]
+    fn one_unreadable_profile_does_not_hide_the_preview_for_the_healthy_ones() {
+        let env = scratch_env("preview-degrades");
+        let dir = env.dir.clone();
+        let broken = dir.join("broken.json");
+        let healthy = dir.join("healthy.json");
+        std::fs::write(&broken, "{ this is not json").unwrap();
+        std::fs::write(&healthy, "{ \"model\": \"opus\" }").unwrap();
+
+        // Broken first, so an all-or-nothing `?` would take the healthy one down with it.
+        let previews = preview_to(&[broken.clone(), healthy.clone()], &binary()).unwrap();
+
+        assert_eq!(previews.len(), 2, "every profile gets a row");
+        assert!(
+            previews[0].error.is_some(),
+            "the unreadable profile must say why it has no dry run"
+        );
+        assert!(previews[0].after.is_empty());
+        assert!(
+            previews[1].error.is_none() && previews[1].after.contains(HOOK_MARKER),
+            "the healthy profile still previews: {:?}",
+            previews[1]
+        );
 
     }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -12,6 +12,7 @@ mod desktop;
 pub mod downstream;
 pub mod gateway_publish;
 pub mod gatewaylog;
+pub mod hooks;
 pub mod inspect;
 pub mod instructions;
 pub mod integrity;

--- a/src-tauri/src/registry.rs
+++ b/src-tauri/src/registry.rs
@@ -77,6 +77,81 @@ pub fn open_append_private(path: &Path) -> std::io::Result<std::fs::File> {
     Ok(file)
 }
 
+/// Keep the last `keep` non-empty lines of `content`, newline-terminated.
+pub(crate) fn trimmed_tail(content: &str, keep: usize) -> String {
+    let lines: Vec<&str> = content.lines().filter(|l| !l.trim().is_empty()).collect();
+    let start = lines.len().saturating_sub(keep);
+    let mut out = lines[start..].join("\n");
+    if !out.is_empty() {
+        out.push('\n');
+    }
+    out
+}
+
+/// Append one already-serialized JSONL `line` to `path` under the cross-process
+/// lock for that path, then trim to `keep_lines` once the file passes `max_bytes`.
+///
+/// Shared by the tool-call audit log ([`crate::audit`]) and the agent-hook sensor
+/// log ([`crate::hooks`]). Both are appended to by several independent processes at
+/// once - every client's gateway, and one short-lived process per hook event - so an
+/// in-process mutex is not enough. Atomic replacement protects readers from partial
+/// files, but only this shared critical section prevents a stale rotation snapshot
+/// from replacing an append that completed in another process (#708).
+///
+/// `after_snapshot` is a test seam: it runs between reading the file for rotation and
+/// writing the trimmed result, so a test can prove an append landing in that window
+/// is not lost.
+///
+/// Returns `Err` only when the line could not be recorded. Trimming is best-effort:
+/// a failure there never fails the append it follows.
+pub(crate) fn append_line_locked(
+    path: &Path,
+    line: &str,
+    max_bytes: u64,
+    keep_lines: usize,
+    after_snapshot: Option<&mut dyn FnMut()>,
+) -> Result<(), String> {
+    use std::io::Write as _;
+
+    let _lock = lock_at(path)?;
+    // Owner-only from creation, not from the first rotation onward (SBS-868).
+    let open = || open_append_private(path);
+    // The registry normally created this directory before any call. Avoid a
+    // redundant create-directory syscall on every append, but retain the
+    // standalone/first-writer behavior by creating it and retrying on NotFound.
+    let mut file = match open() {
+        Ok(file) => file,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            if let Some(parent) = path.parent() {
+                let _ = std::fs::create_dir_all(parent);
+            }
+            open().map_err(|e| e.to_string())?
+        }
+        Err(error) => return Err(error.to_string()),
+    };
+    let mut bytes = line.to_string();
+    if !bytes.ends_with('\n') {
+        bytes.push('\n');
+    }
+    file.write_all(bytes.as_bytes()).map_err(|e| e.to_string())?;
+    // Query size through the handle we already opened instead of reopening the
+    // path for metadata. Drop it before rotation so Windows can atomically replace
+    // the log when the cap is crossed.
+    let size = file.metadata().map(|metadata| metadata.len()).unwrap_or(0);
+    drop(file);
+    if size > max_bytes {
+        if let Ok(content) = std::fs::read_to_string(path) {
+            if let Some(hook) = after_snapshot {
+                hook();
+            }
+            // Atomic + unique temp: several processes share this file, so a bespoke
+            // fixed temp name could let two rotations collide.
+            let _ = atomic_write(path, &trimmed_tail(&content, keep_lines));
+        }
+    }
+    Ok(())
+}
+
 trait AtomicWriteOps {
     fn set_owner_only(&self, file: &std::fs::File) -> std::io::Result<()>;
     fn write_all(&self, file: &mut std::fs::File, contents: &[u8]) -> std::io::Result<()>;
@@ -759,6 +834,16 @@ pub struct Registry {
     /// Same role as `TeamConnection::team_instructions_targets`.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub rules_targets: Vec<String>,
+    /// Whether the native-agent hook sensor is installed. OFF until the user opts in:
+    /// it writes into a settings file they own and it observes every native tool call
+    /// their agent makes. See [`crate::hooks`].
+    #[serde(default)]
+    pub hooks_enabled: bool,
+    /// Absolute paths of the agent settings files we have written hooks into, so
+    /// removal touches exactly what we created. Same role as `rules_targets`, and the
+    /// reason a profile that disappears between apply and remove is not an error.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub hook_targets: Vec<String>,
     /// Top-level fields THIS build doesn't know, preserved verbatim across
     /// load -> save. The registry is shared by mixed versions of the app and
     /// long-running gateways (a dev build, the installed release, and gateways
@@ -1017,6 +1102,8 @@ impl Default for Registry {
             active_rule_set_id: None,
             rules_clients: HashMap::new(),
             rules_targets: Vec::new(),
+            hooks_enabled: false,
+            hook_targets: Vec::new(),
             unknown_fields: serde_json::Map::new(),
         }
     }
@@ -5570,5 +5657,56 @@ mod tests {
                 "Toolport"
             }
         );
+    }
+
+    #[test]
+    fn trimmed_tail_keeps_last_n_lines() {
+        assert_eq!(trimmed_tail("a\nb\nc\nd\ne\n", 2), "d\ne\n");
+        // Fewer lines than the cap -> unchanged (re-normalized with trailing \n).
+        assert_eq!(trimmed_tail("x\ny\n", 5), "x\ny\n");
+        // Blank lines are dropped.
+        assert_eq!(trimmed_tail("a\n\n\nb\n", 5), "a\nb\n");
+        assert_eq!(trimmed_tail("", 5), "");
+    }
+
+    #[test]
+    fn append_line_locked_creates_parent_and_terminates_the_line() {
+        let dir = std::env::temp_dir().join(format!(
+            "toolport-append-line-{}-{}",
+            std::process::id(),
+            ATOMIC_WRITE_SEQ.fetch_add(1, Ordering::Relaxed)
+        ));
+        let path = dir.join("nested").join("log.jsonl");
+
+        // No trailing newline from the caller: the appender supplies it, so two
+        // appends cannot end up concatenated on one line.
+        append_line_locked(&path, "{\"a\":1}", 1024 * 1024, 100, None).unwrap();
+        append_line_locked(&path, "{\"a\":2}\n", 1024 * 1024, 100, None).unwrap();
+
+        let content = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(content, "{\"a\":1}\n{\"a\":2}\n");
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn append_line_locked_trims_once_past_the_cap() {
+        let dir = std::env::temp_dir().join(format!(
+            "toolport-append-trim-{}-{}",
+            std::process::id(),
+            ATOMIC_WRITE_SEQ.fetch_add(1, Ordering::Relaxed)
+        ));
+        let path = dir.join("log.jsonl");
+
+        // A 1-byte cap makes every append cross it, so the keep_lines window is
+        // what bounds the file.
+        for i in 0..10 {
+            append_line_locked(&path, &format!("{{\"i\":{i}}}"), 1, 3, None).unwrap();
+        }
+
+        let content = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(content, "{\"i\":7}\n{\"i\":8}\n{\"i\":9}\n");
+
+        let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/src-tauri/src/registry.rs
+++ b/src-tauri/src/registry.rs
@@ -140,10 +140,24 @@ pub(crate) fn append_line_locked(
     let size = file.metadata().map(|metadata| metadata.len()).unwrap_or(0);
     drop(file);
     if size > max_bytes {
-        if let Ok(content) = std::fs::read_to_string(path) {
+        // Read BYTES, not a String. `read_to_string` fails with `InvalidData` on invalid
+        // UTF-8, and an ignored `Err` there disables rotation PERMANENTLY: the file is
+        // never trimmed, every later append grows it, and the cap that is the whole point
+        // of this branch stops existing. One torn write from a killed process, or a hand
+        // edit, is enough to arm that forever (SBS-822 review).
+        //
+        // A lossy conversion cannot fail, so the trim always runs. A mangled line survives
+        // as replacement characters, which readers already skip (they `filter_map` the
+        // JSON parse), and it ages out of the keep window like any other line.
+        //
+        // The `atomic_write` result stays ignored on purpose, and is a different case: a
+        // failed rotation leaves the file oversized, so the NEXT append past the cap tries
+        // again. That self-heals; an unreadable file never would.
+        if let Ok(bytes) = std::fs::read(path) {
             if let Some(hook) = after_snapshot {
                 hook();
             }
+            let content = String::from_utf8_lossy(&bytes);
             // Atomic + unique temp: several processes share this file, so a bespoke
             // fixed temp name could let two rotations collide.
             let _ = atomic_write(path, &trimmed_tail(&content, keep_lines));
@@ -5685,6 +5699,43 @@ mod tests {
 
         let content = std::fs::read_to_string(&path).unwrap();
         assert_eq!(content, "{\"a\":1}\n{\"a\":2}\n");
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn append_line_locked_still_trims_a_log_holding_invalid_utf8() {
+        // The permanent-disable case: `read_to_string` would fail here and the ignored
+        // Err would leave the file growing past its cap forever (SBS-822 review).
+        let dir = std::env::temp_dir().join(format!(
+            "toolport-append-utf8-{}-{}",
+            std::process::id(),
+            ATOMIC_WRITE_SEQ.fetch_add(1, Ordering::Relaxed)
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("log.jsonl");
+
+        // A torn write: a line ending mid-codepoint, exactly what a killed process leaves.
+        let mut seeded: Vec<u8> = b"{\"i\":0}\n{\"i\":1,\"x\":\"".to_vec();
+        seeded.push(0xff);
+        seeded.extend_from_slice(b"\"}\n");
+        std::fs::write(&path, &seeded).unwrap();
+        assert!(
+            std::fs::read_to_string(&path).is_err(),
+            "test premise: this file is not readable as UTF-8"
+        );
+
+        // A 1-byte cap makes this append cross it, so rotation must run.
+        append_line_locked(&path, "{\"i\":2}", 1, 2, None).unwrap();
+
+        let after = std::fs::read(&path).unwrap();
+        assert!(
+            after.len() < seeded.len() + 16,
+            "the log must have been trimmed, not just appended to"
+        );
+        let text = String::from_utf8_lossy(&after);
+        assert_eq!(text.lines().count(), 2, "keep_lines still bounds it: {text}");
+        assert!(text.ends_with("{\"i\":2}\n"), "the new line survives: {text}");
 
         let _ = std::fs::remove_dir_all(&dir);
     }


### PR DESCRIPTION
Sensor half of SBS-822, and the collector [SBS-823](https://linear.app/southboundsoftware/issue/SBS-823) depends on. Item 2 of epic [SBS-820](https://linear.app/southboundsoftware/issue/SBS-820).

Toolport governs calls routed through the gateway and is blind to what Claude Code does natively. `Bash`, `Edit`, `Read` and `WebFetch` never touch MCP, so the audit log, the destructive-tool gate and human approval all stop at that boundary.

## It observes; it cannot refuse

Three properties, structural rather than promises the code keeps:

- **`PreToolUse` is not registered.** It is the event whose exit status can refuse a user's tool call. Leaving it out means no defect in this module can block an agent. `SessionStart` / `PostToolUse` / `SessionEnd` are enough to group tool use by session, which is what the dashboard needs.
- **No payload content is stored.** Payloads carry `tool_input` and `tool_response`: the `Bash` command line, the bytes of an `Edit`, whatever a `Read` returned. A row keeps a tool name, session id, cwd and args hash, the same contract `audit.jsonl` already holds. A test asserts a payload carrying a recognizable secret produces a row that does not contain it.
- **The hook exits 0 on every path**, including unparseable stdin and a full disk, and writes nothing to stdout, which the harness reads.

The enforcer is deliberately not here. Its one unanswered question is what happens when a call needs a decision and Toolport is not running; both obvious answers are bad, and shipping "enforcement" that is advisory would be the exact lie this codebase keeps fixing (SBS-873, SBS-932, SBS-702). The spec records the proposed answer so that ship starts from a decision.

## Design notes

**Transport** is a subcommand on the gateway binary (`--toolport-hook <event>`), so it inherits the install location, version pinning, pruning and signing that path already has, instead of adding a fourth artifact to build, sign, notarize and ship. The same literal is the removal marker: JSON has no comments, so entries are identified by content, the rule `instructions::remove_recorded` already uses.

**Rows go to their own `hooks.jsonl`, not `audit.jsonl`.** One active session fires `PostToolUse` on every `Read`, `Edit` and `Bash`, one to two orders of magnitude more rows than gateway traffic. Sharing the file would push governance rows out through the audit log's own trim and let telemetry evict the compliance artifact. The locked cross-process append and rotation both files need is extracted to `registry::append_line_locked`, so #708, SBS-868 and SBS-869 stay true for both by construction rather than by two copies staying in step.

**Every Claude Code profile, not just the resolved one.** `claude_code_config_paths_from` exists because a machine routinely has `~/.claude` beside `~/.claude-work`, chosen per shell by `CLAUDE_CONFIG_DIR`. A sensor in only one of them under-reports silently.

**Off by default**, re-applied at launch. The published gateway path is versioned and the reaper prunes superseded builds, so hooks written before an update would name a binary that no longer exists; `upsert_hooks` is idempotent and rewrites a stale path, and `install_at` compares first so a steady-state launch writes no bytes.

## Two bugs found while testing this

- **Removing a top-level key stripped every comment in the file.** `atomic_write_json_config` only rewrites a key it can still find, so once uninstall pruned `hooks` it fell through to a pretty-print of the whole document. Uninstalling a feature cost the user their annotations. Added `remove_json_key_preserving`, a CST delete. Caught by `install_preserves_comments_and_every_unrelated_setting`.
- **`apply()` could strand a settings file.** Cleanup was keyed on "failed to write this pass", so a transient read failure dropped the path from `hook_targets` and nothing ever tried again. Now keyed on "no longer a candidate", and a target whose removal failed stays recorded for the next pass. Same shape as SBS-914 on the rules path.

## Testing

`cargo test --lib --bins`: 1252 + 334 pass. CI-equivalent clippy (`--no-default-features --lib --bins`) exits 0.

The 29 hooks tests were proven load-bearing by mutation: registering `PreToolUse`, storing `tool_input` verbatim, defaulting an undecidable outcome to success, and dropping the container pruning each turned the expected test red, and only those.

## Not in this PR

No UI and no CHANGELOG entry. Nothing here is user-visible until the dashboard lands, and #796 is holding the `Unreleased` section for the agent-rules docs.

Spec is `docs/specs/agent-permissions.md`, local-only like every other spec (`/docs/specs/` is gitignored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add agent hook sensor so Toolport can observe native Claude Code tool calls
> - Adds a new [`hooks` module](https://github.com/tsouth89/toolport/pull/804/files#diff-ca5b63da4c148bc065b9fac5eb4131f089f3fdb9044919c8dfe7c56b7be60bb4) that installs command hooks into Claude Code's `settings.json` profiles for `SessionStart`, `PostToolUse`, and `SessionEnd` events, recording non-content metadata rows to `hooks.jsonl` via cross-process-safe JSONL append with size-bounded rotation.
> - Extends the `toolport-gateway` binary to act as a lightweight hook recorder when invoked with the `HOOK_MARKER` flag: reads a capped stdin payload, records the event row, and exits 0 without starting the gateway.
> - Exposes four new Tauri IPC commands (`hooks_view`, `hooks_set_enabled`, `hooks_preview`, `hooks_recent`) and calls `hooks::apply_on_startup()` at launch to repair stale binary paths after updates.
> - Adds `hooks_enabled` and `hook_targets` fields to the `Registry` struct and refactors audit log rotation into a shared `append_line_locked` utility in [`registry.rs`](https://github.com/tsouth89/toolport/pull/804/files#diff-8187fea44e15daa4059544c5fcff94f80f39fa1ec39c67eccccc153a98b39349).
> - Risk: hook installation modifies Claude Code's `settings.json` files across all detected profiles; a failed write leaves a partial state that `apply_on_startup` will attempt to repair on next launch.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f2c2ccd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->