### PR TITLE
test(reaper): probe the stand-in binary instead of trusting `sleep`

### DIFF
--- a/src-tauri/src/gateway_publish.rs
+++ b/src-tauri/src/gateway_publish.rs
@@ -2232,27 +2232,105 @@ mod tests {
         );
     }
 
-    /// A small, long-running binary to stand in for a gateway image.
+    /// A small, long-running binary to stand in for a gateway image, and the
+    /// arguments that keep it alive.
     ///
     /// Searches `PATH` rather than assuming `/bin/sleep`, so the tests still run on
     /// layouts that put it elsewhere (NixOS, busybox images, minimal containers).
+    ///
+    /// The candidate is *probed*, never trusted. Ubuntu 26.04 ships uutils coreutils
+    /// as a single multi-call binary that every `/usr/bin/<tool>` hardlinks to, and it
+    /// dispatches on `argv[0]`: copied to `toolport-gateway` it prints
+    /// `coreutils: unknown program 'toolport-gateway'` and exits, so every process
+    /// [`SpawnedGateway`] spawns is already dead by the time the enumeration under
+    /// test runs and three reaper tests fail for a reason that has nothing to do with
+    /// the reaper. Nothing on disk gives it away - the copy is a plain ELF, the link
+    /// is a hardlink rather than a symlink, and `canonicalize` still ends in `sleep` -
+    /// so the only reliable check is behavioural: copy the candidate under a foreign
+    /// name, run it, and see whether it is still alive a moment later.
+    ///
+    /// The fallback is a shell blocking on `read`, for two properties `sleep` cannot
+    /// be relied on for here: a shell must ignore `argv[0]` (POSIX gives it meaning
+    /// only for a leading `-`), and reading a pipe this process holds open blocks
+    /// forever without forking a child that would outlive the kill.
+    ///
+    /// Probed once per test binary and memoized, so the 250ms costs one test run, not
+    /// one spawn.
     #[cfg(all(unix, not(target_os = "macos")))]
