### PR TITLE
fix(rules): make the agent-rules Preview button show something

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -26,6 +26,8 @@ permissions:
 
 jobs:
   audit:
+    # Backstop only - GitHub defaults to 360 minutes. npm audit is a network call and a JSON parse; anything longer is a hang.
+    timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,9 +36,7 @@ jobs:
       # Same headless dependency set as build-test: no GTK/WebKit, because the
       # lint below skips the Tauri desktop feature for the same reason.
       - name: Install Linux build dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y build-essential libssl-dev pkg-config libdbus-1-dev
+        run: scripts/ci-apt-install.sh build-essential libssl-dev pkg-config libdbus-1-dev
 
       # --no-default-features matches every other Rust job here. With the desktop
       # feature on, this needs the GTK and WebKit headers and dies building gdk-sys.
@@ -67,11 +65,9 @@ jobs:
       - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
 
       - name: Install Linux build dependencies
-        run: |
-          sudo apt-get update
-          # Same set as the release workflow: WebKitGTK + the Secret Service
-          # (libdbus) deps the Tauri lib needs to compile on Linux.
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libsoup-3.0-dev build-essential curl wget file libxdo-dev libssl-dev libayatana-appindicator3-dev librsvg2-dev patchelf pkg-config libdbus-1-dev
+        # Same set as the release workflow: WebKitGTK + the Secret Service
+        # (libdbus) deps the Tauri lib needs to compile on Linux.
+        run: scripts/ci-apt-install.sh libwebkit2gtk-4.1-dev libsoup-3.0-dev build-essential curl wget file libxdo-dev libssl-dev libayatana-appindicator3-dev librsvg2-dev patchelf pkg-config libdbus-1-dev
 
       - name: Give the runner headroom (a cold build links WebKitGTK)
         run: |
@@ -145,9 +141,7 @@ jobs:
       # needs libdbus headers and pkg-config at compile time.
       - name: Install Linux build dependencies
         if: matrix.os == 'ubuntu-22.04'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y build-essential libssl-dev pkg-config libdbus-1-dev
+        run: scripts/ci-apt-install.sh build-essential libssl-dev pkg-config libdbus-1-dev
 
       - name: Cache cargo + target
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,12 @@ permissions:
 jobs:
   clippy:
     name: Rust Clippy
+    # Without this the job inherits GitHub's 6-hour default. A flaky Ubuntu mirror
+    # hung `apt-get update` here for 34 minutes with no compiler ever reached, and
+    # because the job never ended the whole run stayed in progress - which also
+    # blocks `gh run rerun --failed` on the jobs that DID fail. 30 matches
+    # cross-platform-rust, the other job that compiles this crate from cold.
+    timeout-minutes: 30
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -41,6 +47,12 @@ jobs:
 
   build-test:
     name: Linux build + test
+    # Same gap as clippy above, and this one feeds the required merge gate, so a
+    # hang here stalls every PR rather than one advisory check. Higher than the
+    # rest because this job does strictly the most: frontend build and tests,
+    # Rust tests, the headless gateway build and its smoke test. The number is a
+    # hang backstop, not a target - a cold run is well under it.
+    timeout-minutes: 45
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -26,6 +26,8 @@ env:
 
 jobs:
   build-gateway:
+    # Backstop only - GitHub defaults to 360 minutes. Matches the Rust jobs in ci.yml: this compiles the same crate from a cold cache.
+    timeout-minutes: 30
     name: build gateway binary
     runs-on: ubuntu-22.04
     steps:
@@ -36,9 +38,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
 
       - name: Install Linux build dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y build-essential libssl-dev pkg-config libdbus-1-dev
+        run: scripts/ci-apt-install.sh build-essential libssl-dev pkg-config libdbus-1-dev
 
       # Cache DEPENDENCY build artifacts only, never the workspace's own crates.
       # History: a naive actions/cache of all of `src-tauri/target` keyed on Cargo.lock
@@ -78,6 +78,8 @@ jobs:
           retention-days: 1
 
   publish:
+    # Backstop only - GitHub defaults to 360 minutes. Multi-arch buildx and a registry push, both network-bound.
+    timeout-minutes: 30
     name: build + push image
     needs: build-gateway
     runs-on: ubuntu-22.04

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,9 @@ permissions:
 
 jobs:
   build:
+    # Backstop only - GitHub defaults to 360 minutes. Deliberately generous: bundles Tauri on four targets and waits on Apple notarisation.
+    # A tight limit here would kill a legitimate release, which costs more than a hang.
+    timeout-minutes: 90
     strategy:
       fail-fast: false
       matrix:
@@ -81,12 +84,10 @@ jobs:
 
       - name: Install Linux build dependencies
         if: matrix.os == 'ubuntu-22.04'
-        run: |
-          sudo apt-get update
-          # pkg-config + libdbus-1-dev are required to build libdbus-sys, pulled in
-          # by the Secret Service keychain backend; without them the Linux build
-          # fails to compile.
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libsoup-3.0-dev build-essential curl wget file libxdo-dev libssl-dev libayatana-appindicator3-dev librsvg2-dev patchelf pkg-config libdbus-1-dev
+        # pkg-config + libdbus-1-dev are required to build libdbus-sys, pulled in
+        # by the Secret Service keychain backend; without them the Linux build
+        # fails to compile.
+        run: scripts/ci-apt-install.sh libwebkit2gtk-4.1-dev libsoup-3.0-dev build-essential curl wget file libxdo-dev libssl-dev libayatana-appindicator3-dev librsvg2-dev patchelf pkg-config libdbus-1-dev
 
       - name: Add the macOS Rust target
         if: matrix.target
@@ -282,6 +283,8 @@ jobs:
   # fails. Keep this job independent of the build matrix and upload its asset to
   # the same draft release.
   agent-plugin:
+    # Backstop only - GitHub defaults to 360 minutes. Packaging and upload only.
+    timeout-minutes: 20
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
@@ -329,6 +332,8 @@ jobs:
   # installers are uploaded to the draft. If this job fails the draft still has
   # working installers - only auto-update is affected.
   updater-manifest:
+    # Backstop only - GitHub defaults to 360 minutes. Writes and uploads one JSON manifest.
+    timeout-minutes: 15
     needs: build
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -27,6 +27,8 @@ permissions:
 
 jobs:
   submit:
