### PR TITLE
fix(linux): give host binaries the host environment, not the AppImage's

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,32 @@ Entries before the rename below shipped under the project's former name, Conduit
   of reaching for an AUR helper. `toolport-bin` is still published and still a
   good choice if you want a real package; it is no longer a workaround.
 
+- **Linux: spawned processes inherited the AppImage's bundled library paths.**
+  `AppRun` exports `LD_LIBRARY_PATH`, `GTK_PATH`, `GIO_EXTRA_MODULES`,
+  `PYTHONHOME` and friends into Toolport, and every child inherited them. Right
+  for our own bundled payload, poison for anything else: a _system_ binary loaded
+  Ubuntu 22.04's glib or brotli instead of the host's and died at dynamic-link
+  time on a rolling release, before running any of its own code. In practice
+  clicking **Authenticate** on an OAuth server said "opening browser" and nothing
+  happened, because the browser `xdg-open` launched exited with
+  `undefined symbol: BrotliDecoderAttachDictionary`. The same hazard applied to
+  any stdio MCP server that is a native binary or pulls a native node/python
+  module. Anything that is not our own payload is now spawned with those
+  variables removed (new `hostenv` module); `XDG_DATA_DIRS` keeps its host
+  entries so `xdg-open` can still find `.desktop` files, and nothing else in the
+  environment is touched, so a server's own `env` block still wins. A no-op
+  outside an AppImage, so the `.deb`, the AUR package and dev builds are
+  unaffected.
+
+### Changed
+
+- **External links no longer go through `tauri-plugin-opener`.** The plugin
+  spawns with our inherited environment and offers no hook to change it, so under
+  an AppImage every link in the UI hit the bug above. They now go through an
+  `open_external` command that reuses the same sanitised spawn as the OAuth
+  flow. The `http`/`https`-only and link-local/metadata guards are unchanged and
+  are now enforced on the IPC boundary as well as in the renderer.
+
 ## [1.15.0] - 2026-08-20
 
 ### Security

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-autostart": "^2.5.1",
         "@tauri-apps/plugin-dialog": "^2.7.1",
-        "@tauri-apps/plugin-opener": "^2",
         "@tauri-apps/plugin-process": "^2.3.1",
         "@tauri-apps/plugin-updater": "^2.10.1",
         "class-variance-authority": "^0.7.1",
