### PR TITLE
review-only: CodeRev pass on #818's round-4 fixes (do not merge)

### DIFF
--- a/.github/workflows/aur.yml
+++ b/.github/workflows/aur.yml
@@ -209,12 +209,21 @@ jobs:
           # `paru -S toolport-bin` would start handing out the older release while
           # already-upgraded machines stay put. Read what is there and refuse to
           # go backwards.
-          new_version="${TAG#v}"
-          existing=$(sed -n 's/^pkgver=//p' aur-repo/PKGBUILD 2>/dev/null | head -1)
-          if [ -n "$existing" ] && [ "$existing" != "$new_version" ]; then
-            newest=$(printf '%s\n%s\n' "$existing" "$new_version" | sort -V | tail -1)
-            if [ "$newest" != "$new_version" ]; then
-              echo "::notice::The AUR carries $existing, which is newer than $new_version. Not downgrading."
+          #
+          # Compare pkgver-pkgrel, not pkgver. pkgrel is the other half of what
+          # pacman orders by, and the documented retry - dispatch the same tag
+          # again - defaults pkgrel back to 1. Against an AUR already carrying
+          # 1.15.0-2 from a PKGBUILD fix, a pkgver-only comparison finds them
+          # equal, skips the guard, and pushes 1.15.0-1 over it: machines on -2
+          # never upgrade and new installs get the older revision.
+          new_full="${TAG#v}-${AUR_PKGREL}"
+          existing_ver=$(sed -n 's/^pkgver=//p' aur-repo/PKGBUILD 2>/dev/null | head -1)
+          existing_rel=$(sed -n 's/^pkgrel=//p' aur-repo/PKGBUILD 2>/dev/null | head -1)
+          if [ -n "$existing_ver" ]; then
+            existing_full="$existing_ver-${existing_rel:-1}"
+            newest=$(printf '%s\n%s\n' "$existing_full" "$new_full" | sort -V | tail -1)
+            if [ "$existing_full" != "$new_full" ] && [ "$newest" != "$new_full" ]; then
+              echo "::notice::The AUR carries $existing_full, which is newer than $new_full. Not downgrading."
               exit 0
             fi
           fi
@@ -224,11 +233,11 @@ jobs:
           git config user.name "toolport release"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           if [ -z "$(git status --porcelain)" ]; then
-            echo "The AUR already carries $new_version at this pkgrel; nothing to push."
+            echo "The AUR already carries $new_full; nothing to push."
             exit 0
           fi
           git add PKGBUILD .SRCINFO
-          git commit -m "toolport-bin $new_version-$AUR_PKGREL"
+          git commit -m "toolport-bin $new_full"
           git push origin HEAD:master
 
       - name: Say why nothing was published

--- a/scripts/install.Tests.bash
+++ b/scripts/install.Tests.bash
@@ -92,6 +92,38 @@ case "$1" in
 esac
 EOF
   chmod +x "$shim_dir/uname"
+
+  # Shadow pacman and every AUR helper install.sh knows about.
+  #
+  # Without this, running these tests on an Arch or Manjaro box finds the REAL
+  # pacman and the REAL paru/yay/pamac on PATH, and the Arch branch then builds
+  # and sudo-installs toolport-bin from the actual AUR in the middle of a unit
+  # test. Ubuntu CI never runs this file, so that hole only ever opens on the
+  # maintainer's own machine, which is the worst place for it.
+  #
+  # `pacman` exists so the Arch branch is entered on every platform, making the
+  # coverage below deterministic instead of dependent on the host distro. Each
+  # helper records its argv and its stdin, then fails - unless it is named in
+  # TOOLPORT_TEST_AUR_HELPER, which is how the success path is exercised.
+  cat > "$shim_dir/pacman" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+  chmod +x "$shim_dir/pacman"
+  local helper
+  for helper in paru yay pamac pikaur trizen omarchy; do
+    cat > "$shim_dir/$helper" <<EOF
+#!/usr/bin/env bash
+me=\$(basename "\$0")
+printf '%s %s\n' "\$me" "\$*" >> "$shim_dir/helper-argv.log"
+# Whatever this reads from stdin is what a real helper's prompt would have
+# swallowed. install.sh must hand it /dev/null, so this must stay empty.
+cat >> "$shim_dir/helper-stdin.log"
+[ "\${TOOLPORT_TEST_AUR_HELPER:-}" = "\$me" ] && exit 0
+exit 1
+EOF
+    chmod +x "$shim_dir/$helper"
+  done
 }
 
 # run_install <release-json> [ENV=value ...] -> prints "<rc>\t<output>"
