### PR TITLE
fix(registry): keep new server ids distinct under sanitize_segment (SBS-880)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ Entries before the rename below shipped under the project's former name, Conduit
 
 ## [Unreleased]
 
+### Fixed
+
+- **Two server ids that differ only by `-` and `_` could become one server.** The
+  gateway rewrites ids to the tool-name charset for exposed names, and that rewrite
+  also keyed client scope, PII pseudonym origins, injection block exemptions and result
+  budgets, so a local server named "Team Acme CRM" and a synced team server
+  `team_acme-crm`, or a hand-edited `gh_api` beside a new `gh-api`, shared scope and
+  exemptions. New ids, local or team-synced, are now kept distinct under that rewrite
+  the same way an exact duplicate is renamed.
+
 ## [1.18.0] - 2026-08-30
 
 Toolport 1.18.0 adds a native GTK shell for Arch and other current-GTK Linux

--- a/src-tauri/src/registry.rs
+++ b/src-tauri/src/registry.rs
@@ -1625,15 +1625,31 @@ pub fn migrate_profile_stores(registry: &Registry) -> Result<(), String> {
     Ok(())
 }
 
+/// Two ids the gateway would treat as one principal (SBS-880).
+///
+/// `sanitize_segment` rewrites an id to the tool-name charset and is deliberately
+/// lossy: `gh-api` and `gh_api` both become `gh_api`. The client scope set, the PII
+/// origin, injection block exemptions and result budgets all key on that form, so
+/// two registry ids that meet there share scope, exemptions and pseudonym origins.
+/// Every id factory goes through [`unique_id`], which refuses a candidate that
+/// lands on an existing id under this map, so ids stay injective at creation
+/// whatever charset the existing id came from (a `team_` prefix, a hand-edited
+/// `registry.json`). Case-insensitive because the gateway's prefix-owner tables
+/// lowercase the sanitized form.
+pub(crate) fn ids_collide(a: &str, b: &str) -> bool {
+    sanitize_segment(a).eq_ignore_ascii_case(&sanitize_segment(b))
+}
+
 pub(crate) fn unique_id(base: &str, existing: &[String]) -> String {
     let base = if base.is_empty() { "item" } else { base };
-    if !existing.iter().any(|e| e == base) {
+    let taken = |candidate: &str| existing.iter().any(|e| ids_collide(e, candidate));
+    if !taken(base) {
         return base.to_string();
     }
     let mut n = 2;
     loop {
         let candidate = format!("{base}-{n}");
-        if !existing.iter().any(|e| e == &candidate) {
+        if !taken(&candidate) {
             return candidate;
         }
         n += 1;
@@ -4689,6 +4705,36 @@ mod tests {
         assert_eq!(loaded.servers, r.servers);
         assert_eq!(loaded.profiles, r.profiles);
         assert_eq!(loaded.active_profile_id, r.active_profile_id);
+    }
+
+    /// SBS-880: the gateway keys scope, PII origin, block exemptions and budgets
+    /// on `sanitize_segment(id)`, which is lossy. A new id must never land on an
+    /// existing id's sanitized form, whatever charset that id came from.
+    #[test]
+    fn new_ids_never_collide_with_existing_ids_under_sanitize() {
+        assert!(ids_collide("gh-api", "gh_api"));
+        assert!(ids_collide("team-acme-crm", "team_acme-crm"));
+        assert!(ids_collide("GH_API", "gh-api"));
+        assert!(!ids_collide("gh-api", "gh-api-2"));
+
+        let mut r = Registry::default();
+        // A legacy or hand-edited id carrying an underscore.
+        let mut legacy = sample_server("GH API");
+        legacy.id = "gh_api".into();
+        r.servers.push(legacy);
+        assert_eq!(r.add_server(sample_server("GH API")), "gh-api-2");
+
+        // The team prefix against a local name that slugifies to `team-...`.
+        let mut team = sample_server("Acme CRM");
+        team.id = "team_acme-crm".into();
+        r.servers.push(team);
+        assert_eq!(
+            r.add_server(sample_server("Team Acme CRM")),
+            "team-acme-crm-2"
+        );
+
+        // Exact reuse still renames the same way it always did.
+        assert_eq!(r.add_server(sample_server("GH API")), "gh-api-3");
     }
 
     #[test]

--- a/src-tauri/src/router.rs
+++ b/src-tauri/src/router.rs
@@ -145,6 +145,11 @@ fn retry_wait(retry_after: Option<std::time::Duration>, attempt: u32) -> std::ti
 
 /// Rewrite a name segment to the function-name charset clients accept
 /// (`[A-Za-z0-9_]`); every other character becomes `_`.
+///
+/// A charset rewrite, not an identity: `gh-api` and `gh_api` meet here. The
+/// gateway still keys client scope, PII origin, block exemptions and result
+/// budgets on this form, so `registry::unique_id` keeps new ids injective under
+/// it (SBS-880). Compare raw ids wherever a raw id is available.
 pub fn sanitize_segment(s: &str) -> String {
     s.chars()
         .map(|c| {

--- a/src-tauri/src/teams.rs
+++ b/src-tauri/src/teams.rs
@@ -3639,6 +3639,7 @@ mod tests {
             disabled_tools: vec![],
             cwd: None,
             client_credentials: None,
+            request_timeout_ms: None,
             unknown_fields: serde_json::Map::new(),
         });
         let cfg = json!({ "servers": [

--- a/src-tauri/src/teams.rs
+++ b/src-tauri/src/teams.rs
@@ -3621,6 +3621,43 @@ mod tests {
         }
     }
 
+    /// SBS-880: a team id is `team_<slug>`, and a member's own server named
+    /// "Team Acme CRM" is `team-acme-crm`. The gateway would treat those as one
+    /// server, so the team entry must be renamed the way an exact collision is.
+    #[test]
+    fn team_id_never_collides_with_a_local_id_under_sanitize() {
+        let mut r = base_registry();
+        r.servers.push(ServerEntry {
+            id: "team-acme-crm".into(),
+            name: "Team Acme CRM".into(),
+            transport: "http".into(),
+            command: None,
+            args: vec![],
+            env: vec![],
+            url: Some("https://crm.example.com/mcp".into()),
+            source: Some("manual".into()),
+            disabled_tools: vec![],
+            cwd: None,
+            client_credentials: None,
+            unknown_fields: serde_json::Map::new(),
+        });
+        let cfg = json!({ "servers": [
+            { "id": "acme-crm", "name": "Acme CRM", "transport": "http", "url": "https://1.2.3.4/mcp" }
+        ]});
+        assert_eq!(apply_team_config(&mut r, "t1", &cfg).applied, 1);
+        let team = r
+            .servers
+            .iter()
+            .find(|s| s.source.as_deref() == Some("team:t1"))
+            .expect("team server applied");
+        assert_eq!(team.id, "team_acme-crm-2");
+        assert!(
+            !crate::registry::ids_collide(&team.id, "team-acme-crm"),
+            "the renamed team id must not share the local server's sanitized form"
+        );
+        assert!(r.servers.iter().any(|s| s.id == "team-acme-crm"));
+    }
+
     #[test]
     fn request_timeout_round_trips_through_team_import_and_export() {
         let mut reg = base_registry();


### PR DESCRIPTION
## What and why

`sanitize_segment` maps every character outside `[A-Za-z0-9_]` to `_`. That is correct for exposed tool names and wrong as an identity, but the client scope set, PII origin, injection block exemptions and result budgets all key on it. Both id factories emit `[a-z0-9-]` (one with a literal `team_` prefix), so two fresh ids cannot collide, but a hand-edited `gh_api` beside a new `gh-api`, or a team server `team_acme-crm` beside a local server named "Team Acme CRM", become one principal at the gateway.

This is the creation-time half of SBS-880:

- `registry::ids_collide` names the invariant: two ids collide when their sanitized forms match, case-insensitively.
- `unique_id`, which every factory already goes through (local adds, team sync, profiles, rule sets), now treats a candidate as taken when any existing id collides with it, so it renames the way an exact duplicate already did (`gh-api-2`, `team_acme-crm-2`).
- `sanitize_segment` documents that it is not an identity and points at the invariant.

Not in this PR: rekeying the five gateway isolation sites on raw ids. Existing collisions in a registry are not rewritten. The gateway's prefix-owner tables already refuse ambiguous prefixes (SBS-866), so that remains the fallback for legacy data.

## Testing

- [x] `cargo test --no-default-features --lib` (1305 passed; new tests cover legacy underscore ids, the team prefix case, case-insensitivity, and the team sync rename)
- [x] `cargo fmt --check`
- [ ] Full CI on this PR

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tsouth89/toolport/pull/859" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how new server ids are assigned at creation and during team sync, in an area tied to client scope and security isolation; existing colliding entries are left unchanged.
> 
> **Overview**
> Fixes **SBS-880** by treating two registry server ids as conflicting when the gateway’s lossy `sanitize_segment` rewrite would make them the same principal (hyphen vs underscore, case, and the local `team-acme-crm` vs synced `team_acme-crm` pattern).
> 
> Adds **`registry::ids_collide`** (case-insensitive compare of sanitized forms) and changes **`unique_id`**—used for local adds, team sync, profiles, and rule sets—to reject candidates that collide under that map, appending numeric suffixes the same way exact duplicates already did. **`sanitize_segment`** in `router.rs` is documented as a charset rewrite, not a stable identity.
> 
> Regression tests cover underscore legacy ids, team import rename, and case-insensitivity. **Does not** rekey existing gateway isolation sites or migrate registries that already contain colliding ids.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ba26743334eca7c7f0f2e4869cc0ee533e8b5c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `registry.unique_id` to keep new server ids distinct under `sanitize_segment`
> - Adds `registry.ids_collide` helper that sanitizes both identifiers and compares them case-insensitively, catching hyphen/underscore equivalence and ASCII case differences
> - Replaces raw-string occupancy checks in `registry.unique_id` with `ids_collide` checks, so the allocator suffixes any new id whose sanitized form matches an existing one
> - Adds regression tests in `registry.rs` and `teams.rs` covering hyphen/underscore collisions, case differences, team-import collisions, and non-collisions
> - Risk: `registry.unique_id` now allocates more numeric-suffixed ids than before when existing ids share a sanitized form; callers that assumed exact-string uniqueness may see new suffixed names
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8ba2674.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->