### PR TITLE
Isolate code mode execution with memory and IPC limits

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -32,6 +32,26 @@ gateway entry, written for you when you connect a client:
 Every `TOOLPORT_*` name still accepts the pre-rename `CONDUIT_*` alias (for example
 `CONDUIT_HTTP_TOKEN` continues to work). Prefer `TOOLPORT_*` in new configs.
 
+**Code mode limits.** Execution, validation, and saved routines run Boa in a separate
+worker process. The parent enforces the 60-second wall-clock budget even during pure
+JavaScript and permits at most four simultaneous runs. Saved routines can set lower
+execution limits. Each worker has a 512 MiB allocation budget: Linux uses `RLIMIT_AS`
+before exec, Windows assigns the suspended child to a memory-limited Job Object, and
+macOS uses a worker-only Rust allocator cap because Darwin's `RLIMIT_AS` is advisory.
+The macOS cap covers Boa's Rust heap, not the process's total resident memory. Allocation
+refusal terminates the worker and returns a script error; the gateway stays available.
+On all supported platforms, a worker allocation guard uses a dedicated exit code even
+for fallible buffer allocations. Memory-budget audit attribution comes from the
+worker's exit status, not error text thrown by JavaScript.
+
+Source is capped at 256 KiB, `data` or `input` at 4 MiB of JSON, and `inputSchema` at
+64 KiB on both stdio and HTTP. HTTP's 4 MiB whole-request cap still applies. Worker
+messages, including host results and the final aggregate, are capped at 16 MiB per
+frame. Oversized messages fail explicitly. Host calls still run through the parent's
+scope, approval, content-defense, and rate-limit checks. On failure, completed calls
+and the last checkpoint remain available; calls already in flight are cancelled where
+supported and must not be automatically retried.
+
 **Semantic search (optional).** Lazy discovery ranks tools lexically by default. Point it
 at any `/v1/embeddings` endpoint (LM Studio, Ollama, or a cloud provider) to blend in
 embedding similarity for paraphrased queries: `TOOLPORT_SEMANTIC=on`,

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -858,6 +858,7 @@ dependencies = [
  "keyring",
  "ksni",
  "libadwaita",
+ "libc",
  "regex",
  "security-framework 3.7.0",
  "security-framework-sys",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -115,6 +115,9 @@ windows-sys = { version = "0.61", features = [
     "Win32_System_Threading",
 ] }
 
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+
 [target.'cfg(target_os = "macos")'.dependencies]
 keyring = { version = "3", features = ["apple-native"] }
 security-framework = "3"

--- a/src-tauri/src/bin/toolport-gateway.rs
+++ b/src-tauri/src/bin/toolport-gateway.rs
@@ -31,6 +31,7 @@ use serde_json::{json, Value};
 use conduit_lib::approval;
 use conduit_lib::clients;
 use conduit_lib::codemode;
+use conduit_lib::codemode_worker as worker;
 use conduit_lib::downstream::{
     self, CacheHint, DownstreamServer, MrtrRequest, ResourceUpdatedSink, ServerRequestAction,
     ServerRequestHandler, StdioTransport, Transport, MODERN_PROTOCOL_VERSION, PROTOCOL_VERSION,
@@ -54,6 +55,10 @@ use conduit_lib::secrets;
 use conduit_lib::semantic;
 use conduit_lib::shaping;
 use conduit_lib::{audit, usage_report};
+
+#[cfg(any(unix, windows))]
+#[global_allocator]
+static CODE_MODE_ALLOCATOR: worker::WorkerAllocator = worker::WorkerAllocator;
 
 /// Context that belongs to the request currently executing on this worker.
 ///
@@ -5602,8 +5607,16 @@ fn validate_script(
     let fetch: codemode::FetchBinding =
         Arc::new(|_args: codemode::FetchArgs| json!({ "content": [], "isError": false }));
 
-    let outcome =
-        codemode::run_script_with_input(script, input, call, Some(fetch), limits, &catalog);
+    let outcome = run_code_mode_isolated(
+        script,
+        input,
+        call,
+        Some(fetch),
+        limits,
+        &catalog,
+        None,
+        worker::HostCalls::default(),
+    );
 
     // No `savings::record_orchestration` here: a dry run replaced no round-trips,
     // and counting it would inflate the savings the real feature is measured by.
@@ -6180,6 +6193,12 @@ fn run_script_dispatch_with_candidates(
             });
         }
     };