@@ -3852,13 +3851,6 @@
     },
     "node_modules/@tauri-apps/plugin-dialog": {
       "version": "2.7.1",
-      "license": "MIT OR Apache-2.0",
-      "dependencies": {
-        "@tauri-apps/api": "^2.11.0"
-      }
-    },
-    "node_modules/@tauri-apps/plugin-opener": {
-      "version": "2.5.4",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@tauri-apps/api": "^2.11.0"

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "@tauri-apps/api": "^2",
     "@tauri-apps/plugin-autostart": "^2.5.1",
     "@tauri-apps/plugin-dialog": "^2.7.1",
-    "@tauri-apps/plugin-opener": "^2",
     "@tauri-apps/plugin-process": "^2.3.1",
     "@tauri-apps/plugin-updater": "^2.10.1",
     "class-variance-authority": "^0.7.1",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -834,7 +834,6 @@ dependencies = [
  "tauri-plugin-deep-link",
  "tauri-plugin-dialog",
  "tauri-plugin-notification",
- "tauri-plugin-opener",
  "tauri-plugin-process",
  "tauri-plugin-single-instance",
  "tauri-plugin-updater",
@@ -2455,25 +2454,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
-name = "is-docker"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "928bae27f42bc99b60d9ac7334e3a21d10ad8f1835a4e12ec3ec0464765ed1b3"
-dependencies = [
- "once_cell",
-]
-
-[[package]]
-name = "is-wsl"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5"
-dependencies = [
- "is-docker",
- "once_cell",
-]
-
-[[package]]
 name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3310,18 +3290,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
-name = "open"
-version = "5.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fbaa89d2ddc8473c78a3adf69eea8cffa28c483b8e02a971ef31527cd0fc92c"
-dependencies = [
- "dunce",
- "is-wsl",
- "libc",
- "pathdiff",
-]
-
-[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3432,12 +3400,6 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
-
-[[package]]
-name = "pathdiff"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
 name = "percent-encoding"
@@ -5097,28 +5059,6 @@ dependencies = [
  "thiserror 2.0.18",
  "time",
  "url",
-]
-
-[[package]]
-name = "tauri-plugin-opener"
-version = "2.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17e1bea14edce6b793a04e2417e3fd924b9bc4faae83cdee7d714156cceeed29"
-dependencies = [
- "dunce",
- "glob",
- "objc2-app-kit",
- "objc2-foundation",
- "open",
- "schemars 0.8.22",
- "serde",
- "serde_json",
- "tauri",
- "tauri-plugin",
- "thiserror 2.0.18",
- "url",
- "windows",
- "zbus 5.16.0",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -18,7 +18,6 @@ default = ["desktop"]
 desktop = [
     "dep:tauri",
     "dep:tauri-build",
-    "dep:tauri-plugin-opener",
     "dep:tauri-plugin-updater",
     "dep:tauri-plugin-process",
     "dep:tauri-plugin-dialog",
@@ -46,7 +45,6 @@ tauri-build = { version = "2", features = [], optional = true }
 
 [dependencies]
 tauri = { version = "2", features = ["tray-icon", "image-png"], optional = true }
-tauri-plugin-opener = { version = "2", optional = true }
 tauri-plugin-updater = { version = "2", optional = true }
 tauri-plugin-process = { version = "2", optional = true }
 tauri-plugin-dialog = { version = "2", optional = true }

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -5,7 +5,6 @@
   "windows": ["main"],
   "permissions": [
     "core:default",
-    "opener:default",
     "updater:default",
     "process:allow-restart",
     "dialog:allow-save",

--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -5180,20 +5180,63 @@ fn open_external(url: String) -> Result<(), String> {
         return Err("only http and https URLs can be opened".into());
     }
     let host = parsed.host_str().ok_or("URL has no host")?;
-    // `host_str` keeps IPv6 literals in brackets; strip them before parsing.
-    if let Ok(ip) = host.trim_matches(['[', ']']).parse::<std::net::IpAddr>() {
-        if crate::oauth::ip_is_link_local(&ip) {
-            return Err("refusing to open a link-local/metadata address".into());
-        }
-    } else if host.eq_ignore_ascii_case("metadata.google.internal")
-        || host.eq_ignore_ascii_case("metadata")
-    {
-        // These names resolve to the metadata service without a link-local
-        // literal ever appearing in the URL. Mirrors the same pair in openUrl.ts.
+    if host_reaches_metadata(host) {
         return Err("refusing to open a link-local/metadata address".into());
     }
     crate::oauth::open_browser(parsed.as_str());
     Ok(())
+}
+
+/// Hosts that must never reach the OS browser.
+///
+/// This mirrors `isLinkLocalHost` in `src/lib/openUrl.ts` case for case, and the
+/// tests below use that file's vectors. It has to: the point of checking here is
+/// that a compromised renderer cannot `invoke` its way past the frontend guard,
+/// and a backend check that is a strict subset of the frontend one does not do
+/// that. `oauth::ip_is_link_local` alone is such a subset - it has no opinion on
+/// CGNAT, unspecified or broadcast addresses - so it is one input here, not the
+/// whole answer.
+///
+/// Deliberately narrower than `oauth::ip_is_private`: loopback and RFC1918 LAN
+/// hosts are legitimate browser targets (locally served docs, an intranet page).
+/// Only the ranges that reach a metadata service are refused.
+fn host_reaches_metadata(host: &str) -> bool {
+    // WHATWG keeps a trailing dot on named hosts and brackets on IPv6 literals.
+    let host = host.trim_matches(['[', ']']);
+    let host = host.strip_suffix('.').unwrap_or(host);
+    // Well-known metadata names resolve to the service without a link-local
+    // literal ever appearing in the URL, so match them directly.
+    if host.eq_ignore_ascii_case("metadata.google.internal") || host.eq_ignore_ascii_case("metadata")
+    {
+        return true;
+    }
+    let Ok(ip) = host.parse::<std::net::IpAddr>() else {
+        return false;
+    };
+    ip_reaches_metadata(&ip)
+}
+
+fn ip_reaches_metadata(ip: &std::net::IpAddr) -> bool {
+    use std::net::IpAddr;
+    // Covers 169.254/16 (incl. 169.254.169.254), fe80::/10, fd00:ec2::254, and
+    // the IPv4-mapped forms of the first.
+    if crate::oauth::ip_is_link_local(ip) {
+        return true;
+    }
+    let v4 = match ip {
+        IpAddr::V4(v4) => Some(*v4),
+        IpAddr::V6(v6) => {
+            if v6.is_unspecified() {
+                return true; // `::`
+            }
+            v6.to_ipv4_mapped()
+        }
+    };
+    let Some(v4) = v4 else { return false };
+    let [a, b, ..] = v4.octets();
+    // CGNAT 100.64/10 (Alibaba/OCI metadata), "this network" 0/8 (0.0.0.0
+    // reaches loopback/IMDS on some stacks), and the broadcast address.
+    (a == 100 && b & 0xc0 == 64) || a == 0 || v4.is_broadcast()
 }
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
@@ -8100,3 +8143,49 @@ mod tests {
     }
 }
 
+#[cfg(test)]
+mod opener_host_tests {
+    use super::host_reaches_metadata;
+
+    /// The vectors are lifted from `src/lib/openUrl.test.ts`. Keeping them
+    /// identical is the point: this guard exists so a compromised renderer
+    /// cannot `invoke` past the frontend one, which it could if the backend
+    /// refused a smaller set.
+    #[test]
+    fn refuses_every_host_the_renderer_refuses() {
+        for host in [
+            "169.254.169.254",
+            "169.254.169.254.", // WHATWG keeps the trailing dot
+            "100.100.100.200",  // CGNAT 100.64/10
+            "0.0.0.0",
+            "255.255.255.255",
+            "[fe80::1]",
+            "[::ffff:169.254.169.254]",
+            "[::]",
+            "[fd00:ec2::254]",
+            "metadata.google.internal",
+            "metadata",
+            "METADATA.GOOGLE.INTERNAL",
+        ] {
+            assert!(host_reaches_metadata(host), "{host} should be refused");
+        }
+    }
+
+    /// Narrower than `ip_is_private` on purpose: locally served docs and an
+    /// intranet page are ordinary browsing.
+    #[test]
+    fn keeps_loopback_lan_and_the_public_internet_reachable() {
+        for host in [
+            "example.com",
+            "localhost",
+            "127.0.0.1",
+            "192.168.1.10",
+            "10.0.0.5",
+            "[::1]",
+            "100.32.0.1", // 100.32/11, outside CGNAT
+            "1.1.1.1",
+        ] {
+            assert!(!host_reaches_metadata(host), "{host} should be allowed");
+        }
+    }
+}

--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -3528,8 +3528,11 @@ fn open_data_dir() -> Result<(), String> {
     let program = "open";
     #[cfg(target_os = "linux")]
     let program = "xdg-open";
-    std::process::Command::new(program)
-        .arg(&dir)
+    let mut cmd = std::process::Command::new(program);
+    // The file manager this launches is a host binary, so it must not inherit an
+    // AppImage's bundled library paths (see hostenv).
+    crate::hostenv::strip_bundled_env(&mut cmd);
+    cmd.arg(&dir)
         .spawn()
         .map_err(|e| format!("could not open the data directory: {e}"))?;
     Ok(())
@@ -5157,6 +5160,42 @@ fn is_launch_at_login_enabled(app: AppHandle) -> Result<bool, String> {
     }
 }
 
+/// Open a web link in the user's browser.
+///
+/// This replaces `tauri-plugin-opener` for the frontend. The plugin spawns with
+/// our inherited environment and offers no hook to change it, so under an
+/// AppImage the browser it launches inherits the bundle's library paths and dies
+/// on `undefined symbol` before drawing anything (see `hostenv`). Going through
+/// `oauth::open_browser` gives every link the same sanitised spawn the OAuth
+/// sign-in already uses, on all three platforms.
+///
+/// SECURITY: some of these URLs come from registry/vendor data, which is not
+/// fully trusted. `openUrl.ts` refuses anything that is not an `http`/`https`
+/// URL with a non-link-local host; this is the matching guard on the IPC
+/// boundary, which the renderer cannot talk its way around.
+#[tauri::command]
+fn open_external(url: String) -> Result<(), String> {
+    let parsed = url::Url::parse(&url).map_err(|_| "not a URL".to_string())?;
+    if !matches!(parsed.scheme(), "http" | "https") {
+        return Err("only http and https URLs can be opened".into());
+    }
+    let host = parsed.host_str().ok_or("URL has no host")?;
+    // `host_str` keeps IPv6 literals in brackets; strip them before parsing.
+    if let Ok(ip) = host.trim_matches(['[', ']']).parse::<std::net::IpAddr>() {
+        if crate::oauth::ip_is_link_local(&ip) {
+            return Err("refusing to open a link-local/metadata address".into());
+        }
+    } else if host.eq_ignore_ascii_case("metadata.google.internal")
+        || host.eq_ignore_ascii_case("metadata")
+    {
+        // These names resolve to the metadata service without a link-local
+        // literal ever appearing in the URL. Mirrors the same pair in openUrl.ts.
+        return Err("refusing to open a link-local/metadata address".into());
+    }
+    crate::oauth::open_browser(parsed.as_str());
+    Ok(())
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     // `generate_context!()` must expand exactly once in this crate: on macOS dev
@@ -5229,7 +5268,6 @@ pub fn run() {
             show_main_window(app);
         }))
         .plugin(tauri_plugin_deep_link::init())
-        .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(tauri_plugin_process::init())
         .plugin(tauri_plugin_dialog::init())
@@ -5386,6 +5424,7 @@ pub fn run() {
             enable_launch_at_login,
             disable_launch_at_login,
             is_launch_at_login_enabled,
+            open_external,
         ])
         // Close-to-tray: the window's X hides it instead of quitting, so the gateway and
         // approval broker keep running (HITL only works while the app is alive). Quit is
@@ -8060,3 +8099,4 @@ mod tests {
         );
     }
 }
+

--- a/src-tauri/src/downstream.rs
+++ b/src-tauri/src/downstream.rs
@@ -1598,10 +1598,12 @@ pub fn augmented_path() -> &'static str {
         };
         // Best effort: the login shell's PATH (covers nvm/asdf/homebrew/volta).
         if let Ok(shell) = std::env::var("SHELL") {
-            if let Ok(out) = std::process::Command::new(&shell)
-                .args(["-ilc", "printf %s \"$PATH\""])
-                .output()
-            {
+            let mut cmd = std::process::Command::new(&shell);
+            // The user's login shell is a host binary, and this probe fails
+            // silently: an AppImage's library paths could make it die at link
+            // time and we would just report a shorter PATH (see hostenv).
+            crate::hostenv::strip_bundled_env(&mut cmd);
+            if let Ok(out) = cmd.args(["-ilc", "printf %s \"$PATH\""]).output() {
                 if out.status.success() {
                     for d in String::from_utf8_lossy(&out.stdout).split(':') {
                         push(d.to_string(), &mut dirs_list);
@@ -3238,6 +3240,10 @@ impl StdioTransport {
         let spawn_args = container_args.as_slice();
         let resolved = resolve_command(spawn_command);
         let mut cmd = Command::new(&resolved);
+        // A downstream server is not our bundled payload, so it must not inherit
+        // an AppImage's library and plugin paths (see hostenv). Applied BEFORE the
+        // server's own `env` below, so anything it configures deliberately wins.
+        crate::hostenv::strip_bundled_env(&mut cmd);
         cmd.args(spawn_args)
             .envs(env.iter().cloned())
             .stdin(Stdio::piped())

--- a/src-tauri/src/hostenv.rs
+++ b/src-tauri/src/hostenv.rs
@@ -1,0 +1,194 @@
+//! Hand host binaries the host's environment, not the AppImage's.
+//!
+//! An AppImage launches through `AppRun`, which exports the bundle's own
+//! library and plugin paths into our process so our bundled payload can find
+//! them:
+//!
+//! ```text
+//! LD_LIBRARY_PATH=$APPDIR/usr/lib/:$APPDIR/usr/lib/x86_64-linux-gnu/:...
+//! GTK_PATH, GIO_EXTRA_MODULES, GSETTINGS_SCHEMA_DIR, PYTHONHOME, ...
+//! ```
+//!
+//! Every process we spawn inherits that. For our own payload (the bundled
+//! gateway) it is exactly right. For anything else it is poison: the bundle
+//! carries Ubuntu 22.04's libraries, so a *system* binary loads our old glib
+//! or brotli instead of the host's and dies at dynamic-link time on a rolling
+//! release, before it runs a line of its own code:
+//!
+//! ```text
+//! zenity:   symbol lookup error: /usr/lib/libjson-glib-1.0.so.0:
+//!           undefined symbol: g_once_init_leave_pointer
+//! chromium: symbol lookup error: /usr/lib/chromium/chromium:
+//!           undefined symbol: BrotliDecoderAttachDictionary
+//! ```
+//!
+//! That is what makes an OAuth "opening browser" do nothing at all, and it is
+//! latent on every MCP server that is a native binary or pulls a native node or
+//! python module. So anything we exec that is not our own bundled payload goes
+//! through [`strip_bundled_env`] first.
+//!
+//! Gated on `APPDIR`, which only an AppImage sets, so this is a no-op for the
+//! `.deb`, the AUR package, and a dev build.
+//!
+//! Deliberately NOT an `env_clear()`: an MCP server legitimately needs the
+//! user's `PATH`, `HOME`, proxy variables, and whatever its own `env` block
+//! configures. Only the variables `AppRun` and its GTK hook introduce are
+//! removed. `PATH` is also left alone even though `AppRun` prepends
+//! `$APPDIR/usr/bin` to it: the only things that shadows are `xdg-open`,
+//! `xdg-mime` and our own binaries, none of which has caused a failure, and
+//! rewriting it would have to happen after every other `PATH` edit at the call
+//! site.
+//!
+//! The `ps` / `kill` helpers in `gateway_publish.rs` are deliberately left
+//! alone. They are host binaries too, but they resolve to libc and nothing else,
+//! and both were checked under the bundle's `LD_LIBRARY_PATH` and ran clean. The
+//! spawns that go through this are the ones that reach real desktop or user
+//! software: a browser, a file manager, a login shell, an MCP server.
+
+use std::process::Command;
+
+/// Every variable `AppRun.wrapped` and `apprun-hooks/linuxdeploy-plugin-gtk.sh`
+/// export, minus the two handled specially below (`XDG_DATA_DIRS`, which is
+/// prepended to rather than replaced, and `PATH`, see the module docs).
+///
+/// Taken from the shipped AppImage rather than from linuxdeploy's source, so it
+/// describes what we actually build. A future linuxdeploy that exports one more
+/// variable leaves that one leaking; it does not break anything here.
+#[cfg(all(unix, not(target_os = "macos")))]
+const BUNDLED_VARS: &[&str] = &[
+    // AppRun.wrapped
+    "LD_LIBRARY_PATH",
+    "PERLLIB",
+    "PYTHONHOME",
+    "PYTHONPATH",
+    "QT_PLUGIN_PATH",
+    "GST_PLUGIN_SYSTEM_PATH",
+    "GST_PLUGIN_SYSTEM_PATH_1_0",
+    // linuxdeploy-plugin-gtk.sh
+    "APPDIR",
+    "GDK_BACKEND",
+    "GDK_PIXBUF_MODULE_FILE",
+    "GIO_EXTRA_MODULES",
+    "GSETTINGS_SCHEMA_DIR",
+    "GTK_DATA_PREFIX",
+    "GTK_EXE_PREFIX",
+    "GTK_IM_MODULE_FILE",
+    "GTK_PATH",
+    "GTK_THEME",
+    // Not exported by this AppRun, but the loader honours it and a future hook
+    // could set it; removing an unset variable costs nothing.
+    "LD_PRELOAD",
+];
+
+/// Remove the AppImage's bundled library and plugin paths from `cmd`.
+///
+/// Call it on any [`Command`] that runs something other than our own bundled
+/// payload, and call it *before* applying caller-supplied environment, so a
+/// value the caller set on purpose still wins.
+///
+/// A no-op outside an AppImage, and on macOS and Windows.
+#[cfg(all(unix, not(target_os = "macos")))]
+pub fn strip_bundled_env(cmd: &mut Command) {
+    let Ok(appdir) = std::env::var("APPDIR") else {
+        return; // not running from an AppImage
+    };
+    strip_for_appdir(cmd, &appdir, std::env::var("XDG_DATA_DIRS").ok().as_deref());
+}
+
+#[cfg(not(all(unix, not(target_os = "macos"))))]
+pub fn strip_bundled_env(_cmd: &mut Command) {}
+
+/// The half of [`strip_bundled_env`] that does not read the process environment,
+/// so it can be tested without mutating it.
+#[cfg(all(unix, not(target_os = "macos")))]
+fn strip_for_appdir(cmd: &mut Command, appdir: &str, data_dirs: Option<&str>) {
+    for key in BUNDLED_VARS {
+        cmd.env_remove(key);
+    }
+    // XDG_DATA_DIRS is the one AppRun *prepends* to rather than replaces, so it
+    // still carries the host's entries. Dropping the whole variable would leave
+    // xdg-open unable to find any .desktop file; drop only our entries.
+    if let Some(dirs) = data_dirs {
+        let kept: Vec<&str> = dirs
+            .split(':')
+            .filter(|p| !p.is_empty() && !p.starts_with(appdir))
+            .collect();
+        cmd.env("XDG_DATA_DIRS", kept.join(":"));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(all(unix, not(target_os = "macos")))]
+    use super::*;
+
+    #[cfg(all(unix, not(target_os = "macos")))]
+    fn env_of(cmd: &Command) -> Vec<(String, Option<String>)> {
+        cmd.get_envs()
+            .map(|(k, v)| {
+                (
+                    k.to_string_lossy().into_owned(),
+                    v.map(|v| v.to_string_lossy().into_owned()),
+                )
+            })
+            .collect()
+    }
+
+    #[cfg(all(unix, not(target_os = "macos")))]
+    #[test]
+    fn removes_every_bundled_var() {
+        let mut cmd = Command::new("true");
+        strip_for_appdir(&mut cmd, "/tmp/.mount_Toolpo1234", None);
+        let env = env_of(&cmd);
+        for key in BUNDLED_VARS {
+            let entry = env.iter().find(|(k, _)| k == key);
+            assert_eq!(
+                entry.map(|(_, v)| v.clone()),
+                Some(None),
+                "{key} should be marked for removal"
+            );
+        }
+    }
+
+    #[cfg(all(unix, not(target_os = "macos")))]
+    #[test]
+    fn keeps_host_data_dirs_and_drops_ours() {
+        let appdir = "/tmp/.mount_Toolpo1234";
+        let mut cmd = Command::new("true");
+        strip_for_appdir(
+            &mut cmd,
+            appdir,
+            Some(&format!("{appdir}/usr/share:/usr/share:/home/u/.local/share")),
+        );
+        let dirs = env_of(&cmd)
+            .into_iter()
+            .find(|(k, _)| k == "XDG_DATA_DIRS")
+            .and_then(|(_, v)| v)
+            .expect("XDG_DATA_DIRS should be rewritten, not removed");
+        assert_eq!(dirs, "/usr/share:/home/u/.local/share");
+    }
+
+    #[cfg(all(unix, not(target_os = "macos")))]
+    #[test]
+    fn leaves_xdg_data_dirs_alone_when_unset() {
+        let mut cmd = Command::new("true");
+        strip_for_appdir(&mut cmd, "/tmp/.mount_Toolpo1234", None);
+        assert!(!env_of(&cmd).iter().any(|(k, _)| k == "XDG_DATA_DIRS"));
+    }
+
+    /// The .deb, the AUR package and a dev build must be untouched. They never
+    /// set APPDIR, so the guard in `strip_bundled_env` is what protects them.
+    #[cfg(all(unix, not(target_os = "macos")))]
+    #[test]
+    fn no_op_without_appdir() {
+        let previous = std::env::var("APPDIR").ok();
+        std::env::remove_var("APPDIR");
+        let mut cmd = Command::new("true");
+        strip_bundled_env(&mut cmd);
+        let empty = cmd.get_envs().next().is_none();
+        if let Some(v) = previous {
+            std::env::set_var("APPDIR", v);
+        }
+        assert!(empty, "nothing should be changed outside an AppImage");
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -15,6 +15,7 @@ pub mod downstream;
 pub mod gateway_publish;
 pub mod gatewaylog;
 pub mod hooks;
+pub mod hostenv;
 pub mod inspect;
 pub mod instructions;
 pub mod integrity;

--- a/src-tauri/src/oauth.rs
+++ b/src-tauri/src/oauth.rs
@@ -1358,7 +1358,7 @@ fn redact_secret(text: &str, secret: &str) -> String {
     text.replace(secret, "***")
 }
 
-fn open_browser(url: &str) {
+pub(crate) fn open_browser(url: &str) {
     // NOT `cmd /C start` on Windows: cmd treats `&` in the URL as a command
     // separator and truncates it. rundll32 passes the URL through verbatim.
     #[cfg(windows)]
@@ -1367,8 +1367,15 @@ fn open_browser(url: &str) {
         .spawn();
     #[cfg(target_os = "macos")]
     let _ = std::process::Command::new("open").arg(url).spawn();
+    // xdg-open is a host binary, and so is the browser it goes on to exec, so
+    // neither may inherit an AppImage's bundled library paths - it makes the
+    // browser die on `undefined symbol` and the sign-in silently never opens.
     #[cfg(all(unix, not(target_os = "macos")))]
-    let _ = std::process::Command::new("xdg-open").arg(url).spawn();
+    {
+        let mut cmd = std::process::Command::new("xdg-open");
+        crate::hostenv::strip_bundled_env(&mut cmd);
+        let _ = cmd.arg(url).spawn();
+    }
 }
 
 fn validate_authorization_response_issuer(

--- a/src/lib/openUrl.test.ts
+++ b/src/lib/openUrl.test.ts
@@ -1,29 +1,34 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
-const { openUrl } = vi.hoisted(() => ({ openUrl: vi.fn() }));
+const { invoke } = vi.hoisted(() => ({ invoke: vi.fn() }));
 
-vi.mock("@tauri-apps/plugin-opener", () => ({ openUrl }));
+vi.mock("@tauri-apps/api/core", () => ({ invoke }));
 
 // Import after mock so the module binds to the mock.
 const { openExternal } = await import("./openUrl");
 
 describe("openExternal", () => {
   beforeEach(() => {
-    openUrl.mockClear();
+    invoke.mockClear();
+    invoke.mockResolvedValue(undefined);
   });
 
   it("allows http and https URLs through to the opener", async () => {
     await openExternal("https://example.com/docs");
     await openExternal("http://localhost:3000");
-    expect(openUrl).toHaveBeenCalledWith("https://example.com/docs");
-    expect(openUrl).toHaveBeenCalledWith("http://localhost:3000");
-    expect(openUrl).toHaveBeenCalledTimes(2);
+    expect(invoke).toHaveBeenCalledWith("open_external", {
+      url: "https://example.com/docs",
+    });
+    expect(invoke).toHaveBeenCalledWith("open_external", {
+      url: "http://localhost:3000",
+    });
+    expect(invoke).toHaveBeenCalledTimes(2);
   });
 
   it("keeps loopback and private-LAN docs reachable", async () => {
     await openExternal("http://127.0.0.1:8080/docs");
     await openExternal("http://192.168.1.10/manual");
-    expect(openUrl).toHaveBeenCalledTimes(2);
+    expect(invoke).toHaveBeenCalledTimes(2);
   });
 
   it("refuses link-local and cloud-metadata hosts", async () => {
@@ -37,7 +42,14 @@ describe("openExternal", () => {
     await openExternal("http://[fd00:ec2::254]/latest/meta-data/");
     await openExternal("http://metadata.google.internal/computeMetadata/v1/");
     await openExternal("http://metadata/computeMetadata/v1/");
-    expect(openUrl).not.toHaveBeenCalled();
+    expect(invoke).not.toHaveBeenCalled();
+  });
+
+  // These are all fire-and-forget click handlers, so a backend that refuses the
+  // URL or cannot find a browser must not reject into an unhandled rejection.
+  it("swallows a rejection from the backend", async () => {
+    invoke.mockRejectedValue("no browser");
+    await expect(openExternal("https://example.com")).resolves.toBeUndefined();
   });
 
   it("refuses file:, javascript:, malformed, and empty inputs", async () => {
@@ -48,6 +60,6 @@ describe("openExternal", () => {
     await openExternal(null);
     await openExternal(undefined);
     await openExternal(42 as unknown as string);
-    expect(openUrl).not.toHaveBeenCalled();
+    expect(invoke).not.toHaveBeenCalled();
   });
 });

--- a/src/lib/openUrl.ts
+++ b/src/lib/openUrl.ts
@@ -1,4 +1,4 @@
-import { openUrl } from "@tauri-apps/plugin-opener";
+import { invoke } from "@tauri-apps/api/core";
 
 /**
  * Open an external link, but only real web URLs.
@@ -7,8 +7,15 @@ import { openUrl } from "@tauri-apps/plugin-opener";
  * homepage, an auth hint's docs link), which is not fully trusted. Handing a
  * `file://` (Windows SMB -> NTLM-hash leak) or a custom-scheme handler URI to
  * the OS opener is a real risk, so allow only `http`/`https` through. The
- * backend also validates at the source (see `catalog.rs`); this is the matching
- * frontend guard so every `openUrl` call site is covered.
+ * backend also validates at the source (see `catalog.rs`), and the `open_external`
+ * command re-checks on the IPC boundary; this is the matching frontend guard so
+ * every call site is covered.
+ *
+ * Goes through our own `open_external` command rather than
+ * `tauri-plugin-opener`: the plugin spawns the browser with whatever environment
+ * we inherited, and under an AppImage that means the bundle's library paths, so
+ * the browser dies on `undefined symbol` and the link silently never opens
+ * (see `hostenv.rs`).
  *
  * Link-local and metadata-range hosts are refused too: clicking "docs" on an
  * untrusted registry entry must not reach `http://169.254.169.254/…` (IMDSv1)
@@ -35,7 +42,9 @@ export function openExternal(url: string | null | undefined): Promise<void> {
     console.warn(`openExternal: refusing to open link-local/metadata URL: ${url}`);
     return Promise.resolve();
   }
-  return openUrl(url);
+  return invoke<void>("open_external", { url }).catch((error: unknown) => {
+    console.warn(`openExternal: could not open ${url}: ${String(error)}`);
+  });
 }
 
 /** Link-local and metadata address ranges only — deliberately narrower than


### PR DESCRIPTION
> [!IMPORTANT]
> Stacked on #831 — base is `fix/appimage-unbundle-wayland`, so the diff shown here is this change only. Merge #831 first and this retargets to `main` automatically.

## The bug

Same root cause as #831, pointed the other way. `AppRun` exports the bundle's library and plugin paths into our process so our own payload can find them:

```
LD_LIBRARY_PATH=$APPDIR/usr/lib/:…
GTK_PATH, GIO_EXTRA_MODULES, GSETTINGS_SCHEMA_DIR, PYTHONHOME, …
```

Every process we spawn inherited that. Correct for the bundled gateway; poison for anything else, because the bundle carries Ubuntu 22.04's libraries, so a *system* binary loads our old glib or brotli instead of the host's and dies at dynamic-link time on a rolling release — before running a line of its own code:

```
zenity:   symbol lookup error: /usr/lib/libjson-glib-1.0.so.0:
          undefined symbol: g_once_init_leave_pointer
chromium: symbol lookup error: /usr/lib/chromium/chromium:
          undefined symbol: BrotliDecoderAttachDictionary
```

**Symptom:** clicking **Authenticate** on an OAuth server said "opening browser" and nothing happened — no window, no error. `python3` failed the same way, which is what makes this class so hard to place: it looks like a bug in whatever the child was trying to do.

Reproducible without Toolport, with the AppImage mounted:

```bash
LD_LIBRARY_PATH=/tmp/.mount_Toolpo*/usr/lib zenity --list --column=X A
```

## The fix

New `hostenv::strip_bundled_env`, gated on `APPDIR` so the `.deb`, the AUR package and dev builds are a no-op. The variable list is taken from the **shipped AppImage's** `AppRun.wrapped` and GTK hook rather than from linuxdeploy's source, so it describes what we actually build.

Deliberately **not** `env_clear()`: an MCP server legitimately needs the user's `PATH`, `HOME`, proxy variables and its own `env` block. Only the named variables go, and `XDG_DATA_DIRS` is filtered rather than dropped — `AppRun` prepends to it, and `xdg-open` still needs the host's `.desktop` files. In `downstream.rs` it is applied *before* the server's configured `env`, so a value set on purpose still wins.

## Spawn sites

Wired into everything that reaches real desktop or user software — three more than the original report found:

| site | impact |
|---|---|
| `oauth.rs` `open_browser` → `xdg-open` | OAuth sign-in silently never opened |
| `downstream.rs` stdio MCP server spawn | any native-binary or native-module server |
| `desktop.rs` `open_data_dir` → file manager | *(newly found)* |
| `downstream.rs` login-shell `PATH` probe | *(newly found)* fails silently → shorter PATH, so servers stop finding `node` |
| `src/lib/openUrl.ts` → every link in the UI | *(newly found reach)* see below |

`ps` / `kill` in `gateway_publish.rs` are deliberately left alone. They're host binaries too, but they resolve to libc and nothing else, and both were checked under the bundle's `LD_LIBRARY_PATH` and run clean. `PATH` is also left alone — `AppRun` prepends `$APPDIR/usr/bin`, but the only things that shadows are `xdg-open`, `xdg-mime` and our own binaries, and rewriting it would have to happen after every other `PATH` edit at the call site. Both decisions are written down in the module docs.

## Retiring `tauri-plugin-opener`

Frontend links needed a different fix: the plugin spawns with the inherited environment and exposes **no hook** to change it, so `strip_bundled_env` cannot reach it.

Rather than special-case Linux in the renderer — which would have meant pulling in `@tauri-apps/plugin-os` purely to ask what platform we're on — `openUrl.ts` now calls a new `open_external` command that reuses `oauth::open_browser`'s sanitised spawn on all three platforms, and the plugin is dropped (`openUrl.ts` was its only consumer, so the dep, the feature, and the `opener:default` capability go with it).

**The URL validation is preserved and strengthened.** The `http`/`https`-only guard and the link-local/metadata-range blocking are unchanged in the renderer, and the same checks now also run in `open_external` — on the IPC boundary, where the renderer cannot talk its way around them. That matters because some of these URLs come from registry/vendor data, which is not fully trusted.

## Testing

- Four unit tests on `hostenv`: every variable removed, `XDG_DATA_DIRS` keeps host entries and drops `$APPDIR` ones, it is left alone when unset, and the whole thing is a no-op without `APPDIR` (the test that protects the `.deb`/AUR builds). The env-reading half is split out so the tests never mutate the process environment.
- `openUrl.test.ts` retargeted to the command, plus a new case that a backend rejection is swallowed — these are fire-and-forget click handlers and must not become unhandled rejections.
- Full suites green: 1313 Rust lib tests, 621 frontend tests, clippy (incl. `--no-default-features`) and `tsc` clean.

> [!NOTE]
> Not verified end to end in a real AppImage — that needs a CI build, and `env -i` won't reproduce it because you need the actual `AppRun`. Worth confirming an OAuth sign-in on the first 1.16.0 AppImage.
>
> On the reporting machine the browser symptom is **masked**: a local `chromium-profile-chooser` is registered as the `http`/`https` handler and strips these same variables itself. Verify elsewhere, or `xdg-mime default chromium.desktop x-scheme-handler/http x-scheme-handler/https` first. That workaround never helped the MCP-server path at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how Linux AppImage children inherit environment (browsers, MCP servers, file manager) and moves URL opening onto a new IPC command with metadata-host guards. Wrong env stripping or a mismatched URL check could break native servers or open unsafe links.
> 
> **Overview**
> Linux AppImage children no longer inherit bundled library paths (`LD_LIBRARY_PATH`, GTK/GIO/Python, etc.). That leak made host browsers and native MCP servers die at dynamic-link time (OAuth “opening browser” with no window). New `hostenv::strip_bundled_env` is gated on `APPDIR` (no-op for .deb/AUR/dev) and is applied to OAuth `xdg-open`, stdio MCP spawn, the login-shell PATH probe, and opening the data directory. `XDG_DATA_DIRS` keeps host entries so `.desktop` lookup still works; a server’s own `env` still wins.
> 
> UI links drop `tauri-plugin-opener` (no env hook) and go through a new `open_external` command that reuses the same sanitised spawn. `http`/`https` and link-local/metadata host checks now run on the IPC boundary as well as in the renderer.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit abe6f72e2c84483ed67053976788da469da9e274. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Linux AppImage env leaking into spawned processes and replace `opener` plugin
> - Adds `hostenv::strip_bundled_env`, a no-op except on Unix non-macOS when `APPDIR` is set, which removes AppImage-introduced env vars and rewrites `XDG_DATA_DIRS` to drop AppImage-prefixed entries.
> - Applies the utility at all host-binary spawn sites: `desktop::open_data_dir`, `downstream::augmented_path`, `StdioTransport::spawn_watched`, and `oauth::open_browser`, preventing dynamic-linker failures in native binaries and modules.
> - Removes `tauri-plugin-opener` and adds a new `open_external` Tauri command that enforces http/https schemes, rejects metadata/link-local hosts via `host_reaches_metadata`, and delegates to `oauth::open_browser`. Frontend `openUrl.ts` now calls `invoke('open_external')` and swallows backend rejections with a warning.
> - Behavioral Change: `open_external` rejects non-web URLs and link-local/metadata/CGNAT hosts that `tauri-plugin-opener` would have opened; frontend no longer throws on backend rejection.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized abe6f72.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->