### PR TITLE
Make the disconnected Teams tab explain Toolport Teams

### DIFF
--- a/src/components/TeamsView.test.tsx
+++ b/src/components/TeamsView.test.tsx
@@ -19,7 +19,18 @@ vi.mock("@tauri-apps/api/event", () => ({
   listen: vi.fn().mockResolvedValue(vi.fn()),
 }));
 
+const { openExternal } = vi.hoisted(() => ({ openExternal: vi.fn() }));
+vi.mock("@/lib/openUrl", () => ({ openExternal }));
+
 import { TeamsView } from "./TeamsView";
+import { TEAMS_CREATE_URL, TEAMS_PRICING_URL, TEAMS_SELFHOST_URL } from "@/lib/teamUrl";
+import {
+  TEAMS_BASE_PRICE,
+  TEAMS_FREE_LINE,
+  TEAMS_FREE_SEATS,
+  TEAMS_PAID_LINE,
+  TEAMS_SEAT_PRICE,
+} from "@/lib/teamsPlan";
 
 const registry: Registry = {
   version: 1,
@@ -33,6 +44,9 @@ const registry: Registry = {
     lastVersion: 6,
   },
 };
+
+/** The same registry with no team on it, which is what every free user sees. */
+const noTeam: Registry = { ...registry, team: null };
 
 describe("TeamsView shared-server update", () => {
   beforeEach(() => {
@@ -135,5 +149,116 @@ describe("TeamsView shared-server update", () => {
 
     await userEvent.click(screen.getByRole("button", { name: "Update shared servers" }));
     await waitFor(() => expect(api.teamPushPreview).toHaveBeenCalledTimes(2));
+  });
+});
+
+/** The disconnected Teams tab is the only sales page Toolport Teams gets in front of a
+ * free user, and it is also the join form for someone who already has a code. These
+ * tests hold both halves: the pitch has to be there, and it must not have pushed the
+ * form down or broken it. */
+describe("TeamsView disconnected pitch", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    openExternal.mockClear();
+  });
+
+  it("keeps the connect form ahead of the pitch in the DOM", () => {
+    render(<TeamsView registry={noTeam} onRegistryChange={vi.fn()} />);
+
+    const form = screen.getByRole("heading", { name: "Have an invite or connect code?" });
+    const pitch = screen.getByRole("heading", { name: "No team yet?" });
+
+    // Someone who came here holding a code is the conversion this page already has. If
+    // the pitch ever lands first in the DOM it also lands first on a narrow window,
+    // where the lanes stack, and that person has to scroll past an ad to paste a code.
+    expect(form.compareDocumentPosition(pitch)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+  });
+
+  it("still connects with a pasted invite code", async () => {
+    const onRegistryChange = vi.fn();
+    api.teamConnect.mockResolvedValue({ status: "connected", registry: noTeam });
+
+    render(<TeamsView registry={noTeam} onRegistryChange={onRegistryChange} />);
+    await userEvent.type(
+      screen.getByPlaceholderText("Paste your invite or connect code"),
+      "invite-abc",
+    );
+    await userEvent.click(screen.getByRole("button", { name: "Connect" }));
+
+    await waitFor(() =>
+      expect(api.teamConnect).toHaveBeenCalledWith(
+        "https://teams.toolport.app",
+        "invite-abc",
+        undefined,
+      ),
+    );
+    expect(onRegistryChange).toHaveBeenCalledWith(noTeam);
+  });
+
+  it("offers a way to start a team, which the desktop app cannot do itself", async () => {
+    render(<TeamsView registry={noTeam} onRegistryChange={vi.fn()} />);
+
+    await userEvent.click(screen.getByRole("button", { name: /Create a free team/ }));
+
+    // The hosted app reads both of these: `intent` restores team creation after the
+    // sign-in round trip, `from` attributes the app tab separately from the marketing
+    // funnel. Dropping either silently degrades to the generic manage view.
+    expect(openExternal).toHaveBeenCalledWith(TEAMS_CREATE_URL);
+    expect(TEAMS_CREATE_URL).toContain("intent=create-team");
+    expect(TEAMS_CREATE_URL).toContain("from=app-teams-tab");
+  });
+
+  it("states the free tier and what the paid tier actually buys", () => {
+    render(<TeamsView registry={noTeam} onRegistryChange={vi.fn()} />);
+
+    expect(screen.getByText(TEAMS_FREE_LINE)).toBeInTheDocument();
+    expect(screen.getByText(TEAMS_PAID_LINE)).toBeInTheDocument();
+    // Team costs the same at the free seat count as Free does; the difference is
+    // governance. Quoting a per-person price on its own would read as a seat paywall.
+    expect(TEAMS_PAID_LINE).toMatch(/access control/i);
+    expect(TEAMS_FREE_LINE).toContain(String(TEAMS_FREE_SEATS));
+  });
+
+  it("keeps self-hosting a first-class option, not a footnote", async () => {
+    render(<TeamsView registry={noTeam} onRegistryChange={vi.fn()} />);
+
+    expect(screen.getByText(/self-hosted on your own network/i)).toBeInTheDocument();
+    await userEvent.click(screen.getByRole("button", { name: /Self-host it/ }));
+    expect(openExternal).toHaveBeenCalledWith(TEAMS_SELFHOST_URL);
+  });
+
+  it("links out for the authoritative price", async () => {
+    render(<TeamsView registry={noTeam} onRegistryChange={vi.fn()} />);
+
+    await userEvent.click(screen.getByRole("button", { name: /Pricing/ }));
+    expect(openExternal).toHaveBeenCalledWith(TEAMS_PRICING_URL);
+  });
+
+  it("shows none of the pitch once a team is connected", () => {
+    render(<TeamsView registry={registry} onRegistryChange={vi.fn()} />);
+
+    // The ask happens once, on a tab the person chose to open, and stops the moment it
+    // has been answered. A member should never see marketing for the thing they joined.
+    expect(screen.queryByRole("heading", { name: "No team yet?" })).toBeNull();
+    expect(screen.queryByText(TEAMS_FREE_LINE)).toBeNull();
+    expect(screen.queryByText(TEAMS_PAID_LINE)).toBeNull();
+  });
+});
+
+/** The app quotes a price in exactly one place. This is the guard that the copy and the
+ * numbers behind it cannot drift apart inside the app; toolport.app/teams#pricing stays
+ * the authority for whether the numbers themselves are still right. */
+describe("Teams plan copy", () => {
+  it("builds its copy from the shared numbers", () => {
+    expect(TEAMS_PAID_LINE).toContain(`$${TEAMS_BASE_PRICE}/month`);
+    expect(TEAMS_PAID_LINE).toContain(`$${TEAMS_SEAT_PRICE} per person`);
+    expect(TEAMS_PAID_LINE).toContain(`up to ${TEAMS_FREE_SEATS}`);
+    expect(TEAMS_PAID_LINE).toMatch(/same price hosted or self-hosted/i);
+  });
+
+  it("uses no em dashes or en dashes", () => {
+    for (const line of [TEAMS_FREE_LINE, TEAMS_PAID_LINE]) {
+      expect(line).not.toMatch(/[—–]/);
+    }
   });
 });

