### PR TITLE
fix(windows): report launch at login correctly

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -846,6 +846,7 @@ dependencies = [
  "url",
  "urlencoding",
  "windows-sys 0.61.2",
+ "winreg 0.55.0",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -96,6 +96,7 @@ tauri-plugin-single-instance = { version = "2", features = ["deep-link"], option
 # OS keychain, with the native backend per platform.
 [target.'cfg(target_os = "windows")'.dependencies]
 keyring = { version = "3", features = ["windows-native"] }
+winreg = "0.55"
 windows-sys = { version = "0.61", features = [
     "Win32_Foundation",
     "Win32_Security",

--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -5146,7 +5146,11 @@ fn is_launch_at_login_enabled(app: AppHandle) -> Result<bool, String> {
     {
         return crate::autostart::is_enabled_linux(&app.package_info().name);
     }
-    #[cfg(not(target_os = "linux"))]
+    #[cfg(target_os = "windows")]
+    {
+        return crate::windows_autostart::is_enabled(&app.package_info().name);
+    }
+    #[cfg(target_os = "macos")]
     {
         use tauri_plugin_autostart::ManagerExt;
         app.autolaunch().is_enabled().map_err(|e| e.to_string())

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3,6 +3,8 @@ pub mod approval;
 mod approval_broker;
 pub mod audit;
 pub mod autostart;
+#[cfg(target_os = "windows")]
+pub mod windows_autostart;
 pub mod brand;
 pub mod catalog;
 pub mod clients;

--- a/src-tauri/src/windows_autostart.rs
+++ b/src-tauri/src/windows_autostart.rs
@@ -5,7 +5,7 @@
 //! timestamp is not a reliable enabled flag after a restart.
 
 use std::io::ErrorKind;
-use winreg::enums::{HKEY_CURRENT_USER, KEY_READ};
+use winreg::enums::{RegType, HKEY_CURRENT_USER, KEY_READ};
 use winreg::RegKey;
 
 const RUN_KEY: &str = r"SOFTWARE\Microsoft\Windows\CurrentVersion\Run";
@@ -16,9 +16,15 @@ const STARTUP_APPROVED_KEY: &str =
 /// converting an unknown or malformed value into a false Off state.
 pub fn is_enabled(app_name: &str) -> Result<bool, String> {
     let current_user = RegKey::predef(HKEY_CURRENT_USER);
-    let run = current_user
-        .open_subkey_with_flags(RUN_KEY, KEY_READ)
-        .map_err(|error| format!("Could not read the Windows startup registry: {error}"))?;
+    let run = match current_user.open_subkey_with_flags(RUN_KEY, KEY_READ) {
+        Ok(key) => key,
+        Err(error) if error.kind() == ErrorKind::NotFound => return Ok(false),
+        Err(error) => {
+            return Err(format!(
+                "Could not read the Windows startup registry: {error}"
+            ))
+        }
+    };
     match run.get_value::<String, _>(app_name) {
         Ok(_) => {}
         Err(error) if error.kind() == ErrorKind::NotFound => return Ok(false),
@@ -35,8 +41,15 @@ pub fn is_enabled(app_name: &str) -> Result<bool, String> {
         Err(error) if error.kind() == ErrorKind::NotFound => return Ok(true),
         Err(error) => return Err(format!("Could not read Windows startup approval: {error}")),
     };
-    startup_approved_enabled(&raw.bytes)
+    startup_approved_value_enabled(raw.vtype, &raw.bytes)
         .ok_or_else(|| "Windows returned an invalid startup approval value".to_string())
+}
+
+fn startup_approved_value_enabled(vtype: RegType, bytes: &[u8]) -> Option<bool> {
+    if vtype != RegType::REG_BINARY || bytes.len() != 12 {
+        return None;
+    }
+    startup_approved_enabled(bytes)
 }
 
 /// Windows uses 1, 3, and 7 for disabled states. Known enabled states include
@@ -51,7 +64,8 @@ fn startup_approved_enabled(bytes: &[u8]) -> Option<bool> {
 
 #[cfg(test)]
 mod tests {
-    use super::startup_approved_enabled;
+    use super::{startup_approved_enabled, startup_approved_value_enabled};
+    use winreg::enums::RegType;
 
     #[test]
     fn startup_approval_uses_state_byte_not_timestamp() {
@@ -66,5 +80,22 @@ mod tests {
         assert_eq!(startup_approved_enabled(&[7, 0, 0, 0]), Some(false));
         assert_eq!(startup_approved_enabled(&[]), None);
         assert_eq!(startup_approved_enabled(&[9]), None);
+    }
+
+    #[test]
+    fn startup_approval_rejects_wrong_type_and_length() {
+        let enabled = [2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+        assert_eq!(
+            startup_approved_value_enabled(RegType::REG_SZ, &enabled),
+            None
+        );
+        assert_eq!(
+            startup_approved_value_enabled(RegType::REG_BINARY, &enabled[..4]),
+            None
+        );
+        assert_eq!(
+            startup_approved_value_enabled(RegType::REG_BINARY, &enabled),
+            Some(true)
+        );
     }
 }

--- a/src-tauri/src/windows_autostart.rs
+++ b/src-tauri/src/windows_autostart.rs
@@ -39,12 +39,12 @@ pub fn is_enabled(app_name: &str) -> Result<bool, String> {
         .ok_or_else(|| "Windows returned an invalid startup approval value".to_string())
 }
 
-/// Windows uses 1 and 3 for disabled states. Known enabled states include 0, 2,
-/// and 6. Reject other values so Settings can show an unreadable state, not Off.
+/// Windows uses 1, 3, and 7 for disabled states. Known enabled states include
+/// 0, 2, and 6. Reject other values so Settings can show unreadable, not Off.
 fn startup_approved_enabled(bytes: &[u8]) -> Option<bool> {
     match bytes.first().copied()? {
         0 | 2 | 6 => Some(true),
-        1 | 3 => Some(false),
+        1 | 3 | 7 => Some(false),
         _ => None,
     }
 }
@@ -63,6 +63,7 @@ mod tests {
             startup_approved_enabled(&[3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
             Some(false)
         );
+        assert_eq!(startup_approved_enabled(&[7, 0, 0, 0]), Some(false));
         assert_eq!(startup_approved_enabled(&[]), None);
         assert_eq!(startup_approved_enabled(&[9]), None);
     }

--- a/src-tauri/src/windows_autostart.rs
+++ b/src-tauri/src/windows_autostart.rs
@@ -1,0 +1,69 @@
+//! Authoritative Windows launch-at-login status.
+//!
+//! `auto-launch` infers the Task Manager state from timestamp bytes in
+//! `StartupApproved`. Windows records the state in the first byte, and the
+//! timestamp is not a reliable enabled flag after a restart.
+
+use std::io::ErrorKind;
+use winreg::enums::{HKEY_CURRENT_USER, KEY_READ};
+use winreg::RegKey;
+
+const RUN_KEY: &str = r"SOFTWARE\Microsoft\Windows\CurrentVersion\Run";
+const STARTUP_APPROVED_KEY: &str =
+    r"SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\StartupApproved\Run";
+
+/// Read Toolport's Run entry and Windows' Task Manager override without
+/// converting an unknown or malformed value into a false Off state.
+pub fn is_enabled(app_name: &str) -> Result<bool, String> {
+    let current_user = RegKey::predef(HKEY_CURRENT_USER);
+    let run = current_user
+        .open_subkey_with_flags(RUN_KEY, KEY_READ)
+        .map_err(|error| format!("Could not read the Windows startup registry: {error}"))?;
+    match run.get_value::<String, _>(app_name) {
+        Ok(_) => {}
+        Err(error) if error.kind() == ErrorKind::NotFound => return Ok(false),
+        Err(error) => return Err(format!("Could not read Toolport's startup entry: {error}")),
+    }
+
+    let approved = match current_user.open_subkey_with_flags(STARTUP_APPROVED_KEY, KEY_READ) {
+        Ok(key) => key,
+        Err(error) if error.kind() == ErrorKind::NotFound => return Ok(true),
+        Err(error) => return Err(format!("Could not read Windows startup approval: {error}")),
+    };
+    let raw = match approved.get_raw_value(app_name) {
+        Ok(raw) => raw,
+        Err(error) if error.kind() == ErrorKind::NotFound => return Ok(true),
+        Err(error) => return Err(format!("Could not read Windows startup approval: {error}")),
+    };
+    startup_approved_enabled(&raw.bytes)
+        .ok_or_else(|| "Windows returned an invalid startup approval value".to_string())
+}
+
+/// Windows uses 1 and 3 for disabled states. Known enabled states include 0, 2,
+/// and 6. Reject other values so Settings can show an unreadable state, not Off.
+fn startup_approved_enabled(bytes: &[u8]) -> Option<bool> {
+    match bytes.first().copied()? {
+        0 | 2 | 6 => Some(true),
+        1 | 3 => Some(false),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::startup_approved_enabled;
+
+    #[test]
+    fn startup_approval_uses_state_byte_not_timestamp() {
+        assert_eq!(
+            startup_approved_enabled(&[2, 0, 0, 0, 0xa5, 0x20, 0xf6, 0x4a, 0x95, 0xd7, 0xd9, 1]),
+            Some(true)
+        );
+        assert_eq!(
+            startup_approved_enabled(&[3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
+            Some(false)
+        );
+        assert_eq!(startup_approved_enabled(&[]), None);
+        assert_eq!(startup_approved_enabled(&[9]), None);
+    }
+}


### PR DESCRIPTION
Reads Windows startup approval from its state byte so enabled entries do not appear off after restart. Invalid registry state now shows as unreadable instead of off.

Closes #828.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only HKCU registry lookup for autostart status; enable/disable paths are unchanged. Unknown approval bytes now error instead of reporting Off.
> 
> **Overview**
> Fixes Windows launch-at-login status so enabled apps no longer look **Off** after a restart.
> 
> `is_launch_at_login_enabled` now reads HKCU `Run` plus the first byte of `Explorer\StartupApproved\Run` instead of the autostart plugin’s timestamp heuristic. Missing Run means disabled; missing approval means enabled; unknown or malformed values error so Settings can show unreadable rather than Off. Enable/disable still go through the existing plugin.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 37d8fb55f5248683264254c9f6ad86071fbfeacd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Windows `is_launch_at_login_enabled` to use registry-based autostart check
> - Replaces the `tauri_plugin_autostart` check on Windows with a custom [windows_autostart.rs](https://github.com/tsouth89/toolport/pull/830/files#diff-dc8959234fc47e4cd756909d8ff17c5f262b82ac13f7717126f85b745c1c926d) module that reads the `HKCU\Run` key and `Explorer\StartupApproved\Run` raw value to honor Task Manager enable/disable toggles.
> - `is_enabled` returns `Ok(false)` when the Run entry is missing, `Ok(true)` when StartupApproved is missing, and `Err` for unexpected registry errors or invalid `REG_BINARY` data (wrong type, length != 12, or unknown state byte).
> - State byte mapping: `0,2,6` => enabled, `1,3,7` => disabled, anything else => error.
> - Adds Windows-only `winreg = 0.55` dependency in [Cargo.toml](https://github.com/tsouth89/toolport/pull/830/files#diff-fe4c6a80a21e81339e2e0faeb9134d0f9636c168987df13c8abf1927a1caee39).
> - Behavioral Change: Windows launch-at-login status now derives from registry state instead of the autostart plugin; users with a valid Run entry but missing StartupApproved value will now report as enabled.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 37d8fb5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->