### PR TITLE
fix(desktop): report gateway log read errors instead of masking as absent (#733)

### DIFF
--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -1813,29 +1813,7 @@ fn redact_arg_for_sharing(arg: &str) -> String {
 /// The last `n` lines of the always-on gateway log, or a friendly note when it
 /// hasn't been written yet (no client has connected through the gateway).
 fn gateway_log_tail(n: usize) -> String {
-    let Some(path) = registry::gateway_log_path() else {
-        return "(log path unavailable)\n".to_string();
-    };
-    match std::fs::read_to_string(&path) {
-        Ok(text) if !text.trim().is_empty() => last_lines(&text, n),
-        Ok(_) => "(no gateway log yet, connect a client to populate it)\n".to_string(),
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-            "(no gateway log yet, connect a client to populate it)\n".to_string()
-        }
-        Err(e) => format!("(failed to read gateway log: {e})\n"),
-    }
-}
-
-/// The last `n` lines of `text`, newline-terminated. Returns everything when the
-/// text has fewer than `n` lines.
-fn last_lines(text: &str, n: usize) -> String {
-    let lines: Vec<&str> = text.lines().collect();
-    let start = lines.len().saturating_sub(n);
-    let mut tail = lines[start..].join("\n");
-    if !tail.is_empty() {
-        tail.push('\n');
-    }
-    tail
+    crate::gatewaylog::tail(n)
 }
 
 /// How long to wait for one server's probe before giving up on it. Generous
@@ -5561,45 +5539,6 @@ mod tests {
         let _ = std::fs::remove_dir_all(&dir);
     }
 
-    /// A read error must be reported as a read error, not as "no gateway log yet"
-    /// (#733) — the same class of bug as SBS-873's audit-log dashboard, and the
-    /// same fixture trick: point the log path at a directory, which fails on
-    /// every OS with no permission bits to fight in CI.
-    #[test]
-    fn gateway_log_tail_reports_read_error_not_absence() {
-        let _lock = crate::registry::data_dir_test_lock();
-        let dir = unique_update_test_dir("gateway-log-unreadable");
-        std::fs::create_dir_all(&dir).unwrap();
-        let _override = crate::registry::DataDirOverride::set(&dir);
-        let path = registry::gateway_log_path().expect("gateway log path under override");
-        std::fs::create_dir_all(&path).unwrap();
-
-        let result = gateway_log_tail(5);
-        assert!(
-            result.starts_with("(failed to read gateway log:"),
-            "expected read-error wording, got: {result}"
-        );
-        assert!(!result.contains("no gateway log yet"));
-
-        let _ = std::fs::remove_dir_all(&dir);
-    }
-
-    /// The other half of the contract: a genuinely missing log keeps its
-    /// existing, reassuring wording.
-    #[test]
-    fn gateway_log_tail_reports_absence_for_missing_log() {
-        let _lock = crate::registry::data_dir_test_lock();
-        let dir = unique_update_test_dir("gateway-log-missing");
-        std::fs::create_dir_all(&dir).unwrap();
-        let _override = crate::registry::DataDirOverride::set(&dir);
-        let path = registry::gateway_log_path().expect("gateway log path under override");
-        assert!(!path.exists(), "fixture must not create the log");
-
-        let result = gateway_log_tail(5);
-        assert!(result.contains("no gateway log yet"));
-
-        let _ = std::fs::remove_dir_all(&dir);
-    }
 
     /// The other half of the contract: a missing log is an honest empty
     /// dashboard, so a first run still resolves.
@@ -6559,17 +6498,6 @@ mod tests {
         assert_eq!(parse_share_url("toolport://import?x=1"), None);
         assert_eq!(parse_share_url("conduit://import?s=../etc"), None);
         assert_eq!(parse_share_url("https://example.com?s=abc"), None);
-    }
-
-    #[test]
-    fn last_lines_returns_the_tail() {
-        let text = "a\nb\nc\nd\ne";
-        // Fewer requested than available: just the tail, newline-terminated.
-        assert_eq!(last_lines(text, 2), "d\ne\n");
-        // More requested than available: everything.
-        assert_eq!(last_lines(text, 99), "a\nb\nc\nd\ne\n");
-        // Empty input stays empty (no stray newline).
-        assert_eq!(last_lines("", 10), "");
     }
 
     #[test]

--- a/src-tauri/src/desktop.rs
+++ b/src-tauri/src/desktop.rs
@@ -1818,7 +1818,11 @@ fn gateway_log_tail(n: usize) -> String {
     };
     match std::fs::read_to_string(&path) {
         Ok(text) if !text.trim().is_empty() => last_lines(&text, n),
-        _ => "(no gateway log yet, connect a client to populate it)\n".to_string(),
+        Ok(_) => "(no gateway log yet, connect a client to populate it)\n".to_string(),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            "(no gateway log yet, connect a client to populate it)\n".to_string()
+        }
+        Err(e) => format!("(failed to read gateway log: {e})\n"),
     }
 }
 
@@ -5553,6 +5557,46 @@ mod tests {
             result.is_err(),
             "a failed activity-log read must reject, not resolve to null: {result:?}"
         );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// A read error must be reported as a read error, not as "no gateway log yet"
