### PR TITLE
fix(activity): distinguish load failures from empty results in three Activity panels (#728)

### DIFF
--- a/src/components/ActivityView.test.tsx
+++ b/src/components/ActivityView.test.tsx
@@ -7,6 +7,8 @@ import type { AuditEntry, SearchTrace } from "@/lib/types";
 const getAuditLog = vi.fn();
 const getSearchTraces = vi.fn();
 const getSecurityEvents = vi.fn();
+const getToolIdentities = vi.fn();
+const getInspectLog = vi.fn();
 
 const clearActivityLogs = vi.fn();
 
@@ -15,11 +17,11 @@ vi.mock("@/lib/api", () => ({
   exportAuditToPath: vi.fn(),
   getAuditLog: (...a: unknown[]) => getAuditLog(...a),
   getAuditStats: vi.fn(() => Promise.resolve(null)),
-  getInspectLog: vi.fn(() => Promise.resolve([])),
+  getInspectLog: (...a: unknown[]) => getInspectLog(...a),
   getSavingsSummary: vi.fn(() => Promise.resolve(null)),
   getSearchTraces: (...a: unknown[]) => getSearchTraces(...a),
   getSecurityEvents: (...a: unknown[]) => getSecurityEvents(...a),
-  getToolIdentities: vi.fn(() => Promise.resolve([])),
+  getToolIdentities: (...a: unknown[]) => getToolIdentities(...a),
 }));
 
 vi.mock("sonner", () => ({
@@ -56,6 +58,8 @@ beforeEach(() => {
   getAuditLog.mockResolvedValue(initialLog);
   getSearchTraces.mockResolvedValue([]);
   getSecurityEvents.mockResolvedValue([]);
+  getToolIdentities.mockResolvedValue([]);
+  getInspectLog.mockResolvedValue([]);
 });
 
 afterEach(() => {
@@ -325,6 +329,23 @@ describe("ActivityView recent calls", () => {
 });
 
 describe("ActivityView discovery", () => {
+  it("shows an error with retry instead of a false empty state when discovery traces fail to load (#728)", async () => {
+    const user = userEvent.setup({
+      advanceTimers: (ms) => vi.advanceTimersByTime(ms),
+    });
+    getSearchTraces.mockRejectedValueOnce(new Error("offline")).mockResolvedValueOnce([]);
+
+    render(<ActivityView refreshKey={0} registry={null} />);
+    await act(async () => {});
+
+    expect(screen.getByText("Couldn't load discovery.")).toBeInTheDocument();
+    expect(screen.queryByText(/Nothing searched yet/)).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Retry loading discovery" }));
+    await act(async () => {});
+    expect(screen.getByText(/Nothing searched yet/)).toBeInTheDocument();
+  });
+
   it("shows a tiny nonzero saving without rounding it down to zero", async () => {
     const user = userEvent.setup({
       advanceTimers: (ms) => vi.advanceTimersByTime(ms),
@@ -352,5 +373,51 @@ describe("ActivityView discovery", () => {
 
     expect(row.parentElement).toHaveTextContent(/<0\.1% less this turn\)\./);
     expect(row.parentElement).not.toHaveTextContent(/\(0% less this turn\)\./);
+  });
+});
+
+describe("ActivityView tool identities", () => {
+  it("shows an error with retry instead of hiding the panel when identities fail to load (#728)", async () => {
+    const user = userEvent.setup({
+      advanceTimers: (ms) => vi.advanceTimersByTime(ms),
+    });
+    getToolIdentities
+      .mockRejectedValueOnce(new Error("offline"))
+      .mockResolvedValueOnce([]);
+
+    render(<ActivityView refreshKey={0} registry={null} />);
+    await act(async () => {});
+
+    expect(screen.getByText("Couldn't load tool identities.")).toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole("button", { name: "Retry loading tool identities" }),
+    );
+    await act(async () => {});
+    expect(screen.queryByText("Couldn't load tool identities.")).not.toBeInTheDocument();
+  });
+});
+
+describe("ActivityView live inspector", () => {
+  it("shows an error with retry instead of a false empty state when the inspect log fails to load (#728)", async () => {
+    const user = userEvent.setup({
+      advanceTimers: (ms) => vi.advanceTimersByTime(ms),
+    });
+    getInspectLog.mockRejectedValueOnce(new Error("offline")).mockResolvedValueOnce([]);
+
+    // LiveInspector only mounts while live inspection is on (ActivityView.tsx:1772).
+    render(<ActivityView refreshKey={0} registry={{ liveInspect: true } as never} />);
+    await act(async () => {});
+
+    expect(screen.getByText("Couldn't load live inspector.")).toBeInTheDocument();
+    expect(
+      screen.queryByText(/No calls captured yet\. Run a tool/),
+    ).not.toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole("button", { name: "Retry loading live inspector" }),
+    );
+    await act(async () => {});
+    expect(screen.getByText(/No calls captured yet\. Run a tool/)).toBeInTheDocument();
   });
 });

--- a/src/components/ActivityView.tsx
+++ b/src/components/ActivityView.tsx
@@ -17,6 +17,7 @@ import {
   X,
   XCircle,
 } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
 import { toast } from "sonner";
 import {
   fmtDollars,
@@ -1092,21 +1093,86 @@ function DiscoveryRow({ t }: { t: SearchTrace }) {
  * Lists recent toolport_search_tools calls with what matched and the exact per-turn
  * tool-definition token overhead. Self-hides until something has searched. Always-on,
  * local, bounded. */
+/** Loading placeholder for a self-contained Activity panel, shown only while its
+ * first fetch is in flight (never once real rows exist — a live refresh should not
+ * flash this over last-known data). */
+function PanelLoadingNotice({ label, icon: Icon }: { label: string; icon: LucideIcon }) {
+  return (
+    <div
+      role="status"
+      className="mb-6 flex items-center gap-2 rounded-lg border border-border/60 bg-muted/20 p-4 text-xs text-muted-foreground"
+    >
+      <Icon className="size-4 shrink-0" />
+      <span>Loading {label.toLowerCase()}…</span>
+    </div>
+  );
+}
+
+/** A failed load for a self-contained Activity panel. Distinguishes "couldn't check"
+ * from "nothing to show" with an explicit retry, so a backend failure never collapses
+ * into the same wording as a genuinely empty panel (#728). */
+function PanelErrorNotice({ label, onRetry }: { label: string; onRetry: () => void }) {
+  return (
+    <div
+      role="alert"
+      className="mb-6 flex items-center gap-3 rounded-lg border border-warning/40 bg-warning/5 p-4 text-xs"
+    >
+      <AlertTriangle className="size-4 shrink-0 text-warning" />
+      <span className="text-muted-foreground">
+        <span className="font-medium text-foreground">
+          Couldn't load {label.toLowerCase()}.
+        </span>{" "}
+        This isn't necessarily empty — Toolport couldn't check.
+      </span>
+      <button
+        type="button"
+        onClick={onRetry}
+        aria-label={`Retry loading ${label.toLowerCase()}`}
+        className="ml-auto shrink-0 rounded-md border px-2.5 py-1 font-medium text-foreground transition-colors hover:bg-accent focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none"
+      >
+        Retry
+      </button>
+    </div>
+  );
+}
+
 function DiscoveryTraces({ refreshKey }: { refreshKey: number }) {
   const [entries, setEntries] = useState<SearchTrace[]>([]);
   // Collapsed by default: this is glanceable telemetry, not an alert, and the list can run
   // to 100 rows. Leading with it open was a big part of the Activity tab feeling busy.
   const [open, setOpen] = useState(false);
+  // Distinguishes a load failure from a genuinely empty result (#728): both leave
+  // `entries` empty, but only one should show "Nothing searched yet."
+  const [status, setStatus] = useState<"loading" | "ready" | "error">("loading");
+  const [retryTick, setRetryTick] = useState(0);
 
   useEffect(() => {
     let alive = true;
+    setStatus((s) => (s === "error" ? "loading" : s));
     getSearchTraces(100)
-      .then((e) => alive && setEntries(e))
-      .catch(() => alive && setEntries([]));
+      .then((e) => {
+        if (!alive) return;
+        setEntries(e);
+        setStatus("ready");
+      })
+      .catch(() => {
+        if (!alive) return;
+        setStatus("error");
+      });
     return () => {
       alive = false;
     };
-  }, [refreshKey]);
+  }, [refreshKey, retryTick]);
+
+  if (status === "loading" && entries.length === 0) {
+    return <PanelLoadingNotice label="Discovery" icon={Search} />;
+  }
+
+  if (status === "error") {
+    return (
+      <PanelErrorNotice label="Discovery" onRetry={() => setRetryTick((t) => t + 1)} />
+    );
+  }
 
   if (entries.length === 0)
     return (
@@ -1292,16 +1358,28 @@ function ToolIdentities({ refreshKey }: { refreshKey: number }) {
   const [rows, setRows] = useState<ToolIdentity[]>([]);
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState("");
+  // Distinguishes a load failure from a genuinely empty result (#728): both leave
+  // `rows` empty, but only one should hide the panel.
+  const [status, setStatus] = useState<"loading" | "ready" | "error">("loading");
+  const [retryTick, setRetryTick] = useState(0);
 
   useEffect(() => {
     let alive = true;
+    setStatus((s) => (s === "error" ? "loading" : s));
     getToolIdentities()
-      .then((r) => alive && setRows(r))
-      .catch(() => alive && setRows([]));
+      .then((r) => {
+        if (!alive) return;
+        setRows(r);
+        setStatus("ready");
+      })
+      .catch(() => {
+        if (!alive) return;
+        setStatus("error");
+      });
     return () => {
       alive = false;
     };
-  }, [refreshKey]);
+  }, [refreshKey, retryTick]);
 
   const q = query.trim().toLowerCase();
 
@@ -1335,6 +1413,19 @@ function ToolIdentities({ refreshKey }: { refreshKey: number }) {
       })
       .filter(([, items]) => items.length > 0);
   }, [groups, q]);
+
+  if (status === "loading" && rows.length === 0) {
+    return <PanelLoadingNotice label="Tool identities" icon={Fingerprint} />;
+  }
+
+  if (status === "error") {
+    return (
+      <PanelErrorNotice
+        label="Tool identities"
+        onRetry={() => setRetryTick((t) => t + 1)}
+      />
+    );
+  }
 
   if (rows.length === 0) return null;
 
@@ -1414,16 +1505,28 @@ function ToolIdentities({ refreshKey }: { refreshKey: number }) {
 function LiveInspector({ refreshKey }: { refreshKey: number }) {
   const [entries, setEntries] = useState<InspectEntry[]>([]);
   const [open, setOpen] = useState(true);
+  // Distinguishes a load failure from a genuinely empty buffer (#728): both leave
+  // `entries` empty, but only one should say "run a tool and it'll show here."
+  const [status, setStatus] = useState<"loading" | "ready" | "error">("loading");
+  const [retryTick, setRetryTick] = useState(0);
 
   useEffect(() => {
     let alive = true;
+    setStatus((s) => (s === "error" ? "loading" : s));
     getInspectLog(50)
-      .then((e) => alive && setEntries(e))
-      .catch(() => alive && setEntries([]));
+      .then((e) => {
+        if (!alive) return;
+        setEntries(e);
+        setStatus("ready");
+      })
+      .catch(() => {
+        if (!alive) return;
+        setStatus("error");
+      });
     return () => {
       alive = false;
     };
-  }, [refreshKey]);
+  }, [refreshKey, retryTick]);
 
   return (
     <div className="mb-6 rounded-lg border border-info/30 bg-info/[0.04] p-4">
@@ -1451,7 +1554,16 @@ function LiveInspector({ refreshKey }: { refreshKey: number }) {
             is separate from the audit log, never leaves your machine, and clears when you
             turn inspection off or restart the gateway.
           </p>
-          {entries.length === 0 ? (
+          {status === "loading" && entries.length === 0 ? (
+            <p role="status" className="py-6 text-center text-sm text-muted-foreground">
+              Checking for captured calls…
+            </p>
+          ) : status === "error" ? (
+            <PanelErrorNotice
+              label="Live inspector"
+              onRetry={() => setRetryTick((t) => t + 1)}
+            />
+          ) : entries.length === 0 ? (
             <p className="py-6 text-center text-sm text-muted-foreground">
               No calls captured yet. Run a tool through Toolport and it'll show here.
             </p>


### PR DESCRIPTION
Fixes #728. DiscoveryTraces, ToolIdentities, and LiveInspector now track loading/ready/error status the same way the audit log and security-event panels already do, instead of collapsing a rejected fetch into an empty-state message. ToolIdentities no longer returns null on a failed load. Tests cover a rejected fetch for each panel.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Distinguish load failures from empty results in three Activity panels
> - Adds reusable `PanelLoadingNotice` and `PanelErrorNotice` components to [ActivityView.tsx](https://github.com/tsouth89/toolport/pull/861/files#diff-84a6bbaa6ab65156581be177909fb5076e4e87500a0beb1c1584af2e23f32ff6)
> - Updates `DiscoveryTraces`, `ToolIdentities`, and `LiveInspector` to track loading, ready, and error states with a retry counter
> - Load failures now render a retryable alert instead of the empty state, and initial loads show a loading notice
> - Behavioral Change: `DiscoveryTraces`, `ToolIdentities`, and `LiveInspector` effect dependency arrays now include a retry counter to support refetches on retry clicks
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 736ec7a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->