### PR TITLE
feat(ui): ask for a GitHub star, at most twice, never again

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -102,6 +102,7 @@ const SettingsView = lazy(() =>
 import { Button } from "@/components/ui/button";
 import { Callout } from "@/components/Callout";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
+import { GitHubStarPrompt, type StarSurface } from "@/components/GitHubStarPrompt";
 import { ConfirmDialog } from "@/components/ConfirmDialog";
 import { Input } from "@/components/ui/input";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
@@ -165,6 +166,12 @@ function App() {
   // Toolport into their tools.
   const [onboardingStep, setOnboardingStep] = useState(0);
   const [resumeAtConnect, setResumeAtConnect] = useState(false);
+  // Set when the wizard is completed in this session, which is the only trigger
+  // for the GitHub star card (see GitHubStarPrompt).
+  const [justOnboarded, setJustOnboarded] = useState(false);
+  // The star prompt shares the bottom-right corner with the toast stack, so
+  // toasts are offset upward while it is on screen instead of covering it.
+  const [starSurface, setStarSurface] = useState<StarSurface>(null);
 
   const lastProbeRef = useRef(0);
   const probeFlightRef = useRef(createSingleFlight<ProbeResult[]>());
@@ -698,6 +705,7 @@ function App() {
     // Drop the pre-rename key so brand remnants do not linger in DevTools.
     localStorage.removeItem("conduit.onboarded");
     setOnboarded(true);
+    setJustOnboarded(true);
     setShowOnboarding(false);
     setResumeAtConnect(false);
     setOnboardingStep(0);
@@ -1170,6 +1178,11 @@ function App() {
           />
         </Suspense>
       )}
+      <GitHubStarPrompt
+        justOnboarded={justOnboarded}
+        enabledCount={enabledCount}
+        onVisibleChange={setStarSurface}
+      />
       <PendingApprovals />
       {/* Quarantine has no global signal otherwise: the first sign used to be an agent
           call failing, with the only fix buried in Settings (SOU-293). */}
@@ -1262,7 +1275,17 @@ function App() {
           </dl>
         </DialogContent>
       </Dialog>
-      <Toaster theme={resolvedTheme} position="bottom-right" />
+      <Toaster
+        theme={resolvedTheme}
+        position="bottom-right"
+        offset={
+          starSurface === "chip"
+            ? { bottom: "3.5rem" }
+            : starSurface
+              ? { bottom: "10rem" }
+              : undefined
+        }
+      />
     </TooltipProvider>
   );
 }

--- a/src/components/GitHubStarPrompt.test.tsx
+++ b/src/components/GitHubStarPrompt.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, act } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { GitHubStarPrompt } from "./GitHubStarPrompt";
+import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
 import { STAR_PROMPT_KEY, STAR_REPO_URL } from "@/lib/starPrompt";
 
 const openExternal = vi.fn();
@@ -12,13 +13,36 @@ vi.mock("@/lib/openUrl", () => ({
 // Toolport lives in the tray. The prompt must show nothing, and spend nothing,
 // while the window is hidden; see windowVisible.test.ts for the signal itself.
 let windowVisible = true;
-vi.mock("@/lib/windowVisible", () => ({ useWindowVisible: () => windowVisible }));
+// Only the native visibility signal is faked. useModalOpen stays real, so the
+// dialog tests below run against the same body attribute a shipped dialog sets
+// and would break loudly if that signal ever moved.
+vi.mock("@/lib/windowVisible", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/windowVisible")>()),
+  useWindowVisible: () => windowVisible,
+}));
+
+/** A real modal dialog, so the "covered by a dialog" tests exercise Radix's own
+ *  overlay, focus trap and scroll lock rather than a hand-rolled stand-in. */
+function CoveringDialog({ open }: { open: boolean }) {
+  return (
+    <Dialog open={open}>
+      <DialogContent>
+        <DialogTitle>Settings</DialogTitle>
+      </DialogContent>
+    </Dialog>
+  );
+}
 
 /** Both cards are delayed: one waits out the closing wizard, the other leaves a
- *  returning user alone for a few seconds after launch. */
+ *  returning user alone for a few seconds after launch. The second pass drains
+ *  the beat the prompt waits before recording a surface as shown, which is only
+ *  scheduled once the surface has actually rendered. */
 async function flushDelays() {
   await act(async () => {
     vi.advanceTimersByTime(15000);
+  });
+  await act(async () => {
+    vi.advanceTimersByTime(1);
   });
 }
 
@@ -317,6 +341,139 @@ describe("while the app sits in the tray", () => {
 
     await flushDelays();
     expect(returningCard()).not.toBeNull();
+  });
+});
+
+describe("while a modal dialog covers the app", () => {
+  it("shows nothing and spends nothing", async () => {
+    // The dialog paints over the corner, traps focus and aria-hides everything
+    // under it. Rendering the card there would burn the one ask on something
+    // nobody can see, click or reach with a screen reader.
+    existingInstall();
+    render(
+      <>
+        <CoveringDialog open />
+        <GitHubStarPrompt justOnboarded={false} enabledCount={4} />
+      </>,
+    );
+    await flushDelays();
+
+    expect(returningCard()).toBeNull();
+    expect(localStorage.getItem(STAR_PROMPT_KEY)).toBeNull();
+  });
+
+  it("asks once the dialog is closed", async () => {
+    existingInstall();
+    const { rerender } = render(
+      <>
+        <CoveringDialog open />
+        <GitHubStarPrompt justOnboarded={false} enabledCount={4} />
+      </>,
+    );
+    await flushDelays();
+    expect(returningCard()).toBeNull();
+
+    rerender(
+      <>
+        <CoveringDialog open={false} />
+        <GitHubStarPrompt justOnboarded={false} enabledCount={4} />
+      </>,
+    );
+    await flushDelays();
+
+    expect(returningCard()).not.toBeNull();
+    expect(localStorage.getItem(STAR_PROMPT_KEY)).toBe("done");
+  });
+
+  it("does not let a dialog burn the chip either", async () => {
+    localStorage.setItem(STAR_PROMPT_KEY, "later");
+    render(
+      <>
+        <CoveringDialog open />
+        <GitHubStarPrompt justOnboarded={false} enabledCount={5} />
+      </>,
+    );
+    await flushDelays();
+
+    expect(chip()).toBeNull();
+    expect(localStorage.getItem(STAR_PROMPT_KEY)).toBe("later");
+  });
+});
+
+describe("a launch that ends before a delay does", () => {
+  it("drops the card timer when the prompt unmounts mid-delay", async () => {
+    const { unmount } = render(
+      <GitHubStarPrompt justOnboarded={true} enabledCount={0} />,
+    );
+    act(() => {
+      vi.advanceTimersByTime(300); // inside the 700ms wait
+    });
+    expect(onboardingCard()).toBeNull();
+
+    unmount();
+    expect(vi.getTimerCount()).toBe(0);
+    await flushDelays();
+    expect(onboardingCard()).toBeNull();
+  });
+
+  it("drops the returning timer when the prompt unmounts mid-delay", async () => {
+    existingInstall();
+    const { unmount } = render(
+      <GitHubStarPrompt justOnboarded={false} enabledCount={4} />,
+    );
+    act(() => {
+      vi.advanceTimersByTime(3000); // inside the 8s wait
+    });
+
+    unmount();
+    expect(vi.getTimerCount()).toBe(0);
+    await flushDelays();
+    // The card never appeared, so the single ask is still owed next launch.
+    expect(localStorage.getItem(STAR_PROMPT_KEY)).toBeNull();
+  });
+
+  it("books the chip when onboarding finishes but the window hides first", async () => {
+    // finishOnboarding writes the onboarding flag straight away, while the card
+    // waits out the closing wizard. A hide in between used to record nothing, so
+    // the next launch read an onboarded install with no star record and handed a
+    // day-old install the months-old wording, with no second chance.
+    windowVisible = false;
+    const first = render(<GitHubStarPrompt justOnboarded={true} enabledCount={4} />);
+    await flushDelays();
+    expect(onboardingCard()).toBeNull();
+    expect(localStorage.getItem(STAR_PROMPT_KEY)).toBe("later");
+    first.unmount();
+
+    windowVisible = true;
+    existingInstall(); // the flag finishOnboarding wrote for real
+    render(<GitHubStarPrompt justOnboarded={false} enabledCount={4} />);
+    await flushDelays();
+
+    expect(returningCard()).toBeNull();
+    expect(chip()).not.toBeNull();
+  });
+});
+
+describe("starring while a delay is still in flight", () => {
+  it("leaves storage at done, whatever lands afterwards", async () => {
+    // The card spends the ask as "later" when it appears, so a pending delay or
+    // a late flush after the click must not downgrade a finished ask and bring
+    // the chip back next launch.
+    const u = user();
+    const first = render(<GitHubStarPrompt justOnboarded={true} enabledCount={5} />);
+    await flushDelays();
+
+    await u.click(starButton());
+    expect(localStorage.getItem(STAR_PROMPT_KEY)).toBe("done");
+
+    await flushDelays();
+    expect(localStorage.getItem(STAR_PROMPT_KEY)).toBe("done");
+    expect(onboardingCard()).toBeNull();
+    first.unmount();
+
+    render(<GitHubStarPrompt justOnboarded={false} enabledCount={5} />);
+    await flushDelays();
+    expect(chip()).toBeNull();
   });
 });
 