+    if script.len() > worker::MAX_SCRIPT_BYTES {
+        return routine_error(format!(
+            "run_script `script` exceeds the {}-byte source limit.",
+            worker::MAX_SCRIPT_BYTES
+        ));
+    }
     if let Err(error) = reject_unknown_arguments(
         arguments,
         &["script", "data", "input", "inputSchema", "validate"],
@@ -6199,9 +6218,21 @@ fn run_script_dispatch_with_candidates(
         if !value.is_object() {
             return routine_error("run_script `input` must be an object.");
         }
+        if worker::json_size(&value, worker::MAX_VALUE_BYTES).is_none() {
+            return routine_error(format!(
+                "run_script `input` exceeds the {}-byte value limit.",
+                worker::MAX_VALUE_BYTES
+            ));
+        }
         let Some(schema) = arguments.get("inputSchema").cloned() else {
             return routine_error("run_script `input` requires `inputSchema`.");
         };
+        if worker::json_size(&schema, worker::MAX_SCHEMA_BYTES).is_none() {
+            return routine_error(format!(
+                "run_script `inputSchema` exceeds the {}-byte schema limit.",
+                worker::MAX_SCHEMA_BYTES
+            ));
+        }
         if let Err(error) = routines::validate_arguments(&schema, &value) {
             return routine_error(format!(
                 "run_script input validation failed before execution. {error}"
@@ -6213,13 +6244,14 @@ fn run_script_dispatch_with_candidates(
             true,
         )
     } else {
-        (
-            codemode::ScriptInput::Data(
-                arguments.get("data").cloned().unwrap_or_else(|| json!({})),
-            ),
-            None,
-            false,
-        )
+        let data = arguments.get("data").cloned().unwrap_or_else(|| json!({}));
+        if worker::json_size(&data, worker::MAX_VALUE_BYTES).is_none() {
+            return routine_error(format!(
+                "run_script `data` exceeds the {}-byte value limit.",
+                worker::MAX_VALUE_BYTES
+            ));
+        }
+        (codemode::ScriptInput::Data(data), None, false)
     };
 
     // Dry run: same compile, same scoped `servers.*` surface, same limits, but a
@@ -6324,7 +6356,8 @@ fn execute_script_dispatch_with_candidate(
     let client_owned = client.map(str::to_string);
     let client_name_owned = client_name.map(str::to_string);
     let allowed_owned = allowed.cloned();
-    let cancel_owned = cancel;
+    let host_calls = worker::HostCalls::default();
+    let host_calls_for_binding = host_calls.clone();
     let receipts = Arc::new(Mutex::new(Vec::<ToolReceipt>::new()));
     let receipts_for_call = Arc::clone(&receipts);
 
@@ -6340,6 +6373,7 @@ fn execute_script_dispatch_with_candidate(
     // context). Content defense still runs. Final aggregate is shaped below.
     let call: codemode::CallBinding = Arc::new(move |name: &str, args: Value| {
         let run = || {
+            let host_call = host_calls_for_binding.start();
             let result = execute_call(
                 &reg_owned,
                 &router_owned,
@@ -6347,7 +6381,7 @@ fn execute_script_dispatch_with_candidate(
                 client_owned.as_deref(),
                 client_name_owned.as_deref(),
                 allowed_owned.as_ref(),
-                cancel_owned.clone(),
+                Some(host_call.context.clone()),
                 None,
                 name,
                 args,
@@ -6364,9 +6398,8 @@ fn execute_script_dispatch_with_candidate(
             );
             let fingerprint = tool_fingerprint_for(name, &cached_owned, &router_owned);
             let risk_class = tool_risk_class(name, &cached_owned, &router_owned);
-            let result_bytes = serde_json::to_vec(&result)
-                .map(|bytes| bytes.len())
-                .unwrap_or(0);
+            let result_bytes = worker::json_size(&result, worker::MAX_FRAME_BYTES)
+                .unwrap_or(worker::MAX_FRAME_BYTES + 1);
             receipts_for_call
                 .lock()
                 .unwrap_or_else(std::sync::PoisonError::into_inner)
@@ -6404,8 +6437,16 @@ fn execute_script_dispatch_with_candidate(
         owner_of_exposed_tool(Some(router_arc.as_ref()), &owners, name)
     });
 
-    let outcome =
-        codemode::run_script_with_input(script, input, call, Some(fetch), limits, &catalog);
+    let outcome = run_code_mode_isolated(
+        script,
+        input,
+        call,
+        Some(fetch),
+        limits,
+        &catalog,
+        cancel.clone(),
+        host_calls,
+    );
 
     let candidate_started = Instant::now();
     let candidate_assessment = candidate.map(|context| {
@@ -6516,9 +6557,13 @@ fn execute_script_dispatch_with_candidate(
         Some(v) => format!("checkpoint: {v}. "),
         None => String::new(),
     };
-    let protected_failure_prefix_bytes = checkpoint.as_ref().map_or(0, |checkpoint| {
-        format!("Toolport code mode: the script failed. checkpoint: {checkpoint}. ").len()
-    });
+    let failure_prefix = match routine {
+        Some(routine) => format!("Toolport routine {} failed. ", routine.id()),
+        None => "Toolport code mode: the script failed. ".to_string(),
+    };
+    let protected_failure_prefix_bytes = checkpoint
+        .as_ref()
+        .map_or(0, |_| failure_prefix.len() + checkpoint_text.len());
 
     let ledger_text = if outcome.progress.is_empty() {
         "no calls completed".to_string()
@@ -6546,7 +6591,7 @@ fn execute_script_dispatch_with_candidate(
         (Some(err), Some(routine)) => json!({
             "content": [{
                 "type": "text",
-                "text": format!("Toolport routine {} failed. {ledger_text}. Error: {err}", routine.id())
+                "text": format!("{failure_prefix}{checkpoint_text}{ledger_text}. Error: {err}")
             }],
             "isError": true,
             "structuredContent": {
@@ -6557,6 +6602,7 @@ fn execute_script_dispatch_with_candidate(
                     "ok": false,
                     "calls": outcome.calls,
                     "progress": progress,
+                    "checkpoint": checkpoint,
                     "error": err
                 }
             }
@@ -6564,7 +6610,7 @@ fn execute_script_dispatch_with_candidate(
         (Some(err), None) => json!({
             "content": [{
                 "type": "text",
-                "text": format!("Toolport code mode: the script failed. {checkpoint_text}{ledger_text}. Error: {err}")
+                "text": format!("{failure_prefix}{checkpoint_text}{ledger_text}. Error: {err}")
             }],
             "isError": true,
             "structuredContent": { "toolportScript": { "ok": false, "calls": outcome.calls, "progress": progress, "checkpoint": checkpoint, "error": err } }
@@ -8316,21 +8362,48 @@ fn handle_request_with_cancel(
                         }),
                     ));
                 }
-                return Some(success(
-                    id,
-                    run_script_dispatch_with_candidates(
-                        reg,
-                        router_arc,
-                        cached,
-                        client,
-                        client_name,
-                        allowed,
-                        cancel,
-                        &arguments,
-                        live_router,
-                        candidates,
-                    ),
-                ));
+                let started = Instant::now();
+                let result = run_script_dispatch_with_candidates(
+                    reg,
+                    router_arc,
+                    cached,
+                    client,
+                    client_name,
+                    allowed,
+                    cancel,
+                    &arguments,
+                    live_router,
+                    candidates,
+                );
+                let failed = result
+                    .get("isError")
+                    .and_then(Value::as_bool)
+                    .unwrap_or(false);
+                let detail = result
+                    .pointer("/structuredContent/toolportScript/error")
+                    .or_else(|| result.pointer("/structuredContent/toolportValidate/error"))
+                    .and_then(Value::as_str)
+                    .unwrap_or_default();
+                // Log attribution and a bounded category, never submitted source,
+                // input values, or arbitrary text thrown by a script.
+                let reason = failed.then_some(
+                    if detail.starts_with("code mode script exceeded its memory budget") {
+                        "code_mode_memory_budget"
+                    } else if detail.contains("wall-clock") {
+                        "code_mode_deadline"
+                    } else {
+                        "code_mode_failed"
+                    },
+                );
+                audit::record_timed(
+                    "toolport",
+                    "run_script",
+                    !failed,
+                    Some(started.elapsed().as_millis().min(u64::MAX as u128) as u64),
+                    reason,
+                    client,
+                );
+                return Some(success(id, result));
             }
 
             if matches!(
@@ -15345,6 +15418,33 @@ fn parse_args(args: &[String]) -> ArgAction {
     ArgAction::Run
 }
 
+#[allow(clippy::too_many_arguments)]
+fn run_code_mode_isolated(
+    script: &str,
+    input: codemode::ScriptInput,
+    call: codemode::CallBinding,
+    fetch: Option<codemode::FetchBinding>,
+    limits: codemode::Limits,
+    catalog: &[String],
+    cancel: Option<downstream::CancelContext>,
+    host_calls: worker::HostCalls,
+) -> codemode::ScriptOutcome {
+    if let Err(error) = worker::check_input(script, &input) {
+        return worker::terminated_outcome(0, Vec::new(), error);
+    }
+    #[cfg(test)]
+    {
+        // Cargo's unit-test harness cannot re-enter the gateway's worker mode.
+        // Integration tests exercise the real executable and process boundary.
+        let _ = (cancel, host_calls);
+        codemode::run_script_with_input(script, input, call, fetch, limits, catalog)
+    }
+    #[cfg(not(test))]
+    worker::run_script(
+        script, input, call, fetch, limits, catalog, cancel, host_calls,
+    )
+}
+
 /// Usage text shared by `--help` and the unknown-flag error, so a typo and a
 /// deliberate `--help` land on the same page.
 fn usage() -> String {
@@ -15415,6 +15515,9 @@ fn main() {
     // else touches disk, the keychain, or stdin - see #605. Positional args
     // and the existing four flags fall through to `Run` unchanged.
     let cli_args: Vec<String> = std::env::args().skip(1).collect();
+    if cli_args.first().map(String::as_str) == Some(worker::WORKER_ARG) {
+        worker::worker_main();
+    }
     match parse_args(&cli_args) {
         ArgAction::Help => {
             println!("{}", usage());

--- a/src-tauri/src/codemode.rs
+++ b/src-tauri/src/codemode.rs
@@ -26,27 +26,28 @@
 //! Downstream calls from a script still pass scope, HITL, and content-defense gates, but
 //! intermediate results are **not** byte-budget shaped: full bodies stay in the sandbox
 //! (they never enter model context). The gateway shapes only the script's final aggregate
-//! for the client. Limits: call budget, wall-clock deadline, max concurrent host calls,
-//! promise-job budget, and boa's loop/recursion caps.
+//! for the client. The gateway runs this interpreter in [`crate::codemode_worker`],
+//! which adds a memory budget, bounded IPC, and an independent wall-clock supervisor
+//! to the call, concurrency, promise-job, loop, and recursion limits below.
 //!
-//! # What actually bounds a pure-JS runaway (SBS-430)
+//! # Interpreter counters and worker containment
 //!
-//! [`Limits::wall_clock`] is NOT enforced while synchronous JS is running. It is checked
+//! Inside this interpreter, [`Limits::wall_clock`] is checked
 //! when a script reserves a host call ([`reserve_budget`]) and between promise jobs
 //! ([`BoundedJobExecutor`]), and boa 0.21 exposes no time-based interrupt to check it
-//! anywhere else. A script that never calls a tool and never awaits is bounded only by
-//! boa's own counters:
+//! anywhere else. The gateway's parent process enforces the deadline even during
+//! synchronous JS and result serialization. Direct in-process callers of this module
+//! have only Boa's own counters on that path:
 //!
 //!   * `loop_iteration_limit` — total loop iterations, across nested loops, not per-loop.
 //!   * recursion limit — depth, which trips almost immediately.
 //!
-//! Both fail closed, so a runaway always terminates. The gap is that the loop bound counts
-//! *iterations*, not *time*: at the 10M default a trivial body measured ~15s, and a heavier
-//! body scales from there with nothing consulting the 60s wall clock. Treat `wall_clock` as
-//! a bound on host-call and async work, not as a hard ceiling on a CPU-bound script.
+//! These count iterations and depth, not allocation or elapsed time. Production
+//! execution, dry runs, and saved routines all require the worker boundary to contain
+//! allocation failures and terminate expensive built-ins.
 //!
 //! `pure_js_runaways_are_bounded_by_count_not_wall_clock` pins this so a boa upgrade that
-//! drops either counter is caught rather than silently removing the only real bound.
+//! drops either counter is caught, independently of the process-isolation tests.
 
 use std::cell::{Cell, RefCell};
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
@@ -60,6 +61,7 @@ use boa_engine::object::builtins::JsPromise;
 use boa_engine::property::Attribute;
 use boa_engine::{js_string, Context, JsError, JsNativeError, JsValue, NativeFunction, Source};
 use boa_gc::{Finalize, Trace};
+use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 
 /// Host binding used for every downstream tool invocation from a script.
@@ -67,6 +69,11 @@ use serde_json::{json, Value};
 /// `Send + Sync` so independent `callAsync` work can run on a small thread pool without
 /// serializing every host call on the JS thread.
 pub type CallBinding = Arc<dyn Fn(&str, Value) -> Value + Send + Sync>;
+
+/// Internal worker binding carries the ledger position across concurrent IPC.
+pub(crate) type IndexedCallBinding = Arc<dyn Fn(usize, &str, Value) -> Value + Send + Sync>;
+
+pub(crate) type CheckpointBinding = Arc<dyn Fn(&Value) -> Result<(), String> + Send + Sync>;
 
 /// Arguments for [`FetchBinding`] / `toolport.fetchResult`.
 #[derive(Debug, Clone)]
@@ -91,12 +98,13 @@ pub enum ScriptInput {
 
 /// Resource limits for one script run. All are fail-closed: exceeding any of them aborts
 /// the script with an error result the agent can read and recover from.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 pub struct Limits {
     /// Max number of `toolport.call` / `callAsync` / `fetchResult` invocations.
     /// Bounds fan-out, load, and unbounded result paging (WS2-2).
     pub max_calls: usize,
-    /// Wall-clock budget for the whole run, checked at each host call.
+    /// Wall-clock budget for the whole run, enforced by the parent worker supervisor
+    /// and checked by the interpreter at host calls and between promise jobs.
     pub wall_clock: Duration,
     /// Max concurrent host tool calls when scripts fan out with `callAsync` / `Promise.all`.
     pub max_parallel: usize,
@@ -244,7 +252,7 @@ impl JobExecutor for BoundedJobExecutor {
 /// out for exactly that reason. The cost is that the ledger is ORDINAL — it says
 /// which positions in the call sequence completed, not which argument values
 /// did. See [`ScriptOutcome::progress`] for what that means for the caller.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct CallRecord {
     /// Position in the call sequence, from zero. Explicit rather than implied by
     /// array order so the ordinal contract survives serialization and is legible
@@ -260,7 +268,7 @@ pub struct CallRecord {
 }
 
 /// The outcome of running a script.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ScriptOutcome {
     /// The script's return value as JSON (`null` if it returned nothing). Meaningful only
     /// when `error` is `None`.
@@ -340,7 +348,7 @@ unsafe impl Trace for PendingCall {
 
 /// Host state shared with the `__toolport_call` / `__toolport_call_async` native functions.
 struct HostState {
-    call: CallBinding,
+    call: IndexedCallBinding,
     /// Shared with the run so the count survives after the closure is moved into boa.
     calls_made: Rc<Cell<usize>>,
     /// Ledger of calls that actually executed, shared with the run the same way
@@ -350,6 +358,7 @@ struct HostState {
     /// Last checkpoint value the script recorded via `toolport.checkpoint(value)`.
     /// Last-write-wins — a fresh call overwrites, it doesn't append (#663).
     checkpoint: Rc<RefCell<Option<Value>>>,
+    checkpoint_binding: Option<CheckpointBinding>,
     /// Maximum serialized checkpoint size for this run. This is capped against
     /// the active result budget so an accepted checkpoint can always be surfaced
     /// immediately when the script fails.
@@ -363,7 +372,7 @@ struct HostState {
 
 /// A checkpoint is a resume marker, not a payload. Keep it bounded so even a
 /// failure response can surface it without becoming an unbounded escape hatch.
-const MAX_CHECKPOINT_BYTES: usize = 4096;
+pub(crate) const MAX_CHECKPOINT_BYTES: usize = 4096;
 
 /// Space reserved for the failure prefix, shaping marker, and MCP result
 /// envelope. The remainder of the active result budget is available to the
@@ -423,6 +432,7 @@ impl Clone for HostState {
             calls_made: Rc::clone(&self.calls_made),
             executed: Rc::clone(&self.executed),
             checkpoint: Rc::clone(&self.checkpoint),
+            checkpoint_binding: self.checkpoint_binding.clone(),
             max_checkpoint_bytes: self.max_checkpoint_bytes,
             max_calls: self.max_calls,
             max_parallel: self.max_parallel,
@@ -710,6 +720,27 @@ pub fn run_script_with_input(
     limits: Limits,
     catalog: &[String],
 ) -> ScriptOutcome {
+    run_script_indexed(
+        script,
+        input,
+        Arc::new(move |_, name, args| call(name, args)),
+        fetch,
+        limits,
+        catalog,
+        None,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn run_script_indexed(
+    script: &str,
+    input: ScriptInput,
+    call: IndexedCallBinding,
+    fetch: Option<FetchBinding>,
+    limits: Limits,
+    catalog: &[String],
+    checkpoint_binding: Option<CheckpointBinding>,
+) -> ScriptOutcome {
     let calls_made = Rc::new(Cell::new(0usize));
     let executed = Rc::new(RefCell::new(Vec::new()));
     let checkpoint = Rc::new(RefCell::new(None::<Value>));
@@ -747,6 +778,7 @@ pub fn run_script_with_input(
         calls_made: calls_made.clone(),
         executed: executed.clone(),
         checkpoint: checkpoint.clone(),
+        checkpoint_binding,
         max_checkpoint_bytes,
         max_calls: limits.max_calls,
         max_parallel: limits.max_parallel.max(1),
@@ -759,7 +791,8 @@ pub fn run_script_with_input(
             reserve_call_slot(state)?;
             let (name, parsed) = parse_call_args(args);
             state.calls_made.set(state.calls_made.get() + 1);
-            let result = (state.call)(&name, parsed);
+            let index = state.executed.borrow().len();
+            let result = (state.call)(index, &name, parsed);
             // After the binding returns: the side effect has committed, so the
             // ledger reflects work actually done (#646).
             {
@@ -804,6 +837,11 @@ pub fn run_script_with_input(
                 .map(|s| s.to_std_string_escaped())
                 .unwrap_or_else(|| "null".to_string());
             store_checkpoint(&state.checkpoint, &raw, state.max_checkpoint_bytes)?;
+            if let Some(binding) = &state.checkpoint_binding {
+                if let Some(value) = state.checkpoint.borrow().as_ref() {
+                    binding(value).map_err(|error| JsNativeError::error().with_message(error))?;
+                }
+            }
             Ok(JsValue::undefined())
         },
         state.clone(),
@@ -1105,7 +1143,7 @@ fn flush_pending_host_calls(context: &mut Context, state: &HostState) -> Result<
             .iter()
             .map(|p| (p.name.clone(), p.args.clone()))
             .collect();
-        let results = run_calls_parallel(&state.call, names_args);
+        let results = run_calls_parallel(&state.call, state.executed.borrow().len(), names_args);
 
         // Record before resolving the promises: these calls have already run, and
         // a resolver that throws must not lose the fact that they did (#646).
@@ -1143,13 +1181,17 @@ fn flush_pending_host_calls(context: &mut Context, state: &HostState) -> Result<
 
 /// Run independent host tool calls, using a short-lived thread scope when more than one
 /// is ready so wall-clock tracks the slowest call in the batch rather than the sum.
-fn run_calls_parallel(call: &CallBinding, items: Vec<(String, Value)>) -> Vec<Value> {
+fn run_calls_parallel(
+    call: &IndexedCallBinding,
+    start_index: usize,
+    items: Vec<(String, Value)>,
+) -> Vec<Value> {
     if items.is_empty() {
         return Vec::new();
     }
     if items.len() == 1 {
         let (name, args) = &items[0];
-        return vec![call(name, args.clone())];
+        return vec![call(start_index, name, args.clone())];
     }
 
     let n = items.len();
@@ -1158,7 +1200,7 @@ fn run_calls_parallel(call: &CallBinding, items: Vec<(String, Value)>) -> Vec<Va
         let mut handles = Vec::with_capacity(n);
         for (i, (name, args)) in items.into_iter().enumerate() {
             let call = call;
-            handles.push(scope.spawn(move || (i, call(&name, args))));
+            handles.push(scope.spawn(move || (i, call(start_index + i, &name, args))));
         }
         for handle in handles {
             match handle.join() {

--- a/src-tauri/src/codemode_worker.rs
+++ b/src-tauri/src/codemode_worker.rs
@@ -1,0 +1,298 @@
+//! Framing and wire types for the isolated Code Mode worker.
+//!
+//! The gateway and the worker communicate over the worker's stdin/stdout. A
+//! length-prefixed frame is used instead of newline-delimited JSON so the
+//! receiver can reject an oversized payload before allocating its body.
+
+use std::fmt;
+use std::io::{self, Read, Write};
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::codemode::{CallRecord, Limits, ScriptOutcome};
+
+mod host_calls;
+mod memory;
+mod process;
+
+pub use host_calls::HostCalls;
+#[cfg(any(unix, windows))]
+pub use memory::WorkerAllocator;
+pub use process::{run_script, worker_main};
+
+pub const WORKER_ARG: &str = "--code-mode-worker";
+pub const MAX_SCRIPT_BYTES: usize = crate::routines::MAX_SOURCE_BYTES;
+pub const MAX_VALUE_BYTES: usize = 4 * 1024 * 1024;
+pub const MAX_SCHEMA_BYTES: usize = crate::routines::MAX_SCHEMA_BYTES;
+pub const MEMORY_LIMIT_BYTES: usize = 512 * 1024 * 1024;
+
+/// Maximum encoded JSON payload in one worker frame.
+pub const MAX_FRAME_BYTES: usize = 16 * 1024 * 1024;
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum Frame {
+    Start {
+        script: String,
+        input: Value,
+        immutable_input: bool,
+        limits: Limits,
+        catalog: Vec<String>,
+    },
+    Call {
+        id: u64,
+        index: usize,
+        name: String,
+        args: Value,
+    },
+    CallResult {
+        id: u64,
+        result: Value,
+    },
+    Fetch {
+        id: u64,
+        args: FetchFrameArgs,
+    },
+    FetchResult {
+        id: u64,
+        result: Value,
+    },
+    Checkpoint {
+        value: Value,
+    },
+    Outcome {
+        outcome: ScriptOutcome,
+    },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FetchFrameArgs {
+    pub cursor: String,
+    pub offset: usize,
+    pub len: usize,
+    pub projection: Option<String>,
+}
+
+#[derive(Debug)]
+pub enum FrameError {
+    Io(io::Error),
+    Oversized { size: usize },
+    InvalidJson(serde_json::Error),
+}
+
+impl fmt::Display for FrameError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Io(error) => write!(f, "worker pipe I/O error: {error}"),
+            Self::Oversized { size } => write!(
+                f,
+                "worker frame is {size} bytes, over the {MAX_FRAME_BYTES}-byte limit"
+            ),
+            Self::InvalidJson(error) => write!(f, "worker frame is not valid JSON: {error}"),
+        }
+    }
+}
+
+impl std::error::Error for FrameError {}
+
+impl From<io::Error> for FrameError {
+    fn from(error: io::Error) -> Self {
+        Self::Io(error)
+    }
+}
+
+/// Write one frame as a 4-byte big-endian length followed by its JSON bytes.
+pub fn write_frame<W: Write>(writer: &mut W, frame: &Frame) -> Result<(), FrameError> {
+    let mut payload = Vec::new();
+    let mut bounded = LimitedWriter::new(&mut payload, MAX_FRAME_BYTES);
+    if let Err(error) = serde_json::to_writer(&mut bounded, frame) {
+        return Err(if bounded.exceeded {
+            FrameError::Oversized {
+                size: MAX_FRAME_BYTES + 1,
+            }
+        } else {
+            FrameError::InvalidJson(error)
+        });
+    }
+    let size = u32::try_from(payload.len()).map_err(|_| FrameError::Oversized {
+        size: payload.len(),
+    })?;
+    writer.write_all(&size.to_be_bytes())?;
+    writer.write_all(&payload)?;
+    writer.flush()?;
+    Ok(())
+}
+
+/// Read one frame. The body allocation happens only after the checked length
+/// prefix has been received. A clean EOF before a new prefix is represented by
+/// `Ok(None)`; a truncated prefix/body is an error.
+pub fn read_frame<R: Read>(reader: &mut R) -> Result<Option<Frame>, FrameError> {
+    let mut header = [0u8; 4];
+    let first = loop {
+        match reader.read(&mut header[..1]) {
+            Ok(0) => return Ok(None),
+            Ok(1) => break 1,
+            Ok(_) => unreachable!("a one-byte read cannot return more than one byte"),
+            Err(error) if error.kind() == io::ErrorKind::Interrupted => continue,
+            Err(error) => return Err(FrameError::Io(error)),
+        }
+    };
+    reader.read_exact(&mut header[first..])?;
+    let size = u32::from_be_bytes(header) as usize;
+    if size == 0 || size > MAX_FRAME_BYTES {
+        return Err(FrameError::Oversized { size });
+    }
+    let mut payload = vec![0u8; size];
+    reader.read_exact(&mut payload)?;
+    serde_json::from_slice(&payload)
+        .map(Some)
+        .map_err(FrameError::InvalidJson)
+}
+
+/// Construct an outcome when the parent detects that the worker disappeared
+/// before it could send a normal result.
+pub fn terminated_outcome(
+    calls: usize,
+    progress: Vec<CallRecord>,
+    reason: String,
+) -> ScriptOutcome {
+    ScriptOutcome {
+        value: Value::Null,
+        calls,
+        progress,
+        final_result_bytes: 0,
+        checkpoint: None,
+        error: Some(reason),
+    }
+}
+
+struct LimitedWriter<W> {
+    inner: W,
+    limit: usize,
+    written: usize,
+    exceeded: bool,
+}
+
+impl<W> LimitedWriter<W> {
+    fn new(inner: W, limit: usize) -> Self {
+        Self {
+            inner,
+            limit,
+            written: 0,
+            exceeded: false,
+        }
+    }
+}
+
+impl<W: Write> Write for LimitedWriter<W> {
+    fn write(&mut self, bytes: &[u8]) -> io::Result<usize> {
+        if bytes.len() > self.limit.saturating_sub(self.written) {
+            self.exceeded = true;
+            return Err(io::Error::other("code mode byte limit exceeded"));
+        }
+        let count = self.inner.write(bytes)?;
+        self.written += count;
+        Ok(count)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.inner.flush()
+    }
+}
+
+/// Count encoded bytes without making an additional, potentially unbounded copy.
+pub fn json_size(value: &impl Serialize, limit: usize) -> Option<usize> {
+    let mut writer = LimitedWriter::new(io::sink(), limit);
+    serde_json::to_writer(&mut writer, value).ok()?;
+    Some(writer.written)
+}
+
+pub fn check_input(script: &str, input: &crate::codemode::ScriptInput) -> Result<(), String> {
+    if script.len() > MAX_SCRIPT_BYTES {
+        return Err(format!(
+            "code mode script exceeds the {MAX_SCRIPT_BYTES}-byte source limit"
+        ));
+    }
+    let (name, value) = match input {
+        crate::codemode::ScriptInput::Data(value) => ("data", value),
+        crate::codemode::ScriptInput::ImmutableInput(value) => ("input", value),
+    };
+    if json_size(value, MAX_VALUE_BYTES).is_none() {
+        return Err(format!(
+            "code mode {name} exceeds the {MAX_VALUE_BYTES}-byte value limit"
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Cursor;
+
+    #[test]
+    fn frame_round_trip() {
+        let frame = Frame::Call {
+            id: 7,
+            index: 0,
+            name: "server__tool".to_string(),
+            args: serde_json::json!({ "value": 1 }),
+        };
+        let mut bytes = Vec::new();
+        write_frame(&mut bytes, &frame).expect("write frame");
+        let decoded = read_frame(&mut Cursor::new(bytes))
+            .expect("read frame")
+            .expect("frame");
+        match decoded {
+            Frame::Call { id, name, .. } => {
+                assert_eq!(id, 7);
+                assert_eq!(name, "server__tool");
+            }
+            _ => panic!("wrong frame type"),
+        }
+    }
+
+    #[test]
+    fn oversized_prefix_is_rejected_before_body_read() {
+        let size = (MAX_FRAME_BYTES as u32).saturating_add(1);
+        let mut reader = Cursor::new(size.to_be_bytes().to_vec());
+        let error = read_frame(&mut reader).expect_err("oversized frame must fail");
+        assert!(matches!(error, FrameError::Oversized { .. }));
+        assert_eq!(reader.position(), 4, "body must not be read or allocated");
+    }
+
+    #[test]
+    fn truncated_body_is_an_error() {
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&5u32.to_be_bytes());
+        bytes.extend_from_slice(b"{}");
+        let error = read_frame(&mut Cursor::new(bytes)).expect_err("truncated frame");
+        assert!(matches!(error, FrameError::Io(_)));
+    }
+
+    #[test]
+    fn oversized_write_leaves_the_pipe_untouched() {
+        let frame = Frame::CallResult {
+            id: 1,
+            result: Value::String("x".repeat(MAX_FRAME_BYTES)),
+        };
+        let mut bytes = Vec::new();
+        assert!(matches!(
+            write_frame(&mut bytes, &frame),
+            Err(FrameError::Oversized { .. })
+        ));
+        assert!(
+            bytes.is_empty(),
+            "a rejected payload must not leave a partial frame"
+        );
+    }
+
+    #[test]
+    fn json_size_counts_encoded_bytes_and_stops_at_the_limit() {
+        let value = serde_json::json!({ "text": "\"\\\n" });
+        let size = serde_json::to_vec(&value).unwrap().len();
+        assert_eq!(json_size(&value, size), Some(size));
+        assert_eq!(json_size(&value, size - 1), None);
+    }
+}

--- a/src-tauri/src/codemode_worker/host_calls.rs
+++ b/src-tauri/src/codemode_worker/host_calls.rs
@@ -1,0 +1,84 @@
+use std::collections::HashSet;
+use std::sync::{Arc, Mutex};
+
+use crate::downstream::{CancelContext, CancelRegistry};
+
+/// Cancellation owned by a script run, separate from its upstream request.
+/// Stopping host work must not suppress the script's error response to a client.
+#[derive(Clone, Default)]
+pub struct HostCalls(Arc<Mutex<State>>);
+
+#[derive(Default)]
+struct State {
+    registry: CancelRegistry,
+    next: u64,
+    active: HashSet<String>,
+    stopped: bool,
+}
+
+pub struct HostCall {
+    owner: HostCalls,
+    id: String,
+    pub context: CancelContext,
+}
+
+impl HostCalls {
+    pub fn start(&self) -> HostCall {
+        let mut state = self
+            .0
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let id = state.next.to_string();
+        state.next += 1;
+        state.registry.begin_client_request(id.clone());
+        state.active.insert(id.clone());
+        if state.stopped {
+            state.registry.cancel(&id, Some("code mode worker stopped"));
+        }
+        HostCall {
+            owner: self.clone(),
+            context: state.registry.context(id.clone()),
+            id,
+        }
+    }
+
+    pub fn stop(&self) {
+        let mut state = self
+            .0
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        state.stopped = true;
+        for id in &state.active {
+            state.registry.cancel(id, Some("code mode worker stopped"));
+        }
+    }
+}
+
+impl Drop for HostCall {
+    fn drop(&mut self) {
+        let mut state = self
+            .owner
+            .0
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        state.active.remove(&self.id);
+        state.registry.finish_client_request(&self.id);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn stopping_a_run_cancels_every_host_and_prevents_late_dispatch() {
+        let calls = HostCalls::default();
+        let first = calls.start();
+        let second = calls.start();
+        assert!(!first.context.is_cancelled());
+        calls.stop();
+        assert!(first.context.is_cancelled());
+        assert!(second.context.is_cancelled());
+        assert!(calls.start().context.is_cancelled());
+    }
+}

--- a/src-tauri/src/codemode_worker/memory.rs
+++ b/src-tauri/src/codemode_worker/memory.rs
@@ -1,0 +1,308 @@
+use std::process::{Child, Command};
+
+use super::MEMORY_LIMIT_BYTES;
+
+pub const MEMORY_EXIT_CODE: i32 = 86;
+
+pub fn is_memory_termination(status: &std::process::ExitStatus) -> bool {
+    if status.code() == Some(MEMORY_EXIT_CODE) {
+        return true;
+    }
+    #[cfg(windows)]
+    {
+        // Native allocation/commitment exhaustion can also terminate a worker.
+        // Generic fail-fast (0xC0000409) is not specific to memory exhaustion.
+        return status
+            .code()
+            .is_some_and(|code| matches!(code as u32, 0xC0000017 | 0xC000012D));
+    }
+    #[cfg(not(windows))]
+    {
+        false
+    }
+}
+
+#[cfg(all(unix, not(target_os = "macos")))]
+pub fn configure(command: &mut Command) -> std::io::Result<()> {
+    use std::os::unix::process::CommandExt;
+    // glibc otherwise reserves a large arena per host-call thread, consuming
+    // the address-space limit even for small, ordinary parallel scripts.
+    #[cfg(target_os = "linux")]
+    command.env("MALLOC_ARENA_MAX", "2");
+    // SAFETY: only async-signal-safe resource-limit syscalls run after fork.
+    unsafe {
+        command.pre_exec(|| {
+            let mut inherited = libc::rlimit {
+                rlim_cur: 0,
+                rlim_max: 0,
+            };
+            if libc::getrlimit(libc::RLIMIT_AS, &mut inherited) != 0 {
+                return Err(std::io::Error::last_os_error());
+            }
+            let bytes = (MEMORY_LIMIT_BYTES as libc::rlim_t)
+                .min(inherited.rlim_cur)
+                .min(inherited.rlim_max);
+            let memory = libc::rlimit {
+                rlim_cur: bytes,
+                rlim_max: bytes,
+            };
+            let core = libc::rlimit {
+                rlim_cur: 0,
+                rlim_max: 0,
+            };
+            if libc::setrlimit(libc::RLIMIT_AS, &memory) != 0
+                || libc::setrlimit(libc::RLIMIT_CORE, &core) != 0
+            {
+                return Err(std::io::Error::last_os_error());
+            }
+            Ok(())
+        });
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "macos")]
+pub fn configure(command: &mut Command) -> std::io::Result<()> {
+    use std::os::unix::process::CommandExt;
+    // Darwin's RLIMIT_AS is an RSS hint and cannot be lowered below the
+    // already mapped gateway image. The worker allocator enforces the actual
+    // heap budget after exec; disable core dumps as a second containment aid.
+    // SAFETY: only the async-signal-safe setrlimit call runs after fork.
+    unsafe {
+        command.pre_exec(|| {
+            let core = libc::rlimit {
+                rlim_cur: 0,
+                rlim_max: 0,
+            };
+            if libc::setrlimit(libc::RLIMIT_CORE, &core) != 0 {
+                return Err(std::io::Error::last_os_error());
+            }
+            Ok(())
+        });
+    }
+    Ok(())
+}
+
+#[cfg(windows)]
+pub fn configure(command: &mut Command) -> std::io::Result<()> {
+    use std::os::windows::process::CommandExt;
+    use windows_sys::Win32::System::Threading::{CREATE_NO_WINDOW, CREATE_SUSPENDED};
+    // No worker instruction may execute before it belongs to the limited job.
+    command.creation_flags(CREATE_NO_WINDOW | CREATE_SUSPENDED);
+    Ok(())
+}
+
+#[cfg(not(any(unix, windows)))]
+pub fn configure(_command: &mut Command) -> std::io::Result<()> {
+    Err(std::io::Error::other(
+        "code mode memory isolation is unavailable on this platform",
+    ))
+}
+
+#[cfg(not(windows))]
+pub struct Job;
+
+#[cfg(not(windows))]
+impl Job {
+    pub fn attach(_child: &Child) -> std::io::Result<Self> {
+        Ok(Self)
+    }
+}
+
+#[cfg(windows)]
+pub struct Job(windows_sys::Win32::Foundation::HANDLE);
+
+#[cfg(windows)]
+impl Job {
+    pub fn attach(child: &Child) -> std::io::Result<Self> {
+        use std::mem::{size_of, zeroed};
+        use std::os::windows::io::AsRawHandle;
+        use std::ptr;
+        use windows_sys::Win32::System::JobObjects::{
+            AssignProcessToJobObject, CreateJobObjectW, JobObjectExtendedLimitInformation,
+            SetInformationJobObject, JOBOBJECT_EXTENDED_LIMIT_INFORMATION,
+            JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE, JOB_OBJECT_LIMIT_PROCESS_MEMORY,
+        };
+        // SAFETY: initialized structures, checked handles, and a suspended child.
+        unsafe {
+            let handle = CreateJobObjectW(ptr::null(), ptr::null());
+            if handle.is_null() {
+                return Err(std::io::Error::last_os_error());
+            }
+            let job = Self(handle);
+            let mut info: JOBOBJECT_EXTENDED_LIMIT_INFORMATION = zeroed();
+            info.BasicLimitInformation.LimitFlags =
+                JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE | JOB_OBJECT_LIMIT_PROCESS_MEMORY;
+            info.ProcessMemoryLimit = MEMORY_LIMIT_BYTES;
+            if SetInformationJobObject(
+                handle,
+                JobObjectExtendedLimitInformation,
+                &info as *const _ as *const _,
+                size_of::<JOBOBJECT_EXTENDED_LIMIT_INFORMATION>() as u32,
+            ) == 0
+                || AssignProcessToJobObject(handle, child.as_raw_handle() as _) == 0
+            {
+                return Err(std::io::Error::last_os_error());
+            }
+            Self::resume(child)?;
+            Ok(job)
+        }
+    }
+
+    fn resume(child: &Child) -> std::io::Result<()> {
+        use std::mem::size_of;
+        use windows_sys::Win32::Foundation::{CloseHandle, INVALID_HANDLE_VALUE};
+        use windows_sys::Win32::System::Diagnostics::ToolHelp::{
+            CreateToolhelp32Snapshot, Thread32First, Thread32Next, TH32CS_SNAPTHREAD, THREADENTRY32,
+        };
+        use windows_sys::Win32::System::Threading::{
+            OpenThread, ResumeThread, THREAD_SUSPEND_RESUME,
+        };
+        // std::process::Child exposes only the process handle. The suspended
+        // process has exactly one thread; locate it without running the loader.
+        // SAFETY: snapshot/thread handles are checked and closed on every path.
+        unsafe {
+            let snapshot = CreateToolhelp32Snapshot(TH32CS_SNAPTHREAD, 0);
+            if snapshot == INVALID_HANDLE_VALUE {
+                return Err(std::io::Error::last_os_error());
+            }
+            let result = (|| {
+                let mut entry = THREADENTRY32 {
+                    dwSize: size_of::<THREADENTRY32>() as u32,
+                    ..Default::default()
+                };
+                let mut found = Thread32First(snapshot, &mut entry);
+                while found != 0 {
+                    if entry.th32OwnerProcessID == child.id() {
+                        let thread = OpenThread(THREAD_SUSPEND_RESUME, 0, entry.th32ThreadID);
+                        if thread.is_null() {
+                            return Err(std::io::Error::last_os_error());
+                        }
+                        let resumed = ResumeThread(thread);
+                        let error = (resumed == u32::MAX).then(std::io::Error::last_os_error);
+                        CloseHandle(thread);
+                        return error.map_or(Ok(()), Err);
+                    }
+                    found = Thread32Next(snapshot, &mut entry);
+                }
+                Err(std::io::Error::other(
+                    "code mode worker primary thread was not found",
+                ))
+            })();
+            CloseHandle(snapshot);
+            result
+        }
+    }
+}
+
+#[cfg(windows)]
+impl Drop for Job {
+    fn drop(&mut self) {
+        // SAFETY: this value exclusively owns the job handle.
+        unsafe {
+            windows_sys::Win32::Foundation::CloseHandle(self.0);
+        }
+    }
+}
+
+// Account from process startup so frees of pre-worker allocations cannot
+// undercount the heap. Allocation failure exits before Boa can turn a refused
+// allocation into a catchable RangeError. The exit code supplies attribution
+// without trusting script-controlled error text. The OS limits still apply on
+// Linux and Windows; this allocator supplies the heap cap on Darwin.
+#[cfg(any(unix, windows))]
+mod allocator {
+    use std::alloc::{GlobalAlloc, Layout, System};
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+
+    static USED: AtomicUsize = AtomicUsize::new(0);
+    static LIMITED: AtomicBool = AtomicBool::new(false);
+
+    pub struct WorkerAllocator;
+
+    pub fn enable() {
+        LIMITED.store(true, Ordering::SeqCst);
+        reserve(0);
+    }
+
+    fn memory_exit() -> ! {
+        // No allocating panic, destructors, or atexit handlers on this path.
+        #[cfg(unix)]
+        unsafe {
+            libc::_exit(super::MEMORY_EXIT_CODE);
+        }
+        #[cfg(windows)]
+        unsafe {
+            use windows_sys::Win32::System::Threading::{GetCurrentProcess, TerminateProcess};
+            TerminateProcess(GetCurrentProcess(), super::MEMORY_EXIT_CODE as u32);
+            std::process::abort();
+        }
+    }
+
+    fn allocation_failed() {
+        if LIMITED.load(Ordering::SeqCst) {
+            memory_exit();
+        }
+    }
+
+    fn reserve(bytes: usize) {
+        let previous = USED.fetch_add(bytes, Ordering::SeqCst);
+        if LIMITED.load(Ordering::SeqCst)
+            && previous.saturating_add(bytes) > super::MEMORY_LIMIT_BYTES
+        {
+            memory_exit();
+        }
+    }
+
+    // SAFETY: pointers and layouts are forwarded unchanged to System. The
+    // counters never allocate and failed allocations undo their reservation.
+    unsafe impl GlobalAlloc for WorkerAllocator {
+        unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+            reserve(layout.size());
+            let ptr = unsafe { System.alloc(layout) };
+            if ptr.is_null() {
+                allocation_failed();
+                USED.fetch_sub(layout.size(), Ordering::SeqCst);
+            }
+            ptr
+        }
+
+        unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
+            reserve(layout.size());
+            let ptr = unsafe { System.alloc_zeroed(layout) };
+            if ptr.is_null() {
+                allocation_failed();
+                USED.fetch_sub(layout.size(), Ordering::SeqCst);
+            }
+            ptr
+        }
+
+        unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+            unsafe {
+                System.dealloc(ptr, layout);
+            }
+            USED.fetch_sub(layout.size(), Ordering::SeqCst);
+        }
+
+        unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, size: usize) -> *mut u8 {
+            let growth = size.saturating_sub(layout.size());
+            reserve(growth);
+            let next = unsafe { System.realloc(ptr, layout, size) };
+            if next.is_null() {
+                allocation_failed();
+                USED.fetch_sub(growth, Ordering::SeqCst);
+            } else if size < layout.size() {
+                USED.fetch_sub(layout.size() - size, Ordering::SeqCst);
+            }
+            next
+        }
+    }
+}
+
+#[cfg(any(unix, windows))]
+pub use allocator::WorkerAllocator;
+
+pub fn enable_worker_limit() {
+    #[cfg(any(unix, windows))]
+    allocator::enable();
+}

--- a/src-tauri/src/codemode_worker/process.rs
+++ b/src-tauri/src/codemode_worker/process.rs
@@ -1,0 +1,591 @@
+use std::collections::HashMap;
+use std::io::{BufReader, BufWriter};
+use std::process::{Child, Command, Stdio};
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+use std::sync::{mpsc, Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use serde_json::{json, Value};
+
+use super::{memory, FetchFrameArgs, Frame};
+use crate::codemode::{
+    self, CallBinding, CallRecord, FetchBinding, Limits, ScriptInput, ScriptOutcome,
+};
+use crate::downstream::CancelContext;
+
+const MAX_WORKERS: usize = 4;
+static WORKERS: AtomicUsize = AtomicUsize::new(0);
+
+struct RunPermit;
+
+impl RunPermit {
+    fn acquire() -> Option<Arc<Self>> {
+        WORKERS
+            .fetch_update(Ordering::AcqRel, Ordering::Acquire, |count| {
+                (count < MAX_WORKERS).then_some(count + 1)
+            })
+            .ok()
+            .map(|_| Arc::new(Self))
+    }
+}
+
+impl Drop for RunPermit {
+    fn drop(&mut self) {
+        WORKERS.fetch_sub(1, Ordering::AcqRel);
+    }
+}
+
+struct ChildGuard(Child);
+
+impl Drop for ChildGuard {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
+}
+
+enum Event {
+    Frame(Frame),
+    PipeClosed(String),
+    Failure(String),
+    HostReply(Frame),
+}
+
+fn pipe_error(error: super::FrameError) -> Event {
+    match error {
+        super::FrameError::Io(_) => Event::PipeClosed(error.to_string()),
+        _ => Event::Failure(error.to_string()),
+    }
+}
+
+fn exit_reason(child: &mut Child) -> String {
+    // Windows can close the pipes hundreds of milliseconds before signaling
+    // the process handle. Give the dedicated memory exit code time to become
+    // observable, while keeping even a broken worker's cleanup bounded.
+    let grace = if cfg!(windows) {
+        Duration::from_secs(1)
+    } else {
+        Duration::from_millis(25)
+    };
+    let until = Instant::now() + grace;
+    loop {
+        match child.try_wait() {
+            Ok(Some(status)) if memory::is_memory_termination(&status) => {
+                return format!(
+                    "code mode script exceeded its memory budget ({} MiB)",
+                    super::MEMORY_LIMIT_BYTES / (1024 * 1024)
+                );
+            }
+            Ok(Some(status)) => {
+                return format!("code mode worker terminated before returning a result ({status})")
+            }
+            _ if Instant::now() >= until => {
+                return "code mode worker pipe closed before returning a result".into()
+            }
+            _ => std::thread::sleep(Duration::from_millis(1)),
+        }
+    }
+}
+
+fn error_result(error: &str) -> Value {
+    json!({ "content": [{ "type": "text", "text": error }], "isError": true })
+}
+
+/// Only the parent owns host bindings. Every script, including dry runs and
+/// routines, uses the same process boundary and bounded pipe queues.
+#[allow(clippy::too_many_arguments)]
+pub fn run_script(
+    script: &str,
+    input: ScriptInput,
+    call: CallBinding,
+    fetch: Option<FetchBinding>,
+    limits: Limits,
+    catalog: &[String],
+    cancel: Option<CancelContext>,
+    host_calls: super::HostCalls,
+) -> ScriptOutcome {
+    let fail = |error| super::terminated_outcome(0, Vec::new(), error);
+    if let Err(error) = super::check_input(script, &input) {
+        return fail(error);
+    }
+    let Some(permit) = RunPermit::acquire() else {
+        return fail(format!("code mode concurrent worker limit reached ({MAX_WORKERS}); retry after a running script finishes"));
+    };
+    let deadline = Instant::now() + limits.wall_clock;
+    let (value, immutable_input) = match input {
+        ScriptInput::Data(value) => (value, false),
+        ScriptInput::ImmutableInput(value) => (value, true),
+    };
+    let start = Frame::Start {
+        script: script.to_string(),
+        input: value,
+        immutable_input,
+        limits,
+        catalog: catalog.to_vec(),
+    };
+    if super::json_size(&start, super::MAX_FRAME_BYTES).is_none() {
+        return fail("code mode start payload exceeds the IPC frame limit".into());
+    }
+    let executable = match std::env::current_exe() {
+        Ok(path) => path,
+        Err(error) => return fail(format!("code mode worker executable unavailable: {error}")),
+    };
+    let mut command = Command::new(executable);
+    command
+        .arg(super::WORKER_ARG)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null());
+    if let Err(error) = memory::configure(&mut command) {
+        return fail(format!("code mode memory limit setup failed: {error}"));
+    }
+    let mut child = match command.spawn() {
+        Ok(child) => ChildGuard(child),
+        Err(error) => {
+            return fail(format!(
+                "code mode worker could not start with its memory budget: {error}"
+            ))
+        }
+    };
+    let _job = match memory::Job::attach(&child.0) {
+        Ok(job) => job,
+        Err(error) => {
+            return fail(format!(
+                "code mode worker memory limit setup failed: {error}"
+            ))
+        }
+    };
+    let stdin = child.0.stdin.take().expect("piped worker stdin");
+    let stdout = child.0.stdout.take().expect("piped worker stdout");
+    // One received frame at a time; host fan-out and outgoing responses are
+    // separately bounded. No pipe operation runs on the deadline supervisor.
+    let (events, incoming) = mpsc::sync_channel(1);
+    let (outgoing, responses) = mpsc::sync_channel(limits.max_parallel.max(1) + 1);
+    let read_events = events.clone();
+    let reader = match std::thread::Builder::new()
+        .name("code-mode-read".into())
+        .spawn(move || {
+            let mut reader = BufReader::new(stdout);
+            loop {
+                let event = match super::read_frame(&mut reader) {
+                    Ok(Some(frame)) => Event::Frame(frame),
+                    Ok(None) => Event::PipeClosed("worker pipe closed without an outcome".into()),
+                    Err(error) => pipe_error(error),
+                };
+                let failed = matches!(event, Event::Failure(_) | Event::PipeClosed(_));
+                if read_events.send(event).is_err() || failed {
+                    break;
+                }
+            }
+        }) {
+        Ok(thread) => thread,
+        Err(error) => return fail(format!("code mode reader could not start: {error}")),
+    };
+    let write_events = events.clone();
+    let writer = match std::thread::Builder::new()
+        .name("code-mode-write".into())
+        .spawn(move || {
+            let mut writer = BufWriter::new(stdin);
+            for frame in std::iter::once(start).chain(responses) {
+                if let Err(error) = super::write_frame(&mut writer, &frame) {
+                    let _ = write_events.send(pipe_error(error));
+                    break;
+                }
+            }
+        }) {
+        Ok(thread) => thread,
+        Err(error) => return fail(format!("code mode writer could not start: {error}")),
+    };
+
+    let progress = Arc::new(Mutex::new(Vec::<CallRecord>::new()));
+    let mut calls = 0;
+    let mut inflight = 0;
+    let mut seen_ids = std::collections::HashSet::new();
+    let mut seen_indices = std::collections::HashSet::new();
+    let mut checkpoint = None;
+    let result = loop {
+        if cancel.as_ref().is_some_and(CancelContext::is_cancelled) {
+            break Err("code mode script was cancelled".to_string());
+        }
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            break Err("code mode worker exceeded its wall-clock deadline".to_string());
+        }
+        let event = match incoming.recv_timeout(remaining.min(Duration::from_millis(25))) {
+            Ok(event) => event,
+            Err(mpsc::RecvTimeoutError::Timeout) => continue,
+            Err(mpsc::RecvTimeoutError::Disconnected) => {
+                break Err("code mode worker IPC disconnected".to_string())
+            }
+        };
+        match event {
+            Event::PipeClosed(error) => {
+                break Err(format!("{}: {error}", exit_reason(&mut child.0)));
+            }
+            Event::Failure(error) => break Err(error),
+            Event::HostReply(frame) => {
+                inflight -= 1;
+                if outgoing.try_send(frame).is_err() {
+                    break Err(
+                        "code mode response pipe exceeded its queue limit or disconnected"
+                            .to_string(),
+                    );
+                }
+            }
+            Event::Frame(Frame::Outcome { outcome }) => {
+                if inflight != 0 {
+                    break Err(
+                        "code mode worker returned with host calls still pending".to_string()
+                    );
+                }
+                break Ok(outcome);
+            }
+            Event::Frame(Frame::Checkpoint { value }) => {
+                if super::json_size(&value, codemode::MAX_CHECKPOINT_BYTES).is_none() {
+                    break Err("code mode checkpoint exceeded its byte limit".to_string());
+                }
+                checkpoint = Some(value);
+            }
+            Event::Frame(frame @ (Frame::Call { .. } | Frame::Fetch { .. })) => {
+                let id = match &frame {
+                    Frame::Call { id, .. } | Frame::Fetch { id, .. } => *id,
+                    _ => unreachable!(),
+                };
+                if calls >= limits.max_calls || !seen_ids.insert(id) {
+                    break Err(
+                        "code mode worker exceeded its call budget or reused a request id"
+                            .to_string(),
+                    );
+                }
+                if inflight >= limits.max_parallel.max(1) {
+                    break Err(
+                        "code mode worker exceeded its host-call parallelism limit".to_string()
+                    );
+                }
+                if super::json_size(&frame, super::MAX_VALUE_BYTES).is_none() {
+                    break Err("code mode host arguments exceed the value limit".to_string());
+                }
+                calls += 1;
+                inflight += 1;
+                if let Frame::Call { index, .. } = &frame {
+                    if *index >= limits.max_calls || !seen_indices.insert(*index) {
+                        break Err("code mode worker sent an invalid call position".to_string());
+                    }
+                }
+                let call = Arc::clone(&call);
+                let fetch = fetch.clone();
+                let progress = Arc::clone(&progress);
+                let events = events.clone();
+                let permit = Arc::clone(&permit);
+                let spawned = std::thread::Builder::new()
+                    .name("code-mode-host".into())
+                    .spawn(move || {
+                        // A timed-out binding retains its permit until it drains, so
+                        // repeated failures cannot accumulate unlimited host threads.
+                        let _permit = permit;
+                        let (name, result) = match frame {
+                            Frame::Call {
+                                index, name, args, ..
+                            } => {
+                                let result =
+                                    std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                                        call(&name, args)
+                                    }))
+                                    .unwrap_or_else(|_| {
+                                        error_result("code mode host call panicked")
+                                    });
+                                (Some((index, name)), result)
+                            }
+                            Frame::Fetch { args, .. } => {
+                                let run = || match fetch {
+                                    Some(fetch) => fetch(codemode::FetchArgs {
+                                        cursor: args.cursor,
+                                        offset: args.offset,
+                                        len: args.len,
+                                        projection: args.projection,
+                                    }),
+                                    None => error_result(
+                                        "toolport.fetchResult is unavailable in this context",
+                                    ),
+                                };
+                                let result =
+                                    std::panic::catch_unwind(std::panic::AssertUnwindSafe(run))
+                                        .unwrap_or_else(|_| {
+                                            error_result("code mode fetchResult panicked")
+                                        });
+                                (None, result)
+                            }
+                            _ => unreachable!(),
+                        };
+                        let result_bytes = super::json_size(&result, super::MAX_FRAME_BYTES);
+                        let is_call = name.is_some();
+                        if let Some((index, name)) = name {
+                            progress
+                                .lock()
+                                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                                .push(CallRecord {
+                                    index,
+                                    name,
+                                    ok: !result
+                                        .get("isError")
+                                        .and_then(Value::as_bool)
+                                        .unwrap_or(false),
+                                    result_bytes: result_bytes
+                                        .unwrap_or(super::MAX_FRAME_BYTES + 1),
+                                });
+                        }
+                        let reply = if is_call {
+                            Frame::CallResult { id, result }
+                        } else {
+                            Frame::FetchResult { id, result }
+                        };
+                        let event = if result_bytes.is_none()
+                            || super::json_size(&reply, super::MAX_FRAME_BYTES).is_none()
+                        {
+                            Event::Failure(
+                                "host result exceeded the code mode IPC frame limit".into(),
+                            )
+                        } else {
+                            Event::HostReply(reply)
+                        };
+                        let _ = events.send(event);
+                    });
+                if let Err(error) = spawned {
+                    break Err(format!("code mode host worker could not start: {error}"));
+                }
+            }
+            Event::Frame(_) => break Err("code mode worker sent an unexpected frame".to_string()),
+        }
+    };
+
+    host_calls.stop();
+    // Closing the bounded queues first releases senders, then killing the child
+    // releases blocked pipe I/O. Already dispatched host bindings retain their
+    // permit until they drain, and are never joined without a deadline.
+    drop(incoming);
+    drop(outgoing);
+    let _ = child.0.kill();
+    let _ = child.0.wait();
+    let _ = reader.join();
+    let _ = writer.join();
+    let mut records = progress
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .clone();
+    records.sort_by_key(|record| record.index);
+    match result {
+        Ok(mut outcome) => {
+            // Boa also counts callAsync entries queued before an early JS error.
+            outcome.calls = outcome.calls.max(calls).min(limits.max_calls);
+            outcome.progress = records;
+            outcome.checkpoint = checkpoint;
+            outcome
+        }
+        Err(mut error) => {
+            if inflight != 0 {
+                error.push_str("; host calls may still be in flight, cancellation requested; do not automatically retry them");
+            }
+            let mut outcome = super::terminated_outcome(calls, records, error);
+            outcome.checkpoint = checkpoint;
+            outcome
+        }
+    }
+}
+
+#[derive(Default)]
+struct Pending {
+    senders: HashMap<u64, mpsc::Sender<Result<Value, String>>>,
+    error: Option<String>,
+}
+
+#[derive(Clone)]
+struct WorkerClient {
+    writer: Arc<Mutex<BufWriter<std::io::Stdout>>>,
+    pending: Arc<Mutex<Pending>>,
+    next_id: Arc<AtomicU64>,
+    deadline: Instant,
+}
+
+impl WorkerClient {
+    fn new(mut reader: BufReader<std::io::Stdin>, deadline: Instant) -> Self {
+        let pending = Arc::new(Mutex::new(Pending::default()));
+        let replies = Arc::clone(&pending);
+        std::thread::spawn(move || {
+            let error = loop {
+                match super::read_frame(&mut reader) {
+                    Ok(Some(
+                        Frame::CallResult { id, result } | Frame::FetchResult { id, result },
+                    )) => {
+                        let sender = replies
+                            .lock()
+                            .unwrap_or_else(std::sync::PoisonError::into_inner)
+                            .senders
+                            .remove(&id);
+                        if let Some(sender) = sender {
+                            let _ = sender.send(Ok(result));
+                        } else {
+                            break "code mode parent returned an unknown request id".to_string();
+                        }
+                    }
+                    Ok(None) => {
+                        // The parent disappeared. Pure JS must not outlive it.
+                        std::process::exit(0);
+                    }
+                    Ok(Some(_)) => {
+                        break "code mode parent sent an unexpected response".to_string()
+                    }
+                    Err(error) => break format!("code mode parent response was invalid: {error}"),
+                }
+            };
+            let mut pending = replies
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            pending.error = Some(error.clone());
+            for (_, sender) in pending.senders.drain() {
+                let _ = sender.send(Err(error.clone()));
+            }
+        });
+        Self {
+            writer: Arc::new(Mutex::new(BufWriter::new(std::io::stdout()))),
+            pending,
+            next_id: Arc::new(AtomicU64::new(0)),
+            deadline,
+        }
+    }
+
+    fn request(&self, frame: Frame, id: u64) -> Value {
+        let (sender, receiver) = mpsc::channel();
+        {
+            let mut pending = self
+                .pending
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            if let Some(error) = &pending.error {
+                return error_result(error);
+            }
+            pending.senders.insert(id, sender);
+        }
+        let sent = super::write_frame(
+            &mut *self
+                .writer
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner),
+            &frame,
+        );
+        let result = match sent {
+            Ok(()) => receiver
+                .recv_timeout(self.deadline.saturating_duration_since(Instant::now()))
+                .unwrap_or_else(|_| {
+                    Err("code mode parent did not answer before the deadline".into())
+                }),
+            Err(error) => Err(format!("code mode host request failed: {error}")),
+        };
+        match result {
+            Ok(value) => value,
+            Err(error) => {
+                let mut pending = self
+                    .pending
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner);
+                pending.senders.remove(&id);
+                pending.error = Some(error.clone());
+                error_result(&error)
+            }
+        }
+    }
+}
+
+/// Internal entry point, before registry, router, keychain, or listeners exist.
+pub fn worker_main() -> ! {
+    memory::enable_worker_limit();
+    let mut reader = BufReader::new(std::io::stdin());
+    let (script, input, immutable, limits, catalog) = match super::read_frame(&mut reader) {
+        Ok(Some(Frame::Start {
+            script,
+            input,
+            immutable_input,
+            limits,
+            catalog,
+        })) => (script, input, immutable_input, limits, catalog),
+        _ => std::process::exit(1),
+    };
+    let client = WorkerClient::new(reader, Instant::now() + limits.wall_clock);
+    let call_client = client.clone();
+    let call: codemode::IndexedCallBinding = Arc::new(move |index, name, args| {
+        let id = call_client.next_id.fetch_add(1, Ordering::Relaxed);
+        call_client.request(
+            Frame::Call {
+                id,
+                index,
+                name: name.into(),
+                args,
+            },
+            id,
+        )
+    });
+    let fetch_client = client.clone();
+    let fetch: FetchBinding = Arc::new(move |args| {
+        let id = fetch_client.next_id.fetch_add(1, Ordering::Relaxed);
+        fetch_client.request(
+            Frame::Fetch {
+                id,
+                args: FetchFrameArgs {
+                    cursor: args.cursor,
+                    offset: args.offset,
+                    len: args.len,
+                    projection: args.projection,
+                },
+            },
+            id,
+        )
+    });
+    let input = if immutable {
+        ScriptInput::ImmutableInput(input)
+    } else {
+        ScriptInput::Data(input)
+    };
+    let checkpoint_client = client.clone();
+    let checkpoint: codemode::CheckpointBinding = Arc::new(move |value| {
+        super::write_frame(
+            &mut *checkpoint_client
+                .writer
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner),
+            &Frame::Checkpoint {
+                value: value.clone(),
+            },
+        )
+        .map_err(|error| error.to_string())
+    });
+    let mut outcome = codemode::run_script_indexed(
+        &script,
+        input,
+        call,
+        Some(fetch),
+        limits,
+        &catalog,
+        Some(checkpoint),
+    );
+    if let Some(error) = client
+        .pending
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .error
+        .clone()
+    {
+        outcome.error = Some(error);
+    }
+    let mut writer = client
+        .writer
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    if let Err(error) = super::write_frame(&mut *writer, &Frame::Outcome { outcome }) {
+        let outcome = super::terminated_outcome(
+            0,
+            Vec::new(),
+            format!("code mode final result exceeded the IPC limit or could not be sent: {error}"),
+        );
+        let _ = super::write_frame(&mut *writer, &Frame::Outcome { outcome });
+    }
+    std::process::exit(0);
+}

--- a/src-tauri/src/codemode_worker/process.rs
+++ b/src-tauri/src/codemode_worker/process.rs
@@ -14,6 +14,7 @@ use crate::codemode::{
 use crate::downstream::CancelContext;
 
 const MAX_WORKERS: usize = 4;
+const WORKER_STACK_BYTES: usize = 8 * 1024 * 1024;
 static WORKERS: AtomicUsize = AtomicUsize::new(0);
 
 struct RunPermit;
@@ -498,6 +499,20 @@ impl WorkerClient {
 /// Internal entry point, before registry, router, keychain, or listeners exist.
 pub fn worker_main() -> ! {
     memory::enable_worker_limit();
+    // Executable entry threads can have a smaller stack than Rust-created
+    // threads. Give Boa a fixed, bounded stack so ordinary nested callbacks do
+    // not overflow before any host call or interpreter recursion check.
+    if let Ok(worker) = std::thread::Builder::new()
+        .name("code-mode-script".into())
+        .stack_size(WORKER_STACK_BYTES)
+        .spawn(worker_run)
+    {
+        let _ = worker.join();
+    }
+    std::process::exit(1);
+}
+
+fn worker_run() {
     let mut reader = BufReader::new(std::io::stdin());
     let (script, input, immutable, limits, catalog) = match super::read_frame(&mut reader) {
         Ok(Some(Frame::Start {

--- a/src-tauri/src/codemode_worker/process.rs
+++ b/src-tauri/src/codemode_worker/process.rs
@@ -59,23 +59,48 @@ fn pipe_error(error: super::FrameError) -> Event {
     }
 }
 
-fn exit_reason(child: &mut Child) -> String {
+fn exit_grace() -> Duration {
     // Windows can close the pipes hundreds of milliseconds before signaling
     // the process handle. Give the dedicated memory exit code time to become
     // observable, while keeping even a broken worker's cleanup bounded.
-    let grace = if cfg!(windows) {
+    if cfg!(windows) {
         Duration::from_secs(1)
     } else {
         Duration::from_millis(25)
-    };
-    let until = Instant::now() + grace;
+    }
+}
+
+fn memory_budget_error() -> String {
+    format!(
+        "code mode script exceeded its memory budget ({} MiB)",
+        super::MEMORY_LIMIT_BYTES / (1024 * 1024)
+    )
+}
+
+/// A worker that exceeds its memory budget calls `_exit` from the thread that
+/// trips the allocator, so another thread can be inside a stdout write and the
+/// parent reads a truncated frame. Wait out the same exit-signal window
+/// `exit_reason` uses, then report a memory termination when one is present.
+fn memory_termination(child: &mut Child) -> Option<String> {
+    let until = Instant::now() + exit_grace();
     loop {
         match child.try_wait() {
             Ok(Some(status)) if memory::is_memory_termination(&status) => {
-                return format!(
-                    "code mode script exceeded its memory budget ({} MiB)",
-                    super::MEMORY_LIMIT_BYTES / (1024 * 1024)
-                );
+                return Some(memory_budget_error());
+            }
+            Ok(Some(_)) => return None,
+            _ if Instant::now() >= until => return None,
+            _ => std::thread::sleep(Duration::from_millis(1)),
+        }
+    }
+}
+
+fn exit_reason(child: &mut Child) -> String {
+    let until = Instant::now() + exit_grace();
+    loop {
+        match child.try_wait() {
+            Ok(Some(status)) if memory::is_memory_termination(&status) => {
+                return memory_budget_error();
             }
             Ok(Some(status)) => {
                 return format!("code mode worker terminated before returning a result ({status})")
@@ -223,7 +248,16 @@ pub fn run_script(
             Event::PipeClosed(error) => {
                 break Err(format!("{}: {error}", exit_reason(&mut child.0)));
             }
-            Event::Failure(error) => break Err(error),
+            Event::Failure(error) => {
+                // A worker killed for exceeding its budget can be torn down
+                // mid-write, so a truncated frame may surface here instead of a
+                // clean pipe close. Attribute a memory termination with the same
+                // message the pipe-close path uses.
+                break Err(match memory_termination(&mut child.0) {
+                    Some(reason) => format!("{reason}: {error}"),
+                    None => error,
+                });
+            }
             Event::HostReply(frame) => {
                 inflight -= 1;
                 if outgoing.try_send(frame).is_err() {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -9,6 +9,7 @@ pub mod brand;
 pub mod catalog;
 pub mod clients;
 pub mod codemode;
+pub mod codemode_worker;
 #[cfg(feature = "desktop")]
 mod desktop;
 pub mod diagnostics_controller;

--- a/src-tauri/tests/codemode_isolation.rs
+++ b/src-tauri/tests/codemode_isolation.rs
@@ -26,10 +26,10 @@ struct Gateway {
 
 impl Gateway {
     fn start() -> Self {
-        Self::configured(|_, _| {}, false)
+        Self::configured(|_, _| {}, None)
     }
 
-    fn configured(configure: impl FnOnce(&mut Registry, &Path), http: bool) -> Self {
+    fn configured(configure: impl FnOnce(&mut Registry, &Path), http_token: Option<&str>) -> Self {
         let dir = std::env::temp_dir().join(format!(
             "toolport-759-{}-{}",
             std::process::id(),
@@ -61,7 +61,7 @@ impl Gateway {
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::inherit());
-        let http_port = http.then(|| {
+        let http_port = http_token.map(|_| {
             let socket = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
             socket.local_addr().unwrap().port()
         });
@@ -97,14 +97,27 @@ impl Gateway {
             next_id: 0,
             http_port,
         };
-        if let Some(port) = http_port {
+        if let (Some(port), Some(token)) = (http_port, http_token) {
             let deadline = Instant::now() + Duration::from_secs(20);
+            let agent = ureq::AgentBuilder::new()
+                .timeout(Duration::from_millis(500))
+                .build();
             loop {
                 assert!(
                     gateway.child.try_wait().unwrap().is_none(),
                     "HTTP gateway exited"
                 );
-                if std::net::TcpStream::connect(("127.0.0.1", port)).is_ok() {
+                // Wait for the authenticated gateway response before sending
+                // scripts: a successful TCP connect alone can report readiness
+                // before this child has actually bound its HTTP listener.
+                let ready = agent
+                    .get(&format!("http://127.0.0.1:{port}/"))
+                    .set("Authorization", &format!("Bearer {token}"))
+                    .call()
+                    .ok()
+                    .and_then(|response| response.into_string().ok())
+                    .is_some_and(|body| body.starts_with("Toolport gateway (HTTP mode)."));
+                if ready {
                     return gateway;
                 }
                 assert!(Instant::now() < deadline, "HTTP gateway failed to listen");
@@ -351,13 +364,13 @@ fn mock_registry(reg: &mut Registry, dir: &Path) {
 
 #[test]
 fn host_calls_remain_ordered_and_completed_work_survives_worker_failure() {
-    let mut gateway = Gateway::configured(mock_registry, false);
+    let mut gateway = Gateway::configured(mock_registry, None);
     let normal = gateway.run(json!({
         "script": "const r = await toolport.callAll(Array.from({ length: 8 }, (_, i) => ({ name: 's__echo', args: { text: String(i) } }))); toolport.checkpoint({ page: 8 }); throw new Error('stop');"
     }));
     assert_eq!(normal["isError"], true, "{normal}");
     let metadata = &normal["structuredContent"]["toolportScript"];
-    assert_eq!(metadata["calls"], 8);
+    assert_eq!(metadata["calls"], 8, "{normal}");
     assert_eq!(metadata["checkpoint"]["page"], 8);
     for (index, entry) in metadata["progress"].as_array().unwrap().iter().enumerate() {
         assert_eq!(entry["index"], index);
@@ -392,7 +405,7 @@ fn isolated_host_calls_preserve_confirmation_pii_and_rate_limits() {
             "rateLimits": [{ "id": "echo-cap", "window": "day", "maxCalls": 1, "tool": "s/echo" }]
         })).unwrap());
         },
-        false,
+        None,
     );
     let result = gateway.run(json!({ "script": "const a = toolport.call('s__echo', {text: 'ada@example.com'}); const b = toolport.call('s__echo', {text: 'second'}); const c = toolport.call('s__delete_item', {a:1,b:2}); return {a,b,c};" }));
     assert_eq!(result["isError"], false, "{result}");
@@ -431,7 +444,7 @@ fn isolated_host_call_cannot_skip_human_approval() {
             mock_registry(reg, dir);
             reg.human_approval = true;
         },
-        false,
+        None,
     );
     let result =
         gateway.run(json!({ "script": "return toolport.call('s__delete_item', {a:1,b:2});" }));
@@ -527,7 +540,7 @@ fn parent_enforces_saved_routine_deadline_during_pure_js() {
             )
             .unwrap();
         },
-        false,
+        None,
     );
     // Cold executable loading and fixture discovery can exceed a short routine
     // budget under Windows ARM's x64 emulation. Warm those paths before timing
@@ -590,7 +603,7 @@ fn http_client_memory_failure_does_not_stop_other_clients_and_scope_stays_enforc
                 });
             }
         },
-        true,
+        Some("client-a"),
     );
     let failure = gateway.http_call("client-a", "toolport_run_script", json!({
         "script": "const buffers = []; for (let i = 0; i < 32; i++) buffers.push(new ArrayBuffer(32 * 1024 * 1024)); return 1;"

--- a/src-tauri/tests/codemode_isolation.rs
+++ b/src-tauri/tests/codemode_isolation.rs
@@ -1,0 +1,621 @@
+//! #759: exercise the shipped gateway/worker boundary, not an in-process Boa harness.
+
+use std::io::{BufRead, BufReader, Write};
+use std::path::{Path, PathBuf};
+use std::process::{Child, ChildStdin, Command, Stdio};
+use std::sync::{
+    atomic::{AtomicUsize, Ordering},
+    mpsc,
+};
+use std::time::{Duration, Instant};
+
+use conduit_lib::registry::{self, Registry};
+use serde_json::{json, Value};
+
+static NEXT: AtomicUsize = AtomicUsize::new(0);
+
+struct Gateway {
+    child: Child,
+    stdin: ChildStdin,
+    replies: mpsc::Receiver<Value>,
+    reader: Option<std::thread::JoinHandle<()>>,
+    dir: PathBuf,
+    next_id: u64,
+    http_port: Option<u16>,
+}
+
+impl Gateway {
+    fn start() -> Self {
+        Self::configured(|_, _| {}, false)
+    }
+
+    fn configured(configure: impl FnOnce(&mut Registry, &Path), http: bool) -> Self {
+        let dir = std::env::temp_dir().join(format!(
+            "toolport-759-{}-{}",
+            std::process::id(),
+            NEXT.fetch_add(1, Ordering::Relaxed)
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let mut reg = Registry::default();
+        configure(&mut reg, &dir);
+        registry::save_to(&dir.join("registry.json"), &reg).unwrap();
+        let executable = dir.join(format!("toolport-gateway{}", std::env::consts::EXE_SUFFIX));
+        // Allow a cross-compiled harness to run in a VM whose paths differ from
+        // the build host. Native cargo test keeps using Cargo's exact binary.
+        let gateway_binary = std::env::var_os("TOOLPORT_TEST_GATEWAY")
+            .unwrap_or_else(|| env!("CARGO_BIN_EXE_toolport-gateway").into());
+        std::fs::copy(gateway_binary, &executable).unwrap();
+        let mut command = Command::new(executable);
+        command
+            .env("TOOLPORT_REGISTRY", dir.join("registry.json"))
+            .env("TOOLPORT_DATA_DIR", &dir)
+            .env("TOOLPORT_CLIENT_ID", "code-mode-isolation-test")
+            .env("TOOLPORT_CODE_MODE", "1")
+            .env("TOOLPORT_RESULT_BUDGET", "49152")
+            .env_remove("TOOLPORT_HTTP")
+            .env_remove("CONDUIT_HTTP")
+            .env_remove("TOOLPORT_HTTP_TOKEN")
+            .env_remove("CONDUIT_HTTP_TOKEN")
+            .env_remove("TOOLPORT_PROFILE")
+            .env_remove("CONDUIT_PROFILE")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::inherit());
+        let http_port = http.then(|| {
+            let socket = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+            socket.local_addr().unwrap().port()
+        });
+        if let Some(port) = http_port {
+            command
+                .arg("--http")
+                .arg(port.to_string())
+                .env("TOOLPORT_HTTP_HOST", "127.0.0.1");
+        }
+        let mut child = command.spawn().expect("start gateway");
+        let stdin = child.stdin.take().unwrap();
+        let stdout = child.stdout.take().unwrap();
+        let (tx, replies) = mpsc::channel();
+        let reader = std::thread::spawn(move || {
+            for line in BufReader::new(stdout).lines() {
+                let Ok(line) = line else {
+                    break;
+                };
+                let Ok(value) = serde_json::from_str::<Value>(&line) else {
+                    continue;
+                };
+                if tx.send(value).is_err() {
+                    break;
+                }
+            }
+        });
+        let mut gateway = Self {
+            child,
+            stdin,
+            replies,
+            reader: Some(reader),
+            dir,
+            next_id: 0,
+            http_port,
+        };
+        if let Some(port) = http_port {
+            let deadline = Instant::now() + Duration::from_secs(20);
+            loop {
+                assert!(
+                    gateway.child.try_wait().unwrap().is_none(),
+                    "HTTP gateway exited"
+                );
+                if std::net::TcpStream::connect(("127.0.0.1", port)).is_ok() {
+                    return gateway;
+                }
+                assert!(Instant::now() < deadline, "HTTP gateway failed to listen");
+                std::thread::sleep(Duration::from_millis(25));
+            }
+        }
+        let initialized = gateway.request(
+            "initialize",
+            json!({
+                "protocolVersion": "2025-11-25", "capabilities": {},
+                "clientInfo": { "name": "isolation-test", "version": "1" }
+            }),
+        );
+        assert!(
+            initialized.get("result").is_some(),
+            "initialize: {initialized}"
+        );
+        gateway
+    }
+
+    fn request(&mut self, method: &str, params: Value) -> Value {
+        self.next_id += 1;
+        let id = self.next_id;
+        let request = json!({ "jsonrpc": "2.0", "id": id, "method": method, "params": params });
+        serde_json::to_writer(&mut self.stdin, &request).unwrap();
+        writeln!(&mut self.stdin).unwrap();
+        self.stdin.flush().unwrap();
+        let deadline = Instant::now() + Duration::from_secs(75);
+        loop {
+            let reply = self
+                .replies
+                .recv_timeout(deadline.saturating_duration_since(Instant::now()))
+                .expect("gateway must answer without exiting or hanging");
+            if reply["id"] == id {
+                return reply;
+            }
+        }
+    }
+
+    fn run(&mut self, arguments: Value) -> Value {
+        self.request(
+            "tools/call",
+            json!({ "name": "toolport_run_script", "arguments": arguments }),
+        )["result"]
+            .clone()
+    }
+
+    fn assert_alive(&mut self) {
+        assert!(
+            self.child.try_wait().unwrap().is_none(),
+            "parent gateway exited"
+        );
+        let response = self.request(
+            "tools/call",
+            json!({ "name": "toolport_status", "arguments": {} }),
+        );
+        assert_ne!(
+            response["result"]["isError"], true,
+            "status failed: {response}"
+        );
+        assert!(
+            response["result"].is_object(),
+            "missing status response: {response}"
+        );
+    }
+
+    fn http_call(&self, token: &str, name: &str, args: Value) -> Value {
+        let agent = ureq::AgentBuilder::new()
+            .timeout(Duration::from_secs(75))
+            .build();
+        let response = agent
+            .post(&format!(
+                "http://127.0.0.1:{}/{name}",
+                self.http_port.unwrap()
+            ))
+            .set("Authorization", &format!("Bearer {token}"))
+            .send_json(args);
+        let response = match response {
+            Ok(response) | Err(ureq::Error::Status(_, response)) => response,
+            Err(error) => panic!("HTTP gateway failed: {error}"),
+        };
+        response.into_json().expect("JSON HTTP result")
+    }
+
+    fn audit(&self) -> Vec<Value> {
+        std::fs::read_to_string(self.dir.join("audit.jsonl"))
+            .unwrap_or_default()
+            .lines()
+            .filter_map(|line| serde_json::from_str(line).ok())
+            .collect()
+    }
+}
+
+impl Drop for Gateway {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+        if let Some(reader) = self.reader.take() {
+            let _ = reader.join();
+        }
+        let _ = std::fs::remove_dir_all(&self.dir);
+    }
+}
+
+#[test]
+fn allocating_scripts_fail_without_killing_stdio_gateway() {
+    let mut gateway = Gateway::start();
+    let normal = gateway.run(json!({
+        "script": "const buffer = new ArrayBuffer(32 * 1024 * 1024); return { answer: data.value + 1, bytes: buffer.byteLength };",
+        "data": { "value": 41 }
+    }));
+    assert_eq!(normal["isError"], false, "normal script failed: {normal}");
+    assert_eq!(normal["structuredContent"]["result"]["answer"], 42);
+    assert_eq!(
+        normal["structuredContent"]["result"]["bytes"],
+        32 * 1024 * 1024
+    );
+
+    for validate in [false, true] {
+        let failure = gateway.run(json!({
+            "script": "const buffers = []; for (let i = 0; i < 32; i++) buffers.push(new ArrayBuffer(32 * 1024 * 1024)); return buffers.length;",
+            "validate": validate
+        }));
+        assert_eq!(
+            failure["isError"], true,
+            "allocating script succeeded: {failure}"
+        );
+        let field = if validate {
+            "toolportValidate"
+        } else {
+            "toolportScript"
+        };
+        let error = failure["structuredContent"][field]["error"]
+            .as_str()
+            .unwrap_or_default();
+        assert!(error.contains("memory budget"), "wrong failure: {failure}");
+        gateway.assert_alive();
+        let recovery = gateway.run(json!({ "script": "return 7;" }));
+        assert_eq!(recovery["isError"], false, "next worker failed: {recovery}");
+    }
+    assert_eq!(
+        gateway
+            .audit()
+            .iter()
+            .filter(|entry| entry["server"] == "toolport"
+                && entry["tool"] == "run_script"
+                && entry["error"] == "code_mode_memory_budget")
+            .count(),
+        2
+    );
+}
+
+#[test]
+fn script_error_text_cannot_impersonate_memory_exhaustion() {
+    let mut gateway = Gateway::start();
+    for (constructor, message) in [
+        ("Error", "out of memory from a downstream service"),
+        ("Error", "memory allocation failed in the remote tool"),
+        (
+            "RangeError",
+            "invalid layout Layout { size: 33554432, align: 64 (1 << 6) } while allocating data block",
+        ),
+        ("Error", "code mode script exceeded its memory budget (512 MiB)"),
+    ] {
+        let failure = gateway.run(json!({
+            "script": format!("toolport.checkpoint({{step:1}}); throw new {constructor}(data.message);"),
+            "data": { "message": message }
+        }));
+        assert_eq!(failure["isError"], true, "{failure}");
+        let metadata = &failure["structuredContent"]["toolportScript"];
+        let error = metadata["error"].as_str().unwrap();
+        assert!(error.ends_with(message), "script error was replaced: {failure}");
+        assert!(
+            !error.starts_with("code mode script exceeded its memory budget"),
+            "script error was classified as an allocation failure: {failure}"
+        );
+        assert_eq!(metadata["checkpoint"]["step"], 1, "{failure}");
+    }
+    let failures: Vec<Value> = gateway
+        .audit()
+        .into_iter()
+        .filter(|entry| entry["server"] == "toolport" && entry["tool"] == "run_script")
+        .collect();
+    assert_eq!(failures.len(), 4, "{failures:?}");
+    assert!(
+        failures
+            .iter()
+            .all(|entry| entry["error"] == "code_mode_failed"),
+        "script text changed the audit category: {failures:?}"
+    );
+    gateway.assert_alive();
+}
+
+#[test]
+fn stdio_rejects_oversized_source_data_input_and_schema() {
+    use conduit_lib::codemode_worker::{MAX_SCHEMA_BYTES, MAX_SCRIPT_BYTES, MAX_VALUE_BYTES};
+    let mut gateway = Gateway::start();
+    for (arguments, expected) in [
+        (
+            json!({ "script": "x".repeat(MAX_SCRIPT_BYTES + 1) }),
+            "source limit",
+        ),
+        (
+            json!({ "script": "return 1;", "data": "x".repeat(MAX_VALUE_BYTES) }),
+            "value limit",
+        ),
+        (
+            json!({ "script": "return 1;", "input": { "x": "x".repeat(MAX_VALUE_BYTES) }, "inputSchema": { "type": "object" } }),
+            "value limit",
+        ),
+        (
+            json!({ "script": "return 1;", "input": {}, "inputSchema": { "description": "x".repeat(MAX_SCHEMA_BYTES) } }),
+            "schema limit",
+        ),
+    ] {
+        let result = gateway.run(arguments);
+        assert_eq!(result["isError"], true, "payload was accepted: {result}");
+        assert!(
+            result.to_string().contains(expected),
+            "wrong error: {result}"
+        );
+    }
+    gateway.assert_alive();
+}
+
+fn mock_registry(reg: &mut Registry, dir: &Path) {
+    let mock = dir.join(format!("mock-mcp-server{}", std::env::consts::EXE_SUFFIX));
+    let mock_binary = std::env::var_os("TOOLPORT_TEST_MOCK")
+        .unwrap_or_else(|| env!("CARGO_BIN_EXE_mock-mcp-server").into());
+    std::fs::copy(mock_binary, &mock).unwrap();
+    reg.servers.push(serde_json::from_value(json!({
+        "id": "s", "name": "Fixture", "transport": "stdio", "command": mock,
+        "env": [{ "key": "MOCK_MCP_TRANSCRIPT", "value": dir.join("downstream.jsonl"), "secret": false }]
+    })).unwrap());
+    reg.profiles[0].enabled_server_ids.push("s".into());
+    reg.tool_overrides.entry("s".into()).or_default().insert(
+        "add".into(),
+        registry::ToolOverride {
+            name: Some("s__delete_item".into()),
+            description: None,
+        },
+    );
+}
+
+#[test]
+fn host_calls_remain_ordered_and_completed_work_survives_worker_failure() {
+    let mut gateway = Gateway::configured(mock_registry, false);
+    let normal = gateway.run(json!({
+        "script": "const r = await toolport.callAll(Array.from({ length: 8 }, (_, i) => ({ name: 's__echo', args: { text: String(i) } }))); toolport.checkpoint({ page: 8 }); throw new Error('stop');"
+    }));
+    assert_eq!(normal["isError"], true, "{normal}");
+    let metadata = &normal["structuredContent"]["toolportScript"];
+    assert_eq!(metadata["calls"], 8);
+    assert_eq!(metadata["checkpoint"]["page"], 8);
+    for (index, entry) in metadata["progress"].as_array().unwrap().iter().enumerate() {
+        assert_eq!(entry["index"], index);
+        assert_eq!(entry["name"], "s__echo");
+        assert_eq!(entry["ok"], true);
+    }
+    assert_eq!(metadata["progress"].as_array().unwrap().len(), 8);
+    let failure = gateway.run(json!({
+        "script": "toolport.call('s__echo', {text: 'committed'}); toolport.checkpoint({ page: 1 }); const buffers = []; for (let i = 0; i < 32; i++) buffers.push(new ArrayBuffer(32 * 1024 * 1024)); return 1;"
+    }));
+    let metadata = &failure["structuredContent"]["toolportScript"];
+    assert_eq!(failure["isError"], true, "{failure}");
+    assert!(metadata["error"]
+        .as_str()
+        .unwrap()
+        .contains("memory budget"));
+    assert_eq!(metadata["progress"][0]["name"], "s__echo");
+    assert_eq!(metadata["progress"][0]["ok"], true);
+    assert_eq!(metadata["checkpoint"]["page"], 1);
+    gateway.assert_alive();
+}
+
+#[test]
+fn isolated_host_calls_preserve_confirmation_pii_and_rate_limits() {
+    let mut gateway = Gateway::configured(
+        |reg, dir| {
+            mock_registry(reg, dir);
+            reg.confirm_destructive = true;
+            reg.pii_redaction = true;
+            reg.team = Some(serde_json::from_value(json!({
+            "serverUrl": "https://example.invalid", "teamId": "test", "role": "member",
+            "rateLimits": [{ "id": "echo-cap", "window": "day", "maxCalls": 1, "tool": "s/echo" }]
+        })).unwrap());
+        },
+        false,
+    );
+    let result = gateway.run(json!({ "script": "const a = toolport.call('s__echo', {text: 'ada@example.com'}); const b = toolport.call('s__echo', {text: 'second'}); const c = toolport.call('s__delete_item', {a:1,b:2}); return {a,b,c};" }));
+    assert_eq!(result["isError"], false, "{result}");
+    let values = &result["structuredContent"]["result"];
+    assert_eq!(values["a"]["isError"], false, "{result}");
+    assert!(
+        !values["a"].to_string().contains("ada@example.com"),
+        "{result}"
+    );
+    assert_eq!(values["b"]["isError"], true, "{result}");
+    assert!(
+        values["b"].to_string().to_lowercase().contains("limit"),
+        "{result}"
+    );
+    assert_eq!(values["c"]["isError"], true, "{result}");
+    assert!(
+        values["c"]
+            .to_string()
+            .contains("requires per-call confirmation"),
+        "{result}"
+    );
+    let transcript = std::fs::read_to_string(gateway.dir.join("downstream.jsonl")).unwrap();
+    let executed: Vec<Value> = transcript
+        .lines()
+        .map(|line| serde_json::from_str::<Value>(line).unwrap())
+        .filter(|req| req["method"] == "tools/call")
+        .collect();
+    assert_eq!(executed.len(), 1, "{executed:?}");
+    assert_eq!(executed[0]["params"]["name"], "echo");
+}
+
+#[test]
+fn isolated_host_call_cannot_skip_human_approval() {
+    let mut gateway = Gateway::configured(
+        |reg, dir| {
+            mock_registry(reg, dir);
+            reg.human_approval = true;
+        },
+        false,
+    );
+    let result =
+        gateway.run(json!({ "script": "return toolport.call('s__delete_item', {a:1,b:2});" }));
+    let value = &result["structuredContent"]["result"];
+    assert_eq!(value["isError"], true, "{result}");
+    assert!(value.to_string().contains("unreachable"), "{result}");
+    let transcript = std::fs::read_to_string(gateway.dir.join("downstream.jsonl")).unwrap();
+    assert!(!transcript
+        .lines()
+        .map(|line| serde_json::from_str::<Value>(line).unwrap())
+        .any(|req| req["method"] == "tools/call"));
+    assert!(gateway
+        .audit()
+        .iter()
+        .any(|entry| entry["server"] == "s" && entry["decision"] == "unreachable"));
+}
+
+#[test]
+fn isolated_fetch_reads_parent_cache_and_oversized_output_fails_cleanly() {
+    let mut gateway = Gateway::start();
+    let shaped = gateway.run(json!({ "script": "return 'x'.repeat(100000);" }));
+    let text = shaped["content"][0]["text"].as_str().unwrap();
+    let cursor = text
+        .split("\"cursor\":\"")
+        .nth(1)
+        .unwrap()
+        .split('"')
+        .next()
+        .unwrap();
+    let fetched = gateway.run(json!({
+        "script": "return toolport.fetchResult({cursor:data.cursor, offset:0, len:16});",
+        "data": { "cursor": cursor }
+    }));
+    assert_eq!(fetched["isError"], false, "{fetched}");
+    assert_eq!(
+        fetched["structuredContent"]["result"]["isError"], false,
+        "{fetched}"
+    );
+    assert!(fetched["structuredContent"]["result"]["content"][0]["text"]
+        .as_str()
+        .unwrap()
+        .contains("xxxxxxxx"));
+
+    let result = gateway.run(
+        json!({ "script": "toolport.checkpoint({page:2}); return 'x'.repeat(17 * 1024 * 1024);" }),
+    );
+    assert_eq!(result["isError"], true, "{result}");
+    assert!(result.to_string().contains("IPC limit"), "{result}");
+    assert!(!result.to_string().contains("memory budget"), "{result}");
+    assert_eq!(
+        result["structuredContent"]["toolportScript"]["checkpoint"]["page"],
+        2
+    );
+    gateway.assert_alive();
+}
+
+#[test]
+fn parent_enforces_saved_routine_deadline_during_pure_js() {
+    use conduit_lib::{integrity, routines};
+    let wall_clock = Duration::from_secs(5);
+    let mut routine_id = String::new();
+    let mut gateway = Gateway::configured(
+        |reg, dir| {
+            mock_registry(reg, dir);
+            let fingerprint = integrity::fingerprint(&json!({
+                "name": "s__echo", "description": "Echo back the text argument.",
+                "inputSchema": { "type": "object", "properties": { "text": { "type": "string" } } }
+            }));
+            let evidence = routines::PromotionEvidence::new(
+                format!("run_{}", "1".repeat(32)),
+                1,
+                1,
+                vec![
+                    routines::ObservedDependency::new("s__echo".into(), Some(fingerprint)).unwrap(),
+                ],
+                routines::RoutineRiskClass::Low,
+            )
+            .unwrap();
+            let definition = routines::new_promoted_definition(
+            "Deadline test".into(), None,
+            "const result = toolport.call('s__echo', {text:'before'}); if (result.content.length) { toolport.checkpoint({step:1}); while (true) { Math.sin(1); } } return 1;".into(),
+            json!({ "type": "object" }),
+            routines::RoutineLimits { wall_clock_ms: wall_clock.as_millis() as u64, ..Default::default() },
+            evidence,
+        ).unwrap();
+            routine_id = definition.id().into();
+            std::fs::write(
+                dir.join("routines.json"),
+                serde_json::to_vec(&json!({
+                    "schemaVersion": routines::STORE_SCHEMA_VERSION, "routines": [definition]
+                }))
+                .unwrap(),
+            )
+            .unwrap();
+        },
+        false,
+    );
+    // Cold executable loading and fixture discovery can exceed a short routine
+    // budget under Windows ARM's x64 emulation. Warm those paths before timing
+    // the pure-JS deadline; each invocation still starts its own worker.
+    let warmup = gateway.run(json!({
+        "script": "return toolport.call('s__echo', {text:'warmup'});"
+    }));
+    assert_eq!(warmup["isError"], false, "{warmup}");
+    assert_eq!(
+        warmup["structuredContent"]["result"]["isError"], false,
+        "{warmup}"
+    );
+    let started = Instant::now();
+    let reply = gateway.request(
+        "tools/call",
+        json!({
+            "name": "toolport_run_routine", "arguments": { "id": routine_id, "arguments": {} }
+        }),
+    );
+    let result = &reply["result"];
+    assert_eq!(result["isError"], true, "{result}");
+    assert_eq!(
+        result["structuredContent"]["toolportRoutine"]["error"],
+        "code mode worker exceeded its wall-clock deadline",
+        "{result}"
+    );
+    assert_eq!(
+        result["structuredContent"]["toolportRoutine"]["checkpoint"]["step"], 1,
+        "{result}"
+    );
+    let elapsed = started.elapsed();
+    assert!(
+        elapsed >= wall_clock,
+        "deadline fired early after {elapsed:?}"
+    );
+    assert!(
+        elapsed < wall_clock + Duration::from_secs(5),
+        "deadline took {elapsed:?}"
+    );
+    gateway.assert_alive();
+}
+
+#[test]
+fn http_client_memory_failure_does_not_stop_other_clients_and_scope_stays_enforced() {
+    let mut gateway = Gateway::configured(
+        |reg, dir| {
+            mock_registry(reg, dir);
+            reg.profiles.push(
+                serde_json::from_value(
+                    json!({ "id": "empty", "name": "Empty", "enabledServerIds": [] }),
+                )
+                .unwrap(),
+            );
+            for (id, profile) in [("client-a", "Empty"), ("client-b", "Default")] {
+                reg.http_clients.push(registry::HttpClient {
+                    id: id.into(),
+                    label: id.into(),
+                    token_sha256: registry::sha256_hex(id),
+                    profile: profile.into(),
+                });
+            }
+        },
+        true,
+    );
+    let failure = gateway.http_call("client-a", "toolport_run_script", json!({
+        "script": "const buffers = []; for (let i = 0; i < 32; i++) buffers.push(new ArrayBuffer(32 * 1024 * 1024)); return 1;"
+    }));
+    assert!(failure.to_string().contains("memory budget"), "{failure}");
+    assert!(gateway.child.try_wait().unwrap().is_none());
+    let status = gateway.http_call("client-b", "toolport_status", json!({}));
+    assert!(status.is_string(), "status failed: {status}");
+    let scoped = gateway.http_call(
+        "client-a",
+        "toolport_run_script",
+        json!({
+            "script": "return toolport.call('s__echo', { text: 'denied' });"
+        }),
+    );
+    assert!(
+        scoped.to_string().contains("not available to this client"),
+        "{scoped}"
+    );
+    let normal = gateway.http_call(
+        "client-b",
+        "toolport_run_script",
+        json!({
+            "script": "return toolport.call('s__echo', { text: 'allowed' });"
+        }),
+    );
+    assert!(normal.to_string().contains("allowed"), "{normal}");
+}

--- a/src-tauri/tests/codemode_isolation.rs
+++ b/src-tauri/tests/codemode_isolation.rs
@@ -39,13 +39,14 @@ impl Gateway {
         let mut reg = Registry::default();
         configure(&mut reg, &dir);
         registry::save_to(&dir.join("registry.json"), &reg).unwrap();
-        let executable = dir.join(format!("toolport-gateway{}", std::env::consts::EXE_SUFFIX));
         // Allow a cross-compiled harness to run in a VM whose paths differ from
         // the build host. Native cargo test keeps using Cargo's exact binary.
         let gateway_binary = std::env::var_os("TOOLPORT_TEST_GATEWAY")
             .unwrap_or_else(|| env!("CARGO_BIN_EXE_toolport-gateway").into());
-        std::fs::copy(gateway_binary, &executable).unwrap();
-        let mut command = Command::new(executable);
+        // Reuse the immutable build artifact. Copying executables while other
+        // tests spawn processes can leave inherited write handles (ETXTBSY).
+        // The registry and data directory still belong to this fixture alone.
+        let mut command = Command::new(gateway_binary);
         command
             .env("TOOLPORT_REGISTRY", dir.join("registry.json"))
             .env("TOOLPORT_DATA_DIR", &dir)
@@ -344,10 +345,10 @@ fn stdio_rejects_oversized_source_data_input_and_schema() {
 }
 
 fn mock_registry(reg: &mut Registry, dir: &Path) {
-    let mock = dir.join(format!("mock-mcp-server{}", std::env::consts::EXE_SUFFIX));
-    let mock_binary = std::env::var_os("TOOLPORT_TEST_MOCK")
-        .unwrap_or_else(|| env!("CARGO_BIN_EXE_mock-mcp-server").into());
-    std::fs::copy(mock_binary, &mock).unwrap();
+    let mock = PathBuf::from(
+        std::env::var_os("TOOLPORT_TEST_MOCK")
+            .unwrap_or_else(|| env!("CARGO_BIN_EXE_mock-mcp-server").into()),
+    );
     reg.servers.push(serde_json::from_value(json!({
         "id": "s", "name": "Fixture", "transport": "stdio", "command": mock,
         "env": [{ "key": "MOCK_MCP_TRANSCRIPT", "value": dir.join("downstream.jsonl"), "secret": false }]


### PR DESCRIPTION
## What and why

Code mode runs untrusted JavaScript inside the gateway today, so an allocation-heavy script can abort the process and disconnect every client using the HTTP bridge. This change runs scripts, validation, and saved routines in separate workers; exceeding the memory or time budget returns a script error while the gateway remains available.

Fixes #759.

- Give each worker a 512 MiB memory budget, a parent-enforced wall-clock deadline, and bounded IPC. Limit source to 256 KiB, input/data to 4 MiB, schemas to 64 KiB, and IPC frames to 16 MiB. Bound concurrent workers and host-call queues as well.
- Run the interpreter on an explicit 8 MiB thread stack so ordinary nested callbacks do not depend on executable entry-stack defaults.
- Keep downstream calls in the parent so scope, human approval, confirmation, PII handling, content defense, and rate limits continue to apply. Preserve completed-call positions and checkpoints on failure, and request cancellation of calls still in flight.
- Attribute allocation failures through a dedicated worker exit code instead of matching JavaScript error text. Allow a bounded interval for the process exit status to become observable after its pipes close.
- Add integration tests that exercise the actual gateway/worker processes over stdio and HTTP, including allocation failure, recovery, governance, byte limits, cache paging, checkpoints, and pure-JavaScript deadlines.

## Testing

- [x] macOS: 125 related tests passed (58 interpreter/worker tests, 58 gateway/routine tests, and 9 process integration tests).
  - `cargo test --manifest-path src-tauri/Cargo.toml --no-default-features --lib codemode -- --test-threads=1`
  - `cargo test --manifest-path src-tauri/Cargo.toml --no-default-features --bin toolport-gateway -- script validate_ checkpoint routine_ --test-threads=1`
  - `cargo test --manifest-path src-tauri/Cargo.toml --no-default-features --test codemode_isolation` (all 9 pass with the default parallel runner)
- [x] `prettier --check docs/configuration.md` and `git diff --check`.

The allocation-error regression was observed failing before the fix. The final process integration suite verifies both real allocation failures and ordinary script errors that contain allocation-related text.

The host-call regression was also reproduced with a 1 MiB executable entry stack, then verified passing under the same constraint after giving the interpreter its own bounded stack. HTTP integration fixtures wait for an authenticated gateway response before sending scripts. They reuse Cargo's built executables to avoid write-handle races during parallel process startup.

## Notes

- Linux uses `RLIMIT_AS` before exec. macOS uses a worker-only Rust heap cap because Darwin's `RLIMIT_AS` is advisory; this does not bound total process RSS.
- The PR's CI runs the complete headless test suite. No frontend or desktop UI code changed; local validation used the headless Rust workflow documented in `CONTRIBUTING.md`.
- The diff contains no credentials, diagnostic artifacts, or machine-specific paths.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Run Code Mode scripts in isolated worker processes with memory and IPC limits
> - Code Mode scripts now execute in a separately spawned, memory-limited worker process instead of in-process, with a parent-side wall-clock supervisor and bounded IPC framing via `Frame` messages
> - Platform-specific memory isolation: Unix children get address-space and malloc-arena limits; Windows children are assigned to a job object with a process-memory limit before thread resume; a global `WorkerAllocator` enforces a 512 MiB budget and exits with a dedicated `MEMORY_EXIT_CODE` on exhaustion
> - Host calls cross the worker boundary over length-prefixed JSON frames with request-ID matching, deadline-bounded responses, and a cancellation registry that cancels all active calls when a run is stopped
> - Concurrency is capped at four simultaneous workers via `RunPermit`; oversized script source, input data, and schemas are rejected before execution; completed call progress and checkpoints survive worker failures
> - Test builds retain the in-process runner via `run_code_mode_isolated`; non-test builds delegate to `worker::run_script`
> - Risk: the gateway process now installs `WorkerAllocator` as the global allocator on Unix and Windows (`CODE_MODE_ALLOCATOR` in [toolport-gateway.rs](https://github.com/tsouth89/toolport/pull/865/files#diff-fe5f13c01103f5adf39c870989b67ecdb11c19b3ba86b88c4acb028a7374cc01)), so all process allocations are routed through byte-counted accounting; launching the executable with the worker argument enters `worker_main` before normal argument parsing
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7269017.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->


