### PR TITLE
Make remote request timeout configurable

### DIFF
--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -22094,6 +22094,7 @@ mod tests {
                 disabled_tools: vec![],
                 cwd: None,
                 client_credentials: None,
+                request_timeout_ms: None,
                 unknown_fields: serde_json::Map::new(),
             });
         }
@@ -22131,6 +22132,7 @@ mod tests {
                 disabled_tools: vec![],
                 cwd: None,
                 client_credentials: None,
+                request_timeout_ms: None,
                 unknown_fields: serde_json::Map::new(),
             });
             reg.set_server_enabled("default", id, true).unwrap();
@@ -22203,6 +22205,7 @@ mod tests {
             disabled_tools: vec![],
             cwd: None,
             client_credentials: None,
+            request_timeout_ms: None,
             unknown_fields: serde_json::Map::new(),
         });
         reg.set_server_enabled("default", "github", true).unwrap();
@@ -23478,6 +23481,7 @@ mod tests {
             disabled_tools: vec![],
             cwd: None,
             client_credentials: None,
+            request_timeout_ms: None,
             unknown_fields: serde_json::Map::new(),
         }
     }
@@ -26229,6 +26233,7 @@ mod tests {
             disabled_tools: vec![],
             cwd: None,
             client_credentials: None,
+            request_timeout_ms: None,
             unknown_fields: serde_json::Map::new(),
         });
         reg.set_server_enabled("default", &id, true).unwrap();

--- a/src-tauri/src/clients.rs
+++ b/src-tauri/src/clients.rs
@@ -5453,6 +5453,7 @@ fn gateway_entry(profile: Option<&str>, client_id: &str) -> Result<ServerEntry, 
         disabled_tools: Vec::new(),
         cwd: None,
         client_credentials: None,
+        request_timeout_ms: None,
         unknown_fields: serde_json::Map::new(),
     })
 }
@@ -5542,6 +5543,7 @@ pub fn gateway_entry_shared_http(
             disabled_tools: Vec::new(),
             cwd: None,
             client_credentials: None,
+            request_timeout_ms: None,
             unknown_fields: serde_json::Map::new(),
         }
     } else {
@@ -5575,6 +5577,7 @@ pub fn gateway_entry_shared_http(
             disabled_tools: Vec::new(),
             cwd: None,
             client_credentials: None,
+            request_timeout_ms: None,
             unknown_fields: serde_json::Map::new(),
         }
     }
@@ -6974,6 +6977,7 @@ mod tests {
             disabled_tools: Vec::new(),
             cwd: None,
             client_credentials: None,
+            request_timeout_ms: None,
             unknown_fields: serde_json::Map::new(),
         }
     }
@@ -7072,6 +7076,7 @@ mod tests {
             disabled_tools: vec![],
             cwd: None,
             client_credentials: None,
+            request_timeout_ms: None,
             unknown_fields: serde_json::Map::new(),
         }
     }
@@ -7093,6 +7098,7 @@ mod tests {
             disabled_tools: vec![],
             cwd: None,
             client_credentials: None,
+            request_timeout_ms: None,
             unknown_fields: serde_json::Map::new(),
         }
     }

--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -4855,6 +4855,7 @@ mod tests {
             disabled_tools: vec![],
             cwd: None,
             client_credentials: None,
+            request_timeout_ms: None,
             unknown_fields: serde_json::Map::new(),
         }
     }
@@ -4889,6 +4890,7 @@ mod tests {
             disabled_tools: vec![],
             cwd: None,
             client_credentials: None,
+            request_timeout_ms: None,
             unknown_fields: serde_json::Map::new(),
         }
     }
@@ -5428,6 +5430,7 @@ mod tests {
             disabled_tools: vec![],
             cwd: None,
             client_credentials: None,
+            request_timeout_ms: None,
             unknown_fields: serde_json::Map::new(),
         });
 
@@ -5534,6 +5537,7 @@ mod tests {
             disabled_tools: vec![],
             cwd: None,
             client_credentials: None,
+            request_timeout_ms: None,
             unknown_fields: serde_json::Map::new(),
         });
         let doc = build_export(&reg, None, None, None);
@@ -5602,6 +5606,7 @@ mod tests {
             disabled_tools: vec![],
             cwd: None,
             client_credentials: None,
+            request_timeout_ms: None,
             unknown_fields: serde_json::Map::new(),
         });
         let doc = build_export(&reg, None, None, None);
@@ -5652,6 +5657,7 @@ mod tests {
             disabled_tools: vec![],
             cwd: None,
             client_credentials: None,
+            request_timeout_ms: None,
             unknown_fields: serde_json::Map::new(),
         });
         let serialized = serde_json::to_string(&build_export(&reg, None, None, None)).unwrap();
@@ -5692,6 +5698,7 @@ mod tests {
             disabled_tools: vec![],
             cwd: None,
             client_credentials: None,
+            request_timeout_ms: None,
             unknown_fields: serde_json::Map::new(),
         });
         let json = serde_json::to_string(&build_export(&reg, None, None, None)).unwrap();