@@ -202,6 +234,49 @@ else
 fi
 echo "    output: $(printf '%s' "$curl_fail_output" | tr '\n' ' ' | cut -c1-150)"
 rm -rf "$workdir"
+
+echo "Arch: the AUR helper loop"
+arch_workdir="$(mktemp -d)"
+arch_shim="$arch_workdir/shim"; arch_home="$arch_workdir/home"; arch_bin="$arch_workdir/bin"
+mkdir -p "$arch_home" "$arch_bin"
+make_shim "$arch_shim" "$(fake_release "sha256:$fake_sha256" 64)"
+set +e
+arch_output="$(cd "$arch_workdir" && PATH="$arch_shim:$PATH" HOME="$arch_home" XDG_BIN_HOME="$arch_bin"   TOOLPORT_TEST_AUR_HELPER=yay bash "$INSTALL_SH" 2>&1)"
+arch_rc=$?
+set -e
+arch_argv="$(cat "$arch_shim/helper-argv.log" 2>/dev/null || true)"
+
+check "installs through the AUR helper" "Launch Toolport from your app menu" "$arch_output"
+if [ "$arch_rc" = "0" ]; then
+  echo "  ok: exit code 0"; pass=$((pass + 1))
+else
+  echo "  FAIL: exit code $arch_rc (wanted 0)"; fail=$((fail + 1))
+fi
+# A failing first helper must not end the loop, or a working second one never runs.
+check "tries paru before yay" "paru -S" "$arch_argv"
+check "falls through to yay after paru fails" "yay -S" "$arch_argv"
+# pacman's --noconfirm does not cover a helper's own PKGBUILD review prompt.
+check "passes paru --skipreview" "--skipreview" "$arch_argv"
+check "passes yay's answer flags" "--answerdiff None" "$arch_argv"
+# The AUR path succeeded, so the AppImage must not also have been installed.
+if [ ! -e "$arch_bin/toolport" ]; then
+  echo "  ok: no AppImage installed once the helper succeeded"; pass=$((pass + 1))
+else
+  echo "  FAIL: AppImage installed even though the AUR helper succeeded"; fail=$((fail + 1))
+fi
+# The documented entry point is `curl ... | bash`, so stdin is the script itself.
+# A helper that prompts would eat the rest of it; install.sh hands it /dev/null.
+if [ ! -s "$arch_shim/helper-stdin.log" ]; then
+  echo "  ok: no helper read from the installer's stdin"; pass=$((pass + 1))
+else
+  echo "  FAIL: a helper consumed stdin: $(head -c 80 "$arch_shim/helper-stdin.log")"; fail=$((fail + 1))
+fi
+echo "    argv: $(printf '%s' "$arch_argv" | tr '
+' ' ' | cut -c1-160)"
+rm -rf "$arch_workdir"
+
+echo "Arch: every helper failing still installs something"
+run_check "falls back to the AppImage" "Installed the AppImage" 0 "$(fake_release "sha256:$fake_sha256" 64)"
 
 echo
 echo "$pass passed, $fail failed"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -236,11 +236,16 @@ install_linux() {
   #     the belt to the flags' braces: a helper we do not know about still cannot
   #     consume the script, it just fails and we move on.
   if command -v pacman >/dev/null 2>&1; then
-    for helper in paru yay pikaur trizen omarchy; do
+    for helper in paru yay pamac pikaur trizen omarchy; do
       command -v "$helper" >/dev/null 2>&1 || continue
       case "$helper" in
         paru) helper_args=(-S --needed --noconfirm --skipreview toolport-bin) ;;
         yay) helper_args=(-S --needed --noconfirm --answerdiff None --answerclean None --answeredit None toolport-bin) ;;
+        # Manjaro's default, and usually the ONLY helper a stock Manjaro has:
+        # without this the distro the README names would skip every branch here
+        # and land on the AppImage. `build` is the AUR verb; `install` is repos
+        # only.
+        pamac) helper_args=(build --no-confirm toolport-bin) ;;
         # Omarchy's wrapper around the AUR; it drives a helper underneath.
         omarchy) helper_args=(pkg aur add toolport-bin) ;;
         *) helper_args=(-S --needed --noconfirm toolport-bin) ;;
