### PR TITLE
fix(unix): detach Codex-launched gateways reliably

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,6 +124,13 @@ Entries before the rename below shipped under the project's former name, Conduit
 
 ### Fixed
 
+- **A gateway launched by Codex no longer stops before answering its first call.**
+  Codex starts each MCP child as a process-group leader, which made the gateway's
+  terminal-session detach fail; its login-shell PATH probe could then receive SIGTTIN
+  as a background group and stop the whole gateway. Normal Unix startup now handles
+  that launch shape and leaves the client's terminal session before any probe or
+  downstream spawn. (SBS-1063)
+
 - **Linux gateways launched without the desktop session environment can reach the
   Secret Service again.** Orca and some AI clients start MCP children with only
   `HOME` and `USER`; on Omarchy that left the gateway without a D-Bus address, so

--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -15111,6 +15111,41 @@ fn usage() -> String {
     )
 }
 
+/// Leave the launcher's terminal session before normal gateway startup.
+///
+/// Some clients, including Codex, make each MCP child a process-group leader.
+/// `setsid` rejects a process-group leader with `EPERM`, so briefly rejoin the
+/// launcher's group and retry. The second call then creates a new session with no
+/// controlling terminal before PATH discovery or any downstream child can receive
+/// a job-control signal.
+#[cfg(unix)]
+fn detach_from_client_session() {
+    unsafe {
+        extern "C" {
+            fn getpgid(pid: i32) -> i32;
+            fn getpgrp() -> i32;
+            fn getpid() -> i32;
+            fn getppid() -> i32;
+            fn setpgid(pid: i32, pgid: i32) -> i32;
+            fn setsid() -> i32;
+        }
+
+        // SAFETY: these POSIX calls take and return integer process identifiers.
+        // This runs before gateway threads start; a failed fallback leaves the
+        // process in a valid group and preserves the old best-effort behavior.
+        if setsid() >= 0 || getpgrp() != getpid() {
+            return;
+        }
+        let parent_group = getpgid(getppid());
+        if parent_group >= 0 && setpgid(0, parent_group) == 0 {
+            let _ = setsid();
+        }
+    }
+}
+
+#[cfg(not(unix))]
+fn detach_from_client_session() {}
+
 fn main() {
     // `--help`/`--version`/an unrecognized flag are decided before anything
     // else touches disk, the keychain, or stdin - see #605. Positional args
@@ -15164,6 +15199,10 @@ fn main() {
         }
         ArgAction::Run => {}
     }
