### PR TITLE
fix(catalog): surface stack loading failures

### DIFF
--- a/src/components/CatalogView.stacks.test.tsx
+++ b/src/components/CatalogView.stacks.test.tsx
@@ -1,0 +1,104 @@
+import { act, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { addServer, listStacks, popularCatalog, searchCatalog } from "@/lib/api";
+import type { CatalogEntry, Registry, Stack } from "@/lib/types";
+import { CatalogView } from "./CatalogView";
+
+vi.mock("@/lib/api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/api")>();
+  return {
+    ...actual,
+    addServer: vi.fn(),
+    listStacks: vi.fn(),
+    popularCatalog: vi.fn(),
+    searchCatalog: vi.fn(),
+  };
+});
+vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+vi.mock("@/lib/toast", () => ({ toastError: vi.fn() }));
+
+const entry: CatalogEntry = {
+  name: "GitHub",
+  description: "Work with repositories and issues.",
+  transport: "stdio",
+  command: "npx",
+  args: ["-y", "github-mcp"],
+  url: null,
+  envKeys: [],
+  source: "curated",
+  homepage: null,
+  category: "Code & infrastructure",
+};
+
+const stack: Stack = {
+  id: "developer",
+  name: "Developer",
+  description: "A developer stack.",
+  servers: [entry],
+};
+
+const registry: Registry = {
+  version: 1,
+  servers: [],
+  profiles: [],
+  activeProfileId: null,
+};
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(popularCatalog).mockResolvedValue([entry]);
+  vi.mocked(searchCatalog).mockResolvedValue([]);
+  vi.mocked(addServer).mockResolvedValue(registry);
+});
+
+describe("CatalogView stack loading", () => {
+  it("keeps the catalog visible and retries a failed stacks fetch", async () => {
+    vi.mocked(listStacks)
+      .mockRejectedValueOnce(new Error("registry unavailable"))
+      .mockResolvedValueOnce([stack]);
+    const user = userEvent.setup();
+
+    render(<CatalogView registry={registry} onAdded={vi.fn()} />);
+
+    expect(await screen.findByText("Stacks couldn't load")).toBeInTheDocument();
+    expect(screen.getByText("GitHub")).toBeInTheDocument();
+    expect(screen.queryByText("Catalog couldn't load")).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Try again" }));
+
+    expect(await screen.findByText("Developer")).toBeInTheDocument();
+    expect(screen.queryByText("Stacks couldn't load")).not.toBeInTheDocument();
+    expect(listStacks).toHaveBeenCalledTimes(2);
+  });
+
+  it("shows a skeleton while loading and stays quiet for an empty stack catalog", async () => {
+    const pending = deferred<Stack[]>();
+    vi.mocked(listStacks).mockReturnValueOnce(pending.promise);
+
+    render(<CatalogView registry={registry} onAdded={vi.fn()} />);
+
+    expect(
+      await screen.findByRole("status", { name: "Loading stacks" }),
+    ).toBeInTheDocument();
+
+    await act(async () => pending.resolve([]));
+
+    await waitFor(() =>
+      expect(
+        screen.queryByRole("status", { name: "Loading stacks" }),
+      ).not.toBeInTheDocument(),
+    );
+    expect(screen.queryByText("Stacks couldn't load")).not.toBeInTheDocument();
+    expect(screen.queryByRole("heading", { name: /^Stacks/ })).not.toBeInTheDocument();
+    expect(screen.getByText("GitHub")).toBeInTheDocument();
+  });
+});

--- a/src/components/CatalogView.stacks.test.tsx
+++ b/src/components/CatalogView.stacks.test.tsx
@@ -80,6 +80,35 @@ describe("CatalogView stack loading", () => {
     expect(listStacks).toHaveBeenCalledTimes(2);
   });
 