+    /// (#733) — the same class of bug as SBS-873's audit-log dashboard, and the
+    /// same fixture trick: point the log path at a directory, which fails on
+    /// every OS with no permission bits to fight in CI.
+    #[test]
+    fn gateway_log_tail_reports_read_error_not_absence() {
+        let _lock = crate::registry::data_dir_test_lock();
+        let dir = unique_update_test_dir("gateway-log-unreadable");
+        std::fs::create_dir_all(&dir).unwrap();
+        let _override = crate::registry::DataDirOverride::set(&dir);
+        let path = registry::gateway_log_path().expect("gateway log path under override");
+        std::fs::create_dir_all(&path).unwrap();
+
+        let result = gateway_log_tail(5);
+        assert!(
+            result.starts_with("(failed to read gateway log:"),
+            "expected read-error wording, got: {result}"
+        );
+        assert!(!result.contains("no gateway log yet"));
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// The other half of the contract: a genuinely missing log keeps its
+    /// existing, reassuring wording.
+    #[test]
+    fn gateway_log_tail_reports_absence_for_missing_log() {
+        let _lock = crate::registry::data_dir_test_lock();
+        let dir = unique_update_test_dir("gateway-log-missing");
+        std::fs::create_dir_all(&dir).unwrap();
+        let _override = crate::registry::DataDirOverride::set(&dir);
+        let path = registry::gateway_log_path().expect("gateway log path under override");
+        assert!(!path.exists(), "fixture must not create the log");
+
+        let result = gateway_log_tail(5);
+        assert!(result.contains("no gateway log yet"));
 
         let _ = std::fs::remove_dir_all(&dir);
     }

--- a/src-tauri/src/gatewaylog.rs
+++ b/src-tauri/src/gatewaylog.rs
@@ -102,6 +102,38 @@ pub fn trim_log_if_large(path: &Path) {
     let _ = crate::registry::atomic_write(path, &kept);
 }
 
+
+/// The last `n` lines of the gateway log, formatted for the diagnostics bundle
+/// and the debug dashboard.
+///
+/// A read error is reported as a read error, including its cause, never
+/// conflated with a genuinely absent log (#733).
+pub fn tail(n: usize) -> String {
+    let Some(path) = crate::registry::gateway_log_path() else {
+        return "(log path unavailable)\n".to_string();
+    };
+    match std::fs::read_to_string(&path) {
+        Ok(text) if !text.trim().is_empty() => last_lines(&text, n),
+        Ok(_) => "(no gateway log yet, connect a client to populate it)\n".to_string(),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            "(no gateway log yet, connect a client to populate it)\n".to_string()
+        }
+        Err(e) => format!("(failed to read gateway log: {e})\n"),
+    }
+}
+
+/// The last `n` lines of `text`, newline-terminated. Returns everything when
+/// the text has fewer than `n` lines.
+fn last_lines(text: &str, n: usize) -> String {
+    let lines: Vec<&str> = text.lines().collect();
+    let start = lines.len().saturating_sub(n);
+    let mut tail = lines[start..].join("\n");
+    if !tail.is_empty() {
+        tail.push('\n');
+    }
+    tail
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -120,6 +152,64 @@ mod tests {
             "toolport-sbs869-gatewaylog-{}-{nanos}-{n}.log",
             std::process::id()
         ))
+    }
+
+    fn unique_data_dir(label: &str) -> PathBuf {
+        let n = TEST_SEQ.fetch_add(1, Ordering::Relaxed);
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0);
+        std::env::temp_dir().join(format!(
+            "toolport-{label}-{}-{nanos}-{n}",
+            std::process::id()
+        ))
+    }
+
+    #[test]
+    fn last_lines_returns_the_tail() {
+        let text = "a\nb\nc\nd\ne";
+        assert_eq!(last_lines(text, 2), "d\ne\n");
+        assert_eq!(last_lines(text, 99), "a\nb\nc\nd\ne\n");
+        assert_eq!(last_lines("", 10), "");
+    }
+
+    /// A read error must be reported as a read error, not as "no gateway log
+    /// yet" (#733).
+    #[test]
+    fn tail_reports_read_error_not_absence() {
+        let _lock = crate::registry::data_dir_test_lock();
+        let dir = unique_data_dir("gateway-log-unreadable");
+        std::fs::create_dir_all(&dir).unwrap();
+        let _override = crate::registry::DataDirOverride::set(&dir);
+        let path = crate::registry::gateway_log_path().expect("gateway log path under override");
+        std::fs::create_dir_all(&path).unwrap();
+
+        let result = tail(5);
+        assert!(
+            result.starts_with("(failed to read gateway log:"),
+            "expected read-error wording, got: {result}"
+        );
+        assert!(!result.contains("no gateway log yet"));
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// The other half of the contract: a genuinely missing log keeps its
+    /// existing, reassuring wording.
+    #[test]
+    fn tail_reports_absence_for_missing_log() {
+        let _lock = crate::registry::data_dir_test_lock();
+        let dir = unique_data_dir("gateway-log-missing");
+        std::fs::create_dir_all(&dir).unwrap();
+        let _override = crate::registry::DataDirOverride::set(&dir);
+        let path = crate::registry::gateway_log_path().expect("gateway log path under override");
+        assert!(!path.exists(), "fixture must not create the log");
+
+        let result = tail(5);
+        assert!(result.contains("no gateway log yet"));
+
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     fn lock_sibling(path: &Path) -> PathBuf {


### PR DESCRIPTION
Fixes #733. `gateway_log_tail` now distinguishes a genuine read error from an absent log — matches the pattern already used for the registry arm in `gather_diagnostics_blocking`. Adds tests for both the unreadable and missing cases.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Report read errors in `gateway_log_tail` instead of masking them as absent
> The `gateway_log_tail` helper in [desktop.rs](https://github.com/tsouth89/toolport/pull/860/files#diff-fe6823673f9c91b7a17eb4b96e5bc54bc3c58e75d02ae0a2d2fae6f7ce03ecd5) previously treated all read failures the same as a missing log file. It now returns the no-log message only when the file is missing or empty, and returns a formatted read-error message for other failures. Adds two regression tests covering read-error reporting and retained absence wording.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1cdee40. (Automatic summaries will resume when PR exits draft mode or review begins).</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->