-    fn stand_in_binary_source() -> PathBuf {
-        if let Some(path) = std::env::var_os("PATH") {
-            for dir in std::env::split_paths(&path) {
-                let candidate = dir.join("sleep");
-                if candidate.is_file() {
-                    return candidate;
+    fn stand_in_binary() -> &'static (PathBuf, Vec<&'static str>) {
+        static CHOICE: std::sync::OnceLock<(PathBuf, Vec<&'static str>)> =
+            std::sync::OnceLock::new();
+        CHOICE.get_or_init(|| {
+            let mut candidates: Vec<(PathBuf, Vec<&'static str>)> = Vec::new();
+            let mut push = |path: PathBuf, args: Vec<&'static str>| {
+                if path.is_file() && !candidates.iter().any(|(p, _)| *p == path) {
+                    candidates.push((path, args));
+                }
+            };
+            if let Some(path) = std::env::var_os("PATH") {
+                for dir in std::env::split_paths(&path) {
+                    push(dir.join("sleep"), vec!["300"]);
                 }
             }
+            for fixed in ["/bin/sleep", "/usr/bin/sleep"] {
+                push(PathBuf::from(fixed), vec!["300"]);
+            }
+            for shell in ["/bin/sh", "/bin/dash", "/bin/bash", "/usr/bin/sh"] {
+                push(PathBuf::from(shell), vec!["-c", "read _standin"]);
+            }
+            candidates
+                .into_iter()
+                .find(|(path, args)| stand_in_survives_rename(path, args))
+                .expect(
+                    "no binary on this system stays alive when copied to a gateway's \
+                     name, so no reaper test can spawn anything to enumerate",
+                )
+        })
+    }
+
+    /// True when `source`, copied under a gateway's name and run with `args`, is still
+    /// running a moment later. The behavioural half of [`stand_in_binary`].
+    ///
+    /// Every failure is a `false` rather than a panic: a candidate that cannot be
+    /// copied, chmod'd or spawned is simply not the one to use, and the next one gets
+    /// a turn. That includes a spurious `ETXTBSY` from another thread's fork, which
+    /// costs a usable `sleep` its place and falls through to the shell - a worse
+    /// stand-in, not a broken one.
+    #[cfg(all(unix, not(target_os = "macos")))]
+    fn stand_in_survives_rename(source: &Path, args: &[&str]) -> bool {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let dir = std::env::temp_dir().join(format!(
+            "toolport-standin-probe-{}-{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        if std::fs::create_dir_all(&dir).is_err() {
+            return false;
         }
-        // into_iter, not iter().map(Path::new): the latter returns a &Path borrowed
-        // from the temporary array, which does not outlive the statement.
-        ["/bin/sleep", "/usr/bin/sleep"]
-            .into_iter()
-            .map(PathBuf::from)
-            .find(|p| p.is_file())
-            .expect("no sleep binary on PATH to stand in for a gateway")
+        let exe = dir.join("toolport-gateway");
+        let alive = (|| {
+            std::fs::copy(source, &exe).ok()?;
+            std::fs::set_permissions(&exe, std::fs::Permissions::from_mode(0o755)).ok()?;
+            let mut child = std::process::Command::new(&exe)
+                .args(args)
+                .stdin(std::process::Stdio::piped())
+                .stdout(std::process::Stdio::null())
+                .stderr(std::process::Stdio::null())
+                .spawn()
+                .ok()?;
+            // Long enough for a multi-call binary to reject the name and exit, short
+            // enough that a healthy candidate is not worth optimising further.
+            std::thread::sleep(std::time::Duration::from_millis(250));
+            let alive = matches!(child.try_wait(), Ok(None));
+            let _ = child.kill();
+            let _ = child.wait();
+            Some(alive)
+        })()
+        .unwrap_or(false);
+        let _ = std::fs::remove_dir_all(&dir);
+        alive
     }
 
     /// Scratch tree removed on drop.
@@ -2352,7 +2430,8 @@ mod tests {
             if let Some(parent) = exe.parent() {
                 std::fs::create_dir_all(parent).expect("create gateway dir");
             }
-            std::fs::copy(stand_in_binary_source(), &exe).expect("copy stand-in binary");
+            let (stand_in, stand_in_args) = stand_in_binary();
+            std::fs::copy(stand_in, &exe).expect("copy stand-in binary");
             std::fs::set_permissions(&exe, std::fs::Permissions::from_mode(0o755))
                 .expect("chmod +x");
 
@@ -2372,7 +2451,14 @@ mod tests {
             // unprotected version was 5/8.
             let mut waited = std::time::Duration::ZERO;
             let child = loop {
-                match std::process::Command::new(&exe).arg("300").spawn() {
+                match std::process::Command::new(&exe)
+                    .args(stand_in_args)
+                    // The stand-in may block on stdin rather than on a timer. `Child`
+                    // owns the write end and nothing takes it, so the pipe stays open
+                    // for exactly as long as this `SpawnedGateway` does.
+                    .stdin(std::process::Stdio::piped())
+                    .spawn()
+                {
                     Ok(child) => break child,
                     // ETXTBSY. Matched on the raw errno so this does not depend on
                     // `ErrorKind::ExecutableFileBusy`, and the block is Linux-only.


### PR DESCRIPTION
## What

Three Linux reaper tests fail on Ubuntu 26.04 and pass on the `ubuntu-22.04` runner:

- `linux_enumeration_finds_a_versioned_gateway_via_the_exe_fallback`
- `linux_deleted_image_is_enumerated_but_misses_its_own_keep_path`
- `linux_reap_keeps_the_live_keep_path_and_kills_stale_and_unlinked_images`

None of them fail for a reaper reason.

## Why

`SpawnedGateway` needs a live process whose `/proc/<pid>/exe` is a path the test chose, so it copies `sleep` to that path and runs it.

Ubuntu 26.04 ships **uutils coreutils** as a single multi-call binary that every `/usr/bin/<tool>` hardlinks to, and it dispatches on `argv[0]`. Copied to `toolport-gateway` it prints `coreutils: unknown program 'toolport-gateway'` and exits. Every process the helper spawns is therefore dead before the enumeration under test runs, and the failure reads as *"the `/proc/<pid>/exe` fallback is broken and no Toolport-named gateway would be reaped on Linux"* — a scary message about shipped code, caused entirely by the fixture.

Nothing on disk gives it away. The copy is a plain ELF, the link is a hardlink rather than a symlink, and `canonicalize` still ends in `sleep`.

## How

The stand-in candidate is now **probed rather than trusted**: copied under a foreign name, run, and checked for a pulse 250ms later. A shell blocking on `read` from a pipe the test holds open is the fallback, because a shell must ignore `argv[0]` and forks no child that would outlive the kill. Probed once per test binary and memoized.

## Scope

Test-only. No shipped code changes.

## Verification

On Ubuntu 26.04 (uutils coreutils 0.8.0):

- the 3 tests: **pass** (they fail on `main` on the same box)
- `cargo test --lib --bins --tests`: **1247 + 333 + 15 passed, 0 failed**
- `cargo clippy --no-default-features --lib --bins` (the CI command): clean, no new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Probe stand-in binary for liveness after rename in gateway reaper tests
> - Replaces the hardcoded `sleep` stand-in with a probed candidate selected via `stand_in_binary()`, which checks both `PATH` and fixed locations for `sleep` and various shells.
> - Adds `stand_in_survives_rename()` to validate each candidate by copying it to a temp dir as `toolport-gateway`, spawning it, and confirming it is still alive after 250ms — filtering out multi-call binaries (e.g. coreutils) that exit when `argv[0]` changes.
> - Updates `SpawnedGateway::at` to use the validated binary and its corresponding args, and pipes stdin so shell-based stand-ins blocking on `read` stay alive.
> - All changes are Linux/Unix-only via `cfg(all(unix, not(target_os = "macos")))`.
> - Behavioral Change: tests now fail earlier with a clear probe failure rather than silently spawning a process that exits immediately.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ffb8398.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->