@@ -5806,6 +5813,7 @@ mod tests {
             disabled_tools: vec![],
             cwd: None,
             client_credentials: None,
+            request_timeout_ms: None,
             unknown_fields: serde_json::Map::new(),
         });
         reg.add_server(ServerEntry {
@@ -5820,6 +5828,7 @@ mod tests {
             disabled_tools: vec![],
             cwd: None,
             client_credentials: None,
+            request_timeout_ms: None,
             unknown_fields: serde_json::Map::new(),
         });
 

--- a/src-tauri/src/downstream.rs
+++ b/src-tauri/src/downstream.rs
@@ -9861,7 +9861,10 @@ mod tests {
             true,
         );
 
-        assert!(result.is_err(), "the delayed response must exceed the configured timeout");
+        assert!(
+            result.is_err(),
+            "the delayed response must exceed the configured timeout"
+        );
         assert!(
             started.elapsed() < Duration::from_millis(800),
             "the custom timeout was not applied: {:?}",
@@ -11726,14 +11729,10 @@ mod tests {
             }
         }
         transport.url = format!("http://127.0.0.1:{recovery_port}/");
-        transport.agent = super::guarded_agent_with_timeout(
-            false,
-            super::DEFAULT_HTTP_REQUEST_TIMEOUT,
-        );
-        transport.inline_agent = super::guarded_agent_with_timeout(
-            false,
-            super::DEFAULT_HTTP_REQUEST_TIMEOUT,
-        );
+        transport.agent =
+            super::guarded_agent_with_timeout(false, super::DEFAULT_HTTP_REQUEST_TIMEOUT);
+        transport.inline_agent =
+            super::guarded_agent_with_timeout(false, super::DEFAULT_HTTP_REQUEST_TIMEOUT);
         let result = transport
             .request("tools/call", json!({ "name": "after-cancel" }))
             .expect("restored transport accepts a fresh request");

--- a/src-tauri/src/downstream.rs
+++ b/src-tauri/src/downstream.rs
@@ -934,8 +934,9 @@ pub(crate) const HTTP_RETRY_BASE: Duration = Duration::from_millis(250);
 pub(crate) const HTTP_RETRY_CAP: Duration = Duration::from_secs(10);
 /// Cancellation is observed at this cadence while a blocking HTTP attempt drains on
 /// its bounded worker. The router slot is released within one tick; the wire attempt
-/// remains owned by that single worker until ureq's 30s request timeout closes it.
+/// remains owned by that single worker until ureq's configured request timeout closes it.
 const HTTP_CANCEL_POLL: Duration = Duration::from_millis(25);
+const DEFAULT_HTTP_REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
 /// A cancellation notification is best-effort and must never replace one blocked
 /// request with another. Its independent connection has this much total time.
 const HTTP_CANCEL_FORWARD_TIMEOUT: Duration = Duration::from_secs(1);
@@ -3968,12 +3969,6 @@ pub(crate) fn guarded_agent_with_timeout(
         .build()
 }
 
-/// The remote MCP transport allows longer-lived calls than short auxiliary HTTP
-/// requests such as semantic embedding lookups.
-fn guarded_agent(block_private: bool) -> ureq::Agent {
-    guarded_agent_with_timeout(block_private, std::time::Duration::from_secs(30))
-}
-
 /// Talks to a remote MCP server over the Streamable HTTP transport: each request
 /// is a POST, and the response is either a JSON body or an SSE stream carrying
 /// the JSON-RPC message. A session id from `initialize` is echoed on later calls.
@@ -4152,10 +4147,29 @@ impl HttpTransport {
         refresh: Option<RefreshFn>,
         block_private: bool,
     ) -> Self {
+        Self::guarded_with_timeout(
+            url,
+            auth,
+            refresh,
+            block_private,
+            DEFAULT_HTTP_REQUEST_TIMEOUT,
+        )
+    }
+
+    /// Build a transport whose main and inline HTTP agents share the same total
+    /// per-request deadline. This covers initialization, ordinary calls, and SSE
+    /// response reads without changing the independent cancellation budget.
+    pub fn guarded_with_timeout(
+        url: &str,
+        auth: Option<String>,
+        refresh: Option<RefreshFn>,
+        block_private: bool,
+        request_timeout: Duration,
+    ) -> Self {
         HttpTransport {
             url: url.to_string(),
-            agent: guarded_agent(block_private),
-            inline_agent: guarded_agent(block_private),
+            agent: guarded_agent_with_timeout(block_private, request_timeout),
+            inline_agent: guarded_agent_with_timeout(block_private, request_timeout),
             session_id: None,
             next_id: 1,
             auth: Arc::new(Mutex::new(auth)),
@@ -4954,7 +4968,7 @@ impl Transport for HttpTransport {
         // state to exactly one bounded wire worker, leaving this slot with only a
         // receiver and immutable cancellation context. On cancellation the caller
         // returns within HTTP_CANCEL_POLL; the worker owns no Router/ServerSlot borrow
-        // and drains for at most the agent's 30s request timeout.
+        // and drains for at most the agent's configured request timeout.
         let downstream_id = self.downstream_request_id();
         let request_already_live = self.pending_mrtr.is_some();
         let (sender, receiver) = std::sync::mpsc::sync_channel(1);
@@ -9819,6 +9833,44 @@ mod tests {
     }
 
     #[test]
+    fn configured_http_timeout_bounds_the_response_read() {
+        use super::HttpTransport;
+        use std::time::{Duration, Instant};
+
+        let server = tiny_http::Server::http("127.0.0.1:0").unwrap();
+        let port = server.server_addr().to_ip().unwrap().port();
+        let handle = std::thread::spawn(move || {
+            let request = server.recv().expect("receive timed request");
+            std::thread::sleep(Duration::from_secs(1));
+            let _ = request.respond(tiny_http::Response::from_string(
+                r#"{"jsonrpc":"2.0","id":1,"result":{}}"#,
+            ));
+        });
+
+        let url = format!("http://127.0.0.1:{port}/");
+        let mut transport = HttpTransport::guarded_with_timeout(
+            &url,
+            None,
+            None,
+            false,
+            Duration::from_millis(100),
+        );
+        let started = Instant::now();
+        let result = transport.post(
+            &json!({ "jsonrpc": "2.0", "id": 1, "method": "ping" }),
+            true,
+        );
+
+        assert!(result.is_err(), "the delayed response must exceed the configured timeout");
+        assert!(
+            started.elapsed() < Duration::from_millis(800),
+            "the custom timeout was not applied: {:?}",
+            started.elapsed()
+        );
+        handle.join().unwrap();
+    }
+
+    #[test]
     fn notifications_carry_the_connections_protocol_meta() {
         // The request path stamps protocol `_meta`; `notify` has its own copy of
         // that logic and had no coverage, so a modern connection could have sent
@@ -11674,8 +11726,14 @@ mod tests {
             }
         }
         transport.url = format!("http://127.0.0.1:{recovery_port}/");
-        transport.agent = super::guarded_agent(false);
-        transport.inline_agent = super::guarded_agent(false);
+        transport.agent = super::guarded_agent_with_timeout(
+            false,
+            super::DEFAULT_HTTP_REQUEST_TIMEOUT,
+        );
+        transport.inline_agent = super::guarded_agent_with_timeout(
+            false,
+            super::DEFAULT_HTTP_REQUEST_TIMEOUT,
+        );
         let result = transport
             .request("tools/call", json!({ "name": "after-cancel" }))
             .expect("restored transport accepts a fresh request");

--- a/src-tauri/src/linux_native/onboarding.rs
+++ b/src-tauri/src/linux_native/onboarding.rs
@@ -1102,6 +1102,7 @@ mod tests {
             source: None,
             disabled_tools: Vec::new(),
             client_credentials: None,
+            request_timeout_ms: None,
             unknown_fields: serde_json::Map::new(),
         });
         assert!(!should_offer(&registry, &empty));

--- a/src-tauri/src/linux_native/state.rs
+++ b/src-tauri/src/linux_native/state.rs
@@ -636,6 +636,7 @@ mod tests {
             source: None,
             disabled_tools: Vec::new(),
             client_credentials: None,
+            request_timeout_ms: None,
             unknown_fields: serde_json::Map::new(),
         }
     }

--- a/src-tauri/src/registry.rs
+++ b/src-tauri/src/registry.rs
@@ -441,6 +441,23 @@ pub struct EnvVar {
     pub secret: bool,
 }
 
+/// Long-running generation calls need room beyond the historical 30-second
+/// default, but a bounded ceiling ensures cancellation cannot leave a server's
+/// single HTTP worker draining for an effectively unlimited period.
+pub(crate) const MAX_REQUEST_TIMEOUT_MS: u64 = 24 * 60 * 60 * 1000;
+
+pub(crate) fn validate_request_timeout_ms(milliseconds: u64) -> Result<u64, String> {
+    if milliseconds == 0 {
+        return Err("requestTimeoutMs must be greater than zero".to_string());
+    }
+    if milliseconds > MAX_REQUEST_TIMEOUT_MS {
+        return Err(format!(
+            "requestTimeoutMs must not exceed {MAX_REQUEST_TIMEOUT_MS} (24 hours)"
+        ));
+    }
+    Ok(milliseconds)
+}
+
 // No `Eq`: the `unknown_fields` flatten map (a serde_json::Map) is only `PartialEq`.
 // Dropping `Eq` is what lets an older binary preserve per-server fields it doesn't
 // recognize on re-save, mirroring the same forward-compat protection already on
@@ -485,7 +502,8 @@ pub struct ServerEntry {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub client_credentials: Option<ClientCredentials>,
     /// Total deadline for each HTTP request to this server, in milliseconds.
-    /// Unset preserves the historical 30-second default. Only applies to HTTP/SSE.
+    /// Valid values are 1 through 86,400,000 (24 hours). Unset preserves the
+    /// historical 30-second default. Only applies to HTTP/SSE.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub request_timeout_ms: Option<u64>,
     /// Per-server fields written by a newer build that this binary doesn't know

--- a/src-tauri/src/registry.rs
+++ b/src-tauri/src/registry.rs
@@ -484,6 +484,10 @@ pub struct ServerEntry {
     /// interactive OAuth and pasted-token behaviour exactly as before.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub client_credentials: Option<ClientCredentials>,
+    /// Total deadline for each HTTP request to this server, in milliseconds.
+    /// Unset preserves the historical 30-second default. Only applies to HTTP/SSE.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub request_timeout_ms: Option<u64>,
     /// Per-server fields written by a newer build that this binary doesn't know
     /// about. Captured on load and re-emitted on save so a mixed-version binary
     /// never strips them (same contract as `Registry::unknown_fields`).
@@ -3904,6 +3908,7 @@ mod tests {
             disabled_tools: vec![],
             cwd: None,
             client_credentials: None,
+            request_timeout_ms: None,
             unknown_fields: serde_json::Map::new(),
         }
     }
@@ -4666,6 +4671,23 @@ mod tests {
         assert_eq!(loaded.servers, r.servers);
         assert_eq!(loaded.profiles, r.profiles);
         assert_eq!(loaded.active_profile_id, r.active_profile_id);
+    }
+
+    #[test]
+    fn server_request_timeout_is_optional_and_round_trips_in_milliseconds() {
+        let server = sample_server("remote");
+        let without_timeout = serde_json::to_value(&server).unwrap();
+        assert!(
+            without_timeout.get("requestTimeoutMs").is_none(),
+            "the historical default must not add a registry field"
+        );
+
+        let mut configured = server;
+        configured.request_timeout_ms = Some(75_000);
+        let json = serde_json::to_value(&configured).unwrap();
+        assert_eq!(json["requestTimeoutMs"], 75_000);
+        let loaded: ServerEntry = serde_json::from_value(json).unwrap();
+        assert_eq!(loaded.request_timeout_ms, Some(75_000));
     }
 
     #[test]
@@ -5707,6 +5729,7 @@ mod tests {
             disabled_tools: vec![],
             cwd: None,
             client_credentials: None,
+            request_timeout_ms: None,
             unknown_fields: serde_json::Map::new(),
         });
         // Inject a per-server field this binary's ServerEntry doesn't define.

--- a/src-tauri/src/registry_controller.rs
+++ b/src-tauri/src/registry_controller.rs
@@ -359,6 +359,7 @@ pub fn apply_add_server(registry: &mut Registry, fields: ServerFields) -> Result
             source: Some("manual".into()),
             disabled_tools: Vec::new(),
             client_credentials: None,
+            request_timeout_ms: None,
             unknown_fields: serde_json::Map::new(),
         },
     ))