--- a/src/components/GitHubStarPrompt.test.tsx
+++ b/src/components/GitHubStarPrompt.test.tsx
@@ -1,0 +1,297 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, act } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { GitHubStarPrompt } from "./GitHubStarPrompt";
+import { STAR_PROMPT_KEY, STAR_REPO_URL } from "@/lib/starPrompt";
+
+const openExternal = vi.fn();
+vi.mock("@/lib/openUrl", () => ({
+  openExternal: (...a: unknown[]) => openExternal(...a),
+}));
+
+// Toolport lives in the tray. The prompt must show nothing, and spend nothing,
+// while the window is hidden; see windowVisible.test.ts for the signal itself.
+let windowVisible = true;
+vi.mock("@/lib/windowVisible", () => ({ useWindowVisible: () => windowVisible }));
+
+/** Both cards are delayed: one waits out the closing wizard, the other leaves a
+ *  returning user alone for a few seconds after launch. */
+async function flushDelays() {
+  await act(async () => {
+    vi.advanceTimersByTime(15000);
+  });
+}
+
+const onboardingCard = () => screen.queryByText(/you.re all set/i);
+const returningCard = () => screen.queryByText(/enjoying toolport/i);
+const chip = () => screen.queryByRole("button", { name: /star toolport on github/i });
+const starButton = () => screen.getByRole("button", { name: /^star on github$/i });
+
+/** Marks the install as one that onboarded before this prompt shipped. */
+function existingInstall() {
+  localStorage.setItem("toolport.onboarded", "1");
+}
+
+const user = () => userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+
+beforeEach(() => {
+  openExternal.mockReset();
+  localStorage.clear();
+  windowVisible = true;
+  vi.useFakeTimers({ shouldAdvanceTime: true });
+});
+
+describe("a new install", () => {
+  it("shows nothing until onboarding is finished", async () => {
+    const { rerender } = render(
+      <GitHubStarPrompt justOnboarded={false} enabledCount={9} />,
+    );
+    await flushDelays();
+    expect(onboardingCard()).toBeNull();
+    // 9 servers is past the chip threshold, but a fresh user must not get both
+    // asks, and must never get the existing-user card.
+    expect(chip()).toBeNull();
+    expect(returningCard()).toBeNull();
+
+    rerender(<GitHubStarPrompt justOnboarded={true} enabledCount={9} />);
+    await flushDelays();
+    expect(onboardingCard()).not.toBeNull();
+  });
+
+  it("opens the repo and never asks again once starred", async () => {
+    const u = user();
+    render(<GitHubStarPrompt justOnboarded={true} enabledCount={0} />);
+    await flushDelays();
+
+    await u.click(starButton());
+
+    expect(openExternal).toHaveBeenCalledWith(STAR_REPO_URL);
+    expect(localStorage.getItem(STAR_PROMPT_KEY)).toBe("done");
+    expect(onboardingCard()).toBeNull();
+  });
+
+  it("does not hand off to the chip in the same session", async () => {
+    // Onboarding adds servers, so an immediate chip would read as nagging.
+    const u = user();
+    const { rerender } = render(
+      <GitHubStarPrompt justOnboarded={true} enabledCount={6} />,
+    );
+    await flushDelays();
+    await u.click(screen.getByRole("button", { name: /^later$/i }));
+
+    rerender(<GitHubStarPrompt justOnboarded={true} enabledCount={7} />);
+    expect(chip()).toBeNull();
+  });
+
+  it("hands off to the chip on the next launch, once enough servers are on", async () => {
+    const u = user();
+    const first = render(<GitHubStarPrompt justOnboarded={true} enabledCount={6} />);
+    await flushDelays();
+    await u.click(screen.getByRole("button", { name: /^later$/i }));
+    expect(localStorage.getItem(STAR_PROMPT_KEY)).toBe("later");
+    first.unmount();
+
+    const { rerender } = render(
+      <GitHubStarPrompt justOnboarded={false} enabledCount={1} />,
+    );
+    await flushDelays();
+    expect(chip()).toBeNull(); // still under the threshold
+
+    rerender(<GitHubStarPrompt justOnboarded={false} enabledCount={6} />);
+    expect(chip()).not.toBeNull();
+    expect(onboardingCard()).toBeNull();
+  });
+
+  it("closing the chip ends the prompt for good", async () => {
+    const u = user();
+    localStorage.setItem(STAR_PROMPT_KEY, "later");
+    const first = render(<GitHubStarPrompt justOnboarded={false} enabledCount={5} />);
+    await u.click(screen.getByRole("button", { name: /dismiss/i }));
+    expect(localStorage.getItem(STAR_PROMPT_KEY)).toBe("done");
+    first.unmount();
+
+    render(<GitHubStarPrompt justOnboarded={false} enabledCount={5} />);
+    await flushDelays();
+    expect(chip()).toBeNull();
+  });
+
+  it("opens the repo from the chip", async () => {
+    const u = user();
+    localStorage.setItem(STAR_PROMPT_KEY, "later");
+    render(<GitHubStarPrompt justOnboarded={false} enabledCount={3} />);
+
+    await u.click(chip()!);
+
+    expect(openExternal).toHaveBeenCalledWith(STAR_REPO_URL);
+    expect(localStorage.getItem(STAR_PROMPT_KEY)).toBe("done");
+    expect(chip()).toBeNull();
+  });
+});
+
+describe("an install that predates the prompt", () => {
+  it("gets one card a few seconds into the launch, not at second zero", async () => {
+    existingInstall();
+    render(<GitHubStarPrompt justOnboarded={false} enabledCount={4} />);
+    expect(returningCard()).toBeNull();
+
+    await flushDelays();
+    expect(returningCard()).not.toBeNull();
+    // Worded for a months-old install, not with onboarding wording.
+    expect(onboardingCard()).toBeNull();
+  });
+
+  it("stays quiet on an install that was never set up", async () => {
+    existingInstall();
+    const { rerender } = render(
+      <GitHubStarPrompt justOnboarded={false} enabledCount={0} />,
+    );
+    await flushDelays();
+    expect(returningCard()).toBeNull();
+    // Nothing was spent, so the ask is still owed once they enable a server.
+    expect(localStorage.getItem(STAR_PROMPT_KEY)).toBeNull();
+
+    rerender(<GitHubStarPrompt justOnboarded={false} enabledCount={1} />);
+    expect(returningCard()).not.toBeNull();
+  });
+
+  it("never follows the card with a chip", async () => {
+    const u = user();
+    existingInstall();
+    const first = render(<GitHubStarPrompt justOnboarded={false} enabledCount={8} />);
+    await flushDelays();
+    await u.click(screen.getByRole("button", { name: /^no thanks$/i }));
+    expect(localStorage.getItem(STAR_PROMPT_KEY)).toBe("done");
+    first.unmount();
+
+    render(<GitHubStarPrompt justOnboarded={false} enabledCount={8} />);
+    await flushDelays();
+    expect(chip()).toBeNull();
+    expect(returningCard()).toBeNull();
+  });
+
+  it("opens the repo when starred", async () => {
+    const u = user();
+    existingInstall();
+    render(<GitHubStarPrompt justOnboarded={false} enabledCount={2} />);
+    await flushDelays();
+
+    await u.click(starButton());
+
+    expect(openExternal).toHaveBeenCalledWith(STAR_REPO_URL);
+    expect(localStorage.getItem(STAR_PROMPT_KEY)).toBe("done");
+    expect(returningCard()).toBeNull();
+  });
+});
+
+describe("an ask is spent when it is shown", () => {
+  it("does not re-show a card that was ignored and then quit", async () => {
+    existingInstall();
+    const first = render(<GitHubStarPrompt justOnboarded={false} enabledCount={3} />);
+    await flushDelays();
+    expect(returningCard()).not.toBeNull();
+    first.unmount(); // quit without answering
+
+    render(<GitHubStarPrompt justOnboarded={false} enabledCount={3} />);
+    await flushDelays();
+    expect(returningCard()).toBeNull();
+  });
+
+  it("still owes the chip when the onboarding card was ignored", async () => {
+    const first = render(<GitHubStarPrompt justOnboarded={true} enabledCount={5} />);
+    await flushDelays();
+    expect(onboardingCard()).not.toBeNull();
+    expect(localStorage.getItem(STAR_PROMPT_KEY)).toBe("later");
+    first.unmount();
+
+    render(<GitHubStarPrompt justOnboarded={false} enabledCount={5} />);
+    expect(chip()).not.toBeNull();
+  });
+});
+
+describe("while the app sits in the tray", () => {
+  it("shows nothing and spends nothing", async () => {
+    windowVisible = false;
+    existingInstall();
+    render(<GitHubStarPrompt justOnboarded={false} enabledCount={4} />);
+    await flushDelays();
+
+    expect(returningCard()).toBeNull();
+    // The single ask is still owed, not burned on an empty screen.
+    expect(localStorage.getItem(STAR_PROMPT_KEY)).toBeNull();
+  });
+
+  it("does not let a backgrounded server toggle burn the chip", async () => {
+    // The gateway can enable servers while the window is hidden.
+    windowVisible = false;
+    localStorage.setItem(STAR_PROMPT_KEY, "later");
+    render(<GitHubStarPrompt justOnboarded={false} enabledCount={5} />);
+    await flushDelays();
+
+    expect(chip()).toBeNull();
+    expect(localStorage.getItem(STAR_PROMPT_KEY)).toBe("later");
+  });
+
+  it("starts the wait over when the window is opened", async () => {
+    windowVisible = false;
+    existingInstall();
+    const { rerender } = render(
+      <GitHubStarPrompt justOnboarded={false} enabledCount={4} />,
+    );
+    await flushDelays();
+    expect(returningCard()).toBeNull();
+
+    windowVisible = true;
+    rerender(<GitHubStarPrompt justOnboarded={false} enabledCount={4} />);
+    expect(returningCard()).toBeNull(); // the delay runs from the open, not the launch
+
+    await flushDelays();
+    expect(returningCard()).not.toBeNull();
+  });
+});
+
+describe("the toast-offset callback", () => {
+  it("reports the surface on screen, and clears it on unmount", async () => {
+    const u = user();
+    const onVisibleChange = vi.fn();
+    const first = render(
+      <GitHubStarPrompt
+        justOnboarded={true}
+        enabledCount={4}
+        onVisibleChange={onVisibleChange}
+      />,
+    );
+    await flushDelays();
+    expect(onVisibleChange).toHaveBeenLastCalledWith("card");
+
+    await u.click(screen.getByRole("button", { name: /^later$/i }));
+    expect(onVisibleChange).toHaveBeenLastCalledWith(null);
+    first.unmount();
+
+    onVisibleChange.mockClear();
+    const second = render(
+      <GitHubStarPrompt
+        justOnboarded={false}
+        enabledCount={4}
+        onVisibleChange={onVisibleChange}
+      />,
+    );
+    expect(onVisibleChange).toHaveBeenLastCalledWith("chip");
+
+    second.unmount();
+    expect(onVisibleChange).toHaveBeenLastCalledWith(null);
+  });
+
+  it("reports the existing-user card too", async () => {
+    const onVisibleChange = vi.fn();
+    existingInstall();
+    render(
+      <GitHubStarPrompt
+        justOnboarded={false}
+        enabledCount={2}
+        onVisibleChange={onVisibleChange}
+      />,
+    );
+    await flushDelays();
+    expect(onVisibleChange).toHaveBeenLastCalledWith("returning");
+  });
+});

