### PR TITLE
feat(gateway): per-server requestTimeoutMs for stdio live calls

### DIFF
--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -9118,8 +9118,17 @@ fn connect_one(
         Ok(mut ds) => {
             ds.set_server_request_handler(server_handler);
             // Only the gateway needs resources/prompts (to proxy them); fetch
-            // them here, off the health-probe path.
+            // them here, off the health-probe path. These initial catalog reads
+            // intentionally run at the bounded STDIO_READ_TIMEOUT — the widened
+            // live-call timeout is applied after, so a server with a large
+            // requestTimeoutMs cannot stall startup.
             ds.load_resources_prompts();
+            // Per-server `requestTimeoutMs` widens only this server's live-call
+            // read deadline; connect budgets stay bounded. Clamped to >=1ms so a
+            // zero entry cannot become an instant timeout on every call.
+            if let Some(ms) = server.request_timeout_ms {
+                ds.set_call_timeout(Duration::from_millis(ms.max(1)));
+            }
             let msg = format!("connected '{}' ({} tools)", server.id, ds.tools.len());
             eprintln!("toolport: {msg}");
             glog(&msg);

--- a/src-tauri/src/downstream.rs
+++ b/src-tauri/src/downstream.rs
@@ -5364,6 +5364,11 @@ pub struct DownstreamServer {
     /// Desired per-resource notification set carried by the modern listener.
     /// Legacy servers keep using resources/subscribe and resources/unsubscribe.
     modern_resource_subscriptions: HashSet<String>,
+    /// Live-call read deadline. Starts at STDIO_READ_TIMEOUT; a per-server
+    /// `requestTimeoutMs` widens it through `set_call_timeout`. Connect,
+    /// handshake, and probe budgets are never widened, so a hung server still
+    /// fails fast.
+    call_timeout: Duration,
     /// Existing legacy server-to-client request bridge. Modern downstream
     /// `input_required` results use it as a compatibility shim when the upstream
     /// client predates MRTR.
@@ -5615,8 +5620,18 @@ impl DownstreamServer {
             era,
             modern_http,
             modern_resource_subscriptions: std::collections::HashSet::new(),
+            call_timeout: STDIO_READ_TIMEOUT,
             server_handler: None,
         })
+    }
+
+    /// Widen the live-call read deadline for this server (per-server
+    /// `requestTimeoutMs`). Post-handshake requests only: connect, handshake,
+    /// and probe budgets keep their tighter bounds so a hung server still fails
+    /// fast, and a zero/near-zero configured value is clamped by the caller.
+    pub fn set_call_timeout(&mut self, timeout: Duration) {
+        self.call_timeout = timeout;
+        self.transport.set_read_timeout(timeout);
     }
 
     /// Install the upstream request bridge on both this server wrapper and its
@@ -5867,7 +5882,7 @@ impl DownstreamServer {
                 );
             }
         }
-        self.transport.set_read_timeout(STDIO_READ_TIMEOUT);
+        self.transport.set_read_timeout(self.call_timeout);
     }
 
     /// Re-fetch the resource list on the existing connection after the server
@@ -5957,7 +5972,7 @@ impl DownstreamServer {
                 );
             }
         }
-        self.transport.set_read_timeout(STDIO_READ_TIMEOUT);
+        self.transport.set_read_timeout(self.call_timeout);
     }
 
     /// Re-fetch the prompt list on the existing connection after the server
@@ -6006,7 +6021,7 @@ impl DownstreamServer {
                 );
             }
         }
-        self.transport.set_read_timeout(STDIO_READ_TIMEOUT);
+        self.transport.set_read_timeout(self.call_timeout);
     }
 
     /// Fetch the resources, resource templates, and prompts the server advertised.
@@ -6862,6 +6877,7 @@ mod tests {
             },
             modern_http: false,
             modern_resource_subscriptions: std::collections::HashSet::new(),
+            call_timeout: super::STDIO_READ_TIMEOUT,
             server_handler: None,
         };
         server.refresh_tools();
@@ -6897,6 +6913,7 @@ mod tests {
             },
             modern_http: false,
             modern_resource_subscriptions: std::collections::HashSet::new(),
+            call_timeout: super::STDIO_READ_TIMEOUT,
             server_handler: None,
         };
         server.refresh_tools();