@@ -389,6 +390,7 @@ pub(crate) fn server_from_detected(server: &clients::McpServer, client_id: &str)
         disabled_tools: Vec::new(),
         cwd: None,
         client_credentials: None,
+        request_timeout_ms: None,
         unknown_fields: serde_json::Map::new(),
     }
 }
@@ -576,6 +578,7 @@ fn catalog_server(entry: crate::catalog::CatalogEntry) -> ServerEntry {
         source: Some(format!("catalog:{}", entry.source)),
         disabled_tools: Vec::new(),
         client_credentials: None,
+        request_timeout_ms: None,
         unknown_fields: serde_json::Map::new(),
     }
 }
@@ -650,6 +653,7 @@ pub fn server_entry_for_probe(
                 source: Some("manual".into()),
                 disabled_tools: Vec::new(),
                 client_credentials: None,
+                request_timeout_ms: None,
                 unknown_fields: serde_json::Map::new(),
             })
         }
@@ -1838,6 +1842,7 @@ mod tests {
             source: None,
             disabled_tools: Vec::new(),
             client_credentials: None,
+            request_timeout_ms: None,
             unknown_fields: serde_json::Map::new(),
         }
     }

--- a/src-tauri/src/remote.rs
+++ b/src-tauri/src/remote.rs
@@ -30,8 +30,8 @@ const DEFAULT_REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
 
 fn request_timeout(server: &ServerEntry) -> Result<Duration, String> {
     match server.request_timeout_ms {
-        Some(0) => Err("requestTimeoutMs must be greater than zero".to_string()),
-        Some(milliseconds) => Ok(Duration::from_millis(milliseconds)),
+        Some(milliseconds) => crate::registry::validate_request_timeout_ms(milliseconds)
+            .map(Duration::from_millis),
         None => Ok(DEFAULT_REQUEST_TIMEOUT),
     }
 }