+  it("shows stacks when the popular catalog is empty", async () => {
+    vi.mocked(popularCatalog).mockResolvedValueOnce([]);
+    vi.mocked(listStacks).mockResolvedValueOnce([stack]);
+
+    render(<CatalogView registry={registry} onAdded={vi.fn()} />);
+
+    expect(await screen.findByText("Developer")).toBeInTheDocument();
+    expect(screen.getByText("No popular servers available")).toBeInTheDocument();
+  });
+
+  it("keeps stack failure and retry visible when the popular catalog is empty", async () => {
+    vi.mocked(popularCatalog).mockResolvedValueOnce([]);
+    vi.mocked(listStacks)
+      .mockRejectedValueOnce(new Error("registry unavailable"))
+      .mockResolvedValueOnce([stack]);
+    const user = userEvent.setup();
+
+    render(<CatalogView registry={registry} onAdded={vi.fn()} />);
+
+    expect(await screen.findByText("Stacks couldn't load")).toBeInTheDocument();
+    expect(screen.getByText("No popular servers available")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Try again" }));
+
+    expect(await screen.findByText("Developer")).toBeInTheDocument();
+    expect(screen.queryByText("Stacks couldn't load")).not.toBeInTheDocument();
+    expect(listStacks).toHaveBeenCalledTimes(2);
+  });
+
   it("shows a skeleton while loading and stays quiet for an empty stack catalog", async () => {
     const pending = deferred<Stack[]>();
     vi.mocked(listStacks).mockReturnValueOnce(pending.promise);

--- a/src/components/CatalogView.tsx
+++ b/src/components/CatalogView.tsx
@@ -249,6 +249,42 @@ export function CatalogView({ registry, onAdded }: Props) {
         )}
       </div>
 
+      {browsing &&
+        (stacksLoading ? (
+          <div
+            role="status"
+            aria-label="Loading stacks"
+            className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3"
+          >
+            {Array.from({ length: 3 }).map((_, i) => (
+              <Skeleton key={i} className="h-32 rounded-lg" />
+            ))}
+          </div>
+        ) : stacksError ? (
+          <div
+            role="status"
+            aria-live="polite"
+            className="flex items-center justify-between gap-3 rounded-lg border px-3 py-2.5"
+          >
+            <div>
+              <p className="text-sm font-medium">Stacks couldn't load</p>
+              <p className="text-xs text-muted-foreground">
+                Toolport couldn't load the one-click bundles. Try again in a moment.
+              </p>
+            </div>
+            <Button variant="outline" size="sm" onClick={reloadStacks}>
+              Try again
+            </Button>
+          </div>
+        ) : stacks.length > 0 ? (
+          <StacksSection
+            stacks={stacks}
+            haveNames={have}
+            busyId={stackBusy}
+            onSetup={setupStack}
+          />
+        ) : null)}
+
       {shown.length === 0 ? (
         browsing && popularLoading ? (
           <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
@@ -325,40 +361,6 @@ export function CatalogView({ registry, onAdded }: Props) {
         )
       ) : browsing ? (
         <div className="flex flex-col gap-6">
-          {stacksLoading ? (
-            <div
-              role="status"
-              aria-label="Loading stacks"
-              className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3"
-            >
-              {Array.from({ length: 3 }).map((_, i) => (
-                <Skeleton key={i} className="h-32 rounded-lg" />
-              ))}
-            </div>
-          ) : stacksError ? (
-            <div
-              role="status"
-              aria-live="polite"
-              className="flex items-center justify-between gap-3 rounded-lg border px-3 py-2.5"
-            >
-              <div>
-                <p className="text-sm font-medium">Stacks couldn't load</p>
-                <p className="text-xs text-muted-foreground">
-                  Toolport couldn't load the one-click bundles. Try again in a moment.
-                </p>
-              </div>
-              <Button variant="outline" size="sm" onClick={reloadStacks}>
-                Try again
-              </Button>
-            </div>
-          ) : stacks.length > 0 ? (
-            <StacksSection
-              stacks={stacks}
-              haveNames={have}
-              busyId={stackBusy}
-              onSetup={setupStack}
-            />
-          ) : null}
           {byCategory.map(([cat, entries]) => (
             <section key={cat}>
               <h2 className="mb-2 flex items-center gap-2 text-xs font-medium tracking-wide text-muted-foreground uppercase">

--- a/src/components/CatalogView.tsx
+++ b/src/components/CatalogView.tsx
@@ -39,16 +39,25 @@ export function CatalogView({ registry, onAdded }: Props) {
   const [searchError, setSearchError] = useState(false);
   const [searchNonce, setSearchNonce] = useState(0);
   const [stacks, setStacks] = useState<Stack[]>([]);
+  const [stacksLoading, setStacksLoading] = useState(true);
+  const [stacksError, setStacksError] = useState(false);
   const [stackBusy, setStackBusy] = useState<string | null>(null);
   const [configEntry, setConfigEntry] = useState<CatalogEntry | null>(null);
 
   const have = new Set((registry?.servers ?? []).map((s) => s.name.toLowerCase()));
 
-  useEffect(() => {
+  const reloadStacks = useCallback(() => {
+    setStacksLoading(true);
+    setStacksError(false);
     listStacks()
       .then(setStacks)
-      .catch(() => {});
+      .catch(() => setStacksError(true))
+      .finally(() => setStacksLoading(false));
   }, []);
+
+  useEffect(() => {
+    reloadStacks();
+  }, [reloadStacks]);
 
   const reloadPopular = useCallback(() => {
     setPopularLoading(true);
@@ -316,14 +325,40 @@ export function CatalogView({ registry, onAdded }: Props) {
         )
       ) : browsing ? (
         <div className="flex flex-col gap-6">
-          {stacks.length > 0 && (
+          {stacksLoading ? (
+            <div
+              role="status"
+              aria-label="Loading stacks"
+              className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3"
+            >
+              {Array.from({ length: 3 }).map((_, i) => (
+                <Skeleton key={i} className="h-32 rounded-lg" />
+              ))}
+            </div>
+          ) : stacksError ? (
+            <div
+              role="status"
+              aria-live="polite"
+              className="flex items-center justify-between gap-3 rounded-lg border px-3 py-2.5"
+            >
+              <div>
+                <p className="text-sm font-medium">Stacks couldn't load</p>
+                <p className="text-xs text-muted-foreground">
+                  Toolport couldn't load the one-click bundles. Try again in a moment.
+                </p>
+              </div>
+              <Button variant="outline" size="sm" onClick={reloadStacks}>
+                Try again
+              </Button>
+            </div>
+          ) : stacks.length > 0 ? (
             <StacksSection
               stacks={stacks}
               haveNames={have}
               busyId={stackBusy}
               onSetup={setupStack}
             />
-          )}
+          ) : null}
           {byCategory.map(([cat, entries]) => (
             <section key={cat}>
               <h2 className="mb-2 flex items-center gap-2 text-xs font-medium tracking-wide text-muted-foreground uppercase">

--- a/src/components/Onboarding.stacks.test.tsx
+++ b/src/components/Onboarding.stacks.test.tsx
@@ -1,0 +1,97 @@
+import { act, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { listStacks } from "@/lib/api";
+import type { Registry, Stack } from "@/lib/types";
+import { Onboarding } from "./Onboarding";
+
+vi.mock("@/lib/api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/api")>();
+  return {
+    ...actual,
+    listStacks: vi.fn(),
+  };
+});
+vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+vi.mock("@/lib/toast", () => ({ toastError: vi.fn() }));
+vi.mock("@/components/ClientLogo", () => ({ ClientLogo: () => null }));
+
+const registry: Registry = {
+  version: 1,
+  servers: [],
+  profiles: [{ id: "default", name: "Default", enabledServerIds: [] }],
+  activeProfileId: "default",
+};
+
+const stack: Stack = {
+  id: "developer",
+  name: "Developer",
+  description: "A developer stack.",
+  servers: [],
+};
+
+const props = {
+  initialStep: 1,
+  clients: [],
+  registry,
+  onRegistryChange: vi.fn(),
+  onClientsRefresh: vi.fn(),
+  onBrowseCatalog: vi.fn(),
+  onProbe: vi.fn().mockResolvedValue([]),
+  onOpenPlayground: vi.fn(),
+  onOpenRules: vi.fn(),
+  onFinish: vi.fn(),
+};
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("Onboarding stack loading", () => {
+  it("keeps onboarding usable and retries a failed stacks fetch", async () => {
+    vi.mocked(listStacks)
+      .mockRejectedValueOnce(new Error("registry unavailable"))
+      .mockResolvedValueOnce([stack]);
+    const user = userEvent.setup();
+
+    render(<Onboarding {...props} />);
+
+    expect(await screen.findByText("Starter stacks couldn't load")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Browse the full catalog" })).toBeEnabled();
+    expect(screen.getByRole("button", { name: "I'll add servers later" })).toBeEnabled();
+
+    await user.click(screen.getByRole("button", { name: "Try again" }));
+
+    expect(await screen.findByRole("button", { name: "Developer" })).toBeInTheDocument();
+    expect(screen.queryByText("Starter stacks couldn't load")).not.toBeInTheDocument();
+    expect(listStacks).toHaveBeenCalledTimes(2);
+  });
+
+  it("shows a skeleton while loading and stays quiet for an empty stack catalog", async () => {
+    const pending = deferred<Stack[]>();
+    vi.mocked(listStacks).mockReturnValueOnce(pending.promise);
+
+    render(<Onboarding {...props} />);
+
+    expect(
+      screen.getByRole("status", { name: "Loading starter stacks" }),
+    ).toBeInTheDocument();
+
+    await act(async () => pending.resolve([]));
+
+    await waitFor(() =>
+      expect(
+        screen.queryByRole("status", { name: "Loading starter stacks" }),
+      ).not.toBeInTheDocument(),
+    );
+    expect(screen.queryByText("Starter stacks couldn't load")).not.toBeInTheDocument();
+    expect(screen.queryByText("What do you work on?")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Browse the full catalog" })).toBeEnabled();
+  });
+});

--- a/src/components/Onboarding.tsx
+++ b/src/components/Onboarding.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import {
   ArrowLeft,
   ArrowRight,
@@ -47,6 +47,7 @@ import { openExternal } from "@/lib/openUrl";
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
 import { ImportReviewDialog } from "@/components/ImportReviewDialog";
+import { Skeleton } from "@/components/ui/skeleton";
 
 interface Props {
   /** Step to open at (0 = Welcome). Used to resume mid-flow. */
@@ -568,16 +569,25 @@ function AddServers({
   const [importPreview, setImportPreview] = useState<ImportItem[] | null>(null);
   const [imported, setImported] = useState<number | null>(null);
   const [stacks, setStacks] = useState<Stack[]>([]);
+  const [stacksLoading, setStacksLoading] = useState(true);
+  const [stacksError, setStacksError] = useState(false);
   const [selected, setSelected] = useState<string | null>(null);
   const [applying, setApplying] = useState(false);
   // True once the user has added a stack or imported, so "Next" replaces "later".
   const [touched, setTouched] = useState(false);
 
-  useEffect(() => {
+  const reloadStacks = useCallback(() => {
+    setStacksLoading(true);
+    setStacksError(false);
     listStacks()
       .then(setStacks)
-      .catch(() => {});
+      .catch(() => setStacksError(true))
+      .finally(() => setStacksLoading(false));
   }, []);
+
+  useEffect(() => {
+    reloadStacks();
+  }, [reloadStacks]);
 
   const have = new Set(registry.servers.map((s) => s.name.toLowerCase()));
   const stack = stacks.find((s) => s.id === selected) ?? null;
@@ -657,7 +667,33 @@ function AddServers({
 
       <div className="flex flex-col gap-3">
         {/* Role picker: each stack is a use case / role. */}
-        {stacks.length > 0 && (
+        {stacksLoading ? (
+          <div
+            role="status"
+            aria-label="Loading starter stacks"
+            className="flex flex-wrap gap-1.5"
+          >
+            {Array.from({ length: 3 }).map((_, i) => (
+              <Skeleton key={i} className="h-7 w-24 rounded-full" />
+            ))}
+          </div>
+        ) : stacksError ? (
+          <div
+            role="status"
+            aria-live="polite"
+            className="flex items-center justify-between gap-3 rounded-md border px-3 py-2.5"
+          >
+            <div>
+              <p className="text-sm font-medium">Starter stacks couldn't load</p>
+              <p className="text-xs text-muted-foreground">
+                Try again to see role-based recommendations.
+              </p>
+            </div>
+            <Button variant="outline" size="sm" onClick={reloadStacks}>
+              Try again
+            </Button>
+          </div>
+        ) : stacks.length > 0 ? (
           <div className="flex flex-col gap-1.5">
             <span className="text-xs text-muted-foreground">What do you work on?</span>
             <div className="flex flex-wrap gap-1.5">
@@ -678,7 +714,7 @@ function AddServers({
               ))}
             </div>
           </div>
-        )}
+        ) : null}
 
         {/* The recommended stack for the chosen role. */}
         {stack && (


### PR DESCRIPTION
## What and why

Closes #732.

Distinguish loading, empty, and failed stack fetches in Catalog and Onboarding. Failed requests now show a small inline retry state without hiding the rest of either screen.

## Testing

- [x] `npm run build` passes
- [x] `npm run test` passes
- [x] `npm run audit:prod` passes
- [ ] `npm run test:rust` — not applicable; frontend-only
- [ ] Ran the app manually

Also ran `npm run format:check`, `npm run lint`, and focused stack-loading tests.

## Notes

No secrets, credentials, or personal paths are included.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Surface stack loading failures with skeleton and retry UI in catalog and onboarding
> - [`CatalogView`](https://github.com/tsouth89/toolport/pull/817/files#diff-0a454832c4541c744bf77a9abc15ab8285466c137194af246ae4a074dbc58361) and the [`AddServers`](https://github.com/tsouth89/toolport/pull/817/files#diff-fc54b08f00cdfbc30c47be583682bf85cb2526c7989027425af76d69134e9ae8) onboarding step both previously swallowed `listStacks` errors silently; they now track loading and error state explicitly.
> - While stacks are loading, a skeleton placeholder is shown (`role='status'`); on failure, an inline error message and a 'Try again' button are rendered, wired to a `reloadStacks` callback.
> - Tests covering these states (loading skeleton, error + retry, empty catalog) are added in [`CatalogView.stacks.test.tsx`](https://github.com/tsouth89/toolport/pull/817/files#diff-73e3e764be9e88884ffe30905d61f329f0602134d6723dbd44aa6de9746739b4) and [`Onboarding.stacks.test.tsx`](https://github.com/tsouth89/toolport/pull/817/files#diff-96dc295042396ffd1c67d5007f16e60de6006c3f3d19152008e2e195620b8b55).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6541e8a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->