### PR TITLE
fix(diagnostics): report an unreadable gateway log instead of an absent one

### DIFF
--- a/src-tauri/src/diagnostics_controller.rs
+++ b/src-tauri/src/diagnostics_controller.rs
@@ -140,7 +140,13 @@ fn gateway_log_tail(lines: usize) -> String {
     };
     match std::fs::read_to_string(path) {
         Ok(text) if !text.trim().is_empty() => last_lines(&text, lines),
-        _ => "(no gateway log yet, connect a client to populate it)\n".to_string(),
+        Ok(_) => "(no gateway log yet, connect a client to populate it)\n".to_string(),
+        // A log that could not be read is exactly what a bug report needs to
+        // carry, which is why `registry::load`'s error is written out above
+        // rather than defaulted away. Reporting a permission error or a locked
+        // file as an absent log sends the reader looking for a client that
+        // never connected.
+        Err(error) => format!("(gateway log unreadable: {error})\n"),
     }
 }
 

--- a/src-tauri/src/diagnostics_controller.rs
+++ b/src-tauri/src/diagnostics_controller.rs
@@ -141,11 +141,16 @@ fn gateway_log_tail(lines: usize) -> String {
     match std::fs::read_to_string(path) {
         Ok(text) if !text.trim().is_empty() => last_lines(&text, lines),
         Ok(_) => "(no gateway log yet, connect a client to populate it)\n".to_string(),
-        // A log that could not be read is exactly what a bug report needs to
-        // carry, which is why `registry::load`'s error is written out above
-        // rather than defaulted away. Reporting a permission error or a locked
-        // file as an absent log sends the reader looking for a client that
-        // never connected.
+        // gatewaylog::append creates the file on the first line written, so
+        // before any client has connected there is genuinely no log yet. That
+        // is the absent case, not a failure, and it stays worded as one.
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            "(no gateway log yet, connect a client to populate it)\n".to_string()
+        }
+        // Every other error is what a bug report needs to carry, which is why
+        // `registry::load`'s failure is written out above rather than defaulted
+        // away. Reporting a permission error or a locked file as an absent log
+        // sends the reader looking for a client that never connected.
         Err(error) => format!("(gateway log unreadable: {error})\n"),
     }
 }


### PR DESCRIPTION
Closes #733

**Problem.** `gateway_log_tail` matched only the non-empty `Ok` case, and the catch-all `_` arm absorbed every `Err` — permission denied, an I/O error, a log held by another process — behind the same reassuring sentence as a log that was never written. That text goes straight into the shareable diagnostics bundle, so a user reporting "my client will not connect" pastes a line that sends the reader looking for a client that never connected.

**Change.** Split the arm, exactly as `gather_diagnostics_blocking` already does for the registry immediately above:

```rust
Ok(text) if !text.trim().is_empty() => last_lines(&text, lines),
Ok(_)  => "(no gateway log yet, connect a client to populate it)\n".to_string(),
Err(error) => format!("(gateway log unreadable: {error})\n"),
```

The empty-log message is unchanged, so the common case reads the same. The path is deliberately not interpolated: `io::Error` does not carry it, and the bundle is shared.

**Verify.**

```
cd src-tauri && cargo check
```

Clean — the only warning is the pre-existing `unused mut` in `approval_broker.rs:634`, untouched here. One file, +7/-1, no behaviour change on the success or empty paths.

Note the issue cites `src-tauri/src/desktop.rs:1672`; the function now lives in `src-tauri/src/diagnostics_controller.rs:137` and is otherwise identical.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `gateway_log_tail` to report unreadable gateway logs instead of absent ones
> `gateway_log_tail` in [diagnostics_controller.rs](https://github.com/tsouth89/toolport/pull/864/files#diff-01d22268ecc2ef02f5742b66277e0f24805c8580237157702c151ba9737f2634) previously treated all read failures the same as a missing log. Now it separates empty successful reads, `NotFound` errors, and other read errors. Empty files and missing files keep the existing absent-log message, while other read failures surface a message with the underlying error.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9bac1d2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->