### PR TITLE
fix(servers): discard stale connection test results

### DIFF
--- a/src/components/ServerDialog.test.tsx
+++ b/src/components/ServerDialog.test.tsx
@@ -1,9 +1,56 @@
-import { describe, it, expect, vi } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, it, expect, vi } from "vitest";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import type { ProbeResult } from "@/lib/types";
+
+const api = vi.hoisted(() => ({
+  addServer: vi.fn(),
+  parseServerSnippet: vi.fn(),
+  setSecret: vi.fn(),
+  testServer: vi.fn(),
+  updateServer: vi.fn(),
+}));
+
+vi.mock("@/lib/api", () => api);
+
 import { ServerDialog } from "./ServerDialog";
 
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+const success: ProbeResult = {
+  serverId: "",
+  ok: true,
+  toolCount: 2,
+  error: null,
+  authRequired: false,
+};
+
+const failure: ProbeResult = {
+  serverId: "",
+  ok: false,
+  toolCount: 0,
+  error: "The updated command could not connect.",
+  authRequired: false,
+};
+
+async function fillServer(user: ReturnType<typeof userEvent.setup>, command: string) {
+  await user.type(screen.getByLabelText("Name"), "demo");
+  await user.type(screen.getByLabelText("Command"), command);
+}
+
 describe("ServerDialog", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it("opens from its trigger and shows the add form", async () => {
     render(<ServerDialog trigger={<button>Add server</button>} onSaved={vi.fn()} />);
     expect(screen.queryByText("Add MCP server")).not.toBeInTheDocument();
@@ -50,5 +97,69 @@ describe("ServerDialog", () => {
     expect(screen.getByText("Add MCP server")).toBeInTheDocument();
     await userEvent.click(screen.getByRole("button", { name: "Cancel" }));
     expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps an edited in-flight test busy and discards its result", async () => {
+    const request = deferred<ProbeResult>();
+    api.testServer.mockReturnValueOnce(request.promise);
+    const user = userEvent.setup();
+
+    render(<ServerDialog trigger={<button>Add server</button>} onSaved={vi.fn()} />);
+    await user.click(screen.getByRole("button", { name: "Add server" }));
+    await fillServer(user, "working-command");
+    await user.click(screen.getByRole("button", { name: "Test connection" }));
+
+    expect(api.testServer).toHaveBeenCalledWith(
+      expect.objectContaining({ command: "working-command" }),
+    );
+    expect(screen.getByRole("button", { name: /testing/i })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Add" })).toBeDisabled();
+
+    await user.clear(screen.getByLabelText("Command"));
+    await user.type(screen.getByLabelText("Command"), "broken-command");
+
+    expect(screen.getByRole("button", { name: /testing/i })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Add" })).toBeDisabled();
+
+    await act(async () => request.resolve(success));
+
+    expect(screen.queryByText(/Connected\. Found/)).not.toBeInTheDocument();
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "Test connection" })).toBeEnabled(),
+    );
+    expect(screen.getByRole("button", { name: "Add" })).toBeEnabled();
+  });
+
+  it("keeps a newer result when tests resolve out of order after reopening", async () => {
+    const first = deferred<ProbeResult>();
+    const second = deferred<ProbeResult>();
+    api.testServer.mockReturnValueOnce(first.promise).mockReturnValueOnce(second.promise);
+    const user = userEvent.setup();
+
+    render(<ServerDialog trigger={<button>Add server</button>} onSaved={vi.fn()} />);
+    await user.click(screen.getByRole("button", { name: "Add server" }));
+    await fillServer(user, "working-command");
+    await user.click(screen.getByRole("button", { name: "Test connection" }));
+
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+    await user.click(screen.getByRole("button", { name: "Add server" }));
+    await fillServer(user, "broken-command");
+    await user.click(screen.getByRole("button", { name: "Test connection" }));
+
+    expect(api.testServer).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ command: "working-command" }),
+    );
+    expect(api.testServer).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ command: "broken-command" }),
+    );
+
+    await act(async () => second.resolve(failure));
+    expect(screen.getByText(failure.error as string)).toBeInTheDocument();
+
+    await act(async () => first.resolve(success));
+    expect(screen.getByText(failure.error as string)).toBeInTheDocument();
+    expect(screen.queryByText(/Connected\. Found/)).not.toBeInTheDocument();
   });
 });

