### PR TITLE
feat(permissions): rules Claude Code enforces on its own native tool calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,19 @@ Entries before the rename below shipped under the project's former name, Conduit
 
 ### Added
 
+- **Agent permissions: rules Claude Code enforces on its own native tool calls.** A new
+  Agent permissions tab holds a policy in Claude Code's own rule syntax (`Bash(rm -rf *)`,
+  `Read(./.env)`, `WebFetch(domain:...)`, `mcp__server__tool`, each set to never / ask
+  first / always allow) and writes it into every Claude Code profile's `settings.json`
+  under `permissions`, so Claude Code itself refuses, or asks before, a matching shell
+  command, file read or edit, web fetch or MCP call - on every call, whatever any hook
+  says. Off by default and empty by default; presets (never delete recursively, never
+  force-push, ask before any push, never read `.env` or SSH keys) are one-click adds.
+  Only the rule strings Toolport added are ever added or removed, so a rule you already
+  had in the file stays; a profile that appears later picks the policy up at the next
+  start. Claude Code only for now, and the tab says so. See
+  [docs/agent-permissions.md](docs/agent-permissions.md). (SBS-1058)
+
 - **Agent rules: start a new set from a rules file you already have.** The tab opened on an
   empty editor, and the first thing it asked of someone with a `~/.claude/CLAUDE.md` or a
   `~/.codex/AGENTS.md` was to retype it. **Start from a file** lists the rules files the

--- a/README.md
+++ b/README.md
@@ -94,6 +94,12 @@ fixes both.
   file or owns a marked block and leaves every other byte alone, and turning a client
   off removes what it wrote. Each client is off until you turn it on, and a preview
   shows the exact bytes first. See [docs/agent-rules.md](docs/agent-rules.md).
+- **Rules Claude Code enforces itself.** Write a permission policy once - never
+  `rm -rf`, never force-push, ask before any push, never read `.env` - in Claude Code's
+  own rule syntax, and Toolport writes it into every Claude Code profile's
+  `settings.json`, where Claude Code refuses or asks before a matching native tool call
+  on every call, whatever any hook says. Off and empty by default; only what Toolport
+  added is ever removed. See [docs/agent-permissions.md](docs/agent-permissions.md).
 - **Obvious auth.** OAuth or API key, stored once in the OS keychain, a single click per
   server. Newly-authed servers propagate to connected clients without a restart.
 - **No secrets in client configs.** Clients only ever say "talk to Toolport." Keys live