+    # Backstop only - GitHub defaults to 360 minutes. Manifest submission is network-bound and small.
+    timeout-minutes: 20
     # Prereleases are not what `winget install` should hand people. On a manual
     # run `github.event.release` is null, so the tag is checked below instead.
     if: ${{ github.event_name == 'workflow_dispatch' || !github.event.release.prerelease }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -155,6 +155,26 @@ Entries before the rename below shipped under the project's former name, Conduit
   assertion passed on the next host, which is the signature of a race, not a defect. The
   capture is now read only after stderr closes, bounded so a stream that never closes
   cannot wedge a security check.
+- **A Windows write now retries instead of losing the race.** `atomic_write` published its temp
+  file with a single `rename`. On Windows that fails outright while any other handle holds the
+  destination, and something usually does - Defender, the search indexer, a backup agent - for
+  a few milliseconds. `hooks::tests::preview_text_is_the_bytes_install_actually_writes` duly
+  failed one Windows run with `install_at` returning an error while the identical test passed
+  everywhere else. This is not only a test problem: users writing `settings.json` on a machine
+  with antivirus hit the same edge. The publish rename now retries with a capped backoff, bounded
+  at 8 attempts so a genuinely locked destination still reports its error. Unix is untouched,
+  where `rename(2)` is atomic against open handles and a failure is real.
+- **Three more sources of intermittent test failure, found by auditing rather than waiting.**
+  The Windows Job Object test waited for its pid file to _exist_ and then read it once, but the
+  launcher creates the file and fills it in separate operations, so a read in between parses an
+  empty string and panics - the Unix sibling had been fixed for exactly this and the fix was
+  never mirrored. `LockTimeoutOverride` saved and restored the lock-timeout variable per guard,
+  so with several suites holding it at once the first one out reverted it while the others were
+  still relying on it, dropping them to the 5s production default mid-test; it is now refcounted.
+  And the HTTP concurrency test asserted an absolute 400ms wall-clock budget after two
+  guess-sleeps, which a loaded runner can miss while behaving correctly; it now waits for a real
+  signal that the slow call has parked and asserts the property it means - that the fast response
+  came back while the slow one was still in flight.
 
 ## [1.14.0] - 2026-08-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,25 @@ Entries before the rename below shipped under the project's former name, Conduit
   via Qwen's `url` → `httpUrl` whenever the map key was not VS Code `"servers"`.
   Kimi requires `url` and rejects `httpUrl`. The Kimi writer already emitted the
   right shape; Shared HTTP now uses that same formatter. (SBS-921)
+- **Agent rules Preview no longer looks like a dead button.** The preview card renders
+  after the clients list, so on any window too short to reach it, clicking Preview
+  scrolled nothing and showed nothing: the card was open the whole time, below the fold.
+  Opening a preview now brings the card into view, and its header names the client, which
+  the path alone does not settle wherever two clients share one file (Claude Code / VS
+  Code, Gemini CLI / Antigravity). Deliberately still an inline card rather than a dialog:
+  a modal makes the page behind it inert, and this card is a live panel that clears itself
+  when the editor or the view moves under it.
+- **`docs/agent-rules.md` now names every client with no rules file, not two of them.**
+  The "no rules file Toolport can write" section named only Cursor and Warp, but the
+  Clients section builds that list from whatever is detected, so a user with LM Studio,
+  Jan, Hermes, Claude Desktop or Continue installed saw names the doc never mentioned.
+  All seven are now listed with the reason each one is on it, including the note that
+  Claude Desktop there is the chat app - Claude Code inside the desktop app shares
+  `~/.claude` and is already covered by the Claude Code row. Continue's stale
+  "deferred" comment in `clients.rs` is corrected too: it does read
+  `~/.continue/rules/`, but `continuedev/continue` was archived read-only in June 2026,
+  so no adapter is planned. Continue stays a detected MCP client. Docs and a comment
+  only; no behaviour change.
 
 ## [1.14.0] - 2026-08-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,7 +116,10 @@ Entries before the rename below shipped under the project's former name, Conduit
   the path alone does not settle wherever two clients share one file (Claude Code / VS
   Code, Gemini CLI / Antigravity). Deliberately still an inline card rather than a dialog:
   a modal makes the page behind it inert, and this card is a live panel that clears itself
-  when the editor or the view moves under it.
+  when the editor or the view moves under it. The scroll is not animated for anyone whose
+  system asks for reduced motion: `index.css` already zeroes `scroll-behavior`, but an
+  explicit `behavior` in the options dict beats that CSS property, so the component reads
+  the preference itself.
 - **`docs/agent-rules.md` now names every client with no rules file, not two of them.**
   The "no rules file Toolport can write" section named only Cursor and Warp, but the
   Clients section builds that list from whatever is detected, so a user with LM Studio,
@@ -124,10 +127,26 @@ Entries before the rename below shipped under the project's former name, Conduit
   All seven are now listed with the reason each one is on it, including the note that
   Claude Desktop there is the chat app - Claude Code inside the desktop app shares
   `~/.claude` and is already covered by the Claude Code row. Continue's stale
-  "deferred" comment in `clients.rs` is corrected too: it does read
-  `~/.continue/rules/`, but `continuedev/continue` was archived read-only in June 2026,
-  so no adapter is planned. Continue stays a detected MCP client. Docs and a comment
-  only; no behaviour change.
+  "deferred" comment in `clients.rs` is corrected too: its `.continue/rules/` is
+  per-project and its user-level rules are a `rules:` array inside
+  `~/.continue/config.yaml`, which fits neither of Toolport's strategies, and
+  `continuedev/continue` was archived read-only in June 2026 besides. Continue stays a
+  detected MCP client. Docs and a comment only; no behaviour change.
+
+### Internal
+
+- **Every CI job now has a timeout, and apt retries instead of hanging.** `Rust Clippy`
+  and `Linux build + test` carried no `timeout-minutes`, so they inherited GitHub's
+  6-hour default; the jobs in `audit`, `docker-publish`, `release` and `winget` had none
+  either. A flaky Ubuntu mirror made that concrete on one pull request, stalling
+  `apt-get update` in three separate jobs without ever reaching a compiler. An unbounded
+  hang is the worst shape available: it burns the whole budget, and a run stuck in
+  progress also blocks `gh run rerun --failed` on the jobs that genuinely failed, so
+  recovery needs a manual cancel. All 14 jobs across the 6 workflows now carry an
+  explicit backstop, sized per job and generous where a tight limit could kill a real
+  release. The five `apt-get update` call sites are now one script,
+  `scripts/ci-apt-install.sh`, which bounds each attempt and retries, so a bad mirror
+  costs seconds rather than a job.
 
 ## [1.14.0] - 2026-08-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -147,6 +147,14 @@ Entries before the rename below shipped under the project's former name, Conduit
   release. The five `apt-get update` call sites are now one script,
   `scripts/ci-apt-install.sh`, which bounds each attempt and retries, so a bad mirror
   costs seconds rather than a job.
+- **The headless security smoke no longer fails on a stderr race.** `expectBindRefusal`
+  read the gateway's captured stderr as soon as the process emitted `exit`, but Node fires
+  that while piped stdio can still hold undelivered bytes. The Windows runner duly reported
+  `refusing to bind 0.0.0.0` without the `without HTTP authentication` tail the assertion
+  matches on, failing a run in which the gateway had behaved correctly - and the identical
+  assertion passed on the next host, which is the signature of a race, not a defect. The
+  capture is now read only after stderr closes, bounded so a stream that never closes
+  cannot wedge a security check.
 
 ## [1.14.0] - 2026-08-16
 

--- a/docs/agent-rules.md
+++ b/docs/agent-rules.md
@@ -80,10 +80,25 @@ assistant in VS Code, paste the rules into its own file.
 
 ### Clients with no rules file Toolport can write
 
-**Cursor** and **Warp** keep their global rules in their own UI or account rather
-than in a file on disk. They have no checkbox; the Clients section names them
-underneath ("No rules file Toolport can write for Cursor, Warp"), so you know to
-paste your rules in yourself. Toolport does not silently skip them.
+Some clients keep their global rules somewhere Toolport cannot write. They have no
+checkbox; the Clients section lists whichever of them it detects underneath ("No rules
+file Toolport can write for ..."), so you know to paste your rules in yourself. Toolport
+does not silently skip them. Which names appear depends on what is installed, so the list
+below is the full set rather than what you will see.
+
+- **Cursor** and **Warp** keep global rules in their own UI or account: Cursor's User
+  rules in _Customize -> Rules_, Warp's in Warp Drive. Both also read per-project files
+  (`.cursor/rules/`, `AGENTS.md`, `WARP.md`), which Agent rules does not cover yet either
+  (see [Project-level rules](#project-level-rules)).
+- **LM Studio**, **Jan** and **Hermes** keep the system prompt per chat or per model in
+  their own store, not in a global file.
+- **Claude Desktop** here means the chat app, which has no rules file. Claude Code running
+  _inside_ the desktop app is a separate thing and shares `~/.claude` with the CLI, so it
+  is already covered by the Claude Code row above.
+- **Continue** is the one entry that is a choice rather than a limit. It does read
+  `~/.continue/rules/`, so Toolport could write it, but `continuedev/continue` was archived
+  read-only in June 2026, so no adapter is planned. Continue is still detected as an MCP
+  client.
 
 ## Per-client states
 

--- a/docs/agent-rules.md
+++ b/docs/agent-rules.md
@@ -95,10 +95,12 @@ below is the full set rather than what you will see.
 - **Claude Desktop** here means the chat app, which has no rules file. Claude Code running
   _inside_ the desktop app is a separate thing and shares `~/.claude` with the CLI, so it
   is already covered by the Claude Code row above.
-- **Continue** is the one entry that is a choice rather than a limit. It does read
-  `~/.continue/rules/`, so Toolport could write it, but `continuedev/continue` was archived
-  read-only in June 2026, so no adapter is planned. Continue is still detected as an MCP
-  client.
+- **Continue** has no global rules file of the shape Toolport writes. Its `.continue/rules/`
+  directory is per-project, and its user-level rules are a `rules:` array inside
+  `~/.continue/config.yaml` listing hub references or `file://` paths - a YAML list in the
+  same file Toolport already writes MCP config into, not a markdown file it could own or
+  bracket with markers. With `continuedev/continue` archived read-only in June 2026, no
+  adapter is planned. Continue is still detected as an MCP client.
 
 ## Per-client states
 

--- a/packaging/homebrew/toolport.rb
+++ b/packaging/homebrew/toolport.rb
@@ -1,5 +1,5 @@
 cask "toolport" do
-  version "1.14.0"
+  version "1.15.0-rc.1"
 
   on_arm do
     sha256 "ab87135036bade39e8aebcb93988a7319cd85c9b83ae1ffe807d9c108446646f"

--- a/scripts/ci-apt-install.sh
+++ b/scripts/ci-apt-install.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Install apt packages on a GitHub Ubuntu runner, tolerating a flaky mirror.
+#
+# `apt-get update` on the hosted runners intermittently stops responding rather
+# than failing. It hung three separate jobs on one pull request (PR #812), each
+# time burning the job's whole timeout without ever reaching a compiler. An
+# unbounded hang is the worst shape available: it wastes the full budget, and a
+# run stuck in progress also blocks `gh run rerun --failed` on the jobs that
+# genuinely failed.
+#
+# So bound each attempt and retry. A bad mirror costs seconds instead of the job.
+# `timeout` sends SIGTERM at the limit, which apt handles cleanly.
+#
+# Usage: scripts/ci-apt-install.sh <package>...
+set -euo pipefail
+
+if [ "$#" -eq 0 ]; then
+  echo "usage: $0 <package>..." >&2
+  exit 2
+fi
+
+attempts=3
+per_attempt_secs=120
+
+updated=
+for attempt in $(seq 1 "$attempts"); do
+  if sudo timeout "$per_attempt_secs" apt-get update; then
+    updated=1
+    break
+  fi
+  echo "apt-get update attempt ${attempt}/${attempts} failed or hung; retrying" >&2
+  sleep 5
+done
+
+if [ -z "$updated" ]; then
+  echo "apt-get update failed ${attempts} times; the mirror is unreachable" >&2
+  exit 1
+fi
+
+sudo apt-get install -y "$@"

--- a/scripts/smoke-headless.mjs
+++ b/scripts/smoke-headless.mjs
@@ -89,6 +89,37 @@ function startGateway({ port, host, authToken, insecureLoopback = false }) {
   return { child, stderr: boundedStderr(child) };
 }
 
+/**
+ * Wait, bounded, for a child's stderr to close.
+ *
+ * `waitForExit` resolves on `exit`, which Node fires as soon as the process ends - while the
+ * piped stderr can still hold bytes that have not been delivered. Anything reading the captured
+ * stderr at that moment can therefore see a truncated message.
+ *
+ * That is not theoretical. The Windows runner once reported `refusing to bind 0.0.0.0` without
+ * the `without HTTP authentication` tail that `expectBindRefusal` matches on, failing a run in
+ * which the gateway had done exactly the right thing. The same assertion passed on the next
+ * host, which is the signature of a race rather than a defect.
+ *
+ * Resolving on `end`/`close` means the capture is complete before it is read. The timeout keeps
+ * a stream that never closes from wedging a security smoke test.
+ */
+function drainStderr(child, timeoutMs = 2_000) {
+  const stream = child.stderr;
+  if (!stream || stream.readableEnded || stream.destroyed) return Promise.resolve();
+  return new Promise((resolve) => {
+    function finish() {
+      clearTimeout(timer);
+      stream.off("end", finish);
+      stream.off("close", finish);
+      resolve();
+    }
+    const timer = setTimeout(finish, timeoutMs);
+    stream.once("end", finish);
+    stream.once("close", finish);
+  });
+}
+
 function waitForExit(child, timeoutMs) {
   if (child.exitCode !== null || child.signalCode !== null) {
     return Promise.resolve({ code: child.exitCode, signal: child.signalCode });
@@ -315,6 +346,9 @@ async function expectBindRefusal({ name, host }) {
   const { child, stderr } = startGateway({ port, host });
   try {
     const exited = await waitForExit(child, 10_000);
+    // Read the capture only once stderr has closed: `exit` alone does not guarantee the whole
+    // refusal message has arrived, and a half-delivered one fails an assertion the gateway passed.
+    await drainStderr(child);
     const output = stderr();
     if (
       exited &&

--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -20502,7 +20502,10 @@ mod tests {
     fn http_slow_call_does_not_block_other_requests() {
         // A downstream whose tools/call blocks ~800ms; initialize/tools/list stay fast
         // so the connect handshake and routing (`s__wait`) work normally.
-        struct SlowRoute;
+        struct SlowRoute {
+            /// Set the instant the blocking call actually reaches dispatch.
+            entered: std::sync::Arc<std::sync::atomic::AtomicBool>,
+        }
         impl conduit_lib::downstream::Transport for SlowRoute {
             fn request(
                 &mut self,
@@ -20513,6 +20516,8 @@ mod tests {
                     "initialize" => Ok(json!({ "protocolVersion": "2025-06-18" })),
                     "tools/list" => Ok(json!({ "tools": [{ "name": "wait", "description": "" }] })),
                     "tools/call" => {
+                        self.entered
+                            .store(true, std::sync::atomic::Ordering::SeqCst);
                         std::thread::sleep(Duration::from_millis(800));
                         Ok(json!({ "content": [{ "type": "text", "text": "done" }] }))
                     }
@@ -20530,7 +20535,14 @@ mod tests {
             }
         }
 
-        let ds = DownstreamServer::connect("s".into(), Box::new(SlowRoute)).unwrap();
+        let entered = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let ds = DownstreamServer::connect(
+            "s".into(),
+            Box::new(SlowRoute {
+                entered: entered.clone(),
+            }),
+        )
+        .unwrap();
         let mut router = Router::new();
         router.add(ds);
         let mut state = http_state(false);
@@ -20543,22 +20555,41 @@ mod tests {
         std::thread::spawn(move || serve_http_loop(server, state, None, search, confirm, true));
         std::thread::sleep(Duration::from_millis(50)); // let the listener come up
 
-        // Kick off the slow (blocking) call on its own thread, then let it get parked
-        // in dispatch before timing the fast request.
-        let slow = std::thread::spawn(move || http_post(port, "/s__wait", "{}"));
-        std::thread::sleep(Duration::from_millis(150));
+        // Kick off the slow (blocking) call on its own thread. `slow_done` flips only once
+        // that request has fully returned.
+        let slow_done = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let slow_done_writer = slow_done.clone();
+        let slow = std::thread::spawn(move || {
+            let response = http_post(port, "/s__wait", "{}");
+            slow_done_writer.store(true, std::sync::atomic::Ordering::SeqCst);
+            response
+        });
 
-        // A concurrent fast request must return well before the slow call's 800ms sleep.
-        let t0 = Instant::now();
+        // Wait for the slow call to be genuinely parked in dispatch instead of guessing at it.
+        // A fixed sleep here is a bet that 150ms is enough on every runner; when it is not, the
+        // measurement below starts before the slow call has even begun and the test fails for a
+        // reason that has nothing to do with the behaviour it covers.
+        let parked_deadline = Instant::now() + Duration::from_secs(10);
+        while !entered.load(std::sync::atomic::Ordering::SeqCst) {
+            assert!(
+                Instant::now() < parked_deadline,
+                "the slow call never reached dispatch, so nothing was being blocked on"
+            );
+            std::thread::sleep(Duration::from_millis(5));
+        }
+
         let fast = http_get(port, "/");
-        let elapsed = t0.elapsed();
         assert!(
             fast.contains("Toolport gateway"),
             "fast response was: {fast}"
         );
+        // The property is ordering, not milliseconds: the fast request came back while the slow
+        // one was still in flight. Under a serialized accept loop that is impossible, so this
+        // discriminates exactly what the test is named for - and unlike a wall-clock budget it
+        // does not also fail when a loaded runner simply descheduled this thread for a while.
         assert!(
-            elapsed < Duration::from_millis(400),
-            "fast request was blocked behind the slow call ({elapsed:?}); the loop serialized"
+            !slow_done.load(std::sync::atomic::Ordering::SeqCst),
+            "fast request only returned after the slow call finished; the loop serialized"
         );
 
         // The slow call still completes correctly.

--- a/src-tauri/src/clients.rs
+++ b/src-tauri/src/clients.rs
@@ -10982,8 +10982,11 @@ rules:
 
     #[test]
     fn rules_target_unsupported_clients_return_none() {
-        // Cursor/Warp store globals in UI/cloud; Continue is deferred; chat/identity apps have
-        // no global rules file we manage.
+        // Cursor/Warp store globals in UI/cloud; chat/identity apps have no global rules file
+        // we manage. Continue is the one entry here that is a decision rather than a limit: it
+        // does read `~/.continue/rules/`, so an adapter is possible, but `continuedev/continue`
+        // was archived read-only in June 2026 and will not track provider changes, so none is
+        // planned. It stays a detected MCP client for anyone running a pinned build or fork.
         for id in [
             "cursor",
             "warp",

--- a/src-tauri/src/clients.rs
+++ b/src-tauri/src/clients.rs
@@ -10983,10 +10983,13 @@ rules:
     #[test]
     fn rules_target_unsupported_clients_return_none() {
         // Cursor/Warp store globals in UI/cloud; chat/identity apps have no global rules file
-        // we manage. Continue is the one entry here that is a decision rather than a limit: it
-        // does read `~/.continue/rules/`, so an adapter is possible, but `continuedev/continue`
-        // was archived read-only in June 2026 and will not track provider changes, so none is
-        // planned. It stays a detected MCP client for anyone running a pinned build or fork.
+        // we manage. Continue has no global rules FILE either: `.continue/rules/` is
+        // workspace-local, and its user-level rules are a `rules:` array inside
+        // `~/.continue/config.yaml` whose entries are hub refs or `file://` paths. That fits
+        // neither strategy here - it is a YAML list in the same file we already write MCP config
+        // into, not a markdown file we can own or bracket with sentinels. With
+        // `continuedev/continue` archived read-only in June 2026, a third strategy for one dead
+        // client is not worth building. It stays a detected MCP client for pinned builds and forks.
         for id in [
             "cursor",
             "warp",

--- a/src-tauri/src/downstream.rs
+++ b/src-tauri/src/downstream.rs
@@ -7029,15 +7029,25 @@ mod tests {
         let transport = StdioTransport::spawn("powershell.exe", &args, &[], None)
             .expect("spawn Job Object-owned launcher");
 
+        // Poll for parsable CONTENT, not mere existence - the same fix the Unix sibling
+        // below already carries, and for the same reason. `WriteAllText` creates the file
+        // and fills it as separate operations, so a read landing between the two returns an
+        // empty string and `parse` panics on a test that was about to pass. Waiting on
+        // `exists()` is waiting on the wrong event.
         let created_deadline = Instant::now() + Duration::from_secs(8);
-        while !pid_file.exists() && Instant::now() < created_deadline {
+        let grandchild_pid: u32 = loop {
+            if let Some(pid) = std::fs::read_to_string(&pid_file)
+                .ok()
+                .and_then(|s| s.trim().parse::<u32>().ok())
+            {
+                break pid;
+            }
+            assert!(
+                Instant::now() < created_deadline,
+                "launcher should record its grandchild pid"
+            );
             std::thread::sleep(Duration::from_millis(25));
-        }
-        let grandchild_pid: u32 = std::fs::read_to_string(&pid_file)
-            .expect("launcher should record its grandchild pid")
-            .trim()
-            .parse()
-            .expect("grandchild pid should be numeric");
+        };
         assert!(
             process_is_running(grandchild_pid),
             "grandchild must be alive before the Job Object closes"

--- a/src-tauri/src/registry.rs
+++ b/src-tauri/src/registry.rs
@@ -170,6 +170,79 @@ trait AtomicWriteOps {
     fn set_owner_only(&self, file: &std::fs::File) -> std::io::Result<()>;
     fn write_all(&self, file: &mut std::fs::File, contents: &[u8]) -> std::io::Result<()>;
     fn sync_all(&self, file: &std::fs::File) -> std::io::Result<()>;
+
+    /// The rename that publishes the finished temp file over the destination.
+    fn rename(&self, from: &Path, to: &Path) -> std::io::Result<()> {
+        std::fs::rename(from, to)
+    }
+
+    /// Whether a failed publish rename is worth another attempt.
+    ///
+    /// Split from [`AtomicWriteOps::rename`] so the retry loop itself is testable on every
+    /// platform: the real answer is Windows-only, and a Linux-only test run would otherwise
+    /// never execute the loop it is meant to cover.
+    fn rename_is_retryable(&self, error: &std::io::Error) -> bool {
+        transient_rename_error(error)
+    }
+}
+
+/// Attempts for the publish rename, including the first.
+const RENAME_ATTEMPTS: u32 = 8;
+/// Backoff before the second attempt; doubles up to [`RENAME_BACKOFF_CAP`].
+const RENAME_BACKOFF_START: std::time::Duration = std::time::Duration::from_millis(2);
+const RENAME_BACKOFF_CAP: std::time::Duration = std::time::Duration::from_millis(64);
+
+/// Is this rename failure the transient kind that retrying fixes?
+///
+/// Windows only. There, a rename fails outright while any other handle holds the destination
+/// open, and something usually does: Defender, the search indexer, a backup agent. The handle is
+/// released within milliseconds, so the operation was never impossible - only early.
+///
+/// This is not hypothetical. `hooks::tests::preview_text_is_the_bytes_install_actually_writes`
+/// failed one Windows CI run with `install_at` returning `Err`, while the identical test passed
+/// on every other host and on every other run. Users hit the same edge writing `settings.json`
+/// on a machine with antivirus running; CI just reports it more visibly.
+///
+/// Unix needs none of this: `rename(2)` is atomic against open handles, so a failure there is a
+/// real permission or layout problem and retrying only delays the report.
+#[cfg(windows)]
+fn transient_rename_error(error: &std::io::Error) -> bool {
+    /// `ERROR_SHARING_VIOLATION`. No `std::io::ErrorKind` maps to it, so match the raw code.
+    const ERROR_SHARING_VIOLATION: i32 = 32;
+    matches!(error.kind(), std::io::ErrorKind::PermissionDenied)
+        || error.raw_os_error() == Some(ERROR_SHARING_VIOLATION)
+}
+
+#[cfg(not(windows))]
+fn transient_rename_error(_error: &std::io::Error) -> bool {
+    false
+}
+
+/// Publish the temp file, retrying while the failure looks transient.
+///
+/// Bounded on both axes - at most [`RENAME_ATTEMPTS`] tries and a capped backoff - so a
+/// destination that is genuinely locked forever still reports its error instead of hanging.
+/// A non-retryable error returns on the first attempt, unchanged and undelayed.
+fn rename_with_retry(
+    ops: &impl AtomicWriteOps,
+    from: &Path,
+    to: &Path,
+) -> std::io::Result<()> {
+    let mut delay = RENAME_BACKOFF_START;
+    let mut attempt = 1;
+    loop {
+        match ops.rename(from, to) {
+            Ok(()) => return Ok(()),
+            Err(error) => {
+                if attempt >= RENAME_ATTEMPTS || !ops.rename_is_retryable(&error) {
+                    return Err(error);
+                }
+                std::thread::sleep(delay);
+                delay = (delay * 2).min(RENAME_BACKOFF_CAP);
+                attempt += 1;
+            }
+        }
+    }
 }
 
 struct FsAtomicWriteOps;
@@ -344,7 +417,7 @@ fn atomic_write_with_ops(
     // leave a truncated registry.json. `fs::write` + `rename` alone did not.
     ops.sync_all(&f).map_err(|e| e.to_string())?;
     drop(f);
-    std::fs::rename(&tmp, &dest).map_err(|e| e.to_string())?;
+    rename_with_retry(ops, &tmp, &dest).map_err(|e| e.to_string())?;
     cleanup.disarm();
     // Best-effort: fsync the containing directory so the rename entry itself is durable
     // (Unix). Opening a directory as a File fails on Windows, where NTFS journals the
@@ -2938,23 +3011,48 @@ fn registry_lock_timeout() -> std::time::Duration {
 #[cfg(any(debug_assertions, test, feature = "test-support"))]
 #[doc(hidden)]
 #[must_use = "the override is reverted when the guard drops, so it must be bound"]
-pub struct LockTimeoutOverride(Option<std::ffi::OsString>);
+pub struct LockTimeoutOverride(());
+
+/// Live [`LockTimeoutOverride`] guards, and the value to put back when the last one drops.
+///
+/// Refcounted rather than each guard saving and restoring for itself. Rust runs tests
+/// multi-threaded, and several suites take this override at once. With save-and-restore, the
+/// FIRST guard to drop reverted the variable while later guards were still relying on it: the
+/// survivors silently fell back to the 5s production default part-way through a concurrent-writer
+/// stress test, which is precisely the flake this override exists to prevent (SBS-895) - only
+/// between overriders instead of against production. The baseline is captured once, on the way
+/// in from zero, so an externally set value still survives the whole nest.
+#[cfg(any(debug_assertions, test, feature = "test-support"))]
+static LOCK_TIMEOUT_OVERRIDES: std::sync::Mutex<(usize, Option<std::ffi::OsString>)> =
+    std::sync::Mutex::new((0, None));
 
 #[cfg(any(debug_assertions, test, feature = "test-support"))]
 impl LockTimeoutOverride {
     pub fn generous() -> Self {
-        let previous = std::env::var_os("TOOLPORT_LOCK_TIMEOUT_MS");
+        let mut state = LOCK_TIMEOUT_OVERRIDES
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if state.0 == 0 {
+            state.1 = std::env::var_os("TOOLPORT_LOCK_TIMEOUT_MS");
+        }
+        state.0 += 1;
         std::env::set_var("TOOLPORT_LOCK_TIMEOUT_MS", "60000");
-        Self(previous)
+        Self(())
     }
 }
 
 #[cfg(any(debug_assertions, test, feature = "test-support"))]
 impl Drop for LockTimeoutOverride {
     fn drop(&mut self) {
-        match &self.0 {
-            Some(value) => std::env::set_var("TOOLPORT_LOCK_TIMEOUT_MS", value),
-            None => std::env::remove_var("TOOLPORT_LOCK_TIMEOUT_MS"),
+        let mut state = LOCK_TIMEOUT_OVERRIDES
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        state.0 = state.0.saturating_sub(1);
+        if state.0 == 0 {
+            match state.1.take() {
+                Some(value) => std::env::set_var("TOOLPORT_LOCK_TIMEOUT_MS", value),
+                None => std::env::remove_var("TOOLPORT_LOCK_TIMEOUT_MS"),
+            }
         }
     }
 }
@@ -4504,6 +4602,130 @@ mod tests {
         Permissions,
         Write,
         Sync,
+    }
+
+    /// Fails the publish rename `fail_times` times, then lets it through.
+    ///
+    /// Reports every failure as retryable so the loop runs on Linux and macOS too. The real
+    /// predicate is Windows-only, so without this override the retry path would be dead code
+    /// on two of the three hosts CI runs.
+    struct FlakyRenameOps {
+        fail_times: std::cell::Cell<u32>,
+        attempts: std::cell::Cell<u32>,
+        retryable: bool,
+    }
+
+    impl FlakyRenameOps {
+        fn new(fail_times: u32, retryable: bool) -> Self {
+            Self {
+                fail_times: std::cell::Cell::new(fail_times),
+                attempts: std::cell::Cell::new(0),
+                retryable,
+            }
+        }
+    }
+
+    impl AtomicWriteOps for FlakyRenameOps {
+        fn set_owner_only(&self, _file: &std::fs::File) -> std::io::Result<()> {
+            Ok(())
+        }
+
+        fn write_all(&self, file: &mut std::fs::File, contents: &[u8]) -> std::io::Result<()> {
+            std::io::Write::write_all(file, contents)
+        }
+
+        fn sync_all(&self, file: &std::fs::File) -> std::io::Result<()> {
+            file.sync_all()
+        }
+
+        fn rename(&self, from: &Path, to: &Path) -> std::io::Result<()> {
+            self.attempts.set(self.attempts.get() + 1);
+            let left = self.fail_times.get();
+            if left > 0 {
+                self.fail_times.set(left - 1);
+                // Shaped like the Windows failure this exists for.
+                return Err(std::io::Error::from(std::io::ErrorKind::PermissionDenied));
+            }
+            std::fs::rename(from, to)
+        }
+
+        fn rename_is_retryable(&self, _error: &std::io::Error) -> bool {
+            self.retryable
+        }
+    }
+
+    /// A destination held open for a moment must not lose the write. On Windows the publish
+    /// rename fails outright while any other handle has the file, which cost one CI run a green
+    /// tick with no defect behind it.
+    #[test]
+    fn atomic_write_retries_a_transient_publish_rename() {
+        let _lock = data_dir_test_lock();
+        let dir = std::env::temp_dir().join(format!(
+            "toolport-rename-retry-{}-{}",
+            std::process::id(),
+            ATOMIC_WRITE_SEQ.fetch_add(1, Ordering::Relaxed)
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("settings.json");
+
+        let ops = FlakyRenameOps::new(3, true);
+        atomic_write_with_ops(&path, "landed", &ops).expect("a transient rename must be retried");
+
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), "landed");
+        assert_eq!(ops.attempts.get(), 4, "three refusals then the successful one");
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// The retry is bounded, and a failure it cannot classify as transient is reported at once
+    /// rather than slept over. A permanently locked destination must still surface its error.
+    #[test]
+    fn atomic_write_gives_up_on_a_rename_that_never_succeeds() {
+        let _lock = data_dir_test_lock();
+        let dir = std::env::temp_dir().join(format!(
+            "toolport-rename-giveup-{}-{}",
+            std::process::id(),
+            ATOMIC_WRITE_SEQ.fetch_add(1, Ordering::Relaxed)
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("settings.json");
+
+        let forever = FlakyRenameOps::new(u32::MAX, true);
+        atomic_write_with_ops(&path, "never", &forever).unwrap_err();
+        assert_eq!(forever.attempts.get(), RENAME_ATTEMPTS, "bounded, not endless");
+        assert!(!path.exists(), "a failed publish leaves no partial file behind");
+
+        // Not classified as transient: reported on the first attempt, with no backoff spent.
+        let permanent = FlakyRenameOps::new(u32::MAX, false);
+        atomic_write_with_ops(&path, "never", &permanent).unwrap_err();
+        assert_eq!(permanent.attempts.get(), 1, "a permanent error is not retried");
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// An inner override dropping must not disarm an outer one that is still live.
+    ///
+    /// Tests run multi-threaded and several suites take this guard at once, so overlapping
+    /// lifetimes are the normal case, not an exotic one. Save-and-restore let the first
+    /// dropped guard revert the variable out from under the others.
+    #[test]
+    fn overlapping_lock_timeout_overrides_survive_the_first_drop() {
+        let outer = LockTimeoutOverride::generous();
+        {
+            let _inner = LockTimeoutOverride::generous();
+            assert_eq!(
+                std::env::var("TOOLPORT_LOCK_TIMEOUT_MS").as_deref(),
+                Ok("60000")
+            );
+        }
+        assert_eq!(
+            std::env::var("TOOLPORT_LOCK_TIMEOUT_MS").as_deref(),
+            Ok("60000"),
+            "the inner guard's drop must not revert while the outer one is still held"
+        );
+        drop(outer);
+        assert!(
+            std::env::var_os("TOOLPORT_LOCK_TIMEOUT_MS").is_none(),
+            "the last guard out restores the baseline"
+        );
     }
 
     struct FailingAtomicWriteOps(FailingAtomicWriteStep);

--- a/src/components/QuarantineAlert.test.tsx
+++ b/src/components/QuarantineAlert.test.tsx
@@ -283,8 +283,16 @@ describe("QuarantineAlert", () => {
     expect(await screen.findByRole("region")).toBeInTheDocument();
 
     listQuarantined.mockRejectedValue(new Error("backend down"));
-    // Give the poll a chance to land and (incorrectly) clear the list.
-    await new Promise((r) => setTimeout(r, 2100));
+    // Wait for a poll to actually land, rather than sleeping past the interval and hoping one
+    // did. The old fixed 2100ms sleep gave a 2000ms timer only 100ms of headroom, and a loaded
+    // runner routinely slips further than that - in which case the failing poll never fired and
+    // the assertion below passed without exercising the failure path at all. Waiting on the call
+    // count makes it impossible to pass for that reason, and returns as soon as the poll lands.
+    const pollsBefore = listQuarantined.mock.calls.length;
+    await waitFor(
+      () => expect(listQuarantined.mock.calls.length).toBeGreaterThan(pollsBefore),
+      { timeout: 8000 },
+    );
     expect(screen.getByRole("region")).toBeInTheDocument();
   });
 });

--- a/src/components/RulesView.test.tsx
+++ b/src/components/RulesView.test.tsx
@@ -294,8 +294,8 @@ describe("RulesView", () => {
 
   it("scrolls the preview into view and names the client it belongs to", async () => {
     // The card renders after the clients list, so on a short window it opens below the fold and
-    // Preview reads as a dead button. jsdom implements no scrollIntoView, so there is nothing to
-    // spy on until we put one there.
+    // Preview reads as a dead button. `src/test/setup.ts` stubs scrollIntoView as a no-op, so
+    // swap in a spy for the length of this test and put the stub back afterwards.
     const scrollIntoView = vi.fn();
     const original = Object.getOwnPropertyDescriptor(Element.prototype, "scrollIntoView");
     Element.prototype.scrollIntoView = scrollIntoView;
@@ -314,12 +314,66 @@ describe("RulesView", () => {
       await userEvent.click(screen.getAllByRole("button", { name: /Preview/ })[0]);
       expect(await screen.findByText("/home/a/.codex/AGENTS.md")).toBeInTheDocument();
 
-      expect(scrollIntoView).toHaveBeenCalled();
+      // Smooth by default; the reduced-motion branch is covered below.
+      expect(scrollIntoView).toHaveBeenCalledWith({
+        behavior: "smooth",
+        block: "start",
+      });
       // Two clients can share one file, so the path alone does not say whose preview this is.
       expect(screen.getByRole("heading", { name: "Preview: Codex" })).toBeInTheDocument();
     } finally {
       if (original) Object.defineProperty(Element.prototype, "scrollIntoView", original);
       else delete (Element.prototype as Partial<Element>).scrollIntoView;
+    }
+  });
+
+  it("does not animate the preview scroll for a reduced-motion reader", async () => {
+    // index.css already zeroes scroll-behavior under prefers-reduced-motion, but an explicit
+    // `behavior` in the options dict beats that CSS property, so the component has to read the
+    // preference itself. Without that, this is the one animation the stylesheet cannot reach.
+    const scrollIntoView = vi.fn();
+    const originalScroll = Object.getOwnPropertyDescriptor(
+      Element.prototype,
+      "scrollIntoView",
+    );
+    Element.prototype.scrollIntoView = scrollIntoView;
+    const matchMedia = vi.spyOn(window, "matchMedia").mockImplementation(
+      (query: string) =>
+        ({
+          matches: query.includes("prefers-reduced-motion"),
+          media: query,
+          onchange: null,
+          addListener: () => {},
+          removeListener: () => {},
+          addEventListener: () => {},
+          removeEventListener: () => {},
+          dispatchEvent: () => false,
+        }) as unknown as MediaQueryList,
+    );
+    try {
+      api.rulesPreview.mockResolvedValue({
+        clientId: "codex",
+        path: "/home/a/.codex/AGENTS.md",
+        strategy: "sentinelBlock",
+        before: "",
+        after: "Always run tests.\n",
+        state: "stale",
+      });
+      render(<RulesView />);
+      await screen.findByLabelText("Rules");
+
+      await userEvent.click(screen.getAllByRole("button", { name: /Preview/ })[0]);
+      expect(await screen.findByText("/home/a/.codex/AGENTS.md")).toBeInTheDocument();
+
+      // Still scrolled - the card must reach the screen either way. Just not animated.
+      expect(scrollIntoView).toHaveBeenCalledWith({ behavior: "auto", block: "start" });
+    } finally {
+      matchMedia.mockRestore();
+      if (originalScroll) {
+        Object.defineProperty(Element.prototype, "scrollIntoView", originalScroll);
+      } else {
+        delete (Element.prototype as Partial<Element>).scrollIntoView;
+      }
     }
   });
 

--- a/src/components/RulesView.test.tsx
+++ b/src/components/RulesView.test.tsx
@@ -292,6 +292,37 @@ describe("RulesView", () => {
     expect(screen.getByLabelText("Rules")).toHaveValue("Always run tests. And lint.");
   });
 
+  it("scrolls the preview into view and names the client it belongs to", async () => {
+    // The card renders after the clients list, so on a short window it opens below the fold and
+    // Preview reads as a dead button. jsdom implements no scrollIntoView, so there is nothing to
+    // spy on until we put one there.
+    const scrollIntoView = vi.fn();
+    const original = Object.getOwnPropertyDescriptor(Element.prototype, "scrollIntoView");
+    Element.prototype.scrollIntoView = scrollIntoView;
+    try {
+      api.rulesPreview.mockResolvedValue({
+        clientId: "codex",
+        path: "/home/a/.codex/AGENTS.md",
+        strategy: "sentinelBlock",
+        before: "",
+        after: "Always run tests.\n",
+        state: "stale",
+      });
+      render(<RulesView />);
+      await screen.findByLabelText("Rules");
+
+      await userEvent.click(screen.getAllByRole("button", { name: /Preview/ })[0]);
+      expect(await screen.findByText("/home/a/.codex/AGENTS.md")).toBeInTheDocument();
+
+      expect(scrollIntoView).toHaveBeenCalled();
+      // Two clients can share one file, so the path alone does not say whose preview this is.
+      expect(screen.getByRole("heading", { name: "Preview: Codex" })).toBeInTheDocument();
+    } finally {
+      if (original) Object.defineProperty(Element.prototype, "scrollIntoView", original);
+      else delete (Element.prototype as Partial<Element>).scrollIntoView;
+    }
+  });
+
   it("clears a stale preview when the view is reseated", async () => {
     api.rulesPreview.mockResolvedValue({
       clientId: "codex",

--- a/src/components/RulesView.tsx
+++ b/src/components/RulesView.tsx
@@ -78,13 +78,22 @@ export function RulesView() {
    * makes the page behind it inert, and this card is deliberately a live panel that clears itself
    * when the editor or the view moves under it. Scrolling keeps that.
    *
-   * `scrollIntoView` is absent in jsdom, hence the optional call.
+   * Both `scrollIntoView` and `matchMedia` are optional calls: jsdom ships neither, and
+   * `src/test/setup.ts` only stubs them for suites that opt in.
    */
   const previewRef = useRef<HTMLDivElement | null>(null);
   useEffect(() => {
-    if (preview) {
-      previewRef.current?.scrollIntoView?.({ behavior: "smooth", block: "start" });
-    }
+    if (!preview) return;
+    // The `scroll-behavior: auto !important` reduced-motion rule in index.css does NOT cover
+    // this. An explicit `behavior` in the options dict beats the CSS property, so the preference
+    // has to be read here as well. Getting the card on screen is the fix; the smoothness is a
+    // nicety, and the first thing to drop for anyone who asked for less motion.
+    const reduceMotion =
+      window.matchMedia?.("(prefers-reduced-motion: reduce)").matches ?? false;
+    previewRef.current?.scrollIntoView?.({
+      behavior: reduceMotion ? "auto" : "smooth",
+      block: "start",
+    });
   }, [preview]);
 
   const active = data?.sets.find((s) => s.id === data.activeSetId) ?? null;

--- a/src/components/RulesView.tsx
+++ b/src/components/RulesView.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Eye, FileText, Plus, RefreshCw, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -68,6 +68,24 @@ export function RulesView() {
 
   const [preview, setPreview] = useState<RulesPreview | null>(null);
   const [confirmDelete, setConfirmDelete] = useState<string | null>(null);
+
+  /**
+   * The preview card renders after the clients list, so on a window too short to reach it the
+   * Preview button looks like it does nothing at all - the worst failure available to the one
+   * control whose entire job is to show you something. Bring the card into view when it opens.
+   *
+   * A dialog would also solve this, and the Agent activity tab uses one, but not here: a modal
+   * makes the page behind it inert, and this card is deliberately a live panel that clears itself
+   * when the editor or the view moves under it. Scrolling keeps that.
+   *
+   * `scrollIntoView` is absent in jsdom, hence the optional call.
+   */
+  const previewRef = useRef<HTMLDivElement | null>(null);
+  useEffect(() => {
+    if (preview) {
+      previewRef.current?.scrollIntoView?.({ behavior: "smooth", block: "start" });
+    }
+  }, [preview]);
 
   const active = data?.sets.find((s) => s.id === data.activeSetId) ?? null;
   const dirty =
@@ -273,6 +291,11 @@ export function RulesView() {
   const supported = clients.filter((c) => c.path);
   const unsupported = clients.filter((c) => !c.path);
   const onCount = supported.filter((c) => c.enabled).length;
+  // Name the client in the card header. The path alone is ambiguous wherever two clients share a
+  // file (Claude Code / VS Code, Gemini CLI / Antigravity).
+  const previewClientName = preview
+    ? (clients.find((c) => c.id === preview.clientId)?.name ?? null)
+    : null;
 
   return (
     <div className="flex flex-col gap-5">
@@ -446,9 +469,11 @@ export function RulesView() {
       </div>
 
       {preview && (
-        <div className="rounded-xl border bg-card p-5">
+        <div ref={previewRef} className="scroll-mt-4 rounded-xl border bg-card p-5">
           <div className="mb-1 flex items-center justify-between gap-3">
-            <h2 className="text-sm font-medium">Preview</h2>
+            <h2 className="text-sm font-medium">
+              Preview{previewClientName ? `: ${previewClientName}` : ""}
+            </h2>
             <button
               type="button"
               onClick={() => setPreview(null)}


### PR DESCRIPTION
Three small things, found while answering a question about the Agent rules tab.

## 1. Preview looked like a dead button

The preview card renders after the clients list. On any window too short to reach it, clicking **Preview** scrolled nothing and showed nothing — the card was open the whole time, below the fold. That is the worst failure available to the one control whose entire job is to show you something.

Opening a preview now scrolls the card into view, and its header names the client. The path alone does not settle whose preview it is wherever two clients share one file (Claude Code / VS Code, Gemini CLI / Antigravity).

**Still an inline card, not a dialog — on purpose.** A modal was tried first and broke three tests, correctly: Radix makes the page behind it inert, so `adopt`-while-open and edit-while-open become unreachable. That card is deliberately a live panel that clears itself when the editor or the view moves under it. A dialog would trade that design away to fix a scroll problem.

The regression test was checked against the unfixed component — it fails without the scroll and passes with it, so it is not vacuous.

## 2. `docs/agent-rules.md` named 2 of 7 unwritable clients

The "no rules file Toolport can write" section named only Cursor and Warp, but the Clients section builds that list from whatever is detected (`RulesView.tsx`). A user with LM Studio, Jan, Hermes, Claude Desktop or Continue installed saw names the doc never mentioned. All seven are now listed with the reason each one is on it, verified against each client's current docs.

Two worth calling out:

- **Claude Desktop** there is the chat app, which has no rules file. Claude Code running *inside* the desktop app is a separate thing — it shares `~/.claude` with the CLI and is already covered by the Claude Code row.
- **Continue**'s `deferred` comment in `clients.rs` was stale in a way that mattered: it reads as planned work. Continue does read `~/.continue/rules/`, so an adapter is possible, but `continuedev/continue` was archived read-only in June 2026 after the Cursor acqui-hire. No adapter is planned. It stays a detected MCP client for anyone running a pinned build or a fork.

## 3. main was red

`chore(release): 1.15.0-rc.1` moved `package.json` but not the cask snapshot, so `src/test/homebrew-cask.test.ts` has failed on main since. CI runs vitest, so every PR inherited it.

`RELEASING.md` step 1 splits that file in two: the `version` line moves with `package.json` at bump time, and only the two `sha256`s wait for a published release. This is the first half, which needed nothing published. Stale hashes staying put is what the doc prescribes, and `brew install` reads the live tap rather than this snapshot.

Whenever a version does ship, that file still needs the real hashes. The test will say so.

## Checks

| Gate | Result |
| --- | --- |
| `npx prettier --check .` | clean |
| `npx eslint src/` | 0 errors (51 pre-existing warnings) |
| `npx tsc --noEmit` | clean |
| `npx vitest run` | 581/581 |
| `cargo check --lib --bins --tests` | clean, no new warnings |
| `cargo test --lib rules_target_` | 9/9 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Scroll rules preview into view and show client name in header
> - When a rules preview is opened in [RulesView.tsx](https://github.com/tsouth89/toolport/pull/812/files#diff-4e009b33fddd42d77b29dcb73137bb9411ea8428b2bb159b7b62149beb3f11d7), the preview card now scrolls into view automatically and displays the owning client's name in the card header.
> - Scroll behavior uses `smooth` by default but switches to `auto` when `prefers-reduced-motion` is set.
> - Also adds CI job timeouts across all workflows and a retrying `apt-get` helper script to reduce flaky CI failures.
> - Atomic file writes on Windows now retry transient rename failures (e.g. from antivirus file scanners) with exponential backoff up to 8 attempts.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bbe5362.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->