--- a/src/components/TeamsView.test.tsx
+++ b/src/components/TeamsView.test.tsx
@@ -25,12 +25,32 @@ vi.mock("@/lib/openUrl", () => ({ openExternal }));
 import { TeamsView } from "./TeamsView";
 import { TEAMS_CREATE_URL, TEAMS_PRICING_URL, TEAMS_SELFHOST_URL } from "@/lib/teamUrl";
 import {
+  TEAMS_ANNUAL_PRICE,
   TEAMS_BASE_PRICE,
   TEAMS_FREE_LINE,
   TEAMS_FREE_SEATS,
   TEAMS_PAID_LINE,
   TEAMS_SEAT_PRICE,
+  TEAMS_TRIAL_DAYS,
 } from "@/lib/teamsPlan";
+
+/** Everything on this tab that only a person without a team should ever see. Named once
+ * so the "connected", "loading" and "waiting for approval" tests all assert against the
+ * same list, and adding a new piece of pitch copy in one place fails all three. */
+const PITCH_CTAS = [/Create a free team/, /Pricing/, /Self-host it/];
+const PAIN_TILES = ["New teammate, day one", "No more config drift", "No shared secrets"];
+
+function expectNoPitch() {
+  expect(screen.queryByRole("heading", { name: "No team yet?" })).toBeNull();
+  expect(screen.queryByText(TEAMS_FREE_LINE)).toBeNull();
+  expect(screen.queryByText(TEAMS_PAID_LINE)).toBeNull();
+  for (const name of PITCH_CTAS) {
+    expect(screen.queryByRole("button", { name })).toBeNull();
+  }
+  for (const title of PAIN_TILES) {
+    expect(screen.queryByText(title)).toBeNull();
+  }
+}
 
 const registry: Registry = {
   version: 1,
@@ -216,7 +236,48 @@ describe("TeamsView disconnected pitch", () => {
     // Team costs the same at the free seat count as Free does; the difference is
     // governance. Quoting a per-person price on its own would read as a seat paywall.
     expect(TEAMS_PAID_LINE).toMatch(/access control/i);
-    expect(TEAMS_FREE_LINE).toContain(String(TEAMS_FREE_SEATS));
+    // Anchored to the phrase, not to the bare digit: "5" also appears inside "$39" and
+    // "$390", so a `toContain("5")` would survive the seat count being dropped entirely.
+    expect(TEAMS_FREE_LINE).toContain(`up to ${TEAMS_FREE_SEATS} people`);
+  });
+
+  it("says how long the free trial of Team features lasts", () => {
+    render(<TeamsView registry={noTeam} onRegistryChange={vi.fn()} />);
+
+    // The number is the whole reason "Create a free team" is not a commitment. It is
+    // interpolated, so it can silently vanish without the surrounding sentence changing.
+    expect(
+      screen.getByText(new RegExp(`free to try for ${TEAMS_TRIAL_DAYS} days`)),
+    ).toBeInTheDocument();
+  });
+
+  it("shows why a team is worth having, not just what it costs", () => {
+    render(<TeamsView registry={noTeam} onRegistryChange={vi.fn()} />);
+
+    // Price answers "how much", these answer "why at all". They are the only part of the
+    // page that names a problem the reader already has.
+    for (const title of PAIN_TILES) {
+      expect(screen.getByText(title)).toBeInTheDocument();
+    }
+  });
+
+  it("refuses a non-https team server URL before it reaches the backend", async () => {
+    render(<TeamsView registry={noTeam} onRegistryChange={vi.fn()} />);
+
+    const url = screen.getByPlaceholderText("https://toolport.yourcompany.com");
+    await userEvent.clear(url);
+    await userEvent.type(url, "http://teams.evil.example.com");
+    await userEvent.type(
+      screen.getByPlaceholderText("Paste your invite or connect code"),
+      "invite-abc",
+    );
+    await userEvent.click(screen.getByRole("button", { name: "Connect" }));
+
+    // The check has to be worth something to the person reading it: a rejected URL that
+    // says nothing is indistinguishable from a broken button. And it must run before the
+    // call, not after — an invite code posted over plaintext http is already spent.
+    expect(await screen.findByText(/must use https:\/\//i)).toBeInTheDocument();
+    expect(api.teamConnect).not.toHaveBeenCalled();
   });
 
   it("keeps self-hosting a first-class option, not a footnote", async () => {
@@ -238,10 +299,40 @@ describe("TeamsView disconnected pitch", () => {
     render(<TeamsView registry={registry} onRegistryChange={vi.fn()} />);
 
     // The ask happens once, on a tab the person chose to open, and stops the moment it
-    // has been answered. A member should never see marketing for the thing they joined.
-    expect(screen.queryByRole("heading", { name: "No team yet?" })).toBeNull();
-    expect(screen.queryByText(TEAMS_FREE_LINE)).toBeNull();
-    expect(screen.queryByText(TEAMS_PAID_LINE)).toBeNull();
+    // has been answered. A member should never see marketing for the thing they joined,
+    // and that covers every piece of it: headings, prices, buttons and pain tiles alike.
+    expectNoPitch();
+    expect(screen.getByText("Connected")).toBeInTheDocument();
+  });
+
+  it("shows no pitch before the registry has loaded", () => {
+    render(<TeamsView registry={null} onRegistryChange={vi.fn()} />);
+
+    // `registry` is null until the first read lands, and stays null all session if that
+    // read fails. Treating that as "no team" pitches Teams at people who are already on
+    // one — the single audience this page must never sell to. Not knowing is its own
+    // state, and it renders as neither answer.
+    expectNoPitch();
+    expect(screen.getByLabelText("Loading Toolport Teams")).toBeInTheDocument();
+  });
+
+  it("drops the pitch while a join waits for an admin", async () => {
+    api.teamConnect.mockResolvedValue({ status: "pending", requestToken: "req-1" });
+    api.teamJoinPoll.mockResolvedValue({ status: "pending" });
+
+    render(<TeamsView registry={noTeam} onRegistryChange={vi.fn()} />);
+    await userEvent.type(
+      screen.getByPlaceholderText("Paste your invite or connect code"),
+      "invite-abc",
+    );
+    await userEvent.click(screen.getByRole("button", { name: "Connect" }));
+
+    expect(
+      await screen.findByText(/Leave this open, it finishes on its own/),
+    ).toBeVisible();
+    // This person has picked their team and is waiting on a human. Offering them a second
+    // team to create, at a price, is the app arguing against the thing it just did.
+    expectNoPitch();
   });
 });
 
@@ -251,7 +342,10 @@ describe("TeamsView disconnected pitch", () => {
 describe("Teams plan copy", () => {
   it("builds its copy from the shared numbers", () => {
     expect(TEAMS_PAID_LINE).toContain(`$${TEAMS_BASE_PRICE}/month`);
-    expect(TEAMS_PAID_LINE).toContain(`$${TEAMS_SEAT_PRICE} per person`);
+    // "/month" on the seat price too: "$12 per person" reads as a one-time charge to add
+    // someone, which undersells nothing and oversells the bill.
+    expect(TEAMS_PAID_LINE).toContain(`$${TEAMS_SEAT_PRICE}/month per person`);
+    expect(TEAMS_PAID_LINE).toContain(`$${TEAMS_ANNUAL_PRICE}/year`);
     expect(TEAMS_PAID_LINE).toContain(`up to ${TEAMS_FREE_SEATS}`);
     expect(TEAMS_PAID_LINE).toMatch(/same price hosted or self-hosted/i);
   });

--- a/src/components/TeamsView.tsx
+++ b/src/components/TeamsView.tsx
@@ -19,6 +19,7 @@ import { Callout } from "@/components/Callout";
 import { RuleStateBadge } from "@/components/RuleStateBadge";
 import { TransportPill } from "@/components/TransportPill";
 import { Input } from "@/components/ui/input";
+import { Skeleton } from "@/components/ui/skeleton";
 import {
   teamConnect,
   teamJoinPoll,
@@ -300,6 +301,27 @@ export function TeamsView({
     );
   };
 
+  // `registry` is null until the first `getRegistry()` resolves, and stays null for the
+  // rest of the session if that call fails. `registry?.team ?? null` folds that state into
+  // "no team", which would show a member of a team the sales pitch for the team they are
+  // already in — the one audience this page must never pitch to. Nothing below can tell
+  // the two apart, so answer the question here: not loaded yet is neither state.
+  if (registry === null) {
+    return (
+      <div className="mx-auto max-w-2xl">
+        <div className="mb-5 flex items-center gap-2">
+          <Users className="size-5 text-muted-foreground" />
+          <h2 className="text-base font-semibold">Toolport Teams</h2>
+        </div>
+        <div className="flex flex-col gap-2" aria-label="Loading Toolport Teams">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <Skeleton key={i} className="h-14 w-full rounded-lg" />
+          ))}
+        </div>
+      </div>
+    );
+  }
+
   return (
     // The connected view is a single column of cards and stays narrow. The
     // disconnected one runs two lanes side by side, which needs the extra width to
@@ -343,7 +365,9 @@ export function TeamsView({
               first in the DOM and first on screen at every width; the pitch sits beside
               it, never above it. Below `lg` the lanes stack and the form stays first. */}
           <div className="grid gap-4 lg:grid-cols-5 lg:items-start">
-            <div className="rounded-xl border bg-card p-5 lg:col-span-3">
+            <div
+              className={`rounded-xl border bg-card p-5 ${pending ? "lg:col-span-5" : "lg:col-span-3"}`}
+            >
               <h3 className="text-sm font-medium">Have an invite or connect code?</h3>
               <p className="mt-1 mb-4 text-sm text-muted-foreground">
                 Paste it here and the team's shared servers appear in your active profile,
@@ -411,98 +435,108 @@ export function TeamsView({
               </div>
             </div>
 
-            <div className="rounded-xl border border-primary/25 bg-primary/[0.04] p-5 lg:col-span-2">
-              <h3 className="text-sm font-medium">No team yet?</h3>
-              <p className="mt-1 mb-3 text-sm text-muted-foreground">
-                Pick the MCP servers once and everyone's Claude, Cursor, and other agents
-                get the same stack.
-              </p>
-              <ul className="mb-3 grid gap-2">
-                {[
-                  TEAMS_FREE_LINE,
-                  "Hosted by us or self-hosted on your own network, same features either way.",
-                  "Keys never reach the server, so there is no shared secret to rotate.",
-                ].map((point) => (
-                  <li
-                    key={point}
-                    className="flex gap-2 text-2xs leading-relaxed text-muted-foreground"
-                  >
-                    <Check className="mt-0.5 size-3.5 shrink-0 text-primary" />
-                    <span>{point}</span>
-                  </li>
-                ))}
-              </ul>
-              <p className="mb-4 text-2xs leading-relaxed text-muted-foreground">
-                {TEAMS_PAID_LINE}
-              </p>
-              {/* The desktop app has no create-a-team flow, so this hands off to the
+            {/* Someone waiting on an admin has already picked a team, so the ask is
+                answered: no "No team yet?", no prices, no second team to create beside
+                the one they are joining. The lane is dropped rather than dimmed, and the
+                form takes the full width while the wait lasts. */}
+            {!pending && (
+              <div className="rounded-xl border border-primary/25 bg-primary/[0.04] p-5 lg:col-span-2">
+                <h3 className="text-sm font-medium">No team yet?</h3>
+                <p className="mt-1 mb-3 text-sm text-muted-foreground">
+                  Pick the MCP servers once and everyone's Claude, Cursor, and other
+                  agents get the same stack.
+                </p>
+                <ul className="mb-3 grid gap-2">
+                  {[
+                    TEAMS_FREE_LINE,
+                    "Hosted by us or self-hosted on your own network, same features either way.",
+                    "Keys never reach the server, so there is no shared secret to rotate.",
+                  ].map((point) => (
+                    <li
+                      key={point}
+                      className="flex gap-2 text-2xs leading-relaxed text-muted-foreground"
+                    >
+                      <Check className="mt-0.5 size-3.5 shrink-0 text-primary" />
+                      <span>{point}</span>
+                    </li>
+                  ))}
+                </ul>
+                <p className="mb-4 text-2xs leading-relaxed text-muted-foreground">
+                  {TEAMS_PAID_LINE}
+                </p>
+                {/* The desktop app has no create-a-team flow, so this hands off to the
                   hosted app rather than pretending to start one here. */}
-              <Button className="w-full" onClick={() => openExternal(TEAMS_CREATE_URL)}>
-                Create a free team
-                <ArrowUpRight className="size-4" />
-              </Button>
-              <p className="mt-2 text-2xs text-muted-foreground">
-                Opens in your browser. Google, GitHub, or an email link, no card. Team
-                features are free to try for {TEAMS_TRIAL_DAYS} days.
-              </p>
-              <div className="mt-4 flex flex-wrap gap-x-4 gap-y-1 border-t pt-3 text-2xs">
-                <button
-                  type="button"
-                  onClick={() => openExternal(TEAMS_MARKETING_URL)}
-                  className="text-muted-foreground transition hover:text-foreground"
-                >
-                  How it works →
-                </button>
-                <button
-                  type="button"
-                  onClick={() => openExternal(TEAMS_PRICING_URL)}
-                  className="text-muted-foreground transition hover:text-foreground"
-                >
-                  Pricing →
-                </button>
-                <button
-                  type="button"
-                  onClick={() => openExternal(TEAMS_SELFHOST_URL)}
-                  className="text-muted-foreground transition hover:text-foreground"
-                >
-                  Self-host it →
-                </button>
+                <Button className="w-full" onClick={() => openExternal(TEAMS_CREATE_URL)}>
+                  Create a free team
+                  <ArrowUpRight className="size-4" />
+                </Button>
+                <p className="mt-2 text-2xs text-muted-foreground">
+                  Opens in your browser. Google, GitHub, or an email link, no card. Team
+                  features are free to try for {TEAMS_TRIAL_DAYS} days.
+                </p>
+                <div className="mt-4 flex flex-wrap gap-x-4 gap-y-1 border-t pt-3 text-2xs">
+                  <button
+                    type="button"
+                    onClick={() => openExternal(TEAMS_MARKETING_URL)}
+                    className="text-muted-foreground transition hover:text-foreground"
+                  >
+                    How it works →
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => openExternal(TEAMS_PRICING_URL)}
+                    className="text-muted-foreground transition hover:text-foreground"
+                  >
+                    Pricing →
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => openExternal(TEAMS_SELFHOST_URL)}
+                    className="text-muted-foreground transition hover:text-foreground"
+                  >
+                    Self-host it →
+                  </button>
+                </div>
               </div>
-            </div>
+            )}
           </div>
 
-          <div className="grid gap-2.5 sm:grid-cols-3">
-            {[
-              {
-                icon: Server,
-                title: "New teammate, day one",
-                body: "Send one code instead of walking someone through every server by hand. Their agents come up already configured.",
-              },
-              {
-                icon: RefreshCw,
-                title: "No more config drift",
-                body: "Six people, six slightly different server lists, and a bug only one of them can reproduce. One shared set ends that.",
-              },
-              {
-                icon: ShieldCheck,
-                title: "No shared secrets",
-                body: "The team server stores config, never a credential. Every key stays in its owner's OS keychain.",
-              },
-            ].map(({ icon: Icon, title, body }) => (
-              <div
-                key={title}
-                className="rounded-lg border border-border/60 bg-muted/20 p-3"
-              >
-                <div className="flex items-center gap-1.5 text-sm font-medium">
-                  <Icon className="size-3.5 text-primary" />
-                  {title}
+          {/* Same reason as the lane above: these three are the argument for having a
+              team at all, and it is settled once a request is out. */}
+          {!pending && (
+            <div className="grid gap-2.5 sm:grid-cols-3">
+              {[
+                {
+                  icon: Server,
+                  title: "New teammate, day one",
+                  body: "Send one code instead of walking someone through every server by hand. Their agents come up already configured.",
+                },
+                {
+                  icon: RefreshCw,
+                  title: "No more config drift",
+                  body: "Six people, six slightly different server lists, and a bug only one of them can reproduce. One shared set ends that.",
+                },
+                {
+                  icon: ShieldCheck,
+                  title: "No shared secrets",
+                  body: "The team server stores config, never a credential. Every key stays in its owner's OS keychain.",
+                },
+              ].map(({ icon: Icon, title, body }) => (
+                <div
+                  key={title}
+                  className="rounded-lg border border-border/60 bg-muted/20 p-3"
+                >
+                  <div className="flex items-center gap-1.5 text-sm font-medium">
+                    <Icon className="size-3.5 text-primary" />
+                    {title}
+                  </div>
+                  <p className="mt-1 text-2xs leading-relaxed text-muted-foreground">
+                    {body}
+                  </p>
                 </div>
-                <p className="mt-1 text-2xs leading-relaxed text-muted-foreground">
-                  {body}
-                </p>
-              </div>
-            ))}
-          </div>
+              ))}
+            </div>
+          )}
         </div>
       ) : (
         <div className="grid gap-4">

--- a/src/components/TeamsView.tsx
+++ b/src/components/TeamsView.tsx
@@ -8,6 +8,8 @@ import {
   Server,
   AlertTriangle,
   FileText,
+  ArrowUpRight,
+  Check,
 } from "lucide-react";
 import { listen } from "@tauri-apps/api/event";
 import { Badge } from "@/components/ui/badge";
@@ -27,7 +29,16 @@ import {
   teamInstructionsStatus,
   setServerEnabled,
 } from "@/lib/api";
-import { HOSTED_TEAMS_URL, teamUrlError } from "@/lib/teamUrl";
+import {
+  HOSTED_TEAMS_URL,
+  TEAMS_CREATE_URL,
+  TEAMS_MARKETING_URL,
+  TEAMS_PRICING_URL,
+  TEAMS_SELFHOST_URL,
+  teamUrlError,
+} from "@/lib/teamUrl";
+import { TEAMS_FREE_LINE, TEAMS_PAID_LINE, TEAMS_TRIAL_DAYS } from "@/lib/teamsPlan";
+import { openExternal } from "@/lib/openUrl";
 import { isEnabled, activeProfile } from "@/lib/types";
 import type { TeamPushPreview } from "@/lib/api";
 import type { Registry, InstructionsStatusView } from "@/lib/types";
@@ -290,7 +301,10 @@ export function TeamsView({
   };
 
   return (
-    <div className="mx-auto max-w-2xl">
+    // The connected view is a single column of cards and stays narrow. The
+    // disconnected one runs two lanes side by side, which needs the extra width to
+    // keep the connect form's fields from turning into a column of stubs.
+    <div className={team ? "mx-auto max-w-2xl" : "mx-auto max-w-4xl"}>
       <div className="mb-5 flex items-center gap-2">
         <Users className="size-5 text-muted-foreground" />
         <h2 className="text-base font-semibold">Toolport Teams</h2>
@@ -313,28 +327,166 @@ export function TeamsView({
       )}
 
       {!team ? (
-        <div className="rounded-xl border bg-card p-5">
-          <h3 className="text-sm font-medium">Connect to a team</h3>
-          <p className="mt-1 mb-4 max-w-prose text-sm text-muted-foreground">
-            Join your team's Toolport Teams server and its shared MCP servers appear in
-            your active profile, kept in sync as your admin updates them.
-          </p>
-          <div className="mb-5 grid gap-2.5 sm:grid-cols-3">
+        <div className="grid gap-4">
+          <div>
+            <h3 className="text-sm font-medium">
+              Everyone gets the same MCP servers. Nobody shares a key.
+            </h3>
+            <p className="mt-1 max-w-prose text-sm text-muted-foreground">
+              A Toolport Teams server holds the shared server list and its config. Each
+              person still vaults their own credentials on their own machine.
+            </p>
+          </div>
+
+          {/* Two lanes, and the order matters. Someone who opened this tab holding an
+              invite code is the one conversion this page already has, so the form is
+              first in the DOM and first on screen at every width; the pitch sits beside
+              it, never above it. Below `lg` the lanes stack and the form stays first. */}
+          <div className="grid gap-4 lg:grid-cols-5 lg:items-start">
+            <div className="rounded-xl border bg-card p-5 lg:col-span-3">
+              <h3 className="text-sm font-medium">Have an invite or connect code?</h3>
+              <p className="mt-1 mb-4 text-sm text-muted-foreground">
+                Paste it here and the team's shared servers appear in your active profile,
+                kept in sync as your admin updates them.
+              </p>
+              <div className="grid gap-3">
+                <label className="grid gap-1 text-sm">
+                  <span className="text-muted-foreground">Team server URL</span>
+                  <Input
+                    placeholder="https://toolport.yourcompany.com"
+                    value={serverUrl}
+                    onChange={(e) => setServerUrl(e.target.value)}
+                  />
+                  <span className="text-xs text-muted-foreground">
+                    Defaults to hosted Toolport Teams. Self-hosting? Replace it with your
+                    own server URL.
+                  </span>
+                </label>
+                <label className="grid gap-1 text-sm">
+                  <span className="text-muted-foreground">Invite or connect code</span>
+                  <Input
+                    placeholder="Paste your invite or connect code"
+                    value={inviteCode}
+                    onChange={(e) => setInviteCode(e.target.value)}
+                  />
+                  <span className="text-xs text-muted-foreground">
+                    An invite code joins you to a team. A connect code links this device
+                    to a seat you already have.
+                  </span>
+                </label>
+                <label className="grid gap-1 text-sm">
+                  <span className="text-muted-foreground">Your name (optional)</span>
+                  <Input
+                    placeholder="e.g. Tyler"
+                    value={memberName}
+                    onChange={(e) => setMemberName(e.target.value)}
+                  />
+                </label>
+                <div>
+                  {pending ? (
+                    <div className="flex items-center gap-3 rounded-lg border border-primary/40 bg-primary/5 p-3 text-sm">
+                      <RefreshCw className="size-4 shrink-0 animate-spin text-primary" />
+                      <span className="text-muted-foreground">
+                        Waiting for an admin to approve your request. Leave this open, it
+                        finishes on its own once they approve.
+                      </span>
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        className="ml-auto shrink-0"
+                        onClick={() => {
+                          setPending(null);
+                          setNotice(null);
+                        }}
+                      >
+                        Cancel
+                      </Button>
+                    </div>
+                  ) : (
+                    <Button onClick={onConnect} disabled={busy !== null}>
+                      {busy === "connect" ? "Connecting…" : "Connect"}
+                    </Button>
+                  )}
+                </div>
+              </div>
+            </div>
+
+            <div className="rounded-xl border border-primary/25 bg-primary/[0.04] p-5 lg:col-span-2">
+              <h3 className="text-sm font-medium">No team yet?</h3>
+              <p className="mt-1 mb-3 text-sm text-muted-foreground">
+                Pick the MCP servers once and everyone's Claude, Cursor, and other agents
+                get the same stack.
+              </p>
+              <ul className="mb-3 grid gap-2">
+                {[
+                  TEAMS_FREE_LINE,
+                  "Hosted by us or self-hosted on your own network, same features either way.",
+                  "Keys never reach the server, so there is no shared secret to rotate.",
+                ].map((point) => (
+                  <li
+                    key={point}
+                    className="flex gap-2 text-2xs leading-relaxed text-muted-foreground"
+                  >
+                    <Check className="mt-0.5 size-3.5 shrink-0 text-primary" />
+                    <span>{point}</span>
+                  </li>
+                ))}
+              </ul>
+              <p className="mb-4 text-2xs leading-relaxed text-muted-foreground">
+                {TEAMS_PAID_LINE}
+              </p>
+              {/* The desktop app has no create-a-team flow, so this hands off to the
+                  hosted app rather than pretending to start one here. */}
+              <Button className="w-full" onClick={() => openExternal(TEAMS_CREATE_URL)}>
+                Create a free team
+                <ArrowUpRight className="size-4" />
+              </Button>
+              <p className="mt-2 text-2xs text-muted-foreground">
+                Opens in your browser. Google, GitHub, or an email link, no card. Team
+                features are free to try for {TEAMS_TRIAL_DAYS} days.
+              </p>
+              <div className="mt-4 flex flex-wrap gap-x-4 gap-y-1 border-t pt-3 text-2xs">
+                <button
+                  type="button"
+                  onClick={() => openExternal(TEAMS_MARKETING_URL)}
+                  className="text-muted-foreground transition hover:text-foreground"
+                >
+                  How it works →
+                </button>
+                <button
+                  type="button"
+                  onClick={() => openExternal(TEAMS_PRICING_URL)}
+                  className="text-muted-foreground transition hover:text-foreground"
+                >
+                  Pricing →
+                </button>
+                <button
+                  type="button"
+                  onClick={() => openExternal(TEAMS_SELFHOST_URL)}
+                  className="text-muted-foreground transition hover:text-foreground"
+                >
+                  Self-host it →
+                </button>
+              </div>
+            </div>
+          </div>
+
+          <div className="grid gap-2.5 sm:grid-cols-3">
             {[
               {
                 icon: Server,
-                title: "Shared server set",
-                body: "Your admin curates the MCP servers; they show up in your profile.",
-              },
-              {
-                icon: ShieldCheck,
-                title: "Keys stay local",
-                body: "The team holds config only, never a secret. You vault keys on your machine.",
+                title: "New teammate, day one",
+                body: "Send one code instead of walking someone through every server by hand. Their agents come up already configured.",
               },
               {
                 icon: RefreshCw,
-                title: "Always in sync",
-                body: "One source of truth; updates arrive when you Sync.",
+                title: "No more config drift",
+                body: "Six people, six slightly different server lists, and a bug only one of them can reproduce. One shared set ends that.",
+              },
+              {
+                icon: ShieldCheck,
+                title: "No shared secrets",
+                body: "The team server stores config, never a credential. Every key stays in its owner's OS keychain.",
               },
             ].map(({ icon: Icon, title, body }) => (
               <div
@@ -350,66 +502,6 @@ export function TeamsView({
                 </p>
               </div>
             ))}
-          </div>
-          <div className="grid gap-3">
-            <label className="grid gap-1 text-sm">
-              <span className="text-muted-foreground">Team server URL</span>
-              <Input
-                placeholder="https://toolport.yourcompany.com"
-                value={serverUrl}
-                onChange={(e) => setServerUrl(e.target.value)}
-              />
-              <span className="text-xs text-muted-foreground">
-                Defaults to hosted Toolport Teams. Self-hosting? Replace it with your own
-                server URL.
-              </span>
-            </label>
-            <label className="grid gap-1 text-sm">
-              <span className="text-muted-foreground">Invite or connect code</span>
-              <Input
-                placeholder="Paste your invite or connect code"
-                value={inviteCode}
-                onChange={(e) => setInviteCode(e.target.value)}
-              />
-              <span className="text-xs text-muted-foreground">
-                An invite code joins you to a team. A connect code links this device to a
-                seat you already have.
-              </span>
-            </label>
-            <label className="grid gap-1 text-sm">
-              <span className="text-muted-foreground">Your name (optional)</span>
-              <Input
-                placeholder="e.g. Tyler"
-                value={memberName}
-                onChange={(e) => setMemberName(e.target.value)}
-              />
-            </label>
-            <div>
-              {pending ? (
-                <div className="flex items-center gap-3 rounded-lg border border-primary/40 bg-primary/5 p-3 text-sm">
-                  <RefreshCw className="size-4 shrink-0 animate-spin text-primary" />
-                  <span className="text-muted-foreground">
-                    Waiting for an admin to approve your request. Leave this open, it
-                    finishes on its own once they approve.
-                  </span>
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    className="ml-auto shrink-0"
-                    onClick={() => {
-                      setPending(null);
-                      setNotice(null);
-                    }}
-                  >
-                    Cancel
-                  </Button>
-                </div>
-              ) : (
-                <Button onClick={onConnect} disabled={busy !== null}>
-                  {busy === "connect" ? "Connecting…" : "Connect"}
-                </Button>
-              )}
-            </div>
           </div>
         </div>
       ) : (

--- a/src/lib/teamUrl.ts
+++ b/src/lib/teamUrl.ts
@@ -10,6 +10,28 @@ export const HOSTED_TEAMS_URL = "https://teams.toolport.app";
  * literals across two components, which is how they drifted (SBS-461). */
 export const TEAMS_MARKETING_URL = "https://toolport.app/teams";
 
+/** The pricing block on the explainer page. The exact numbers live there, not in
+ * the app: the app ships on a release cadence and Stripe does not, so an in-app
+ * dollar figure is a stale figure waiting to happen. The Teams tab states the
+ * *shape* (free for a small team, paid past that, same price hosted or self-hosted)
+ * and links here for the number. */
+export const TEAMS_PRICING_URL = `${TEAMS_MARKETING_URL}#pricing`;
+
+/** The self-hosting instructions on the explainer page. Self-hosting is not a
+ * downgrade path here: the free tier is the same size either way, so this link is
+ * offered next to the hosted one rather than buried under it. */
+export const TEAMS_SELFHOST_URL = `${TEAMS_MARKETING_URL}#selfhost`;
+
+/** Self-serve team creation, which exists only on the web. The desktop app has no
+ * create-a-team flow, so "Create a free team" hands off to the hosted app.
+ *
+ * `intent=create-team` survives the OAuth/email round trip and drops the person on
+ * team creation instead of the manage view; `from` is an attribution key, so
+ * `app-teams-tab` separates people who found Teams inside the app they already
+ * installed from the marketing-page funnel. Both are parsed in the hosted app's
+ * `web/onboarding.js` (`authContext`). */
+export const TEAMS_CREATE_URL = `${HOSTED_TEAMS_URL}/?intent=create-team&from=app-teams-tab`;
+
 export function teamUrlError(raw: string): string | null {
   const value = raw.trim();
   if (!value) return "Server URL is required.";

--- a/src/lib/teamsPlan.ts
+++ b/src/lib/teamsPlan.ts
@@ -1,0 +1,40 @@
+/**
+ * What Toolport Teams costs, in one place.
+ *
+ * The Teams tab is the only place in the app that quotes a price, and a price that
+ * disagrees with toolport.app/teams is worse than no price at all. These values mirror
+ * the pricing section there (and `FREE_SEATS_LIMIT` in the toolport-teams server, which
+ * is what actually enforces the free seat count). If you change one, change all three,
+ * and check the live page before you do:
+ *
+ *   https://toolport.app/teams#pricing
+ *
+ * The app ships on a release cadence and Stripe does not, so treat everything here as a
+ * summary with a link, never as the authority. `TEAMS_PRICING_URL` is the authority.
+ *
+ * Verified against the live page on 2026-08-18.
+ */
+
+/** People included before a plan is required. Enforced server-side as `FREE_SEATS_LIMIT`. */
+export const TEAMS_FREE_SEATS = 5;
+
+/** Monthly price of the Team plan, flat, covering `TEAMS_FREE_SEATS` people. */
+export const TEAMS_BASE_PRICE = 39;
+
+/** Monthly price per person past `TEAMS_FREE_SEATS` on the Team plan. */
+export const TEAMS_SEAT_PRICE = 12;
+
+/** Annual price of the Team plan, which is two months off the monthly rate. */
+export const TEAMS_ANNUAL_PRICE = 390;
+
+/** Length of the Team trial, in days. No card is taken for it. */
+export const TEAMS_TRIAL_DAYS = 14;
+
+/** The free tier, stated the way the pricing page states it. */
+export const TEAMS_FREE_LINE = `Free for up to ${TEAMS_FREE_SEATS} people. It does not expire and needs no card.`;
+
+/** The paid tier. Deliberately says what the money buys, because seats alone do not
+ * explain it: Team costs the same at ${TEAMS_FREE_SEATS} people as Free does, and the
+ * difference is governance. Quoting only the per-person number would read as a seat
+ * paywall, which is not what the plan is. */
+export const TEAMS_PAID_LINE = `Team is $${TEAMS_BASE_PRICE}/month for up to ${TEAMS_FREE_SEATS}, then $${TEAMS_SEAT_PRICE} per person, and adds access control, rate limits, and audit. Same price hosted or self-hosted.`;

--- a/src/lib/teamsPlan.ts
+++ b/src/lib/teamsPlan.ts
@@ -24,7 +24,9 @@ export const TEAMS_BASE_PRICE = 39;
 /** Monthly price per person past `TEAMS_FREE_SEATS` on the Team plan. */
 export const TEAMS_SEAT_PRICE = 12;
 
-/** Annual price of the Team plan, which is two months off the monthly rate. */
+/** Annual price of the Team plan, which is two months off the monthly rate. Quoted in
+ * `TEAMS_PAID_LINE` so this number has a render site: an exported constant nothing
+ * displays is a number nothing can catch drifting. */
 export const TEAMS_ANNUAL_PRICE = 390;
 
 /** Length of the Team trial, in days. No card is taken for it. */
@@ -37,4 +39,4 @@ export const TEAMS_FREE_LINE = `Free for up to ${TEAMS_FREE_SEATS} people. It do
  * explain it: Team costs the same at ${TEAMS_FREE_SEATS} people as Free does, and the
  * difference is governance. Quoting only the per-person number would read as a seat
  * paywall, which is not what the plan is. */
-export const TEAMS_PAID_LINE = `Team is $${TEAMS_BASE_PRICE}/month for up to ${TEAMS_FREE_SEATS}, then $${TEAMS_SEAT_PRICE} per person, and adds access control, rate limits, and audit. Same price hosted or self-hosted.`;
+export const TEAMS_PAID_LINE = `Team is $${TEAMS_BASE_PRICE}/month (or $${TEAMS_ANNUAL_PRICE}/year) for up to ${TEAMS_FREE_SEATS}, then $${TEAMS_SEAT_PRICE}/month per person, and adds access control, rate limits, and audit. Same price hosted or self-hosted.`;


### PR DESCRIPTION
Closes SBS-939.

## The problem

Every free user has a Teams tab. Until now it was a sign-in form for a product they had never heard of: a heading, three feature tiles, and a field asking for an invite code.

Every word assumed the reader already had a team and a code. There was no answer to "I do not have a team, what is this, and how do I start one". Specifically: no start-a-team path, no pricing, no free tier, no mention that self-hosting is free, and no link to the explainer page even though `TEAMS_MARKETING_URL` already existed and only Onboarding used it.

That audience is qualified. They installed a local MCP gateway and then opened a tab named Teams.

## What the page does now

Three jobs, in this priority order.

**1. Serves the person who arrived holding a code.** The connect form is first in the DOM and first on screen at every width. At the 940px minimum window the two lanes stack and the whole form, Connect button included, sits above the fold, with the pitch starting below it. At the 1240px default the whole page fits with no scrolling at all. A test asserts the DOM order so a later layout change cannot quietly invert it.

**2. Explains the product.** One lede line, then three pain-led tiles instead of feature-led ones: onboarding a new teammate, config drift across a team, and having no shared secret to hand a security reviewer.

**3. Gives a next step.** "Create a free team" hands off to the hosted app, because the desktop app has no create-a-team flow to pretend to. Self-hosting sits next to it as a peer, not a footnote.

## Pricing

The numbers are stated, not hinted at, and they live in one module (`src/lib/teamsPlan.ts`) checked against the live toolport.app/teams and against `FREE_SEATS_LIMIT` in the teams server:

- Free for up to 5 people. Does not expire, no card.
- Team at $39/month for up to 5, then $12 per person.
- Same price hosted or self-hosted. 14-day trial, no card.

The paid line says what the money buys rather than quoting a per-person figure alone. Team costs the same at 5 people as Free does, so the difference is governance, not seats, and a bare per-seat number would read as a paywall the plan does not have. An in-app number can still go stale between releases, so "Pricing →" links to the page that is authoritative.

## What it deliberately is not

No fake urgency, no invented team activity, no countdown. Not a nag: it is one tab a person chose to open, and there is no banner, modal, or notification anywhere else. Connected members see none of it. No feature flag, since this is a static page state.

## Verification

`npx vitest run` (485 passed, 1 skipped), `npx tsc --noEmit`, `npx eslint src/`, `npx prettier --check src/` all clean. Nine new tests cover the disconnected state, including that the existing connect flow still works and that none of the pitch appears once a team is connected.

Screenshots taken in both themes and at both the default (1240x820) and minimum (940x600) window sizes, with the real `w-72` sidebar accounted for.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add a marketing pitch panel to the disconnected Teams tab
> - Reworks the disconnected state in [`TeamsView.tsx`](https://github.com/tsouth89/toolport/pull/807/files#diff-50aab01534927ae5e73a7befd618e46927fa4f3023098ec1e72623d135e7d569) into a two-column layout: the existing connect form on the left and a new pitch panel on the right showing pricing tiers, feature bullets, and action links.
> - Adds a loading skeleton when `registry === null` (not yet loaded), preventing the pitch from rendering prematurely.
> - Extracts pricing copy and numeric constants into [`teamsPlan.ts`](https://github.com/tsouth89/toolport/pull/807/files#diff-3efe7b2ac1a7e8e099654c3fc2263318d4ebebe498dddbc169229e902ca2f47c) and new URL constants (`TEAMS_PRICING_URL`, `TEAMS_CREATE_URL`, `TEAMS_SELFHOST_URL`) into [`teamUrl.ts`](https://github.com/tsouth89/toolport/pull/807/files#diff-2ea50bd9df5bdd12a9607ccac7e098a65afb596ae06dd2abafe3121e660b4518).
> - Hides the pitch panel when a join is pending (awaiting admin approval).
> - Behavioral Change: the disconnected container width increases from `max-w-2xl` to `max-w-4xl` to accommodate the two-column layout.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d3f70f9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->