--- a/docs/agent-permissions.md
+++ b/docs/agent-permissions.md
@@ -1,0 +1,79 @@
+# Agent permissions
+
+Write the rules Claude Code should enforce on its own native tool calls once in Toolport
+and have them in every Claude Code profile on your machine, instead of hand-editing each
+`settings.json` and keeping them in sync yourself.
+
+Open the **Agent permissions** tab in the sidebar. No MCP server or gateway needed.
+
+## What it does, and what it does not
+
+Toolport's gateway governs MCP calls: approvals, destructive-call blocking, per-tool
+policy. It cannot see, let alone stop, what Claude Code does natively - a shell command,
+a file edit, a web fetch - because none of that is MCP.
+
+Claude Code has a native switch for exactly that: the `permissions` lists in its
+`settings.json`. Every native tool call is checked against `deny`, then `ask`, then
+`allow`, on every call, and per Claude Code's own
+[permissions documentation](https://code.claude.com/docs/en/permissions) a matching deny
+or ask rule applies "regardless of what a PreToolUse hook returns". So a policy written in
+Claude Code's rule syntax needs no hook and no Toolport process in the loop to be
+enforced; it needs to be in the file, in every profile, and to come back out cleanly.
+That is the whole of this feature.
+
+It is **Claude Code only** for now. Cursor has hooks but no settings-level rule list;
+Codex uses approval and sandbox settings of a different shape; Gemini CLI is mixed. The
+tab says so rather than pretending. The gateway's own gates still cover every MCP call
+from every client.
+
+## Rules
+
+A rule is a pattern in Claude Code's own syntax plus what to do when a native call
+matches it:
+
+| Action           | Claude Code list | Meaning                                                          |
+| ---------------- | ---------------- | ---------------------------------------------------------------- |
+| **Never**        | `deny`           | The call is refused. A bare tool name removes the tool entirely. |
+| **Ask first**    | `ask`            | Claude Code prompts you before the call runs.                    |
+| **Always allow** | `allow`          | The call runs without a prompt.                                  |
+
+Patterns: a tool name, optionally followed by a specifier in parentheses.
+`Bash(rm -rf *)`, `Bash(git push --force*)`, `Read(./.env)`, `Edit(src/**/*.ts)`,
+`WebFetch(domain:example.com)`, `mcp__github__create_issue`, or a bare `WebFetch`. When
+more than one rule matches, deny beats ask beats allow, exactly as Claude Code evaluates
+them. Toolport checks the shape of a pattern (it must be a tool name with an optional
+parenthesised specifier) and refuses anything else; Claude Code owns the meaning.
+
+Presets - never delete recursively, never force-push, ask before any git push, never
+read `.env` files, never read SSH keys - are one-click adds to the list. They are never
+applied on their own.
+
+## Before anything is written
+
+- **Off by default, empty by default.** Nothing is written until you turn the switch on,
+  and the rule list starts empty.
+- **Preview shows the exact bytes** each profile's `settings.json` would hold, before
+  the first write, including your own formatting and comments, which are preserved
+  (only the `permissions` key is rewritten).
+- **Every Claude Code profile is covered**, including ones selected with
+  `CLAUDE_CONFIG_DIR`. A rule in only one profile would quietly not apply in the others.
+
+## What Toolport owns
+
+JSON arrays of strings cannot carry a marker, so ownership is by record: for each file,
+Toolport remembers exactly which rule strings it added. A rule you already had in the
+file is not added and not recorded, so turning Toolport off, or removing the rule in
+Toolport, never takes away a rule you wrote yourself. Changing a rule's action moves it
+between lists; removing it from the policy removes it from every file; a profile that
+appears later picks the policy up at the next start. A hand edit that drops one of the
+rules is put back at the next start - these are restrictions you asked for, so, unlike
+[agent rules](agent-rules.md), a hand edit is not a reason to stand down.
+
+A `settings.json` that cannot be parsed is reported, left untouched, and does not stop
+the other profiles from being written or cleaned.
+
+## Next
+
+A `PreToolUse` hook that asks through Toolport's own approval window, records every
+decision in Agent activity, and can start in observe-only mode is the next step; it
+builds on this and on the authenticated approval broker shipped in 1.17.

--- a/src-tauri/src/agent_permissions.rs
+++ b/src-tauri/src/agent_permissions.rs
@@ -730,7 +730,10 @@ mod tests {
             .unwrap()
             .push(rule("Bash(git push*)", Ask));
         assert_eq!(view_with(&reg_with_leftover, &profiles).profiles[1].state, "stale");
-        apply_to(None, None, &profiles).unwrap();
+        // Put the hand-edited file back to a plain state so the final teardown below is
+        // about our own strings only.
+        std::fs::write(&b, "{}\n").unwrap();
+        apply_to(None, Some(policy2.clone()), &profiles).unwrap();
 
         // Off: exactly ours leaves; the user's own Read(./.env) in `a` stays.
         apply_to(Some(false), None, &profiles).unwrap();

--- a/src-tauri/src/agent_permissions.rs
+++ b/src-tauri/src/agent_permissions.rs
@@ -302,16 +302,23 @@ fn view_with(reg: &crate::registry::Registry, profiles: &[PathBuf]) -> Permissio
         .iter()
         .map(|path| {
             let key = path.display().to_string();
-            let added = reg
+            let recorded = reg
                 .agent_permission_targets
                 .get(&key)
-                .map(|v| v.len())
-                .unwrap_or(0);
+                .cloned()
+                .unwrap_or_default();
+            let added = recorded.len();
             match crate::clients::read_settings_json(path) {
                 Ok((root, _)) => {
+                    // A rule we added that the policy no longer has, still on disk, is a
+                    // write that did not land: it keeps enforcing, so the row must not read
+                    // Applied just because the surviving rules are present.
+                    let leftover = recorded
+                        .iter()
+                        .any(|r| !reg.agent_permission_rules.contains(r) && contains(&root, r));
                     let state = if reg.agent_permissions_enabled {
                         // An empty policy is trivially applied.
-                        if is_applied(&root, &reg.agent_permission_rules) {
+                        if is_applied(&root, &reg.agent_permission_rules) && !leftover {
                             "applied"
                         } else {
                             "stale"
@@ -348,7 +355,7 @@ fn view_with(reg: &crate::registry::Registry, profiles: &[PathBuf]) -> Permissio
 /// Turn the policy on or off, then make every profile match. Opt-in and write commit
 /// together (see [`crate::hooks::set_enabled`] for why).
 pub fn set_enabled(enabled: bool) -> Result<PermissionsView, String> {
-    apply_with(Some(enabled), None)?;
+    report(apply_with(Some(enabled), None)?)?;
     Ok(view())
 }
 
@@ -356,8 +363,29 @@ pub fn set_enabled(enabled: bool) -> Result<PermissionsView, String> {
 /// written for an invalid policy.
 pub fn set_rules(rules: Vec<PermissionRule>) -> Result<PermissionsView, String> {
     validate_rules(&rules)?;
-    apply_with(None, Some(rules))?;
+    report(apply_with(None, Some(rules))?)?;
     Ok(view())
+}
+
+/// A profile that could not be written or cleaned is an error the caller must see, not a
+/// row that quietly reads wrong. The registry change itself stands (the policy is what the
+/// user asked for; the other profiles got it), so the message names the file(s) and the
+/// view, refreshed, shows their real state.
+fn report(statuses: Vec<ProfileStatus>) -> Result<(), String> {
+    let failed: Vec<String> = statuses
+        .iter()
+        .filter(|s| s.state == "error")
+        .map(|s| format!("{}: {}", s.path, s.error.clone().unwrap_or_default()))
+        .collect();
+    if failed.is_empty() {
+        Ok(())
+    } else {
+        Err(format!(
+            "The policy was saved, but {} could not be updated: {}",
+            if failed.len() == 1 { "one profile" } else { "some profiles" },
+            failed.join("; ")
+        ))
+    }
 }
 
 /// Write the policy into every profile when enabled, and remove what was recorded
@@ -681,7 +709,27 @@ mod tests {
         let statuses = apply_to(None, None, &profiles).unwrap();
         assert_eq!(statuses.iter().filter(|s| s.state == "error").count(), 1);
         assert!(crate::registry::load().unwrap().agent_permission_targets.contains_key(&b.display().to_string()));
+        // And the user-facing setters say so rather than returning a clean view.
+        let err = report(statuses).unwrap_err();
+        assert!(err.contains("could not be updated") && err.contains("settings.json"), "{err}");
         std::fs::write(&b, "{}\n").unwrap();
+        apply_to(None, None, &profiles).unwrap();
+
+        // A rule dropped from the policy whose removal did not land (here: the file was
+        // restored by hand to an older state that still carries it) must not read Applied
+        // just because the remaining rules are present.
+        let policy3 = vec![rule("Read(./.env)", Deny)];
+        apply_to(None, Some(policy3.clone()), &profiles).unwrap();
+        std::fs::write(&b, "{\n  \"permissions\": { \"deny\": [\"Read(./.env)\"], \"ask\": [\"Bash(git push*)\"] }\n}\n").unwrap();
+        let reg = crate::registry::load().unwrap();
+        // Simulate the record still naming the dropped rule (a failed strip keeps it).
+        let mut reg_with_leftover = reg.clone();
+        reg_with_leftover
+            .agent_permission_targets
+            .get_mut(&b.display().to_string())
+            .unwrap()
+            .push(rule("Bash(git push*)", Ask));
+        assert_eq!(view_with(&reg_with_leftover, &profiles).profiles[1].state, "stale");
         apply_to(None, None, &profiles).unwrap();
 
         // Off: exactly ours leaves; the user's own Read(./.env) in `a` stays.

--- a/src-tauri/src/agent_permissions.rs
+++ b/src-tauri/src/agent_permissions.rs
@@ -1,0 +1,695 @@
+//! Native permission policy for Claude Code - the enforcer half of SBS-820 item 2
+//! (SBS-1058), settings-based.
+//!
+//! Toolport's gateway policies govern MCP calls. They cannot stop Claude Code from
+//! running `rm -rf`, force-pushing, or reading `.env`, because none of that is MCP.
+//! Claude Code does have a native switch for exactly that: `permissions.deny` /
+//! `permissions.ask` / `permissions.allow` in its `settings.json`, evaluated on every
+//! native tool call, deny first, and - per its own docs - regardless of what any hook
+//! says. So a policy written in Claude Code's own rule syntax needs no hook to be
+//! enforced; it needs to be in every profile's settings file, and to come back out
+//! cleanly.
+//!
+//! Three properties this module holds, inherited from [`crate::hooks`]:
+//!
+//!   * **Off by default, empty by default.** Nothing is written until the user turns it
+//!     on, and the rule list starts empty. Presets are offered, never pre-applied.
+//!   * **It adds only its own strings and removes only those.** JSON arrays of strings
+//!     cannot carry a marker, so ownership is by record: for each file, the registry
+//!     holds exactly the strings Toolport added. A rule the user already had is not
+//!     added and not recorded, so turning Toolport off never takes away a rule the user
+//!     wrote themselves.
+//!   * **Every profile.** `CLAUDE_CONFIG_DIR` makes `~/.claude` and `~/.claude-work`
+//!     both real; a policy in only one of them would quietly not apply in the other.
+//!
+//! Only Claude Code, for now. Cursor has hooks but no settings-level rule list, Codex
+//! has approval/sandbox settings of a different shape, Gemini CLI is mixed; the UI and
+//! docs say so rather than pretending. A `PreToolUse` hook that asks through the app's
+//! approval broker is the next step (phase 2), not this one.
+
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+pub use crate::registry::{PermissionAction, PermissionRule};
+
+/// One Claude Code settings file and what the policy's state in it is.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ProfileStatus {
+    /// Absolute path to the profile's `settings.json`.
+    pub path: String,
+    /// `applied` (every rule present), `stale` (policy changed or file edited since), `off`
+    /// (policy disabled and nothing of ours recorded there), or `error`.
+    pub state: String,
+    /// How many of the policy's rules Toolport itself added to this file (the rest, if
+    /// any, were already there and are the user's).
+    pub added: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+/// A rule the UI offers as a one-click add. Never applied on its own.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Preset {
+    pub label: String,
+    pub rules: Vec<PermissionRule>,
+}
+
+/// Everything the Agent permissions view needs, in one round trip.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PermissionsView {
+    pub enabled: bool,
+    pub rules: Vec<PermissionRule>,
+    pub profiles: Vec<ProfileStatus>,
+    pub presets: Vec<Preset>,
+}
+
+/// A dry run: the exact bytes one profile's file would hold.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PermissionsPreview {
+    pub path: String,
+    pub before: String,
+    pub after: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+fn rule(pattern: &str, action: PermissionAction) -> PermissionRule {
+    PermissionRule {
+        pattern: pattern.to_string(),
+        action,
+    }
+}
+
+/// The presets offered in the UI. Each is a judgement about what a person almost always
+/// means by "don't let it do the dangerous thing"; the list is short on purpose.
+pub fn presets() -> Vec<Preset> {
+    use PermissionAction::{Ask, Deny};
+    vec![
+        Preset {
+            label: "Never delete recursively".into(),
+            rules: vec![rule("Bash(rm -rf *)", Deny), rule("Bash(rm -r *)", Deny)],
+        },
+        Preset {
+            label: "Never force-push".into(),
+            rules: vec![
+                rule("Bash(git push --force*)", Deny),
+                rule("Bash(git push -f *)", Deny),
+                rule("Bash(git push * --force*)", Deny),
+            ],
+        },
+        Preset {
+            label: "Ask before any git push".into(),
+            rules: vec![rule("Bash(git push*)", Ask)],
+        },
+        Preset {
+            label: "Never read .env files".into(),
+            rules: vec![rule("Read(./.env)", Deny), rule("Read(./.env.*)", Deny)],
+        },
+        Preset {
+            label: "Never read SSH keys".into(),
+            rules: vec![rule("Read(~/.ssh/**)", Deny)],
+        },
+    ]
+}
+
+/// Claude Code's rule syntax: `Tool` or `Tool(specifier)`. A bare tool name removes the
+/// tool (deny) or pre-approves it (allow); a specifier scopes it. MCP tools are
+/// `mcp__server__tool`. We check shape, not semantics: Claude Code owns the meaning.
+pub fn validate_pattern(pattern: &str) -> Result<(), String> {
+    let p = pattern.trim();
+    if p.is_empty() {
+        return Err("A rule needs a pattern, such as Bash(rm -rf *).".to_string());
+    }
+    if p != pattern {
+        return Err("A pattern must not start or end with whitespace.".to_string());
+    }
+    if p.contains('\n') || p.contains('\r') {
+        return Err("A pattern is one line.".to_string());
+    }
+    let (tool, spec) = match p.find('(') {
+        Some(i) => (&p[..i], Some(&p[i..])),
+        None => (p, None),
+    };
+    let tool_ok = !tool.is_empty()
+        && tool
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-' || c == ':');
+    if !tool_ok {
+        return Err(format!(
+            "\"{tool}\" is not a tool name. Use Claude Code's syntax: a tool such as Bash, \
+             Read, Edit, WebFetch, or mcp__server__tool, optionally followed by (pattern)."
+        ));
+    }
+    if let Some(spec) = spec {
+        if !spec.ends_with(')') || spec.len() < 3 {
+            return Err(
+                "A specifier is written in parentheses after the tool, such as Bash(rm -rf *)."
+                    .to_string(),
+            );
+        }
+    }
+    Ok(())
+}
+
+/// Validate a whole policy: every pattern well-formed, no duplicate pattern.
+pub fn validate_rules(rules: &[PermissionRule]) -> Result<(), String> {
+    let mut seen = std::collections::HashSet::new();
+    for r in rules {
+        validate_pattern(&r.pattern)?;
+        if !seen.insert(r.pattern.as_str()) {
+            return Err(format!(
+                "\"{}\" appears more than once. A pattern maps to one action.",
+                r.pattern
+            ));
+        }
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Pure functions over a settings value
+// ---------------------------------------------------------------------------
+
+fn list(root: &Value, action: PermissionAction) -> Option<&Vec<Value>> {
+    root.get("permissions")?
+        .get(action.list_key())?
+        .as_array()
+}
+
+fn contains(root: &Value, r: &PermissionRule) -> bool {
+    list(root, r.action)
+        .map(|l| l.iter().any(|v| v.as_str() == Some(r.pattern.as_str())))
+        .unwrap_or(false)
+}
+
+/// Return `root` with exactly `added` removed from the lists they were added to, pruning a
+/// list, and then the `permissions` object, that this pass emptied. A list the user left
+/// empty and we then filled is indistinguishable afterwards from one we created, so it is
+/// pruned too; an empty list carries no rule, so nothing of theirs is lost. A string present
+/// more than once (the user duplicated it) loses one occurrence, ours.
+pub fn strip_rules(root: &Value, added: &[PermissionRule]) -> Value {
+    let mut out = root.clone();
+    let Some(obj) = out.as_object_mut() else {
+        return out;
+    };
+    let Some(perms) = obj.get_mut("permissions").and_then(Value::as_object_mut) else {
+        return out;
+    };
+    for r in added {
+        let key = r.action.list_key();
+        let Some(arr) = perms.get_mut(key).and_then(Value::as_array_mut) else {
+            continue;
+        };
+        if let Some(i) = arr
+            .iter()
+            .position(|v| v.as_str() == Some(r.pattern.as_str()))
+        {
+            arr.remove(i);
+            if arr.is_empty() {
+                perms.remove(key);
+            }
+        }
+    }
+    if perms.is_empty() {
+        obj.remove("permissions");
+    }
+    out
+}
+
+/// Return `root` carrying every rule in `rules`, plus the list of rules THIS pass owns:
+/// `previously_added` is removed first (so a rule dropped from the policy leaves, and a
+/// rule whose action changed moves lists), then each rule not already present is added
+/// and recorded. A rule already present was the user's and is neither touched nor
+/// recorded. Idempotent over its own output.
+pub fn upsert_rules(
+    root: &Value,
+    rules: &[PermissionRule],
+    previously_added: &[PermissionRule],
+) -> Result<(Value, Vec<PermissionRule>), String> {
+    let mut out = strip_rules(root, previously_added);
+    let obj = out
+        .as_object_mut()
+        .ok_or_else(|| "settings root is not a JSON object".to_string())?;
+    let mut added = Vec::new();
+    for r in rules {
+        // Already there (the user's own, or a duplicate pattern across actions is not
+        // our business): do not add, do not own.
+        if contains(&Value::Object(obj.clone()), r) {
+            continue;
+        }
+        let perms = obj
+            .entry("permissions".to_string())
+            .or_insert_with(|| Value::Object(Map::new()));
+        let perms = perms
+            .as_object_mut()
+            .ok_or_else(|| "`permissions` is present but is not an object".to_string())?;
+        let arr = perms
+            .entry(r.action.list_key().to_string())
+            .or_insert_with(|| Value::Array(Vec::new()));
+        let arr = arr.as_array_mut().ok_or_else(|| {
+            format!(
+                "`permissions.{}` is present but is not an array",
+                r.action.list_key()
+            )
+        })?;
+        arr.push(Value::String(r.pattern.clone()));
+        added.push(r.clone());
+    }
+    Ok((out, added))
+}
+
+/// True when every policy rule is present in `root`.
+pub fn is_applied(root: &Value, rules: &[PermissionRule]) -> bool {
+    rules.iter().all(|r| contains(root, r))
+}
+
+// ---------------------------------------------------------------------------
+// Apply / view / preview
+// ---------------------------------------------------------------------------
+
+/// Reconcile at startup: a profile created since the last apply (a new
+/// `CLAUDE_CONFIG_DIR`) picks the policy up, and a file edited by hand is put back -
+/// these are restrictions the user asked for, so, unlike agent rules, a hand edit is
+/// not a reason to stand down. No-op when the feature is off and nothing is recorded.
+pub fn apply_on_startup() {
+    let active = crate::registry::load()
+        .map(|reg| reg.agent_permissions_enabled || !reg.agent_permission_targets.is_empty())
+        .unwrap_or(false);
+    if !active {
+        return;
+    }
+    if let Err(error) = apply() {
+        crate::gatewaylog::append(&format!(
+            "toolport: agent permissions startup apply failed: {error}"
+        ));
+    }
+}
+
+/// Current state, without writing anything.
+pub fn view() -> PermissionsView {
+    let reg = crate::registry::load().unwrap_or_default();
+    view_with(&reg, &crate::clients::claude_settings_paths())
+}
+
+fn view_with(reg: &crate::registry::Registry, profiles: &[PathBuf]) -> PermissionsView {
+    let profiles = profiles
+        .iter()
+        .map(|path| {
+            let key = path.display().to_string();
+            let added = reg
+                .agent_permission_targets
+                .get(&key)
+                .map(|v| v.len())
+                .unwrap_or(0);
+            match crate::clients::read_settings_json(path) {
+                Ok((root, _)) => {
+                    let state = if reg.agent_permissions_enabled {
+                        // An empty policy is trivially applied.
+                        if is_applied(&root, &reg.agent_permission_rules) {
+                            "applied"
+                        } else {
+                            "stale"
+                        }
+                    } else if added > 0 {
+                        "stale"
+                    } else {
+                        "off"
+                    };
+                    ProfileStatus {
+                        path: key,
+                        state: state.to_string(),
+                        added,
+                        error: None,
+                    }
+                }
+                Err(error) => ProfileStatus {
+                    path: key,
+                    state: "error".to_string(),
+                    added,
+                    error: Some(error),
+                },
+            }
+        })
+        .collect();
+    PermissionsView {
+        enabled: reg.agent_permissions_enabled,
+        rules: reg.agent_permission_rules.clone(),
+        profiles,
+        presets: presets(),
+    }
+}
+
+/// Turn the policy on or off, then make every profile match. Opt-in and write commit
+/// together (see [`crate::hooks::set_enabled`] for why).
+pub fn set_enabled(enabled: bool) -> Result<PermissionsView, String> {
+    apply_with(Some(enabled), None)?;
+    Ok(view())
+}
+
+/// Replace the rule list, then make every profile match. Validated first; nothing is
+/// written for an invalid policy.
+pub fn set_rules(rules: Vec<PermissionRule>) -> Result<PermissionsView, String> {
+    validate_rules(&rules)?;
+    apply_with(None, Some(rules))?;
+    Ok(view())
+}
+
+/// Write the policy into every profile when enabled, and remove what was recorded
+/// everywhere when not.
+pub fn apply() -> Result<Vec<ProfileStatus>, String> {
+    apply_with(None, None)
+}
+
+fn apply_with(
+    set_enabled: Option<bool>,
+    set_rules: Option<Vec<PermissionRule>>,
+) -> Result<Vec<ProfileStatus>, String> {
+    apply_to(set_enabled, set_rules, &crate::clients::claude_settings_paths())
+}
+
+/// [`apply_with`] over an explicit profile set, so tests drive known files. Runs inside
+/// `registry::update_authoritative`, for the reasons [`crate::hooks::apply_to`] gives.
+fn apply_to(
+    set_enabled: Option<bool>,
+    set_rules: Option<Vec<PermissionRule>>,
+    profiles: &[PathBuf],
+) -> Result<Vec<ProfileStatus>, String> {
+    let (_, statuses) = crate::registry::update_authoritative(|reg| {
+        if let Some(enabled) = set_enabled {
+            reg.agent_permissions_enabled = enabled;
+        }
+        if let Some(rules) = set_rules {
+            reg.agent_permission_rules = rules;
+        }
+        let rules = reg.agent_permission_rules.clone();
+        let candidates: Vec<String> = if reg.agent_permissions_enabled {
+            profiles.iter().map(|p| p.display().to_string()).collect()
+        } else {
+            Vec::new()
+        };
+        let mut statuses = Vec::new();
+        let mut targets: HashMap<String, Vec<PermissionRule>> = HashMap::new();
+
+        for path in &candidates {
+            let previous = reg
+                .agent_permission_targets
+                .get(path)
+                .cloned()
+                .unwrap_or_default();
+            match install_at(Path::new(path), &rules, &previous) {
+                Ok(added) => {
+                    let n = added.len();
+                    if !added.is_empty() {
+                        targets.insert(path.clone(), added);
+                    }
+                    statuses.push(ProfileStatus {
+                        path: path.clone(),
+                        state: "applied".into(),
+                        added: n,
+                        error: None,
+                    });
+                }
+                Err(error) => {
+                    // Keep what we believed we had there: we could not see the file, so
+                    // we cannot say our strings are gone (same reasoning as hooks).
+                    if !previous.is_empty() {
+                        targets.insert(path.clone(), previous);
+                    }
+                    statuses.push(ProfileStatus {
+                        path: path.clone(),
+                        state: "error".into(),
+                        added: 0,
+                        error: Some(error),
+                    });
+                }
+            }
+        }
+
+        // Clean what we recorded and no longer want: every profile when off, or one that
+        // disappeared from the candidate list. A failed removal stays recorded.
+        for (path, previous) in reg.agent_permission_targets.iter() {
+            if candidates.contains(path) {
+                continue;
+            }
+            if let Err(error) = remove_at(Path::new(path), previous) {
+                targets.insert(path.clone(), previous.clone());
+                statuses.push(ProfileStatus {
+                    path: path.clone(),
+                    state: "error".into(),
+                    added: previous.len(),
+                    error: Some(error),
+                });
+            }
+        }
+        reg.agent_permission_targets = targets;
+        Ok(statuses)
+    })?;
+    Ok(statuses)
+}
+
+/// Write the policy into one file and return what THIS write owns there. No write when
+/// the file already says exactly what it should.
+fn install_at(
+    path: &Path,
+    rules: &[PermissionRule],
+    previous: &[PermissionRule],
+) -> Result<Vec<PermissionRule>, String> {
+    let (root, original) = crate::clients::read_settings_json(path)?;
+    let (updated, added) = upsert_rules(&root, rules, previous)?;
+    if updated != root {
+        crate::clients::write_settings_key(path, original.as_deref(), &updated, "permissions")?;
+    }
+    Ok(added)
+}
+
+/// Remove what we added from one file. Gone file = success; unparseable = error.
+fn remove_at(path: &Path, added: &[PermissionRule]) -> Result<(), String> {
+    let (root, original) = match crate::clients::read_settings_json(path) {
+        Ok(pair) => pair,
+        Err(error) => {
+            if !path.exists() {
+                return Ok(());
+            }
+            return Err(error);
+        }
+    };
+    if original.is_none() {
+        return Ok(());
+    }
+    let stripped = strip_rules(&root, added);
+    if stripped == root {
+        return Ok(());
+    }
+    crate::clients::write_settings_key(path, original.as_deref(), &stripped, "permissions")
+}
+
+/// The exact bytes each profile would hold with the CURRENT registry policy (or `rules`
+/// when given, so an edited-but-unsaved policy can be previewed). Writes nothing.
+pub fn preview(rules: Option<Vec<PermissionRule>>) -> Result<Vec<PermissionsPreview>, String> {
+    let reg = crate::registry::load()?;
+    let rules = rules.unwrap_or_else(|| reg.agent_permission_rules.clone());
+    validate_rules(&rules)?;
+    Ok(preview_to(&reg, &rules, &crate::clients::claude_settings_paths()))
+}
+
+fn preview_to(
+    reg: &crate::registry::Registry,
+    rules: &[PermissionRule],
+    profiles: &[PathBuf],
+) -> Vec<PermissionsPreview> {
+    profiles
+        .iter()
+        .map(|path| {
+            let key = path.display().to_string();
+            let previous = reg
+                .agent_permission_targets
+                .get(&key)
+                .cloned()
+                .unwrap_or_default();
+            let rendered = crate::clients::read_settings_json(path).and_then(|(root, original)| {
+                let (updated, _) = upsert_rules(&root, rules, &previous)?;
+                let after = crate::clients::render_settings_key(original.as_deref(), &updated, "permissions")?;
+                Ok((original.unwrap_or_default(), after))
+            });
+            match rendered {
+                Ok((before, after)) => PermissionsPreview {
+                    path: key,
+                    before,
+                    after,
+                    error: None,
+                },
+                Err(error) => PermissionsPreview {
+                    path: key,
+                    before: String::new(),
+                    after: String::new(),
+                    error: Some(error),
+                },
+            }
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use PermissionAction::{Allow, Ask, Deny};
+
+    #[test]
+    fn patterns_follow_claude_codes_syntax() {
+        for ok in [
+            "Bash",
+            "Bash(rm -rf *)",
+            "Read(./.env)",
+            "WebFetch(domain:example.com)",
+            "mcp__github__create_issue",
+            "Edit(src/**/*.ts)",
+        ] {
+            validate_pattern(ok).unwrap_or_else(|e| panic!("{ok}: {e}"));
+        }
+        for bad in ["", " Bash", "Bash(", "Bash()", "rm -rf *", "Bash(x)\nRead"] {
+            assert!(validate_pattern(bad).is_err(), "{bad:?} should be refused");
+        }
+        assert!(validate_rules(&[rule("Bash(x)", Deny), rule("Bash(x)", Ask)]).is_err());
+        assert!(validate_rules(&[rule("Bash(x)", Deny), rule("Bash(y)", Ask)]).is_ok());
+    }
+
+    #[test]
+    fn upsert_adds_only_what_is_missing_and_strip_removes_only_what_was_added() {
+        let theirs = json!({
+            "theme": "dark",
+            "permissions": { "deny": ["Read(./.env)"], "allow": ["Bash(npm test)"] }
+        });
+        let policy = vec![
+            rule("Read(./.env)", Deny), // already theirs
+            rule("Bash(rm -rf *)", Deny),
+            rule("Bash(git push*)", Ask),
+        ];
+        let (with, added) = upsert_rules(&theirs, &policy, &[]).unwrap();
+        assert_eq!(added, vec![rule("Bash(rm -rf *)", Deny), rule("Bash(git push*)", Ask)]);
+        assert_eq!(with["permissions"]["deny"], json!(["Read(./.env)", "Bash(rm -rf *)"]));
+        assert_eq!(with["permissions"]["ask"], json!(["Bash(git push*)"]));
+        assert_eq!(with["permissions"]["allow"], json!(["Bash(npm test)"]), "untouched");
+        assert_eq!(with["theme"], "dark");
+        assert!(is_applied(&with, &policy));
+
+        // Idempotent over its own output; what it owns does not grow.
+        let (again, added2) = upsert_rules(&with, &policy, &added).unwrap();
+        assert_eq!(again, with);
+        assert_eq!(added2, added);
+
+        // Strip takes back exactly ours; the user's deny and allow survive, the emptied
+        // `ask` list is pruned, `permissions` itself stays because it is not empty.
+        let back = strip_rules(&with, &added);
+        assert_eq!(back, theirs);
+
+        // A rule whose action changed moves lists on the next upsert.
+        let moved = vec![rule("Bash(git push*)", Deny)];
+        let (moved_root, moved_added) = upsert_rules(&with, &moved, &added).unwrap();
+        assert_eq!(moved_root["permissions"].get("ask"), None);
+        assert_eq!(moved_root["permissions"]["deny"], json!(["Read(./.env)", "Bash(git push*)"]));
+        assert_eq!(moved_added, moved);
+    }
+
+    #[test]
+    fn a_file_with_no_permissions_gets_them_and_loses_them_whole() {
+        let fresh = json!({ "model": "opus" });
+        let policy = vec![rule("Bash(rm -rf *)", Deny)];
+        let (with, added) = upsert_rules(&fresh, &policy, &[]).unwrap();
+        assert_eq!(with, json!({ "model": "opus", "permissions": { "deny": ["Bash(rm -rf *)"] } }));
+        assert_eq!(strip_rules(&with, &added), fresh, "the shape we created is removed with it");
+        // A list the user left empty cannot be told from one we created once we have
+        // filled and emptied it, so it is pruned; it carried no rule, so nothing is lost.
+        let empty = json!({ "permissions": { "deny": [] } });
+        let (w, a) = upsert_rules(&empty, &policy, &[]).unwrap();
+        assert_eq!(strip_rules(&w, &a), json!({}));
+        // Allow rules land in allow.
+        let (w, _) = upsert_rules(&fresh, &[rule("Bash(npm test)", Allow)], &[]).unwrap();
+        assert_eq!(w["permissions"]["allow"], json!(["Bash(npm test)"]));
+    }
+
+    #[test]
+    fn presets_are_valid_policies() {
+        for p in presets() {
+            validate_rules(&p.rules).unwrap_or_else(|e| panic!("{}: {e}", p.label));
+        }
+    }
+
+    /// End to end over scratch files: opt in writes, a policy change rewrites, a hand edit
+    /// is put back by startup, turning off removes exactly ours, and a profile we could not
+    /// parse is reported but does not stop the others.
+    #[test]
+    fn apply_writes_reconciles_and_cleans_exactly_what_it_owns() {
+        let _dirs = crate::registry::data_dir_test_lock();
+        let scratch = std::env::temp_dir().join(format!(
+            "toolport-agent-permissions-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&scratch);
+        std::fs::create_dir_all(&scratch).unwrap();
+        let _data = crate::registry::DataDirOverride::set(scratch.join("data"));
+        let a = scratch.join("a").join("settings.json");
+        let b = scratch.join("b").join("settings.json");
+        std::fs::create_dir_all(a.parent().unwrap()).unwrap();
+        std::fs::create_dir_all(b.parent().unwrap()).unwrap();
+        std::fs::write(&a, "{\n  \"theme\": \"dark\",\n  \"permissions\": { \"deny\": [\"Read(./.env)\"] }\n}\n").unwrap();
+        // b does not exist yet: a fresh profile.
+        let profiles = vec![a.clone(), b.clone()];
+        let policy = vec![rule("Read(./.env)", Deny), rule("Bash(rm -rf *)", Deny)];
+
+        // Rules set while OFF: stored, nothing written.
+        apply_to(None, Some(policy.clone()), &profiles).unwrap();
+        assert!(!std::fs::read_to_string(&a).unwrap().contains("rm -rf"));
+        assert!(!b.exists());
+
+        // On: both written; `a` owns only the rule it did not already have.
+        let statuses = apply_to(Some(true), None, &profiles).unwrap();
+        assert!(statuses.iter().all(|s| s.state == "applied"), "{statuses:?}");
+        let reg = crate::registry::load().unwrap();
+        assert_eq!(reg.agent_permission_targets[&a.display().to_string()], vec![rule("Bash(rm -rf *)", Deny)]);
+        assert_eq!(reg.agent_permission_targets[&b.display().to_string()], policy);
+        let a_text = std::fs::read_to_string(&a).unwrap();
+        assert!(a_text.contains("\"theme\": \"dark\""), "user formatting kept: {a_text}");
+        assert!(a_text.contains("Bash(rm -rf *)"));
+        assert!(std::fs::read_to_string(&b).unwrap().contains("Read(./.env)"));
+        let view = view_with(&reg, &profiles);
+        assert!(view.profiles.iter().all(|p| p.state == "applied"));
+        assert_eq!(view.profiles[0].added, 1);
+        assert_eq!(view.profiles[1].added, 2);
+
+        // Hand-edit b to drop a rule: stale in the view, and startup puts it back.
+        std::fs::write(&b, "{\n  \"permissions\": { \"deny\": [\"Read(./.env)\"] }\n}\n").unwrap();
+        assert_eq!(view_with(&reg, &profiles).profiles[1].state, "stale");
+        apply_to(None, None, &profiles).unwrap();
+        assert!(std::fs::read_to_string(&b).unwrap().contains("rm -rf"));
+
+        // Policy change: the dropped rule leaves every file, the new one arrives.
+        let policy2 = vec![rule("Read(./.env)", Deny), rule("Bash(git push*)", Ask)];
+        apply_to(None, Some(policy2.clone()), &profiles).unwrap();
+        let a_text = std::fs::read_to_string(&a).unwrap();
+        assert!(!a_text.contains("rm -rf") && a_text.contains("git push*"), "{a_text}");
+
+        // A profile that cannot be parsed is reported, the other still applies, and the
+        // broken one's record is kept (we cannot see whether our strings are in it).
+        std::fs::write(&b, "{ not json").unwrap();
+        let statuses = apply_to(None, None, &profiles).unwrap();
+        assert_eq!(statuses.iter().filter(|s| s.state == "error").count(), 1);
+        assert!(crate::registry::load().unwrap().agent_permission_targets.contains_key(&b.display().to_string()));
+        std::fs::write(&b, "{}\n").unwrap();
+        apply_to(None, None, &profiles).unwrap();
+
+        // Off: exactly ours leaves; the user's own Read(./.env) in `a` stays.
+        apply_to(Some(false), None, &profiles).unwrap();
+        let a_text = std::fs::read_to_string(&a).unwrap();
+        assert!(a_text.contains("Read(./.env)") && !a_text.contains("git push"), "{a_text}");
+        assert!(!std::fs::read_to_string(&b).unwrap().contains("git push"));
+        assert!(crate::registry::load().unwrap().agent_permission_targets.is_empty());
+        let _ = std::fs::remove_dir_all(&scratch);
+    }
+}

--- a/src-tauri/src/clients.rs
+++ b/src-tauri/src/clients.rs
@@ -652,10 +652,21 @@ pub(crate) fn write_settings_json(
     original: Option<&str>,
     root: &serde_json::Value,
 ) -> Result<(), String> {
+    write_settings_key(path, original, root, "hooks")
+}
+
+/// [`write_settings_json`] for a caller that owns a different top-level key (the
+/// permission policy owns `permissions`). Same backup, same CST rewrite of only that key.
+pub(crate) fn write_settings_key(
+    path: &Path,
+    original: Option<&str>,
+    root: &serde_json::Value,
+    key: &str,
+) -> Result<(), String> {
     if original.is_some() {
         backup_file_named("claude-code", path, &claude_settings_backup_name(path))?;
     }
-    atomic_write(path, &render_settings_json(original, root)?)
+    atomic_write(path, &render_settings_key(original, root, key)?)
 }
 
 /// The exact bytes [`write_settings_json`] would put on disk.
@@ -667,13 +678,23 @@ pub(crate) fn render_settings_json(
     original: Option<&str>,
     root: &serde_json::Value,
 ) -> Result<String, String> {
-    match (original, root.get("hooks")) {
+    render_settings_key(original, root, "hooks")
+}
+
+/// [`render_settings_json`] for one top-level `key`: rewrite that key through the CST,
+/// or delete it through the CST when `root` no longer has it.
+pub(crate) fn render_settings_key(
+    original: Option<&str>,
+    root: &serde_json::Value,
+    key: &str,
+) -> Result<String, String> {
+    match (original, root.get(key)) {
         // The key is gone, which is what uninstall produces. `render_json_config`
         // only rewrites a key it can still find, so this case would fall through to a
         // pretty-print of the whole file and strip every comment in it. Delete the key
         // through the CST instead.
-        (Some(src), None) if !src.trim().is_empty() => remove_json_key_preserving(src, "hooks"),
-        _ => render_json_config(original, root, "hooks"),
+        (Some(src), None) if !src.trim().is_empty() => remove_json_key_preserving(src, key),
+        _ => render_json_config(original, root, key),
     }
 }
 

--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -12,6 +12,7 @@ use tauri_plugin_dialog::{DialogExt, MessageDialogButtons, MessageDialogKind};
 use tauri_plugin_notification::NotificationExt;
 
 use crate::approval;
+use crate::agent_permissions;
 use crate::approval_broker;
 use crate::audit;
 use crate::catalog;
@@ -3280,6 +3281,45 @@ async fn rules_apply() -> Result<rules::RulesView, String> {
         .map_err(|e| e.to_string())?
 }
 
+// --- Native permission policy for Claude Code (SBS-1058) -------------------------
+//
+// Same shape as the hook sensor: every one of these reads or writes an agent settings
+// file, so none runs on the UI thread.
+
+#[tauri::command]
+async fn agent_permissions_view() -> Result<agent_permissions::PermissionsView, String> {
+    tauri::async_runtime::spawn_blocking(agent_permissions::view)
+        .await
+        .map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+async fn agent_permissions_set_enabled(
+    enabled: bool,
+) -> Result<agent_permissions::PermissionsView, String> {
+    tauri::async_runtime::spawn_blocking(move || agent_permissions::set_enabled(enabled))
+        .await
+        .map_err(|e| e.to_string())?
+}
+
+#[tauri::command]
+async fn agent_permissions_set_rules(
+    rules: Vec<agent_permissions::PermissionRule>,
+) -> Result<agent_permissions::PermissionsView, String> {
+    tauri::async_runtime::spawn_blocking(move || agent_permissions::set_rules(rules))
+        .await
+        .map_err(|e| e.to_string())?
+}
+
+#[tauri::command]
+async fn agent_permissions_preview(
+    rules: Option<Vec<agent_permissions::PermissionRule>>,
+) -> Result<Vec<agent_permissions::PermissionsPreview>, String> {
+    tauri::async_runtime::spawn_blocking(move || agent_permissions::preview(rules))
+        .await
+        .map_err(|e| e.to_string())?
+}
+
 // --- Agent hook sensor (SBS-822) -------------------------------------------
 //
 // Same shape and the same reasons as the rules commands above: every one of these
@@ -5526,6 +5566,10 @@ pub fn run() {
             rules_project_preview,
             rules_import_candidates,
             rules_import_file,
+            agent_permissions_view,
+            agent_permissions_set_enabled,
+            agent_permissions_set_rules,
+            agent_permissions_preview,
             hooks_view,
             hooks_set_enabled,
             hooks_preview,
@@ -5731,6 +5775,7 @@ pub fn run() {
                 // no longer exists. Returns immediately when the sensor was never
                 // turned on.
                 hooks::apply_on_startup();
+                agent_permissions::apply_on_startup();
 
                 // Stop obsolete gateway processes. Path-based identity on all OS
                 // (SOU-414); not gated on repoint (SOU-306).

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -15,6 +15,7 @@ pub mod downstream;
 pub mod gateway_publish;
 pub mod gatewaylog;
 pub mod hooks;
+pub mod agent_permissions;
 pub mod hostenv;
 pub mod inspect;
 pub mod instructions;

--- a/src-tauri/src/registry.rs
+++ b/src-tauri/src/registry.rs
@@ -599,6 +599,36 @@ pub struct RuleSet {
     pub revision: i64,
 }
 
+/// What Claude Code should do with a native tool call that matches a rule (SBS-1058). The
+/// names are Claude Code's own `permissions` list names, so a rule maps to one list.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[serde(rename_all = "snake_case")]
+pub enum PermissionAction {
+    Allow,
+    Ask,
+    Deny,
+}
+
+impl PermissionAction {
+    /// The key under `permissions` this action writes to.
+    pub fn list_key(self) -> &'static str {
+        match self {
+            PermissionAction::Allow => "allow",
+            PermissionAction::Ask => "ask",
+            PermissionAction::Deny => "deny",
+        }
+    }
+}
+
+/// One native permission rule: a pattern in Claude Code's rule syntax (`Bash(rm -rf *)`,
+/// `Read(./.env)`, `WebFetch(domain:example.com)`, `mcp__server__tool`) and what to do.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[serde(rename_all = "camelCase")]
+pub struct PermissionRule {
+    pub pattern: String,
+    pub action: PermissionAction,
+}
+
 /// One registered project folder for project-level agent rules (SBS-1037). The consent unit
 /// inside it is a FILE, not a client: at project level nearly every client reads the root
 /// `AGENTS.md`, Gemini reads `GEMINI.md`, Claude Code and VS Code read `.claude/rules/`, so
@@ -957,6 +987,18 @@ pub struct Registry {
     /// written only by an explicit Apply for that project, never at startup.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub rules_projects: Vec<RulesProject>,
+    /// Native permission policy for Claude Code (SBS-1058): rules in Claude Code's own
+    /// `permissions` syntax that Toolport writes into every profile's `settings.json`. Off
+    /// until the user opts in; nothing is written until then. See [`crate::agent_permissions`].
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub agent_permissions_enabled: bool,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub agent_permission_rules: Vec<PermissionRule>,
+    /// Per settings file, exactly the rule strings Toolport ADDED there (a rule the user
+    /// already had is not added and not recorded, so it is never removed). Removal and
+    /// policy changes strip exactly these. Same role as `hook_targets` / `rules_targets`.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub agent_permission_targets: HashMap<String, Vec<PermissionRule>>,
     /// Whether the native-agent hook sensor is installed. OFF until the user opts in:
     /// it writes into a settings file they own and it observes every native tool call
     /// their agent makes. See [`crate::hooks`].
@@ -1228,6 +1270,9 @@ impl Default for Registry {
             rules_clients: HashMap::new(),
             rules_targets: Vec::new(),
             rules_projects: Vec::new(),
+            agent_permissions_enabled: false,
+            agent_permission_rules: Vec::new(),
+            agent_permission_targets: HashMap::new(),
             hooks_enabled: false,
             hook_targets: Vec::new(),
             unknown_fields: serde_json::Map::new(),

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -93,6 +93,11 @@ const PlaygroundView = lazy(() =>
 const RulesView = lazy(() =>
   import("@/components/RulesView").then((m) => ({ default: m.RulesView })),
 );
+const AgentPermissionsView = lazy(() =>
+  import("@/components/AgentPermissionsView").then((m) => ({
+    default: m.AgentPermissionsView,
+  })),
+);
 const HooksView = lazy(() =>
   import("@/components/HooksView").then((m) => ({ default: m.HooksView })),
 );
@@ -884,13 +889,15 @@ function App() {
                           ? "Agent rules"
                           : view === "hooks"
                             ? "Agent activity"
-                            : view === "teams"
-                              ? "Teams"
-                              : view === "settings"
-                                ? "Settings"
-                                : view === "clients"
-                                  ? (selectedClient?.name ?? "Clients")
-                                  : "Servers"}
+                            : view === "permissions"
+                              ? "Agent permissions"
+                              : view === "teams"
+                                ? "Teams"
+                                : view === "settings"
+                                  ? "Settings"
+                                  : view === "clients"
+                                    ? (selectedClient?.name ?? "Clients")
+                                    : "Servers"}
                 </h1>
                 <p className="truncate text-sm text-muted-foreground">
                   {view === "activity"
@@ -903,17 +910,19 @@ function App() {
                           ? "Write your rules once, apply them to every AI client"
                           : view === "hooks"
                             ? "See what your agents do outside Toolport"
-                            : view === "teams"
-                              ? "Share one MCP server set across your team"
-                              : view === "settings"
-                                ? "Global discovery and security policy"
-                                : view === "clients"
-                                  ? selectedClient
-                                    ? "MCP client"
-                                    : "Manage Toolport in your installed AI tools"
-                                  : loading || !registry
-                                    ? "Loading…"
-                                    : "One gateway in front of every MCP server you run"}
+                            : view === "permissions"
+                              ? "Rules Claude Code enforces on its own native tool calls"
+                              : view === "teams"
+                                ? "Share one MCP server set across your team"
+                                : view === "settings"
+                                  ? "Global discovery and security policy"
+                                  : view === "clients"
+                                    ? selectedClient
+                                      ? "MCP client"
+                                      : "Manage Toolport in your installed AI tools"
+                                    : loading || !registry
+                                      ? "Loading…"
+                                      : "One gateway in front of every MCP server you run"}
                 </p>
               </div>
             </div>
@@ -1076,6 +1085,8 @@ function App() {
                     <RulesView />
                   ) : view === "hooks" ? (
                     <HooksView refreshKey={activityKey} />
+                  ) : view === "permissions" ? (
+                    <AgentPermissionsView />
                   ) : view === "teams" ? (
                     <TeamsView
                       registry={registry}

--- a/src/components/AgentPermissionsView.test.tsx
+++ b/src/components/AgentPermissionsView.test.tsx
@@ -145,6 +145,21 @@ describe("AgentPermissionsView", () => {
     ).toBeInTheDocument();
   });
 
+  it("a refused duplicate keeps the typed pattern even though the list already has it", async () => {
+    api.agentPermissionsView.mockResolvedValue(
+      view({ rules: [{ pattern: "Bash(rm -rf *)", action: "deny" }] }),
+    );
+    api.agentPermissionsSetRules.mockRejectedValue(
+      new Error('"Bash(rm -rf *)" appears more than once. A pattern maps to one action.'),
+    );
+    render(<AgentPermissionsView />);
+    await screen.findByRole("button", { name: "Remove rule Bash(rm -rf *)" });
+    await userEvent.type(screen.getByLabelText("Rule pattern"), "Bash(rm -rf *)");
+    await userEvent.click(screen.getByRole("button", { name: "Add rule" }));
+    expect(await screen.findByRole("alert")).toHaveTextContent("more than once");
+    expect(screen.getByLabelText("Rule pattern")).toHaveValue("Bash(rm -rf *)");
+  });
+
   it("a preset whose patterns are all present, even under another action, is disabled", async () => {
     api.agentPermissionsView.mockResolvedValue(
       view({

--- a/src/components/AgentPermissionsView.test.tsx
+++ b/src/components/AgentPermissionsView.test.tsx
@@ -1,0 +1,141 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { PermissionsView as PermissionsViewData } from "@/lib/types";
+
+const api = vi.hoisted(() => ({
+  agentPermissionsView: vi.fn(),
+  agentPermissionsSetEnabled: vi.fn(),
+  agentPermissionsSetRules: vi.fn(),
+  agentPermissionsPreview: vi.fn(),
+}));
+vi.mock("@/lib/api", () => api);
+
+import { AgentPermissionsView } from "./AgentPermissionsView";
+
+function view(over: Partial<PermissionsViewData> = {}): PermissionsViewData {
+  return {
+    enabled: false,
+    rules: [],
+    profiles: [{ path: "/home/a/.claude/settings.json", state: "off", added: 0 }],
+    presets: [
+      {
+        label: "Never force-push",
+        rules: [
+          { pattern: "Bash(git push --force*)", action: "deny" },
+          { pattern: "Bash(git push -f *)", action: "deny" },
+        ],
+      },
+    ],
+    ...over,
+  };
+}
+
+describe("AgentPermissionsView", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    api.agentPermissionsView.mockResolvedValue(view());
+  });
+
+  it("starts off and empty, and adding a rule sends the whole list without writing", async () => {
+    api.agentPermissionsSetRules.mockResolvedValue(
+      view({ rules: [{ pattern: "Bash(rm -rf *)", action: "deny" }] }),
+    );
+    render(<AgentPermissionsView />);
+    expect(
+      await screen.findByLabelText("Enforce my permission rules in Claude Code"),
+    ).not.toBeChecked();
+    expect(screen.getByText(/No rules yet/)).toBeInTheDocument();
+    await userEvent.type(screen.getByLabelText("Rule pattern"), "Bash(rm -rf *)");
+    await userEvent.click(screen.getByRole("button", { name: "Add rule" }));
+    await waitFor(() =>
+      expect(api.agentPermissionsSetRules).toHaveBeenCalledWith([
+        { pattern: "Bash(rm -rf *)", action: "deny" },
+      ]),
+    );
+    // The rule row is there (the syntax help also mentions this pattern, hence the button).
+    expect(
+      screen.getByRole("button", { name: "Remove rule Bash(rm -rf *)" }),
+    ).toBeInTheDocument();
+    // Badge + the <option> both read "Never"; the row's badge is the second occurrence.
+    expect(screen.getAllByText("Never").length).toBeGreaterThanOrEqual(2);
+    expect(api.agentPermissionsSetEnabled).not.toHaveBeenCalled();
+  });
+
+  it("a preset adds its rules, a rule can be removed, and the switch calls through", async () => {
+    const withPreset = view({
+      rules: [
+        { pattern: "Bash(git push --force*)", action: "deny" },
+        { pattern: "Bash(git push -f *)", action: "deny" },
+      ],
+    });
+    api.agentPermissionsSetRules.mockResolvedValueOnce(withPreset);
+    render(<AgentPermissionsView />);
+    await screen.findByText(/No rules yet/);
+    await userEvent.click(screen.getByRole("button", { name: "Never force-push" }));
+    await waitFor(() =>
+      expect(api.agentPermissionsSetRules).toHaveBeenCalledWith(withPreset.rules),
+    );
+    // The preset is now "already in the list" and disabled.
+    expect(screen.getByRole("button", { name: "Never force-push" })).toBeDisabled();
+
+    api.agentPermissionsSetRules.mockResolvedValueOnce(
+      view({ rules: [{ pattern: "Bash(git push -f *)", action: "deny" }] }),
+    );
+    await userEvent.click(
+      screen.getByRole("button", { name: "Remove rule Bash(git push --force*)" }),
+    );
+    await waitFor(() =>
+      expect(api.agentPermissionsSetRules).toHaveBeenLastCalledWith([
+        { pattern: "Bash(git push -f *)", action: "deny" },
+      ]),
+    );
+
+    api.agentPermissionsSetEnabled.mockResolvedValue(
+      view({
+        enabled: true,
+        rules: [{ pattern: "Bash(git push -f *)", action: "deny" }],
+        profiles: [{ path: "/home/a/.claude/settings.json", state: "applied", added: 1 }],
+      }),
+    );
+    await userEvent.click(
+      screen.getByLabelText("Enforce my permission rules in Claude Code"),
+    );
+    await waitFor(() =>
+      expect(api.agentPermissionsSetEnabled).toHaveBeenCalledWith(true),
+    );
+    expect(await screen.findByText("Applied")).toBeInTheDocument();
+  });
+
+  it("an invalid rule is surfaced and the list is reseated from the backend", async () => {
+    api.agentPermissionsSetRules.mockRejectedValue(
+      new Error('"rm -rf *" is not a tool name. Use Claude Code\'s syntax'),
+    );
+    render(<AgentPermissionsView />);
+    await screen.findByText(/No rules yet/);
+    await userEvent.type(screen.getByLabelText("Rule pattern"), "rm -rf *");
+    await userEvent.click(screen.getByRole("button", { name: "Add rule" }));
+    expect(await screen.findByRole("alert")).toHaveTextContent("not a tool name");
+    expect(screen.getByText(/No rules yet/)).toBeInTheDocument();
+    expect(api.agentPermissionsView).toHaveBeenCalledTimes(2);
+  });
+
+  it("preview shows the bytes and writes nothing", async () => {
+    api.agentPermissionsPreview.mockResolvedValue([
+      {
+        path: "/home/a/.claude/settings.json",
+        before: "{}\n",
+        after: '{\n  "permissions": { "deny": ["Bash(rm -rf *)"] }\n}\n',
+      },
+    ]);
+    render(<AgentPermissionsView />);
+    await screen.findByText(/No rules yet/);
+    await userEvent.click(
+      screen.getByRole("button", { name: "Preview what would be written" }),
+    );
+    expect(await screen.findByText("What would be written")).toBeInTheDocument();
+    expect(screen.getByText(/"deny": \["Bash\(rm -rf \*\)"\]/)).toBeInTheDocument();
+    expect(api.agentPermissionsSetRules).not.toHaveBeenCalled();
+    expect(api.agentPermissionsSetEnabled).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/AgentPermissionsView.test.tsx
+++ b/src/components/AgentPermissionsView.test.tsx
@@ -118,6 +118,23 @@ describe("AgentPermissionsView", () => {
     expect(await screen.findByRole("alert")).toHaveTextContent("not a tool name");
     expect(screen.getByText(/No rules yet/)).toBeInTheDocument();
     expect(api.agentPermissionsView).toHaveBeenCalledTimes(2);
+    // The refused pattern stays in the box to be fixed, not wiped.
+    expect(screen.getByLabelText("Rule pattern")).toHaveValue("rm -rf *");
+  });
+
+  it("a preset whose patterns are all present, even under another action, is disabled", async () => {
+    api.agentPermissionsView.mockResolvedValue(
+      view({
+        rules: [
+          { pattern: "Bash(git push --force*)", action: "ask" },
+          { pattern: "Bash(git push -f *)", action: "ask" },
+        ],
+      }),
+    );
+    render(<AgentPermissionsView />);
+    expect(
+      await screen.findByRole("button", { name: "Never force-push" }),
+    ).toBeDisabled();
   });
 
   it("preview shows the bytes and writes nothing", async () => {

--- a/src/components/AgentPermissionsView.test.tsx
+++ b/src/components/AgentPermissionsView.test.tsx
@@ -122,6 +122,29 @@ describe("AgentPermissionsView", () => {
     expect(screen.getByLabelText("Rule pattern")).toHaveValue("rm -rf *");
   });
 
+  it("a rule that saved but failed to reach one profile still clears the input and shows the error", async () => {
+    api.agentPermissionsSetRules.mockRejectedValue(
+      new Error(
+        "The policy was saved, but one profile could not be updated: /x/settings.json: not JSON",
+      ),
+    );
+    // The refresh after the error shows the rule in the list (it was saved).
+    api.agentPermissionsView
+      .mockResolvedValueOnce(view())
+      .mockResolvedValueOnce(
+        view({ rules: [{ pattern: "Bash(rm -rf *)", action: "deny" }] }),
+      );
+    render(<AgentPermissionsView />);
+    await screen.findByText(/No rules yet/);
+    await userEvent.type(screen.getByLabelText("Rule pattern"), "Bash(rm -rf *)");
+    await userEvent.click(screen.getByRole("button", { name: "Add rule" }));
+    expect(await screen.findByRole("alert")).toHaveTextContent("could not be updated");
+    await waitFor(() => expect(screen.getByLabelText("Rule pattern")).toHaveValue(""));
+    expect(
+      screen.getByRole("button", { name: "Remove rule Bash(rm -rf *)" }),
+    ).toBeInTheDocument();
+  });
+
   it("a preset whose patterns are all present, even under another action, is disabled", async () => {
     api.agentPermissionsView.mockResolvedValue(
       view({

--- a/src/components/AgentPermissionsView.tsx
+++ b/src/components/AgentPermissionsView.tsx
@@ -112,8 +112,11 @@ export function AgentPermissionsView() {
     if (!p) return;
     // Clear the input once the rule is in the list - including when a profile write failed
     // after the policy saved - and keep a refused pattern put to be fixed.
+    const wasThere = data.rules.some((r) => r.pattern === p);
     const next = await withRules([...data.rules, { pattern: p, action }]);
-    if (next?.rules.some((r) => r.pattern === p)) setPattern("");
+    const isThere =
+      next?.rules.some((r) => r.pattern === p && r.action === action) ?? false;
+    if (isThere && !wasThere) setPattern("");
   }
 
   async function openPreview() {

--- a/src/components/AgentPermissionsView.tsx
+++ b/src/components/AgentPermissionsView.tsx
@@ -1,0 +1,414 @@
+import { useCallback, useEffect, useState } from "react";
+import { Eye, Plus, ShieldCheck, Trash2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Callout } from "@/components/Callout";
+import { Input } from "@/components/ui/input";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  agentPermissionsPreview,
+  agentPermissionsSetEnabled,
+  agentPermissionsSetRules,
+  agentPermissionsView,
+} from "@/lib/api";
+import type {
+  PermissionAction,
+  PermissionRule,
+  PermissionsPreview,
+  PermissionsView as PermissionsViewData,
+} from "@/lib/types";
+
+const ACTION_LABEL: Record<PermissionAction, string> = {
+  deny: "Never",
+  ask: "Ask first",
+  allow: "Always allow",
+};
+
+/** What each per-profile state means, in the row. */
+const STATE_LABEL: Record<string, { label: string; className: string }> = {
+  applied: { label: "Applied", className: "text-success" },
+  stale: { label: "Not applied yet", className: "text-warning" },
+  off: { label: "Off", className: "text-muted-foreground" },
+  error: { label: "Error", className: "text-destructive" },
+};
+
+/**
+ * Native permission policy for Claude Code (SBS-1058): rules in Claude Code's own syntax that
+ * Toolport writes into every profile's `settings.json` so Claude Code itself refuses, or asks
+ * before, a matching native tool call. No hook, no Toolport process in the loop: Claude Code
+ * enforces its `permissions` lists on every call, deny first, whatever any hook says.
+ *
+ * Off by default and empty by default. Nothing is written until the switch is on; presets are
+ * one-click adds, never pre-applied. Only Toolport's own rule strings are ever added or
+ * removed: a rule you already had in the file is left exactly where it is.
+ */
+export function AgentPermissionsView() {
+  const [data, setData] = useState<PermissionsViewData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [preview, setPreview] = useState<PermissionsPreview[] | null>(null);
+  const [pattern, setPattern] = useState("");
+  const [action, setAction] = useState<PermissionAction>("deny");
+
+  const refresh = useCallback(async () => {
+    setData(await agentPermissionsView());
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    agentPermissionsView()
+      .then((v) => {
+        if (!cancelled) setData(v);
+      })
+      .catch((e) => {
+        if (!cancelled) setError(String(e));
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  async function act(fn: () => Promise<PermissionsViewData>) {
+    setBusy(true);
+    setError(null);
+    try {
+      setData(await fn());
+    } catch (e) {
+      setError(String(e));
+      // Reseat on what the backend actually did, so a failed write cannot leave the switch
+      // or the list claiming something the files do not hold.
+      try {
+        await refresh();
+      } catch {
+        // the first error is the one worth showing
+      }
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  function withRules(rules: PermissionRule[]) {
+    return act(() => agentPermissionsSetRules(rules));
+  }
+
+  async function addRule() {
+    if (!data) return;
+    const p = pattern.trim();
+    if (!p) return;
+    await withRules([...data.rules, { pattern: p, action }]);
+    setPattern("");
+  }
+
+  async function openPreview() {
+    setBusy(true);
+    setError(null);
+    try {
+      setPreview(await agentPermissionsPreview());
+    } catch (e) {
+      setError(String(e));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  if (loading) return <p className="text-sm text-muted-foreground">Loading…</p>;
+  if (!data) {
+    return (
+      <Callout variant="danger" role="alert">
+        {error ?? "Could not load the permission policy."}
+      </Callout>
+    );
+  }
+
+  const rulesForAction = (a: PermissionAction) =>
+    data.rules.filter((r) => r.action === a);
+
+  return (
+    <div className="grid gap-4">
+      {error && (
+        <Callout variant="danger" role="alert">
+          {error}
+        </Callout>
+      )}
+
+      <div className="rounded-xl border bg-card p-5">
+        <label className="flex items-start gap-3">
+          <input
+            type="checkbox"
+            className="mt-1"
+            checked={data.enabled}
+            disabled={busy || preview !== null}
+            aria-label="Enforce my permission rules in Claude Code"
+            onChange={(e) => {
+              const next = e.target.checked;
+              void act(() => agentPermissionsSetEnabled(next));
+            }}
+          />
+          <span className="min-w-0">
+            <span className="text-sm font-medium">
+              Enforce my permission rules in Claude Code
+            </span>
+            <span className="mt-1 block text-xs text-muted-foreground">
+              Toolport writes the rules below into every Claude Code profile&rsquo;s{" "}
+              <span className="font-mono">settings.json</span>, under{" "}
+              <span className="font-mono">permissions</span>. Claude Code itself then
+              refuses, or asks before, a matching native tool call &mdash; shell commands,
+              file reads and edits, web fetches, MCP tools &mdash; on every call, whatever
+              any hook says. Turning this off removes only what Toolport added; a rule you
+              already had stays.
+            </span>
+          </span>
+        </label>
+        <div className="mt-3 flex flex-wrap items-center gap-2 border-t pt-3">
+          <Button variant="outline" size="sm" disabled={busy} onClick={openPreview}>
+            <Eye className="size-3.5" />
+            Preview what would be written
+          </Button>
+        </div>
+      </div>
+
+      <div className="rounded-xl border bg-card p-5">
+        <div className="mb-1 flex items-center gap-2">
+          <ShieldCheck className="size-4 text-muted-foreground" />
+          <h2 className="text-sm font-medium">Rules</h2>
+        </div>
+        <p className="mb-3 text-xs text-muted-foreground">
+          Claude Code&rsquo;s own rule syntax: a tool name, optionally with a pattern in
+          parentheses &mdash; <span className="font-mono">Bash(rm -rf *)</span>,{" "}
+          <span className="font-mono">Read(./.env)</span>,{" "}
+          <span className="font-mono">WebFetch(domain:example.com)</span>,{" "}
+          <span className="font-mono">mcp__github__create_issue</span>. A bare tool name
+          covers every use of it. &ldquo;Never&rdquo; beats &ldquo;Ask first&rdquo; beats
+          &ldquo;Always allow&rdquo; when more than one matches.
+        </p>
+
+        {data.rules.length === 0 ? (
+          <p className="mb-3 text-sm text-muted-foreground">
+            No rules yet. Add one below, or start from a preset.
+          </p>
+        ) : (
+          <ul className="mb-3 grid gap-1.5">
+            {(["deny", "ask", "allow"] as PermissionAction[]).flatMap((a) =>
+              rulesForAction(a).map((r) => (
+                <li
+                  key={`${a}:${r.pattern}`}
+                  className="flex items-center justify-between gap-3 rounded-md border px-2 py-1 text-sm"
+                >
+                  <span className="min-w-0 truncate">
+                    <span className="mr-2 rounded bg-muted px-1.5 py-0.5 text-xs text-muted-foreground">
+                      {ACTION_LABEL[a]}
+                    </span>
+                    <span className="font-mono text-xs">{r.pattern}</span>
+                  </span>
+                  <button
+                    type="button"
+                    disabled={busy}
+                    aria-label={`Remove rule ${r.pattern}`}
+                    title="Remove this rule"
+                    onClick={() =>
+                      void withRules(
+                        data.rules.filter(
+                          (x) => !(x.pattern === r.pattern && x.action === a),
+                        ),
+                      )
+                    }
+                    className="rounded p-0.5 text-muted-foreground hover:bg-accent hover:text-destructive disabled:opacity-50"
+                  >
+                    <Trash2 className="size-3.5" />
+                  </button>
+                </li>
+              )),
+            )}
+          </ul>
+        )}
+
+        <form
+          className="flex flex-wrap items-center gap-2"
+          onSubmit={(e) => {
+            e.preventDefault();
+            void addRule();
+          }}
+        >
+          <select
+            aria-label="Action"
+            value={action}
+            disabled={busy}
+            onChange={(e) => setAction(e.target.value as PermissionAction)}
+            className="h-9 rounded-md border bg-background px-2 text-sm"
+          >
+            <option value="deny">Never</option>
+            <option value="ask">Ask first</option>
+            <option value="allow">Always allow</option>
+          </select>
+          <Input
+            value={pattern}
+            disabled={busy}
+            aria-label="Rule pattern"
+            placeholder="Bash(rm -rf *)"
+            onChange={(e) => setPattern(e.target.value)}
+            className="h-9 w-72 font-mono text-xs"
+          />
+          <Button type="submit" size="sm" disabled={busy || !pattern.trim()}>
+            <Plus className="size-3.5" />
+            Add rule
+          </Button>
+        </form>
+
+        <div className="mt-3 border-t pt-3">
+          <p className="mb-2 text-xs text-muted-foreground">
+            Presets (added to the list, nothing written until the switch is on):
+          </p>
+          <div className="flex flex-wrap gap-1.5">
+            {data.presets.map((p) => {
+              const already = p.rules.every((r) =>
+                data.rules.some((x) => x.pattern === r.pattern && x.action === r.action),
+              );
+              return (
+                <Button
+                  key={p.label}
+                  variant="outline"
+                  size="sm"
+                  disabled={busy || already}
+                  title={
+                    already
+                      ? "Already in the list"
+                      : p.rules
+                          .map((r) => `${ACTION_LABEL[r.action]}: ${r.pattern}`)
+                          .join("\n")
+                  }
+                  onClick={() => {
+                    const merged = [...data.rules];
+                    for (const r of p.rules) {
+                      if (!merged.some((x) => x.pattern === r.pattern)) merged.push(r);
+                    }
+                    void withRules(merged);
+                  }}
+                >
+                  {p.label}
+                </Button>
+              );
+            })}
+          </div>
+        </div>
+      </div>
+
+      <div className="rounded-xl border bg-card p-5">
+        <h2 className="mb-1 text-sm font-medium">Claude Code profiles</h2>
+        <p className="mb-3 text-xs text-muted-foreground">
+          Every profile on this machine is covered, including ones selected with{" "}
+          <span className="font-mono">CLAUDE_CONFIG_DIR</span>; a rule in only one of them
+          would quietly not apply in the others.
+        </p>
+        {data.profiles.length === 0 ? (
+          <p className="text-sm text-muted-foreground">No Claude Code profile found.</p>
+        ) : (
+          <ul className="grid gap-1.5 text-sm">
+            {data.profiles.map((p) => {
+              const meta = STATE_LABEL[p.state] ?? STATE_LABEL.error;
+              return (
+                <li key={p.path} className="flex items-center justify-between gap-3">
+                  <span className="min-w-0 truncate font-mono text-xs" title={p.path}>
+                    {p.path}
+                  </span>
+                  <span
+                    className={`flex shrink-0 items-center gap-2 text-xs ${meta.className}`}
+                    title={p.error}
+                  >
+                    {meta.label}
+                    {p.state === "applied" &&
+                      p.added < data.rules.length &&
+                      data.rules.length > 0 && (
+                        <span className="text-muted-foreground">
+                          ({data.rules.length - p.added} already yours)
+                        </span>
+                      )}
+                  </span>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </div>
+
+      <div className="rounded-xl border bg-card p-5">
+        <h2 className="mb-1 text-sm font-medium">Which agents this reaches</h2>
+        <ul className="grid gap-1 text-xs text-muted-foreground">
+          <li>
+            <span className="text-foreground">Claude Code</span> &mdash; enforced through
+            its own <span className="font-mono">permissions</span> settings, on every
+            native tool call.
+          </li>
+          <li>
+            <span className="text-foreground">Cursor, Codex, Gemini CLI</span> &mdash; not
+            yet. Cursor has hooks but no settings-level rule list; Codex uses approval and
+            sandbox settings of a different shape; Gemini CLI is mixed. Toolport says so
+            rather than pretending. The gateway&rsquo;s own approval and destructive-call
+            gates still cover every MCP call from every client.
+          </li>
+        </ul>
+      </div>
+
+      <PreviewDialog previews={preview} onClose={() => setPreview(null)} />
+    </div>
+  );
+}
+
+function PreviewDialog({
+  previews,
+  onClose,
+}: {
+  previews: PermissionsPreview[] | null;
+  onClose: () => void;
+}) {
+  return (
+    <Dialog open={previews !== null} onOpenChange={(open) => !open && onClose()}>
+      <DialogContent className="sm:max-w-3xl">
+        <DialogHeader>
+          <DialogTitle>What would be written</DialogTitle>
+        </DialogHeader>
+        <div className="grid gap-4 overflow-auto">
+          {previews?.length === 0 && (
+            <p className="text-sm text-muted-foreground">
+              No Claude Code profile was found, so there is nothing to write.
+            </p>
+          )}
+          {previews?.map((p) => (
+            <div key={p.path} className="grid gap-1">
+              <p className="font-mono text-xs text-muted-foreground">{p.path}</p>
+              {p.error ? (
+                <p className="rounded-md bg-warning/10 px-3 py-2 text-xs text-warning">
+                  No preview for this profile: {p.error}
+                </p>
+              ) : (
+                <>
+                  <pre className="max-h-64 overflow-auto rounded-md border bg-muted/40 p-3 text-xs whitespace-pre-wrap">
+                    {p.after}
+                  </pre>
+                  {p.before === "" && (
+                    <p className="text-xs text-muted-foreground">
+                      This file does not exist yet and would be created.
+                    </p>
+                  )}
+                </>
+              )}
+            </div>
+          ))}
+        </div>
+        <DialogFooter className="text-xs text-muted-foreground sm:justify-start">
+          Nothing has been written. Only the{" "}
+          <span className="font-mono">permissions</span> key changes; everything else in
+          the file, including your comments, is left exactly as it is.
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/AgentPermissionsView.tsx
+++ b/src/components/AgentPermissionsView.tsx
@@ -77,11 +77,13 @@ export function AgentPermissionsView() {
     };
   }, []);
 
-  async function act(fn: () => Promise<PermissionsViewData>) {
+  /** Run a mutating call; `true` when it succeeded. */
+  async function act(fn: () => Promise<PermissionsViewData>): Promise<boolean> {
     setBusy(true);
     setError(null);
     try {
       setData(await fn());
+      return true;
     } catch (e) {
       setError(String(e));
       // Reseat on what the backend actually did, so a failed write cannot leave the switch
@@ -91,6 +93,7 @@ export function AgentPermissionsView() {
       } catch {
         // the first error is the one worth showing
       }
+      return false;
     } finally {
       setBusy(false);
     }
@@ -104,8 +107,8 @@ export function AgentPermissionsView() {
     if (!data) return;
     const p = pattern.trim();
     if (!p) return;
-    await withRules([...data.rules, { pattern: p, action }]);
-    setPattern("");
+    // Clear the input only once the rule is in; a refused pattern stays put to be fixed.
+    if (await withRules([...data.rules, { pattern: p, action }])) setPattern("");
   }
 
   async function openPreview() {
@@ -269,8 +272,11 @@ export function AgentPermissionsView() {
           </p>
           <div className="flex flex-wrap gap-1.5">
             {data.presets.map((p) => {
+              // A pattern already in the list is never overridden by a preset (your "never" is
+              // not downgraded to a preset's "ask"), so the preset has nothing to add exactly
+              // when every one of its patterns is already present, whatever the action.
               const already = p.rules.every((r) =>
-                data.rules.some((x) => x.pattern === r.pattern && x.action === r.action),
+                data.rules.some((x) => x.pattern === r.pattern),
               );
               return (
                 <Button
@@ -280,7 +286,7 @@ export function AgentPermissionsView() {
                   disabled={busy || already}
                   title={
                     already
-                      ? "Already in the list"
+                      ? "Every pattern in this preset is already in the list"
                       : p.rules
                           .map((r) => `${ACTION_LABEL[r.action]}: ${r.pattern}`)
                           .join("\n")

--- a/src/components/AgentPermissionsView.tsx
+++ b/src/components/AgentPermissionsView.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import { Eye, Plus, ShieldCheck, Trash2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Callout } from "@/components/Callout";
@@ -56,10 +56,6 @@ export function AgentPermissionsView() {
   const [pattern, setPattern] = useState("");
   const [action, setAction] = useState<PermissionAction>("deny");
 
-  const refresh = useCallback(async () => {
-    setData(await agentPermissionsView());
-  }, []);
-
   useEffect(() => {
     let cancelled = false;
     agentPermissionsView()
@@ -77,23 +73,30 @@ export function AgentPermissionsView() {
     };
   }, []);
 
-  /** Run a mutating call; `true` when it succeeded. */
-  async function act(fn: () => Promise<PermissionsViewData>): Promise<boolean> {
+  /**
+   * Run a mutating call and return the view it left behind: the call's own result, or,
+   * when it failed, the backend's current state (a failed profile write still saves the
+   * policy, and the rows must show what the files really hold). `null` only when even that
+   * could not be read.
+   */
+  async function act(
+    fn: () => Promise<PermissionsViewData>,
+  ): Promise<PermissionsViewData | null> {
     setBusy(true);
     setError(null);
     try {
-      setData(await fn());
-      return true;
+      const next = await fn();
+      setData(next);
+      return next;
     } catch (e) {
       setError(String(e));
-      // Reseat on what the backend actually did, so a failed write cannot leave the switch
-      // or the list claiming something the files do not hold.
       try {
-        await refresh();
+        const next = await agentPermissionsView();
+        setData(next);
+        return next;
       } catch {
-        // the first error is the one worth showing
+        return null; // the first error is the one worth showing
       }
-      return false;
     } finally {
       setBusy(false);
     }
@@ -107,8 +110,10 @@ export function AgentPermissionsView() {
     if (!data) return;
     const p = pattern.trim();
     if (!p) return;
-    // Clear the input only once the rule is in; a refused pattern stays put to be fixed.
-    if (await withRules([...data.rules, { pattern: p, action }])) setPattern("");
+    // Clear the input once the rule is in the list - including when a profile write failed
+    // after the policy saved - and keep a refused pattern put to be fixed.
+    const next = await withRules([...data.rules, { pattern: p, action }]);
+    if (next?.rules.some((r) => r.pattern === p)) setPattern("");
   }
 
   async function openPreview() {

--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -17,6 +17,7 @@ import {
   Store,
   Users,
   Zap,
+  ShieldCheck,
 } from "lucide-react";
 import { getVersion } from "@tauri-apps/api/app";
 import { openExternal } from "@/lib/openUrl";
@@ -532,6 +533,9 @@ export function AppSidebar({
           )}
           {navItem(Activity, "Agent activity", view === "hooks", () =>
             onSelectView("hooks"),
+          )}
+          {navItem(ShieldCheck, "Agent permissions", view === "permissions", () =>
+            onSelectView("permissions"),
           )}
           {navItem(Users, "Teams", view === "teams", () => onSelectView("teams"))}
           {navItem(

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -33,6 +33,9 @@ import type {
   ToolCallResult,
   Stack,
   WriteOutcome,
+  PermissionRule,
+  PermissionsPreview,
+  PermissionsView,
 } from "./types";
 
 /** The hand-verified popular catalog (offline, instant). */
@@ -1015,6 +1018,28 @@ export function disableAutostart(): Promise<void> {
 // on. Every mutating call returns the refreshed view, so the tab never re-fetches to stay honest.
 
 /** Current state: the opt-in, the events registered, and every Claude Code profile found. */
+// ---- Native permission policy for Claude Code (SBS-1058) ----
+
+export function agentPermissionsView(): Promise<PermissionsView> {
+  return invoke<PermissionsView>("agent_permissions_view");
+}
+export function agentPermissionsSetEnabled(enabled: boolean): Promise<PermissionsView> {
+  return invoke<PermissionsView>("agent_permissions_set_enabled", { enabled });
+}
+export function agentPermissionsSetRules(
+  rules: PermissionRule[],
+): Promise<PermissionsView> {
+  return invoke<PermissionsView>("agent_permissions_set_rules", { rules });
+}
+/** Dry run with the given rules (an unsaved policy) or, when omitted, the saved one. */
+export function agentPermissionsPreview(
+  rules?: PermissionRule[],
+): Promise<PermissionsPreview[]> {
+  return invoke<PermissionsPreview[]>("agent_permissions_preview", {
+    rules: rules ?? null,
+  });
+}
+
 export function hooksView(): Promise<HooksViewData> {
   return invoke<HooksViewData>("hooks_view");
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -9,6 +9,7 @@ export type View =
   | "playground"
   | "rules"
   | "hooks"
+  | "permissions"
   | "teams"
   | "settings";
 
@@ -740,6 +741,44 @@ export interface HooksView {
   /** Absent when no gateway binary has been published yet, which is the one thing that stops
    *  the sensor being installable. */
   binary?: string;
+}
+
+// ---- Native permission policy for Claude Code (SBS-1058) ----
+
+export type PermissionAction = "allow" | "ask" | "deny";
+
+/** One rule in Claude Code's own syntax (`Bash(rm -rf *)`, `Read(./.env)`, `mcp__server__tool`). */
+export interface PermissionRule {
+  pattern: string;
+  action: PermissionAction;
+}
+
+export interface PermissionProfileStatus {
+  path: string;
+  /** applied | stale | off | error */
+  state: string;
+  /** How many of the policy's rules Toolport itself added to this file. */
+  added: number;
+  error?: string;
+}
+
+export interface PermissionPreset {
+  label: string;
+  rules: PermissionRule[];
+}
+
+export interface PermissionsView {
+  enabled: boolean;
+  rules: PermissionRule[];
+  profiles: PermissionProfileStatus[];
+  presets: PermissionPreset[];
+}
+
+export interface PermissionsPreview {
+  path: string;
+  before: string;
+  after: string;
+  error?: string;
 }
 
 /** A dry run of one profile's write. Nothing is written to produce it. */


### PR DESCRIPTION
## Summary

Closes **SBS-1058** — the enforcer half of SBS-820 item 2, settings-based, Claude Code first.

- Toolport's gateway governs MCP calls and is blind to what Claude Code does natively. Claude Code's own `permissions.deny/ask/allow` in `settings.json` are evaluated on **every** native tool call, deny first, and per its docs "regardless of what a PreToolUse hook returns" — so a policy in Claude Code's rule syntax needs no hook to be enforced; it needs to be in every profile's settings file and to come back out cleanly.
- **New `agent_permissions` module + Agent permissions tab:** rule list (`pattern` + never / ask first / always allow), presets as one-click adds (never `rm -rf`, never force-push, ask before any push, never read `.env`, never read SSH keys — never pre-applied), per-profile state, Preview of the exact bytes. **Off by default, empty by default.**
- **Ownership by record:** JSON string arrays can't carry a marker, so per file the registry holds exactly the strings Toolport added; a rule the user already had is neither added nor recorded, so it is never removed. Action change moves a rule between lists; removal strips it from every file; a profile that can't be parsed is reported, kept on record, and doesn't stop the others; a new profile picks the policy up at startup; a hand edit that drops a rule is put back at startup (restrictions the user asked for — deliberately unlike agent rules' drift handling, documented).
- `clients::write_settings_json` / `render_settings_json` generalised by top-level key (`write_settings_key` / `render_settings_key`); hooks keep `"hooks"`, this owns `"permissions"`, so comments/formatting are preserved the same way.
- Pattern validation is shape-only (tool name, optional parenthesised specifier, one line, no dup patterns); Claude Code owns the meaning.
- Claude Code only; the tab and `docs/agent-permissions.md` say what Cursor/Codex/Gemini would take. Phase 2 (PreToolUse hook → approval broker, observe mode, event capture) is a follow-up.

## Test plan

- [x] `cargo test --lib -- agent_permissions hooks::` — 50 passed (5 new: syntax validation incl. refusals; upsert adds only what's missing / strip removes only what was added / idempotent / action move; fresh file gets and loses the shape whole; presets valid; end-to-end over scratch files: rules set while off write nothing, on writes both profiles with per-file ownership, user formatting kept, hand edit → stale → startup restores, policy change rewrites, unparseable profile reported but others apply and its record is kept, off removes exactly ours and the user's own rule stays)
- [x] `vitest` AgentPermissionsView (4) + AppSidebar — 19 passed
- [x] `tsc`, `eslint` clean; `cargo clippy --lib` clean on new code
- [ ] Manual: turn on with the "Never force-push" preset, `cat ~/.claude/settings.json`, run `claude` and try `git push --force` → refused; turn off → lines gone, own rules intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Opt-in writes to Claude Code `settings.json` `permissions` lists, which can deny or auto-allow native tools. Ownership tracking and CST-scoped edits limit blast radius, but a bad policy or apply bug would change agent behavior on disk.
> 
> **Overview**
> Lets users write a Claude Code permission policy once (never / ask first / always allow) and have Toolport put it in every profile’s `settings.json`, so Claude Code itself refuses or prompts on matching native tool calls.
> 
> **Off and empty by default.** Only strings Toolport added are recorded and later removed; user-owned rules stay. Presets (no recursive delete, no force-push, ask before push, never read `.env` or SSH keys) are one-click adds, never auto-applied. Startup reapplies the policy (including restoring dropped rules) and covers new `CLAUDE_CONFIG_DIR` profiles. Unparseable files are reported and skipped.
> 
> Settings writes now target a chosen top-level key so `permissions` is rewritten through the same CST path as `hooks`, preserving comments and formatting. Claude Code only for now.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5549b18ac65c28dc4a3be3a95c8f2ed7a0beaa01. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `agent_permissions` module to manage Claude Code tool call rules
> - Introduces a new Agent Permissions UI tab and backend module ([agent_permissions.rs](https://github.com/tsouth89/toolport/pull/842/files#diff-28cd4684d4e77a67f21e7c6ef865a1e6e9ceaa1940e15aac2e2eb779b4e6bb8d)) to manage rules Claude Code enforces on its own native tool calls in `settings.json`.
> - The backend reads and writes only the `permissions` key using CST-preserving logic generalized in [clients.rs](https://github.com/tsouth89/toolport/pull/842/files#diff-6f95d037b6a920242364b6cfc2417b10affa37691d35ce5da93633c9da12c167), ensuring user formatting and other keys are untouched.
> - Rules can be added, removed, or applied via presets (e.g., deny recursive delete). The app reconciles rules on startup and tracks which rules it added, so disabling the feature cleanly removes them without disturbing user-defined rules.
> - Risk: `Registry` struct gains three optional fields (`agent_permissions_enabled`, `agent_permission_rules`, `agent_permission_targets`); missing fields default to `false`/empty and are omitted on output if empty.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5549b18.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->