### PR TITLE
fix(rules): stop reporting VS Code as Applied for a rules file it never reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to Toolport are documented here. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/); versions match the GitHub releases.
 Entries before the rename below shipped under the project's former name, Conduit.
 
+## [Unreleased]
+
+### Fixed
+
+- **Agent rules and Team Instructions no longer report VS Code as "Applied" for a
+  file it never reads.** VS Code was mapped onto Claude Code's `~/.claude/rules/`
+  directory on the claim that Copilot reads it. Nothing supports that: Copilot's
+  instruction files are `.github/copilot-instructions.md` and repo-level
+  `AGENTS.md`, both project-scoped, so for a Copilot-only install the rules landed in a
+  directory nothing looked at while both the Agent rules tab and the Teams coverage
+  receipt said they had been applied. VS Code now reports as a client with no rules
+  file Toolport can write, alongside Cursor and Warp, so you know to paste them in.
+  The Claude Code VS Code extension shares `~/.claude` with the CLI and was, and is,
+  covered by the Claude Code row. (SBS-916)
+
 ## [1.16.0] - 2026-08-22
 
 ### Fixed

--- a/docs/agent-rules.md
+++ b/docs/agent-rules.md
@@ -52,7 +52,6 @@ own text.
 | Client                  | Rules file                                                                       | Strategy     |
 | ----------------------- | -------------------------------------------------------------------------------- | ------------ |
 | Claude Code             | `~/.claude/rules/toolport-rules.md`                                              | Owned file   |
-| VS Code                 | `~/.claude/rules/toolport-rules.md` (shared with Claude Code)                    | Owned file   |
 | Kiro                    | `~/.kiro/steering/toolport-rules.md`                                             | Owned file   |
 | Roo Code                | `~/.roo/rules/toolport-rules.md`                                                 | Owned file   |
 | Cline                   | `~/Documents/Cline/Rules/toolport-rules.md`                                      | Owned file   |
@@ -72,12 +71,14 @@ they use the roaming config directory.
 Where two clients share a file, Toolport writes it once. Both are covered even if
 only one is installed.
 
