### PR TITLE
ci: bound and retry the apt download, not just the index refresh

### DIFF
--- a/scripts/ci-apt-install.sh
+++ b/scripts/ci-apt-install.sh
@@ -29,13 +29,23 @@ fi
 attempts=3
 per_attempt_secs=120
 # Downloads are bulkier than an index refresh, so they get their own budget:
-# a healthy WebKitGTK fetch is well under two minutes, and 3 x 300s still caps
-# the whole step at 15 rather than letting it eat the job.
+# a healthy WebKitGTK fetch is well under two minutes. Worst case the two loops
+# together are 3x120s + 3x300s plus the retry sleeps, so roughly 21 minutes -
+# still a backstop well inside the job's 45, which is the point.
 download_attempt_secs=300
+# SIGTERM is the polite ask. An apt wedged on a dead socket can sit through it,
+# which would put the unbounded wait straight back; follow up with SIGKILL.
+kill_after_secs=30
+
+run_apt() {
+  local budget="$1"
+  shift
+  sudo timeout --kill-after="$kill_after_secs" "$budget" apt-get "$@"
+}
 
 updated=
 for attempt in $(seq 1 "$attempts"); do
-  if sudo timeout "$per_attempt_secs" apt-get update; then
+  if run_apt "$per_attempt_secs" update; then
     updated=1
     break
   fi
@@ -44,7 +54,7 @@ for attempt in $(seq 1 "$attempts"); do
 done
 
 if [ -z "$updated" ]; then
-  echo "apt-get update failed ${attempts} times; the mirror is unreachable" >&2
+  echo "apt-get update failed ${attempts} times; see the apt error above" >&2
   exit 1
 fi
 
@@ -54,7 +64,14 @@ fi
 # instead of starting the whole set again.
 downloaded=
 for attempt in $(seq 1 "$attempts"); do
-  if sudo timeout "$download_attempt_secs" apt-get install -y --download-only "$@"; then
+  # Refresh the index before each retry, never on the first pass. A mirror that
+  # publishes a new version between our update and our download 404s every
+  # attempt on the version we were told to ask for, and retrying the same stale
+  # plan just burns the budget three times over.
+  if [ "$attempt" -gt 1 ] && ! run_apt "$per_attempt_secs" update; then
+    echo "index refresh before download attempt ${attempt} failed; trying the download anyway" >&2
+  fi
+  if run_apt "$download_attempt_secs" install -y --download-only "$@"; then
     downloaded=1
     break
   fi
@@ -63,11 +80,18 @@ for attempt in $(seq 1 "$attempts"); do
 done
 
 if [ -z "$downloaded" ]; then
-  echo "apt-get could not download the packages after ${attempts} attempts; the mirror is unreachable" >&2
+  echo "apt-get could not download the packages after ${attempts} attempts; see the apt error above" >&2
   exit 1
 fi
 
-# Unbounded on purpose. Everything is in the local cache by now, so this is
-# fast and offline, and a SIGTERM landing inside dpkg is the one interruption
-# that leaves a half-configured system needing `dpkg --configure -a`.
-sudo apt-get install -y "$@"
+# Install straight from the cache the loop above filled. `--no-download` is what
+# makes "offline" true rather than merely likely: without it this is a fresh
+# acquire session, so one truncated or superseded .deb sends it back to the
+# mirror unbounded, which is the exact hang this script exists to stop. A
+# missing file now fails fast and loudly instead. Deliberately no `-m`: that
+# would drop the missing package and install a quiet subset.
+#
+# No timeout here on purpose. There is no network left to stall on, and a
+# SIGTERM landing inside dpkg is the one interruption that leaves a
+# half-configured system needing `dpkg --configure -a`.
+sudo apt-get install -y --no-download "$@"

--- a/scripts/ci-apt-install.sh
+++ b/scripts/ci-apt-install.sh
@@ -11,6 +11,13 @@
 # So bound each attempt and retry. A bad mirror costs seconds instead of the job.
 # `timeout` sends SIGTERM at the limit, which apt handles cleanly.
 #
+# The download side of `apt-get install` needs the same treatment, and only got
+# it later: with `update` bounded, a throttled mirror moved the hang one step
+# down. On PR #813 the mirror served ~12 kB/s, so the install crept through 130
+# small packages and then died inside the 27 MB libwebkit2gtk-4.1-0, twice,
+# each time burning the full 45-minute budget. Only the heavy WebKitGTK job hit
+# it; the jobs asking for four packages finished in three minutes.
+#
 # Usage: scripts/ci-apt-install.sh <package>...
 set -euo pipefail
 
