### PR TITLE
chore(homebrew): refresh cask checksums for 1.17.0

### DIFF
--- a/packaging/homebrew/toolport.rb
+++ b/packaging/homebrew/toolport.rb
@@ -2,12 +2,12 @@ cask "toolport" do
   version "1.17.0"
 
   on_arm do
-    sha256 "ce9a7d129e1baf422b975ed76c2a493cc04794956cc9f09855e22a980fff94a3"
+    sha256 "cca6a5afe8a36e08c394518875747c540a74b4eae22725781b6586ff18350076"
     url "https://github.com/tsouth89/toolport/releases/download/v#{version}/Toolport_aarch64-apple-darwin.dmg",
         verified: "github.com/tsouth89/toolport/"
   end
   on_intel do
-    sha256 "50afcf218c3198d4b1ce3b95190ece9e66a382283d03d33621928bfd9d52a054"
+    sha256 "7294b4d3d65580ad7525e17b3a11928ae5655c59559382bbf29b716bf93991cb"
     url "https://github.com/tsouth89/toolport/releases/download/v#{version}/Toolport_x86_64-apple-darwin.dmg",
         verified: "github.com/tsouth89/toolport/"
   end


### PR DESCRIPTION
Update the in-repo cask snapshot with SHA-256 hashes calculated from the published 1.17.0 DMGs.

Check: `npx vitest run src/test/homebrew-cask.test.ts`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Packaging-only checksum refresh; no application or security logic changes. Wrong hashes would break Homebrew installs until corrected.
> 
> **Overview**
> Updates the Homebrew cask SHA-256 hashes for the published 1.17.0 ARM and Intel DMGs so `brew install`/`upgrade` match the release artifacts. Version stays `1.17.0`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4705ba53ffee407803919dc684f41be3a3cd7c0c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Update `sha256` checksums in `toolport` cask for 1.17.0
> Replaces the `on_arm` and `on_intel` sha256 values in [toolport.rb](https://github.com/tsouth89/toolport/pull/847/files#diff-4dd9ff051b91df7b7e2288c4aecb6e70d3e9e32e62b9f05b3283a4b2a4ec3744) to match the 1.17.0 DMG artifacts. No other cask stanzas changed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4705ba5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->