@@ -6938,6 +6955,7 @@ mod tests {
             },
             modern_http: false,
             modern_resource_subscriptions: std::collections::HashSet::new(),
+            call_timeout: super::STDIO_READ_TIMEOUT,
             server_handler: None,
         };
         server.refresh_tools();
@@ -6979,6 +6997,7 @@ mod tests {
             },
             modern_http: false,
             modern_resource_subscriptions: std::collections::HashSet::new(),
+            call_timeout: super::STDIO_READ_TIMEOUT,
             server_handler: None,
         };
         server.refresh_tools();
@@ -7017,6 +7036,7 @@ mod tests {
             },
             modern_http: false,
             modern_resource_subscriptions: std::collections::HashSet::new(),
+            call_timeout: super::STDIO_READ_TIMEOUT,
             server_handler: None,
         };
         server.refresh_resources();
@@ -7064,6 +7084,7 @@ mod tests {
             },
             modern_http: false,
             modern_resource_subscriptions: std::collections::HashSet::new(),
+            call_timeout: super::STDIO_READ_TIMEOUT,
             server_handler: None,
         };
         server.refresh_resources();

--- a/src-tauri/src/registry.rs
+++ b/src-tauri/src/registry.rs
@@ -501,9 +501,10 @@ pub struct ServerEntry {
     /// interactive OAuth and pasted-token behaviour exactly as before.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub client_credentials: Option<ClientCredentials>,
-    /// Total deadline for each HTTP request to this server, in milliseconds.
+    /// Total deadline for each request to this server, in milliseconds.
     /// Valid values are 1 through 86,400,000 (24 hours). Unset preserves the
-    /// historical 30-second default. Only applies to HTTP/SSE.
+    /// historical 30-second default. Applies to both HTTP/SSE and stdio
+    /// transports.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub request_timeout_ms: Option<u64>,
     /// Per-server fields written by a newer build that this binary doesn't know

--- a/src-tauri/src/sharing_controller.rs
+++ b/src-tauri/src/sharing_controller.rs
@@ -49,9 +49,6 @@ pub(crate) fn build_export(
             if let Some(url) = server.url.as_deref() {
                 server.url = Some(registry::redact_url_userinfo(url));
             }
-            if server.transport == "stdio" || server.command.is_some() {
-                server.request_timeout_ms = None;
-            }
             server
         })
         .collect::<Vec<ServerEntry>>();