@@ -21,6 +28,10 @@ fi
 
 attempts=3
 per_attempt_secs=120
+# Downloads are bulkier than an index refresh, so they get their own budget:
+# a healthy WebKitGTK fetch is well under two minutes, and 3 x 300s still caps
+# the whole step at 15 rather than letting it eat the job.
+download_attempt_secs=300
 
 updated=
 for attempt in $(seq 1 "$attempts"); do
@@ -37,4 +48,26 @@ if [ -z "$updated" ]; then
   exit 1
 fi
 
+# Fetch first, on a bound, so a stalled mirror is interrupted and retried. This
+# is safe to cut off mid-flight: apt keeps each completed .deb in
+# /var/cache/apt/archives, so a retry resumes with only what is still missing
+# instead of starting the whole set again.
+downloaded=
+for attempt in $(seq 1 "$attempts"); do
+  if sudo timeout "$download_attempt_secs" apt-get install -y --download-only "$@"; then
+    downloaded=1
+    break
+  fi
+  echo "apt-get download attempt ${attempt}/${attempts} failed or hung; retrying" >&2
+  sleep 5
+done
+
+if [ -z "$downloaded" ]; then
+  echo "apt-get could not download the packages after ${attempts} attempts; the mirror is unreachable" >&2
+  exit 1
+fi
+
+# Unbounded on purpose. Everything is in the local cache by now, so this is
+# fast and offline, and a SIGTERM landing inside dpkg is the one interruption
+# that leaves a half-configured system needing `dpkg --configure -a`.
 sudo apt-get install -y "$@"

--- a/scripts/ci-apt-install.sh
+++ b/scripts/ci-apt-install.sh
@@ -47,6 +47,34 @@ download_attempt_secs=300
 # which would put the unbounded wait straight back; follow up with SIGKILL.
 kill_after_secs=30
 