+    let selftest_secrets = cli_args.first().map(String::as_str) == Some("--selftest-secrets");
+    if !selftest_secrets {
+        detach_from_client_session();
+    }
     if let Some(bus) = conduit_lib::hostenv::restore_session_bus_env() {
         eprintln!(
             "toolport-gateway: recovered the Linux session bus at {}",
@@ -15184,7 +15223,7 @@ fn main() {
     // shared-access ACL: this runs as a separate process from the app, exactly the
     // cross-process read path. If it reads the secrets with NO keychain prompt, the
     // gateway has silent access and the fix works.
-    if std::env::args().nth(1).as_deref() == Some("--selftest-secrets") {
+    if selftest_secrets {
         let reg = match registry::load_resolved() {
             Ok(r) => r,
             Err(e) => {
@@ -15229,29 +15268,6 @@ fn main() {
         println!("\nselftest-secrets: {ok} read OK, {unset} unset, {err} errors");
         println!("If NO keychain prompt appeared, the gateway has silent access (the ACL works).");
         std::process::exit(0);
-    }
-
-    // Detach from the spawning client's session so the gateway and its
-    // downstream server children run in their own session/process group with
-    // no controlling terminal. Without this, the gateway and every downstream
-    // server it spawns share the AI client's process group, so terminal
-    // job-control signals (SIGTTIN/SIGTTOU) generated during child startup
-    // can propagate to the client and disrupt its terminal I/O. TUI clients
-    // holding the terminal in raw mode around a blocking stdin read are
-    // especially sensitive. A multi-spawn gateway should not share a process
-    // group with its parent client.
-    //
-    // setsid() creates a new session; EPERM (already a session leader) is
-    // harmless. Unix only: Windows has no controlling-terminal analog.
-    #[cfg(unix)]
-    unsafe {
-        extern "C" {
-            fn setsid() -> i32;
-        }
-        // SAFETY: setsid() is a POSIX syscall taking no pointers and returning
-        // an integer. The worst case is EPERM (already a session leader),
-        // which we ignore. The signature matches libc::setsid exactly.
-        let _ = setsid();
     }
 
     // Discovery mode resolves from an explicit env override first (per-client), then

--- a/src-tauri/tests/gateway_session_detach.rs
+++ b/src-tauri/tests/gateway_session_detach.rs
@@ -1,0 +1,84 @@
+//! Regression guard for gateways launched as process-group leaders (SBS-1063).
+//!
+//! Codex puts each MCP child in a new process group before `exec`. A process-group
+//! leader cannot call `setsid`, so a gateway that ignored the resulting `EPERM`
+//! stayed attached to Codex's controlling terminal. Its login-shell PATH probe then
+//! received SIGTTIN as a background group and stopped the whole gateway before it
+//! could answer `toolport_status`.
+
+#![cfg(unix)]
+
+use std::os::unix::process::CommandExt;
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant};
+
+struct ChildGuard(Child);
+
+impl Drop for ChildGuard {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
+}
+
+unsafe fn get_process_group(pid: i32) -> i32 {
+    extern "C" {
+        fn getpgid(pid: i32) -> i32;
+    }
+    getpgid(pid)
+}
+
+unsafe fn get_session(pid: i32) -> i32 {
+    extern "C" {
+        fn getsid(pid: i32) -> i32;
+    }
+    getsid(pid)
+}
+
+#[test]
+fn process_group_leader_gateway_still_creates_its_own_session() {
+    let dir = std::env::temp_dir().join(format!(
+        "toolport-sbs1063-session-detach-{}",
+        std::process::id()
+    ));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).expect("create test data dir");
+
+    let gateway = env!("CARGO_BIN_EXE_toolport-gateway");
+    let child = Command::new(gateway)
+        .env("TOOLPORT_REGISTRY", dir.join("registry.json"))
+        .env("TOOLPORT_CLIENT_ID", "session-detach-test")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .process_group(0)
+        .spawn()
+        .expect("spawn gateway as a process-group leader");
+    let mut child = ChildGuard(child);
+    let pid = child.0.id() as i32;
+
+    assert_eq!(
+        unsafe { get_process_group(pid) },
+        pid,
+        "fixture must launch the gateway as its own process-group leader"
+    );
+
+    let deadline = Instant::now() + Duration::from_secs(2);
+    loop {
+        assert!(
+            child.0.try_wait().expect("read gateway status").is_none(),
+            "gateway exited before detaching"
+        );
+        if unsafe { get_session(pid) } == pid {
+            break;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "gateway remained in its launcher's terminal session"
+        );
+        std::thread::sleep(Duration::from_millis(10));
+    }
+
+    drop(child);
+    std::fs::remove_dir_all(&dir).expect("remove test data dir");
+}


### PR DESCRIPTION
## What and why

Codex starts MCP children as process-group leaders. That made Toolport's `setsid()` fail, leaving the gateway in Codex's terminal session. The login-shell PATH probe could then receive SIGTTIN and stop the whole gateway before its first response.

Normal Unix startup now handles that launch shape and detaches before startup I/O or PATH discovery. Early diagnostic modes keep their existing terminal behavior.

Closes SBS-1063.

## Testing

- [x] Added a subprocess regression using `process_group(0)`
- [x] `cargo clippy --manifest-path src-tauri/Cargo.toml --no-default-features --all-targets`
- [x] `cargo test --manifest-path src-tauri/Cargo.toml --no-default-features --lib --bins --tests`
- [x] Codex-style live launch with D-Bus variables removed answered status and fetched Linear

## Notes

No Omarchy or client configuration changes are required.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches process-group and session leadership at gateway startup via unsafe POSIX calls. Failure modes are fail-open to the previous best-effort detach, but a bad detach could still affect job-control or child spawn on Unix.
> 
> **Overview**
> Unix gateways launched as process-group leaders (Codex’s MCP spawn) now leave the client’s terminal session instead of failing `setsid` with `EPERM` and stopping on SIGTTIN during the PATH probe.
> 
> `detach_from_client_session` briefly rejoins the parent group and retries `setsid` before session-bus restore or any child spawn. `--selftest-secrets` still skips detach so that diagnostic path keeps its old terminal behavior. A Unix subprocess test launches the binary with `process_group(0)` and asserts it becomes its own session.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 31bb5e53b50c33ef7f16f617f663bc0f3b59b45a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix gateway stall by robustly detaching from client terminal session on Unix
> - Replaces the single inline `setsid()` call with a new `detach_from_client_session()` function in [toolport-gateway.rs](https://github.com/tsouth89/toolport/pull/845/files#diff-fe5f13c01103f5adf39c870989b67ecdb11c19b3ba86b88c4acb028a7374cc01) that handles the case where the gateway is already a process-group leader: it temporarily reattaches to the parent's group via `setpgid(0, parent_group)` then calls `setsid()` again.
> - Moves the detach earlier in startup — before environment restoration and PATH probing — so downstream spawns and probes run without a controlling terminal. Detach is skipped when the binary is invoked with `--selftest-secrets`.
> - Adds a Unix-only integration test in [gateway_session_detach.rs](https://github.com/tsouth89/toolport/pull/845/files#diff-804d41ab83b67ac33ddb98816324223b0e85a7e768362f760fb19cbbdb4eee67) that spawns the gateway as a process-group leader and polls until its session id equals its pid.
> - Behavioral Change: all normal Unix startup now detaches from the client's terminal session before any probes or downstream spawns; non-Unix platforms are unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 31bb5e5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->