### PR TITLE
fix(hitl): make the broker prove it holds the token before the gateway sends anything

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,10 +20,11 @@ Entries before the rename below shipped under the project's former name, Conduit
   a peer that cannot read the owner-only descriptor cannot produce it, so it sees no
   request and its answer is never read. The failure is reported as `unreachable`, so a
   restarted app is still found on the re-read, and it is still fail-closed. On Unix the
-  broker also moves off loopback TCP onto a socket file in a `0700` directory under the
-  data dir, so such a peer cannot connect at all (loopback TCP remains as the fallback
-  and on Windows; the challenge protects both). A gateway from before this change is
-  still answered by the new broker. (SBS-867)
+  broker also listens on a socket file in a `0700` directory under the data dir, which
+  a current gateway prefers, so such a peer cannot even connect on that path; the
+  loopback listener stays (and is all there is on Windows), and the challenge protects
+  both the same way. A gateway from before this change still reads only the loopback
+  address, still reaches the broker, and is still answered. (SBS-867)
 
   What this does not claim: a process running as the same user as Toolport can read
   the descriptor and `registry.json` alike, and can switch human approval off directly;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,31 @@ All notable changes to Toolport are documented here. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/); versions match the GitHub releases.
 Entries before the rename below shipped under the project's former name, Conduit.
 
+## [Unreleased]
+
+### Security
+
+- **A process that bound the approval broker's endpoint after the app had gone could
+  approve gated calls in its place, and be handed the arguments first.** The gateway
+  dialed whatever `approval-endpoint.json` named and believed whatever came back. The
+  descriptor survives a crash or a force-kill, and nothing authenticated the peer that
+  answered: the literal bytes `"approved"` were a complete decision. Because the
+  request is written before the reply is read, such a peer also received the call's
+  real arguments, including the rehydrated values behind a PII release. The gateway now
+  opens every dial with a random challenge that the broker must answer with an
+  HMAC-SHA256 proof of the shared token, and sends nothing until the proof checks out;
+  a peer that cannot read the owner-only descriptor cannot produce it, so it sees no
+  request and its answer is never read. The failure is reported as `unreachable`, so a
+  restarted app is still found on the re-read, and it is still fail-closed. On Unix the
+  broker also moves off loopback TCP onto a socket file in a `0700` directory under the
+  data dir, so such a peer cannot connect at all (loopback TCP remains as the fallback
+  and on Windows; the challenge protects both). A gateway from before this change is
+  still answered by the new broker. (SBS-867)
+
+  What this does not claim: a process running as the same user as Toolport can read
+  the descriptor and `registry.json` alike, and can switch human approval off directly;
+  that is a sandboxing question (SBS-185), not an authentication one.
+
 ## [1.16.0] - 2026-08-22
 
 ### Fixed

