### PR TITLE
fix(linux): recover the session bus for stripped gateways

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,6 +124,15 @@ Entries before the rename below shipped under the project's former name, Conduit
 
 ### Fixed
 
+- **Linux gateways launched without the desktop session environment can reach the
+  Secret Service again.** Orca and some AI clients start MCP children with only
+  `HOME` and `USER`; on Omarchy that left the gateway without a D-Bus address, so
+  vaulted servers such as Linear appeared in the cached catalog but every call failed
+  with `no route for tool`. When the address is absent, the gateway now recovers the
+  current user's standard systemd session bus after verifying the runtime directory
+  and Unix socket are owned by that user. Explicit environment values are left alone.
+  (SBS-1060)
+
 - **Team Instructions: losing a write race no longer deletes the winner's block.** When
   the team changed or was cleared while an apply was writing its files, the apply that
   lost the compare-and-set removed every file it had just written. If the apply that won

--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -15164,6 +15164,12 @@ fn main() {
         }
         ArgAction::Run => {}
     }
+    if let Some(bus) = conduit_lib::hostenv::restore_session_bus_env() {
+        eprintln!(
+            "toolport-gateway: recovered the Linux session bus at {}",
+            bus.display()
+        );
+    }
     // Persist org rate-limit counters across restarts (SOU-340). Safe if dir missing;
     // counters then stay process-local until the first successful bind.
     if let Some(dir) = registry::conduit_dir() {

--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -15169,6 +15169,10 @@ fn main() {
             "toolport-gateway: recovered the Linux session bus at {}",
             bus.display()
         );
+        glog(&format!(
+            "recovered the Linux session bus at {}",
+            bus.display()
+        ));
     }
     // Persist org rate-limit counters across restarts (SOU-340). Safe if dir missing;
     // counters then stay process-local until the first successful bind.

--- a/src-tauri/src/hostenv.rs
+++ b/src-tauri/src/hostenv.rs
@@ -47,6 +47,84 @@
 
 use std::process::Command;
 
+#[cfg(target_os = "linux")]
+use std::ffi::OsStr;
+#[cfg(target_os = "linux")]
+use std::os::unix::fs::{FileTypeExt, MetadataExt};
+#[cfg(target_os = "linux")]
+use std::path::{Path, PathBuf};
+
+/// Restore the standard per-user D-Bus address when a terminal or agent launcher
+/// stripped the desktop session environment.
+///
+/// systemd-logind creates `/run/user/<uid>` and its `bus` socket on Omarchy and
+/// other systemd Linux desktops. Some AI clients launch MCP children with only
+/// `HOME` and `USER`; Secret Service then attempts X11 autolaunch, which is disabled
+/// on Wayland, and every vaulted server disappears from the live router. Recover only
+/// the current user's owned runtime directory and owned Unix socket. An explicit
+/// `DBUS_SESSION_BUS_ADDRESS` is authoritative and is never replaced.
+#[cfg(target_os = "linux")]
+pub fn restore_session_bus_env() -> Option<PathBuf> {
+    let dbus = std::env::var_os("DBUS_SESSION_BUS_ADDRESS");
+    let runtime = std::env::var_os("XDG_RUNTIME_DIR");
+    let uid = effective_uid();
+    let (runtime_dir, bus) = session_bus_candidate(
+        dbus.as_deref(),
+        runtime.as_deref(),
+        uid,
+        Path::new("/run/user"),
+    )?;
+
+    if runtime.as_ref().map_or(true, |v| v.is_empty()) {
+        std::env::set_var("XDG_RUNTIME_DIR", &runtime_dir);
+    }
+    std::env::set_var(
+        "DBUS_SESSION_BUS_ADDRESS",
+        format!("unix:path={}", bus.to_str()?),
+    );
+    Some(bus)
+}
+
+#[cfg(not(target_os = "linux"))]
+pub fn restore_session_bus_env() -> Option<std::path::PathBuf> {
+    None
+}
+
+#[cfg(target_os = "linux")]
+fn effective_uid() -> u32 {
+    extern "C" {
+        fn geteuid() -> u32;
+    }
+    // SAFETY: geteuid takes no arguments and has no failure mode.
+    unsafe { geteuid() }
+}
+
+#[cfg(target_os = "linux")]
+fn session_bus_candidate(
+    dbus: Option<&OsStr>,
+    runtime: Option<&OsStr>,
+    uid: u32,
+    runtime_root: &Path,
+) -> Option<(PathBuf, PathBuf)> {
+    if dbus.is_some_and(|value| !value.is_empty()) {
+        return None;
+    }
+    let runtime_dir = runtime
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+        .unwrap_or_else(|| runtime_root.join(uid.to_string()));
+    let runtime_meta = std::fs::symlink_metadata(&runtime_dir).ok()?;
+    if !runtime_meta.file_type().is_dir() || runtime_meta.uid() != uid {
+        return None;
+    }
+    let bus = runtime_dir.join("bus");
+    let bus_meta = std::fs::symlink_metadata(&bus).ok()?;
+    if !bus_meta.file_type().is_socket() || bus_meta.uid() != uid {
+        return None;
+    }
+    Some((runtime_dir, bus))
+}
+
 /// Every variable `AppRun.wrapped` and `apprun-hooks/linuxdeploy-plugin-gtk.sh`
 /// export, minus the two handled specially below (`XDG_DATA_DIRS`, which is
 /// prepended to rather than replaced, and `PATH`, see the module docs).
