### PR TITLE
refactor(gateway): remove dead McpSession::upstream_call shim

### DIFF
--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -11307,10 +11307,6 @@ impl McpSession {
         serde_json::to_string(&tagged).ok()
     }
 
-    fn upstream_call(&self, method: &str, params: Value) -> Result<Value, String> {
-        self.upstream_call_timeout(method, params, upstream_rpc_timeout(method))
-    }
-
     fn upstream_call_timeout(
         &self,
         method: &str,


### PR DESCRIPTION
## Summary

- Remove the unused `McpSession::upstream_call` forwarding shim.
- Keep `upstream_rpc_timeout` and explicit timeout call sites unchanged.

## Tests

- `npm run test:rust`

Closes #734

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove dead `McpSession::upstream_call` shim in gateway
> Deletes the unused `upstream_call` helper method from `McpSession` in [toolport-gateway.rs](https://github.com/tsouth89/toolport/pull/805/files#diff-fe5f13c01103f5adf39c870989b67ecdb11c19b3ba86b88c4acb028a7374cc01), which wrapped `upstream_call_timeout` with a timeout derived from `upstream_rpc_timeout(method)`. The method was dead code with no callers.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 91ebc96.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->