### PR TITLE
feat(permissions): the same rules reach Cursor through a guard hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,21 @@ Entries before the rename below shipped under the project's former name, Conduit
 
 ### Added
 
+- **Agent permissions: the same rules now reach Cursor, through a guard hook.** Cursor has
+  hooks but no settings-level rule list, so Toolport installs a small guard into
+  `~/.cursor/hooks.json` that runs `toolport-gateway --toolport-guard cursor` before a
+  shell command runs, an MCP tool is called, or a file is read, and answers allow / deny /
+  ask from the permission rules you already wrote - `Bash(...)` for shell commands,
+  `Read(...)` for file reads, `mcp__server__tool` for MCP tools, with Claude Code's
+  matching semantics (wildcards, the word-boundary trailing ` *`, compound commands
+  judged per part, wrappers stripped). Three modes: Off (default), Observe (installed,
+  every call recorded in Agent activity with what the rules would have decided, nothing
+  blocked) and Enforce (Never and Ask first take effect; Ask uses Cursor's own prompt;
+  the hook is installed fail-closed). Only Toolport's own entries are ever added or
+  removed; a Preview shows the bytes first. `Edit` / `WebFetch` rules have no Cursor
+  event and the tab says so. See
+  [docs/agent-permissions.md](docs/agent-permissions.md#cursor). (SBS-1059)
+
 - **Agent permissions: rules Claude Code enforces on its own native tool calls.** A new
   Agent permissions tab holds a policy in Claude Code's own rule syntax (`Bash(rm -rf *)`,
   `Read(./.env)`, `WebFetch(domain:...)`, `mcp__server__tool`, each set to never / ask

--- a/docs/agent-permissions.md
+++ b/docs/agent-permissions.md
@@ -109,9 +109,12 @@ Three modes, chosen in the tab:
   guard itself crashes or times out Cursor blocks the call rather than letting it through.
 
 When no rule matches, the guard answers Cursor's own canonical "proceed" response. When
-the guard cannot judge a call - a payload it does not understand - it answers the same
-and records that it could not, because a guard that breaks your work over its own parse
-error is worse than one that stands aside; in Enforce, `failClosed` still covers a crash.
+the guard cannot judge a call - a payload it does not understand, or one larger than it
+reads (64 MiB; a file read carries the file's content) - it depends on the mode: in
+**Observe** it answers allow and records that it could not judge; in **Enforce** it
+**refuses**, with a message saying why, because an agent must not be able to get a call
+past a rule by making the payload unreadable, and Cursor's `failClosed` would not catch
+a well-formed allow. Cursor's `failClosed` still covers the guard crashing or timing out.
 
 Only entries carrying `--toolport-guard` are ever added to or removed from
 `hooks.json`; your own hooks stay exactly where they are, and the file's formatting is

--- a/docs/agent-permissions.md
+++ b/docs/agent-permissions.md
@@ -21,10 +21,11 @@ Claude Code's rule syntax needs no hook and no Toolport process in the loop to b
 enforced; it needs to be in the file, in every profile, and to come back out cleanly.
 That is the whole of this feature.
 
-It is **Claude Code only** for now. Cursor has hooks but no settings-level rule list;
-Codex uses approval and sandbox settings of a different shape; Gemini CLI is mixed. The
-tab says so rather than pretending. The gateway's own gates still cover every MCP call
-from every client.
+Claude Code enforces the rules itself. **Cursor** has no settings-level rule list, so
+Toolport enforces the same rules there through a guard hook - see
+[Cursor](#cursor) below. Codex uses approval and sandbox settings of a different shape
+and Gemini CLI is mixed; neither is covered yet, and the tab says so rather than
+pretending. The gateway's own gates still cover every MCP call from every client.
 
 ## Rules
 
@@ -72,8 +73,52 @@ rules is put back at the next start - these are restrictions you asked for, so, 
 A `settings.json` that cannot be parsed is reported, left untouched, and does not stop
 the other profiles from being written or cleaned.
 
+## Cursor
+
+Cursor has hooks (`beforeShellExecution`, `beforeMCPExecution`, `beforeReadFile`) but no
+rule list, so Toolport installs a small **guard hook** into `~/.cursor/hooks.json`: before
+a shell command runs, an MCP tool is called, or a file is read, Cursor runs
+`toolport-gateway --toolport-guard cursor` with the call on stdin and acts on the JSON it
+prints - `allow`, `deny`, or `ask`. The guard evaluates the **same rules** as above, so
+you write them once.
+
+Because the rule language is Claude Code's, here is exactly what carries over:
+
+| Rule                                             | Cursor event           | Notes                                                                                       |
+| ------------------------------------------------ | ---------------------- | ------------------------------------------------------------------------------------------- |
+| `Bash(...)`                                      | `beforeShellExecution` | Matched against the command as Cursor reports it, with Claude Code's semantics below.       |
+| `Read(...)`                                      | `beforeReadFile`       | `~/` is your home, `//` is absolute, anything else is relative to the workspace root.       |
+| `mcp__server__tool`                              | `beforeMCPExecution`   | Cursor names the tool, not the server, so the server part cannot be checked and is ignored. |
+| `Edit`, `WebFetch`, `Agent`, `Tool(param:value)` | -                      | No Cursor event; these rules do nothing in Cursor (they still work in Claude Code).         |
+
+Matching follows Claude Code where it documents it: `*` spans anything including
+spaces; a trailing ` *` needs a word boundary (`Bash(ls *)` matches `ls -la` but not
+`lsof`); `:*` is the same as ` *`; a compound command (`&&`, `||`, `;`, `|`) is denied
+or asked if **any** part matches and allowed only if **every** part is; `timeout N`,
+`time`, `nice` and `nohup` are stripped first. Deny beats ask beats allow when more than
+one rule matches.
+
+Three modes, chosen in the tab:
+
+- **Off** - no hook installed (the default).
+- **Observe** - the hook is installed, every call is evaluated and recorded in **Agent
+  activity** with what the rules _would_ have decided, and the answer is always allow.
+  Use this to read a policy's effect before letting it act.
+- **Enforce** - Never and Ask first take effect. "Ask first" uses Cursor's own
+  confirmation prompt. The hook is installed with Cursor's `failClosed` set, so if the
+  guard itself crashes or times out Cursor blocks the call rather than letting it through.
+
+When no rule matches, the guard answers Cursor's own canonical "proceed" response. When
+the guard cannot judge a call - a payload it does not understand - it answers the same
+and records that it could not, because a guard that breaks your work over its own parse
+error is worse than one that stands aside; in Enforce, `failClosed` still covers a crash.
+
+Only entries carrying `--toolport-guard` are ever added to or removed from
+`hooks.json`; your own hooks stay exactly where they are, and the file's formatting is
+preserved. A Preview shows the exact bytes before the first write.
+
 ## Next
 
-A `PreToolUse` hook that asks through Toolport's own approval window, records every
-decision in Agent activity, and can start in observe-only mode is the next step; it
-builds on this and on the authenticated approval broker shipped in 1.17.
+Routing "ask" through Toolport's own approval window (instead of Cursor's prompt) and a
+`PreToolUse` guard for Claude Code for the same purpose are the next steps; they build
+on this and on the authenticated approval broker shipped in 1.17.

--- a/src-tauri/src/agent_guard.rs
+++ b/src-tauri/src/agent_guard.rs
@@ -181,12 +181,13 @@ fn split_compound(command: &str) -> Vec<String> {
             continue;
         }
         let two: String = chars[i..(i + 2).min(chars.len())].iter().collect();
-        if two == "&&" || two == "||" {
+        if two == "&&" || two == "||" || two == "|&" {
             parts.push(std::mem::take(&mut cur));
             i += 2;
             continue;
         }
-        if c == ';' || c == '|' || c == '\n' {
+        // `;`, a pipe, a newline, and a lone `&` (background) all start a new command.
+        if c == ';' || c == '|' || c == '\n' || c == '&' {
             parts.push(std::mem::take(&mut cur));
             i += 1;
             continue;
@@ -209,9 +210,10 @@ fn split_compound(command: &str) -> Vec<String> {
 /// not expect. When a wrapper's shape is not understood the command is left as it is.
 fn strip_wrappers(command: &str) -> String {
     let mut words: Vec<&str> = command.split_whitespace().collect();
-    loop {
-        let Some(&first) = words.first() else { break };
-        match first {
+    while let Some(&first) = words.first() {
+        // `/usr/bin/timeout` is `timeout`: a wrapper named by path is still that wrapper.
+        let name = first.rsplit('/').next().unwrap_or(first);
+        match name {
             "nohup" => {
                 words.remove(0);
             }
@@ -292,19 +294,49 @@ fn bash_spec_matches(spec: &str, command: &str) -> bool {
 
 fn resolve_read_spec(spec: &str, root: Option<&str>, home: Option<&str>) -> String {
     let spec = spec.replace('\\', "/");
-    if let Some(rest) = spec.strip_prefix("~/") {
-        return format!("{}/{}", home.unwrap_or("~").trim_end_matches('/'), rest);
+    let resolved = if let Some(rest) = spec.strip_prefix("~/") {
+        format!("{}/{}", home.unwrap_or("~").trim_end_matches('/'), rest)
+    } else if let Some(rest) = spec.strip_prefix("//") {
+        format!("/{rest}")
+    } else if spec.starts_with('/') {
+        spec
+    } else {
+        let rel = spec.strip_prefix("./").unwrap_or(&spec);
+        match root {
+            Some(r) => format!("{}/{}", r.trim_end_matches('/').replace('\\', "/"), rel),
+            None => rel.to_string(),
+        }
+    };
+    normalize_path(&resolved)
+}
+
+/// Lexical normalisation so two spellings of one file compare equal: backslashes to
+/// slashes, `.` and doubled slashes dropped, `..` folded, and on the case-insensitive
+/// filesystems (macOS, Windows) everything lower-cased. A path that reaches a denied file
+/// through `..` or a different case must not slip past the rule.
+fn normalize_path(path: &str) -> String {
+    let p = path.replace('\\', "/");
+    let absolute = p.starts_with('/');
+    let mut out: Vec<&str> = Vec::new();
+    for seg in p.split('/') {
+        match seg {
+            "" | "." => {}
+            ".." => {
+                if out.last().is_some_and(|s| *s != "..") {
+                    out.pop();
+                } else if !absolute {
+                    out.push("..");
+                }
+            }
+            s => out.push(s),
+        }
     }
-    if let Some(rest) = spec.strip_prefix("//") {
-        return format!("/{rest}");
-    }
-    if spec.starts_with('/') {
-        return spec;
-    }
-    let rel = spec.strip_prefix("./").unwrap_or(&spec);
-    match root {
-        Some(r) => format!("{}/{}", r.trim_end_matches('/').replace('\\', "/"), rel),
-        None => rel.to_string(),
+    let joined = out.join("/");
+    let joined = if absolute { format!("/{joined}") } else { joined };
+    if cfg!(any(target_os = "macos", target_os = "windows")) {
+        joined.to_lowercase()
+    } else {
+        joined
     }
 }
 
@@ -338,7 +370,7 @@ fn rule_matches(rule: &PermissionRule, subject: &Subject) -> bool {
             }
             let Some(spec) = spec else { return true };
             let want = resolve_read_spec(spec, *root, *home);
-            let have = path.replace('\\', "/");
+            let have = normalize_path(path);
             path_glob_match(&want, &have)
         }
         Subject::Mcp { tool: name } => {
@@ -878,6 +910,11 @@ mod tests {
         assert!(hit(&deny("Bash(rm -rf *)"), "time -p nohup rm -rf x"));
         // A wrapper whose own name is denied is still denied as written.
         assert!(hit(&deny("Bash(timeout *)"), "timeout 5 ls"));
+        // Background `&`, `|&`, and a wrapper named by path are all seen through.
+        assert!(hit(&deny("Bash(rm -rf *)"), "sleep 1 & rm -rf x"));
+        assert!(hit(&deny("Bash(rm -rf *)"), "ls |& rm -rf x"));
+        assert!(hit(&deny("Bash(rm -rf *)"), "/usr/bin/timeout 5 rm -rf x"));
+        assert!(hit(&deny("Bash(rm -rf *)"), "/usr/bin/nice -n 5 /usr/bin/nohup rm -rf x"));
         assert!(!hit(&deny("Bash(rm -rf *)"), "echo 'rm -rf' && ls"), "quoted operators do not split; the echo is not rm");
         // Allow covers a compound only when every part is allowed.
         let allow = vec![rule("Bash(npm *)", Allow)];
@@ -909,6 +946,13 @@ mod tests {
         assert!(hit(&deny("Read(src/**/*.key)"), "/work/repo/src/c.key"), "`**/` also matches zero directories");
         assert!(!hit(&deny("Read(src/*.key)"), "/work/repo/src/a/c.key"), "`*` stays in one segment");
         assert!(hit(&deny("Read(//etc/passwd)"), "/etc/passwd"));
+        // Lexically equivalent spellings reach the same rule.
+        assert!(hit(&deny("Read(~/.ssh/**)"), "/home/u/proj/../.ssh/id_ed25519"));
+        assert!(hit(&deny("Read(./.env)"), "/work/repo/./sub/..//.env"));
+        assert!(hit(&deny("Read(~/.ssh/**)"), "/home/u/.ssh/./keys/../id_rsa"));
+        if cfg!(any(target_os = "macos", target_os = "windows")) {
+            assert!(hit(&deny("Read(~/.ssh/**)"), "/home/u/.SSH/ID_RSA"));
+        }
         assert!(hit(&deny("Read"), "/anything"));
         assert!(!hit(&deny("Bash(cat *)"), "/work/repo/.env"));
     }

--- a/src-tauri/src/agent_guard.rs
+++ b/src-tauri/src/agent_guard.rs
@@ -54,6 +54,13 @@ const CURSOR_EVENTS: [&str; 3] = ["beforeShellExecution", "beforeMCPExecution", 
 /// Seconds Cursor should allow the hook. A wedged guard must cost a bounded pause.
 const GUARD_TIMEOUT_SECS: u64 = 10;
 
+/// Cap on the payload read from stdin. Generous on purpose: a `beforeReadFile` payload
+/// embeds the file's content, and in Enforce a call the guard cannot see is DENIED, so a
+/// small cap would turn every large read into a refusal. Past this the payload is
+/// truncated, unparseable, and - in Enforce - denied, which is also what stops an agent
+/// from padding a denied command past the cap to slip it through.
+pub const MAX_GUARD_STDIN_BYTES: u64 = 64 * 1024 * 1024;
+
 // ---------------------------------------------------------------------------
 // Policy evaluation (pure)
 // ---------------------------------------------------------------------------
@@ -190,27 +197,84 @@ fn split_compound(command: &str) -> Vec<String> {
     parts.push(cur);
     parts
         .into_iter()
-        .map(|p| strip_wrappers(p.trim()))
+        .map(|p| p.trim().to_string())
         .filter(|p| !p.is_empty())
         .collect()
 }
 
-/// Drop a leading `timeout N`, `time`, `nice`, `nohup` so `Bash(npm test *)` also sees
-/// `timeout 30 npm test`, as Claude Code does.
+/// Drop leading wrappers - `timeout [options] DURATION`, `time [options]`, `nice [options]`,
+/// `nohup` - so `Bash(npm test *)` also sees `timeout 30 npm test`, as Claude Code does.
+/// Options are consumed properly (`nice -n 19`, `timeout --preserve-status -s KILL 5`), so a
+/// wrapper cannot smuggle a denied command past a rule by carrying a flag the stripper did
+/// not expect. When a wrapper's shape is not understood the command is left as it is.
 fn strip_wrappers(command: &str) -> String {
     let mut words: Vec<&str> = command.split_whitespace().collect();
     loop {
-        match words.first().copied() {
-            Some("time") | Some("nice") | Some("nohup") => {
+        let Some(&first) = words.first() else { break };
+        match first {
+            "nohup" => {
                 words.remove(0);
             }
-            Some("timeout") if words.len() > 1 => {
-                words.drain(0..2);
+            "time" => {
+                words.remove(0);
+                // `time -p`, `time -v`, `time -f FMT`, `time -o FILE`, `--format=`, ...
+                while let Some(&w) = words.first() {
+                    if !w.starts_with('-') {
+                        break;
+                    }
+                    let takes_value = matches!(w, "-f" | "-o" | "--format" | "--output");
+                    words.remove(0);
+                    if takes_value && !words.is_empty() {
+                        words.remove(0);
+                    }
+                }
+            }
+            "nice" => {
+                words.remove(0);
+                while let Some(&w) = words.first() {
+                    if !w.starts_with('-') {
+                        break;
+                    }
+                    let takes_value = matches!(w, "-n" | "--adjustment");
+                    words.remove(0);
+                    if takes_value && !words.is_empty() {
+                        words.remove(0);
+                    }
+                }
+            }
+            "timeout" => {
+                words.remove(0);
+                while let Some(&w) = words.first() {
+                    if !w.starts_with('-') {
+                        break;
+                    }
+                    let takes_value = matches!(w, "-s" | "-k" | "--signal" | "--kill-after");
+                    words.remove(0);
+                    if takes_value && !words.is_empty() {
+                        words.remove(0);
+                    }
+                }
+                // The duration, then the command.
+                if !words.is_empty() {
+                    words.remove(0);
+                }
             }
             _ => break,
         }
     }
     words.join(" ")
+}
+
+/// Every reading of a command part a deny or ask must be checked against: as written, and
+/// with wrappers stripped. Matching any of them is enough to refuse; an allow rule has to
+/// match the stripped form, which is the command that actually runs.
+fn readings(part: &str) -> Vec<String> {
+    let stripped = strip_wrappers(part);
+    let mut v = vec![part.to_string()];
+    if stripped != part {
+        v.push(stripped);
+    }
+    v
 }
 
 /// Claude Code's Bash specifier semantics on ONE (non-compound) command.
@@ -257,12 +321,15 @@ fn rule_matches(rule: &PermissionRule, subject: &Subject) -> bool {
                 return false;
             }
             match rule.action {
-                // A deny or ask fires if any part matches; an allow covers the command only
-                // if every part is allowed (Claude Code's compound-command rule).
-                PermissionAction::Deny | PermissionAction::Ask => {
-                    parts.iter().any(|p| bash_spec_matches(spec, p))
-                }
-                PermissionAction::Allow => parts.iter().all(|p| bash_spec_matches(spec, p)),
+                // A deny or ask fires if any part, in any reading, matches; an allow covers
+                // the command only if every part's stripped form is allowed (Claude Code's
+                // compound-command rule).
+                PermissionAction::Deny | PermissionAction::Ask => parts
+                    .iter()
+                    .any(|p| readings(p).iter().any(|r| bash_spec_matches(spec, r))),
+                PermissionAction::Allow => parts
+                    .iter()
+                    .all(|p| bash_spec_matches(spec, &strip_wrappers(p))),
             }
         }
         Subject::Read { path, root, home } => {
@@ -374,12 +441,30 @@ fn truncate(s: &str, n: usize) -> String {
 
 /// Run the guard for one Cursor call: returns the JSON to print and the exit code. Always
 /// exit 0 with a complete response; `deny` is expressed in the JSON, as Cursor documents.
-pub fn handle_stdin(agent: &str, stdin: &str) -> (String, i32) {
-    let out = handle(agent, stdin);
+/// `truncated` says the payload hit [`MAX_GUARD_STDIN_BYTES`] and is not whole.
+pub fn handle_stdin(agent: &str, stdin: &str, truncated: bool) -> (String, i32) {
+    let out = handle(agent, stdin, truncated);
     (out.to_string(), 0)
 }
 
-fn handle(agent: &str, stdin: &str) -> Value {
+/// What the guard answers when it cannot judge a call: in Enforce, deny - an agent must
+/// not be able to slip a call past a rule by making the payload unreadable (padding it past
+/// the cap, say), and Cursor's `failClosed` would not catch a well-formed allow. Otherwise
+/// allow, and record that it could not judge.
+fn cannot_judge(reg: &crate::registry::Registry, why: &str) -> Value {
+    if reg.guard_cursor_mode == GuardMode::Enforce {
+        json!({
+            "continue": true,
+            "permission": "deny",
+            "user_message": format!("Toolport: this call was refused because the guard could not read it ({why}). Switch the Cursor guard to Observe if this keeps happening."),
+            "agent_message": format!("Toolport could not evaluate this call ({why}) and is enforcing, so it was refused. Do not retry it in a different form; tell the user."),
+        })
+    } else {
+        allow_response()
+    }
+}
+
+fn handle(agent: &str, stdin: &str, truncated: bool) -> Value {
     if agent != "cursor" {
         crate::gatewaylog::append(&format!("toolport: guard invoked for unknown agent {agent:?}"));
         return allow_response();
@@ -387,16 +472,24 @@ fn handle(agent: &str, stdin: &str) -> Value {
     let reg = match crate::registry::load() {
         Ok(reg) => reg,
         Err(error) => {
+            // No registry means no mode to read either; the hook would not be installed
+            // without one, so this is a broken install. Say so, stand aside.
             crate::gatewaylog::append(&format!("toolport: guard could not load the registry: {error}"));
             return allow_response();
         }
     };
+    // Cursor on Windows is documented to prefix hook stdin with a UTF-8 BOM.
+    let stdin = stdin.trim_start_matches('\u{FEFF}');
+    if truncated {
+        record(json!({ "agent": "cursor", "event": "guard", "malformed": true, "truncated": true, "decision": if reg.guard_cursor_mode == GuardMode::Enforce { "deny" } else { "allow" }, "mode": reg.guard_cursor_mode }));
+        return cannot_judge(&reg, "the payload was larger than the guard reads");
+    }
     let payload: Value = match serde_json::from_str(stdin) {
         Ok(v) => v,
         Err(error) => {
-            record(json!({ "agent": "cursor", "event": "guard", "malformed": true, "decision": "allow", "mode": reg.guard_cursor_mode }));
+            record(json!({ "agent": "cursor", "event": "guard", "malformed": true, "decision": if reg.guard_cursor_mode == GuardMode::Enforce { "deny" } else { "allow" }, "mode": reg.guard_cursor_mode }));
             crate::gatewaylog::append(&format!("toolport: guard payload did not parse: {error}"));
-            return allow_response();
+            return cannot_judge(&reg, "the payload did not parse");
         }
     };
     let event = payload
@@ -404,10 +497,18 @@ fn handle(agent: &str, stdin: &str) -> Value {
         .and_then(Value::as_str)
         .unwrap_or("")
         .to_string();
+    let cwd = payload
+        .get("cwd")
+        .and_then(Value::as_str)
+        .or_else(|| payload.get("workspace_roots").and_then(Value::as_array).and_then(|a| a.first()).and_then(Value::as_str))
+        .map(str::to_string);
     let home = dirs::home_dir().map(|h| h.to_string_lossy().to_string());
     let Some((subject, what)) = cursor_subject(&event, &payload, home.as_deref()) else {
-        record(json!({ "agent": "cursor", "event": "guard", "hookEvent": event, "unhandled": true, "decision": "allow", "mode": reg.guard_cursor_mode }));
-        return allow_response();
+        // An event we did not register for, or one of ours missing its subject field. The
+        // first is benign (allow); the second, in Enforce, is a call we cannot judge.
+        let registered = CURSOR_EVENTS.contains(&event.as_str());
+        record(json!({ "agent": "cursor", "event": "guard", "hookEvent": event, "cwd": cwd, "unhandled": true, "decision": if registered && reg.guard_cursor_mode == GuardMode::Enforce { "deny" } else { "allow" }, "mode": reg.guard_cursor_mode }));
+        return if registered { cannot_judge(&reg, "the call had no command, path or tool to check") } else { allow_response() };
     };
     let verdict = evaluate(&reg.agent_permission_rules, &subject);
     let (tool, hash_src) = match &subject {
@@ -425,6 +526,7 @@ fn handle(agent: &str, stdin: &str) -> Value {
         "agent": "cursor",
         "event": "guard",
         "hookEvent": event,
+        "cwd": cwd,
         "tool": tool,
         "argsHash": crate::audit::args_hash(&json!({ "subject": hash_src })),
         "mode": reg.guard_cursor_mode,
@@ -768,6 +870,14 @@ mod tests {
         assert!(hit(&deny("Bash(rm -rf *)"), "cd /tmp; rm -rf x"));
         assert!(hit(&deny("Bash(rm -rf *)"), "timeout 30 rm -rf x"));
         assert!(hit(&deny("Bash(rm -rf *)"), "nohup rm -rf x"));
+        // Wrappers with options cannot smuggle a denied command past the rule.
+        assert!(hit(&deny("Bash(rm -rf *)"), "nice -n 19 rm -rf x"));
+        assert!(hit(&deny("Bash(rm -rf *)"), "nice --adjustment 5 rm -rf x"));
+        assert!(hit(&deny("Bash(rm -rf *)"), "timeout --preserve-status -s KILL 5 rm -rf x"));
+        assert!(hit(&deny("Bash(rm -rf *)"), "timeout -k 2 10 rm -rf x"));
+        assert!(hit(&deny("Bash(rm -rf *)"), "time -p nohup rm -rf x"));
+        // A wrapper whose own name is denied is still denied as written.
+        assert!(hit(&deny("Bash(timeout *)"), "timeout 5 ls"));
         assert!(!hit(&deny("Bash(rm -rf *)"), "echo 'rm -rf' && ls"), "quoted operators do not split; the echo is not rm");
         // Allow covers a compound only when every part is allowed.
         let allow = vec![rule("Bash(npm *)", Allow)];
@@ -827,6 +937,18 @@ mod tests {
         assert_eq!(r["permission"], "ask");
         assert_eq!(decision_response(Allow, "x", "y"), allow_response());
         assert_eq!(allow_response(), serde_json::json!({ "continue": true, "permission": "allow" }));
+    }
+
+    #[test]
+    fn unjudgeable_input_is_denied_only_when_enforcing() {
+        let enforce = crate::registry::Registry { guard_cursor_mode: GuardMode::Enforce, ..Default::default() };
+        let observe = crate::registry::Registry { guard_cursor_mode: GuardMode::Observe, ..Default::default() };
+        assert_eq!(cannot_judge(&enforce, "x")["permission"], "deny");
+        assert_eq!(cannot_judge(&observe, "x"), allow_response());
+        // A BOM-prefixed payload parses once the BOM is stripped.
+        let bom = "\u{FEFF}{\"hook_event_name\":\"beforeShellExecution\",\"command\":\"ls\"}";
+        assert!(serde_json::from_str::<Value>(bom).is_err());
+        assert!(serde_json::from_str::<Value>(bom.trim_start_matches('\u{FEFF}')).is_ok());
     }
 
     #[test]

--- a/src-tauri/src/agent_guard.rs
+++ b/src-tauri/src/agent_guard.rs
@@ -1,0 +1,922 @@
+//! Guard hook - enforce the permission policy in agents that have hooks but no rule list.
+//! Phase 2 of SBS-820 item 2 (SBS-1059), Cursor first.
+//!
+//! Claude Code enforces [`crate::agent_permissions`]' rules natively from its settings.
+//! Cursor has no such list; what it has is hooks: `beforeShellExecution`,
+//! `beforeMCPExecution` and `beforeReadFile` run a command with the call on stdin and
+//! read `{"permission": "allow" | "deny" | "ask"}` back. So the SAME rules - the user
+//! writes them once, in Claude Code's syntax - are evaluated here, by the gateway binary
+//! invoked as `--toolport-guard cursor`, against Cursor's payload.
+//!
+//! What carries over and what does not, said plainly because the rule language is
+//! Claude Code's: `Bash(...)` rules guard shell commands; `Read(...)` rules guard file
+//! reads; `mcp__server__tool` rules guard MCP tools (Cursor names the tool, not the
+//! server, so the server segment cannot be checked and is ignored); `Edit`, `WebFetch`,
+//! `Agent` and parameter rules have no Cursor event and do nothing here. Matching follows
+//! Claude Code's documented semantics where they are documented: `*` spans anything
+//! including spaces, a trailing ` *` needs a word boundary, `:*` is the same as ` *`, a
+//! compound command (`&&`, `||`, `;`, `|`) is denied or asked if ANY part matches and
+//! allowed only if EVERY part matches, a handful of wrappers (`timeout N`, `time`, `nice`,
+//! `nohup`) are stripped first, Read paths are `~/`, `//absolute`, or relative to the
+//! workspace root, with `*` and `**` globs.
+//!
+//! Three properties, inherited from the sensor:
+//!
+//!   * **Off by default, observe before enforce.** `Observe` installs the hook but always
+//!     answers allow and records what it WOULD have decided; `Enforce` lets deny and ask
+//!     act. `failClosed` is set on the hook only in `Enforce`.
+//!   * **Ask is Cursor's own prompt.** `permission: "ask"` makes Cursor confirm with the
+//!     user in its own UI; routing the ask through Toolport's approval window is a later
+//!     step, not this one.
+//!   * **It adds only entries carrying [`GUARD_MARKER`] and removes only those**, the
+//!     sensor's ownership rule, in `~/.cursor/hooks.json`.
+//!
+//! When no rule matches, the answer is Cursor's own canonical "proceed" response
+//! (`{"continue": true, "permission": "allow"}`); when Toolport cannot judge (a payload it
+//! does not understand), it answers the same and records that it could not, because a
+//! guard that breaks the user's work over its own parse error is worse than one that
+//! stands aside - and in `Enforce` Cursor's `failClosed` still covers a crash or timeout.
+
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Map, Value};
+use std::path::{Path, PathBuf};
+
+pub use crate::registry::GuardMode;
+use crate::registry::{PermissionAction, PermissionRule};
+
+/// The literal that marks a hooks.json entry as Toolport's guard, and the flag the gateway
+/// binary recognises.
+pub const GUARD_MARKER: &str = "--toolport-guard";
+
+/// Cursor events the guard registers, with the subject each carries.
+const CURSOR_EVENTS: [&str; 3] = ["beforeShellExecution", "beforeMCPExecution", "beforeReadFile"];
+
+/// Seconds Cursor should allow the hook. A wedged guard must cost a bounded pause.
+const GUARD_TIMEOUT_SECS: u64 = 10;
+
+// ---------------------------------------------------------------------------
+// Policy evaluation (pure)
+// ---------------------------------------------------------------------------
+
+/// What a rule is being matched against.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Subject<'a> {
+    Shell(&'a str),
+    Read {
+        path: &'a str,
+        /// Workspace root, for rules written relative to the project.
+        root: Option<&'a str>,
+        home: Option<&'a str>,
+    },
+    Mcp {
+        tool: &'a str,
+    },
+}
+
+/// The outcome of matching a policy against a subject.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Verdict {
+    /// `None` when no rule matched: Toolport has no opinion.
+    pub action: Option<PermissionAction>,
+    /// The rule that decided it.
+    pub rule: Option<String>,
+}
+
+fn split_rule(pattern: &str) -> (&str, Option<&str>) {
+    match pattern.find('(') {
+        Some(i) if pattern.ends_with(')') => (&pattern[..i], Some(&pattern[i + 1..pattern.len() - 1])),
+        _ => (pattern, None),
+    }
+}
+
+/// `*` matches any sequence of characters (including spaces and `/`); everything else
+/// is literal. Full-string match.
+pub fn glob_match(pattern: &str, text: &str) -> bool {
+    fn go(p: &[char], t: &[char]) -> bool {
+        match p.first() {
+            None => t.is_empty(),
+            Some('*') => {
+                let rest = &p[1..];
+                (0..=t.len()).any(|i| go(rest, &t[i..]))
+            }
+            Some(c) => t.first() == Some(c) && go(&p[1..], &t[1..]),
+        }
+    }
+    let p: Vec<char> = pattern.chars().collect();
+    let t: Vec<char> = text.chars().collect();
+    go(&p, &t)
+}
+
+/// Path glob: `**` spans directories, `*` and `?` stay within one segment. A pattern that
+/// names a directory also matches everything under it.
+fn path_glob_match(pattern: &str, path: &str) -> bool {
+    let mut re = String::from("^");
+    let chars: Vec<char> = pattern.chars().collect();
+    let mut i = 0;
+    while i < chars.len() {
+        let c = chars[i];
+        if c == '*' {
+            if i + 1 < chars.len() && chars[i + 1] == '*' {
+                re.push_str(".*");
+                i += 2;
+                // a `**/` swallows the slash too so `a/**/b` matches `a/b`
+                if i < chars.len() && chars[i] == '/' {
+                    re.pop();
+                    re.pop();
+                    re.push_str("(?:.*/)?");
+                    i += 1;
+                }
+                continue;
+            }
+            re.push_str("[^/]*");
+        } else if c == '?' {
+            re.push_str("[^/]");
+        } else {
+            if regex_syntax_special(c) {
+                re.push('\\');
+            }
+            re.push(c);
+        }
+        i += 1;
+    }
+    let dir_re = format!("{re}(?:/.*)?$");
+    regex::Regex::new(&dir_re)
+        .map(|r| r.is_match(path))
+        .unwrap_or(false)
+}
+
+fn regex_syntax_special(c: char) -> bool {
+    matches!(c, '.' | '+' | '(' | ')' | '[' | ']' | '{' | '}' | '^' | '$' | '|' | '\\')
+}
+
+/// Command separators Claude Code recognises; a compound command is judged per part.
+fn split_compound(command: &str) -> Vec<String> {
+    let mut parts = Vec::new();
+    let mut cur = String::new();
+    let chars: Vec<char> = command.chars().collect();
+    let mut i = 0;
+    let mut quote: Option<char> = None;
+    while i < chars.len() {
+        let c = chars[i];
+        if let Some(q) = quote {
+            cur.push(c);
+            if c == q {
+                quote = None;
+            }
+            i += 1;
+            continue;
+        }
+        if c == '\'' || c == '"' {
+            quote = Some(c);
+            cur.push(c);
+            i += 1;
+            continue;
+        }
+        let two: String = chars[i..(i + 2).min(chars.len())].iter().collect();
+        if two == "&&" || two == "||" {
+            parts.push(std::mem::take(&mut cur));
+            i += 2;
+            continue;
+        }
+        if c == ';' || c == '|' || c == '\n' {
+            parts.push(std::mem::take(&mut cur));
+            i += 1;
+            continue;
+        }
+        cur.push(c);
+        i += 1;
+    }
+    parts.push(cur);
+    parts
+        .into_iter()
+        .map(|p| strip_wrappers(p.trim()))
+        .filter(|p| !p.is_empty())
+        .collect()
+}
+
+/// Drop a leading `timeout N`, `time`, `nice`, `nohup` so `Bash(npm test *)` also sees
+/// `timeout 30 npm test`, as Claude Code does.
+fn strip_wrappers(command: &str) -> String {
+    let mut words: Vec<&str> = command.split_whitespace().collect();
+    loop {
+        match words.first().copied() {
+            Some("time") | Some("nice") | Some("nohup") => {
+                words.remove(0);
+            }
+            Some("timeout") if words.len() > 1 => {
+                words.drain(0..2);
+            }
+            _ => break,
+        }
+    }
+    words.join(" ")
+}
+
+/// Claude Code's Bash specifier semantics on ONE (non-compound) command.
+fn bash_spec_matches(spec: &str, command: &str) -> bool {
+    let spec = spec.strip_suffix(":*").map(|s| format!("{s} *")).unwrap_or_else(|| spec.to_string());
+    if spec == "*" {
+        return true;
+    }
+    if let Some(base) = spec.strip_suffix(" *") {
+        // Word boundary: the prefix, then end of string or a space.
+        return glob_match(base, command) || glob_match(&format!("{base} *"), command);
+    }
+    glob_match(&spec, command)
+}
+
+fn resolve_read_spec(spec: &str, root: Option<&str>, home: Option<&str>) -> String {
+    let spec = spec.replace('\\', "/");
+    if let Some(rest) = spec.strip_prefix("~/") {
+        return format!("{}/{}", home.unwrap_or("~").trim_end_matches('/'), rest);
+    }
+    if let Some(rest) = spec.strip_prefix("//") {
+        return format!("/{rest}");
+    }
+    if spec.starts_with('/') {
+        return spec;
+    }
+    let rel = spec.strip_prefix("./").unwrap_or(&spec);
+    match root {
+        Some(r) => format!("{}/{}", r.trim_end_matches('/').replace('\\', "/"), rel),
+        None => rel.to_string(),
+    }
+}
+
+fn rule_matches(rule: &PermissionRule, subject: &Subject) -> bool {
+    let (tool, spec) = split_rule(&rule.pattern);
+    match subject {
+        Subject::Shell(command) => {
+            if !glob_match(tool, "Bash") {
+                return false;
+            }
+            let Some(spec) = spec else { return true };
+            let parts = split_compound(command);
+            if parts.is_empty() {
+                return false;
+            }
+            match rule.action {
+                // A deny or ask fires if any part matches; an allow covers the command only
+                // if every part is allowed (Claude Code's compound-command rule).
+                PermissionAction::Deny | PermissionAction::Ask => {
+                    parts.iter().any(|p| bash_spec_matches(spec, p))
+                }
+                PermissionAction::Allow => parts.iter().all(|p| bash_spec_matches(spec, p)),
+            }
+        }
+        Subject::Read { path, root, home } => {
+            if !glob_match(tool, "Read") {
+                return false;
+            }
+            let Some(spec) = spec else { return true };
+            let want = resolve_read_spec(spec, *root, *home);
+            let have = path.replace('\\', "/");
+            path_glob_match(&want, &have)
+        }
+        Subject::Mcp { tool: name } => {
+            let Some(rest) = tool.strip_prefix("mcp__") else {
+                return tool == "*" && spec.is_none();
+            };
+            // `mcp__server__tool`: Cursor's payload names the tool only, so the server
+            // segment cannot be checked; match the tool part (or the whole remainder, for a
+            // payload that happens to carry `server__tool`).
+            if let Some((_, tool_glob)) = rest.split_once("__") {
+                return glob_match(tool_glob, name) || glob_match(rest, name);
+            }
+            glob_match(rest, name)
+        }
+    }
+}
+
+/// Match every rule; deny beats ask beats allow; `None` when nothing matched.
+pub fn evaluate(rules: &[PermissionRule], subject: &Subject) -> Verdict {
+    let mut best: Option<&PermissionRule> = None;
+    let rank = |a: PermissionAction| match a {
+        PermissionAction::Deny => 3,
+        PermissionAction::Ask => 2,
+        PermissionAction::Allow => 1,
+    };
+    for r in rules {
+        if rule_matches(r, subject) && best.map(|b| rank(r.action) > rank(b.action)).unwrap_or(true) {
+            best = Some(r);
+        }
+    }
+    Verdict {
+        action: best.map(|b| b.action),
+        rule: best.map(|b| b.pattern.clone()),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// The hook itself: Cursor payload in, decision out
+// ---------------------------------------------------------------------------
+
+/// Cursor's canonical "proceed" response.
+fn allow_response() -> Value {
+    json!({ "continue": true, "permission": "allow" })
+}
+
+fn decision_response(action: PermissionAction, rule: &str, what: &str) -> Value {
+    match action {
+        PermissionAction::Deny => json!({
+            "continue": true,
+            "permission": "deny",
+            "user_message": format!("Toolport: blocked by your permission rule {rule}."),
+            "agent_message": format!("Toolport blocked {what}: it matches the user's permission rule {rule} (deny). Do not retry it or work around it; explain and ask the user how to proceed."),
+        }),
+        PermissionAction::Ask => json!({
+            "continue": true,
+            "permission": "ask",
+            "user_message": format!("Toolport: your permission rule {rule} asks before this."),
+            "agent_message": format!("{what} matches the user's permission rule {rule} (ask); wait for their answer."),
+        }),
+        PermissionAction::Allow => allow_response(),
+    }
+}
+
+/// The subject Cursor's payload describes, and a short human label for it.
+fn cursor_subject<'a>(
+    event: &str,
+    payload: &'a Value,
+    home: Option<&'a str>,
+) -> Option<(Subject<'a>, String)> {
+    let root = payload
+        .get("workspace_roots")
+        .and_then(Value::as_array)
+        .and_then(|a| a.first())
+        .and_then(Value::as_str)
+        .or_else(|| payload.get("cwd").and_then(Value::as_str));
+    match event {
+        "beforeShellExecution" => {
+            let command = payload.get("command")?.as_str()?;
+            Some((Subject::Shell(command), format!("the shell command `{}`", truncate(command, 120))))
+        }
+        "beforeReadFile" => {
+            let path = payload.get("file_path")?.as_str()?;
+            Some((Subject::Read { path, root, home }, format!("reading `{}`", truncate(path, 160))))
+        }
+        "beforeMCPExecution" => {
+            let tool = payload.get("tool_name")?.as_str()?;
+            Some((Subject::Mcp { tool }, format!("the MCP tool `{}`", truncate(tool, 80))))
+        }
+        _ => None,
+    }
+}
+
+fn truncate(s: &str, n: usize) -> String {
+    if s.chars().count() <= n {
+        s.to_string()
+    } else {
+        format!("{}…", s.chars().take(n).collect::<String>())
+    }
+}
+
+/// Run the guard for one Cursor call: returns the JSON to print and the exit code. Always
+/// exit 0 with a complete response; `deny` is expressed in the JSON, as Cursor documents.
+pub fn handle_stdin(agent: &str, stdin: &str) -> (String, i32) {
+    let out = handle(agent, stdin);
+    (out.to_string(), 0)
+}
+
+fn handle(agent: &str, stdin: &str) -> Value {
+    if agent != "cursor" {
+        crate::gatewaylog::append(&format!("toolport: guard invoked for unknown agent {agent:?}"));
+        return allow_response();
+    }
+    let reg = match crate::registry::load() {
+        Ok(reg) => reg,
+        Err(error) => {
+            crate::gatewaylog::append(&format!("toolport: guard could not load the registry: {error}"));
+            return allow_response();
+        }
+    };
+    let payload: Value = match serde_json::from_str(stdin) {
+        Ok(v) => v,
+        Err(error) => {
+            record(json!({ "agent": "cursor", "event": "guard", "malformed": true, "decision": "allow", "mode": reg.guard_cursor_mode }));
+            crate::gatewaylog::append(&format!("toolport: guard payload did not parse: {error}"));
+            return allow_response();
+        }
+    };
+    let event = payload
+        .get("hook_event_name")
+        .and_then(Value::as_str)
+        .unwrap_or("")
+        .to_string();
+    let home = dirs::home_dir().map(|h| h.to_string_lossy().to_string());
+    let Some((subject, what)) = cursor_subject(&event, &payload, home.as_deref()) else {
+        record(json!({ "agent": "cursor", "event": "guard", "hookEvent": event, "unhandled": true, "decision": "allow", "mode": reg.guard_cursor_mode }));
+        return allow_response();
+    };
+    let verdict = evaluate(&reg.agent_permission_rules, &subject);
+    let (tool, hash_src) = match &subject {
+        Subject::Shell(c) => ("Bash", (*c).to_string()),
+        Subject::Read { path, .. } => ("Read", (*path).to_string()),
+        Subject::Mcp { tool } => ("mcp", (*tool).to_string()),
+    };
+    let enforced = reg.guard_cursor_mode == GuardMode::Enforce;
+    let decision = match (enforced, verdict.action) {
+        (_, None) => "allow",
+        (true, Some(a)) => a.list_key(),
+        (false, Some(_)) => "allow",
+    };
+    record(json!({
+        "agent": "cursor",
+        "event": "guard",
+        "hookEvent": event,
+        "tool": tool,
+        "argsHash": crate::audit::args_hash(&json!({ "subject": hash_src })),
+        "mode": reg.guard_cursor_mode,
+        "wouldBe": verdict.action.map(|a| a.list_key()),
+        "rule": verdict.rule,
+        "decision": decision,
+    }));
+    match (enforced, verdict.action) {
+        (true, Some(action)) => decision_response(action, verdict.rule.as_deref().unwrap_or("?"), &what),
+        _ => allow_response(),
+    }
+}
+
+/// One line in the sensor log (SBS-822's), so Agent activity and the SBS-823 dashboard see
+/// guard decisions next to the tool calls they were about. No content: a tool name, a hash.
+fn record(mut row: Value) {
+    if let Some(obj) = row.as_object_mut() {
+        obj.insert(
+            "ts".into(),
+            json!(std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_millis() as u64)
+                .unwrap_or(0)),
+        );
+    }
+    let Some(path) = crate::hooks::log_path() else {
+        return;
+    };
+    let _ = crate::registry::append_line_locked(&path, &row.to_string(), 4 * 1024 * 1024, 10_000, None);
+}
+
+// ---------------------------------------------------------------------------
+// Install into ~/.cursor/hooks.json
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GuardProfile {
+    pub path: String,
+    pub installed: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GuardView {
+    pub cursor_mode: GuardMode,
+    /// Absent when Cursor's config directory cannot be resolved.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cursor: Option<GuardProfile>,
+    pub events: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub binary: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GuardPreview {
+    pub path: String,
+    pub before: String,
+    pub after: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+fn cursor_hooks_path() -> Option<PathBuf> {
+    Some(dirs::home_dir()?.join(".cursor").join("hooks.json"))
+}
+
+fn guard_command(binary: &Path) -> String {
+    format!("\"{}\" {GUARD_MARKER} cursor", binary.display())
+}
+
+fn is_ours(entry: &Value) -> bool {
+    entry
+        .get("command")
+        .and_then(Value::as_str)
+        .map(|c| c.contains(GUARD_MARKER))
+        .unwrap_or(false)
+}
+
+pub fn is_installed(root: &Value) -> bool {
+    root.get("hooks")
+        .and_then(Value::as_object)
+        .map(|hooks| {
+            hooks.values().any(|entries| {
+                entries
+                    .as_array()
+                    .map(|e| e.iter().any(is_ours))
+                    .unwrap_or(false)
+            })
+        })
+        .unwrap_or(false)
+}
+
+/// `root` with every guard entry removed, pruning an event list this emptied and then the
+/// `hooks` object; `version` is left alone (it is the file's, not ours).
+pub fn strip_guard(root: &Value) -> Value {
+    let mut out = root.clone();
+    let Some(obj) = out.as_object_mut() else {
+        return out;
+    };
+    let Some(hooks) = obj.get_mut("hooks").and_then(Value::as_object_mut) else {
+        return out;
+    };
+    let events: Vec<String> = hooks.keys().cloned().collect();
+    for event in events {
+        if let Some(list) = hooks.get_mut(&event).and_then(Value::as_array_mut) {
+            let before = list.len();
+            list.retain(|e| !is_ours(e));
+            if list.is_empty() && before > 0 {
+                hooks.remove(&event);
+            }
+        }
+    }
+    if hooks.is_empty() {
+        obj.remove("hooks");
+    }
+    out
+}
+
+/// `root` carrying exactly one guard entry per Cursor event. Strip-then-add, so idempotent
+/// and convergent across binary paths; `failClosed` only when enforcing.
+pub fn upsert_guard(root: &Value, binary: &Path, enforce: bool) -> Result<Value, String> {
+    let mut out = strip_guard(root);
+    let obj = out
+        .as_object_mut()
+        .ok_or_else(|| "hooks.json root is not a JSON object".to_string())?;
+    obj.entry("version".to_string()).or_insert(json!(1));
+    let hooks = obj
+        .entry("hooks".to_string())
+        .or_insert_with(|| Value::Object(Map::new()));
+    let hooks = hooks
+        .as_object_mut()
+        .ok_or_else(|| "`hooks` is present but is not an object".to_string())?;
+    for event in CURSOR_EVENTS {
+        let list = hooks
+            .entry(event.to_string())
+            .or_insert_with(|| Value::Array(Vec::new()));
+        let list = list
+            .as_array_mut()
+            .ok_or_else(|| format!("`hooks.{event}` is present but is not an array"))?;
+        list.push(json!({
+            "command": guard_command(binary),
+            "timeout": GUARD_TIMEOUT_SECS,
+            "failClosed": enforce,
+        }));
+    }
+    Ok(out)
+}
+
+pub fn apply_on_startup() {
+    let active = crate::registry::load()
+        .map(|reg| !reg.guard_cursor_mode.is_off() || !reg.guard_targets.is_empty())
+        .unwrap_or(false);
+    if !active {
+        return;
+    }
+    if let Err(error) = apply_with(None) {
+        crate::gatewaylog::append(&format!("toolport: guard startup apply failed: {error}"));
+    }
+}
+
+pub fn view() -> GuardView {
+    let reg = crate::registry::load().unwrap_or_default();
+    view_with(&reg, cursor_hooks_path().as_deref())
+}
+
+fn view_with(reg: &crate::registry::Registry, cursor: Option<&Path>) -> GuardView {
+    let cursor = cursor.map(|path| match crate::clients::read_settings_json(path) {
+        Ok((root, _)) => GuardProfile {
+            path: path.display().to_string(),
+            installed: is_installed(&root),
+            error: None,
+        },
+        Err(error) => GuardProfile {
+            path: path.display().to_string(),
+            installed: false,
+            error: Some(error),
+        },
+    });
+    GuardView {
+        cursor_mode: reg.guard_cursor_mode,
+        cursor,
+        events: CURSOR_EVENTS.iter().map(|e| (*e).to_string()).collect(),
+        binary: crate::clients::resolve_gateway_path_readonly().map(|p| p.display().to_string()),
+    }
+}
+
+/// Set Cursor's mode and make the file match, in one transaction.
+pub fn set_cursor_mode(mode: GuardMode) -> Result<GuardView, String> {
+    report(apply_with(Some(mode))?)?;
+    Ok(view())
+}
+
+fn report(profiles: Vec<GuardProfile>) -> Result<(), String> {
+    let failed: Vec<String> = profiles
+        .iter()
+        .filter_map(|p| p.error.as_ref().map(|e| format!("{}: {e}", p.path)))
+        .collect();
+    if failed.is_empty() {
+        Ok(())
+    } else {
+        Err(format!("The mode was saved, but the hooks file could not be updated: {}", failed.join("; ")))
+    }
+}
+
+fn apply_with(set_mode: Option<GuardMode>) -> Result<Vec<GuardProfile>, String> {
+    apply_to(set_mode, cursor_hooks_path().as_deref(), &|| {
+        crate::clients::resolve_gateway_path().filter(|p| p.is_file())
+    })
+}
+
+fn apply_to(
+    set_mode: Option<GuardMode>,
+    cursor: Option<&Path>,
+    resolve_binary: &dyn Fn() -> Option<PathBuf>,
+) -> Result<Vec<GuardProfile>, String> {
+    let (_, statuses) = crate::registry::update_authoritative(|reg| {
+        if let Some(mode) = set_mode {
+            reg.guard_cursor_mode = mode;
+        }
+        let mut statuses = Vec::new();
+        let mut targets: Vec<String> = Vec::new();
+        let want = match (reg.guard_cursor_mode, cursor) {
+            (GuardMode::Off, _) | (_, None) => None,
+            (mode, Some(path)) => Some((path.to_path_buf(), mode == GuardMode::Enforce)),
+        };
+        if let Some((path, enforce)) = &want {
+            let binary = resolve_binary()
+                .ok_or_else(|| "no gateway binary is available to run as a hook".to_string())?;
+            let key = path.display().to_string();
+            match install_at(path, &binary, *enforce) {
+                Ok(()) => {
+                    targets.push(key.clone());
+                    statuses.push(GuardProfile { path: key, installed: true, error: None });
+                }
+                Err(error) => {
+                    if reg.guard_targets.contains(&key) {
+                        targets.push(key.clone());
+                    }
+                    statuses.push(GuardProfile { path: key, installed: false, error: Some(error) });
+                }
+            }
+        }
+        let wanted: Vec<String> = want.iter().map(|(p, _)| p.display().to_string()).collect();
+        for stale in reg.guard_targets.iter().filter(|t| !wanted.contains(t)) {
+            if let Err(error) = remove_at(Path::new(stale)) {
+                targets.push(stale.clone());
+                statuses.push(GuardProfile { path: stale.clone(), installed: false, error: Some(error) });
+            }
+        }
+        reg.guard_targets = targets;
+        Ok(statuses)
+    })?;
+    Ok(statuses)
+}
+
+fn install_at(path: &Path, binary: &Path, enforce: bool) -> Result<(), String> {
+    let (root, original) = crate::clients::read_settings_json(path)?;
+    let updated = upsert_guard(&root, binary, enforce)?;
+    if updated == root {
+        return Ok(());
+    }
+    crate::clients::write_settings_key_for("cursor", path, original.as_deref(), &updated, "hooks")
+}
+
+fn remove_at(path: &Path) -> Result<(), String> {
+    let (root, original) = match crate::clients::read_settings_json(path) {
+        Ok(pair) => pair,
+        Err(error) => {
+            if !path.exists() {
+                return Ok(());
+            }
+            return Err(error);
+        }
+    };
+    if original.is_none() {
+        return Ok(());
+    }
+    let stripped = strip_guard(&root);
+    if stripped == root {
+        return Ok(());
+    }
+    crate::clients::write_settings_key_for("cursor", path, original.as_deref(), &stripped, "hooks")
+}
+
+/// The bytes `~/.cursor/hooks.json` would hold in `mode` (Off = with the guard removed).
+pub fn preview(mode: GuardMode) -> Result<Option<GuardPreview>, String> {
+    let Some(path) = cursor_hooks_path() else {
+        return Ok(None);
+    };
+    let binary = crate::clients::resolve_gateway_path_readonly().ok_or_else(|| {
+        "no gateway binary has been published yet, so there is nothing to preview".to_string()
+    })?;
+    Ok(Some(preview_at(&path, &binary, mode)))
+}
+
+fn preview_at(path: &Path, binary: &Path, mode: GuardMode) -> GuardPreview {
+    let rendered = crate::clients::read_settings_json(path).and_then(|(root, original)| {
+        let updated = match mode {
+            GuardMode::Off => strip_guard(&root),
+            m => upsert_guard(&root, binary, m == GuardMode::Enforce)?,
+        };
+        let after = crate::clients::render_settings_key(original.as_deref(), &updated, "hooks")?;
+        Ok((original.unwrap_or_default(), after))
+    });
+    match rendered {
+        Ok((before, after)) => GuardPreview { path: path.display().to_string(), before, after, error: None },
+        Err(error) => GuardPreview { path: path.display().to_string(), before: String::new(), after: String::new(), error: Some(error) },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use PermissionAction::{Allow, Ask, Deny};
+
+    fn rule(p: &str, a: PermissionAction) -> PermissionRule {
+        PermissionRule { pattern: p.into(), action: a }
+    }
+
+    #[test]
+    fn bash_rules_follow_claude_codes_matching() {
+        let deny = |p: &str| vec![rule(p, Deny)];
+        let hit = |rules: &[PermissionRule], cmd: &str| evaluate(rules, &Subject::Shell(cmd)).action == Some(Deny);
+        // Exact, prefix with word boundary, `:*`, wildcards anywhere, bare tool.
+        assert!(hit(&deny("Bash(npm run build)"), "npm run build"));
+        assert!(!hit(&deny("Bash(npm run build)"), "npm run build --watch"));
+        assert!(hit(&deny("Bash(ls *)"), "ls"));
+        assert!(hit(&deny("Bash(ls *)"), "ls -la"));
+        assert!(!hit(&deny("Bash(ls *)"), "lsof -i"), "a trailing ` *` needs a word boundary");
+        assert!(hit(&deny("Bash(ls:*)"), "ls -la"));
+        assert!(hit(&deny("Bash(git * main)"), "git push origin main"));
+        assert!(hit(&deny("Bash(* --version)"), "node --version"));
+        assert!(hit(&deny("Bash"), "anything at all"));
+        assert!(hit(&deny("Bash(*)"), "anything at all"));
+        // Compound: a deny fires if any part matches; wrappers are stripped first.
+        assert!(hit(&deny("Bash(rm -rf *)"), "echo hi && rm -rf /tmp/x"));
+        assert!(hit(&deny("Bash(rm -rf *)"), "cd /tmp; rm -rf x"));
+        assert!(hit(&deny("Bash(rm -rf *)"), "timeout 30 rm -rf x"));
+        assert!(hit(&deny("Bash(rm -rf *)"), "nohup rm -rf x"));
+        assert!(!hit(&deny("Bash(rm -rf *)"), "echo 'rm -rf' && ls"), "quoted operators do not split; the echo is not rm");
+        // Allow covers a compound only when every part is allowed.
+        let allow = vec![rule("Bash(npm *)", Allow)];
+        assert_eq!(evaluate(&allow, &Subject::Shell("npm test && npm run lint")).action, Some(Allow));
+        assert_eq!(evaluate(&allow, &Subject::Shell("npm test && curl evil")).action, None);
+        // Precedence: deny beats ask beats allow when several match.
+        let mixed = vec![rule("Bash(git push*)", Ask), rule("Bash(git *)", Allow), rule("Bash(git push --force*)", Deny)];
+        assert_eq!(evaluate(&mixed, &Subject::Shell("git push --force origin main")).action, Some(Deny));
+        assert_eq!(evaluate(&mixed, &Subject::Shell("git push origin main")).action, Some(Ask));
+        assert_eq!(evaluate(&mixed, &Subject::Shell("git status")).action, Some(Allow));
+        assert_eq!(evaluate(&mixed, &Subject::Shell("ls")).action, None);
+        // A Read rule never matches a shell command and vice versa.
+        assert_eq!(evaluate(&[rule("Read(./.env)", Deny)], &Subject::Shell("cat .env")).action, None);
+    }
+
+    #[test]
+    fn read_rules_resolve_against_workspace_and_home() {
+        let deny = |p: &str| vec![rule(p, Deny)];
+        let hit = |rules: &[PermissionRule], path: &str| {
+            evaluate(rules, &Subject::Read { path, root: Some("/work/repo"), home: Some("/home/u") }).action == Some(Deny)
+        };
+        assert!(hit(&deny("Read(./.env)"), "/work/repo/.env"));
+        assert!(!hit(&deny("Read(./.env)"), "/work/repo/sub/.env"), "`./.env` is the root one");
+        assert!(hit(&deny("Read(./.env.*)"), "/work/repo/.env.local"));
+        assert!(hit(&deny("Read(~/.ssh/**)"), "/home/u/.ssh/id_ed25519"));
+        assert!(hit(&deny("Read(~/.ssh)"), "/home/u/.ssh/id_ed25519"), "a directory rule covers what is under it");
+        assert!(!hit(&deny("Read(~/.ssh/**)"), "/home/u/.sshx/key"));
+        assert!(hit(&deny("Read(src/**/*.key)"), "/work/repo/src/a/b/c.key"));
+        assert!(hit(&deny("Read(src/**/*.key)"), "/work/repo/src/c.key"), "`**/` also matches zero directories");
+        assert!(!hit(&deny("Read(src/*.key)"), "/work/repo/src/a/c.key"), "`*` stays in one segment");
+        assert!(hit(&deny("Read(//etc/passwd)"), "/etc/passwd"));
+        assert!(hit(&deny("Read"), "/anything"));
+        assert!(!hit(&deny("Bash(cat *)"), "/work/repo/.env"));
+    }
+
+    #[test]
+    fn mcp_rules_match_the_tool_name_and_globs() {
+        let deny = |p: &str| vec![rule(p, Deny)];
+        let hit = |rules: &[PermissionRule], tool: &str| evaluate(rules, &Subject::Mcp { tool }).action == Some(Deny);
+        assert!(hit(&deny("mcp__github__create_issue"), "create_issue"));
+        assert!(hit(&deny("mcp__github__create_issue"), "github__create_issue"));
+        assert!(!hit(&deny("mcp__github__create_issue"), "list_issues"));
+        assert!(hit(&deny("mcp__github__*"), "anything"));
+        assert!(hit(&deny("mcp__*"), "anything"));
+        assert!(hit(&deny("*"), "anything"), "a bare `*` is every tool");
+        assert!(!hit(&deny("Bash"), "create_issue"));
+    }
+
+    #[test]
+    fn responses_follow_cursors_shape_and_observe_never_blocks() {
+        let r = decision_response(Deny, "Bash(rm -rf *)", "the shell command `rm -rf x`");
+        assert_eq!(r["permission"], "deny");
+        assert_eq!(r["continue"], true);
+        assert!(r["user_message"].as_str().unwrap().contains("Bash(rm -rf *)"));
+        assert!(r["agent_message"].as_str().unwrap().contains("Do not retry"));
+        let r = decision_response(Ask, "Bash(git push*)", "x");
+        assert_eq!(r["permission"], "ask");
+        assert_eq!(decision_response(Allow, "x", "y"), allow_response());
+        assert_eq!(allow_response(), serde_json::json!({ "continue": true, "permission": "allow" }));
+    }
+
+    #[test]
+    fn cursor_payloads_map_to_subjects() {
+        let home = Some("/home/u");
+        let p = serde_json::json!({ "hook_event_name": "beforeShellExecution", "command": "rm -rf x", "cwd": "/w", "workspace_roots": ["/w"] });
+        let (s, what) = cursor_subject("beforeShellExecution", &p, home).unwrap();
+        assert_eq!(s, Subject::Shell("rm -rf x"));
+        assert!(what.contains("rm -rf x"));
+        let p = serde_json::json!({ "hook_event_name": "beforeReadFile", "file_path": "/w/.env", "workspace_roots": ["/w"] });
+        let (s, _) = cursor_subject("beforeReadFile", &p, home).unwrap();
+        assert_eq!(s, Subject::Read { path: "/w/.env", root: Some("/w"), home });
+        let p = serde_json::json!({ "hook_event_name": "beforeMCPExecution", "tool_name": "create_issue", "tool_input": "{}" });
+        let (s, _) = cursor_subject("beforeMCPExecution", &p, home).unwrap();
+        assert_eq!(s, Subject::Mcp { tool: "create_issue" });
+        assert!(cursor_subject("afterFileEdit", &p, home).is_none());
+        assert!(cursor_subject("beforeShellExecution", &serde_json::json!({}), home).is_none());
+    }
+
+    #[test]
+    fn hooks_json_gets_exactly_our_entries_and_loses_exactly_them() {
+        let theirs = serde_json::json!({
+            "version": 1,
+            "hooks": { "beforeShellExecution": [{ "command": "./my-own.sh" }], "stop": [{ "command": "./done.sh" }] }
+        });
+        let bin = Path::new("/opt/toolport/toolport-gateway");
+        let with = upsert_guard(&theirs, bin, true).unwrap();
+        assert!(is_installed(&with));
+        assert!(!is_installed(&theirs));
+        let shell = with["hooks"]["beforeShellExecution"].as_array().unwrap();
+        assert_eq!(shell.len(), 2, "ours is added beside theirs");
+        assert_eq!(shell[0]["command"], "./my-own.sh");
+        assert_eq!(shell[1]["command"], "\"/opt/toolport/toolport-gateway\" --toolport-guard cursor");
+        assert_eq!(shell[1]["failClosed"], true);
+        assert_eq!(with["hooks"]["beforeMCPExecution"].as_array().unwrap().len(), 1);
+        assert_eq!(with["hooks"]["beforeReadFile"].as_array().unwrap().len(), 1);
+        assert_eq!(with["hooks"]["stop"], theirs["hooks"]["stop"]);
+        // Idempotent, and re-upserting with observe flips only failClosed.
+        assert_eq!(upsert_guard(&with, bin, true).unwrap(), with);
+        let observe = upsert_guard(&with, bin, false).unwrap();
+        assert_eq!(observe["hooks"]["beforeReadFile"][0]["failClosed"], false);
+        // Strip gives theirs back, pruning only the lists we created.
+        assert_eq!(strip_guard(&with), theirs);
+        let fresh = upsert_guard(&serde_json::json!({}), bin, false).unwrap();
+        assert_eq!(fresh["version"], 1);
+        assert_eq!(strip_guard(&fresh), serde_json::json!({ "version": 1 }), "version was ours to add but is the file's to keep");
+    }
+
+    #[test]
+    fn apply_installs_flips_and_removes_over_a_scratch_file() {
+        let _dirs = crate::registry::data_dir_test_lock();
+        let scratch = std::env::temp_dir().join(format!("toolport-guard-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&scratch);
+        std::fs::create_dir_all(&scratch).unwrap();
+        let _data = crate::registry::DataDirOverride::set(scratch.join("data"));
+        let hooks = scratch.join(".cursor").join("hooks.json");
+        std::fs::create_dir_all(hooks.parent().unwrap()).unwrap();
+        std::fs::write(&hooks, "{\n  \"version\": 1,\n  \"hooks\": { \"stop\": [{ \"command\": \"./done.sh\" }] }\n}\n").unwrap();
+        let bin = scratch.join("toolport-gateway");
+        std::fs::write(&bin, "").unwrap();
+        let resolve = || Some(bin.clone());
+
+        // Off: nothing written.
+        apply_to(None, Some(&hooks), &resolve).unwrap();
+        assert!(!std::fs::read_to_string(&hooks).unwrap().contains("toolport-guard"));
+
+        // Observe: installed, failClosed false, user's hook kept and formatting too.
+        let st = apply_to(Some(GuardMode::Observe), Some(&hooks), &resolve).unwrap();
+        assert!(st[0].installed && st[0].error.is_none(), "{st:?}");
+        let text = std::fs::read_to_string(&hooks).unwrap();
+        assert!(text.contains("toolport-guard cursor") && text.contains("\"failClosed\": false") && text.contains("./done.sh"), "{text}");
+        let reg = crate::registry::load().unwrap();
+        assert_eq!(reg.guard_targets, vec![hooks.display().to_string()]);
+        assert!(view_with(&reg, Some(&hooks)).cursor.unwrap().installed);
+
+        // Enforce: same entries, failClosed true.
+        apply_to(Some(GuardMode::Enforce), Some(&hooks), &resolve).unwrap();
+        let text = std::fs::read_to_string(&hooks).unwrap();
+        assert!(text.contains("\"failClosed\": true") && !text.contains("\"failClosed\": false"), "{text}");
+
+        // A hand-removed entry comes back at startup reconcile.
+        std::fs::write(&hooks, "{\n  \"version\": 1,\n  \"hooks\": { \"stop\": [{ \"command\": \"./done.sh\" }] }\n}\n").unwrap();
+        apply_to(None, Some(&hooks), &resolve).unwrap();
+        assert!(std::fs::read_to_string(&hooks).unwrap().contains("toolport-guard"));
+
+        // Off: exactly ours leaves; the user's stop hook and version stay.
+        apply_to(Some(GuardMode::Off), Some(&hooks), &resolve).unwrap();
+        let text = std::fs::read_to_string(&hooks).unwrap();
+        assert!(!text.contains("toolport-guard") && text.contains("./done.sh") && text.contains("\"version\": 1"), "{text}");
+        assert!(crate::registry::load().unwrap().guard_targets.is_empty());
+        let _ = std::fs::remove_dir_all(&scratch);
+    }
+}

--- a/src-tauri/src/agent_guard.rs
+++ b/src-tauri/src/agent_guard.rs
@@ -186,8 +186,10 @@ fn split_compound(command: &str) -> Vec<String> {
             i += 2;
             continue;
         }
-        // `;`, a pipe, a newline, and a lone `&` (background) all start a new command.
-        if c == ';' || c == '|' || c == '\n' || c == '&' {
+        // An ampersand next to `>` belongs to a redirection (`2>&1`, `&>`, `>&`).
+        let redirect_ampersand = c == '&'
+            && (i.checked_sub(1).is_some_and(|j| chars[j] == '>') || chars.get(i + 1) == Some(&'>'));
+        if c == ';' || c == '|' || c == '\n' || (c == '&' && !redirect_ampersand) {
             parts.push(std::mem::take(&mut cur));
             i += 1;
             continue;
@@ -212,7 +214,7 @@ fn strip_wrappers(command: &str) -> String {
     let mut words: Vec<&str> = command.split_whitespace().collect();
     while let Some(&first) = words.first() {
         // `/usr/bin/timeout` is `timeout`: a wrapper named by path is still that wrapper.
-        let name = first.rsplit('/').next().unwrap_or(first);
+        let name = first.rsplit(['/', '\\']).next().unwrap_or(first);
         match name {
             "nohup" => {
                 words.remove(0);
@@ -496,18 +498,29 @@ fn cannot_judge(reg: &crate::registry::Registry, why: &str) -> Value {
     }
 }
 
+fn registry_unavailable(why: &str) -> Value {
+    json!({
+        "continue": true,
+        "permission": "deny",
+        "user_message": format!("Toolport: this call was refused because the guard could not load its policy ({why})."),
+        "agent_message": format!("Toolport could not load its permission policy ({why}), so it refused this call. Tell the user."),
+    })
+}
+
 fn handle(agent: &str, stdin: &str, truncated: bool) -> Value {
     if agent != "cursor" {
         crate::gatewaylog::append(&format!("toolport: guard invoked for unknown agent {agent:?}"));
         return allow_response();
     }
-    let reg = match crate::registry::load() {
-        Ok(reg) => reg,
+    let reg = match crate::registry::load_resolved_with_source() {
+        Ok((reg, source)) if source.is_authoritative() => reg,
+        Ok((_reg, source)) => {
+            crate::gatewaylog::append(&format!("toolport: guard registry is not authoritative: {source:?}"));
+            return registry_unavailable("the registry was recovered or unreadable");
+        }
         Err(error) => {
-            // No registry means no mode to read either; the hook would not be installed
-            // without one, so this is a broken install. Say so, stand aside.
             crate::gatewaylog::append(&format!("toolport: guard could not load the registry: {error}"));
-            return allow_response();
+            return registry_unavailable("the registry could not be read");
         }
     };
     // Cursor on Windows is documented to prefix hook stdin with a UTF-8 BOM.
@@ -821,7 +834,7 @@ fn apply_to(
 fn install_at(path: &Path, binary: &Path, enforce: bool) -> Result<(), String> {
     let (root, original) = crate::clients::read_settings_json(path)?;
     let updated = upsert_guard(&root, binary, enforce)?;
-    if updated == root {
+    if updated.get("hooks") == root.get("hooks") {
         return Ok(());
     }
     crate::clients::write_settings_key_for("cursor", path, original.as_deref(), &updated, "hooks")
@@ -914,7 +927,11 @@ mod tests {
         assert!(hit(&deny("Bash(rm -rf *)"), "sleep 1 & rm -rf x"));
         assert!(hit(&deny("Bash(rm -rf *)"), "ls |& rm -rf x"));
         assert!(hit(&deny("Bash(rm -rf *)"), "/usr/bin/timeout 5 rm -rf x"));
+        assert!(hit(&deny("Bash(rm -rf *)"), r"C:\tools\timeout 5 rm -rf x"));
         assert!(hit(&deny("Bash(rm -rf *)"), "/usr/bin/nice -n 5 /usr/bin/nohup rm -rf x"));
+        let allow_redirects = vec![rule("Bash(npm test *)", Allow)];
+        assert_eq!(evaluate(&allow_redirects, &Subject::Shell("npm test 2>&1")).action, Some(Allow));
+        assert_eq!(evaluate(&allow_redirects, &Subject::Shell("npm test &>out.log")).action, Some(Allow));
         assert!(!hit(&deny("Bash(rm -rf *)"), "echo 'rm -rf' && ls"), "quoted operators do not split; the echo is not rm");
         // Allow covers a compound only when every part is allowed.
         let allow = vec![rule("Bash(npm *)", Allow)];
@@ -977,6 +994,7 @@ mod tests {
         assert_eq!(r["continue"], true);
         assert!(r["user_message"].as_str().unwrap().contains("Bash(rm -rf *)"));
         assert!(r["agent_message"].as_str().unwrap().contains("Do not retry"));
+        assert_eq!(registry_unavailable("test failure")["permission"], "deny");
         let r = decision_response(Ask, "Bash(git push*)", "x");
         assert_eq!(r["permission"], "ask");
         assert_eq!(decision_response(Allow, "x", "y"), allow_response());

--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -15154,8 +15154,11 @@ fn main() {
             // read. The ONLY difference is that this one speaks: its stdout is the
             // decision the agent acts on, and it always exits 0 with a complete
             // response - a deny is said in the JSON, never by crashing out.
-            let (payload, _truncated) = conduit_lib::hooks::read_payload(std::io::stdin());
-            let (out, code) = conduit_lib::agent_guard::handle_stdin(&agent, &payload);
+            let (payload, truncated) = conduit_lib::hooks::read_payload_capped(
+                std::io::stdin(),
+                conduit_lib::agent_guard::MAX_GUARD_STDIN_BYTES,
+            );
+            let (out, code) = conduit_lib::agent_guard::handle_stdin(&agent, &payload, truncated);
             println!("{out}");
             std::process::exit(code);
         }

--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -15035,6 +15035,10 @@ enum ArgAction {
     /// flag was written without one - [`conduit_lib::hooks::handle_event`] treats
     /// that as an unknown event rather than a reason to fail.
     Hook(String),
+    /// Invoked as an agent's blocking guard hook (`--toolport-guard <agent>`). Read the
+    /// call from stdin, evaluate the permission policy, print the agent's decision JSON
+    /// to stdout, exit 0. Carries the agent name.
+    Guard(String),
     /// Nothing that changes startup mode; fall through to normal gateway
     /// startup.
     Run,
@@ -15063,6 +15067,12 @@ fn parse_args(args: &[String]) -> ArgAction {
     {
         return ArgAction::Hook(args.get(index + 1).cloned().unwrap_or_default());
     }
+    if let Some(index) = args
+        .iter()
+        .position(|a| a == conduit_lib::agent_guard::GUARD_MARKER)
+    {
+        return ArgAction::Guard(args.get(index + 1).cloned().unwrap_or_default());
+    }
     for arg in args {
         if arg.starts_with('-') && !KNOWN_FLAGS.contains(&arg.as_str()) {
             return ArgAction::Unknown(arg.clone());
@@ -15086,6 +15096,9 @@ fn usage() -> String {
          \x20   --selftest-secrets    Diagnostic: read every vaulted secret and report\n\
          \x20   --toolport-hook EVENT Record one agent lifecycle event and exit (installed\n\
          \x20                         into an agent's settings by Toolport; always exits 0)\n\
+         \x20   --toolport-guard AGENT Decide one native tool call against the permission\n\
+         \x20                         policy and print the agent's decision JSON (installed\n\
+         \x20                         into an agent's hooks by Toolport; always exits 0)\n\
          \x20   -h, --help            Print this message and exit\n\
          \x20   -V, --version         Print the version and exit\n\
          \n\
@@ -15135,6 +15148,16 @@ fn main() {
             let (payload, _truncated) = conduit_lib::hooks::read_payload(std::io::stdin());
             conduit_lib::hooks::handle_event(&event, &payload);
             std::process::exit(0);
+        }
+        ArgAction::Guard(agent) => {
+            // Same discipline as the sensor: first thing, no gateway startup, bounded
+            // read. The ONLY difference is that this one speaks: its stdout is the
+            // decision the agent acts on, and it always exits 0 with a complete
+            // response - a deny is said in the JSON, never by crashing out.
+            let (payload, _truncated) = conduit_lib::hooks::read_payload(std::io::stdin());
+            let (out, code) = conduit_lib::agent_guard::handle_stdin(&agent, &payload);
+            println!("{out}");
+            std::process::exit(code);
         }
         ArgAction::Run => {}
     }

--- a/src-tauri/src/clients.rs
+++ b/src-tauri/src/clients.rs
@@ -663,8 +663,20 @@ pub(crate) fn write_settings_key(
     root: &serde_json::Value,
     key: &str,
 ) -> Result<(), String> {
+    write_settings_key_for("claude-code", path, original, root, key)
+}
+
+/// [`write_settings_key`] for another client's JSON settings file (the Cursor guard writes
+/// `~/.cursor/hooks.json`); the backup is filed under that client.
+pub(crate) fn write_settings_key_for(
+    client_id: &str,
+    path: &Path,
+    original: Option<&str>,
+    root: &serde_json::Value,
+    key: &str,
+) -> Result<(), String> {
     if original.is_some() {
-        backup_file_named("claude-code", path, &claude_settings_backup_name(path))?;
+        backup_file_named(client_id, path, &claude_settings_backup_name(path))?;
     }
     atomic_write(path, &render_settings_key(original, root, key)?)
 }

--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -12,6 +12,7 @@ use tauri_plugin_dialog::{DialogExt, MessageDialogButtons, MessageDialogKind};
 use tauri_plugin_notification::NotificationExt;
 
 use crate::approval;
+use crate::agent_guard;
 use crate::agent_permissions;
 use crate::approval_broker;
 use crate::audit;
@@ -3281,6 +3282,33 @@ async fn rules_apply() -> Result<rules::RulesView, String> {
         .map_err(|e| e.to_string())?
 }
 
+// --- Guard hook for Cursor (SBS-1059) ----------------------------------------------
+
+#[tauri::command]
+async fn agent_guard_view() -> Result<agent_guard::GuardView, String> {
+    tauri::async_runtime::spawn_blocking(agent_guard::view)
+        .await
+        .map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+async fn agent_guard_set_cursor_mode(
+    mode: agent_guard::GuardMode,
+) -> Result<agent_guard::GuardView, String> {
+    tauri::async_runtime::spawn_blocking(move || agent_guard::set_cursor_mode(mode))
+        .await
+        .map_err(|e| e.to_string())?
+}
+
+#[tauri::command]
+async fn agent_guard_preview(
+    mode: agent_guard::GuardMode,
+) -> Result<Option<agent_guard::GuardPreview>, String> {
+    tauri::async_runtime::spawn_blocking(move || agent_guard::preview(mode))
+        .await
+        .map_err(|e| e.to_string())?
+}
+
 // --- Native permission policy for Claude Code (SBS-1058) -------------------------
 //
 // Same shape as the hook sensor: every one of these reads or writes an agent settings
@@ -5566,6 +5594,9 @@ pub fn run() {
             rules_project_preview,
             rules_import_candidates,
             rules_import_file,
+            agent_guard_view,
+            agent_guard_set_cursor_mode,
+            agent_guard_preview,
             agent_permissions_view,
             agent_permissions_set_enabled,
             agent_permissions_set_rules,
@@ -5776,6 +5807,7 @@ pub fn run() {
                 // turned on.
                 hooks::apply_on_startup();
                 agent_permissions::apply_on_startup();
+                agent_guard::apply_on_startup();
 
                 // Stop obsolete gateway processes. Path-based identity on all OS
                 // (SOU-414); not gated on repoint (SOU-306).

--- a/src-tauri/src/hooks.rs
+++ b/src-tauri/src/hooks.rs
@@ -349,6 +349,13 @@ fn epoch_millis() -> u64 {
 /// after writing and kills a hook that overruns its own timeout, so waiting on EOF is
 /// bounded by the caller rather than by us.
 pub fn read_payload(reader: impl std::io::Read) -> (String, bool) {
+    read_payload_capped(reader, MAX_HOOK_STDIN_BYTES)
+}
+
+/// [`read_payload`] with an explicit cap. The guard (SBS-1059) reads far more than the
+/// sensor: a `beforeReadFile` payload embeds the file's content, and a guard that cannot
+/// see a call must fail closed, so a small cap would turn every large read into a denial.
+pub fn read_payload_capped(reader: impl std::io::Read, cap: u64) -> (String, bool) {
     use std::io::Read as _;
 
     // BYTES, not a String, and this is load-bearing for the exit-0 guarantee:
@@ -368,10 +375,10 @@ pub fn read_payload(reader: impl std::io::Read) -> (String, bool) {
     let mut bytes: Vec<u8> = Vec::new();
     // cap + 1 so filling the cap is distinguishable from a payload that ends exactly
     // on it.
-    let _ = reader.take(MAX_HOOK_STDIN_BYTES + 1).read_to_end(&mut bytes);
-    let truncated = bytes.len() as u64 > MAX_HOOK_STDIN_BYTES;
+    let _ = reader.take(cap + 1).read_to_end(&mut bytes);
+    let truncated = bytes.len() as u64 > cap;
     if truncated {
-        bytes.truncate(MAX_HOOK_STDIN_BYTES as usize);
+        bytes.truncate(cap as usize);
     }
     (String::from_utf8_lossy(&bytes).into_owned(), truncated)
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -16,6 +16,7 @@ pub mod gateway_publish;
 pub mod gatewaylog;
 pub mod hooks;
 pub mod agent_permissions;
+pub mod agent_guard;
 pub mod hostenv;
 pub mod inspect;
 pub mod instructions;

--- a/src-tauri/src/registry.rs
+++ b/src-tauri/src/registry.rs
@@ -620,6 +620,26 @@ impl PermissionAction {
     }
 }
 
+/// How a guard hook acts on the permission rules (SBS-1059).
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum GuardMode {
+    /// Hook not installed.
+    #[default]
+    Off,
+    /// Hook installed; every call is evaluated and the decision recorded, but the answer is
+    /// always "allow". For seeing what a policy WOULD do before letting it act.
+    Observe,
+    /// Hook installed; deny and ask rules take effect.
+    Enforce,
+}
+
+impl GuardMode {
+    pub fn is_off(&self) -> bool {
+        *self == GuardMode::Off
+    }
+}
+
 /// One native permission rule: a pattern in Claude Code's rule syntax (`Bash(rm -rf *)`,
 /// `Read(./.env)`, `WebFetch(domain:example.com)`, `mcp__server__tool`) and what to do.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
@@ -987,6 +1007,13 @@ pub struct Registry {
     /// written only by an explicit Apply for that project, never at startup.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub rules_projects: Vec<RulesProject>,
+    /// Cursor guard hook (SBS-1059): how the `--toolport-guard cursor` hook Toolport installs
+    /// into `~/.cursor/hooks.json` treats the same permission rules. `Off` = not installed.
+    #[serde(default, skip_serializing_if = "GuardMode::is_off")]
+    pub guard_cursor_mode: GuardMode,
+    /// Absolute paths of the hooks files the guard has been written into, for exact cleanup.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub guard_targets: Vec<String>,
     /// Native permission policy for Claude Code (SBS-1058): rules in Claude Code's own
     /// `permissions` syntax that Toolport writes into every profile's `settings.json`. Off
     /// until the user opts in; nothing is written until then. See [`crate::agent_permissions`].
@@ -1270,6 +1297,8 @@ impl Default for Registry {
             rules_clients: HashMap::new(),
             rules_targets: Vec::new(),
             rules_projects: Vec::new(),
+            guard_cursor_mode: GuardMode::Off,
+            guard_targets: Vec::new(),
             agent_permissions_enabled: false,
             agent_permission_rules: Vec::new(),
             agent_permission_targets: HashMap::new(),

--- a/src/components/AgentPermissionsView.test.tsx
+++ b/src/components/AgentPermissionsView.test.tsx
@@ -8,6 +8,9 @@ const api = vi.hoisted(() => ({
   agentPermissionsSetEnabled: vi.fn(),
   agentPermissionsSetRules: vi.fn(),
   agentPermissionsPreview: vi.fn(),
+  agentGuardView: vi.fn(),
+  agentGuardSetCursorMode: vi.fn(),
+  agentGuardPreview: vi.fn(),
 }));
 vi.mock("@/lib/api", () => api);
 
@@ -32,9 +35,55 @@ function view(over: Partial<PermissionsViewData> = {}): PermissionsViewData {
 }
 
 describe("AgentPermissionsView", () => {
+  const guard = (over: Partial<import("@/lib/types").GuardView> = {}) => ({
+    cursorMode: "off" as const,
+    cursor: { path: "/home/a/.cursor/hooks.json", installed: false },
+    events: ["beforeShellExecution", "beforeMCPExecution", "beforeReadFile"],
+    binary: "/opt/toolport/toolport-gateway",
+    ...over,
+  });
+
   beforeEach(() => {
     vi.clearAllMocks();
     api.agentPermissionsView.mockResolvedValue(view());
+    api.agentGuardView.mockResolvedValue(guard());
+  });
+
+  it("the Cursor guard starts off, and choosing Observe then Enforce calls through", async () => {
+    api.agentGuardSetCursorMode
+      .mockResolvedValueOnce(
+        guard({
+          cursorMode: "observe",
+          cursor: { path: "/home/a/.cursor/hooks.json", installed: true },
+        }),
+      )
+      .mockResolvedValueOnce(
+        guard({
+          cursorMode: "enforce",
+          cursor: { path: "/home/a/.cursor/hooks.json", installed: true },
+        }),
+      );
+    render(<AgentPermissionsView />);
+    expect(await screen.findByLabelText("Cursor guard Off")).toBeChecked();
+    expect(screen.getByText(/no guard installed/)).toBeInTheDocument();
+    await userEvent.click(screen.getByLabelText("Cursor guard Observe"));
+    await waitFor(() =>
+      expect(api.agentGuardSetCursorMode).toHaveBeenCalledWith("observe"),
+    );
+    expect(await screen.findByText(/guard installed/)).toBeInTheDocument();
+    await userEvent.click(screen.getByLabelText("Cursor guard Enforce"));
+    await waitFor(() =>
+      expect(api.agentGuardSetCursorMode).toHaveBeenLastCalledWith("enforce"),
+    );
+    expect(screen.getByLabelText("Cursor guard Enforce")).toBeChecked();
+  });
+
+  it("without a published gateway binary the guard cannot be switched on", async () => {
+    api.agentGuardView.mockResolvedValue(guard({ binary: undefined }));
+    render(<AgentPermissionsView />);
+    expect(await screen.findByLabelText("Cursor guard Observe")).toBeDisabled();
+    expect(screen.getByLabelText("Cursor guard Off")).toBeEnabled();
+    expect(screen.getByText(/No gateway binary has been published/)).toBeInTheDocument();
   });
 
   it("starts off and empty, and adding a rule sends the whole list without writing", async () => {

--- a/src/components/AgentPermissionsView.test.tsx
+++ b/src/components/AgentPermissionsView.test.tsx
@@ -78,6 +78,21 @@ describe("AgentPermissionsView", () => {
     expect(screen.getByLabelText("Cursor guard Enforce")).toBeChecked();
   });
 
+  it("the Cursor preview names hooks.json's key, not Claude Code's", async () => {
+    api.agentGuardPreview.mockResolvedValue({
+      path: "/home/a/.cursor/hooks.json",
+      before: "{}\n",
+      after: '{\n  "version": 1,\n  "hooks": { "beforeShellExecution": [] }\n}\n',
+    });
+    render(<AgentPermissionsView />);
+    await screen.findByLabelText("Cursor guard Off");
+    await userEvent.click(screen.getByRole("button", { name: "Preview hooks.json" }));
+    await waitFor(() => expect(api.agentGuardPreview).toHaveBeenCalledWith("observe"));
+    expect(await screen.findByText("What would be written")).toBeInTheDocument();
+    expect(screen.getByText(/Only the/).textContent).toContain("hooks");
+    expect(screen.getByText(/Only the/).textContent).not.toContain("permissions");
+  });
+
   it("without a published gateway binary the guard cannot be switched on", async () => {
     api.agentGuardView.mockResolvedValue(guard({ binary: undefined }));
     render(<AgentPermissionsView />);

--- a/src/components/AgentPermissionsView.test.tsx
+++ b/src/components/AgentPermissionsView.test.tsx
@@ -101,6 +101,16 @@ describe("AgentPermissionsView", () => {
     expect(screen.getByText(/No gateway binary has been published/)).toBeInTheDocument();
   });
 
+  it("shows a Cursor guard load error and retries it", async () => {
+    api.agentGuardView
+      .mockRejectedValueOnce(new Error("registry unavailable"))
+      .mockResolvedValueOnce(guard());
+    render(<AgentPermissionsView />);
+    expect(await screen.findByText(/registry unavailable/)).toBeInTheDocument();
+    await userEvent.click(screen.getByRole("button", { name: "Retry" }));
+    expect(await screen.findByLabelText("Cursor guard Off")).toBeChecked();
+  });
+
   it("starts off and empty, and adding a rule sends the whole list without writing", async () => {
     api.agentPermissionsSetRules.mockResolvedValue(
       view({ rules: [{ pattern: "Bash(rm -rf *)", action: "deny" }] }),

--- a/src/components/AgentPermissionsView.tsx
+++ b/src/components/AgentPermissionsView.tsx
@@ -11,12 +11,17 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import {
+  agentGuardPreview,
+  agentGuardSetCursorMode,
+  agentGuardView,
   agentPermissionsPreview,
   agentPermissionsSetEnabled,
   agentPermissionsSetRules,
   agentPermissionsView,
 } from "@/lib/api";
 import type {
+  GuardMode,
+  GuardView,
   PermissionAction,
   PermissionRule,
   PermissionsPreview,
@@ -55,9 +60,19 @@ export function AgentPermissionsView() {
   const [preview, setPreview] = useState<PermissionsPreview[] | null>(null);
   const [pattern, setPattern] = useState("");
   const [action, setAction] = useState<PermissionAction>("deny");
+  // The Cursor guard hook (SBS-1059): same rules, enforced by a hook because Cursor has no
+  // settings-level rule list. Loaded beside the policy; absent until it arrives.
+  const [guard, setGuard] = useState<GuardView | null>(null);
 
   useEffect(() => {
     let cancelled = false;
+    agentGuardView()
+      .then((g) => {
+        if (!cancelled) setGuard(g);
+      })
+      .catch(() => {
+        // The guard card says "could not load" on its own; the policy still renders.
+      });
     agentPermissionsView()
       .then((v) => {
         if (!cancelled) setData(v);
@@ -117,6 +132,36 @@ export function AgentPermissionsView() {
     const isThere =
       next?.rules.some((r) => r.pattern === p && r.action === action) ?? false;
     if (isThere && !wasThere) setPattern("");
+  }
+
+  async function setCursorMode(mode: GuardMode) {
+    setBusy(true);
+    setError(null);
+    try {
+      setGuard(await agentGuardSetCursorMode(mode));
+    } catch (e) {
+      setError(String(e));
+      try {
+        setGuard(await agentGuardView());
+      } catch {
+        // the first error is the one worth showing
+      }
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function openGuardPreview(mode: GuardMode) {
+    setBusy(true);
+    setError(null);
+    try {
+      const p = await agentGuardPreview(mode);
+      setPreview(p ? [p] : []);
+    } catch (e) {
+      setError(String(e));
+    } finally {
+      setBusy(false);
+    }
   }
 
   async function openPreview() {
@@ -354,6 +399,99 @@ export function AgentPermissionsView() {
       </div>
 
       <div className="rounded-xl border bg-card p-5">
+        <h2 className="mb-1 text-sm font-medium">Cursor</h2>
+        <p className="mb-3 text-xs text-muted-foreground">
+          Cursor has no settings-level rule list, so Toolport installs a small guard hook
+          into <span className="font-mono">~/.cursor/hooks.json</span> that evaluates the
+          same rules before a shell command runs, an MCP tool is called, or a file is
+          read. <span className="font-mono">Bash(&hellip;)</span> rules guard shell
+          commands, <span className="font-mono">Read(&hellip;)</span> rules guard file
+          reads, <span className="font-mono">mcp__server__tool</span> rules guard MCP
+          tools (Cursor names the tool, not the server, so the server part is not
+          checked); <span className="font-mono">Edit</span> and{" "}
+          <span className="font-mono">WebFetch</span> rules have no Cursor event and do
+          nothing there. &ldquo;Ask first&rdquo; uses Cursor&rsquo;s own confirmation.
+          Every decision is recorded in Agent activity.
+        </p>
+        {guard === null ? (
+          <p className="text-sm text-muted-foreground">Loading&hellip;</p>
+        ) : (
+          <>
+            <div
+              role="radiogroup"
+              aria-label="Cursor guard mode"
+              className="mb-2 flex flex-wrap gap-3 text-sm"
+            >
+              {(
+                [
+                  ["off", "Off", "No hook installed."],
+                  [
+                    "observe",
+                    "Observe",
+                    "Hook installed; every call is recorded with what the rules would decide, but nothing is blocked or asked.",
+                  ],
+                  ["enforce", "Enforce", "Never and Ask first take effect in Cursor."],
+                ] as [GuardMode, string, string][]
+              ).map(([value, label, help]) => (
+                <label key={value} className="flex items-start gap-2" title={help}>
+                  <input
+                    type="radio"
+                    name="cursor-guard-mode"
+                    value={value}
+                    checked={guard.cursorMode === value}
+                    disabled={
+                      busy || preview !== null || (value !== "off" && !guard.binary)
+                    }
+                    aria-label={`Cursor guard ${label}`}
+                    onChange={() => void setCursorMode(value)}
+                    className="mt-1"
+                  />
+                  <span>
+                    <span className="font-medium">{label}</span>
+                    <span className="block text-xs text-muted-foreground">{help}</span>
+                  </span>
+                </label>
+              ))}
+            </div>
+            {guard.cursor ? (
+              <p className="mb-2 text-xs text-muted-foreground">
+                <span className="font-mono">{guard.cursor.path}</span>{" "}
+                {guard.cursor.error ? (
+                  <span className="text-destructive">&mdash; {guard.cursor.error}</span>
+                ) : guard.cursor.installed ? (
+                  <span className="text-success">&mdash; guard installed</span>
+                ) : (
+                  <span>&mdash; no guard installed</span>
+                )}
+              </p>
+            ) : (
+              <p className="mb-2 text-xs text-muted-foreground">
+                Cursor&rsquo;s config folder could not be resolved.
+              </p>
+            )}
+            {!guard.binary && (
+              <p className="mb-2 text-xs text-warning">
+                No gateway binary has been published yet, so the hook cannot be installed.
+              </p>
+            )}
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={busy || !guard.binary}
+              onClick={() =>
+                void openGuardPreview(
+                  guard.cursorMode === "off" ? "observe" : guard.cursorMode,
+                )
+              }
+            >
+              <Eye className="size-3.5" />
+              Preview hooks.json
+            </Button>
+          </>
+        )}
+      </div>
+
+      <div className="rounded-xl border bg-card p-5">
         <h2 className="mb-1 text-sm font-medium">Which agents this reaches</h2>
         <ul className="grid gap-1 text-xs text-muted-foreground">
           <li>
@@ -362,11 +500,16 @@ export function AgentPermissionsView() {
             native tool call.
           </li>
           <li>
-            <span className="text-foreground">Cursor, Codex, Gemini CLI</span> &mdash; not
-            yet. Cursor has hooks but no settings-level rule list; Codex uses approval and
-            sandbox settings of a different shape; Gemini CLI is mixed. Toolport says so
-            rather than pretending. The gateway&rsquo;s own approval and destructive-call
-            gates still cover every MCP call from every client.
+            <span className="text-foreground">Cursor</span> &mdash; enforced by the guard
+            hook above for shell commands, file reads and MCP tools, once you set it to
+            Enforce.
+          </li>
+          <li>
+            <span className="text-foreground">Codex, Gemini CLI</span> &mdash; not yet.
+            Codex uses approval and sandbox settings of a different shape; Gemini CLI is
+            mixed. Toolport says so rather than pretending. The gateway&rsquo;s own
+            approval and destructive-call gates still cover every MCP call from every
+            client.
           </li>
         </ul>
       </div>

--- a/src/components/AgentPermissionsView.tsx
+++ b/src/components/AgentPermissionsView.tsx
@@ -58,6 +58,9 @@ export function AgentPermissionsView() {
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [preview, setPreview] = useState<PermissionsPreview[] | null>(null);
+  // Cursor's hooks.json dry run, kept apart from the Claude Code one so the dialog can say
+  // which file and which key it is about.
+  const [guardPreview, setGuardPreview] = useState<PermissionsPreview[] | null>(null);
   const [pattern, setPattern] = useState("");
   const [action, setAction] = useState<PermissionAction>("deny");
   // The Cursor guard hook (SBS-1059): same rules, enforced by a hook because Cursor has no
@@ -156,7 +159,7 @@ export function AgentPermissionsView() {
     setError(null);
     try {
       const p = await agentGuardPreview(mode);
-      setPreview(p ? [p] : []);
+      setGuardPreview(p ? [p] : []);
     } catch (e) {
       setError(String(e));
     } finally {
@@ -440,7 +443,10 @@ export function AgentPermissionsView() {
                     value={value}
                     checked={guard.cursorMode === value}
                     disabled={
-                      busy || preview !== null || (value !== "off" && !guard.binary)
+                      busy ||
+                      preview !== null ||
+                      guardPreview !== null ||
+                      (value !== "off" && !guard.binary)
                     }
                     aria-label={`Cursor guard ${label}`}
                     onChange={() => void setCursorMode(value)}
@@ -515,6 +521,12 @@ export function AgentPermissionsView() {
       </div>
 
       <PreviewDialog previews={preview} onClose={() => setPreview(null)} />
+      <PreviewDialog
+        previews={guardPreview}
+        onClose={() => setGuardPreview(null)}
+        keyName="hooks"
+        emptyText="Cursor's config folder could not be resolved, so there is nothing to write."
+      />
     </div>
   );
 }
@@ -522,9 +534,14 @@ export function AgentPermissionsView() {
 function PreviewDialog({
   previews,
   onClose,
+  keyName = "permissions",
+  emptyText = "No Claude Code profile was found, so there is nothing to write.",
 }: {
   previews: PermissionsPreview[] | null;
   onClose: () => void;
+  /** The one top-level key the write touches, named in the footer. */
+  keyName?: string;
+  emptyText?: string;
 }) {
   return (
     <Dialog open={previews !== null} onOpenChange={(open) => !open && onClose()}>
@@ -534,9 +551,7 @@ function PreviewDialog({
         </DialogHeader>
         <div className="grid gap-4 overflow-auto">
           {previews?.length === 0 && (
-            <p className="text-sm text-muted-foreground">
-              No Claude Code profile was found, so there is nothing to write.
-            </p>
+            <p className="text-sm text-muted-foreground">{emptyText}</p>
           )}
           {previews?.map((p) => (
             <div key={p.path} className="grid gap-1">
@@ -561,9 +576,9 @@ function PreviewDialog({
           ))}
         </div>
         <DialogFooter className="text-xs text-muted-foreground sm:justify-start">
-          Nothing has been written. Only the{" "}
-          <span className="font-mono">permissions</span> key changes; everything else in
-          the file, including your comments, is left exactly as it is.
+          Nothing has been written. Only the <span className="font-mono">{keyName}</span>{" "}
+          key changes; everything else in the file, including your comments, is left
+          exactly as it is.
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/src/components/AgentPermissionsView.tsx
+++ b/src/components/AgentPermissionsView.tsx
@@ -66,6 +66,14 @@ export function AgentPermissionsView() {
   // The Cursor guard hook (SBS-1059): same rules, enforced by a hook because Cursor has no
   // settings-level rule list. Loaded beside the policy; absent until it arrives.
   const [guard, setGuard] = useState<GuardView | null>(null);
+  const [guardError, setGuardError] = useState<string | null>(null);
+
+  function loadGuard() {
+    setGuardError(null);
+    agentGuardView()
+      .then(setGuard)
+      .catch((e) => setGuardError(String(e)));
+  }
 
   useEffect(() => {
     let cancelled = false;
@@ -73,8 +81,8 @@ export function AgentPermissionsView() {
       .then((g) => {
         if (!cancelled) setGuard(g);
       })
-      .catch(() => {
-        // The guard card says "could not load" on its own; the policy still renders.
+      .catch((e) => {
+        if (!cancelled) setGuardError(String(e));
       });
     agentPermissionsView()
       .then((v) => {
@@ -228,7 +236,12 @@ export function AgentPermissionsView() {
           </span>
         </label>
         <div className="mt-3 flex flex-wrap items-center gap-2 border-t pt-3">
-          <Button variant="outline" size="sm" disabled={busy} onClick={openPreview}>
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={busy || guardPreview !== null}
+            onClick={openPreview}
+          >
             <Eye className="size-3.5" />
             Preview what would be written
           </Button>
@@ -416,7 +429,14 @@ export function AgentPermissionsView() {
           nothing there. &ldquo;Ask first&rdquo; uses Cursor&rsquo;s own confirmation.
           Every decision is recorded in Agent activity.
         </p>
-        {guard === null ? (
+        {guardError ? (
+          <div className="flex items-center gap-2 text-sm text-destructive">
+            <span>Could not load the Cursor guard: {guardError}</span>
+            <Button variant="outline" size="sm" onClick={loadGuard}>
+              Retry
+            </Button>
+          </div>
+        ) : guard === null ? (
           <p className="text-sm text-muted-foreground">Loading&hellip;</p>
         ) : (
           <>
@@ -483,7 +503,7 @@ export function AgentPermissionsView() {
             <Button
               variant="outline"
               size="sm"
-              disabled={busy || !guard.binary}
+              disabled={busy || !guard.binary || preview !== null}
               onClick={() =>
                 void openGuardPreview(
                   guard.cursorMode === "off" ? "observe" : guard.cursorMode,

--- a/src/components/HooksView.tsx
+++ b/src/components/HooksView.tsx
@@ -443,6 +443,25 @@ export function HooksView({ refreshKey = 0 }: { refreshKey?: number }) {
               >
                 <span className="min-w-0 flex-1 truncate font-mono text-foreground">
                   {r.tool ?? r.event ?? "unknown"}
+                  {r.event === "guard" && r.decision && (
+                    // A guard row (Cursor hook): what the hook answered, and in observe mode
+                    // what it would have answered, so the user can read the policy's effect
+                    // before letting it act.
+                    <span
+                      className={`ml-2 rounded px-1 text-[10px] ${
+                        r.decision === "deny"
+                          ? "bg-destructive/15 text-destructive"
+                          : r.decision === "ask"
+                            ? "bg-warning/15 text-warning"
+                            : "bg-muted text-muted-foreground"
+                      }`}
+                      title={r.rule ? `rule ${r.rule}` : undefined}
+                    >
+                      {r.mode === "observe" && r.wouldBe && r.wouldBe !== "allow"
+                        ? `would ${r.wouldBe}`
+                        : r.decision}
+                    </span>
+                  )}
                 </span>
                 <span
                   className="min-w-0 flex-1 truncate text-muted-foreground"

--- a/src/components/HooksView.tsx
+++ b/src/components/HooksView.tsx
@@ -449,9 +449,14 @@ export function HooksView({ refreshKey = 0 }: { refreshKey?: number }) {
                     // before letting it act.
                     <span
                       className={`ml-2 rounded px-1 text-[10px] ${
-                        r.decision === "deny"
+                        // In observe mode the answer is always allow; colour by what the
+                        // rules WOULD have done, which is the thing worth seeing.
+                        (r.mode === "observe" ? (r.wouldBe ?? "allow") : r.decision) ===
+                        "deny"
                           ? "bg-destructive/15 text-destructive"
-                          : r.decision === "ask"
+                          : (r.mode === "observe"
+                                ? (r.wouldBe ?? "allow")
+                                : r.decision) === "ask"
                             ? "bg-warning/15 text-warning"
                             : "bg-muted text-muted-foreground"
                       }`}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -36,6 +36,9 @@ import type {
   PermissionRule,
   PermissionsPreview,
   PermissionsView,
+  GuardMode,
+  GuardPreview,
+  GuardView,
 } from "./types";
 
 /** The hand-verified popular catalog (offline, instant). */
@@ -1038,6 +1041,18 @@ export function agentPermissionsPreview(
   return invoke<PermissionsPreview[]>("agent_permissions_preview", {
     rules: rules ?? null,
   });
+}
+
+// ---- Guard hook for Cursor (SBS-1059) ----
+
+export function agentGuardView(): Promise<GuardView> {
+  return invoke<GuardView>("agent_guard_view");
+}
+export function agentGuardSetCursorMode(mode: GuardMode): Promise<GuardView> {
+  return invoke<GuardView>("agent_guard_set_cursor_mode", { mode });
+}
+export function agentGuardPreview(mode: GuardMode): Promise<GuardPreview | null> {
+  return invoke<GuardPreview | null>("agent_guard_preview", { mode });
 }
 
 export function hooksView(): Promise<HooksViewData> {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -809,4 +809,35 @@ export interface HookEvent {
   /** Absent means UNKNOWN, never success. */
   ok?: boolean;
   malformed?: boolean;
+  /** Guard rows (SBS-1059): the Cursor event, what the hook answered, and the rule that decided. */
+  hookEvent?: string;
+  decision?: string;
+  rule?: string | null;
+  mode?: string;
+  /** In observe mode: what the answer WOULD have been. */
+  wouldBe?: string | null;
+}
+
+// ---- Guard hook for Cursor (SBS-1059) ----
+
+export type GuardMode = "off" | "observe" | "enforce";
+
+export interface GuardProfile {
+  path: string;
+  installed: boolean;
+  error?: string;
+}
+
+export interface GuardView {
+  cursorMode: GuardMode;
+  cursor?: GuardProfile;
+  events: string[];
+  binary?: string;
+}
+
+export interface GuardPreview {
+  path: string;
+  before: string;
+  after: string;
+  error?: string;
 }


### PR DESCRIPTION
## Summary

Closes **SBS-1059** — phase 2 of the permissions enforcer, Cursor first.

- Cursor has hooks (`beforeShellExecution`, `beforeMCPExecution`, `beforeReadFile`) but no settings-level rule list, so the policy from #842 is enforced there by the gateway binary invoked as **`--toolport-guard cursor`** from `~/.cursor/hooks.json`: Cursor hands the call over on stdin and acts on the JSON answer (`allow` / `deny` / `ask`).
- **Same rules, said plainly:** `Bash(...)` → shell commands, `Read(...)` → file reads, `mcp__server__tool` → MCP tools (Cursor names the tool, not the server, so the server part is ignored); `Edit`/`WebFetch`/`Agent`/param rules have no Cursor event and do nothing there. Matching follows Claude Code's documented semantics: `*` spans anything, a trailing ` *` needs a word boundary, `:*` = ` *`, compound commands judged per part (deny/ask on any, allow only on all), `timeout N`/`time`/`nice`/`nohup` stripped, Read paths `~/` / `//` / workspace-relative with `*` and `**`.
- **Three modes:** Off (default, nothing installed), **Observe** (installed; every call evaluated and recorded in the sensor log with what the rules *would* decide; always allow), **Enforce** (deny/ask act; ask = Cursor's own prompt; `failClosed` set). No match → Cursor's canonical proceed response; a payload the guard can't judge → same, recorded (breaking the user's work over our own parse error is worse than standing aside; `failClosed` covers a crash).
- Ownership by `--toolport-guard` marker in `hooks.json`, as the sensor does in `settings.json`; user's hooks and formatting untouched; Preview. Agent activity shows the decision (or "would deny") on guard rows.
- Verified the real binary end to end against a temp registry: deny/ask/allow JSON per rule, observe records without blocking, malformed → allow + log.

## Test plan

- [x] `cargo test --lib -- agent_guard agent_permissions hooks::` — 57 passed (7 new: Bash matching incl. word boundary / `:*` / compound / wrappers / quoted operators / precedence; Read path resolution `./` `~/` `//` `**` dir-rule; MCP tool globs; response shape; payload→subject mapping; hooks.json upsert/strip/idempotence/failClosed flip; end-to-end install/flip/reconcile/remove over a scratch file)
- [x] `cargo test --bin toolport-gateway -- parse_args` — 7 passed; `cargo clippy --lib --bins` clean on new code
- [x] `vitest` AgentPermissionsView (9) + HooksView (22) — 31 passed
- [x] `tsc`, `eslint` clean
- [ ] Manual: set Observe, run a `rm -rf` in Cursor's agent, see the "would deny" row in Agent activity; set Enforce, see Cursor block it with the Toolport message

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> This is a new enforcement path for shell, file-read, and MCP calls in Cursor, including fail-closed denials and writes to ~/.cursor/hooks.json. Matching bugs or hook install mistakes can block legitimate work or let a call through.
> 
> **Overview**
> The same Agent permissions policy now reaches **Cursor**. Toolport installs a marked hook in `~/.cursor/hooks.json` that runs `toolport-gateway --toolport-guard cursor` before shell, MCP, and file-read events and returns allow / deny / ask.
> 
> **Off** (default) installs nothing. **Observe** records what the rules would decide and always allows. **Enforce** applies Never and Ask first (Cursor’s own prompt), with `failClosed` on the hook. Unreadable or oversized payloads are denied only in Enforce so they cannot slip past a rule.
> 
> Matching follows Claude Code’s documented Bash / Read / MCP semantics (compound commands, wrappers, path globs). `Edit` / `WebFetch` have no Cursor event. Only `--toolport-guard` entries are added or removed; Preview shows the bytes first. Decisions show up in Agent activity.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d40a60e0dece940255903178e9f375876b43e3c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Cursor guard hook to enforce permission rules via `--toolport-guard`
> - Introduces the `agent_guard` module, which evaluates `PermissionRule`s against Cursor tool calls (Bash, Read, MCP tools) and returns allow/deny/ask decisions as JSON
> - Adds `--toolport-guard AGENT` to `toolport-gateway.rs` so the binary can act as a blocking guard process; reads capped stdin and prints a decision with exit code 0
> - Adds `GuardMode` (Off/Observe/Enforce) to the registry with `guard_cursor_mode` and `guard_targets` fields; startup reconciles `~/.cursor/hooks.json` entries via `apply_on_startup`\n- Updates `AgentPermissionsView` and `HooksView` with UI for viewing, previewing, and changing Cursor guard mode, plus Activity row rendering for guard decisions
> - Generalizes `write_settings_key` into `write_settings_key_for` and `read_payload` into `read_payload_capped` to support per-client backups and larger guard stdin payloads
> - Behavioral Change: Enforce mode is fail-closed — if the guard cannot read or judge the payload, it returns a deny/ask response via `cannot_judge`/`registry_unavailable`; verify `agent_guard::handle_stdin` and `decision_response` paths in `src-tauri/src/agent_guard.rs`
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2d40a60.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->