### PR TITLE
fix(teams): preserve instructions status on refresh failure

### DIFF
--- a/src/components/TeamsView.test.tsx
+++ b/src/components/TeamsView.test.tsx
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import type { Registry } from "@/lib/types";
+import type { InstructionsStatusView, Registry } from "@/lib/types";
 
 const api = vi.hoisted(() => ({
   teamConnect: vi.fn(),
@@ -169,6 +169,119 @@ describe("TeamsView shared-server update", () => {
 
     await userEvent.click(screen.getByRole("button", { name: "Update shared servers" }));
     await waitFor(() => expect(api.teamPushPreview).toHaveBeenCalledTimes(2));
+  });
+});
+
+describe("TeamsView instructions status", () => {
+  const instructions: InstructionsStatusView = {
+    content: "Use the approved tools.",
+    version: 6,
+    clients: [{ id: "claude", name: "Claude", state: "applied" }],
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("keeps the last status after a failed refresh and retries", async () => {
+    const refreshed: InstructionsStatusView = {
+      content: "Use the newly approved tools.",
+      version: 7,
+      clients: [{ id: "claude", name: "Claude", state: "stale" }],
+    };
+    api.teamInstructionsStatus
+      .mockResolvedValueOnce(instructions)
+      .mockRejectedValueOnce(new Error("temporary read failure"))
+      .mockResolvedValueOnce(refreshed);
+    const onRegistryChange = vi.fn();
+    const { rerender } = render(
+      <TeamsView registry={registry} onRegistryChange={onRegistryChange} />,
+    );
+
+    expect(await screen.findByText(instructions.content)).toBeInTheDocument();
+    expect(screen.getByText("Applied")).toBeInTheDocument();
+
+    rerender(
+      <TeamsView
+        registry={{
+          ...registry,
+          team: { ...registry.team!, lastVersion: 7 },
+        }}
+        onRegistryChange={onRegistryChange}
+      />,
+    );
+
+    expect(
+      await screen.findByText("Couldn't refresh this status. Showing the last result."),
+    ).toBeInTheDocument();
+    expect(screen.getByText(instructions.content)).toBeInTheDocument();
+    expect(screen.getByText("Applied")).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: "Try again" }));
+
+    expect(await screen.findByText(refreshed.content)).toBeInTheDocument();
+    expect(screen.getByText("Not applied yet")).toBeInTheDocument();
+    expect(
+      screen.queryByText("Couldn't refresh this status. Showing the last result."),
+    ).not.toBeInTheDocument();
+    expect(api.teamInstructionsStatus).toHaveBeenCalledTimes(3);
+  });
+
+  it("does not show another team's cached instructions after a failed refresh", async () => {
+    api.teamInstructionsStatus
+      .mockResolvedValueOnce(instructions)
+      .mockRejectedValueOnce(new Error("temporary read failure"));
+    const onRegistryChange = vi.fn();
+    const { rerender } = render(
+      <TeamsView registry={registry} onRegistryChange={onRegistryChange} />,
+    );
+
+    expect(await screen.findByText(instructions.content)).toBeInTheDocument();
+
+    rerender(
+      <TeamsView
+        registry={{
+          ...registry,
+          team: { ...registry.team!, teamId: "team-2", lastVersion: 1 },
+        }}
+        onRegistryChange={onRegistryChange}
+      />,
+    );
+
+    expect(
+      await screen.findByText("Toolport couldn't load the instructions status."),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(instructions.content)).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Try again" })).toBeInTheDocument();
+  });
+
+  it("clears the card when a successful refresh reports no active instructions", async () => {
+    api.teamInstructionsStatus
+      .mockResolvedValueOnce(instructions)
+      .mockResolvedValueOnce(null);
+    const onRegistryChange = vi.fn();
+    const { rerender } = render(
+      <TeamsView registry={registry} onRegistryChange={onRegistryChange} />,
+    );
+
+    expect(await screen.findByText(instructions.content)).toBeInTheDocument();
+
+    rerender(
+      <TeamsView
+        registry={{
+          ...registry,
+          team: { ...registry.team!, lastVersion: 7 },
+        }}
+        onRegistryChange={onRegistryChange}
+      />,
+    );
+
+    await waitFor(() =>
+      expect(screen.queryByText(instructions.content)).not.toBeInTheDocument(),
+    );
+    expect(
+      screen.queryByRole("heading", { name: "Team instructions" }),
+    ).not.toBeInTheDocument();
   });
 });
 