@@ -190,5 +268,66 @@ mod tests {
             std::env::set_var("APPDIR", v);
         }
         assert!(empty, "nothing should be changed outside an AppImage");
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn recovers_an_owned_systemd_session_bus_from_a_stripped_environment() {
+        use std::os::unix::net::UnixListener;
+
+        let dir =
+            std::env::temp_dir().join(format!("toolport-hostenv-recover-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir(&dir).unwrap();
+        let runtime = dir.join(effective_uid().to_string());
+        std::fs::create_dir(&runtime).unwrap();
+        let bus = runtime.join("bus");
+        let _listener = UnixListener::bind(&bus).unwrap();
+
+        assert_eq!(
+            session_bus_candidate(None, None, effective_uid(), &dir),
+            Some((runtime, bus))
+        );
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn never_replaces_an_explicit_bus_or_trusts_an_unsafe_candidate() {
+        use std::os::unix::net::UnixListener;
+
+        let dir =
+            std::env::temp_dir().join(format!("toolport-hostenv-unsafe-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir(&dir).unwrap();
+        let runtime = dir.join(effective_uid().to_string());
+        std::fs::create_dir(&runtime).unwrap();
+        let bus = runtime.join("bus");
+        let listener = UnixListener::bind(&bus).unwrap();
+
+        assert_eq!(
+            session_bus_candidate(
+                Some(OsStr::new("unix:path=/explicit/bus")),
+                Some(runtime.as_os_str()),
+                effective_uid(),
+                &dir,
+            ),
+            None
+        );
+        assert_eq!(
+            session_bus_candidate(None, Some(runtime.as_os_str()), effective_uid() + 1, &dir),
+            None,
+            "a runtime directory owned by another uid is not trusted"
+        );
+
+        drop(listener);
+        std::fs::remove_file(&bus).unwrap();
+        std::fs::write(&bus, "not a socket").unwrap();
+        assert_eq!(
+            session_bus_candidate(None, Some(runtime.as_os_str()), effective_uid(), &dir),
+            None,
+            "a regular file named bus is not trusted"
+        );
+        std::fs::remove_dir_all(&dir).unwrap();
     }
 }


### PR DESCRIPTION
## What and why

Some AI clients launch MCP children without the desktop session environment. On systemd Linux desktops, that prevents Toolport from reaching Secret Service, leaving cached tools visible but unroutable.

Recover the current user's standard session bus only when the address is absent and after validating ownership and socket type. Explicit environment values remain authoritative.

Closes SBS-1060.

## Testing

- [x] `cargo clippy --manifest-path src-tauri/Cargo.toml --no-default-features --lib --bins`
- [x] `cargo test --manifest-path src-tauri/Cargo.toml --no-default-features --lib --bins --tests`
- [x] Started the gateway with `DBUS_SESSION_BUS_ADDRESS` and `XDG_RUNTIME_DIR` removed, then called Linear successfully

## Notes

No Omarchy or user configuration changes are required.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mutates process D-Bus/runtime env used for Secret Service, so a wrong recovery could point vault reads at a dead or unexpected bus. Ownership and socket-type checks plus leaving an explicit address alone keep the blast radius small.
> 
> **Overview**
> Linux gateways started with a stripped environment (often only `HOME`/`USER`) can reach Secret Service again. When `DBUS_SESSION_BUS_ADDRESS` is missing, the gateway restores the current user's systemd session bus at `/run/user/<uid>/bus` and fills `XDG_RUNTIME_DIR` if needed.
> 
> Recovery only proceeds after the runtime dir and Unix socket are confirmed to exist and be owned by the effective uid. An explicit bus address is never overwritten. Non-Linux builds are a no-op. Tests cover a successful owned-socket recovery and rejection of another uid or a non-socket `bus` file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc5e2a1315af47f410993dee7a5d092dc73d84c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Restore D-Bus session bus env for stripped Linux gateways
> - Adds `restore_session_bus_env` in [hostenv.rs](https://github.com/tsouth89/toolport/pull/844/files#diff-d4927dc264489f4ed038648168da6eecb35035a86b2b809f430025972354b29c) to recover `DBUS_SESSION_BUS_ADDRESS` when a gateway starts without a desktop session, validating the `/run/user/<uid>` directory and `bus` socket exist and are owned by the effective uid before setting env vars.
> - Calls this function early in the gateway `main` in [toolport-gateway.rs](https://github.com/tsouth89/toolport/pull/844/files#diff-fe5f13c01103f5adf39c870989b67ecdb11c19b3ba86b88c4acb028a7374cc01), logging the recovered bus path on success.
> - Explicit preexisting `DBUS_SESSION_BUS_ADDRESS` values are left untouched; a non-Linux stub returns `None`.
> - Risk: if `session_bus_candidate` accepts a socket not actually backed by systemd, D-Bus calls may fail or connect to an unexpected bus; verify ownership checks in `session_bus_candidate` match your runtime expectations.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fc5e2a1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->