### PR TITLE
Strip AI attribution trailers from commit messages

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,15 @@
+# Strip AI attribution trailers from commit messages.
+# The global hook at ~/.config/git/hooks does not run here, because husky sets
+# core.hooksPath to .husky/_ for this repo.
+msg=$1
+tmp=$(mktemp)
+trap 'rm -f "$tmp"' EXIT
+sed -E \
+	-e '/^[[:space:]]*Claude-Session:/d' \
+	-e '/^[[:space:]]*Co-[Aa]uthored-[Bb]y:[[:space:]]*Claude/d' \
+	-e '/^[[:space:]]*(🤖[[:space:]]*)?Generated with \[?Claude Code/d' \
+	-e '/^[[:space:]]*https:\/\/claude\.ai\/code\//d' \
+	"$msg" >"$tmp"
+# Drop blank lines left dangling at the end.
+awk '{l[NR]=$0} END{e=NR; while(e>0 && l[e]~/^[[:space:]]*$/) e--; for(i=1;i<=e;i++) print l[i]}' \
+	"$tmp" >"$msg"


### PR DESCRIPTION
Adds a husky commit-msg hook that strips AI attribution trailers (Claude-Session, Co-Authored-By: Claude, "Generated with Claude Code") from commit messages.

I have a global hook that does this, but it does not apply here because husky points core.hooksPath at .husky/_ for this repo, so this needs to live in the repo to take effect.

Body text is preserved, only the trailers and any blank lines they leave behind are removed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Commit-time message cleanup only; no application runtime, security, or data-path changes.
> 
> **Overview**
> Adds a **repo-local** `.husky/commit-msg` hook so AI attribution trailers are removed when commits are made here. Husky sets `core.hooksPath` to `.husky/_`, so a global `~/.config/git/hooks` hook does not run for this project.
> 
> On each commit, the hook rewrites the message file: `sed` drops lines matching `Claude-Session:`, `Co-Authored-By: Claude`, “Generated with Claude Code” (optional emoji), and `claude.ai/code` URLs; `awk` then strips trailing blank lines. **Commit body text is left intact**—only those trailer lines and trailing empties are removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f102ced23f81ce3f6e16f9a40e27f0d7d4f748fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Husky `commit-msg` hook to strip Claude AI attribution trailers
> - Adds a `commit-msg` hook that uses `sed` to delete lines matching Claude session, co-authorship, generation, and URL trailers, writing filtered output to a temp file
> - Uses `awk` to rewrite the commit message file from the temp file while trimming trailing blank lines
> - Behavioral Change: commit messages on this repo will have AI-attribution lines automatically removed before the commit is accepted
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f102ced.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->