### PR TITLE
Reduce startup and Activity overhead; add repeatable verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,6 +139,24 @@ jobs:
       - name: Frontend tests
         run: npm run test
 
+      - name: Startup bundle budget
+        run: npm run bench:bundle
+
+      - name: Install browser for offline UI smoke
+        run: npx playwright install --with-deps chromium
+
+      - name: Offline browser fixture smoke
+        run: npm run smoke:browser
+
+      - name: Keep browser failure diagnostics
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: browser-smoke-diagnostics
+          path: .verify/browser-*/
+          include-hidden-files: true
+          if-no-files-found: ignore
+
       # Run the library, standalone binary, and integration targets explicitly.
       # Keeping all three flags prevents any test class from silently dropping
       # out of CI when the command is updated.

--- a/.gitignore
+++ b/.gitignore
@@ -121,3 +121,6 @@ src-tauri/rate_limit_counters.test.json
 /packaging/linux/aur/PKGBUILD
 /packaging/linux/aur/.SRCINFO
 /aur/
+
+# Local verification logs and screenshots
+/.verify/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,70 @@
+# Working on Toolport
+
+Toolport has a React/Vite frontend, a Tauri desktop shell, an optional GTK shell,
+and a Rust headless gateway. `src-tauri/src/bin/toolport-gateway.rs` owns the gateway
+protocol and catalog search; `router.rs` routes calls; `audit.rs` records and
+aggregates Activity history. Frontend IPC wrappers are in `src/lib/api.ts`.
+
+## Setup and verification
+
+- Run `npm run doctor` for tools, dependencies, browser, and artifact paths.
+- Install JavaScript dependencies with `npm ci`. Use stable Rust. Headless Linux
+  builds need pkg-config plus D-Bus and OpenSSL development packages; desktop
+  builds also need GTK/WebKit headers.
+- Run `npm run verify` for formatting, lint, frontend build/tests, startup bundle
+  budget, browser fixture smoke, headless Rust tests, and gateway smoke.
+- Use `npm run verify:frontend` or `npm run verify:headless` for scoped changes.
+  The headless path skips GTK/WebKit. Desktop-specific changes still need the
+  desktop Rust checks from CI (`npm run test:rust`).
+- Every verification run writes step logs and a JSON summary under `.verify/`.
+  A failed command stops the run and prints its log path. Do not call a partial
+  run a full pass.
+- `npm test -- --project logic` runs pure tests without jsdom. Component tests
+  use `--project ui`; individual file filters also work. Local tests default to
+  two workers; override `--maxWorkers` when appropriate.
+
+## Browser fixtures and worktrees
+
+`npm run smoke:browser` starts its own server on a free loopback port and uses an
+isolated headless browser. It checks the seeded Servers and Activity screens and
+captures both logo themes. Unknown IPC commands fail the fixture; add intentional
+responses in `src/test/browser-fixture.tsx` as coverage grows. Requests to external
+origins are blocked. These tests do not exercise the native backend or keychain.
+
+For manual inspection, run `npm run dev:fixture -- --port 1430`. Choose a different
+port in each worktree. This fixture has in-memory data and cannot change your real
+registry. It is a separate development entry, absent from production builds.
+Install Chromium with `npx playwright install chromium`, or set
+`TOOLPORT_BROWSER_BIN` to a compatible browser. Linux also uses `/usr/bin/chromium`
+when available. Failed browser checks and screenshots go under `.verify/`.
+
+Worktrees have independent Node dependencies and Cargo artifacts by default. A
+shared `CARGO_TARGET_DIR` reuses Rust builds but Cargo serializes access to it.
+The gateway smoke and latency tools honor `CARGO_TARGET_DIR`,
+`TOOLPORT_GATEWAY_BIN`, and `TOOLPORT_MOCK_BIN`. Both allocate temporary data;
+the HTTP smoke also allocates loopback ports. Latency RPCs have a ten-second
+deadline and clean up child processes and fixture data on failure.
+Use `registry::DataDirOverride` and the existing data-dir test lock in Rust tests
+that touch logs; never point tests at the user's installed data directory.
+
+## Performance evidence
+
+- `npm run build && npm run bench:bundle` measures the full static startup JS
+  dependency graph and checks its raw and gzip budgets.
+- `npm run bench:audit` measures a synthetic 10,000-row audit log. Add `-- --release`
+  for optimized measurements. Run the release example with `--memory-uncached`
+  and `--memory-streamed` separately for Linux peak RSS comparisons.
+  The benchmark compares the original uncached
+  aggregation with caching, including equal-length log rewrites.
+- Keep before/after data and state the build profile and fixture size. Browser
+  fixtures verify UI behavior; they are not native desktop performance evidence.
+- Inspect `git status` before editing. Preserve existing work and report unrelated
+  baseline failures separately. Do not commit, push, or publish without approval.
+
+## Public communication and external services
+
+Keep public posts short and human. Never use em dashes. Inspect the exact title
+and description before creating or updating a pull request; exclude terminal
+transcripts, scratch notes, and full logs. Use a draft until both code and copy
+are ready. After writing a PR, fetch its live title, description, diff, branch,
+and checks, and correct unexpected content. Access Linear through Toolport.

--- a/benchmark/bundle.mjs
+++ b/benchmark/bundle.mjs
@@ -1,0 +1,37 @@
+#!/usr/bin/env node
+// Measure all statically imported startup JS, not just a renamed entry chunk.
+import { readFile } from "node:fs/promises";
+import { gzipSync } from "node:zlib";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const manifest = JSON.parse(
+  await readFile(path.join(root, "dist/.vite/manifest.json"), "utf8"),
+);
+const visited = new Set();
+function visit(key) {
+  if (visited.has(key)) return;
+  visited.add(key);
+  for (const child of manifest[key].imports || []) visit(child);
+}
+for (const [key, item] of Object.entries(manifest)) if (item.isEntry) visit(key);
+let bytes = 0;
+let gzipBytes = 0;
+for (const key of visited) {
+  const content = await readFile(path.join(root, "dist", manifest[key].file));
+  bytes += content.length;
+  gzipBytes += gzipSync(content).length;
+}
+const result = {
+  startupChunks: visited.size,
+  startupJsBytes: bytes,
+  startupGzipBytes: gzipBytes,
+};
+console.log(JSON.stringify(result, null, 2));
+// Baseline before externalizing logos: 649,253 bytes / 210,862 gzip.
+if (bytes > 580_000 || gzipBytes > 185_000) {
+  console.error(
+    "Startup bundle exceeds budget (580 kB raw / 185 kB gzip). Inspect eager imports before changing the budget.",
+  );
+  process.exitCode = 1;
+}

--- a/benchmark/latency.mjs
+++ b/benchmark/latency.mjs
@@ -12,19 +12,22 @@
 //   node benchmark/latency.mjs 200 --check               (enforce latency-budget.json)
 //
 // Needs a debug build first:
-//   cargo build --manifest-path src-tauri/Cargo.toml --bins
+//   npm run build:gateway
 
 import { spawn } from "node:child_process";
 import { mkdtempSync, writeFileSync, rmSync, existsSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
-import { dirname, join } from "node:path";
+import { dirname, join, resolve } from "node:path";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const DEBUG = join(__dirname, "..", "src-tauri", "target", "debug");
+const DEBUG = join(
+  resolve(__dirname, "..", process.env.CARGO_TARGET_DIR || "src-tauri/target"),
+  "debug",
+);
 const exe = (n) => join(DEBUG, process.platform === "win32" ? `${n}.exe` : n);
-const GATEWAY = exe("toolport-gateway");
-const MOCK = exe("mock-mcp-server");
+const GATEWAY = process.env.TOOLPORT_GATEWAY_BIN || exe("toolport-gateway");
+const MOCK = process.env.TOOLPORT_MOCK_BIN || exe("mock-mcp-server");
 const args = process.argv.slice(2);
 const N = Math.max(20, Number(args.find((arg) => /^\d+$/.test(arg)) || 200));
 const JSON_OUTPUT = args.includes("--json");
@@ -36,9 +39,7 @@ for (const [label, p] of [
   ["mock server", MOCK],
 ]) {
   if (!existsSync(p)) {
-    console.error(
-      `Missing ${label} at ${p}\nBuild it first:\n  cargo build --manifest-path src-tauri/Cargo.toml --bins`,
-    );
+    console.error(`Missing ${label} at ${p}\nBuild it first:\n  npm run build:gateway`);
     process.exit(1);
   }
 }
@@ -55,6 +56,21 @@ const stats = (xs) => {
 function client(proc) {
   const pending = new Map();
   let buf = "";
+  let stopped;
+  const failPending = (error) => {
+    stopped = error;
+    for (const request of pending.values()) {
+      clearTimeout(request.timer);
+      request.reject(error);
+    }
+    pending.clear();
+  };
+  proc.once("error", failPending);
+  proc.stdin.on("error", failPending);
+  proc.stdout.on("error", failPending);
+  proc.once("close", (code, signal) =>
+    failPending(new Error(`RPC process closed (${code ?? signal})`)),
+  );
   proc.stdout.on("data", (d) => {
     buf += d.toString();
     let i;
@@ -69,17 +85,26 @@ function client(proc) {
         continue;
       }
       if (m.id != null && pending.has(m.id)) {
-        pending.get(m.id)(m);
+        const request = pending.get(m.id);
+        clearTimeout(request.timer);
         pending.delete(m.id);
+        if (m.error || m.result?.isError)
+          request.reject(new Error(`RPC failed: ${JSON.stringify(m.error || m.result)}`));
+        else request.resolve(m);
       }
     }
   });
   let id = 0;
   return {
     call: (method, params) =>
-      new Promise((res) => {
+      new Promise((resolve, reject) => {
+        if (stopped) return reject(stopped);
         const myId = ++id;
-        pending.set(myId, res);
+        const timer = setTimeout(() => {
+          pending.delete(myId);
+          reject(new Error(`${method} timed out after 10 seconds`));
+        }, 10_000);
+        pending.set(myId, { resolve, reject, timer });
         proc.stdin.write(
           JSON.stringify({ jsonrpc: "2.0", id: myId, method, params }) + "\n",
         );
@@ -115,9 +140,58 @@ const INIT = {
   clientInfo: { name: "bench", version: "0" },
 };
 
+const children = new Set();
+let scratch;
+let cleanupPromise;
+function start(binary, options) {
+  const proc = spawn(binary, [], options);
+  children.add(proc);
+  proc.once("close", () => children.delete(proc));
+  return proc;
+}
+function cleanup() {
+  return (cleanupPromise ??= (async () => {
+    await Promise.all(
+      [...children].map(
+        (proc) =>
+          new Promise((resolve) => {
+            const timer = setTimeout(() => proc.kill("SIGKILL"), 2000);
+            proc.once("close", () => {
+              clearTimeout(timer);
+              resolve();
+            });
+            proc.kill();
+          }),
+      ),
+    );
+    if (scratch)
+      rmSync(scratch, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+  })());
+}
+for (const [signal, code] of [
+  ["SIGINT", 130],
+  ["SIGTERM", 143],
+]) {
+  process.once(signal, () => {
+    void cleanup().finally(() => process.exit(code));
+  });
+}
+
 async function main() {
   const dir = mkdtempSync(join(tmpdir(), "conduit-lat-"));
+  scratch = dir;
   const regPath = join(dir, "registry.json");
+  // Benchmarks must not inherit the user's data/profile overrides or write logs
+  // and caches into an installed Toolport instance.
+  const env = Object.fromEntries(
+    Object.entries(process.env).filter(([key]) => !/^(TOOLPORT|CONDUIT)_/.test(key)),
+  );
+  Object.assign(env, {
+    TOOLPORT_DATA_DIR: dir,
+    TOOLPORT_REGISTRY: regPath,
+    TOOLPORT_PROFILE: "bench",
+    TOOLPORT_DISCOVERY: "lazy",
+  });
   writeFileSync(
     regPath,
     JSON.stringify({
@@ -139,15 +213,14 @@ async function main() {
   );
 
   // 1) The mock directly: discover a tool name and measure the bare call latency.
-  const mk = spawn(MOCK, [], { stdio: ["pipe", "pipe", "ignore"] });
+  const mk = start(MOCK, { env, stdio: ["pipe", "pipe", "ignore"] });
   const m = client(mk);
   await m.call("initialize", INIT);
   m.notify("notifications/initialized");
   await sleep(200);
   const tools = (await m.call("tools/list", {})).result?.tools || [];
   if (!tools.length) {
-    console.error("mock advertised no tools; cannot benchmark the call path");
-    process.exit(1);
+    throw new Error("mock advertised no tools; cannot benchmark the call path");
   }
   const bare = tools[0].name;
   for (let k = 0; k < 15; k++) await m.call("tools/call", { name: bare, arguments: {} });
@@ -155,13 +228,8 @@ async function main() {
 
   // 2) Through the gateway.
   const gatewayStarted = now();
-  const gw = spawn(GATEWAY, [], {
-    env: {
-      ...process.env,
-      CONDUIT_REGISTRY: regPath,
-      CONDUIT_PROFILE: "bench",
-      CONDUIT_DISCOVERY: "lazy",
-    },
+  const gw = start(GATEWAY, {
+    env,
     stdio: ["pipe", "pipe", "ignore"],
   });
   const g = client(gw);
@@ -194,12 +262,6 @@ async function main() {
       }),
     N,
   );
-
-  mk.stdin.end();
-  mk.kill();
-  gw.stdin.end();
-  gw.kill();
-  rmSync(dir, { recursive: true, force: true });
 
   const overhead = {
     median: gwCall.median - direct.median,
@@ -280,7 +342,9 @@ async function main() {
   }
 }
 
-main().catch((e) => {
-  console.error(e);
-  process.exit(1);
-});
+main()
+  .catch((e) => {
+    console.error(`Latency benchmark failed: ${e.message}`);
+    process.exitCode = 1;
+  })
+  .finally(cleanup);

--- a/docs/performance-audit.md
+++ b/docs/performance-audit.md
@@ -1,0 +1,109 @@
+# Performance and agent verification audit
+
+Measured locally on Linux on 2026-09-04. The PR branch was verified against
+`main` at `2149d34`.
+
+## Findings and results
+
+| Path                                        |       Before |     After | What changed                                                            |
+| ------------------------------------------- | -----------: | --------: | ----------------------------------------------------------------------- |
+| Static startup JavaScript                   |    649.25 kB | 551.65 kB | Vendored logos load as local image assets instead of eager SVG strings  |
+| Startup JavaScript, gzip                    |    210.86 kB | 170.40 kB | About 19% fewer compressed startup bytes                                |
+| Unchanged audit stats, release median       |      8.00 ms |   0.42 ms | Compare exact log bytes and reuse the aggregate                         |
+| Rewrite plus audit stats, release median    |      7.75 ms |   7.01 ms | Aggregate rows as they are parsed instead of keeping every JSON tree    |
+| Audit fixture peak process RSS              |   20,272 KiB | 9,744 KiB | Separate uncached/streamed processes, including fixture setup           |
+| Activity refreshes during 60 seconds hidden | 20 scheduled |         0 | Native visibility and window focus gate the refresh timer               |
+| Frontend tests, two workers                 |      24.95 s |   20.78 s | Pure tests use Node; only UI tests initialize jsdom and Testing Library |
+
+Startup bytes were remeasured against the PR base using the original components
+and the same production build settings. The test timings compare the initial
+audit checkout with the optimized configuration; the final PR branch ran 657
+tests in 22.79 seconds. Test timings varied while the machine was in use.
+
+The audit benchmark uses 10,000 synthetic rows occupying 3,466,600 bytes. The
+uncached reference is the previous `read_all` plus aggregation path. Its final
+comparison runs both paths in the same optimized executable. Each timed workload
+gets five warmups and 50 samples, or 20 samples when rewriting the log. Final
+unchanged-stats p95 was 10.87 ms uncached and 0.44 ms cached. Rewrite-plus-stats p95
+was 8.97 ms uncached and 7.45 ms streamed. The filesystem cache was warm; these are
+not cold-disk or production API measurements. This machine was also in active use.
+
+A preliminary debug build measured unchanged stats at 49.59 ms before and 0.65 ms
+after caching. That is diagnostic evidence, not a shipped-build latency claim.
+The first cache implementation made changed snapshots somewhat slower. Streaming
+aggregation replaced that implementation and removed the measured regression.
+
+The cache retains at most one normal-sized log snapshot, up to 4 MiB, plus its
+summary. It still reads the file on each request. Exact byte comparison catches
+same-size rewrites without trusting modification timestamps. Missing files return
+empty stats, read failures still fail, and oversized logs aggregate without being
+cached. No policy or permission decisions are cached.
+
+Logo masks preserve inherited monochrome colors. The mixed-color Amazon mark
+remains inline. Screenshots of all client logos in both themes were compared with
+the original components: 61 of 1,116,000 pixels differed by more than 8 in a color
+channel, consistent with rasterization differences. Local SVG files keep the
+existing CSP. Native WebKit rendering still needs platform verification.
+
+The startup byte reduction is measured. A specific cold-start time improvement is
+not claimed. Browser fixtures run development React and mocked IPC, so their load
+time cannot stand in for installed desktop startup latency.
+
+## Verification and agent DX
+
+- `npm run doctor` identifies missing dependencies and browser/native tooling.
+- `npm run verify` runs the full frontend and headless flow, stopping on failure
+  with per-stage logs and a machine-readable summary under `.verify/`.
+- `verify:frontend` and `verify:headless` support scoped work. `typecheck` is
+  available separately; `npm test -- --project logic` skips browser setup.
+- `smoke:browser` starts an isolated loopback server on a free port. It checks
+  seeded Servers and Activity screens, validates logo asset loads, blocks
+  external requests, and captures screenshots plus a Playwright trace. Failures
+  retain HTML, screenshots, and errors. It needs no credentials or real registry.
+- `dev:fixture -- --port 1430` supports interactive inspection in a worktree.
+- `bench:bundle` measures every statically imported startup chunk, so merely
+  splitting the entry chunk does not evade the byte budget.
+- `bench:audit` provides reproducible timing and separate-process Linux RSS cases.
+- Gateway smoke and latency tools respect custom Cargo target directories and
+  binary overrides. The latency harness now isolates data and environment,
+  rejects RPC errors, times out hung requests, and cleans up failed child runs.
+  Both immediate process exit and a nonresponding mock were exercised; the latter
+  failed in about ten seconds and left no benchmark directory behind.
+- CI now checks the startup bundle budget and offline browser smoke, retaining
+  browser diagnostics on failure. Remote CI results are tracked on the PR.
+- Shared UI test cleanup now drains Radix's delayed focus restoration before
+  jsdom teardown. A focused regression fails with the original setup and passes
+  with the fix, covering the unhandled Event-realm error found during this audit.
+- The verification runner terminates its owned process tree on cancellation or
+  timeout. A nested test process was confirmed stopped after cancelling a run.
+- `AGENTS.md` documents setup, relevant code paths, scoped checks, worktrees,
+  fixture isolation, and the limits of the available evidence.
+
+The complete `npm run verify` flow passed on the PR branch: formatting, lint,
+typechecked production build, 657 frontend tests, startup bundle budget, browser
+smoke, 1,715 headless Rust tests (one pre-existing ignored test), gateway build,
+and all ten headless smoke checks. Lint still reports pre-existing warnings.
+Headless gateway overhead against the mock measured about 0.44 ms median in a
+debug build; no before/after improvement is claimed for that path.
+
+## Experiments not retained and remaining work
+
+No final optimization was removed for lack of benefit. The initial cache that
+materialized every row was replaced by the faster streamed version. Whole-file
+recent-entry reads measured about 0.4 ms for 200 rows from the 3.5 MB fixture, so a
+reverse-file reader was not implemented. Its complexity was not justified by that
+measurement. Existing catalog indexing and route splitting already avoid several
+obvious sources of repeated work.
+
+The startup bundle still includes closed dialog implementations and substantial
+React/Radix code. Deferring dialogs is a remaining opportunity, but needs checks
+for focus restoration, keyboard opening, form state, and async failures. Long
+lists also merit profiling with realistic registry/catalog sizes before adding
+virtualization. Other sidebar polling continues independently of Activity.
+
+Further verification would benefit from authenticated staging MCP accounts,
+representative large registries and log distributions, installed Windows/macOS
+builds, native GTK/WebKit traces, and cold-cache startup profiles. These are
+needed to measure real downstream API latency, keychain prompts, packaging, and
+native window behavior. The offline fixture and headless checks do not replace
+those platform checks.

--- a/fixtures/index.html
+++ b/fixtures/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Toolport local fixture</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/test/browser-fixture.tsx"></script>
+  </body>
+</html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
+        "@playwright/test": "^1.63.0",
         "@tauri-apps/cli": "^2",
         "@testing-library/dom": "^10.4.1",
         "@testing-library/jest-dom": "^6.9.1",
@@ -1586,6 +1587,22 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.63.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.63.0.tgz",
+      "integrity": "sha512-oxMK4vllB9RK5NQ2l1pq1IfOf2AvnEuj/vYGDj0H2nMtmtZpKtCwt/l00GEO6xjGfpBNAvjovvYdCm50dRQkpQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.63.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@radix-ui/number": {
@@ -9234,6 +9251,35 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.63.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.63.0.tgz",
+      "integrity": "sha512-+7ziBLidS4NaNCdt57SUDT+wYmmd5fmiQejUic/kb+YsYSCPyOOE9sebzMjNmQrsnNpDJqd4WHvV/8lfKfUDUg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.63.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.63.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.63.0.tgz",
+      "integrity": "sha512-rYCsBF/M5HjUch52bbtVONEFjv6Xu8sm8h72dNlR5bzIE1fvC/bxgspzkjSfU+MweEMmPM8KJebG6nnyxo5mCg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,16 @@
     "bench:compare": "node benchmark/compare-local.mjs",
     "bench:mcp-native": "node benchmark/mcp-native.mjs",
     "audit:prod": "npm audit --omit=dev",
-    "prepare": "husky"
+    "prepare": "husky",
+    "doctor": "node scripts/doctor.mjs",
+    "verify": "node scripts/verify.mjs",
+    "verify:frontend": "node scripts/verify.mjs --frontend",
+    "verify:headless": "node scripts/verify.mjs --headless",
+    "typecheck": "tsc --noEmit",
+    "smoke:browser": "node scripts/browser-smoke.mjs",
+    "dev:fixture": "vite --host 127.0.0.1 --open /fixtures/",
+    "bench:bundle": "node benchmark/bundle.mjs",
+    "bench:audit": "cargo run --manifest-path src-tauri/Cargo.toml --no-default-features --features test-support --example audit-performance"
   },
   "dependencies": {
     "@fontsource-variable/geist": "^5.2.9",
@@ -50,6 +59,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
+    "@playwright/test": "^1.63.0",
     "@tauri-apps/cli": "^2",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.9.1",

--- a/scripts/browser-smoke.mjs
+++ b/scripts/browser-smoke.mjs
@@ -1,0 +1,103 @@
+#!/usr/bin/env node
+/* global window, document, getComputedStyle, Image */
+import { chromium, expect } from "@playwright/test";
+import { createServer } from "vite";
+import { existsSync, realpathSync } from "node:fs";
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const output = path.join(root, ".verify", `browser-${Date.now()}-${process.pid}`);
+await mkdir(output, { recursive: true });
+const server = await createServer({
+  root,
+  server: {
+    host: "127.0.0.1",
+    port: 0,
+    strictPort: false,
+    open: false,
+    hmr: false,
+    fs: { allow: [root, realpathSync(path.join(root, "node_modules"))] },
+  },
+  logLevel: "error",
+});
+let browser;
+let context;
+let page;
+const errors = [];
+try {
+  await server.listen();
+  const address = server.httpServer.address();
+  const baseURL = `http://127.0.0.1:${address.port}`;
+  browser = await chromium.launch({
+    executablePath:
+      process.env.TOOLPORT_BROWSER_BIN ||
+      (existsSync("/usr/bin/chromium") ? "/usr/bin/chromium" : undefined),
+    headless: true,
+  });
+  context = await browser.newContext({ viewport: { width: 1240, height: 900 } });
+  await context.tracing.start({ screenshots: true, snapshots: true });
+  page = await context.newPage();
+  page.on("pageerror", (error) => errors.push(error.message));
+  page.on("response", (response) => {
+    if (response.status() >= 400)
+      errors.push(`HTTP ${response.status()}: ${response.url()}`);
+  });
+  // Fixtures must stay offline even if an application path starts using fetch.
+  await page.route("**/*", (route) => {
+    if (new URL(route.request().url()).origin === baseURL) return route.continue();
+    errors.push(`Unexpected external request: ${route.request().url()}`);
+    return route.abort();
+  });
+  await page.goto(`${baseURL}/fixtures/`);
+  await expect(page.getByText("GitHub", { exact: true })).toBeVisible();
+  await page.screenshot({ path: path.join(output, "servers.png") });
+  await page.getByRole("button", { name: "Activity", exact: true }).click();
+  await expect(page.getByText("Protection active.", { exact: true })).toBeVisible();
+  await page.screenshot({ path: path.join(output, "activity.png") });
+  const fixture = await page.evaluate(() => window.toolportFixture);
+  expect(fixture.missing).toEqual([]);
+  expect(errors).toEqual([]);
+  await page.goto(`${baseURL}/fixtures/?logos`);
+  await expect(page.getByText("Dark logo fixture")).toBeVisible();
+  await page.evaluate(() => document.fonts.ready);
+  await expect
+    .poll(() =>
+      page
+        .locator("img")
+        .evaluateAll((images) =>
+          images.every((img) => img.complete && img.naturalWidth > 0),
+        ),
+    )
+    .toBe(true);
+  // Wait for CSS mask assets too, so screenshots do not capture blank logos.
+  await page.evaluate(async () => {
+    await Promise.all(
+      [...document.querySelectorAll("[style]")].map(async (element) => {
+        const match = getComputedStyle(element).maskImage.match(/^url\("?(.*?)"?\)$/);
+        if (!match) return;
+        const image = new Image();
+        image.src = match[1];
+        await image.decode();
+      }),
+    );
+  });
+  await page.screenshot({ path: path.join(output, "logos.png"), fullPage: true });
+  expect(errors).toEqual([]);
+  console.log(`Browser smoke passed. Screenshots: ${output}`);
+} catch (error) {
+  if (page) {
+    await page.screenshot({ path: path.join(output, "failure.png") }).catch(() => {});
+    await writeFile(path.join(output, "failure.html"), await page.content()).catch(
+      () => {},
+    );
+  }
+  console.error(`Browser smoke failed. Artifacts: ${output}`);
+  throw error;
+} finally {
+  await writeFile(path.join(output, "errors.json"), JSON.stringify(errors, null, 2));
+  await context?.tracing.stop({ path: path.join(output, "trace.zip") });
+  await browser?.close();
+  await server.close();
+}

--- a/scripts/doctor.mjs
+++ b/scripts/doctor.mjs
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { createRequire } from "node:module";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const require = createRequire(import.meta.url);
+let failures = 0;
+function check(label, ok, remedy) {
+  console.log(`${ok ? "OK" : "MISSING"} ${label}${ok ? "" : `: ${remedy}`}`);
+  if (!ok) failures++;
+}
+function command(bin, args) {
+  return spawnSync(bin, args, { encoding: "utf8", cwd: root }).status === 0;
+}
+const [nodeMajor, nodeMinor] = process.versions.node.split(".").map(Number);
+check(
+  "Node compatible with Vite 7",
+  (nodeMajor === 20 && nodeMinor >= 19) ||
+    (nodeMajor === 22 && nodeMinor >= 12) ||
+    nodeMajor > 22,
+  "install Node 20.19+ or 22.12+ (Node 21 is unsupported)",
+);
+for (const dependency of ["vite", "vitest", "@playwright/test"]) {
+  let installed = false;
+  try {
+    require.resolve(dependency);
+    installed = true;
+  } catch {
+    /* missing */
+  }
+  check(dependency, installed, "run npm ci");
+}
+check(
+  "Rust compiler",
+  command("rustc", ["--version"]),
+  "install stable Rust with rustup",
+);
+check("Cargo", command("cargo", ["--version"]), "install stable Rust with rustup");
+if (process.platform === "linux") {
+  check(
+    "Headless native dependencies",
+    command("pkg-config", ["--exists", "dbus-1", "openssl"]),
+    "install pkg-config, OpenSSL and D-Bus development packages",
+  );
+  console.log(
+    `INFO Desktop headers: ${command("pkg-config", ["--exists", "webkit2gtk-4.1", "gtk+-3.0"]) ? "available" : "missing (optional for headless verification)"}`,
+  );
+}
+let browser =
+  process.env.TOOLPORT_BROWSER_BIN ||
+  (existsSync("/usr/bin/chromium") ? "/usr/bin/chromium" : "");
+if (!browser) {
+  try {
+    browser = require("@playwright/test").chromium.executablePath();
+  } catch {
+    /* missing */
+  }
+}
+check(
+  "Headless Chromium",
+  Boolean(browser && existsSync(browser)),
+  "run npx playwright install chromium, or set TOOLPORT_BROWSER_BIN",
+);
+console.log(`INFO Checkout: ${root}`);
+console.log(
+  `INFO Cargo artifacts: ${process.env.CARGO_TARGET_DIR || path.join(root, "src-tauri", "target")}`,
+);
+console.log(
+  "INFO Browser fixtures need no API keys, account, database, or running desktop.",
+);
+process.exitCode = failures ? 1 : 0;

--- a/scripts/smoke-headless.mjs
+++ b/scripts/smoke-headless.mjs
@@ -14,21 +14,14 @@ import { createHmac } from "node:crypto";
 import { isDeepStrictEqual } from "node:util";
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
-const defaultBinary = path.join(
+const targetDir = path.resolve(
   repoRoot,
-  "src-tauri",
-  "target",
-  "debug",
-  process.platform === "win32" ? "toolport-gateway.exe" : "toolport-gateway",
+  process.env.CARGO_TARGET_DIR || "src-tauri/target",
 );
-const gatewayBinary = process.env.TOOLPORT_GATEWAY_BIN || defaultBinary;
-const mockBinary = path.join(
-  repoRoot,
-  "src-tauri",
-  "target",
-  "debug",
-  process.platform === "win32" ? "mock-mcp-server.exe" : "mock-mcp-server",
-);
+const binaryPath = (name) =>
+  path.join(targetDir, "debug", process.platform === "win32" ? `${name}.exe` : name);
+const gatewayBinary = process.env.TOOLPORT_GATEWAY_BIN || binaryPath("toolport-gateway");
+const mockBinary = process.env.TOOLPORT_MOCK_BIN || binaryPath("mock-mcp-server");
 const token = "smoke-test-token-32chars-minimum!!";
 const children = new Set();
 let smokeDir;

--- a/scripts/verify.mjs
+++ b/scripts/verify.mjs
@@ -1,0 +1,126 @@
+#!/usr/bin/env node
+// One bounded, logged verification flow. Fails at the first unsuccessful stage.
+import { spawn, spawnSync } from "node:child_process";
+import { mkdir, writeFile } from "node:fs/promises";
+import { createWriteStream } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const args = new Set(process.argv.slice(2));
+for (const arg of args) {
+  if (!["--frontend", "--headless"].includes(arg))
+    throw new Error(`Unknown option: ${arg}`);
+}
+if (args.size > 1)
+  throw new Error("Choose --frontend or --headless, or omit both for all checks");
+const output = path.join(root, ".verify", `run-${Date.now()}-${process.pid}`);
+await mkdir(output, { recursive: true });
+const npm = process.platform === "win32" ? "npm.cmd" : "npm";
+const steps = [];
+const runNpm = (name) => steps.push([name, npm, ["run", name]]);
+if (!args.has("--headless")) {
+  for (const name of [
+    "format:check",
+    "lint",
+    "build",
+    "test",
+    "bench:bundle",
+    "smoke:browser",
+  ])
+    runNpm(name);
+}
+if (!args.has("--frontend")) {
+  steps.push([
+    "rust-tests",
+    "cargo",
+    [
+      "test",
+      "--locked",
+      "--manifest-path",
+      "src-tauri/Cargo.toml",
+      "--no-default-features",
+      "--lib",
+      "--bins",
+      "--tests",
+    ],
+  ]);
+  runNpm("build:gateway");
+  runNpm("smoke:headless");
+}
+const results = [];
+console.log(`Verification logs: ${output}`);
+for (const [name, bin, argv] of steps) {
+  const start = Date.now();
+  const logPath = path.join(output, `${name.replaceAll(":", "-")}.log`);
+  const log = createWriteStream(logPath);
+  console.log(`Running ${name}...`);
+  const status = await new Promise((resolve) => {
+    const child = spawn(bin, argv, {
+      cwd: root,
+      env: {
+        ...process.env,
+        CARGO_BUILD_JOBS: process.env.CARGO_BUILD_JOBS || "2",
+        NO_COLOR: "1",
+      },
+      shell: process.platform === "win32" && bin === "npm.cmd",
+      detached: process.platform !== "win32",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    child.stdout.pipe(log, { end: false });
+    child.stderr.pipe(log, { end: false });
+    let requestedExit;
+    let forceTimer;
+    const killTree = (signal) => {
+      if (!child.pid) return;
+      if (process.platform === "win32") {
+        spawnSync("taskkill", ["/pid", String(child.pid), "/T", "/F"], {
+          stdio: "ignore",
+          timeout: 10_000,
+        });
+      } else {
+        try {
+          process.kill(-child.pid, signal);
+        } catch (error) {
+          if (error.code !== "ESRCH") log.write(`Cleanup failed: ${error.message}\n`);
+        }
+      }
+    };
+    const stop = (code) => {
+      if (requestedExit !== undefined) return;
+      requestedExit = code;
+      killTree("SIGTERM");
+      forceTimer = setTimeout(() => killTree("SIGKILL"), 2000);
+    };
+    const onInterrupt = () => stop(130);
+    const onTerminate = () => stop(143);
+    process.once("SIGINT", onInterrupt);
+    process.once("SIGTERM", onTerminate);
+    const timer = setTimeout(() => stop(124), 30 * 60 * 1000);
+    child.once("error", (error) => {
+      log.write(`${error.message}\n`);
+    });
+    child.once("close", (code) => {
+      clearTimeout(timer);
+      clearTimeout(forceTimer);
+      process.off("SIGINT", onInterrupt);
+      process.off("SIGTERM", onTerminate);
+      // Descendants can outlive npm even after its own process has closed.
+      if (requestedExit !== undefined) killTree("SIGKILL");
+      log.end(() => resolve(requestedExit ?? code ?? 1));
+    });
+  });
+  results.push({ name, status, seconds: (Date.now() - start) / 1000, log: logPath });
+  await writeFile(
+    path.join(output, "summary.json"),
+    JSON.stringify(results, null, 2) + "\n",
+  );
+  console.log(
+    `${status === 0 ? "PASS" : "FAIL"} ${name} (${results.at(-1).seconds.toFixed(1)}s)`,
+  );
+  if (status !== 0) {
+    console.error(`Inspect ${logPath}`);
+    process.exitCode = status;
+    break;
+  }
+}

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -141,3 +141,7 @@ debug = "line-tables-only"
 # Same for the profile `cargo test` builds under.
 [profile.test]
 debug = "line-tables-only"
+
+[[example]]
+name = "audit-performance"
+required-features = ["test-support"]

--- a/src-tauri/examples/audit-performance.rs
+++ b/src-tauri/examples/audit-performance.rs
@@ -1,0 +1,122 @@
+//! Offline Activity benchmark. Uses a private temporary directory, never user logs.
+//! cargo run --manifest-path src-tauri/Cargo.toml --no-default-features --features test-support --example audit-performance
+use conduit_lib::{audit, registry::DataDirOverride};
+use serde_json::json;
+use std::{hint::black_box, time::Instant};
+
+fn measure(mut work: impl FnMut(), samples: usize) -> serde_json::Value {
+    for _ in 0..5 {
+        work();
+    }
+    let mut times = Vec::with_capacity(samples);
+    for _ in 0..samples {
+        let start = Instant::now();
+        work();
+        times.push(start.elapsed().as_secs_f64() * 1000.0);
+    }
+    times.sort_by(f64::total_cmp);
+    json!({"median_ms": times[samples / 2], "p95_ms": times[samples * 95 / 100]})
+}
+
+fn main() {
+    let dir = std::env::temp_dir().join(format!(
+        "toolport-audit-bench-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    std::fs::create_dir(&dir).unwrap();
+    struct Cleanup(std::path::PathBuf);
+    impl Drop for Cleanup {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
+    let _cleanup = Cleanup(dir.clone());
+    let _data = DataDirOverride::set(&dir);
+    let mut content = String::new();
+    for i in 0..10_000 {
+        content.push_str(
+            &json!({"ts": i, "server": format!("server-{}", i % 10),
+            "tool": format!("tool-{}", i % 100), "ok": i % 11 != 0,
+            "durationMs": i % 500, "error": "x".repeat(260)})
+            .to_string(),
+        );
+        content.push('\n');
+    }
+    let path = dir.join("audit.jsonl");
+    std::fs::write(&path, &content).unwrap();
+    // Run memory cases in separate processes so the old JSON tree cannot
+    // contaminate the streamed path's peak RSS. VmHWM is Linux-only.
+    if let Some(mode) =
+        std::env::args().find(|arg| arg == "--memory-uncached" || arg == "--memory-streamed")
+    {
+        let result = if mode == "--memory-uncached" {
+            audit::stats_for_entries(&audit::read_all().unwrap())
+        } else {
+            audit::stats().unwrap()
+        };
+        assert_eq!(result["total"], 10_000);
+        let peak_rss_kib = std::fs::read_to_string("/proc/self/status")
+            .ok()
+            .and_then(|status| {
+                status.lines().find_map(|line| {
+                    line.strip_prefix("VmHWM:")
+                        .and_then(|value| value.split_whitespace().next()?.parse::<u64>().ok())
+                })
+            });
+        println!(
+            "{}",
+            json!({"mode": mode, "rows": 10_000, "bytes": content.len(), "peak_rss_kib": peak_rss_kib})
+        );
+        return;
+    }
+    assert_eq!(audit::read_recent(200).unwrap().len(), 200);
+    assert_eq!(audit::stats().unwrap()["total"], 10_000);
+    let recent = measure(
+        || {
+            black_box(audit::read_recent(200).unwrap());
+        },
+        50,
+    );
+    let uncached = measure(
+        || {
+            black_box(audit::stats_for_entries(&audit::read_all().unwrap()));
+        },
+        50,
+    );
+    let unchanged = measure(
+        || {
+            black_box(audit::stats().unwrap());
+        },
+        50,
+    );
+    // Alternate equal-length snapshots to catch caches based only on file size.
+    let changed = content.replace("server-0", "server-X");
+    let mut flip = false;
+    let changing_uncached = measure(
+        || {
+            std::fs::write(&path, if flip { &content } else { &changed }).unwrap();
+            flip = !flip;
+            black_box(audit::stats_for_entries(&audit::read_all().unwrap()));
+        },
+        20,
+    );
+    let changing = measure(
+        || {
+            std::fs::write(&path, if flip { &content } else { &changed }).unwrap();
+            flip = !flip;
+            black_box(audit::stats().unwrap());
+        },
+        20,
+    );
+    println!(
+        "{}",
+        json!({"profile": if cfg!(debug_assertions) {"debug"} else {"release"},
+        "rows": 10_000, "bytes": content.len(), "recent_200": recent,
+        "stats_uncached": uncached, "stats_unchanged": unchanged,
+        "rewrite_and_uncached_stats": changing_uncached, "rewrite_and_stats": changing})
+    );
+}

--- a/src-tauri/src/audit.rs
+++ b/src-tauri/src/audit.rs
@@ -682,7 +682,58 @@ pub fn tool_call_ok(entry: &Value) -> Option<bool> {
 /// retained (the byte cap bounds it), not a fixed window, so the error rate stays consistent
 /// with the call count instead of being taken over an arbitrary slice.
 pub fn stats() -> std::io::Result<Value> {
-    Ok(aggregate(&read_all()?))
+    // Read on every request: metadata alone can miss equal-length replacements,
+    // coarse timestamps, and changes from another gateway process.
+    let content = match audit_path().map(std::fs::read_to_string) {
+        None => String::new(),
+        Some(Ok(content)) => content,
+        Some(Err(e)) if e.kind() == std::io::ErrorKind::NotFound => String::new(),
+        Some(Err(e)) => return Err(e),
+    };
+    static CACHE: std::sync::Mutex<StatsCache> = std::sync::Mutex::new(StatsCache {
+        content: None,
+        stats: Value::Null,
+    });
+    Ok(CACHE
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .get(content))
+}
+
+/// Cache one exact snapshot, bounded by the normal log cap. Idle Activity polls
+/// still read the file but avoid reparsing every retained row and sorting all
+/// duration samples. Errors are returned before consulting this cache.
+struct StatsCache {
+    content: Option<String>,
+    stats: Value,
+}
+
+impl StatsCache {
+    fn get(&mut self, content: String) -> Value {
+        if self.content.as_ref() == Some(&content) {
+            return self.stats.clone();
+        }
+        // Release the previous snapshot before parsing its replacement. Feed
+        // rows directly to the accumulator instead of retaining a JSON tree
+        // for every row (including error text that stats never uses).
+        self.content = None;
+        self.stats = Value::Null;
+        let stats = aggregate_rows(
+            content
+                .lines()
+                .rev()
+                .filter_map(|line| serde_json::from_str::<Value>(line).ok()),
+        );
+        if content.len() as u64 <= MAX_AUDIT_BYTES {
+            self.content = Some(content);
+            self.stats = stats.clone();
+        } else {
+            // Oversized imports still aggregate correctly without being retained.
+            self.content = None;
+            self.stats = Value::Null;
+        }
+        stats
+    }
 }
 
 /// [`stats`] over entries the caller already read, so a view that needs both the
@@ -694,6 +745,10 @@ pub fn stats_for_entries(entries: &[Value]) -> Value {
 /// Pure aggregation of audit entries into per-server + global stats. Split from
 /// `stats` so the dashboard math is testable without touching the on-disk log.
 fn aggregate(entries: &[Value]) -> Value {
+    aggregate_rows(entries)
+}
+
+fn aggregate_rows<T: std::borrow::Borrow<Value>>(entries: impl IntoIterator<Item = T>) -> Value {
     use std::collections::HashMap;
 
     #[derive(Default)]
@@ -717,7 +772,8 @@ fn aggregate(entries: &[Value]) -> Value {
     let mut total = 0u64;
     let mut errors = 0u64;
 
-    for e in entries {
+    for row in entries {
+        let e = row.borrow();
         let Some(ok) = tool_call_ok(e) else {
             continue;
         };
@@ -930,6 +986,27 @@ mod tests {
             }
             let _ = std::fs::remove_dir_all(&self.root);
         }
+    }
+
+    #[test]
+    fn stats_cache_tracks_exact_contents_and_bounds_retention() {
+        let mut cache = StatsCache {
+            content: None,
+            stats: Value::Null,
+        };
+        let first = "{\"server\":\"old\",\"ok\":true,\"durationMs\":10}\n";
+        let expected = aggregate(&[serde_json::from_str(first).unwrap()]);
+        assert_eq!(cache.get(first.into()), expected);
+        assert_eq!(cache.get(first.into()), expected);
+        let replaced = first.replace("old", "new");
+        assert_eq!(replaced.len(), first.len());
+        assert_eq!(cache.get(replaced.clone())["servers"][0]["server"], "new");
+        assert_eq!(cache.get(format!("{replaced}{first}broken\n"))["total"], 2);
+        assert_eq!(cache.get(String::new())["total"], 0);
+        let oversized = format!("{}{first}", " ".repeat(MAX_AUDIT_BYTES as usize + 1));
+        assert_eq!(cache.get(oversized)["total"], 1);
+        assert!(cache.content.is_none());
+        assert_eq!(cache.get(first.into()), expected);
     }
 
     #[test]
@@ -1587,6 +1664,28 @@ mod tests {
         let _ = std::fs::remove_dir_all(&path);
         std::fs::create_dir_all(&path).expect("scratch data dir");
         (crate::registry::DataDirOverride::set(&path), path)
+    }
+
+    #[test]
+    fn stats_cache_never_hides_read_errors_or_cleared_history() {
+        let _lock = crate::registry::data_dir_test_lock();
+        let (_override, root) = isolated_data_dir("stats-cache");
+        let _cleanup = AuditProcessFixture::new(root);
+        let path = audit_path().unwrap();
+        std::fs::write(&path, "{\"server\":\"s\",\"ok\":true}\n").unwrap();
+        assert_eq!(stats().unwrap()["total"], 1);
+        assert_eq!(stats().unwrap()["total"], 1);
+        std::fs::write(&path, [0xff]).unwrap();
+        assert_eq!(stats().unwrap_err().kind(), std::io::ErrorKind::InvalidData);
+        std::fs::remove_file(&path).unwrap();
+        std::fs::create_dir(&path).unwrap();
+        assert!(stats().is_err());
+        std::fs::remove_dir(&path).unwrap();
+        assert_eq!(stats().unwrap()["total"], 0);
+        std::fs::write(&path, "{\"server\":\"s\",\"ok\":false}\n").unwrap();
+        assert_eq!(stats().unwrap()["errors"], 1);
+        try_clear().unwrap();
+        assert_eq!(stats().unwrap()["total"], 0);
     }
 
     /// A missing audit.jsonl is an empty log, not a load failure.

--- a/src/components/ActivityView.test.tsx
+++ b/src/components/ActivityView.test.tsx
@@ -4,6 +4,9 @@ import userEvent from "@testing-library/user-event";
 import { ActivityView } from "./ActivityView";
 import type { AuditEntry, SearchTrace } from "@/lib/types";
 
+let windowVisible = true;
+vi.mock("@/lib/windowVisible", () => ({ useWindowVisible: () => windowVisible }));
+
 const getAuditLog = vi.fn();
 const getSearchTraces = vi.fn();
 const getSecurityEvents = vi.fn();
@@ -52,6 +55,7 @@ const initialLog = [failed, entry()];
 const refreshedLog = [entry({ ts: 1700000002000, tool: "list_issues" }), ...initialLog];
 
 beforeEach(() => {
+  windowVisible = true;
   vi.useFakeTimers({ shouldAdvanceTime: true });
   getAuditLog.mockResolvedValue(initialLog);
   getSearchTraces.mockResolvedValue([]);
@@ -61,6 +65,22 @@ beforeEach(() => {
 afterEach(() => {
   vi.useRealTimers();
   vi.clearAllMocks();
+});
+
+it("pauses Activity polling while hidden and resumes when visible", async () => {
+  const view = render(<ActivityView refreshKey={0} registry={null} />);
+  await act(async () => {});
+  const loaded = getAuditLog.mock.calls.length;
+  await act(() => vi.advanceTimersByTimeAsync(3000));
+  expect(getAuditLog).toHaveBeenCalledTimes(loaded + 1);
+  windowVisible = false;
+  view.rerender(<ActivityView refreshKey={0} registry={null} />);
+  await act(() => vi.advanceTimersByTimeAsync(60_000));
+  expect(getAuditLog).toHaveBeenCalledTimes(loaded + 1);
+  windowVisible = true;
+  view.rerender(<ActivityView refreshKey={0} registry={null} />);
+  await act(() => vi.advanceTimersByTimeAsync(3000));
+  expect(getAuditLog).toHaveBeenCalledTimes(loaded + 2);
 });
 
 describe("ActivityView trust-state loading", () => {

--- a/src/components/ActivityView.tsx
+++ b/src/components/ActivityView.tsx
@@ -1,3 +1,4 @@
+import { useWindowVisible } from "@/lib/windowVisible";
 import { useEffect, useMemo, useRef, useState } from "react";
 import {
   Activity,
@@ -1528,20 +1529,16 @@ export function ActivityView({
     }
   }
 
-  // Live update (SOU-142): tool calls never touch the registry, so the parent's refreshKey
-  // never bumps for them and the feed would sit frozen while an agent works. While Activity
-  // is mounted, tick every few seconds so the call list + Live Inspector refetch the local
-  // logs in place (silent, no spinner). Mirrors how PendingApprovals polls. The visibility
-  // check skips a tick when the webview reports the page hidden; it's best-effort (a desktop
-  // webview doesn't reliably flip visibilityState on minimize), but each tick is only a few
-  // cheap local-file reads, so continuing while minimized costs next to nothing.
+  // Native visibility also covers a window hidden to the tray, where the
+  // webview may keep reporting "visible". Pause file reads and rerenders while
+  // the user is elsewhere; resume within one tick when they return.
+  const windowVisible = useWindowVisible();
   const [liveTick, setLiveTick] = useState(0);
   useEffect(() => {
-    const id = setInterval(() => {
-      if (document.visibilityState === "visible") setLiveTick((t) => t + 1);
-    }, 3000);
+    if (!windowVisible) return;
+    const id = setInterval(() => setLiveTick((t) => t + 1), 3000);
     return () => clearInterval(id);
-  }, []);
+  }, [windowVisible]);
   // Combined so panels refetch on either a registry change or a live tick. Both counters
   // only increase, so the sum always changes when either does (no collisions).
   const liveKey = refreshKey + liveTick;

--- a/src/components/ClientLogo.tsx
+++ b/src/components/ClientLogo.tsx
@@ -1,31 +1,43 @@
+import amazonQ from "@/assets/client-logos/amazon-q.svg?raw";
 import { cn } from "@/lib/utils";
 
-/**
- * Official client brand logos.
- *
- * SVGs are vendored under src/assets/client-logos (no runtime dependency), sourced from
- * @lobehub/icons-static-svg (MIT), simple-icons (CC0), and devicon (MIT), plus a handful
- * taken from the vendor's own published mark where no icon set carries it (Factory Droid,
- * BoltAI, AnythingLLM, Continue, Oh My Pi). Full-color marks keep their own
- * fills; monochrome marks are authored with `fill="currentColor"`, so they inherit the
- * surrounding text color and stay legible on both the light and dark (navy) themes.
- *
- * Each file is a 24x24 viewBox sized in `1em`, so the wrapper's font-size sets the render
- * size. Clients without a vendored logo fall back to a neutral monogram badge.
- */
-const RAW = import.meta.glob("../assets/client-logos/*.svg", {
-  query: "?raw",
+// Vendored official marks from @lobehub/icons-static-svg (MIT), simple-icons
+// (CC0), devicon (MIT), and vendor-published marks for Factory Droid, BoltAI,
+// AnythingLLM, Continue, and Oh My Pi.
+// External local assets load only for clients actually on screen and can be
+// cached by the webview. Keep the mixed-color Amazon mark inline because its
+// orange accent and inherited foreground cannot both be expressed by a mask.
+const URLS = import.meta.glob("../assets/client-logos/*.svg", {
+  query: "?url&no-inline",
   import: "default",
   eager: true,
 }) as Record<string, string>;
-
-// basename (without .svg) -> raw SVG markup
-const LOGOS: Record<string, string> = Object.fromEntries(
-  Object.entries(RAW).map(([path, svg]) => [
+const LOGOS = Object.fromEntries(
+  Object.entries(URLS).map(([path, url]) => [
     path.split("/").pop()!.replace(".svg", ""),
-    svg,
+    url,
   ]),
 );
+const MONOCHROME = new Set([
+  "amp",
+  "anythingllm",
+  "boltai",
+  "cline",
+  "continue",
+  "cursor",
+  "devin",
+  "droid",
+  "github-copilot-cli",
+  "goose",
+  "grok",
+  "hermes",
+  "kilo-code",
+  "kimi-code",
+  "lm-studio",
+  "opencode",
+  "pi",
+  "roo-code",
+]);
 
 /**
  * Client id -> logo file basename. Most ids match their filename; the two Claude clients
@@ -90,16 +102,30 @@ export function ClientLogo({
   size?: number;
   className?: string;
 }) {
-  const svg = LOGOS[CLIENT_LOGO[id] ?? ""];
+  const key = CLIENT_LOGO[id] ?? "";
+  const url = LOGOS[key];
 
-  if (svg) {
+  if (url) {
     return (
       <span
         aria-hidden
         className={cn("inline-flex shrink-0 items-center justify-center", className)}
         style={{ fontSize: size, lineHeight: 0, width: size, height: size }}
-        dangerouslySetInnerHTML={{ __html: svg }}
-      />
+      >
+        {key === "amazon-q" ? (
+          <span dangerouslySetInnerHTML={{ __html: amazonQ }} />
+        ) : MONOCHROME.has(key) ? (
+          <span
+            className="size-full bg-current"
+            style={{
+              mask: `url("${url}") center / contain no-repeat`,
+              WebkitMask: `url("${url}") center / contain no-repeat`,
+            }}
+          />
+        ) : (
+          <img src={url} alt="" className="size-full object-contain" />
+        )}
+      </span>
     );
   }
 

--- a/src/components/ServerLogo.tsx
+++ b/src/components/ServerLogo.tsx
@@ -2,18 +2,16 @@ import { Globe, Terminal } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { serverLogoKey } from "@/lib/serverLogo";
 
-const RAW = import.meta.glob("../assets/server-logos/*.svg", {
-  query: "?raw",
+const URLS = import.meta.glob("../assets/server-logos/*.svg", {
+  query: "?url&no-inline",
   import: "default",
   eager: true,
 }) as Record<string, string>;
 
 const LOGOS: Record<string, string> = Object.fromEntries(
-  Object.entries(RAW).map(([path, svg]) => [
+  Object.entries(URLS).map(([path, url]) => [
     path.split("/").pop()!.replace(".svg", ""),
-    // The surrounding element is decorative. Remove the source title so it
-    // does not become a second accessible copy of the adjacent server name.
-    svg.replace(/<title>.*?<\/title>/i, ""),
+    url,
   ]),
 );
 
@@ -30,7 +28,7 @@ export function ServerLogo({
   className?: string;
 }) {
   const key = serverLogoKey(name);
-  const svg = key ? LOGOS[key] : null;
+  const url = key ? LOGOS[key] : null;
 
   return (
     <span
@@ -41,11 +39,8 @@ export function ServerLogo({
       )}
       style={{ width: size, height: size }}
     >
-      {svg ? (
-        <span
-          className="inline-flex size-full items-center justify-center [&>svg]:size-full"
-          dangerouslySetInnerHTML={{ __html: svg }}
-        />
+      {url ? (
+        <img src={url} alt="" className="size-full object-contain" />
       ) : transport === "stdio" ? (
         <Terminal className="size-full" />
       ) : (

--- a/src/test/browser-fixture.tsx
+++ b/src/test/browser-fixture.tsx
@@ -1,0 +1,135 @@
+// Separate development entry. Never imported by the shipping application.
+import { mockIPC } from "@tauri-apps/api/mocks";
+import { createRoot } from "react-dom/client";
+import { ClientLogo } from "@/components/ClientLogo";
+import { ServerLogo } from "@/components/ServerLogo";
+import type { Registry, ServerEntry } from "@/lib/types";
+import "../index.css";
+
+if (!import.meta.env.DEV) throw new Error("Fixtures require the development server");
+
+const servers: ServerEntry[] = ["GitHub", "Linear", "Stripe"].map((name, i) => ({
+  id: `fixture-${i}`,
+  name,
+  transport: "stdio",
+  command: "fixture-only",
+  args: [],
+  env: [],
+  url: null,
+  source: "manual",
+}));
+const registry: Registry = {
+  version: 1,
+  servers,
+  profiles: [
+    { id: "local", name: "Local fixture", enabledServerIds: servers.map((s) => s.id) },
+  ],
+  activeProfileId: "local",
+};
+const auditRows = Array.from({ length: 200 }, (_, i) => ({
+  ts: 1_700_000_000_000 - i * 1000,
+  server: "GitHub",
+  tool: "list_issues",
+  ok: true,
+  durationMs: 12,
+}));
+const calls: Record<string, number> = {};
+const missing: string[] = [];
+Object.assign(window, { toolportFixture: { calls, missing } });
+localStorage.setItem("toolport.onboarded", "1");
+
+mockIPC(
+  (command) => {
+    calls[command] = (calls[command] ?? 0) + 1;
+    switch (command) {
+      case "get_registry":
+        return registry;
+      case "detect_clients":
+        return [
+          {
+            id: "codex",
+            name: "Codex",
+            usesConnectors: false,
+            configPath: "/fixture/codex.toml",
+            configExists: true,
+            appPresent: true,
+            servers: [],
+            pluginServers: [],
+            gatewayInstalled: true,
+            entryState: "managed",
+            error: null,
+          },
+        ];
+      case "probe_servers":
+        return servers.map((s) => ({
+          serverId: s.id,
+          ok: true,
+          toolCount: 25,
+          error: null,
+        }));
+      case "main_window_visible":
+        return true;
+      case "take_pending_tray_approvals":
+        return false;
+      case "take_pending_shared":
+      case "take_registry_recovery_notice":
+      case "plugin:updater|check":
+      case "savings_summary":
+        return null;
+      case "plugin:app|version":
+        return "1.18.0-fixture";
+      case "get_audit_log":
+        return auditRows;
+      case "audit_stats":
+        return { total: 200, errors: 0, errorRate: 0, servers: [] };
+      case "list_quarantined":
+      case "list_pending_approvals":
+      case "list_routine_suggestions":
+      case "get_security_events":
+      case "get_search_traces":
+      case "get_inspect_log":
+      case "list_tool_identities":
+        return [];
+      default:
+        missing.push(command);
+        throw new Error(`Unimplemented fixture command: ${command}`);
+    }
+  },
+  { shouldMockEvents: true },
+);
+
+if (new URLSearchParams(location.search).has("logos")) {
+  const paths = Object.keys(import.meta.glob("../assets/client-logos/*.svg"));
+  const aliases: Record<string, string> = {
+    claude: "claude-desktop",
+    devin: "devin-cli",
+  };
+  const clients = paths.map((p) => p.split("/").pop()!.replace(".svg", ""));
+  createRoot(document.getElementById("root")!).render(
+    <main>
+      {[false, true].map((dark) => (
+        <section key={String(dark)} className={dark ? "dark" : ""}>
+          <div className="bg-background text-foreground p-6">
+            <h1>{dark ? "Dark" : "Light"} logo fixture</h1>
+            <div className="grid grid-cols-8 gap-4 mt-4">
+              {clients.map((id) => (
+                <div key={id} className="flex flex-col items-center gap-2 text-xs">
+                  <ClientLogo id={aliases[id] ?? id} name={id} size={32} />
+                  {id}
+                </div>
+              ))}
+              {servers.map((s) => (
+                <div key={s.id} className="flex flex-col items-center gap-2 text-xs">
+                  <ServerLogo name={s.name} transport={s.transport} size={32} />
+                  {s.name}
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
+      ))}
+    </main>,
+  );
+} else {
+  await import("../main");
+}

--- a/src/test/setup.test.tsx
+++ b/src/test/setup.test.tsx
@@ -1,0 +1,22 @@
+import { afterAll, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
+
+const restoredFocus = vi.fn();
+
+afterAll(() => {
+  // The shared afterEach must finish Radix's delayed unmount before this file's
+  // jsdom realm disappears. Otherwise it can dispatch a Node Event on old DOM.
+  expect(restoredFocus).toHaveBeenCalledOnce();
+});
+
+it("finishes dialog focus restoration during shared cleanup", () => {
+  render(
+    <Dialog open>
+      <DialogContent onCloseAutoFocus={restoredFocus} aria-describedby={undefined}>
+        <DialogTitle>Cleanup fixture</DialogTitle>
+      </DialogContent>
+    </Dialog>,
+  );
+  expect(screen.getByRole("dialog")).toBeVisible();
+});

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,12 +1,18 @@
 // Vitest setup for React component tests. The existing src/lib tests use explicit
 // vitest imports (globals off), so we register jest-dom matchers and Testing Library
 // cleanup here rather than relying on auto-injected globals.
-import { afterEach } from "vitest";
+import { afterEach, vi } from "vitest";
+import { setTimeout as nextTimerTurn } from "node:timers/promises";
 import { cleanup } from "@testing-library/react";
 import "@testing-library/jest-dom/vitest";
 
-afterEach(() => {
+afterEach(async () => {
   cleanup();
+  // Radix restores focus on a zero-delay timer when a dialog unmounts. Let it
+  // run before jsdom tears down its Event realm; otherwise the timer can create
+  // a Node Event and dispatch it on an old jsdom element after the file passed.
+  if (vi.isFakeTimers()) await vi.advanceTimersByTimeAsync(0);
+  await nextTimerTurn(0);
   // Reset the in-memory storage so localStorage state never leaks across tests.
   storageData.clear();
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,20 +8,12 @@ const host = process.env.TAURI_DEV_HOST;
 // https://vite.dev/config/
 export default defineConfig(async () => ({
   plugins: [react(), tailwindcss()],
+  build: { manifest: true },
 
   resolve: {
     alias: {
       "@": fileURLToPath(new URL("./src", import.meta.url)),
     },
-  },
-
-  // Vitest config: reuses the alias above so tests can import via "@/lib/...".
-  // jsdom + Testing Library so component (*.test.tsx) flows run alongside the
-  // pure-logic src/lib tests; setup registers jest-dom matchers and RTL cleanup.
-  test: {
-    environment: "jsdom",
-    include: ["src/**/*.test.{ts,tsx}"],
-    setupFiles: ["./src/test/setup.ts"],
   },
 
   // Vite options tailored for Tauri development and only applied in `tauri dev` or `tauri build`

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,37 @@
+import { defineConfig } from "vitest/config";
+import react from "@vitejs/plugin-react";
+import { fileURLToPath, URL } from "node:url";
+
+const domLogicTests = ["src/lib/starPrompt.test.ts", "src/lib/windowVisible.test.ts"];
+
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: { "@": fileURLToPath(new URL("./src", import.meta.url)) },
+  },
+  test: {
+    // Keep local verification usable alongside a desktop and a Rust build.
+    // Override with --maxWorkers when the machine is dedicated to tests.
+    maxWorkers: 2,
+    projects: [
+      {
+        extends: true,
+        test: {
+          name: "logic",
+          environment: "node",
+          include: ["src/**/*.test.ts"],
+          exclude: domLogicTests,
+        },
+      },
+      {
+        extends: true,
+        test: {
+          name: "ui",
+          environment: "jsdom",
+          include: ["src/**/*.test.tsx", ...domLogicTests],
+          setupFiles: ["./src/test/setup.ts"],
+        },
+      },
+    ],
+  },
+});


### PR DESCRIPTION
Load logos as local assets, pause Activity polling while hidden, and cache audit summaries while streaming changed logs. Add one-command verification, offline browser fixtures with screenshots and traces, and CI bundle budgets. Fix delayed dialog cleanup in UI tests and isolate the gateway benchmark.

Measured locally on Linux:

- Startup JavaScript gzip: 210.86 kB → 170.40 kB (19% smaller).
- Unchanged audit stats, 10,000-row release fixture: 8.00 ms → 0.42 ms median.
- Audit fixture peak process RSS: 20,272 KiB → 9,744 KiB.

Validation: full `npm run verify` passed, including 657 frontend tests, 1,715 headless Rust tests (one existing ignored), browser smoke, and all ten gateway smoke checks. Native desktop startup and Windows/macOS behavior still need platform checks.

Details and measurement limits: [performance audit](https://github.com/btsouth/toolport/blob/17639a8/docs/performance-audit.md).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Cache `audit::stats`, gate `ActivityView` polling, and add verification tooling
> - Adds an exact-content cache to `audit::stats()` in [src-tauri/src/audit.rs](https://github.com/tsouth89/toolport/pull/863/files#diff-853a8e9a7f76700c4050b1c24c17426ec0f3ae9ba14b4dec35d0f7a5ecc91dd1) that skips re-parsing and re-aggregation when the audit file bytes are unchanged; oversized logs are aggregated but not retained.
> - Gates the `ActivityView` three-second refresh interval on native window visibility in [src/components/ActivityView.tsx](https://github.com/tsouth89/toolport/pull/863/files#diff-84a6bbaa6ab65156581be177909fb5076e4e87500a0beb1c1584af2e23f32ff6): the interval tears down while hidden and recreates when visible.
> - Reworks client/server logo rendering in [src/components/ClientLogo.tsx](https://github.com/tsouth89/toolport/pull/863/files#diff-93ab51f6e8ccd425c8ad81c4792313281261f2447c3d565ab035ce01486d6940) and [src/components/ServerLogo.tsx](https://github.com/tsouth89/toolport/pull/863/files#diff-69d0aff0f8aad64d6487b1ab014e4e91625be6e649261f5aaa670133a16ba2a5) to use local asset URLs and CSS masks instead of inline raw SVG markup.
> - Adds repeatable local verification in [scripts/verify.mjs](https://github.com/tsouth89/toolport/pull/863/files#diff-abf791bfeecab5c22aef3d8fa0483659571a0c4c8e8ce63bcbf0a53806633abf), a `doctor` prerequisite check in [scripts/doctor.mjs](https://github.com/tsouth89/toolport/pull/863/files#diff-76df9bec428b87202ee7d195b24295a2e9e48b3865cc50ee3828cbf2a3a2d8f7), a headless Chromium smoke in [scripts/browser-smoke.mjs](https://github.com/tsouth89/toolport/pull/863/files#diff-5476129e5e87ebec8c775539ee79eb6847079887cddfd24c48c55ce69481f176), and bundle/audit/latency benchmarks; CI in [.github/workflows/ci.yml](https://github.com/tsouth89/toolport/pull/863/files#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03f) now runs a startup bundle budget and browser smoke with failure-only artifacts.
> - Splits Vitest into Node `logic` and jsdom `ui` projects in [vitest.config.ts](https://github.com/tsouth89/toolport/pull/863/files#diff-2ee894bf23aa44ff4ce12a3da8af19ab20180474ebf2176dbe5f2eea3f96dc92) and enables Vite build manifest output.
> - Behavioral Change: `npm run bench:bundle` fails above 580,000 raw bytes or 185,000 gzip bytes; `StatsCache` discards snapshots exceeding `MAX_AUDIT_BYTES` so repeated identical oversized logs re-aggregate each call; Activity polling now stops entirely while the window is hidden; Playwright is a new dev dependency; Vitest settings were moved out of `vite.config.ts`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 883dd09.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->