### PR TITLE
fix(http): restore endpoint after restart

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,6 +354,12 @@ the AUR** on Arch and its derivatives (Manjaro, EndeavourOS, Omarchy). The
 Ubuntu 22.04's WebKitGTK, which a rolling release's Mesa is too new for (see
 Troubleshooting). To run from source, see Development below.
 
+**Exception: Arch with the proprietary NVIDIA driver.** The EGL failure that
+motivates the native package is a *Mesa* one, and NVIDIA's EGL is a separate
+implementation that does not hit it. On those machines the advice inverts: the
+native package is the one that breaks, and the **AppImage is the working
+install** (see Troubleshooting). Pick by driver, not by distro.
+
 ```bash
 # Arch / Manjaro / EndeavourOS
 paru -S toolport-bin        # or: yay -S toolport-bin
@@ -472,6 +478,31 @@ The frontend is typechecked with `npx tsc --noEmit`.
   launch and you get a grey window. None of `WEBKIT_DISABLE_DMABUF_RENDERER`,
   `WEBKIT_DISABLE_COMPOSITING_MODE` or `WEBKIT_FORCE_SANDBOX=0` avoids that one.
   (This is a packaging/GPU-stack issue, not a Toolport bug.)
+
+  **On NVIDIA's proprietary driver, do the opposite: use the AppImage.**
+  Everything above is a *Mesa* failure. NVIDIA ships its own EGL, never hits it,
+  and there the native package is the broken one. `conduit` from the `.deb`
+  payload exits immediately at startup with:
+
+  ```
+  Gdk-Message: Error 71 (Protocol error) dispatching to Wayland display.
+  ```
+
+  Forcing `GDK_BACKEND=x11` gets past that, but the window then cannot allocate
+  any buffers and the app is unusable:
+
+  ```
+  Failed to create GBM buffer of size 1240x820: Invalid argument
+  ```
+
+  The AppImage bundles its own GTK and WebKitGTK, sidesteps both, and renders
+  correctly. Verified on Omarchy (Hyprland via uwsm), RTX 4070 SUPER,
+  `nvidia-open-dkms` 610.57.04, against system GTK 3.24.52 / WebKitGTK 2.52.6.
+
+  Note Omarchy already exports `GDK_BACKEND=wayland,x11,*` (from
+  `/usr/share/omarchy/default/hypr/envs.lua`), so the AppImage's own
+  `GDK_BACKEND="${GDK_BACKEND:-x11}"` default never applies and it runs on
+  Wayland, which is the path that works. Don't override it.
 
   **If the AppImage is all you have** (a distro with no `.deb` and no AUR), the
   older workarounds are still worth a try, because a virtualized GPU can fail EGL

--- a/README.md
+++ b/README.md
@@ -355,7 +355,7 @@ Ubuntu 22.04's WebKitGTK, which a rolling release's Mesa is too new for (see
 Troubleshooting). To run from source, see Development below.
 
 **Exception: Arch with the proprietary NVIDIA driver.** The EGL failure that
-motivates the native package is a *Mesa* one, and NVIDIA's EGL is a separate
+motivates the native package is a _Mesa_ one, and NVIDIA's EGL is a separate
 implementation that does not hit it. On those machines the advice inverts: the
 native package is the one that breaks, and the **AppImage is the working
 install** (see Troubleshooting). Pick by driver, not by distro.
@@ -480,7 +480,7 @@ The frontend is typechecked with `npx tsc --noEmit`.
   (This is a packaging/GPU-stack issue, not a Toolport bug.)
 
   **On NVIDIA's proprietary driver, do the opposite: use the AppImage.**
-  Everything above is a *Mesa* failure. NVIDIA ships its own EGL, never hits it,
+  Everything above is a _Mesa_ failure. NVIDIA ships its own EGL, never hits it,
   and there the native package is the broken one. `conduit` from the `.deb`
   payload exits immediately at startup with:
 

--- a/packaging/linux/aur/README.md
+++ b/packaging/linux/aur/README.md
@@ -1,7 +1,18 @@
 # Arch Linux (AUR): `toolport-bin`
 
-Arch and Arch-derived distros (Manjaro, EndeavourOS, **Omarchy**) should install
-Toolport from the AUR, not from the AppImage.
+Arch and Arch-derived distros (Manjaro, EndeavourOS, **Omarchy**) running on
+**Mesa** (AMD or Intel graphics) should install Toolport from the AUR, not from
+the AppImage.
+
+> **Not on the proprietary NVIDIA driver.** The EGL breakage this package exists
+> to avoid is Mesa-specific. NVIDIA's EGL is a separate implementation that never
+> hits it, and there this package is the one that fails: `conduit` exits at
+> startup with `Gdk-Message: Error 71 (Protocol error) dispatching to Wayland
+> display`, and under `GDK_BACKEND=x11` it survives but cannot allocate buffers
+> (`Failed to create GBM buffer of size 1240x820: Invalid argument`). Send NVIDIA
+> users to the AppImage, which bundles its own GTK/WebKitGTK and renders fine.
+> Verified on Omarchy/Hyprland, RTX 4070 SUPER, `nvidia-open-dkms` 610.57.04,
+> system GTK 3.24.52 / WebKitGTK 2.52.6. Choose by **driver**, not by distro.
 
 ```bash
 # any AUR helper

