### PR TITLE
fix(gateway): OpenAPI tool failures return 400/404 instead of 200 (SBS-937)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,14 @@ Entries before the rename below shipped under the project's former name, Conduit
   exemptions. New ids, local or team-synced, are now kept distinct under that rewrite
   the same way an exact duplicate is renamed.
 
+- **The OpenAPI endpoint answered failed tool calls with HTTP 200.** The gateway's
+  `POST /{tool}` surface for Open WebUI, n8n and generated OpenAPI clients never looked
+  at the MCP result's `isError` flag, so a timeout, a denied destructive call, a
+  downstream crash or a misspelt tool name all came back as a 200 carrying the error
+  text as a string. Clients that branch on the status code, which is what the spec
+  documents, ran their success path. A failed call is now a 400 and an unknown tool
+  name a 404, both with `{"error": ...}` bodies; MCP clients are unaffected.
+
 ## [1.18.0] - 2026-08-30
 
 Toolport 1.18.0 adds a native GTK shell for Arch and other current-GTK Linux

--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -13214,22 +13214,46 @@ fn result_text(resp: &Value) -> String {
 /// such flag: its whole contract is the status code, and the spec above promises
 /// 400 for a failed call and 404 for an unknown tool. Returning 200 with the
 /// error text as a string let a timeout, a denied destructive call and a
-/// misspelt tool name all run the caller's success path (SBS-937).
-fn openapi_status(resp: &Value, name: &str) -> u16 {
+/// misspelt tool name all run the caller's success path (SBS-937). `known` is
+/// whether the requested name resolves at all (a gateway meta-tool, a grouped
+/// browse tool, a live route, or a catalog entry); the result text is never
+/// consulted for that, since a real tool's error may echo any wording.
+fn openapi_status(resp: &Value, known: bool) -> u16 {
     let is_error = resp
         .pointer("/result/isError")
         .and_then(Value::as_bool)
         .unwrap_or(false);
-    if !is_error {
-        return 200;
+    match (is_error, known) {
+        (false, _) => 200,
+        (true, true) => 400,
+        (true, false) => 404,
     }
-    // The router's own wording for a name nothing routes; the only signal an
-    // unknown tool leaves, since MCP has no dedicated code for it.
-    if result_text(resp).contains(&format!("no route for tool '{name}'")) {
-        404
-    } else {
-        400
+}
+
+/// Whether an OpenAPI tool path names something the gateway can dispatch. Checked
+/// after the call so a lazily connected server's route, if the call connected it,
+/// counts; the catalog covers a known tool whose server failed to connect.
+fn openapi_tool_is_known(state: &GatewayState, name: &str) -> bool {
+    let canonical = canonical_meta(name).unwrap_or(name);
+    if is_fixed_meta_tool(canonical) || grouped_help_target(name).is_some() {
+        return true;
     }
+    let routed = state
+        .router
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .route_of(name)
+        .is_some();
+    if routed {
+        return true;
+    }
+    state
+        .cached_tools
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .tools
+        .iter()
+        .any(|tool| tool.get("name").and_then(Value::as_str) == Some(name))
 }
 
 /// HTTP handler result: status, content-type, body, plus optional extra headers
@@ -13943,7 +13967,7 @@ fn handle_http_with_headers(
                         return HttpOut::json_err(400, msg);
                     }
                     let text = result_text(&resp);
-                    let status = openapi_status(&resp, name);
+                    let status = openapi_status(&resp, openapi_tool_is_known(state, name));
                     if status != 200 {
                         return HttpOut::json_err(status, &text);
                     }
@@ -22376,29 +22400,24 @@ mod tests {
     #[test]
     fn openapi_status_follows_the_result_error_flag() {
         let ok = json!({ "result": { "content": [{ "type": "text", "text": "done" }] } });
-        assert_eq!(openapi_status(&ok, "s__work"), 200);
+        assert_eq!(openapi_status(&ok, true), 200);
         let explicit_ok = json!({ "result": { "content": [], "isError": false } });
-        assert_eq!(openapi_status(&explicit_ok, "s__work"), 200);
+        assert_eq!(openapi_status(&explicit_ok, true), 200);
 
         let timed_out = json!({ "result": {
             "content": [{ "type": "text", "text": "Toolport: timed out waiting for 'tools/call' response" }],
             "isError": true
         } });
-        assert_eq!(openapi_status(&timed_out, "s__work"), 400);
-        let denied = json!({ "result": {
-            "content": [{ "type": "text", "text": "Toolport: the call to s__work was denied, so it did not run." }],
-            "isError": true
-        } });
-        assert_eq!(openapi_status(&denied, "s__work"), 400);
+        assert_eq!(openapi_status(&timed_out, true), 400);
+        assert_eq!(openapi_status(&timed_out, false), 404);
 
-        let unknown = json!({ "result": {
-            "content": [{ "type": "text", "text": "Toolport: no route for tool 'nope'" }],
+        // A known tool whose error happens to echo the router's wording is still a
+        // failed call on a tool that exists, never a missing route.
+        let echoing = json!({ "result": {
+            "content": [{ "type": "text", "text": "Toolport: no route for tool 's__work'" }],
             "isError": true
         } });
-        assert_eq!(openapi_status(&unknown, "nope"), 404);
-        // A downstream tool echoing the phrase about some other name is still a
-        // failed call on a tool that exists, not a missing route.
-        assert_eq!(openapi_status(&unknown, "s__work"), 400);
+        assert_eq!(openapi_status(&echoing, true), 400);
     }
 
     #[test]

--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -13986,6 +13986,12 @@ fn handle_http_with_headers(
                     }
                     let text = result_text(&resp);
                     let status = openapi_status(&resp, openapi_tool_is_known(state, name, allowed));
+                    // A 404 body is fixed text: the result text for a hidden tool names
+                    // its owning server, which is exactly what a scoped client must not
+                    // learn from probing names.
+                    if status == 404 {
+                        return HttpOut::json_err(404, &format!("unknown tool '{name}'"));
+                    }
                     if status != 200 {
                         return HttpOut::json_err(status, &text);
                     }
@@ -22460,12 +22466,7 @@ mod tests {
 
         let missing = post("/no_such_tool");
         assert_eq!(missing.status, 404, "body={}", missing.body);
-        let body: Value = serde_json::from_str(&missing.body).expect("json error body");
-        let error = body["error"].as_str().expect("error string");
-        assert!(
-            error.contains("no route for tool 'no_such_tool'"),
-            "error={error}"
-        );
+        assert_eq!(missing.body, r#"{"error":"unknown tool 'no_such_tool'"}"#);
         assert_eq!(calls.load(Ordering::SeqCst), 1, "nothing was dispatched");
 
         // A client scoped to another server must not learn that s__work exists:
@@ -22484,6 +22485,8 @@ mod tests {
             None,
         );
         assert_eq!(hidden.status, 404, "body={}", hidden.body);
+        // Same body as a nonexistent name: the owning server must not leak either.
+        assert_eq!(hidden.body, r#"{"error":"unknown tool 's__work'"}"#);
         let missing = handle_http(
             &state,
             &search,

--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -13124,7 +13124,7 @@ fn openapi_spec(
                                 "description": "The tool's text output."
                             } } }
                         },
-                        "400": err_resp("Invalid JSON body, or the tool itself returned an error."),
+                        "400": err_resp("Invalid JSON body, or the call failed: the tool returned an error, timed out, or was denied."),
                         "401": err_resp("Missing or invalid bearer token."),
                         "404": err_resp("Unknown tool name."),
                         "500": err_resp("Internal gateway error.")
@@ -13205,6 +13205,31 @@ fn result_text(resp: &Value) -> String {
         }
     }
     serde_json::to_string(result).unwrap_or_default()
+}
+
+/// The HTTP status an OpenAPI consumer should see for a tools/call result.
+///
+/// MCP reports a failed call as a successful JSON-RPC envelope whose result
+/// carries `isError`, which is right for MCP clients. An OpenAPI client has no
+/// such flag: its whole contract is the status code, and the spec above promises
+/// 400 for a failed call and 404 for an unknown tool. Returning 200 with the
+/// error text as a string let a timeout, a denied destructive call and a
+/// misspelt tool name all run the caller's success path (SBS-937).
+fn openapi_status(resp: &Value, name: &str) -> u16 {
+    let is_error = resp
+        .pointer("/result/isError")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    if !is_error {
+        return 200;
+    }
+    // The router's own wording for a name nothing routes; the only signal an
+    // unknown tool leaves, since MCP has no dedicated code for it.
+    if result_text(resp).contains(&format!("no route for tool '{name}'")) {
+        404
+    } else {
+        400
+    }
 }
 
 /// HTTP handler result: status, content-type, body, plus optional extra headers
@@ -13917,11 +13942,15 @@ fn handle_http_with_headers(
                             .unwrap_or("error");
                         return HttpOut::json_err(400, msg);
                     }
+                    let text = result_text(&resp);
+                    let status = openapi_status(&resp, name);
+                    if status != 200 {
+                        return HttpOut::json_err(status, &text);
+                    }
                     HttpOut::new(
                         200,
                         "application/json",
-                        serde_json::to_string(&result_text(&resp))
-                            .unwrap_or_else(|_| "\"\"".into()),
+                        serde_json::to_string(&text).unwrap_or_else(|_| "\"\"".into()),
                     )
                 }
                 None => HttpOut::json_err(500, "no response"),
@@ -22342,6 +22371,65 @@ mod tests {
         );
         assert_eq!(out.status, 204);
         assert!(out.body.is_empty());
+    }
+
+    #[test]
+    fn openapi_status_follows_the_result_error_flag() {
+        let ok = json!({ "result": { "content": [{ "type": "text", "text": "done" }] } });
+        assert_eq!(openapi_status(&ok, "s__work"), 200);
+        let explicit_ok = json!({ "result": { "content": [], "isError": false } });
+        assert_eq!(openapi_status(&explicit_ok, "s__work"), 200);
+
+        let timed_out = json!({ "result": {
+            "content": [{ "type": "text", "text": "Toolport: timed out waiting for 'tools/call' response" }],
+            "isError": true
+        } });
+        assert_eq!(openapi_status(&timed_out, "s__work"), 400);
+        let denied = json!({ "result": {
+            "content": [{ "type": "text", "text": "Toolport: the call to s__work was denied, so it did not run." }],
+            "isError": true
+        } });
+        assert_eq!(openapi_status(&denied, "s__work"), 400);
+
+        let unknown = json!({ "result": {
+            "content": [{ "type": "text", "text": "Toolport: no route for tool 'nope'" }],
+            "isError": true
+        } });
+        assert_eq!(openapi_status(&unknown, "nope"), 404);
+        // A downstream tool echoing the phrase about some other name is still a
+        // failed call on a tool that exists, not a missing route.
+        assert_eq!(openapi_status(&unknown, "s__work"), 400);
+    }
+
+    #[test]
+    fn openapi_post_reports_failed_and_unknown_tools_by_status() {
+        // SBS-937: Open WebUI, n8n and generated OpenAPI clients branch on the
+        // status code. A 200 carrying error text runs their success path.
+        let (router, calls, _catalog) = counting_router(false);
+        let mut state = http_state(true);
+        state.router = Arc::new(Mutex::new(router));
+        let search = SearchGuard::default();
+        let confirm = ConfirmGuard::new();
+        let post = |path: &str| {
+            handle_http(
+                &state, &search, &confirm, "POST", path, "{}", None, None, None, None,
+            )
+        };
+
+        let ok = post("/s__work");
+        assert_eq!(ok.status, 200, "body={}", ok.body);
+        assert_eq!(ok.body, "\"called\"");
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+
+        let missing = post("/no_such_tool");
+        assert_eq!(missing.status, 404, "body={}", missing.body);
+        let body: Value = serde_json::from_str(&missing.body).expect("json error body");
+        let error = body["error"].as_str().expect("error string");
+        assert!(
+            error.contains("no route for tool 'no_such_tool'"),
+            "error={error}"
+        );
+        assert_eq!(calls.load(Ordering::SeqCst), 1, "nothing was dispatched");
     }
 
     fn mcp_session_of(out: &HttpOut) -> String {

--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -13230,30 +13230,48 @@ fn openapi_status(resp: &Value, known: bool) -> u16 {
     }
 }
 
-/// Whether an OpenAPI tool path names something the gateway can dispatch. Checked
+/// Whether an OpenAPI tool path names something this caller can dispatch. Checked
 /// after the call so a lazily connected server's route, if the call connected it,
 /// counts; the catalog covers a known tool whose server failed to connect.
-fn openapi_tool_is_known(state: &GatewayState, name: &str) -> bool {
+///
+/// Scope is part of "known": a registered HTTP client only sees its servers'
+/// tools in `/openapi.json` and `tools/list`, and 404 versus 400 would otherwise
+/// tell it which names exist on servers it cannot list (the inventory boundary
+/// SBS-866 keeps fail-closed). For a scoped client only a meta-tool or a live
+/// route on an allowed server counts; anything it cannot see is 404.
+fn openapi_tool_is_known(
+    state: &GatewayState,
+    name: &str,
+    allowed: Option<&std::collections::HashSet<String>>,
+) -> bool {
     let canonical = canonical_meta(name).unwrap_or(name);
-    if is_fixed_meta_tool(canonical) || grouped_help_target(name).is_some() {
+    if is_fixed_meta_tool(canonical) {
         return true;
     }
-    let routed = state
+    let routed_in_scope = state
         .router
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner)
         .route_of(name)
-        .is_some();
-    if routed {
+        .map(|(server_id, _)| match allowed {
+            Some(set) => server_in_allowed_scope(server_id, set),
+            None => true,
+        })
+        .unwrap_or(false);
+    if routed_in_scope {
         return true;
     }
-    state
-        .cached_tools
-        .lock()
-        .unwrap_or_else(std::sync::PoisonError::into_inner)
-        .tools
-        .iter()
-        .any(|tool| tool.get("name").and_then(Value::as_str) == Some(name))
+    if allowed.is_some() {
+        return false;
+    }
+    grouped_help_target(name).is_some()
+        || state
+            .cached_tools
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .tools
+            .iter()
+            .any(|tool| tool.get("name").and_then(Value::as_str) == Some(name))
 }
 
 /// HTTP handler result: status, content-type, body, plus optional extra headers
@@ -13967,7 +13985,7 @@ fn handle_http_with_headers(
                         return HttpOut::json_err(400, msg);
                     }
                     let text = result_text(&resp);
-                    let status = openapi_status(&resp, openapi_tool_is_known(state, name));
+                    let status = openapi_status(&resp, openapi_tool_is_known(state, name, allowed));
                     if status != 200 {
                         return HttpOut::json_err(status, &text);
                     }
@@ -22448,6 +22466,37 @@ mod tests {
             error.contains("no route for tool 'no_such_tool'"),
             "error={error}"
         );
+        assert_eq!(calls.load(Ordering::SeqCst), 1, "nothing was dispatched");
+
+        // A client scoped to another server must not learn that s__work exists:
+        // out of scope reads the same as nonexistent.
+        let scoped: std::collections::HashSet<String> = ["other".to_string()].into();
+        let hidden = handle_http(
+            &state,
+            &search,
+            &confirm,
+            "POST",
+            "/s__work",
+            "{}",
+            None,
+            None,
+            Some(&scoped),
+            None,
+        );
+        assert_eq!(hidden.status, 404, "body={}", hidden.body);
+        let missing = handle_http(
+            &state,
+            &search,
+            &confirm,
+            "POST",
+            "/no_such_tool",
+            "{}",
+            None,
+            None,
+            Some(&scoped),
+            None,
+        );
+        assert_eq!(missing.status, 404, "body={}", missing.body);
         assert_eq!(calls.load(Ordering::SeqCst), 1, "nothing was dispatched");
     }
 


### PR DESCRIPTION
## What and why

The gateway's OpenAPI surface (`POST /{tool}`, used by Open WebUI, n8n and generated OpenAPI clients) never inspected the MCP result's `isError` flag. A timeout, a HITL deny, a downstream failure or an unknown tool name all returned HTTP 200 with the error text as a JSON string, so clients that branch on status ran their success path. The spec already documented 400 for a failed call and 404 for an unknown tool.

- `openapi_status` reads `result.isError`; a true flag becomes 400, or 404 when the text carries the router's `no route for tool '<name>'` wording for the requested name.
- Error responses use the same `{"error": ...}` body shape the spec's `err_resp` describes.
- MCP stdio and `/mcp` are untouched; they already carry `isError` correctly.
- Spec text for 400 now lists the failure kinds it covers.

## Testing

- [x] `cargo test --no-default-features --bin toolport-gateway openapi` (unit test on the status mapping plus an end-to-end POST asserting 200 / 404 through `handle_http`)
- [x] `cargo fmt --check`
- [ ] Full CI on this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes HTTP semantics for OpenAPI consumers (intentional spec alignment) and tightens scoped-client responses so out-of-scope tool names return 404 without executing; MCP paths are untouched.
> 
> **Overview**
> **OpenAPI `POST /{tool}` now maps MCP outcomes to real HTTP status codes** instead of always returning 200 with error text as a JSON string. After a successful JSON-RPC envelope, the gateway reads `result.isError` and returns **400** for a failed call on a known tool, **404** for errors on an unknown name, and keeps **200** only for success; non-200 bodies use `{"error": ...}` so Open WebUI, n8n, and generated clients can branch on status as the spec describes. **MCP stdio and `/mcp` are unchanged.**
> 
> **Tool “known” is decided separately from error wording** via `openapi_tool_is_known`: meta-tools, in-scope live routes, grouped help targets, and (for unscoped callers) catalog entries count as known, so a real tool’s error message cannot be mistaken for “no route.” **Scoped HTTP clients** treat out-of-scope tools like missing ones (**404**, no dispatch), preserving the inventory boundary.
> 
> The generated OpenAPI doc’s **400** description now mentions timeouts and denials; **CHANGELOG** documents the fix (SBS-937). Unit and `handle_http` integration tests cover status mapping and scoped 404 behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a90790dfe268245de20904289f22350cadccba93. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Return 400/404 for failed OpenAPI tool calls in `toolport-gateway` instead of 200
> - `openapi_status` now maps the MCP result `isError` flag to HTTP status: 200 for success, 400 for failed known tools, and 404 for unknown or out-of-scope tools.
> - `openapi_tool_is_known` classifies a tool name as known based on fixed meta-tools, in-scope live routes, and applicable catalog entries; scoped callers do not match out-of-scope catalog entries.
> - `handle_http_with_headers` returns a generic unknown-tool error body for 404s and wraps result text in an `error` envelope for 400s; successful results still return 200 with JSON text.
> - The generated OpenAPI spec now documents HTTP 400 for tool errors, timeouts, and denied calls.
> - Risk: `openapi_tool_is_known` scope logic means a scoped client that previously received a 200 with an error payload for an out-of-scope tool now gets a 404 with a generic body — clients parsing the old error text on hidden tools will break.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5f35045.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->