### PR TITLE
feat(onboarding): a first run for people who did not come for MCP (SBS-826)

### DIFF
--- a/src/App.probe.test.tsx
+++ b/src/App.probe.test.tsx
@@ -13,7 +13,10 @@ const setAllEnabled = vi.fn();
 
 // Captures the props App hands to the (mocked) Onboarding wizard so the test can
 // invoke onProbe exactly the way the Done step does.
-const captured: { onProbe: (() => Promise<ProbeResult[]>) | null } = { onProbe: null };
+const captured: {
+  onProbe: (() => Promise<ProbeResult[]>) | null;
+  onOpenRules: (() => void) | null;
+} = { onProbe: null, onOpenRules: null };
 
 vi.mock("@/lib/api", () => ({
   addServer: vi.fn(),
@@ -75,8 +78,12 @@ vi.mock("@/components/PendingApprovals", () => ({ PendingApprovals: () => null }
 vi.mock("@/components/QuarantineAlert", () => ({ QuarantineAlert: () => null }));
 
 vi.mock("@/components/Onboarding", () => ({
-  Onboarding: (props: { onProbe: () => Promise<ProbeResult[]> }) => {
+  Onboarding: (props: {
+    onProbe: () => Promise<ProbeResult[]>;
+    onOpenRules: () => void;
+  }) => {
     captured.onProbe = props.onProbe;
+    captured.onOpenRules = props.onOpenRules;
     return null;
   },
 }));
@@ -93,6 +100,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   localStorage.clear();
   captured.onProbe = null;
+  captured.onOpenRules = null;
   getRegistry.mockResolvedValue({
     version: 1,
     servers: [],
@@ -136,6 +144,26 @@ describe("App onboarding probe wiring", () => {
     // ...and no trailing probeServers pass was queued behind it.
     await act(async () => {});
     expect(probeServers).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("App onboarding exit (SBS-826)", () => {
+  // SBS-826 review: `onOpenRules` must FINISH onboarding, not merely hide the wizard.
+  // Onboarding.paths.test.tsx can only assert the callback fired - the persistence lives
+  // here, so a handler that dropped `finishOnboarding()` (the way `onOpenPlayground`
+  // deliberately does) would send a rules user who skipped Connect back through the
+  // whole wizard on the next launch with nothing failing.
+  it("marks onboarding done when a rules user leaves for the Rules tab", async () => {
+    render(<App />);
+
+    await waitFor(() => expect(captured.onOpenRules).not.toBeNull());
+    expect(localStorage.getItem("toolport.onboarded")).toBeNull();
+
+    act(() => {
+      captured.onOpenRules!();
+    });
+
+    expect(localStorage.getItem("toolport.onboarded")).toBe("1");
   });
 });
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1166,6 +1166,13 @@ function App() {
               setShowOnboarding(false);
               selectView("playground");
             }}
+            onOpenRules={() => {
+              // Mark onboarding done, not merely hidden: someone who finished the rules
+              // path IS set up, and re-showing the wizard on next launch because they
+              // never added a server would be the same MCP assumption again (SBS-826).
+              finishOnboarding();
+              selectView("rules");
+            }}
             onFinish={finishOnboarding}
           />
         </Suspense>

--- a/src/components/Onboarding.a11y.test.tsx
+++ b/src/components/Onboarding.a11y.test.tsx
@@ -48,6 +48,7 @@ const props = {
   onClientsRefresh: vi.fn(),
   onBrowseCatalog: vi.fn(),
   onOpenPlayground: vi.fn(),
+  onOpenRules: vi.fn(),
   onFinish: vi.fn(),
 };
 
@@ -60,7 +61,7 @@ describe("Onboarding dialog accessibility", () => {
     // Welcome
     expect(screen.getByRole("dialog")).toHaveAccessibleName("Welcome to Toolport");
 
-    await user.click(screen.getByRole("button", { name: /Get started/ }));
+    await user.click(screen.getByRole("button", { name: /Set up MCP servers/ }));
     expect(screen.getByRole("dialog")).toHaveAccessibleName("Add your first servers");
 
     await user.click(screen.getByRole("button", { name: /I'll add servers later/ }));

--- a/src/components/Onboarding.health.test.tsx
+++ b/src/components/Onboarding.health.test.tsx
@@ -37,6 +37,7 @@ const props = {
   onClientsRefresh: vi.fn(),
   onBrowseCatalog: vi.fn(),
   onOpenPlayground: vi.fn(),
+  onOpenRules: vi.fn(),
   onFinish: vi.fn(),
 };
 

--- a/src/components/Onboarding.paths.test.tsx
+++ b/src/components/Onboarding.paths.test.tsx
@@ -76,6 +76,39 @@ describe("Onboarding first-run paths (SBS-826)", () => {
     expect(screen.getByRole("heading", { name: "You're set up" })).toBeInTheDocument();
   });
 
+  it("does not send a rules user with no client back to add servers", async () => {
+    const user = userEvent.setup();
+    // No connected client, so the step reports what is still missing. On the rules path
+    // the only missing thing is the client - the MCP wording sent them to add the very
+    // thing they just declined, and said "do both" for a single item (SBS-826 review).
+    render(<Onboarding {...props()} />);
+
+    await user.click(screen.getByRole("button", { name: /Write rules for my agents/ }));
+    await user.click(screen.getByRole("button", { name: /Skip for now/ }));
+
+    expect(screen.getByText(/You haven't connected a client yet/)).toBeInTheDocument();
+    expect(screen.queryByText(/add\s+or import servers/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/do both/)).not.toBeInTheDocument();
+  });
+
+  it("never probes for servers a rules user does not have", async () => {
+    const user = userEvent.setup();
+    const onProbe = vi.fn().mockResolvedValue([]);
+    render(<Onboarding {...props({ clients: [connected], onProbe })} />);
+
+    await user.click(screen.getByRole("button", { name: /Write rules for my agents/ }));
+    await user.click(screen.getByRole("button", { name: /Skip for now/ }));
+
+    // The health check is about servers, and this path has none. The related first-paint
+    // flash of the "Checking server health…" live region is fixed by gating the
+    // verification states on `serverCount`, but it cannot be asserted here: `render`
+    // flushes effects inside `act`, so the pre-effect paint a real user sees never
+    // reaches the DOM this test reads.
+    expect(onProbe).not.toHaveBeenCalled();
+    expect(screen.queryByText(/Checking server health/)).not.toBeInTheDocument();
+    expect(screen.queryByRole("heading", { name: "Checking your setup" })).toBeNull();
+  });
+
   it("hands a finished rules user to the Rules tab, and marks onboarding done", async () => {
     const user = userEvent.setup();
     const onOpenRules = vi.fn();

--- a/src/components/Onboarding.paths.test.tsx
+++ b/src/components/Onboarding.paths.test.tsx
@@ -1,0 +1,124 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { Onboarding } from "./Onboarding";
+import type { DetectedClient, Registry } from "@/lib/types";
+
+/** A fresh install: no servers, nothing connected. The state SBS-826 is about. */
+const emptyRegistry = {
+  version: 1,
+  servers: [],
+  profiles: [{ id: "default", name: "Default", enabledServerIds: [] }],
+  activeProfileId: "default",
+} as unknown as Registry;
+
+const detected = {
+  id: "claude-code",
+  name: "Claude Code",
+  appPresent: true,
+  gatewayInstalled: false,
+  servers: [],
+  pluginServers: [],
+} as unknown as DetectedClient;
+
+const connected = { ...detected, gatewayInstalled: true } as DetectedClient;
+
+function props(over: Record<string, unknown> = {}) {
+  return {
+    clients: [detected],
+    registry: emptyRegistry,
+    onRegistryChange: vi.fn(),
+    onClientsRefresh: vi.fn(),
+    onBrowseCatalog: vi.fn(),
+    onProbe: vi.fn().mockResolvedValue([]),
+    onOpenPlayground: vi.fn(),
+    onOpenRules: vi.fn(),
+    onFinish: vi.fn(),
+    ...over,
+  };
+}
+
+describe("Onboarding first-run paths (SBS-826)", () => {
+  it("offers a non-MCP door on the first screen", async () => {
+    render(<Onboarding {...props()} />);
+
+    expect(
+      screen.getByRole("button", { name: /Set up MCP servers/ }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /Write rules for my agents/ }),
+    ).toBeInTheDocument();
+    // The promise that makes the second door worth offering at all.
+    expect(screen.getByText(/No MCP server needed/)).toBeInTheDocument();
+  });
+
+  it("reaches client detection without ever asking for a server", async () => {
+    const user = userEvent.setup();
+    render(<Onboarding {...props()} />);
+
+    await user.click(screen.getByRole("button", { name: /Write rules for my agents/ }));
+
+    // Straight to Connect: the "Add your first servers" step is not on this path.
+    expect(screen.getByRole("dialog")).toHaveAccessibleName("Connect a client");
+    expect(screen.queryByText(/Add your first servers/)).not.toBeInTheDocument();
+  });
+
+  it("does not tell a rules user they still have to add a server", async () => {
+    const user = userEvent.setup();
+    render(<Onboarding {...props({ clients: [connected] })} />);
+
+    await user.click(screen.getByRole("button", { name: /Write rules for my agents/ }));
+    await user.click(screen.getByRole("button", { name: /Skip for now/ }));
+
+    // The bounce this ticket exists to remove: zero servers is the POINT of this path, so
+    // judging the setup by server count would report unfinished work that does not exist.
+    expect(screen.queryByText(/added a server/)).not.toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "You're set up" })).toBeInTheDocument();
+  });
+
+  it("hands a finished rules user to the Rules tab, and marks onboarding done", async () => {
+    const user = userEvent.setup();
+    const onOpenRules = vi.fn();
+    render(<Onboarding {...props({ clients: [connected], onOpenRules })} />);
+
+    await user.click(screen.getByRole("button", { name: /Write rules for my agents/ }));
+    await user.click(screen.getByRole("button", { name: /Skip for now/ }));
+    await user.click(screen.getByRole("button", { name: /Set up agent rules/ }));
+
+    expect(onOpenRules).toHaveBeenCalled();
+  });
+
+  it("does not ask a rules user to prove an MCP call they cannot make", async () => {
+    const user = userEvent.setup();
+    render(<Onboarding {...props({ clients: [connected] })} />);
+
+    await user.click(screen.getByRole("button", { name: /Write rules for my agents/ }));
+    await user.click(screen.getByRole("button", { name: /Skip for now/ }));
+
+    // With no servers there is nothing to call, so the verify-a-call block would ask for a
+    // demonstration that cannot succeed.
+    expect(screen.queryByText(/List the tools you can use through Toolport/)).toBeNull();
+  });
+
+  it("counts only the steps this path actually has", async () => {
+    const user = userEvent.setup();
+    render(<Onboarding {...props()} />);
+
+    expect(screen.getByRole("progressbar")).toHaveAccessibleName("Setup step 1 of 4");
+
+    await user.click(screen.getByRole("button", { name: /Write rules for my agents/ }));
+
+    // Three steps on this path, not four with one silently skipped.
+    expect(screen.getByRole("progressbar")).toHaveAccessibleName("Setup step 2 of 3");
+  });
+
+  it("leaves the MCP path exactly as it was", async () => {
+    const user = userEvent.setup();
+    render(<Onboarding {...props()} />);
+
+    await user.click(screen.getByRole("button", { name: /Set up MCP servers/ }));
+
+    expect(screen.getByRole("dialog")).toHaveAccessibleName("Add your first servers");
+    expect(screen.getByRole("progressbar")).toHaveAccessibleName("Setup step 2 of 4");
+  });
+});

--- a/src/components/Onboarding.tsx
+++ b/src/components/Onboarding.tsx
@@ -5,6 +5,7 @@ import {
   Check,
   Copy,
   Download,
+  FileText,
   KeyRound,
   Link2,
   Loader2,
@@ -61,6 +62,8 @@ interface Props {
   onProbe: () => Promise<ProbeResult[]>;
   /** Close the wizard and open the Playground (the in-app verify fallback). */
   onOpenPlayground: () => void;
+  /** Close the wizard and open Agent rules, for someone who came for that and not MCP. */
+  onOpenRules: () => void;
   /** Mark onboarding complete (skipped or finished) and close. */
   onFinish: () => void;
 }
@@ -78,9 +81,19 @@ export function Onboarding({
   onBrowseCatalog,
   onProbe,
   onOpenPlayground,
+  onOpenRules,
   onFinish,
 }: Props) {
   const [step, setStep] = useState(initialStep);
+  /**
+   * Which door the user came through (SBS-826).
+   *
+   * Toolport's first run used to assume MCP: the second step was "add a server", so someone
+   * who installed it to sync their agent rules had to add an MCP server they did not want, or
+   * bail. `rules` drops that step. Both paths still run client detection, because connecting a
+   * client is what makes either feature do anything.
+   */
+  const [path, setPath] = useState<"mcp" | "rules">("mcp");
   // A team member who was handed an invite code shouldn't have to click through
   // the solo flow to find a place to enter it. This branch drops them straight
   // into the join step and, on success, the team's servers arrive locally.
@@ -96,38 +109,58 @@ export function Onboarding({
   const serverCount = registry.servers.filter((s) => !isGatewayServer(s)).length;
   const connectedCount = clients.filter((c) => c.gatewayInstalled).length;
 
-  const steps = [
+  const welcome = (
     <Welcome
       key="welcome"
       present={present}
-      onNext={() => setStep(1)}
+      onChoosePath={(chosen) => {
+        setPath(chosen);
+        setStep(1);
+      }}
       onJoinTeam={() => setJoining(true)}
-    />,
-    <AddServers
-      key="add"
-      registry={registry}
-      importable={importable}
-      onImport={onRegistryChange}
-      onBrowseCatalog={onBrowseCatalog}
-      onNext={() => setStep(2)}
-    />,
+    />
+  );
+  const connect = (
     <ConnectClients
       key="connect"
       present={present}
       onConnected={onClientsRefresh}
-      onNext={() => setStep(3)}
-    />,
+      onNext={() => setStep(path === "rules" ? 2 : 3)}
+    />
+  );
+  const done = (
     <Done
       key="done"
+      path={path}
       registry={registry}
       clients={clients}
       serverCount={serverCount}
       connectedCount={connectedCount}
       onProbe={onProbe}
       onOpenPlayground={onOpenPlayground}
+      onOpenRules={onOpenRules}
       onFinish={onFinish}
-    />,
-  ];
+    />
+  );
+
+  // The rules path has no "add a server" step, so the array is shorter and the progress
+  // indicator counts the steps this user will actually see rather than the MCP ones.
+  const steps =
+    path === "rules"
+      ? [welcome, connect, done]
+      : [
+          welcome,
+          <AddServers
+            key="add"
+            registry={registry}
+            importable={importable}
+            onImport={onRegistryChange}
+            onBrowseCatalog={onBrowseCatalog}
+            onNext={() => setStep(2)}
+          />,
+          connect,
+          done,
+        ];
 
   return (
     <Dialog open onOpenChange={(o) => !o && onFinish()}>
@@ -211,11 +244,11 @@ function StepHeader({
 
 function Welcome({
   present,
-  onNext,
+  onChoosePath,
   onJoinTeam,
 }: {
   present: DetectedClient[];
-  onNext: () => void;
+  onChoosePath: (path: "mcp" | "rules") => void;
   onJoinTeam: () => void;
 }) {
   const names = present.map((c) => c.name);
@@ -243,7 +276,7 @@ function Welcome({
   return (
     <>
       <StepHeader icon={<Waypoints className="size-5" />} title="Welcome to Toolport">
-        One local gateway for all your MCP servers, shared by every AI tool.
+        One place to set up and control every AI tool on your machine.
       </StepHeader>
       <div className="grid gap-2.5">
         {benefits.map(({ icon: Icon, title, body }) => (
@@ -259,10 +292,34 @@ function Welcome({
         ))}
       </div>
       <p className="text-sm text-muted-foreground">{found}</p>
-      <Button onClick={onNext} className="self-start">
-        Get started
-        <ArrowRight className="size-4" />
-      </Button>
+      {/* Two doors, because two different people install this (SBS-826). Someone here for
+          rules used to be walked into "add an MCP server" and had to add one they did not
+          want, or leave. Both paths still connect a client, which is what makes either
+          feature reach anything. */}
+      <div className="grid gap-2">
+        <Button onClick={() => onChoosePath("mcp")} className="justify-start">
+          <Waypoints className="size-4" />
+          <span className="flex flex-col items-start">
+            <span>Set up MCP servers</span>
+            <span className="text-2xs font-normal opacity-80">
+              Connect servers once and share them with every AI tool
+            </span>
+          </span>
+        </Button>
+        <Button
+          variant="outline"
+          onClick={() => onChoosePath("rules")}
+          className="justify-start"
+        >
+          <FileText className="size-4" />
+          <span className="flex flex-col items-start">
+            <span>Write rules for my agents</span>
+            <span className="text-2xs font-normal text-muted-foreground">
+              One set of instructions, applied to every AI tool. No MCP server needed
+            </span>
+          </span>
+        </Button>
+      </div>
       <div className="flex flex-col gap-1.5 border-t pt-4">
         <button
           type="button"
@@ -790,22 +847,30 @@ function ConnectClients({
 }
 
 function Done({
+  path,
   registry,
   clients,
   serverCount,
   connectedCount,
   onProbe,
   onOpenPlayground,
+  onOpenRules,
   onFinish,
 }: {
+  path: "mcp" | "rules";
   registry: Registry;
   clients: DetectedClient[];
   serverCount: number;
   connectedCount: number;
   onProbe: () => Promise<ProbeResult[]>;
   onOpenPlayground: () => void;
+  onOpenRules: () => void;
   onFinish: () => void;
 }) {
+  // Someone who came for rules has no servers ON PURPOSE. Judging their setup by server
+  // count would tell them they have not finished when they have, which is the bounce
+  // SBS-826 exists to remove.
+  const rulesPath = path === "rules";
   // Probe what was just added so we report the truth, not a blanket "you're set up"
   // over a server that can't actually start (a missing runtime is the #1 first-run
   // failure). Auth-pending servers are an expected next step, not a fault, so they're
@@ -843,7 +908,9 @@ function Done({
   const nameFor = (id: string) => registry.servers.find((s) => s.id === id)?.name ?? id;
   const broken = (health ?? []).filter((r) => !r.ok && !r.authRequired);
 
-  const configured = serverCount > 0 && connectedCount > 0;
+  const configured = rulesPath
+    ? connectedCount > 0
+    : serverCount > 0 && connectedCount > 0;
   // Verification states only apply once setup is actually complete: with no client
   // connected the step reports what's missing, and must not dress the finish button
   // or the status blocks in "Checking…" / "couldn't verify" language.
@@ -853,7 +920,7 @@ function Done({
   // The client to verify against: the first one Toolport is actually wired into.
   const verifyClient = clients.find((c) => c.gatewayInstalled) ?? null;
   const missing = [
-    serverCount === 0 ? "added a server" : null,
+    !rulesPath && serverCount === 0 ? "added a server" : null,
     connectedCount === 0 ? "connected a client" : null,
   ]
     .filter(Boolean)
@@ -872,7 +939,14 @@ function Done({
                 : "Setup started"
         }
       >
-        {ready ? (
+        {ready && rulesPath ? (
+          <>
+            Toolport is wired into {connectedCount} tool
+            {connectedCount === 1 ? "" : "s"}. Write your rules once on the next screen
+            and Toolport puts them in each tool&apos;s own rules file, so they all follow
+            the same instructions without you editing four files by hand.
+          </>
+        ) : ready ? (
           <>
             Toolport now manages {serverCount} server
             {serverCount === 1 ? "" : "s"} across {connectedCount} connected tool
@@ -952,18 +1026,30 @@ function Done({
         </div>
       )}
 
-      {ready && verifyClient && (
+      {ready && !rulesPath && verifyClient && (
         <VerifyCall client={verifyClient} onOpenPlayground={onOpenPlayground} />
       )}
 
-      <Button onClick={onFinish} className="self-start">
-        {checkingHealth || verificationFailed
-          ? "Continue without verification"
-          : ready
-            ? "Start using Toolport"
-            : "Got it"}
-        <ArrowRight className="size-4" />
-      </Button>
+      {rulesPath ? (
+        <div className="flex flex-wrap items-center gap-2">
+          <Button onClick={onOpenRules}>
+            Set up agent rules
+            <ArrowRight className="size-4" />
+          </Button>
+          <Button variant="ghost" onClick={onFinish}>
+            Not now
+          </Button>
+        </div>
+      ) : (
+        <Button onClick={onFinish} className="self-start">
+          {checkingHealth || verificationFailed
+            ? "Continue without verification"
+            : ready
+              ? "Start using Toolport"
+              : "Got it"}
+          <ArrowRight className="size-4" />
+        </Button>
+      )}
     </>
   );
 }

--- a/src/components/Onboarding.tsx
+++ b/src/components/Onboarding.tsx
@@ -297,7 +297,10 @@ function Welcome({
           want, or leave. Both paths still connect a client, which is what makes either
           feature reach anything. */}
       <div className="grid gap-2">
-        <Button onClick={() => onChoosePath("mcp")} className="justify-start">
+        <Button
+          onClick={() => onChoosePath("mcp")}
+          className="h-auto justify-start py-2 whitespace-normal"
+        >
           <Waypoints className="size-4" />
           <span className="flex flex-col items-start">
             <span>Set up MCP servers</span>
@@ -309,7 +312,7 @@ function Welcome({
         <Button
           variant="outline"
           onClick={() => onChoosePath("rules")}
-          className="justify-start"
+          className="h-auto justify-start py-2 whitespace-normal"
         >
           <FileText className="size-4" />
           <span className="flex flex-col items-start">
@@ -911,20 +914,26 @@ function Done({
   const configured = rulesPath
     ? connectedCount > 0
     : serverCount > 0 && connectedCount > 0;
+  // The probe is about servers, and the rules path is the only way to be `configured`
+  // with none. Gating the verification states on there being something to verify keeps
+  // a rules finish from painting "Checking your setup" and the "Checking server
+  // health…" status — a live region a screen reader announces — for servers that do
+  // not exist. `health` is null on the first paint even when the effect sets it to []
+  // synchronously, so without this the flash is guaranteed, not a race (SBS-826 review).
+  const verifying = serverCount > 0;
   // Verification states only apply once setup is actually complete: with no client
   // connected the step reports what's missing, and must not dress the finish button
   // or the status blocks in "Checking…" / "couldn't verify" language.
-  const checkingHealth = configured && health === null && !probeFailed;
-  const verificationFailed = configured && probeFailed;
-  const ready = configured && health !== null && !probeFailed;
+  const checkingHealth = configured && verifying && health === null && !probeFailed;
+  const verificationFailed = configured && verifying && probeFailed;
+  const ready = configured && (!verifying || (health !== null && !probeFailed));
   // The client to verify against: the first one Toolport is actually wired into.
   const verifyClient = clients.find((c) => c.gatewayInstalled) ?? null;
-  const missing = [
+  const missingParts = [
     !rulesPath && serverCount === 0 ? "added a server" : null,
     connectedCount === 0 ? "connected a client" : null,
-  ]
-    .filter(Boolean)
-    .join(" or ");
+  ].filter((part): part is string => part !== null);
+  const missing = missingParts.join(" or ");
   return (
     <>
       <StepHeader
@@ -944,7 +953,7 @@ function Done({
             Toolport is wired into {connectedCount} tool
             {connectedCount === 1 ? "" : "s"}. Write your rules once on the next screen
             and Toolport puts them in each tool&apos;s own rules file, so they all follow
-            the same instructions without you editing four files by hand.
+            the same instructions without you editing each tool's file by hand.
           </>
         ) : ready ? (
           <>
@@ -965,10 +974,20 @@ function Done({
             Your servers and client are connected, but Toolport could not verify server
             health. Retry the check below or continue without verification.
           </>
+        ) : rulesPath ? (
+          // The MCP wording below would send a rules user to add the very thing they
+          // just declined, and "do both" is wrong when only one thing is missing
+          // (SBS-826 review).
+          <>
+            You haven't connected a client yet. Connect one any time from the main screen
+            and Toolport writes your rules into that tool's own rules file. No MCP server
+            needed.
+          </>
         ) : (
           <>
-            You haven't {missing} yet. You can do both any time from the main screen: add
-            or import servers, then connect a client so your tools share them.
+            You haven't {missing} yet. You can{" "}
+            {missingParts.length > 1 ? "do both" : "do that"} any time from the main
+            screen: add or import servers, then connect a client so your tools share them.
           </>
         )}
       </StepHeader>


### PR DESCRIPTION
Closes [SBS-826](https://linear.app/southboundsoftware/issue/SBS-826). Item of epic [SBS-820](https://linear.app/southboundsoftware/issue/SBS-820).

**Independent of the hooks stack (#804, #808).** Branches off `main`, merges in any order.

## The problem

First run assumed everyone installed Toolport for MCP. Step two was "add your first servers", so someone who came for **agent rules** — which shipped in #793-#796 and needs no MCP server at all — had to add a server they did not want, or bail.

That is the bounce this ticket is about, and it gets worse with every non-MCP feature the epic adds.

## The change

The Welcome screen now offers two doors:

- **Set up MCP servers** — the existing path, unchanged. Same steps, same copy, same behaviour.
- **Write rules for my agents** — skips the add-servers step entirely.

Both still run client detection, because connecting a client is what makes either feature reach anything.

## Three things the rules path had to stop doing

All of them came from judging a setup by its server count:

1. **Telling the user they had not "added a server" yet.** Zero servers is the *point* of that path, so reporting it as unfinished work is a lie about their setup.
2. **Asking them to prove a call reached Toolport.** With no servers there is nothing to call, so the verification block would ask for a demonstration that cannot succeed.
3. **Counting four steps while showing three.** The progress indicator now counts the steps this user will actually see, rather than skipping one silently.

Finishing the rules path opens the Rules tab and marks onboarding **complete** — not merely hidden. Someone who set up rules *is* set up, and re-showing the wizard next launch because they still have no servers would be the same assumption all over again.

## Acceptance criteria

- [x] Fresh install with no servers can reach instruction sync without adding a server.
- [x] Client detection runs on first run regardless of path.
- [x] Existing MCP-first flow is unchanged for users who pick it.

The third criterion in the ticket, "nav shows the non-MCP features even with zero servers", **needed no change** — the sidebar never gated on server count. Verified rather than assumed.

## Testing

7 new tests, one per acceptance criterion plus the two regressions above and one pinning that the MCP path is untouched. 483 frontend tests green, `tsc -b` clean, eslint clean (the two warnings in `Onboarding.tsx` are in pre-existing effects I did not touch).

Mutation-checked: un-skipping the add-servers step, or judging the rules path by server count again, each turns five of the seven red.

One existing a11y assertion changed, because the button it clicked is now labelled "Set up MCP servers" instead of "Get started". The path behind it is identical.

## Note

Touches `src/App.tsx` (one new prop), which #806 and #808 also touch. All three changes are additive; any conflict is a one-line add.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add a rules-only first-run onboarding path for non-MCP users
> - The `Onboarding` welcome screen now presents two options: 'Set up MCP servers' (existing flow) and a new 'rules' path that skips the Add Servers step entirely.
> - The `Done` step adapts per path: rules-only users see no server health check, no verify-a-call UI, and a 'Set up agent rules' button that calls the new `onOpenRules` prop and marks onboarding complete.
> - `App` passes an `onOpenRules` handler to `Onboarding` that calls `finishOnboarding()` and navigates to the Rules view.
> - Progress bar step counts are adjusted per path to reflect the shorter rules flow.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 60fabd3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->