### PR TITLE
fix(rules): stop lumping every no-rules-file client into one unsupported line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ Entries before the rename below shipped under the project's former name, Conduit
 
 ## [Unreleased]
 
+### Fixed
+
+- **Agent rules: the "no rules file" line no longer lumps three different situations
+  together.** Cursor and GitHub Copilot CLI have no global rules file but do read project
+  rules, so the Clients section now points them at the Projects section instead of calling
+  them unsupported; Claude Desktop is named as the chat app, with Claude Code inside it
+  covered by the Claude Code row; only clients with no rules file anywhere still say to
+  paste rules in by hand.
+
 ## [1.17.0] - 2026-08-23
 
 Toolport 1.17.0 brings one permission policy to Claude Code and Cursor, makes

--- a/docs/agent-rules.md
+++ b/docs/agent-rules.md
@@ -108,10 +108,12 @@ Claude Code extension, and one write covers both when both are installed.
 ### Clients with no rules file Toolport can write
 
 Some clients keep their global rules somewhere Toolport cannot write. They have no
-checkbox; the Clients section lists whichever of them it detects underneath ("No rules
-file Toolport can write for ..."), so you know to paste your rules in yourself. Toolport
-does not silently skip them. Which names appear depends on what is installed, so the list
-below is the full set rather than what you will see.
+checkbox; the Clients section lists whichever of them it detects underneath, so nothing
+is silently skipped, and it says which of three cases each one is: clients that read
+project rules (Cursor, GitHub Copilot CLI) are pointed at the Projects section, Claude
+Desktop is noted as the chat app with Claude Code inside it already covered, and the
+rest say to paste your rules in by hand. Which names appear depends on what is
+installed, so the list below is the full set rather than what you will see.
 
 - **Cursor** and **Warp** keep global rules in their own UI or account: Cursor's User
   rules in _Customize -> Rules_, Warp's in Warp Drive. Both also read per-project files

--- a/src-tauri/src/rules.rs
+++ b/src-tauri/src/rules.rs
@@ -37,6 +37,11 @@ pub struct ClientStatus {
     /// `None` when this client has no global-rules location we can write (Cursor, Warp).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub path: Option<String>,
+    /// `true` when a client with no global rules file still reads one of the files the Projects
+    /// section writes (Cursor, GitHub Copilot CLI), so the UI can point at Projects instead of
+    /// calling the client unsupported. Always `false` when `path` is set.
+    #[serde(default)]
+    pub project_covered: bool,
     pub state: ApplyState,
     /// When `state` is [`ApplyState::Drifted`]: the body as it is on disk right now, so the UI
     /// can show the difference and offer to pull it into the set. Absent otherwise.
@@ -160,6 +165,8 @@ fn status_from(
                     .target
                     .as_ref()
                     .map(|t| t.path.to_string_lossy().to_string()),
+                project_covered: c.target.is_none()
+                    && PROJECT_FILES.iter().any(|f| f.clients.contains(&c.id.as_str())),
                 state,
                 on_disk,
             }

--- a/src/components/RulesView.test.tsx
+++ b/src/components/RulesView.test.tsx
@@ -48,7 +48,13 @@ function view(over: Partial<RulesViewData> = {}): RulesViewData {
         path: "/home/a/.claude/rules/toolport-rules.md",
         state: "stale",
       },
-      { id: "cursor", name: "Cursor", enabled: false, state: "unsupported" },
+      {
+        id: "cursor",
+        name: "Cursor",
+        enabled: false,
+        state: "unsupported",
+        projectCovered: true,
+      },
     ],
     projects: [],
     ...over,
@@ -77,12 +83,37 @@ describe("RulesView", () => {
   });
 
   it("names the clients it cannot write instead of hiding them", async () => {
+    api.rulesView.mockResolvedValue(
+      view({
+        clients: [
+          {
+            id: "cursor",
+            name: "Cursor",
+            enabled: false,
+            state: "unsupported",
+            projectCovered: true,
+          },
+          {
+            id: "claude-desktop",
+            name: "Claude Desktop",
+            enabled: false,
+            state: "unsupported",
+          },
+          { id: "opencode", name: "OpenCode", enabled: false, state: "unsupported" },
+        ],
+      }),
+    );
     render(<RulesView />);
     await screen.findByLabelText("Rules");
-    // Cursor has no rules file we manage: it must be called out, not silently dropped, or the
-    // user thinks their rules reached it.
+    // Cursor reads project AGENTS.md: pointed at Projects, not written off as unsupported.
+    expect(screen.getByText(/No global rules file for/)).toHaveTextContent("Cursor");
+    expect(screen.getByText(/add a folder under Projects below/)).toBeInTheDocument();
+    // Claude Desktop is the chat app; saying "unsupported" reads as Claude Code being missed.
+    expect(screen.getByText(/Claude Desktop is the chat app/)).toBeInTheDocument();
+    // A client with rules nowhere is still called out, not silently dropped, or the user
+    // thinks their rules reached it.
     expect(screen.getByText(/No rules file Toolport can write for/)).toHaveTextContent(
-      "Cursor",
+      "OpenCode",
     );
     expect(screen.queryByLabelText("Cursor")).not.toBeInTheDocument();
   });

--- a/src/components/RulesView.tsx
+++ b/src/components/RulesView.tsx
@@ -455,6 +455,14 @@ export function RulesView() {
   const clients = data?.clients ?? [];
   const supported = clients.filter((c) => c.path);
   const unsupported = clients.filter((c) => !c.path);
+  // Three different truths hide behind "no global rules file", and lumping them into one
+  // "unsupported" sentence overstates it: Cursor and Copilot CLI are reached per project,
+  // and Claude Desktop is the chat app while Claude Code inside it is already covered.
+  const projectOnly = unsupported.filter((c) => c.projectCovered);
+  const chatDesktop = unsupported.filter((c) => c.id === "claude-desktop");
+  const manualOnly = unsupported.filter(
+    (c) => !c.projectCovered && c.id !== "claude-desktop",
+  );
   const onCount = supported.filter((c) => c.enabled).length;
   // Name the client in the card header. The path alone is ambiguous wherever two clients share a
   // file (Claude Code / VS Code, Gemini CLI / Antigravity).
@@ -707,10 +715,27 @@ export function RulesView() {
         </ul>
 
         {unsupported.length > 0 && (
-          <p className="mt-3 text-xs text-muted-foreground">
-            No rules file Toolport can write for{" "}
-            {unsupported.map((c) => c.name).join(", ")}. Paste your rules in by hand.
-          </p>
+          <div className="mt-3 space-y-1 text-xs text-muted-foreground">
+            {projectOnly.length > 0 && (
+              <p>
+                No global rules file for {projectOnly.map((c) => c.name).join(", ")}, but
+                project rules reach {projectOnly.length === 1 ? "it" : "them"}: add a
+                folder under Projects below.
+              </p>
+            )}
+            {chatDesktop.length > 0 && (
+              <p>
+                Claude Desktop is the chat app and has no rules file; Claude Code inside
+                it is covered by the Claude Code row above.
+              </p>
+            )}
+            {manualOnly.length > 0 && (
+              <p>
+                No rules file Toolport can write for{" "}
+                {manualOnly.map((c) => c.name).join(", ")}. Paste your rules in by hand.
+              </p>
+            )}
+          </div>
         )}
       </div>
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -597,6 +597,11 @@ export interface RulesClientStatus {
   enabled: boolean;
   /** Absent when this client has no global-rules file Toolport can manage (Cursor, Warp). */
   path?: string;
+  /**
+   * No global rules file, but the client reads one of the files the Projects section writes
+   * (Cursor, GitHub Copilot CLI), so the UI points at Projects instead of "unsupported".
+   */
+  projectCovered?: boolean;
   state: InstructionsApplyState;
   /** When `state` is `drifted`: the block's body as it is on disk, for the diff and Pull into set. */
   onDisk?: string;


### PR DESCRIPTION
The Agent rules tab said "No rules file Toolport can write for Claude Desktop, Cursor, OpenCode, Grok Build, GitHub Copilot CLI. Paste your rules in by hand." That line hides three different truths, and it reads as "Cursor is unsupported" when project rules reach Cursor fine.

Now the Clients section says which case each client is:

- Cursor and GitHub Copilot CLI: "No global rules file for Cursor, GitHub Copilot CLI, but project rules reach them: add a folder under Projects below."
- Claude Desktop: "Claude Desktop is the chat app and has no rules file; Claude Code inside it is covered by the Claude Code row above."
- The rest keep the old sentence and the paste-by-hand advice.

The backend marks a pathless client `projectCovered` when its id is in PROJECT_FILES, so the split follows the project-file roster instead of hardcoded names in the frontend. Claude Desktop stays a frontend special case since it is about what the client is, not about files.

Tests: RulesView vitest suite (40 pass) including an expanded callout test, rules:: cargo tests (29 pass), tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy and a read-only API field on the rules view; no changes to how rules are written or to auth/data handling.
> 
> **Overview**
> The Agent rules **Clients** section no longer uses one **"No rules file Toolport can write for … Paste by hand"** line for every client without a global path.
> 
> **Backend:** `ClientStatus` gains **`projectCovered`**, set when there is no writable global file but the client id appears on the **`PROJECT_FILES`** roster (e.g. Cursor, GitHub Copilot CLI), so the UI can route users to **Projects** without hardcoding names in the frontend.
> 
> **UI:** Unsupported clients are split into up to three messages—project-reachable clients are told to add a folder under **Projects**; **Claude Desktop** is explained as the chat app with Claude Code already covered above; everyone else keeps the paste-by-hand guidance.
> 
> Docs and **CHANGELOG** match the new behavior; **RulesView** tests assert the three cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e632ccce5b566e8b40c74e523c82c471a02620fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Split no-rules-file clients into project-covered, Claude Desktop, and manual-only groups in `RulesView`
> - Adds a `projectCovered` boolean to `ClientStatus` ([rules.rs](https://github.com/tsouth89/toolport/pull/848/files#diff-95ba6d6d222bbceda1b2370fcec193a459a1a3fb8065e0fa9521ec07a1cbad51)) so the backend can flag clients without a writable global rules file that are still covered by project-level files (e.g. Cursor, GitHub Copilot CLI).
> - `status_from` sets `projectCovered=true` when a client has no target path but its id appears in `PROJECT_FILES`.
> - `RulesView` ([RulesView.tsx](https://github.com/tsouth89/toolport/pull/848/files#diff-4e009b33fddd42d77b29dcb73137bb9411ea8428b2bb159b7b62149beb3f11d7)) partitions unsupported clients into three buckets — project-only (points to Projects), Claude Desktop (explains Claude Code coverage), and manual-only — each with its own guidance instead of a single generic message.
> - Updates [types.ts](https://github.com/tsouth89/toolport/pull/848/files#diff-b8b77f5be18cf56dca425b3a5b8e9d2e754dd37fe0e3612b95cd4e9bccda08a5), tests, docs, and changelog accordingly.
> - Risk: clients with `path` set always have `projectCovered=false`; any frontend code that ignores the flag and groups all pathless clients together will lose the new guidance.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e632ccc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->