+# Let apt do its own failover before we cut it off.
+#
+# The runner image already points apt at a three-mirror list through
+# `mirror+file:/etc/apt/apt-mirrors.txt` - azure.archive.ubuntu.com first, then
+# archive.ubuntu.com, then security.ubuntu.com - so a dead primary is something
+# apt can recover from unaided. It never got the chance: the image sets no
+# acquire timeout, apt's default idle timeout is at least as long as the bound
+# below, and so the SIGTERM always landed first. Three attempts against a silent
+# azure mirror produced no error, no failover, and six minutes gone, on three
+# pull requests in one evening (#813, #815, #816).
+#
+# So give apt a much shorter fuse than our own and the fallback engages inside a
+# single attempt, turning the outage into a few wasted seconds.
+#
+# This is an INACTIVITY timeout, not a transfer budget: it measures the gap
+# between bytes, so it does not punish a slow-but-progressing mirror. The
+# throttled ~12 kB/s mirror that broke PR #817 keeps resetting it and is left to
+# the outer bound, which is the right tool for that failure.
+apt_conf=/etc/apt/apt.conf.d/99toolport-ci-acquire
+if ! printf '%s\n' \
+  'Acquire::http::Timeout "20";' \
+  'Acquire::https::Timeout "20";' \
+  'Acquire::Retries "3";' | sudo tee "$apt_conf" >/dev/null; then
+  # Not fatal: without it apt keeps its own defaults and the loops below still
+  # bound the damage. Say so rather than failing a build over a tuning file.
+  echo "could not write ${apt_conf}; apt keeps its default timeouts" >&2
+fi
+
 run_apt() {
   local budget="$1"
   shift

--- a/scripts/ci-apt-install.sh
+++ b/scripts/ci-apt-install.sh
@@ -29,9 +29,19 @@ fi
 attempts=3
 per_attempt_secs=120
 # Downloads are bulkier than an index refresh, so they get their own budget:
-# a healthy WebKitGTK fetch is well under two minutes. Worst case the two loops
-# together are 3x120s + 3x300s plus the retry sleeps, so roughly 21 minutes -
-# still a backstop well inside the job's 45, which is the point.
+# a healthy WebKitGTK fetch is well under two minutes.
+#
+# Worst case, counted honestly: `timeout --kill-after` can spend budget+30s per
+# call, the download loop refreshes the index before each retry, and only the
+# gaps between attempts sleep. That is 3x150s + 2x5s = 460s of update, then
+# 3x330s + 2x150s + 2x5s = 1300s of download: about 29 minutes.
+#
+# That is a backstop, not a plan - it needs every attempt to burn its full bound
+# and still come good. But it is not comfortably inside every caller either: the
+# WebKitGTK job allows 45 minutes, while the four-package jobs in ci.yml and
+# docker-publish.yml allow 30. Those jobs pull a handful of small debs, so they
+# reach the bounds only if the mirror is dead, in which case they were losing the
+# job anyway. Re-check this arithmetic before raising either budget.
 download_attempt_secs=300
 # SIGTERM is the polite ask. An apt wedged on a dead socket can sit through it,
 # which would put the unbounded wait straight back; follow up with SIGKILL.
@@ -49,8 +59,12 @@ for attempt in $(seq 1 "$attempts"); do
     updated=1
     break
   fi
-  echo "apt-get update attempt ${attempt}/${attempts} failed or hung; retrying" >&2
-  sleep 5
+  # Only sleep between attempts. After the last one the caller is about to see
+  # the failure, and five more seconds of dead air buys nothing.
+  if [ "$attempt" -lt "$attempts" ]; then
+    echo "apt-get update attempt ${attempt}/${attempts} failed or hung; retrying" >&2
+    sleep 5
+  fi
 done
 
 if [ -z "$updated" ]; then
@@ -75,8 +89,10 @@ for attempt in $(seq 1 "$attempts"); do
     downloaded=1
     break
   fi
-  echo "apt-get download attempt ${attempt}/${attempts} failed or hung; retrying" >&2
-  sleep 5
+  if [ "$attempt" -lt "$attempts" ]; then
+    echo "apt-get download attempt ${attempt}/${attempts} failed or hung; retrying" >&2
+    sleep 5
+  fi
 done
 
 if [ -z "$downloaded" ]; then


### PR DESCRIPTION
## What and why

`scripts/ci-apt-install.sh` bounds and retries `apt-get update`, which was the hang PR #812 ran into. It left `apt-get install` unbounded, so a throttled mirror just moved the hang one step down.

PR #813 hit it twice in a row. Both runs of `Linux build + test` burned the full 45 minute timeout without reaching a compiler.

From the job log, the mirror was serving roughly 12 kB/s:

```
12:14:26 Get:116 ... libnghttp2-dev amd64 ... [117 kB]
12:14:36 Get:117 ... libwebrtc-audio-processing1 ...
...
12:17:25 Get:130 ... libwebkit2gtk-4.1-0 amd64 ... [27.3 MB]   <- job killed at 12:21
```

`apt-get update` succeeded fine. The install crept through 130 small packages and died inside the 27 MB WebKitGTK library.

Only `Linux build + test` is affected, because it is the one job that installs the whole WebKitGTK set. The jobs asking for four packages finished in three minutes on the same runner.

## The fix

Split the install in two:

- **Fetch** runs as `apt-get install --download-only` inside the same bounded retry loop. Safe to interrupt: apt keeps each completed `.deb` in `/var/cache/apt/archives`, so a retry resumes with only what is still missing rather than starting the set over.
- **Unpack** then runs unbounded against that local cache. It is fast and offline at that point, and a SIGTERM landing inside dpkg is the one interruption that leaves a half-configured system needing `dpkg --configure -a`.

Downloads get a 300s per-attempt budget instead of the index refresh's 120s, so the step caps at 15 minutes rather than eating the job.

## Testing

- [x] `bash -n scripts/ci-apt-install.sh` passes
- [x] Retry logic exercised against a stub `apt-get`: a download that stalls twice then succeeds retries and exits 0; a download that always stalls gives up after 3 attempts and exits 1 without running the unpack
- [x] The real effect is only visible on a CI runner, so this PR's own `Linux build + test` job is the live check

## Notes

No application code. CI script only.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bound and retry apt package downloads in CI install script
> - Adds a `run_apt` wrapper in [ci-apt-install.sh](https://github.com/tsouth89/toolport/pull/816/files#diff-dae0e31f1a90bcc93baa772ee932b0a5181249dfd919099d03125b96a171a5c8) that runs `apt-get` under `timeout` with a per-phase wall-clock budget and a `--kill-after` window to send SIGKILL if SIGTERM is ignored.
> - Splits the install flow into three phases: a bounded `apt-get update` loop, a bounded `apt-get install --download-only` loop (up to 3 retries, refreshing indices before each retry), and a final `apt-get install --no-download` that installs strictly from the local cache with no network access.
> - Writes an apt config file under `/etc/apt/apt.conf.d` to set HTTP(S) inactivity timeouts and retry counts, enabling mirror failover within a single attempt.
> - Behavioral Change: missing or undownloadable packages now cause a fast failure instead of a partial install or hang; the final install phase has no timeout, so a slow dpkg unpack will not be killed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 769293f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->