--- a/src/components/ServerDialog.test.tsx
+++ b/src/components/ServerDialog.test.tsx
@@ -130,6 +130,48 @@ describe("ServerDialog", () => {
     expect(screen.getByRole("button", { name: "Add" })).toBeEnabled();
   });
 
+  it("keeps an in-flight test busy when parsed config replaces the form", async () => {
+    const request = deferred<ProbeResult>();
+    api.testServer.mockReturnValueOnce(request.promise);
+    api.parseServerSnippet.mockResolvedValueOnce([
+      {
+        name: "parsed",
+        transport: "stdio",
+        command: "parsed-command",
+        args: [],
+        url: null,
+        env: [],
+      },
+    ]);
+    const user = userEvent.setup();
+
+    render(<ServerDialog trigger={<button>Add server</button>} onSaved={vi.fn()} />);
+    await user.click(screen.getByRole("button", { name: "Add server" }));
+    await fillServer(user, "working-command");
+    await user.click(screen.getByRole("button", { name: "Test connection" }));
+
+    await user.click(screen.getByRole("button", { name: "Paste from client config" }));
+    await user.type(
+      screen.getByPlaceholderText(/Paste a config snippet/i),
+      "parsed config",
+    );
+    await user.click(screen.getByRole("button", { name: "Parse & fill" }));
+
+    await waitFor(() =>
+      expect(screen.getByLabelText("Command")).toHaveValue("parsed-command"),
+    );
+    expect(screen.getByRole("button", { name: /testing/i })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Add" })).toBeDisabled();
+
+    await act(async () => request.resolve(success));
+
+    expect(screen.queryByText(/Connected\. Found/)).not.toBeInTheDocument();
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "Test connection" })).toBeEnabled(),
+    );
+    expect(screen.getByRole("button", { name: "Add" })).toBeEnabled();
+  });
+
   it("keeps a newer result when tests resolve out of order after reopening", async () => {
     const first = deferred<ProbeResult>();
     const second = deferred<ProbeResult>();

--- a/src/components/ServerDialog.tsx
+++ b/src/components/ServerDialog.tsx
@@ -1,4 +1,4 @@
-import { useState, type ReactNode } from "react";
+import { useRef, useState, type ReactNode } from "react";
 import {
   AlertTriangle,
   CheckCircle2,
@@ -60,6 +60,15 @@ interface Props {
   urlHint?: string;
 }
 
+type TestState =
+  | { status: "idle"; message: "" }
+  | { status: "testing"; message: ""; requestId: number; stale: boolean }
+  | { status: "ok" | "fail"; message: string };
+
+type TestResult = Extract<TestState, { status: "ok" | "fail" }>;
+
+const IDLE_TEST: TestState = { status: "idle", message: "" };
+
 export function ServerDialog({
   trigger,
   onSaved,
@@ -85,10 +94,8 @@ export function ServerDialog({
     initial?.env.map((e) => ({ key: e.key, value: "" })) ?? [],
   );
   const [busy, setBusy] = useState(false);
-  const [test, setTest] = useState<{
-    status: "idle" | "testing" | "ok" | "fail";
-    message: string;
-  }>({ status: "idle", message: "" });
+  const [test, setTest] = useState<TestState>(IDLE_TEST);
+  const testRequestId = useRef(0);
   const isStdio = form.transport === "stdio";
   const editing = editId !== undefined;
 
@@ -97,15 +104,23 @@ export function ServerDialog({
   const [pasteText, setPasteText] = useState("");
   const [parsing, setParsing] = useState(false);
 
-  // A prior test result is stale the moment the connection details change.
+  // A completed result clears immediately when the connection details change. An in-flight
+  // test stays visibly busy until it settles, but its result is then discarded as stale.
   function clearTest() {
-    setTest((t) => (t.status === "idle" ? t : { status: "idle", message: "" }));
+    setTest((current) => {
+      if (current.status === "idle") return current;
+      if (current.status === "testing") {
+        return current.stale ? current : { ...current, stale: true };
+      }
+      return IDLE_TEST;
+    });
   }
 
   // The dialog instance is mounted persistently (e.g. the header "Add server"
   // button), so reset the form each time it opens - otherwise it keeps the last
   // entry's values instead of starting blank (or re-deriving from `initial`).
   function onOpenChange(next: boolean) {
+    if (!next) setTest(IDLE_TEST);
     if (!next && onClose) {
       onClose();
       return;
@@ -120,7 +135,7 @@ export function ServerDialog({
         cwd: initial?.cwd ?? "",
       });
       setEnvRows(initial?.env.map((e) => ({ key: e.key, value: "" })) ?? []);
-      setTest({ status: "idle", message: "" });
+      setTest(IDLE_TEST);
       setShowPaste(false);
       setPasteText("");
     }
@@ -169,7 +184,7 @@ export function ServerDialog({
           value: e.value ?? "",
         })),
       );
-      setTest({ status: "idle", message: "" });
+      setTest(IDLE_TEST);
       if (servers.length > 1) {
         toast.info(
           `Found ${servers.length} servers, filled "${s.name}". Add the rest separately.`,
@@ -229,17 +244,25 @@ export function ServerDialog({
     (existingNames ?? []).some((n) => n.trim().toLowerCase() === nameTrim.toLowerCase());
   const canSave = errors.length === 0 && !busy && test.status !== "testing";
 
+  function finishTest(requestId: number, result: TestResult) {
+    setTest((current) => {
+      if (current.status !== "testing" || current.requestId !== requestId) return current;
+      return current.stale ? IDLE_TEST : result;
+    });
+  }
+
   async function handleTest() {
-    setTest({ status: "testing", message: "" });
+    const requestId = ++testRequestId.current;
+    setTest({ status: "testing", message: "", requestId, stale: false });
     try {
       const r = await testServer(buildEntry(true));
       if (r.ok) {
-        setTest({
+        finishTest(requestId, {
           status: "ok",
           message: `Connected. Found ${r.toolCount} tool${r.toolCount === 1 ? "" : "s"}.`,
         });
       } else {
-        setTest({
+        finishTest(requestId, {
           status: "fail",
           message: r.authRequired
             ? `Reachable, but needs credentials: ${r.error ?? "authentication required"}`
@@ -247,7 +270,7 @@ export function ServerDialog({
         });
       }
     } catch (e) {
-      setTest({ status: "fail", message: String(e) });
+      finishTest(requestId, { status: "fail", message: String(e) });
     }
   }
 

--- a/src/components/ServerDialog.tsx
+++ b/src/components/ServerDialog.tsx
@@ -184,7 +184,7 @@ export function ServerDialog({
           value: e.value ?? "",
         })),
       );
-      setTest(IDLE_TEST);
+      clearTest();
       if (servers.length > 1) {
         toast.info(
           `Found ${servers.length} servers, filled "${s.name}". Add the rest separately.`,


### PR DESCRIPTION
## What and why

Keep an in-flight connection test visibly busy when the server form changes, then discard its now-stale result instead of reporting it against the edited configuration. Request IDs also prevent an older test from overwriting a newer result after the dialog is closed and reopened.

Fixes #739

## Testing

- [x] Targeted ServerDialog tests pass (7/7)
- [x] npm run build passes
- [x] npm run lint passes (0 errors; existing warnings only)
- [ ] npm run test passes: 581/582 pass; upstream main currently fails the Homebrew cask lockstep test because package.json is 1.15.0-rc.1 while packaging/homebrew/toolport.rb is 1.14.0
- [ ] npm run audit:prod passes (not run)
- [ ] npm run test:rust passes (frontend-only change; not run)
- [ ] Ran the app manually (not run)

## Notes

No API or Rust changes. The Tauri invoke is allowed to finish because it is not cancellable; only a matching, current request can publish a result.