### PR TITLE
chore(release): 1.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ Entries before the rename below shipped under the project's former name, Conduit
 
 ## [Unreleased]
 
+## [1.17.0] - 2026-08-23
+
+Toolport 1.17.0 brings one permission policy to Claude Code and Cursor, makes
+agent rules project-aware and safe around hand edits, hardens approval and Teams
+trust boundaries, and fixes fresh Codex gateway startup on Omarchy.
+
 ### Security
 
 - **A process that bound the approval broker's endpoint after the app had gone could
@@ -3143,7 +3149,9 @@ driven by the agent on your terms, and supports two more clients.
 - First public release: local MCP gateway and manager with lazy discovery,
   per-agent profiles, the catalog, the tool playground, and the activity log.
 
-[Unreleased]: https://github.com/tsouth89/toolport/compare/v1.6.2...HEAD
+[Unreleased]: https://github.com/tsouth89/toolport/compare/v1.17.0...HEAD
+[1.17.0]: https://github.com/tsouth89/toolport/compare/v1.16.0...v1.17.0
+[1.16.0]: https://github.com/tsouth89/toolport/releases/tag/v1.16.0
 [1.6.2]: https://github.com/tsouth89/toolport/compare/v1.6.1...v1.6.2
 [1.6.1]: https://github.com/tsouth89/toolport/compare/v1.6.0...v1.6.1
 [1.6.0]: https://github.com/tsouth89/toolport/releases/tag/v1.6.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "toolport",
-  "version": "1.16.0",
+  "version": "1.17.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "toolport",
-      "version": "1.16.0",
+      "version": "1.17.0",
       "dependencies": {
         "@fontsource-variable/geist": "^5.2.9",
         "@tailwindcss/vite": "^4.3.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "toolport",
   "private": true,
-  "version": "1.16.0",
+  "version": "1.17.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/packaging/agent-plugin/toolport/.claude-plugin/plugin.json
+++ b/packaging/agent-plugin/toolport/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "toolport",
-  "version": "1.16.0",
+  "version": "1.17.0",
   "description": "Every tool. One port. Connects this agent to your local Toolport gateway: every MCP server you set up in Toolport, exposed through a handful of compact meta-tools instead of hundreds of tool definitions (~90% fewer tokens, measured).",
   "author": { "name": "Toolport", "url": "https://toolport.app" },
   "homepage": "https://toolport.app",

--- a/packaging/agent-plugin/toolport/plugin.json
+++ b/packaging/agent-plugin/toolport/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "toolport",
-  "version": "1.16.0",
+  "version": "1.17.0",
   "description": "Every tool. One port. Connects this agent to your local Toolport gateway: every MCP server you set up in Toolport, exposed through a handful of compact meta-tools instead of hundreds of tool definitions (~90% fewer tokens, measured).",
   "author": { "name": "Toolport", "url": "https://toolport.app" },
   "homepage": "https://toolport.app",

--- a/packaging/homebrew/toolport.rb
+++ b/packaging/homebrew/toolport.rb
@@ -1,5 +1,5 @@
 cask "toolport" do
-  version "1.16.0"
+  version "1.17.0"
 
   on_arm do
     sha256 "ce9a7d129e1baf422b975ed76c2a493cc04794956cc9f09855e22a980fff94a3"

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -806,7 +806,7 @@ dependencies = [
 
 [[package]]
 name = "conduit"
-version = "1.16.0"
+version = "1.17.0"
 dependencies = [
  "base64 0.22.1",
  "boa_engine",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conduit"
-version = "1.16.0"
+version = "1.17.0"
 description = "Local MCP gateway: manage all your MCP servers in one place, set up once and shared by every AI client, with ~90% fewer tokens per request"
 authors = ["South Forge AI"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Toolport",
-  "version": "1.16.0",
+  "version": "1.17.0",
   "identifier": "com.tsout.conduit",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## What

- bump every packaged version to 1.17.0
- publish the Unreleased changelog as the release notes
- refresh changelog comparison links

No external human contributions were found in this release scope, so there is no attribution section to add.

## Checks

- `npm run format:check`
- `npm run lint`
- `npm test`
- `npm run build`
- `cargo metadata --locked --no-deps`
- `cargo test --no-default-features --lib --bins --tests`
- `bash scripts/install.Tests.bash`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only version and changelog updates; no runtime or security-path code changes.
> 
> **Overview**
> Cuts **1.17.0** as the current release: every packaged version (`package.json`, Tauri, Cargo, agent plugin, Homebrew cask) moves from `1.16.0` to `1.17.0`.
> 
> The Unreleased notes become dated **2026-08-23** release notes (permissions, agent rules, approval/Teams hardening, Codex/Omarchy fixes). Comparison links now point Unreleased at `v1.17.0...HEAD`. Homebrew DMG hashes are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28ce0b24b72ed61a8fe9296a248639e4ec90c255. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bump version to 1.17.0 across manifests and Homebrew cask
> Release prep for v1.17.0. Updates the version field in [package.json](https://github.com/tsouth89/toolport/pull/846/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519), [src-tauri/Cargo.toml](https://github.com/tsouth89/toolport/pull/846/files#diff-fe4c6a80a21e81339e2e0faeb9134d0f9636c168987df13c8abf1927a1caee39), [src-tauri/tauri.conf.json](https://github.com/tsouth89/toolport/pull/846/files#diff-fa09f1dac39604a735cd6a53957d3c35e0c3298cca9cf4829180f167abbd69b7), and both Claude/agent plugin manifests, and updates the [Homebrew cask](https://github.com/tsouth89/toolport/pull/846/files#diff-4dd9ff051b91df7b7e2288c4aecb6e70d3e9e32e62b9f05b3283a4b2a4ec3744) URLs to fetch v1.17.0 artifacts. Adds the 1.17.0 section to [CHANGELOG.md](https://github.com/tsouth89/toolport/pull/846/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed) with Security and Changed entries, and shifts the Unreleased comparison link to v1.17.0..HEAD.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 28ce0b2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->