### PR TITLE
docs(changelog): credit the 1.15.0 contributors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,13 @@ makepkg -si` builds the identical package with no AUR account). The AppImage
 
 ### Fixed
 
+- **Stopping the HTTP bridge no longer reports a false success.** When the child
+  process survived the stop, the app cleared the handle, port and bearer token
+  anyway, so the bridge read as stopped while it was still listening and nothing
+  was left to retry with. The stop failure is reported, and the state is kept
+  when the child is still running so a later stop can finish the job.
+  (#736, thanks @YuukiRitoTeng)
+
 - **The gateway no longer speaks on stdout before the client has handshaked.**
   MCP forbids a server sending anything before the client's
   `notifications/initialized`, and the gateway builds its catalog on a
@@ -200,6 +207,9 @@ makepkg -si` builds the identical package with no AUR account). The AppImage
 
 ### Internal
 
+- **Dead `McpSession::upstream_call` shim removed.** Nothing called it.
+  (#805, thanks @forever-ivy)
+
 - **CI apt installs are bounded and retried instead of hanging.** `apt-get
 update` on the hosted runners intermittently stops responding rather than
   failing, which burned three jobs' entire timeouts on one pull request without
@@ -253,6 +263,21 @@ update` on the hosted runners intermittently stops responding rather than
   guess-sleeps, which a loaded runner can miss while behaving correctly; it now waits for a real
   signal that the slow call has parked and asserts the property it means - that the fast response
   came back while the slow one was still in flight.
+
+### Thanks
+
+Four of the patches in this release came from outside.
+
+- **[forever-ivy](https://github.com/forever-ivy)** - the stale connection-test
+  verdict, so a test whose connection details changed underneath it stops
+  reporting on the old ones (#814), and the removal of a dead
+  `McpSession::upstream_call` shim (#805).
+- **[YuukiRitoTeng](https://github.com/YuukiRitoTeng)** - stopping the HTTP bridge
+  now reports a failure instead of a false success, and keeps the child handle so
+  a later stop can retry (#788).
+- **[rohankumardubey](https://github.com/rohankumardubey)** - stack loading
+  failures surfaced in the catalog and in onboarding, instead of a failed fetch
+  rendering as "no stacks" with no way to retry (#817).
 
 ## [1.14.0] - 2026-08-16
 


### PR DESCRIPTION
Four patches in 1.15.0 came from outside and none were credited. Adds a `### Thanks` section in the same shape 1.14.0 uses.

Checking who to thank turned up that **two of the four had no changelog entry at all**:

- **#788 (@YuukiRitoTeng)** is a real user-facing fix that was simply missed. Stopping the HTTP bridge cleared the handle, port and bearer token even when the child process survived, so the bridge read as stopped while it was still listening and nothing was left to retry with. Now under Fixed.
- **#805 (@forever-ivy)** removed a dead `McpSession::upstream_call` shim. Under Internal, since nothing called it.

The draft release body has already been updated to match, using the same awk extraction `release.yml` uses.

## On the tag

`v1.15.0` is already cut, so the copy of `CHANGELOG.md` at that tag will not carry this — the "Full changelog" link in the release body points there. Re-cutting the tag would rebuild four platforms' binaries and replace the 13 assets already sitting on the draft, for a docs change. Not worth it. The release notes are what people read and those are correct; `main` is correct from here on.

Docs only. 618 tests, prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Document 1.15.0 fixes and credit contributors in `CHANGELOG.md`
> Adds a Fixed entry noting that stopping the HTTP bridge previously reported false success when the child process survived; the stop failure is now reported and the child handle is retained for retry. Adds an Internal entry for removing the dead `McpSession::upstream_call` shim. Appends a Thanks section crediting contributors for patches including the stale connection-test verdict update, HTTP bridge stop fix, and surfacing stack loading failures in the catalog and onboarding.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f5294c0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->