--- a/src/components/TeamsView.tsx
+++ b/src/components/TeamsView.tsx
@@ -74,22 +74,35 @@ export function TeamsView({
   // The member-facing Team Instructions status on this machine (spec W4): what the org pushed
   // and how each installed AI client currently holds it. Refetched on connect and whenever a sync
   // bumps the config version, so it tracks the files the writer just wrote.
-  const [instr, setInstr] = useState<InstructionsStatusView | null>(null);
+  const [instrSnapshot, setInstrSnapshot] = useState<{
+    teamId: string;
+    status: InstructionsStatusView | null;
+  } | null>(null);
+  const [instrErrorTeamId, setInstrErrorTeamId] = useState<string | null>(null);
+  const [instrRetry, setInstrRetry] = useState(0);
+  const instrTeamId = team?.teamId ?? null;
+  // A last-good result is safe to preserve across version refreshes for the same team, but
+  // must never appear after switching organizations.
+  const instr = instrSnapshot?.teamId === instrTeamId ? instrSnapshot.status : null;
+  const instrError = instrTeamId !== null && instrErrorTeamId === instrTeamId;
   useEffect(() => {
     // The command returns null when there's no team (or no active instructions), so there's no
     // synchronous clear here — the result always lands via the async resolution.
     let cancelled = false;
+    const requestedTeamId = instrTeamId;
     teamInstructionsStatus()
       .then((s) => {
-        if (!cancelled) setInstr(s);
+        if (cancelled) return;
+        setInstrSnapshot(requestedTeamId ? { teamId: requestedTeamId, status: s } : null);
+        setInstrErrorTeamId(null);
       })
       .catch(() => {
-        if (!cancelled) setInstr(null);
+        if (!cancelled) setInstrErrorTeamId(requestedTeamId);
       });
     return () => {
       cancelled = true;
     };
-  }, [team?.teamId, team?.lastVersion]);
+  }, [instrTeamId, team?.lastVersion, instrRetry]);
   // Set while an approval-gated join waits for an admin. Holds the connect inputs so a poll
   // uses the values from when the request was made, not whatever the fields say later.
   const [pending, setPending] = useState<{
@@ -706,36 +719,77 @@ export function TeamsView({
             )}
           </div>
 
-          {instr && (
+          {(instr || instrError) && (
             <div className="rounded-xl border bg-card p-5">
               <div className="mb-1 flex items-center gap-2">
                 <FileText className="size-4 text-muted-foreground" />
                 <h3 className="text-sm font-medium">Team instructions</h3>
-                <span className="text-xs text-muted-foreground">v{instr.version}</span>
+                {instr && (
+                  <span className="text-xs text-muted-foreground">v{instr.version}</span>
+                )}
               </div>
-              <p className="mb-3 text-xs text-muted-foreground">
-                Org-managed agent rules, written to your AI clients alongside — never over
-                — your own instructions. Leaving the team removes them.
-              </p>
-              <pre className="mb-3 max-h-40 overflow-auto whitespace-pre-wrap rounded-lg border bg-muted/20 p-3 font-mono text-xs text-foreground">
-                {instr.content}
-              </pre>
-              {instr.clients.length === 0 ? (
-                <p className="text-xs text-muted-foreground">
-                  No supported AI clients detected on this machine.
-                </p>
-              ) : (
-                <ul className="grid gap-1.5">
-                  {instr.clients.map((c) => (
-                    <li
-                      key={c.id}
-                      className="flex items-center justify-between gap-3 text-sm"
+              {instr ? (
+                <>
+                  <p className="mb-3 text-xs text-muted-foreground">
+                    Org-managed agent rules, written to your AI clients alongside — never
+                    over — your own instructions. Leaving the team removes them.
+                  </p>
+                  {instrError && (
+                    <Callout
+                      variant="warning"
+                      role="status"
+                      className="mb-3 flex items-center justify-between gap-3"
                     >
-                      <span className="truncate">{c.name}</span>
-                      <RuleStateBadge state={c.state} />
-                    </li>
-                  ))}
-                </ul>
+                      <span>Couldn't refresh this status. Showing the last result.</span>
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        className="shrink-0"
+                        onClick={() => setInstrRetry((n) => n + 1)}
+                      >
+                        <RefreshCw className="size-3.5" />
+                        Try again
+                      </Button>
+                    </Callout>
+                  )}
+                  <pre className="mb-3 max-h-40 overflow-auto whitespace-pre-wrap rounded-lg border bg-muted/20 p-3 font-mono text-xs text-foreground">
+                    {instr.content}
+                  </pre>
+                  {instr.clients.length === 0 ? (
+                    <p className="text-xs text-muted-foreground">
+                      No supported AI clients detected on this machine.
+                    </p>
+                  ) : (
+                    <ul className="grid gap-1.5">
+                      {instr.clients.map((c) => (
+                        <li
+                          key={c.id}
+                          className="flex items-center justify-between gap-3 text-sm"
+                        >
+                          <span className="truncate">{c.name}</span>
+                          <RuleStateBadge state={c.state} />
+                        </li>
+                      ))}
+                    </ul>
+                  )}
+                </>
+              ) : (
+                <Callout
+                  variant="danger"
+                  role="status"
+                  className="mt-3 flex items-center justify-between gap-3"
+                >
+                  <span>Toolport couldn't load the instructions status.</span>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="shrink-0"
+                    onClick={() => setInstrRetry((n) => n + 1)}
+                  >
+                    <RefreshCw className="size-3.5" />
+                    Try again
+                  </Button>
+                </Callout>
               )}
             </div>
           )}


### PR DESCRIPTION
## What and why

Closes #731.

Preserve the last successful Team Instructions status when a same-team refresh fails, showing an inline warning and retry action instead of hiding the card. Initial failures remain retryable, and cached instructions are scoped to the active team.

## Testing

- [x] `npm run build` passes
- [x] `npm run test` passes
- [x] `npm run audit:prod` passes
- [ ] `npm run test:rust` — not applicable; frontend-only change
- [ ] Ran the app (`npm run tauri dev`) and checked the change by hand

Also ran the focused TeamsView tests, `npm run format:check`, `npm run lint`, and `git diff --check`.

## Notes

No secrets, credentials, or personal paths are included in the diff.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve `TeamsView` instructions status on refresh failure
> Reworks instructions-status state in [TeamsView.tsx](https://github.com/tsouth89/toolport/pull/849/files#diff-50aab01534927ae5e73a7befd618e46927fa4f3023098ec1e72623d135e7d569) to keep a snapshot object keyed by `teamId` instead of a single status. On a failed refresh, the component now retains and displays the last-good content for the same team with a warning callout and a 'Try again' retry button, rather than clearing the card.
>
> - Avoids cross-team leakage by deriving the effective status only when the snapshot `teamId` matches the current team; otherwise shows a danger callout with retry.
> - Clears the card when a successful refresh reports no active instructions.
> - Adds tests in [TeamsView.test.tsx](https://github.com/tsouth89/toolport/pull/849/files#diff-b7123bd63b46cbd601b9715dc4eea6c92ccf96b13d99f55c880d8511938d6ba9) covering last-good retention with retry, cross-team error handling, and card clearing on empty success.
> - Behavioral Change: a failed refresh no longer clears the instructions card; it now persists the last-known status with a warning, and the card renders on error even without a prior status.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b6225d4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->