--- a/scripts/smoke-headless.mjs
+++ b/scripts/smoke-headless.mjs
@@ -10,6 +10,7 @@ import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { spawn } from "node:child_process";
+import { createHmac } from "node:crypto";
 import { isDeepStrictEqual } from "node:util";
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
@@ -289,15 +290,29 @@ async function startApprovalBroker() {
     socket.setEncoding("utf8");
     socket.on("data", (chunk) => {
       buffer += chunk;
-      const newline = buffer.indexOf("\n");
-      if (newline < 0) return;
-      try {
-        const approval = JSON.parse(buffer.slice(0, newline));
-        resolveRequest(approval);
-        socket.end(`${JSON.stringify("approved")}\n`);
-      } catch (error) {
-        rejectRequest(error);
-        socket.destroy();
+      // Line-oriented: the gateway opens with a challenge it expects a proof for
+      // before it will send the request (SBS-867), then sends the request itself.
+      for (;;) {
+        const newline = buffer.indexOf("\n");
+        if (newline < 0) return;
+        const line = buffer.slice(0, newline);
+        buffer = buffer.slice(newline + 1);
+        try {
+          const message = JSON.parse(line);
+          const nonce = message?.toolportApprovalChallenge;
+          if (typeof nonce === "string") {
+            const proof = createHmac("sha256", approvalToken).update(nonce).digest("hex");
+            socket.write(`${JSON.stringify({ toolportApprovalProof: proof })}\n`);
+            continue;
+          }
+          resolveRequest(message);
+          socket.end(`${JSON.stringify("approved")}\n`);
+          return;
+        } catch (error) {
+          rejectRequest(error);
+          socket.destroy();
+          return;
+        }
       }
     });
     socket.once("error", rejectRequest);

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -816,6 +816,7 @@ dependencies = [
  "dirs 5.0.1",
  "fs2",
  "getrandom 0.2.17",
+ "hmac",
  "json5",
  "jsonc-parser",
  "jsonschema",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -66,6 +66,9 @@ toml_edit = "0.22"
 dirs = "5"
 ureq = { version = "2", features = ["json"] }
 sha2 = "0.10"
+# HMAC-SHA256 for the approval broker's challenge-response (SBS-867); already in
+# the tree transitively, promoted to a direct dep.
+hmac = "0.12"
 subtle = "2.6"
 # Pure-Rust JS engine for server-side "code mode" orchestration (SOU-184): run one
 # agent script that calls many downstream tools, so an N-step task costs one round-trip

--- a/src-tauri/src/approval.rs
+++ b/src-tauri/src/approval.rs
@@ -9,7 +9,11 @@
 //! the wire types, the gating policy, and the on-disk endpoint descriptor. Keeping it in
 //! the lib means there is exactly one definition of the protocol.
 
+use std::io::{self, BufRead, Read, Write};
+use std::time::Duration;
+
 use serde::{Deserialize, Serialize};
+use subtle::ConstantTimeEq;
 
 /// The broker descriptor's filename inside the Conduit data dir. The app writes it on
 /// startup; every gateway process reads it. It holds ONLY the endpoint address and an auth
@@ -24,12 +28,14 @@ pub const DEFAULT_TIMEOUT_SECS: u64 = 120;
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct EndpointDescriptor {
-    /// The address a gateway connects to (e.g. `127.0.0.1:PORT`, or a named-pipe / uds path
-    /// once the transport is hardened). Opaque to policy.
+    /// The address a gateway connects to: `127.0.0.1:PORT` for loopback TCP, or
+    /// `unix:/absolute/path` for a Unix domain socket (see [`UNIX_ENDPOINT_PREFIX`]).
+    /// Opaque to policy; [`BrokerStream::connect`] understands both.
     pub endpoint: String,
-    /// A 128-bit random token the gateway must present. Defense-in-depth over the local-user
-    /// filesystem trust boundary: only a process that can read the Conduit data dir (same as
-    /// secrets) can obtain it.
+    /// A random token both sides hold. The gateway presents it in every request, and the
+    /// broker proves it holds it before the gateway sends anything (see [`dial_broker`]).
+    /// Defense-in-depth over the local-user filesystem trust boundary: only a process that
+    /// can read the Conduit data dir (same as secrets) can obtain it.
     pub token: String,
 }
 
@@ -203,6 +209,236 @@ pub fn fingerprint_allow_key(server: &str, tool: &str, fingerprint: &str) -> Str
     format!("{}/{}/{}", server, tool, fingerprint)
 }
 
+// ---------------------------------------------------------------------------------------
+// Broker transport and mutual authentication
+// ---------------------------------------------------------------------------------------
+//
+// The endpoint descriptor is owner-only on disk, so holding the token proves a process can
+// read the Toolport data dir. The token has always authenticated the GATEWAY to the broker.
+// Nothing authenticated the broker to the gateway: a gateway dialed whatever the descriptor
+// named and believed whatever came back, so any process that could bind the published port
+// after the app had gone - a stale descriptor survives a crash or a force-kill - could
+// answer `"approved"` to every gated call and, worse, RECEIVE the request first, including
+// the real values behind a PII release (SBS-867).
+//
+// The fix is a challenge before anything else crosses the wire. The gateway sends a fresh
+// random nonce; the broker answers with HMAC-SHA256(token, nonce); the gateway verifies that
+// against the token in the descriptor it read, and only then sends the request. A peer that
+// cannot read the descriptor cannot produce the proof, so it never sees the request and its
+// decision is never read. Unix additionally moves the listener off loopback TCP onto a
+// socket file in a 0700 directory, so such a peer cannot connect at all; the challenge still
+// runs there, so the guarantee does not depend on which transport was chosen.
+//
+// Out of scope, on purpose: a process running as the SAME user as Toolport. It can read the
+// descriptor and registry.json alike, so it can answer the challenge - and it can switch
+// human approval off directly. Nothing in a same-user trust model stops that; per-server
+// sandboxing (SBS-185) is the answer there, not a stronger handshake.
+
+/// Marks a Unix-domain-socket endpoint in [`EndpointDescriptor::endpoint`]:
+/// `unix:/absolute/path/approval.sock`. Anything else is a `host:port` loopback address.
+pub const UNIX_ENDPOINT_PREFIX: &str = "unix:";
+
+/// How long each side waits on the other during the handshake. Short on purpose: a peer
+/// that cannot answer the challenge promptly is not the app, and the gateway's caller is
+/// holding a tool call open.
+pub const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Upper bound on the proof line a gateway reads before deciding the peer is not a broker.
+/// A real proof is well under 200 bytes.
+const MAX_PROOF_LINE_BYTES: u64 = 1024;
+
+/// The first line a gateway writes after connecting. The key name doubles as the protocol
+/// marker: a broker that sees it answers with a [`BrokerProof`] before reading the request;
+/// a request or suggestion line never carries it.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BrokerChallenge {
+    /// Hex-encoded random nonce, fresh per dial.
+    pub toolport_approval_challenge: String,
+}
+
+/// The broker's answer to a [`BrokerChallenge`].
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BrokerProof {
+    /// Hex HMAC-SHA256 keyed by the broker token over the nonce string exactly as sent.
+    pub toolport_approval_proof: String,
+}
+
+fn hex(bytes: &[u8]) -> String {
+    bytes.iter().map(|b| format!("{b:02x}")).collect()
+}
+
+/// The proof a broker holding `token` gives for `nonce` (the hex string as sent, not the
+/// decoded bytes, so neither side has to agree on a decoding).
+pub fn challenge_proof(token: &str, nonce: &str) -> String {
+    use hmac::{Hmac, Mac};
+    let mut mac = Hmac::<sha2::Sha256>::new_from_slice(token.as_bytes())
+        .expect("HMAC accepts a key of any length");
+    mac.update(nonce.as_bytes());
+    hex(&mac.finalize().into_bytes())
+}
+
+/// Constant-time comparison of a presented proof against the expected one.
+pub fn proof_matches(expected: &str, presented: &str) -> bool {
+    expected.len() == presented.len()
+        && bool::from(expected.as_bytes().ct_eq(presented.as_bytes()))
+}
+
+/// Broker side: if `first_line` is a [`BrokerChallenge`], the [`BrokerProof`] line to write
+/// back (without its trailing newline). `None` means the line is not a challenge - a gateway
+/// from before the handshake existed, sending its request straight away - and the caller
+/// should treat it as the request itself.
+pub fn answer_challenge(first_line: &[u8], token: &str) -> Option<String> {
+    let challenge: BrokerChallenge = serde_json::from_slice(first_line).ok()?;
+    serde_json::to_string(&BrokerProof {
+        toolport_approval_proof: challenge_proof(token, &challenge.toolport_approval_challenge),
+    })
+    .ok()
+}
+
+/// A connection between a gateway and the broker over whichever transport the descriptor
+/// names: Read + Write plus the timeout and clone controls both sides use.
+#[derive(Debug)]
+pub enum BrokerStream {
+    Tcp(std::net::TcpStream),
+    #[cfg(unix)]
+    Unix(std::os::unix::net::UnixStream),
+}
+
+impl BrokerStream {
+    /// Connect to `endpoint` as written in a descriptor. No handshake; see [`dial_broker`].
+    pub fn connect(endpoint: &str) -> io::Result<Self> {
+        match endpoint.strip_prefix(UNIX_ENDPOINT_PREFIX) {
+            #[cfg(unix)]
+            Some(path) => std::os::unix::net::UnixStream::connect(path).map(Self::Unix),
+            #[cfg(not(unix))]
+            Some(_) => Err(io::Error::new(
+                io::ErrorKind::Unsupported,
+                "unix socket endpoints are not available on this platform",
+            )),
+            None => std::net::TcpStream::connect(endpoint).map(Self::Tcp),
+        }
+    }
+
+    pub fn set_read_timeout(&self, dur: Option<Duration>) -> io::Result<()> {
+        match self {
+            Self::Tcp(s) => s.set_read_timeout(dur),
+            #[cfg(unix)]
+            Self::Unix(s) => s.set_read_timeout(dur),
+        }
+    }
+
+    pub fn set_write_timeout(&self, dur: Option<Duration>) -> io::Result<()> {
+        match self {
+            Self::Tcp(s) => s.set_write_timeout(dur),
+            #[cfg(unix)]
+            Self::Unix(s) => s.set_write_timeout(dur),
+        }
+    }
+
+    pub fn try_clone(&self) -> io::Result<Self> {
+        match self {
+            Self::Tcp(s) => s.try_clone().map(Self::Tcp),
+            #[cfg(unix)]
+            Self::Unix(s) => s.try_clone().map(Self::Unix),
+        }
+    }
+}
+
+impl Read for BrokerStream {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        match self {
+            Self::Tcp(s) => s.read(buf),
+            #[cfg(unix)]
+            Self::Unix(s) => s.read(buf),
+        }
+    }
+}
+
+impl Write for BrokerStream {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        match self {
+            Self::Tcp(s) => s.write(buf),
+            #[cfg(unix)]
+            Self::Unix(s) => s.write(buf),
+        }
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        match self {
+            Self::Tcp(s) => s.flush(),
+            #[cfg(unix)]
+            Self::Unix(s) => s.flush(),
+        }
+    }
+}
+
+/// Gateway side: connect to the broker `desc` names and make it prove it holds `desc.token`
+/// before anything else is sent. Every failure is an `Err`, which the caller treats as "no
+/// broker was reached": the request was never written, so no human was asked and nothing
+/// confidential left this process. On `Ok` the stream sits right after the proof line with
+/// the handshake timeouts still set; the caller sets its own before the long wait.
+pub fn dial_broker(desc: &EndpointDescriptor) -> io::Result<BrokerStream> {
+    // An empty token means the app's CSPRNG failed at startup. The broker denies every
+    // request in that state anyway; refusing here as well keeps an empty-key proof, which
+    // anyone can compute, from ever counting as authentication.
+    if desc.token.is_empty() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "broker descriptor carries no token",
+        ));
+    }
+    let mut nonce = [0u8; 32];
+    getrandom::getrandom(&mut nonce).map_err(|_| io::Error::other("CSPRNG unavailable"))?;
+    let nonce = hex(&nonce);
+
+    let mut stream = BrokerStream::connect(&desc.endpoint)?;
+    stream.set_write_timeout(Some(HANDSHAKE_TIMEOUT))?;
+    stream.set_read_timeout(Some(HANDSHAKE_TIMEOUT))?;
+    let challenge = serde_json::to_string(&BrokerChallenge {
+        toolport_approval_challenge: nonce.clone(),
+    })?;
+    stream.write_all(challenge.as_bytes())?;
+    stream.write_all(b"\n")?;
+    stream.flush()?;
+
+    // The broker writes nothing after the proof until it has our request, so a buffered
+    // reader over a clone cannot swallow anything the caller will later want.
+    let mut reply = String::new();
+    let read = io::BufReader::new(stream.try_clone()?)
+        .take(MAX_PROOF_LINE_BYTES)
+        .read_line(&mut reply)?;
+    if read == 0 {
+        return Err(io::Error::new(
+            io::ErrorKind::UnexpectedEof,
+            "peer closed before answering the challenge",
+        ));
+    }
+    if !reply.ends_with('\n') {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "proof line exceeds the bound",
+        ));
+    }
+    let proof: BrokerProof = serde_json::from_str(reply.trim()).map_err(|_| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            "peer did not answer the challenge",
+        )
+    })?;
+    if !proof_matches(
+        &challenge_proof(&desc.token, &nonce),
+        &proof.toolport_approval_proof,
+    ) {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            "peer failed the token proof",
+        ));
+    }
+    Ok(stream)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -308,5 +544,180 @@ mod tests {
             serde_json::from_str(&serde_json::to_string(&d).unwrap()).unwrap();
         assert_eq!(round.endpoint, "127.0.0.1:8790");
         assert_eq!(round.token, "s3cret");
+    }
+
+    #[test]
+    fn challenge_proof_is_hmac_sha256_over_the_nonce() {
+        // RFC 4231 test case 2, so the proof is exactly what a reviewer expects and not a
+        // home-grown construction.
+        assert_eq!(
+            challenge_proof("Jefe", "what do ya want for nothing?"),
+            "5bdcc146bf60754e6a042426089575c75a003f089d2739839dec58b964ec3843"
+        );
+        assert_ne!(challenge_proof("tok", "nonce-a"), challenge_proof("tok", "nonce-b"));
+        assert_ne!(challenge_proof("tok-a", "nonce"), challenge_proof("tok-b", "nonce"));
+        assert!(proof_matches("abc", "abc"));
+        assert!(!proof_matches("abc", "abd"));
+        assert!(!proof_matches("abc", "abcd"));
+        assert!(!proof_matches("", "a"));
+    }
+
+    #[test]
+    fn broker_answers_a_challenge_and_passes_anything_else_through() {
+        let line = serde_json::to_vec(&BrokerChallenge {
+            toolport_approval_challenge: "00ff".into(),
+        })
+        .unwrap();
+        let answer = answer_challenge(&line, "tok").expect("a challenge is answered");
+        let proof: BrokerProof = serde_json::from_str(&answer).unwrap();
+        assert_eq!(proof.toolport_approval_proof, challenge_proof("tok", "00ff"));
+
+        // A pre-handshake gateway's request is not a challenge: the caller treats it as
+        // the request itself, authenticated by its own token field exactly as before.
+        let req = serde_json::to_vec(&ApprovalRequest {
+            token: "tok".into(),
+            id: "abc".into(),
+            client: None,
+            server: "db".into(),
+            tool: "drop_table".into(),
+            reason: ApprovalReason::Destructive,
+            arguments: serde_json::json!({}),
+            tool_fingerprint: None,
+            url_elicitation: None,
+            pii_release: None,
+        })
+        .unwrap();
+        assert!(answer_challenge(&req, "tok").is_none());
+        assert!(answer_challenge(b"not json", "tok").is_none());
+    }
+
+    /// A loopback peer that answers every line it receives with `reply(line)` and reports
+    /// each line it saw. Stands in for the real broker, and for an impostor.
+    fn scripted_peer(
+        reply: impl Fn(&str) -> String + Send + 'static,
+    ) -> (String, std::sync::mpsc::Receiver<String>) {
+        let listener = std::net::TcpListener::bind(("127.0.0.1", 0)).unwrap();
+        let endpoint = listener.local_addr().unwrap().to_string();
+        let (tx, rx) = std::sync::mpsc::channel();
+        std::thread::spawn(move || {
+            let Ok((mut stream, _)) = listener.accept() else {
+                return;
+            };
+            let mut reader = io::BufReader::new(stream.try_clone().unwrap());
+            let mut line = String::new();
+            while reader.read_line(&mut line).map(|n| n > 0).unwrap_or(false) {
+                let seen = line.trim().to_string();
+                line.clear();
+                let answer = reply(&seen);
+                let _ = tx.send(seen);
+                if stream
+                    .write_all(answer.as_bytes())
+                    .and_then(|_| stream.write_all(b"\n"))
+                    .is_err()
+                {
+                    break;
+                }
+            }
+        });
+        (endpoint, rx)
+    }
+
+    fn desc(endpoint: String, token: &str) -> EndpointDescriptor {
+        EndpointDescriptor {
+            endpoint,
+            token: token.into(),
+        }
+    }
+
+    #[test]
+    fn dial_succeeds_against_a_peer_that_proves_the_token() {
+        let (endpoint, seen) = scripted_peer(|line| {
+            answer_challenge(line.as_bytes(), "tok").unwrap_or_else(|| "\"approved\"".into())
+        });
+        let mut stream = dial_broker(&desc(endpoint, "tok")).expect("an honest broker passes");
+        let first = seen.recv_timeout(Duration::from_secs(5)).unwrap();
+        assert!(first.contains("toolportApprovalChallenge"), "{first}");
+        assert!(!first.contains("tok"), "the token never travels in the clear: {first}");
+
+        // The stream is usable for the request/decision exchange afterwards.
+        stream.write_all(b"{\"request\":1}\n").unwrap();
+        let second = seen.recv_timeout(Duration::from_secs(5)).unwrap();
+        assert_eq!(second, "{\"request\":1}");
+        let mut decision = String::new();
+        io::BufReader::new(stream).read_line(&mut decision).unwrap();
+        assert_eq!(decision.trim(), "\"approved\"");
+    }
+
+    /// SBS-867: a peer that merely holds the published port answers the first line with
+    /// `"approved"` - exactly what a pre-handshake gateway would have believed. It must be
+    /// refused, and it must never be sent the request.
+    #[test]
+    fn dial_refuses_a_peer_that_answers_without_the_proof() {
+        let (endpoint, seen) = scripted_peer(|_| "\"approved\"".into());
+        let err = dial_broker(&desc(endpoint, "tok")).expect_err("an impostor is refused");
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData, "{err}");
+        let first = seen.recv_timeout(Duration::from_secs(5)).unwrap();
+        assert!(first.contains("toolportApprovalChallenge"), "{first}");
+        assert!(
+            seen.recv_timeout(Duration::from_millis(500)).is_err(),
+            "nothing follows a failed challenge"
+        );
+    }
+
+    #[test]
+    fn dial_refuses_a_proof_for_the_wrong_token() {
+        let (endpoint, _seen) = scripted_peer(|line| {
+            answer_challenge(line.as_bytes(), "not-the-token").unwrap_or_default()
+        });
+        let err = dial_broker(&desc(endpoint, "tok")).expect_err("a wrong proof is refused");
+        assert_eq!(err.kind(), io::ErrorKind::PermissionDenied, "{err}");
+    }
+
+    #[test]
+    fn dial_refuses_an_empty_token_before_connecting() {
+        // Port 1 would be ConnectionRefused if a connect were attempted; InvalidInput shows
+        // the refusal happened first.
+        let err = dial_broker(&desc("127.0.0.1:1".into(), "")).expect_err("no token, no dial");
+        assert_eq!(err.kind(), io::ErrorKind::InvalidInput, "{err}");
+    }
+
+    #[test]
+    fn dial_reports_a_peer_that_hangs_up_as_unreachable_not_decided() {
+        let listener = std::net::TcpListener::bind(("127.0.0.1", 0)).unwrap();
+        let endpoint = listener.local_addr().unwrap().to_string();
+        std::thread::spawn(move || {
+            let _ = listener.accept(); // accept, then drop immediately
+        });
+        let err = dial_broker(&desc(endpoint, "tok")).expect_err("a hang-up is an error");
+        assert_eq!(err.kind(), io::ErrorKind::UnexpectedEof, "{err}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn dial_works_over_a_unix_socket_endpoint() {
+        let dir = std::env::temp_dir().join(format!(
+            "toolport-broker-uds-{}-{}",
+            std::process::id(),
+            challenge_proof("salt", "dial_works_over_a_unix_socket_endpoint").get(..8).unwrap()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("approval.sock");
+        let listener = std::os::unix::net::UnixListener::bind(&path).unwrap();
+        std::thread::spawn(move || {
+            let Ok((mut stream, _)) = listener.accept() else {
+                return;
+            };
+            let mut reader = io::BufReader::new(stream.try_clone().unwrap());
+            let mut line = String::new();
+            reader.read_line(&mut line).unwrap();
+            let proof = answer_challenge(line.as_bytes(), "tok").unwrap();
+            stream.write_all(proof.as_bytes()).unwrap();
+            stream.write_all(b"\n").unwrap();
+        });
+        let endpoint = format!("{UNIX_ENDPOINT_PREFIX}{}", path.display());
+        let stream = dial_broker(&desc(endpoint, "tok")).expect("uds broker passes");
+        assert!(matches!(stream, BrokerStream::Unix(_)));
+        drop(stream);
+        let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/src-tauri/src/approval.rs
+++ b/src-tauri/src/approval.rs
@@ -689,7 +689,19 @@ mod tests {
             let _ = listener.accept(); // accept, then drop immediately
         });
         let err = dial_broker(&desc(endpoint, "tok")).expect_err("a hang-up is an error");
-        assert_eq!(err.kind(), io::ErrorKind::UnexpectedEof, "{err}");
+        // Whether the OS reports the early close as a clean EOF or as a reset depends on
+        // whether our challenge write had landed when the peer dropped; either way the
+        // caller sees an error, and the caller maps every error to Unreachable.
+        assert!(
+            matches!(
+                err.kind(),
+                io::ErrorKind::UnexpectedEof
+                    | io::ErrorKind::ConnectionReset
+                    | io::ErrorKind::ConnectionAborted
+                    | io::ErrorKind::BrokenPipe
+            ),
+            "{err:?}"
+        );
     }
 
     #[cfg(unix)]

--- a/src-tauri/src/approval.rs
+++ b/src-tauri/src/approval.rs
@@ -28,10 +28,17 @@ pub const DEFAULT_TIMEOUT_SECS: u64 = 120;
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct EndpointDescriptor {
-    /// The address a gateway connects to: `127.0.0.1:PORT` for loopback TCP, or
-    /// `unix:/absolute/path` for a Unix domain socket (see [`UNIX_ENDPOINT_PREFIX`]).
-    /// Opaque to policy; [`BrokerStream::connect`] understands both.
+    /// The loopback TCP address a gateway connects to (`127.0.0.1:PORT`). Always present,
+    /// so a gateway from before [`Self::unix_endpoint`] existed - which reads only this field
+    /// and dials only TCP - still finds the broker.
     pub endpoint: String,
+    /// On Unix, the broker's socket file as well (`unix:/absolute/path`, see
+    /// [`UNIX_ENDPOINT_PREFIX`]). A gateway that knows the field prefers it and falls back to
+    /// `endpoint` if the connect fails. Additive and optional on purpose: long-lived
+    /// client-spawned gateways outlive app updates, and one that predates this field must not
+    /// be cut off from the broker by it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub unix_endpoint: Option<String>,
     /// A random token both sides hold. The gateway presents it in every request, and the
     /// broker proves it holds it before the gateway sends anything (see [`dial_broker`]).
     /// Defense-in-depth over the local-user filesystem trust boundary: only a process that
@@ -225,9 +232,10 @@ pub fn fingerprint_allow_key(server: &str, tool: &str, fingerprint: &str) -> Str
 // random nonce; the broker answers with HMAC-SHA256(token, nonce); the gateway verifies that
 // against the token in the descriptor it read, and only then sends the request. A peer that
 // cannot read the descriptor cannot produce the proof, so it never sees the request and its
-// decision is never read. Unix additionally moves the listener off loopback TCP onto a
-// socket file in a 0700 directory, so such a peer cannot connect at all; the challenge still
-// runs there, so the guarantee does not depend on which transport was chosen.
+// decision is never read. On Unix the broker additionally listens on a socket file in a 0700
+// directory, which a current gateway prefers, so such a peer cannot even connect on that
+// path; the loopback listener stays for gateways that predate the field, and the challenge
+// runs on both, so the guarantee does not depend on which transport was chosen.
 //
 // Out of scope, on purpose: a process running as the SAME user as Toolport. It can read the
 // descriptor and registry.json alike, so it can answer the challenge - and it can switch
@@ -393,7 +401,14 @@ pub fn dial_broker(desc: &EndpointDescriptor) -> io::Result<BrokerStream> {
     getrandom::getrandom(&mut nonce).map_err(|_| io::Error::other("CSPRNG unavailable"))?;
     let nonce = hex(&nonce);
 
-    let mut stream = BrokerStream::connect(&desc.endpoint)?;
+    // Prefer the socket file when the broker published one; a connect failure there (stale
+    // path, or a platform without it) falls back to the loopback address. The challenge below
+    // protects both the same way, so the fallback changes nothing about the guarantee.
+    let mut stream = match desc.unix_endpoint.as_deref() {
+        Some(unix) => BrokerStream::connect(unix)
+            .or_else(|_| BrokerStream::connect(&desc.endpoint))?,
+        None => BrokerStream::connect(&desc.endpoint)?,
+    };
     stream.set_write_timeout(Some(HANDSHAKE_TIMEOUT))?;
     stream.set_read_timeout(Some(HANDSHAKE_TIMEOUT))?;
     let challenge = serde_json::to_string(&BrokerChallenge {
@@ -539,11 +554,31 @@ mod tests {
         let d = EndpointDescriptor {
             endpoint: "127.0.0.1:8790".into(),
             token: "s3cret".into(),
+            unix_endpoint: None,
         };
-        let round: EndpointDescriptor =
-            serde_json::from_str(&serde_json::to_string(&d).unwrap()).unwrap();
+        let json = serde_json::to_string(&d).unwrap();
+        assert!(
+            !json.contains("unixEndpoint"),
+            "an absent socket file is not written, so the shape an older gateway parses is byte-identical to before: {json}"
+        );
+        let round: EndpointDescriptor = serde_json::from_str(&json).unwrap();
         assert_eq!(round.endpoint, "127.0.0.1:8790");
         assert_eq!(round.token, "s3cret");
+        assert_eq!(round.unix_endpoint, None);
+
+        // A descriptor an older app wrote (no socket field) still parses, and one with the
+        // field round-trips.
+        let legacy: EndpointDescriptor =
+            serde_json::from_str(r#"{"endpoint":"127.0.0.1:1","token":"t"}"#).unwrap();
+        assert_eq!(legacy.unix_endpoint, None);
+        let with_unix = EndpointDescriptor {
+            endpoint: "127.0.0.1:8790".into(),
+            token: "s3cret".into(),
+            unix_endpoint: Some("unix:/tmp/x/approval.sock".into()),
+        };
+        let round: EndpointDescriptor =
+            serde_json::from_str(&serde_json::to_string(&with_unix).unwrap()).unwrap();
+        assert_eq!(round.unix_endpoint.as_deref(), Some("unix:/tmp/x/approval.sock"));
     }
 
     #[test]
@@ -626,6 +661,7 @@ mod tests {
         EndpointDescriptor {
             endpoint,
             token: token.into(),
+            unix_endpoint: None,
         }
     }
 
@@ -726,10 +762,28 @@ mod tests {
             stream.write_all(proof.as_bytes()).unwrap();
             stream.write_all(b"\n").unwrap();
         });
-        let endpoint = format!("{UNIX_ENDPOINT_PREFIX}{}", path.display());
-        let stream = dial_broker(&desc(endpoint, "tok")).expect("uds broker passes");
+        // The socket file is preferred over the loopback address when both are published;
+        // port 1 would refuse, so reaching Ok proves the unix path was taken.
+        let mut d = desc("127.0.0.1:1".into(), "tok");
+        d.unix_endpoint = Some(format!("{UNIX_ENDPOINT_PREFIX}{}", path.display()));
+        let stream = dial_broker(&d).expect("uds broker passes");
         assert!(matches!(stream, BrokerStream::Unix(_)));
         drop(stream);
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn dial_falls_back_to_loopback_when_the_socket_file_is_gone() {
+        let (endpoint, _seen) = scripted_peer(|line| {
+            answer_challenge(line.as_bytes(), "tok").unwrap_or_default()
+        });
+        let mut d = desc(endpoint, "tok");
+        d.unix_endpoint = Some(format!(
+            "{UNIX_ENDPOINT_PREFIX}/nonexistent/toolport-{}/approval.sock",
+            std::process::id()
+        ));
+        let stream = dial_broker(&d).expect("falls back to the loopback listener");
+        assert!(matches!(stream, BrokerStream::Tcp(_)));
     }
 }

--- a/src-tauri/src/approval_broker.rs
+++ b/src-tauri/src/approval_broker.rs
@@ -6,16 +6,19 @@
 //! do not hold a gateway request. This is the counterpart to the gateway's
 //! `request_human_decision` (see `bin/toolport-gateway.rs`).
 //!
-//! Protocol: the gateway connects over loopback TCP, sends one JSON line
-//! ([`ApprovalRequest`]) carrying the shared token, and reads one JSON line back
+//! Protocol: the gateway connects (a socket file in a private directory on Unix, loopback
+//! TCP on Windows), opens with a challenge the broker must answer with a proof of the
+//! shared token ([`crate::approval::dial_broker`]), then sends one JSON line
+//! ([`ApprovalRequest`]) carrying that token, and reads one JSON line back
 //! ([`ApprovalDecision`]). Arguments travel over the socket and are never written to
 //! disk. The only thing on disk is the endpoint descriptor (address + token). The
-//! human decides in the app UI; a fail-closed timeout denies. Transport is loopback
-//! TCP + token for now; hardening to a named-pipe / uds is a follow-up.
+//! human decides in the app UI; a fail-closed timeout denies. The challenge is what keeps
+//! a process that merely binds the published endpoint after the app has gone from
+//! answering in its place (SBS-867); the transport choice is defense in depth on top.
 
 use std::collections::{HashMap, HashSet};
 use std::io::{self, BufRead, BufReader, Read, Write};
-use std::net::{TcpListener, TcpStream};
+use std::net::TcpListener;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::mpsc::{channel, Sender};
 use std::sync::{Arc, Mutex, PoisonError};
@@ -27,8 +30,8 @@ use tauri::{AppHandle, Emitter, Manager};
 use tauri_plugin_notification::NotificationExt;
 
 use crate::approval::{
-    ApprovalDecision, ApprovalReason, ApprovalRequest, EndpointDescriptor, PiiReleaseRequest,
-    UrlElicitationRequest, DEFAULT_TIMEOUT_SECS, ENDPOINT_FILE,
+    ApprovalDecision, ApprovalReason, ApprovalRequest, BrokerStream, EndpointDescriptor,
+    PiiReleaseRequest, UrlElicitationRequest, DEFAULT_TIMEOUT_SECS, ENDPOINT_FILE,
 };
 
 /// A pending approval as the UI sees it. The auth token is deliberately NOT included.
@@ -349,66 +352,156 @@ pub fn start(app: AppHandle) -> ApprovalBroker {
         }),
     };
 
-    match TcpListener::bind(("127.0.0.1", 0)) {
-        Ok(listener) => {
-            if let Some(port) = listener.local_addr().ok().map(|a| a.port()) {
-                if let Some(dir) = crate::registry::conduit_dir() {
-                    let desc = EndpointDescriptor {
-                        endpoint: format!("127.0.0.1:{port}"),
-                        token,
-                    };
-                    let path = dir.join(ENDPOINT_FILE);
-                    // A stale descriptor (app crashed) points at a dead port, so a gateway
-                    // connect fails and denies - fail-closed either way. The gateway also
-                    // re-reads the descriptor and retries once, which self-heals the case
-                    // where the app restarted and rebound to a new port.
-                    // Written via atomic_write so the HITL endpoint + auth token land
-                    // owner-only (0600) on Unix rather than world-readable: a same-user
-                    // process reading the token could otherwise spoof approval decisions.
-                    let _ = crate::registry::atomic_write(
-                        &path,
-                        &serde_json::to_string(&desc).unwrap_or_default(),
-                    );
-                    // Record WHERE we published, into the same always-on log the gateway
-                    // writes its `dir_resolution=` line to. If a client-spawned gateway
-                    // resolves the data dir differently from the app (MSIX virtualization,
-                    // a differently-spelled HOME), that mismatch is now a one-line read
-                    // instead of a multi-hour hunt - it was the root cause of a live
-                    // "HITL blocks every call but no prompt appears" incident.
-                    log_broker_event(&format!(
-                        "bound 127.0.0.1:{port}; endpoint published at {}",
-                        path.display()
-                    ));
-                } else {
-                    log_broker_event(
-                        "conduit_dir() unavailable; endpoint NOT published (HITL fails closed)",
-                    );
-                }
-                let accept_broker = broker.clone();
-                std::thread::spawn(move || {
-                    let active_workers = Arc::new(AtomicUsize::new(0));
-                    for conn in listener.incoming().flatten() {
-                        let Some(permit) = try_acquire_connection(&active_workers) else {
-                            // Closing immediately is fail-closed and keeps a slow or
-                            // stalled peer from consuming an unbounded thread count.
-                            drop(conn);
-                            continue;
-                        };
-                        let b = accept_broker.clone();
-                        let a = app.clone();
-                        let _ = std::thread::Builder::new()
-                            .name("toolport-approval".into())
-                            .spawn(move || {
-                                let _permit = permit;
-                                handle_conn(conn, b, a);
-                            });
-                    }
-                });
+    match bind_listener() {
+        Some((listener, endpoint)) => {
+            if let Some(dir) = crate::registry::conduit_dir() {
+                let desc = EndpointDescriptor {
+                    endpoint: endpoint.clone(),
+                    token,
+                };
+                let path = dir.join(ENDPOINT_FILE);
+                // A stale descriptor (app crashed) points at a dead endpoint, so a gateway
+                // connect fails and denies - fail-closed either way. The gateway also
+                // re-reads the descriptor and retries once, which self-heals the case
+                // where the app restarted and rebound somewhere new. Should some other
+                // process bind the stale endpoint instead, the gateway's challenge refuses
+                // it before a byte of any request is sent (SBS-867).
+                // Written via atomic_write so the HITL endpoint + auth token land
+                // owner-only (0600) on Unix rather than world-readable: the token is what
+                // the challenge proves, so nothing but the app (or a process that can
+                // already read its data dir) may hold it.
+                let _ = crate::registry::atomic_write(
+                    &path,
+                    &serde_json::to_string(&desc).unwrap_or_default(),
+                );
+                // Record WHERE we published, into the same always-on log the gateway
+                // writes its `dir_resolution=` line to. If a client-spawned gateway
+                // resolves the data dir differently from the app (MSIX virtualization,
+                // a differently-spelled HOME), that mismatch is now a one-line read
+                // instead of a multi-hour hunt - it was the root cause of a live
+                // "HITL blocks every call but no prompt appears" incident.
+                log_broker_event(&format!(
+                    "bound {endpoint}; endpoint published at {}",
+                    path.display()
+                ));
+            } else {
+                log_broker_event(
+                    "conduit_dir() unavailable; endpoint NOT published (HITL fails closed)",
+                );
             }
+            let accept_broker = broker.clone();
+            std::thread::spawn(move || {
+                let active_workers = Arc::new(AtomicUsize::new(0));
+                loop {
+                    let conn = match listener.accept() {
+                        Ok(conn) => conn,
+                        Err(_) => {
+                            // Transient (EMFILE, EINTR): don't spin flat out on it.
+                            std::thread::sleep(Duration::from_millis(20));
+                            continue;
+                        }
+                    };
+                    let Some(permit) = try_acquire_connection(&active_workers) else {
+                        // Closing immediately is fail-closed and keeps a slow or
+                        // stalled peer from consuming an unbounded thread count.
+                        drop(conn);
+                        continue;
+                    };
+                    let b = accept_broker.clone();
+                    let a = app.clone();
+                    let _ = std::thread::Builder::new()
+                        .name("toolport-approval".into())
+                        .spawn(move || {
+                            let _permit = permit;
+                            handle_conn(conn, b, a);
+                        });
+                }
+            });
         }
-        Err(_) => { /* inert broker; HITL never fires, gateways fail-closed */ }
+        None => { /* inert broker; HITL never fires, gateways fail-closed */ }
     }
     broker
+}
+
+/// The listener the broker accepts on, over whichever transport [`bind_listener`] got.
+enum Listener {
+    Tcp(TcpListener),
+    #[cfg(unix)]
+    Unix(std::os::unix::net::UnixListener),
+}
+
+impl Listener {
+    fn accept(&self) -> io::Result<BrokerStream> {
+        match self {
+            Listener::Tcp(l) => l.accept().map(|(s, _)| BrokerStream::Tcp(s)),
+            #[cfg(unix)]
+            Listener::Unix(l) => l.accept().map(|(s, _)| BrokerStream::Unix(s)),
+        }
+    }
+}
+
+/// Where the Unix broker socket lives: a 0700 directory of its own under the data dir, so
+/// no other user can connect to it. The data dir's own mode is whatever the platform gave
+/// it, and the socket path ends up in a log line, so the directory carries the guarantee.
+#[cfg(unix)]
+fn unix_socket_path() -> Option<std::path::PathBuf> {
+    Some(
+        crate::registry::conduit_dir()?
+            .join("broker")
+            .join("approval.sock"),
+    )
+}
+
+/// Bind the broker's listener and return it with the endpoint string to publish. Unix
+/// prefers a socket file in a private directory and falls back to loopback TCP if that
+/// cannot be had (data dir unavailable, or a path too long for `sun_path`); the challenge
+/// in [`crate::approval::dial_broker`] protects both equally, so the fallback loses defense
+/// in depth, not the guarantee. Windows is loopback TCP.
+fn bind_listener() -> Option<(Listener, String)> {
+    #[cfg(unix)]
+    match bind_unix_listener() {
+        Ok(bound) => return Some(bound),
+        Err(e) => log_broker_event(&format!(
+            "unix socket unavailable ({e}); falling back to loopback TCP"
+        )),
+    }
+    let listener = TcpListener::bind(("127.0.0.1", 0)).ok()?;
+    let port = listener.local_addr().ok()?.port();
+    Some((Listener::Tcp(listener), format!("127.0.0.1:{port}")))
+}
+
+#[cfg(unix)]
+fn bind_unix_listener() -> io::Result<(Listener, String)> {
+    use std::os::unix::fs::{DirBuilderExt, PermissionsExt};
+    let path = unix_socket_path().ok_or_else(|| io::Error::other("data dir unavailable"))?;
+    let dir = path
+        .parent()
+        .ok_or_else(|| io::Error::other("socket path has no parent"))?;
+    std::fs::DirBuilder::new()
+        .recursive(true)
+        .mode(0o700)
+        .create(dir)?;
+    // `create` leaves a pre-existing directory's mode alone; make the private mode hold
+    // across runs and across anything else that may have created it.
+    std::fs::set_permissions(dir, std::fs::Permissions::from_mode(0o700))?;
+    // A socket file survives a crash or a force-kill. Nothing is listening on it (the app
+    // is single-instance), so a connect would only ever be refused; unlink it so the bind
+    // below does not fail on EADDRINUSE.
+    match std::fs::remove_file(&path) {
+        Ok(()) => {}
+        Err(e) if e.kind() == io::ErrorKind::NotFound => {}
+        Err(e) => return Err(e),
+    }
+    let listener = std::os::unix::net::UnixListener::bind(&path)?;
+    std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600))?;
+    Ok((
+        Listener::Unix(listener),
+        format!(
+            "{}{}",
+            crate::approval::UNIX_ENDPOINT_PREFIX,
+            path.display()
+        ),
+    ))
 }
 
 /// Append a line to the shared, always-on gateway log, so the broker's bind/publish
@@ -427,6 +520,10 @@ pub fn clear_endpoint() {
         if std::fs::remove_file(dir.join(ENDPOINT_FILE)).is_ok() {
             log_broker_event("endpoint descriptor cleared on shutdown");
         }
+    }
+    #[cfg(unix)]
+    if let Some(path) = unix_socket_path() {
+        let _ = std::fs::remove_file(path);
     }
 }
 
@@ -480,17 +577,37 @@ fn preflight(
 
 /// Serve one gateway connection: read the request, authenticate it, park it for a human
 /// decision (or a fail-closed timeout), and write the decision back.
-fn handle_conn(stream: TcpStream, broker: ApprovalBroker, app: AppHandle) {
+fn handle_conn(stream: BrokerStream, broker: ApprovalBroker, app: AppHandle) {
     // Read the request promptly; a slow/stalled sender must not tie up a thread.
     let _ = stream.set_read_timeout(Some(Duration::from_secs(10)));
+    let _ = stream.set_write_timeout(Some(Duration::from_secs(10)));
     let reader_stream = match stream.try_clone() {
         Ok(s) => s,
         Err(_) => return,
     };
-    let line = match read_approval_request(&mut BufReader::new(reader_stream)) {
+    let mut reader = BufReader::new(reader_stream);
+    let mut line = match read_approval_request(&mut reader) {
         Ok(line) => line,
         Err(_) => return,
     };
+    // A current gateway opens with a challenge and sends nothing else until it is
+    // answered: prove we hold the token, then read the request on the same buffered
+    // reader. A gateway from before the handshake sends its request first, and that line
+    // IS the request. Either way the request is authenticated below exactly as before;
+    // the handshake only adds the other direction (SBS-867).
+    if let Some(proof) = crate::approval::answer_challenge(&line, &broker.inner.token) {
+        let mut out = match stream.try_clone() {
+            Ok(s) => s,
+            Err(_) => return,
+        };
+        if writeln!(out, "{proof}").and_then(|_| out.flush()).is_err() {
+            return;
+        }
+        line = match read_approval_request(&mut reader) {
+            Ok(line) => line,
+            Err(_) => return,
+        };
+    }
 
     // A routine-save suggestion rides the same authenticated endpoint but is
     // fire-and-forget: store, notify the UI, acknowledge, done. Nothing parks and
@@ -520,7 +637,7 @@ fn handle_conn(stream: TcpStream, broker: ApprovalBroker, app: AppHandle) {
     };
 
     let mut out = stream;
-    let deny = |out: &mut TcpStream| {
+    let deny = |out: &mut BrokerStream| {
         let _ = out.set_write_timeout(Some(Duration::from_secs(10)));
         let _ = writeln!(
             out,

--- a/src-tauri/src/approval_broker.rs
+++ b/src-tauri/src/approval_broker.rs
@@ -6,9 +6,10 @@
 //! do not hold a gateway request. This is the counterpart to the gateway's
 //! `request_human_decision` (see `bin/toolport-gateway.rs`).
 //!
-//! Protocol: the gateway connects (a socket file in a private directory on Unix, loopback
-//! TCP on Windows), opens with a challenge the broker must answer with a proof of the
-//! shared token ([`crate::approval::dial_broker`]), then sends one JSON line
+//! Protocol: the gateway connects (loopback TCP everywhere; on Unix a socket file in a
+//! private directory is published as well and preferred by gateways that know of it),
+//! opens with a challenge the broker must answer with a proof of the shared token
+//! ([`crate::approval::dial_broker`]), then sends one JSON line
 //! ([`ApprovalRequest`]) carrying that token, and reads one JSON line back
 //! ([`ApprovalDecision`]). Arguments travel over the socket and are never written to
 //! disk. The only thing on disk is the endpoint descriptor (address + token). The
@@ -352,12 +353,13 @@ pub fn start(app: AppHandle) -> ApprovalBroker {
         }),
     };
 
-    match bind_listener() {
-        Some((listener, endpoint)) => {
+    match bind_listeners() {
+        Some(bound) => {
             if let Some(dir) = crate::registry::conduit_dir() {
                 let desc = EndpointDescriptor {
-                    endpoint: endpoint.clone(),
+                    endpoint: bound.endpoint.clone(),
                     token,
+                    unix_endpoint: bound.unix_endpoint.clone(),
                 };
                 let path = dir.join(ENDPOINT_FILE);
                 // A stale descriptor (app crashed) points at a dead endpoint, so a gateway
@@ -381,7 +383,13 @@ pub fn start(app: AppHandle) -> ApprovalBroker {
                 // instead of a multi-hour hunt - it was the root cause of a live
                 // "HITL blocks every call but no prompt appears" incident.
                 log_broker_event(&format!(
-                    "bound {endpoint}; endpoint published at {}",
+                    "bound {}{}; endpoint published at {}",
+                    bound.endpoint,
+                    bound
+                        .unix_endpoint
+                        .as_deref()
+                        .map(|u| format!(" and {u}"))
+                        .unwrap_or_default(),
                     path.display()
                 ));
             } else {
@@ -389,41 +397,72 @@ pub fn start(app: AppHandle) -> ApprovalBroker {
                     "conduit_dir() unavailable; endpoint NOT published (HITL fails closed)",
                 );
             }
-            let accept_broker = broker.clone();
-            std::thread::spawn(move || {
-                let active_workers = Arc::new(AtomicUsize::new(0));
-                loop {
-                    let conn = match listener.accept() {
-                        Ok(conn) => conn,
-                        Err(_) => {
-                            // Transient (EMFILE, EINTR): don't spin flat out on it.
-                            std::thread::sleep(Duration::from_millis(20));
-                            continue;
-                        }
-                    };
-                    let Some(permit) = try_acquire_connection(&active_workers) else {
-                        // Closing immediately is fail-closed and keeps a slow or
-                        // stalled peer from consuming an unbounded thread count.
-                        drop(conn);
-                        continue;
-                    };
-                    let b = accept_broker.clone();
-                    let a = app.clone();
-                    let _ = std::thread::Builder::new()
-                        .name("toolport-approval".into())
-                        .spawn(move || {
-                            let _permit = permit;
-                            handle_conn(conn, b, a);
-                        });
-                }
-            });
+            // One worker budget across every listener: the cap is on concurrent
+            // connections, not per transport.
+            let active_workers = Arc::new(AtomicUsize::new(0));
+            for listener in bound.listeners {
+                let b = broker.clone();
+                let a = app.clone();
+                let workers = Arc::clone(&active_workers);
+                std::thread::spawn(move || accept_loop(listener, b, a, workers));
+            }
         }
-        None => { /* inert broker; HITL never fires, gateways fail-closed */ }
+        None => {
+            // Inert broker: HITL never fires and every gateway fails closed. Say so in
+            // the log, since "no prompt ever appears" is otherwise a silent mystery.
+            log_broker_event(
+                "could not bind a loopback listener; HITL fails closed until restart",
+            );
+        }
     }
     broker
 }
 
-/// The listener the broker accepts on, over whichever transport [`bind_listener`] got.
+/// Accept on one listener until it errors out for good, handing each connection to a
+/// bounded worker. Shared across transports through `active_workers`.
+fn accept_loop(
+    listener: Listener,
+    broker: ApprovalBroker,
+    app: AppHandle,
+    active_workers: Arc<AtomicUsize>,
+) {
+    loop {
+        let conn = match listener.accept() {
+            Ok(conn) => conn,
+            Err(_) => {
+                // Transient (EMFILE, EINTR): don't spin flat out on it.
+                std::thread::sleep(Duration::from_millis(20));
+                continue;
+            }
+        };
+        let Some(permit) = try_acquire_connection(&active_workers) else {
+            // Closing immediately is fail-closed and keeps a slow or
+            // stalled peer from consuming an unbounded thread count.
+            drop(conn);
+            continue;
+        };
+        let b = broker.clone();
+        let a = app.clone();
+        let _ = std::thread::Builder::new()
+            .name("toolport-approval".into())
+            .spawn(move || {
+                let _permit = permit;
+                handle_conn(conn, b, a);
+            });
+    }
+}
+
+/// What [`bind_listeners`] got: every listener to accept on, plus the endpoint strings to
+/// publish for each.
+struct Bound {
+    listeners: Vec<Listener>,
+    /// Loopback TCP, always. The field a pre-socket gateway reads.
+    endpoint: String,
+    /// The socket file, on Unix when it could be had.
+    unix_endpoint: Option<String>,
+}
+
+/// The listener the broker accepts on, for one transport.
 enum Listener {
     Tcp(TcpListener),
     #[cfg(unix)]
@@ -452,22 +491,34 @@ fn unix_socket_path() -> Option<std::path::PathBuf> {
     )
 }
 
-/// Bind the broker's listener and return it with the endpoint string to publish. Unix
-/// prefers a socket file in a private directory and falls back to loopback TCP if that
-/// cannot be had (data dir unavailable, or a path too long for `sun_path`); the challenge
-/// in [`crate::approval::dial_broker`] protects both equally, so the fallback loses defense
-/// in depth, not the guarantee. Windows is loopback TCP.
-fn bind_listener() -> Option<(Listener, String)> {
+/// Bind the broker's listeners. Loopback TCP is required and always published as
+/// `endpoint`: gateways that predate the socket field read only that, and long-lived
+/// client-spawned gateways outlive app updates, so dropping it would cut them off from
+/// approvals until their client restarts them. On Unix a socket file in a private directory
+/// is bound as well and published as `unix_endpoint`, which current gateways prefer; if it
+/// cannot be had (data dir unavailable, or a path too long for `sun_path`) the broker is
+/// TCP-only, which loses defense in depth, not the guarantee - the challenge in
+/// [`crate::approval::dial_broker`] protects both the same way. Windows is TCP-only.
+fn bind_listeners() -> Option<Bound> {
+    let tcp = TcpListener::bind(("127.0.0.1", 0)).ok()?;
+    let port = tcp.local_addr().ok()?.port();
+    let mut listeners = vec![Listener::Tcp(tcp)];
+    let mut unix_endpoint = None;
     #[cfg(unix)]
     match bind_unix_listener() {
-        Ok(bound) => return Some(bound),
+        Ok((listener, endpoint)) => {
+            listeners.push(listener);
+            unix_endpoint = Some(endpoint);
+        }
         Err(e) => log_broker_event(&format!(
-            "unix socket unavailable ({e}); falling back to loopback TCP"
+            "unix socket unavailable ({e}); loopback TCP only"
         )),
     }
-    let listener = TcpListener::bind(("127.0.0.1", 0)).ok()?;
-    let port = listener.local_addr().ok()?.port();
-    Some((Listener::Tcp(listener), format!("127.0.0.1:{port}")))
+    Some(Bound {
+        listeners,
+        endpoint: format!("127.0.0.1:{port}"),
+        unix_endpoint,
+    })
 }
 
 #[cfg(unix)]

--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -3906,8 +3906,10 @@ enum BrokerAttempt {
 }
 
 /// One dial to the broker described by `desc`. FAIL-CLOSED throughout: the arguments travel
-/// over the socket and never touch disk. Transport is loopback TCP + token for now;
-/// hardening to an OS-permissioned named-pipe / uds is a follow-up.
+/// over the socket and never touch disk. The dial itself ([`approval::dial_broker`]) makes
+/// the peer prove it holds the descriptor's token before a byte of the request is written,
+/// so a process that merely binds the published endpoint after the app has gone gets
+/// neither the arguments nor a say in the decision (SBS-867).
 ///
 /// The key invariant: `Unreachable` is returned ONLY when the request never reached a
 /// broker (so no human saw it). Once the request is written, any later failure - including
@@ -3918,12 +3920,13 @@ fn try_decide_once(
     req: &mut approval::ApprovalRequest,
 ) -> BrokerAttempt {
     use std::io::{BufRead, BufReader, Write};
-    use std::net::TcpStream;
     let Some(desc) = desc else {
         return BrokerAttempt::Unreachable;
     };
     req.token = desc.token.clone();
-    let Ok(mut stream) = TcpStream::connect(&desc.endpoint) else {
+    // Connect refused, no answer to the challenge, or a wrong proof: in every case the
+    // request was never written, so no human was asked and a re-dial is safe.
+    let Ok(mut stream) = approval::dial_broker(&desc) else {
         return BrokerAttempt::Unreachable;
     };
     let _ = stream.set_write_timeout(Some(Duration::from_secs(10)));
@@ -6050,11 +6053,12 @@ fn publish_routine_suggestion(suggestion: routines::RoutineSuggestion, client: O
     );
     std::thread::spawn(move || {
         use std::io::{BufRead, BufReader, Write};
-        use std::net::TcpStream;
         let Some(desc) = read_endpoint_descriptor() else {
             return;
         };
-        let Ok(mut stream) = TcpStream::connect(&desc.endpoint) else {
+        // Same handshake as an approval: the envelope below carries the token, and a peer
+        // that cannot prove it already holds it must not be handed it (SBS-867).
+        let Ok(mut stream) = approval::dial_broker(&desc) else {
             return;
         };
         let _ = stream.set_write_timeout(Some(Duration::from_secs(5)));
@@ -15759,6 +15763,28 @@ mod tests {
         }
     }
 
+    /// Serve the gateway's handshake on a stub broker: answer the opening challenge with
+    /// the proof for `token`, then return the line that follows (the request). `None` if
+    /// the gateway hung up first - which is what a gateway does to a peer that fails the
+    /// challenge.
+    fn stub_handshake(stream: &mut TcpStream, token: &str) -> Option<String> {
+        use std::io::{BufRead, BufReader, Write};
+        let mut reader = BufReader::new(stream.try_clone().ok()?);
+        let mut line = String::new();
+        if reader.read_line(&mut line).ok()? == 0 {
+            return None;
+        }
+        if let Some(proof) = approval::answer_challenge(line.as_bytes(), token) {
+            writeln!(stream, "{proof}").ok()?;
+            stream.flush().ok()?;
+            line.clear();
+            if reader.read_line(&mut line).ok()? == 0 {
+                return None;
+            }
+        }
+        Some(line)
+    }
+
     /// Publish a stub broker into `env`'s data dir that answers one request with
     /// `decision`, handing back what it was asked.
     fn stub_broker(
@@ -15793,20 +15819,17 @@ mod tests {
 
         let (tx, rx) = std::sync::mpsc::channel();
         std::thread::spawn(move || {
-            use std::io::{BufRead, BufReader, Write};
-            let Ok((stream, _)) = listener.accept() else {
+            use std::io::Write;
+            let Ok((mut stream, _)) = listener.accept() else {
                 return;
             };
-            let mut line = String::new();
-            let reader_stream = stream.try_clone().expect("a clonable stream");
-            if BufReader::new(reader_stream).read_line(&mut line).is_err() {
+            let Some(line) = stub_handshake(&mut stream, "stub-broker-token") else {
                 return;
-            }
+            };
             if let Ok(req) = serde_json::from_str::<approval::ApprovalRequest>(&line) {
                 let _ = tx.send(req);
             }
             during();
-            let mut stream = stream;
             let answer = serde_json::to_string(&decision).expect("a serializable decision");
             let _ = stream.write_all(answer.as_bytes());
             let _ = stream.write_all(b"\n");
@@ -17294,6 +17317,67 @@ mod tests {
         let d = decide_via_broker(bad, &mut r);
         assert!(!d.is_approved());
         assert_eq!(d, approval::ApprovalDecision::Unreachable);
+    }
+
+    /// SBS-867: the gateway must not believe a decision from a peer that merely holds the
+    /// published endpoint. The impostor here answers the very first line with `"approved"`,
+    /// which is exactly what a pre-handshake gateway would have accepted. It must get no
+    /// request (so no arguments and no PII leave the gateway) and the outcome must be
+    /// fail-closed - as Unreachable, so the self-healing re-read may still find the app.
+    #[test]
+    fn an_impostor_broker_gets_no_request_and_no_approval() {
+        use std::io::{BufRead, BufReader, Write};
+        let listener = TcpListener::bind(("127.0.0.1", 0)).expect("a loopback port");
+        let endpoint = listener.local_addr().expect("a bound address").to_string();
+        let (seen_tx, seen_rx) = std::sync::mpsc::channel::<String>();
+        std::thread::spawn(move || {
+            let Ok((mut stream, _)) = listener.accept() else {
+                return;
+            };
+            let mut reader = BufReader::new(stream.try_clone().expect("clonable"));
+            let mut line = String::new();
+            while reader.read_line(&mut line).map(|n| n > 0).unwrap_or(false) {
+                let _ = seen_tx.send(line.clone());
+                line.clear();
+                if writeln!(stream, "\"approved\"").is_err() {
+                    break;
+                }
+            }
+        });
+        let mut req = approval::ApprovalRequest {
+            token: String::new(),
+            id: "id".into(),
+            client: None,
+            server: "crm".into(),
+            tool: "export_all".into(),
+            reason: approval::ApprovalReason::Destructive,
+            arguments: serde_json::json!({ "secret": "hunter2" }),
+            tool_fingerprint: Some("v2:abc".into()),
+            url_elicitation: None,
+            pii_release: None,
+        };
+        let desc = Some(approval::EndpointDescriptor {
+            endpoint,
+            token: "the-real-token".into(),
+        });
+        let d = decide_via_broker(desc, &mut req);
+        assert_eq!(d, approval::ApprovalDecision::Unreachable);
+        assert!(!d.is_approved());
+        let first = seen_rx
+            .recv_timeout(Duration::from_secs(5))
+            .expect("the impostor saw the challenge");
+        assert!(
+            first.contains("toolportApprovalChallenge"),
+            "first line is the challenge, got {first}"
+        );
+        assert!(
+            !first.contains("the-real-token") && !first.contains("hunter2"),
+            "nothing confidential before the proof: {first}"
+        );
+        assert!(
+            seen_rx.recv_timeout(Duration::from_millis(500)).is_err(),
+            "the request must never be sent to a peer that failed the challenge"
+        );
     }
 
     /// The audit record and the agent-facing envelope must name every outcome the same way,
@@ -19820,7 +19904,7 @@ mod tests {
         std::thread::JoinHandle<()>,
         std::sync::mpsc::Receiver<approval::ApprovalRequest>,
     ) {
-        use std::io::{BufRead, Write};
+        use std::io::Write;
 
         let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
         let endpoint = listener.local_addr().unwrap().to_string();
@@ -19836,11 +19920,8 @@ mod tests {
         let (request_tx, request_rx) = std::sync::mpsc::channel();
         let handle = std::thread::spawn(move || {
             let (mut stream, _) = listener.accept().unwrap();
-            let mut line = String::new();
-            {
-                let mut reader = std::io::BufReader::new(&mut stream);
-                reader.read_line(&mut line).unwrap();
-            }
+            let line = stub_handshake(&mut stream, "routine-approval-token")
+                .expect("the gateway sends its request once the broker has proved the token");
             let request: approval::ApprovalRequest = serde_json::from_str(&line).unwrap();
             request_tx.send(request).unwrap();
             if let Some(before_reply) = before_reply {

--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -15812,6 +15812,7 @@ mod tests {
             serde_json::to_string(&approval::EndpointDescriptor {
                 endpoint,
                 token: "stub-broker-token".to_string(),
+                unix_endpoint: None,
             })
             .expect("a serializable descriptor"),
         )
@@ -17313,6 +17314,7 @@ mod tests {
         let bad = Some(approval::EndpointDescriptor {
             endpoint: "127.0.0.1:1".into(),
             token: "t".into(),
+            unix_endpoint: None,
         });
         let d = decide_via_broker(bad, &mut r);
         assert!(!d.is_approved());
@@ -17359,6 +17361,7 @@ mod tests {
         let desc = Some(approval::EndpointDescriptor {
             endpoint,
             token: "the-real-token".into(),
+            unix_endpoint: None,
         });
         let d = decide_via_broker(desc, &mut req);
         assert_eq!(d, approval::ApprovalDecision::Unreachable);
@@ -19911,6 +19914,7 @@ mod tests {
         let descriptor = approval::EndpointDescriptor {
             endpoint,
             token: "routine-approval-token".to_string(),
+            unix_endpoint: None,
         };
         registry::atomic_write(
             &dir.join(approval::ENDPOINT_FILE),


### PR DESCRIPTION
## Summary

Closes **SBS-867** (Urgent): HITL approval decisions were unauthenticated in the broker → gateway direction.

- The gateway dialed whatever `approval-endpoint.json` named and believed whatever came back. The descriptor survives a crash or force-kill; any process that then bound the published port could answer `"approved"` to every gated call — and, because the request is written before the reply is read, it received the call's real arguments first, including the rehydrated values behind a PII release.
- **Fix:** every dial now opens with a random challenge the broker must answer with `HMAC-SHA256(token, nonce)` before a byte of the request is written (`approval::dial_broker`). A peer that cannot read the owner-only descriptor cannot produce the proof, so it sees no request and its answer is never read. Failure is `Unreachable`, so the self-healing re-read still finds a restarted app; still fail-closed. The routine-suggestion push uses the same dial (its envelope carries the token too).
- **Defense in depth (Unix):** the broker moves off loopback TCP onto a socket file in a `0700` directory under the data dir (`<data>/broker/approval.sock`, endpoint `unix:/…`). Loopback TCP remains as the fallback and on Windows; the challenge protects both equally.
- **Compat:** a gateway from before the handshake is still served — the broker treats a first line that is not a challenge as the request, authenticated by its own token exactly as before. A new gateway against an old broker fails closed (`Unreachable`), which only matters in the update window and is the safe direction.
- `hmac` promoted from transitive to direct dep (same 0.12.1 already in the lock).

### Scope note (differs from the ticket's proposed fix)

The ticket proposed OS peer identity (`SO_PEERCRED` / pipe client PID → exe path). I didn't do that, deliberately: a same-user process can read the descriptor *and* `registry.json`, so it can flip `human_approval` off directly — no handshake of any kind discriminates same-user, and an exe-path check adds real regression risk (AppImage mounts, renamed binaries, dev builds) to a gate that has already had "blocks every call, no prompt" incidents. The attacker this change *does* stop is the one who can bind the endpoint but cannot read the 0600 descriptor — the cross-user case the world-readable broker log (SBS-868) makes practical — plus anyone hoping the stale port trick works. The module docs say exactly this; per-server sandboxing (SBS-185) is the same-user answer.

## Test plan

- [x] `cargo test --lib -- approval` — 36 passed (new: RFC 4231 HMAC vector; honest peer passes; impostor answering `"approved"` refused with nothing sent after the challenge; wrong-token proof refused; empty token refused before connecting; hang-up is `UnexpectedEof`; unix-socket endpoint round-trip)
- [x] `cargo test --bin toolport-gateway -- broker approval impostor routine_save pii_release elicitation …` — 17 passed, including the new `an_impostor_broker_gets_no_request_and_no_approval` and every existing stub-broker test (stubs now serve the handshake via one shared helper)
- [x] `cargo clippy --no-default-features --lib --bins` (as CI) and `cargo clippy --lib --bins` (desktop feature on, so `approval_broker.rs` is covered) — no warnings in touched files
- [ ] Manual: run the app, trigger a destructive-tool approval from a legacy client and from code mode; confirm the prompt appears and approve/deny/timeout behave; confirm `<data>/broker/approval.sock` exists 0600 in a 0700 dir and the descriptor says `unix:…`; kill -9 the app and confirm a gateway dial reports unreachable (not a hang)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes the HITL approval wire protocol and broker transport: a failed handshake now fail-closes as Unreachable, and a new gateway cannot talk to a pre-handshake broker. This is security-critical (gated tools and PII arguments).
> 
> **Overview**
> Stops a stale-port impostor from auto-approving gated calls or seeing their arguments (including PII). The gateway used to dial whatever `approval-endpoint.json` named and treat `"approved"` as a decision; the descriptor survives a crash, so a later binder of that port could impersonate the app.
> 
> Every dial now starts with a random nonce. The broker must answer with HMAC-SHA256 of the shared token before any request is written (`dial_broker`). Failed proof is `Unreachable` (retry-safe, still fail-closed). Routine-suggestion push uses the same handshake.
> 
> On Unix the broker also listens on a `0600` socket in a `0700` dir under the data dir; current gateways prefer that and fall back to loopback TCP. Loopback stays for Windows and for older gateways that only read `endpoint`. Old gateways still work against a new broker (first line that is not a challenge is treated as the request). A new gateway against an old broker fail-closes during the update window. Same-user attackers who can already read the descriptor are explicitly out of scope.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc0fb0e14f3e63600281d9d5cb12682ed811d7cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Require broker to prove token before gateway sends approval requests
> - Gateway sends a random 32-byte nonce challenge and waits for an HMAC-SHA256 proof from the broker before sending any request bytes; proof failures are classified as `Unreachable`.
> - Broker binds both loopback TCP and, on Unix, a private Unix-domain socket (`0700` directory, `0600` socket) and answers challenges by computing HMAC-SHA256 over the nonce with the shared token.
> - Legacy one-line requests still work: if the first line is not a challenge, the broker treats it as the request.
> - Behavioral Change: `approval::dial_broker` in [src-tauri/src/approval.rs](https://github.com/tsouth89/toolport/pull/834/files#diff-129f59de3d10dd13553ab2d072c3b08cc14fe204332204150aa2e3bfe85ea01d) replaces direct `TcpStream::connect` in `try_decide_once` and `publish_routine_suggestion` in [src-tauri/src/bin/toolport-gateway.rs](https://github.com/tsouth89/toolport/pull/834/files#diff-fe5f13c01103f5adf39c870989b67ecdb11c19b3ba86b88c4acb028a7374cc01); `EndpointDescriptor` gains an optional `unix_endpoint` field that legacy gateways ignore.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cc0fb0e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->