### PR TITLE
docs(rules): cite VS Code's own docs for the ~/.claude/rules mapping

### DIFF
--- a/docs/agent-rules.md
+++ b/docs/agent-rules.md
@@ -72,12 +72,12 @@ they use the roaming config directory.
 Where two clients share a file, Toolport writes it once. Both are covered even if
 only one is installed.
 
-The VS Code row resolves to Claude Code's rules directory, which is what Toolport
-has always done for team instructions. That covers a VS Code install running a
-Claude-compatible extension. It is **not** a claim that GitHub Copilot Chat reads
-that directory: Copilot's own instruction files are `.github/copilot-instructions.md`
-and repo-level `AGENTS.md`, which Toolport does not write. If Copilot is your only
-assistant in VS Code, paste the rules into its own file.
+The VS Code row resolves to Claude Code's rules directory because VS Code reads it:
+its [custom instructions documentation](https://code.visualstudio.com/docs/copilot/customization/custom-instructions)
+lists `~/.claude/rules` (alongside `~/.copilot/instructions`) as a user-profile
+instructions location, and `~/.claude/CLAUDE.md` as personal instructions across all
+projects. So the file Toolport writes there reaches GitHub Copilot Chat as well as the
+Claude Code extension, and one write covers both when both are installed.
 
 ### Clients with no rules file Toolport can write
 

--- a/src-tauri/src/clients.rs
+++ b/src-tauri/src/clients.rs
@@ -831,9 +831,10 @@ fn resolve_rules_target(
     };
     let target = match client_id {
         // Strategy A — Toolport owns a whole file in the client's rules DIRECTORY.
-        // Claude Code's `~/.claude/rules/` is also read by VS Code Copilot (Claude-compat
-        // paths), so both map here; path-dedup writes it once when both are installed and a
-        // standalone VS Code install is still covered.
+        // Claude Code's `~/.claude/rules/` is also read by VS Code: its custom-instructions
+        // docs list "User profile: ~/.copilot/instructions or ~/.claude/rules" as a user-level
+        // location (verified 2026-08-22, SBS-916), so both map here; path-dedup writes it once
+        // when both are installed and a standalone VS Code install is still covered.
         "claude-code" | "vscode" => owned(home.join(".claude").join("rules")),
         "kiro" => owned(home.join(".kiro").join("steering")),
         "roo-code" => owned(home.join(".roo").join("rules")),


### PR DESCRIPTION
## Summary

Closes **SBS-916** as *verified correct* (supersedes #833, which was withdrawn).

- SBS-916 asked whether VS Code actually reads `~/.claude/rules` or whether Agent rules / Team Instructions were reporting **Applied** for a file nothing read. VS Code's [custom instructions docs](https://code.visualstudio.com/docs/copilot/customization/custom-instructions) list **"User profile: `~/.copilot/instructions` or `~/.claude/rules`"** as a user-level instructions location, and `~/.claude/CLAUDE.md` for personal instructions across all projects. The existing `vscode → ~/.claude/rules` mapping is right.
- `docs/agent-rules.md` replaces its "this is not a claim that Copilot reads that directory" hedge with the citation; the `resolve_rules_target` comment cites it too. No behaviour change.

## Test plan

- Docs + comment only; CI build confirms nothing else moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and a comment only; no runtime, mapping, or write-path changes.
> 
> **Overview**
> Corrects the Agent rules docs and the `vscode`/`claude-code` mapping comment: VS Code **does** read `~/.claude/rules` (per its custom-instructions docs), so Toolport’s shared write also reaches GitHub Copilot Chat.
> 
> No mapping or write behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a21b60443f44cf529ee466592f7b2686ff2457ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Cite VS Code docs for `~/.claude/rules` mapping in agent rules
> Rewrites the VS Code paragraph in [agent-rules.md](https://github.com/tsouth89/toolport/pull/838/files#diff-e26a0f163aa98c9b6b162b32cb45bf71c0f876d52e2b4a49e756cb30d6b1bdc4) to state that VS Code reads `~/.claude/rules` per its custom instructions docs and that `~/.claude/CLAUDE.md` covers personal instructions across projects. Updates inline comments in `resolve_rules_target` in [clients.rs](https://github.com/tsouth89/toolport/pull/838/files#diff-6f95d037b6a920242364b6cfc2417b10affa37691d35ce5da93633c9da12c167) to reference the same documentation, including a verified date and ticket. No executable logic changes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a21b604.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->