### PR TITLE
fix(servers): retry partial adds without duplicates

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1260,14 +1260,7 @@ function App() {
         <ServerDialog
           autoOpen
           onClose={() => setAddServerOpen(false)}
-          onSaved={(reg) => {
-            applyRegistryChange(reg);
-            // A successful save closes the dialog internally without going through
-            // onOpenChange, so `onClose` never fires and this stays mounted-but-open.
-            // Without clearing it here the next Ctrl+N is a silent no-op. Same pattern
-            // CatalogView already uses for its autoOpen dialog.
-            setAddServerOpen(false);
-          }}
+          onSaved={applyRegistryChange}
           existingNames={servers.map((s) => s.name)}
         />
       )}

--- a/src/components/CatalogView.tsx
+++ b/src/components/CatalogView.tsx
@@ -378,10 +378,7 @@ export function CatalogView({ registry, onAdded }: Props) {
       )}
       {configEntry && (
         <ServerDialog
-          onSaved={(reg) => {
-            onAdded(reg);
-            setConfigEntry(null);
-          }}
+          onSaved={onAdded}
           onClose={() => setConfigEntry(null)}
           initial={{
             id: "",

--- a/src/components/ServerDialog.autoopen.test.tsx
+++ b/src/components/ServerDialog.autoopen.test.tsx
@@ -16,29 +16,16 @@ vi.mock("sonner", () => ({
   toast: { success: vi.fn(), error: vi.fn(), warning: vi.fn(), message: vi.fn() },
 }));
 
-/**
- * A parent that opens ServerDialog the way a keyboard shortcut does: mount-on-demand
- * with `autoOpen`, unmount when it reports closed.
- *
- * The bug this pins (SBS-143 review): a successful save closes the dialog through its
- * own `setOpen(false)` rather than `onOpenChange`, so `onClose` never fires. A parent
- * that only clears its state in `onClose` stays stuck `true`, and the next press is a
- * silent no-op because nothing remounts to re-trigger `autoOpen`.
- */
-function ShortcutHost({ clearOnSaved }: { clearOnSaved: boolean }) {
+/** A parent that opens ServerDialog the way a keyboard shortcut does: mount-on-demand
+ * with `autoOpen`, and unmount when the dialog reports that it closed. */
+function ShortcutHost() {
   const [open, setOpen] = useState(false);
   return (
     <div>
       <button onClick={() => setOpen(true)}>shortcut</button>
       <span data-testid="mounted">{open ? "yes" : "no"}</span>
       {open && (
-        <ServerDialog
-          autoOpen
-          onClose={() => setOpen(false)}
-          onSaved={() => {
-            if (clearOnSaved) setOpen(false);
-          }}
-        />
+        <ServerDialog autoOpen onClose={() => setOpen(false)} onSaved={() => undefined} />
       )}
     </div>
   );
@@ -57,7 +44,7 @@ describe("ServerDialog opened by a shortcut (autoOpen)", () => {
 
   it("stays reopenable after a successful save", async () => {
     const user = userEvent.setup();
-    render(<ShortcutHost clearOnSaved />);
+    render(<ShortcutHost />);
 
     await user.click(screen.getByText("shortcut"));
     expect(screen.getByTestId("mounted")).toHaveTextContent("yes");
@@ -70,22 +57,9 @@ describe("ServerDialog opened by a shortcut (autoOpen)", () => {
     expect(screen.getByTestId("mounted")).toHaveTextContent("yes");
   });
 
-  it("regression: a parent that clears only in onClose gets stuck after saving", async () => {
-    // Documents WHY App.tsx clears in onSaved as well. If ServerDialog is ever changed
-    // to route save through onOpenChange, this test flips and can be deleted.
-    const user = userEvent.setup();
-    render(<ShortcutHost clearOnSaved={false} />);
-
-    await user.click(screen.getByText("shortcut"));
-    await saveAServer(user);
-
-    // Still mounted: onClose never fired, because save bypasses onOpenChange.
-    expect(screen.getByTestId("mounted")).toHaveTextContent("yes");
-  });
-
   it("cancelling does release the parent", async () => {
     const user = userEvent.setup();
-    render(<ShortcutHost clearOnSaved />);
+    render(<ShortcutHost />);
 
     await user.click(screen.getByText("shortcut"));
     await user.click(screen.getByRole("button", { name: /cancel/i }));

--- a/src/components/ServerDialog.test.tsx
+++ b/src/components/ServerDialog.test.tsx
@@ -1,7 +1,7 @@
 import { beforeEach, describe, it, expect, vi } from "vitest";
 import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import type { ProbeResult } from "@/lib/types";
+import type { ProbeResult, Registry } from "@/lib/types";
 
 const api = vi.hoisted(() => ({
   addServer: vi.fn(),
@@ -10,8 +10,14 @@ const api = vi.hoisted(() => ({
   testServer: vi.fn(),
   updateServer: vi.fn(),
 }));
+const toast = vi.hoisted(() => ({
+  success: vi.fn(),
+  warning: vi.fn(),
+}));
 
 vi.mock("@/lib/api", () => api);
+vi.mock("sonner", () => ({ toast }));
+vi.mock("@/lib/toast", () => ({ toastError: vi.fn() }));
 
 import { ServerDialog } from "./ServerDialog";
 
@@ -40,6 +46,30 @@ const failure: ProbeResult = {
   error: "The updated command could not connect.",
   authRequired: false,
 };
+
+function savedRegistry(id: string): Registry {
+  return {
+    version: 1,
+    servers: [
+      {
+        id,
+        name: "demo",
+        transport: "stdio",
+        command: "npx",
+        args: [],
+        env: ["KEY_A", "KEY_B", "KEY_C"].map((key) => ({
+          key,
+          value: null,
+          secret: true,
+        })),
+        url: null,
+        source: "manual",
+      },
+    ],
+    profiles: [],
+    activeProfileId: null,
+  };
+}
 
 async function fillServer(user: ReturnType<typeof userEvent.setup>, command: string) {
   await user.type(screen.getByLabelText("Name"), "demo");
@@ -97,6 +127,65 @@ describe("ServerDialog", () => {
     expect(screen.getByText("Add MCP server")).toBeInTheDocument();
     await userEvent.click(screen.getByRole("button", { name: "Cancel" }));
     expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports partial secret failure and retries by updating the added server", async () => {
+    const added = savedRegistry("demo");
+    const afterFirstSecret = savedRegistry("demo");
+    const updated = savedRegistry("demo");
+    const afterRetryA = savedRegistry("demo");
+    const afterRetryB = savedRegistry("demo");
+    const afterRetryC = savedRegistry("demo");
+    api.addServer.mockResolvedValueOnce(added);
+    api.updateServer.mockResolvedValueOnce(updated);
+    api.setSecret
+      .mockResolvedValueOnce(afterFirstSecret)
+      .mockRejectedValueOnce(new Error("keychain locked"))
+      .mockRejectedValueOnce(new Error("keychain locked"))
+      .mockResolvedValueOnce(afterRetryA)
+      .mockResolvedValueOnce(afterRetryB)
+      .mockResolvedValueOnce(afterRetryC);
+    const onSaved = vi.fn();
+    const user = userEvent.setup();
+
+    render(<ServerDialog trigger={<button>Add server</button>} onSaved={onSaved} />);
+    await user.click(screen.getByRole("button", { name: "Add server" }));
+    await fillServer(user, "npx");
+
+    for (let i = 0; i < 3; i += 1) {
+      await user.click(screen.getByRole("button", { name: "Add variable" }));
+    }
+    const keyInputs = screen.getAllByPlaceholderText("ENV_NAME");
+    const valueInputs = screen.getAllByPlaceholderText("value");
+    for (const [i, key] of ["KEY_A", "KEY_B", "KEY_C"].entries()) {
+      await user.type(keyInputs[i], key);
+      await user.type(valueInputs[i], `secret-${i}`);
+    }
+
+    await user.click(screen.getByRole("button", { name: "Add" }));
+
+    await waitFor(() => expect(api.setSecret).toHaveBeenCalledTimes(3));
+    expect(api.setSecret).toHaveBeenNthCalledWith(1, "demo", "KEY_A", "secret-0");
+    expect(api.setSecret).toHaveBeenNthCalledWith(2, "demo", "KEY_B", "secret-1");
+    expect(api.setSecret).toHaveBeenNthCalledWith(3, "demo", "KEY_C", "secret-2");
+    expect(onSaved).toHaveBeenLastCalledWith(afterFirstSecret);
+    expect(toast.warning).toHaveBeenCalledWith(
+      "Added demo, but couldn't save: KEY_B, KEY_C",
+    );
+    expect(screen.getByText("Edit server")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Save" })).toBeEnabled();
+
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => expect(api.setSecret).toHaveBeenCalledTimes(6));
+    expect(api.addServer).toHaveBeenCalledTimes(1);
+    expect(api.updateServer).toHaveBeenCalledTimes(1);
+    expect(api.updateServer).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "demo", name: "demo" }),
+    );
+    expect(onSaved).toHaveBeenLastCalledWith(afterRetryC);
+    expect(toast.success).toHaveBeenCalledWith("Saved demo");
+    expect(screen.queryByText("Edit server")).not.toBeInTheDocument();
   });
 
   it("keeps an edited in-flight test busy and discards its result", async () => {

--- a/src/components/ServerDialog.tsx
+++ b/src/components/ServerDialog.tsx
@@ -96,8 +96,12 @@ export function ServerDialog({
   const [busy, setBusy] = useState(false);
   const [test, setTest] = useState<TestState>(IDLE_TEST);
   const testRequestId = useRef(0);
+  const [partialEdit, setPartialEdit] = useState<{ id: string; name: string } | null>(
+    null,
+  );
+  const currentEditId = editId ?? partialEdit?.id;
   const isStdio = form.transport === "stdio";
-  const editing = editId !== undefined;
+  const editing = currentEditId !== undefined;
 
   // Paste-from-config state.
   const [showPaste, setShowPaste] = useState(false);
@@ -126,6 +130,7 @@ export function ServerDialog({
       return;
     }
     if (next) {
+      setPartialEdit(null);
       setForm({
         name: initial?.name ?? "",
         transport: (initial?.transport ?? "stdio") as Transport,
@@ -207,7 +212,7 @@ export function ServerDialog({
   function buildEntry(withSecretValues: boolean): ServerEntry {
     const declared = envRows.filter((r) => r.key.trim());
     return {
-      id: editId ?? "",
+      id: currentEditId ?? "",
       name: form.name.trim(),
       transport: form.transport,
       command: isStdio ? form.command.trim() || null : null,
@@ -237,7 +242,9 @@ export function ServerDialog({
   } else if (!/^https?:\/\//i.test(urlTrim)) {
     errors.push("The URL must start with http:// or https://.");
   }
-  const ownName = editing ? initial?.name?.trim().toLowerCase() : undefined;
+  const ownName = editing
+    ? (initial?.name ?? partialEdit?.name)?.trim().toLowerCase()
+    : undefined;
   const duplicateName =
     !!nameTrim &&
     nameTrim.toLowerCase() !== ownName &&
@@ -278,21 +285,38 @@ export function ServerDialog({
     if (errors.length > 0) return;
     const entry = buildEntry(false);
     const declared = envRows.filter((r) => r.key.trim());
+    const wasEditing = editing;
     setBusy(true);
     try {
-      let result = editing ? await updateServer(entry) : await addServer(entry);
+      let result = wasEditing ? await updateServer(entry) : await addServer(entry);
       // Vault any values the user entered now. setSecret keys by server id. For a
       // new server, add_server appends it, so it's the last entry - resolving by
       // name would pick the wrong one if two servers share a name.
-      const id = editing ? editId : result.servers[result.servers.length - 1]?.id;
+      const id = wasEditing
+        ? currentEditId
+        : result.servers[result.servers.length - 1]?.id;
+      const failedKeys: string[] = [];
       if (id) {
         for (const r of declared) {
-          if (r.value) result = await setSecret(id, r.key.trim(), r.value);
+          if (!r.value) continue;
+          const key = r.key.trim();
+          try {
+            result = await setSecret(id, key, r.value);
+          } catch {
+            failedKeys.push(key);
+          }
         }
       }
       onSaved(result);
-      toast.success(editing ? `Saved ${entry.name}` : `Added ${entry.name}`);
-      setOpen(false);
+      if (failedKeys.length > 0) {
+        if (!wasEditing && id) setPartialEdit({ id, name: entry.name });
+        toast.warning(
+          `${wasEditing ? "Saved" : "Added"} ${entry.name}, but couldn't save: ${failedKeys.join(", ")}`,
+        );
+        return;
+      }
+      toast.success(wasEditing ? `Saved ${entry.name}` : `Added ${entry.name}`);
+      onOpenChange(false);
     } catch (e) {
       toastError(`Couldn't save ${entry.name}: ${e}`);
     } finally {


### PR DESCRIPTION
## What and why

Closes #738.

Treat secret-write failures after a successful server add as partial success. All secret writes are attempted, failed keys are reported, and the dialog remains open in edit mode so retrying updates the existing server instead of creating a duplicate.

Auto-open dialogs now use `onSaved` only to update registry state and `onClose` for successful dismissal, allowing partial failures to remain open.

## Testing

- [x] `npm run build` passes
- [x] `npm run test` passes
- [x] `npm run audit:prod` passes
- [ ] `npm run test:rust` — not applicable; frontend-only
- [ ] Ran the app manually

Also ran focused ServerDialog tests, `npm run format:check`, `npm run lint`, and `git diff --check`.

## Notes

No secrets, credentials, or personal paths are included.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Handle partial secret save failures in `ServerDialog` with retry
> - `ServerDialog.handleSave` now saves secrets individually with try/catch. If any fail, the server is still added/updated, a warning toast lists the failed keys, and the dialog stays open in edit mode (via `partialEdit` state) so the user can retry without creating a duplicate.
> - On full success, the dialog emits a success toast and closes itself through `onOpenChange(false)`, which propagates `onClose` to the parent.
> - Parents ([App.tsx](https://github.com/tsouth89/toolport/pull/826/files#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2) and [CatalogView.tsx](https://github.com/tsouth89/toolport/pull/826/files#diff-0a454832c4541c744bf77a9abc15ab8285466c137194af246ae4a074dbc58361)) no longer inline-clear their own open state on `onSaved`; they rely on the dialog's `onClose` for unmount.
> - Risk: `ownName` duplicate validation now includes `partialEdit.name` in [ServerDialog.tsx](https://github.com/tsouth89/toolport/pull/826/files#diff-68aae418c9ad023485060a4193bf49cdd578e15c8e4e2ab2af62e61b42e7ebd5); callers that previously closed the dialog on save completion now wait for `onClose`, which only fires after all secrets succeed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3e3bcb1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->