@@ -254,6 +259,7 @@ install_linux() {
     done
     say "The native Arch package is the reliable one. Once it is on the AUR:"
     say "    paru -S toolport-bin      # or: yay -S toolport-bin"
+    say "    pamac build toolport-bin  # Manjaro"
     say "    omarchy pkg aur add toolport-bin"
     say "Until then you can build the same package from source:"
     say "    git clone https://github.com/tsouth89/toolport && cd toolport"

--- a/src/test/linux-packaging.test.ts
+++ b/src/test/linux-packaging.test.ts
@@ -258,19 +258,28 @@ describe("the AUR package ships to Arch", () => {
     // version, so a workflow_dispatch catch-up for an old tag could overwrite a
     // newer AUR package and start handing out the older release.
     const push = byName("Publish to the AUR")!;
-    const start = push.run!.indexOf('new_version="${TAG#v}"');
+    const start = push.run!.indexOf('new_full="${TAG#v}-${AUR_PKGREL}"');
     const end = push.run!.indexOf("cp aur/PKGBUILD");
     expect(start, "no downgrade guard").toBeGreaterThan(-1);
     const guard = push.run!.slice(start, end);
 
-    const run = (onAur: string, tag: string) => {
+    // onAur / pushing are "<pkgver>-<pkgrel>", the pair pacman actually orders by.
+    const run = (onAur: string, pushing: string) => {
       const dir = mkdtempSync(join(tmpdir(), "toolport-aurver-"));
+      const [haveVer, haveRel] = onAur.split("-");
+      const [wantVer, wantRel] = pushing.split("-");
       try {
         mkdirSync(join(dir, "aur-repo"));
-        writeFileSync(join(dir, "aur-repo", "PKGBUILD"), `pkgver=${onAur}\n`);
+        writeFileSync(
+          join(dir, "aur-repo", "PKGBUILD"),
+          `pkgver=${haveVer}\npkgrel=${haveRel}\n`,
+        );
         return execFileSync(
           "bash",
-          ["-c", `cd ${JSON.stringify(dir)}\nTAG=v${tag}\n${guard}\necho PROCEEDED`],
+          [
+            "-c",
+            `cd ${JSON.stringify(dir)}\nTAG=v${wantVer}\nAUR_PKGREL=${wantRel}\n${guard}\necho PROCEEDED`,
+          ],
           { encoding: "utf8" },
         );
       } finally {
@@ -278,12 +287,18 @@ describe("the AUR package ships to Arch", () => {
       }
     };
 
-    expect(run("1.16.0", "1.15.0")).toContain("Not downgrading");
-    expect(run("1.16.0", "1.15.0")).not.toContain("PROCEEDED");
-    expect(run("1.14.0", "1.15.0")).toContain("PROCEEDED");
-    expect(run("1.15.0", "1.15.0")).toContain("PROCEEDED"); // same version, new pkgrel
+    expect(run("1.16.0-1", "1.15.0-1")).toContain("Not downgrading");
+    expect(run("1.16.0-1", "1.15.0-1")).not.toContain("PROCEEDED");
+    // pkgrel is the other half of the ordering. Re-dispatching the same tag
+    // defaults pkgrel back to 1, so a pkgver-only guard would push 1.15.0-1
+    // over a 1.15.0-2 that fixed the PKGBUILD, and nobody on -2 would upgrade.
+    expect(run("1.15.0-2", "1.15.0-1")).toContain("Not downgrading");
+    expect(run("1.15.0-2", "1.15.0-1")).not.toContain("PROCEEDED");
+    expect(run("1.15.0-1", "1.15.0-2")).toContain("PROCEEDED");
+    expect(run("1.14.0-1", "1.15.0-1")).toContain("PROCEEDED");
+    expect(run("1.15.0-1", "1.15.0-1")).toContain("PROCEEDED"); // identical, porcelain skips
     // Not lexical: 1.9.0 must not read as newer than 1.10.0.
-    expect(run("1.9.0", "1.10.0")).toContain("PROCEEDED");
+    expect(run("1.9.0-1", "1.10.0-1")).toContain("PROCEEDED");
   });
 
   it("can bump pkgrel so a same-version PKGBUILD fix actually upgrades", () => {
@@ -374,5 +389,24 @@ describe("install.sh routes Arch users without hanging or eating itself", () => 
 
   it("tries Omarchy's wrapper, which the docs tell those users to run", () => {
     expect(installer).toContain("omarchy) helper_args=(pkg aur add toolport-bin)");
+  });
+
+  it("tries pamac, which is all a stock Manjaro has", () => {
+    // The README names Manjaro. A default Manjaro ships pamac and usually none
+    // of paru/yay, so without this the named distro skips every branch and
+    // lands on the AppImage this whole change exists to avoid there.
+    expect(installer).toContain("pamac) helper_args=(build --no-confirm toolport-bin)");
+    expect(installer).toMatch(/^ *for helper in [a-z ]*\bpamac\b/m);
+  });
+
+  it("cannot reach a real AUR helper from the bash installer tests", () => {
+    // These tests only shimmed curl and uname, so on an Arch or Manjaro box the
+    // Arch branch found the REAL pacman and paru and sudo-installed from the
+    // actual AUR mid-test. Ubuntu CI never runs this file, so that only ever
+    // fired on a maintainer's own machine.
+    const harness = read("scripts", "install.Tests.bash");
+    expect(harness).toContain('cat > "$shim_dir/pacman"');
+    expect(harness).toMatch(/for helper in paru yay pamac pikaur trizen omarchy/);
+    expect(harness).toContain("helper-stdin.log");
   });
 });


### PR DESCRIPTION
**Review-only. Do not merge — this is already on `main`.**

`965a214` landed in #818 without a machine review: CodeRev skipped its round 5 on the 4-round budget, and rounds 3 and 4 had each found something real, so that is a genuine gap rather than a formality.

This PR exists purely to give CodeRev that one commit as a fresh round-1 diff before `v1.15.0` is tagged. Base is `81894d2` (the commit before it), head is `965a214`. Both branches are throwaway and get deleted once the review lands.

What is under review — the four round-4 findings from #818:

- the AUR downgrade guard now compares `pkgver-pkgrel` instead of `pkgver`, so re-dispatching a tag at the default `pkgrel=1` cannot overwrite a `-2` that fixed the PKGBUILD;
- `pamac` added to the AUR helper loop, which is what a stock Manjaro actually has;
- `scripts/install.Tests.bash` now shadows `pacman` and all six helpers, so the tests cannot sudo-install from the live AUR on an Arch machine;
- eight new assertions over the helper loop, including that no helper reads the installer's own stdin.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Harden AUR publish downgrade guard to compare `pkgver-pkgrel` and add `pamac` helper support
> - The `aur.yml` publish step now parses both `pkgver` and `pkgrel` from the AUR PKGBUILD and compares the full `pkgver-pkgrel` string via `sort -V`, refusing to push when the AUR carries a newer full version
> - [install.sh](https://github.com/tsouth89/toolport/pull/820/files#diff-e076e43cb817ecc8b3c2ed18cd58baa50544ecc66293ed6e61129c43ca6a09cc) adds `pamac` to the Arch helper iteration list with `build --no-confirm toolport-bin`, and user guidance now mentions pamac for Manjaro users
> - [install.Tests.bash](https://github.com/tsouth89/toolport/pull/820/files#diff-35d1dc19cfc5e3d1ba1a06854b952e09075cb3cea4e3ed57e1b122a1cb6b28e1) adds shims for `pacman` and all AUR helpers so tests never reach the real system; helper shims log argv/stdin and succeed only when `TOOLPORT_TEST_AUR_HELPER` matches
> - New tests in both the bash harness and [linux-packaging.test.ts](https://github.com/tsouth89/toolport/pull/820/files#diff-30e0243268363659e9df40085a2db24ca84ed7f2a00f0875943b173a4c66df03) cover the full-version downgrade guard, pamac inclusion, helper fallthrough ordering, stdin handling, and AppImage fallback
> - Risk: the downgrade guard now treats a higher `pkgrel` as a newer version; any manual PKGBUILD pushed with only a `pkgver` bump but lower `pkgrel` than the AUR will be blocked
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 965a214.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->