-The VS Code row resolves to Claude Code's rules directory, which is what Toolport
-has always done for team instructions. That covers a VS Code install running a
-Claude-compatible extension. It is **not** a claim that GitHub Copilot Chat reads
-that directory: Copilot's own instruction files are `.github/copilot-instructions.md`
-and repo-level `AGENTS.md`, which Toolport does not write. If Copilot is your only
-assistant in VS Code, paste the rules into its own file.
+There is no VS Code row. Toolport detects VS Code by its own MCP config, which is
+the GitHub Copilot integration, and Copilot's instruction files are
+`.github/copilot-instructions.md` and repo-level `AGENTS.md`: project files, which
+Toolport does not write (see [Project-level rules](#project-level-rules)). Earlier
+versions mapped VS Code onto Claude Code's rules directory and reported it as applied;
+nothing we can cite reads it there, so VS Code is now listed among the clients
+Toolport cannot write for. If you use the Claude Code extension inside VS Code, it
+shares `~/.claude` with the CLI and is covered by the Claude Code row.
 
 ### Clients with no rules file Toolport can write
 
@@ -87,6 +88,9 @@ file Toolport can write for ..."), so you know to paste your rules in yourself. 
 does not silently skip them. Which names appear depends on what is installed, so the list
 below is the full set rather than what you will see.
 
+- **VS Code** (GitHub Copilot) has no global instructions file. Its instruction files
+  are per-project (`.github/copilot-instructions.md`, `AGENTS.md`), which Agent rules does
+  not cover yet. The Claude Code extension is covered by the Claude Code row.
 - **Cursor** and **Warp** keep global rules in their own UI or account: Cursor's User
   rules in _Customize -> Rules_, Warp's in Warp Drive. Both also read per-project files
   (`.cursor/rules/`, `AGENTS.md`, `WARP.md`), which Agent rules does not cover yet either

--- a/src-tauri/src/clients.rs
+++ b/src-tauri/src/clients.rs
@@ -798,8 +798,11 @@ fn resolve_client_config_path_linux(client_id: &str, home: &std::path::Path) -> 
 /// This is DISTINCT from the client's MCP-config path — e.g. Claude Code's config is
 /// `~/.claude.json` but its rules live under `~/.claude/rules/`. `None` means the client has
 /// no global-rules location we write: either its globals are UI/cloud-stored (Cursor, Warp),
-/// or it's covered transitively by another client's file (Antigravity reads Gemini's
-/// `GEMINI.md`; VS Code Copilot reads Claude Code's `~/.claude` rules). Most of these
+/// it's covered transitively by another client's file (Antigravity reads Gemini's
+/// `GEMINI.md`), or we cannot show the client reads anywhere we could write (VS Code: the
+/// detection is VS Code's own `mcp.json`, i.e. Copilot, whose instruction files are
+/// repo-scoped; a Claude Code extension install is the `claude-code` row, since it shares
+/// `~/.claude`). Most of these
 /// paths are home-anchored. Goose and Zed on Linux follow `XDG_CONFIG_HOME` via
 /// [`client_rules_target`] / `dirs::config_dir()`, matching [`client_config_path`]
 /// (SBS-899 / #757). Goose also honours absolute `GOOSE_PATH_ROOT`, which relocates
@@ -831,10 +834,13 @@ fn resolve_rules_target(
     };
     let target = match client_id {
         // Strategy A — Toolport owns a whole file in the client's rules DIRECTORY.
-        // Claude Code's `~/.claude/rules/` is also read by VS Code Copilot (Claude-compat
-        // paths), so both map here; path-dedup writes it once when both are installed and a
-        // standalone VS Code install is still covered.
-        "claude-code" | "vscode" => owned(home.join(".claude").join("rules")),
+        // `vscode` used to map here too, on the claim that VS Code Copilot reads Claude Code's
+        // `~/.claude/rules/`. No citation supports that: Copilot's instruction files are
+        // `.github/copilot-instructions.md` and repo-level `AGENTS.md`, which are project-scoped
+        // and not written here. Mapping it produced a false Applied for a file nothing read,
+        // which is worse than the honest Unsupported it reports now (SBS-916). The Claude Code
+        // VS Code extension shares `~/.claude` and so is the `claude-code` row already.
+        "claude-code" => owned(home.join(".claude").join("rules")),
         "kiro" => owned(home.join(".kiro").join("steering")),
         "roo-code" => owned(home.join(".roo").join("rules")),
         "cline" => owned(home.join("Documents").join("Cline").join("Rules")),
@@ -11047,7 +11053,7 @@ rules:
         use crate::instructions::Scope;
         let home = mock_home(Platform::MacOs);
         let p = Platform::MacOs;
-        for client in ["claude-code", "vscode", "kiro", "roo-code", "cline"] {
+        for client in ["claude-code", "kiro", "roo-code", "cline"] {
             let team = resolve_rules_target(client, &home, p, Scope::Team).expect("supported");
             let personal =
                 resolve_rules_target(client, &home, p, Scope::Personal).expect("supported");
@@ -11199,10 +11205,13 @@ rules:
             team_rules_target("gemini-cli", &home, p),
             "Antigravity shares Gemini's GEMINI.md"
         );
+        // VS Code used to be mapped onto Claude Code's rules directory. Nothing we can cite reads
+        // it there (Copilot's instruction files are repo-scoped), so it reports Unsupported
+        // rather than a false Applied (SBS-916).
         assert_eq!(
             team_rules_target("vscode", &home, p),
-            team_rules_target("claude-code", &home, p),
-            "VS Code Copilot shares Claude Code's rules file"
+            None,
+            "VS Code has no global rules file Toolport can show it reads"
         );
     }
 

--- a/src-tauri/src/rules.rs
+++ b/src-tauri/src/rules.rs
@@ -95,7 +95,7 @@ fn installed_targets() -> Vec<ClientTarget> {
 }
 
 /// The distinct paths to write this pass: opted-in clients only, de-duped by path so a file two
-/// clients share (Claude Code + VS Code Copilot, Gemini CLI + Antigravity) is written once.
+/// clients share (Gemini CLI + Antigravity) is written once.
 fn enabled_targets(reg: &crate::registry::Registry, installed: &[ClientTarget]) -> Vec<Target> {
     let mut seen = std::collections::HashSet::new();
     installed

--- a/src/components/RulesView.tsx
+++ b/src/components/RulesView.tsx
@@ -301,7 +301,7 @@ export function RulesView() {
   const unsupported = clients.filter((c) => !c.path);
   const onCount = supported.filter((c) => c.enabled).length;
   // Name the client in the card header. The path alone is ambiguous wherever two clients share a
-  // file (Claude Code / VS Code, Gemini CLI / Antigravity).
+  // file (Gemini CLI / Antigravity).
   const previewClientName = preview
     ? (clients.find((c) => c.id === preview.clientId)?.name ?? null)
     : null;


### PR DESCRIPTION
## Summary

- `resolve_rules_target` mapped `vscode` onto Claude Code's `~/.claude/rules/` on the claim that VS Code Copilot reads it. No citation supports that; Copilot's instruction files are `.github/copilot-instructions.md` and repo-level `AGENTS.md`, both project-scoped and not written by Toolport.
- The `vscode` detection is VS Code's own `mcp.json` (Copilot), so for most installs the rules landed in a directory nothing read while the Agent rules tab **and** the Teams coverage receipt said Applied. A false Applied is worse than Unsupported.
- VS Code now resolves to `None` and is listed with Cursor and Warp as a client with no rules file Toolport can write. The Claude Code VS Code extension shares `~/.claude` and is the `claude-code` row already, so no real coverage is lost.
- Docs (`docs/agent-rules.md`) and CHANGELOG updated; the stale "VS Code Copilot shares Claude Code's rules file" test now asserts the honest answer.

Closes SBS-916. Real Copilot support is project-scoped and tracked under SBS-1037 (project-level rules).

## Test plan

- [x] `cargo test --lib -- rules_target instructions:: rules::` — 69 passed
- [x] `cargo test --lib -- clients::tests` — 227 passed
- [x] `npm run lint` — 0 errors (53 pre-existing warnings, none in touched files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Corrects a false coverage status for one client’s global rules path. No auth, MCP, or write-path changes beyond dropping an unsupported mapping.
> 
> **Overview**
> Stops Agent rules and Team Instructions from reporting VS Code as **Applied** when Copilot never reads the file Toolport wrote.
> 
> `vscode` was mapped onto Claude Code's `~/.claude/rules/` on the claim that Copilot reads it. Copilot's instruction files are project-scoped (`.github/copilot-instructions.md`, `AGENTS.md`), so a Copilot-only install got a false Applied. VS Code now resolves to no writable global rules file (same class as Cursor and Warp). The Claude Code VS Code extension still shares `~/.claude` and stays covered by the Claude Code row.
> 
> Docs and changelog match; tests now expect `None` for `vscode` instead of sharing Claude Code's path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4526849be5fc5211c562b61a3579ca35372aa4c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix VS Code rules target: stop mapping it to `~/.claude/rules`
> VS Code (Copilot) has no global rules file Toolport can write, so reporting it as sharing Claude Code's `~/.claude/rules` path was incorrect. `resolve_rules_target("vscode", …)` now returns `None` instead of a `~/.claude/rules/*` path. Docs in [docs/agent-rules.md](https://github.com/tsouth89/toolport/pull/833/files#diff-e26a0f163aa98c9b6b162b32cb45bf71c0f876d52e2b4a49e756cb30d6b1bdc4) and [CHANGELOG.md](https://github.com/tsouth89/toolport/pull/833/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed) are updated to move VS Code to the "no rules file" section and clarify that the Claude Code VS Code extension is covered by the Claude Code row. Tests in [clients.rs](https://github.com/tsouth89/toolport/pull/833/files#diff-6f95d037b6a920242364b6cfc2417b10affa37691d35ce5da93633c9da12c167) now assert `None` for the VS Code target.
> - Risk: any code that previously relied on `resolve_rules_target("vscode", …)` returning a path will now receive `None`; check consumers of that return value in [rules.rs](https://github.com/tsouth89/toolport/pull/833/files#diff-95ba6d6d222bbceda1b2370fcec193a459a1a3fb8065e0fa9521ec07a1cbad51) and [RulesView.tsx](https://github.com/tsouth89/toolport/pull/833/files#diff-4e009b33fddd42d77b29dcb73137bb9411ea8428b2bb159b7b62149beb3f11d7) (both updated here for comments only).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4526849.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->