@@ -101,9 +98,7 @@ pub(crate) fn apply_import_selected(
         {
             continue;
         }
-        if server.transport == "stdio" || server.command.is_some() {
-            server.request_timeout_ms = None;
-        } else if let Some(milliseconds) = server.request_timeout_ms {
+        if let Some(milliseconds) = server.request_timeout_ms {
             registry::validate_request_timeout_ms(milliseconds).map_err(|error| {
                 format!("Invalid request timeout for '{}': {error}", server.name)
             })?;
@@ -366,33 +361,35 @@ mod controller_tests {
     }
 
     #[test]
-    fn shared_import_and_export_clear_timeouts_for_local_commands() {
+    fn shared_import_and_export_round_trip_timeouts_for_local_commands() {
         let mut registry = Registry::default();
         let json = serde_json::json!({ "servers": [
             {
                 "name": "Local",
                 "transport": "stdio",
                 "command": "local-server",
-                "requestTimeoutMs": 0
+                "requestTimeoutMs": 90_000
             },
             {
                 "name": "Local wrapper",
                 "transport": "http",
                 "command": "local-server",
-                "requestTimeoutMs": registry::MAX_REQUEST_TIMEOUT_MS + 1
+                "requestTimeoutMs": 120_000
             }
         ]});
 
         assert_eq!(apply_import(&mut registry, &json.to_string()).unwrap(), 2);
-        assert!(registry
-            .servers
-            .iter()
-            .all(|server| server.request_timeout_ms.is_none()));
+        assert_eq!(
+            registry.servers[0].request_timeout_ms,
+            Some(90_000)
+        );
+        assert_eq!(
+            registry.servers[1].request_timeout_ms,
+            Some(120_000)
+        );
         let exported = build_export(&registry, None, None, None);
-        assert!(exported["servers"]
-            .as_array()
-            .unwrap()
-            .iter()
-            .all(|server| server["requestTimeoutMs"].is_null()));
+        let servers = exported["servers"].as_array().unwrap();
+        assert_eq!(servers[0]["requestTimeoutMs"], 90_000);
+        assert_eq!(servers[1]["requestTimeoutMs"], 120_000);
     }
 }

--- a/src-tauri/src/teams.rs
+++ b/src-tauri/src/teams.rs
@@ -1666,14 +1666,6 @@ fn team_server_export(reg: &Registry) -> Value {
                 })
                 .collect();
             let url = s.url.as_deref().map(crate::redact_url_userinfo);
-            // A command-bearing entry is executed locally even if its transport
-            // label says otherwise. Do not publish a remote-only setting that
-            // cannot affect that server.
-            let request_timeout_ms = if s.transport == "stdio" || s.command.is_some() {
-                None
-            } else {
-                s.request_timeout_ms
-            };
             serde_json::json!({
                 "id": s.id,
                 "name": s.name,
@@ -1683,7 +1675,7 @@ fn team_server_export(reg: &Registry) -> Value {
                 "url": url,
                 "env": s.env.iter().map(|e| serde_json::json!({ "key": e.key, "secret": e.secret })).collect::<Vec<_>>(),
                 "disabledTools": s.disabled_tools,
-                "requestTimeoutMs": request_timeout_ms,
+                "requestTimeoutMs": s.request_timeout_ms,
                 // Non-secret by construction: client id, method and scopes only.
                 // The client SECRET is vaulted per member and is never in this
                 // payload, so a teammate importing this gets a server that tells
@@ -2119,6 +2111,15 @@ fn classify_team_server(s: &Value, tag: &str) -> TeamClass {
             Some(c) => entry.command = Some(c),
             None => return TeamClass::Skip, // stdio with no command is unusable
         }
+        entry.request_timeout_ms = match s.get("requestTimeoutMs").filter(|value| !value.is_null()) {
+            Some(value) => match value.as_u64().and_then(|milliseconds| {
+                crate::registry::validate_request_timeout_ms(milliseconds).ok()
+            }) {
+                Some(milliseconds) => Some(milliseconds),
+                None => return TeamClass::Blocked,
+            },
+            None => None,
+        };
         return TeamClass::Review(entry);
     }
 
@@ -3686,11 +3687,12 @@ mod tests {
     }
 
     #[test]
-    fn team_import_ignores_request_timeout_for_local_commands() {
-        for request_timeout_ms in [
-            Value::from(0),
-            Value::from("not-a-number"),
-            Value::from(crate::registry::MAX_REQUEST_TIMEOUT_MS + 1),
+    fn team_import_validates_request_timeout_for_local_commands() {
+        for (request_timeout_ms, should_block) in [
+            (Value::from(0), true),
+            (Value::from("not-a-number"), true),
+            (Value::from(crate::registry::MAX_REQUEST_TIMEOUT_MS + 1), true),
+            (Value::from(90_000), false),
         ] {
             let server = serde_json::json!({
                 "id": "local",
@@ -3700,8 +3702,14 @@ mod tests {
                 "requestTimeoutMs": request_timeout_ms,
             });
             match classify_team_server(&server, "team:t1") {
-                TeamClass::Review(imported) => assert_eq!(imported.request_timeout_ms, None),
-                _ => panic!("a local server must not be blocked by an irrelevant timeout"),
+                TeamClass::Review(imported) => {
+                    assert!(!should_block, "expected Blocked for {request_timeout_ms}");
+                    assert_eq!(imported.request_timeout_ms, Some(90_000));
+                }
+                TeamClass::Blocked => {
+                    assert!(should_block, "expected Review for {request_timeout_ms}");
+                }
+                _ => panic!("unexpected classification for {request_timeout_ms}"),
             }
         }
 
@@ -3711,23 +3719,23 @@ mod tests {
             "transport": "http",
             "command": "local-server",
             "url": "https://mcp.example.com/mcp",
-            "requestTimeoutMs": 0,
+            "requestTimeoutMs": 90_000,
         });
         match classify_team_server(&command_bearing_http, "team:t1") {
-            TeamClass::Review(imported) => assert_eq!(imported.request_timeout_ms, None),
+            TeamClass::Review(imported) => assert_eq!(imported.request_timeout_ms, Some(90_000)),
             _ => panic!("command-bearing entries must use local-server semantics"),
         }
     }
 
     #[test]
-    fn team_export_clears_request_timeout_for_local_commands() {
+    fn team_export_preserves_request_timeout_for_local_commands() {
         let mut reg = base_registry();
         let server = reg
             .servers
             .iter_mut()
             .find(|s| s.id == "mine")
             .expect("fixture server");
-        server.request_timeout_ms = Some(crate::registry::MAX_REQUEST_TIMEOUT_MS + 1);
+        server.request_timeout_ms = Some(90_000);
 
         let exported = team_server_export(&reg);
         let entry = exported
@@ -3738,7 +3746,7 @@ mod tests {
                     .find(|server| server.get("id").and_then(Value::as_str) == Some("mine"))
             })
             .expect("the server must be exported");
-        assert_eq!(entry.get("requestTimeoutMs"), Some(&Value::Null));
+        assert_eq!(entry.get("requestTimeoutMs"), Some(&Value::from(90_000)));
     }
 
     #[test]


### PR DESCRIPTION
Closes #853. Companion to #852 (remote HTTP/SSE) — same field name, so one registry concept covers both transports.

## What and why

Remote HTTP/SSE servers can carry a per-server `requestTimeoutMs` (#852), but stdio live calls stay pinned to the 30-second `STDIO_READ_TIMEOUT` constant, so a local server with legitimately long synchronous tools is killed at 30 s — and each such call counts as a health failure, tripping the circuit breaker after three occurrences (BREAKER_FAILURE_THRESHOLD).

This honors the same `requestTimeoutMs` field for stdio servers:

- `ServerEntry::request_timeout_ms()` reads the field out of the existing `unknown_fields` flatten map — no `ServerEntry` shape change, so the 55+ struct-literal sites are untouched and older binaries already preserve the key on re-save (the documented mixed-version contract). When a typed field lands, this getter is the only site to update.
- `DownstreamServer` gains `call_timeout` (defaults to `STDIO_READ_TIMEOUT`) with a `set_call_timeout` setter; the three catalog-refresh restore sites use it instead of the const.
- `connect_one` applies the configured value right after `connect`, clamped to >= 1 ms so a zero entry degrades to fast visible failure, not an inverted deadline. `connect_one` is also the reconnect factory, so re-spawned adapters re-inherit the value.

## What deliberately does not change

Connect handshake (10 s), launcher cold-start budget (120 s), the `server/discover` probe (750 ms), and every batch health-probe path keep their current bounds — a hung server still fails fast and the grid still can't stall on one slow probe. Only the post-handshake read deadline widens, per server.

## Testing

- [x] `cargo test --no-default-features --lib` — 1283 passed / 0 failed
      (includes new `server_entry_request_timeout_ms_round_trips_and_survives_resave`)
- [x] End-to-end probe against the built gateway: stdio tool sleeping 45 s with
      `requestTimeoutMs: 90000` answered at 45.009 s; the same call without the
      field is killed at 30.007 s on v1.17.0
- [x] Live smoke through the real gateway: identity tool returns normally with
      the field set on a 38-tool stdio server
- [ ] `npm run test` (frontend untouched by this change)
- [x] Registry round-trip: field survives re-save; absent → default 30 s

## Notes

- The `unknown_fields` read is deliberate for review-ability of the stdio/HTTP
  symmetry; if you'd rather have a typed `request_timeout_ms` field on
  `ServerEntry` (touching ~55 construction sites), say the word and I'll rework.
- Zero-value policy: clamped to 1 ms here; #852 rejects zero for HTTP with a
  config error — easy to align either way.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tsouth89/toolport/pull/854" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Apply per-server `requestTimeoutMs` to stdio live calls in `gateway.connect_one`
> After the initial catalog load completes, the connection handler sets the downstream server's request timeout to the configured per-server `requestTimeoutMs` value. The value is clamped to a minimum of 1ms. Connection, handshake, probe, and initial catalog-load operations continue to use the default bounded read timeout.
> - Risk: a misconfigured `requestTimeoutMs` that is too low could cause live calls to time out prematurely; reviewers should check the clamping logic in [toolport-gateway.rs](https://github.com/tsouth89/toolport/pull/854/files#diff-fe5f13c01103f5adf39c870989b67ecdb11c19b3ba86b88c4acb028a7374cc01).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0d29cd9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->