--- a/src/components/GitHubStarPrompt.test.tsx
+++ b/src/components/GitHubStarPrompt.test.tsx
@@ -208,6 +208,77 @@ describe("an ask is spent when it is shown", () => {
   });
 });
 
+describe("a server toggled off and back on", () => {
+  it("does not make the chip flicker away and return", async () => {
+    // The count is a gate for reaching the ask, not a condition to keep
+    // meeting. The ask is already spent, so a second showing is pure flicker.
+    localStorage.setItem(STAR_PROMPT_KEY, "later");
+    const { rerender } = render(
+      <GitHubStarPrompt justOnboarded={false} enabledCount={3} />,
+    );
+    expect(chip()).not.toBeNull();
+
+    rerender(<GitHubStarPrompt justOnboarded={false} enabledCount={2} />);
+    expect(chip()).not.toBeNull();
+
+    rerender(<GitHubStarPrompt justOnboarded={false} enabledCount={3} />);
+    expect(chip()).not.toBeNull();
+  });
+
+  it("does not make the existing-user card flicker either", async () => {
+    existingInstall();
+    const { rerender } = render(
+      <GitHubStarPrompt justOnboarded={false} enabledCount={1} />,
+    );
+    await flushDelays();
+    expect(returningCard()).not.toBeNull();
+
+    rerender(<GitHubStarPrompt justOnboarded={false} enabledCount={0} />);
+    expect(returningCard()).not.toBeNull();
+  });
+
+  it("still waits for the threshold the first time", () => {
+    localStorage.setItem(STAR_PROMPT_KEY, "later");
+    const { rerender } = render(
+      <GitHubStarPrompt justOnboarded={false} enabledCount={2} />,
+    );
+    expect(chip()).toBeNull();
+    // A dip before the threshold was ever met must not bank a high-water mark
+    // the user never actually reached.
+    rerender(<GitHubStarPrompt justOnboarded={false} enabledCount={1} />);
+    expect(chip()).toBeNull();
+  });
+
+  it("reports one surface change, not a flicker, to the toast offset", () => {
+    const onVisibleChange = vi.fn();
+    localStorage.setItem(STAR_PROMPT_KEY, "later");
+    const { rerender } = render(
+      <GitHubStarPrompt
+        justOnboarded={false}
+        enabledCount={4}
+        onVisibleChange={onVisibleChange}
+      />,
+    );
+    onVisibleChange.mockClear();
+
+    rerender(
+      <GitHubStarPrompt
+        justOnboarded={false}
+        enabledCount={1}
+        onVisibleChange={onVisibleChange}
+      />,
+    );
+    rerender(
+      <GitHubStarPrompt
+        justOnboarded={false}
+        enabledCount={4}
+        onVisibleChange={onVisibleChange}
+      />,
+    );
+    expect(onVisibleChange).not.toHaveBeenCalled();
+  });
+});
+
 describe("while the app sits in the tray", () => {
   it("shows nothing and spends nothing", async () => {
     windowVisible = false;

--- a/src/components/GitHubStarPrompt.tsx
+++ b/src/components/GitHubStarPrompt.tsx
@@ -1,0 +1,194 @@
+import { useEffect, useState, type ReactNode } from "react";
+import { CircleCheck, Star, X } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { openExternal } from "@/lib/openUrl";
+import { useWindowVisible } from "@/lib/windowVisible";
+import {
+  CHIP_MIN_ENABLED_SERVERS,
+  RETURNING_MIN_ENABLED_SERVERS,
+  STAR_REPO_URL,
+  readStarStage,
+  writeStarStage,
+  type StarStage,
+} from "@/lib/starPrompt";
+
+/** Lets the onboarding dialog finish closing before the card slides in, so the
+ *  two do not animate over each other. */
+const CARD_DELAY_MS = 700;
+
+/** How long an existing user is left alone before the one-off card appears. The
+ *  clock only runs while the window is actually on screen: Toolport lives in the
+ *  tray, so a launch-time timer would spend the single ask on nobody. */
+const RETURNING_DELAY_MS = 8000;
+
+const FOCUS_RING =
+  "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring";
+const SHELL =
+  "pointer-events-auto animate-in fade-in slide-in-from-bottom-2 border bg-popover/95 text-popover-foreground shadow-2xl backdrop-blur";
+
+/** Which surface is on screen (null when none), for the toast-offset callback. */
+export type StarSurface = "card" | "returning" | "chip" | null;
+
+interface Props {
+  /** True once the wizard has been finished in this session (card trigger). */
+  justOnboarded: boolean;
+  /** Enabled servers in the active profile. */
+  enabledCount: number;
+  /** Told which surface is on screen, so the toast stack can move up by the
+   *  right amount instead of landing on top of it. Both live bottom-right. */
+  onVisibleChange?: (surface: StarSurface) => void;
+}
+
+/**
+ * The GitHub star ask. See `@/lib/starPrompt` for the rules this implements.
+ */
+export function GitHubStarPrompt({
+  justOnboarded,
+  enabledCount,
+  onVisibleChange,
+}: Props) {
+  // Frozen at mount, so a stage change made during this session cannot promote
+  // one surface into another. A "Later" answered by a chip minutes later would
+  // be nagging; the chip belongs to the next launch.
+  const [stage] = useState<StarStage>(readStarStage);
+  const [dismissed, setDismissed] = useState(false);
+  const [cardReady, setCardReady] = useState(false);
+  const [returningReady, setReturningReady] = useState(false);
+  // Nothing is shown, and so nothing is spent, while the app sits in the tray.
+  // The gateway can enable servers from there, which would otherwise let the
+  // chip appear and burn its one showing with no window on screen.
+  const windowVisible = useWindowVisible();
+
+  const surface: StarSurface =
+    dismissed || !windowVisible
+      ? null
+      : stage === "card" && justOnboarded && cardReady
+        ? "card"
+        : stage === "returning" &&
+            returningReady &&
+            enabledCount >= RETURNING_MIN_ENABLED_SERVERS
+          ? "returning"
+          : stage === "later" && enabledCount >= CHIP_MIN_ENABLED_SERVERS
+            ? "chip"
+            : null;
+
+  useEffect(() => {
+    if (stage !== "card" || !justOnboarded) return;
+    const timer = setTimeout(() => setCardReady(true), CARD_DELAY_MS);
+    return () => clearTimeout(timer);
+  }, [stage, justOnboarded]);
+
+  useEffect(() => {
+    if (stage !== "returning" || !windowVisible) return;
+    const timer = setTimeout(() => setReturningReady(true), RETURNING_DELAY_MS);
+    return () => clearTimeout(timer);
+  }, [stage, windowVisible]);
+
+  // Showing is what spends the ask. Quitting without answering must not earn a
+  // second showing of the same surface. The new-user card falls back to the
+  // chip; everything else is the last ask this install gets.
+  useEffect(() => {
+    if (!surface) return;
+    writeStarStage(surface === "card" ? "later" : "done");
+  }, [surface]);
+
+  useEffect(() => {
+    onVisibleChange?.(surface);
+  }, [surface, onVisibleChange]);
+
+  // Unmounting has to release the offset too, otherwise toasts stay pushed up.
+  useEffect(() => () => onVisibleChange?.(null), [onVisibleChange]);
+
+  function star() {
+    void openExternal(STAR_REPO_URL);
+    writeStarStage("done");
+    setDismissed(true);
+  }
+
+  if (!surface) return null;
+
+  if (surface === "chip") {
+    return (
+      <Corner>
+        <div
+          role="status"
+          className={`${SHELL} flex items-center gap-1 rounded-full py-1 pr-1 pl-3`}
+        >
+          <button
+            type="button"
+            onClick={star}
+            className={`inline-flex items-center gap-1.5 rounded-full text-xs font-medium transition hover:text-primary ${FOCUS_RING}`}
+          >
+            <Star className="size-3.5" />
+            Star Toolport on GitHub
+          </button>
+          <CloseButton onClick={() => setDismissed(true)} className="rounded-full p-1" />
+        </div>
+      </Corner>
+    );
+  }
+
+  return (
+    <Corner>
+      <div
+        role="status"
+        aria-label="Star Toolport on GitHub"
+        className={`${SHELL} w-[min(20rem,calc(100vw-2rem))] rounded-xl p-4`}
+      >
+        <div className="flex items-start gap-2">
+          {surface === "card" ? (
+            <CircleCheck className="mt-0.5 size-4 shrink-0 text-success" />
+          ) : (
+            <Star className="mt-0.5 size-4 shrink-0 text-warning" />
+          )}
+          <p className="flex-1 text-sm font-medium">
+            {surface === "card" ? "You're all set" : "Enjoying Toolport?"}
+          </p>
+          <CloseButton
+            onClick={() => setDismissed(true)}
+            className="-mt-0.5 -mr-0.5 rounded p-0.5"
+          />
+        </div>
+        <p className="mt-1.5 text-sm text-muted-foreground">
+          {surface === "card"
+            ? "If Toolport is useful, a GitHub star helps other developers find it."
+            : "A GitHub star helps other developers find it."}
+        </p>
+        <div className="mt-3 flex items-center gap-2">
+          <Button size="sm" onClick={star}>
+            <Star className="size-3.5" />
+            Star on GitHub
+          </Button>
+          <Button size="sm" variant="ghost" onClick={() => setDismissed(true)}>
+            {/* "Later" is only honest on the new-user card, which really does
+                get a second (and final) chance as the chip. */}
+            {surface === "card" ? "Later" : "No thanks"}
+          </Button>
+        </div>
+      </div>
+    </Corner>
+  );
+}
+
+function Corner({ children }: { children: ReactNode }) {
+  return (
+    <div className="pointer-events-none fixed right-4 bottom-4 z-40 flex justify-end">
+      {children}
+    </div>
+  );
+}
+
+/** Closing is always a "not now", never a separate refusal: the stage was
+ *  already spent when the surface appeared, so this only hides it. */
+function CloseButton({ onClick, className }: { onClick: () => void; className: string }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-label="Dismiss"
+      className={`text-muted-foreground transition hover:text-foreground ${FOCUS_RING} ${className}`}
+    >
+      <X className="size-3.5" />
+    </button>
+  );
+}

--- a/src/components/GitHubStarPrompt.tsx
+++ b/src/components/GitHubStarPrompt.tsx
@@ -54,6 +54,12 @@ export function GitHubStarPrompt({
   const [dismissed, setDismissed] = useState(false);
   const [cardReady, setCardReady] = useState(false);
   const [returningReady, setReturningReady] = useState(false);
+  // The most servers that have been enabled at once this session. The count is
+  // a gate for reaching the ask, not a condition to keep meeting: without the
+  // high-water mark, toggling a server off and back on retracts a prompt and
+  // then shows it again, which is flicker for an ask that is already spent.
+  const [peakEnabled, setPeakEnabled] = useState(enabledCount);
+  if (enabledCount > peakEnabled) setPeakEnabled(enabledCount);
   // Nothing is shown, and so nothing is spent, while the app sits in the tray.
   // The gateway can enable servers from there, which would otherwise let the
   // chip appear and burn its one showing with no window on screen.
@@ -66,9 +72,9 @@ export function GitHubStarPrompt({
         ? "card"
         : stage === "returning" &&
             returningReady &&
-            enabledCount >= RETURNING_MIN_ENABLED_SERVERS
+            peakEnabled >= RETURNING_MIN_ENABLED_SERVERS
           ? "returning"
-          : stage === "later" && enabledCount >= CHIP_MIN_ENABLED_SERVERS
+          : stage === "later" && peakEnabled >= CHIP_MIN_ENABLED_SERVERS
             ? "chip"
             : null;
 

--- a/src/components/GitHubStarPrompt.tsx
+++ b/src/components/GitHubStarPrompt.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState, type ReactNode } from "react";
 import { CircleCheck, Star, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { openExternal } from "@/lib/openUrl";
-import { useWindowVisible } from "@/lib/windowVisible";
+import { modalLayerOpen, useModalOpen, useWindowVisible } from "@/lib/windowVisible";
 import {
   CHIP_MIN_ENABLED_SERVERS,
   RETURNING_MIN_ENABLED_SERVERS,
@@ -60,13 +60,17 @@ export function GitHubStarPrompt({
   // then shows it again, which is flicker for an ask that is already spent.
   const [peakEnabled, setPeakEnabled] = useState(enabledCount);
   if (enabledCount > peakEnabled) setPeakEnabled(enabledCount);
-  // Nothing is shown, and so nothing is spent, while the app sits in the tray.
-  // The gateway can enable servers from there, which would otherwise let the
-  // chip appear and burn its one showing with no window on screen.
+  // Nothing is shown, and so nothing is spent, unless the corner is genuinely
+  // reachable. The app sits in the tray and the gateway can enable servers from
+  // there, which would otherwise let the chip appear and burn its one showing
+  // with no window on screen; a modal dialog is the same problem one layer up,
+  // since it covers the corner, traps focus and aria-hides everything under it.
   const windowVisible = useWindowVisible();
+  const modalOpen = useModalOpen();
+  const reachable = windowVisible && !modalOpen;
 
   const surface: StarSurface =
-    dismissed || !windowVisible
+    dismissed || !reachable
       ? null
       : stage === "card" && justOnboarded && cardReady
         ? "card"
@@ -85,18 +89,40 @@ export function GitHubStarPrompt({
   }, [stage, justOnboarded]);
 
   useEffect(() => {
-    if (stage !== "returning" || !windowVisible) return;
+    if (stage !== "returning" || !reachable) return;
     const timer = setTimeout(() => setReturningReady(true), RETURNING_DELAY_MS);
     return () => clearTimeout(timer);
-  }, [stage, windowVisible]);
+  }, [stage, reachable]);
+
+  // Finishing the wizard is what makes this install definitely a new one, and
+  // that fact is only in storage while the session lasts. The card itself is
+  // delayed and gated on the window, so a launch that hides to the tray in
+  // between would record nothing at all, and the next launch would read an
+  // onboarding flag with no star record and mistake a day-old install for a
+  // months-old one. Booking the chip fallback here costs a new user nothing:
+  // it is the same value the card writes when it appears.
+  useEffect(() => {
+    if (stage === "card" && justOnboarded) writeStarStage("later");
+  }, [stage, justOnboarded]);
 
   // Showing is what spends the ask. Quitting without answering must not earn a
   // second showing of the same surface. The new-user card falls back to the
   // chip; everything else is the last ask this install gets.
+  //
+  // Recorded a beat after the render rather than during it, because "shown" is
+  // a claim about the screen and the screen is not settled yet. A dialog going
+  // up in the same beat raises its overlay through a portal, which React mounts
+  // on a later commit, so a surface can render into a corner that is about to
+  // be covered. Letting the DOM settle and re-reading it is what stops the one
+  // ask being spent behind a blurred overlay nobody can click through.
   useEffect(() => {
-    if (!surface) return;
-    writeStarStage(surface === "card" ? "later" : "done");
-  }, [surface]);
+    if (!surface || modalOpen) return;
+    const spend = setTimeout(() => {
+      if (modalLayerOpen()) return;
+      writeStarStage(surface === "card" ? "later" : "done");
+    });
+    return () => clearTimeout(spend);
+  }, [surface, modalOpen]);
 
   useEffect(() => {
     onVisibleChange?.(surface);

--- a/src/lib/starPrompt.test.ts
+++ b/src/lib/starPrompt.test.ts
@@ -1,55 +1,97 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { readStarStage, writeStarStage, STAR_PROMPT_KEY } from "./starPrompt";
 
-beforeEach(() => localStorage.clear());
+// The module carries a "storage is broken" latch that must outlive a component,
+// so each test gets a fresh copy of it rather than a leaked one.
+let mod: typeof import("./starPrompt");
+
+beforeEach(async () => {
+  vi.resetModules();
+  localStorage.clear();
+  mod = await import("./starPrompt");
+});
+
 afterEach(() => vi.restoreAllMocks());
 
 describe("readStarStage", () => {
   it("starts a brand-new install at the onboarding card", () => {
-    expect(readStarStage()).toBe("card");
+    expect(mod.readStarStage()).toBe("card");
   });
 
   it("starts an install that predates the prompt at the one-off card", () => {
     localStorage.setItem("toolport.onboarded", "1");
-    expect(readStarStage()).toBe("returning");
+    expect(mod.readStarStage()).toBe("returning");
   });
 
   it("honours the pre-rename onboarding key", () => {
     localStorage.setItem("conduit.onboarded", "1");
-    expect(readStarStage()).toBe("returning");
+    expect(mod.readStarStage()).toBe("returning");
   });
 
   it("prefers a recorded stage over the predates-the-prompt guess", () => {
     // Otherwise an existing user would get the one-off card on every launch.
     localStorage.setItem("toolport.onboarded", "1");
-    writeStarStage("done");
-    expect(readStarStage()).toBe("done");
+    mod.writeStarStage("done");
+    expect(mod.readStarStage()).toBe("done");
   });
 
   it("round-trips the two stages that are written", () => {
-    writeStarStage("later");
-    expect(readStarStage()).toBe("later");
-    writeStarStage("done");
-    expect(readStarStage()).toBe("done");
+    mod.writeStarStage("later");
+    expect(mod.readStarStage()).toBe("later");
+    mod.writeStarStage("done");
+    expect(mod.readStarStage()).toBe("done");
   });
 
   it("ignores a garbage value", () => {
-    localStorage.setItem(STAR_PROMPT_KEY, "yes-please");
-    expect(readStarStage()).toBe("card");
+    localStorage.setItem(mod.STAR_PROMPT_KEY, "yes-please");
+    expect(mod.readStarStage()).toBe("card");
+  });
+});
+
+describe("done is terminal", () => {
+  it("refuses to downgrade a finished ask back to later", () => {
+    // The effect that spends an ask when it is shown can flush after a click on
+    // Star has already finished it. Without this the chip would come back.
+    mod.writeStarStage("done");
+    mod.writeStarStage("later");
+    expect(mod.readStarStage()).toBe("done");
   });
 
-  it("stays silent when storage is unavailable", () => {
+  it("still allows the ordinary later write", () => {
+    mod.writeStarStage("later");
+    expect(localStorage.getItem(mod.STAR_PROMPT_KEY)).toBe("later");
+  });
+});
+
+describe("when storage is unusable", () => {
+  it("stays silent when a read is refused", () => {
     // A spent ask that can't be recorded would mean asking on every launch.
     vi.spyOn(localStorage, "getItem").mockImplementation(() => {
       throw new Error("denied");
     });
-    expect(readStarStage()).toBe("done");
+    expect(mod.readStarStage()).toBe("done");
   });
 
-  it("does not throw when a write is refused", () => {
-    vi.spyOn(localStorage, "setItem").mockImplementation(() => {
+  it("stays silent for the rest of the session after a write is refused", () => {
+    const setItem = vi.spyOn(localStorage, "setItem").mockImplementation(() => {
       throw new Error("quota");
     });
-    expect(() => writeStarStage("done")).not.toThrow();
+
+    expect(() => mod.writeStarStage("done")).not.toThrow();
+
+    // The write is what would have recorded the ask as spent. Since it did not
+    // land, reading must not hand back a fresh ask to show again.
+    setItem.mockRestore();
+    expect(mod.readStarStage()).toBe("done");
+  });
+
+  it("does not write again once storage has failed", () => {
+    const setItem = vi.spyOn(localStorage, "setItem").mockImplementationOnce(() => {
+      throw new Error("quota");
+    });
+    mod.writeStarStage("later");
+
+    setItem.mockClear();
+    mod.writeStarStage("done");
+    expect(setItem).not.toHaveBeenCalled();
   });
 });

--- a/src/lib/starPrompt.test.ts
+++ b/src/lib/starPrompt.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { readStarStage, writeStarStage, STAR_PROMPT_KEY } from "./starPrompt";
+
+beforeEach(() => localStorage.clear());
+afterEach(() => vi.restoreAllMocks());
+
+describe("readStarStage", () => {
+  it("starts a brand-new install at the onboarding card", () => {
+    expect(readStarStage()).toBe("card");
+  });
+
+  it("starts an install that predates the prompt at the one-off card", () => {
+    localStorage.setItem("toolport.onboarded", "1");
+    expect(readStarStage()).toBe("returning");
+  });
+
+  it("honours the pre-rename onboarding key", () => {
+    localStorage.setItem("conduit.onboarded", "1");
+    expect(readStarStage()).toBe("returning");
+  });
+
+  it("prefers a recorded stage over the predates-the-prompt guess", () => {
+    // Otherwise an existing user would get the one-off card on every launch.
+    localStorage.setItem("toolport.onboarded", "1");
+    writeStarStage("done");
+    expect(readStarStage()).toBe("done");
+  });
+
+  it("round-trips the two stages that are written", () => {
+    writeStarStage("later");
+    expect(readStarStage()).toBe("later");
+    writeStarStage("done");
+    expect(readStarStage()).toBe("done");
+  });
+
+  it("ignores a garbage value", () => {
+    localStorage.setItem(STAR_PROMPT_KEY, "yes-please");
+    expect(readStarStage()).toBe("card");
+  });
+
+  it("stays silent when storage is unavailable", () => {
+    // A spent ask that can't be recorded would mean asking on every launch.
+    vi.spyOn(localStorage, "getItem").mockImplementation(() => {
+      throw new Error("denied");
+    });
+    expect(readStarStage()).toBe("done");
+  });
+
+  it("does not throw when a write is refused", () => {
+    vi.spyOn(localStorage, "setItem").mockImplementation(() => {
+      throw new Error("quota");
+    });
+    expect(() => writeStarStage("done")).not.toThrow();
+  });
+});

--- a/src/lib/starPrompt.test.ts
+++ b/src/lib/starPrompt.test.ts
@@ -84,6 +84,39 @@ describe("when storage is unusable", () => {
     expect(mod.readStarStage()).toBe("done");
   });
 
+  it("stays silent across a relaunch while writes keep failing", async () => {
+    // The module latch only lasts a session. A store that serves reads but
+    // refuses writes — quota exceeded, a locked webview store — would otherwise
+    // derive a fresh ask on every launch and show the card forever.
+    vi.spyOn(localStorage, "setItem").mockImplementation(() => {
+      throw new Error("quota");
+    });
+    expect(mod.readStarStage()).toBe("done");
+
+    vi.resetModules();
+    const relaunched = await import("./starPrompt");
+    expect(relaunched.readStarStage()).toBe("done");
+  });
+
+  it("gives the ask back once writes work again", async () => {
+    // A quota that was freed between launches is a working store, and pretending
+    // otherwise would silently retire the prompt on a healthy install.
+    const setItem = vi.spyOn(localStorage, "setItem").mockImplementation(() => {
+      throw new Error("quota");
+    });
+    expect(mod.readStarStage()).toBe("done");
+
+    setItem.mockRestore();
+    vi.resetModules();
+    const relaunched = await import("./starPrompt");
+    expect(relaunched.readStarStage()).toBe("card");
+  });
+
+  it("leaves nothing behind after probing the write path", () => {
+    expect(mod.readStarStage()).toBe("card");
+    expect(localStorage.length).toBe(0);
+  });
+
   it("does not write again once storage has failed", () => {
     const setItem = vi.spyOn(localStorage, "setItem").mockImplementationOnce(() => {
       throw new Error("quota");

--- a/src/lib/starPrompt.ts
+++ b/src/lib/starPrompt.ts
@@ -19,6 +19,10 @@
 export const STAR_PROMPT_KEY = "toolport.starPrompt";
 export const STAR_REPO_URL = "https://github.com/tsouth89/toolport";
 
+/** Written and deleted at read time to find out whether a spent ask could be
+ *  recorded at all. Never read back, so a leftover from a crash is harmless. */
+const STORAGE_PROBE_KEY = "toolport.starPrompt.probe";
+
 /** Enabled servers before the chip is allowed to appear. The point is to ask
  *  someone who got value out of the app, not someone who just installed it. */
 export const CHIP_MIN_ENABLED_SERVERS = 3;
@@ -57,6 +61,28 @@ function readRaw(key: string): string | null {
   }
 }
 
+/**
+ * Whether a spent ask could actually be recorded.
+ *
+ * The invariant this prompt promises is "an ask that cannot be recorded is
+ * treated as already spent". A latch in module state cannot keep that promise,
+ * because a quota-exceeded or blocked store fails writes while still serving
+ * reads: the stage would be derived from scratch on every relaunch and the card
+ * would come back forever. So the write path is probed, not remembered, and the
+ * probe re-runs on each launch. Storage that recovers gets its ask back, which
+ * is the honest reading of a store that works again.
+ */
+function canRecord(): boolean {
+  try {
+    localStorage.setItem(STORAGE_PROBE_KEY, "1");
+    localStorage.removeItem(STORAGE_PROBE_KEY);
+    return true;
+  } catch {
+    storageBroken = true;
+    return false;
+  }
+}
+
 function onboardedAlready(): boolean {
   return (
     readRaw("toolport.onboarded") === "1" ||
@@ -68,12 +94,14 @@ function onboardedAlready(): boolean {
 /** Resolve the stage to start this session at. */
 export function readStarStage(): StarStage {
   const raw = readRaw(STAR_PROMPT_KEY);
-  if (storageBroken) return "done";
-  if (raw === "done" || raw === "later") return raw;
+  if (storageBroken || raw === "done") return "done";
+  // Every remaining stage can still put something on screen, and showing it is
+  // what spends it. Refuse to show what cannot be written down afterwards.
+  if (!canRecord()) return "done";
+  if (raw === "later") return "later";
   // No record at all. An install that has already onboarded predates this
   // prompt, so it gets the single existing-user card rather than nothing.
-  const stage = onboardedAlready() ? "returning" : "card";
-  return storageBroken ? "done" : stage;
+  return onboardedAlready() ? "returning" : "card";
 }
 
 export function writeStarStage(stage: "later" | "done"): void {

--- a/src/lib/starPrompt.ts
+++ b/src/lib/starPrompt.ts
@@ -1,0 +1,70 @@
+/**
+ * One-time "star us on GitHub" ask.
+ *
+ * Two audiences, deliberately different:
+ *
+ * - New install: a card right after onboarding, and (only if that card was
+ *   deferred) a small chip on a later launch, once a few servers are enabled.
+ * - Existing install, i.e. someone who onboarded before this prompt shipped:
+ *   exactly one card, a few seconds into a launch. They have used the app for
+ *   months; one ask is the polite amount, so there is no chip afterwards.
+ *
+ * An ask is spent when it is shown, not when it is clicked. Ignoring a prompt
+ * and quitting therefore does not bring it back on the next launch, which is
+ * the difference between asking and nagging.
+ *
+ * Deliberately in-app only: no OS notification, no toast that steals focus.
+ */
+
+export const STAR_PROMPT_KEY = "toolport.starPrompt";
+export const STAR_REPO_URL = "https://github.com/tsouth89/toolport";
+
+/** Enabled servers before the chip is allowed to appear. The point is to ask
+ *  someone who got value out of the app, not someone who just installed it. */
+export const CHIP_MIN_ENABLED_SERVERS = 3;
+
+/** Enabled servers before the existing-user card appears. Only skips installs
+ *  that were never actually set up. */
+export const RETURNING_MIN_ENABLED_SERVERS = 1;
+
+/**
+ * What this install is owed next.
+ *
+ * `card` and `returning` are derived at read time and never stored: an install
+ * is one or the other by whether it had onboarded before the prompt existed.
+ * Only `later` and `done` are written, since those are the states that have to
+ * survive a restart.
+ */
+export type StarStage = "card" | "returning" | "later" | "done";
+
+function onboardedAlready(): boolean {
+  return (
+    localStorage.getItem("toolport.onboarded") === "1" ||
+    // Pre-rename key, still present on installs that onboarded as Conduit.
+    localStorage.getItem("conduit.onboarded") === "1"
+  );
+}
+
+/** Resolve the stage to start this session at. */
+export function readStarStage(): StarStage {
+  let raw: string | null;
+  try {
+    raw = localStorage.getItem(STAR_PROMPT_KEY);
+  } catch {
+    // Without storage a spent ask can't be remembered, so the prompt would come
+    // back every launch. That is exactly the nag this feature must not be.
+    return "done";
+  }
+  if (raw === "done" || raw === "later") return raw;
+  // No record at all. An install that has already onboarded predates this
+  // prompt, so it gets the single existing-user card rather than nothing.
+  return onboardedAlready() ? "returning" : "card";
+}
+
+export function writeStarStage(stage: "later" | "done"): void {
+  try {
+    localStorage.setItem(STAR_PROMPT_KEY, stage);
+  } catch {
+    // Best effort. In-memory state still suppresses the prompt for this session.
+  }
+}

--- a/src/lib/starPrompt.ts
+++ b/src/lib/starPrompt.ts
@@ -37,34 +37,54 @@ export const RETURNING_MIN_ENABLED_SERVERS = 1;
  */
 export type StarStage = "card" | "returning" | "later" | "done";
 
+/**
+ * Set the first time localStorage refuses a read or a write.
+ *
+ * Storage is the only thing that remembers a spent ask, so once it is gone the
+ * honest answer is to stop asking rather than to ask again on every mount. This
+ * is module state on purpose: it has to outlive the component that discovered
+ * the failure.
+ */
+let storageBroken = false;
+
+function readRaw(key: string): string | null {
+  if (storageBroken) return null;
+  try {
+    return localStorage.getItem(key);
+  } catch {
+    storageBroken = true;
+    return null;
+  }
+}
+
 function onboardedAlready(): boolean {
   return (
-    localStorage.getItem("toolport.onboarded") === "1" ||
+    readRaw("toolport.onboarded") === "1" ||
     // Pre-rename key, still present on installs that onboarded as Conduit.
-    localStorage.getItem("conduit.onboarded") === "1"
+    readRaw("conduit.onboarded") === "1"
   );
 }
 
 /** Resolve the stage to start this session at. */
 export function readStarStage(): StarStage {
-  let raw: string | null;
-  try {
-    raw = localStorage.getItem(STAR_PROMPT_KEY);
-  } catch {
-    // Without storage a spent ask can't be remembered, so the prompt would come
-    // back every launch. That is exactly the nag this feature must not be.
-    return "done";
-  }
+  const raw = readRaw(STAR_PROMPT_KEY);
+  if (storageBroken) return "done";
   if (raw === "done" || raw === "later") return raw;
   // No record at all. An install that has already onboarded predates this
   // prompt, so it gets the single existing-user card rather than nothing.
-  return onboardedAlready() ? "returning" : "card";
+  const stage = onboardedAlready() ? "returning" : "card";
+  return storageBroken ? "done" : stage;
 }
 
 export function writeStarStage(stage: "later" | "done"): void {
+  if (storageBroken) return;
+  // "done" is terminal. The effect that spends an ask when it is shown can flush
+  // after a click on Star has already finished the ask, and without this guard
+  // that late write would reopen it and bring the chip back next launch.
+  if (stage === "later" && readRaw(STAR_PROMPT_KEY) === "done") return;
   try {
     localStorage.setItem(STAR_PROMPT_KEY, stage);
   } catch {
-    // Best effort. In-memory state still suppresses the prompt for this session.
+    storageBroken = true;
   }
 }

--- a/src/lib/windowVisible.test.ts
+++ b/src/lib/windowVisible.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { renderHook, act, waitFor } from "@testing-library/react";
-import { useWindowVisible } from "./windowVisible";
+import { useModalOpen, useWindowVisible } from "./windowVisible";
 
 const mainWindowVisible = vi.fn();
 vi.mock("@/lib/api", () => ({
@@ -34,16 +34,42 @@ function setDocumentHidden(hidden: boolean) {
   });
 }
 
+/** jsdom reports `document.hasFocus()` as "something is focused", not "this
+ *  window has focus", so the real signal has to be stubbed to model a window
+ *  that is on screen while the user works in another app. */
+let focused = true;
+Object.defineProperty(document, "hasFocus", {
+  value: () => focused,
+  configurable: true,
+});
+
+function setWindowFocused(next: boolean) {
+  focused = next;
+  act(() => {
+    window.dispatchEvent(new Event(next ? "focus" : "blur"));
+  });
+}
+
+/** Stands in for react-remove-scroll, which counts modal layers on <body>. */
+function setModalOpen(open: boolean) {
+  if (open) document.body.setAttribute("data-scroll-locked", "1");
+  else document.body.removeAttribute("data-scroll-locked");
+}
+
 beforeEach(() => {
   handlers = [];
   listenFails = false;
   mainWindowVisible.mockReset();
   mainWindowVisible.mockResolvedValue(true);
+  focused = true;
   setDocumentHidden(false);
+  setModalOpen(false);
 });
 
 afterEach(() => {
   Object.defineProperty(document, "hidden", { value: false, configurable: true });
+  focused = true;
+  setModalOpen(false);
 });
 
 describe("useWindowVisible", () => {
@@ -133,5 +159,82 @@ describe("useWindowVisible", () => {
 
     unmount();
     await waitFor(() => expect(handlers).toHaveLength(0));
+  });
+
+  it("does not count a window the user has alt-tabbed away from", async () => {
+    // document.hidden stays false on every desktop platform for a window that
+    // is merely unfocused or fully covered, so focus is the only signal that
+    // says nobody is looking at what we just rendered.
+    const { result } = renderHook(() => useWindowVisible());
+    await waitFor(() => expect(result.current).toBe(true));
+
+    setWindowFocused(false);
+    expect(result.current).toBe(false);
+
+    setWindowFocused(true);
+    expect(result.current).toBe(true);
+  });
+
+  it("stays hidden when the window was never focused at launch", async () => {
+    // A launch that opens behind the editor must not read as on screen just
+    // because no blur has fired yet.
+    focused = false;
+    const { result } = renderHook(() => useWindowVisible());
+
+    await waitFor(() => expect(mainWindowVisible).toHaveBeenCalled());
+    expect(result.current).toBe(false);
+  });
+
+  it("stays hidden when the page is already hidden at mount", async () => {
+    // A minimized window: no visibilitychange will ever fire, so the very first
+    // reading has to fold in document.hidden rather than wait for an event.
+    Object.defineProperty(document, "hidden", { value: true, configurable: true });
+    const { result } = renderHook(() => useWindowVisible());
+
+    await waitFor(() => expect(mainWindowVisible).toHaveBeenCalled());
+    expect(result.current).toBe(false);
+  });
+
+  it("stops listening for focus on unmount", async () => {
+    // React swallows a setState on an unmounted component, so a leaked focus
+    // listener is silent. Watch the removal itself instead.
+    const remove = vi.spyOn(window, "removeEventListener");
+    const { result, unmount } = renderHook(() => useWindowVisible());
+    await waitFor(() => expect(result.current).toBe(true));
+
+    unmount();
+    const removed = remove.mock.calls.map(([event]) => event);
+    expect(removed).toContain("focus");
+    expect(removed).toContain("blur");
+  });
+});
+
+describe("useModalOpen", () => {
+  it("reports a modal layer that was already up at mount", () => {
+    setModalOpen(true);
+    const { result } = renderHook(() => useModalOpen());
+    expect(result.current).toBe(true);
+  });
+
+  it("tracks a modal layer opening and closing", async () => {
+    const { result } = renderHook(() => useModalOpen());
+    expect(result.current).toBe(false);
+
+    act(() => setModalOpen(true));
+    await waitFor(() => expect(result.current).toBe(true));
+
+    act(() => setModalOpen(false));
+    await waitFor(() => expect(result.current).toBe(false));
+  });
+
+  it("stops observing on unmount", () => {
+    // Same trap as the focus listener: an observer left attached to <body> for
+    // every mount is invisible from the hook's own return value.
+    const disconnect = vi.spyOn(MutationObserver.prototype, "disconnect");
+    const { unmount } = renderHook(() => useModalOpen());
+    expect(disconnect).not.toHaveBeenCalled();
+
+    unmount();
+    expect(disconnect).toHaveBeenCalled();
   });
 });

--- a/src/lib/windowVisible.test.ts
+++ b/src/lib/windowVisible.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { useWindowVisible } from "./windowVisible";
+
+const mainWindowVisible = vi.fn();
+vi.mock("@/lib/api", () => ({
+  mainWindowVisible: () => mainWindowVisible(),
+}));
+
+/** Handlers registered for the Rust show/hide event, so a test can fire it. */
+let handlers: Array<(e: { payload: boolean }) => void> = [];
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: (_name: string, handler: (e: { payload: boolean }) => void) => {
+    handlers.push(handler);
+    return Promise.resolve(() => {
+      handlers = handlers.filter((h) => h !== handler);
+    });
+  },
+}));
+
+function emitVisible(payload: boolean) {
+  act(() => {
+    for (const h of handlers) h({ payload });
+  });
+}
+
+function setDocumentHidden(hidden: boolean) {
+  Object.defineProperty(document, "hidden", { value: hidden, configurable: true });
+  act(() => {
+    document.dispatchEvent(new Event("visibilitychange"));
+  });
+}
+
+beforeEach(() => {
+  handlers = [];
+  mainWindowVisible.mockReset();
+  mainWindowVisible.mockResolvedValue(true);
+  setDocumentHidden(false);
+});
+
+afterEach(() => {
+  Object.defineProperty(document, "hidden", { value: false, configurable: true });
+});
+
+describe("useWindowVisible", () => {
+  it("starts hidden and only reports visible once the seed answers", async () => {
+    // A launch straight to the tray must never read as on screen, not even for
+    // the render or two before the seed resolves.
+    mainWindowVisible.mockResolvedValue(false);
+    const { result } = renderHook(() => useWindowVisible());
+
+    expect(result.current).toBe(false);
+    await waitFor(() => expect(mainWindowVisible).toHaveBeenCalled());
+    expect(result.current).toBe(false);
+  });
+
+  it("reports a window that was already on screen at launch", async () => {
+    const { result } = renderHook(() => useWindowVisible());
+    await waitFor(() => expect(result.current).toBe(true));
+  });
+
+  it("tracks show and hide from the Rust side", async () => {
+    const { result } = renderHook(() => useWindowVisible());
+    await waitFor(() => expect(result.current).toBe(true));
+
+    // Hiding to the tray does not flip document.hidden on Windows, so this
+    // event is the only signal that says the window went away.
+    emitVisible(false);
+    expect(result.current).toBe(false);
+
+    emitVisible(true);
+    expect(result.current).toBe(true);
+  });
+
+  it("folds in the webview signal for a real minimize", async () => {
+    const { result } = renderHook(() => useWindowVisible());
+    await waitFor(() => expect(result.current).toBe(true));
+
+    setDocumentHidden(true);
+    expect(result.current).toBe(false);
+
+    setDocumentHidden(false);
+    expect(result.current).toBe(true);
+  });
+
+  it("falls back to the webview when there is no desktop shell", async () => {
+    mainWindowVisible.mockRejectedValue(new Error("no tauri"));
+    const { result } = renderHook(() => useWindowVisible());
+    await waitFor(() => expect(result.current).toBe(true));
+  });
+
+  it("stops listening on unmount", async () => {
+    const { unmount } = renderHook(() => useWindowVisible());
+    await waitFor(() => expect(handlers).toHaveLength(1));
+
+    unmount();
+    await waitFor(() => expect(handlers).toHaveLength(0));
+  });
+});

--- a/src/lib/windowVisible.test.ts
+++ b/src/lib/windowVisible.test.ts
@@ -9,8 +9,11 @@ vi.mock("@/lib/api", () => ({
 
 /** Handlers registered for the Rust show/hide event, so a test can fire it. */
 let handlers: Array<(e: { payload: boolean }) => void> = [];
+/** Set by a test to simulate running outside the desktop shell entirely. */
+let listenFails = false;
 vi.mock("@tauri-apps/api/event", () => ({
   listen: (_name: string, handler: (e: { payload: boolean }) => void) => {
+    if (listenFails) return Promise.reject(new Error("no tauri"));
     handlers.push(handler);
     return Promise.resolve(() => {
       handlers = handlers.filter((h) => h !== handler);
@@ -33,6 +36,7 @@ function setDocumentHidden(hidden: boolean) {
 
 beforeEach(() => {
   handlers = [];
+  listenFails = false;
   mainWindowVisible.mockReset();
   mainWindowVisible.mockResolvedValue(true);
   setDocumentHidden(false);
@@ -81,6 +85,40 @@ describe("useWindowVisible", () => {
 
     setDocumentHidden(false);
     expect(result.current).toBe(true);
+  });
+
+  it("does not let a slow seed overwrite a newer event", async () => {
+    // The seed is a snapshot of when the effect ran. If the window is hidden
+    // between then and the answer, the event is the truth and must win.
+    let resolveSeed: (v: boolean) => void = () => {};
+    mainWindowVisible.mockReturnValue(
+      new Promise<boolean>((r) => {
+        resolveSeed = r;
+      }),
+    );
+    const { result } = renderHook(() => useWindowVisible());
+    await waitFor(() => expect(handlers).toHaveLength(1));
+
+    emitVisible(false);
+    expect(result.current).toBe(false);
+
+    await act(async () => {
+      resolveSeed(true); // stale: taken before the window was hidden
+    });
+    expect(result.current).toBe(false);
+  });
+
+  it("survives a listener that never registers", async () => {
+    // Outside the desktop shell there is no native event stream at all. The
+    // hook must fall back to the webview signal instead of throwing.
+    listenFails = true;
+    const { result, unmount } = renderHook(() => useWindowVisible());
+
+    await waitFor(() => expect(result.current).toBe(true));
+    setDocumentHidden(true);
+    expect(result.current).toBe(false);
+
+    expect(() => unmount()).not.toThrow();
   });
 
   it("falls back to the webview when there is no desktop shell", async () => {

--- a/src/lib/windowVisible.ts
+++ b/src/lib/windowVisible.ts
@@ -1,0 +1,59 @@
+import { useEffect, useState } from "react";
+import { listen } from "@tauri-apps/api/event";
+import { mainWindowVisible } from "@/lib/api";
+
+/**
+ * Whether the main window is actually on screen.
+ *
+ * The webview's own Page Visibility API is not enough: on Windows, hiding a
+ * Tauri window to the tray does not flip `document.hidden`, so a purely
+ * web-based gate thinks a tray'd app is being looked at. The source of truth is
+ * the Rust side, which emits `team-window-visible` on every show/hide, plus a
+ * `mainWindowVisible()` pull to seed a launch that goes straight to the tray.
+ * `document.hidden` is folded in as a secondary signal for the platforms where
+ * it does fire, such as a real minimize.
+ *
+ * Starts pessimistic (hidden) so a tray'd launch cannot briefly count as
+ * on-screen before the seed answers. If the seed fails, which is anything that
+ * is not the desktop app, it falls back to the webview signal.
+ *
+ * The team-sync loop in App.tsx tracks the same two signals imperatively,
+ * because it parks a long-poll rather than rendering. Same event, different
+ * shape; this hook is for components.
+ */
+export function useWindowVisible(): boolean {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    let shown = false;
+    const apply = () => {
+      if (!cancelled) setVisible(shown && !document.hidden);
+    };
+
+    void mainWindowVisible()
+      .then((v) => {
+        shown = v;
+        apply();
+      })
+      .catch(() => {
+        // Not the desktop app (a browser, a test): trust the webview alone.
+        shown = true;
+        apply();
+      });
+
+    const unlisten = listen<boolean>("team-window-visible", (e) => {
+      shown = e.payload;
+      apply();
+    });
+    document.addEventListener("visibilitychange", apply);
+
+    return () => {
+      cancelled = true;
+      document.removeEventListener("visibilitychange", apply);
+      void unlisten.then((f) => f());
+    };
+  }, []);
+
+  return visible;
+}

--- a/src/lib/windowVisible.ts
+++ b/src/lib/windowVisible.ts
@@ -27,24 +27,32 @@ export function useWindowVisible(): boolean {
   useEffect(() => {
     let cancelled = false;
     let shown = false;
+    // A live show/hide event always beats the seed. The seed is a snapshot of
+    // the moment the effect ran, so once an event has spoken, a seed resolving
+    // afterwards is stale and would put the hook back on the wrong answer.
+    let eventArrived = false;
     const apply = () => {
       if (!cancelled) setVisible(shown && !document.hidden);
     };
+    const seed = (v: boolean) => {
+      if (eventArrived) return;
+      shown = v;
+      apply();
+    };
 
     void mainWindowVisible()
-      .then((v) => {
-        shown = v;
-        apply();
-      })
-      .catch(() => {
-        // Not the desktop app (a browser, a test): trust the webview alone.
-        shown = true;
-        apply();
-      });
+      .then(seed)
+      // Not the desktop app (a browser, a test): trust the webview alone.
+      .catch(() => seed(true));
 
     const unlisten = listen<boolean>("team-window-visible", (e) => {
+      eventArrived = true;
       shown = e.payload;
       apply();
+    }).catch(() => {
+      // No native event stream, so there is nothing to unsubscribe. The webview
+      // signal still applies, and the seed above has already had its say.
+      return () => {};
     });
     document.addEventListener("visibilitychange", apply);
 

--- a/src/lib/windowVisible.ts
+++ b/src/lib/windowVisible.ts
@@ -3,23 +3,28 @@ import { listen } from "@tauri-apps/api/event";
 import { mainWindowVisible } from "@/lib/api";
 
 /**
- * Whether the main window is actually on screen.
+ * Whether the main window is actually on screen and being looked at.
  *
- * The webview's own Page Visibility API is not enough: on Windows, hiding a
- * Tauri window to the tray does not flip `document.hidden`, so a purely
- * web-based gate thinks a tray'd app is being looked at. The source of truth is
- * the Rust side, which emits `team-window-visible` on every show/hide, plus a
- * `mainWindowVisible()` pull to seed a launch that goes straight to the tray.
- * `document.hidden` is folded in as a secondary signal for the platforms where
- * it does fire, such as a real minimize.
+ * Three signals, because no one of them is enough:
+ *
+ * - The Rust `team-window-visible` event, plus a `mainWindowVisible()` pull to
+ *   seed a launch that goes straight to the tray. On Windows, hiding a Tauri
+ *   window to the tray does not flip `document.hidden`, so a purely web-based
+ *   gate thinks a tray'd app is being looked at.
+ * - `document.hidden`, folded in for the platforms where it does fire, such as
+ *   a real minimize.
+ * - Window focus. `document.hidden` stays false on every desktop platform when
+ *   the window is merely unfocused or completely covered by another app, so
+ *   without this an alt-tab straight after launch would let a prompt render
+ *   behind the editor and count as shown.
  *
  * Starts pessimistic (hidden) so a tray'd launch cannot briefly count as
  * on-screen before the seed answers. If the seed fails, which is anything that
- * is not the desktop app, it falls back to the webview signal.
+ * is not the desktop app, it falls back to the webview signals.
  *
- * The team-sync loop in App.tsx tracks the same two signals imperatively,
- * because it parks a long-poll rather than rendering. Same event, different
- * shape; this hook is for components.
+ * The team-sync loop in App.tsx tracks the native signals imperatively, because
+ * it parks a long-poll rather than rendering. Same event, different shape; this
+ * hook is for components.
  */
 export function useWindowVisible(): boolean {
   const [visible, setVisible] = useState(false);
@@ -32,7 +37,7 @@ export function useWindowVisible(): boolean {
     // afterwards is stale and would put the hook back on the wrong answer.
     let eventArrived = false;
     const apply = () => {
-      if (!cancelled) setVisible(shown && !document.hidden);
+      if (!cancelled) setVisible(shown && !document.hidden && document.hasFocus());
     };
     const seed = (v: boolean) => {
       if (eventArrived) return;
@@ -55,13 +60,67 @@ export function useWindowVisible(): boolean {
       return () => {};
     });
     document.addEventListener("visibilitychange", apply);
+    window.addEventListener("focus", apply);
+    window.addEventListener("blur", apply);
 
     return () => {
       cancelled = true;
       document.removeEventListener("visibilitychange", apply);
+      window.removeEventListener("focus", apply);
+      window.removeEventListener("blur", apply);
       void unlisten.then((f) => f());
     };
   }, []);
 
   return visible;
+}
+
+/**
+ * Set on `<body>` by react-remove-scroll for as long as a modal layer is up.
+ * Every Radix modal primitive this app uses (Dialog, DropdownMenu, Select)
+ * mounts it, so one attribute answers for all of them.
+ */
+const SCROLL_LOCK_ATTRIBUTE = "data-scroll-locked";
+
+/**
+ * Whether a modal layer is covering the app.
+ *
+ * A modal dialog paints a blurred overlay above everything, focus-traps into
+ * itself and marks the rest of the document `aria-hidden`. Anything rendered
+ * outside it is therefore dimmed, unclickable and invisible to a screen reader,
+ * even though it is still mounted. A corner prompt that treats being mounted as
+ * being seen would spend its one ask on something nobody could reach.
+ *
+ * The counted body attribute is the signal rather than app state, because it is
+ * already correct for nested and stacked layers and needs no dialog in the app
+ * to opt in. It is watched instead of polled so the answer changes the moment
+ * the last layer closes.
+ */
+export function useModalOpen(): boolean {
+  const [open, setOpen] = useState(modalLayerOpen);
+
+  useEffect(() => {
+    const sync = () => setOpen(modalLayerOpen());
+    sync();
+    const observer = new MutationObserver(sync);
+    observer.observe(document.body, {
+      attributes: true,
+      attributeFilter: [SCROLL_LOCK_ATTRIBUTE],
+    });
+    return () => observer.disconnect();
+  }, []);
+
+  return open;
+}
+
+/**
+ * The same answer without the subscription, for code that has to decide against
+ * the DOM as it is right now rather than as of the last render. Radix mounts a
+ * dialog's overlay through a portal, which lands on a later commit than the one
+ * that rendered the dialog, so a neighbour rendering in the same beat sees no
+ * lock at all until the DOM has settled. Anything that has to be right about a
+ * covered screen must re-read it rather than trust what it rendered with.
+ */
+export function modalLayerOpen(): boolean {
+  return document.body.hasAttribute(SCROLL_LOCK_ATTRIBUTE);
 }


### PR DESCRIPTION
Toolport has never asked for a star. This adds the ask in-app only: no OS notification, no toast that steals focus, and nothing that reappears on the next launch.

## Who sees what

| Who | Surface | When |
| --- | --- | --- |
| New install | Card, "You're all set" | after onboarding |
| New install that hit Later | Chip | a later launch, once 3 servers are enabled |
| Install that predates this prompt | Card, "Enjoying Toolport?", once ever | a few seconds into a launch, if 1+ server is enabled |

Existing users get **one** ask and no chip. They have been here for months, so one is the polite amount.

The chip deliberately belongs to a later launch rather than the same session. Onboarding itself adds servers, so a chip appearing minutes after a "Later" would read as nagging.

## Reaching existing users without a version check

Detection is "has onboarded, but has no star record", not a version number. That reaches every existing install on whatever update it takes next, never reaches a fresh install, and leaves no dead version check behind.

## An ask is spent when it is shown

Not when it is clicked. Ignore a card, quit, and it does not come back. Previously the state only advanced on a click, which would have turned one ask into a prompt on every launch.

## Nothing is spent while the app is in the tray

Toolport usually sits in the tray. Two consequences, both handled:

- The existing-user delay counts only while the window is on screen, and restarts each time it opens.
- The gateway can enable servers while the window is hidden. Without this gate, the chip would appear and burn its one showing with nobody looking.

The new `useWindowVisible` hook reads the Rust show/hide event plus a seed pull, because `document.hidden` does not flip when a Tauri window hides to the tray on Windows. It starts pessimistic (hidden) so a launch straight to the tray never counts as on screen. The team-sync loop in `App.tsx` tracks the same two signals imperatively; it parks a long poll rather than rendering, so it is left alone rather than refactored under this change.

## Other details

- The prompt shares the bottom-right corner with the toast stack, so toasts are offset upward while it is on screen instead of landing on top of it.
- The existing-user card says "No thanks", not "Later", because there is no second chance. No fake promise.
- An existing install with no servers enabled sees nothing and keeps the ask owed. If they enable one next month, they get it then.
- If `localStorage` is unavailable, the prompt stays silent. A dismissal that cannot be recorded would mean asking on every launch.
- Links open through `openExternal`, so the existing URL guard applies.

## Testing

- 22 new tests across the two units, plus 6 for the visibility hook. Full suite: 507 passing.
- `npx tsc --noEmit` clean, `npx eslint src/` 0 errors (51 warnings, unchanged from main), `npx prettier --check src/` clean.
- All three surfaces rendered and checked in a browser against the real stylesheet.

https://claude.ai/code/session_014S6QTd8veckZU8NEiXBS3B


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add a GitHub star prompt that appears at most twice after onboarding
> - Adds [GitHubStarPrompt.tsx](https://github.com/tsouth89/toolport/pull/806/files#diff-39bb5e02d2e987bb7f40a410919ecc6bd73d59ea13c3b58a95cae1732b19376f) which shows a card (new installs, post-onboarding) or a delayed card (existing installs), falling back to a compact chip once the card has been shown once.
> - Prompt state (`card` → `later` → `done`) is persisted in `localStorage` via [starPrompt.ts](https://github.com/tsouth89/toolport/pull/806/files#diff-00d21564f874493e0fc619c21155f1bb9725152073970226a6285df8bf25281f), with `done` as a terminal state and safeguards for broken storage.
> - Prompt is suppressed when the window is hidden, unfocused, or a modal is open, using new `useWindowVisible` and `useModalOpen` hooks in [windowVisible.ts](https://github.com/tsouth89/toolport/pull/806/files#diff-953d9119ea2a5d23e4e492eb5eaf46a10ad9f35ddb2f4b10157ae77eaac53dd3).
> - [App.tsx](https://github.com/tsouth89/toolport/pull/806/files#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2) passes a `starSurface` state to `<Toaster>` to adjust its bottom offset (3.5rem for chip, 10rem for card) and avoid overlap with the prompt.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7831841.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->