--- a/packaging/linux/aur/README.md
+++ b/packaging/linux/aur/README.md
@@ -8,7 +8,7 @@ the AppImage.
 > to avoid is Mesa-specific. NVIDIA's EGL is a separate implementation that never
 > hits it, and there this package is the one that fails: `conduit` exits at
 > startup with `Gdk-Message: Error 71 (Protocol error) dispatching to Wayland
-> display`, and under `GDK_BACKEND=x11` it survives but cannot allocate buffers
+display`, and under `GDK_BACKEND=x11` it survives but cannot allocate buffers
 > (`Failed to create GBM buffer of size 1240x820: Invalid argument`). Send NVIDIA
 > users to the AppImage, which bundles its own GTK/WebKitGTK and renders fine.
 > Verified on Omarchy/Hyprland, RTX 4070 SUPER, `nvidia-open-dkms` 610.57.04,

--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -421,6 +421,7 @@ struct HttpBridge {
     token: Option<String>,
 }
 type HttpBridgeState = Mutex<HttpBridge>;
+static HTTP_BRIDGE_LIFECYCLE: Mutex<()> = Mutex::new(());
 
 const HTTP_BRIDGE_VAULT_SERVER: &str = "__toolport_http_bridge__";
 const HTTP_BRIDGE_VAULT_KEY: &str = "bearer";
@@ -4111,6 +4112,9 @@ fn stop_spawned_gateways(bridge: State<HttpBridgeState>) -> UpdateShutdownReport
         FailedBeforeIntent(String),
     }
 
+    let _lifecycle = HTTP_BRIDGE_LIFECYCLE
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
     let owned_bridge = {
         let mut bridge = bridge
             .lock()
@@ -4213,9 +4217,12 @@ struct UpdateRecoveryReport {
 /// would create disconnected processes and a false recovery claim.
 #[tauri::command]
 fn recover_update_gateways(
-    bridge: State<HttpBridgeState>,
+    app: AppHandle,
     http_bridge_port: Option<u16>,
 ) -> Result<UpdateRecoveryReport, String> {
+    let _lifecycle = HTTP_BRIDGE_LIFECYCLE
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
     let Some(port) = http_bridge_port else {
         return Ok(UpdateRecoveryReport::default());
     };
@@ -4227,7 +4234,12 @@ fn recover_update_gateways(
             intent.port
         ));
     }
-    ensure_http_bridge_at(bridge.inner(), port, Some(intent.token))?;
+    ensure_http_bridge_at(
+        app.state::<HttpBridgeState>().inner(),
+        port,
+        Some(intent.token.clone()),
+    )?;
+    persist_restored_http_bridge(app.state::<RegistryState>().inner(), port, &intent.token)?;
     let cleanup_warning = clear_update_http_bridge_intent().err();
     Ok(UpdateRecoveryReport {
         http_bridge_recovered: true,
@@ -4388,6 +4400,9 @@ fn announce_restart_needed(
 /// Connected clients are unaffected by the new process: they authenticate with the
 /// per-client bearers in `http_clients`, not the bridge's own env token.
 fn reap_stale_and_restore_bridge(bridge: &HttpBridgeState, advice: &RestartAdvice) -> ReapOutcome {
+    let _lifecycle = HTTP_BRIDGE_LIFECYCLE
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
     let mut extra_keep = Vec::new();
     if let Some(p) = clients::resolve_gateway_path() {
         extra_keep.push(p);
@@ -4524,6 +4539,9 @@ fn start_persisted_http_bridge(
     registry: &RegistryState,
     port: Option<u16>,
 ) -> Result<HttpBridgeStatus, String> {
+    let _lifecycle = HTTP_BRIDGE_LIFECYCLE
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
     let was_alive = {
         let mut bridge = state
             .lock()
@@ -4702,7 +4720,11 @@ fn stop_http_bridge_with(
 #[tauri::command]
 async fn stop_http_bridge(app: AppHandle) -> Result<HttpBridgeStatus, String> {
     tauri::async_runtime::spawn_blocking(move || {
+        let _lifecycle = HTTP_BRIDGE_LIFECYCLE
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let registry = app.state::<RegistryState>();
+        clear_update_http_bridge_intent()?;
         write_registry(registry.inner(), |reg| {
             reg.http_bridge_enabled = false;
             Ok(())
@@ -4711,9 +4733,6 @@ async fn stop_http_bridge(app: AppHandle) -> Result<HttpBridgeStatus, String> {
         let mut bridge = state
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
-        // Clear the update marker before stopping the live endpoint. The durable
-        // preference is already off, so a later launch cannot resurrect it.
-        clear_update_http_bridge_intent()?;
         stop_http_bridge_with(&mut bridge, std::process::Child::kill)
     })
     .await
@@ -4721,6 +4740,9 @@ async fn stop_http_bridge(app: AppHandle) -> Result<HttpBridgeStatus, String> {
 }
 
 fn restore_persisted_http_bridge(state: &HttpBridgeState) -> Result<bool, String> {
+    let _lifecycle = HTTP_BRIDGE_LIFECYCLE
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
     let registry = registry::load()?;
     if !registry.http_bridge_enabled {
         return Ok(false);
@@ -4734,11 +4756,35 @@ fn restore_persisted_http_bridge(state: &HttpBridgeState) -> Result<bool, String
     Ok(true)
 }
 
-fn resume_http_bridge_after_update(state: &HttpBridgeState) -> Result<bool, String> {
+/// Make an update-restored endpoint durable before its one-shot recovery marker
+/// is removed, including when upgrading from a version without registry state.
+fn persist_restored_http_bridge(
+    registry: &RegistryState,
+    port: u16,
+    token: &str,
+) -> Result<(), String> {
+    secrets::set_secret(HTTP_BRIDGE_VAULT_SERVER, HTTP_BRIDGE_VAULT_KEY, token)
+        .map_err(|error| format!("Could not save the HTTP endpoint token: {error}"))?;
+    write_registry(registry, |reg| {
+        reg.http_bridge_enabled = true;
+        reg.http_bridge_port = Some(port);
+        Ok(())
+    })?;
+    Ok(())
+}
+
+fn resume_http_bridge_after_update(
+    state: &HttpBridgeState,
+    registry: &RegistryState,
+) -> Result<bool, String> {
+    let _lifecycle = HTTP_BRIDGE_LIFECYCLE
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
     let Some(intent) = load_update_http_bridge_intent()? else {
         return Ok(false);
     };
-    ensure_http_bridge_at(state, intent.port, Some(intent.token))?;
+    ensure_http_bridge_at(state, intent.port, Some(intent.token.clone()))?;
+    persist_restored_http_bridge(registry, intent.port, &intent.token)?;
     if let Err(error) = clear_update_http_bridge_intent() {
         eprintln!(
             "toolport: restored the HTTP endpoint, but could not clear its update resume state: {error}"
@@ -5407,6 +5453,7 @@ pub fn run() {
                 // restores connectivity without rotating credentials.
                 match resume_http_bridge_after_update(
                     migrate_handle.state::<HttpBridgeState>().inner(),
+                    migrate_handle.state::<RegistryState>().inner(),
                 ) {
                     Ok(true) => eprintln!(
                         "toolport: restored the HTTP endpoint after the in-app update"

--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -4206,6 +4206,9 @@ struct UpdateRecoveryReport {
     /// True only when an HTTP endpoint existed before shutdown and is available
     /// again. External stdio clients are deliberately not represented as restored.
     http_bridge_recovered: bool,
+    /// The endpoint is live, but its durable token or registry state could not
+    /// be saved. The recovery marker is retained so a later launch can retry.
+    persistence_warning: Option<String>,
     /// Endpoint availability and marker cleanup are separate facts. A failed
     /// delete must not turn a verified live endpoint into a false "not restored"
     /// message, but the retained marker still needs to be surfaced.
@@ -4242,12 +4245,13 @@ fn recover_update_gateways(
     let persistence_warning =
         persist_restored_http_bridge(app.state::<RegistryState>().inner(), port, &intent.token)
             .err();
-    let cleanup_warning = match persistence_warning {
-        Some(error) => Some(error),
-        None => clear_update_http_bridge_intent().err(),
-    };
+    let cleanup_warning = persistence_warning
+        .is_none()
+        .then(clear_update_http_bridge_intent)
+        .and_then(Result::err);
     Ok(UpdateRecoveryReport {
         http_bridge_recovered: true,
+        persistence_warning,
         cleanup_warning,
     })
 }

--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -4239,8 +4239,13 @@ fn recover_update_gateways(
         port,
         Some(intent.token.clone()),
     )?;
-    persist_restored_http_bridge(app.state::<RegistryState>().inner(), port, &intent.token)?;
-    let cleanup_warning = clear_update_http_bridge_intent().err();
+    let persistence_warning =
+        persist_restored_http_bridge(app.state::<RegistryState>().inner(), port, &intent.token)
+            .err();
+    let cleanup_warning = match persistence_warning {
+        Some(error) => Some(error),
+        None => clear_update_http_bridge_intent().err(),
+    };
     Ok(UpdateRecoveryReport {
         http_bridge_recovered: true,
         cleanup_warning,
@@ -4784,7 +4789,12 @@ fn resume_http_bridge_after_update(
         return Ok(false);
     };
     ensure_http_bridge_at(state, intent.port, Some(intent.token.clone()))?;
-    persist_restored_http_bridge(registry, intent.port, &intent.token)?;
+    if let Err(error) = persist_restored_http_bridge(registry, intent.port, &intent.token) {
+        eprintln!(
+            "toolport: restored the HTTP endpoint, but could not save its persistent state: {error}"
+        );
+        return Ok(true);
+    }
     if let Err(error) = clear_update_http_bridge_intent() {
         eprintln!(
             "toolport: restored the HTTP endpoint, but could not clear its update resume state: {error}"

--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -422,6 +422,9 @@ struct HttpBridge {
 }
 type HttpBridgeState = Mutex<HttpBridge>;
 
+const HTTP_BRIDGE_VAULT_SERVER: &str = "__toolport_http_bridge__";
+const HTTP_BRIDGE_VAULT_KEY: &str = "bearer";
+
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct UpdateHttpBridgeIntent {
@@ -1012,7 +1015,7 @@ async fn install_gateway(
         {
             // Ensure the supervised bridge is up, mint/reuse a per-client bearer, write
             // native remote or mcp-remote into the client config (SOU-407).
-            let status = start_http_bridge_at(bridge.inner(), None)?;
+            let status = start_persisted_http_bridge(bridge.inner(), state.inner(), None)?;
             let port = status.port.unwrap_or(8765);
             let url = format!("http://127.0.0.1:{port}/mcp");
             let token = ensure_client_http_token(state.inner(), &client_id, profile.as_deref())?;
@@ -1346,7 +1349,7 @@ async fn migrate_client(
     let migrate_write = if transport.eq_ignore_ascii_case("sharedHttp")
         || transport.eq_ignore_ascii_case("shared_http")
     {
-        let status = start_http_bridge_at(bridge.inner(), None)?;
+        let status = start_persisted_http_bridge(bridge.inner(), state.inner(), None)?;
         let port = status.port.unwrap_or(8765);
         let url = format!("http://127.0.0.1:{port}/mcp");
         let token = ensure_client_http_token(state.inner(), &client_id, profile.as_deref())?;
@@ -1754,6 +1757,14 @@ fn registry_summary(reg: &Registry) -> String {
         let _ = writeln!(out, "  per-client discovery: {}", overrides.join(", "));
     }
     let _ = writeln!(out, "  deny destructive: {}", reg.deny_destructive);
+    let _ = writeln!(
+        out,
+        "  HTTP endpoint: {}{}",
+        if reg.http_bridge_enabled { "on" } else { "off" },
+        reg.http_bridge_port
+            .map(|port| format!(" (port {port})"))
+            .unwrap_or_default()
+    );
     let _ = writeln!(out, "  active profile: {active}");
 
     let _ = writeln!(out, "\nservers ({}):", reg.servers.len());
@@ -4496,24 +4507,66 @@ fn ensure_http_bridge_at(
 /// clients can connect. Idempotent: if it's already running, returns the current
 /// status; otherwise spawns the bundled gateway binary and tracks it.
 #[tauri::command]
-fn start_http_bridge(
-    state: State<HttpBridgeState>,
-    port: Option<u16>,
-) -> Result<HttpBridgeStatus, String> {
-    start_http_bridge_at(state.inner(), port)
+async fn start_http_bridge(app: AppHandle, port: Option<u16>) -> Result<HttpBridgeStatus, String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        let state = app.state::<HttpBridgeState>();
+        let registry = app.state::<RegistryState>();
+        start_persisted_http_bridge(state.inner(), registry.inner(), port)
+    })
+    .await
+    .map_err(|error| format!("HTTP endpoint task failed: {error}"))?
 }
 
-/// Body of [`start_http_bridge`], taking the state directly so non-command callers
-/// (the reaper's bridge restore) can reach it without a `State` wrapper.
-fn start_http_bridge_at(
+/// Start the endpoint and durably remember the user's intent. Shared HTTP client
+/// setup also uses this path, since those clients need the endpoint after restart.
+fn start_persisted_http_bridge(
     state: &HttpBridgeState,
+    registry: &RegistryState,
     port: Option<u16>,
 ) -> Result<HttpBridgeStatus, String> {
-    // Every ordinary/user-initiated start supersedes an interrupted-update
-    // marker, including install/migration paths that call this helper directly.
-    // Recovery paths use the token-preserving lower-level function instead.
+    let was_alive = {
+        let mut bridge = state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        http_bridge_alive(&mut bridge)
+    };
+    let saved_token = secrets::get_secret_result(
+        HTTP_BRIDGE_VAULT_SERVER,
+        HTTP_BRIDGE_VAULT_KEY,
+    )?;
     clear_update_http_bridge_intent()?;
-    start_http_bridge_with_token_at(state, port, None)
+    let status = start_http_bridge_with_token_at(state, port, saved_token)?;
+    let token = status
+        .token
+        .as_deref()
+        .ok_or("The HTTP endpoint started without a bearer token")?;
+    if let Err(error) = secrets::set_secret(
+        HTTP_BRIDGE_VAULT_SERVER,
+        HTTP_BRIDGE_VAULT_KEY,
+        token,
+    ) {
+        if !was_alive {
+            let mut bridge = state
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            let _ = stop_http_bridge_with(&mut bridge, std::process::Child::kill);
+        }
+        return Err(format!("Could not save the HTTP endpoint token: {error}"));
+    }
+    if let Err(error) = write_registry(registry, |reg| {
+        reg.http_bridge_enabled = true;
+        reg.http_bridge_port = status.port;
+        Ok(())
+    }) {
+        if !was_alive {
+            let mut bridge = state
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            let _ = stop_http_bridge_with(&mut bridge, std::process::Child::kill);
+        }
+        return Err(format!("Could not save the HTTP endpoint setting: {error}"));
+    }
+    Ok(status)
 }
 
 fn http_bridge_identity_ready(port: u16, token: &str) -> bool {
@@ -4647,13 +4700,38 @@ fn stop_http_bridge_with(
 
 /// Stop the supervised HTTP bridge child, if any.
 #[tauri::command]
-fn stop_http_bridge(state: State<HttpBridgeState>) -> Result<HttpBridgeStatus, String> {
-    let mut bridge = state.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
-    // Clear the resume marker before stopping the live endpoint. If cleanup is
-    // denied, leave the endpoint running and report the error; otherwise a later
-    // launch could silently resurrect something the user explicitly disabled.
-    clear_update_http_bridge_intent()?;
-    stop_http_bridge_with(&mut bridge, std::process::Child::kill)
+async fn stop_http_bridge(app: AppHandle) -> Result<HttpBridgeStatus, String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        let registry = app.state::<RegistryState>();
+        write_registry(registry.inner(), |reg| {
+            reg.http_bridge_enabled = false;
+            Ok(())
+        })?;
+        let state = app.state::<HttpBridgeState>();
+        let mut bridge = state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        // Clear the update marker before stopping the live endpoint. The durable
+        // preference is already off, so a later launch cannot resurrect it.
+        clear_update_http_bridge_intent()?;
+        stop_http_bridge_with(&mut bridge, std::process::Child::kill)
+    })
+    .await
+    .map_err(|error| format!("HTTP endpoint task failed: {error}"))?
+}
+
+fn restore_persisted_http_bridge(state: &HttpBridgeState) -> Result<bool, String> {
+    let registry = registry::load()?;
+    if !registry.http_bridge_enabled {
+        return Ok(false);
+    }
+    let token = secrets::get_secret_result(
+        HTTP_BRIDGE_VAULT_SERVER,
+        HTTP_BRIDGE_VAULT_KEY,
+    )?
+    .ok_or("The HTTP endpoint is enabled, but its saved bearer token is missing")?;
+    start_http_bridge_with_token_at(state, registry.http_bridge_port, Some(token))?;
+    Ok(true)
 }
 
 fn resume_http_bridge_after_update(state: &HttpBridgeState) -> Result<bool, String> {
@@ -5336,6 +5414,15 @@ pub fn run() {
                     Ok(false) => {}
                     Err(error) => eprintln!(
                         "toolport: could not restore the HTTP endpoint after the in-app update: {error}"
+                    ),
+                }
+                match restore_persisted_http_bridge(
+                    migrate_handle.state::<HttpBridgeState>().inner(),
+                ) {
+                    Ok(true) => eprintln!("toolport: restored the saved HTTP endpoint"),
+                    Ok(false) => {}
+                    Err(error) => eprintln!(
+                        "toolport: could not restore the saved HTTP endpoint: {error}"
                     ),
                 }
                 // Ownership map from disk (this launch thread has no RegistryState handle).

--- a/src-tauri/src/registry.rs
+++ b/src-tauri/src/registry.rs
@@ -900,6 +900,13 @@ pub struct Registry {
     /// only the legacy single `CONDUIT_HTTP_TOKEN` (back-compat).
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub http_clients: Vec<HttpClient>,
+    /// Whether the user wants Toolport's supervised HTTP endpoint restored on
+    /// future launches. The bearer itself remains in the OS keychain.
+    #[serde(default)]
+    pub http_bridge_enabled: bool,
+    /// Port last selected for the supervised HTTP endpoint.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub http_bridge_port: Option<u16>,
     /// Bumped when vaulted secrets change so running gateways reload even when
     /// the rest of the registry JSON is unchanged.
     #[serde(default)]
@@ -1184,6 +1191,8 @@ impl Default for Registry {
             client_discovery: HashMap::new(),
             client_managed_entries: HashMap::new(),
             http_clients: Vec::new(),
+            http_bridge_enabled: false,
+            http_bridge_port: None,
             secrets_generation: 0,
             rule_sets: Vec::new(),
             active_rule_set_id: None,
@@ -4442,12 +4451,17 @@ mod tests {
         let id = r.add_server(sample_server("vercel"));
         r.set_server_enabled("default", &id, true).unwrap();
         r.add_profile("Work");
+        r.http_bridge_enabled = true;
+        r.http_bridge_port = Some(9876);
 
         let mut path = std::env::temp_dir();
         path.push(format!("conduit-test-{}.json", std::process::id()));
         save_to(&path, &r).unwrap();
         let loaded = load_from(&path).unwrap();
         std::fs::remove_file(&path).ok();
+
+        assert!(loaded.http_bridge_enabled);
+        assert_eq!(loaded.http_bridge_port, Some(9876));
 
         assert_eq!(loaded.servers, r.servers);
         assert_eq!(loaded.profiles, r.profiles);

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -510,6 +510,10 @@ export interface Registry {
   /** Consumers registered to reach the gateway over the HTTP/OpenAPI bridge,
    * each with its own hashed token and scope (multi-tenant bridge). */
   httpClients?: HttpClient[];
+  /** Whether the supervised HTTP endpoint should return after an app restart. */
+  httpBridgeEnabled?: boolean;
+  /** Last port selected for the supervised HTTP endpoint. */
+  httpBridgePort?: number | null;
 }
 
 /** Snapshot of the gateway entry Toolport last wrote (SOU-406/407). */

--- a/src/lib/updater.test.ts
+++ b/src/lib/updater.test.ts
@@ -221,6 +221,7 @@ describe("installUpdate", () => {
       if (command === "recover_update_gateways") {
         return {
           httpBridgeRecovered: true,
+          persistenceWarning: null,
           cleanupWarning: "access denied",
         };
       }
@@ -235,6 +236,31 @@ describe("installUpdate", () => {
     expect(advice).toContain("endpoint is available");
     expect(advice).toContain("access denied");
     expect(advice).not.toContain("could not restore its HTTP endpoint");
+  });
+
+  it("labels endpoint persistence failures accurately", async () => {
+    const download = vi.fn().mockResolvedValue(undefined);
+    const install = vi.fn().mockRejectedValue(new Error("installer rejected"));
+    invoke.mockImplementation(async (command: string) => {
+      if (command === "stop_spawned_gateways") {
+        return { ...cleanShutdown, httpBridgePort: 8765 };
+      }
+      if (command === "recover_update_gateways") {
+        return {
+          httpBridgeRecovered: true,
+          persistenceWarning: "keychain locked",
+          cleanupWarning: null,
+        };
+      }
+      throw new Error(`unexpected command ${command}`);
+    });
+
+    const failure = await installUpdate({ download, install } as unknown as Update).catch(
+      (error: unknown) => error,
+    );
+    const advice = (failure as UpdateInstallError).recoveryAdvice;
+    expect(advice).toContain("could not save its persistent state: keychain locked");
+    expect(advice).not.toContain("could not clear its update recovery marker");
   });
 
   it("gives generic restart guidance only for a proven but unnamed external client", async () => {

--- a/src/lib/updater.ts
+++ b/src/lib/updater.ts
@@ -33,6 +33,7 @@ export interface UpdateShutdownReport {
 
 interface UpdateRecoveryReport {
   httpBridgeRecovered: boolean;
+  persistenceWarning: string | null;
   cleanupWarning: string | null;
 }
 
@@ -110,6 +111,11 @@ function recoveryAdvice(
       advice.push(
         `Toolport restored its HTTP endpoint on port ${shutdown.httpBridgePort}.`,
       );
+      if (recovery.persistenceWarning) {
+        advice.push(
+          `The endpoint is available, but Toolport could not save its persistent state: ${recovery.persistenceWarning}.`,
+        );
+      }
       if (recovery.cleanupWarning) {
         advice.push(
           `The endpoint is available, but Toolport could not clear its update recovery marker: ${recovery.cleanupWarning}.`,


### PR DESCRIPTION
Keeps the HTTP endpoint enabled across app restarts and reuses its saved bearer token from the OS keychain.

Closes #822.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches HTTP bearer storage in the OS keychain and process start/stop around the local gateway. Persistence failures now stop a newly started endpoint, which is safer but can surprise users if the keychain is locked.
> 
> **Overview**
> The supervised HTTP/OpenAPI endpoint now survives app restarts: enablement and port are stored in the registry, and the bearer is reused from the OS keychain instead of rotating on every launch.
> 
> Start/stop/restore are serialized with a lifecycle mutex. Shared-HTTP client install and update recovery write the same durable state; if persistence fails after a fresh start, the child is torn down rather than left running without a saved token. Update failure advice now distinguishes a live endpoint that could not be persisted from a failed recovery-marker cleanup.
> 
> Linux install docs now tell proprietary-NVIDIA users to use the AppImage (native packages fail on NVIDIA EGL), while Mesa users still prefer the AUR/`.deb`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef57cf998f16270df057ed6fd143e715558208ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Persist and restore HTTP bridge endpoint across restarts and updates
> - Adds `http_bridge_enabled` and `http_bridge_port` fields to the registry so the endpoint's on/off state and port survive restarts
> - Introduces `start_persisted_http_bridge`, `restore_persisted_http_bridge`, and `persist_restored_http_bridge` helpers in [desktop.rs](https://github.com/tsouth89/toolport/pull/829/files#diff-fe6823673f9c91b7a17eb4b96e5bc54bc3c58e75d02ae0a2d2fae6f7ce03ecd5) that store the bearer token in the keychain and write registry state on start, stop, and restore
> - Serializes all lifecycle operations via a global `HTTP_BRIDGE_LIFECYCLE` mutex to prevent races during updates and reaping
> - On app launch, automatically restores any user-enabled endpoint using the saved token; on update failure recovery, keeps the endpoint live and surfaces a `persistence_warning` distinct from cleanup warnings
> - Behavioral Change: `start_http_bridge` and `stop_http_bridge` Tauri commands are now async and take `AppHandle` instead of `State<HttpBridgeState>`; stopping now sets `http_bridge_enabled=false` in the registry, preventing auto-restore on next launch
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ef57cf9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->