@@ -1480,6 +1480,21 @@ mod tests {
         assert_eq!(
             request_timeout(&server).unwrap_err(),
             "requestTimeoutMs must be greater than zero"
+        );
+
+        server.request_timeout_ms = Some(crate::registry::MAX_REQUEST_TIMEOUT_MS);
+        assert_eq!(
+            request_timeout(&server).unwrap(),
+            Duration::from_millis(crate::registry::MAX_REQUEST_TIMEOUT_MS)
+        );
+
+        server.request_timeout_ms = Some(crate::registry::MAX_REQUEST_TIMEOUT_MS + 1);
+        assert_eq!(
+            request_timeout(&server).unwrap_err(),
+            format!(
+                "requestTimeoutMs must not exceed {} (24 hours)",
+                crate::registry::MAX_REQUEST_TIMEOUT_MS
+            )
         );
     }
 

--- a/src-tauri/src/remote.rs
+++ b/src-tauri/src/remote.rs
@@ -9,7 +9,7 @@ use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use std::sync::atomic::AtomicU8;
 use std::sync::{Arc, Mutex};
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use crate::downstream::{
     DownstreamServer, HttpTransport, ProgressSink, RefreshFn, ResourceUpdatedSink,
@@ -26,6 +26,15 @@ const PROACTIVE_REFRESH_SKEW_SECS: u64 = 60;
 /// Avoid hammering a temporarily unavailable OAuth endpoint on every tool call
 /// while still retrying within the pre-expiry safety window.
 const PROACTIVE_REFRESH_RETRY_SECS: u64 = 15;
+const DEFAULT_REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
+
+fn request_timeout(server: &ServerEntry) -> Result<Duration, String> {
+    match server.request_timeout_ms {
+        Some(0) => Err("requestTimeoutMs must be greater than zero".to_string()),
+        Some(milliseconds) => Ok(Duration::from_millis(milliseconds)),
+        None => Ok(DEFAULT_REQUEST_TIMEOUT),
+    }
+}
 
 #[derive(Serialize, Deserialize)]
 struct OAuthState {
@@ -772,6 +781,7 @@ fn authed_transport(
     token: Option<String>,
     server_id: &str,
     block_private: bool,
+    request_timeout: Duration,
 ) -> Result<HttpTransport, String> {
     if token.is_some() {
         require_secure_for_auth(url)?;
@@ -865,7 +875,13 @@ fn authed_transport(
     // The resolver enforces the SSRF policy at connect time (DNS-rebind safe); it
     // mirrors `guard_connect_target`: link-local/metadata blocked for all, private
     // blocked only for untrusted-provenance servers.
-    let mut transport = HttpTransport::guarded(url, token, refresh, block_private);
+    let mut transport = HttpTransport::guarded_with_timeout(
+        url,
+        token,
+        refresh,
+        block_private,
+        request_timeout,
+    );
     transport.set_scope_reauthorize(scope_reauthorize);
     // Declared per request only while the flow is actually in use, which is what
     // the extension requires. Keyed off vaulted state rather than registry config
@@ -1002,6 +1018,7 @@ pub fn connect_remote_with_handler(
     // Untrusted-provenance servers also get private/loopback refused at the resolver,
     // matching `guard_connect_target`'s pre-check but closing the DNS-rebind TOCTOU.
     let block_private = is_untrusted_source(server.source.as_deref());
+    let request_timeout = request_timeout(server)?;
     // First connect for a headless server: mint a token now. Only this path has the
     // registry config (client id, method, scopes); every later reacquisition runs
     // from the state vaulted here, which is why it can go through the shared seam
@@ -1050,7 +1067,7 @@ pub fn connect_remote_with_handler(
     // differs from this afterwards, an exchange already happened during this
     // connect (SOU-474).
     let sent_auth = auth.clone();
-    let mut transport = authed_transport(url, auth, server_id, block_private)?;
+    let mut transport = authed_transport(url, auth, server_id, block_private, request_timeout)?;
     if let Some(ref handler) = server_handler {
         transport.set_server_request_handler(handler.clone());
     }
@@ -1096,8 +1113,13 @@ pub fn connect_remote_with_handler(
             }
             match refresh_token(server_id) {
                 Ok(fresh) => {
-                    let mut transport =
-                        authed_transport(url, Some(fresh), server_id, block_private)?;
+                    let mut transport = authed_transport(
+                        url,
+                        Some(fresh),
+                        server_id,
+                        block_private,
+                        request_timeout,
+                    )?;
                     if let Some(handler) = server_handler.clone() {
                         transport.set_server_request_handler(handler);
                     }
@@ -1438,8 +1460,27 @@ mod tests {
             disabled_tools: vec![],
             cwd: None,
             client_credentials: None,
+            request_timeout_ms: None,
             unknown_fields: serde_json::Map::new(),
         }
+    }
+
+    #[test]
+    fn request_timeout_uses_the_legacy_default_or_the_server_override() {
+        let mut server = remote_server("https://mcp.example.com/mcp", None);
+        assert_eq!(request_timeout(&server).unwrap(), Duration::from_secs(30));
+
+        server.request_timeout_ms = Some(65_000);
+        assert_eq!(
+            request_timeout(&server).unwrap(),
+            Duration::from_millis(65_000)
+        );
+
+        server.request_timeout_ms = Some(0);
+        assert_eq!(
+            request_timeout(&server).unwrap_err(),
+            "requestTimeoutMs must be greater than zero"
+        );
     }
 
     #[test]

--- a/src-tauri/src/remote.rs
+++ b/src-tauri/src/remote.rs
@@ -30,8 +30,9 @@ const DEFAULT_REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
 
 fn request_timeout(server: &ServerEntry) -> Result<Duration, String> {
     match server.request_timeout_ms {
-        Some(milliseconds) => crate::registry::validate_request_timeout_ms(milliseconds)
-            .map(Duration::from_millis),
+        Some(milliseconds) => {
+            crate::registry::validate_request_timeout_ms(milliseconds).map(Duration::from_millis)
+        }
         None => Ok(DEFAULT_REQUEST_TIMEOUT),
     }
 }
@@ -875,13 +876,8 @@ fn authed_transport(
     // The resolver enforces the SSRF policy at connect time (DNS-rebind safe); it
     // mirrors `guard_connect_target`: link-local/metadata blocked for all, private
     // blocked only for untrusted-provenance servers.
-    let mut transport = HttpTransport::guarded_with_timeout(
-        url,
-        token,
-        refresh,
-        block_private,
-        request_timeout,
-    );
+    let mut transport =
+        HttpTransport::guarded_with_timeout(url, token, refresh, block_private, request_timeout);
     transport.set_scope_reauthorize(scope_reauthorize);
     // Declared per request only while the flow is actually in use, which is what
     // the extension requires. Keyed off vaulted state rather than registry config

--- a/src-tauri/src/server_runtime.rs
+++ b/src-tauri/src/server_runtime.rs
@@ -152,6 +152,7 @@ mod tests {
             source: None,
             disabled_tools: Vec::new(),
             client_credentials: None,
+            request_timeout_ms: None,
             unknown_fields: serde_json::Map::new(),
         }
     }

--- a/src-tauri/src/sharing_controller.rs
+++ b/src-tauri/src/sharing_controller.rs
@@ -49,6 +49,9 @@ pub(crate) fn build_export(
             if let Some(url) = server.url.as_deref() {
                 server.url = Some(registry::redact_url_userinfo(url));
             }
+            if server.transport == "stdio" || server.command.is_some() {
+                server.request_timeout_ms = None;
+            }
             server
         })
         .collect::<Vec<ServerEntry>>();
@@ -80,7 +83,7 @@ pub(crate) fn apply_import_selected(
     }
     let document: Document = serde_json::from_str(json)
         .map_err(|error| format!("That doesn't look like a Toolport setup: {error}"))?;
-    let mut added = 0usize;
+    let mut to_add = Vec::<ServerEntry>::new();
     for mut server in document.servers {
         if let Some(selected) = selected {
             if !selected
@@ -93,17 +96,28 @@ pub(crate) fn apply_import_selected(
         if registry
             .servers
             .iter()
+            .chain(to_add.iter())
             .any(|entry| entry.name.eq_ignore_ascii_case(&server.name))
         {
             continue;
+        }
+        if server.transport == "stdio" || server.command.is_some() {
+            server.request_timeout_ms = None;
+        } else if let Some(milliseconds) = server.request_timeout_ms {
+            registry::validate_request_timeout_ms(milliseconds).map_err(|error| {
+                format!("Invalid request timeout for '{}': {error}", server.name)
+            })?;
         }
         server.id.clear();
         for entry in &mut server.env {
             entry.value = None;
         }
         server.source = Some("shared".to_string());
+        to_add.push(server);
+    }
+    let added = to_add.len();
+    for server in to_add {
         registry.add_server(server);
-        added += 1;
     }
     Ok(added)
 }
@@ -311,5 +325,74 @@ mod controller_tests {
         assert_eq!(registry.servers.len(), 1);
         assert_eq!(registry.servers[0].name, "GitHub");
         assert_eq!(registry.servers[0].source.as_deref(), Some("shared"));
+    }
+
+    #[test]
+    fn shared_import_enforces_remote_request_timeout_bounds_atomically() {
+        let mut registry = Registry::default();
+        let invalid = serde_json::json!({ "servers": [
+            {
+                "name": "Valid",
+                "transport": "http",
+                "url": "https://example.com/mcp",
+                "requestTimeoutMs": 90_000
+            },
+            {
+                "name": "Invalid",
+                "transport": "http",
+                "url": "https://example.com/slow",
+                "requestTimeoutMs": registry::MAX_REQUEST_TIMEOUT_MS + 1
+            }
+        ]});
+
+        let error = apply_import(&mut registry, &invalid.to_string()).unwrap_err();
+        assert!(error.contains("Invalid request timeout for 'Invalid'"));
+        assert!(
+            registry.servers.is_empty(),
+            "a rejected document must not be partially imported"
+        );
+
+        let valid = serde_json::json!({ "servers": [{
+            "name": "Maximum",
+            "transport": "http",
+            "url": "https://example.com/mcp",
+            "requestTimeoutMs": registry::MAX_REQUEST_TIMEOUT_MS
+        }]});
+        assert_eq!(apply_import(&mut registry, &valid.to_string()).unwrap(), 1);
+        assert_eq!(
+            registry.servers[0].request_timeout_ms,
+            Some(registry::MAX_REQUEST_TIMEOUT_MS)
+        );
+    }
+
+    #[test]
+    fn shared_import_and_export_clear_timeouts_for_local_commands() {
+        let mut registry = Registry::default();
+        let json = serde_json::json!({ "servers": [
+            {
+                "name": "Local",
+                "transport": "stdio",
+                "command": "local-server",
+                "requestTimeoutMs": 0
+            },
+            {
+                "name": "Local wrapper",
+                "transport": "http",
+                "command": "local-server",
+                "requestTimeoutMs": registry::MAX_REQUEST_TIMEOUT_MS + 1
+            }
+        ]});
+
+        assert_eq!(apply_import(&mut registry, &json.to_string()).unwrap(), 2);
+        assert!(registry
+            .servers
+            .iter()
+            .all(|server| server.request_timeout_ms.is_none()));
+        let exported = build_export(&registry, None, None, None);
+        assert!(exported["servers"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .all(|server| server["requestTimeoutMs"].is_null()));
     }
 }

--- a/src-tauri/src/teams.rs
+++ b/src-tauri/src/teams.rs
@@ -1665,6 +1665,14 @@ fn team_server_export(reg: &Registry) -> Value {
                 })
                 .collect();
             let url = s.url.as_deref().map(crate::redact_url_userinfo);
+            // A command-bearing entry is executed locally even if its transport
+            // label says otherwise. Do not publish a remote-only setting that
+            // cannot affect that server.
+            let request_timeout_ms = if s.transport == "stdio" || s.command.is_some() {
+                None
+            } else {
+                s.request_timeout_ms
+            };
             serde_json::json!({
                 "id": s.id,
                 "name": s.name,
@@ -1674,7 +1682,7 @@ fn team_server_export(reg: &Registry) -> Value {
                 "url": url,
                 "env": s.env.iter().map(|e| serde_json::json!({ "key": e.key, "secret": e.secret })).collect::<Vec<_>>(),
                 "disabledTools": s.disabled_tools,
-                "requestTimeoutMs": s.request_timeout_ms,
+                "requestTimeoutMs": request_timeout_ms,
                 // Non-secret by construction: client id, method and scopes only.
                 // The client SECRET is vaulted per member and is never in this
                 // payload, so a teammate importing this gets a server that tells
@@ -2083,18 +2091,6 @@ fn classify_team_server(s: &Value, tag: &str) -> TeamClass {
 
     let transport = str_field("transport").unwrap_or("stdio").to_string();
     let command = str_field("command").map(String::from);
-    let request_timeout_ms = match s.get("requestTimeoutMs").filter(|value| !value.is_null()) {
-        Some(value) => match value
-            .as_u64()
-            .and_then(|milliseconds| {
-                crate::registry::validate_request_timeout_ms(milliseconds).ok()
-            })
-        {
-            Some(milliseconds) => Some(milliseconds),
-            None => return TeamClass::Blocked,
-        },
-        None => None,
-    };
     let mut entry = ServerEntry {
         id,
         name: name.to_string(),
@@ -2110,7 +2106,7 @@ fn classify_team_server(s: &Value, tag: &str) -> TeamClass {
         // silently downgraded the member to interactive OAuth, which is exactly
         // what this flow exists to avoid; the secret is still theirs to add.
         client_credentials,
-        request_timeout_ms,
+        request_timeout_ms: None,
         unknown_fields: serde_json::Map::new(),
     };
 
@@ -2139,6 +2135,15 @@ fn classify_team_server(s: &Value, tag: &str) -> TeamClass {
         return TeamClass::Blocked;
     }
     entry.url = Some(url.to_string());
+    entry.request_timeout_ms = match s.get("requestTimeoutMs").filter(|value| !value.is_null()) {
+        Some(value) => match value.as_u64().and_then(|milliseconds| {
+            crate::registry::validate_request_timeout_ms(milliseconds).ok()
+        }) {
+            Some(milliseconds) => Some(milliseconds),
+            None => return TeamClass::Blocked,
+        },
+        None => None,
+    };
     // Loopback / LAN (RFC1918) is a legit internal server, but require opt-in like stdio.
     if crate::oauth::host_is_private(&host) {
         return TeamClass::Review(entry);
@@ -3661,16 +3666,69 @@ mod tests {
             ),
             TeamClass::Blocked
         ));
-        match classify_team_server(
-            &server(crate::registry::MAX_REQUEST_TIMEOUT_MS),
-            "team:t1",
-        ) {
+        match classify_team_server(&server(crate::registry::MAX_REQUEST_TIMEOUT_MS), "team:t1") {
             TeamClass::Review(imported) | TeamClass::Ready(imported) => assert_eq!(
                 imported.request_timeout_ms,
                 Some(crate::registry::MAX_REQUEST_TIMEOUT_MS)
             ),
             _ => panic!("the maximum request timeout must be accepted"),
         }
+    }
+
+    #[test]
+    fn team_import_ignores_request_timeout_for_local_commands() {
+        for request_timeout_ms in [
+            Value::from(0),
+            Value::from("not-a-number"),
+            Value::from(crate::registry::MAX_REQUEST_TIMEOUT_MS + 1),
+        ] {
+            let server = serde_json::json!({
+                "id": "local",
+                "name": "Local",
+                "transport": "stdio",
+                "command": "local-server",
+                "requestTimeoutMs": request_timeout_ms,
+            });
+            match classify_team_server(&server, "team:t1") {
+                TeamClass::Review(imported) => assert_eq!(imported.request_timeout_ms, None),
+                _ => panic!("a local server must not be blocked by an irrelevant timeout"),
+            }
+        }
+
+        let command_bearing_http = serde_json::json!({
+            "id": "local-http",
+            "name": "Local HTTP wrapper",
+            "transport": "http",
+            "command": "local-server",
+            "url": "https://mcp.example.com/mcp",
+            "requestTimeoutMs": 0,
+        });
+        match classify_team_server(&command_bearing_http, "team:t1") {
+            TeamClass::Review(imported) => assert_eq!(imported.request_timeout_ms, None),
+            _ => panic!("command-bearing entries must use local-server semantics"),
+        }
+    }
+
+    #[test]
+    fn team_export_clears_request_timeout_for_local_commands() {
+        let mut reg = base_registry();
+        let server = reg
+            .servers
+            .iter_mut()
+            .find(|s| s.id == "mine")
+            .expect("fixture server");
+        server.request_timeout_ms = Some(crate::registry::MAX_REQUEST_TIMEOUT_MS + 1);
+
+        let exported = team_server_export(&reg);
+        let entry = exported
+            .as_array()
+            .and_then(|servers| {
+                servers
+                    .iter()
+                    .find(|server| server.get("id").and_then(Value::as_str) == Some("mine"))
+            })
+            .expect("the server must be exported");
+        assert_eq!(entry.get("requestTimeoutMs"), Some(&Value::Null));
     }
 
     #[test]

--- a/src-tauri/src/teams.rs
+++ b/src-tauri/src/teams.rs
@@ -1674,6 +1674,7 @@ fn team_server_export(reg: &Registry) -> Value {
                 "url": url,
                 "env": s.env.iter().map(|e| serde_json::json!({ "key": e.key, "secret": e.secret })).collect::<Vec<_>>(),
                 "disabledTools": s.disabled_tools,
+                "requestTimeoutMs": s.request_timeout_ms,
                 // Non-secret by construction: client id, method and scopes only.
                 // The client SECRET is vaulted per member and is never in this
                 // payload, so a teammate importing this gets a server that tells
@@ -2083,7 +2084,12 @@ fn classify_team_server(s: &Value, tag: &str) -> TeamClass {
     let transport = str_field("transport").unwrap_or("stdio").to_string();
     let command = str_field("command").map(String::from);
     let request_timeout_ms = match s.get("requestTimeoutMs").filter(|value| !value.is_null()) {
-        Some(value) => match value.as_u64().filter(|milliseconds| *milliseconds > 0) {
+        Some(value) => match value
+            .as_u64()
+            .and_then(|milliseconds| {
+                crate::registry::validate_request_timeout_ms(milliseconds).ok()
+            })
+        {
             Some(milliseconds) => Some(milliseconds),
             None => return TeamClass::Blocked,
         },
@@ -3597,6 +3603,73 @@ mod tests {
                 );
             }
             _ => panic!("expected the http server to import"),
+        }
+    }
+
+    #[test]
+    fn request_timeout_round_trips_through_team_import_and_export() {
+        let mut reg = base_registry();
+        let server = reg
+            .servers
+            .iter_mut()
+            .find(|s| s.id == "mine")
+            .expect("fixture server");
+        server.transport = "http".into();
+        server.command = None;
+        server.url = Some("https://mcp.example.com/mcp".into());
+        server.request_timeout_ms = Some(90_000);
+
+        let exported = team_server_export(&reg);
+        let entry = exported
+            .as_array()
+            .and_then(|servers| {
+                servers
+                    .iter()
+                    .find(|server| server.get("id").and_then(Value::as_str) == Some("mine"))
+            })
+            .expect("the server must be exported");
+        assert_eq!(entry.get("requestTimeoutMs"), Some(&Value::from(90_000)));
+
+        match classify_team_server(entry, "team:t1") {
+            TeamClass::Review(imported) | TeamClass::Ready(imported) => {
+                assert_eq!(imported.request_timeout_ms, Some(90_000));
+            }
+            _ => panic!("expected the http server to import"),
+        }
+    }
+
+    #[test]
+    fn team_import_enforces_request_timeout_bounds() {
+        let server = |request_timeout_ms| {
+            serde_json::json!({
+                "id": "s",
+                "name": "S",
+                "transport": "http",
+                "url": "https://mcp.example.com/mcp",
+                "requestTimeoutMs": request_timeout_ms,
+            })
+        };
+
+        assert!(matches!(
+            classify_team_server(&server(0), "team:t1"),
+            TeamClass::Blocked
+        ));
+        assert!(matches!(
+            classify_team_server(
+                &server(crate::registry::MAX_REQUEST_TIMEOUT_MS + 1),
+                "team:t1"
+            ),
+            TeamClass::Blocked
+        ));
+        match classify_team_server(
+            &server(crate::registry::MAX_REQUEST_TIMEOUT_MS),
+            "team:t1",
+        ) {
+            TeamClass::Review(imported) | TeamClass::Ready(imported) => assert_eq!(
+                imported.request_timeout_ms,
+                Some(crate::registry::MAX_REQUEST_TIMEOUT_MS)
+            ),
+            _ => panic!("the maximum request timeout must be accepted"),
         }
     }
 

--- a/src-tauri/src/teams.rs
+++ b/src-tauri/src/teams.rs
@@ -2082,6 +2082,13 @@ fn classify_team_server(s: &Value, tag: &str) -> TeamClass {
 
     let transport = str_field("transport").unwrap_or("stdio").to_string();
     let command = str_field("command").map(String::from);
+    let request_timeout_ms = match s.get("requestTimeoutMs").filter(|value| !value.is_null()) {
+        Some(value) => match value.as_u64().filter(|milliseconds| *milliseconds > 0) {
+            Some(milliseconds) => Some(milliseconds),
+            None => return TeamClass::Blocked,
+        },
+        None => None,
+    };
     let mut entry = ServerEntry {
         id,
         name: name.to_string(),
@@ -2097,6 +2104,7 @@ fn classify_team_server(s: &Value, tag: &str) -> TeamClass {
         // silently downgraded the member to interactive OAuth, which is exactly
         // what this flow exists to avoid; the secret is still theirs to add.
         client_credentials,
+        request_timeout_ms,
         unknown_fields: serde_json::Map::new(),
     };
 
@@ -2821,6 +2829,7 @@ mod tests {
             disabled_tools: vec![],
             cwd: None,
             client_credentials: None,
+            request_timeout_ms: None,
             unknown_fields: serde_json::Map::new(),
         });
         let active = r.active_profile_id.clone().unwrap();
@@ -2848,7 +2857,7 @@ mod tests {
         let mut r = base_registry();
         let cfg = json!({ "servers": [
             { "id": "github", "name": "GitHub", "transport": "http", "url": "https://1.2.3.4/mcp",
-              "env": [{ "key": "TOKEN", "secret": true }] },
+              "env": [{ "key": "TOKEN", "secret": true }], "requestTimeoutMs": 90_000 },
             { "id": "stripe", "name": "Stripe", "transport": "http", "url": "https://1.2.3.5/mcp" }
         ]});
         assert_eq!(apply_team_config(&mut r, "t1", &cfg).applied, 2);
@@ -2860,6 +2869,7 @@ mod tests {
         let gh = r.servers.iter().find(|s| s.id == "team_github").unwrap();
         assert_eq!(gh.source.as_deref(), Some("team:t1"));
         assert_eq!(gh.env[0].key, "TOKEN");
+        assert_eq!(gh.request_timeout_ms, Some(90_000));
         assert!(
             gh.env[0].value.is_none(),
             "no secret value carried from the team"
@@ -3000,6 +3010,7 @@ mod tests {
             disabled_tools: vec![],
             cwd: None,
             client_credentials: None,
+            request_timeout_ms: None,
             unknown_fields: serde_json::Map::new(),
         });
         let cfg = json!({ "servers": [
@@ -3137,6 +3148,7 @@ mod tests {
             disabled_tools: vec![],
             cwd: None,
             client_credentials: None,
+            request_timeout_ms: None,
             unknown_fields: serde_json::Map::new(),
         });
         apply_team_config(
@@ -3764,6 +3776,7 @@ mod tests {
             disabled_tools: vec![],
             cwd: None,
             client_credentials: None,
+            request_timeout_ms: None,
             unknown_fields: serde_json::Map::new(),
         });
         // A team-sourced server: excluded too (don't echo the team's own set back).
@@ -3779,6 +3792,7 @@ mod tests {
             disabled_tools: vec![],
             cwd: None,
             client_credentials: None,
+            request_timeout_ms: None,
             unknown_fields: serde_json::Map::new(),
         });
         let servers = team_server_export(&r);
@@ -4128,6 +4142,7 @@ mod tests {
             disabled_tools: vec![],
             cwd: None,
             client_credentials: None,
+            request_timeout_ms: None,
             unknown_fields: serde_json::Map::new(),
         };
         let fp = consent_fingerprint(&base);

--- a/src/components/ServerDialog.test.tsx
+++ b/src/components/ServerDialog.test.tsx
@@ -1,7 +1,7 @@
 import { beforeEach, describe, it, expect, vi } from "vitest";
 import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import type { ProbeResult, Registry } from "@/lib/types";
+import type { ProbeResult, Registry, ServerEntry } from "@/lib/types";
 
 const api = vi.hoisted(() => ({
   addServer: vi.fn(),
@@ -102,6 +102,37 @@ describe("ServerDialog", () => {
 
     await userEvent.type(screen.getByLabelText("Command"), "npx");
     expect(screen.getByRole("button", { name: "Add" })).toBeEnabled();
+  });
+
+  it("does not reactivate a local-only timeout when switching to HTTP", async () => {
+    const initial: ServerEntry = {
+      id: "local",
+      name: "Local",
+      transport: "stdio",
+      command: "local-server",
+      args: [],
+      env: [],
+      url: null,
+      source: "manual",
+      requestTimeoutMs: 90_000,
+    };
+    api.updateServer.mockResolvedValueOnce(savedRegistry("local"));
+    const user = userEvent.setup();
+
+    render(<ServerDialog autoOpen editId="local" initial={initial} onSaved={vi.fn()} />);
+    await user.click(screen.getByLabelText("Transport"));
+    await user.click(screen.getByRole("option", { name: "http (remote)" }));
+    await user.type(screen.getByLabelText("URL"), "https://mcp.example.com/mcp");
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => expect(api.updateServer).toHaveBeenCalledTimes(1));
+    expect(api.updateServer).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: "local",
+        transport: "http",
+        requestTimeoutMs: null,
+      }),
+    );
   });
 
   it("closes on Cancel when it owns its open state (header add flow)", async () => {

--- a/src/components/ServerDialog.tsx
+++ b/src/components/ServerDialog.tsx
@@ -101,6 +101,7 @@ export function ServerDialog({
   );
   const currentEditId = editId ?? partialEdit?.id;
   const isStdio = form.transport === "stdio";
+  const initialUsesLocalCommand = initial?.transport === "stdio" || !!initial?.command;
   const editing = currentEditId !== undefined;
 
   // Paste-from-config state.
@@ -225,7 +226,8 @@ export function ServerDialog({
       url: isStdio ? null : form.url.trim() || null,
       source: initial?.source ?? "manual",
       cwd: isStdio ? form.cwd.trim() || null : null,
-      requestTimeoutMs: isStdio ? null : initial?.requestTimeoutMs,
+      requestTimeoutMs:
+        isStdio || initialUsesLocalCommand ? null : initial?.requestTimeoutMs,
     };
   }
 

--- a/src/components/ServerDialog.tsx
+++ b/src/components/ServerDialog.tsx
@@ -225,6 +225,7 @@ export function ServerDialog({
       url: isStdio ? null : form.url.trim() || null,
       source: initial?.source ?? "manual",
       cwd: isStdio ? form.cwd.trim() || null : null,
+      requestTimeoutMs: isStdio ? null : initial?.requestTimeoutMs,
     };
   }
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -345,7 +345,8 @@ export interface ServerEntry {
   /** Headless outbound OAuth (SBS-524). Present = this server uses the
    * client-credentials flow instead of the interactive browser one. */
   clientCredentials?: ClientCredentials | null;
-  /** Total deadline for each HTTP request, in milliseconds. Unset = 30 seconds. */
+  /** Total deadline for each HTTP request, in milliseconds.
+   * Valid values are 1 ms through 24 hours; unset preserves the 30-second default. */
   requestTimeoutMs?: number | null;
 }
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -345,6 +345,8 @@ export interface ServerEntry {
   /** Headless outbound OAuth (SBS-524). Present = this server uses the
    * client-credentials flow instead of the interactive browser one. */
   clientCredentials?: ClientCredentials | null;
+  /** Total deadline for each HTTP request, in milliseconds. Unset = 30 seconds. */
+  requestTimeoutMs?: number | null;
 }
 
 /** Non-secret client-credentials config. The client SECRET is never here: it


### PR DESCRIPTION
## What and why

Closes #850.

- Adds an optional `requestTimeoutMs` field to each server entry while preserving the existing 30-second default when it is omitted.
- Applies the configured deadline to initialization, normal HTTP/SSE calls, response reads, and the OAuth retry transport.
- Rejects a zero timeout with a clear configuration error.
- Preserves the field through registry serialization, team configuration, and HTTP server edits in the desktop UI.

## Testing

- [x] `npm run build` passes
- [x] `npm run test` passes (653 tests on Linux/WSL)
- [x] `npm run audit:prod` passes
- [x] `npm run test:rust:windows` passes (library, binary, and integration suites)
- [ ] Ran the app (`npm run tauri dev`) and checked the change by hand
- [x] `cargo test --manifest-path src-tauri/Cargo.toml --no-default-features --lib` passes (1,275 tests)
- [x] `npm run format:check` passes
- [x] `npm run lint` passes with no errors

## Notes

- No visible UI control is added; this exposes the timeout through the existing registry configuration surface.
- The behavior is covered by a real delayed HTTP response test plus serialization and configuration tests.
- The app was not run interactively because this change has no visible UI behavior.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tsouth89/toolport/pull/852" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add configurable `request_timeout_ms` to `ServerEntry` and `HttpTransport`
> - Adds optional `request_timeout_ms` field to `ServerEntry` in [registry.rs](https://github.com/tsouth89/toolport/pull/852/files#diff-8187fea44e15daa4059544c5fcff94f80f39fa1ec39c67eccccc153a98b39349), validated to be >0 and <=24h via `validate_request_timeout_ms`. Omitted values preserve the historical 30s default.
> - Introduces `HttpTransport::guarded_with_timeout` in [downstream.rs](https://github.com/tsouth89/toolport/pull/852/files#diff-920fdf1b1d5b155e925a542634d5b599e0e7b1b32319d2349f19f1886a245489); `guarded()` now delegates to it with `DEFAULT_HTTP_REQUEST_TIMEOUT` (30s). Both main and inline agents honor the per-request timeout.
> - Remote connection path in [remote.rs](https://github.com/tsouth89/toolport/pull/852/files#diff-a2c91d9f0132e2eae1239b0204cdc5129b67b5a5e4c05940641306e4619b015d) derives and validates the timeout from the server entry, returning an error on invalid values.
> - Import/export in [sharing_controller.rs](https://github.com/tsouth89/toolport/pull/852/files#diff-e7d85614f0129451001972f44dd104b959b6a44dc248b84fd734908399d405e4) and [teams.rs](https://github.com/tsouth89/toolport/pull/852/files#diff-cd8712bc1a5c6c56e55e867d15f3fb7aaf0c25b20186b10e164686e8f9926526) clears `request_timeout_ms` for local-command servers, validates it for remote-only servers, and rejects entire imports on invalid timeouts.
> - `ServerDialog` UI in [ServerDialog.tsx](https://github.com/tsouth89/toolport/pull/852/files#diff-68aae418c9ad023485060a4193bf49cdd578e15c8e4e2ab2af62e61b42e7ebd5) sets `requestTimeoutMs` to null for stdio or local-command servers.
> - Risk: Import is now atomic — a single invalid `requestTimeoutMs` rejects the whole import in `apply_import_selected` instead of partially applying. Team sync blocks servers with invalid `requestTimeoutMs` values via `classify_team_server`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3399fdd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->