### PR TITLE
test(install): make the stdin assertion able to fail

### DIFF
--- a/scripts/install.Tests.bash
+++ b/scripts/install.Tests.bash
@@ -137,7 +137,11 @@ run_install() {
   make_shim "$shim" "$release_json"
   local output rc
   set +e
-  output="$(cd "$workdir" && PATH="$shim:$PATH" HOME="$home" XDG_BIN_HOME="$bindir" env "$@" bash "$INSTALL_SH" 2>&1)"
+  # </dev/null, not inherited stdin: the helper shims read stdin to prove
+  # install.sh never lets them, and an inherited terminal would block them
+  # forever. Only the Arch test below pipes anything, which is what makes its
+  # stdin assertion falsifiable while these stay deterministic.
+  output="$(cd "$workdir" && PATH="$shim:$PATH" HOME="$home" XDG_BIN_HOME="$bindir" env "$@" bash "$INSTALL_SH" </dev/null 2>&1)"
   rc=$?
   set -e
   printf '%s\t%s' "$rc" "$output"
@@ -187,7 +191,7 @@ mkdir -p "$home" "$bindir"
 printf 'existing working install' > "$bindir/toolport"
 make_shim "$shim" "$(fake_release "sha256:$(printf '0%.0s' $(seq 1 64))" 64)"
 set +e
-mismatch_output="$(cd "$workdir" && PATH="$shim:$PATH" HOME="$home" XDG_BIN_HOME="$bindir" bash "$INSTALL_SH" 2>&1)"
+mismatch_output="$(cd "$workdir" && PATH="$shim:$PATH" HOME="$home" XDG_BIN_HOME="$bindir" bash "$INSTALL_SH" </dev/null 2>&1)"
 mismatch_rc=$?
 set -e
 if [ "$mismatch_rc" = "1" ] && [ "$(cat "$bindir/toolport")" = "existing working install" ]; then
@@ -218,7 +222,7 @@ shim="$workdir/shim"; home="$workdir/home"; bindir="$workdir/bin"
 mkdir -p "$home" "$bindir"
 make_shim "$shim" "$(fake_release "sha256:$fake_sha256" 64)"
 set +e
-curl_fail_output="$(cd "$workdir" && PATH="$shim:$PATH" HOME="$home" XDG_BIN_HOME="$bindir" TOOLPORT_TEST_CURL_FAIL=1 bash "$INSTALL_SH" 2>&1)"
+curl_fail_output="$(cd "$workdir" && PATH="$shim:$PATH" HOME="$home" XDG_BIN_HOME="$bindir" TOOLPORT_TEST_CURL_FAIL=1 bash "$INSTALL_SH" </dev/null 2>&1)"
 curl_fail_rc=$?
 set -e
 check "reports the download failure" "Download failed" "$curl_fail_output"
@@ -240,8 +244,14 @@ arch_workdir="$(mktemp -d)"
 arch_shim="$arch_workdir/shim"; arch_home="$arch_workdir/home"; arch_bin="$arch_workdir/bin"
 mkdir -p "$arch_home" "$arch_bin"
 make_shim "$arch_shim" "$(fake_release "sha256:$fake_sha256" 64)"
+# Feed the script on stdin, the way `curl ... | bash` does. Without this the
+# stdin assertion below is unfalsifiable: run with a file argument and no pipe,
+# a helper's `cat` reads 0 bytes whether or not install.sh redirects, so the
+# check passes on a script that forgot to.
+arch_stdin_sentinel="TOOLPORT_TEST_STDIN_MUST_NOT_BE_READ"
 set +e
-arch_output="$(cd "$arch_workdir" && PATH="$arch_shim:$PATH" HOME="$arch_home" XDG_BIN_HOME="$arch_bin"   TOOLPORT_TEST_AUR_HELPER=yay bash "$INSTALL_SH" 2>&1)"
+arch_output="$(cd "$arch_workdir" && printf '%s
+' "$arch_stdin_sentinel"   | PATH="$arch_shim:$PATH" HOME="$arch_home" XDG_BIN_HOME="$arch_bin"     TOOLPORT_TEST_AUR_HELPER=yay bash "$INSTALL_SH" 2>&1)"
 arch_rc=$?
 set -e
 arch_argv="$(cat "$arch_shim/helper-argv.log" 2>/dev/null || true)"
@@ -266,10 +276,11 @@ else
 fi
 # The documented entry point is `curl ... | bash`, so stdin is the script itself.
 # A helper that prompts would eat the rest of it; install.sh hands it /dev/null.
-if [ ! -s "$arch_shim/helper-stdin.log" ]; then
-  echo "  ok: no helper read from the installer's stdin"; pass=$((pass + 1))
+arch_stdin_seen="$(cat "$arch_shim/helper-stdin.log" 2>/dev/null || true)"
+if [ -z "$arch_stdin_seen" ]; then
+  echo "  ok: no helper read from the installer's piped stdin"; pass=$((pass + 1))
 else
-  echo "  FAIL: a helper consumed stdin: $(head -c 80 "$arch_shim/helper-stdin.log")"; fail=$((fail + 1))
+  echo "  FAIL: a helper consumed stdin: $(printf '%s' "$arch_stdin_seen" | head -c 80)"; fail=$((fail + 1))
 fi
 echo "    argv: $(printf '%s' "$arch_argv" | tr '
 ' ' ' | cut -c1-160)"


### PR DESCRIPTION
Closes the one finding from the [#820](https://github.com/tsouth89/toolport/pull/820) review-only pass over #818's round-4 commit.

**The new stdin assertion could not fail.** The Arch test ran `bash "$INSTALL_SH"` with a file argument and no pipe, so the helper shims' `cat` read 0 bytes whether or not `install.sh` redirected. `if [ ! -s helper-stdin.log ]` passed either way. It asserted nothing.

The test now pipes a sentinel, the way `curl ... | bash` does — which is the entry point the redirect exists for at all. Drop `</dev/null` from `install.sh` and it fails with the sentinel quoted back:

```
FAIL: a helper consumed stdin: TOOLPORT_TEST_STDIN_MUST_NOT_BE_READ
29 passed, 1 failed
```

**Proving that turned up a second problem.** With the redirect gone, the three tests that ran `install.sh` on inherited stdin did not fail — they **hung**. The helper shim's `cat` sat on the harness's own stdin forever, and the suite stalled at "digest mismatch (working install preserved)" before ever reaching the assertion that would have named the bug.

That hang *is* the real user-facing failure mode, which is the point of the fix. But as a test signal it is strictly worse than a failure: it stalls the run and tells you nothing. Those three invocations now pass `</dev/null` explicitly, so exactly one test is sensitive to the redirect and it reports instead of blocking.

Test-only; `scripts/install.sh` is untouched. 30 assertions pass, and the one that matters now goes red under mutation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make stdin-consumption assertion in `install.Tests.bash` falsifiable
> - `run_install` and direct `install.sh` invocations now redirect stdin from `/dev/null`, preventing inherited terminal stdin from making test runs nondeterministic.
> - The Arch test pipes a sentinel line into `install.sh` instead of invoking it directly, so any helper that reads stdin captures known content.
> - The assertion now checks whether `helper-stdin.log` is empty rather than checking file size, and prints up to 80 bytes of any captured content on failure.
> - Behavioral Change: the Arch test will now fail if helper shims consume piped stdin; previously the assertion could not detect this.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 147e4de.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->